### PR TITLE
fix: check if the port is ready to serve

### DIFF
--- a/pkg/ide/browser.go
+++ b/pkg/ide/browser.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
@@ -60,9 +61,18 @@ func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectNam
 		}
 	}
 
-	view_util.RenderInfoMessageBold(fmt.Sprintf("Forwarded %s IDE port to %d.\nOpening browser...", projectName, *browserPort))
+	ideURL := fmt.Sprintf("http://localhost:%d", *browserPort)
+	// Wait for the port to be ready
+	for {
+		if ports.IsPortReady(*browserPort) {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 
-	err = browser.OpenURL(fmt.Sprintf("http://localhost:%d", *browserPort))
+	view_util.RenderInfoMessageBold(fmt.Sprintf("Forwarded %s IDE port to %s.\nOpening browser...\n", projectName, ideURL))
+
+	err = browser.OpenURL(ideURL)
 	if err != nil {
 		log.Error("Error opening URL: " + err.Error())
 	}


### PR DESCRIPTION
# fix: check if the port is ready to serve

## Description
`CheckPortReady` checks if a service is ready on the specified port by making an HTTP GET request.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

closes #68


