### PR TITLE
fix: daytona ssh known hosts file

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -87,22 +87,21 @@ func generateSshConfigEntry(profileId, workspaceName, projectName, knownHostsPat
 }
 
 func EnsureSshConfigEntryAdded(profileId, workspaceName, projectName string) error {
-	configDir, err := GetConfigDir()
+	err := ensureSshFilesLinked()
 	if err != nil {
 		return err
 	}
 
-	err = ensureSshFilesLinked()
+	knownHostsFile := "/dev/null"
+	if runtime.GOOS == "windows" {
+		knownHostsFile = "NUL"
+	}
+
+	data, err := generateSshConfigEntry(profileId, workspaceName, projectName, knownHostsFile)
 	if err != nil {
 		return err
 	}
 
-	data, err := generateSshConfigEntry(profileId, workspaceName, projectName, path.Join(configDir, ".known_hosts"))
-	if err != nil {
-		return err
-	}
-
-	// Make sure ~/.ssh/config file exists
 	sshDir := path.Join(sshHomeDir, ".ssh")
 	configPath := path.Join(sshDir, "daytona_config")
 


### PR DESCRIPTION
# Fix ssh known hosts file

## Description

Updated the known hosts file to `/dev/null` (`NUL` for windows), according to #88. This will ensure that the known hosts file is not written to.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #88 