### PR TITLE
chore: rename prune to purge

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -64,7 +64,7 @@ func Execute() {
 		rootCmd.AddCommand(ProfileUseCmd)
 		rootCmd.AddCommand(whoamiCmd)
 		rootCmd.AddCommand(ProviderCmd)
-		rootCmd.AddCommand(pruneCmd)
+		rootCmd.AddCommand(purgeCmd)
 	}
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true

--- a/pkg/cmd/purge.go
+++ b/pkg/cmd/purge.go
@@ -7,7 +7,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	workspace "github.com/daytonaio/daytona/pkg/cmd/workspace"
 	profile_view "github.com/daytonaio/daytona/pkg/views/profile"
-	view "github.com/daytonaio/daytona/pkg/views/prune"
+	view "github.com/daytonaio/daytona/pkg/views/purge"
 	view_util "github.com/daytonaio/daytona/pkg/views/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -15,10 +15,10 @@ import (
 
 var yesFlag bool
 
-var pruneCmd = &cobra.Command{
-	Use:   "prune",
-	Short: "Prunes all Daytona data from the current device",
-	Long:  "Prunes all Daytona data from the current device - including all workspaces, configuration files, and SSH files. This command is irreversible.",
+var purgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Purges all Daytona data from the current device",
+	Long:  "Purges all Daytona data from the current device - including all workspaces, configuration files, and SSH files. This command is irreversible.",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		var confirmCheck bool
@@ -86,5 +86,5 @@ var pruneCmd = &cobra.Command{
 }
 
 func init() {
-	pruneCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Execute prune without prompt")
+	purgeCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Execute purge without prompt")
 }

--- a/pkg/views/purge/confirm.go
+++ b/pkg/views/purge/confirm.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package prune
+package purge
 
 import (
 	"log"

--- a/pkg/views/purge/server_stopped.go
+++ b/pkg/views/purge/server_stopped.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package prune
+package purge
 
 import (
 	"log"


### PR DESCRIPTION
# Rename daytona prune to purge

## Description

The "prune" word was used incorrectly as it usually means removing unused data/objects (e.g. docker prune, git prune) so we will be renaming it to `daytona purge`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
