### PR TITLE
feat: enable configuration of other server properties

### DIFF
--- a/pkg/cmd/server/configure.go
+++ b/pkg/cmd/server/configure.go
@@ -35,6 +35,6 @@ var configureCmd = &cobra.Command{
 			log.Fatal(apiclient.HandleErrorResponse(res, err))
 		}
 
-		util.RenderInfoMessage("Server configuration updated. You might need to restart the server for the changes to take effect.")
+		util.RenderInfoMessage("Server configuration updated. You need to restart the server for the changes to take effect.")
 	},
 }

--- a/pkg/views/server/configure.go
+++ b/pkg/views/server/configure.go
@@ -4,8 +4,10 @@
 package server
 
 import (
+	"errors"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/charmbracelet/huh"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
@@ -21,26 +23,25 @@ type ServerUpdateKeyView struct {
 
 func ConfigurationForm(config *serverapiclient.ServerConfig) *serverapiclient.ServerConfig {
 	projectStartCommands := view_util.GetJoinedCommands(config.DefaultProjectPostStartCommands)
+	apiPortView := strconv.Itoa(int(config.GetApiPort()))
+	headscalePortView := strconv.Itoa(int(config.GetHeadscalePort()))
+	frpsPortView := strconv.Itoa(int(config.Frps.GetPort()))
 
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Providers Directory").
+				Description("Directory will be created if it does not exist").
 				Value(config.ProvidersDir).
-				Validate(func(s string) error {
-					_, err := os.Stat(s)
-					if os.IsNotExist(err) {
-						return os.MkdirAll(s, 0700)
-					}
-
-					return err
-				}),
+				Validate(directoryValidator(config.ProvidersDir)),
 			huh.NewInput().
 				Title("Registry URL").
 				Value(config.RegistryUrl),
 			huh.NewInput().
 				Title("Server Download URL").
 				Value(config.ServerDownloadUrl),
+		),
+		huh.NewGroup(
 			huh.NewInput().
 				Title("Default Project Image").
 				Value(config.DefaultProjectImage),
@@ -52,6 +53,45 @@ func ConfigurationForm(config *serverapiclient.ServerConfig) *serverapiclient.Se
 				Description(CommandsInputHelp).
 				Value(&projectStartCommands),
 		),
+		huh.NewGroup(
+			huh.NewInput().
+				Title("API Port").
+				Value(&apiPortView).
+				Validate(createPortValidator(config, &apiPortView, config.ApiPort)),
+			huh.NewInput().
+				Title("Headscale Port").
+				Value(&headscalePortView).
+				Validate(createPortValidator(config, &headscalePortView, config.HeadscalePort)),
+			huh.NewInput().
+				Title("Binaries Path").
+				Description("Directory will be created if it does not exist").
+				Value(config.BinariesPath).
+				Validate(directoryValidator(config.BinariesPath)),
+			huh.NewInput().
+				Title("Log File Path").
+				Description("File will be created if it does not exist").
+				Value(config.LogFilePath).
+				Validate(func(s string) error {
+					_, err := os.Stat(s)
+					if os.IsNotExist(err) {
+						_, err = os.Create(s)
+					}
+
+					return err
+				}),
+		),
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Frps Domain").
+				Value(config.Frps.Domain),
+			huh.NewInput().
+				Title("Frps Port").
+				Value(&frpsPortView).
+				Validate(createPortValidator(config, &frpsPortView, config.Frps.Port)),
+			huh.NewInput().
+				Title("Frps Protocol").
+				Value(config.Frps.Protocol),
+		),
 	)
 
 	err := form.Run()
@@ -62,4 +102,34 @@ func ConfigurationForm(config *serverapiclient.ServerConfig) *serverapiclient.Se
 	config.DefaultProjectPostStartCommands = view_util.GetSplitCommands(projectStartCommands)
 
 	return config
+}
+
+func createPortValidator(config *serverapiclient.ServerConfig, portView *string, port *int32) func(string) error {
+	return func(string) error {
+		validatePort, err := strconv.Atoi(*portView)
+		if err != nil {
+			return errors.New("failed to parse port")
+		}
+		if validatePort < 0 || validatePort > 65535 {
+			return errors.New("port out of range")
+		}
+		*port = int32(validatePort)
+
+		if *config.ApiPort == *config.HeadscalePort {
+			return errors.New("port conflict")
+		}
+
+		return nil
+	}
+}
+
+func directoryValidator(path *string) func(string) error {
+	return func(string) error {
+		_, err := os.Stat(*path)
+		if os.IsNotExist(err) {
+			return os.MkdirAll(*path, 0700)
+		}
+
+		return err
+	}
 }


### PR DESCRIPTION
# Enable configuration of other server properties

## Description

This follows up on a stale PR which had the same purpose.
Within this PR, other server properties are enabled for configuration through CLI.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR closes #238