### PR TITLE
feat: add warning when revoking api keys

### DIFF
--- a/internal/apikeys/functions.go
+++ b/internal/apikeys/functions.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package apikeys
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
+
+func HashKey(key string) string {
+	keyHash := sha256.Sum256([]byte(key))
+	return string(keyHash[:])
+}
+
+func GenerateRandomKey() string {
+	uuid := uuid.NewString()
+	return base64.RawStdEncoding.EncodeToString([]byte(uuid))
+}
+
+// Helper function that compares a key with a hash gotten from the API
+func EqualsKeyHashFromApi(key string, keyHashFromApi string) bool {
+	var keyHash string
+	// We need to marshal then unmarshal the key to mimic the behavior of the API
+	// Without this, the hash will be different on a byte level
+	jsonString, err := json.Marshal(HashKey(key))
+	if err != nil {
+		return false
+	}
+
+	err = json.Unmarshal(jsonString, &keyHash)
+	if err != nil {
+		return false
+	}
+
+	return keyHash == keyHashFromApi
+}

--- a/pkg/cmd/server/apikey/revoke.go
+++ b/pkg/cmd/server/apikey/revoke.go
@@ -5,15 +5,23 @@ package apikey
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/charmbracelet/huh"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/apikeys"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
+	"github.com/daytonaio/daytona/pkg/serverapiclient"
+	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/server/apikey"
 	"github.com/daytonaio/daytona/pkg/views/util"
 )
+
+var yesFlag bool
 
 var revokeCmd = &cobra.Command{
 	Use:     "revoke [NAME]",
@@ -22,32 +30,80 @@ var revokeCmd = &cobra.Command{
 	Args:    cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		var keyName string
+
+		c, err := config.GetConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		activeProfile, err := c.GetActiveProfile()
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		apiClient, err := server.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if len(args) == 1 {
-			keyName = args[0]
-		} else {
-			apiKeyList, _, err := apiClient.ApiKeyAPI.ListClientApiKeys(ctx).Execute()
-			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(nil, err))
-			}
+		var selectedApiKey *serverapiclient.ApiKey
 
-			keyName = apikey.GetApiKeyNameFromPrompt(apiKeyList, "Select an API key to revoke")
-			if keyName == "" {
-				log.Fatal("No API key selected")
-			}
-		}
-
-		_, err = apiClient.ApiKeyAPI.RevokeApiKey(ctx, keyName).Execute()
+		apiKeyList, _, err := apiClient.ApiKeyAPI.ListClientApiKeys(ctx).Execute()
 		if err != nil {
 			log.Fatal(apiclient.HandleErrorResponse(nil, err))
 		}
 
-		util.RenderInfoMessage("API key revoked")
+		if len(args) == 1 {
+			for _, apiKey := range apiKeyList {
+				if *apiKey.Name == args[0] {
+					selectedApiKey = &apiKey
+					break
+				}
+			}
+		} else {
+			selectedApiKey = apikey.GetApiKeyFromPrompt(apiKeyList, "Select an API key to revoke")
+		}
+
+		if selectedApiKey == nil {
+			log.Fatal("No API key selected")
+		}
+
+		if !yesFlag {
+			title := fmt.Sprintf("Revoke API Key '%s'?", *selectedApiKey.Name)
+			description := fmt.Sprintf("Are you sure you want to revoke '%s'?", *selectedApiKey.Name)
+			if apikeys.EqualsKeyHashFromApi(activeProfile.Api.Key, *selectedApiKey.KeyHash) {
+				title = fmt.Sprintf("Warning! API Key '%s' is attached to your active profile", *selectedApiKey.Name)
+				description = fmt.Sprintf("Revoking '%s' will lock out your active profile from accessing the server.", *selectedApiKey.Name)
+			}
+
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title(title).
+						Description(description).
+						Value(&yesFlag),
+				),
+			).WithTheme(views.GetCustomTheme())
+
+			err := form.Run()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		if yesFlag {
+			_, err = apiClient.ApiKeyAPI.RevokeApiKey(ctx, *selectedApiKey.Name).Execute()
+			if err != nil {
+				log.Fatal(apiclient.HandleErrorResponse(nil, err))
+			}
+
+			util.RenderInfoMessage("API key revoked")
+		} else {
+			fmt.Println("Operation canceled.")
+		}
 	},
+}
+
+func init() {
+	revokeCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Skip confirmation prompt")
 }

--- a/pkg/server/apikeys/apikeys.go
+++ b/pkg/server/apikeys/apikeys.go
@@ -4,11 +4,8 @@
 package apikeys
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
-
+	"github.com/daytonaio/daytona/internal/apikeys"
 	"github.com/daytonaio/daytona/pkg/apikey"
-	"github.com/google/uuid"
 )
 
 func (s *ApiKeyService) ListClientKeys() ([]*apikey.ApiKey, error) {
@@ -38,10 +35,10 @@ func (s *ApiKeyService) Revoke(name string) error {
 }
 
 func (s *ApiKeyService) Generate(keyType apikey.ApiKeyType, name string) (string, error) {
-	key := generateRandomKey()
+	key := apikeys.GenerateRandomKey()
 
 	apiKey := &apikey.ApiKey{
-		KeyHash: hashKey(key),
+		KeyHash: apikeys.HashKey(key),
 		Type:    keyType,
 		Name:    name,
 	}
@@ -52,14 +49,4 @@ func (s *ApiKeyService) Generate(keyType apikey.ApiKeyType, name string) (string
 	}
 
 	return key, nil
-}
-
-func hashKey(key string) string {
-	keyHash := sha256.Sum256([]byte(key))
-	return string(keyHash[:])
-}
-
-func generateRandomKey() string {
-	uuid := uuid.NewString()
-	return base64.RawStdEncoding.EncodeToString([]byte(uuid))
 }

--- a/pkg/server/apikeys/validate.go
+++ b/pkg/server/apikeys/validate.go
@@ -3,17 +3,20 @@
 
 package apikeys
 
-import "github.com/daytonaio/daytona/pkg/apikey"
+import (
+	"github.com/daytonaio/daytona/internal/apikeys"
+	"github.com/daytonaio/daytona/pkg/apikey"
+)
 
 func (s *ApiKeyService) IsValidApiKey(apiKey string) bool {
-	keyHash := hashKey(apiKey)
+	keyHash := apikeys.HashKey(apiKey)
 
 	_, err := s.apiKeyStore.Find(keyHash)
 	return err == nil
 }
 
 func (s *ApiKeyService) IsProjectApiKey(apiKey string) bool {
-	keyHash := hashKey(apiKey)
+	keyHash := apikeys.HashKey(apiKey)
 
 	key, err := s.apiKeyStore.Find(keyHash)
 	if err != nil {


### PR DESCRIPTION
# Add Warning When Revoking API Keys

## Description

This PR adds a confirmation prompt when revoking API keys. Additionally, if the key being revoked is attached to the users active profile, the user will receive a warning message as shown in the screenshot below.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #399 

## Screenshots
![Screenshot 2024-04-18 at 14 33 36](https://github.com/daytonaio/daytona/assets/26512078/59d218d1-6a39-488c-98af-7a9a51ebc874)
