### PR TITLE
fix: sort JB IDEs for consistent ordering

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -4,6 +4,9 @@
 package config
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/daytonaio/daytona/internal/jetbrains"
 	"github.com/daytonaio/daytona/pkg/os"
 )
@@ -25,9 +28,14 @@ func GetIdeList() []Ide {
 		{"browser", "VS Code - Browser"},
 	}
 
+	sortedJbIdes := []Ide{}
 	for id, ide := range jetbrains.GetIdes() {
-		ides = append(ides, Ide{string(id), ide.Name})
+		sortedJbIdes = append(sortedJbIdes, Ide{string(id), ide.Name})
 	}
+	slices.SortFunc(sortedJbIdes, func(i, j Ide) int {
+		return strings.Compare(i.Name, j.Name)
+	})
+	ides = append(ides, sortedJbIdes...)
 
 	return ides
 }


### PR DESCRIPTION
## Description

With this PR, JetBrains IDEs are sorted in the `daytona ide` list to maintain consistent order across command calls.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #220 
