### PR TITLE
chore: enable to set binary install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ To install Daytona all you need to do is execute this script:
 
 
 ```bash
-# Install Daytona into ~/bin or ~/.local/bin
-curl -sf -L https://download.daytona.io/daytona/get-server.sh | bash
+# Install Daytona into /usr/local/bin
+curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
 
-# OR if you want to install Daytona to /usr/loca/bin or /opt/bin
-# curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
+# OR if you want to install Daytona to some other path where you don`t need sudo
+# curl -sf -L https://download.daytona.io/daytona/get-server.sh | DAYTONA_PATH=/home/user/bin bash
 
 # Start Daytona server
 daytona server
@@ -228,4 +228,3 @@ This project has adapted the Code of Conduct from the [Contributor Covenant](htt
 
 For more information on how to use and develop Daytona, talk to us on
 [Slack](https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q).
-

--- a/hack/get-server.sh
+++ b/hack/get-server.sh
@@ -3,11 +3,11 @@
 # This script downloads the Daytona server binary and installs it to /usr/local/bin
 # You can set the environment variable DAYTONA_SERVER_VERSION to specify the version to download
 # You can set the environment variable DAYTONA_SERVER_DOWNLOAD_URL to specify the base URL to download from
+# You can set the environment variable DAYTONA_PATH to specify the path where to install the binary
 
 VERSION=${DAYTONA_SERVER_VERSION:-"latest"}
 BASE_URL=${DAYTONA_SERVER_DOWNLOAD_URL:-"https://download.daytona.io/daytona"}
-DESTINATION=""
-SUDO_REQUIRED=0
+DESTINATION=${DAYTONA_PATH:-"/usr/local/bin"}
 
 # Print error message to stderr and exit
 err() {
@@ -15,78 +15,66 @@ err() {
   exit 1
 }
 
-# Check if there is a directory in $PATH that we can write to. With this
-# statement the first match from top to bottom will be used.
-# shellcheck disable=SC2088
-case :$PATH: in
-  *:$HOME/bin:*)
-    DESTINATION="$HOME/bin"
-    SUDO_REQUIRED=0
-    ;;
-  *:$HOME/.local/bin:*)
-    DESTINATION="$HOME/.local/bin"
-    SUDO_REQUIRED=0
-    ;;
-  *:/usr/local/bin:*)
-    DESTINATION="/usr/local/bin"
-    SUDO_REQUIRED=1
-    ;;
-  *:/opt/bin:*)
-    DESTINATION="/opt/bin"
-    SUDO_REQUIRED=1
-    ;;
-  *) err "~/bin, ~/.local/bin, /opt/bin and /usr/local/bin not on PATH. No option to install to.";;
-esac
-
 # Check machine architecture
 ARCH=$(uname -m)
 # Check operating system
 OS=$(uname -s)
 
 case $OS in
-  "Darwin")
-    FILENAME="darwin"
-    ;;
-  "Linux")
-    FILENAME="linux"
-    ;;
-  *)
-    err "Unsupported operating system: $OS"
-    ;;
+"Darwin")
+  FILENAME="darwin"
+  ;;
+"Linux")
+  FILENAME="linux"
+  ;;
+*)
+  err "Unsupported operating system: $OS"
+  ;;
 esac
 
 case $ARCH in
-  "arm64" | "ARM64")
-    FILENAME="$FILENAME-arm64"
-    ;;
-  "x86_64" | "AMD64")
-    FILENAME="$FILENAME-amd64"
-    ;;
-  "aarch64")
-    FILENAME="$FILENAME-arm64"
-    ;;
-  *)
-    err "Unsupported architecture: $ARCH"
-    ;;
+"arm64" | "ARM64")
+  FILENAME="$FILENAME-arm64"
+  ;;
+"x86_64" | "AMD64")
+  FILENAME="$FILENAME-amd64"
+  ;;
+"aarch64")
+  FILENAME="$FILENAME-arm64"
+  ;;
+*)
+  err "Unsupported architecture: $ARCH"
+  ;;
 esac
+
+if [ ! "$DAYTONA_PATH" ]; then
+  echo "Default installation directory: /usr/local/bin"
+  echo "You can override this by setting the DAYTONA_PATH environment variable (ie. \`| DAYTONA_PATH=/home/user/bin bash\`)"
+fi
+
+# Check if destination exists and is writable
+if [[ ! -d $DESTINATION ]]; then
+  # Inform user about missing directory or write permissions
+  echo -e "\nWarning: Destination directory $DESTINATION does not exist."
+  # Provide instructions on how to create dir
+  echo "         Create the directory:"
+  echo "           mkdir -p $DESTINATION"
+  exit 1
+fi
+if [[ ! -w $DESTINATION ]]; then
+  echo -e "\nWarning: Destination directory $DESTINATION is not writeable."
+  echo "         Rerun the script with SUDO privileges:"
+  if [ "$DAYTONA_PATH" ]; then
+    echo "           curl -sf -L https://download.daytona.io/daytona/get-server.sh | DAYTONA_PATH=$DESTINATION sudo bash"
+  else
+    echo "           curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash"
+  fi
+  exit 1
+fi
 
 DOWNLOAD_URL="$BASE_URL/$VERSION/daytona-$FILENAME"
 
