### PR TITLE
feat: parse git context from repo url

### DIFF
--- a/internal/testing/server/workspaces/mocks/git_provider_service.go
+++ b/internal/testing/server/workspaces/mocks/git_provider_service.go
@@ -1,0 +1,84 @@
+//go:build testing
+
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import (
+	"github.com/daytonaio/daytona/pkg/gitprovider"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockGitProviderService struct {
+	mock.Mock
+}
+
+func NewMockGitProviderService() *mockGitProviderService {
+	return &mockGitProviderService{}
+}
+
+func (m *mockGitProviderService) GetConfig(id string) (*gitprovider.GitProviderConfig, error) {
+	args := m.Called(id)
+	return args.Get(0).(*gitprovider.GitProviderConfig), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetConfigForUrl(url string) (*gitprovider.GitProviderConfig, error) {
+	args := m.Called(url)
+	return args.Get(0).(*gitprovider.GitProviderConfig), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetGitProvider(id string) (gitprovider.GitProvider, error) {
+	args := m.Called(id)
+	return args.Get(0).(gitprovider.GitProvider), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetGitProviderForUrl(url string) (gitprovider.GitProvider, error) {
+	args := m.Called(url)
+	return args.Get(0).(gitprovider.GitProvider), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetGitUser(gitProviderId string) (*gitprovider.GitUser, error) {
+	args := m.Called(gitProviderId)
+	return args.Get(0).(*gitprovider.GitUser), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetNamespaces(gitProviderId string) ([]*gitprovider.GitNamespace, error) {
+	args := m.Called(gitProviderId)
+	return args.Get(0).([]*gitprovider.GitNamespace), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetRepoBranches(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitBranch, error) {
+	args := m.Called(gitProviderId, namespaceId, repositoryId)
+	return args.Get(0).([]*gitprovider.GitBranch), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetRepoPRs(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitPullRequest, error) {
+	args := m.Called(gitProviderId, namespaceId, repositoryId)
+	return args.Get(0).([]*gitprovider.GitPullRequest), args.Error(1)
+}
+
+func (m *mockGitProviderService) GetRepositories(gitProviderId string, namespaceId string) ([]*gitprovider.GitRepository, error) {
+	args := m.Called(gitProviderId, namespaceId)
+	return args.Get(0).([]*gitprovider.GitRepository), args.Error(1)
+}
+
+func (m *mockGitProviderService) ListConfigs() ([]*gitprovider.GitProviderConfig, error) {
+	args := m.Called()
+	return args.Get(0).([]*gitprovider.GitProviderConfig), args.Error(1)
+}
+
+func (m *mockGitProviderService) RemoveGitProvider(gitProviderId string) error {
+	args := m.Called(gitProviderId)
+	return args.Error(0)
+}
+
+func (m *mockGitProviderService) SetGitProviderConfig(providerConfig *gitprovider.GitProviderConfig) error {
+	args := m.Called(providerConfig)
+	return args.Error(0)
+}
+
+func (m *mockGitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (string, error) {
+	args := m.Called(repo)
+	return args.String(0), args.Error(1)
+}

--- a/pkg/api/controllers/gitprovider/branches.go
+++ b/pkg/api/controllers/gitprovider/branches.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	_ "github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
@@ -27,8 +28,20 @@ import (
 //	@id				GetRepoBranches
 func GetRepoBranches(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
-	namespaceId := ctx.Param("namespaceId")
-	repositoryId := ctx.Param("repositoryId")
+	namespaceArg := ctx.Param("namespaceId")
+	repositoryArg := ctx.Param("repositoryId")
+
+	namespaceId, err := url.QueryUnescape(namespaceArg)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to parse namespace: %s", err.Error()))
+		return
+	}
+
+	repositoryId, err := url.QueryUnescape(repositoryArg)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to parse repository: %s", err.Error()))
+		return
+	}
 
 	server := server.GetInstance(nil)
 

--- a/pkg/api/controllers/gitprovider/pull_requests.go
+++ b/pkg/api/controllers/gitprovider/pull_requests.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
@@ -26,8 +27,20 @@ import (
 //	@id				GetRepoPRs
 func GetRepoPRs(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
-	namespaceId := ctx.Param("namespaceId")
-	repositoryId := ctx.Param("repositoryId")
+	namespaceArg := ctx.Param("namespaceId")
+	repositoryArg := ctx.Param("repositoryId")
+
+	namespaceId, err := url.QueryUnescape(namespaceArg)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to parse namespace: %s", err.Error()))
+		return
+	}
+
+	repositoryId, err := url.QueryUnescape(repositoryArg)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to parse repository: %s", err.Error()))
+		return
+	}
 
 	server := server.GetInstance(nil)
 

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1284,6 +1284,21 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "sha": {
+                    "type": "string"
+                },
+                "sourceRepoId": {
+                    "type": "string"
+                },
+                "sourceRepoName": {
+                    "type": "string"
+                },
+                "sourceRepoOwner": {
+                    "type": "string"
+                },
+                "sourceRepoUrl": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1281,6 +1281,21 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "sha": {
+                    "type": "string"
+                },
+                "sourceRepoId": {
+                    "type": "string"
+                },
+                "sourceRepoName": {
+                    "type": "string"
+                },
+                "sourceRepoOwner": {
+                    "type": "string"
+                },
+                "sourceRepoUrl": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -111,6 +111,16 @@ definitions:
         type: string
       name:
         type: string
+      sha:
+        type: string
+      sourceRepoId:
+        type: string
+      sourceRepoName:
+        type: string
+      sourceRepoOwner:
+        type: string
+      sourceRepoUrl:
+        type: string
     type: object
   GitRepository:
     properties:

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -123,6 +123,9 @@ var ServeCmd = &cobra.Command{
 		provisioner := provisioner.NewProvisioner(provisioner.ProvisionerConfig{
 			ProviderManager: providerManager,
 		})
+		gitProviderService := gitproviders.NewGitProviderService(gitproviders.GitProviderServiceConfig{
+			ConfigStore: gitProviderConfigStore,
+		})
 
 		workspaceService := workspaces.NewWorkspaceService(workspaces.WorkspaceServiceConfig{
 			WorkspaceStore:                  workspaceStore,
@@ -136,10 +139,9 @@ var ServeCmd = &cobra.Command{
 			DefaultProjectPostStartCommands: c.DefaultProjectPostStartCommands,
 			Provisioner:                     provisioner,
 			LoggerFactory:                   loggerFactory,
+			GitProviderService:              gitProviderService,
 		})
-		gitProviderService := gitproviders.NewGitProviderService(gitproviders.GitProviderServiceConfig{
-			ConfigStore: gitProviderConfigStore,
-		})
+
 		profileDataService := profiledata.NewProfileDataService(profiledata.ProfileDataServiceConfig{
 			ProfileDataStore: profileDataStore,
 		})

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -88,7 +88,7 @@ var CreateCmd = &cobra.Command{
 			}
 
 			if workspaceName == "" {
-				workspaceName = workspace_util.GetSuggestedWorkspaceName(*projects[0].Source.Repository.Url, existingWorkspaceNames)
+				workspaceName = workspace_util.GetSuggestedWorkspaceName(projects[0].Name, existingWorkspaceNames)
 			}
 		}
 
@@ -237,7 +237,14 @@ func processPrompting(apiClient *serverapiclient.APIClient, workspaceName *strin
 		return apiclient.HandleErrorResponse(res, err)
 	}
 
-	*workspaceName, *projects, err = workspace_util.GetCreationDataFromPrompt(apiServerConfig, workspaceNames, gitProviders, manualFlag, multiProjectFlag)
+	*workspaceName, *projects, err = workspace_util.GetCreationDataFromPrompt(workspace_util.CreateDataPromptConfig{
+		ApiServerConfig:        apiServerConfig,
+		ExistingWorkspaceNames: workspaceNames,
+		UserGitProviders:       gitProviders,
+		Manual:                 manualFlag,
+		MultiProject:           multiProjectFlag,
+		ApiClient:              apiClient,
+	})
 	if err != nil {
 		return err
 	}
@@ -258,12 +265,10 @@ func processCmdArguments(args []string, apiClient *serverapiclient.APIClient, pr
 		return apiclient.HandleErrorResponse(res, err)
 	}
 
-	projectName := workspace_util.GetProjectNameFromRepo(repoUrl)
-
 	project := &serverapiclient.CreateWorkspaceRequestProject{
-		Name: projectName,
+		Name: *repoResponse.Name,
 		Source: &serverapiclient.CreateWorkspaceRequestProjectSource{
-			Repository: &serverapiclient.GitRepository{Url: repoResponse.Url},
+			Repository: repoResponse,
 		},
 	}
 

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -4,84 +4,86 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
-	"unicode"
 
 	"github.com/daytonaio/daytona/pkg/serverapiclient"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 )
 
-func GetCreationDataFromPrompt(apiServerConfig *serverapiclient.ServerConfig, existingWorkspaceNames []string, userGitProviders []serverapiclient.GitProvider, manual bool, multiProject bool) (string, []serverapiclient.CreateWorkspaceRequestProject, error) {
+type CreateDataPromptConfig struct {
+	ApiServerConfig        *serverapiclient.ServerConfig
+	ExistingWorkspaceNames []string
+	UserGitProviders       []serverapiclient.GitProvider
+	Manual                 bool
+	MultiProject           bool
+	ApiClient              *serverapiclient.APIClient
+}
+
+func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []serverapiclient.CreateWorkspaceRequestProject, error) {
 	var projectList []serverapiclient.CreateWorkspaceRequestProject
-	var providerRepo serverapiclient.GitRepository
-	var providerRepoUrl string
+	var providerRepo *serverapiclient.GitRepository
 	var err error
 	var workspaceName string
 
-	if !manual && userGitProviders != nil && len(userGitProviders) > 0 {
-		providerRepo, err = getRepositoryFromWizard(userGitProviders, 0)
+	if !config.Manual && config.UserGitProviders != nil && len(config.UserGitProviders) > 0 {
+		providerRepo, err = getRepositoryFromWizard(config.UserGitProviders, 0)
 		if err != nil {
 			return "", nil, err
 		}
-		if providerRepo == (serverapiclient.GitRepository{}) {
-			return "", nil, nil
+	}
+
+	if providerRepo == nil {
+		providerRepo, err = create.GetRepositoryFromUrlInput(config.MultiProject, config.ApiClient)
+		if err != nil {
+			return "", nil, err
 		}
 	}
 
-	if providerRepo.Url == nil {
-		providerRepo.Url = new(string)
-	}
+	projectList = []serverapiclient.CreateWorkspaceRequestProject{{
+		Name: *providerRepo.Name,
+		Source: &serverapiclient.CreateWorkspaceRequestProjectSource{
+			Repository: providerRepo,
+		},
+	}}
 
-	workspaceCreationPromptResponse, err := create.RunInitialForm(*providerRepo.Url, multiProject)
-	if err != nil {
-		return "", nil, err
-	}
-
-	if workspaceCreationPromptResponse.InitialProject.Source == nil {
-		return "", nil, errors.New("project repository is required")
-	}
-
-	projectList = []serverapiclient.CreateWorkspaceRequestProject{workspaceCreationPromptResponse.InitialProject}
-
-	if multiProject {
-		for i := 0; workspaceCreationPromptResponse.AddingMoreProjects; i++ {
-
-			if !manual && userGitProviders != nil && len(userGitProviders) > 0 {
-				providerRepo, err = getRepositoryFromWizard(userGitProviders, i+2)
+	if config.MultiProject {
+		addMore := true
+		for i := 2; addMore; i++ {
+			if !config.Manual && config.UserGitProviders != nil && len(config.UserGitProviders) > 0 {
+				providerRepo, err = getRepositoryFromWizard(config.UserGitProviders, i+2)
 				if err != nil {
 					return "", nil, err
 				}
-				if providerRepo == (serverapiclient.GitRepository{}) {
-					return "", nil, nil
+			}
+
+			if providerRepo == nil {
+				providerRepo, addMore, err = create.RunAdditionalProjectRepoForm(i, config.ApiClient)
+				if err != nil {
+					return "", nil, err
 				}
-
-				providerRepoUrl = *providerRepo.Url
+			} else {
+				addMore, err = create.RunAddMoreProjectsForm()
+				if err != nil {
+					return "", nil, err
+				}
 			}
 
-			workspaceCreationPromptResponse, err = create.RunProjectForm(workspaceCreationPromptResponse, providerRepoUrl)
-			if err != nil {
-				return "", nil, err
-			}
-			providerRepoUrl = ""
+			projectList = append(projectList, serverapiclient.CreateWorkspaceRequestProject{
+				Name: *providerRepo.Name,
+				Source: &serverapiclient.CreateWorkspaceRequestProjectSource{
+					Repository: providerRepo,
+				},
+			})
 		}
-		projectList = append(projectList, workspaceCreationPromptResponse.AdditionalProjects...)
 	}
 
-	for i, project := range projectList {
-		if project.Source == nil || project.Source.Repository == nil || project.Source.Repository.Url == nil {
-			return "", nil, errors.New("repository is required")
-		}
-		projectName := GetProjectNameFromRepo(*project.Source.Repository.Url)
-		projectList[i].Name = projectName
-	}
+	suggestedName := GetSuggestedWorkspaceName(projectList[0].Name, config.ExistingWorkspaceNames)
 
-	suggestedName := GetSuggestedWorkspaceName(*workspaceCreationPromptResponse.InitialProject.Source.Repository.Url, existingWorkspaceNames)
-
-	err = create.RunSubmissionForm(&workspaceName, suggestedName, existingWorkspaceNames, &projectList, apiServerConfig)
+	err = create.RunSubmissionForm(&workspaceName, suggestedName, config.ExistingWorkspaceNames, &projectList, config.ApiServerConfig)
 	if err != nil {
 		return "", nil, err
 	}
@@ -94,50 +96,19 @@ func GetProjectNameFromRepo(repoUrl string) string {
 	return projectNameSlugRegex.ReplaceAllString(strings.TrimSuffix(strings.ToLower(filepath.Base(repoUrl)), ".git"), "-")
 }
 
-func GetSuggestedWorkspaceName(repo string, existingWorkspaceNames []string) string {
-	var result strings.Builder
-	input := repo
-	input = strings.TrimSuffix(input, "/")
+func GetSuggestedWorkspaceName(firstProjectName string, existingWorkspaceNames []string) string {
+	suggestion := firstProjectName
 
-	// Find the last index of '/' in the repo string
-	lastIndex := strings.LastIndex(input, "/")
-
-	// If '/' is found, extract the content after it
-	if lastIndex != -1 && lastIndex < len(repo)-1 {
-		input = repo[lastIndex+1:]
-	}
-
-	input = strings.TrimSuffix(input, ".git")
-
-	for _, char := range input {
-		if unicode.IsLetter(char) || unicode.IsNumber(char) || char == '-' {
-			result.WriteRune(char)
-		} else if char == ' ' {
-			result.WriteRune('-')
-		}
-	}
-
-	suggestion := strings.ToLower(result.String())
-
-	if !checkContains(existingWorkspaceNames, suggestion) {
+	if !slices.Contains(existingWorkspaceNames, suggestion) {
 		return suggestion
 	} else {
 		i := 2
 		for {
 			newSuggestion := fmt.Sprintf("%s%d", suggestion, i)
-			if !checkContains(existingWorkspaceNames, newSuggestion) {
+			if !slices.Contains(existingWorkspaceNames, newSuggestion) {
 				return newSuggestion
 			}
 			i++
 		}
 	}
-}
-
-func checkContains(arr []string, target string) bool {
-	for _, s := range arr {
-		if s == target {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/url"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util/apiclient/server"
@@ -89,7 +90,7 @@ func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, add
 
 	var branchList []serverapiclient.GitBranch
 	err = views_util.With(func() error {
-		branchList, _, err = apiClient.GitProviderAPI.GetRepoBranches(ctx, providerId, namespaceId, *chosenRepo.Id).Execute()
+		branchList, _, err = apiClient.GitProviderAPI.GetRepoBranches(ctx, providerId, namespaceId, url.QueryEscape(*chosenRepo.Id)).Execute()
 		return err
 	})
 
@@ -107,14 +108,9 @@ func getRepositoryFromWizard(userGitProviders []serverapiclient.GitProvider, add
 		return chosenRepo, nil
 	}
 
-	// TODO: Add support for Bitbucket
-	if providerId == "bitbucket" {
-		return chosenRepo, nil
-	}
-
 	var prList []serverapiclient.GitPullRequest
 	err = views_util.With(func() error {
-		prList, _, err = apiClient.GitProviderAPI.GetRepoPRs(ctx, providerId, namespaceId, *chosenRepo.Id).Execute()
+		prList, _, err = apiClient.GitProviderAPI.GetRepoPRs(ctx, providerId, namespaceId, url.QueryEscape(*chosenRepo.Id)).Execute()
 		return err
 	})
 

--- a/pkg/db/dto/project.go
+++ b/pkg/db/dto/project.go
@@ -9,12 +9,14 @@ import (
 )
 
 type RepositoryDTO struct {
+	Id       string  `json:"id"`
 	Url      string  `json:"url"`
+	Name     string  `json:"name"`
+	Owner    string  `json:"owner"`
+	Sha      string  `json:"sha"`
+	Source   string  `json:"source"`
 	Branch   *string `default:"main" json:"branch,omitempty"`
-	SHA      *string `json:"sha,omitempty"`
-	Owner    *string `json:"owner,omitempty"`
 	PrNumber *uint32 `json:"prNumber,omitempty"`
-	Source   *string `json:"source,omitempty"`
 	Path     *string `json:"path,omitempty"`
 }
 
@@ -62,21 +64,16 @@ func ToProjectDTO(project *workspace.Project, workspace *workspace.Workspace) Pr
 
 func ToRepositoryDTO(repo *gitprovider.GitRepository) RepositoryDTO {
 	repoDTO := RepositoryDTO{
-		Url: repo.Url,
+		Url:      repo.Url,
+		Name:     repo.Name,
+		Id:       repo.Id,
+		Owner:    repo.Owner,
+		Sha:      repo.Sha,
+		Source:   repo.Source,
+		Branch:   repo.Branch,
+		PrNumber: repo.PrNumber,
+		Path:     repo.Path,
 	}
-
-	repoDTO.Branch = repo.Branch
-	if repo.Sha != "" {
-		repoDTO.SHA = &repo.Sha
-	}
-	if repo.Owner != "" {
-		repoDTO.Owner = &repo.Owner
-	}
-	repoDTO.PrNumber = repo.PrNumber
-	if repo.Source != "" {
-		repoDTO.Source = &repo.Source
-	}
-	repoDTO.Path = repo.Path
 
 	return repoDTO
 }
@@ -178,19 +175,15 @@ func ToProjectState(stateDTO *ProjectStateDTO) *workspace.ProjectState {
 
 func ToRepository(repoDTO RepositoryDTO) *gitprovider.GitRepository {
 	repo := gitprovider.GitRepository{
-		Url: repoDTO.Url,
-	}
-
-	repo.Branch = repoDTO.Branch
-	if repoDTO.SHA != nil {
-		repo.Sha = *repoDTO.SHA
-	}
-	if repoDTO.Owner != nil {
-		repo.Owner = *repoDTO.Owner
-	}
-	repo.PrNumber = repoDTO.PrNumber
-	if repoDTO.Source != nil {
-		repo.Source = *repoDTO.Source
+		Url:      repoDTO.Url,
+		Id:       repoDTO.Id,
+		Name:     repoDTO.Name,
+		Owner:    repoDTO.Owner,
+		Branch:   repoDTO.Branch,
+		Sha:      repoDTO.Sha,
+		PrNumber: repoDTO.PrNumber,
+		Source:   repoDTO.Source,
+		Path:     repoDTO.Path,
 	}
 
 	return &repo

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -8,8 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/ktrysmt/go-bitbucket"
@@ -27,15 +28,21 @@ type BranchResponse struct {
 }
 
 type BitbucketGitProvider struct {
+	*AbstractGitProvider
+
 	username string
 	token    string
 }
 
 func NewBitbucketGitProvider(username string, token string) *BitbucketGitProvider {
-	return &BitbucketGitProvider{
-		username: username,
-		token:    token,
+	provider := &BitbucketGitProvider{
+		username:            username,
+		token:               token,
+		AbstractGitProvider: &AbstractGitProvider{},
 	}
+	provider.AbstractGitProvider.GitProvider = provider
+
+	return provider
 }
 
 func (g *BitbucketGitProvider) GetNamespaces() ([]*GitNamespace, error) {
@@ -88,16 +95,28 @@ func (g *BitbucketGitProvider) GetRepositories(namespace string) ([]*GitReposito
 	for _, repo := range repoList.Items {
 		htmlLink, ok := repo.Links["html"].(map[string]interface{})
 		if !ok {
-			log.Fatal("Invalid HTML link")
+			return nil, fmt.Errorf("Invalid repo links")
 		}
 
-		url := htmlLink["href"].(string)
-		repoSlug := url[strings.LastIndex(url, "/")+1:]
+		repoUrl := htmlLink["href"].(string)
+		repoSlug := repoUrl[strings.LastIndex(repoUrl, "/")+1:]
+
+		u, err := url.Parse(repoUrl)
+		if err != nil {
+			return nil, err
+		}
+
+		ownerUsername, ok := repo.Owner["username"].(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid repo owner")
+		}
 
 		response = append(response, &GitRepository{
-			Id:   repoSlug,
-			Name: repo.Name,
-			Url:  url,
+			Id:     repoSlug,
+			Name:   repo.Name,
+			Url:    repoUrl,
+			Source: u.Host,
+			Owner:  ownerUsername,
 		})
 	}
 
@@ -157,7 +176,7 @@ func (g *BitbucketGitProvider) GetRepoBranches(repositoryId string, namespaceId 
 	for _, branch := range branchesResponse.Values {
 		response = append(response, &GitBranch{
 			Name: branch.Name,
-			SHA:  branch.Target.Hash,
+			Sha:  branch.Target.Hash,
 		})
 	}
 
@@ -184,8 +203,9 @@ func (g *BitbucketGitProvider) GetRepoPRs(repositoryId string, namespaceId strin
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(prList)
 
+	// TODO: Implement this
+	fmt.Println(prList)
 	return response, err
 }
 
@@ -217,7 +237,164 @@ func (g *BitbucketGitProvider) GetUser() (*GitUser, error) {
 	return response, nil
 }
 
+func (g *BitbucketGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (string, error) {
+	client := g.getApiClient()
+
+	branch := ""
+	if staticContext.Branch != nil {
+		branch = *staticContext.Branch
+	}
+
+	include := ""
+	if staticContext.Sha != nil {
+		include = *staticContext.Sha
+	}
+
+	commits, err := client.Repositories.Commits.GetCommits(&bitbucket.CommitsOptions{
+		Owner:       staticContext.Owner,
+		RepoSlug:    staticContext.Id,
+		Branchortag: branch,
+		Include:     include,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	commitsResponse, ok := commits.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("Invalid commits response")
+	}
+
+	valuesResponse, ok := commitsResponse["values"].([]interface{})
+	if !ok {
+		return "", fmt.Errorf("Invalid commits values")
+	}
+
+	commit := valuesResponse[0]
+	commitResponse, ok := commit.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("Invalid commit response")
+	}
+
+	commitHash, ok := commitResponse["hash"].(string)
+	if !ok {
+		return "", fmt.Errorf("Invalid commit hash")
+	}
+
+	return commitHash, nil
+}
+
 func (g *BitbucketGitProvider) getApiClient() *bitbucket.Client {
 	client := bitbucket.NewBasicAuth(g.username, g.token)
 	return client
+}
+
+func (g *BitbucketGitProvider) getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error) {
+	if staticContext.PrNumber == nil {
+		return staticContext, nil
+	}
+
+	repo := *staticContext
+
+	client := g.getApiClient()
+
+	pr, err := client.Repositories.PullRequests.Get(&bitbucket.PullRequestsOptions{
+		Owner:    staticContext.Owner,
+		RepoSlug: staticContext.Id,
+		ID:       fmt.Sprint(*staticContext.PrNumber),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	prMap := pr.(map[string]interface{})
+	source, ok := prMap["source"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Invalid PR source")
+	}
+
+	repository, ok := source["repository"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Invalid PR repository")
+	}
+
+	fullName, ok := repository["full_name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("Invalid PR repository full name")
+	}
+
+	parts := strings.Split(fullName, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid PR repository full name")
+	}
+
+	links, ok := repository["links"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Invalid PR repository links")
+	}
+
+	htmlLink, ok := links["html"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Invalid PR repository html link")
+	}
+
+	url := htmlLink["href"].(string)
+	repoSlug := url[strings.LastIndex(url, "/")+1:]
+
+	repo.Owner = parts[0]
+	repo.Name = parts[1]
+	repo.Id = repoSlug
+
+	branch, ok := source["branch"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Invalid PR branch")
+	}
+
+	branchName, ok := branch["name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("Invalid PR branch name")
+	}
+
+	repo.Branch = &branchName
+
+	return &repo, nil
+}
+
+func (g *BitbucketGitProvider) parseStaticGitContext(repoUrl string) (*StaticGitContext, error) {
+	staticContext, err := g.AbstractGitProvider.parseStaticGitContext(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	if staticContext.Path == nil {
+		return staticContext, nil
+	}
+
+	parts := strings.Split(*staticContext.Path, "/")
+
+	switch {
+	case len(parts) >= 2 && parts[0] == "pull-requests":
+		prNumber, _ := strconv.Atoi(parts[1])
+		prUint := uint32(prNumber)
+		staticContext.PrNumber = &prUint
+		staticContext.Path = nil
+	case len(parts) >= 1 && parts[0] == "src":
+		staticContext.Branch = &parts[1]
+		if len(parts) > 2 {
+			path := strings.Join(parts[2:], "/")
+			staticContext.Path = &path
+		} else {
+			staticContext.Path = nil
+		}
+	case len(parts) >= 3 && parts[0] == "commits" && parts[1] == "branch":
+		staticContext.Branch = &parts[2]
+		staticContext.Path = nil
+	case len(parts) >= 2 && parts[0] == "commits":
+		staticContext.Sha = &parts[1]
+		staticContext.Branch = staticContext.Sha
+		staticContext.Path = nil
+	}
+
+	return staticContext, nil
 }

--- a/pkg/gitprovider/bitbucket_test.go
+++ b/pkg/gitprovider/bitbucket_test.go
@@ -1,0 +1,135 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type BitbucketGitProviderTestSuite struct {
+	gitProvider *BitbucketGitProvider
+	suite.Suite
+}
+
+func NewBitbucketGitProviderTestSuite() *BitbucketGitProviderTestSuite {
+	return &BitbucketGitProviderTestSuite{
+		gitProvider: NewBitbucketGitProvider("", ""),
+	}
+}
+
+func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_PR() {
+	prUrl := "https://bitbucket.org/atlassian/bitbucket-upload-file/pull-requests/1"
+	prContext := &StaticGitContext{
+		Id:       "bitbucket-upload-file",
+		Name:     "bitbucket-upload-file",
+		Owner:    "atlassian",
+		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
+		Source:   "bitbucket.org",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: &[]uint32{1}[0],
+		Path:     nil,
+	}
+
+	require := b.Require()
+
+	httpContext, err := b.gitProvider.parseStaticGitContext(prUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, prContext)
+}
+
+func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Blob() {
+	blobUrl := "https://bitbucket.org/atlassian/bitbucket-upload-file/src/master/README.md"
+	blobContext := &StaticGitContext{
+		Id:       "bitbucket-upload-file",
+		Name:     "bitbucket-upload-file",
+		Owner:    "atlassian",
+		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
+		Source:   "bitbucket.org",
+		Branch:   &[]string{"master"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     &[]string{"README.md"}[0],
+	}
+
+	require := b.Require()
+
+	httpContext, err := b.gitProvider.parseStaticGitContext(blobUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, blobContext)
+}
+
+func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Branch() {
+	branchUrl := "https://bitbucket.org/atlassian/bitbucket-upload-file/src/master"
+	branchContext := &StaticGitContext{
+		Id:       "bitbucket-upload-file",
+		Name:     "bitbucket-upload-file",
+		Owner:    "atlassian",
+		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
+		Source:   "bitbucket.org",
+		Branch:   &[]string{"master"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := b.Require()
+
+	httpContext, err := b.gitProvider.parseStaticGitContext(branchUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, branchContext)
+}
+
+func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Commits() {
+	commitsUrl := "https://bitbucket.org/atlassian/bitbucket-upload-file/commits/branch/master"
+	commitsContext := &StaticGitContext{
+		Id:       "bitbucket-upload-file",
+		Name:     "bitbucket-upload-file",
+		Owner:    "atlassian",
+		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
+		Source:   "bitbucket.org",
+		Branch:   &[]string{"master"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := b.Require()
+
+	httpContext, err := b.gitProvider.parseStaticGitContext(commitsUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitsContext)
+}
+
+func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Commit() {
+	commitUrl := "https://bitbucket.org/atlassian/bitbucket-upload-file/commits/COMMIT_SHA"
+	commitContext := &StaticGitContext{
+		Id:       "bitbucket-upload-file",
+		Name:     "bitbucket-upload-file",
+		Owner:    "atlassian",
+		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
+		Source:   "bitbucket.org",
+		Branch:   &[]string{"COMMIT_SHA"}[0],
+		Sha:      &[]string{"COMMIT_SHA"}[0],
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := b.Require()
+
+	httpContext, err := b.gitProvider.parseStaticGitContext(commitUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitContext)
+}
+
+func TestBitbucketGitProvider(t *testing.T) {
+	suite.Run(t, NewBitbucketGitProviderTestSuite())
+}

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -3,7 +3,27 @@
 
 package gitprovider
 
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
 const personalNamespaceId = "<PERSONAL>"
+
+type StaticGitContext struct {
+	Id       string  `json:"id"`
+	Url      string  `json:"url"`
+	Name     string  `json:"name"`
+	Branch   *string `json:"branch,omitempty"`
+	Sha      *string `json:"sha,omitempty"`
+	Owner    string  `json:"owner"`
+	PrNumber *uint32 `json:"prNumber,omitempty"`
+	Source   string  `json:"source"`
+	Path     *string `json:"path,omitempty"`
+} // @name StaticGitContext
 
 type GitProvider interface {
 	GetNamespaces() ([]*GitNamespace, error)
@@ -11,5 +31,103 @@ type GitProvider interface {
 	GetUser() (*GitUser, error)
 	GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error)
 	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)
-	// ParseGitUrl(string) (*GitRepository, error)
+
+	GetRepositoryFromUrl(repositoryUrl string) (*GitRepository, error)
+	GetLastCommitSha(staticContext *StaticGitContext) (string, error)
+	getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error)
+	parseStaticGitContext(repoUrl string) (*StaticGitContext, error)
+}
+
+type AbstractGitProvider struct {
+	GitProvider
+}
+
+func (a *AbstractGitProvider) GetRepositoryFromUrl(repositoryUrl string) (*GitRepository, error) {
+	staticContext, err := a.GitProvider.parseStaticGitContext(repositoryUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	if staticContext.PrNumber != nil {
+		staticContext, err = a.getPrContext(staticContext)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	lastCommitSha, err := a.GetLastCommitSha(staticContext)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GitRepository{
+		Id:       staticContext.Id,
+		Name:     staticContext.Name,
+		Url:      staticContext.Url,
+		Branch:   staticContext.Branch,
+		Sha:      lastCommitSha,
+		Owner:    staticContext.Owner,
+		PrNumber: staticContext.PrNumber,
+		Source:   staticContext.Source,
+		Path:     staticContext.Path,
+	}, nil
+}
+
+func (a *AbstractGitProvider) parseStaticGitContext(repoUrl string) (*StaticGitContext, error) {
+	if strings.HasPrefix(repoUrl, "git@") {
+		return a.parseSshGitUrl(repoUrl)
+	}
+
+	if !strings.HasPrefix(repoUrl, "http") {
+		return nil, errors.New("can not parse git URL: " + repoUrl)
+	}
+
+	repoUrl = strings.TrimSuffix(repoUrl, ".git")
+
+	u, err := url.Parse(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	repo := &StaticGitContext{}
+
+	path := strings.TrimPrefix(u.Path, "/")
+	parts := strings.Split(path, "/")
+
+	repo.Source = u.Host
+	repo.Owner = parts[0]
+	repo.Name = parts[1]
+	repo.Id = parts[1]
+
+	branchPath := strings.Join(parts[2:], "/")
+	if branchPath != "" {
+		repo.Path = &branchPath
+	}
+
+	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
+
+	return repo, nil
+}
+
+func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, error) {
+	re := regexp.MustCompile(`git@([\w\.]+):(.+?)/(.+?)(?:\.git)?$`)
+	matches := re.FindStringSubmatch(gitURL)
+	if len(matches) != 4 {
+		return nil, errors.New("cannot parse git URL: " + gitURL)
+	}
+
+	repo := &StaticGitContext{}
+
+	repo.Source = matches[1]
+	repo.Owner = matches[2]
+	repo.Name = matches[3]
+	repo.Id = matches[3]
+
+	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
+
+	return repo, nil
+}
+
+func getCloneUrl(source, owner, repo string) string {
+	return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
 }

--- a/pkg/gitprovider/git_provider_test.go
+++ b/pkg/gitprovider/git_provider_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type AbstractGitProviderTestSuite struct {
+	*AbstractGitProvider
+	suite.Suite
+}
+
+func NewAbstractGitProviderTestSuite() *AbstractGitProviderTestSuite {
+	return &AbstractGitProviderTestSuite{}
+}
+
+func (a *AbstractGitProviderTestSuite) TestParseGitContext_HTTP() {
+	httpSimple := "https://github.com/daytonaio/daytona.git"
+	simpleContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: nil,
+		Source:   "github.com",
+		Path:     nil,
+	}
+
+	require := a.Require()
+
+	httpContext, err := a.AbstractGitProvider.parseStaticGitContext(httpSimple)
+
+	require.Nil(err)
+	require.Equal(httpContext, simpleContext)
+}
+
+func (a *AbstractGitProviderTestSuite) TestParseGitContext_SSH() {
+	sshSimple := "git@github.com:daytonaio/daytona.git"
+	simpleContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: nil,
+		Source:   "github.com",
+		Path:     nil,
+	}
+
+	require := a.Require()
+
+	sshContext, err := a.AbstractGitProvider.parseStaticGitContext(sshSimple)
+
+	require.Nil(err)
+	require.Equal(sshContext, simpleContext)
+}
+
+func (a *AbstractGitProviderTestSuite) TestParseGitContext_HTTPWithPath() {
+	httpWithPath := "https://github.com/daytonaio/daytona/blob/main/README.md"
+	contextWithPath := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: nil,
+		Source:   "github.com",
+		Path:     &[]string{"blob/main/README.md"}[0],
+	}
+
+	require := a.Require()
+
+	httpContext, err := a.AbstractGitProvider.parseStaticGitContext(httpWithPath)
+
+	require.Nil(err)
+	require.Equal(httpContext, contextWithPath)
+}
+
+func TestAbstractGitProvider(t *testing.T) {
+	suite.Run(t, NewAbstractGitProviderTestSuite())
+}

--- a/pkg/gitprovider/gitea.go
+++ b/pkg/gitprovider/gitea.go
@@ -5,21 +5,29 @@ package gitprovider
 
 import (
 	"context"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"code.gitea.io/sdk/gitea"
 )
 
 type GiteaGitProvider struct {
+	*AbstractGitProvider
+
 	token      string
 	baseApiUrl string
 }
 
 func NewGiteaGitProvider(token string, baseApiUrl string) *GiteaGitProvider {
-	return &GiteaGitProvider{
-		token:      token,
-		baseApiUrl: baseApiUrl,
+	provider := &GiteaGitProvider{
+		token:               token,
+		baseApiUrl:          baseApiUrl,
+		AbstractGitProvider: &AbstractGitProvider{},
 	}
+	provider.AbstractGitProvider.GitProvider = provider
+
+	return provider
 }
 
 func (g *GiteaGitProvider) GetNamespaces() ([]*GitNamespace, error) {
@@ -91,10 +99,17 @@ func (g *GiteaGitProvider) GetRepositories(namespace string) ([]*GitRepository, 
 	response := []*GitRepository{}
 
 	for _, repo := range repoList {
+		u, err := url.Parse(repo.HTMLURL)
+		if err != nil {
+			return nil, err
+		}
 		response = append(response, &GitRepository{
-			Id:   repo.Name,
-			Name: repo.Name,
-			Url:  repo.HTMLURL,
+			Id:     repo.Name,
+			Name:   repo.Name,
+			Url:    repo.HTMLURL,
+			Branch: &repo.DefaultBranch,
+			Owner:  repo.Owner.UserName,
+			Source: u.Host,
 		})
 	}
 
@@ -132,7 +147,7 @@ func (g *GiteaGitProvider) GetRepoBranches(repositoryId string, namespaceId stri
 			Name: branch.Name,
 		}
 		if branch.Commit != nil {
-			responseBranch.SHA = branch.Commit.ID
+			responseBranch.Sha = branch.Commit.ID
 		}
 		response = append(response, responseBranch)
 	}
@@ -170,8 +185,13 @@ func (g *GiteaGitProvider) GetRepoPRs(repositoryId string, namespaceId string) (
 
 	for _, pr := range prList {
 		response = append(response, &GitPullRequest{
-			Name:   pr.Title,
-			Branch: pr.Head.Ref,
+			Name:            pr.Title,
+			Branch:          pr.Head.Ref,
+			Sha:             pr.Head.Sha,
+			SourceRepoId:    pr.Head.Repository.Name,
+			SourceRepoName:  pr.Head.Repository.Name,
+			SourceRepoUrl:   pr.Head.Repository.HTMLURL,
+			SourceRepoOwner: pr.Head.Repository.Owner.UserName,
 		})
 	}
 
@@ -197,8 +217,116 @@ func (g *GiteaGitProvider) GetUser() (*GitUser, error) {
 	}, nil
 }
 
+func (g *GiteaGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (string, error) {
+	client, err := g.getApiClient()
+	if err != nil {
+		return "", err
+	}
+
+	branch := ""
+	if staticContext.Branch != nil {
+		branch = *staticContext.Branch
+	}
+
+	commits, _, err := client.ListRepoCommits(staticContext.Owner, staticContext.Id, gitea.ListCommitOptions{
+		SHA: branch,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(commits) == 0 {
+		return "", nil
+	}
+
+	return commits[0].SHA, nil
+}
+
 func (g *GiteaGitProvider) getApiClient() (*gitea.Client, error) {
 	ctx := context.Background()
 
-	return gitea.NewClient(g.baseApiUrl, gitea.SetContext(ctx), gitea.SetToken(g.token))
+	options := []gitea.ClientOption{
+		gitea.SetContext(ctx),
+	}
+
+	if g.token != "" {
+		options = append(options, gitea.SetToken(g.token))
+	}
+
+	return gitea.NewClient(g.baseApiUrl, options...)
+}
+
+func (g *GiteaGitProvider) getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error) {
+	if staticContext.PrNumber == nil {
+		return staticContext, nil
+	}
+
+	client, err := g.getApiClient()
+	if err != nil {
+		return nil, err
+	}
+
+	pr, _, err := client.GetPullRequest(staticContext.Owner, staticContext.Id, int64(*staticContext.PrNumber))
+	if err != nil {
+		return nil, err
+	}
+
+	repo := *staticContext
+	repo.Branch = &pr.Head.Ref
+	repo.Url = pr.Head.Repository.CloneURL
+	repo.Name = pr.Head.Repository.Name
+	repo.Id = pr.Head.Repository.Name
+	repo.Owner = pr.Head.Repository.Owner.UserName
+
+	return &repo, nil
+}
+
+func (g *GiteaGitProvider) parseStaticGitContext(repoUrl string) (*StaticGitContext, error) {
+	staticContext, err := g.AbstractGitProvider.parseStaticGitContext(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	if staticContext.Path == nil {
+		return staticContext, nil
+	}
+
+	parts := strings.Split(*staticContext.Path, "/")
+
+	switch {
+	case len(parts) >= 2 && parts[0] == "pulls":
+		prNumber, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return nil, err
+		}
+		prUint := uint32(prNumber)
+		staticContext.PrNumber = &prUint
+		staticContext.Path = nil
+	case len(parts) >= 3 && parts[0] == "src" && parts[1] == "branch":
+		staticContext.Branch = &parts[2]
+		if len(parts) > 3 {
+			branchPath := strings.Join(parts[3:], "/")
+			staticContext.Path = &branchPath
+		} else {
+			staticContext.Path = nil
+		}
+	case len(parts) >= 3 && parts[0] == "src" && parts[1] == "commit":
+		staticContext.Sha = &parts[2]
+		staticContext.Branch = staticContext.Sha
+		if len(parts) > 3 {
+			branchPath := strings.Join(parts[3:], "/")
+			staticContext.Path = &branchPath
+		} else {
+			staticContext.Path = nil
+		}
+	case len(parts) >= 2 && parts[0] == "commit":
+		staticContext.Sha = &parts[1]
+		staticContext.Branch = staticContext.Sha
+		staticContext.Path = nil
+	case len(parts) == 3 && parts[0] == "commits" && parts[1] == "branch":
+		staticContext.Branch = &parts[2]
+		staticContext.Path = nil
+	}
+
+	return staticContext, nil
 }

--- a/pkg/gitprovider/gitea_test.go
+++ b/pkg/gitprovider/gitea_test.go
@@ -1,0 +1,135 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type GiteaGitProviderTestSuite struct {
+	gitProvider *GiteaGitProvider
+	suite.Suite
+}
+
+func NewGiteaGitProviderTestSuite() *GiteaGitProviderTestSuite {
+	return &GiteaGitProviderTestSuite{
+		gitProvider: NewGiteaGitProvider("", ""),
+	}
+}
+
+func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_PR() {
+	prUrl := "https://gitea.com/gitea/go-sdk/pulls/1"
+	prContext := &StaticGitContext{
+		Id:       "go-sdk",
+		Name:     "go-sdk",
+		Owner:    "gitea",
+		Url:      "https://gitea.com/gitea/go-sdk.git",
+		Source:   "gitea.com",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: &[]uint32{1}[0],
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(prUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, prContext)
+}
+
+func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Blob() {
+	blobUrl := "https://gitea.com/gitea/go-sdk/src/branch/main/README.md"
+	blobContext := &StaticGitContext{
+		Id:       "go-sdk",
+		Name:     "go-sdk",
+		Owner:    "gitea",
+		Url:      "https://gitea.com/gitea/go-sdk.git",
+		Source:   "gitea.com",
+		Branch:   &[]string{"main"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(blobUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, blobContext)
+}
+
+func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Branch() {
+	branchUrl := "https://gitea.com/gitea/go-sdk/src/branch/test-branch"
+	branchContext := &StaticGitContext{
+		Id:       "go-sdk",
+		Name:     "go-sdk",
+		Owner:    "gitea",
+		Url:      "https://gitea.com/gitea/go-sdk.git",
+		Source:   "gitea.com",
+		Branch:   &[]string{"test-branch"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(branchUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, branchContext)
+}
+
+func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Commits() {
+	commitsUrl := "https://gitea.com/gitea/go-sdk/commits/branch/main"
+	commitsContext := &StaticGitContext{
+		Id:       "go-sdk",
+		Name:     "go-sdk",
+		Owner:    "gitea",
+		Url:      "https://gitea.com/gitea/go-sdk.git",
+		Source:   "gitea.com",
+		Branch:   &[]string{"main"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(commitsUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitsContext)
+}
+
+func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Commit() {
+	commitUrl := "https://gitea.com/gitea/go-sdk/commit/COMMIT_SHA"
+	commitContext := &StaticGitContext{
+		Id:       "go-sdk",
+		Name:     "go-sdk",
+		Owner:    "gitea",
+		Url:      "https://gitea.com/gitea/go-sdk.git",
+		Source:   "gitea.com",
+		Branch:   &[]string{"COMMIT_SHA"}[0],
+		Sha:      &[]string{"COMMIT_SHA"}[0],
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(commitUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitContext)
+}
+
+func TestGiteaGitProvider(t *testing.T) {
+	suite.Run(t, NewGiteaGitProviderTestSuite())
+}

--- a/pkg/gitprovider/github_test.go
+++ b/pkg/gitprovider/github_test.go
@@ -1,0 +1,135 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type GitHubGitProviderTestSuite struct {
+	gitProvider *GitHubGitProvider
+	suite.Suite
+}
+
+func NewGitHubGitProviderTestSuite() *GitHubGitProviderTestSuite {
+	return &GitHubGitProviderTestSuite{
+		gitProvider: NewGitHubGitProvider(""),
+	}
+}
+
+func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_PR() {
+	prUrl := "https://github.com/daytonaio/daytona/pull/1"
+	prContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Source:   "github.com",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: &[]uint32{1}[0],
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(prUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, prContext)
+}
+
+func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Blob() {
+	blobUrl := "https://github.com/daytonaio/daytona/blob/main/README.md"
+	blobContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Source:   "github.com",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   &[]string{"main"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(blobUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, blobContext)
+}
+
+func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Branch() {
+	branchUrl := "https://github.com/daytonaio/daytona/tree/test-branch"
+	branchContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Source:   "github.com",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   &[]string{"test-branch"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(branchUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, branchContext)
+}
+
+func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Commits() {
+	commitsUrl := "https://github.com/daytonaio/daytona/commits/test-branch"
+	commitsContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Source:   "github.com",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   &[]string{"test-branch"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(commitsUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitsContext)
+}
+
+func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Commit() {
+	commitUrl := "https://github.com/daytonaio/daytona/commit/COMMIT_SHA"
+	commitContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Source:   "github.com",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   &[]string{"COMMIT_SHA"}[0],
+		Sha:      &[]string{"COMMIT_SHA"}[0],
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(commitUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitContext)
+}
+
+func TestGitHubGitProvider(t *testing.T) {
+	suite.Run(t, NewGitHubGitProviderTestSuite())
+}

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -4,22 +4,31 @@
 package gitprovider
 
 import (
+	"fmt"
 	"log"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/xanzy/go-gitlab"
 )
 
 type GitLabGitProvider struct {
+	*AbstractGitProvider
+
 	token      string
 	baseApiUrl *string
 }
 
 func NewGitLabGitProvider(token string, baseApiUrl *string) *GitLabGitProvider {
-	return &GitLabGitProvider{
-		token:      token,
-		baseApiUrl: baseApiUrl,
+	gitProvider := &GitLabGitProvider{
+		token:               token,
+		baseApiUrl:          baseApiUrl,
+		AbstractGitProvider: &AbstractGitProvider{},
 	}
+	gitProvider.AbstractGitProvider.GitProvider = gitProvider
+
+	return gitProvider
 }
 
 func (g *GitLabGitProvider) GetNamespaces() ([]*GitNamespace, error) {
@@ -82,10 +91,18 @@ func (g *GitLabGitProvider) GetRepositories(namespace string) ([]*GitRepository,
 	}
 
 	for _, repo := range repoList {
+		u, err := url.Parse(repo.WebURL)
+		if err != nil {
+			return nil, err
+		}
+
 		response = append(response, &GitRepository{
-			Id:   strconv.Itoa(repo.ID),
-			Name: repo.Name,
-			Url:  repo.WebURL,
+			Id:     strconv.Itoa(repo.ID),
+			Name:   repo.Path,
+			Url:    repo.WebURL,
+			Branch: &repo.DefaultBranch,
+			Owner:  repo.Namespace.Path,
+			Source: u.Host,
 		})
 	}
 
@@ -106,7 +123,7 @@ func (g *GitLabGitProvider) GetRepoBranches(repositoryId string, namespaceId str
 			Name: branch.Name,
 		}
 		if branch.Commit != nil {
-			responseBranch.SHA = branch.Commit.ID
+			responseBranch.Sha = branch.Commit.ID
 		}
 		response = append(response, responseBranch)
 	}
@@ -124,9 +141,19 @@ func (g *GitLabGitProvider) GetRepoPRs(repositoryId string, namespaceId string) 
 	}
 
 	for _, mergeRequest := range mergeRequests {
+		sourceRepo, _, err := client.Projects.GetProject(mergeRequest.SourceProjectID, nil)
+		if err != nil {
+			return nil, err
+		}
+
 		response = append(response, &GitPullRequest{
-			Name:   mergeRequest.Title,
-			Branch: mergeRequest.SourceBranch,
+			Name:            mergeRequest.Title,
+			Branch:          mergeRequest.SourceBranch,
+			Sha:             mergeRequest.SHA,
+			SourceRepoId:    fmt.Sprint(mergeRequest.SourceProjectID),
+			SourceRepoUrl:   sourceRepo.WebURL,
+			SourceRepoOwner: sourceRepo.Namespace.Path,
+			SourceRepoName:  sourceRepo.Path,
 		})
 	}
 
@@ -153,6 +180,35 @@ func (g *GitLabGitProvider) GetUser() (*GitUser, error) {
 	return response, nil
 }
 
+func (g *GitLabGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (string, error) {
+	client := g.getApiClient()
+
+	var sha *string
+
+	if staticContext.Branch != nil {
+		sha = staticContext.Branch
+	}
+
+	if staticContext.Sha != nil {
+		sha = staticContext.Sha
+	}
+
+	commits, _, err := client.Commits.ListCommits(staticContext.Id, &gitlab.ListCommitsOptions{
+		ListOptions: gitlab.ListOptions{
+			PerPage: 1,
+		},
+		RefName: sha,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(commits) == 0 {
+		return "", nil
+	}
+
+	return commits[0].ID, nil
+}
+
 func (g *GitLabGitProvider) getApiClient() *gitlab.Client {
 	var client *gitlab.Client
 	var err error
@@ -167,4 +223,148 @@ func (g *GitLabGitProvider) getApiClient() *gitlab.Client {
 	}
 
 	return client
+}
+
+func (g *GitLabGitProvider) parseStaticGitContext(repoUrl string) (*StaticGitContext, error) {
+	if strings.HasPrefix(repoUrl, "git@") {
+		return g.parseSshGitUrl(repoUrl)
+	}
+
+	if !strings.HasPrefix(repoUrl, "http") {
+		return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+	}
+
+	repoUrl = strings.TrimSuffix(repoUrl, ".git")
+
+	u, err := url.Parse(repoUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	staticContext := &StaticGitContext{
+		Source: u.Host,
+	}
+
+	parts := strings.Split(u.Path, "/-/")
+
+	ownerRepo := strings.TrimPrefix(parts[0], "/")
+
+	if len(parts) == 2 {
+		staticContext.Path = &parts[1]
+	}
+
+	if len(parts) > 2 {
+		return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+	}
+
+	ownerRepoParts := strings.Split(ownerRepo, "/")
+	if len(ownerRepoParts) < 2 {
+		return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+	}
+
+	staticContext.Name = ownerRepoParts[len(ownerRepoParts)-1]
+	staticContext.Owner = strings.Join(ownerRepoParts[:len(ownerRepoParts)-1], "/")
+	staticContext.Url = getCloneUrl(staticContext.Source, staticContext.Owner, staticContext.Name)
+	staticContext.Id = fmt.Sprintf("%s/%s", staticContext.Owner, staticContext.Name)
+
+	if staticContext.Path == nil {
+		return staticContext, nil
+	}
+
+	switch {
+	case strings.Contains(*staticContext.Path, "merge_requests"):
+		parts := strings.Split(*staticContext.Path, "merge_requests/")
+		mrParts := strings.Split(parts[1], "/")
+		if len(mrParts) < 1 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+		mrNumber, err := strconv.Atoi(mrParts[0])
+		if err != nil {
+			return nil, err
+		}
+		mrNumberUint := uint32(mrNumber)
+		staticContext.PrNumber = &mrNumberUint
+		staticContext.Path = nil
+	case strings.Contains(*staticContext.Path, "tree/"):
+		parts := strings.Split(*staticContext.Path, "tree/")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		branchParts := strings.Split(parts[1], "/")
+		if len(branchParts) < 1 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		staticContext.Branch = &branchParts[0]
+		staticContext.Path = nil
+	case strings.Contains(*staticContext.Path, "blob/"):
+		parts := strings.Split(*staticContext.Path, "blob/")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		branchParts := strings.Split(parts[1], "/")
+		if len(branchParts) < 1 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		staticContext.Branch = &branchParts[0]
+		branchPath := strings.Join(branchParts[1:], "/")
+		staticContext.Path = &branchPath
+	case strings.Contains(*staticContext.Path, "commit/"):
+		parts := strings.Split(*staticContext.Path, "commit/")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		commitParts := strings.Split(parts[1], "/")
+		if len(commitParts) < 1 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		staticContext.Sha = &commitParts[0]
+		staticContext.Branch = &commitParts[0]
+		staticContext.Path = nil
+	case strings.Contains(*staticContext.Path, "commits/"):
+		parts := strings.Split(*staticContext.Path, "commits/")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		branchParts := strings.Split(parts[1], "/")
+		if len(branchParts) < 1 {
+			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
+		}
+
+		staticContext.Branch = &branchParts[0]
+		staticContext.Path = nil
+	}
+
+	return staticContext, nil
+}
+
+func (g *GitLabGitProvider) getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error) {
+	if staticContext.PrNumber == nil {
+		return staticContext, nil
+	}
+
+	client := g.getApiClient()
+
+	pull, _, err := client.MergeRequests.GetMergeRequest(staticContext.Id, int(*staticContext.PrNumber), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	project, _, err := client.Projects.GetProject(staticContext.Id, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	repo := *staticContext
+	repo.Branch = &pull.SourceBranch
+	repo.Url = project.HTTPURLToRepo
+	repo.Owner = pull.Author.Username
+
+	return &repo, nil
 }

--- a/pkg/gitprovider/gitlab_test.go
+++ b/pkg/gitprovider/gitlab_test.go
@@ -1,0 +1,179 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type GitLabGitProviderTestSuite struct {
+	gitProvider *GitLabGitProvider
+	suite.Suite
+}
+
+func NewGitLabGitProviderTestSuite() *GitLabGitProviderTestSuite {
+	return &GitLabGitProviderTestSuite{
+		gitProvider: NewGitLabGitProvider("", nil),
+	}
+}
+
+func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_HTTP() {
+	httpSimple := "https://gitlab.com/gitlab-org/gitlab"
+	simpleContext := &StaticGitContext{
+		Id:       "gitlab-org/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org",
+		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(httpSimple)
+
+	require.Nil(err)
+	require.Equal(httpContext, simpleContext)
+}
+
+func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_HTTP_Subgroups() {
+	httpSimple := "https://gitlab.com/gitlab-org/subgroup1/subgroup2/gitlab"
+	simpleContext := &StaticGitContext{
+		Id:       "gitlab-org/subgroup1/subgroup2/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org/subgroup1/subgroup2",
+		Url:      "https://gitlab.com/gitlab-org/subgroup1/subgroup2/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(httpSimple)
+
+	require.Nil(err)
+	require.Equal(httpContext, simpleContext)
+}
+
+func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_MR() {
+	mrUrl := "https://gitlab.com/gitlab-org/gitlab/-/merge_requests/1"
+	mrContext := &StaticGitContext{
+		Id:       "gitlab-org/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org",
+		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   nil,
+		Sha:      nil,
+		PrNumber: &[]uint32{1}[0],
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(mrUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, mrContext)
+}
+
+func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Blob() {
+	blobUrl := "https://gitlab.com/gitlab-org/gitlab/-/blob/master/README.md"
+	blobContext := &StaticGitContext{
+		Id:       "gitlab-org/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org",
+		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   &[]string{"master"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(blobUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, blobContext)
+}
+
+func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Branch() {
+	branchUrl := "https://gitlab.com/gitlab-org/gitlab/-/tree/test-branch?ref_type=HEAD"
+	branchContext := &StaticGitContext{
+		Id:       "gitlab-org/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org",
+		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   &[]string{"test-branch"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(branchUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, branchContext)
+}
+
+func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commits() {
+	commitsUrl := "https://gitlab.com/gitlab-org/gitlab/-/commits/master/?ref_type=HEADS"
+	commitsContext := &StaticGitContext{
+		Id:       "gitlab-org/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org",
+		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   &[]string{"master"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(commitsUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitsContext)
+}
+
+func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commit() {
+	commitUrl := "https://gitlab.com/gitlab-org/gitlab/-/commit/COMMIT_SHA"
+	commitContext := &StaticGitContext{
+		Id:       "gitlab-org/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org",
+		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   &[]string{"COMMIT_SHA"}[0],
+		Sha:      &[]string{"COMMIT_SHA"}[0],
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(commitUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitContext)
+}
+
+func TestGitLabGitProvider(t *testing.T) {
+	suite.Run(t, NewGitLabGitProviderTestSuite())
+}

--- a/pkg/gitprovider/types.go
+++ b/pkg/gitprovider/types.go
@@ -36,10 +36,15 @@ type GitNamespace struct {
 
 type GitBranch struct {
 	Name string `json:"name"`
-	SHA  string `json:"sha"`
+	Sha  string `json:"sha"`
 } // @name GitBranch
 
 type GitPullRequest struct {
-	Name   string `json:"name"`
-	Branch string `json:"branch"`
+	Name            string `json:"name"`
+	Branch          string `json:"branch"`
+	Sha             string `json:"sha"`
+	SourceRepoId    string `json:"sourceRepoId"`
+	SourceRepoUrl   string `json:"sourceRepoUrl"`
+	SourceRepoOwner string `json:"sourceRepoOwner"`
+	SourceRepoName  string `json:"sourceRepoName"`
 } // @name GitPullRequest

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -40,6 +40,14 @@ func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*wor
 	w.Projects = []*workspace.Project{}
 
 	for _, project := range req.Projects {
+		if project.Source.Repository != nil && project.Source.Repository.Sha == "" {
+			sha, err := s.gitProviderService.GetLastCommitSha(project.Source.Repository)
+			if err != nil {
+				return nil, err
+			}
+			project.Source.Repository.Sha = sha
+		}
+
 		apiKey, err := s.apiKeyService.Generate(apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", w.Id, project.Name))
 		if err != nil {
 			return nil, err

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/server/apikeys"
+	"github.com/daytonaio/daytona/pkg/server/gitproviders"
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
 	"github.com/daytonaio/daytona/pkg/workspace"
 )
@@ -46,6 +47,7 @@ type WorkspaceServiceConfig struct {
 	DefaultProjectPostStartCommands []string
 	ApiKeyService                   apikeys.IApiKeyService
 	LoggerFactory                   logger.LoggerFactory
+	GitProviderService              gitproviders.IGitProviderService
 }
 
 func NewWorkspaceService(config WorkspaceServiceConfig) IWorkspaceService {
@@ -61,6 +63,7 @@ func NewWorkspaceService(config WorkspaceServiceConfig) IWorkspaceService {
 		provisioner:                     config.Provisioner,
 		loggerFactory:                   config.LoggerFactory,
 		apiKeyService:                   config.ApiKeyService,
+		gitProviderService:              config.GitProviderService,
 	}
 }
 
@@ -76,6 +79,7 @@ type WorkspaceService struct {
 	defaultProjectUser              string
 	defaultProjectPostStartCommands []string
 	loggerFactory                   logger.LoggerFactory
+	gitProviderService              gitproviders.IGitProviderService
 }
 
 func (s *WorkspaceService) SetProjectState(workspaceId, projectName string, state *workspace.ProjectState) (*workspace.Workspace, error) {

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -90,6 +90,7 @@ func TestWorkspaceService(t *testing.T) {
 	require.Nil(t, err)
 
 	apiKeyService := mocks.NewMockApiKeyService()
+	gitProviderService := mocks.NewMockGitProviderService()
 	provisioner := mocks.NewMockProvisioner()
 
 	logsDir := t.TempDir()
@@ -106,6 +107,7 @@ func TestWorkspaceService(t *testing.T) {
 		ApiKeyService:                   apiKeyService,
 		Provisioner:                     provisioner,
 		LoggerFactory:                   logger.NewLoggerFactory(logsDir),
+		GitProviderService:              gitProviderService,
 	})
 
 	t.Run("CreateWorkspace", func(t *testing.T) {
@@ -115,6 +117,7 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
 
 		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceRequest.Id).Return(createWorkspaceRequest.Id, nil)
+		gitProviderService.On("GetLastCommitSha", createWorkspaceRequest.Projects[0].Source.Repository).Return("123", nil)
 
 		for _, project := range createWorkspaceRequest.Projects {
 			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceRequest.Id, project.Name)).Return(project.Name, nil)

--- a/pkg/serverapiclient/api/openapi.yaml
+++ b/pkg/serverapiclient/api/openapi.yaml
@@ -1004,12 +1004,27 @@ components:
       type: object
     GitPullRequest:
       example:
+        sourceRepoUrl: sourceRepoUrl
+        sourceRepoId: sourceRepoId
         name: name
+        sourceRepoOwner: sourceRepoOwner
         branch: branch
+        sha: sha
+        sourceRepoName: sourceRepoName
       properties:
         branch:
           type: string
         name:
+          type: string
+        sha:
+          type: string
+        sourceRepoId:
+          type: string
+        sourceRepoName:
+          type: string
+        sourceRepoOwner:
+          type: string
+        sourceRepoUrl:
           type: string
       type: object
     GitRepository:

--- a/pkg/serverapiclient/docs/GitPullRequest.md
+++ b/pkg/serverapiclient/docs/GitPullRequest.md
@@ -6,6 +6,11 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Branch** | Pointer to **string** |  | [optional] 
 **Name** | Pointer to **string** |  | [optional] 
+**Sha** | Pointer to **string** |  | [optional] 
+**SourceRepoId** | Pointer to **string** |  | [optional] 
+**SourceRepoName** | Pointer to **string** |  | [optional] 
+**SourceRepoOwner** | Pointer to **string** |  | [optional] 
+**SourceRepoUrl** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -75,6 +80,131 @@ SetName sets Name field to given value.
 `func (o *GitPullRequest) HasName() bool`
 
 HasName returns a boolean if a field has been set.
+
+### GetSha
+
+`func (o *GitPullRequest) GetSha() string`
+
+GetSha returns the Sha field if non-nil, zero value otherwise.
+
+### GetShaOk
+
+`func (o *GitPullRequest) GetShaOk() (*string, bool)`
+
+GetShaOk returns a tuple with the Sha field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSha
+
+`func (o *GitPullRequest) SetSha(v string)`
+
+SetSha sets Sha field to given value.
+
+### HasSha
+
+`func (o *GitPullRequest) HasSha() bool`
+
+HasSha returns a boolean if a field has been set.
+
+### GetSourceRepoId
+
+`func (o *GitPullRequest) GetSourceRepoId() string`
+
+GetSourceRepoId returns the SourceRepoId field if non-nil, zero value otherwise.
+
+### GetSourceRepoIdOk
+
+`func (o *GitPullRequest) GetSourceRepoIdOk() (*string, bool)`
+
+GetSourceRepoIdOk returns a tuple with the SourceRepoId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSourceRepoId
+
+`func (o *GitPullRequest) SetSourceRepoId(v string)`
+
+SetSourceRepoId sets SourceRepoId field to given value.
+
+### HasSourceRepoId
+
+`func (o *GitPullRequest) HasSourceRepoId() bool`
+
+HasSourceRepoId returns a boolean if a field has been set.
+
+### GetSourceRepoName
+
+`func (o *GitPullRequest) GetSourceRepoName() string`
+
+GetSourceRepoName returns the SourceRepoName field if non-nil, zero value otherwise.
+
+### GetSourceRepoNameOk
+
+`func (o *GitPullRequest) GetSourceRepoNameOk() (*string, bool)`
+
+GetSourceRepoNameOk returns a tuple with the SourceRepoName field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSourceRepoName
+
+`func (o *GitPullRequest) SetSourceRepoName(v string)`
+
+SetSourceRepoName sets SourceRepoName field to given value.
+
+### HasSourceRepoName
+
+`func (o *GitPullRequest) HasSourceRepoName() bool`
+
+HasSourceRepoName returns a boolean if a field has been set.
+
+### GetSourceRepoOwner
+
+`func (o *GitPullRequest) GetSourceRepoOwner() string`
+
+GetSourceRepoOwner returns the SourceRepoOwner field if non-nil, zero value otherwise.
+
+### GetSourceRepoOwnerOk
+
+`func (o *GitPullRequest) GetSourceRepoOwnerOk() (*string, bool)`
+
+GetSourceRepoOwnerOk returns a tuple with the SourceRepoOwner field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSourceRepoOwner
+
+`func (o *GitPullRequest) SetSourceRepoOwner(v string)`
+
+SetSourceRepoOwner sets SourceRepoOwner field to given value.
+
+### HasSourceRepoOwner
+
+`func (o *GitPullRequest) HasSourceRepoOwner() bool`
+
+HasSourceRepoOwner returns a boolean if a field has been set.
+
+### GetSourceRepoUrl
+
+`func (o *GitPullRequest) GetSourceRepoUrl() string`
+
+GetSourceRepoUrl returns the SourceRepoUrl field if non-nil, zero value otherwise.
+
+### GetSourceRepoUrlOk
+
+`func (o *GitPullRequest) GetSourceRepoUrlOk() (*string, bool)`
+
+GetSourceRepoUrlOk returns a tuple with the SourceRepoUrl field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSourceRepoUrl
+
+`func (o *GitPullRequest) SetSourceRepoUrl(v string)`
+
+SetSourceRepoUrl sets SourceRepoUrl field to given value.
+
+### HasSourceRepoUrl
+
+`func (o *GitPullRequest) HasSourceRepoUrl() bool`
+
+HasSourceRepoUrl returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/pkg/serverapiclient/model_git_pull_request.go
+++ b/pkg/serverapiclient/model_git_pull_request.go
@@ -19,8 +19,13 @@ var _ MappedNullable = &GitPullRequest{}
 
 // GitPullRequest struct for GitPullRequest
 type GitPullRequest struct {
-	Branch *string `json:"branch,omitempty"`
-	Name   *string `json:"name,omitempty"`
+	Branch          *string `json:"branch,omitempty"`
+	Name            *string `json:"name,omitempty"`
+	Sha             *string `json:"sha,omitempty"`
+	SourceRepoId    *string `json:"sourceRepoId,omitempty"`
+	SourceRepoName  *string `json:"sourceRepoName,omitempty"`
+	SourceRepoOwner *string `json:"sourceRepoOwner,omitempty"`
+	SourceRepoUrl   *string `json:"sourceRepoUrl,omitempty"`
 }
 
 // NewGitPullRequest instantiates a new GitPullRequest object
@@ -104,6 +109,166 @@ func (o *GitPullRequest) SetName(v string) {
 	o.Name = &v
 }
 
+// GetSha returns the Sha field value if set, zero value otherwise.
+func (o *GitPullRequest) GetSha() string {
+	if o == nil || IsNil(o.Sha) {
+		var ret string
+		return ret
+	}
+	return *o.Sha
+}
+
+// GetShaOk returns a tuple with the Sha field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitPullRequest) GetShaOk() (*string, bool) {
+	if o == nil || IsNil(o.Sha) {
+		return nil, false
+	}
+	return o.Sha, true
+}
+
+// HasSha returns a boolean if a field has been set.
+func (o *GitPullRequest) HasSha() bool {
+	if o != nil && !IsNil(o.Sha) {
+		return true
+	}
+
+	return false
+}
+
+// SetSha gets a reference to the given string and assigns it to the Sha field.
+func (o *GitPullRequest) SetSha(v string) {
+	o.Sha = &v
+}
+
+// GetSourceRepoId returns the SourceRepoId field value if set, zero value otherwise.
+func (o *GitPullRequest) GetSourceRepoId() string {
+	if o == nil || IsNil(o.SourceRepoId) {
+		var ret string
+		return ret
+	}
+	return *o.SourceRepoId
+}
+
+// GetSourceRepoIdOk returns a tuple with the SourceRepoId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitPullRequest) GetSourceRepoIdOk() (*string, bool) {
+	if o == nil || IsNil(o.SourceRepoId) {
+		return nil, false
+	}
+	return o.SourceRepoId, true
+}
+
+// HasSourceRepoId returns a boolean if a field has been set.
+func (o *GitPullRequest) HasSourceRepoId() bool {
+	if o != nil && !IsNil(o.SourceRepoId) {
+		return true
+	}
+
+	return false
+}
+
+// SetSourceRepoId gets a reference to the given string and assigns it to the SourceRepoId field.
+func (o *GitPullRequest) SetSourceRepoId(v string) {
+	o.SourceRepoId = &v
+}
+
+// GetSourceRepoName returns the SourceRepoName field value if set, zero value otherwise.
+func (o *GitPullRequest) GetSourceRepoName() string {
+	if o == nil || IsNil(o.SourceRepoName) {
+		var ret string
+		return ret
+	}
+	return *o.SourceRepoName
+}
+
+// GetSourceRepoNameOk returns a tuple with the SourceRepoName field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitPullRequest) GetSourceRepoNameOk() (*string, bool) {
+	if o == nil || IsNil(o.SourceRepoName) {
+		return nil, false
+	}
+	return o.SourceRepoName, true
+}
+
+// HasSourceRepoName returns a boolean if a field has been set.
+func (o *GitPullRequest) HasSourceRepoName() bool {
+	if o != nil && !IsNil(o.SourceRepoName) {
+		return true
+	}
+
+	return false
+}
+
+// SetSourceRepoName gets a reference to the given string and assigns it to the SourceRepoName field.
+func (o *GitPullRequest) SetSourceRepoName(v string) {
+	o.SourceRepoName = &v
+}
+
+// GetSourceRepoOwner returns the SourceRepoOwner field value if set, zero value otherwise.
+func (o *GitPullRequest) GetSourceRepoOwner() string {
+	if o == nil || IsNil(o.SourceRepoOwner) {
+		var ret string
+		return ret
+	}
+	return *o.SourceRepoOwner
+}
+
+// GetSourceRepoOwnerOk returns a tuple with the SourceRepoOwner field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitPullRequest) GetSourceRepoOwnerOk() (*string, bool) {
+	if o == nil || IsNil(o.SourceRepoOwner) {
+		return nil, false
+	}
+	return o.SourceRepoOwner, true
+}
+
+// HasSourceRepoOwner returns a boolean if a field has been set.
+func (o *GitPullRequest) HasSourceRepoOwner() bool {
+	if o != nil && !IsNil(o.SourceRepoOwner) {
+		return true
+	}
+
+	return false
+}
+
+// SetSourceRepoOwner gets a reference to the given string and assigns it to the SourceRepoOwner field.
+func (o *GitPullRequest) SetSourceRepoOwner(v string) {
+	o.SourceRepoOwner = &v
+}
+
+// GetSourceRepoUrl returns the SourceRepoUrl field value if set, zero value otherwise.
+func (o *GitPullRequest) GetSourceRepoUrl() string {
+	if o == nil || IsNil(o.SourceRepoUrl) {
+		var ret string
+		return ret
+	}
+	return *o.SourceRepoUrl
+}
+
+// GetSourceRepoUrlOk returns a tuple with the SourceRepoUrl field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitPullRequest) GetSourceRepoUrlOk() (*string, bool) {
+	if o == nil || IsNil(o.SourceRepoUrl) {
+		return nil, false
+	}
+	return o.SourceRepoUrl, true
+}
+
+// HasSourceRepoUrl returns a boolean if a field has been set.
+func (o *GitPullRequest) HasSourceRepoUrl() bool {
+	if o != nil && !IsNil(o.SourceRepoUrl) {
+		return true
+	}
+
+	return false
+}
+
+// SetSourceRepoUrl gets a reference to the given string and assigns it to the SourceRepoUrl field.
+func (o *GitPullRequest) SetSourceRepoUrl(v string) {
+	o.SourceRepoUrl = &v
+}
+
 func (o GitPullRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -119,6 +284,21 @@ func (o GitPullRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.Sha) {
+		toSerialize["sha"] = o.Sha
+	}
+	if !IsNil(o.SourceRepoId) {
+		toSerialize["sourceRepoId"] = o.SourceRepoId
+	}
+	if !IsNil(o.SourceRepoName) {
+		toSerialize["sourceRepoName"] = o.SourceRepoName
+	}
+	if !IsNil(o.SourceRepoOwner) {
+		toSerialize["sourceRepoOwner"] = o.SourceRepoOwner
+	}
+	if !IsNil(o.SourceRepoUrl) {
+		toSerialize["sourceRepoUrl"] = o.SourceRepoUrl
 	}
 	return toSerialize, nil
 }

--- a/pkg/views/workspace/selection/branch.go
+++ b/pkg/views/workspace/selection/branch.go
@@ -49,10 +49,18 @@ func selectBranchPrompt(branches []serverapiclient.GitBranch, additionalProjectO
 	}
 }
 
-func GetBranchNameFromPrompt(branches []serverapiclient.GitBranch, additionalProjectOrder int) string {
+func GetBranchFromPrompt(branches []serverapiclient.GitBranch, additionalProjectOrder int) *serverapiclient.GitBranch {
 	choiceChan := make(chan string)
 
 	go selectBranchPrompt(branches, additionalProjectOrder, choiceChan)
 
-	return <-choiceChan
+	branchName := <-choiceChan
+
+	for _, b := range branches {
+		if *b.Name == branchName {
+			return &b
+		}
+	}
+
+	return nil
 }

--- a/pkg/views/workspace/selection/pullrequest.go
+++ b/pkg/views/workspace/selection/pullrequest.go
@@ -49,7 +49,7 @@ func selectPullRequestPrompt(pullRequests []serverapiclient.GitPullRequest, addi
 	}
 }
 
-func GetPullRequestFromPrompt(pullRequests []serverapiclient.GitPullRequest, additionalProjectOrder int) serverapiclient.GitPullRequest {
+func GetPullRequestFromPrompt(pullRequests []serverapiclient.GitPullRequest, additionalProjectOrder int) *serverapiclient.GitPullRequest {
 	choiceChan := make(chan string)
 
 	go selectPullRequestPrompt(pullRequests, additionalProjectOrder, choiceChan)
@@ -58,8 +58,8 @@ func GetPullRequestFromPrompt(pullRequests []serverapiclient.GitPullRequest, add
 
 	for _, pr := range pullRequests {
 		if *pr.Name == pullRequestName {
-			return pr
+			return &pr
 		}
 	}
-	return serverapiclient.GitPullRequest{}
+	return nil
 }

--- a/pkg/views/workspace/selection/repository.go
+++ b/pkg/views/workspace/selection/repository.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, additionalProjectOrder int, choiceChan chan<- string) {
+func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, index int, choiceChan chan<- string) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -26,8 +26,8 @@ func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, additi
 	l := views.GetStyledSelectList(items)
 
 	title := "Choose a Repository"
-	if additionalProjectOrder > 0 {
-		title += fmt.Sprintf(" (Project #%d)", additionalProjectOrder)
+	if index > 0 {
+		title += fmt.Sprintf(" (Project #%d)", index)
 	}
 	l.Title = views.GetStyledMainTitle(title)
 	l.Styles.Title = titleStyle
@@ -46,18 +46,18 @@ func selectRepositoryPrompt(repositories []serverapiclient.GitRepository, additi
 	}
 }
 
-func GetRepositoryFromPrompt(repositories []serverapiclient.GitRepository, additionalProjectOrder int) serverapiclient.GitRepository {
+func GetRepositoryFromPrompt(repositories []serverapiclient.GitRepository, index int) *serverapiclient.GitRepository {
 	choiceChan := make(chan string)
 
-	go selectRepositoryPrompt(repositories, additionalProjectOrder, choiceChan)
+	go selectRepositoryPrompt(repositories, index, choiceChan)
 
 	choice := <-choiceChan
 
 	for _, repository := range repositories {
 		if *repository.Url == choice {
-			return repository
+			return &repository
 		}
 	}
 
-	return serverapiclient.GitRepository{}
+	return nil
 }


### PR DESCRIPTION
# Parse Git Context from Repo URL

## Description

This PR contributes git context parsing to all git providers. It also provides a significant refactor to the TUI creation flow. With this PR, branches and PRs correctly attach the associated commit SHA and source repository.

The SHA property on project source repositories is now required and is set by the workspace service if not provided by the creation params.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #85 
Closes #551 
Closes #487 