### PR TITLE
feat: update container registry list styling to match rest of TUI

### DIFF
--- a/pkg/cmd/containerregistry/list.go
+++ b/pkg/cmd/containerregistry/list.go
@@ -41,9 +41,6 @@ var containerRegistryListCmd = &cobra.Command{
 			return
 		}
 
-		err = containerregistry_view.ListRegistries(containerRegistries)
-		if err != nil {
-			log.Fatal(err)
-		}
+		containerregistry_view.ListRegistries(containerRegistries)
 	},
 }


### PR DESCRIPTION
## Description

This PR updates the container registry command styling to reflect the rest of the CLI/TUI list views

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #501 
/claim #501

## Screenshots
If relevant, please add screenshots.

**Before:**
<img width="386" alt="image" src="https://github.com/daytonaio/daytona/assets/34857453/5f0e014b-7c9f-4118-82b9-5206d650cf72">


**After:**
<img width="963" alt="image" src="https://github.com/daytonaio/daytona/assets/34857453/37c6f277-8002-4009-87f2-4ea5a1e70744">
