### PR TITLE
feat: add more workspace info on prompting screen

### DIFF
--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -1,0 +1,73 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+var timeLayout = "2006-01-02T15:04:05.999999999Z"
+
+func FormatCreatedTime(input string) string {
+	t, err := time.Parse(timeLayout, input)
+	if err != nil {
+		return "/"
+	}
+
+	duration := time.Since(t)
+
+	if duration < time.Minute {
+		return "< 1 minute ago"
+	} else if duration < time.Hour {
+		minutes := int(duration.Minutes())
+		if minutes == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", minutes)
+	} else if duration < 24*time.Hour {
+		hours := int(duration.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	} else {
+		days := int(duration.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
+}
+
+func FormatStatusTime(input string) string {
+	t, err := time.Parse(timeLayout, input)
+	if err != nil {
+		return "stopped"
+	}
+
+	duration := time.Since(t)
+
+	if duration < time.Minute {
+		return "up < 1 minute"
+	} else if duration < time.Hour {
+		minutes := int(duration.Minutes())
+		if minutes == 1 {
+			return "up 1 minute"
+		}
+		return fmt.Sprintf("up %d minutes", minutes)
+	} else if duration < 24*time.Hour {
+		hours := int(duration.Hours())
+		if hours == 1 {
+			return "up 1 hour"
+		}
+		return fmt.Sprintf("up %d hours", hours)
+	} else {
+		days := int(duration.Hours() / 24)
+		if days == 1 {
+			return "up 1 day"
+		}
+		return fmt.Sprintf("up %d days", days)
+	}
+}

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -17,6 +17,7 @@ var (
 	Red         = lipgloss.AdaptiveColor{Light: "#ff4567", Dark: "#ff4567"}
 	DimmedBlue  = lipgloss.AdaptiveColor{Light: "#3398fe", Dark: "#3398fe"}
 	White       = lipgloss.AdaptiveColor{Light: "000", Dark: "fff"}
+	Gray        = lipgloss.AdaptiveColor{Light: "243", Dark: "243"}
 )
 
 func ColorGrid(xSteps, ySteps int) [][]string {

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -8,11 +8,11 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
 	"github.com/daytonaio/daytona/pkg/types"
 	"golang.org/x/term"
@@ -20,7 +20,6 @@ import (
 
 var defaultColumnWidth = 12
 var columnPadding = 3
-var timeLayout = "2006-01-02T15:04:05.999999999Z"
 
 type RowData struct {
 	WorkspaceName string
@@ -159,10 +158,10 @@ func getWorkspaceTableRowData(workspace serverapiclient.Workspace, specifyGitPro
 		rowData.Repository = getRepositorySlugFromUrl(*workspace.Projects[0].Repository.Url, specifyGitProviders)
 	}
 	if workspace.Info != nil && workspace.Info.Projects != nil && len(workspace.Info.Projects) > 0 && workspace.Info.Projects[0].Created != nil {
-		rowData.Created = formatCreatedTime(*workspace.Info.Projects[0].Created)
+		rowData.Created = util.FormatCreatedTime(*workspace.Info.Projects[0].Created)
 	}
 	if workspace.Info != nil && workspace.Info.Projects != nil && len(workspace.Info.Projects) > 0 && workspace.Info.Projects[0].Started != nil {
-		rowData.Status = formatStatusTime(*workspace.Info.Projects[0].Started)
+		rowData.Status = util.FormatStatusTime(*workspace.Info.Projects[0].Started)
 	}
 	return rowData
 }
@@ -196,8 +195,8 @@ func getProjectTableRowData(workspace serverapiclient.Workspace, project servera
 	if project.Repository != nil && project.Repository.Url != nil {
 		rowData.Repository = getRepositorySlugFromUrl(*project.Repository.Url, specifyGitProviders)
 	}
-	rowData.Created = formatCreatedTime(currentProjectInfo.Created)
-	rowData.Status = formatStatusTime(currentProjectInfo.Started)
+	rowData.Created = util.FormatCreatedTime(currentProjectInfo.Created)
+	rowData.Status = util.FormatStatusTime(currentProjectInfo.Started)
 	return rowData
 }
 
@@ -217,68 +216,6 @@ func getRepositorySlugFromUrl(url string, specifyGitProviders bool) string {
 	}
 
 	return parts[len(parts)-2] + "/" + parts[len(parts)-1]
-}
-
-func formatCreatedTime(input string) string {
-	t, err := time.Parse(timeLayout, input)
-	if err != nil {
-		return "/"
-	}
-
-	duration := time.Since(t)
-
-	if duration < time.Minute {
-		return "< 1 minute ago"
-	} else if duration < time.Hour {
-		minutes := int(duration.Minutes())
-		if minutes == 1 {
-			return "1 minute ago"
-		}
-		return fmt.Sprintf("%d minutes ago", minutes)
-	} else if duration < 24*time.Hour {
-		hours := int(duration.Hours())
-		if hours == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", hours)
-	} else {
-		days := int(duration.Hours() / 24)
-		if days == 1 {
-			return "1 day ago"
-		}
-		return fmt.Sprintf("%d days ago", days)
-	}
-}
-
-func formatStatusTime(input string) string {
-	t, err := time.Parse(timeLayout, input)
-	if err != nil {
-		return "stopped"
-	}
-
-	duration := time.Since(t)
-
-	if duration < time.Minute {
-		return "up < 1 minute"
-	} else if duration < time.Hour {
-		minutes := int(duration.Minutes())
-		if minutes == 1 {
-			return "up 1 minute"
-		}
-		return fmt.Sprintf("up %d minutes", minutes)
-	} else if duration < 24*time.Hour {
-		hours := int(duration.Hours())
-		if hours == 1 {
-			return "up 1 hour"
-		}
-		return fmt.Sprintf("up %d hours", hours)
-	} else {
-		days := int(duration.Hours() / 24)
-		if days == 1 {
-			return "up 1 day"
-		}
-		return fmt.Sprintf("up %d days", days)
-	}
 }
 
 func ListWorkspaces(workspaceList []serverapiclient.Workspace, specifyGitProviders bool) {

--- a/pkg/views/workspace/selection/view.go
+++ b/pkg/views/workspace/selection/view.go
@@ -4,9 +4,14 @@
 package selection
 
 import (
+	"fmt"
+	"io"
+	"strings"
+
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/daytonaio/daytona/pkg/views"
 )
 
 var CustomRepoIdentifier = "<CUSTOM_REPO>"
@@ -14,13 +19,17 @@ var CustomRepoIdentifier = "<CUSTOM_REPO>"
 var docStyle = lipgloss.NewStyle().Margin(1, 2)
 
 type item[T any] struct {
-	id, title, desc string
-	choiceProperty  T
+	id, title, desc, createdTime, statusTime, target string
+	choiceProperty                                   T
 }
 
 func (i item[T]) Title() string       { return i.title }
+func (i item[T]) Id() string          { return i.id }
 func (i item[T]) Description() string { return i.desc }
 func (i item[T]) FilterValue() string { return i.title }
+func (i item[T]) CreatedTime() string { return i.createdTime }
+func (i item[T]) StatusTime() string  { return i.statusTime }
+func (i item[T]) Target() string      { return i.target }
 
 type model[T any] struct {
 	list   list.Model
@@ -57,4 +66,70 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m model[T]) View() string {
 	return docStyle.Render(m.list.View())
+}
+
+type ItemDelegate[T any] struct {
+}
+
+func (d ItemDelegate[T]) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, _ := listItem.(item[T]) // Cast the listItem to your custom item type
+	s := strings.Builder{}
+
+	var isSelected = index == m.Index()
+
+	baseStyles := lipgloss.NewStyle().Padding(0, 0, 0, 2)
+
+	title := baseStyles.Copy().Render(i.Title())
+	idWithTargetString := fmt.Sprintf("%s (%s)", i.Id(), i.Target())
+	idWithTarget := baseStyles.Copy().Foreground(views.Gray).Render(idWithTargetString)
+	description := baseStyles.Copy().Render(i.Description())
+
+	// Add the created/updated time if it's available
+	timeWidth := m.Width() - baseStyles.GetHorizontalFrameSize() - lipgloss.Width(title)
+	timeStyles := lipgloss.NewStyle().
+		Align(lipgloss.Right).
+		Width(timeWidth)
+	timeString := timeStyles.Render("")
+	if i.StatusTime() != "" {
+		timeString = timeStyles.Render(i.StatusTime())
+	} else if i.CreatedTime() != "" {
+		timeString = timeStyles.Render(fmt.Sprintf("created %s", i.CreatedTime()))
+	}
+
+	// Adjust styles as the user moves through the menu
+	if isSelected {
+		selectedStyles := lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			BorderForeground(views.Blue).
+			Bold(true).
+			Padding(0, 0, 0, 1)
+
+		title = selectedStyles.Copy().Foreground(views.Blue).Render(i.Title())
+		idWithTarget = selectedStyles.Copy().Foreground(views.Gray).Render(idWithTargetString)
+		description = selectedStyles.Copy().Foreground(views.DimmedBlue).Render(i.Description())
+		timeString = timeStyles.Copy().Foreground(views.DimmedBlue).Render(timeString)
+	}
+
+	// Render to the terminal
+	s.WriteString(lipgloss.JoinHorizontal(lipgloss.Bottom, title, timeString))
+	s.WriteRune('\n')
+	s.WriteString(idWithTarget)
+	s.WriteRune('\n')
+	s.WriteString(description)
+	s.WriteRune('\n')
+
+	fmt.Fprint(w, s.String())
+}
+
+func (d ItemDelegate[T]) Height() int {
+	height := lipgloss.NewStyle().GetVerticalFrameSize() + 4
+	return height
+}
+
+func (d ItemDelegate[T]) Spacing() int {
+	return 0
+}
+
+func (d ItemDelegate[T]) Update(msg tea.Msg, m *list.Model) tea.Cmd {
+	return nil
 }


### PR DESCRIPTION
# Add more workspace info on prompting screen

## Description

- [x] Adds additional info (Workspace ID, created/updated time) to the workspace selection view (eg. `daytona info`)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Related Issue(s)

This PR addresses issue #134 
/claim #134

## Screenshots

<img width="1239" alt="image" src="https://github.com/daytonaio/daytona/assets/16005567/0b9c5036-4a1c-4728-b7a3-b88e799f5ad4">
