### PR TITLE
daytona prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
 ```
 ### Windows
 <details>
-<summary>Windows PowerShell</summary>
+<summary>Windows PowerShell</summary> 
 This command downloads and installs Daytona and runs the Daytona Server:
 
 ```pwsh
 $architecture = if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") { "amd64" } else { "arm64" }
-md -Force "$Env:APPDATA\daytona"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://download.daytona.io/daytona/latest/daytona-windows-$architecture.exe" -OutFile "$Env:APPDATA\daytona\daytona.exe";
-$env:Path += ";" + $Env:APPDATA + "\daytona"; [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
+md -Force "$Env:APPDATA\bin\daytona"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
+Invoke-WebRequest -URI "https://download.daytona.io/daytona/latest/daytona-windows-$architecture.exe" -OutFile "$Env:APPDATA\bin\daytona\daytona.exe";
+$env:Path += ";" + $Env:APPDATA + "\bin\daytona"; [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 daytona server;
 ```
 

--- a/cmd/daytona/config/autocompletion.go
+++ b/cmd/daytona/config/autocompletion.go
@@ -1,0 +1,87 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"regexp"
+)
+
+const completionScriptNameRoot = "daytona.completion_script."
+
+var shellNames = []string{"bash", "zsh", "fish", "powershell"}
+
+func DeleteAutocompletionData() error {
+	for _, shellName := range shellNames {
+		err := removeAutocompletionDataForShell(shellName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func removeAutocompletionDataForShell(shellName string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	completionScriptPath := homeDir
+	runCommandFilePath := homeDir
+
+	switch shellName {
+	case "bash":
+		completionScriptPath += "/." + completionScriptNameRoot + "bash"
+		runCommandFilePath += "/.bashrc"
+	case "zsh":
+		completionScriptPath += "/." + completionScriptNameRoot + "zsh"
+		runCommandFilePath += "/.zshrc"
+	case "fish":
+		completionScriptPath += "/." + completionScriptNameRoot + "fish"
+		runCommandFilePath += "/.config/fish/config.fish"
+	case "powershell":
+		completionScriptPath += "/" + completionScriptNameRoot + "ps1"
+		runCommandFilePath += "/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
+	default:
+		return nil
+	}
+
+	// Remove the line that sources the completion script if it exists
+	err = removeLineFromFile(runCommandFilePath, completionScriptNameRoot)
+	if err != nil {
+		return err
+	}
+
+	// Remove the completion script if it exists
+	_, err = os.Stat(completionScriptPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	return os.Remove(completionScriptPath)
+}
+
+func removeLineFromFile(filePath string, lineText string) error {
+	_, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile("(?m:^.*" + regexp.QuoteMeta(lineText) + ".*$\n?)")
+	newContent := re.ReplaceAllString(string(content), "")
+
+	err = os.WriteFile(filePath, []byte(newContent), 0600)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -190,3 +190,17 @@ func GetConfigDir() (string, error) {
 
 	return filepath.Join(userConfigDir, "daytona"), nil
 }
+
+func DeleteConfigDir() error {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(configDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -66,6 +66,39 @@ func ensureSshFilesLinked() error {
 	return nil
 }
 
+func UnlinkSshFiles() error {
+	sshDirPath := filepath.Join(sshHomeDir, ".ssh")
+	sshConfigPath := filepath.Join(sshDirPath, "config")
+	daytonaConfigPath := filepath.Join(sshDirPath, "daytona_config")
+
+	// Remove the include line from the config file
+	_, err := os.Stat(sshConfigPath)
+	if os.IsExist(err) {
+		content, err := os.ReadFile(sshConfigPath)
+		if err != nil {
+			return err
+		}
+
+		newContent := strings.ReplaceAll(string(content), "Include daytona_config\n\n", "")
+		newContent = strings.ReplaceAll(string(newContent), "Include daytona_config", "")
+		err = os.WriteFile(sshConfigPath, []byte(newContent), 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Remove the daytona_config file
+	_, err = os.Stat(daytonaConfigPath)
+	if os.IsExist(err) {
+		err = os.Remove(daytonaConfigPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Add ssh entry
 
 func generateSshConfigEntry(profileId, workspaceId, projectName, knownHostsPath string) (string, error) {

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -64,6 +64,7 @@ func Execute() {
 		rootCmd.AddCommand(ProfileUseCmd)
 		rootCmd.AddCommand(whoamiCmd)
 		rootCmd.AddCommand(ProviderCmd)
+		rootCmd.AddCommand(pruneCmd)
 	}
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true

--- a/pkg/cmd/prune.go
+++ b/pkg/cmd/prune.go
@@ -1,0 +1,90 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	workspace "github.com/daytonaio/daytona/pkg/cmd/workspace"
+	profile_view "github.com/daytonaio/daytona/pkg/views/profile"
+	view "github.com/daytonaio/daytona/pkg/views/prune"
+	view_util "github.com/daytonaio/daytona/pkg/views/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var yesFlag bool
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Prunes all Daytona data from the current device",
+	Long:  "Prunes all Daytona data from the current device - including all workspaces, configuration files, and SSH files. This command is irreversible.",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		var confirmCheck bool
+		var serverStoppedCheck bool
+		var switchProfileCheck bool
+
+		c, err := config.GetConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if c.ActiveProfileId != "default" {
+			profile_view.SwitchToDefaultPrompt(&switchProfileCheck)
+			if !switchProfileCheck {
+				view_util.RenderInfoMessage("Operation cancelled.")
+				return
+			}
+			c.ActiveProfileId = "default"
+			err = c.Save()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		if !yesFlag {
+			view.ConfirmPrompt(&confirmCheck)
+			if !confirmCheck {
+				view_util.RenderInfoMessage("Operation cancelled.")
+				return
+			}
+		}
+
+		view_util.RenderLine("\nDeleting all workspaces")
+		err = workspace.DeleteAllWorkspaces()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		view_util.RenderLine("Deleting the SSH configuration file")
+		err = config.UnlinkSshFiles()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		view_util.RenderLine("Deleting autocompletion data")
+		err = config.DeleteAutocompletionData()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		view.ServerStoppedPrompt(&serverStoppedCheck)
+		if !serverStoppedCheck {
+			view_util.RenderInfoMessage("Operation cancelled.")
+			return
+		}
+
+		view_util.RenderLine("Deleting the Daytona config directory")
+		err = config.DeleteConfigDir()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		view_util.RenderInfoMessage("All Daytona data has been successfully cleared from the device.\nYou may now delete the binary.")
+	},
+}
+
+func init() {
+	pruneCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Execute prune without prompt")
+}

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/util"
+	view_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
 	log "github.com/sirupsen/logrus"
@@ -30,7 +31,7 @@ var DeleteCmd = &cobra.Command{
 		if allFlag {
 			if yesFlag {
 				fmt.Println("Deleting all workspaces.")
-				err := deleteAllWorkspaces()
+				err := DeleteAllWorkspaces()
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -50,7 +51,7 @@ var DeleteCmd = &cobra.Command{
 				}
 
 				if yesFlag {
-					err := deleteAllWorkspaces()
+					err := DeleteAllWorkspaces()
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -122,7 +123,7 @@ func init() {
 	DeleteCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Confirm deletion without prompt")
 }
 
-func deleteAllWorkspaces() error {
+func DeleteAllWorkspaces() error {
 	ctx := context.Background()
 	apiClient, err := server.GetApiClient(nil)
 	if err != nil {
@@ -140,7 +141,7 @@ func deleteAllWorkspaces() error {
 			log.Errorf("Failed to delete workspace %s: %v", *workspace.Id, apiclient.HandleErrorResponse(res, err))
 			continue
 		}
-		fmt.Printf("Workspace %s successfully deleted\n", *workspace.Name)
+		view_util.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", *workspace.Name))
 	}
 	return nil
 }

--- a/pkg/views/profile/switch_to_default.go
+++ b/pkg/views/profile/switch_to_default.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"log"
+
+	"github.com/charmbracelet/huh"
+	"github.com/daytonaio/daytona/pkg/views"
+)
+
+func SwitchToDefaultPrompt(profileSwitchCheck *bool) {
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Switch to the default Daytona profile?").
+				Description("This action is allowed only on the default (local) profile.").
+				Value(profileSwitchCheck),
+		),
+	).WithTheme(views.GetCustomTheme())
+
+	err := form.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/views/prune/confirm.go
+++ b/pkg/views/prune/confirm.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package prune
+
+import (
+	"log"
+
+	"github.com/charmbracelet/huh"
+	"github.com/daytonaio/daytona/pkg/views"
+)
+
+func ConfirmPrompt(confirmCheck *bool) {
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Are you sure you want to clear all the data from Daytona?").
+				Description("This action is irreversible.").
+				Value(confirmCheck),
+		),
+	).WithTheme(views.GetCustomTheme())
+
+	err := form.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/views/prune/server_stopped.go
+++ b/pkg/views/prune/server_stopped.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package prune
+
+import (
+	"log"
+
+	"github.com/charmbracelet/huh"
+	"github.com/daytonaio/daytona/pkg/views"
+)
+
+func ServerStoppedPrompt(serverStoppedCheck *bool) {
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Please stop the Daytona Server before continuing").
+				Description("Removing the config directory requires the Daytona Server to be stopped.").
+				Affirmative("Continue").
+				Negative("Abort").
+				Value(serverStoppedCheck),
+		),
+	).WithTheme(views.GetCustomTheme())
+
+	err := form.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/views/util/globals.go
+++ b/pkg/views/util/globals.go
@@ -14,6 +14,10 @@ func RenderMainTitle(title string) {
 	fmt.Println(lipgloss.NewStyle().Foreground(views.Green).Bold(true).Padding(1, 0, 1, 0).Render(title))
 }
 
+func RenderLine(message string) {
+	fmt.Println(lipgloss.NewStyle().PaddingLeft(1).Render(message))
+}
+
 func RenderInfoMessage(message string) {
 	fmt.Println(lipgloss.NewStyle().Padding(1, 0, 1, 1).Render(message))
 }


### PR DESCRIPTION
# Daytona prune command

## Description

`daytona prune` clears all the data associated with Daytona from the machine:
- deletes all workspaces
- deletes the daytona ssh config file and unlinks it from the main ssh config file
- deletes the daytona autocomplete file and unlinks it from the "run command" (.rc) file
- deletes the daytona config directory after prompting the user to turn off the Daytona Server

When ran in a non-default profile, it prompts the user to switch to the default profile or abort

Confirmation prompt for pruning implemented (Y/n)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - Windows "quick start" users will need to reinstall Daytona for prune to work - because the daytona binary is no longer stored in the main config folder
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #200
