### PR TITLE
fix: stop reading logs on workspace create

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -290,8 +290,8 @@ func readWorkspaceLogs(activeProfile config.Profile, workspaceId string, project
 				}
 
 				readLog(ws, stopLogs)
-
 				ws.Close()
+				break
 			}
 		}(project)
 	}
@@ -358,6 +358,10 @@ func readLog(ws *websocket.Conn, stopLogs *bool) {
 	for {
 		_, msg, err := ws.ReadMessage()
 		if err != nil {
+			return
+		}
+
+		if *stopLogs {
 			return
 		}
 


### PR DESCRIPTION
# Stop Reading Logs on Workspace Create

## Description

This PR fixes a small issue for stopping the reading of logs on workspace create.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #552 