### PR TITLE
chore: workspace-project image fixes

### DIFF
--- a/hack/project_image/.devcontainer/devcontainer.json
+++ b/hack/project_image/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/devcontainers-contrib/features/typescript:2": {},
 		"ghcr.io/wxw-matt/devcontainer-features/command_runner:latest": {
-			"devcontainers": "npm install -g @devcontainers/cli"
+			"command1": "npm install -g @devcontainers/cli"
 		}
 	},
 	"overrideFeatureInstallOrder": [

--- a/hack/project_image/Dockerfile
+++ b/hack/project_image/Dockerfile
@@ -6,4 +6,6 @@ FROM ubuntu:22.04
 RUN apt update -y && \
     apt install curl libgit2-1.1 -y
 
-CMD ["tail", "-f", "/dev/null"]
+USER daytona
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
# Default Project Image fixes

## Description

Minor fixes for the default project image:
* `USER daytona` now correctly assumes the `daytona` user in the container
* Changed `CMD` to `ENTRYPOINT` to allow overrides
* Fixed devcontainer CLI install

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation