### PR TITLE
fix: workspace logs retry

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -279,34 +279,45 @@ func processCmdArguments(cmd *cobra.Command, args []string, apiClient *serverapi
 }
 
 func readWorkspaceLogs(activeProfile config.Profile, workspaceId string, projects []serverapiclient.CreateWorkspaceRequestProject, stopLogs *bool) {
-	time.Sleep(2 * time.Second)
-
-	query := "follow=true"
-	ws, res, err := server.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s", workspaceId), &activeProfile, &query)
-	if err != nil {
-		log.Fatal(apiclient.HandleErrorResponse(res, err))
-	}
-
-	defer ws.Close()
-
 	var wg sync.WaitGroup
 	for _, project := range projects {
 		wg.Add(1)
 		go func(project serverapiclient.CreateWorkspaceRequestProject) {
 			defer wg.Done()
 			query := "follow=true"
-			ws, res, err := server.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s/%s", workspaceId, project.Name), &activeProfile, &query)
-			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
+
+			for {
+				ws, res, err := server.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s/%s", workspaceId, project.Name), &activeProfile, &query)
+				// We want to retry getting the logs if it fails
+				if err != nil {
+					log.Trace(apiclient.HandleErrorResponse(res, err))
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
+
+				readLog(ws, stopLogs)
+
+				ws.Close()
 			}
-
-			defer ws.Close()
-
-			readLog(ws, stopLogs)
 		}(project)
 	}
 
-	readLog(ws, stopLogs)
+	query := "follow=true"
+
+	for {
+		ws, res, err := server.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s", workspaceId), &activeProfile, &query)
+		// We want to retry getting the logs if it fails
+		if err != nil {
+			log.Trace(apiclient.HandleErrorResponse(res, err))
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		readLog(ws, stopLogs)
+		ws.Close()
+		break
+	}
+
 	wg.Wait()
 }
 


### PR DESCRIPTION
# Workspace Logs Retry

## Description

This PR adds retries to getting the workspace (and project) logs. It also removes a 2 second timeout before attempting to get the logs which brings an improvement into the overall experience as now the user will get updates sooner.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #478 