### PR TITLE
chore:making ide selection consistent with other TUI

### DIFF
--- a/pkg/views/ide/view.go
+++ b/pkg/views/ide/view.go
@@ -20,15 +20,12 @@ import (
 
 var ModelInstance model
 
-const listHeight = 8
-
 var (
-	titleStyle        = lipgloss.NewStyle().MarginLeft(2)
-	itemStyle         = lipgloss.NewStyle().PaddingLeft(4)
-	selectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(views.Blue).Bold(true)
-	paginationStyle   = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
-	helpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
-	quitTextStyle     = lipgloss.NewStyle().Margin(1, 0, 2, 4)
+	titleStyle      = lipgloss.NewStyle().Foreground(views.Green).Bold(true)
+	paginationStyle = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
+	helpStyle       = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
+	quitTextStyle   = lipgloss.NewStyle().Margin(1, 0, 2, 4)
+	docStyle        = lipgloss.NewStyle().Margin(1, 2)
 )
 
 type item struct {
@@ -39,25 +36,31 @@ func (i item) FilterValue() string { return "" }
 
 type itemDelegate struct{}
 
-func (d itemDelegate) Height() int                             { return 1 }
+func (d itemDelegate) Height() int {
+	return lipgloss.NewStyle().GetVerticalFrameSize() + 2
+}
 func (d itemDelegate) Spacing() int                            { return 0 }
 func (d itemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
 func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
-	i, ok := listItem.(item)
-	if !ok {
-		return
+	i, _ := listItem.(item)
+	s := strings.Builder{}
+
+	var isSelected = index == m.Index()
+	itemStyles := lipgloss.NewStyle().Padding(0, 0, 0, 2)
+
+	ideString := itemStyles.Copy().Render(i.name)
+
+	if isSelected {
+		selectedItemStyle := lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			BorderForeground(views.Blue).
+			Bold(true).
+			Padding(0, 0, 0, 1)
+		ideString = selectedItemStyle.Copy().Foreground(views.Blue).Render(i.name)
 	}
-
-	str := fmt.Sprintf("%d. %s", index+1, i.name)
-
-	fn := itemStyle.Render
-	if index == m.Index() {
-		fn = func(s ...string) string {
-			return selectedItemStyle.Render("> " + strings.Join(s, " "))
-		}
-	}
-
-	fmt.Fprint(w, fn(str))
+	s.WriteString(ideString)
+	s.WriteRune('\n')
+	fmt.Fprint(w, s.String())
 }
 
 type model struct {
@@ -73,8 +76,8 @@ func (m model) Init() tea.Cmd {
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.list.SetWidth(msg.Width)
-		return m, nil
+		h, v := docStyle.GetFrameSize()
+		m.list.SetSize(msg.Width-h, msg.Height-v)
 
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
@@ -103,7 +106,7 @@ func (m model) View() string {
 	if m.quitting {
 		return quitTextStyle.Render("Canceled")
 	}
-	return "\n" + m.list.View()
+	return docStyle.Render(m.list.View())
 }
 
 func Render(ideList []config.Ide, choiceChan chan<- string) {
@@ -111,9 +114,7 @@ func Render(ideList []config.Ide, choiceChan chan<- string) {
 		return item{id: ide.Id, name: ide.Name}
 	})
 
-	const defaultWidth = 20
-
-	l := list.New(items, itemDelegate{}, defaultWidth, listHeight)
+	l := list.New(items, itemDelegate{}, 0, 0)
 	l.Title = lipgloss.NewStyle().Foreground(views.Green).Bold(true).Render("Choose your default IDE")
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(false)


### PR DESCRIPTION
# chore:making ide selection consistent with other TUI


## Description

The IDE selection was inconsistent and incomplete, with options being cut off . This has been fixed to ensure a complete and consistent selection experience across the TUI. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

closes #196
/claim #196 

## Screenshots
If relevant, please add screenshots.

![image](https://github.com/daytonaio/daytona/assets/71957674/cb38b79a-c0ed-4f7c-96db-25df98f33b0b)


## Notes
Please add any relevant notes if necessary.
