### PR TITLE
fix: Ensure SSH configuration files are created and configured correctly

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -137,6 +137,15 @@ func EnsureSshConfigEntryAdded(profileId, workspaceName, projectName string) err
 
 	sshDir := filepath.Join(sshHomeDir, ".ssh")
 	configPath := filepath.Join(sshDir, "daytona_config")
+	_, err = os.Stat(configPath)
+	if os.IsNotExist(err) {
+		err = os.WriteFile(configPath, []byte{}, 0600)
+		if err != nil {
+			return err
+		}
+	}  else if err != nil {
+		return err
+	}
 
 	// Read existing content from the file
 	existingContent, err := os.ReadFile(configPath)


### PR DESCRIPTION
## Description

This PR addresses an issue where the SSH configuration files (`~/.ssh/config` and `~/.ssh/daytona_config`) were not being created or configured correctly during the `daytona create` process, causing the IDE (VS Code) to fail to connect to the newly created workspace.

## Type of Change

- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ✅] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #312 
/claim #312 

