### PR TITLE
fix: download url join

### DIFF
--- a/pkg/server/api/controllers/binary/binaries.go
+++ b/pkg/server/api/controllers/binary/binaries.go
@@ -3,8 +3,8 @@ package binary
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -61,7 +61,10 @@ func getBinaryPath(binaryName, binaryVersion string) (string, error) {
 		return binaryPath, nil
 	}
 
-	downloadUrl := path.Join(c.RegistryUrl, binaryVersion, binaryName)
+	downloadUrl, err := url.JoinPath(c.RegistryUrl, binaryVersion, binaryName)
+	if err != nil {
+		return "", err
+	}
 
 	err = daytona_os.DownloadFile(downloadUrl, binaryPath)
 	if err != nil {


### PR DESCRIPTION
## Description

Minor fix for joining a URL. Uses `url.JoinPath` instead of `path.Join`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

