### PR TITLE
feat: shorter workspace IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/juanfont/headscale v0.23.0-alpha3
 	github.com/kardianos/service v1.2.2
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pkg/sftp v1.13.6
 	github.com/rs/zerolog v1.31.0
@@ -157,6 +156,7 @@ require (
 	github.com/kortschak/wol v0.0.0-20200729010619-da482cc4850a // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -22,7 +22,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/target"
 	"github.com/daytonaio/daytona/pkg/views/workspace/info"
 	"github.com/daytonaio/daytona/pkg/workspace"
-	"github.com/google/uuid"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/gorilla/websocket"
 	"tailscale.com/tsnet"
 
@@ -103,7 +103,8 @@ var CreateCmd = &cobra.Command{
 		}
 
 		stopLogs := false
-		id := uuid.NewString()
+		id := stringid.GenerateRandomID()
+		id = stringid.TruncateID(id)
 
 		go readWorkspaceLogs(activeProfile, id, projects, &stopLogs)
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -4,10 +4,8 @@
 package workspace
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"strings"
 
 	"github.com/daytonaio/daytona/internal"
@@ -89,8 +87,11 @@ func GetProjectEnvVars(project *Project, apiUrl, serverUrl string) map[string]st
 }
 
 func GetProjectHostname(workspaceId string, projectName string) string {
-	h := fnv.New64()
-	h.Write([]byte(fmt.Sprintf("%s-%s", workspaceId, projectName)))
+	hostname := fmt.Sprintf("%s-%s", workspaceId, projectName)
 
-	return base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprint(h.Sum64())))
+	if len(hostname) > 63 {
+		return hostname[:63]
+	}
+
+	return hostname
 }


### PR DESCRIPTION
# Shorter Workspace IDs

## Description

This PR changes how workspace IDs are generated. They are now generated with the [stringid](https://github.com/moby/moby/blob/master/pkg/stringid/stringid.go) package from Docker that is also used to generate container names. The new workspace ID is 12 characters long.

Additionally, project hostnames are now generated as `Truncate(workspaceId-projectName, 63)`. Truncating is necessary to comply with the subdomain length limit.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #474.

## Screenshots
![Screenshot 2024-05-06 at 12 49 47](https://github.com/daytonaio/daytona/assets/26512078/9f8a7d81-58b7-46ee-9119-34f0759ae95e)

## Notes
Breaking change: Because of the change to generating project hostnames, users will fail to connect to existing workspaces. We recommend that users remove all their workspaces before upgrading to a version with this update.
