### PR TITLE
chore: set codeowners for automatic PR reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @daytonaio/daytona-oss team members will be requested for
+# review when someone opens a pull request.
+* @daytonaio/daytona-oss
+
+
+# Owners of all documentation
+*.txt       @daytonaio/operations
+*.md        @daytonaio/operations
+COPYRIGHT   @daytonaio/operations
+LICENSE     @daytonaio/operations
+NOTICE      @daytonaio/operations


### PR DESCRIPTION
# Add CODEOWNERS

## Description

This will setup daytona-oss team to automatically be set as `Reviewers` on any new PR created in the repo

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)
N/A

## Screenshots
N/A

## Notes
More on CODEWONERS functionality if needed [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)