### PR TITLE
fix: default ssh to HOME if project dir is not present

### DIFF
--- a/pkg/agent/ssh/server.go
+++ b/pkg/agent/ssh/server.go
@@ -85,6 +85,10 @@ func handlePty(s ssh.Session, ptyReq ssh.Pty, winCh <-chan ssh.Window) {
 
 	cmd.Dir = c.ProjectDir
 
+	if _, err := os.Stat(c.ProjectDir); os.IsNotExist(err) {
+		cmd.Dir = os.Getenv("HOME")
+	}
+
 	if ssh.AgentRequested(s) {
 		l, err := ssh.NewAgentListener()
 		if err != nil {
@@ -144,6 +148,10 @@ func handleNonPty(s ssh.Session) {
 	}
 
 	cmd.Dir = c.ProjectDir
+	if _, err := os.Stat(c.ProjectDir); os.IsNotExist(err) {
+		cmd.Dir = os.Getenv("HOME")
+	}
+
 	cmd.Stdout = s
 	cmd.Stderr = s.Stderr()
 	stdinPipe, err := cmd.StdinPipe()


### PR DESCRIPTION
## Description

Default the SSH connection to `$HOME` if the project directory is not present.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #236 
