### PR TITLE
fix: daytona list panic

### DIFF
--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -191,6 +191,10 @@ func getWorkspaceTableRowData(workspace serverapiclient.WorkspaceDTO, specifyGit
 func getProjectTableRowData(workspaceDTO serverapiclient.WorkspaceDTO, project serverapiclient.Project, specifyGitProviders bool) RowData {
 	var currentProjectInfo *workspace.ProjectInfo
 
+	if workspaceDTO.Info == nil || workspaceDTO.Info.Projects == nil {
+		return RowData{}
+	}
+
 	for _, projectInfo := range workspaceDTO.Info.Projects {
 		if *projectInfo.Name == *project.Name {
 			currentProjectInfo = &workspace.ProjectInfo{


### PR DESCRIPTION
# Daytona list panic
## Description

When workspace projects' properties are malformed, `daytona list` panics due to a missing check for the "Info" and "Info.Projects" pointer checks. We should avoid panics in any case.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #X

## Screenshots
![image](https://github.com/daytonaio/daytona/assets/25279767/3c26842c-c1c6-45e8-8f71-64d087dbc7cb)


## Notes
Please add any relevant notes if necessary.
