### PR TITLE
fix: uninstall existing provider before installing

### DIFF
--- a/pkg/server/api/controllers/provider/install.go
+++ b/pkg/server/api/controllers/provider/install.go
@@ -31,6 +31,14 @@ func InstallProvider(ctx *gin.Context) {
 		return
 	}
 
+	if _, err := manager.GetProvider(req.Name); err == nil {
+		err := manager.UninstallProvider(req.Name)
+		if err != nil {
+			ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to uninstall current provider: %s", err.Error()))
+			return
+		}
+	}
+
 	c, err := config.GetConfig()
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get config: %s", err.Error()))


### PR DESCRIPTION
# Uninstall existing provider before installing

## Description

This PR fixes installation of an already existing provider. The fix includes uninstalling the already installed provider beforehand.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #47 
