### PR TITLE
fix: git service branch clone

### DIFF
--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -200,7 +200,7 @@ func (s *Service) shouldCloneBranch(project *workspace.Project) bool {
 		return true
 	}
 
-	return *project.Repository.Branch == project.Repository.Sha
+	return *project.Repository.Branch != project.Repository.Sha
 }
 
 func (s *Service) shouldCheckoutSha(project *workspace.Project) bool {
@@ -209,7 +209,7 @@ func (s *Service) shouldCheckoutSha(project *workspace.Project) bool {
 	}
 
 	if project.Repository.Branch == nil || *project.Repository.Branch == "" {
-		return true
+		return false
 	}
 
 	return *project.Repository.Branch == project.Repository.Sha


### PR DESCRIPTION
# Fix Git Service Branch Clone

## Description

This PR fixes cloning conditions in the git service. It will now correctly clone the repo in the following scenarios:
```jsonc
# Branch clone
{
  "branch": "BRANCH_NAME",
  "sha": "commit_sha"
}
# Clones to BRANCH_NAME
```

```jsonc
# SHA checkout
{
  "branch": "commit_sha",
  "sha": "commit_sha"
}
# Clones the repo and then checkouts commit_sha
```

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #553 