### PR TITLE
fix: headscale grpc regression

### DIFF
--- a/pkg/server/headscale/client.go
+++ b/pkg/server/headscale/client.go
@@ -34,7 +34,7 @@ func (s *HeadscaleServer) getClient() (context.Context, v1.HeadscaleServiceClien
 	)
 
 	log.Trace().Caller().Str("address", address).Msg("Connecting via gRPC")
-	conn, err := grpc.NewClient(address, grpcOptions...)
+	conn, err := grpc.DialContext(ctx, address, grpcOptions...) // nolint:staticcheck
 	if err != nil {
 		cancel()
 		return nil, nil, nil, nil, err


### PR DESCRIPTION
# Fix Headscale GRPC regression

## Description

In #433, we updated the GRPC package to 1.63.0 which marked `DialContext` as deprecated and suggested to use `NewClient` instead. Unfortunately, `NewClient` does not work for us currently and would require more investigation into how to migrate successfully.
In the meantime, this PR reverts to `DialContext`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Notes

More info on how to migrate should be available here [https://github.com/grpc/grpc-go/issues/7049](https://github.com/grpc/grpc-go/issues/7049).
