### PR TITLE
Reworking the get-server.sh to install as non root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ To install Daytona all you need to do is execute this script:
 
 
 ```bash
-# Install Daytona
-curl https://download.daytona.io/daytona/get-server.sh | bash
+# Install Daytona into ~/bin or ~/.local/bin
+curl -sf -L https://download.daytona.io/daytona/get-server.sh | bash
 
-# Start Daytona server 
+# OR if you want to install Daytona to /usr/loca/bin or /opt/bin
+curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
+
+# Start Daytona server
 daytona server
 ```
 Create your first dev environment by opening a new terminal, and executing just this command:
@@ -78,13 +81,13 @@ Start coding.
 ## Why Daytona?
 Daytona is a radically simple open source development environment manager.
 
-Setting up development environments has become increasingly challenging over time, especially when aiming to set up remotely, where the complexity increases by a order of magnitude. The process is so complex that we've compiled a [comprehensive guide](https://www.daytona.io/dotfiles/diy-guide-to-transform-any-machine-into-a-codespace) detailing all the necessary steps to set one up—spanning __5,000 words__, __7 steps__, and requiring anywhere from 15 to __45 minutes__. 
+Setting up development environments has become increasingly challenging over time, especially when aiming to set up remotely, where the complexity increases by a order of magnitude. The process is so complex that we've compiled a [comprehensive guide](https://www.daytona.io/dotfiles/diy-guide-to-transform-any-machine-into-a-codespace) detailing all the necessary steps to set one up—spanning __5,000 words__, __7 steps__, and requiring anywhere from 15 to __45 minutes__.
 
 This complexity is unnecessary.
 
 With Daytona, you need only to execute a single command: `daytona create`.
 
-Daytona automates the entire process; provisioning the instance, interpreting and applying the configuration, setting up prebuilds, establishing a secure VPN connection, securely connecting your local or a Web IDE, and assigning a fully qualified domain name to the development environment for easy sharing and collaboration. 
+Daytona automates the entire process; provisioning the instance, interpreting and applying the configuration, setting up prebuilds, establishing a secure VPN connection, securely connecting your local or a Web IDE, and assigning a fully qualified domain name to the development environment for easy sharing and collaboration.
 
 As a developer, you can immediately start focusing on what matters most—your code.
 
@@ -105,8 +108,8 @@ So, we took everything we learned and decided to solve these issues once and for
 ## Getting Started
 ### Requirements
 Before starting the installation script, please go over all the necessary requirements:
