### PR TITLE
feat: Force workspace removal

### DIFF
--- a/docs/daytona_delete.md
+++ b/docs/daytona_delete.md
@@ -9,8 +9,9 @@ daytona delete [WORKSPACE] [flags]
 ### Options
 
 ```
-  -a, --all   Delete all workspaces
-  -y, --yes   Confirm deletion without prompt
+  -a, --all     Delete all workspaces
+  -f, --force   Delete a workspace by force
+  -y, --yes     Confirm deletion without prompt
 ```
 
 ### Options inherited from parent commands

--- a/pkg/api/controllers/workspace/workspace.go
+++ b/pkg/api/controllers/workspace/workspace.go
@@ -96,3 +96,17 @@ func RemoveWorkspace(ctx *gin.Context) {
 
 	ctx.Status(200)
 }
+
+func ForceRemoveWorkspace(ctx *gin.Context) {
+	workspaceId := ctx.Param("workspaceId")
+
+	server := server.GetInstance(nil)
+
+	err := server.WorkspaceService.ForceRemoveWorkspace(workspaceId)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to force remove workspace: %s", err.Error()))
+		return
+	}
+
+	ctx.Status(200)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -118,6 +118,7 @@ func (a *ApiServer) Start() error {
 		workspaceController.POST("/:workspaceId/start", workspace.StartWorkspace)
 		workspaceController.POST("/:workspaceId/stop", workspace.StopWorkspace)
 		workspaceController.DELETE("/:workspaceId", workspace.RemoveWorkspace)
+		workspaceController.DELETE("/:workspaceId/force", workspace.ForceRemoveWorkspace)
 		workspaceController.POST("/:workspaceId/:projectId/start", workspace.StartProject)
 		workspaceController.POST("/:workspaceId/:projectId/stop", workspace.StopProject)
 	}

