### PR TITLE
fix: ssh agent forwarding

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -118,7 +118,8 @@ func generateSshConfigEntry(profileId, workspaceId, projectName, knownHostsPath 
 		tab+"User daytona\n"+
 		tab+"StrictHostKeyChecking no\n"+
 		tab+"UserKnownHostsFile %s\n"+
-		tab+"ProxyCommand %s ssh-proxy %s %s %s\n\n", projectHostname, knownHostsPath, daytonaPath, profileId, workspaceId, projectName)
+		tab+"ProxyCommand %s ssh-proxy %s %s %s\n"+
+		tab+"ForwardAgent yes\n\n", projectHostname, knownHostsPath, daytonaPath, profileId, workspaceId, projectName)
 
 	return config, nil
 }


### PR DESCRIPTION
# SSH Agent Forwarding

## Description

This PR fixes SSH agent forwarding when connecting to projects. The `ForwardAgent yes` line was missing from the SSH config entry.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #369 