### PR TITLE
fix: required project name

### DIFF
--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1084,6 +1084,9 @@ const docTemplate = `{
         },
         "CreateWorkspaceRequest": {
             "type": "object",
+            "required": [
+                "projects"
+            ],
             "properties": {
                 "id": {
                     "type": "string"
@@ -1104,15 +1107,15 @@ const docTemplate = `{
         },
         "CreateWorkspaceRequestProject": {
             "type": "object",
+            "required": [
+                "name"
+            ],
             "properties": {
                 "envVars": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
-                },
-                "id": {
-                    "type": "string"
                 },
                 "image": {
                     "type": "string"

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1081,6 +1081,9 @@
         },
         "CreateWorkspaceRequest": {
             "type": "object",
+            "required": [
+                "projects"
+            ],
             "properties": {
                 "id": {
                     "type": "string"
@@ -1101,15 +1104,15 @@
         },
         "CreateWorkspaceRequestProject": {
             "type": "object",
+            "required": [
+                "name"
+            ],
             "properties": {
                 "envVars": {
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
                     }
-                },
-                "id": {
-                    "type": "string"
                 },
                 "image": {
                     "type": "string"

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -31,6 +31,8 @@ definitions:
         type: array
       target:
         type: string
+    required:
+    - projects
     type: object
   CreateWorkspaceRequestProject:
     properties:
@@ -38,8 +40,6 @@ definitions:
         additionalProperties:
           type: string
         type: object
-      id:
-        type: string
       image:
         type: string
       name:
@@ -48,6 +48,8 @@ definitions:
         $ref: '#/definitions/CreateWorkspaceRequestProjectSource'
       user:
         type: string
+    required:
+    - name
     type: object
   CreateWorkspaceRequestProjectSource:
     properties:

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/api/controllers/workspace"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	log "github.com/sirupsen/logrus"
 
 	swaggerfiles "github.com/swaggo/files"
@@ -68,6 +69,8 @@ func (a *ApiServer) Start() error {
 	docs.SwaggerInfo.BasePath = "/"
 	docs.SwaggerInfo.Description = "Daytona Server API"
 	docs.SwaggerInfo.Title = "Daytona Server API"
+
+	binding.Validator = new(defaultValidator)
 
 	if mode, ok := os.LookupEnv("DAYTONA_SERVER_MODE"); ok && mode == "development" {
 		a.router = gin.Default()

--- a/pkg/api/validator.go
+++ b/pkg/api/validator.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/gin-gonic/gin/binding"
+	"github.com/go-playground/validator/v10"
+)
+
+type defaultValidator struct {
+	once     sync.Once
+	validate *validator.Validate
+}
+
+var _ binding.StructValidator = &defaultValidator{}
+
+func (v *defaultValidator) ValidateStruct(obj interface{}) error {
+	if kindOfData(obj) == reflect.Struct {
+		v.lazyinit()
+
+		if err := v.validate.Struct(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *defaultValidator) Engine() interface{} {
+	v.lazyinit()
+	return v.validate
+}
+
+func (v *defaultValidator) lazyinit() {
+	v.once.Do(func() {
+		v.validate = validator.New(validator.WithRequiredStructEnabled())
+	})
+}
+
+func kindOfData(data interface{}) reflect.Kind {
+	value := reflect.ValueOf(data)
+	valueType := value.Kind()
+
+	if valueType == reflect.Ptr {
+		valueType = value.Elem().Kind()
+	}
+
+	return valueType
+}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -123,8 +123,7 @@ var CreateCmd = &cobra.Command{
 			projectNameSlugRegex := regexp.MustCompile(`[^a-zA-Z0-9-]`)
 			projectName := projectNameSlugRegex.ReplaceAllString(strings.TrimSuffix(strings.ToLower(filepath.Base(*repo.Url)), ".git"), "-")
 			projects = append(projects, serverapiclient.CreateWorkspaceRequestProject{
-				Id:   &projectName,
-				Name: &projectName,
+				Name: projectName,
 				Source: &serverapiclient.CreateWorkspaceRequestProjectSource{
 					Repository: &repo,
 				},

--- a/pkg/server/workspaces/dto/workspace.go
+++ b/pkg/server/workspaces/dto/workspace.go
@@ -23,8 +23,7 @@ type CreateWorkspaceRequestProjectSource struct {
 } // @name CreateWorkspaceRequestProjectSource
 
 type CreateWorkspaceRequestProject struct {
-	Id      string                              `json:"id"`
-	Name    string                              `json:"name"`
+	Name    string                              `json:"name" validate:"required,gt=0"`
 	Image   *string                             `json:"image,omitempty"`
 	User    *string                             `json:"user,omitempty"`
 	Source  CreateWorkspaceRequestProjectSource `json:"source"`
@@ -35,5 +34,5 @@ type CreateWorkspaceRequest struct {
 	Id       string                          `json:"id"`
 	Name     string                          `json:"name"`
 	Target   string                          `json:"target"`
-	Projects []CreateWorkspaceRequestProject `json:"projects"`
+	Projects []CreateWorkspaceRequestProject `json:"projects" validate:"required,gt=0,dive"`
 } //	@name	CreateWorkspaceRequest

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -53,7 +53,6 @@ var createWorkspaceRequest = dto.CreateWorkspaceRequest{
 	Target: target.Name,
 	Projects: []dto.CreateWorkspaceRequestProject{
 		{
-			Id:   "project1",
 			Name: "project1",
 			Source: dto.CreateWorkspaceRequestProjectSource{
 				Repository: &gitprovider.GitRepository{

--- a/pkg/serverapiclient/api/openapi.yaml
+++ b/pkg/serverapiclient/api/openapi.yaml
@@ -787,7 +787,6 @@ components:
           envVars:
             key: envVars
           name: name
-          id: id
           source:
             repository:
               owner: owner
@@ -804,7 +803,6 @@ components:
           envVars:
             key: envVars
           name: name
-          id: id
           source:
             repository:
               owner: owner
@@ -831,6 +829,8 @@ components:
           type: array
         target:
           type: string
+      required:
+      - projects
       type: object
     CreateWorkspaceRequestProject:
       example:
@@ -838,7 +838,6 @@ components:
         envVars:
           key: envVars
         name: name
-        id: id
         source:
           repository:
             owner: owner
@@ -856,8 +855,6 @@ components:
           additionalProperties:
             type: string
           type: object
-        id:
-          type: string
         image:
           type: string
         name:
@@ -866,6 +863,8 @@ components:
           $ref: '#/components/schemas/CreateWorkspaceRequestProjectSource'
         user:
           type: string
+      required:
+      - name
       type: object
     CreateWorkspaceRequestProjectSource:
       example:

--- a/pkg/serverapiclient/docs/CreateWorkspaceRequest.md
+++ b/pkg/serverapiclient/docs/CreateWorkspaceRequest.md
@@ -6,14 +6,14 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | Pointer to **string** |  | [optional] 
 **Name** | Pointer to **string** |  | [optional] 
-**Projects** | Pointer to [**[]CreateWorkspaceRequestProject**](CreateWorkspaceRequestProject.md) |  | [optional] 
+**Projects** | [**[]CreateWorkspaceRequestProject**](CreateWorkspaceRequestProject.md) |  | 
 **Target** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
 ### NewCreateWorkspaceRequest
 
-`func NewCreateWorkspaceRequest() *CreateWorkspaceRequest`
+`func NewCreateWorkspaceRequest(projects []CreateWorkspaceRequestProject, ) *CreateWorkspaceRequest`
 
 NewCreateWorkspaceRequest instantiates a new CreateWorkspaceRequest object
 This constructor will assign default values to properties that have it defined,
@@ -97,11 +97,6 @@ and a boolean to check if the value has been set.
 
 SetProjects sets Projects field to given value.
 
-### HasProjects
-
-`func (o *CreateWorkspaceRequest) HasProjects() bool`
-
-HasProjects returns a boolean if a field has been set.
 
 ### GetTarget
 

--- a/pkg/serverapiclient/docs/CreateWorkspaceRequestProject.md
+++ b/pkg/serverapiclient/docs/CreateWorkspaceRequestProject.md
@@ -5,9 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnvVars** | Pointer to **map[string]string** |  | [optional] 
-**Id** | Pointer to **string** |  | [optional] 
 **Image** | Pointer to **string** |  | [optional] 
-**Name** | Pointer to **string** |  | [optional] 
+**Name** | **string** |  | 
 **Source** | Pointer to [**CreateWorkspaceRequestProjectSource**](CreateWorkspaceRequestProjectSource.md) |  | [optional] 
 **User** | Pointer to **string** |  | [optional] 
 
@@ -15,7 +14,7 @@ Name | Type | Description | Notes
 
 ### NewCreateWorkspaceRequestProject
 
-`func NewCreateWorkspaceRequestProject() *CreateWorkspaceRequestProject`
+`func NewCreateWorkspaceRequestProject(name string, ) *CreateWorkspaceRequestProject`
 
 NewCreateWorkspaceRequestProject instantiates a new CreateWorkspaceRequestProject object
 This constructor will assign default values to properties that have it defined,
@@ -54,31 +53,6 @@ SetEnvVars sets EnvVars field to given value.
 `func (o *CreateWorkspaceRequestProject) HasEnvVars() bool`
 
 HasEnvVars returns a boolean if a field has been set.
-
-### GetId
-
-`func (o *CreateWorkspaceRequestProject) GetId() string`
-
-GetId returns the Id field if non-nil, zero value otherwise.
-
-### GetIdOk
-
-`func (o *CreateWorkspaceRequestProject) GetIdOk() (*string, bool)`
-
-GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetId
-
-`func (o *CreateWorkspaceRequestProject) SetId(v string)`
-
-SetId sets Id field to given value.
-
-### HasId
-
-`func (o *CreateWorkspaceRequestProject) HasId() bool`
-
-HasId returns a boolean if a field has been set.
 
 ### GetImage
 
@@ -124,11 +98,6 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
-### HasName
-
-`func (o *CreateWorkspaceRequestProject) HasName() bool`
-
-HasName returns a boolean if a field has been set.
 
 ### GetSource
 

--- a/pkg/serverapiclient/docs/WorkspaceAPI.md
+++ b/pkg/serverapiclient/docs/WorkspaceAPI.md
@@ -37,7 +37,7 @@ import (
 )
 
 func main() {
-	workspace := *openapiclient.NewCreateWorkspaceRequest() // CreateWorkspaceRequest | Create workspace
+	workspace := *openapiclient.NewCreateWorkspaceRequest([]openapiclient.CreateWorkspaceRequestProject{*openapiclient.NewCreateWorkspaceRequestProject("Name_example")}) // CreateWorkspaceRequest | Create workspace
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/serverapiclient/model_create_workspace_request.go
+++ b/pkg/serverapiclient/model_create_workspace_request.go
@@ -11,7 +11,9 @@ API version: 0.1.0
 package serverapiclient
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the CreateWorkspaceRequest type satisfies the MappedNullable interface at compile time
@@ -21,16 +23,19 @@ var _ MappedNullable = &CreateWorkspaceRequest{}
 type CreateWorkspaceRequest struct {
 	Id       *string                         `json:"id,omitempty"`
 	Name     *string                         `json:"name,omitempty"`
-	Projects []CreateWorkspaceRequestProject `json:"projects,omitempty"`
+	Projects []CreateWorkspaceRequestProject `json:"projects"`
 	Target   *string                         `json:"target,omitempty"`
 }
+
+type _CreateWorkspaceRequest CreateWorkspaceRequest
 
 // NewCreateWorkspaceRequest instantiates a new CreateWorkspaceRequest object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCreateWorkspaceRequest() *CreateWorkspaceRequest {
+func NewCreateWorkspaceRequest(projects []CreateWorkspaceRequestProject) *CreateWorkspaceRequest {
 	this := CreateWorkspaceRequest{}
+	this.Projects = projects
 	return &this
 }
 
@@ -106,34 +111,26 @@ func (o *CreateWorkspaceRequest) SetName(v string) {
 	o.Name = &v
 }
 
-// GetProjects returns the Projects field value if set, zero value otherwise.
+// GetProjects returns the Projects field value
 func (o *CreateWorkspaceRequest) GetProjects() []CreateWorkspaceRequestProject {
-	if o == nil || IsNil(o.Projects) {
+	if o == nil {
 		var ret []CreateWorkspaceRequestProject
 		return ret
 	}
+
 	return o.Projects
 }
 
-// GetProjectsOk returns a tuple with the Projects field value if set, nil otherwise
+// GetProjectsOk returns a tuple with the Projects field value
 // and a boolean to check if the value has been set.
 func (o *CreateWorkspaceRequest) GetProjectsOk() ([]CreateWorkspaceRequestProject, bool) {
-	if o == nil || IsNil(o.Projects) {
+	if o == nil {
 		return nil, false
 	}
 	return o.Projects, true
 }
 
-// HasProjects returns a boolean if a field has been set.
-func (o *CreateWorkspaceRequest) HasProjects() bool {
-	if o != nil && !IsNil(o.Projects) {
-		return true
-	}
-
-	return false
-}
-
-// SetProjects gets a reference to the given []CreateWorkspaceRequestProject and assigns it to the Projects field.
+// SetProjects sets field value
 func (o *CreateWorkspaceRequest) SetProjects(v []CreateWorkspaceRequestProject) {
 	o.Projects = v
 }
@@ -186,13 +183,48 @@ func (o CreateWorkspaceRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}
-	if !IsNil(o.Projects) {
-		toSerialize["projects"] = o.Projects
-	}
+	toSerialize["projects"] = o.Projects
 	if !IsNil(o.Target) {
 		toSerialize["target"] = o.Target
 	}
 	return toSerialize, nil
+}
+
+func (o *CreateWorkspaceRequest) UnmarshalJSON(data []byte) (err error) {
+	// This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"projects",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(data, &allProperties)
+
+	if err != nil {
+		return err
+	}
+
+	for _, requiredProperty := range requiredProperties {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varCreateWorkspaceRequest := _CreateWorkspaceRequest{}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varCreateWorkspaceRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateWorkspaceRequest(varCreateWorkspaceRequest)
+
+	return err
 }
 
 type NullableCreateWorkspaceRequest struct {

--- a/pkg/serverapiclient/model_create_workspace_request_project.go
+++ b/pkg/serverapiclient/model_create_workspace_request_project.go
@@ -11,7 +11,9 @@ API version: 0.1.0
 package serverapiclient
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the CreateWorkspaceRequestProject type satisfies the MappedNullable interface at compile time
@@ -20,19 +22,21 @@ var _ MappedNullable = &CreateWorkspaceRequestProject{}
 // CreateWorkspaceRequestProject struct for CreateWorkspaceRequestProject
 type CreateWorkspaceRequestProject struct {
 	EnvVars *map[string]string                   `json:"envVars,omitempty"`
-	Id      *string                              `json:"id,omitempty"`
 	Image   *string                              `json:"image,omitempty"`
-	Name    *string                              `json:"name,omitempty"`
+	Name    string                               `json:"name"`
 	Source  *CreateWorkspaceRequestProjectSource `json:"source,omitempty"`
 	User    *string                              `json:"user,omitempty"`
 }
+
+type _CreateWorkspaceRequestProject CreateWorkspaceRequestProject
 
 // NewCreateWorkspaceRequestProject instantiates a new CreateWorkspaceRequestProject object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCreateWorkspaceRequestProject() *CreateWorkspaceRequestProject {
+func NewCreateWorkspaceRequestProject(name string) *CreateWorkspaceRequestProject {
 	this := CreateWorkspaceRequestProject{}
+	this.Name = name
 	return &this
 }
 
@@ -76,38 +80,6 @@ func (o *CreateWorkspaceRequestProject) SetEnvVars(v map[string]string) {
 	o.EnvVars = &v
 }
 
-// GetId returns the Id field value if set, zero value otherwise.
-func (o *CreateWorkspaceRequestProject) GetId() string {
-	if o == nil || IsNil(o.Id) {
-		var ret string
-		return ret
-	}
-	return *o.Id
-}
-
-// GetIdOk returns a tuple with the Id field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *CreateWorkspaceRequestProject) GetIdOk() (*string, bool) {
-	if o == nil || IsNil(o.Id) {
-		return nil, false
-	}
-	return o.Id, true
-}
-
-// HasId returns a boolean if a field has been set.
-func (o *CreateWorkspaceRequestProject) HasId() bool {
-	if o != nil && !IsNil(o.Id) {
-		return true
-	}
-
-	return false
-}
-
-// SetId gets a reference to the given string and assigns it to the Id field.
-func (o *CreateWorkspaceRequestProject) SetId(v string) {
-	o.Id = &v
-}
-
 // GetImage returns the Image field value if set, zero value otherwise.
 func (o *CreateWorkspaceRequestProject) GetImage() string {
 	if o == nil || IsNil(o.Image) {
@@ -140,36 +112,28 @@ func (o *CreateWorkspaceRequestProject) SetImage(v string) {
 	o.Image = &v
 }
 
-// GetName returns the Name field value if set, zero value otherwise.
+// GetName returns the Name field value
 func (o *CreateWorkspaceRequestProject) GetName() string {
-	if o == nil || IsNil(o.Name) {
+	if o == nil {
 		var ret string
 		return ret
 	}
-	return *o.Name
+
+	return o.Name
 }
 
-// GetNameOk returns a tuple with the Name field value if set, nil otherwise
+// GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
 func (o *CreateWorkspaceRequestProject) GetNameOk() (*string, bool) {
-	if o == nil || IsNil(o.Name) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Name, true
+	return &o.Name, true
 }
 
-// HasName returns a boolean if a field has been set.
-func (o *CreateWorkspaceRequestProject) HasName() bool {
-	if o != nil && !IsNil(o.Name) {
-		return true
-	}
-
-	return false
-}
-
-// SetName gets a reference to the given string and assigns it to the Name field.
+// SetName sets field value
 func (o *CreateWorkspaceRequestProject) SetName(v string) {
-	o.Name = &v
+	o.Name = v
 }
 
 // GetSource returns the Source field value if set, zero value otherwise.
@@ -249,15 +213,10 @@ func (o CreateWorkspaceRequestProject) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.EnvVars) {
 		toSerialize["envVars"] = o.EnvVars
 	}
-	if !IsNil(o.Id) {
-		toSerialize["id"] = o.Id
-	}
 	if !IsNil(o.Image) {
 		toSerialize["image"] = o.Image
 	}
-	if !IsNil(o.Name) {
-		toSerialize["name"] = o.Name
-	}
+	toSerialize["name"] = o.Name
 	if !IsNil(o.Source) {
 		toSerialize["source"] = o.Source
 	}
@@ -265,6 +224,43 @@ func (o CreateWorkspaceRequestProject) ToMap() (map[string]interface{}, error) {
 		toSerialize["user"] = o.User
 	}
 	return toSerialize, nil
+}
+
+func (o *CreateWorkspaceRequestProject) UnmarshalJSON(data []byte) (err error) {
+	// This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(data, &allProperties)
+
+	if err != nil {
+		return err
+	}
+
+	for _, requiredProperty := range requiredProperties {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varCreateWorkspaceRequestProject := _CreateWorkspaceRequestProject{}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varCreateWorkspaceRequestProject)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateWorkspaceRequestProject(varCreateWorkspaceRequestProject)
+
+	return err
 }
 
 type NullableCreateWorkspaceRequestProject struct {


### PR DESCRIPTION
# Make project name required in backend
## Description

Makes project name required and non-empty when creating a workspace.
This is done by implementing an api level validator which will be used in the future

After consideration, ID is unnecessary as a part of the project request DTO so it has been removed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
