### PR TITLE
chore: formatter typo

### DIFF
--- a/pkg/server/logs/log_formatter.go
+++ b/pkg/server/logs/log_formatter.go
@@ -15,12 +15,12 @@ import (
 var logFilePath *string
 
 type logFormatter struct {
-	textFormater *log.TextFormatter
-	file         *os.File
+	textFormatter *log.TextFormatter
+	file          *os.File
 }
 
 func (f *logFormatter) Format(entry *log.Entry) ([]byte, error) {
-	formatted, err := f.textFormater.Format(entry)
+	formatted, err := f.textFormatter.Format(entry)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func Init() error {
 	}
 
 	logFormatter := &logFormatter{
-		textFormater: &log.TextFormatter{
+		textFormatter: &log.TextFormatter{
 			ForceColors: true,
 		},
 		file: file,


### PR DESCRIPTION
# Formatter naming inconsistency
## Description

Fix typo, some places used "formater" instead of "formatter"

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings