### PR TITLE
feat: run server after get-server installs

### DIFF
--- a/hack/get-server.sh
+++ b/hack/get-server.sh
@@ -112,8 +112,7 @@ if [[ ! :"$PATH:" == *":$DESTINATION:"* ]]; then
   echo "             daytona server"
   else 
     # Prompt the user for running the Daytona Server
-    echo -e "\nDo you want to run 'daytona server'? (Y/n) "
-    read choice
+    read -p "Do you want to proceed with the installation? (Y/n) " choice
 
     # Check if the input is 'Y' or 'y' or 'yes'
     if [[ $choice == "Y" || $choice == "y" || $choice == "yes" ]]; then

--- a/hack/get-server.sh
+++ b/hack/get-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script downloads the Daytona server binary and installs it to /usr/local/bin
+# This script downloads the Daytona server binary, installs it to /usr/local/bin and runs the Daytona Server
 # You can set the environment variable DAYTONA_SERVER_VERSION to specify the version to download
 # You can set the environment variable DAYTONA_SERVER_DOWNLOAD_URL to specify the base URL to download from
 # You can set the environment variable DAYTONA_PATH to specify the path where to install the binary
@@ -108,5 +108,17 @@ if [[ ! :"$PATH:" == *":$DESTINATION:"* ]]; then
   echo "         Edit your shell configuration file (e.g., ~/.bashrc or ~/.zshrc)"
   echo "         Add the following line:"
   echo "             export PATH=\$PATH:$DESTINATION"
-  echo "         Source the configuration file to apply the changes (e.g., source ~/.bashrc)"
+  echo "         Source the configuration file to apply the changes (e.g., source ~/.bashrc) and run the Daytona Server:"
+  echo "             daytona server"
+  else 
+    # Prompt the user for running the Daytona Server
+    echo -e "\nDo you want to run 'daytona server'? (Y/n) "
+    read choice
+
+    # Check if the input is 'Y' or 'y' or 'yes'
+    if [[ $choice == "Y" || $choice == "y" || $choice == "yes" ]]; then
+        daytona server
+    else
+        echo "No action taken. Run 'daytona server' when you're ready."
+    fi
 fi

--- a/hack/get-server.sh
+++ b/hack/get-server.sh
@@ -112,7 +112,8 @@ if [[ ! :"$PATH:" == *":$DESTINATION:"* ]]; then
   echo "             daytona server"
   else 
     # Prompt the user for running the Daytona Server
-    read -p "Do you want to proceed with the installation? (Y/n) " choice
+    echo -e "\nDo you want to run 'daytona server'? (Y/n) "
+    read -t 5 -r choice
 
     # Check if the input is 'Y' or 'y' or 'yes'
     if [[ $choice == "Y" || $choice == "y" || $choice == "yes" ]]; then


### PR DESCRIPTION
# Run server after get-server installs

## Description

Makes get-server.sh also run the Daytona Server at the end
Adds a description update and tells the user to run the server if there's an issue with the PATH

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related PR(s)

After merging this, #229 can be merged