### PR TITLE
feat: project naming

### DIFF
--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -41,17 +41,17 @@ func GetCreationDataFromPrompt(apiServerConfig *serverapiclient.ServerConfig, ex
 		return "", nil, err
 	}
 
-	if workspaceCreationPromptResponse.PrimaryProject.Source == nil {
-		return "", nil, errors.New("primary project is required")
+	if workspaceCreationPromptResponse.InitialProject.Source == nil {
+		return "", nil, errors.New("project repository is required")
 	}
 
-	projectList = []serverapiclient.CreateWorkspaceRequestProject{workspaceCreationPromptResponse.PrimaryProject}
+	projectList = []serverapiclient.CreateWorkspaceRequestProject{workspaceCreationPromptResponse.InitialProject}
 
 	if multiProject {
 		for i := 0; workspaceCreationPromptResponse.AddingMoreProjects; i++ {
 
 			if !manual && userGitProviders != nil && len(userGitProviders) > 0 {
-				providerRepo, err = getRepositoryFromWizard(userGitProviders, i+1)
+				providerRepo, err = getRepositoryFromWizard(userGitProviders, i+2)
 				if err != nil {
 					return "", nil, err
 				}
@@ -68,7 +68,7 @@ func GetCreationDataFromPrompt(apiServerConfig *serverapiclient.ServerConfig, ex
 			}
 			providerRepoUrl = ""
 		}
-		projectList = append(projectList, workspaceCreationPromptResponse.SecondaryProjects...)
+		projectList = append(projectList, workspaceCreationPromptResponse.AdditionalProjects...)
 	}
 
 	for i, project := range projectList {
@@ -79,7 +79,7 @@ func GetCreationDataFromPrompt(apiServerConfig *serverapiclient.ServerConfig, ex
 		projectList[i].Name = projectName
 	}
 
-	suggestedName := GetSuggestedWorkspaceName(*workspaceCreationPromptResponse.PrimaryProject.Source.Repository.Url, existingWorkspaceNames)
+	suggestedName := GetSuggestedWorkspaceName(*workspaceCreationPromptResponse.InitialProject.Source.Repository.Url, existingWorkspaceNames)
 
 	err = create.RunSubmissionForm(&workspaceName, suggestedName, existingWorkspaceNames, &projectList, apiServerConfig)
 	if err != nil {

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -16,7 +16,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 )
 
-func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, secondaryProjectOrder int) (serverapiclient.GitRepository, error) {
+func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, additionalProjectOrder int) (serverapiclient.GitRepository, error) {
 	var providerId string
 	var namespaceId string
 	var branchName string
@@ -38,7 +38,7 @@ func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, sec
 			}
 		}
 	}
-	providerId = selection.GetProviderIdFromPrompt(gitProviderViewList, secondaryProjectOrder)
+	providerId = selection.GetProviderIdFromPrompt(gitProviderViewList, additionalProjectOrder)
 	if providerId == "" {
 		return serverapiclient.GitRepository{}, nil
 	}
@@ -69,7 +69,7 @@ func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, sec
 	if len(namespaceList) == 1 {
 		namespaceId = *namespaceList[0].Id
 	} else {
-		namespaceId = selection.GetNamespaceIdFromPrompt(namespaceList, secondaryProjectOrder)
+		namespaceId = selection.GetNamespaceIdFromPrompt(namespaceList, additionalProjectOrder)
 		if namespaceId == "" {
 			return serverapiclient.GitRepository{}, errors.New("namespace not found")
 		}
@@ -85,7 +85,7 @@ func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, sec
 		return serverapiclient.GitRepository{}, err
 	}
 
-	chosenRepo := selection.GetRepositoryFromPrompt(providerRepos, secondaryProjectOrder)
+	chosenRepo := selection.GetRepositoryFromPrompt(providerRepos, additionalProjectOrder)
 	if chosenRepo == (serverapiclient.GitRepository{}) {
 		return serverapiclient.GitRepository{}, nil
 	}
