### PR TITLE
feat: ghe server support

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -44,6 +44,7 @@ func GetIdeList() []Ide {
 func GetSupportedGitProviders() []GitProvider {
 	return []GitProvider{
 		{"github", "GitHub"},
+		{"github-enterprise-server", "GitHub Enterprise Server"},
 		{"gitlab", "GitLab"},
 		{"gitlab-self-managed", "GitLab Self-managed"},
 		{"bitbucket", "Bitbucket"},
@@ -55,6 +56,8 @@ func GetSupportedGitProviders() []GitProvider {
 func GetDocsLinkFromGitProvider(providerId string) string {
 	switch providerId {
 	case "github":
+		fallthrough
+	case "github-enterprise-server":
 		return "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic"
 	case "gitlab":
 		fallthrough

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -16,12 +16,14 @@ import (
 type GitHubGitProvider struct {
 	*AbstractGitProvider
 
-	token string
+	token      string
+	baseApiUrl *string
 }
 
-func NewGitHubGitProvider(token string) *GitHubGitProvider {
+func NewGitHubGitProvider(token string, baseApiUrl *string) *GitHubGitProvider {
 	gitProvider := &GitHubGitProvider{
 		token:               token,
+		baseApiUrl:          baseApiUrl,
 		AbstractGitProvider: &AbstractGitProvider{},
 	}
 	gitProvider.AbstractGitProvider.GitProvider = gitProvider
@@ -242,6 +244,18 @@ func (g *GitHubGitProvider) getApiClient() *github.Client {
 	}
 
 	client := github.NewClient(tc)
+
+	if g.baseApiUrl != nil {
+		trimmedUrl := strings.TrimPrefix(*g.baseApiUrl, "https://")
+		trimmedUrl = strings.TrimSuffix(trimmedUrl, "api/v3/")
+		trimmedUrl = strings.TrimSuffix(trimmedUrl, "/")
+
+		client.BaseURL = &url.URL{
+			Scheme: "https",
+			Host:   trimmedUrl,
+			Path:   "api/v3/",
+		}
+	}
 
 	return client
 }

--- a/pkg/gitprovider/github_test.go
+++ b/pkg/gitprovider/github_test.go
@@ -16,7 +16,7 @@ type GitHubGitProviderTestSuite struct {
 
 func NewGitHubGitProviderTestSuite() *GitHubGitProviderTestSuite {
 	return &GitHubGitProviderTestSuite{
-		gitProvider: NewGitHubGitProvider(""),
+		gitProvider: NewGitHubGitProvider("", nil),
 	}
 }
 

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -60,6 +60,10 @@ func (s *GitProviderService) GetConfigForUrl(url string) (*gitprovider.GitProvid
 			return p, nil
 		}
 
+		if p.BaseApiUrl == nil || *p.BaseApiUrl == "" {
+			continue
+		}
+
 		hostname, err := getHostnameFromUrl(*p.BaseApiUrl)
 		if err != nil {
 			return nil, err
@@ -96,5 +100,5 @@ func getHostnameFromUrl(urlToParse string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimPrefix("www.", parsed.Hostname()), nil
+	return strings.TrimPrefix(parsed.Hostname(), "www."), nil
 }

--- a/pkg/server/gitproviders/service.go
+++ b/pkg/server/gitproviders/service.go
@@ -126,7 +126,9 @@ func (s *GitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (
 func (s *GitProviderService) newGitProvider(config *gitprovider.GitProviderConfig) (gitprovider.GitProvider, error) {
 	switch config.Id {
 	case "github":
-		return gitprovider.NewGitHubGitProvider(config.Token), nil
+		return gitprovider.NewGitHubGitProvider(config.Token, nil), nil
+	case "github-enterprise-server":
+		return gitprovider.NewGitHubGitProvider(config.Token, config.BaseApiUrl), nil
 	case "gitlab":
 		return gitprovider.NewGitLabGitProvider(config.Token, nil), nil
 	case "bitbucket":

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -71,7 +71,7 @@ func GitProviderSelectionView(gitProviderAddView *serverapiclient.GitProvider, u
 			huh.NewInput().
 				Title("Self-managed API URL").
 				Value(gitProviderAddView.BaseApiUrl).
-				Description("For example: http://gitlab-host/api/v4/ or https://gitea-host").
+				Description(getApiUrlDescription(*gitProviderAddView.Id)).
 				Validate(func(str string) error {
 					if str == "" {
 						return errors.New("URL can not be blank")
@@ -108,5 +108,16 @@ func providerRequiresUsername(gitProviderId string) bool {
 }
 
 func providerRequiresApiUrl(gitProviderId string) bool {
-	return gitProviderId == "gitlab-self-managed" || gitProviderId == "gitea"
+	return gitProviderId == "github-enterprise-server" || gitProviderId == "gitlab-self-managed" || gitProviderId == "gitea"
+}
+
+func getApiUrlDescription(gitProviderId string) string {
+	if gitProviderId == "gitlab-self-managed" {
+		return "For example: http://gitlab-host/api/v4/"
+	} else if gitProviderId == "github-enterprise-server" {
+		return "For example: https://github-host"
+	} else if gitProviderId == "gitea" {
+		return "For example: http://gitea-host"
+	}
+	return ""
 }


### PR DESCRIPTION
# GitHub Enterprise Server support

## Description

Adds GitHub Enterprise Server option as a Git provider

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #181 

## Screenshots

![image](https://github.com/daytonaio/daytona/assets/25279767/4eb6a25c-53d5-4848-82af-3075b84c00ec)

## Notes
Please add any relevant notes if necessary.
