### PR TITLE
feat: support opening projects in JetBrains IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ daytona target set
 Following the steps this command adds SSH machines to your targets.
 
 __4. Choose Your Default IDE:__
-The default setting for Daytona is VS Code locally. If you prefer, you can switch to VS Code - Browser or any IDE from the JetBrains portfolio (Contributions welcome here!) using the command:
+The default setting for Daytona is VS Code locally. If you prefer, you can switch to VS Code - Browser or any IDE from the JetBrains portfolio using the command:
 ```bash
 daytona ide
 ```

--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -3,7 +3,10 @@
 
 package config
 
-import "github.com/daytonaio/daytona/pkg/os"
+import (
+	"github.com/daytonaio/daytona/internal/jetbrains"
+	"github.com/daytonaio/daytona/pkg/os"
+)
 
 func GetBinaryUrls() map[os.OperatingSystem]string {
 	return map[os.OperatingSystem]string{
@@ -17,10 +20,16 @@ func GetBinaryUrls() map[os.OperatingSystem]string {
 }
 
 func GetIdeList() []Ide {
-	return []Ide{
+	ides := []Ide{
 		{"vscode", "VS Code"},
 		{"browser", "VS Code - Browser"},
 	}
+
+	for id, ide := range jetbrains.GetIdes() {
+		ides = append(ides, Ide{string(id), ide.Name})
+	}
+
+	return ides
 }
 
 func GetGitProviderList() []GitProvider {

--- a/internal/jetbrains/ides.go
+++ b/internal/jetbrains/ides.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package jetbrains
+
+func GetIdes() map[Id]Ide {
+	return map[Id]Ide{
+		CLion:    clion,
+		IntelliJ: intellij,
+		GoLand:   goland,
+		PyCharm:  pycharm,
+		PhpStorm: phpstorm,
+		WebStorm: webstorm,
+		Rider:    rider,
+		RubyMine: rubymine,
+	}
+}
+
+var clion = Ide{
+	Name:    "CLion",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/cpp/CLion-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/cpp/CLion-%s-aarch64.tar.gz",
+	},
+}
+
+var intellij = Ide{
+	Name:    "IntelliJ IDEA Ultimate",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/idea/ideaIU-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/idea/ideaIU-%s-aarch64.tar.gz",
+	},
+}
+
+var goland = Ide{
+	Name:    "GoLand",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/go/goland-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/go/goland-%s-aarch64.tar.gz",
+	},
+}
+
+var pycharm = Ide{
+	Name:    "PyCharm Professional",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/python/pycharm-professional-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/python/pycharm-professional-%s-aarch64.tar.gz",
+	},
+}
+
+var phpstorm = Ide{
+	Name:    "PhpStorm",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/webide/PhpStorm-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/webide/PhpStorm-%s-aarch64.tar.gz",
+	},
+}
+
+var webstorm = Ide{
+	Name:    "WebStorm",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/webstorm/WebStorm-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/webstorm/WebStorm-%s-aarch64.tar.gz",
+	},
+}
+
+var rider = Ide{
+	Name:    "Rider",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/rider/JetBrains.Rider-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/rider/JetBrains.Rider-%s-aarch64.tar.gz",
+	},
+}
+
+var rubymine = Ide{
+	Name:    "RubyMine",
+	Version: "2023.2.2",
+	UrlTemplates: UrlTemplates{
+		Amd64: "https://download.jetbrains.com/ruby/RubyMine-%s.tar.gz",
+		Arm64: "https://download.jetbrains.com/ruby/RubyMine-%s-aarch64.tar.gz",
+	},
+}

--- a/internal/jetbrains/types.go
+++ b/internal/jetbrains/types.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package jetbrains
+
+type Ide struct {
+	Name         string
+	Version      string
+	UrlTemplates UrlTemplates
+}
+
+type UrlTemplates struct {
+	Amd64 string
+	Arm64 string
+}
+
+type Id string
+
+const (
+	CLion    Id = "clion"
+	IntelliJ Id = "intellij"
+	GoLand   Id = "goland"
+	PyCharm  Id = "pycharm"
+	PhpStorm Id = "phpstorm"
+	WebStorm Id = "webstorm"
+	Rider    Id = "rider"
+	RubyMine Id = "rubymine"
+)

