### PR TITLE
fix: use gitprovider username when cloning a repo

### DIFF
--- a/internal/testing/agent/mocks/gitservice.go
+++ b/internal/testing/agent/mocks/gitservice.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient/server/conversion"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
 	"github.com/daytonaio/daytona/pkg/workspace"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,8 +17,8 @@ type mockGitService struct {
 	mock.Mock
 }
 
-func (m *mockGitService) CloneRepository(project *serverapiclient.Project, authToken *string) error {
-	args := m.Called(project, authToken)
+func (m *mockGitService) CloneRepository(project *serverapiclient.Project, auth *http.BasicAuth) error {
+	args := m.Called(project, auth)
 	return args.Error(0)
 }
 

--- a/pkg/agent/git/service.go
+++ b/pkg/agent/git/service.go
@@ -21,22 +21,16 @@ type Service struct {
 	LogWriter         io.Writer
 }
 
-func (s *Service) CloneRepository(project *serverapiclient.Project, authToken *string) error {
+func (s *Service) CloneRepository(project *serverapiclient.Project, auth *http.BasicAuth) error {
 	cloneOptions := &git.CloneOptions{
 		URL:             *project.Repository.Url,
 		SingleBranch:    true,
 		InsecureSkipTLS: true,
+		Auth:            auth,
 	}
 
 	if s.LogWriter != nil {
 		cloneOptions.Progress = s.LogWriter
-	}
-
-	if authToken != nil {
-		cloneOptions.Auth = &http.BasicAuth{
-			Username: "daytona",
-			Password: *authToken,
-		}
 	}
 
 	if s.shouldCloneBranch(project) {

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/daytonaio/daytona/pkg/agent/config"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 type GitService interface {
-	CloneRepository(project *serverapiclient.Project, authToken *string) error
+	CloneRepository(project *serverapiclient.Project, auth *http.BasicAuth) error
 	RepositoryExists(project *serverapiclient.Project) (bool, error)
 	SetGitConfig(userData *serverapiclient.GitUser) error
 }


### PR DESCRIPTION
# Use GitProvider Username when Cloning a Repo

## Description

This PR introduces the use of the username property found in the GitProvider when cloning a repo. Before, we hardcoded the `daytona` username which might not work with all git providers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings