### PR TITLE
feat: daytona info consistency

### DIFF
--- a/internal/util/workspace.go
+++ b/internal/util/workspace.go
@@ -51,3 +51,21 @@ func GetValidatedUrl(input string) (string, error) {
 	// If parsing was successful, return the fixed URL
 	return parsedURL.String(), nil
 }
+
+func GetRepositorySlugFromUrl(url string, specifyGitProviders bool) string {
+	if url == "" {
+		return "/"
+	}
+	url = strings.TrimSuffix(url, "/")
+
+	parts := strings.Split(url, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	if specifyGitProviders {
+		return parts[len(parts)-3] + "/" + parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+
+	return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+}

--- a/pkg/views/workspace/info/view.go
+++ b/pkg/views/workspace/info/view.go
@@ -39,10 +39,10 @@ func Render(workspace *serverapiclient.WorkspaceDTO, ide string, forceUnstyled b
 	output += "\n"
 	output += getInfoLine(nameLabel, *workspace.Name) + "\n"
 
+	output += getInfoLine("ID", *workspace.Id) + "\n"
+
 	if isCreationView {
 		output += getInfoLine("Editor", ide) + "\n"
-	} else {
-		output += getInfoLine("ID", *workspace.Id) + "\n"
 	}
 
 	if len(workspace.Projects) == 1 {

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
@@ -174,7 +173,7 @@ func getWorkspaceTableRowData(workspace serverapiclient.WorkspaceDTO, specifyGit
 		rowData.Name = *workspace.Name + views_util.AdditionalPropertyPadding
 	}
 	if workspace.Projects != nil && len(workspace.Projects) > 0 && workspace.Projects[0].Repository != nil {
-		rowData.Repository = getRepositorySlugFromUrl(*workspace.Projects[0].Repository.Url, specifyGitProviders)
+		rowData.Repository = util.GetRepositorySlugFromUrl(*workspace.Projects[0].Repository.Url, specifyGitProviders)
 		if workspace.Projects[0].Repository.Branch != nil {
 			rowData.Branch = *workspace.Projects[0].Repository.Branch
 		}
@@ -197,7 +196,7 @@ func getProjectTableRowData(workspaceDTO serverapiclient.WorkspaceDTO, project s
 		rowData.Name = " └ " + *project.Name
 	}
 	if project.Repository != nil && project.Repository.Url != nil {
-		rowData.Repository = getRepositorySlugFromUrl(*project.Repository.Url, specifyGitProviders)
+		rowData.Repository = util.GetRepositorySlugFromUrl(*project.Repository.Url, specifyGitProviders)
 		if project.Repository.Branch != nil {
 			rowData.Branch = *project.Repository.Branch
 		}
@@ -221,22 +220,4 @@ func getProjectTableRowData(workspaceDTO serverapiclient.WorkspaceDTO, project s
 	}
 
 	return &rowData
-}
-
-func getRepositorySlugFromUrl(url string, specifyGitProviders bool) string {
-	if url == "" {
-		return "/"
-	}
-	url = strings.TrimSuffix(url, "/")
-
-	parts := strings.Split(url, "/")
-	if len(parts) < 2 {
-		return ""
-	}
-
-	if specifyGitProviders {
-		return parts[len(parts)-3] + "/" + parts[len(parts)-2] + "/" + parts[len(parts)-1]
-	}
-
-	return parts[len(parts)-2] + "/" + parts[len(parts)-1]
 }

--- a/pkg/views/workspace/selection/workspace.go
+++ b/pkg/views/workspace/selection/workspace.go
@@ -23,9 +23,20 @@ func selectWorkspacePrompt(workspaces []serverapiclient.WorkspaceDTO, actionVerb
 
 	// Populate items with titles and descriptions from workspaces.
 	for _, workspace := range workspaces {
-		var projectNames []string
-		for _, project := range workspace.Projects {
-			projectNames = append(projectNames, *project.Name)
+		var projectsInfo []string
+
+		if workspace.Projects == nil || len(workspace.Projects) == 0 {
+			continue
+		}
+
+		if len(workspace.Projects) == 1 {
+			if workspace.Projects[0].Repository != nil && workspace.Projects[0].Repository.Url != nil {
+				projectsInfo = append(projectsInfo, util.GetRepositorySlugFromUrl(*workspace.Projects[0].Repository.Url, true))
+			}
+		} else {
+			for _, project := range workspace.Projects {
+				projectsInfo = append(projectsInfo, *project.Name)
+			}
 		}
 
 		// Get the time if available
@@ -41,7 +52,7 @@ func selectWorkspacePrompt(workspaces []serverapiclient.WorkspaceDTO, actionVerb
 		newItem := item[serverapiclient.WorkspaceDTO]{
 			title:          *workspace.Name,
 			id:             *workspace.Id,
-			desc:           strings.Join(projectNames, ", "),
+			desc:           strings.Join(projectsInfo, ", "),
 			createdTime:    createdTime,
 			uptime:         uptime,
 			target:         *workspace.Target,


### PR DESCRIPTION
# Daytona info consistency

## Description

Added ID to post-creation workspace info view
Workspace selection description row now shows the repository url for single project workspaces. Multi project workspaces still show just the project name

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #454 

## Screenshots
![Screenshot 2024-05-10 at 14 57 19](https://github.com/daytonaio/daytona/assets/25279767/8c7c3e62-0b56-46f1-9a7d-384b7ac4d942)

![Screenshot 2024-05-10 at 14 57 10](https://github.com/daytonaio/daytona/assets/25279767/7efd24f1-ae1f-44ff-be56-f3ca0a2d4bf9)
![Screenshot 2024-05-10 at 14 54 18](https://github.com/daytonaio/daytona/assets/25279767/5a5df8b7-a88d-49c8-a9b0-219d5d4ef8fb)

^workspace `idagelic` has one project while workspace `idagelic2` has two