### PR TITLE
fix: workspace start stop message to user

### DIFF
--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -55,7 +55,7 @@ var StartCmd = &cobra.Command{
 			if workspace == nil {
 				return
 			}
-			workspaceId = *workspace.Id
+			workspaceId = *workspace.Name
 		} else {
 			workspaceId = args[0]
 		}

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -52,7 +52,7 @@ var StopCmd = &cobra.Command{
 			if workspace == nil {
 				return
 			}
-			workspaceId = *workspace.Id
+			workspaceId = *workspace.Name
 		} else {
 			workspaceId = args[0]
 		}


### PR DESCRIPTION
# Workspace start stop message to user

## Description

Noticed that using the TUI to select a workspace for starting/stopping (`daytona start`, `daytona stop`) still displays the workspace ID instead of the workspace name in message on success.

First command shows the issue, second and third command show it working correctly when passing argument:
![image](https://github.com/daytonaio/daytona/assets/25279767/2edafd6c-009c-4b17-9772-682b39f93732)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
