### PR TITLE
fix: store project and workspace api keys in db

### DIFF
--- a/pkg/db/dto/project.go
+++ b/pkg/db/dto/project.go
@@ -45,6 +45,7 @@ type ProjectDTO struct {
 	Repository        RepositoryDTO    `json:"repository"`
 	WorkspaceId       string           `json:"workspaceId"`
 	Target            string           `json:"target"`
+	ApiKey            string           `json:"apiKey"`
 	State             *ProjectStateDTO `json:"state,omitempty" gorm:"serializer:json"`
 	PostStartCommands []string         `json:"postStartCommands,omitempty"`
 }
@@ -59,6 +60,7 @@ func ToProjectDTO(project *workspace.Project, workspace *workspace.Workspace) Pr
 		Target:            project.Target,
 		State:             ToProjectStateDTO(project.State),
 		PostStartCommands: project.PostStartCommands,
+		ApiKey:            workspace.ApiKey,
 	}
 }
 
@@ -129,6 +131,7 @@ func ToProject(projectDTO ProjectDTO) *workspace.Project {
 		Target:            projectDTO.Target,
 		State:             ToProjectState(projectDTO.State),
 		PostStartCommands: projectDTO.PostStartCommands,
+		ApiKey:            projectDTO.ApiKey,
 	}
 }
 

--- a/pkg/db/dto/workspace.go
+++ b/pkg/db/dto/workspace.go
@@ -13,6 +13,7 @@ type WorkspaceDTO struct {
 	Id       string       `gorm:"primaryKey"`
 	Name     string       `json:"name" gorm:"unique"`
 	Target   string       `json:"target"`
+	ApiKey   string       `json:"apiKey"`
 	Projects []ProjectDTO `gorm:"serializer:json"`
 }
 
@@ -31,6 +32,7 @@ func ToWorkspaceDTO(workspace *workspace.Workspace) WorkspaceDTO {
 		Id:     workspace.Id,
 		Name:   workspace.Name,
 		Target: workspace.Target,
+		ApiKey: workspace.ApiKey,
 	}
 
 	for _, project := range workspace.Projects {
@@ -45,6 +47,7 @@ func ToWorkspace(workspaceDTO WorkspaceDTO) *workspace.Workspace {
 		Id:     workspaceDTO.Id,
 		Name:   workspaceDTO.Name,
 		Target: workspaceDTO.Target,
+		ApiKey: workspaceDTO.ApiKey,
 	}
 
 	for _, projectDTO := range workspaceDTO.Projects {


### PR DESCRIPTION
# Store Project and Workspace API Keys in DB

## Description

This PR adds storing project and workspace api keys in the database.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #590 