### PR TITLE
Add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ build
 DEV_WORKSPACES
 ./daytona
 .DS_Store
-
 tmp
+./result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,79 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710313540,
+        "narHash": "sha256-HtTTpGe0azsEJVaT9RvbGFGB4idUneraLiUTxFb3ABM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4008381882569ab4773f2ba0d7b7bbde8f665672",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Dayton Flake Development Shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = inputs @ { self, flake-parts, systems, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import systems;
+
+    imports = [
+      inputs.flake-parts.flakeModules.easyOverlay
+    ];
+
+    perSystem = { self', inputs', config, pkgs, system, lib, ... }: {
+      _module.args.pkgs = import self.inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          self.overlays.default
+        ];
+      };
+
+      apps = {
+        daytona = {
+          type = "app";
+          program = lib.getExe pkgs.daytona-dev;
+        };
+      };
+
+      packages = {
+        daytona-dev = pkgs.callPackage ./nix/pkgs/daytona {
+          src = lib.cleanSource ./.;
+          version = self.rev or "dirty";
+        };
+      };
+
+      devShells = {
+        default = pkgs.mkShell {
+          name = "development-shell";
+          packages = [
+            pkgs.go_1_22
+            pkgs.nodejs_18
+          ];
+        };
+      };
+
+      overlayAttrs = self'.packages;
+    };
+  };
+}

--- a/nix/pkgs/daytona/default.nix
+++ b/nix/pkgs/daytona/default.nix
@@ -1,0 +1,29 @@
+args@{ lib
+, buildGo122Module
+, src
+, version
+}:
+
+buildGo122Module rec {
+  pname = "daytona";
+  version = "dev";
+
+  inherit src;
+
+  vendorHash = "sha256-6wjooiaYKkyaEttcYEtDIYV4m7mA35v87Q9DBdKq8n8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/daytonaio/daytona/internal.Version=${version}-${args.version}"
+  ];
+
+  meta = {
+    changelog = "https://github.com/daytonaio/daytona/releases/tag/v${version}";
+    description = "The Open Source Dev Environment Manager";
+    homepage = "https://github.com/daytonaio/daytona";
+    license = lib.licenses.asl20;
+    mainProgram = "daytona";
+    maintainers = with lib.maintainers; [ ];
+  };
+}


### PR DESCRIPTION
This PR:

- Is not meant to be merged, and merely serve as an example on how to use Nix to build Daytona

What can you do with it?

### Build Daytona locally

1. Checkout the branch `gh pr checkout 195`
2. Build Daytona: `nix build .#daytona-dev`, the resulting binary will be in `./result/bin/daytona`

### Enter a development shell

This will provide a development shell containing Go 1.22 and NodeJS 18

1. Checkout the branch `gh pr checkout 195`
2. `nix develop`

### Run Daytona immediately

If you have Nix, just run this command to immediately run Daytona

1. `nix run github:drupol/daytona/add-nix-flake#daytona`

# Pull Request Title

## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #X

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
