### PR TITLE
fix: single project create

### DIFF
--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -114,7 +114,7 @@ func runInitialForm(providerRepo types.Repository, multiProject bool) (Workspace
 	m.form = huh.NewForm(
 		huh.NewGroup(
 			primaryRepoPrompt,
-		).WithHide(!multiProject),
+		).WithHide(primaryRepoUrl != ""),
 		huh.NewGroup(
 			secondaryProjectCountPrompt,
 		).WithHide(!multiProject),


### PR DESCRIPTION
# Single project create fix

## Description

When no git providers are registered, running "daytona create" errored when doing a single project workspace. This was caused by a recent PR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings