### PR TITLE
feat: provider project start script util

### DIFF
--- a/pkg/provider/util/project_start_script.go
+++ b/pkg/provider/util/project_start_script.go
@@ -1,0 +1,7 @@
+package util
+
+import "fmt"
+
+func GetProjectStartScript(serverDownloadUrl string) string {
+	return fmt.Sprintf("curl -sfL %s | sudo -E bash && daytona agent", serverDownloadUrl)
+}


### PR DESCRIPTION
# Provider project start script utility

## Description

Added a util function that providers can use to get the project start script. This improves DX by removing the need for provider developers to know the details of what to run to start a project. Providers will be able to call `util.GetProjectStartScript`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #258 