### PR TITLE
feat: check for provider updates on server start

### DIFF
--- a/pkg/provider/manager/installer.go
+++ b/pkg/provider/manager/installer.go
@@ -92,3 +92,24 @@ func GetDefaultProviders(manifest ProvidersManifest) map[string]*Version {
 
 	return defaultProviders
 }
+
+func HasUpdateAvailable(providerName string, currentVersion string, manifest ProvidersManifest) bool {
+	provider, ok := manifest[providerName]
+	if !ok {
+		return false
+	}
+
+	var latestVersion string = "v0.0.0"
+
+	for version := range provider.Versions {
+		if version == "latest" {
+			continue
+		}
+
+		if semver.Compare(version, latestVersion) > 0 {
+			latestVersion = version
+		}
+	}
+
+	return semver.Compare(latestVersion, currentVersion) > 0
+}


### PR DESCRIPTION
# Provider Update Notification

## Description

With this PR, the server will check for provider updates on startup and notify the user if any registered providers have updates available. Additionally, it will instruct the user to use `daytona provider update` to update them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #164 
