### PR TITLE
feat: remote profile flow

### DIFF
--- a/pkg/cmd/apikey/generate.go
+++ b/pkg/cmd/apikey/generate.go
@@ -11,8 +11,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
+	"github.com/daytonaio/daytona/pkg/serverapiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/server/apikey"
 	view "github.com/daytonaio/daytona/pkg/views/server/apikey"
@@ -65,7 +67,14 @@ var GenerateCmd = &cobra.Command{
 			return
 		}
 
-		view.Render(key)
+		serverConfig, _, err := apiClient.ServerAPI.GetConfigExecute(serverapiclient.ApiGetConfigRequest{})
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		apiUrl := util.GetFrpcApiUrl(*serverConfig.Frps.Protocol, *serverConfig.Id, *serverConfig.Frps.Domain)
+
+		view.Render(key, apiUrl)
 	},
 }
 

--- a/pkg/views/profile/create.go
+++ b/pkg/views/profile/create.go
@@ -49,6 +49,7 @@ func ProfileCreationView(c *config.Config, profileAddView *ProfileAddView, editi
 			nameInput,
 			huh.NewInput().
 				Title("Server API URL").
+				Description("If you want to connect to a remote Daytona Server, start by running 'daytona api-key new' on the remote machine").
 				Value(&profileAddView.ApiUrl).
 				Validate(func(str string) error {
 					if str == "" {

--- a/pkg/views/server/apikey/notify.go
+++ b/pkg/views/server/apikey/notify.go
@@ -10,18 +10,18 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-func Render(key string) {
+func Render(key, apiUrl string) {
 	var output string
 
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Generated API key: "), key) + "\n\n"
 
+	output += "Make sure to copy it as you will not be able to see it again." + "\n\n"
+
 	output += views.SeparatorString + "\n\n"
 
-	output += "You can add it to a profile by running:\n\n"
+	output += "You can connect to the Daytona Server from a client machine by running:\n\n"
 
-	output += lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile edit -k %s", key)) + "\n\n"
-
-	output += "Make sure to copy it as you will not be able to see it again."
+	output += lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
 
 	views.RenderContainerLayout(views.GetInfoMessage(output))
 }


### PR DESCRIPTION
# Remote profile flow

## Description

Changed the `daytona api-key new` command response from 

![image](https://github.com/daytonaio/daytona/assets/25279767/a40650b9-460f-414d-b022-d7efbf5f5048)


to
![image](https://github.com/daytonaio/daytona/assets/25279767/2e994fe2-aecc-40f3-be0c-45fd7ba38107)


Updated the profile adding form from
![image](https://github.com/daytonaio/daytona/assets/25279767/d510d711-640e-428f-a834-babad78442ad)


to
![image](https://github.com/daytonaio/daytona/assets/25279767/298ebf50-ce25-437b-9b8c-4328771befb4)


This lets the user know how to setup a remote profile when they run `daytona profile add` and suggests the "add" command instead of "edit" as it is the more likely goal when creating an API key

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #539 

## Notes
Making the minor change in the api-key command response seemed cleaner than having the user run `daytona server config` and view the entire configuration model of the server 
