### PR TITLE
fix: add tailscale connection timeout

### DIFF
--- a/internal/tailscale/connection.go
+++ b/internal/tailscale/connection.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
@@ -53,7 +54,10 @@ func GetConnection(profile *config.Profile) (*tsnet.Server, error) {
 	s.Dir = filepath.Join(configDir, "tailscale", cliId)
 	s.Logf = func(format string, args ...any) {}
 
-	_, err = s.Up(context.Background())
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err = s.Up(timeoutCtx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Add Tailscale Connection Timeout

## Description

This PR is the first part of solving #427. It adds a 10 second timeout to attempting to establish a tailscale connection to the Daytona server. It prevents hanging indefinitely while establishing a connection.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #427.