### PR TITLE
feat: auto inject completions

### DIFF
--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,23 +65,21 @@ var CompletionCmd = &cobra.Command{
 			return
 		}
 
-		sourceCommand := fmt.Sprintf("source %s\n", filePath)
+		sourceCommand := fmt.Sprintf("\nsource %s\n", filePath)
 		if shell == "powershell" {
 			sourceCommand = fmt.Sprintf(". %s\n", filePath)
 		}
 
 		alreadyPresent := false
-		profile, err := os.Open(profilePath)
-		if err == nil {
-			scanner := bufio.NewScanner(profile)
-			for scanner.Scan() {
-				line := strings.TrimSpace(scanner.Text())			
-				if strings.Contains(line, strings.TrimSpace(sourceCommand)) {
-					alreadyPresent = true
-					break
-				}
-			}
-			profile.Close()
+		// Read existing content from the file
+		profile, err := os.ReadFile(profilePath)
+
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Printf("Error while reading profile (%s): %s\n", profilePath, err)
+		}
+	
+		if strings.Contains(string(profile), strings.TrimSpace(sourceCommand)) {
+			alreadyPresent = true
 		}
 
 		if !alreadyPresent {

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CompletionCmd = &cobra.Command{
-	Use:     "completion [bash|zsh|fish|powershell]",
+var AutoCompleteCmd = &cobra.Command{
+	Use:     "autocomplete [bash|zsh|fish|powershell]",
 	Short:   "Adds completion script for your shell enviornment",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+	"fmt"
+	"path/filepath"
+	"github.com/spf13/cobra"
+)
+
+var CompletionCmd = &cobra.Command{
+	Use:     "completion [bash|zsh|fish|powershell]",
+	Short:   "Adds completion script for your shell enviornment",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		shell := args[0]
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Printf("Error finding user home directory: %s\n", err)
+			return
+		}
+
+		var filePath, profilePath string
+		switch shell {
+		case "bash":
+			filePath = filepath.Join(homeDir, ".daytona.completion_script.bash")
+			profilePath = filepath.Join(homeDir, ".bashrc")
+		case "zsh":
+			filePath = filepath.Join(homeDir, ".daytona.completion_script.zsh")
+			profilePath = filepath.Join(homeDir, ".zshrc")
+		case "fish":
+			filePath = filepath.Join(homeDir, ".config", "fish", "daytona.completion_script.fish")
+			profilePath = filepath.Join(homeDir, ".config", "fish", "config.fish")
+		case "powershell":
+			filePath = filepath.Join(homeDir, "daytona.completion_script.ps1")
+			profilePath = filepath.Join(homeDir, "Documents", "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1")
+		default:
+			fmt.Println("Unsupported shell type. Please use bash, zsh, fish, or powershell.")
+			return
+		}
+
+		file, err := os.Create(filePath)
+		if err != nil {
+			fmt.Printf("Error creating completion script file: %s\n", err)
+			return
+		}
+		defer file.Close()
+
+		switch shell {
+		case "bash":
+			err = cmd.Root().GenBashCompletion(file)
+		case "zsh":
+			err = cmd.Root().GenZshCompletion(file)
+		case "fish":
+			err = cmd.Root().GenFishCompletion(file, true)
+		case "powershell":
+			err = cmd.Root().GenPowerShellCompletionWithDesc(file)
+		}
+
+		if err != nil {
+			fmt.Printf("Error generating completion script: %s\n", err)
+			return
+		}
+
+		sourceCommand := fmt.Sprintf("source %s\n", filePath)
+		if shell == "powershell" {
+			sourceCommand = fmt.Sprintf(". %s\n", filePath)
+		}
+
+		// Append the source command to the shell's profile file
+		profile, err := os.OpenFile(profilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			fmt.Printf("Error opening profile file (%s): %s\n", profilePath, err)
+			return
+		}
+		defer profile.Close()
+
+		if _, err := profile.WriteString(sourceCommand); err != nil {
+			fmt.Printf("Error writing to profile file (%s): %s\n", profilePath, err)
+			return
+		}
+
+		fmt.Println("Autocomplete script generated and injected successfully.")
+		fmt.Printf("Please source your %s profile to apply the changes or restart your terminal.\n", shell)
+		fmt.Printf("For manual sourcing, use: source %s\n", profilePath)
+	},
+}

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -36,6 +36,7 @@ var rootCmd = &cobra.Command{
 var originalStdout *os.File
 
 func Execute() {
+	rootCmd.AddCommand(CompletionCmd)
 	rootCmd.AddCommand(InfoCmd)
 	rootCmd.AddCommand(StartCmd)
 	rootCmd.AddCommand(StopCmd)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 var originalStdout *os.File
 
 func Execute() {
-	rootCmd.AddCommand(CompletionCmd)
+	rootCmd.AddCommand(AutoCompleteCmd)
 	rootCmd.AddCommand(InfoCmd)
 	rootCmd.AddCommand(StartCmd)
 	rootCmd.AddCommand(StopCmd)
@@ -63,6 +63,7 @@ func Execute() {
 		rootCmd.AddCommand(ProviderCmd)
 	}
 
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	rootCmd.PersistentFlags().BoolP("help", "", false, "help for daytona")
 	rootCmd.PersistentFlags().StringVarP(&output.FormatFlag, "output", "o", output.FormatFlag, `Output format. Must be one of (yaml, json)`)
 


### PR DESCRIPTION
# Pull Request Title
Automate Shell Completion Configuration

## Description

Adds automatic injection of the autocomplete script into the appropriate shell profile and then instructing the user on how to source the file (or instruct to open a new terminal).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #49 
Closes #49 
/claim #49 

## Screenshots


## Notes
Please add any relevant notes if necessary.
