### PR TITLE
feat: change default server api and headscale ports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
       "env": {
         "DAYTONA_WS_ID": "WS_ID",
         "DAYTONA_WS_PROJECT_NAME": "PROJECT_NAME",
-        "DAYTONA_SERVER_URL": "http://localhost:3000",
+        "DAYTONA_SERVER_URL": "http://localhost:3986",
         "DAYTONA_SERVER_API_KEY": "1234567890",
       },
       "args": [

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1726,7 +1726,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "0.1.0",
-	Host:             "localhost:3000",
+	Host:             "localhost:3986",
 	BasePath:         "/",
 	Schemes:          []string{"http"},
 	Title:            "Daytona Server API",

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -9,7 +9,7 @@
         "contact": {},
         "version": "0.1.0"
     },
-    "host": "localhost:3000",
+    "host": "localhost:3986",
     "basePath": "/",
     "paths": {
         "/apikey": {

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -402,7 +402,7 @@ definitions:
     - ProviderTargetPropertyTypeInt
     - ProviderTargetPropertyTypeFloat
     - ProviderTargetPropertyTypeFilePath
-host: localhost:3000
+host: localhost:3986
 info:
   contact: {}
   description: Daytona Server API

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -5,7 +5,7 @@
 //	@version		0.1.0
 //	@description	Daytona Server API
 
-//	@host		localhost:3000
+//	@host		localhost:3986
 //	@schemes	http
 //	@BasePath	/
 

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -187,7 +188,7 @@ var ServeCmd = &cobra.Command{
 
 		printServerStartedMessage(c, false)
 
-		err = setDefaultConfig(server)
+		err = setDefaultConfig(server, c.ApiPort)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -239,7 +240,7 @@ func getDbPath() (string, error) {
 	return filepath.Join(dir, "db"), nil
 }
 
-func setDefaultConfig(server *server.Server) error {
+func setDefaultConfig(server *server.Server, apiPort uint32) error {
 	existingConfig, err := config.GetConfig()
 	if err != nil && !config.IsNotExist(err) {
 		return err
@@ -263,7 +264,7 @@ func setDefaultConfig(server *server.Server) error {
 			Id:   "default",
 			Name: "default",
 			Api: config.ServerApi{
-				Url: "http://localhost:3000",
+				Url: fmt.Sprintf("http://localhost:%d", apiPort),
 				Key: apiKey,
 			},
 		})
@@ -282,7 +283,7 @@ func setDefaultConfig(server *server.Server) error {
 				Id:   "default",
 				Name: "default",
 				Api: config.ServerApi{
-					Url: "http://localhost:3000",
+					Url: fmt.Sprintf("http://localhost:%d", apiPort),
 					Key: apiKey,
 				},
 			},

--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -18,8 +18,8 @@ import (
 
 const defaultRegistryUrl = "https://download.daytona.io/daytona"
 const defaultServerDownloadUrl = "https://download.daytona.io/daytona/install.sh"
-const defaultHeadscalePort = 3001
-const defaultApiPort = 3000
+const defaultHeadscalePort = 3987
+const defaultApiPort = 3986
 const defaultProjectImage = "daytonaio/workspace-project:latest"
 const defaultProjectUser = "daytona"
 

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const serverApiUrl = "http://localhost:3000"
-const serverUrl = "http://localhost:3001"
+const serverApiUrl = "http://localhost:3986"
+const serverUrl = "http://localhost:3987"
 const defaultProjectImage = "daytonaio/workspace-project:latest"
 const defaultProjectUser = "daytona"
 

--- a/pkg/serverapiclient/README.md
+++ b/pkg/serverapiclient/README.md
@@ -73,7 +73,7 @@ ctx = context.WithValue(context.Background(), serverapiclient.ContextOperationSe
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/pkg/serverapiclient/api/openapi.yaml
+++ b/pkg/serverapiclient/api/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Daytona Server API
   version: 0.1.0
 servers:
-- url: http://localhost:3000/
+- url: http://localhost:3986/
 security:
 - Bearer: []
 paths:

--- a/pkg/serverapiclient/configuration.go
+++ b/pkg/serverapiclient/configuration.go
@@ -93,7 +93,7 @@ func NewConfiguration() *Configuration {
 		Debug:         false,
 		Servers: ServerConfigurations{
 			{
-				URL:         "http://localhost:3000",
+				URL:         "http://localhost:3986",
 				Description: "No description provided",
 			},
 		},

--- a/pkg/serverapiclient/docs/ApiKeyAPI.md
+++ b/pkg/serverapiclient/docs/ApiKeyAPI.md
@@ -1,6 +1,6 @@
 # \ApiKeyAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/pkg/serverapiclient/docs/ContainerRegistryAPI.md
+++ b/pkg/serverapiclient/docs/ContainerRegistryAPI.md
@@ -1,6 +1,6 @@
 # \ContainerRegistryAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/pkg/serverapiclient/docs/GitProviderAPI.md
+++ b/pkg/serverapiclient/docs/GitProviderAPI.md
@@ -1,6 +1,6 @@
 # \GitProviderAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/pkg/serverapiclient/docs/ProfileAPI.md
+++ b/pkg/serverapiclient/docs/ProfileAPI.md
@@ -1,6 +1,6 @@
 # \ProfileAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/pkg/serverapiclient/docs/ProviderAPI.md
+++ b/pkg/serverapiclient/docs/ProviderAPI.md
@@ -1,6 +1,6 @@
 # \ProviderAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/pkg/serverapiclient/docs/ServerAPI.md
+++ b/pkg/serverapiclient/docs/ServerAPI.md
@@ -1,6 +1,6 @@
 # \ServerAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/pkg/serverapiclient/docs/TargetAPI.md
+++ b/pkg/serverapiclient/docs/TargetAPI.md
@@ -1,6 +1,6 @@
 # \TargetAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/pkg/serverapiclient/docs/WorkspaceAPI.md
+++ b/pkg/serverapiclient/docs/WorkspaceAPI.md
@@ -1,6 +1,6 @@
 # \WorkspaceAPI
 
-All URIs are relative to *http://localhost:3000*
+All URIs are relative to *http://localhost:3986*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------


### PR DESCRIPTION
# Change Default Server API and Headscale Ports

## Description

This PR changes the default server API and Headscale ports to 3986 and 3987, respectively.
This change will not influence existing users who already have their configs stored.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #530 