@@ -125,7 +125,7 @@ func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, sec
 		return serverapiclient.GitRepository{}, err
 	}
 	if len(prList) == 0 {
-		branchName = selection.GetBranchNameFromPrompt(branchList, secondaryProjectOrder)
+		branchName = selection.GetBranchNameFromPrompt(branchList, additionalProjectOrder)
 		if branchName == "" {
 			return serverapiclient.GitRepository{}, nil
 		}
@@ -138,19 +138,19 @@ func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, sec
 	checkoutOptions = append(checkoutOptions, selection.CheckoutBranch)
 	checkoutOptions = append(checkoutOptions, selection.CheckoutPR)
 
-	chosenCheckoutOption := selection.GetCheckoutOptionFromPrompt(secondaryProjectOrder, checkoutOptions)
+	chosenCheckoutOption := selection.GetCheckoutOptionFromPrompt(additionalProjectOrder, checkoutOptions)
 	if chosenCheckoutOption == selection.CheckoutDefault {
 		return chosenRepo, nil
 	}
 
 	if chosenCheckoutOption == selection.CheckoutBranch {
-		branchName = selection.GetBranchNameFromPrompt(branchList, secondaryProjectOrder)
+		branchName = selection.GetBranchNameFromPrompt(branchList, additionalProjectOrder)
 		if branchName == "" {
 			return serverapiclient.GitRepository{}, nil
 		}
 		chosenRepo.Branch = &branchName
 	} else if chosenCheckoutOption == selection.CheckoutPR {
-		chosenPullRequest := selection.GetPullRequestFromPrompt(prList, secondaryProjectOrder)
+		chosenPullRequest := selection.GetPullRequestFromPrompt(prList, additionalProjectOrder)
 		if *chosenPullRequest.Branch == "" {
 			return serverapiclient.GitRepository{}, nil
 		}

--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -85,17 +85,10 @@ func RenderSummary(workspaceName string, projectList []serverapiclient.CreateWor
 		}
 	}
 
-	output += fmt.Sprintf("\n\n%s - %s\n", lipgloss.NewStyle().Foreground(views.Green).Render("Primary Project"), *projectList[0].Source.Repository.Url)
-
-	// Remove the primary project from the list
-	projectList = projectList[1:]
-
-	if len(projectList) > 1 {
-		output += "\n"
-	}
+	output += "\n\n"
 
 	for i := range projectList {
-		output += fmt.Sprintf("%s - %s", lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("#%d %s", i+1, "Secondary Project")), (*projectList[i].Source.Repository.Url))
+		output += fmt.Sprintf("%s - %s", lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("%s #%d", "Project", i+1)), (*projectList[i].Source.Repository.Url))
 		if i < len(projectList)-1 {
 			output += "\n"
 		}

