### PR TITLE
feat: added default project image to server config

### DIFF
--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1208,6 +1208,9 @@ const docTemplate = `{
                 "binariesPath": {
                     "type": "string"
                 },
+                "defaultProjectImage": {
+                    "type": "string"
+                },
                 "frps": {
                     "$ref": "#/definitions/FRPSConfig"
                 },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1205,6 +1205,9 @@
                 "binariesPath": {
                     "type": "string"
                 },
+                "defaultProjectImage": {
+                    "type": "string"
+                },
                 "frps": {
                     "$ref": "#/definitions/FRPSConfig"
                 },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -170,6 +170,8 @@ definitions:
         type: integer
       binariesPath:
         type: string
+      defaultProjectImage:
+        type: string
       frps:
         $ref: '#/definitions/FRPSConfig'
       headscalePort:

--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -20,6 +20,7 @@ const defaultRegistryUrl = "https://download.daytona.io/daytona"
 const defaultServerDownloadUrl = "https://download.daytona.io/daytona/install.sh"
 const defaultHeadscalePort = 3001
 const defaultApiPort = 3000
+const defaultProjectImage = "daytonaio/workspace-project:latest"
 
 var us_defaultFrpsConfig = FRPSConfig{
 	Domain:   "try-us.daytona.app",
@@ -93,15 +94,16 @@ func getDefaultConfig() (*Config, error) {
 	}
 
 	c := Config{
-		Id:                generateUuid(),
-		RegistryUrl:       defaultRegistryUrl,
-		ProvidersDir:      providersDir,
-		ServerDownloadUrl: defaultServerDownloadUrl,
-		ApiPort:           defaultApiPort,
-		HeadscalePort:     defaultHeadscalePort,
-		BinariesPath:      binariesPath,
-		Frps:              getDefaultFRPSConfig(),
-		LogFilePath:       logFilePath,
+		Id:                  generateUuid(),
+		RegistryUrl:         defaultRegistryUrl,
+		ProvidersDir:        providersDir,
+		ServerDownloadUrl:   defaultServerDownloadUrl,
+		ApiPort:             defaultApiPort,
+		HeadscalePort:       defaultHeadscalePort,
+		BinariesPath:        binariesPath,
+		Frps:                getDefaultFRPSConfig(),
+		LogFilePath:         logFilePath,
+		DefaultProjectImage: defaultProjectImage,
 	}
 
 	if os.Getenv("DEFAULT_REGISTRY_URL") != "" {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -26,13 +26,14 @@ type NetworkKey struct {
 } // @name NetworkKey
 
 type Config struct {
-	ProvidersDir      string      `json:"providersDir"`
-	RegistryUrl       string      `json:"registryUrl"`
-	Id                string      `json:"id"`
-	ServerDownloadUrl string      `json:"serverDownloadUrl"`
-	Frps              *FRPSConfig `json:"frps,omitempty"`
-	ApiPort           uint32      `json:"apiPort"`
-	HeadscalePort     uint32      `json:"headscalePort"`
-	BinariesPath      string      `json:"binariesPath"`
-	LogFilePath       string      `json:"logFilePath"`
+	ProvidersDir        string      `json:"providersDir"`
+	RegistryUrl         string      `json:"registryUrl"`
+	Id                  string      `json:"id"`
+	ServerDownloadUrl   string      `json:"serverDownloadUrl"`
+	Frps                *FRPSConfig `json:"frps,omitempty"`
+	ApiPort             uint32      `json:"apiPort"`
+	HeadscalePort       uint32      `json:"headscalePort"`
+	BinariesPath        string      `json:"binariesPath"`
+	LogFilePath         string      `json:"logFilePath"`
+	DefaultProjectImage string      `json:"defaultProjectImage"`
 } // @name ServerConfig

--- a/pkg/serverapiclient/api/openapi.yaml
+++ b/pkg/serverapiclient/api/openapi.yaml
@@ -945,6 +945,7 @@ components:
         serverDownloadUrl: serverDownloadUrl
         binariesPath: binariesPath
         logFilePath: logFilePath
+        defaultProjectImage: defaultProjectImage
         providersDir: providersDir
         id: id
         frps:
@@ -955,6 +956,8 @@ components:
         apiPort:
           type: integer
         binariesPath:
+          type: string
+        defaultProjectImage:
           type: string
         frps:
           $ref: '#/components/schemas/FRPSConfig'

--- a/pkg/serverapiclient/docs/ServerConfig.md
+++ b/pkg/serverapiclient/docs/ServerConfig.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ApiPort** | Pointer to **int32** |  | [optional] 
 **BinariesPath** | Pointer to **string** |  | [optional] 
+**DefaultProjectImage** | Pointer to **string** |  | [optional] 
 **Frps** | Pointer to [**FRPSConfig**](FRPSConfig.md) |  | [optional] 
 **HeadscalePort** | Pointer to **int32** |  | [optional] 
 **Id** | Pointer to **string** |  | [optional] 
@@ -82,6 +83,31 @@ SetBinariesPath sets BinariesPath field to given value.
 `func (o *ServerConfig) HasBinariesPath() bool`
 
 HasBinariesPath returns a boolean if a field has been set.
+
+### GetDefaultProjectImage
+
+`func (o *ServerConfig) GetDefaultProjectImage() string`
+
+GetDefaultProjectImage returns the DefaultProjectImage field if non-nil, zero value otherwise.
+
+### GetDefaultProjectImageOk
+
+`func (o *ServerConfig) GetDefaultProjectImageOk() (*string, bool)`
+
+GetDefaultProjectImageOk returns a tuple with the DefaultProjectImage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetDefaultProjectImage
+
+`func (o *ServerConfig) SetDefaultProjectImage(v string)`
+
+SetDefaultProjectImage sets DefaultProjectImage field to given value.
+
+### HasDefaultProjectImage
+
+`func (o *ServerConfig) HasDefaultProjectImage() bool`
+
+HasDefaultProjectImage returns a boolean if a field has been set.
 
 ### GetFrps
 

--- a/pkg/serverapiclient/model_server_config.go
+++ b/pkg/serverapiclient/model_server_config.go
@@ -19,15 +19,16 @@ var _ MappedNullable = &ServerConfig{}
 
 // ServerConfig struct for ServerConfig
 type ServerConfig struct {
-	ApiPort           *int32      `json:"apiPort,omitempty"`
-	BinariesPath      *string     `json:"binariesPath,omitempty"`
-	Frps              *FRPSConfig `json:"frps,omitempty"`
-	HeadscalePort     *int32      `json:"headscalePort,omitempty"`
-	Id                *string     `json:"id,omitempty"`
-	LogFilePath       *string     `json:"logFilePath,omitempty"`
-	ProvidersDir      *string     `json:"providersDir,omitempty"`
-	RegistryUrl       *string     `json:"registryUrl,omitempty"`
-	ServerDownloadUrl *string     `json:"serverDownloadUrl,omitempty"`
+	ApiPort             *int32      `json:"apiPort,omitempty"`
+	BinariesPath        *string     `json:"binariesPath,omitempty"`
+	DefaultProjectImage *string     `json:"defaultProjectImage,omitempty"`
+	Frps                *FRPSConfig `json:"frps,omitempty"`
+	HeadscalePort       *int32      `json:"headscalePort,omitempty"`
+	Id                  *string     `json:"id,omitempty"`
+	LogFilePath         *string     `json:"logFilePath,omitempty"`
+	ProvidersDir        *string     `json:"providersDir,omitempty"`
+	RegistryUrl         *string     `json:"registryUrl,omitempty"`
+	ServerDownloadUrl   *string     `json:"serverDownloadUrl,omitempty"`
 }
 
 // NewServerConfig instantiates a new ServerConfig object
@@ -109,6 +110,38 @@ func (o *ServerConfig) HasBinariesPath() bool {
 // SetBinariesPath gets a reference to the given string and assigns it to the BinariesPath field.
 func (o *ServerConfig) SetBinariesPath(v string) {
 	o.BinariesPath = &v
+}
+
+// GetDefaultProjectImage returns the DefaultProjectImage field value if set, zero value otherwise.
+func (o *ServerConfig) GetDefaultProjectImage() string {
+	if o == nil || IsNil(o.DefaultProjectImage) {
+		var ret string
+		return ret
+	}
+	return *o.DefaultProjectImage
+}
+
+// GetDefaultProjectImageOk returns a tuple with the DefaultProjectImage field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetDefaultProjectImageOk() (*string, bool) {
+	if o == nil || IsNil(o.DefaultProjectImage) {
+		return nil, false
+	}
+	return o.DefaultProjectImage, true
+}
+
+// HasDefaultProjectImage returns a boolean if a field has been set.
+func (o *ServerConfig) HasDefaultProjectImage() bool {
+	if o != nil && !IsNil(o.DefaultProjectImage) {
+		return true
+	}
+
+	return false
+}
+
+// SetDefaultProjectImage gets a reference to the given string and assigns it to the DefaultProjectImage field.
+func (o *ServerConfig) SetDefaultProjectImage(v string) {
+	o.DefaultProjectImage = &v
 }
 
 // GetFrps returns the Frps field value if set, zero value otherwise.
@@ -350,6 +383,9 @@ func (o ServerConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.BinariesPath) {
 		toSerialize["binariesPath"] = o.BinariesPath
+	}
+	if !IsNil(o.DefaultProjectImage) {
+		toSerialize["defaultProjectImage"] = o.DefaultProjectImage
 	}
 	if !IsNil(o.Frps) {
 		toSerialize["frps"] = o.Frps

--- a/pkg/views/server/configure.go
+++ b/pkg/views/server/configure.go
@@ -36,6 +36,9 @@ func ConfigurationForm(config *serverapiclient.ServerConfig) *serverapiclient.Se
 			huh.NewInput().
 				Title("Server Download URL").
 				Value(config.ServerDownloadUrl),
+			huh.NewInput().
+				Title("Default Project Image").
+				Value(config.DefaultProjectImage),
 		),
 	)
 


### PR DESCRIPTION
# Default Project Image

## Description

Add `defaultProjectImage` as a server config property. Currently, it is part of the Docker provider as well. That will need to be removed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #388 