### PR TITLE
fix: workspace name suggestion

### DIFF
--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -467,6 +467,8 @@ func getSuggestedWorkspaceName(repo string) string {
 		input = repo[lastIndex+1:]
 	}
 
+	input = strings.TrimSuffix(input, ".git")
+
 	for _, char := range input {
 		if unicode.IsLetter(char) || unicode.IsNumber(char) || char == '-' {
 			result.WriteRune(char)


### PR DESCRIPTION
## Description

This PR trims `git` suffix being appended to suggested workspace names when using a .git url

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #354 
/claim #354

## Screenshots

<img width="222" alt="image" src="https://github.com/daytonaio/daytona/assets/34857453/b5fd1258-902d-49a6-a14f-6b512d2bee01">