--- a/pkg/views/workspace/selection/branch.go
+++ b/pkg/views/workspace/selection/branch.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectBranchPrompt(branches []serverapiclient.GitBranch, secondaryProjectOrder int, choiceChan chan<- string) {
+func selectBranchPrompt(branches []serverapiclient.GitBranch, additionalProjectOrder int, choiceChan chan<- string) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -29,8 +29,8 @@ func selectBranchPrompt(branches []serverapiclient.GitBranch, secondaryProjectOr
 	l := views.GetStyledSelectList(items)
 
 	title := "Choose a Branch"
-	if secondaryProjectOrder > 0 {
-		title += fmt.Sprintf(" (Secondary Project #%d)", secondaryProjectOrder)
+	if additionalProjectOrder > 0 {
+		title += fmt.Sprintf(" (Project #%d)", additionalProjectOrder)
 	}
 	l.Title = views.GetStyledMainTitle(title)
 	l.Styles.Title = titleStyle
@@ -49,10 +49,10 @@ func selectBranchPrompt(branches []serverapiclient.GitBranch, secondaryProjectOr
 	}
 }
 
-func GetBranchNameFromPrompt(branches []serverapiclient.GitBranch, secondaryProjectOrder int) string {
+func GetBranchNameFromPrompt(branches []serverapiclient.GitBranch, additionalProjectOrder int) string {
 	choiceChan := make(chan string)
 
-	go selectBranchPrompt(branches, secondaryProjectOrder, choiceChan)
+	go selectBranchPrompt(branches, additionalProjectOrder, choiceChan)
 
 	return <-choiceChan
 }

--- a/pkg/views/workspace/selection/checkout.go
+++ b/pkg/views/workspace/selection/checkout.go
@@ -24,7 +24,7 @@ var (
 	CheckoutPR      = CheckoutOption{Title: "Pull/Merge requests", Id: "pullrequest"}
 )
 
-func selectCheckoutPrompt(checkoutOptions []CheckoutOption, secondaryProjectOrder int, choiceChan chan<- string) {
+func selectCheckoutPrompt(checkoutOptions []CheckoutOption, additionalProjectOrder int, choiceChan chan<- string) {
 	items := []list.Item{}
 
 	for _, checkoutOption := range checkoutOptions {
@@ -35,8 +35,8 @@ func selectCheckoutPrompt(checkoutOptions []CheckoutOption, secondaryProjectOrde
 	l := views.GetStyledSelectList(items)
 
 	title := "Cloning Options"
-	if secondaryProjectOrder > 0 {
-		title += fmt.Sprintf(" (Secondary Project #%d)", secondaryProjectOrder)
+	if additionalProjectOrder > 0 {
+		title += fmt.Sprintf(" (Project #%d)", additionalProjectOrder)
 	}
 	l.Title = views.GetStyledMainTitle(title)
 	l.Styles.Title = titleStyle
@@ -55,10 +55,10 @@ func selectCheckoutPrompt(checkoutOptions []CheckoutOption, secondaryProjectOrde
 	}
 }
 
-func GetCheckoutOptionFromPrompt(secondaryProjectOrder int, checkoutOptions []CheckoutOption) CheckoutOption {
+func GetCheckoutOptionFromPrompt(additionalProjectOrder int, checkoutOptions []CheckoutOption) CheckoutOption {
 	choiceChan := make(chan string)
 
-	go selectCheckoutPrompt(checkoutOptions, secondaryProjectOrder, choiceChan)
+	go selectCheckoutPrompt(checkoutOptions, additionalProjectOrder, choiceChan)
 
 	checkoutOptionId := <-choiceChan
 

--- a/pkg/views/workspace/selection/namespace.go
+++ b/pkg/views/workspace/selection/namespace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-func selectNamespacePrompt(namespaces []serverapiclient.GitNamespace, secondaryProjectOrder int, choiceChan chan<- string) {
+func selectNamespacePrompt(namespaces []serverapiclient.GitNamespace, additionalProjectOrder int, choiceChan chan<- string) {
 	items := []list.Item{}
 	var desc string
 
@@ -31,8 +31,8 @@ func selectNamespacePrompt(namespaces []serverapiclient.GitNamespace, secondaryP
 	l := views.GetStyledSelectList(items)
 
 	title := "Choose a Namespace"
-	if secondaryProjectOrder > 0 {
-		title += fmt.Sprintf(" (Secondary Project #%d)", secondaryProjectOrder)
+	if additionalProjectOrder > 0 {
+		title += fmt.Sprintf(" (Project #%d)", additionalProjectOrder)
 	}
 	l.Title = views.GetStyledMainTitle(title)
 	l.Styles.Title = titleStyle
@@ -51,10 +51,10 @@ func selectNamespacePrompt(namespaces []serverapiclient.GitNamespace, secondaryP
 	}
 }
 
-func GetNamespaceIdFromPrompt(namespaces []serverapiclient.GitNamespace, secondaryProjectOrder int) string {
+func GetNamespaceIdFromPrompt(namespaces []serverapiclient.GitNamespace, additionalProjectOrder int) string {
 	choiceChan := make(chan string)
 
-	go selectNamespacePrompt(namespaces, secondaryProjectOrder, choiceChan)
+	go selectNamespacePrompt(namespaces, additionalProjectOrder, choiceChan)
 
 	return <-choiceChan
 }

--- a/pkg/views/workspace/selection/provider.go
+++ b/pkg/views/workspace/selection/provider.go
@@ -17,7 +17,7 @@ import (
 
 var titleStyle = lipgloss.NewStyle()
 
-func selectProviderPrompt(gitProviders []gitprovider_view.GitProviderView, secondaryProjectOrder int, choiceChan chan<- string) {
+func selectProviderPrompt(gitProviders []gitprovider_view.GitProviderView, additionalProjectOrder int, choiceChan chan<- string) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -32,8 +32,8 @@ func selectProviderPrompt(gitProviders []gitprovider_view.GitProviderView, secon
 	l := views.GetStyledSelectList(items)
 
 	title := "Choose a Provider"
-	if secondaryProjectOrder > 0 {
-		title += fmt.Sprintf(" (Secondary Project #%d)", secondaryProjectOrder)
+	if additionalProjectOrder > 0 {
+		title += fmt.Sprintf(" (Project #%d)", additionalProjectOrder)
 	}
 	l.Title = views.GetStyledMainTitle(title)
 	l.Styles.Title = titleStyle
@@ -52,10 +52,10 @@ func selectProviderPrompt(gitProviders []gitprovider_view.GitProviderView, secon
 	}
 }
 
-func GetProviderIdFromPrompt(gitProviders []gitprovider_view.GitProviderView, secondaryProjectOrder int) string {
+func GetProviderIdFromPrompt(gitProviders []gitprovider_view.GitProviderView, additionalProjectOrder int) string {
 	choiceChan := make(chan string)
 
-	go selectProviderPrompt(gitProviders, secondaryProjectOrder, choiceChan)
+	go selectProviderPrompt(gitProviders, additionalProjectOrder, choiceChan)
 
 	return <-choiceChan
 }

--- a/pkg/views/workspace/selection/pullrequest.go
+++ b/pkg/views/workspace/selection/pullrequest.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectPullRequestPrompt(pullRequests []serverapiclient.GitPullRequest, secondaryProjectOrder int, choiceChan chan<- string) {
+func selectPullRequestPrompt(pullRequests []serverapiclient.GitPullRequest, additionalProjectOrder int, choiceChan chan<- string) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -29,8 +29,8 @@ func selectPullRequestPrompt(pullRequests []serverapiclient.GitPullRequest, seco
 	l := views.GetStyledSelectList(items)
 
 	title := "Choose a Pull/Merge Request"
-	if secondaryProjectOrder > 0 {
-		title += fmt.Sprintf(" (Secondary Project #%d)", secondaryProjectOrder)
+	if additionalProjectOrder > 0 {
+		title += fmt.Sprintf(" (Project #%d)", additionalProjectOrder)
 	}
 	l.Title = views.GetStyledMainTitle(title)
 	l.Styles.Title = titleStyle
@@ -49,10 +49,10 @@ func selectPullRequestPrompt(pullRequests []serverapiclient.GitPullRequest, seco
 	}
 }
 
-func GetPullRequestFromPrompt(pullRequests []serverapiclient.GitPullRequest, secondaryProjectOrder int) serverapiclient.GitPullRequest {
+func GetPullRequestFromPrompt(pullRequests []serverapiclient.GitPullRequest, additionalProjectOrder int) serverapiclient.GitPullRequest {
 	choiceChan := make(chan string)
 
-	go selectPullRequestPrompt(pullRequests, secondaryProjectOrder, choiceChan)
+	go selectPullRequestPrompt(pullRequests, additionalProjectOrder, choiceChan)
 
 	pullRequestName := <-choiceChan
 

--- a/pkg/views/workspace/selection/repository.go
+++ b/pkg/views/workspace/selection/repository.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, secondaryProjectOrder int, choiceChan chan<- string) {
+func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, additionalProjectOrder int, choiceChan chan<- string) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -26,8 +26,8 @@ func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, second
 	l := views.GetStyledSelectList(items)
 
 	title := "Choose a Repository"
-	if secondaryProjectOrder > 0 {
-		title += fmt.Sprintf(" (Secondary Project #%d)", secondaryProjectOrder)
+	if additionalProjectOrder > 0 {
+		title += fmt.Sprintf(" (Project #%d)", additionalProjectOrder)
 	}
 	l.Title = views.GetStyledMainTitle(title)
 	l.Styles.Title = titleStyle
@@ -46,10 +46,10 @@ func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, second
 	}
 }
 
-func GetRepositoryFromPrompt(repositories []serverapiclient.GitRepository, secondaryProjectOrder int) serverapiclient.GitRepository {
+func GetRepositoryFromPrompt(repositories []serverapiclient.GitRepository, additionalProjectOrder int) serverapiclient.GitRepository {
 	choiceChan := make(chan string)
 
-	go selectRepositoryPrompt(repositories, secondaryProjectOrder, choiceChan)
+	go selectRepositoryPrompt(repositories, additionalProjectOrder, choiceChan)
 
 	choice := <-choiceChan
 


### PR DESCRIPTION
# Project categorization

## Description

Removes terms "primary" and "secondary" when referring to projects and changes it to simply be "first", "second", "third" etc.
The projects are all treated equally so there is no need for categorizing them.

Terms "initial" and "additional" projects are still kept for some variable/property names as they fit the way creation/display views currently work.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