--- a/pkg/apiclient/api_workspace.go
+++ b/pkg/apiclient/api_workspace.go
@@ -397,7 +397,11 @@ type ApiRemoveWorkspaceRequest struct {
 }
 
 func (r ApiRemoveWorkspaceRequest) Execute() (*http.Response, error) {
-	return r.ApiService.RemoveWorkspaceExecute(r)
+	return r.ApiService.RemoveWorkspaceExecute(r, false)
+}
+
+func (r ApiRemoveWorkspaceRequest) ExecuteForce() (*http.Response, error) {
+	return r.ApiService.RemoveWorkspaceExecute(r, true)
 }
 
 /*
@@ -418,11 +422,12 @@ func (a *WorkspaceAPIService) RemoveWorkspace(ctx context.Context, workspaceId s
 }
 
 // Execute executes the request
-func (a *WorkspaceAPIService) RemoveWorkspaceExecute(r ApiRemoveWorkspaceRequest) (*http.Response, error) {
+func (a *WorkspaceAPIService) RemoveWorkspaceExecute(r ApiRemoveWorkspaceRequest, force bool) (*http.Response, error) {
 	var (
 		localVarHTTPMethod = http.MethodDelete
 		localVarPostBody   interface{}
 		formFiles          []formFile
+		localVarPath       string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspaceAPIService.RemoveWorkspace")
@@ -430,7 +435,11 @@ func (a *WorkspaceAPIService) RemoveWorkspaceExecute(r ApiRemoveWorkspaceRequest
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/workspace/{workspaceId}"
+	if force {
+		localVarPath = localBasePath + "/workspace/{workspaceId}/force"
+	} else {
+		localVarPath = localBasePath + "/workspace/{workspaceId}"
+	}
 	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
 
 	localVarHeaderParams := make(map[string]string)

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -118,7 +118,7 @@ var DeleteCmd = &cobra.Command{
 				}
 
 				if forceFlag {
-					forceRemoveWorkspace(ctx, apiClient, workspace)
+					_ = forceRemoveWorkspace(ctx, apiClient, workspace)
 				} else {
 					err := removeWorkspace(ctx, apiClient, workspace)
 					if err != nil {

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -126,7 +126,7 @@ var DeleteCmd = &cobra.Command{
 					}
 				}
 			} else {
-				forceRemoveWorkspace(ctx, apiClient, workspace)
+				_ = forceRemoveWorkspace(ctx, apiClient, workspace)
 			}
 		} else {
 			fmt.Println("Operation canceled.")

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
@@ -118,7 +119,7 @@ var DeleteCmd = &cobra.Command{
 				}
 
 				if forceFlag {
-					_ = forceRemoveWorkspace(ctx, apiClient, workspace)
+					_ = forceRemoveWorkspace(workspace)
 				} else {
 					err := removeWorkspace(ctx, apiClient, workspace)
 					if err != nil {
@@ -126,7 +127,7 @@ var DeleteCmd = &cobra.Command{
 					}
 				}
 			} else {
-				_ = forceRemoveWorkspace(ctx, apiClient, workspace)
+				_ = forceRemoveWorkspace(workspace)
 			}
 		} else {
 			fmt.Println("Operation canceled.")
@@ -195,13 +196,9 @@ func removeWorkspace(ctx context.Context, apiClient *apiclient.APIClient, worksp
 	return nil
 }
 
-func forceRemoveWorkspace(ctx context.Context, apiClient *apiclient.APIClient, workspace *apiclient.WorkspaceDTO) error {
-	_, _ = apiClient.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
+func forceRemoveWorkspace(workspace *apiclient.WorkspaceDTO) error {
+	server := server.GetInstance(nil)
+	_ = server.WorkspaceService.ForceRemoveWorkspace(*workspace.Id)
 
-	c, _ := config.GetConfig()
-	activeProfile, _ := c.GetActiveProfile()
-	_ = config.RemoveWorkspaceSshEntries(activeProfile.Id, *workspace.Id)
-
-	views.RenderInfoMessage(fmt.Sprintf("Workspace %s successfully deleted", *workspace.Name))
 	return nil
 }

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -196,11 +196,11 @@ func removeWorkspace(ctx context.Context, apiClient *apiclient.APIClient, worksp
 }
 
 func forceRemoveWorkspace(ctx context.Context, apiClient *apiclient.APIClient, workspace *apiclient.WorkspaceDTO) error {
-	apiClient.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
+	_, _ = apiClient.WorkspaceAPI.RemoveWorkspace(ctx, *workspace.Id).Execute()
 
 	c, _ := config.GetConfig()
 	activeProfile, _ := c.GetActiveProfile()
-	config.RemoveWorkspaceSshEntries(activeProfile.Id, *workspace.Id)
+	_ = config.RemoveWorkspaceSshEntries(activeProfile.Id, *workspace.Id)
 
 	views.RenderInfoMessage(fmt.Sprintf("Workspace %s successfully deleted", *workspace.Name))
 	return nil

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -107,7 +107,7 @@ var DeleteCmd = &cobra.Command{
 					huh.NewGroup(
 						huh.NewConfirm().
 							Title(fmt.Sprintf("Delete workspace %s by force?", *workspace.Name)).
-							Description("Provider resources might not be removed.").
+							Description("Provider resources might not be removed if you don't use this option").
 							Value(&forceFlag),
 					),
 				).WithTheme(views.GetCustomTheme())

--- a/pkg/server/workspaces/remove.go
+++ b/pkg/server/workspaces/remove.go
@@ -79,6 +79,8 @@ func (s *WorkspaceService) ForceRemoveWorkspace(workspaceId string) error {
 		return ErrWorkspaceNotFound
 	}
 
+	log.Infof("Destroying workspace %s", workspace.Id)
+
 	target, _ := s.targetStore.Find(workspace.Target)
 
 	for _, project := range workspace.Projects {
@@ -97,5 +99,6 @@ func (s *WorkspaceService) ForceRemoveWorkspace(workspaceId string) error {
 
 	_ = s.workspaceStore.Delete(workspace)
 
+	log.Infof("Workspace %s destroyed", workspace.Id)
 	return nil
 }

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -25,6 +25,7 @@ type IWorkspaceService interface {
 	GetProjectLogReader(workspaceId, projectName string) (io.Reader, error)
 	ListWorkspaces(verbose bool) ([]dto.WorkspaceDTO, error)
 	RemoveWorkspace(workspaceId string) error
+	ForceRemoveWorkspace(workspaceId string) error
 	SetProjectState(workspaceId string, projectName string, state *workspace.ProjectState) (*workspace.Workspace, error)
 	StartProject(workspaceId string, projectName string) error
 	StartWorkspace(workspaceId string) error


### PR DESCRIPTION
## Description

Adds a `force` flag to `daytona delete [workspace]`. This option would ignore any errors arising from the deletion process and proceed to forcibly delete the workspace and related entries to the daytona database.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #576 
/claim #576 
Closes #576 

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
