### PR TITLE
feat: support server in daemon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,13 @@ md -Force "$Env:APPDATA\daytona"; [System.Net.ServicePointManager]::SecurityProt
 ### Start the Daytona server:
 
 ```bash
-
-daytona server
+# Start the Daytona Server (omit -d if you want to run it in the foreground)
+daytona server -d
 ```
 
 ### Create your first dev environment by opening a new terminal, and executing just this command:
 
 ```bash
-
 daytona create
 ```
 
@@ -174,10 +173,10 @@ curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
 ### Initializing Daytona
 To initialize Daytona, follow these steps:
 
-__1. Start the Daytona Service:__
-This initiates the Daytona service, which must always be running for Daytona to function. Use the command:
+__1. Start the Daytona Server:__
+This initiates the Daytona Server in daemon mode. Use the command:
 ```bash
-daytona server
+daytona server -d
 ```
 __2. Add Your Git Provider of Choice:__
 Daytona supports GitHub, GitLab, Bitbucket and Gitea. To add them to your profile, use the command:
@@ -220,6 +219,16 @@ daytona code
 ```
 
 This command opens your development environment in your preferred IDE, allowing you to start coding instantly.
+
+### Stopping the Daytona Server:
+```bash
+daytona server stop
+```
+
+### Restarting the Daytona Server:
+```bash
+daytona server restart
+```
 
 ## How to Extend Daytona
 

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	github.com/josharian/native v1.1.1-0.20230202152459-5c7d0dd6ab86 // indirect
 	github.com/jsimonetti/rtnetlink v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kardianos/service v1.2.2 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/klauspost/reedsolomon v1.9.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1085,6 +1085,8 @@ github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
+github.com/kardianos/service v1.2.2 h1:ZvePhAHfvo0A7Mftk/tEzqEZ7Q4lgnR8sGz4xu1YX60=
+github.com/kardianos/service v1.2.2/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
@@ -1664,6 +1666,7 @@ golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/kardianos/service"
+)
+
+type program struct {
+	service.Interface
+}
+
+func Start() error {
+	cfg, err := getServiceConfig()
+	if err != nil {
+		return err
+	}
+	s, err := service.New(program{}, cfg)
+	if err != nil {
+		return err
+	}
+	err = s.Install()
+	if err != nil {
+		return err
+	}
+	return s.Start()
+}
+
+func Stop() error {
+	cfg, err := getServiceConfig()
+	if err != nil {
+		return err
+	}
+	s, err := service.New(program{}, cfg)
+	if err != nil {
+		return err
+	}
+
+	err = s.Stop()
+	if err != nil {
+		return err
+	}
+
+	return s.Uninstall()
+}
+
+func getServiceConfig() (*service.Config, error) {
+	svcConfig := &service.Config{
+		Name:        "DaytonaServerDaemon",
+		DisplayName: "Daytona Server",
+		Description: "This is the Daytona Server daemon.",
+		Arguments:   []string{"server"},
+		EnvVars: map[string]string{
+			"LOG_LEVEL": "debug",
+		},
+	}
+
+	user := os.Getenv("USER")
+
+	switch runtime.GOOS {
+	case "windows":
+		return nil, fmt.Errorf("daemon mode not supported on Windows")
+	case "linux":
+		if !strings.HasSuffix(service.Platform(), "systemd") {
+			return nil, fmt.Errorf("on Linux, `server -d` is only supported with systemd. %s detected", service.Platform())
+		}
+		fallthrough
+	case "darwin":
+		if user != "" && user != "root" {
+			svcConfig.Option = service.KeyValue{"UserService": true}
+		}
+	}
+
+	return svcConfig, nil
+}

--- a/pkg/cmd/server/restart.go
+++ b/pkg/cmd/server/restart.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/daytonaio/daytona/pkg/cmd/server/daemon"
+)
+
+var restartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restarts the Daytona Server daemon",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Stopping the Daytona Server daemon...")
+		err := daemon.Stop()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("Starting the Daytona Server daemon...")
+		err = daemon.Start()
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Daytona Server daemon restarted successfully")
+	},
+}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/daytonaio/daytona/pkg/cmd/server/daemon"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/daytonaio/daytona/pkg/server/config"
 	"github.com/daytonaio/daytona/pkg/server/frpc"
@@ -15,6 +16,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+var runAsDaemon bool
 
 var ServerCmd = &cobra.Command{
 	Use:   "server",
@@ -25,6 +28,16 @@ var ServerCmd = &cobra.Command{
 			//	for now, force the log level to info when running the server
 			log.SetLevel(log.InfoLevel)
 		}
+
+		if runAsDaemon {
+			fmt.Println("Starting the Daytona Server daemon...")
+			err := daemon.Start()
+			if err != nil {
+				log.Fatal(err)
+			}
+			return
+		}
+
 		errCh := make(chan error)
 
 		err := server.Start(errCh)
@@ -53,7 +66,10 @@ var ServerCmd = &cobra.Command{
 }
 
 func init() {
+	ServerCmd.PersistentFlags().BoolVarP(&runAsDaemon, "daemon", "d", false, "Run the server as a daemon")
 	ServerCmd.AddCommand(configureCmd)
 	ServerCmd.AddCommand(configCmd)
 	ServerCmd.AddCommand(logsCmd)
+	ServerCmd.AddCommand(stopCmd)
+	ServerCmd.AddCommand(restartCmd)
 }

--- a/pkg/cmd/server/stop.go
+++ b/pkg/cmd/server/stop.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/daytonaio/daytona/pkg/cmd/server/daemon"
+)
+
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stops the Daytona Server daemon",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Stopping the Daytona Server daemon...")
+		err := daemon.Stop()
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -6,12 +6,13 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"path"
 
 	"github.com/daytonaio/daytona/pkg/types"
 	"github.com/google/uuid"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func GetConfig() (*types.ServerConfig, error) {

--- a/pkg/server/logs/log_formater.go
+++ b/pkg/server/logs/log_formater.go
@@ -51,8 +51,10 @@ func Init() error {
 	}
 
 	logFormatter := &logFormatter{
-		textFormater: new(log.TextFormatter),
-		file:         file,
+		textFormater: &log.TextFormatter{
+			ForceColors: true,
+		},
+		file: file,
 	}
 
 	log.SetFormatter(logFormatter)


### PR DESCRIPTION
## Description

This PR introduces support for running the server in daemon mode by running `daytona server -d`.

It also adds `server stop` and `server restart` commands to control the daemon once it has been started.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
