### PR TITLE
chore: add cleanup gha for inactive issues and PRs

### DIFF
--- a/.github/workflows/support_stale_and_close.yaml
+++ b/.github/workflows/support_stale_and_close.yaml
@@ -1,0 +1,25 @@
+name: '[Support] Stale-And-Close Inactive Issues And PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
+# Remove all permissions by default. Actions are performed by Daytona Bot
+permissions: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # This step will add the stale comment and label for the first 15 days without activity. It won't close any task
+      - uses: actions/stale@v5
+        with:
+          stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 14 days). It will be closed if no further activity occurs. Thanks for the feedback.'
+          stale-pr-message: 'This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 14 days). It will be closed if no further activity occurs. Thank you for your contribution.'
+          close-issue-message: 'Due to the lack of activity in the last 7 days since it was marked as "stale", we are closing this Issue. Do not hesitate to reopen it later if necessary.'
+          close-pr-message: 'Due to the lack of activity in the last 7 days since it was marked as "stale", we are closing this Pull Request. Do not hesitate to reopen it later if necessary.'
+          days-before-stale: 14
+          days-before-close: 7
+          exempt-issue-labels: 'on-hold'
+          exempt-pr-labels: 'on-hold'
+          operations-per-run: 100
+          repo-token: ${{ secrets.GITHUBBOT_TOKEN }}


### PR DESCRIPTION
# Add GHA to label and afterwards close inactive Issues and PRs

## Description

GitHub Action that first labels with `stale` and then closes issues and PRs that have had no activity for a specified amount of time. Currently it is 14d to label them as stale, then another 7d to close.

If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart.

Also if PR or Issue takes longer intentionally labelling it with `on-hold` will skip this check.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)
N/A

## Screenshots
N/A

## Notes
N/A
