### PR TITLE
fix: daytona server/binary download msg

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script downloads the Daytona server binary and installs it to /usr/local/bin
+# This script downloads the Daytona binary and installs it to /usr/local/bin
 # You can set the environment variable DAYTONA_SERVER_VERSION to specify the version to download
 # You can set the environment variable DAYTONA_SERVER_DOWNLOAD_URL to specify the base URL to download from
 # You can set the environment variable DAYTONA_PATH to specify the path where to install the binary
@@ -74,9 +74,9 @@ fi
 
 DOWNLOAD_URL="$BASE_URL/$VERSION/daytona-$FILENAME"
 
-echo -e "\nDownloading server from $DOWNLOAD_URL"
+echo -e "\nDownloading Daytona binary from $DOWNLOAD_URL"
 
-# Create a temporary file to download the server binary. Just in case the user
+# Create a temporary file to download the Daytona binary. Just in case the user
 # has file named "daytona" in the current directory.
 temp_file="daytona-$RANDOM"
 
@@ -94,7 +94,7 @@ trap 'rm -f "$temp_file"' EXIT
 # -L, --location: Follow redirects.
 # -o, --output <file>: Write output to <file> instead of stdout.
 if ! curl -fsSL "$DOWNLOAD_URL" -o "$temp_file"; then
-  err "Daytona server download failed"
+  err "Daytona binary download failed"
 fi
 chmod +x "$temp_file"
 

--- a/internal/constants/get_daytona_script.go
+++ b/internal/constants/get_daytona_script.go
@@ -54,9 +54,9 @@ esac
 
 DOWNLOAD_URL="$BASE_URL/$VERSION/daytona-$FILENAME"
 
-echo -e "\nDownloading server from $DOWNLOAD_URL"
+echo -e "\nDownloading Daytona binary from $DOWNLOAD_URL"
 
-# Create a temporary file to download the server binary. Just in case the user
+# Create a temporary file to download the Daytona binary. Just in case the user
 # has file named "daytona" in the current directory.
 temp_file="daytona-$RANDOM"
 
@@ -64,7 +64,7 @@ temp_file="daytona-$RANDOM"
 trap 'rm -f "$temp_file"' EXIT
 
 if ! curl -fsSL "$DOWNLOAD_URL" -H "Authorization: Bearer $DAYTONA_SERVER_API_KEY" -o "$temp_file"; then
-  err "Daytona server download failed"
+  err "Daytona binary download failed"
 fi
 chmod +x "$temp_file"
 


### PR DESCRIPTION
# Description

Update daytona server downloading message from Downloading server from -> Downloading Daytona binary from

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #321 
