### PR TITLE
fix: project order number

### DIFF
--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -56,7 +56,7 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 			var providerRepo *apiclient.GitRepository
 
 			if !config.Manual && config.UserGitProviders != nil && len(config.UserGitProviders) > 0 {
-				providerRepo, err = getRepositoryFromWizard(config.UserGitProviders, i+2)
+				providerRepo, err = getRepositoryFromWizard(config.UserGitProviders, i)
 				if err != nil {
 					return "", nil, err
 				}


### PR DESCRIPTION
# Fix project order number

## Description

Fixes regression with 2. project order number being 4.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

The issue was the first additional project having the "#4" order number:
![image](https://github.com/daytonaio/daytona/assets/25279767/173cd140-6d67-4e05-ac21-6c950101dc61)