### PR TITLE
fix: shorter tailscale hostnames

### DIFF
--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -6,7 +6,6 @@
 package agent
 
 import (
-	"fmt"
 	"os"
 	"path"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/agent/git"
 	"github.com/daytonaio/daytona/pkg/agent/ssh"
 	"github.com/daytonaio/daytona/pkg/agent/tailscale"
+	"github.com/daytonaio/daytona/pkg/workspace"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -47,7 +47,7 @@ var AgentCmd = &cobra.Command{
 			DefaultProjectDir: os.Getenv("HOME"),
 		}
 
-		tailscaleHostname := fmt.Sprintf("%s-%s", config.WorkspaceId, config.ProjectName)
+		tailscaleHostname := workspace.GetProjectHostname(config.WorkspaceId, config.ProjectName)
 		if hostModeFlag {
 			tailscaleHostname = config.WorkspaceId
 		}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -25,6 +25,7 @@ import (
 	view_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/info"
 	status "github.com/daytonaio/daytona/pkg/views/workspace/status"
+	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/google/uuid"
 	"tailscale.com/tsnet"
 
@@ -323,7 +324,7 @@ func waitForDial(tsConn *tsnet.Server, workspaceId string, projectName string, d
 			cleanUpTerminal(statusProgram, errors.New("timeout: dialing timed out after 3 minutes"))
 		}
 
-		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s-%s:2222", workspaceId, projectName))
+		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:2222", workspace.GetProjectHostname(workspaceId, projectName)))
 		if err == nil {
 			defer dialConn.Close()
 			break

--- a/pkg/cmd/workspace/ssh-proxy.go
+++ b/pkg/cmd/workspace/ssh-proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/tailscale"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
+	"github.com/daytonaio/daytona/pkg/workspace"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,7 +53,7 @@ var SshProxyCmd = &cobra.Command{
 
 		errChan := make(chan error)
 
-		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s-%s:2222", workspaceId, projectName))
+		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:2222", workspace.GetProjectHostname(workspaceId, projectName)))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/ports/ports.go
+++ b/pkg/ports/ports.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/daytonaio/daytona/internal/tailscale"
+	"github.com/daytonaio/daytona/pkg/workspace"
 	log "github.com/sirupsen/logrus"
 	"tailscale.com/tsnet"
 )
@@ -88,7 +89,7 @@ func ForwardPort(workspaceId, projectName string, targetPort uint16) (*uint16, c
 				return
 			}
 
-			targetUrl := fmt.Sprintf("%s-%s:%d", workspaceId, projectName, targetPort)
+			targetUrl := fmt.Sprintf("%s:%d", workspace.GetProjectHostname(workspaceId, projectName), targetPort)
 
 			go handlePortConnection(conn, tsConn, targetUrl, errChan)
 		}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -4,7 +4,10 @@
 package workspace
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"hash/fnv"
 
 	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/gitprovider"
@@ -68,4 +71,11 @@ func GetProjectEnvVars(project *Project, apiUrl, serverUrl string) map[string]st
 	}
 
 	return envVars
+}
+
+func GetProjectHostname(workspaceId string, projectName string) string {
+	h := fnv.New64()
+	h.Write([]byte(fmt.Sprintf("%s-%s", workspaceId, projectName)))
+
+	return base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprint(h.Sum64())))
 }


### PR DESCRIPTION
# Shorter Tailscale Hostnames

## Description

Hostnames are now a 64-bit encoded string of workspaceId-projectName. This ensures that the hostname does not exceed the 63-character limit of the tailscale hostname

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #394.