### PR TITLE
feat: daytona ssh project

### DIFF
--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -59,12 +59,15 @@ var SshCmd = &cobra.Command{
 			workspaceId = *workspace.Id
 		}
 
-		// Todo: make project_select_prompt view for 0 args
 		if len(args) == 0 || len(args) == 1 {
-			projectName, err = server.GetFirstWorkspaceProjectName(workspaceId, projectName, &activeProfile)
+			selectedProject, err := selectWorkspaceProject(workspaceId, &activeProfile)
 			if err != nil {
 				log.Fatal(err)
 			}
+			if selectedProject == nil {
+				return
+			}
+			projectName = *selectedProject
 		}
 
 		if len(args) == 2 {


### PR DESCRIPTION
# Daytona SSH for multi project

## Description

Added a prompt to users running `daytona ssh` and selecting a multi-project workspace for which project they want to ssh into instead of defaulting to first

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
