### PR TITLE
feat: more control over frp logs

### DIFF
--- a/pkg/server/logs/log_formater.go
+++ b/pkg/server/logs/log_formater.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/daytonaio/daytona/pkg/server/config"
+	frp_log "github.com/fatedier/frp/pkg/util/log"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -55,6 +56,18 @@ func Init() error {
 	}
 
 	log.SetFormatter(logFormatter)
+
+	frpLogLevel := "error"
+	if os.Getenv("FRP_LOG_LEVEL") != "" {
+		frpLogLevel = os.Getenv("FRP_LOG_LEVEL")
+	}
+
+	frpOutput := filePath
+	if os.Getenv("FRP_LOG_OUTPUT") != "" {
+		frpOutput = os.Getenv("FRP_LOG_OUTPUT")
+	}
+
+	frp_log.InitLog(frpOutput, frpLogLevel, 0, false)
 
 	return nil
 }


### PR DESCRIPTION
## Description

This PR reduces FRPC log output by default. It also allows the user to control the FRP log by defining `FRP_LOG_OUTPUT` (which can be "console" or a file path) and `FRP_LOG_LEVEL` to control the log level.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
