### PR TITLE
fix: server daemon foreground logging

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/daytonaio/daytona/pkg/server/config"
 	"github.com/daytonaio/daytona/pkg/server/frpc"
+	"github.com/daytonaio/daytona/pkg/types"
 	"github.com/daytonaio/daytona/pkg/views/util"
 
 	log "github.com/sirupsen/logrus"
@@ -35,6 +36,11 @@ var ServerCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
+			c, err := config.GetConfig()
+			if err != nil {
+				log.Fatal(err)
+			}
+			printServerStartedMessage(c)
 			return
 		}
 
@@ -55,7 +61,7 @@ var ServerCmd = &cobra.Command{
 			log.Fatal(err)
 		// TODO: This is an optimistic check. We should check if the server is actually running
 		case <-time.After(5 * time.Second):
-			util.RenderBorderedMessage(fmt.Sprintf("Daytona Server running on port: %d.\nTo connect to the server remotely, use the following command on the client machine:\n\ndaytona profile add -a %s", c.ApiPort, frpc.GetApiUrl(c)))
+			printServerStartedMessage(c)
 		}
 
 		err = <-errCh
@@ -63,6 +69,10 @@ var ServerCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 	},
+}
+
+func printServerStartedMessage(c *types.ServerConfig) {
+	util.RenderBorderedMessage(fmt.Sprintf("Daytona Server running on port: %d.\nTo connect to the server remotely, use the following command on the client machine:\n\ndaytona profile add -a %s", c.ApiPort, frpc.GetApiUrl(c)))
 }
 
 func init() {

--- a/pkg/server/api/controllers/log/websocket.go
+++ b/pkg/server/api/controllers/log/websocket.go
@@ -67,7 +67,8 @@ func readLog(ginCtx *gin.Context, logFilePath *string) {
 }
 
 func ReadServerLog(ginCtx *gin.Context) {
-	readLog(ginCtx, logs.LogFilePath)
+	logFilePath := logs.GetLogFilePath()
+	readLog(ginCtx, logFilePath)
 }
 
 func ReadWorkspaceLog(ginCtx *gin.Context) {

--- a/pkg/server/logs/log_formater.go
+++ b/pkg/server/logs/log_formater.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var LogFilePath *string
+var logFilePath *string
 
 type logFormatter struct {
 	textFormater *log.TextFormatter
@@ -25,7 +25,7 @@ func (f *logFormatter) Format(entry *log.Entry) ([]byte, error) {
 		return nil, err
 	}
 
-	if LogFilePath != nil {
+	if logFilePath != nil {
 		// Write to file
 		_, err = f.file.Write(formatted)
 		if err != nil {
@@ -36,16 +36,24 @@ func (f *logFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return formatted, nil
 }
 
-func Init() error {
-	configDir, err := config.GetConfigDir()
-	if err != nil {
-		return err
+func GetLogFilePath() *string {
+	if logFilePath == nil {
+		configDir, err := config.GetConfigDir()
+		if err != nil {
+			return nil
+		}
+
+		filePath := filepath.Join(configDir, "daytona.log")
+		logFilePath = &filePath
 	}
 
-	filePath := filepath.Join(configDir, "daytona.log")
-	LogFilePath = &filePath
+	return logFilePath
+}
 
-	file, err := os.OpenFile(*LogFilePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+func Init() error {
+	filePath := GetLogFilePath()
+
+	file, err := os.OpenFile(*filePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -64,7 +72,7 @@ func Init() error {
 		frpLogLevel = os.Getenv("FRP_LOG_LEVEL")
 	}
 
-	frpOutput := filePath
+	frpOutput := *filePath
 	if os.Getenv("FRP_LOG_OUTPUT") != "" {
 		frpOutput = os.Getenv("FRP_LOG_OUTPUT")
 	}


### PR DESCRIPTION
## Description

Adds server daemon foreground logs. Specifically, if the server starts successfully, the server information message is displayed and if the server fails to start, it outputs the logs of the server so the user is informed about the error. Check the Screenshot section for an example.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #250 

## Screenshots
![Screenshot 2024-03-20 at 12 57 00](https://github.com/daytonaio/daytona/assets/26512078/8613074e-81f6-41e3-a151-440bb33cec45)
