### PR TITLE
feat: tailscale ssh tunnel package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -242,6 +242,7 @@ require (
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/tools v0.16.0 // indirect
+	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect
 	google.golang.org/appengine v1.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1924,6 +1924,8 @@ golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=

--- a/internal/cmd/tailscale/connection.go
+++ b/internal/cmd/tailscale/connection.go
@@ -4,28 +4,20 @@
 package tailscale
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
+	"github.com/daytonaio/daytona/pkg/tailscale"
 	"github.com/google/uuid"
 	"tailscale.com/tsnet"
 )
 
-var s *tsnet.Server = nil
-
 func GetConnection(profile *config.Profile) (*tsnet.Server, error) {
-	if s != nil {
-		return s, nil
-	}
-	s = &tsnet.Server{}
-
 	apiClient, err := server.GetApiClient(profile)
 	if err != nil {
 		return nil, err
@@ -47,20 +39,12 @@ func GetConnection(profile *config.Profile) (*tsnet.Server, error) {
 	}
 
 	cliId := uuid.New().String()
-	s.Hostname = fmt.Sprintf("cli-%s", cliId)
-	s.ControlURL = util.GetFrpcServerUrl(*serverConfig.Frps.Protocol, *serverConfig.Id, *serverConfig.Frps.Domain)
-	s.AuthKey = *networkKey.Key
-	s.Ephemeral = true
-	s.Dir = filepath.Join(configDir, "tailscale", cliId)
-	s.Logf = func(format string, args ...any) {}
 
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	_, err = s.Up(timeoutCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	return s, nil
+	return tailscale.GetConnection(&tailscale.TsnetConnConfig{
+		AuthKey:    *networkKey.Key,
+		ControlURL: util.GetFrpcServerUrl(*serverConfig.Frps.Protocol, *serverConfig.Id, *serverConfig.Frps.Domain),
+		Dir:        filepath.Join(configDir, "tailscale", cliId),
+		Logf:       func(format string, args ...any) {},
+		Hostname:   fmt.Sprintf("cli-%s", cliId),
+	})
 }

--- a/pkg/agent/ssh/unix_forward.go
+++ b/pkg/agent/ssh/unix_forward.go
@@ -1,0 +1,288 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// streamLocalForwardPayload describes the extra data sent in a
+// streamlocal-forward@openssh.com containing the socket path to bind to.
+type streamLocalForwardPayload struct {
+	SocketPath string
+}
+
+// forwardedStreamLocalPayload describes the data sent as the payload in the new
+// channel request when a Unix connection is accepted by the listener.
+type forwardedStreamLocalPayload struct {
+	SocketPath string
+	Reserved   uint32
+}
+
+// forwardedUnixHandler is a clone of ssh.ForwardedTCPHandler that does
+// streamlocal forwarding (aka. unix forwarding) instead of TCP forwarding.
+type forwardedUnixHandler struct {
+	sync.Mutex
+	forwards map[forwardKey]net.Listener
+}
+
+type forwardKey struct {
+	sessionID string
+	addr      string
+}
+
+func newForwardedUnixHandler() *forwardedUnixHandler {
+	return &forwardedUnixHandler{
+		forwards: make(map[forwardKey]net.Listener),
+	}
+}
+
+func (h *forwardedUnixHandler) HandleSSHRequest(ctx ssh.Context, _ *ssh.Server, req *gossh.Request) (bool, []byte) {
+	log.Debug(ctx, "handling SSH unix forward")
+	conn, ok := ctx.Value(ssh.ContextKeyConn).(*gossh.ServerConn)
+	if !ok {
+		log.Warn(ctx, "SSH unix forward request from client with no gossh connection")
+		return false, nil
+	}
+
+	switch req.Type {
+	case "streamlocal-forward@openssh.com":
+		var reqPayload streamLocalForwardPayload
+		err := gossh.Unmarshal(req.Payload, &reqPayload)
+		if err != nil {
+			log.Warn(ctx, "parse streamlocal-forward@openssh.com request (SSH unix forward) payload from client", err)
+			return false, nil
+		}
+
+		addr := reqPayload.SocketPath
+		log.Debug(ctx, "request begin SSH unix forward")
+
+		key := forwardKey{
+			sessionID: ctx.SessionID(),
+			addr:      addr,
+		}
+
+		h.Lock()
+		_, ok := h.forwards[key]
+		h.Unlock()
+		if ok {
+			// In cases where `ExitOnForwardFailure=yes` is set, returning false
+			// here will cause the connection to be closed. To avoid this, and
+			// to match OpenSSH behavior, we silently ignore the second forward
+			// request.
+			log.Warn(ctx, "SSH unix forward request for socket path that is already being forwarded on this session, ignoring")
+			return true, nil
+		}
+
+		// Create socket parent dir if not exists.
+		parentDir := filepath.Dir(addr)
+		err = os.MkdirAll(parentDir, 0o700)
+		if err != nil {
+			log.Error(err)
+			return false, nil
+		}
+
+		// Remove existing socket if it exists. We do not use os.Remove() here
+		// so that directories are kept. Note that it's possible that we will
+		// overwrite a regular file here. Both of these behaviors match OpenSSH,
+		// however, which is why we unlink.
+		err = unlink(addr)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			log.Warn(ctx, "remove existing socket for SSH unix forward request", err)
+			return false, nil
+		}
+
+		lc := &net.ListenConfig{}
+		ln, err := lc.Listen(ctx, "unix", addr)
+		if err != nil {
+			log.Warn(ctx, "listen on Unix socket for SSH unix forward request", err)
+			return false, nil
+		}
+		log.Debug(ctx, "SSH unix forward listening on socket")
+
+		// The listener needs to successfully start before it can be added to
+		// the map, so we don't have to worry about checking for an existing
+		// listener.
+		//
+		// This is also what the upstream TCP version of this code does.
+		h.Lock()
+		h.forwards[key] = ln
+		h.Unlock()
+		log.Debug(ctx, "SSH unix forward added to cache")
+
+		ctx, cancel := context.WithCancel(ctx)
+		go func() {
+			<-ctx.Done()
+			_ = ln.Close()
+		}()
+		go func() {
+			defer cancel()
+
+			for {
+				c, err := ln.Accept()
+				if err != nil {
+					if !errors.Is(err, net.ErrClosed) {
+						log.Warn(ctx, "accept on local Unix socket for SSH unix forward request", err)
+					}
+					// closed below
+					log.Debug(ctx, "SSH unix forward listener closed")
+					break
+				}
+				log.Debug(ctx, "accepted SSH unix forward connection")
+				payload := gossh.Marshal(&forwardedStreamLocalPayload{
+					SocketPath: addr,
+				})
+
+				go func() {
+					ch, reqs, err := conn.OpenChannel("forwarded-streamlocal@openssh.com", payload)
+					if err != nil {
+						log.Warn(ctx, "open SSH unix forward channel to client", err)
+						_ = c.Close()
+						return
+					}
+					go gossh.DiscardRequests(reqs)
+					Bicopy(ctx, ch, c)
+				}()
+			}
+
+			h.Lock()
+			if ln2, ok := h.forwards[key]; ok && ln2 == ln {
+				delete(h.forwards, key)
+			}
+			h.Unlock()
+			log.Debug(ctx, "SSH unix forward listener removed from cache")
+			_ = ln.Close()
+		}()
+
+		return true, nil
+
+	case "cancel-streamlocal-forward@openssh.com":
+		var reqPayload streamLocalForwardPayload
+		err := gossh.Unmarshal(req.Payload, &reqPayload)
+		if err != nil {
+			log.Warn(ctx, "parse cancel-streamlocal-forward@openssh.com (SSH unix forward) request payload from client", err)
+			return false, nil
+		}
+		log.Debug(ctx, "request to cancel SSH unix forward", reqPayload.SocketPath)
+
+		key := forwardKey{
+			sessionID: ctx.SessionID(),
+			addr:      reqPayload.SocketPath,
+		}
+
+		h.Lock()
+		ln, ok := h.forwards[key]
+		delete(h.forwards, key)
+		h.Unlock()
+		if !ok {
+			log.Warn(ctx, "SSH unix forward not found in cache")
+			return true, nil
+		}
+		_ = ln.Close()
+		return true, nil
+
+	default:
+		return false, nil
+	}
+}
+
+// directStreamLocalPayload describes the extra data sent in a
+// direct-streamlocal@openssh.com channel request containing the socket path.
+type directStreamLocalPayload struct {
+	SocketPath string
+
+	Reserved1 string
+	Reserved2 uint32
+}
+
+func directStreamLocalHandler(_ *ssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
+	var reqPayload directStreamLocalPayload
+	err := gossh.Unmarshal(newChan.ExtraData(), &reqPayload)
+	if err != nil {
+		_ = newChan.Reject(gossh.ConnectionFailed, "could not parse direct-streamlocal@openssh.com channel payload")
+		return
+	}
+
+	var dialer net.Dialer
+	dconn, err := dialer.DialContext(ctx, "unix", reqPayload.SocketPath)
+	if err != nil {
+		_ = newChan.Reject(gossh.ConnectionFailed, fmt.Sprintf("dial unix socket %q: %+v", reqPayload.SocketPath, err.Error()))
+		return
+	}
+
+	ch, reqs, err := newChan.Accept()
+	if err != nil {
+		_ = dconn.Close()
+		return
+	}
+	go gossh.DiscardRequests(reqs)
+
+	Bicopy(ctx, ch, dconn)
+}
+
+// unlink removes files and unlike os.Remove, directories are kept.
+func unlink(path string) error {
+	// Ignore EINTR like os.Remove, see ignoringEINTR in os/file_posix.go
+	// for more details.
+	for {
+		err := syscall.Unlink(path)
+		if !errors.Is(err, syscall.EINTR) {
+			return err
+		}
+	}
+}
+
+// Bicopy copies all of the data between the two connections and will close them
+// after one or both of them are done writing. If the context is canceled, both
+// of the connections will be closed.
+func Bicopy(ctx context.Context, c1, c2 io.ReadWriteCloser) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	defer func() {
+		_ = c1.Close()
+		_ = c2.Close()
+	}()
+
+	var wg sync.WaitGroup
+	copyFunc := func(dst io.WriteCloser, src io.Reader) {
+		defer func() {
+			wg.Done()
+			// If one side of the copy fails, ensure the other one exits as
+			// well.
+			cancel()
+		}()
+		_, _ = io.Copy(dst, src)
+	}
+
+	wg.Add(2)
+	go copyFunc(c1, c2)
+	go copyFunc(c2, c1)
+
+	// Convert waitgroup to a channel so we can also wait on the context.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-done:
+	}
+}

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -111,6 +111,9 @@ var ServeCmd = &cobra.Command{
 			ServerUrl:             util.GetFrpcServerUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
 			RegistryUrl:           c.RegistryUrl,
 			BaseDir:               c.ProvidersDir,
+			CreateProviderNetworkKey: func(providerName string) (string, error) {
+				return headscaleServer.CreateAuthKey()
+			},
 		})
 		provisioner := provisioner.NewProvisioner(provisioner.ProvisionerConfig{
 			ProviderManager: providerManager,

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -11,10 +11,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/daytonaio/daytona/internal/tailscale"
-	util "github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/internal/cmd/tailscale"
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
+	"github.com/daytonaio/daytona/pkg/agent/ssh"
 	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -334,7 +335,7 @@ func waitForDial(tsConn *tsnet.Server, workspaceId string, projectName string, d
 			return errors.New("timeout: dialing timed out after 3 minutes")
 		}
 
-		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:2222", workspace.GetProjectHostname(workspaceId, projectName)))
+		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:%d", workspace.GetProjectHostname(workspaceId, projectName), ssh.SSH_PORT))
 		if err == nil {
 			defer dialConn.Close()
 			break

--- a/pkg/cmd/workspace/ssh-proxy.go
+++ b/pkg/cmd/workspace/ssh-proxy.go
@@ -10,8 +10,9 @@ import (
 	"os"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
-	"github.com/daytonaio/daytona/internal/tailscale"
+	"github.com/daytonaio/daytona/internal/cmd/tailscale"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
+	"github.com/daytonaio/daytona/pkg/agent/ssh"
 	"github.com/daytonaio/daytona/pkg/workspace"
 
 	log "github.com/sirupsen/logrus"
@@ -53,7 +54,7 @@ var SshProxyCmd = &cobra.Command{
 
 		errChan := make(chan error)
 
-		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:2222", workspace.GetProjectHostname(workspaceId, projectName)))
+		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:%d", workspace.GetProjectHostname(workspaceId, projectName), ssh.SSH_PORT))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/ide/jetbrains.go
+++ b/pkg/ide/jetbrains.go
@@ -13,6 +13,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/jetbrains"
 	"github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/pkg/agent/ssh"
 	ospkg "github.com/daytonaio/daytona/pkg/os"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/pkg/browser"
@@ -54,7 +55,7 @@ func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId, projectNam
 		return err
 	}
 
-	gatewayUrl := fmt.Sprintf("jetbrains-gateway://connect#host=%s&type=ssh&deploy=false&projectPath=%s&user=daytona&port=2222&idePath=%s", projectHostname, projectDir, url.QueryEscape(downloadPath))
+	gatewayUrl := fmt.Sprintf("jetbrains-gateway://connect#host=%s&type=ssh&deploy=false&projectPath=%s&user=daytona&port=%d&idePath=%s", projectHostname, projectDir, ssh.SSH_PORT, url.QueryEscape(downloadPath))
 
 	return browser.OpenURL(gatewayUrl)
 }

--- a/pkg/ports/ports.go
+++ b/pkg/ports/ports.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/daytonaio/daytona/internal/tailscale"
+	"github.com/daytonaio/daytona/internal/cmd/tailscale"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	log "github.com/sirupsen/logrus"
 	"tailscale.com/tsnet"

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -18,6 +18,7 @@ type InitializeProviderRequest struct {
 	ServerDownloadUrl string
 	ServerVersion     string
 	ServerUrl         string
+	NetworkKey        string
 	ServerApiUrl      string
 	LogsDir           string
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -79,22 +79,6 @@ func (s *Server) Start(errCh chan error) error {
 
 	log.Info("Starting Daytona server")
 
-	// Terminate orphaned provider processes
-	err = s.ProviderManager.TerminateProviderProcesses(s.config.ProvidersDir)
-	if err != nil {
-		log.Errorf("Failed to terminate orphaned provider processes: %s", err)
-	}
-
-	err = s.downloadDefaultProviders()
-	if err != nil {
-		return err
-	}
-
-	err = s.registerProviders()
-	if err != nil {
-		return err
-	}
-
 	headscaleFrpcHealthCheck, headscaleFrpcService, err := frpc.GetService(frpc.FrpcConnectParams{
 		ServerDomain: s.config.Frps.Domain,
 		ServerPort:   int(s.config.Frps.Port),
@@ -182,6 +166,22 @@ func (s *Server) Start(errCh chan error) error {
 			break
 		}
 	}
+	if err != nil {
+		return err
+	}
+
+	// Terminate orphaned provider processes
+	err = s.ProviderManager.TerminateProviderProcesses(s.config.ProvidersDir)
+	if err != nil {
+		log.Errorf("Failed to terminate orphaned provider processes: %s", err)
+	}
+
+	err = s.downloadDefaultProviders()
+	if err != nil {
+		return err
+	}
+
+	err = s.registerProviders()
 	if err != nil {
 		return err
 	}

--- a/pkg/tailscale/connection.go
+++ b/pkg/tailscale/connection.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"tailscale.com/tsnet"
+)
+
+var conn *tsnet.Server = nil
+
+type TsnetConnConfig struct {
+	AuthKey    string
+	ControlURL string
+	Dir        string
+	Logf       func(format string, args ...any)
+	Hostname   string
+}
+
+func GetConnection(config *TsnetConnConfig) (*tsnet.Server, error) {
+	if conn != nil {
+		return conn, nil
+	}
+
+	if config == nil {
+		return nil, fmt.Errorf("connection not initialized")
+	}
+
+	conn = &tsnet.Server{
+		AuthKey:    config.AuthKey,
+		ControlURL: config.ControlURL,
+		Dir:        config.Dir,
+		Logf:       config.Logf,
+		Hostname:   config.Hostname,
+		Ephemeral:  true,
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := conn.Up(timeoutCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}

--- a/pkg/tailscale/forward_unix.go
+++ b/pkg/tailscale/forward_unix.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tailscale
+
+import (
+	"context"
+
+	"github.com/daytonaio/daytona/pkg/tailscale/tunnel"
+	log "github.com/sirupsen/logrus"
+	"tailscale.com/tsnet"
+)
+
+type ForwardConfig struct {
+	Ctx        context.Context
+	TsnetConn  *tsnet.Server
+	Hostname   string
+	SshPort    int
+	LocalSock  string
+	RemoteSock string
+}
+
+func ForwardRemoteUnixSock(config ForwardConfig) (chan bool, chan error) {
+	sshTun := tunnel.NewUnix(config.TsnetConn, config.LocalSock, config.Hostname, config.SshPort, config.RemoteSock)
+
+	errChan := make(chan error)
+
+	sshTun.SetTunneledConnState(func(tun *tunnel.SshTunnel, state *tunnel.TunneledConnectionState) {
+		log.Debugf("%+v", state)
+	})
+
+	startedChann := make(chan bool, 1)
+
+	sshTun.SetConnState(func(tun *tunnel.SshTunnel, state tunnel.ConnectionState) {
+		switch state {
+		case tunnel.StateStarting:
+			log.Debugf("SSH Tunnel is Starting")
+		case tunnel.StateStarted:
+			log.Debugf("SSH Tunnel is Started")
+			startedChann <- true
+		case tunnel.StateStopped:
+			log.Debugf("SSH Tunnel is Stopped")
+		}
+	})
+
+	go func() {
+		errChan <- sshTun.Start(config.Ctx)
+	}()
+
+	return startedChann, errChan
+}

--- a/pkg/tailscale/tunnel/endpoint.go
+++ b/pkg/tailscale/tunnel/endpoint.go
@@ -1,0 +1,44 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tunnel
+
+import "fmt"
+
+const (
+	endpointTypeUnixSocket = "unix"
+	endpointTypeTCP        = "tcp"
+)
+
+type Endpoint struct {
+	host       string
+	port       int
+	unixSocket string
+}
+
+func (e *Endpoint) String() string {
+	if e.unixSocket != "" {
+		return e.unixSocket
+	}
+	return fmt.Sprintf("%s:%d", e.host, e.port)
+}
+
+func (e *Endpoint) Type() string {
+	if e.unixSocket != "" {
+		return endpointTypeUnixSocket
+	}
+	return endpointTypeTCP
+}
+
+func NewTCPEndpoint(host string, port int) *Endpoint {
+	return &Endpoint{
+		host: host,
+		port: port,
+	}
+}
+
+func NewUnixEndpoint(socket string) *Endpoint {
+	return &Endpoint{
+		unixSocket: socket,
+	}
+}

--- a/pkg/tailscale/tunnel/forward.go
+++ b/pkg/tailscale/tunnel/forward.go
@@ -1,0 +1,117 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// TunneledConnectionState represents the state of the final connections made through the tunnel.
+type TunneledConnectionState struct {
+	// From is the address initating the connection.
+	From string
+	// Info holds a message with info on the state of the connection (useful for debug purposes).
+	Info string
+	// Error holds an error on the connection or nil if the connection is successful.
+	Error error
+	// Ready indicates if the connection is established.
+	Ready bool
+	// Closed indicates if the coonnection is closed.
+	Closed bool
+}
+
+func (s *TunneledConnectionState) String() string {
+	out := fmt.Sprintf("[%s] ", s.From)
+	if s.Info != "" {
+		out += s.Info
+	}
+	if s.Error != nil {
+		out += fmt.Sprintf("Error: %v", s.Error)
+	}
+	return out
+}
+
+func (tun *SshTunnel) forward(localConn net.Conn) {
+	from := localConn.RemoteAddr().String()
+
+	tun.tunneledState(&TunneledConnectionState{
+		From: from,
+		Info: fmt.Sprintf("accepted %s connection", tun.local.Type()),
+	})
+
+	remoteConn, err := tun.sshClient.Dial(tun.remote.Type(), tun.remote.String())
+	if err != nil {
+		tun.tunneledState(&TunneledConnectionState{
+			From:  from,
+			Error: fmt.Errorf("remote dial %s to %s failed: %w", tun.remote.Type(), tun.remote.String(), err),
+		})
+
+		localConn.Close()
+		return
+	}
+
+	connStr := fmt.Sprintf("%s -(%s)> %s -(ssh)> %s -(%s)> %s", from, tun.local.Type(), tun.local.String(),
+		tun.server.String(), tun.remote.Type(), tun.remote.String())
+
+	tun.tunneledState(&TunneledConnectionState{
+		From:   from,
+		Info:   fmt.Sprintf("connection established: %s", connStr),
+		Ready:  true,
+		Closed: false,
+	})
+
+	connCtx, connCancel := context.WithCancel(tun.ctx)
+	errGroup := &errgroup.Group{}
+
+	errGroup.Go(func() error {
+		defer connCancel()
+		_, err = io.Copy(remoteConn, localConn)
+		if err != nil {
+			return fmt.Errorf("failed copying bytes from remote to local: %w", err)
+		}
+		return remoteConn.Close()
+	})
+
+	errGroup.Go(func() error {
+		defer connCancel()
+		_, err = io.Copy(localConn, remoteConn)
+		if err != nil {
+			return fmt.Errorf("failed copying bytes from local to remote: %w", err)
+		}
+		return localConn.Close()
+	})
+
+	err = errGroup.Wait()
+
+	<-connCtx.Done()
+
+	select {
+	case <-tun.ctx.Done():
+	default:
+		if err != nil {
+			tun.tunneledState(&TunneledConnectionState{
+				From:  from,
+				Error: err,
+			})
+		}
+	}
+
+	tun.tunneledState(&TunneledConnectionState{
+		From:   from,
+		Info:   fmt.Sprintf("connection closed: %s", connStr),
+		Ready:  false,
+		Closed: true,
+	})
+}
+
+func (tun *SshTunnel) tunneledState(state *TunneledConnectionState) {
+	if tun.tunneledConnState != nil {
+		tun.tunneledConnState(tun, state)
+	}
+}

--- a/pkg/tailscale/tunnel/tunnel.go
+++ b/pkg/tailscale/tunnel/tunnel.go
@@ -1,0 +1,239 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
+	"tailscale.com/tsnet"
+)
+
+type SshTunnel struct {
+	mutex             *sync.Mutex
+	ctx               context.Context
+	cancel            context.CancelFunc
+	started           bool
+	server            *Endpoint
+	local             *Endpoint
+	remote            *Endpoint
+	timeout           time.Duration
+	connState         func(*SshTunnel, ConnectionState)
+	tunneledConnState func(*SshTunnel, *TunneledConnectionState)
+	active            int
+	sshClient         *ssh.Client
+	sshConfig         *ssh.ClientConfig
+	tsnetConn         *tsnet.Server
+}
+
+// ConnectionState represents the state of the SSH tunnel. It's returned to an optional function provided to SetConnState.
+type ConnectionState int
+
+const (
+	// StateStopped represents a stopped tunnel. A call to Start will make the state to transition to StateStarting.
+	StateStopped ConnectionState = iota
+
+	// StateStarting represents a tunnel initializing and preparing to listen for connections.
+	// A successful initialization will make the state to transition to StateStarted, otherwise it will transition to StateStopped.
+	StateStarting
+
+	// StateStarted represents a tunnel ready to accept connections.
+	// A call to stop or an error will make the state to transition to StateStopped.
+	StateStarted
+)
+
+// New creates a new SSH tunnel to the specified server redirecting a port on local localhost to a port on remote localhost.
+// The states of the tunnel can be received through a callback function with SetConnState.
+// The states of the tunneled connections can be received through a callback function with SetTunneledConnState.
+func New(tsnetConn *tsnet.Server, localPort int, server string, serverPort, remotePort int) *SshTunnel {
+	sshTun := defaultSSHTun(server, serverPort, tsnetConn)
+	sshTun.local = NewTCPEndpoint("localhost", localPort)
+	sshTun.remote = NewTCPEndpoint("localhost", remotePort)
+	return sshTun
+}
+
+// NewUnix does the same as New but using unix sockets.
+func NewUnix(tsnetConn *tsnet.Server, localUnixSocket, server string, serverPort int, remoteUnixSocket string) *SshTunnel {
+	sshTun := defaultSSHTun(server, serverPort, tsnetConn)
+	sshTun.local = NewUnixEndpoint(localUnixSocket)
+	sshTun.remote = NewUnixEndpoint(remoteUnixSocket)
+	return sshTun
+}
+
+func defaultSSHTun(server string, port int, tsnetConn *tsnet.Server) *SshTunnel {
+	return &SshTunnel{
+		mutex:     &sync.Mutex{},
+		server:    NewTCPEndpoint(server, port),
+		timeout:   time.Second * 15,
+		tsnetConn: tsnetConn,
+	}
+}
+
+// SetConnState specifies an optional callback function that is called when a SSH tunnel changes state.
+// See the ConnState type and associated constants for details.
+func (tun *SshTunnel) SetConnState(connStateFun func(*SshTunnel, ConnectionState)) {
+	tun.connState = connStateFun
+}
+
+// SetTunneledConnState specifies an optional callback function that is called when the underlying tunneled
+// connections change state.
+func (tun *SshTunnel) SetTunneledConnState(tunneledConnStateFun func(*SshTunnel, *TunneledConnectionState)) {
+	tun.tunneledConnState = tunneledConnStateFun
+}
+
+// Start starts the SSH tunnel. It can be stopped by calling `Stop` or cancelling its context.
+// This call will block until the tunnel is stopped either calling those methods or by an error.
+func (tun *SshTunnel) Start(ctx context.Context) error {
+	tun.mutex.Lock()
+	if tun.started {
+		tun.mutex.Unlock()
+		return fmt.Errorf("already started")
+	}
+	tun.started = true
+	tun.ctx, tun.cancel = context.WithCancel(ctx)
+	tun.mutex.Unlock()
+
+	if tun.connState != nil {
+		tun.connState(tun, StateStarting)
+	}
+
+	config, err := tun.initSSHConfig()
+	if err != nil {
+		return tun.stop(fmt.Errorf("ssh config failed: %w", err))
+	}
+	tun.sshConfig = config
+
+	listenConfig := net.ListenConfig{}
+	localListener, err := listenConfig.Listen(tun.ctx, tun.local.Type(), tun.local.String())
+	if err != nil {
+		return tun.stop(fmt.Errorf("local listen %s on %s failed: %w", tun.local.Type(), tun.local.String(), err))
+	}
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- tun.listen(localListener)
+	}()
+
+	if tun.connState != nil {
+		tun.connState(tun, StateStarted)
+	}
+
+	return tun.stop(<-errChan)
+}
+
+// Stop closes all connections and makes Start exit gracefuly.
+func (tun *SshTunnel) Stop() {
+	tun.mutex.Lock()
+	defer tun.mutex.Unlock()
+
+	if tun.started {
+		tun.cancel()
+	}
+}
+
+func (tun *SshTunnel) initSSHConfig() (*ssh.ClientConfig, error) {
+	config := &ssh.ClientConfig{
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			return nil
+		},
+		Timeout: tun.timeout,
+	}
+
+	return config, nil
+}
+
+func (tun *SshTunnel) stop(err error) error {
+	tun.mutex.Lock()
+	tun.started = false
+	tun.mutex.Unlock()
+	if tun.connState != nil {
+		tun.connState(tun, StateStopped)
+	}
+	return err
+}
+
+func (tun *SshTunnel) listen(localListener net.Listener) error {
+	errGroup, groupCtx := errgroup.WithContext(tun.ctx)
+
+	errGroup.Go(func() error {
+		for {
+			localConn, err := localListener.Accept()
+			if err != nil {
+				return fmt.Errorf("local accept %s on %s failed: %w", tun.local.Type(), tun.local.String(), err)
+			}
+
+			errGroup.Go(func() error {
+				return tun.handle(localConn)
+			})
+		}
+	})
+
+	<-groupCtx.Done()
+
+	localListener.Close()
+
+	err := errGroup.Wait()
+
+	select {
+	case <-tun.ctx.Done():
+	default:
+		return err
+	}
+
+	return nil
+}
+
+func (tun *SshTunnel) handle(localConn net.Conn) error {
+	err := tun.addConn()
+	if err != nil {
+		return err
+	}
+
+	tun.forward(localConn)
+	tun.removeConn()
+
+	return nil
+}
+
+func (tun *SshTunnel) addConn() error {
+	tun.mutex.Lock()
+	defer tun.mutex.Unlock()
+
+	if tun.active == 0 {
+		if tun.tsnetConn == nil {
+			return errors.New("tsnetConn is not set")
+		}
+		conn, err := tun.tsnetConn.Dial(tun.ctx, tun.server.Type(), tun.server.String())
+		if err != nil {
+			return err
+		}
+		c, chans, reqs, err := ssh.NewClientConn(conn, tun.server.String(), tun.sshConfig)
+		if err != nil {
+			return err
+		}
+		tun.sshClient = ssh.NewClient(c, chans, reqs)
+	}
+
+	tun.active += 1
+
+	return nil
+}
+
+func (tun *SshTunnel) removeConn() {
+	tun.mutex.Lock()
+	defer tun.mutex.Unlock()
+
+	tun.active -= 1
+
+	if tun.active == 0 {
+		tun.sshClient.Close()
+		tun.sshClient = nil
+	}
+}


### PR DESCRIPTION
# Tailscale SSH tunnel package

## Description

This PR is a small refactor to getting the Tailscale connection inside Daytona but the main contribution is the Tailscale SSH tunnel package that allows for forwarding tcp ports and unix sockets over ssh over Tailscale. This package will make it easier for VM-based provider (e.g. DigitalOcean) to forward the docker.sock from workspace instances. That forwarded sock is then used to create project containers inside VMs.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
