### PR TITLE
Move to the DCO v1.1.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ You can contribute to Daytona by:
 
 Before starting your contribution, especially for core features, we encourage you to reach out to us on [Slack](https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q). This allows us to ensure that your proposed feature aligns with the project's roadmap and goals. Developers are the key to making Daytona the best tool it can be, and we value input from the community.
 
-We look forward to working with you to improve Daytona and make development environments as easy as possible for developers everywhere. 
+We look forward to working with you to improve Daytona and make development environments as easy as possible for developers everywhere.
 
 ### Steps to Contribute Code
 
@@ -39,9 +39,9 @@ Follow the following steps to ensure your contribution goes smoothly.
 1. Read and follow the steps outlined in the [Daytona Contributing Policy](README.md#contributing).
 1. Configure your development environment by either following the guide below.
 1. [Fork](https://help.github.com/articles/working-with-forks/) the GitHub Repository allowing you to make the changes in your own copy of the repository.
-1. Create a [GitHub issue](https://github.com/daytonaio/daytona/issues) if one doesn't exist already.  
+1. Create a [GitHub issue](https://github.com/daytonaio/daytona/issues) if one doesn't exist already.
 1. [Prepare your changes](/PREPARING_YOUR_CHANGES.md) and ensure your commits are descriptive. The document contains an optional commit template, if desired.
-1. Ensure that you are in the [CONTRIBUTORS](CONTRIBUTORS.md) file (see the [Adding Yourself to the Contributors List](#adding-yourself-to-the-contributors-list) section for instructions)
+1. Ensure that you sign off on all your commits to comply with the DCO v1.1. We have more details in [Prepare your changes](/PREPARING_YOUR_CHANGES.md).
 1. Create a pull request on GitHub. If you're new to GitHub, read about [pull requests](https://help.github.com/articles/about-pull-requests/). You are welcome to submit your pull request for commentary or review before it is complete by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests). Please include specific questions or items you'd like feedback on.
 1. A member of the Daytona team will review your PR within three business days (excluding any holidays) and either merge, comment, and/or assign someone for review.
 1. Work with the reviewer to complete a code review. For each change, create a new commit and push it to make changes to your pull request. When necessary, the reviewer can trigger CI to run tests prior to merging.
@@ -51,13 +51,7 @@ Follow the following steps to ensure your contribution goes smoothly.
 
 Note: In some cases, we might decide that a PR should be closed without merging. We'll make sure to provide clear reasoning when this happens.
 
-### Adding Yourself to the Contributors List
-
-When making a pull request to the Daytona software, you must add yourself to the [CONTRIBUTORS](CONTRIBUTORS.md) list.
-You will only have to do this the first time that you contribute to the software.
-For this, we recommend adding yourself with a separate commit (does not have to be a separate PR) to the file.
-
-#### What Does this Mean for You?
+#### What Does Contributing Mean for You?
 
 Here is what being a contributor means for you:
 
@@ -65,66 +59,3 @@ Here is what being a contributor means for you:
 * Have the legal rights to license our contributions ourselves, or get permission to license them from our employers, clients, or others who may have them
 
 For more information, see the [README](README.md) and feel free to reach out to us on [Slack](https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q).
-
-Now, let's walk through how to add yourself to the list.
-
-#### (1) Editing the File
-
-In [the file](CONTRIBUTING.md), there is a delimiter (e.g. `-----------`) followed by a list of names and associated GitHub usernames.
-The format of the contributor lines are as follows:
-
-```
-* <name-you-would-like-to-be-referred-to-as> (@<github-username>)
-```
-
-Here is an example:
-
-```
-* Nick Gerace (@nickgerace)
-```
-
-You do not have to use your legal name. 
-You can provide a name you would like to referred to as, a nickname, etc.
-In fact, you can use your GitHub username in the "name" slot.
-Here is an example:
-
-```
-* nickgerace (@nickgerace)
-```
-
-Your name can be of multiple words and use multiple whitespaces too.
-Here's a totally real example:
-
-```
-* Todd Howard Skyrim McFallout-y Starfield Pants (@totallyrealusername)
-```
-
-Above all, ensure that the format described at the beginning is preserved.
-
-#### (2) Polish Your Addition and Ensure the List is Ready
-
-When making changes, ensure the following:
-
-- Your individual line was appended to the bottom of the list
-- No additional newlines were added
-- Your individual line has no trailing or leading spaces
-- Your individual line matches the aforementioned format
-- Your GitHub username appears exactly once
-- Nothing else in the contributors file changed
-
-#### (3) Commit Your Change
-
-We recommend adding yourself with a separate commit (does not have to be a separate PR) to the file with the following commit title format:
-
-```
-chore: add <github-username> to contributors
-```
-
-Here is an example:
-
-```
-chore: add nickgerace to contributors
-```
-
-After the commit is pushed, you should be good to go!
-

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,7 +4,8 @@ We contributors to Daytona:
 
 * License all our contributions to the project under the Apache License, Version 2.0
 * Have the legal rights to license our contributions ourselves, or get permission to license them from our employers, clients, or others who may have them
-* Add our names and GitHub handles to this CONTRIBUTORS.md file to create a permanent record that users, distributors, and other contributors can all rely on:
+* Signoff on our commits with the Developer Certificate of Origin (DCO) Version 1.1 (https://developercertificate.org/)
+* Previously we added our names and GitHub handles to this CONTRIBUTORS.md file. We leave these names here to record the commits that came before.
 
 -----------
 * Vedran Jukic (@vedranjukic)

--- a/PREPARING_YOUR_CHANGES.md
+++ b/PREPARING_YOUR_CHANGES.md
@@ -1,6 +1,16 @@
 # Preparing Your Changes
 
-This document contains information related to preparing changes for a pull request.
+This document contains information related to preparing changes for a pull request. Here's a quick checklist for a good PR, more details below:
+
+1. A discussion around the change on [Slack](https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q) or in an issue.
+1. A GitHub Issue with a good description associated with the PR
+1. One feature/change per PR
+1. One commit per PR
+1. PR rebased on main (git rebase, not git pull)
+1. Good descriptive commit message, with link to issue
+1. No changes to code not directly related to your PR
+1. Includes functional/integration test
+1. Includes documentation
 
 ## Commit Message Format
 
@@ -21,3 +31,36 @@ If you would like an optional commit template, see the following:
 <sentences-in-paragraph-format-or-bullet-points>
 ```
 
+## Squashed Commits
+
+We require that you squash all changes to a single commit. You can do this with the `git rebase -i HEAD~X` command where X is the number of commits you want to squash. See the [Git Documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) for more details.
+
+## Developer's Certificate of Origin
+
+Any contributions to Daytona must only contain code that can legally be contributed to Daytona, and which the Daytona project can distribute under its license.
+
+Prior to contributing to Daytona please read the [Developer's Certificate of Origin](https://developercertificate.org/) and sign-off all commits with the `--signoff` option provided by `git commit`. For example:
+
+```
+git commit --signoff --message "This is the commit message"
+```
+
+This option adds a `Signed-off-by` trailer at the end of the commit log message.
+
+## DCO Policy on Real Names
+
+The DCO is a representation by someone stating they have the right to contribute the code they have proposed and is important for legal purposes. We have adopted the CNCF DCO Guidelines (https://github.com/cncf/foundation/blob/main/dco-guidelines.md). Which for simplicity we will include here in full:
+
+### DCO Guidelines v1.1
+
+The DCO is a representation by someone stating they have the right to contribute the code they have proposed for acceptance into a project: https://developercertificate.org
+
+That representation is important for legal purposes and was the community-developed outcome after a $1 billion [lawsuit](https://en.wikipedia.org/wiki/SCO%E2%80%93Linux_disputes) by SCO against IBM. The representation is designed to prevent issues but also keep the burden on contributors low. It has proven very adaptable to other projects, is built into git itself (and now also GitHub), and is in use by thousands of projects to avoid more burdensome requirements to contribute (such as a CLA).
+
+### DCO and Real Names
+
+The DCO requires the use of a real name that can be used to identify someone in case there is an issue about a contribution they made.
+
+**A real name does not require a legal name, nor a birth name, nor any name that appears on an official ID (e.g. a passport). Your real name is the name you convey to people in the community for them to use to identify you as you. The key concern is that your identification is sufficient enough to contact you if an issue were to arise in the future about your contribution.**
+
+Your real name should not be an anonymous id or false name that misrepresents who you are.

--- a/README.md
+++ b/README.md
@@ -198,9 +198,8 @@ Similar to providers, plugins are independent projects that conform to the Dayto
 
 Daytona is Open Source under the [Apache License 2.0](LICENSE), and is the [copyright of its contributors](NOTICE). If you would like to contribute to the software, you must:
 
-1. Read the [Contributors](CONTRIBUTORS.md) file.
-2. Agree to the terms by having a commit in your pull request "signing" the file by adding your name and GitHub handle on a new line at the bottom of the file.
-3. Make sure your commits Author metadata matches the name and handle you added to the file.
+1. Read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/)
+2. Signing all commits to the Daytona project.
 
 This ensures that users, distributors, and other contributors can rely on all the software related to Daytona being contributed under the terms of the [License](LICENSE). No contributions will be accepted without following this process.
 


### PR DESCRIPTION
We were using a contributors file to track acceptance of the Apache license by contributors. It was adding a lot of friction for first time contributors. So we're going to move to the DCO v1.1 which only requires that contributors sign or signoff on their commits.

For the contributions up until now, we will leave the contributors file intact. From this commit forward, we will enforce the DCO and all commits will be signed.
