### PR TITLE
fix: use workspace names instead of id in CLI messages

### DIFF
--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -139,7 +139,7 @@ func DeleteAllWorkspaces() error {
 	for _, workspace := range workspaceList {
 		res, err := apiClient.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
 		if err != nil {
-			log.Errorf("Failed to delete workspace %s: %v", *workspace.Id, apiclient.HandleErrorResponse(res, err))
+			log.Errorf("Failed to delete workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
 			continue
 		}
 		views.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", *workspace.Name))

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -108,10 +108,10 @@ func startAllWorkspaces() error {
 	for _, workspace := range workspaceList {
 		res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, *workspace.Id).Execute()
 		if err != nil {
-			log.Errorf("Failed to start workspace %s: %v", *workspace.Id, apiclient.HandleErrorResponse(res, err))
+			log.Errorf("Failed to start workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
 			continue
 		}
-		fmt.Printf("Workspace %s successfully started\n", *workspace.Id)
+		fmt.Printf("Workspace %s successfully started\n", *workspace.Name)
 	}
 	return nil
 }

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -105,10 +105,10 @@ func stopAllWorkspaces() error {
 	for _, workspace := range workspaceList {
 		res, err := apiClient.WorkspaceAPI.StopWorkspace(ctx, *workspace.Id).Execute()
 		if err != nil {
-			log.Errorf("Failed to stop workspace %s: %v", *workspace.Id, apiclient.HandleErrorResponse(res, err))
+			log.Errorf("Failed to stop workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
 			continue
 		}
-		fmt.Printf("Workspace %s successfully stopped\n", *workspace.Id)
+		fmt.Printf("Workspace %s successfully stopped\n", *workspace.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
# Use Workspace Name Instead of Id in CLI Messages

## Description

This PR makes use of workspace names instead of IDs in CLI messages to improve UX.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #515 