### PR TITLE
feat: allow server defaults override via env

### DIFF
--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -10,7 +10,6 @@ import (
 	"path"
 
 	"github.com/daytonaio/daytona/pkg/types"
-	"github.com/google/uuid"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -145,59 +144,18 @@ func GetProjectLogFilePath(workspaceId string, projectId string) (string, error)
 	return filePath, nil
 }
 
-func getDefaultProvidersDir() (string, error) {
-	userConfigDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-
-	return path.Join(userConfigDir, "daytona", "providers"), nil
-}
-
-func getDefaultTargetsPath() (string, error) {
-	configDir, err := GetConfigDir()
-	if err != nil {
-		return "", err
-	}
-
-	return path.Join(configDir, "targets.json"), nil
-
-}
-
-func generateUuid() string {
-	uuid := uuid.New()
-	return uuid.String()
-}
-
 func init() {
 	_, err := GetConfig()
 	if err == nil {
 		return
 	}
 
-	providersDir, err := getDefaultProvidersDir()
+	c, err := getDefaultConfig()
 	if err != nil {
-		log.Fatal("failed to get default providers dir")
+		log.Fatal("failed to get default config")
 	}
 
-	targetsPath, err := getDefaultTargetsPath()
-	if err != nil {
-		log.Fatal("failed to get default targets path")
-	}
-
-	c := types.ServerConfig{
-		RegistryUrl:       defaultRegistryUrl,
-		ProvidersDir:      providersDir,
-		GitProviders:      []types.GitProvider{},
-		ServerDownloadUrl: defaultServerDownloadUrl,
-		ApiPort:           defaultApiPort,
-		HeadscalePort:     defaultHeadscalePort,
-		TargetsFilePath:   targetsPath,
-		Frps:              getDefaultFRPSConfig(),
-		Id:                generateUuid(),
-	}
-
-	err = Save(&c)
+	err = Save(c)
 	if err != nil {
 		log.Fatal("failed to save default config file")
 	}


### PR DESCRIPTION
# Allow server defaults override via env variables

## Description

With this PR, the user will be able to override default configuration values for the server when starting it for the first time. This change is most relevant for using Daytona with Nix.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #234 