### PR TITLE
fix: server side websocket errors

### DIFF
--- a/internal/util/log_reader.go
+++ b/internal/util/log_reader.go
@@ -27,15 +27,13 @@ func ReadLog(ctx context.Context, filePath *string, follow bool, c chan []byte, 
 	for {
 		select {
 		case <-ctx.Done():
-			errChan <- ctx.Err()
 			return
 		default:
 			line, err := reader.ReadBytes('\n')
 			if err != nil {
 				if err != io.EOF {
 					errChan <- err
-				}
-				if !follow {
+				} else if !follow {
 					errChan <- io.EOF
 					return
 				}


### PR DESCRIPTION
Fixing server-side WebSocket errors
## Description

Improved code for WebSocket connection and removed the error of abnormal closure since it occurs when the client closes the connection abruptly and it is not an error.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #271 
/claim #271