-# We want to fail fast so check everything before we download
-
-# Check if the $DESTINATION exists. We are making a decision to not mkdir
-# for the user here. /opt/bin and /usr/local/bin are system directories and
-# the user should decide and explicitly create those.
-if [ ! -d "$DESTINATION" ]; then
-  err "Destination directory $DESTINATION does not exist. Run mkdir -p $DESTINATION and re-run."
-fi
-
-# Check if sudo is required
-if [ "$SUDO_REQUIRED" -eq 1 ] && [ "$EUID" -ne 0 ]; then
-  err "Cannot write to /opt/bin or /usr/local/bin as non root. Please re-run with sudo."
-fi
-
-echo "Downloading server from $DOWNLOAD_URL"
+echo -e "\nDownloading server from $DOWNLOAD_URL"
 
 # Create a temporary file to download the server binary. Just in case the author... user
 # has say a directory named "daytona" in $HOME... the current directory.
@@ -105,11 +93,20 @@ trap 'rm -f "$temp_file"' EXIT
 # -S, --show-error: When used with -s, show error even if silent mode is enabled.
 # -L, --location: Follow redirects.
 # -o, --output <file>: Write output to <file> instead of stdout.
-curl -fsSL "$DOWNLOAD_URL" -o "$temp_file"
-if [ $? -ne 0 ]; then
+if ! curl -fsSL "$DOWNLOAD_URL" -o "$temp_file"; then
   err "Daytona server download failed"
 fi
 chmod +x "$temp_file"
 
 echo "Installing server to $DESTINATION"
 mv "$temp_file" "$DESTINATION/daytona"
+
+# Check if destination is in user's PATH
+if [[ ! :"$PATH:" == *":$DESTINATION:"* ]]; then
+  echo -e "\nWarning: $DESTINATION is not currently in your PATH environment variable."
+  echo "         To be able to run the Daytona server from any directory, you may need to add it to your PATH."
+  echo "         Edit your shell configuration file (e.g., ~/.bashrc or ~/.zshrc)"
+  echo "         Add the following line:"
+  echo "             export PATH=\$PATH:$DESTINATION"
+  echo "         Source the configuration file to apply the changes (e.g., source ~/.bashrc)"
+fi


### PR DESCRIPTION
# Better handling of sudo / non-sudo requirement when running bash install script

As there were some concerns on need to run `get-server.sh` script with sudo privileges we decided to better document it inside the script and also provide the ability for users to change the binary installation path.

## Description

If script is run with current default:
```
curl -sf -L https://download.daytona.io/daytona/get-server.sh | bash
```
...it wont interrupt user and binary will be installed on the default `\usr\local\bin` path.  But we will present info on the option how user can adjust the installation path. Also that could be the one without need of sudo privileges.
```
Default installation directory: /usr/local/bin
You can override this by setting the DAYTONA_PATH environment variable (ie. `| DAYTONA_PATH=/home/user/bin bash`)
```

Also script will check if destination directory exists. If not, it will show a warning to the user:
```
Warning: Destination directory /usr/local/bin2 does not exist.
Create the directory (if needed):
      mkdir -p /usr/local/bin2
```

Last check will be if the user has write permission on the destination path (including /usr/local/bin), show a warning if permission is missing and provide instructions how to rerun the script with sudo privileges:
```
Warning: Destination directory /usr/local/bin is not writeable.
         Rerun the script with SUDO privileges:
           curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
```

And last check would be, if you choose custom path, to check if its in your users PATH. If not it would provide a warning:
```
Warning: /home/user/bin is not currently in your PATH environment variable.
         To be able to run the Daytona server from any directory, you may need to add it to your PATH.
         Edit your shell configuration file (e.g., ~/.bashrc or ~/.zshrc)
         Add the following line:
             export PATH=$PATH:/home/user/bin
         Source the configuration file to apply the changes (e.g., source ~/.bashrc)
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

https://github.com/daytonaio/daytona/issues/146

Some of the PRs that were on the same subject.
https://github.com/daytonaio/daytona/pull/105
https://github.com/daytonaio/daytona/pull/143