### PR TITLE
fix: handle duplicate api key

### DIFF
--- a/pkg/views/server/apikey/create.go
+++ b/pkg/views/server/apikey/create.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"log"
 
+	"github.com/daytonaio/daytona/pkg/types"
 	"github.com/daytonaio/daytona/pkg/views"
 
 	"github.com/charmbracelet/huh"
 )
 
-func ApiKeyCreationView(name *string, saveToDefaultProfile *bool) {
+func ApiKeyCreationView(name *string, saveToDefaultProfile *bool, clientKeys []*types.ApiKey) {
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
@@ -21,6 +22,11 @@ func ApiKeyCreationView(name *string, saveToDefaultProfile *bool) {
 				Validate(func(str string) error {
 					if str == "" {
 						return errors.New("name can not be blank")
+					}
+					for _, key := range clientKeys {
+						if key.Name == str {
+							return errors.New("key name already exists")
+						}
 					}
 					return nil
 				}),


### PR DESCRIPTION
# Handle duplicate api key names gracefully
## Description

Handle duplicate api key names gracefully instead of dumping database error

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #295 
