### PR TITLE
refactor: workspace and project logger

### DIFF
--- a/pkg/logger/project.go
+++ b/pkg/logger/project.go
@@ -1,0 +1,45 @@
+package logger
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type projectLogger struct {
+	logsDir     string
+	workspaceId string
+	projectName string
+	logFile     *os.File
+}
+
+func (pl *projectLogger) Write(p []byte) (n int, err error) {
+	if pl.logFile == nil {
+		filePath := filepath.Join(pl.logsDir, pl.workspaceId, pl.projectName, "log")
+		err = os.MkdirAll(filepath.Dir(filePath), 0755)
+		if err != nil {
+			return 0, err
+		}
+
+		logFile, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return 0, err
+		}
+		pl.logFile = logFile
+	}
+
+	return pl.logFile.Write(p)
+}
+
+func (pl *projectLogger) Close() error {
+	if pl.logFile != nil {
+		err := pl.logFile.Close()
+		pl.logFile = nil
+		return err
+	}
+	return nil
+}
+
+func GetProjectLogger(logsDir, workspaceId, projectName string) io.WriteCloser {
+	return &projectLogger{workspaceId: workspaceId, logsDir: logsDir, projectName: projectName}
+}

--- a/pkg/logger/workspace.go
+++ b/pkg/logger/workspace.go
@@ -1,0 +1,43 @@
+package logger
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type workspaceLogger struct {
+	logsDir     string
+	workspaceId string
+	logFile     *os.File
+}
+
+func (w *workspaceLogger) Write(p []byte) (n int, err error) {
+	if w.logFile == nil {
+		filePath := filepath.Join(w.logsDir, w.workspaceId, "log")
+		err = os.MkdirAll(filepath.Dir(filePath), 0755)
+		if err != nil {
+			return 0, err
+		}
+		logFile, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return 0, err
+		}
+		w.logFile = logFile
+	}
+
+	return w.logFile.Write(p)
+}
+
+func (w *workspaceLogger) Close() error {
+	if w.logFile != nil {
+		err := w.logFile.Close()
+		w.logFile = nil
+		return err
+	}
+	return nil
+}
+
+func GetWorkspaceLogger(logsDir, workspaceId string) io.WriteCloser {
+	return &workspaceLogger{workspaceId: workspaceId, logsDir: logsDir}
+}

--- a/pkg/provider/manager/manager.go
+++ b/pkg/provider/manager/manager.go
@@ -74,7 +74,7 @@ func GetProviders() map[string]Provider {
 	return providers
 }
 
-func RegisterProvider(pluginPath, serverDownloadUrl, serverUrl, serverApiUrl string) error {
+func RegisterProvider(pluginPath, serverDownloadUrl, serverUrl, serverApiUrl, logsDir string) error {
 	pluginName := filepath.Base(pluginPath)
 	pluginBasePath := filepath.Dir(pluginPath)
 
@@ -122,6 +122,7 @@ func RegisterProvider(pluginPath, serverDownloadUrl, serverUrl, serverApiUrl str
 		ServerVersion:     internal.Version,
 		ServerUrl:         serverUrl,
 		ServerApiUrl:      serverApiUrl,
+		LogsDir:           logsDir,
 	})
 	if err != nil {
 		return errors.New("failed to initialize provider: " + err.Error())

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -13,6 +13,7 @@ type InitializeProviderRequest struct {
 	ServerVersion     string
 	ServerUrl         string
 	ServerApiUrl      string
+	LogsDir           string
 }
 
 type WorkspaceRequest struct {

--- a/pkg/server/api/controllers/provider/install.go
+++ b/pkg/server/api/controllers/provider/install.go
@@ -54,7 +54,13 @@ func InstallProvider(ctx *gin.Context) {
 		return
 	}
 
-	err = manager.RegisterProvider(downloadPath, util.GetDaytonaScriptUrl(c), frpc.GetServerUrl(c), frpc.GetApiUrl(c))
+	logsDir, err := config.GetWorkspaceLogsDir()
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get workspace logs dir: %s", err.Error()))
+		return
+	}
+
+	err = manager.RegisterProvider(downloadPath, util.GetDaytonaScriptUrl(c), frpc.GetServerUrl(c), frpc.GetApiUrl(c), logsDir)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to register provider: %s", err.Error()))
 		return

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -137,22 +137,6 @@ func DeleteWorkspaceLogs(workspaceId string) error {
 	return os.RemoveAll(workspaceLogsDir)
 }
 
-func GetProjectLogFilePath(workspaceId string, projectId string) (string, error) {
-	projectLogsDir, err := GetWorkspaceLogsDir()
-	if err != nil {
-		return "", err
-	}
-
-	filePath := filepath.Join(projectLogsDir, workspaceId, projectId, "log")
-
-	err = os.MkdirAll(filepath.Dir(filePath), 0755)
-	if err != nil {
-		return "", err
-	}
-
-	return filePath, nil
-}
-
 func init() {
 	_, err := GetConfig()
 	if err == nil {

--- a/pkg/server/providers.go
+++ b/pkg/server/providers.go
@@ -70,6 +70,11 @@ func registerProviders(c *types.ServerConfig) error {
 		return err
 	}
 
+	logsDir, err := config.GetWorkspaceLogsDir()
+	if err != nil {
+		return err
+	}
+
 	for _, file := range files {
 		if file.IsDir() {
 			pluginPath, err := getPluginPath(filepath.Join(c.ProvidersDir, file.Name()))
@@ -78,7 +83,7 @@ func registerProviders(c *types.ServerConfig) error {
 				continue
 			}
 
-			err = manager.RegisterProvider(pluginPath, util.GetDaytonaScriptUrl(c), frpc.GetServerUrl(c), frpc.GetApiUrl(c))
+			err = manager.RegisterProvider(pluginPath, util.GetDaytonaScriptUrl(c), frpc.GetServerUrl(c), frpc.GetApiUrl(c), logsDir)
 			if err != nil {
 				log.Error(err)
 				continue


### PR DESCRIPTION
# Workspace and Project logger

## Description

Now providers will be able to call `logger.GetWorkspace/ProjectLogger`  and log to the same file as the server.

This can then give users more feedback into everything happening with their workspaces and improves DX when working on providers.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor or utility

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #255 