### PR TITLE
fix: skip repo url on single project workspace creation

### DIFF
--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -114,7 +114,7 @@ func runInitialForm(providerRepo types.Repository, multiProject bool) (Workspace
 	m.form = huh.NewForm(
 		huh.NewGroup(
 			primaryRepoPrompt,
-		),
+		).WithHide(!multiProject),
 		huh.NewGroup(
 			secondaryProjectCountPrompt,
 		).WithHide(!multiProject),


### PR DESCRIPTION
# Pull Request Title

## Description

Skip repo URL prompt during single project workspace creation, as repository URL has already been selected in the previous step. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #132 
/claim #132

## Screenshots
If relevant, please add screenshots.

