### PR TITLE
fix: workspace create fails when repo/project have spaces

### DIFF
--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -43,8 +44,15 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 		}
 	}
 
+	providerRepoName := *providerRepo.Name
+	urlDecodedName, err := url.QueryUnescape(providerRepoName)
+	if err != nil {
+		return "", nil, err
+	}
+	providerRepoName = strings.ReplaceAll(urlDecodedName, " ", "-")
+
 	projectList = []apiclient.CreateWorkspaceRequestProject{{
-		Name: *providerRepo.Name,
+		Name: providerRepoName,
 		Source: &apiclient.CreateWorkspaceRequestProjectSource{
 			Repository: providerRepo,
 		},


### PR DESCRIPTION
## Description

fix workspace create fails when repo/project have spaces
Closes #611
/claim #611

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #611

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
