### PR TITLE
refactor: attach env variables to projects

### DIFF
--- a/pkg/types/workspace.go
+++ b/pkg/types/workspace.go
@@ -22,11 +22,12 @@ type Repository struct {
 } // @name Repository
 
 type Project struct {
-	Name        string      `json:"name"`
-	Repository  *Repository `json:"repository"`
-	WorkspaceId string      `json:"workspaceId"`
-	ApiKey      string      `json:"-"`
-	Target      string      `json:"target"`
+	Name        string            `json:"name"`
+	Repository  *Repository       `json:"repository"`
+	WorkspaceId string            `json:"workspaceId"`
+	ApiKey      string            `json:"-"`
+	Target      string            `json:"target"`
+	EnvVars     map[string]string `json:"-"`
 } // @name Project
 type Workspace struct {
 	Id       string     `json:"id"`


### PR DESCRIPTION
# Project Environment variables

## Description

Environment variables are now attached to a project by the provisioner when sending requests to a provider. This will improve DX when working on providers.

_Note:_ `DAYTONA_WS_DIR` is still required to be defined by the provider.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor, DX improvement

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #259 