### PR TITLE
fix: reset project uptime after stop

### DIFF
--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -185,7 +185,7 @@ func getWorkspaceTableRowData(workspace serverapiclient.WorkspaceDTO, specifyGit
 	if workspace.Info != nil && workspace.Info.Projects != nil && len(workspace.Info.Projects) > 0 && workspace.Info.Projects[0].Created != nil {
 		rowData.Created = util.FormatCreatedTime(*workspace.Info.Projects[0].Created)
 	}
-	if len(workspace.Projects) > 0 && workspace.Projects[0].State != nil && workspace.Projects[0].State.Uptime != nil {
+	if len(workspace.Projects) > 0 && workspace.Projects[0].State != nil && workspace.Projects[0].State.Uptime != nil && *workspace.Projects[0].State.Uptime > 0 {
 		rowData.Status = util.FormatUptime(*workspace.Projects[0].State.Uptime)
 	}
 	return &rowData
@@ -205,7 +205,7 @@ func getProjectTableRowData(workspaceDTO serverapiclient.WorkspaceDTO, project s
 	if project.Target != nil {
 		rowData.Target = *project.Target + views_util.AdditionalPropertyPadding
 	}
-	if project.State != nil && project.State.Uptime != nil {
+	if project.State != nil && project.State.Uptime != nil && *project.State.Uptime > 0 {
 		rowData.Status = util.FormatUptime(*project.State.Uptime)
 	}
 

--- a/pkg/views/workspace/selection/workspace.go
+++ b/pkg/views/workspace/selection/workspace.go
@@ -35,7 +35,11 @@ func selectWorkspacePrompt(workspaces []serverapiclient.WorkspaceDTO, actionVerb
 			createdTime = util.FormatCreatedTime(*workspace.Info.Projects[0].Created)
 		}
 		if len(workspace.Projects) > 0 && workspace.Projects[0].State != nil && workspace.Projects[0].State.Uptime != nil {
-			uptime = fmt.Sprintf("up %s", util.FormatUptime(*workspace.Projects[0].State.Uptime))
+			if *workspace.Projects[0].State.Uptime == 0 {
+				uptime = "STOPPED"
+			} else {
+				uptime = fmt.Sprintf("up %s", util.FormatUptime(*workspace.Projects[0].State.Uptime))
+			}
 		}
 
 		newItem := item[serverapiclient.WorkspaceDTO]{


### PR DESCRIPTION
# Reset Project Uptime after Stop

## Description

This PR includes a fix for stopping a project. After the workspace is stopped, its uptime is reset to 0. Additionally, views that display the state are updated to display projects as stopped if the uptime is 0.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Related Issue(s)

Closes #493 

## Screenshots
<img width="565" alt="Screenshot 2024-05-08 at 15 43 37" src="https://github.com/daytonaio/daytona/assets/26512078/49f56203-77ff-4f4d-9088-0cb56cac90b7">
