### PR TITLE
fix: quick start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Set up a development environment on any infrastructure, with a single command.
 ## Quick Start
 ### Mac / Linux
 ```bash
-curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
+(curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash) && daytona server -d
 ```
 ### Windows
 <details>

--- a/hack/get-server.sh
+++ b/hack/get-server.sh
@@ -109,7 +109,4 @@ if [[ ! :"$PATH:" == *":$DESTINATION:"* ]]; then
   echo "         Add the following line:"
   echo "             export PATH=\$PATH:$DESTINATION"
   echo "         Source the configuration file to apply the changes (e.g., source ~/.bashrc)"
-  else
-  echo -e "\nRunning the Daytona server in daemon mode"
-  daytona server -d
 fi


### PR DESCRIPTION
# Quick start installation and server run
## Description

Running the server removed from get-server.sh and moved to the command call - fixes having the command called as sudo instead of as user.
Lets the user use "get-server" to only install the binary without running the server

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #276 