### PR TITLE
fix: clearer server started message

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -77,7 +77,7 @@ var ServerCmd = &cobra.Command{
 }
 
 func printServerStartedMessage(c *types.ServerConfig) {
-	util.RenderBorderedMessage(fmt.Sprintf("Daytona Server running on port: %d.\nTo connect to the server remotely:\n\n1. Create an API key on this machine:\ndaytona server api-key new\n\n2. On the client machine run:\ndaytona profile add -a %s -k API_KEY", c.ApiPort, frpc.GetApiUrl(c)))
+	util.RenderBorderedMessage(fmt.Sprintf("Daytona Server running on port: %d.\nYou can now begin developing locally.\n\nIf you want to connect to the server remotely:\n\n1. Create an API key on this machine:\ndaytona server api-key new\n\n2. On the client machine run:\ndaytona profile add -a %s -k API_KEY", c.ApiPort, frpc.GetApiUrl(c)))
 }
 
 func init() {


### PR DESCRIPTION
# Clearer Server Started Message

## Description

This PR made the server started message more clear for local and remote usage. Check the screenshots for an example.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #292 

## Screenshots

![Screenshot 2024-03-26 at 16 21 14](https://github.com/daytonaio/daytona/assets/26512078/0f84f90a-38b5-45b6-b600-bfa0062251c9)