### PR TITLE
fix: start stop messages

### DIFF
--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -121,7 +121,7 @@ func selectWorkspaceProject(workspaceId string, profile *config.Profile) (*strin
 	}
 
 	if len(wsInfo.Projects) > 1 {
-		selectedProject := selection.GetProjectFromPrompt(wsInfo.Projects, "open")
+		selectedProject := selection.GetProjectFromPrompt(wsInfo.Projects, "Open")
 		if selectedProject == nil {
 			return nil, nil
 		}

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -71,13 +71,13 @@ var StartCmd = &cobra.Command{
 		}
 
 		if startProjectFlag == "" {
-			message = fmt.Sprintf("Workspace '%s' start request submitted", workspaceId)
+			message = fmt.Sprintf("Workspace '%s' is starting", workspaceId)
 			res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, workspaceId).Execute()
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
 			}
 		} else {
-			message = fmt.Sprintf("Project '%s' from workspace '%s' start request submitted", startProjectFlag, workspaceId)
+			message = fmt.Sprintf("Project '%s' from workspace '%s' is starting", startProjectFlag, workspaceId)
 			res, err := apiClient.WorkspaceAPI.StartProject(ctx, workspaceId, startProjectFlag).Execute()
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
@@ -123,7 +123,7 @@ func startAllWorkspaces() error {
 			log.Errorf("Failed to start workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
 			continue
 		}
-		fmt.Printf("Workspace '%s' start request submitted\n", *workspace.Name)
+		fmt.Printf("Workspace '%s' is starting\n", *workspace.Name)
 	}
 	return nil
 }

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -63,13 +63,13 @@ var StopCmd = &cobra.Command{
 		}
 
 		if stopProjectFlag == "" {
-			message = fmt.Sprintf("Workspace '%s' stop request submitted", workspaceId)
+			message = fmt.Sprintf("Workspace '%s' is stopping", workspaceId)
 			res, err := apiClient.WorkspaceAPI.StopWorkspace(ctx, workspaceId).Execute()
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
 			}
 		} else {
-			message = fmt.Sprintf("Project '%s' from workspace '%s' stop request submitted", stopProjectFlag, workspaceId)
+			message = fmt.Sprintf("Project '%s' from workspace '%s' is stopping", stopProjectFlag, workspaceId)
 			res, err := apiClient.WorkspaceAPI.StopProject(ctx, workspaceId, stopProjectFlag).Execute()
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
@@ -110,7 +110,7 @@ func stopAllWorkspaces() error {
 			log.Errorf("Failed to stop workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
 			continue
 		}
-		fmt.Printf("Workspace '%s' stop request submitted\n", *workspace.Name)
+		fmt.Printf("Workspace '%s' is stopping\n", *workspace.Name)
 	}
 	return nil
 }

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -22,6 +22,9 @@ var StopCmd = &cobra.Command{
 	Short: "Stop a workspace",
 	Args:  cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
+		var workspaceId string
+		var message string
+
 		if allFlag {
 			err := stopAllWorkspaces()
 			if err != nil {
@@ -31,7 +34,6 @@ var StopCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		var workspaceId string
 
 		apiClient, err := server.GetApiClient(nil)
 		if err != nil {
@@ -39,6 +41,13 @@ var StopCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
+			if stopProjectFlag != "" {
+				err := cmd.Help()
+				if err != nil {
+					log.Fatal(err)
+				}
+				return
+			}
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
@@ -54,18 +63,20 @@ var StopCmd = &cobra.Command{
 		}
 
 		if stopProjectFlag == "" {
+			message = fmt.Sprintf("Workspace '%s' stop request submitted", workspaceId)
 			res, err := apiClient.WorkspaceAPI.StopWorkspace(ctx, workspaceId).Execute()
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
 			}
 		} else {
+			message = fmt.Sprintf("Project '%s' from workspace '%s' stop request submitted", stopProjectFlag, workspaceId)
 			res, err := apiClient.WorkspaceAPI.StopProject(ctx, workspaceId, stopProjectFlag).Execute()
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
 			}
 		}
 
-		views.RenderInfoMessage(fmt.Sprintf("Workspace %s successfully stopped", workspaceId))
+		views.RenderInfoMessage(message)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) >= 1 {
@@ -99,7 +110,7 @@ func stopAllWorkspaces() error {
 			log.Errorf("Failed to stop workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
 			continue
 		}
-		fmt.Printf("Workspace %s successfully stopped\n", *workspace.Name)
+		fmt.Printf("Workspace '%s' stop request submitted\n", *workspace.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
# Start stop messages

## Description

Minor UX fixes
- Changes  `daytona start` / `daytona stop` message from "Workspace started" to "Workspace start request submitted"
- Fixes single project `start/stop` commands response from "Workspace started" to "Project x from workspace y started"
- Fixed `daytona start --all` prompting the user for a workspace once they are all started
- `daytona start/stop -p projectName` now displays the help instead of prompting because of the incorrect command format



- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #492 

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
