### PR TITLE
feat: Force workspaces removal after deleting target

### DIFF
--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -50,14 +50,38 @@ var targetRemoveCmd = &cobra.Command{
 			selectedTargetName = args[0]
 		}
 
+		ctx := context.Background()
 		client, err := apiclient.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		res, err := client.TargetAPI.RemoveTarget(context.Background(), selectedTargetName).Execute()
+		res, err := client.TargetAPI.RemoveTarget(ctx, selectedTargetName).Execute()
 		if err != nil {
 			log.Fatal(apiclient.HandleErrorResponse(res, err))
+		}
+
+		workspaceList, res, err := client.WorkspaceAPI.ListWorkspaces(ctx).Execute()
+		if err != nil {
+			log.Error(apiclient.HandleErrorResponse(res, err))
+		}
+
+		if len(workspaceList) > 0 {
+			views.RenderInfoMessage(fmt.Sprintln("Deleting workspaces within target..."))
+			for _, workspace := range workspaceList {
+				if *workspace.Target != selectedTargetName {
+					continue
+				}
+
+				res, err := client.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
+				if err != nil {
+					log.Errorf("Failed to delete workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
+					continue
+				}
+
+				views.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", *workspace.Name))
+
+			}
 		}
 
 		views.RenderInfoMessageBold(fmt.Sprintf("Target %s removed successfully", selectedTargetName))


### PR DESCRIPTION
## Description

This feature enables automatic deletion of all workspaces within the target upon target removal.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #423
/claim #576 
closes #576