### PR TITLE
feat: Use always latest Jetbrains product version 

### DIFF
--- a/internal/jetbrains/ides.go
+++ b/internal/jetbrains/ides.go
@@ -17,8 +17,8 @@ func GetIdes() map[Id]Ide {
 }
 
 var clion = Ide{
-	Name:    "CLion",
-	Version: "2023.2.2",
+	ProductCode: "CL",
+	Name:        "CLion",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/cpp/CLion-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/cpp/CLion-%s-aarch64.tar.gz",
@@ -26,8 +26,8 @@ var clion = Ide{
 }
 
 var intellij = Ide{
-	Name:    "IntelliJ IDEA Ultimate",
-	Version: "2023.2.2",
+	ProductCode: "IIU",
+	Name:        "IntelliJ IDEA Ultimate",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/idea/ideaIU-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/idea/ideaIU-%s-aarch64.tar.gz",
@@ -35,8 +35,8 @@ var intellij = Ide{
 }
 
 var goland = Ide{
-	Name:    "GoLand",
-	Version: "2023.2.2",
+	ProductCode: "GO",
+	Name:        "GoLand",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/go/goland-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/go/goland-%s-aarch64.tar.gz",
@@ -44,8 +44,8 @@ var goland = Ide{
 }
 
 var pycharm = Ide{
-	Name:    "PyCharm Professional",
-	Version: "2023.2.2",
+	ProductCode: "PCP",
+	Name:        "PyCharm Professional",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/python/pycharm-professional-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/python/pycharm-professional-%s-aarch64.tar.gz",
@@ -53,8 +53,8 @@ var pycharm = Ide{
 }
 
 var phpstorm = Ide{
-	Name:    "PhpStorm",
-	Version: "2023.2.2",
+	ProductCode: "PS",
+	Name:        "PhpStorm",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/webide/PhpStorm-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/webide/PhpStorm-%s-aarch64.tar.gz",
@@ -62,8 +62,8 @@ var phpstorm = Ide{
 }
 
 var webstorm = Ide{
-	Name:    "WebStorm",
-	Version: "2023.2.2",
+	ProductCode: "WS",
+	Name:        "WebStorm",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/webstorm/WebStorm-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/webstorm/WebStorm-%s-aarch64.tar.gz",
@@ -71,8 +71,8 @@ var webstorm = Ide{
 }
 
 var rider = Ide{
-	Name:    "Rider",
-	Version: "2023.2.2",
+	ProductCode: "RD",
+	Name:        "Rider",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/rider/JetBrains.Rider-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/rider/JetBrains.Rider-%s-aarch64.tar.gz",
@@ -80,8 +80,8 @@ var rider = Ide{
 }
 
 var rubymine = Ide{
-	Name:    "RubyMine",
-	Version: "2023.2.2",
+	ProductCode: "RM",
+	Name:        "RubyMine",
 	UrlTemplates: UrlTemplates{
 		Amd64: "https://download.jetbrains.com/ruby/RubyMine-%s.tar.gz",
 		Arm64: "https://download.jetbrains.com/ruby/RubyMine-%s-aarch64.tar.gz",

--- a/internal/jetbrains/types.go
+++ b/internal/jetbrains/types.go
@@ -4,8 +4,8 @@
 package jetbrains
 
 type Ide struct {
+	ProductCode  string
 	Name         string
-	Version      string
 	UrlTemplates UrlTemplates
 }
 

--- a/pkg/ide/jetbrains.go
+++ b/pkg/ide/jetbrains.go
@@ -43,7 +43,10 @@ func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId, projectNam
 		return err
 	}
 
-	jbIdeVersion := GetJetbrainsVersion(jbIde.ProductCode)
+	jbIdeVersion, err := getJetbrainsVersion(jbIde.ProductCode)
+	if err != nil {
+		return err
+	}
 
 	switch *remoteOs {
 	case ospkg.Linux_arm64:
@@ -92,11 +95,11 @@ func isAlreadyDownloaded(projectHostname, downloadPath string) bool {
 	return err == nil
 }
 
-func GetJetbrainsVersion(productCode string) string {
+func getJetbrainsVersion(productCode string) (string, error) {
 	jetbrainsDataServicesUrl := fmt.Sprintf("https://data.services.jetbrains.com/products/releases?code=%s&type=release&latest=true&build=", productCode)
 	res, err := http.Get(jetbrainsDataServicesUrl)
 	if err != nil {
-		panic("failed to request version for product")
+		return "", err
 	}
 
 	body, err := io.ReadAll(res.Body)
@@ -112,7 +115,7 @@ func GetJetbrainsVersion(productCode string) string {
 	for _, v := range result {
 		if len(v) > 0 {
 			if version, ok := v[0]["version"].(string); ok {
-				return version
+				return version, nil
 			}
 		}
 	}

--- a/pkg/ide/jetbrains.go
+++ b/pkg/ide/jetbrains.go
@@ -104,12 +104,12 @@ func getJetbrainsVersion(productCode string) (string, error) {
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		panic("failed to read version for product")
+		return "", err
 	}
 
 	var result map[string][]map[string]interface{}
 	if err := json.Unmarshal(body, &result); err != nil {
-		panic("failed to parse json for product")
+		return "", err
 	}
 
 	for _, v := range result {
@@ -119,5 +119,5 @@ func getJetbrainsVersion(productCode string) (string, error) {
 			}
 		}
 	}
-	panic("no version found")
+	return "", fmt.Errorf("jetbrains: no version found for %s", productCode)
 }


### PR DESCRIPTION
# feat: Use always latest Jetbrains product version 

## Description

At the moment an outdated version of Jetbrains is used for the IDE's. The Jetbrains API now reads the latest product version based on the ID and then uses this when starting the IDE. 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
[#545](https://github.com/daytonaio/daytona/issues/545)

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