-- __Hardware Resources__: Depending on the project requirements, ensure your machine has sufficient resources. Minimum hardware specification is 1cpu, 2GB of RAM and 10GB of disk space. 
-- __Docker__: Ensure [Docker](https://www.docker.com/products/docker-desktop/) is installed and running.   
+- __Hardware Resources__: Depending on the project requirements, ensure your machine has sufficient resources. Minimum hardware specification is 1cpu, 2GB of RAM and 10GB of disk space.
+- __Docker__: Ensure [Docker](https://www.docker.com/products/docker-desktop/) is installed and running.
 
 
 
@@ -126,38 +129,38 @@ Alternatively, download and compile Daytona directly from this repository by con
 ### Initializing Daytona
 To initialize Daytona, follow these steps:
 
-__1. Start the Daytona Service:__  
+__1. Start the Daytona Service:__
 This initiates the Daytona service, which must always be running for Daytona to function. Use the command:
 ```bash
 daytona server
 ```
-__2. Add Your Git Provider of Choice:__  
-Daytona supports GitHub, GitLab, and Bitbucket. To add them to your profile, use the command:  
+__2. Add Your Git Provider of Choice:__
+Daytona supports GitHub, GitLab, and Bitbucket. To add them to your profile, use the command:
 ```bash
 daytona git-providers add
 
 ```
 Follow the steps provided. Here's a link to the [documentation](https://daytona.io/docs) for more details.
 
-__3. Add Your Provider Target:__  
+__3. Add Your Provider Target:__
 This step is for choosing where to deploy Development Environments. By default, Daytona includes a Docker provider to spin up environments on your local machine. For remote development environments, use the command:
 ```bash
 daytona target set
 ```
 Following the steps this command adds SSH machines to your targets.
 
-__4. Choose Your Default IDE:__  
+__4. Choose Your Default IDE:__
 The default setting for Daytona is VS Code locally. If you prefer, you can switch to VS Code - Browser or any IDE from the JetBrains portfolio (Contributions welcome here!) using the command:
 ```bash
 daytona ide
 ```
-Now that you have installed and initialized Daytona, you can proceed to setting up your development environments and start coding instantly.  
+Now that you have installed and initialized Daytona, you can proceed to setting up your development environments and start coding instantly.
 
 
 
 
 
-### Creating Dev Environments 
+### Creating Dev Environments
 Creating development environments with Daytona is a straightforward process, accomplished with just one command:
 ```bash
 daytona create
@@ -182,7 +185,7 @@ For more detailed information about each command, please refer to Daytona's [doc
 Daytona offers flexibility for extension through the creation of plugins and providers.
 
 
-### Providers 
+### Providers
 Daytona is designed to be infrastructure-agnostic, capable of creating and managing development environments across various platforms. Providers are the components that encapsulate the logic for provisioning compute resources on a specific target platform. They allow for the configuration of different targets within a single provider, enabling, for instance, multiple AWS profiles within an AWS provider.
 
 How does it work? When executing the `daytona create` command, Daytona communicates the environment details to the selected provider, which then provisions the necessary compute resources. Once provisioned, Daytona sets up the environment on these resources, allowing the user to interact with the environment seamlessly.
@@ -233,5 +236,4 @@ This project has adapted the Code of Conduct from the [Contributor Covenant](htt
 
 For more information on how to use and develop Daytona, talk to us on
 [Slack](https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q) and check out our [documentation](https://www.daytona.io/docs/installation/server/).
-
 

--- a/hack/get-server.sh
+++ b/hack/get-server.sh
@@ -1,55 +1,106 @@
 #!/bin/bash
 
-VERSION="latest"
-if [ -n "$DAYTONA_SERVER_VERSION" ]; then
-  VERSION=$DAYTONA_SERVER_VERSION
-fi 
-  
+# This script downloads the Daytona server binary and installs it to /usr/local/bin
+# You can set the environment variable DAYTONA_SERVER_VERSION to specify the version to download
+# You can set the environment variable DAYTONA_SERVER_DOWNLOAD_URL to specify the base URL to download from
+
+VERSION=${DAYTONA_SERVER_VERSION:-"latest"}
+BASE_URL=${DAYTONA_SERVER_DOWNLOAD_URL:-"https://download.daytona.io/daytona"}
+DESTINATION=""
+SUDO_REQUIRED=0
+
+# Print error message to stderr and exit
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+  exit 1
+}
+
+# Check if there is a directory in $PATH that we can write to. With this
+# statement the first match from top to bottom will be used.
+# shellcheck disable=SC2088
+case :$PATH: in
+  *:$HOME/bin:*)
+    DESTINATION="$HOME/bin"
+    SUDO_REQUIRED=0
+    ;;
+  *:$HOME/.local/bin:*)
+    DESTINATION="$HOME/.local/bin"
+    SUDO_REQUIRED=0
+    ;;
+  *:/usr/local/bin:*)
+    DESTINATION="/usr/local/bin"
+    SUDO_REQUIRED=1
+    ;;
+  *:/opt/bin:*)
+    DESTINATION="/opt/bin"
+    SUDO_REQUIRED=1
+    ;;
+  *) err "~/bin, ~/.local/bin, /opt/bin and /usr/local/bin not on PATH. No option to install to.";;
+esac
+
 # Check machine architecture
 ARCH=$(uname -m)
 # Check operating system
 OS=$(uname -s)
 
-if [ "$OS" == "" ]; then
-  OS=$(ver)
-  ARCH=$(echo %PROCESSOR_ARCHITECTURE%)
-fi
+case $OS in
+  "Darwin")
+    FILENAME="darwin"
+    ;;
+  "Linux")
+    FILENAME="linux"
+    ;;
+  *)
+    err "Unsupported operating system: $OS"
+    ;;
+esac
 
-if [ "$OS" == "Darwin" ]; then
-  FILENAME="darwin"
-elif [ "$OS" == "Linux" ]; then
-  FILENAME="linux"
-elif [[ $OS == *"Windows"* ]]; then
-  FILENAME="windows"
-else
-  echo "Unsupported operating system: $OS"
-  exit 1
-fi
+case $ARCH in
+  "arm64" | "ARM64")
+    FILENAME="$FILENAME-arm64"
+    ;;
+  "x86_64" | "AMD64")
+    FILENAME="$FILENAME-amd64"
+    ;;
+  "aarch64")
+    FILENAME="$FILENAME-arm64"
+    ;;
+  *)
+    err "Unsupported architecture: $ARCH"
+    ;;
+esac
 
-if [ "$ARCH" == "arm64" ]; then
-  FILENAME=$(echo "$FILENAME-arm64")
-elif [ "$ARCH" == "ARM64" ]; then
-  FILENAME=$(echo "$FILENAME-arm64")
-elif [ "$ARCH" == "x86_64" ]; then
-  FILENAME=$(echo "$FILENAME-amd64")
-elif [ "$ARCH" == "AMD64" ]; then
-  FILENAME=$(echo "$FILENAME-amd64")
-elif [ "$ARCH" == "aarch64" ]; then
-  FILENAME=$(echo "$FILENAME-arm64")
-else
-  echo "Unsupported architecture: $ARCH"
-  exit 1
-fi
-
-BASE_URL="https://download.daytona.io/daytona"
-if [ -n "$DAYTONA_SERVER_DOWNLOAD_URL" ]; then
-  BASE_URL=$DAYTONA_SERVER_DOWNLOAD_URL
-fi
-
-DOWNLOAD_URL=$(echo "$BASE_URL/$VERSION/daytona-$FILENAME")
+DOWNLOAD_URL="$BASE_URL/$VERSION/daytona-$FILENAME"
 
 echo "Downloading server from $DOWNLOAD_URL"
 
-sudo curl $DOWNLOAD_URL -Lo daytona
-sudo mv daytona /usr/local/bin/daytona
-sudo chmod +x /usr/local/bin/daytona
+# Create a temporary file to download the server binary. Just in case the author... user
+# has say a directory named "daytona" in $HOME... the current directory.
+temp_file="daytona-$RANDOM"
+
+# Ensure the temporary file is deleted on exit
+trap 'rm -f "$temp_file"' EXIT
+
+# curl does not fail with a non-zero status code when the HTTP status
+# code is not successful (like 404 or 500). You can add -f flag to curl
+# command to fail silently on server errors.
+#
+# Flags:
+# -f, --fail: Fail silently on server errors.
+# -s, --silent: Silent mode. Don't show progress meter or error messages.
+# -S, --show-error: When used with -s, show error even if silent mode is enabled.
+# -L, --location: Follow redirects.
+# -o, --output <file>: Write output to <file> instead of stdout.
+curl -fsSL "$DOWNLOAD_URL" -o "$temp_file"
+if [ $? -ne 0 ]; then
+  err "Daytona server download failed"
+fi
+chmod +x "$temp_file"
+
+echo "Installing server to $DESTINATION"
+# Check if sudo is required
+if [ "$SUDO_REQUIRED" -eq 1 ] && [ "$EUID" -ne 0 ]; then
+  err "Cannot write to /opt/bin or /usr/local/bin as non root. Please re-run with sudo."
+fi
+
+mv "$temp_file" "$DESTINATION/daytona"


### PR DESCRIPTION
Lots of folks get antsy when curl | bash'ing. To the extent we can not use root thats great. So if a user has $HOME/bin or $HOME/.local/bin on their PATH we can use those. Otherwise we can use /usr/local/bin or /opt/bin. But the user needs to use us with sudo explicitly. Rather then us escalating to it.

Also made the code more idomatic bash.

The docs will also need to be updated:

  curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
