### PR TITLE
fix: multi-project create not working

### DIFF
--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -53,6 +53,8 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 	if config.MultiProject {
 		addMore := true
 		for i := 2; addMore; i++ {
+			var providerRepo *apiclient.GitRepository
+
 			if !config.Manual && config.UserGitProviders != nil && len(config.UserGitProviders) > 0 {
 				providerRepo, err = getRepositoryFromWizard(config.UserGitProviders, i+2)
 				if err != nil {


### PR DESCRIPTION
## Description

 fix `--multi-project` create not working

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #577
/claim #577
