### PR TITLE
feat: Force workspaces removal after deleting target

### DIFF
--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/target"
 	"github.com/spf13/cobra"
@@ -58,6 +59,26 @@ var targetRemoveCmd = &cobra.Command{
 		res, err := client.TargetAPI.RemoveTarget(context.Background(), selectedTargetName).Execute()
 		if err != nil {
 			log.Fatal(apiclient.HandleErrorResponse(res, err))
+		}
+
+		workspaceClient, err := apiclient_util.GetApiClient(nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		workspaceList, res, err := workspaceClient.WorkspaceAPI.ListWorkspaces(context.Background()).Execute()
+		if err != nil {
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+		}
+
+		for _, workspace := range workspaceList {
+			res, err := workspaceClient.WorkspaceAPI.RemoveWorkspace(context.Background(), *workspace.Id).Execute()
+
+			if err != nil {
+				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			}
+
+			views.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", *workspace.Name))
 		}
 
 		views.RenderInfoMessageBold(fmt.Sprintf("Target %s removed successfully", selectedTargetName))


### PR DESCRIPTION
## Description

This feature enables automatic deletion of all workspaces within the target upon target removal.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #576
/claim #576

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
