### PR TITLE
feat: remove project logs from workspace logs

### DIFF
--- a/pkg/api/controllers/log/websocket.go
+++ b/pkg/api/controllers/log/websocket.go
@@ -108,3 +108,18 @@ func ReadWorkspaceLog(ginCtx *gin.Context) {
 
 	readLog(ginCtx, wsLogReader)
 }
+
+func ReadProjectLog(ginCtx *gin.Context) {
+	workspaceId := ginCtx.Param("workspaceId")
+	projectName := ginCtx.Param("projectName")
+
+	server := server.GetInstance(nil)
+
+	projectLogReader, err := server.WorkspaceService.GetProjectLogReader(workspaceId, projectName)
+	if err != nil {
+		ginCtx.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
+	readLog(ginCtx, projectLogReader)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -143,6 +143,7 @@ func (a *ApiServer) Start() error {
 	{
 		logController.GET("/server", log_controller.ReadServerLog)
 		logController.GET("/workspace/:workspaceId", log_controller.ReadWorkspaceLog)
+		logController.GET("/workspace/:workspaceId/:projectName", log_controller.ReadProjectLog)
 	}
 
 	gitProviderController := protected.Group("/gitprovider")

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -16,6 +16,7 @@ type LoggerFactory interface {
 	CreateWorkspaceLogger(workspaceId string) Logger
 	CreateProjectLogger(workspaceId, projectName string) Logger
 	CreateWorkspaceLogReader(workspaceId string) (io.Reader, error)
+	CreateProjectLogReader(workspaceId, projectName string) (io.Reader, error)
 }
 
 type loggerFactoryImpl struct {

--- a/pkg/logger/project.go
+++ b/pkg/logger/project.go
@@ -4,6 +4,7 @@
 package logger
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -57,4 +58,9 @@ func (pl *projectLogger) Cleanup() error {
 
 func (l *loggerFactoryImpl) CreateProjectLogger(workspaceId, projectName string) Logger {
 	return &projectLogger{workspaceId: workspaceId, logsDir: l.logsDir, projectName: projectName}
+}
+
+func (l *loggerFactoryImpl) CreateProjectLogReader(workspaceId, projectName string) (io.Reader, error) {
+	filePath := filepath.Join(l.logsDir, workspaceId, projectName, "log")
+	return os.Open(filePath)
 }

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -116,8 +116,7 @@ func (s *WorkspaceService) createWorkspace(workspace *workspace.Workspace) (*wor
 		projectLogger := s.loggerFactory.CreateProjectLogger(workspace.Id, project.Name)
 		defer projectLogger.Close()
 
-		projectLogWriter := io.MultiWriter(wsLogger, projectLogger)
-		err := s.createProject(project, target, projectLogWriter)
+		err := s.createProject(project, target, projectLogger)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -20,6 +20,7 @@ type IWorkspaceService interface {
 	CreateWorkspace(req dto.CreateWorkspaceRequest) (*workspace.Workspace, error)
 	GetWorkspace(workspaceId string) (*dto.WorkspaceDTO, error)
 	GetWorkspaceLogReader(workspaceId string) (io.Reader, error)
+	GetProjectLogReader(workspaceId, projectName string) (io.Reader, error)
 	ListWorkspaces(verbose bool) ([]dto.WorkspaceDTO, error)
 	RemoveWorkspace(workspaceId string) error
 	SetProjectState(workspaceId string, projectName string, state *workspace.ProjectState) (*workspace.Workspace, error)
@@ -95,4 +96,8 @@ func (s *WorkspaceService) SetProjectState(workspaceId, projectName string, stat
 
 func (s *WorkspaceService) GetWorkspaceLogReader(workspaceId string) (io.Reader, error) {
 	return s.loggerFactory.CreateWorkspaceLogReader(workspaceId)
+}
+
+func (s *WorkspaceService) GetProjectLogReader(workspaceId, projectName string) (io.Reader, error) {
+	return s.loggerFactory.CreateProjectLogReader(workspaceId, projectName)
 }

--- a/pkg/server/workspaces/start.go
+++ b/pkg/server/workspaces/start.go
@@ -48,15 +48,10 @@ func (s *WorkspaceService) StartProject(workspaceId, projectName string) error {
 		return err
 	}
 
-	workspaceLogger := s.loggerFactory.CreateWorkspaceLogger(w.Id)
-	defer workspaceLogger.Close()
-
 	projectLogger := s.loggerFactory.CreateProjectLogger(w.Id, project.Name)
 	defer projectLogger.Close()
 
-	projectLogWriter := io.MultiWriter(workspaceLogger, projectLogger)
-
-	return s.startProject(project, target, projectLogWriter)
+	return s.startProject(project, target, projectLogger)
 }
 
 func (s *WorkspaceService) startWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget, wsLogWriter io.Writer) error {
@@ -71,9 +66,7 @@ func (s *WorkspaceService) startWorkspace(workspace *workspace.Workspace, target
 		projectLogger := s.loggerFactory.CreateProjectLogger(workspace.Id, project.Name)
 		defer projectLogger.Close()
 
-		projectLogWriter := io.MultiWriter(wsLogWriter, projectLogger)
-
-		err = s.startProject(project, target, projectLogWriter)
+		err = s.startProject(project, target, projectLogger)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Remove Project Logs from Workspace Logs

## Description

With this PR, project logs are no longer being written to the workspace logs. The create command now reads the workspace and all project logs in the creation flow.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #461 