### PR TITLE
fix: run server service as user

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -86,14 +86,18 @@ func Stop() error {
 }
 
 func getServiceConfig() (*service.Config, error) {
+	user, ok := os.LookupEnv("USER")
+	if !ok {
+		return nil, fmt.Errorf("could not determine user")
+	}
+
 	svcConfig := &service.Config{
 		Name:        "DaytonaServerDaemon",
 		DisplayName: "Daytona Server",
 		Description: "This is the Daytona Server daemon.",
 		Arguments:   []string{"serve"},
+		UserName:    user,
 	}
-
-	user := os.Getenv("USER")
 
 	switch runtime.GOOS {
 	case "windows":


### PR DESCRIPTION
# Run Server Service as User

## Description

This PR adds the user as an argument to the server service that is started with `daytona server`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #537 