### PR TITLE
fix: set vscode as initial default IDE

### DIFF
--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -160,6 +160,7 @@ func (c *Config) GetProfile(profileId string) (Profile, error) {
 func getDefaultConfig() Config {
 	return Config{
 		ActiveProfileId: "default",
+		DefaultIdeId:    "vscode",
 		Profiles: []Profile{
 			{
 				Id:   "default",

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -144,7 +144,7 @@ func openIDE(ideId string, activeProfile config.Profile, workspaceId string, pro
 		}
 	}
 
-	return errors.New("invalid IDE")
+	return errors.New("invalid IDE. Please choose one by running `daytona ide`")
 }
 
 var ideFlag string


### PR DESCRIPTION
## Description

This PR fixes an issue with the initial default IDE. It sets it to VS Code.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
