### PR TITLE
fix: daemon server health check

### DIFF
--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -187,10 +187,10 @@ var ServeCmd = &cobra.Command{
 
 func waitForServerToStart(apiServer *api.ApiServer) error {
 	var err error
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 30; i++ {
+		time.Sleep(1 * time.Second)
 		err = apiServer.HealthCheck()
 		if err != nil {
-			time.Sleep(3 * time.Second)
 			continue
 		}
 


### PR DESCRIPTION
# Daemon Server Health Check Fix

## Description

This PR increases the health check timeout to 30 seconds and decreases the polling interval to 1 second. This should allow the server enough time to boot up while making the command more responsive.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #494.