### PR TITLE
feat: mount volume to project container

### DIFF
--- a/internal/testing/docker/mocks/api_client.go
+++ b/internal/testing/docker/mocks/api_client.go
@@ -101,3 +101,8 @@ func (m *MockApiClient) ContainerInspect(ctx context.Context, container string) 
 	args := m.Called(ctx, container)
 	return args.Get(0).(types.ContainerJSON), args.Error(1)
 }
+
+func (m *MockApiClient) VolumeRemove(ctx context.Context, volume string, force bool) error {
+	args := m.Called(ctx, volume, force)
+	return args.Error(0)
+}

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -26,6 +26,7 @@ type IDockerClient interface {
 	GetWorkspaceInfo(ws *workspace.Workspace) (*workspace.WorkspaceInfo, error)
 
 	GetProjectContainerName(project *workspace.Project) string
+	GetProjectVolumeName(project *workspace.Project) string
 	ExecSync(containerID string, config types.ExecConfig, outputWriter io.Writer) (*ExecResult, error)
 	GetContainerLogs(containerName string, logWriter io.Writer) error
 }
@@ -45,5 +46,9 @@ type DockerClient struct {
 }
 
 func (d *DockerClient) GetProjectContainerName(project *workspace.Project) string {
+	return project.WorkspaceId + "-" + project.Name
+}
+
+func (d *DockerClient) GetProjectVolumeName(project *workspace.Project) string {
 	return project.WorkspaceId + "-" + project.Name
 }

--- a/pkg/docker/create.go
+++ b/pkg/docker/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/registry"
 )
 
@@ -144,6 +145,13 @@ func (d *DockerClient) initProjectContainer(project *workspace.Project, daytonaD
 	_, err := d.apiClient.ContainerCreate(ctx, GetContainerCreateConfig(project, daytonaDownloadUrl), &container.HostConfig{
 		Privileged:  true,
 		NetworkMode: container.NetworkMode(project.WorkspaceId),
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeVolume,
+				Source: d.GetProjectVolumeName(project),
+				Target: fmt.Sprintf("/home/%s/%s", project.User, project.Name),
+			},
+		},
 	}, nil, nil, d.GetProjectContainerName(project))
 	if err != nil {
 		return err

--- a/pkg/docker/create_test.go
+++ b/pkg/docker/create_test.go
@@ -4,12 +4,15 @@
 package docker_test
 
 import (
+	"fmt"
+
 	t_docker "github.com/daytonaio/daytona/internal/testing/docker"
 	"github.com/daytonaio/daytona/pkg/docker"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/mock"
@@ -46,6 +49,13 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 		&container.HostConfig{
 			Privileged:  true,
 			NetworkMode: container.NetworkMode(project1.WorkspaceId),
+			Mounts: []mount.Mount{
+				{
+					Type:   mount.TypeVolume,
+					Source: s.dockerClient.GetProjectVolumeName(project1),
+					Target: fmt.Sprintf("/home/%s/%s", project1.User, project1.Name),
+				},
+			},
 		},
 		networkingConfig,
 		platform,

--- a/pkg/docker/destroy.go
+++ b/pkg/docker/destroy.go
@@ -47,5 +47,10 @@ func (d *DockerClient) removeProjectContainer(project *workspace.Project) error 
 		return err
 	}
 
+	err = d.apiClient.VolumeRemove(ctx, d.GetProjectVolumeName(project), true)
+	if err != nil && !client.IsErrNotFound(err) {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/docker/destroy_test.go
+++ b/pkg/docker/destroy_test.go
@@ -35,6 +35,8 @@ func (s *DockerClientTestSuite) TestDestroyProject() {
 		},
 	).Return(nil)
 
+	s.mockClient.On("VolumeRemove", mock.Anything, s.dockerClient.GetProjectVolumeName(project1), true).Return(nil)
+
 	err := s.dockerClient.DestroyProject(project1)
 	require.Nil(s.T(), err)
 }

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/workspace"
@@ -85,7 +86,7 @@ func (s *Service) CloneRepository(project *workspace.Project, auth *http.BasicAu
 }
 
 func (s *Service) RepositoryExists(project *workspace.Project) (bool, error) {
-	_, err := os.Stat(s.ProjectDir)
+	_, err := os.Stat(filepath.Join(s.ProjectDir, ".git"))
 	if os.IsNotExist(err) {
 		return false, nil
 	}


### PR DESCRIPTION
# Mount Volume to Project Container

## Description

This PR adds a named volume to each project container created by the docker client.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #582 

## Notes
For the changes to take affect, providers will have to be updated as well.
