### PR TITLE
feat: project post start commands

### DIFF
--- a/internal/util/apiclient/server/conversion/project.go
+++ b/internal/util/apiclient/server/conversion/project.go
@@ -10,11 +10,12 @@ import (
 
 func ToProjectDTO(project *workspace.Project) *serverapiclient.Project {
 	projectDto := &serverapiclient.Project{
-		Name:        &project.Name,
-		Target:      &project.Target,
-		WorkspaceId: &project.WorkspaceId,
-		Image:       &project.Image,
-		User:        &project.User,
+		Name:              &project.Name,
+		Target:            &project.Target,
+		WorkspaceId:       &project.WorkspaceId,
+		Image:             &project.Image,
+		User:              &project.User,
+		PostStartCommands: project.PostStartCommands,
 		Repository: &serverapiclient.GitRepository{
 			Id:     &project.Repository.Id,
 			Name:   &project.Repository.Name,

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -24,8 +24,9 @@ var project1 = &workspace.Project{
 		Url:  "https://github.com/daytonaio/daytona",
 		Name: "daytona",
 	},
-	WorkspaceId: "123",
-	Target:      "local",
+	WorkspaceId:       "123",
+	Target:            "local",
+	PostStartCommands: []string{"echo 'test' > test.txt"},
 }
 
 var workspace1 = &workspace.Workspace{
@@ -73,6 +74,9 @@ func TestAgent(t *testing.T) {
 		err := a.Start()
 
 		require.Nil(t, err)
+
+		// Check post start command result
+		require.FileExists(t, mockConfig.ProjectDir+"/test.txt")
 	})
 
 	t.Cleanup(func() {

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1123,6 +1123,12 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "postStartCommands": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "source": {
                     "$ref": "#/definitions/CreateWorkspaceRequestProjectSource"
                 },
@@ -1283,6 +1289,12 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "postStartCommands": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "repository": {
                     "$ref": "#/definitions/GitRepository"
                 },
@@ -1374,6 +1386,12 @@ const docTemplate = `{
                 },
                 "defaultProjectImage": {
                     "type": "string"
+                },
+                "defaultProjectPostStartCommands": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "defaultProjectUser": {
                     "type": "string"

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1120,6 +1120,12 @@
                 "name": {
                     "type": "string"
                 },
+                "postStartCommands": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "source": {
                     "$ref": "#/definitions/CreateWorkspaceRequestProjectSource"
                 },
@@ -1280,6 +1286,12 @@
                 "name": {
                     "type": "string"
                 },
+                "postStartCommands": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "repository": {
                     "$ref": "#/definitions/GitRepository"
                 },
@@ -1371,6 +1383,12 @@
                 },
                 "defaultProjectImage": {
                     "type": "string"
+                },
+                "defaultProjectPostStartCommands": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "defaultProjectUser": {
                     "type": "string"

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -44,6 +44,10 @@ definitions:
         type: string
       name:
         type: string
+      postStartCommands:
+        items:
+          type: string
+        type: array
       source:
         $ref: '#/definitions/CreateWorkspaceRequestProjectSource'
       user:
@@ -149,6 +153,10 @@ definitions:
         type: string
       name:
         type: string
+      postStartCommands:
+        items:
+          type: string
+        type: array
       repository:
         $ref: '#/definitions/GitRepository'
       state:
@@ -209,6 +217,10 @@ definitions:
         type: string
       defaultProjectImage:
         type: string
+      defaultProjectPostStartCommands:
+        items:
+          type: string
+        type: array
       defaultProjectUser:
         type: string
       frps:

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -135,15 +135,16 @@ var ServerCmd = &cobra.Command{
 		})
 
 		workspaceService := workspaces.NewWorkspaceService(workspaces.WorkspaceServiceConfig{
-			WorkspaceStore:         workspaceStore,
-			TargetStore:            providerTargetStore,
-			ApiKeyService:          apiKeyService,
-			ContainerRegistryStore: containerRegistryStore,
-			ServerApiUrl:           util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
-			ServerUrl:              util.GetFrpcServerUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
-			DefaultProjectImage:    c.DefaultProjectImage,
-			DefaultProjectUser:     c.DefaultProjectUser,
-			Provisioner:            provisioner,
+			WorkspaceStore:                  workspaceStore,
+			TargetStore:                     providerTargetStore,
+			ApiKeyService:                   apiKeyService,
+			ContainerRegistryStore:          containerRegistryStore,
+			ServerApiUrl:                    util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
+			ServerUrl:                       util.GetFrpcServerUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
+			DefaultProjectImage:             c.DefaultProjectImage,
+			DefaultProjectUser:              c.DefaultProjectUser,
+			DefaultProjectPostStartCommands: c.DefaultProjectPostStartCommands,
+			Provisioner:                     provisioner,
 			NewWorkspaceLogger: func(workspaceId string) logger.Logger {
 				return logger.NewWorkspaceLogger(logsDir, workspaceId)
 			},

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -39,7 +39,7 @@ func GetCreationDataFromPrompt(workspaceNames []string, userGitProviders []serve
 		return "", nil, err
 	}
 
-	if workspaceCreationPromptResponse.PrimaryProject == (serverapiclient.CreateWorkspaceRequestProject{}) {
+	if workspaceCreationPromptResponse.PrimaryProject.Source == nil {
 		return "", nil, errors.New("primary project is required")
 	}
 

--- a/pkg/db/dto/project.go
+++ b/pkg/db/dto/project.go
@@ -24,20 +24,22 @@ type ProjectStateDTO struct {
 }
 
 type ProjectDTO struct {
-	Name        string           `json:"name"`
-	Repository  RepositoryDTO    `json:"repository"`
-	WorkspaceId string           `json:"workspaceId"`
-	Target      string           `json:"target"`
-	State       *ProjectStateDTO `json:"state,omitempty" gorm:"serializer:json"`
+	Name              string           `json:"name"`
+	Repository        RepositoryDTO    `json:"repository"`
+	WorkspaceId       string           `json:"workspaceId"`
+	Target            string           `json:"target"`
+	State             *ProjectStateDTO `json:"state,omitempty" gorm:"serializer:json"`
+	PostStartCommands []string         `json:"postStartCommands,omitempty"`
 }
 
 func ToProjectDTO(project *workspace.Project, workspace *workspace.Workspace) ProjectDTO {
 	return ProjectDTO{
-		Name:        project.Name,
-		Repository:  ToRepositoryDTO(project.Repository),
-		WorkspaceId: project.WorkspaceId,
-		Target:      project.Target,
-		State:       ToProjectStateDTO(project.State),
+		Name:              project.Name,
+		Repository:        ToRepositoryDTO(project.Repository),
+		WorkspaceId:       project.WorkspaceId,
+		Target:            project.Target,
+		State:             ToProjectStateDTO(project.State),
+		PostStartCommands: project.PostStartCommands,
 	}
 }
 
@@ -75,11 +77,12 @@ func ToProjectStateDTO(state *workspace.ProjectState) *ProjectStateDTO {
 
 func ToProject(projectDTO ProjectDTO) *workspace.Project {
 	return &workspace.Project{
-		Name:        projectDTO.Name,
-		Repository:  ToRepository(projectDTO.Repository),
-		WorkspaceId: projectDTO.WorkspaceId,
-		Target:      projectDTO.Target,
-		State:       ToProjectState(projectDTO.State),
+		Name:              projectDTO.Name,
+		Repository:        ToRepository(projectDTO.Repository),
+		WorkspaceId:       projectDTO.WorkspaceId,
+		Target:            projectDTO.Target,
+		State:             ToProjectState(projectDTO.State),
+		PostStartCommands: projectDTO.PostStartCommands,
 	}
 }
 

--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -21,6 +21,9 @@ const defaultServerDownloadUrl = "https://download.daytona.io/daytona/install.sh
 const defaultHeadscalePort = 3001
 const defaultApiPort = 3000
 const defaultProjectImage = "daytonaio/workspace-project:latest"
+const defaultProjectUser = "daytona"
+
+var defaultProjectPostStartCommands = []string{"sudo dockerd"}
 
 var us_defaultFrpsConfig = FRPSConfig{
 	Domain:   "try-us.daytona.app",
@@ -94,16 +97,18 @@ func getDefaultConfig() (*Config, error) {
 	}
 
 	c := Config{
-		Id:                  generateUuid(),
-		RegistryUrl:         defaultRegistryUrl,
-		ProvidersDir:        providersDir,
-		ServerDownloadUrl:   defaultServerDownloadUrl,
-		ApiPort:             defaultApiPort,
-		HeadscalePort:       defaultHeadscalePort,
-		BinariesPath:        binariesPath,
-		Frps:                getDefaultFRPSConfig(),
-		LogFilePath:         logFilePath,
-		DefaultProjectImage: defaultProjectImage,
+		Id:                              generateUuid(),
+		RegistryUrl:                     defaultRegistryUrl,
+		ProvidersDir:                    providersDir,
+		ServerDownloadUrl:               defaultServerDownloadUrl,
+		ApiPort:                         defaultApiPort,
+		HeadscalePort:                   defaultHeadscalePort,
+		BinariesPath:                    binariesPath,
+		Frps:                            getDefaultFRPSConfig(),
+		LogFilePath:                     logFilePath,
+		DefaultProjectImage:             defaultProjectImage,
+		DefaultProjectUser:              defaultProjectUser,
+		DefaultProjectPostStartCommands: defaultProjectPostStartCommands,
 	}
 
 	if os.Getenv("DEFAULT_REGISTRY_URL") != "" {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -26,15 +26,16 @@ type NetworkKey struct {
 } // @name NetworkKey
 
 type Config struct {
-	ProvidersDir        string      `json:"providersDir"`
-	RegistryUrl         string      `json:"registryUrl"`
-	Id                  string      `json:"id"`
-	ServerDownloadUrl   string      `json:"serverDownloadUrl"`
-	Frps                *FRPSConfig `json:"frps,omitempty"`
-	ApiPort             uint32      `json:"apiPort"`
-	HeadscalePort       uint32      `json:"headscalePort"`
-	BinariesPath        string      `json:"binariesPath"`
-	LogFilePath         string      `json:"logFilePath"`
-	DefaultProjectImage string      `json:"defaultProjectImage"`
-	DefaultProjectUser  string      `json:"defaultProjectUser"`
+	ProvidersDir                    string      `json:"providersDir"`
+	RegistryUrl                     string      `json:"registryUrl"`
+	Id                              string      `json:"id"`
+	ServerDownloadUrl               string      `json:"serverDownloadUrl"`
+	Frps                            *FRPSConfig `json:"frps,omitempty"`
+	ApiPort                         uint32      `json:"apiPort"`
+	HeadscalePort                   uint32      `json:"headscalePort"`
+	BinariesPath                    string      `json:"binariesPath"`
+	LogFilePath                     string      `json:"logFilePath"`
+	DefaultProjectImage             string      `json:"defaultProjectImage"`
+	DefaultProjectUser              string      `json:"defaultProjectUser"`
+	DefaultProjectPostStartCommands []string    `json:"defaultProjectPostStartCommands"`
 } // @name ServerConfig

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -49,15 +49,21 @@ func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*wor
 			projectUser = *project.User
 		}
 
+		postStartCommands := s.defaultProjectPostStartCommands
+		if project.PostStartCommands != nil {
+			postStartCommands = *project.PostStartCommands
+		}
+
 		project := &workspace.Project{
-			Name:        project.Name,
-			Image:       projectImage,
-			User:        projectUser,
-			Repository:  project.Source.Repository,
-			WorkspaceId: w.Id,
-			ApiKey:      apiKey,
-			Target:      w.Target,
-			EnvVars:     project.EnvVars,
+			Name:              project.Name,
+			Image:             projectImage,
+			User:              projectUser,
+			PostStartCommands: postStartCommands,
+			Repository:        project.Source.Repository,
+			WorkspaceId:       w.Id,
+			ApiKey:            apiKey,
+			Target:            w.Target,
+			EnvVars:           project.EnvVars,
 		}
 		w.Projects = append(w.Projects, project)
 	}

--- a/pkg/server/workspaces/dto/workspace.go
+++ b/pkg/server/workspaces/dto/workspace.go
@@ -23,11 +23,12 @@ type CreateWorkspaceRequestProjectSource struct {
 } // @name CreateWorkspaceRequestProjectSource
 
 type CreateWorkspaceRequestProject struct {
-	Name    string                              `json:"name" validate:"required,gt=0"`
-	Image   *string                             `json:"image,omitempty"`
-	User    *string                             `json:"user,omitempty"`
-	Source  CreateWorkspaceRequestProjectSource `json:"source"`
-	EnvVars map[string]string                   `json:"envVars"`
+	Name              string                              `json:"name" validate:"required,gt=0"`
+	Image             *string                             `json:"image,omitempty"`
+	User              *string                             `json:"user,omitempty"`
+	Source            CreateWorkspaceRequestProjectSource `json:"source"`
+	EnvVars           map[string]string                   `json:"envVars"`
+	PostStartCommands *[]string                           `json:"postStartCommands,omitempty"`
 } // @name CreateWorkspaceRequestProject
 
 type CreateWorkspaceRequest struct {

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -34,50 +34,53 @@ type targetStore interface {
 }
 
 type WorkspaceServiceConfig struct {
-	WorkspaceStore         workspace.Store
-	TargetStore            targetStore
-	ContainerRegistryStore containerregistry.Store
-	ServerApiUrl           string
-	ServerUrl              string
-	Provisioner            provisioner.IProvisioner
-	DefaultProjectImage    string
-	DefaultProjectUser     string
-	ApiKeyService          apikeys.IApiKeyService
-	NewWorkspaceLogger     func(workspaceId string) logger.Logger
-	NewProjectLogger       func(workspaceId, projectName string) logger.Logger
-	NewWorkspaceLogReader  func(workspaceId string) (io.Reader, error)
+	WorkspaceStore                  workspace.Store
+	TargetStore                     targetStore
+	ContainerRegistryStore          containerregistry.Store
+	ServerApiUrl                    string
+	ServerUrl                       string
+	Provisioner                     provisioner.IProvisioner
+	DefaultProjectImage             string
+	DefaultProjectUser              string
+	DefaultProjectPostStartCommands []string
+	ApiKeyService                   apikeys.IApiKeyService
+	NewWorkspaceLogger              func(workspaceId string) logger.Logger
+	NewProjectLogger                func(workspaceId, projectName string) logger.Logger
+	NewWorkspaceLogReader           func(workspaceId string) (io.Reader, error)
 }
 
 func NewWorkspaceService(config WorkspaceServiceConfig) IWorkspaceService {
 	return &WorkspaceService{
-		workspaceStore:         config.WorkspaceStore,
-		targetStore:            config.TargetStore,
-		containerRegistryStore: config.ContainerRegistryStore,
-		serverApiUrl:           config.ServerApiUrl,
-		serverUrl:              config.ServerUrl,
-		defaultProjectImage:    config.DefaultProjectImage,
-		defaultProjectUser:     config.DefaultProjectUser,
-		provisioner:            config.Provisioner,
-		newWorkspaceLogger:     config.NewWorkspaceLogger,
-		newProjectLogger:       config.NewProjectLogger,
-		apiKeyService:          config.ApiKeyService,
-		newWorkspaceLogReader:  config.NewWorkspaceLogReader,
+		workspaceStore:                  config.WorkspaceStore,
+		targetStore:                     config.TargetStore,
+		containerRegistryStore:          config.ContainerRegistryStore,
+		serverApiUrl:                    config.ServerApiUrl,
+		serverUrl:                       config.ServerUrl,
+		defaultProjectImage:             config.DefaultProjectImage,
+		defaultProjectUser:              config.DefaultProjectUser,
+		defaultProjectPostStartCommands: config.DefaultProjectPostStartCommands,
+		provisioner:                     config.Provisioner,
+		newWorkspaceLogger:              config.NewWorkspaceLogger,
+		newProjectLogger:                config.NewProjectLogger,
+		apiKeyService:                   config.ApiKeyService,
+		newWorkspaceLogReader:           config.NewWorkspaceLogReader,
 	}
 }
 
 type WorkspaceService struct {
-	workspaceStore         workspace.Store
-	targetStore            targetStore
-	containerRegistryStore containerregistry.Store
-	provisioner            provisioner.IProvisioner
-	apiKeyService          apikeys.IApiKeyService
-	serverApiUrl           string
-	serverUrl              string
-	defaultProjectImage    string
-	defaultProjectUser     string
-	newWorkspaceLogger     func(workspaceId string) logger.Logger
-	newProjectLogger       func(workspaceId, projectName string) logger.Logger
-	newWorkspaceLogReader  func(workspaceId string) (io.Reader, error)
+	workspaceStore                  workspace.Store
+	targetStore                     targetStore
+	containerRegistryStore          containerregistry.Store
+	provisioner                     provisioner.IProvisioner
+	apiKeyService                   apikeys.IApiKeyService
+	serverApiUrl                    string
+	serverUrl                       string
+	defaultProjectImage             string
+	defaultProjectUser              string
+	defaultProjectPostStartCommands []string
+	newWorkspaceLogger              func(workspaceId string) logger.Logger
+	newProjectLogger                func(workspaceId, projectName string) logger.Logger
+	newWorkspaceLogReader           func(workspaceId string) (io.Reader, error)
 }
 
 func (s *WorkspaceService) SetProjectState(workspaceId, projectName string, state *workspace.ProjectState) (*workspace.Workspace, error) {

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -32,6 +32,8 @@ const serverUrl = "http://localhost:3001"
 const defaultProjectImage = "daytonaio/workspace-project:latest"
 const defaultProjectUser = "daytona"
 
+var defaultProjectPostStartCommands = []string{"sudo dockerd"}
+
 var target = provider.ProviderTarget{
 	Name: "test-target",
 	ProviderInfo: provider.ProviderInfo{
@@ -96,15 +98,16 @@ func TestWorkspaceService(t *testing.T) {
 	logsDir := t.TempDir()
 
 	service := workspaces.NewWorkspaceService(workspaces.WorkspaceServiceConfig{
-		WorkspaceStore:         workspaceStore,
-		TargetStore:            targetStore,
-		ServerApiUrl:           serverApiUrl,
-		ServerUrl:              serverUrl,
-		ContainerRegistryStore: crStore,
-		DefaultProjectImage:    defaultProjectImage,
-		DefaultProjectUser:     defaultProjectUser,
-		ApiKeyService:          apiKeyService,
-		Provisioner:            provisioner,
+		WorkspaceStore:                  workspaceStore,
+		TargetStore:                     targetStore,
+		ServerApiUrl:                    serverApiUrl,
+		ServerUrl:                       serverUrl,
+		ContainerRegistryStore:          crStore,
+		DefaultProjectImage:             defaultProjectImage,
+		DefaultProjectUser:              defaultProjectUser,
+		DefaultProjectPostStartCommands: defaultProjectPostStartCommands,
+		ApiKeyService:                   apiKeyService,
+		Provisioner:                     provisioner,
 		NewWorkspaceLogger: func(workspaceId string) logger.Logger {
 			workspaceLogFilePath := filepath.Join(logsDir, workspaceId+".log")
 			workspaceLogFile, err := os.Create(workspaceLogFilePath)

--- a/pkg/serverapiclient/api/openapi.yaml
+++ b/pkg/serverapiclient/api/openapi.yaml
@@ -784,6 +784,9 @@ components:
       example:
         projects:
         - image: image
+          postStartCommands:
+          - postStartCommands
+          - postStartCommands
           envVars:
             key: envVars
           name: name
@@ -800,6 +803,9 @@ components:
               url: url
           user: user
         - image: image
+          postStartCommands:
+          - postStartCommands
+          - postStartCommands
           envVars:
             key: envVars
           name: name
@@ -835,6 +841,9 @@ components:
     CreateWorkspaceRequestProject:
       example:
         image: image
+        postStartCommands:
+        - postStartCommands
+        - postStartCommands
         envVars:
           key: envVars
         name: name
@@ -859,6 +868,10 @@ components:
           type: string
         name:
           type: string
+        postStartCommands:
+          items:
+            type: string
+          type: array
         source:
           $ref: '#/components/schemas/CreateWorkspaceRequestProjectSource'
         user:
@@ -1011,6 +1024,9 @@ components:
     Project:
       example:
         image: image
+        postStartCommands:
+        - postStartCommands
+        - postStartCommands
         name: name
         state:
           updatedAt: updatedAt
@@ -1033,6 +1049,10 @@ components:
           type: string
         name:
           type: string
+        postStartCommands:
+          items:
+            type: string
+          type: array
         repository:
           $ref: '#/components/schemas/GitRepository'
         state:
@@ -1115,6 +1135,9 @@ components:
         defaultProjectUser: defaultProjectUser
         providersDir: providersDir
         id: id
+        defaultProjectPostStartCommands:
+        - defaultProjectPostStartCommands
+        - defaultProjectPostStartCommands
         frps:
           protocol: protocol
           port: 6
@@ -1126,6 +1149,10 @@ components:
           type: string
         defaultProjectImage:
           type: string
+        defaultProjectPostStartCommands:
+          items:
+            type: string
+          type: array
         defaultProjectUser:
           type: string
         frps:
@@ -1154,6 +1181,9 @@ components:
       example:
         projects:
         - image: image
+          postStartCommands:
+          - postStartCommands
+          - postStartCommands
           name: name
           state:
             updatedAt: updatedAt
@@ -1172,6 +1202,9 @@ components:
           target: target
           workspaceId: workspaceId
         - image: image
+          postStartCommands:
+          - postStartCommands
+          - postStartCommands
           name: name
           state:
             updatedAt: updatedAt
@@ -1208,6 +1241,9 @@ components:
       example:
         projects:
         - image: image
+          postStartCommands:
+          - postStartCommands
+          - postStartCommands
           name: name
           state:
             updatedAt: updatedAt
@@ -1226,6 +1262,9 @@ components:
           target: target
           workspaceId: workspaceId
         - image: image
+          postStartCommands:
+          - postStartCommands
+          - postStartCommands
           name: name
           state:
             updatedAt: updatedAt

--- a/pkg/serverapiclient/docs/CreateWorkspaceRequestProject.md
+++ b/pkg/serverapiclient/docs/CreateWorkspaceRequestProject.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **EnvVars** | Pointer to **map[string]string** |  | [optional] 
 **Image** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
+**PostStartCommands** | Pointer to **[]string** |  | [optional] 
 **Source** | Pointer to [**CreateWorkspaceRequestProjectSource**](CreateWorkspaceRequestProjectSource.md) |  | [optional] 
 **User** | Pointer to **string** |  | [optional] 
 
@@ -98,6 +99,31 @@ and a boolean to check if the value has been set.
 
 SetName sets Name field to given value.
 
+
+### GetPostStartCommands
+
+`func (o *CreateWorkspaceRequestProject) GetPostStartCommands() []string`
+
+GetPostStartCommands returns the PostStartCommands field if non-nil, zero value otherwise.
+
+### GetPostStartCommandsOk
+
+`func (o *CreateWorkspaceRequestProject) GetPostStartCommandsOk() (*[]string, bool)`
+
+GetPostStartCommandsOk returns a tuple with the PostStartCommands field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetPostStartCommands
+
+`func (o *CreateWorkspaceRequestProject) SetPostStartCommands(v []string)`
+
+SetPostStartCommands sets PostStartCommands field to given value.
+
+### HasPostStartCommands
+
+`func (o *CreateWorkspaceRequestProject) HasPostStartCommands() bool`
+
+HasPostStartCommands returns a boolean if a field has been set.
 
 ### GetSource
 

--- a/pkg/serverapiclient/docs/Project.md
+++ b/pkg/serverapiclient/docs/Project.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Image** | Pointer to **string** |  | [optional] 
 **Name** | Pointer to **string** |  | [optional] 
+**PostStartCommands** | Pointer to **[]string** |  | [optional] 
 **Repository** | Pointer to [**GitRepository**](GitRepository.md) |  | [optional] 
 **State** | Pointer to [**ProjectState**](ProjectState.md) |  | [optional] 
 **Target** | Pointer to **string** |  | [optional] 
@@ -80,6 +81,31 @@ SetName sets Name field to given value.
 `func (o *Project) HasName() bool`
 
 HasName returns a boolean if a field has been set.
+
+### GetPostStartCommands
+
+`func (o *Project) GetPostStartCommands() []string`
+
+GetPostStartCommands returns the PostStartCommands field if non-nil, zero value otherwise.
+
+### GetPostStartCommandsOk
+
+`func (o *Project) GetPostStartCommandsOk() (*[]string, bool)`
+
+GetPostStartCommandsOk returns a tuple with the PostStartCommands field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetPostStartCommands
+
+`func (o *Project) SetPostStartCommands(v []string)`
+
+SetPostStartCommands sets PostStartCommands field to given value.
+
+### HasPostStartCommands
+
+`func (o *Project) HasPostStartCommands() bool`
+
+HasPostStartCommands returns a boolean if a field has been set.
 
 ### GetRepository
 

--- a/pkg/serverapiclient/docs/ServerConfig.md
+++ b/pkg/serverapiclient/docs/ServerConfig.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **ApiPort** | Pointer to **int32** |  | [optional] 
 **BinariesPath** | Pointer to **string** |  | [optional] 
 **DefaultProjectImage** | Pointer to **string** |  | [optional] 
+**DefaultProjectPostStartCommands** | Pointer to **[]string** |  | [optional] 
 **DefaultProjectUser** | Pointer to **string** |  | [optional] 
 **Frps** | Pointer to [**FRPSConfig**](FRPSConfig.md) |  | [optional] 
 **HeadscalePort** | Pointer to **int32** |  | [optional] 
@@ -109,6 +110,31 @@ SetDefaultProjectImage sets DefaultProjectImage field to given value.
 `func (o *ServerConfig) HasDefaultProjectImage() bool`
 
 HasDefaultProjectImage returns a boolean if a field has been set.
+
+### GetDefaultProjectPostStartCommands
+
+`func (o *ServerConfig) GetDefaultProjectPostStartCommands() []string`
+
+GetDefaultProjectPostStartCommands returns the DefaultProjectPostStartCommands field if non-nil, zero value otherwise.
+
+### GetDefaultProjectPostStartCommandsOk
+
+`func (o *ServerConfig) GetDefaultProjectPostStartCommandsOk() (*[]string, bool)`
+
+GetDefaultProjectPostStartCommandsOk returns a tuple with the DefaultProjectPostStartCommands field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetDefaultProjectPostStartCommands
+
+`func (o *ServerConfig) SetDefaultProjectPostStartCommands(v []string)`
+
+SetDefaultProjectPostStartCommands sets DefaultProjectPostStartCommands field to given value.
+
+### HasDefaultProjectPostStartCommands
+
+`func (o *ServerConfig) HasDefaultProjectPostStartCommands() bool`
+
+HasDefaultProjectPostStartCommands returns a boolean if a field has been set.
 
 ### GetDefaultProjectUser
 

--- a/pkg/serverapiclient/model_create_workspace_request_project.go
+++ b/pkg/serverapiclient/model_create_workspace_request_project.go
@@ -21,11 +21,12 @@ var _ MappedNullable = &CreateWorkspaceRequestProject{}
 
 // CreateWorkspaceRequestProject struct for CreateWorkspaceRequestProject
 type CreateWorkspaceRequestProject struct {
-	EnvVars *map[string]string                   `json:"envVars,omitempty"`
-	Image   *string                              `json:"image,omitempty"`
-	Name    string                               `json:"name"`
-	Source  *CreateWorkspaceRequestProjectSource `json:"source,omitempty"`
-	User    *string                              `json:"user,omitempty"`
+	EnvVars           *map[string]string                   `json:"envVars,omitempty"`
+	Image             *string                              `json:"image,omitempty"`
+	Name              string                               `json:"name"`
+	PostStartCommands []string                             `json:"postStartCommands,omitempty"`
+	Source            *CreateWorkspaceRequestProjectSource `json:"source,omitempty"`
+	User              *string                              `json:"user,omitempty"`
 }
 
 type _CreateWorkspaceRequestProject CreateWorkspaceRequestProject
@@ -136,6 +137,38 @@ func (o *CreateWorkspaceRequestProject) SetName(v string) {
 	o.Name = v
 }
 
+// GetPostStartCommands returns the PostStartCommands field value if set, zero value otherwise.
+func (o *CreateWorkspaceRequestProject) GetPostStartCommands() []string {
+	if o == nil || IsNil(o.PostStartCommands) {
+		var ret []string
+		return ret
+	}
+	return o.PostStartCommands
+}
+
+// GetPostStartCommandsOk returns a tuple with the PostStartCommands field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateWorkspaceRequestProject) GetPostStartCommandsOk() ([]string, bool) {
+	if o == nil || IsNil(o.PostStartCommands) {
+		return nil, false
+	}
+	return o.PostStartCommands, true
+}
+
+// HasPostStartCommands returns a boolean if a field has been set.
+func (o *CreateWorkspaceRequestProject) HasPostStartCommands() bool {
+	if o != nil && !IsNil(o.PostStartCommands) {
+		return true
+	}
+
+	return false
+}
+
+// SetPostStartCommands gets a reference to the given []string and assigns it to the PostStartCommands field.
+func (o *CreateWorkspaceRequestProject) SetPostStartCommands(v []string) {
+	o.PostStartCommands = v
+}
+
 // GetSource returns the Source field value if set, zero value otherwise.
 func (o *CreateWorkspaceRequestProject) GetSource() CreateWorkspaceRequestProjectSource {
 	if o == nil || IsNil(o.Source) {
@@ -217,6 +250,9 @@ func (o CreateWorkspaceRequestProject) ToMap() (map[string]interface{}, error) {
 		toSerialize["image"] = o.Image
 	}
 	toSerialize["name"] = o.Name
+	if !IsNil(o.PostStartCommands) {
+		toSerialize["postStartCommands"] = o.PostStartCommands
+	}
 	if !IsNil(o.Source) {
 		toSerialize["source"] = o.Source
 	}

--- a/pkg/serverapiclient/model_project.go
+++ b/pkg/serverapiclient/model_project.go
@@ -19,13 +19,14 @@ var _ MappedNullable = &Project{}
 
 // Project struct for Project
 type Project struct {
-	Image       *string        `json:"image,omitempty"`
-	Name        *string        `json:"name,omitempty"`
-	Repository  *GitRepository `json:"repository,omitempty"`
-	State       *ProjectState  `json:"state,omitempty"`
-	Target      *string        `json:"target,omitempty"`
-	User        *string        `json:"user,omitempty"`
-	WorkspaceId *string        `json:"workspaceId,omitempty"`
+	Image             *string        `json:"image,omitempty"`
+	Name              *string        `json:"name,omitempty"`
+	PostStartCommands []string       `json:"postStartCommands,omitempty"`
+	Repository        *GitRepository `json:"repository,omitempty"`
+	State             *ProjectState  `json:"state,omitempty"`
+	Target            *string        `json:"target,omitempty"`
+	User              *string        `json:"user,omitempty"`
+	WorkspaceId       *string        `json:"workspaceId,omitempty"`
 }
 
 // NewProject instantiates a new Project object
@@ -107,6 +108,38 @@ func (o *Project) HasName() bool {
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *Project) SetName(v string) {
 	o.Name = &v
+}
+
+// GetPostStartCommands returns the PostStartCommands field value if set, zero value otherwise.
+func (o *Project) GetPostStartCommands() []string {
+	if o == nil || IsNil(o.PostStartCommands) {
+		var ret []string
+		return ret
+	}
+	return o.PostStartCommands
+}
+
+// GetPostStartCommandsOk returns a tuple with the PostStartCommands field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Project) GetPostStartCommandsOk() ([]string, bool) {
+	if o == nil || IsNil(o.PostStartCommands) {
+		return nil, false
+	}
+	return o.PostStartCommands, true
+}
+
+// HasPostStartCommands returns a boolean if a field has been set.
+func (o *Project) HasPostStartCommands() bool {
+	if o != nil && !IsNil(o.PostStartCommands) {
+		return true
+	}
+
+	return false
+}
+
+// SetPostStartCommands gets a reference to the given []string and assigns it to the PostStartCommands field.
+func (o *Project) SetPostStartCommands(v []string) {
+	o.PostStartCommands = v
 }
 
 // GetRepository returns the Repository field value if set, zero value otherwise.
@@ -284,6 +317,9 @@ func (o Project) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.PostStartCommands) {
+		toSerialize["postStartCommands"] = o.PostStartCommands
 	}
 	if !IsNil(o.Repository) {
 		toSerialize["repository"] = o.Repository

--- a/pkg/serverapiclient/model_server_config.go
+++ b/pkg/serverapiclient/model_server_config.go
@@ -19,17 +19,18 @@ var _ MappedNullable = &ServerConfig{}
 
 // ServerConfig struct for ServerConfig
 type ServerConfig struct {
-	ApiPort             *int32      `json:"apiPort,omitempty"`
-	BinariesPath        *string     `json:"binariesPath,omitempty"`
-	DefaultProjectImage *string     `json:"defaultProjectImage,omitempty"`
-	DefaultProjectUser  *string     `json:"defaultProjectUser,omitempty"`
-	Frps                *FRPSConfig `json:"frps,omitempty"`
-	HeadscalePort       *int32      `json:"headscalePort,omitempty"`
-	Id                  *string     `json:"id,omitempty"`
-	LogFilePath         *string     `json:"logFilePath,omitempty"`
-	ProvidersDir        *string     `json:"providersDir,omitempty"`
-	RegistryUrl         *string     `json:"registryUrl,omitempty"`
-	ServerDownloadUrl   *string     `json:"serverDownloadUrl,omitempty"`
+	ApiPort                         *int32      `json:"apiPort,omitempty"`
+	BinariesPath                    *string     `json:"binariesPath,omitempty"`
+	DefaultProjectImage             *string     `json:"defaultProjectImage,omitempty"`
+	DefaultProjectPostStartCommands []string    `json:"defaultProjectPostStartCommands,omitempty"`
+	DefaultProjectUser              *string     `json:"defaultProjectUser,omitempty"`
+	Frps                            *FRPSConfig `json:"frps,omitempty"`
+	HeadscalePort                   *int32      `json:"headscalePort,omitempty"`
+	Id                              *string     `json:"id,omitempty"`
+	LogFilePath                     *string     `json:"logFilePath,omitempty"`
+	ProvidersDir                    *string     `json:"providersDir,omitempty"`
+	RegistryUrl                     *string     `json:"registryUrl,omitempty"`
+	ServerDownloadUrl               *string     `json:"serverDownloadUrl,omitempty"`
 }
 
 // NewServerConfig instantiates a new ServerConfig object
@@ -143,6 +144,38 @@ func (o *ServerConfig) HasDefaultProjectImage() bool {
 // SetDefaultProjectImage gets a reference to the given string and assigns it to the DefaultProjectImage field.
 func (o *ServerConfig) SetDefaultProjectImage(v string) {
 	o.DefaultProjectImage = &v
+}
+
+// GetDefaultProjectPostStartCommands returns the DefaultProjectPostStartCommands field value if set, zero value otherwise.
+func (o *ServerConfig) GetDefaultProjectPostStartCommands() []string {
+	if o == nil || IsNil(o.DefaultProjectPostStartCommands) {
+		var ret []string
+		return ret
+	}
+	return o.DefaultProjectPostStartCommands
+}
+
+// GetDefaultProjectPostStartCommandsOk returns a tuple with the DefaultProjectPostStartCommands field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetDefaultProjectPostStartCommandsOk() ([]string, bool) {
+	if o == nil || IsNil(o.DefaultProjectPostStartCommands) {
+		return nil, false
+	}
+	return o.DefaultProjectPostStartCommands, true
+}
+
+// HasDefaultProjectPostStartCommands returns a boolean if a field has been set.
+func (o *ServerConfig) HasDefaultProjectPostStartCommands() bool {
+	if o != nil && !IsNil(o.DefaultProjectPostStartCommands) {
+		return true
+	}
+
+	return false
+}
+
+// SetDefaultProjectPostStartCommands gets a reference to the given []string and assigns it to the DefaultProjectPostStartCommands field.
+func (o *ServerConfig) SetDefaultProjectPostStartCommands(v []string) {
+	o.DefaultProjectPostStartCommands = v
 }
 
 // GetDefaultProjectUser returns the DefaultProjectUser field value if set, zero value otherwise.
@@ -419,6 +452,9 @@ func (o ServerConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.DefaultProjectImage) {
 		toSerialize["defaultProjectImage"] = o.DefaultProjectImage
+	}
+	if !IsNil(o.DefaultProjectPostStartCommands) {
+		toSerialize["defaultProjectPostStartCommands"] = o.DefaultProjectPostStartCommands
 	}
 	if !IsNil(o.DefaultProjectUser) {
 		toSerialize["defaultProjectUser"] = o.DefaultProjectUser

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -15,15 +15,16 @@ import (
 )
 
 type Project struct {
-	Name        string                     `json:"name"`
-	Image       string                     `json:"image"`
-	User        string                     `json:"user"`
-	Repository  *gitprovider.GitRepository `json:"repository"`
-	WorkspaceId string                     `json:"workspaceId"`
-	ApiKey      string                     `json:"-"`
-	Target      string                     `json:"target"`
-	EnvVars     map[string]string          `json:"-"`
-	State       *ProjectState              `json:"state,omitempty"`
+	Name              string                     `json:"name"`
+	Image             string                     `json:"image"`
+	User              string                     `json:"user"`
+	Repository        *gitprovider.GitRepository `json:"repository"`
+	WorkspaceId       string                     `json:"workspaceId"`
+	ApiKey            string                     `json:"-"`
+	Target            string                     `json:"target"`
+	EnvVars           map[string]string          `json:"-"`
+	State             *ProjectState              `json:"state,omitempty"`
+	PostStartCommands []string                   `json:"postStartCommands,omitempty"`
 } // @name Project
 
 func (p *Project) GetImageServer() string {


### PR DESCRIPTION
# Project Post Start Commands

## Description

This PR introduces the `PostStartCommands` property into the project model. This property holds commands that the agent inside the project once it has been started.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Notes

This change will require users to run `daytona server configure` and add `sudo dockerd` as a default start command once the Docker Provider is updated to not include starting dockerd by itself.