### PR TITLE
feat: git providers command format

### DIFF
--- a/pkg/cmd/gitprovider/gitprovider.go
+++ b/pkg/cmd/gitprovider/gitprovider.go
@@ -4,70 +4,17 @@
 package gitprovider
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/daytonaio/daytona/cmd/daytona/config"
-	"github.com/daytonaio/daytona/internal/util/apiclient"
-	"github.com/daytonaio/daytona/internal/util/apiclient/server"
-	"github.com/daytonaio/daytona/pkg/cmd/output"
-	"github.com/daytonaio/daytona/pkg/views"
-	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var GitProviderCmd = &cobra.Command{
 	Use:     "git-providers",
 	Aliases: []string{"git-provider", "gp"},
-	Short:   "Lists your registered Git providers",
-	Run: func(cmd *cobra.Command, args []string) {
-		apiClient, err := server.GetApiClient(nil)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		gitProviders, res, err := apiClient.GitProviderAPI.ListGitProviders(context.Background()).Execute()
-		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
-		}
-
-		if len(gitProviders) == 0 {
-			views.RenderInfoMessage("No git providers registered. Add a new git provider by\npreparing a Personal Access Token and running 'daytona git-providers add'")
-			return
-		}
-
-		views.RenderMainTitle("Registered Git Providers:")
-
-		supportedProviders := config.GetSupportedGitProviders()
-		var gitProviderViewList []gitprovider_view.GitProviderView
-
-		for _, gitProvider := range gitProviders {
-			for _, supportedProvider := range supportedProviders {
-				if *gitProvider.Id == supportedProvider.Id {
-					gitProviderViewList = append(gitProviderViewList,
-						gitprovider_view.GitProviderView{
-							Id:       *gitProvider.Id,
-							Name:     supportedProvider.Name,
-							Username: *gitProvider.Username,
-						},
-					)
-				}
-			}
-		}
-
-		if output.FormatFlag != "" {
-			output.Output = gitProviderViewList
-			return
-		}
-
-		for _, gitProviderView := range gitProviderViewList {
-			views.RenderListLine(fmt.Sprintf("%s (%s)", gitProviderView.Name, gitProviderView.Username))
-		}
-	},
+	Short:   "Manage Git providers",
 }
 
 func init() {
 	GitProviderCmd.AddCommand(gitProviderAddCmd)
 	GitProviderCmd.AddCommand(gitProviderDeleteCmd)
+	GitProviderCmd.AddCommand(gitProviderListCmd)
 }

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/internal/util/apiclient/server"
+	"github.com/daytonaio/daytona/pkg/cmd/output"
+	"github.com/daytonaio/daytona/pkg/views"
+	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var gitProviderListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "Lists your registered Git providers",
+	Run: func(cmd *cobra.Command, args []string) {
+		apiClient, err := server.GetApiClient(nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		gitProviders, res, err := apiClient.GitProviderAPI.ListGitProviders(context.Background()).Execute()
+		if err != nil {
+			log.Fatal(apiclient.HandleErrorResponse(res, err))
+		}
+
+		if len(gitProviders) == 0 {
+			views.RenderInfoMessage("No git providers registered. Add a new git provider by\npreparing a Personal Access Token and running 'daytona git-providers add'")
+			return
+		}
+
+		views.RenderMainTitle("Registered Git Providers:")
+
+		supportedProviders := config.GetSupportedGitProviders()
+		var gitProviderViewList []gitprovider_view.GitProviderView
+
+		for _, gitProvider := range gitProviders {
+			for _, supportedProvider := range supportedProviders {
+				if *gitProvider.Id == supportedProvider.Id {
+					gitProviderViewList = append(gitProviderViewList,
+						gitprovider_view.GitProviderView{
+							Id:       *gitProvider.Id,
+							Name:     supportedProvider.Name,
+							Username: *gitProvider.Username,
+						},
+					)
+				}
+			}
+		}
+
+		if output.FormatFlag != "" {
+			output.Output = gitProviderViewList
+			return
+		}
+
+		for _, gitProviderView := range gitProviderViewList {
+			views.RenderListLine(fmt.Sprintf("%s (%s)", gitProviderView.Name, gitProviderView.Username))
+		}
+	},
+}


### PR DESCRIPTION
# Git Providers command format
## Description

Changes `daytona git-providers` from listing the git providers by default to instead show the subcommand's help.
Makes `daytona git-providers list` do the listing instead in order to align with the rest of the CLI 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Related Issue(s)

Closes #489 

## Screenshots

![image](https://github.com/daytonaio/daytona/assets/25279767/11481e86-cbbe-4954-b4ae-d5948a3c8151)
