### PR TITLE
chore: dont autostart server quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,29 @@ Set up a development environment on any infrastructure, with a single command.
 * __Works on my Machine__: Never experience it again.
 ## Quick Start
 ### Mac / Linux
+Install Daytona to your machine:
 ```bash
 curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
 ```
+Run the Daytona Server:
+```bash
+daytona server -d
+```
 ### Windows
 <details>
-<summary>Windows PowerShell</summary> 
-This command downloads and installs Daytona and runs the Daytona Server:
+<summary>Windows PowerShell</summary>
+Install Daytona to your machine:
 
 ```pwsh
 $architecture = if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") { "amd64" } else { "arm64" }
 md -Force "$Env:APPDATA\bin\daytona"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
 Invoke-WebRequest -URI "https://download.daytona.io/daytona/latest/daytona-windows-$architecture.exe" -OutFile "$Env:APPDATA\bin\daytona\daytona.exe";
 $env:Path += ";" + $Env:APPDATA + "\bin\daytona"; [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
-daytona server;
+daytona;
+```
+Run the Daytona Server:
+```bash
+daytona server
 ```
 
 </details>

--- a/hack/get-server.sh
+++ b/hack/get-server.sh
@@ -109,7 +109,4 @@ if [[ ! :"$PATH:" == *":$DESTINATION:"* ]]; then
   echo "         Add the following line:"
   echo "             export PATH=\$PATH:$DESTINATION"
   echo "         Source the configuration file to apply the changes (e.g., source ~/.bashrc)"
-  else
-  echo -e "\nRunning the Daytona server in daemon mode"
-  daytona server -d
 fi


### PR DESCRIPTION
# Don't start server on get-server
## Description

Reverting the get-server script back to just installing the binary and not running the Daytona Server

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)
Closes #276 
