### PR TITLE
fix: get agent api client from config

### DIFF
--- a/internal/testing/agent/mocks/apiserver.go
+++ b/internal/testing/agent/mocks/apiserver.go
@@ -8,6 +8,7 @@ package mocks
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/daytonaio/daytona/pkg/server"
@@ -15,7 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func NewMockRestServer(t *testing.T, workspace *workspace.Workspace) *http.Server {
+func NewMockRestServer(t *testing.T, workspace *workspace.Workspace) *httptest.Server {
 	router := gin.Default()
 	serverController := router.Group("/server")
 	{
@@ -51,10 +52,7 @@ func NewMockRestServer(t *testing.T, workspace *workspace.Workspace) *http.Serve
 		})
 	}
 
-	server := &http.Server{
-		Addr:    ":3000",
-		Handler: router,
-	}
+	server := httptest.NewServer(router)
 
 	return server
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -108,9 +108,16 @@ func (a *Agent) startProjectMode() error {
 }
 
 func (a *Agent) getProject() (*serverapiclient.Project, error) {
-	workspace, err := server.GetWorkspace(a.Config.WorkspaceId)
+	ctx := context.Background()
+
+	apiClient, err := server.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
 	if err != nil {
 		return nil, err
+	}
+
+	workspace, res, err := apiClient.WorkspaceAPI.GetWorkspace(ctx, a.Config.WorkspaceId).Execute()
+	if err != nil {
+		return nil, apiclient.HandleErrorResponse(res, err)
 	}
 
 	for _, project := range workspace.Projects {
@@ -125,7 +132,7 @@ func (a *Agent) getProject() (*serverapiclient.Project, error) {
 func (a *Agent) getGitProvider(repoUrl string) (*serverapiclient.GitProvider, error) {
 	ctx := context.Background()
 
-	apiClient, err := server.GetApiClient(nil)
+	apiClient, err := server.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +151,7 @@ func (a *Agent) getGitProvider(repoUrl string) (*serverapiclient.GitProvider, er
 }
 
 func (a *Agent) getGitUser(gitProviderId string) (*serverapiclient.GitUser, error) {
-	apiClient, err := server.GetApiClient(nil)
+	apiClient, err := server.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +202,7 @@ func (a *Agent) uptime() int32 {
 }
 
 func (a *Agent) updateProjectState() error {
-	apiClient, err := server.GetApiClient(nil)
+	apiClient, err := server.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -5,7 +5,6 @@ package agent_test
 
 import (
 	"bytes"
-	"net/http"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -42,7 +41,6 @@ var mockConfig = &config.Config{
 	WorkspaceId: workspace1.Id,
 	ProjectName: project1.Name,
 	Server: config.DaytonaServerConfig{
-		Url:    "http://localhost:3000",
 		ApiKey: "test-api-key",
 	},
 	Mode: config.ModeProject,
@@ -54,11 +52,8 @@ func TestAgent(t *testing.T) {
 
 	apiServer := mocks.NewMockRestServer(t, workspace1)
 	defer apiServer.Close()
-	go func() {
-		if err := apiServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("ListenAndServe(): %s", err)
-		}
-	}()
+
+	mockConfig.Server.ApiUrl = apiServer.URL
 
 	mockGitService := mocks.NewMockGitService(true, project1)
 	mockSshServer := mocks.NewMockSshServer()


### PR DESCRIPTION
# Get Agent API Client from Config

## Description

This PR fixes construction of the API client in the agent. The agent now passes its API URL and key to the helper method. Before this PR, the agent was not testable outside of the development environment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings