### PR TITLE
fix: prevent downloading of already present providers

### DIFF
--- a/pkg/server/providers.go
+++ b/pkg/server/providers.go
@@ -32,6 +32,10 @@ func downloadDefaultProviders() error {
 	for pluginName, plugin := range defaultProviderPlugins {
 		log.Info("Downloading " + pluginName)
 		downloadPath := path.Join(c.ProvidersDir, pluginName, pluginName)
+		if _, err := os.Stat(downloadPath); err == nil {
+			log.Info(pluginName + " already downloaded")
+			continue
+		}
 		err = manager.DownloadProvider(plugin.DownloadUrls, downloadPath)
 		if err != nil {
 			log.Error(err)

--- a/pkg/server/providers.go
+++ b/pkg/server/providers.go
@@ -30,12 +30,12 @@ func downloadDefaultProviders() error {
 
 	log.Info("Downloading default providers")
 	for pluginName, plugin := range defaultProviderPlugins {
-		log.Info("Downloading " + pluginName)
 		downloadPath := path.Join(c.ProvidersDir, pluginName, pluginName)
 		if _, err := os.Stat(downloadPath); err == nil {
 			log.Info(pluginName + " already downloaded")
 			continue
 		}
+		log.Info("Downloading " + pluginName)
 		err = manager.DownloadProvider(plugin.DownloadUrls, downloadPath)
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
# Prevent downloading of already present providers

## Description

This PR prevents the server from downloading already present default providers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #78 

