### PR TITLE
feat: add spinner to git provider functions, fixing the Tui flashing

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -58,13 +58,13 @@ var CreateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		view_util.RenderMainTitle("WORKSPACE CREATION")
-
 		if len(args) == 0 {
 			processPrompting(cmd, apiClient, &workspaceName, &repos, ctx)
 		} else {
 			processCmdArguments(cmd, args, apiClient, &workspaceName, &repos, ctx)
 		}
+
+		view_util.RenderMainTitle("WORKSPACE CREATION")
 
 		if workspaceName == "" || len(repos) == 0 {
 			log.Fatal("workspace name and repository urls are required")

--- a/pkg/views/util/spinner.go
+++ b/pkg/views/util/spinner.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/daytonaio/daytona/pkg/views"
+	log "github.com/sirupsen/logrus"
+)
+
+type model struct {
+	spinner  spinner.Model
+	quitting bool
+}
+
+type Msg string
+
+func initialModel() model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(views.Blue)
+	return model{spinner: s}
+}
+
+func (m model) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case Msg:
+		m.quitting = true
+		return m, tea.Quit
+
+	default:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+}
+
+func With(fn func() error) error {
+	p := start()
+	defer stop(p)
+	return fn()
+}
+
+func start() *tea.Program {
+	p := tea.NewProgram(initialModel(), tea.WithAltScreen())
+	go func() {
+		if _, err := p.Run(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}()
+	return p
+
+}
+
+func stop(p *tea.Program) {
+	p.Send(Msg("quit"))
+	err := p.ReleaseTerminal()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (m model) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	str := fmt.Sprintf("\n\n   %s Loading...\n\n", m.spinner.View())
+
+	return str
+}

--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -15,6 +15,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/types"
 	"github.com/daytonaio/daytona/pkg/views"
+	view_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
 	"github.com/charmbracelet/huh"
@@ -357,7 +358,13 @@ func GetRepositoryFromWizard(userGitProviders []types.GitProvider, secondaryProj
 		return types.Repository{}, errors.New("provider not found")
 	}
 
-	namespaceList, err := gitProvider.GetNamespaces()
+	var namespaceList []gitprovider.GitNamespace
+	var err error
+
+	err = view_util.With(func() error {
+		namespaceList, err = gitProvider.GetNamespaces()
+		return err
+	})
 	if err != nil {
 		return types.Repository{}, err
 	}
@@ -373,7 +380,12 @@ func GetRepositoryFromWizard(userGitProviders []types.GitProvider, secondaryProj
 		}
 	}
 
-	providerRepos, err := gitProvider.GetRepositories(namespaceId)
+	var providerRepos []types.Repository
+	err = view_util.With(func() error {
+		providerRepos, err = gitProvider.GetRepositories(namespaceId)
+		return err
+	})
+
 	if err != nil {
 		return types.Repository{}, err
 	}
@@ -393,7 +405,11 @@ func GetRepositoryFromWizard(userGitProviders []types.GitProvider, secondaryProj
 		return types.Repository{}, nil
 	}
 
-	branchList, err := gitProvider.GetRepoBranches(chosenRepo, namespaceId)
+	var branchList []gitprovider.GitBranch
+	err = view_util.With(func() error {
+		branchList, err = gitProvider.GetRepoBranches(chosenRepo, namespaceId)
+		return err
+	})
 	if err != nil {
 		return types.Repository{}, err
 	}
@@ -413,7 +429,12 @@ func GetRepositoryFromWizard(userGitProviders []types.GitProvider, secondaryProj
 		return chosenRepo, nil
 	}
 
-	prList, err := gitProvider.GetRepoPRs(chosenRepo, namespaceId)
+	var prList []gitprovider.GitPullRequest
+	err = view_util.With(func() error {
+		prList, err = gitProvider.GetRepoPRs(chosenRepo, namespaceId)
+		return err
+	})
+
 	if err != nil {
 		return types.Repository{}, err
 	}


### PR DESCRIPTION
# feat: add spinner to git provider functions, fixing the Tui flashing

## Description
Implemented a spinner for the git provider functions to address the issue of TUI flashing, which occurs due to delays in data retrieval from the git_provider. The spinner indicates loading state improving user experience.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

closes #131 
/claim #131 

## Screenshots
https://github.com/daytonaio/daytona/assets/71957674/13d2e5ef-c3a6-4468-b280-6beab4fc32e2

## Notes
Please add any relevant notes if necessary.
