### PR TITLE
feat: allow server defaults override via cli

### DIFF
--- a/pkg/views/server/configure.go
+++ b/pkg/views/server/configure.go
@@ -4,8 +4,10 @@
 package server
 
 import (
+	"errors"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/charmbracelet/huh"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
@@ -17,6 +19,10 @@ type ServerUpdateKeyView struct {
 }
 
 func ConfigurationForm(config *serverapiclient.ServerConfig) *serverapiclient.ServerConfig {
+	apiPortView := strconv.Itoa(int(config.GetApiPort()))
+	headscalePortView := strconv.Itoa(int(config.GetHeadscalePort()))
+	frpsPortView := strconv.Itoa(int(config.Frps.GetPort()))
+
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
@@ -36,6 +42,32 @@ func ConfigurationForm(config *serverapiclient.ServerConfig) *serverapiclient.Se
 			huh.NewInput().
 				Title("Server Download URL").
 				Value(config.ServerDownloadUrl),
+			huh.NewInput().
+				Title("API Port").
+				Value(&apiPortView).
+				Validate(createPortValidator(config, &apiPortView, config.ApiPort)),
+			huh.NewInput().
+				Title("Headscale Port").
+				Value(&headscalePortView).
+				Validate(createPortValidator(config, &headscalePortView, config.HeadscalePort)),
+			huh.NewInput().
+				Title("Binaries Path").
+				Value(config.BinariesPath),
+			huh.NewInput().
+				Title("Targets File Path").
+				Value(config.TargetsFilePath),
+		),
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Frps Domain").
+				Value(config.Frps.Domain),
+			huh.NewInput().
+				Title("Frps Port").
+				Value(&frpsPortView).
+				Validate(createPortValidator(config, &frpsPortView, config.Frps.Port)),
+			huh.NewInput().
+				Title("Frps Protocol").
+				Value(config.Frps.Protocol),
 		),
 	)
 
@@ -45,4 +77,23 @@ func ConfigurationForm(config *serverapiclient.ServerConfig) *serverapiclient.Se
 	}
 
 	return config
+}
+
+func createPortValidator(config *serverapiclient.ServerConfig, portView *string, port *int32) func(string) error {
+	return func(string) error {
+		validatePort, err := strconv.Atoi(*portView)
+		if err != nil {
+			return errors.New("failed to parse port")
+		}
+		if validatePort < 0 || validatePort > 65535 {
+			return errors.New("port out of range")
+		}
+		*port = int32(validatePort)
+
+		if *config.ApiPort == *config.HeadscalePort {
+			return errors.New("port conflict")
+		}
+
+		return nil
+	}
 }


### PR DESCRIPTION
# Pull Request Title

## Description

With this PR, added missing fields in server defaults configuration, users can now override the default values of all through the CLI. E.g. `daytona server configure`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #238
