### PR TITLE
feat: ask user to remove workspaces when removing target

### DIFF
--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -112,7 +112,7 @@ func RemoveTargetWorkspaces(ctx context.Context, client *apiclient.APIClient, ta
 	}
 
 	for _, workspace := range workspaceList {
-		if workspace.Target != target {
+		if *workspace.Target != *target {
 			continue
 		}
 

--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -62,7 +62,7 @@ var targetRemoveCmd = &cobra.Command{
 
 		if yesFlag {
 			fmt.Println("Deleting all workspaces.")
-			err := RemoveTargetWorkspaces(ctx, client, &selectedTargetName)
+			err := RemoveTargetWorkspaces(ctx, client, selectedTargetName)
 
 			if err != nil {
 				log.Fatal(err)
@@ -83,7 +83,7 @@ var targetRemoveCmd = &cobra.Command{
 			}
 
 			if yesFlag {
-				err := RemoveTargetWorkspaces(ctx, client, &selectedTargetName)
+				err := RemoveTargetWorkspaces(ctx, client, selectedTargetName)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -105,14 +105,14 @@ func init() {
 	targetRemoveCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Confirm deletion of all workspaces without prompt")
 }
 
-func RemoveTargetWorkspaces(ctx context.Context, client *apiclient.APIClient, target *string) error {
+func RemoveTargetWorkspaces(ctx context.Context, client *apiclient.APIClient, target string) error {
 	workspaceList, res, err := client.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 	if err != nil {
 		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
 	for _, workspace := range workspaceList {
-		if *workspace.Target != *target {
+		if *workspace.Target != target {
 			continue
 		}
 

--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -7,14 +7,18 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/charmbracelet/huh"
 	"github.com/daytonaio/daytona/cmd/daytona/config"
-	"github.com/daytonaio/daytona/internal/util/apiclient"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/target"
 	"github.com/spf13/cobra"
 
 	log "github.com/sirupsen/logrus"
 )
+
+var yesFlag bool
 
 var targetRemoveCmd = &cobra.Command{
 	Use:     "remove [TARGET_NAME]",
@@ -35,7 +39,7 @@ var targetRemoveCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			targets, err := apiclient.GetTargetList()
+			targets, err := apiclient_util.GetTargetList()
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -51,39 +55,75 @@ var targetRemoveCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		client, err := apiclient.GetApiClient(nil)
+		client, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 
+		if yesFlag {
+			fmt.Println("Deleting all workspaces.")
+			err := RemoveTargetWorkspaces(ctx, client, &selectedTargetName)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title(fmt.Sprintf("Delete all workspaces within %s?", selectedTargetName)).
+						Description("You might not be able to easily remove these workspaces later.").
+						Value(&yesFlag),
+				),
+			).WithTheme(views.GetCustomTheme())
+
+			err := form.Run()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if yesFlag {
+				err := RemoveTargetWorkspaces(ctx, client, &selectedTargetName)
+				if err != nil {
+					log.Fatal(err)
+				}
+			} else {
+				fmt.Println("Proceeding with target removal without deleting workspaces.")
+			}
+		}
+
 		res, err := client.TargetAPI.RemoveTarget(ctx, selectedTargetName).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
-		}
-
-		workspaceList, res, err := client.WorkspaceAPI.ListWorkspaces(ctx).Execute()
-		if err != nil {
-			log.Error(apiclient.HandleErrorResponse(res, err))
-		}
-
-		if len(workspaceList) > 0 {
-			views.RenderInfoMessage(fmt.Sprintln("Deleting workspaces within target..."))
-			for _, workspace := range workspaceList {
-				if *workspace.Target != selectedTargetName {
-					continue
-				}
-
-				res, err := client.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
-				if err != nil {
-					log.Errorf("Failed to delete workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
-					continue
-				}
-
-				views.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", *workspace.Name))
-
-			}
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
 		views.RenderInfoMessageBold(fmt.Sprintf("Target %s removed successfully", selectedTargetName))
 	},
+}
+
+func init() {
+	targetRemoveCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Confirm deletion of all workspaces without prompt")
+}
+
+func RemoveTargetWorkspaces(ctx context.Context, client *apiclient.APIClient, target *string) error {
+	workspaceList, res, err := client.WorkspaceAPI.ListWorkspaces(ctx).Execute()
+	if err != nil {
+		return apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	for _, workspace := range workspaceList {
+		if workspace.Target != target {
+			continue
+		}
+
+		res, err := client.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
+		if err != nil {
+			log.Errorf("Failed to delete workspace %s: %v", *workspace.Name, apiclient_util.HandleErrorResponse(res, err))
+			continue
+		}
+
+		views.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", *workspace.Name))
+	}
+
+	return nil
 }

--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -50,14 +50,38 @@ var targetRemoveCmd = &cobra.Command{
 			selectedTargetName = args[0]
 		}
 
+		ctx := context.Background()
 		client, err := apiclient.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		res, err := client.TargetAPI.RemoveTarget(context.Background(), selectedTargetName).Execute()
+		res, err := client.TargetAPI.RemoveTarget(ctx, selectedTargetName).Execute()
 		if err != nil {
 			log.Fatal(apiclient.HandleErrorResponse(res, err))
+		}
+
+		workspaceList, res, err := client.WorkspaceAPI.ListWorkspaces(ctx).Execute()
+		if err != nil {
+			log.Error(apiclient.HandleErrorResponse(res, err))
+		}
+
+		if len(workspaceList) > 0 {
+			views.RenderInfoMessage(fmt.Sprintln("Deleting workspaces within target..."))
+			for _, workspace := range workspaceList {
+				if *workspace.Target != selectedTargetName {
+					continue
+				}
+
+				res, err := client.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
+				if err != nil {
+					log.Errorf("Failed to delete workspace %s: %v", *workspace.Name, apiclient.HandleErrorResponse(res, err))
+					continue
+				}
+
+				views.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", *workspace.Name))
+
+			}
 		}
 
 		views.RenderInfoMessageBold(fmt.Sprintf("Target %s removed successfully", selectedTargetName))


### PR DESCRIPTION
## Description

This feature enables automatic deletion of all workspaces within the target upon target removal.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #423 

/claim #423
