### PR TITLE
chore: update issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,9 +24,8 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser: [e.g. chrome, safari]
- - Daytona Version: [e.g. 22]
+ - OS: [e.g. Ubuntu 22.04]
+ - Daytona Version: [e.g. v0.0.1]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,19 +4,8 @@
 
 Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.
 
-## Type of Change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
-
-## Checklist
-
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
 
 ## Related Issue(s)
 


### PR DESCRIPTION
# Update Issue and PR templates

## Description

Updated the templates to be less of a chore. 

1. The bug issue template no longer includes a `Browser` field and the OS example was updated to `Ubuntu 22.04`.
2. The PR template was reduced because we enforce conventional commits which are self-explain the type of the change.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
