### PR TITLE
feat: git provider required scopes

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -73,3 +73,24 @@ func GetDocsLinkFromGitProvider(providerId string) string {
 		return ""
 	}
 }
+
+func GetScopesFromGitProvider(providerId string) string {
+	switch providerId {
+	case "github":
+		fallthrough
+	case "github-enterprise-server":
+		return "repo,read:user,user:email"
+	case "gitlab":
+		fallthrough
+	case "gitlab-self-managed":
+		return "api,read_user,write_repository"
+	case "bitbucket":
+		return "account:read,repositories:write,pullrequests:read"
+	case "codeberg":
+		fallthrough
+	case "gitea":
+		return "read:organization,write:repository,read:user"
+	default:
+		return ""
+	}
+}

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -116,7 +117,7 @@ func GitProviderSelectionView(gitProviderAddView *apiclient.GitProvider, userGit
 		).WithHide(isDeleting),
 	).WithTheme(views.GetCustomTheme())
 
-	views.RenderInfoMessage(fmt.Sprintf("More information on:\n%s", config.GetDocsLinkFromGitProvider(*gitProviderAddView.Id)))
+	views.RenderInfoMessage(getGitProviderHelpMessage(*gitProviderAddView.Id))
 
 	err = userDataForm.Run()
 	if err != nil {
@@ -141,4 +142,12 @@ func getApiUrlDescription(gitProviderId string) string {
 		return "For example: http://gitea-host"
 	}
 	return ""
+}
+
+func getGitProviderHelpMessage(gitProviderId string) string {
+	return fmt.Sprintf("%s\n%s\n\n%s%s",
+		lipgloss.NewStyle().Foreground(views.Green).Bold(true).Render("More information on:"),
+		config.GetDocsLinkFromGitProvider(gitProviderId),
+		lipgloss.NewStyle().Foreground(views.Green).Bold(true).Render("Required scopes: "),
+		config.GetScopesFromGitProvider(gitProviderId))
 }


### PR DESCRIPTION
# Git provider required scopes

## Description

Adds required scopes help line to the `daytona git-provider add` view. Changes "More information on" label to green

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #565 

## Screenshots

![image](https://github.com/daytonaio/daytona/assets/25279767/c2a03fb0-ff60-4f63-b694-9931adfcb341)