### PR TITLE
feat: parse git context from url

### DIFF
--- a/internal/util/workspace.go
+++ b/internal/util/workspace.go
@@ -72,6 +72,16 @@ func GetValidatedWorkspaceName(input string) (string, error) {
 	return input, nil
 }
 
+func GetBranchFromRepoURL(repoURL string) string {
+	pattern := `/tree/([^/]+)`
+	match := regexp.MustCompile(pattern).FindStringSubmatch(repoURL)
+	if len(match) > 1 {
+		return match[1]
+	}
+
+	return ""
+}
+
 func GetValidatedUrl(input string) (string, error) {
 	// Check if the input starts with a scheme (e.g., http:// or https://)
 	if !strings.HasPrefix(input, "http://") && !strings.HasPrefix(input, "https://") {

--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -133,7 +133,12 @@ func runInitialForm(providerRepo types.Repository, multiProject bool) (Workspace
 		secondaryProjectsCount = 0
 	}
 
-	providerRepo.Url = primaryRepoUrl
+	branch := util.GetBranchFromRepoURL(primaryRepoUrl)
+	if branch != "" {
+		providerRepo.Branch = branch
+	}
+
+	providerRepo.Url = strings.Split(primaryRepoUrl, "/tree/")[0]
 
 	return WorkspaceCreationPromptResponse{
 		PrimaryRepository:     providerRepo,


### PR DESCRIPTION
# feat: parse git context from url

## Description
Extracting the git branch name from a repository URL when creating a workspace from a custom URL. 
Example URL- https://github.com/daytonaio/daytona/tree/agent-git-operations

Screenshot - 
![image](https://github.com/daytonaio/daytona/assets/71957674/846d1b7c-5efb-4bd7-8e7c-70c02713a18a)



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

closes #85
/claim #85

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
