### PR TITLE
feat: parse git context from url

### DIFF
--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -11,5 +11,5 @@ type GitProvider interface {
 	GetUser() (*GitUser, error)
 	GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error)
 	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)
-	// ParseGitUrl(string) (*GitRepository, error)
+	ParseGitUrl(string) (*GitRepository, error)
 }

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -150,6 +151,53 @@ func (g *GitHubGitProvider) GetRepoPRs(repositoryId string, namespaceId string) 
 	}
 
 	return response, nil
+}
+
+func (g *GitHubGitProvider) ParseGitUrl(gitURL string) (*GitRepository, error) {
+	client := g.getApiClient()
+	repo, err := parseGitComponents(gitURL)
+
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err = g.parseSpecificPath(repo, client)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return repo, nil
+}
+
+
+func (g *GitHubGitProvider) parseSpecificPath(repo *GitRepository, client *github.Client) (*GitRepository, error) {
+	parts := strings.Split(*repo.Path, "/")
+	repo.Path = nil
+
+	switch {
+	case len(parts) >= 2 && parts[0] == "pull":
+		prNumber, _ := strconv.Atoi(parts[1])
+		pull, _, err := client.PullRequests.Get(context.Background(), repo.Owner, repo.Name, prNumber)
+		if err != nil {
+			return nil, err
+		}
+		repo.Branch = pull.Head.Ref
+		repo.Url = *pull.Head.Repo.CloneURL
+		repo.Owner = *pull.Head.Repo.Owner.Login
+
+	case len(parts) >= 1 && parts[0] == "tree":
+		repo.Branch = &parts[1]
+	case len(parts) >= 2 && parts[0] == "blob":
+		repo.Branch = &parts[1]
+		branchPath := strings.Join(parts[2:], "/")
+		repo.Path = &branchPath
+	case len(parts) >= 2 && (parts[0] == "commit" || parts[0] == "commits"):
+		repo.Sha = parts[1]
+		repo.Branch = &repo.Sha
+	}
+
+	return repo, nil
 }
 
 func (g *GitHubGitProvider) GetUser() (*GitUser, error) {

--- a/pkg/gitprovider/helper.go
+++ b/pkg/gitprovider/helper.go
@@ -1,0 +1,64 @@
+package gitprovider
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+func parseGitURLWithSSH(gitURL string) (*GitRepository, error) {
+	re := regexp.MustCompile(`git@([\w\.]+):(.+?)/(.+?)(?:\.git)?$`)
+	matches := re.FindStringSubmatch(gitURL)
+	if len(matches) != 4 {
+		return nil, errors.New("cannot parse git URL: " + gitURL)
+	}
+
+	source := matches[1]
+	owner := matches[2]
+	repo := matches[3]
+
+	cloneURL := getCloneURL(source, owner, repo)
+
+	return &GitRepository{
+		Owner:  owner,
+		Name:   repo,
+		Source: source,
+		Url:    cloneURL,
+	}, nil
+}
+
+func getCloneURL(source, owner, repo string) string {
+	return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+}
+
+func parseGitComponents(gitURL string) (*GitRepository, error) {
+	if strings.HasPrefix(gitURL, "git@") {
+		return parseGitURLWithSSH(gitURL)
+	}
+
+	if !strings.HasPrefix(gitURL, "http") {
+		return nil, errors.New("cannot parse git URL: " + gitURL)
+	}
+
+	u, err := url.Parse(gitURL)
+	if err != nil {
+		return nil, err
+	}
+
+	repo := &GitRepository{}
+
+	path := strings.TrimPrefix(u.Path, "/")
+	parts := strings.Split(path, "/")
+
+	repo.Source = u.Host
+	repo.Owner = parts[0]
+	repo.Name = parts[1]
+	branchPath := strings.Join(parts[2:], "/")
+	repo.Path = &branchPath
+
+	repo.Url = getCloneURL(repo.Source, repo.Owner, repo.Name)
+
+	return repo, nil
+}


### PR DESCRIPTION
# feat: parse git context from url

## Description

Extracting the git branch name from a repository URL when creating a workspace from a custom URL.
Example URL- https://github.com/harkiratsm/daytona/tree/harkirat-verbosee

Added function to these git-provider ->
- [x] Github
- [x] Gitlab
- [ ] BitBucket
- more

![image](https://github.com/daytonaio/daytona/assets/71957674/850d0a2a-5071-4960-9369-0763d683d8c3)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

closes #85
/claim #85

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
