### PR TITLE
fix: throw error on workspace create if target name is invalid

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -199,6 +199,10 @@ func getTarget() (*serverapiclient.ProviderTarget, error) {
 				break
 			}
 		}
+
+		if selectedTarget == nil {
+			return nil, fmt.Errorf("target '%s' not found", targetNameFlag)
+		}
 	}
 
 	if selectedTarget == nil {


### PR DESCRIPTION
## Description

Throw an error if target name supplied is invalid on workspace create

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #304 
/claim #304

