### PR TITLE
Move to prebuilt devcontainer.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,0 @@
-FROM ubuntu:22.04
-
-ADD postcreate.sh /setup/postcreate.sh
-RUN chmod +x /setup/postcreate.sh
-
-RUN apt update -y && \
-    apt install curl protobuf-compiler openjdk-11-jdk libprotobuf-dev -y
-
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,29 +1,10 @@
 {
 	"name": "Daytona",
-	"build": {
-		"dockerfile": "./Dockerfile"
-	},
-	"features": {
-		"ghcr.io/devcontainers/features/common-utils:1": {
-			"installZsh": "true",
-			"username": "daytona",
-			"uid": "1000",
-			"gid": "1000",
-			"upgradePackages": "false"
-		},
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.22.1"
-		},
-		"ghcr.io/devcontainers/features/node:1": {}
-	},
+	"image": "ghcr.io/daytonaio/go-devcontainer:main",
 	"containerEnv": {
 		"LOG_LEVEL": "debug",
 		"DAYTONA_SERVER_MODE": "development"
 	},
-	"postCreateCommand": {
-		"setup": "/setup/postcreate.sh",
-		"swag": "go install github.com/swaggo/swag/cmd/swag@v1.16.3"
-	},
+	"postCreateCommand":  ".devcontainer/postcreate.sh",
 	"remoteUser": "daytona"
 }

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -1,10 +1,6 @@
-npm install -g @devcontainers/cli
+#!/bin/bash
 
-go get -u google.golang.org/protobuf/cmd/protoc-gen-go
-go install google.golang.org/protobuf/cmd/protoc-gen-go
-
-go get -u google.golang.org/grpc/cmd/protoc-gen-go-grpc
-go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+go install github.com/swaggo/swag/cmd/swag@v1.16.3
 
 go mod tidy
 


### PR DESCRIPTION
Addresses #201.

# Pull Request Title

## Description

This change pulls the devcontainer out of Daytona for two reasons:
  - Prebuilding
  - Reuse across all the provider plugins

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #201 
