### PR TITLE
fix: use wss for https API URLs

### DIFF
--- a/internal/util/apiclient/websocket_url.go
+++ b/internal/util/apiclient/websocket_url.go
@@ -1,0 +1,26 @@
+package apiclient
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+func GetWebSocketUrl(apiUrl string) (string, error) {
+	hostRegex := regexp.MustCompile(`(https*)://(.*)`)
+
+	matches := hostRegex.FindStringSubmatch(apiUrl)
+
+	if len(matches) != 3 {
+		return "", errors.New("invalid API URL")
+	}
+
+	switch matches[1] {
+	case "http":
+		return fmt.Sprintf("ws://%s", matches[2]), nil
+	case "https":
+		return fmt.Sprintf("wss://%s", matches[2]), nil
+	}
+
+	return "", errors.New("invalid API URL protocol")
+}

--- a/pkg/cmd/server/logs.go
+++ b/pkg/cmd/server/logs.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
@@ -30,15 +29,17 @@ var logsCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		hostRegex := regexp.MustCompile(`https*://(.*)`)
-		host := hostRegex.FindStringSubmatch(activeProfile.Api.Url)[1]
-
 		query := ""
 		if followFlag {
 			query = "?follow=true"
 		}
 
-		wsURL := fmt.Sprintf("ws://%s/log/server%s", host, query)
+		wsURL, err := apiclient.GetWebSocketUrl(activeProfile.Api.Url)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		wsURL = fmt.Sprintf("%s/log/server%s", wsURL, query)
 
 		ws, res, err := websocket.DefaultDialer.Dial(wsURL, nil)
 		if err != nil {


### PR DESCRIPTION
## Description

This PR fixes an issue with websocket requests when the API URL of the server used `https`. Now the CLI appropriately uses `wss` in that case and `ws` otherwise.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #198 
