### PR TITLE
fix: info panic

### DIFF
--- a/pkg/views/workspace/info/view.go
+++ b/pkg/views/workspace/info/view.go
@@ -96,8 +96,13 @@ func getSingleProjectOutput(project *serverapiclient.Project, isCreationView boo
 		repositoryUrl = strings.TrimPrefix(repositoryUrl, "http://")
 	}
 
-	output += getInfoLineState("State", project.State) + "\n"
-	output += getInfoLineGitStatus("Branch", project.State.GitStatus) + "\n"
+	if project.State != nil {
+		output += getInfoLineState("State", project.State) + "\n"
+		if project.State.GitStatus != nil {
+			output += getInfoLineGitStatus("Branch", project.State.GitStatus) + "\n"
+		}
+	}
+
 	if project.Target != nil && !isCreationView {
 		output += getInfoLine("Target", *project.Target) + "\n"
 	}


### PR DESCRIPTION
# Daytona info panic fix
## Description

Fixes `daytona info` nil pointer exception when project state is not set

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
