### PR TITLE
feat: remove server border

### DIFF
--- a/pkg/cmd/server/stop.go
+++ b/pkg/cmd/server/stop.go
@@ -15,7 +15,7 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stops the Daytona Server daemon",
 	Run: func(cmd *cobra.Command, args []string) {
-		views.RenderContainerLayout(views.GetBoldedInfoMessage("Stopping the Daytona Server daemon..."))
+		views.RenderInfoMessageBold("Stopping the Daytona Server daemon...")
 		err := daemon.Stop()
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/views/server/started/view.go
+++ b/pkg/views/server/started/view.go
@@ -5,11 +5,9 @@ package started
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/pkg/views"
-	"golang.org/x/term"
 )
 
 func Render(apiPort uint32, frpcUrl string, isDaemonMode bool) {
@@ -20,19 +18,7 @@ func Render(apiPort uint32, frpcUrl string, isDaemonMode bool) {
 	output += "You may now begin developing locally"
 	output += "\n"
 
-	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		fmt.Println(output)
-		return
-	}
-
-	output = lipgloss.NewStyle().PaddingLeft(3).Render(output)
-
-	output = lipgloss.
-		NewStyle().
-		BorderForeground(views.LightGray).
-		Border(lipgloss.RoundedBorder()).Width(views.GetContainerBreakpointWidth(terminalWidth)).
-		Render(output) + "\n"
+	output = lipgloss.NewStyle().PaddingLeft(3).Render(output) + "\n"
 
 	if !isDaemonMode {
 		output = "\n" + output


### PR DESCRIPTION
# Server started message border
## Description

Removing the border in the server started message to align with the rest of the TUI design

Also a minor fix to the "stopping server" message formatting

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

![image](https://github.com/daytonaio/daytona/assets/25279767/c5ac9193-2763-4e34-8d3b-fbe3568a26f7)

![image](https://github.com/daytonaio/daytona/assets/25279767/253e2be3-8105-4b98-9ce3-a4e66e15a913)

