### PR TITLE
fix: use agent api client in tailscale server

### DIFF
--- a/pkg/agent/tailscale/server.go
+++ b/pkg/agent/tailscale/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
+	"github.com/daytonaio/daytona/pkg/agent/config"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
 	"tailscale.com/tsnet"
 
@@ -20,18 +21,18 @@ import (
 )
 
 type Server struct {
-	Hostname  string
-	ServerUrl string
+	Hostname string
+	Server   config.DaytonaServerConfig
 }
 
 func (s *Server) Start() error {
 	flag.Parse()
 	tsnetServer := new(tsnet.Server)
 	tsnetServer.Hostname = s.Hostname
-	tsnetServer.ControlURL = s.ServerUrl
+	tsnetServer.ControlURL = s.Server.Url
 	tsnetServer.Ephemeral = true
 
-	apiClient, err := server.GetApiClient(nil)
+	apiClient, err := server.GetAgentApiClient(s.Server.ApiUrl, s.Server.ApiKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Use Agent API Client in Agent Tailscale Server

## Description

This PR fixes running the agent in host mode inside a workspace instance. The agent tailscale server now uses the agent API client instead of relying on the CLI config.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #528 