### PR TITLE
fix: adding profile when config does not exist

### DIFF
--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -38,12 +38,14 @@ type Ide struct {
 	Name string
 }
 
+const DefaultIdeId = "vscode"
+
 type GitProvider struct {
 	Id   string
 	Name string
 }
 
-const configDoesntExistError = "config does not exist. Run `daytona server` to create a default profile"
+const configDoesntExistError = "config does not exist. Run `daytona server` to create a default profile or `daytona profile add` to connect to a remote server."
 
 func IsNotExist(err error) bool {
 	return err.Error() == configDoesntExistError

--- a/pkg/cmd/profile/add.go
+++ b/pkg/cmd/profile/add.go
@@ -20,7 +20,18 @@ var profileAddCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			if !config.IsNotExist(err) {
+				log.Fatal(err)
+			}
+
+			c = &config.Config{
+				DefaultIdeId: config.DefaultIdeId,
+				Profiles:     []config.Profile{},
+			}
+
+			if err := c.Save(); err != nil {
+				log.Fatal(err)
+			}
 		}
 
 		profileAddView := profile.ProfileAddView{

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -252,9 +252,25 @@ func setDefaultConfig(server *server.Server) error {
 		return err
 	}
 
+	if existingConfig != nil {
+		err := existingConfig.AddProfile(config.Profile{
+			Id:   "default",
+			Name: "default",
+			Api: config.ServerApi{
+				Url: "http://localhost:3000",
+				Key: apiKey,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		return existingConfig.Save()
+	}
+
 	config := &config.Config{
 		ActiveProfileId: "default",
-		DefaultIdeId:    "vscode",
+		DefaultIdeId:    config.DefaultIdeId,
 		Profiles: []config.Profile{
 			{
 				Id:   "default",


### PR DESCRIPTION
# Allow User to Add Profile When Config Does Not Exist

## Description

This PR fixes an issue where the user was unable to add a new profile before running `daytona server` for the first time.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #398 