### PR TITLE
feat: workspace API keys and env variables

### DIFF
--- a/internal/testing/server/workspaces/mocks/api_key_service.go
+++ b/internal/testing/server/workspaces/mocks/api_key_service.go
@@ -33,6 +33,11 @@ func (s *mockApiKeyService) IsValidApiKey(apiKey string) bool {
 	return args.Bool(0)
 }
 
+func (s *mockApiKeyService) IsWorkspaceApiKey(apiKey string) bool {
+	args := s.Called(apiKey)
+	return args.Bool(0)
+}
+
 func (s *mockApiKeyService) ListClientKeys() ([]*apikey.ApiKey, error) {
 	args := s.Called()
 	return args.Get(0).([]*apikey.ApiKey), args.Error(1)

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1551,11 +1551,13 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "client",
-                "project"
+                "project",
+                "workspace"
             ],
             "x-enum-varnames": [
                 "ApiKeyTypeClient",
-                "ApiKeyTypeProject"
+                "ApiKeyTypeProject",
+                "ApiKeyTypeWorkspace"
             ]
         },
         "provider.ProviderInfo": {

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1548,11 +1548,13 @@
             "type": "string",
             "enum": [
                 "client",
-                "project"
+                "project",
+                "workspace"
             ],
             "x-enum-varnames": [
                 "ApiKeyTypeClient",
-                "ApiKeyTypeProject"
+                "ApiKeyTypeProject",
+                "ApiKeyTypeWorkspace"
             ]
         },
         "provider.ProviderInfo": {

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -330,10 +330,12 @@ definitions:
     enum:
     - client
     - project
+    - workspace
     type: string
     x-enum-varnames:
     - ApiKeyTypeClient
     - ApiKeyTypeProject
+    - ApiKeyTypeWorkspace
   provider.ProviderInfo:
     properties:
       name:

--- a/pkg/api/middlewares/project.go
+++ b/pkg/api/middlewares/project.go
@@ -26,7 +26,7 @@ func ProjectAuthMiddleware() gin.HandlerFunc {
 
 		server := server.GetInstance(nil)
 
-		if !server.ApiKeyService.IsProjectApiKey(token) {
+		if !server.ApiKeyService.IsProjectApiKey(token) && !server.ApiKeyService.IsWorkspaceApiKey(token) {
 			ctx.AbortWithError(401, errors.New("unauthorized"))
 		}
 

--- a/pkg/apikey/apikey.go
+++ b/pkg/apikey/apikey.go
@@ -6,8 +6,9 @@ package apikey
 type ApiKeyType string
 
 const (
-	ApiKeyTypeClient  ApiKeyType = "client"
-	ApiKeyTypeProject ApiKeyType = "project"
+	ApiKeyTypeClient    ApiKeyType = "client"
+	ApiKeyTypeProject   ApiKeyType = "project"
+	ApiKeyTypeWorkspace ApiKeyType = "workspace"
 )
 
 type ApiKey struct {

--- a/pkg/server/apikeys/service.go
+++ b/pkg/server/apikeys/service.go
@@ -8,6 +8,7 @@ import "github.com/daytonaio/daytona/pkg/apikey"
 type IApiKeyService interface {
 	Generate(keyType apikey.ApiKeyType, name string) (string, error)
 	IsProjectApiKey(apiKey string) bool
+	IsWorkspaceApiKey(apiKey string) bool
 	IsValidApiKey(apiKey string) bool
 	ListClientKeys() ([]*apikey.ApiKey, error)
 	Revoke(name string) error

--- a/pkg/server/apikeys/validate.go
+++ b/pkg/server/apikeys/validate.go
@@ -29,3 +29,18 @@ func (s *ApiKeyService) IsProjectApiKey(apiKey string) bool {
 
 	return true
 }
+
+func (s *ApiKeyService) IsWorkspaceApiKey(apiKey string) bool {
+	keyHash := apikeys.HashKey(apiKey)
+
+	key, err := s.apiKeyStore.Find(keyHash)
+	if err != nil {
+		return false
+	}
+
+	if key.Type != apikey.ApiKeyTypeWorkspace {
+		return false
+	}
+
+	return true
+}

--- a/pkg/server/apikeys/validate_test.go
+++ b/pkg/server/apikeys/validate_test.go
@@ -49,3 +49,27 @@ func (s *ApiKeyServiceTestSuite) TestIsProjectApiKey_False() {
 	res := s.apiKeyService.IsProjectApiKey(apiKey)
 	require.False(res)
 }
+
+func (s *ApiKeyServiceTestSuite) TestIsWorkspaceApiKey_True() {
+	keyName := "workspaceKey"
+
+	require := s.Require()
+
+	apiKey, err := s.apiKeyService.Generate(apikey.ApiKeyTypeWorkspace, keyName)
+	require.Nil(err)
+
+	res := s.apiKeyService.IsWorkspaceApiKey(apiKey)
+	require.True(res)
+}
+
+func (s *ApiKeyServiceTestSuite) TestIsWorkspaceApiKey_False() {
+	keyName := "clientKey"
+
+	require := s.Require()
+
+	apiKey, err := s.apiKeyService.Generate(apikey.ApiKeyTypeClient, keyName)
+	require.Nil(err)
+
+	res := s.apiKeyService.IsWorkspaceApiKey(apiKey)
+	require.False(res)
+}

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -31,6 +31,12 @@ func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*wor
 		Target: req.Target,
 	}
 
+	apiKey, err := s.apiKeyService.Generate(apikey.ApiKeyTypeWorkspace, w.Id)
+	if err != nil {
+		return nil, err
+	}
+	w.ApiKey = apiKey
+
 	w.Projects = []*workspace.Project{}
 
 	for _, project := range req.Projects {

--- a/pkg/server/workspaces/remove.go
+++ b/pkg/server/workspaces/remove.go
@@ -35,6 +35,12 @@ func (s *WorkspaceService) RemoveWorkspace(workspaceId string) error {
 		return err
 	}
 
+	// Should not fail the whole operation if the API key cannot be revoked
+	err = s.apiKeyService.Revoke(workspace.Id)
+	if err != nil {
+		log.Error(err)
+	}
+
 	for _, project := range workspace.Projects {
 		err := s.apiKeyService.Revoke(fmt.Sprintf("%s/%s", workspace.Id, project.Name))
 		if err != nil {

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -114,6 +114,8 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("CreateWorkspace", mock.Anything, &target).Return(nil)
 		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
 
+		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceRequest.Id).Return(createWorkspaceRequest.Id, nil)
+
 		for _, project := range createWorkspaceRequest.Projects {
 			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceRequest.Id, project.Name)).Return(project.Name, nil)
 		}

--- a/pkg/serverapiclient/api/openapi.yaml
+++ b/pkg/serverapiclient/api/openapi.yaml
@@ -1479,10 +1479,12 @@ components:
       enum:
       - client
       - project
+      - workspace
       type: string
       x-enum-varnames:
       - ApiKeyTypeClient
       - ApiKeyTypeProject
+      - ApiKeyTypeWorkspace
     provider.ProviderInfo:
       example:
         name: name

--- a/pkg/serverapiclient/docs/ApikeyApiKeyType.md
+++ b/pkg/serverapiclient/docs/ApikeyApiKeyType.md
@@ -7,6 +7,8 @@
 
 * `ApiKeyTypeProject` (value: `"project"`)
 
+* `ApiKeyTypeWorkspace` (value: `"workspace"`)
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/pkg/serverapiclient/model_apikey_api_key_type.go
+++ b/pkg/serverapiclient/model_apikey_api_key_type.go
@@ -20,14 +20,16 @@ type ApikeyApiKeyType string
 
 // List of apikey.ApiKeyType
 const (
-	ApiKeyTypeClient  ApikeyApiKeyType = "client"
-	ApiKeyTypeProject ApikeyApiKeyType = "project"
+	ApiKeyTypeClient    ApikeyApiKeyType = "client"
+	ApiKeyTypeProject   ApikeyApiKeyType = "project"
+	ApiKeyTypeWorkspace ApikeyApiKeyType = "workspace"
 )
 
 // All allowed values of ApikeyApiKeyType enum
 var AllowedApikeyApiKeyTypeEnumValues = []ApikeyApiKeyType{
 	"client",
 	"project",
+	"workspace",
 }
 
 func (v *ApikeyApiKeyType) UnmarshalJSON(src []byte) error {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -12,6 +12,7 @@ type Workspace struct {
 	Name     string     `json:"name"`
 	Projects []*Project `json:"projects"`
 	Target   string     `json:"target"`
+	ApiKey   string     `json:"-"`
 } // @name Workspace
 
 type WorkspaceInfo struct {
@@ -27,4 +28,25 @@ func (w *Workspace) GetProject(projectName string) (*Project, error) {
 		}
 	}
 	return nil, errors.New("project not found")
+}
+
+type WorkspaceEnvVarParams struct {
+	ApiUrl        string
+	ApiKey        string
+	ServerUrl     string
+	ServerVersion string
+}
+
+func GetWorkspaceEnvVars(workspace *Workspace, params WorkspaceEnvVarParams) map[string]string {
+	envVars := map[string]string{
+		"DAYTONA_WS_ID":          workspace.Id,
+		"DAYTONA_SERVER_API_KEY": params.ApiKey,
+		"DAYTONA_SERVER_VERSION": params.ServerVersion,
+		"DAYTONA_SERVER_URL":     params.ServerUrl,
+		"DAYTONA_SERVER_API_URL": params.ApiUrl,
+		// $HOME will be replaced at runtime
+		"DAYTONA_AGENT_LOG_FILE_PATH": "$HOME/.daytona-agent.log",
+	}
+
+	return envVars
 }


### PR DESCRIPTION
# Workspace API keys and Env variables

## Description

This PR introduces workspace API keys and exposes a function to get env variables. Both these changes are requirements for VM-based providers that will run the agent in host mode inside a workspace instance.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation