### PR TITLE
feat: server started label update

### DIFF
--- a/pkg/views/server/started/view.go
+++ b/pkg/views/server/started/view.go
@@ -15,7 +15,7 @@ func Render(apiPort uint32, frpcUrl string, isDaemonMode bool) {
 	output += views.GetStyledMainTitle("Daytona") + "\n\n"
 	output += fmt.Sprintf("## Daytona Server is running on port: %d\n\n", apiPort)
 	output += views.SeparatorString + "\n\n"
-	output += "You may now begin developing locally"
+	output += "You may now begin developing"
 	output += "\n"
 
 	output = lipgloss.NewStyle().PaddingLeft(3).Render(output) + "\n"


### PR DESCRIPTION
# Server started label update

## Description

Removing the word "locally" from the message that appears to the user when running `daytona serve` / `daytona server`

It is no longer necessary as the instructions to connect to the server remotely were moved to daytona server config

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
