### PR TITLE
feat: agent host mode

### DIFF
--- a/internal/testing/agent/mocks/gitservice.go
+++ b/internal/testing/agent/mocks/gitservice.go
@@ -41,3 +41,8 @@ func NewMockGitService(repositoryShouldExist bool, project *workspace.Project) *
 
 	return gitService
 }
+
+func NewHostModeMockGitService() *mockGitService {
+	gitService := new(mockGitService)
+	return gitService
+}

--- a/internal/testing/agent/mocks/tailscaleserver.go
+++ b/internal/testing/agent/mocks/tailscaleserver.go
@@ -5,13 +5,19 @@
 
 package mocks
 
-import "github.com/stretchr/testify/mock"
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
 
 type mockTailscaleServer struct {
 	mock.Mock
 }
 
 func (m *mockTailscaleServer) Start() error {
+	// Give time to start the server goroutines
+	time.Sleep(1 * time.Second)
 	args := m.Called()
 	return args.Error(0)
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -45,6 +45,7 @@ var mockConfig = &config.Config{
 		Url:    "http://localhost:3000",
 		ApiKey: "test-api-key",
 	},
+	Mode: config.ModeProject,
 }
 
 func TestAgent(t *testing.T) {
@@ -74,6 +75,36 @@ func TestAgent(t *testing.T) {
 	}
 
 	t.Run("Start agent", func(t *testing.T) {
+		err := a.Start()
+
+		require.Nil(t, err)
+	})
+
+	t.Cleanup(func() {
+		mockGitService.AssertExpectations(t)
+		mockSshServer.AssertExpectations(t)
+		mockTailscaleServer.AssertExpectations(t)
+	})
+}
+
+func TestAgentHostMode(t *testing.T) {
+	mockGitService := mocks.NewHostModeMockGitService()
+	mockSshServer := mocks.NewMockSshServer()
+	mockTailscaleServer := mocks.NewMockTailscaleServer()
+
+	mockConfig := *mockConfig
+	mockConfig.Mode = config.ModeHost
+
+	// Create a new Agent instance
+	a := &agent.Agent{
+		Config:    &mockConfig,
+		Git:       mockGitService,
+		Ssh:       mockSshServer,
+		Tailscale: mockTailscaleServer,
+	}
+
+	t.Run("Start agent in host mode", func(t *testing.T) {
+		mockConfig.Mode = config.ModeHost
 		err := a.Start()
 
 		require.Nil(t, err)

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 
 	"github.com/go-playground/validator/v10"
@@ -19,20 +20,33 @@ type DaytonaServerConfig struct {
 }
 
 type Config struct {
-	ProjectDir  string `envconfig:"DAYTONA_WS_DIR" validate:"required"`
-	ProjectName string `envconfig:"DAYTONA_WS_PROJECT_NAME" validate:"required"`
+	ProjectDir  string `envconfig:"DAYTONA_WS_DIR"`
+	ProjectName string `envconfig:"DAYTONA_WS_PROJECT_NAME"`
 	WorkspaceId string `envconfig:"DAYTONA_WS_ID" validate:"required"`
 	Server      DaytonaServerConfig
+	Mode        Mode
 }
+
+type Mode string
+
+const (
+	ModeHost    Mode = "host"
+	ModeProject Mode = "project"
+)
 
 var config *Config
 
-func GetConfig() (*Config, error) {
+func GetConfig(mode Mode) (*Config, error) {
 	if config != nil {
+		if config.Mode != mode {
+			return nil, errors.New("config mode does not match requested mode")
+		}
 		return config, nil
 	}
 
-	config = &Config{}
+	config = &Config{
+		Mode: mode,
+	}
 
 	err := envconfig.Process("", config)
 	if err != nil {
@@ -44,6 +58,15 @@ func GetConfig() (*Config, error) {
 	err = validate.Struct(config)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.Mode == ModeProject {
+		if config.ProjectDir == "" {
+			return nil, errors.New("DAYTONA_WS_DIR is required in project mode")
+		}
+		if config.ProjectName == "" {
+			return nil, errors.New("DAYTONA_WS_PROJECT_NAME is required in project mode")
+		}
 	}
 
 	return config, nil

--- a/pkg/agent/tailscale/server.go
+++ b/pkg/agent/tailscale/server.go
@@ -20,15 +20,14 @@ import (
 )
 
 type Server struct {
-	WorkspaceId string
-	ProjectName string
-	ServerUrl   string
+	Hostname  string
+	ServerUrl string
 }
 
 func (s *Server) Start() error {
 	flag.Parse()
 	tsnetServer := new(tsnet.Server)
-	tsnetServer.Hostname = fmt.Sprintf("%s-%s", s.WorkspaceId, s.ProjectName)
+	tsnetServer.Hostname = s.Hostname
 	tsnetServer.ControlURL = s.ServerUrl
 	tsnetServer.Ephemeral = true
 


### PR DESCRIPTION
# Agent Host Mode

## Description

This PR adds support for agent host mode. Running the agent in host mode will skip project initialization (git config, repo clone, etc.)

The agent is run in host mode with the `--host` flag.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #385.