### PR TITLE
fix: daytona create help

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -32,7 +32,7 @@ import (
 )
 
 var CreateCmd = &cobra.Command{
-	Use:   "create [WORKSPACE_NAME]",
+	Use:   "create [REPOSITORY_URL]",
 	Short: "Create a workspace",
 	Args:  cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
# Daytona create help

## Description

Fixing the `daytona create` command's short description from `create [WORKSPACE_NAME]` to `create [REPOSITORY_URL]`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

This PR addresses issue #X

## Screenshots

![image](https://github.com/daytonaio/daytona/assets/25279767/2ff05dbf-9a44-4469-82a8-20db51885540)

![image](https://github.com/daytonaio/daytona/assets/25279767/1f35fb4f-f3ef-40c9-8ac7-96cc0846539a)