--- a/internal/util/remote_os.go
+++ b/internal/util/remote_os.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"os/exec"
+
+	"github.com/daytonaio/daytona/pkg/os"
+)
+
+func GetRemoteOS(remote string) (*os.OperatingSystem, error) {
+	unameCmd := exec.Command("ssh", remote, "uname -a")
+
+	output, err := unameCmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	return os.OSFromUnameA(string(output))
+}

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -7,19 +7,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"os/exec"
-	"path"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
-	"github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/internal/jetbrains"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
-	"github.com/daytonaio/daytona/pkg/ports"
+	"github.com/daytonaio/daytona/pkg/ide"
 	view_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
-	"github.com/pkg/browser"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -92,7 +88,7 @@ var CodeCmd = &cobra.Command{
 
 		view_util.RenderInfoMessage(fmt.Sprintf("Opening the workspace project '%s' in your preferred IDE.", projectName))
 
-		openIDE(ideId, activeProfile, workspaceId, projectName)
+		log.Fatal(openIDE(ideId, activeProfile, workspaceId, projectName))
 	},
 }
 
@@ -122,115 +118,20 @@ func selectWorkspaceProject(workspaceId string, profile *config.Profile) (*strin
 	return nil, errors.New("no projects found in workspace")
 }
 
-func openIDE(ideId string, activeProfile config.Profile, workspaceId string, projectName string) {
-	if ideId == "browser" {
-		err := openBrowserIDE(activeProfile, workspaceId, projectName)
-		if err != nil {
-			log.Fatal(err)
-		}
-		return
-	}
-
-	openVSCode(activeProfile, workspaceId, projectName)
-}
-
-func openVSCode(activeProfile config.Profile, workspaceId string, projectName string) {
-	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	checkAndAlertVSCodeInstalled()
-
-	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
-
-	commandArgument := fmt.Sprintf("vscode-remote://ssh-remote+%s/%s", projectHostname, path.Join("/workspaces", projectName))
-
-	var vscCommand *exec.Cmd = exec.Command("code", "--folder-uri", commandArgument)
-
-	err = vscCommand.Run()
-
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-}
-
-func openBrowserIDE(activeProfile config.Profile, workspaceId string, projectName string) error {
-	// Download and start IDE
-	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
-	if err != nil {
-		return err
-	}
-
-	view_util.RenderInfoMessageBold("Downloading OpenVSCode Server...")
-	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
-
-	installServerCommand := exec.Command("ssh", projectHostname, "curl -fsSL https://download.daytona.io/daytona/get-openvscode-server.sh | sh")
-	installServerCommand.Stdout = io.Writer(&util.DebugLogWriter{})
-	installServerCommand.Stderr = io.Writer(&util.DebugLogWriter{})
-
-	err = installServerCommand.Run()
-	if err != nil {
-		return err
-	}
-
-	view_util.RenderInfoMessageBold("Starting OpenVSCode Server...")
-
-	go func() {
-		startServerCommand := exec.CommandContext(context.Background(), "ssh", projectHostname, startVSCodeServerCommand)
-		startServerCommand.Stdout = io.Writer(&util.DebugLogWriter{})
-		startServerCommand.Stderr = io.Writer(&util.DebugLogWriter{})
-
-		err = startServerCommand.Run()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	// Forward IDE port
-	browserPort, errChan := ports.ForwardPort(workspaceId, projectName, 63000)
-	if browserPort == nil {
-		if err := <-errChan; err != nil {
-			return err
+func openIDE(ideId string, activeProfile config.Profile, workspaceId string, projectName string) error {
+	switch ideId {
+	case "vscode":
+		return ide.OpenVSCode(activeProfile, workspaceId, projectName)
+	case "browser":
+		return ide.OpenBrowserIDE(activeProfile, workspaceId, projectName)
+	default:
+		_, ok := jetbrains.GetIdes()[jetbrains.Id(ideId)]
+		if ok {
+			return ide.OpenJetbrainsIDE(activeProfile, ideId, workspaceId, projectName)
 		}
 	}
 
-	view_util.RenderInfoMessageBold(fmt.Sprintf("Forwarded %s IDE port to %d.\nOpening browser...", projectName, *browserPort))
-
-	err = browser.OpenURL(fmt.Sprintf("http://localhost:%d", *browserPort))
-	if err != nil {
-		log.Error("Error opening URL: " + err.Error())
-	}
-
-	for {
-		err := <-errChan
-		if err != nil {
-			// Log only in debug mode
-			// Connection errors to the forwarded port should not exit the process
-			log.Debug(err)
-		}
-	}
-}
-
-const startVSCodeServerCommand = "$HOME/vscode-server/bin/openvscode-server --start-server --port=63000 --host=0.0.0.0 --without-connection-token --disable-workspace-trust --default-folder=$DAYTONA_WS_DIR"
-
-func checkAndAlertVSCodeInstalled() {
-	if err := isVSCodeInstalled(); err != nil {
-		redBold := "\033[1;31m" // ANSI escape code for red and bold
-		reset := "\033[0m"      // ANSI escape code to reset text formatting
-
-		errorMessage := "Please install Visual Studio Code and ensure it's in your PATH. "
-		infoMessage := "More information on: 'https://code.visualstudio.com/docs/editor/command-line#_launching-from-command-line'"
-
-		log.Error(redBold + errorMessage + reset + infoMessage)
-
-		return
-	}
-}
-
-func isVSCodeInstalled() error {
-	_, err := exec.LookPath("code")
-	return err
+	return errors.New("invalid IDE")
 }
 
 var ideFlag string

--- a/pkg/ide/browser.go
+++ b/pkg/ide/browser.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ide
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/pkg/ports"
+	view_util "github.com/daytonaio/daytona/pkg/views/util"
+
+	"github.com/pkg/browser"
+	log "github.com/sirupsen/logrus"
+)
+
+const startVSCodeServerCommand = "$HOME/vscode-server/bin/openvscode-server --start-server --port=63000 --host=0.0.0.0 --without-connection-token --disable-workspace-trust --default-folder=$DAYTONA_WS_DIR"
+
+func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectName string) error {
+	// Download and start IDE
+	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
+	if err != nil {
+		return err
+	}
+
+	view_util.RenderInfoMessageBold("Downloading OpenVSCode Server...")
+	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
+
+	installServerCommand := exec.Command("ssh", projectHostname, "curl -fsSL https://download.daytona.io/daytona/get-openvscode-server.sh | sh")
+	installServerCommand.Stdout = io.Writer(&util.DebugLogWriter{})
+	installServerCommand.Stderr = io.Writer(&util.DebugLogWriter{})
+
+	err = installServerCommand.Run()
+	if err != nil {
+		return err
+	}
+
+	view_util.RenderInfoMessageBold("Starting OpenVSCode Server...")
+
+	go func() {
+		startServerCommand := exec.CommandContext(context.Background(), "ssh", projectHostname, startVSCodeServerCommand)
+		startServerCommand.Stdout = io.Writer(&util.DebugLogWriter{})
+		startServerCommand.Stderr = io.Writer(&util.DebugLogWriter{})
+
+		err = startServerCommand.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// Forward IDE port
+	browserPort, errChan := ports.ForwardPort(workspaceId, projectName, 63000)
+	if browserPort == nil {
+		if err := <-errChan; err != nil {
+			return err
+		}
+	}
+
+	view_util.RenderInfoMessageBold(fmt.Sprintf("Forwarded %s IDE port to %d.\nOpening browser...", projectName, *browserPort))
+
+	err = browser.OpenURL(fmt.Sprintf("http://localhost:%d", *browserPort))
+	if err != nil {
+		log.Error("Error opening URL: " + err.Error())
+	}
+
+	for {
+		err := <-errChan
+		if err != nil {
+			// Log only in debug mode
+			// Connection errors to the forwarded port should not exit the process
+			log.Debug(err)
+		}
+	}
+}

--- a/pkg/ide/jetbrains.go
+++ b/pkg/ide/jetbrains.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ide
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os/exec"
+	"path"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/jetbrains"
+	"github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/pkg/os"
+	"github.com/pkg/browser"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId, projectName string) error {
+	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
+	if err != nil {
+		return err
+	}
+
+	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
+
+	jbIde, ok := jetbrains.GetIdes()[jetbrains.Id(ide)]
+	if !ok {
+		return fmt.Errorf("IDE not found")
+	}
+
+	downloadPath := path.Join("/home/daytona/.cache/JetBrains", ide)
+
+	downloadUrl := ""
+
+	remoteOs, err := util.GetRemoteOS(projectHostname)
+	if err != nil {
+		return err
+	}
+
+	switch *remoteOs {
+	case os.Linux_arm64:
+		downloadUrl = fmt.Sprintf(jbIde.UrlTemplates.Arm64, jbIde.Version)
+	case os.Linux_64_86:
+		downloadUrl = fmt.Sprintf(jbIde.UrlTemplates.Amd64, jbIde.Version)
+	default:
+		return fmt.Errorf("JetBrains remote IDEs are only supported on Linux.")
+	}
+
+	err = downloadJetbrainsIDE(projectHostname, downloadUrl, downloadPath)
+	if err != nil {
+		return err
+	}
+
+	gatewayUrl := fmt.Sprintf("jetbrains-gateway://connect#host=%s&type=ssh&deploy=false&projectPath=%s&user=daytona&port=2222&idePath=%s", projectHostname, path.Join("/workspaces", projectName), url.QueryEscape(downloadPath))
+
+	return browser.OpenURL(gatewayUrl)
+}
+
+func downloadJetbrainsIDE(projectHostname, downloadUrl, downloadPath string) error {
+	if isAlreadyDownloaded(downloadPath) {
+		log.Info("JetBrains IDE already downloaded")
+		return nil
+	}
+
+	log.Infof("Downloading IDE from %s...", downloadUrl)
+
+	downloadIdeCmd := exec.Command("ssh", projectHostname, fmt.Sprintf("mkdir -p %s && curl -fsSL %s | tar -xz -C %s --strip-components=1", downloadPath, downloadUrl, downloadPath))
+	downloadIdeCmd.Stdout = io.Writer(&util.DebugLogWriter{})
+	downloadIdeCmd.Stderr = io.Writer(&util.DebugLogWriter{})
+
+	err := downloadIdeCmd.Run()
+	if err != nil {
+		return err
+	}
+
+	log.Info("IDE downloaded.")
+
+	return nil
+}
+
+func isAlreadyDownloaded(downloadPath string) bool {
+	statCmd := exec.Command("stat", downloadPath)
+	err := statCmd.Run()
+	return err == nil
+}

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ide
+
+import (
+	"fmt"
+	"os/exec"
+	"path"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName string) error {
+	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
+	if err != nil {
+		return err
+	}
+
+	checkAndAlertVSCodeInstalled()
+
+	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
+
+	commandArgument := fmt.Sprintf("vscode-remote://ssh-remote+%s/%s", projectHostname, path.Join("/workspaces", projectName))
+
+	var vscCommand *exec.Cmd = exec.Command("code", "--folder-uri", commandArgument)
+
+	return vscCommand.Run()
+}
+
+func checkAndAlertVSCodeInstalled() {
+	if err := isVSCodeInstalled(); err != nil {
+		redBold := "\033[1;31m" // ANSI escape code for red and bold
+		reset := "\033[0m"      // ANSI escape code to reset text formatting
+
+		errorMessage := "Please install Visual Studio Code and ensure it's in your PATH. "
+		infoMessage := "More information on: 'https://code.visualstudio.com/docs/editor/command-line#_launching-from-command-line'"
+
+		log.Error(redBold + errorMessage + reset + infoMessage)
+
+		return
+	}
+}
+
+func isVSCodeInstalled() error {
+	_, err := exec.LookPath("code")
+	return err
+}

--- a/pkg/views/ide/view.go
+++ b/pkg/views/ide/view.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/views"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -106,13 +107,9 @@ func (m model) View() string {
 }
 
 func Render(ideList []config.Ide, choiceChan chan<- string) {
-	items := make([]list.Item, 0)
-
-	for _, ide := range ideList {
-		if len(ide.Name) > 0 {
-			items = append(items, item{id: ide.Id, name: ide.Name})
-		}
-	}
+	items := util.ArrayMap(ideList, func(ide config.Ide) list.Item {
+		return item{id: ide.Id, name: ide.Name}
+	})
 
 	const defaultWidth = 20
 


### PR DESCRIPTION
# JetBrains IDE support

## Description

This PR introduces support for opening projects in JetBrains IDEs.

The user can now select any JetBrains IDE with the `daytona ide` command.

Opening a JetBrains IDE includes downloading the appropriate IDE into the project and opening it with the JetBrains Gateway SSH plugin.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #179 