### PR TITLE
chore: rename getserver to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Set up a development environment on any infrastructure, with a single command.
 ## Quick Start
 ### Mac / Linux
 ```bash
-(curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash) && daytona server -d
+(curl -sf -L https://download.daytona.io/daytona/install.sh | sudo bash) && daytona server -d
 ```
 ### Windows
 <details>
@@ -123,10 +123,10 @@ Daytona allows you to manage your Development Environments using the Daytona CLI
 
 ```bash
 # Install Daytona into /usr/local/bin
-curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash
+curl -sf -L https://download.daytona.io/daytona/install.sh | sudo bash
 
 # OR if you want to install Daytona to some other path where you don`t need sudo
-# curl -sf -L https://download.daytona.io/daytona/get-server.sh | DAYTONA_PATH=/home/user/bin bash
+# curl -sf -L https://download.daytona.io/daytona/install.sh | DAYTONA_PATH=/home/user/bin bash
 ```
 <details open>
   <summary> Manual installation </summary>

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -65,9 +65,9 @@ if [[ ! -w $DESTINATION ]]; then
   echo -e "\nWarning: Destination directory $DESTINATION is not writeable."
   echo "         Rerun the script with SUDO privileges:"
   if [ "$DAYTONA_PATH" ]; then
-    echo "           curl -sf -L https://download.daytona.io/daytona/get-server.sh | DAYTONA_PATH=$DESTINATION sudo bash"
+    echo "           curl -sf -L https://download.daytona.io/daytona/install.sh | DAYTONA_PATH=$DESTINATION sudo bash"
   else
-    echo "           curl -sf -L https://download.daytona.io/daytona/get-server.sh | sudo bash"
+    echo "           curl -sf -L https://download.daytona.io/daytona/install.sh | sudo bash"
   fi
   exit 1
 fi

--- a/pkg/server/config/defaults.go
+++ b/pkg/server/config/defaults.go
@@ -18,7 +18,7 @@ import (
 )
 
 const defaultRegistryUrl = "https://download.daytona.io/daytona"
-const defaultServerDownloadUrl = "https://download.daytona.io/daytona/get-server.sh"
+const defaultServerDownloadUrl = "https://download.daytona.io/daytona/install.sh"
 const defaultHeadscalePort = 3001
 const defaultApiPort = 3000
 


### PR DESCRIPTION
# Rename get-server.sh to install.sh
## Description

Renaming get-server.sh to install.sh as it is the clearer name for the script
get-server.sh is staying on download.daytona.io along with install.sh for some time

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
