### PR TITLE
fix: api key notify format

### DIFF
--- a/pkg/views/server/apikey/notify.go
+++ b/pkg/views/server/apikey/notify.go
@@ -5,13 +5,23 @@ package apikey
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/pkg/views"
+	"golang.org/x/term"
 )
+
+var minimumLayoutWidth = 80
 
 func Render(key, apiUrl string) {
 	var output string
+
+	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		fmt.Println("error: Unable to get terminal size")
+		return
+	}
 
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Generated API key: "), key) + "\n\n"
 
@@ -19,9 +29,17 @@ func Render(key, apiUrl string) {
 
 	output += views.SeparatorString + "\n\n"
 
-	output += "You can connect to the Daytona Server from a client machine by running:\n\n"
+	output += "You can connect to the Daytona Server from a client machine by running:"
 
-	output += lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
+	formattedCommand := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a \\\n%s \\\n-k %s", apiUrl, key))
+	command := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
 
-	views.RenderContainerLayout(views.GetInfoMessage(output))
+	if terminalWidth >= minimumLayoutWidth {
+		output += "\n\n" + formattedCommand
+		views.RenderContainerLayout(views.GetInfoMessage(output))
+	} else {
+		views.RenderContainerLayout(views.GetInfoMessage(output))
+		fmt.Println(command + "\n\n")
+	}
+
 }


### PR DESCRIPTION
# API key notification format

## Description

Adding a new API key using daytona api-key new no longer adds layout's padding on terminal widths less than 80 as that would cause the profile adding command to have incorrect format with spaces/new lines.
The command is now also split into separate lines with backslash to reduce the amount of needed space

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

Regular sized terminal:
<img width="763" alt="image" src="https://github.com/daytonaio/daytona/assets/25279767/fa37a166-b36a-4077-8897-32685ba71f74">

Very narrow terminal:
<img width="349" alt="image" src="https://github.com/daytonaio/daytona/assets/25279767/7cd97f8b-ef37-4e82-9e52-e93b75f4f6c2">



## Notes
Please add any relevant notes if necessary.
