### PR TITLE
fix: workspace create with .git url appends -git to project

### DIFF
--- a/pkg/server/workspaceservice/create.go
+++ b/pkg/server/workspaceservice/create.go
@@ -92,7 +92,7 @@ func newWorkspace(createWorkspaceDto dto.CreateWorkspace) (*types.Workspace, err
 		}
 
 		projectNameSlugRegex := regexp.MustCompile(`[^a-zA-Z0-9-]`)
-		projectName := projectNameSlugRegex.ReplaceAllString(strings.ToLower(filepath.Base(repo.Url)), "-")
+		projectName := projectNameSlugRegex.ReplaceAllString(strings.TrimSuffix(strings.ToLower(filepath.Base(repo.Url)), ".git"), "-")
 
 		apiKey, err := auth.GenerateApiKey(types.ApiKeyTypeProject, fmt.Sprintf("%s/%s", w.Id, projectName))
 		if err != nil {


### PR DESCRIPTION
## Description
This pull request trims the -git suffix from project name when creating workspaces using a .git url.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #349 
/claim #349


<img width="416" alt="image" src="https://github.com/daytonaio/daytona/assets/34857453/95e5227c-a674-4669-91c1-3abcec9f72bb">
