### PR TITLE
feat: default summary to yes

### DIFF
--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -101,6 +101,8 @@ func NewSummaryModel(workspaceName string, projectList []serverapiclient.CreateW
 	m.workspaceName = workspaceName
 	m.projectList = projectList
 
+	confirmationResult = true
+
 	m.form = huh.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().


### PR DESCRIPTION
# Default summary to yes

## Description

Changes the preselected value for `daytona create --multi-project` to be "Yes" instead of "Abort" in order to improve UX

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots
![image](https://github.com/daytonaio/daytona/assets/25279767/66b6c908-4983-4525-9718-395b7585d952)
