### PR TITLE
replace --skip-ide flag with --connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ daytona server;
 ### Create your first dev environment by opening a new terminal, and running:
 
 ```bash
-daytona create
+daytona create --connect
 ```
 
 **Start coding.**
@@ -94,7 +94,7 @@ Setting up development environments has become increasingly challenging over tim
 
 This complexity is unnecessary.
 
-With Daytona, you need only to execute a single command: `daytona create`.
+With Daytona, you need only to execute a single command: `daytona create --connect`.
 
 Daytona automates the entire process; provisioning the instance, interpreting and applying the configuration, setting up prebuilds, establishing a secure VPN connection, securely connecting your local or a Web IDE, and assigning a fully qualified domain name to the development environment for easy sharing and collaboration.
 
@@ -186,8 +186,11 @@ Now that you have installed and initialized Daytona, you can proceed to setting 
 ### Creating Dev Environments
 Creating development environments with Daytona is a straightforward process, accomplished with just one command:
 ```bash
-daytona create
+daytona create --connect
 ```
+
+You can skip the `--connect` flag if you don't wish to open the IDE immediately after creating the environment.
+
 Upon executing this command, you will be prompted with two questions:
 1. Choose the provider to decide where to create a dev environment.
 2. Select or type the Git repository you wish to use to create a dev environment.
@@ -217,7 +220,7 @@ Daytona offers flexibility for extension through the creation of plugins and pro
 ### Providers
 Daytona is designed to be infrastructure-agnostic, capable of creating and managing development environments across various platforms. Providers are the components that encapsulate the logic for provisioning compute resources on a specific target platform. They allow for the configuration of different targets within a single provider, enabling, for instance, multiple AWS profiles within an AWS provider.
 
-How does it work? When executing the `daytona create` command, Daytona communicates the environment details to the selected provider, which then provisions the necessary compute resources. Once provisioned, Daytona sets up the environment on these resources, allowing the user to interact with the environment seamlessly.
+How does it work? When executing the `daytona create --connect` command, Daytona communicates the environment details to the selected provider, which then provisions the necessary compute resources. Once provisioned, Daytona sets up the environment on these resources, allowing the user to interact with the environment seamlessly.
 
 Providers are independent projects that adhere to the Daytona Provider interface. They can be developed in nearly any major programming language. More details coming soon.
 

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -152,8 +152,8 @@ var CreateCmd = &cobra.Command{
 		fmt.Println()
 		info.Render(wsInfo)
 
-		skipIdeFlag, _ := cmd.Flags().GetBool("skip-ide")
-		if skipIdeFlag {
+		connectFlag, _ := cmd.Flags().GetBool("connect")
+		if !connectFlag {
 			return
 		}
 
@@ -181,7 +181,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&targetNameFlag, "target", "t", "", "Specify the target (e.g. 'local')")
 	CreateCmd.Flags().Bool("manual", false, "Manually enter the git repositories")
 	CreateCmd.Flags().Bool("multi-project", false, "Workspace with multiple projects/repos")
-	CreateCmd.Flags().Bool("skip-ide", false, "Don't open the IDE after workspace creation")
+	CreateCmd.Flags().Bool("connect", false, "Open the workspace in the IDE after workspace creation")
 }
 
 func getTarget() (*serverapiclient.ProviderTarget, error) {


### PR DESCRIPTION
## Description

This PR replaces the --skip-ide flag, which skips IDE opening, with the --connect flag. If the --connect flag is not present in daytona create, the IDE is not opened automatically.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #315
/claim #315
