### PR TITLE
feat: generate yaml docs

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -49,6 +49,7 @@ jobs:
         run: |
           ./hack/generate-cli-docs.sh
           git diff --exit-code docs/* || (echo "CLI Documentation is out of sync! Please generate it with './hack/generate-cli-docs.sh' and commit" && exit 1)
+          git diff --exit-code hack/docs/* || (echo "CLI Documentation is out of sync! Please generate it with './hack/generate-cli-docs.sh' and commit" && exit 1)
   test:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/hack/docs/daytona.yaml
+++ b/hack/docs/daytona.yaml
@@ -1,0 +1,37 @@
+name: daytona
+synopsis: Daytona is a Dev Environment Manager
+description: Daytona is a Dev Environment Manager
+usage: daytona [flags]
+options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona api-key - Api Key commands
+    - daytona autocomplete - Adds completion script for your shell enviornment
+    - daytona code - Open a workspace in your preferred IDE
+    - daytona container-registry - Manage container registries
+    - daytona create - Create a workspace
+    - daytona delete - Delete a workspace
+    - daytona docs - Opens the Daytona documentation in your default browser.
+    - daytona env - Manage profile environment variables that are added to all workspaces
+    - daytona forward - Forward a port from a project to your local machine
+    - daytona git-providers - Manage Git providers
+    - daytona ide - Choose the default IDE
+    - daytona info - Show workspace info
+    - daytona list - List workspaces
+    - daytona profile - Manage profiles
+    - daytona provider - Manage providers
+    - daytona purge - Purges all Daytona data from the current device
+    - daytona serve - Run the server process in the current terminal session
+    - daytona server - Start the server process in daemon mode
+    - daytona ssh - SSH into a project using the terminal
+    - daytona start - Start a workspace
+    - daytona stop - Stop a workspace
+    - daytona target - Manage provider targets
+    - daytona use - Set the active profile
+    - daytona version - Print the version number
+    - daytona whoami - Display information about the active user

--- a/hack/docs/daytona_api-key.yaml
+++ b/hack/docs/daytona_api-key.yaml
@@ -1,0 +1,14 @@
+name: daytona api-key
+synopsis: Api Key commands
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona api-key generate - Generate a new API key
+    - daytona api-key list - List API keys
+    - daytona api-key revoke - Revoke an API key

--- a/hack/docs/daytona_api-key_generate.yaml
+++ b/hack/docs/daytona_api-key_generate.yaml
@@ -1,0 +1,17 @@
+name: daytona api-key generate
+synopsis: Generate a new API key
+usage: daytona api-key generate [NAME] [flags]
+options:
+    - name: save
+      shorthand: s
+      default_value: "false"
+      usage: Save the API key to your default profile on this machine
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona api-key - Api Key commands

--- a/hack/docs/daytona_api-key_list.yaml
+++ b/hack/docs/daytona_api-key_list.yaml
@@ -1,0 +1,12 @@
+name: daytona api-key list
+synopsis: List API keys
+usage: daytona api-key list [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona api-key - Api Key commands

--- a/hack/docs/daytona_api-key_revoke.yaml
+++ b/hack/docs/daytona_api-key_revoke.yaml
@@ -1,0 +1,17 @@
+name: daytona api-key revoke
+synopsis: Revoke an API key
+usage: daytona api-key revoke [NAME] [flags]
+options:
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Skip confirmation prompt
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona api-key - Api Key commands

--- a/hack/docs/daytona_autocomplete.yaml
+++ b/hack/docs/daytona_autocomplete.yaml
@@ -1,0 +1,12 @@
+name: daytona autocomplete
+synopsis: Adds completion script for your shell enviornment
+usage: daytona autocomplete [bash|zsh|fish|powershell] [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_code.yaml
+++ b/hack/docs/daytona_code.yaml
@@ -1,0 +1,16 @@
+name: daytona code
+synopsis: Open a workspace in your preferred IDE
+usage: daytona code [WORKSPACE] [PROJECT] [flags]
+options:
+    - name: ide
+      shorthand: i
+      usage: Specify the IDE ('vscode' or 'browser')
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_container-registry.yaml
+++ b/hack/docs/daytona_container-registry.yaml
@@ -1,0 +1,14 @@
+name: daytona container-registry
+synopsis: Manage container registries
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona container-registry delete - Delete a container registry
+    - daytona container-registry list - Lists container registries
+    - daytona container-registry set - Set container registry

--- a/hack/docs/daytona_container-registry_delete.yaml
+++ b/hack/docs/daytona_container-registry_delete.yaml
@@ -1,0 +1,12 @@
+name: daytona container-registry delete
+synopsis: Delete a container registry
+usage: daytona container-registry delete [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona container-registry - Manage container registries

--- a/hack/docs/daytona_container-registry_list.yaml
+++ b/hack/docs/daytona_container-registry_list.yaml
@@ -1,0 +1,12 @@
+name: daytona container-registry list
+synopsis: Lists container registries
+usage: daytona container-registry list [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona container-registry - Manage container registries

--- a/hack/docs/daytona_container-registry_set.yaml
+++ b/hack/docs/daytona_container-registry_set.yaml
@@ -1,0 +1,22 @@
+name: daytona container-registry set
+synopsis: Set container registry
+usage: daytona container-registry set [flags]
+options:
+    - name: password
+      shorthand: p
+      usage: Password
+    - name: server
+      shorthand: s
+      usage: Server
+    - name: username
+      shorthand: u
+      usage: Username
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona container-registry - Manage container registries

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -1,0 +1,33 @@
+name: daytona create
+synopsis: Create a workspace
+usage: daytona create [REPOSITORY_URL] [flags]
+options:
+    - name: code
+      shorthand: c
+      default_value: "false"
+      usage: Open the workspace in the IDE after workspace creation
+    - name: ide
+      shorthand: i
+      usage: Specify the IDE ('vscode' or 'browser')
+    - name: manual
+      default_value: "false"
+      usage: Manually enter the git repositories
+    - name: multi-project
+      default_value: "false"
+      usage: Workspace with multiple projects/repos
+    - name: name
+      usage: Specify the workspace name
+    - name: provider
+      usage: Specify the provider (e.g. 'docker-provider')
+    - name: target
+      shorthand: t
+      usage: Specify the target (e.g. 'local')
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_delete.yaml
+++ b/hack/docs/daytona_delete.yaml
@@ -1,0 +1,21 @@
+name: daytona delete
+synopsis: Delete a workspace
+usage: daytona delete [WORKSPACE] [flags]
+options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Delete all workspaces
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Confirm deletion without prompt
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_docs.yaml
+++ b/hack/docs/daytona_docs.yaml
@@ -1,0 +1,12 @@
+name: daytona docs
+synopsis: Opens the Daytona documentation in your default browser.
+usage: daytona docs [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_env.yaml
+++ b/hack/docs/daytona_env.yaml
@@ -1,0 +1,14 @@
+name: daytona env
+synopsis: |
+    Manage profile environment variables that are added to all workspaces
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona env list - List profile environment variables
+    - daytona env set - Set profile environment variables

--- a/hack/docs/daytona_env_list.yaml
+++ b/hack/docs/daytona_env_list.yaml
@@ -1,0 +1,12 @@
+name: daytona env list
+synopsis: List profile environment variables
+usage: daytona env list [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona env - Manage profile environment variables that are added to all workspaces

--- a/hack/docs/daytona_env_set.yaml
+++ b/hack/docs/daytona_env_set.yaml
@@ -1,0 +1,12 @@
+name: daytona env set
+synopsis: Set profile environment variables
+usage: daytona env set [KEY=VALUE]... [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona env - Manage profile environment variables that are added to all workspaces

--- a/hack/docs/daytona_forward.yaml
+++ b/hack/docs/daytona_forward.yaml
@@ -1,0 +1,16 @@
+name: daytona forward
+synopsis: Forward a port from a project to your local machine
+usage: daytona forward [PORT] [WORKSPACE] [PROJECT] [flags]
+options:
+    - name: public
+      default_value: "false"
+      usage: Should be port be available publicly via an URL
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_git-providers.yaml
+++ b/hack/docs/daytona_git-providers.yaml
@@ -1,0 +1,14 @@
+name: daytona git-providers
+synopsis: Manage Git providers
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona git-providers add - Register a Git providers
+    - daytona git-providers delete - Unregister a Git providers
+    - daytona git-providers list - Lists your registered Git providers

--- a/hack/docs/daytona_git-providers_add.yaml
+++ b/hack/docs/daytona_git-providers_add.yaml
@@ -1,0 +1,12 @@
+name: daytona git-providers add
+synopsis: Register a Git providers
+usage: daytona git-providers add [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona git-providers - Manage Git providers

--- a/hack/docs/daytona_git-providers_delete.yaml
+++ b/hack/docs/daytona_git-providers_delete.yaml
@@ -1,0 +1,12 @@
+name: daytona git-providers delete
+synopsis: Unregister a Git providers
+usage: daytona git-providers delete [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona git-providers - Manage Git providers

--- a/hack/docs/daytona_git-providers_list.yaml
+++ b/hack/docs/daytona_git-providers_list.yaml
@@ -1,0 +1,12 @@
+name: daytona git-providers list
+synopsis: Lists your registered Git providers
+usage: daytona git-providers list [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona git-providers - Manage Git providers

--- a/hack/docs/daytona_ide.yaml
+++ b/hack/docs/daytona_ide.yaml
@@ -1,0 +1,12 @@
+name: daytona ide
+synopsis: Choose the default IDE
+usage: daytona ide [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_info.yaml
+++ b/hack/docs/daytona_info.yaml
@@ -1,0 +1,12 @@
+name: daytona info
+synopsis: Show workspace info
+usage: daytona info [WORKSPACE] [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_list.yaml
+++ b/hack/docs/daytona_list.yaml
@@ -1,0 +1,17 @@
+name: daytona list
+synopsis: List workspaces
+usage: daytona list [flags]
+options:
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: Show verbose output
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_profile.yaml
+++ b/hack/docs/daytona_profile.yaml
@@ -1,0 +1,17 @@
+name: daytona profile
+synopsis: Manage profiles
+usage: daytona profile [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona profile add - Add profile
+    - daytona profile delete - Delete profile [PROFILE_NAME]
+    - daytona profile edit - Edit profile [PROFILE_NAME]
+    - daytona profile list - List profiles
+    - daytona use - Set the active profile

--- a/hack/docs/daytona_profile_add.yaml
+++ b/hack/docs/daytona_profile_add.yaml
@@ -1,0 +1,22 @@
+name: daytona profile add
+synopsis: Add profile
+usage: daytona profile add [flags]
+options:
+    - name: api-key
+      shorthand: k
+      usage: API Key
+    - name: api-url
+      shorthand: a
+      usage: API URL
+    - name: name
+      shorthand: "n"
+      usage: Profile name
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona profile - Manage profiles

--- a/hack/docs/daytona_profile_delete.yaml
+++ b/hack/docs/daytona_profile_delete.yaml
@@ -1,0 +1,12 @@
+name: daytona profile delete
+synopsis: Delete profile [PROFILE_NAME]
+usage: daytona profile delete [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona profile - Manage profiles

--- a/hack/docs/daytona_profile_edit.yaml
+++ b/hack/docs/daytona_profile_edit.yaml
@@ -1,0 +1,22 @@
+name: daytona profile edit
+synopsis: Edit profile [PROFILE_NAME]
+usage: daytona profile edit [flags]
+options:
+    - name: api-key
+      shorthand: k
+      usage: API Key
+    - name: api-url
+      shorthand: a
+      usage: API URL
+    - name: name
+      shorthand: "n"
+      usage: Profile name
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona profile - Manage profiles

--- a/hack/docs/daytona_profile_list.yaml
+++ b/hack/docs/daytona_profile_list.yaml
@@ -1,0 +1,12 @@
+name: daytona profile list
+synopsis: List profiles
+usage: daytona profile list [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona profile - Manage profiles

--- a/hack/docs/daytona_provider.yaml
+++ b/hack/docs/daytona_provider.yaml
@@ -1,0 +1,15 @@
+name: daytona provider
+synopsis: Manage providers
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona provider install - Install provider
+    - daytona provider list - List installed providers
+    - daytona provider uninstall - Uninstall provider
+    - daytona provider update - Update provider

--- a/hack/docs/daytona_provider_install.yaml
+++ b/hack/docs/daytona_provider_install.yaml
@@ -1,0 +1,12 @@
+name: daytona provider install
+synopsis: Install provider
+usage: daytona provider install [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona provider - Manage providers

--- a/hack/docs/daytona_provider_list.yaml
+++ b/hack/docs/daytona_provider_list.yaml
@@ -1,0 +1,12 @@
+name: daytona provider list
+synopsis: List installed providers
+usage: daytona provider list [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona provider - Manage providers

--- a/hack/docs/daytona_provider_uninstall.yaml
+++ b/hack/docs/daytona_provider_uninstall.yaml
@@ -1,0 +1,12 @@
+name: daytona provider uninstall
+synopsis: Uninstall provider
+usage: daytona provider uninstall [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona provider - Manage providers

--- a/hack/docs/daytona_provider_update.yaml
+++ b/hack/docs/daytona_provider_update.yaml
@@ -1,0 +1,17 @@
+name: daytona provider update
+synopsis: Update provider
+usage: daytona provider update [flags]
+options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Update all providers
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona provider - Manage providers

--- a/hack/docs/daytona_purge.yaml
+++ b/hack/docs/daytona_purge.yaml
@@ -1,0 +1,19 @@
+name: daytona purge
+synopsis: Purges all Daytona data from the current device
+description: |
+    Purges all Daytona data from the current device - including all workspaces, configuration files, and SSH files. This command is irreversible.
+usage: daytona purge [flags]
+options:
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Execute purge without prompt
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_serve.yaml
+++ b/hack/docs/daytona_serve.yaml
@@ -1,0 +1,12 @@
+name: daytona serve
+synopsis: Run the server process in the current terminal session
+usage: daytona serve [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_server.yaml
+++ b/hack/docs/daytona_server.yaml
@@ -1,0 +1,23 @@
+name: daytona server
+synopsis: Start the server process in daemon mode
+usage: daytona server [flags]
+options:
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Execute purge without prompt
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona server config - Output local Daytona Server config
+    - daytona server configure - Configure Daytona Server
+    - daytona server logs - Output Daytona Server logs
+    - daytona server restart - Restarts the Daytona Server daemon
+    - daytona server start - Start the Daytona Server daemon
+    - daytona server stop - Stops the Daytona Server daemon

--- a/hack/docs/daytona_server_config.yaml
+++ b/hack/docs/daytona_server_config.yaml
@@ -1,0 +1,12 @@
+name: daytona server config
+synopsis: Output local Daytona Server config
+usage: daytona server config [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona server - Start the server process in daemon mode

--- a/hack/docs/daytona_server_configure.yaml
+++ b/hack/docs/daytona_server_configure.yaml
@@ -1,0 +1,12 @@
+name: daytona server configure
+synopsis: Configure Daytona Server
+usage: daytona server configure [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona server - Start the server process in daemon mode

--- a/hack/docs/daytona_server_logs.yaml
+++ b/hack/docs/daytona_server_logs.yaml
@@ -1,0 +1,17 @@
+name: daytona server logs
+synopsis: Output Daytona Server logs
+usage: daytona server logs [flags]
+options:
+    - name: follow
+      shorthand: f
+      default_value: "false"
+      usage: Follow logs
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona server - Start the server process in daemon mode

--- a/hack/docs/daytona_server_restart.yaml
+++ b/hack/docs/daytona_server_restart.yaml
@@ -1,0 +1,12 @@
+name: daytona server restart
+synopsis: Restarts the Daytona Server daemon
+usage: daytona server restart [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona server - Start the server process in daemon mode

--- a/hack/docs/daytona_server_start.yaml
+++ b/hack/docs/daytona_server_start.yaml
@@ -1,0 +1,12 @@
+name: daytona server start
+synopsis: Start the Daytona Server daemon
+usage: daytona server start [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona server - Start the server process in daemon mode

--- a/hack/docs/daytona_server_stop.yaml
+++ b/hack/docs/daytona_server_stop.yaml
@@ -1,0 +1,12 @@
+name: daytona server stop
+synopsis: Stops the Daytona Server daemon
+usage: daytona server stop [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona server - Start the server process in daemon mode

--- a/hack/docs/daytona_ssh.yaml
+++ b/hack/docs/daytona_ssh.yaml
@@ -1,0 +1,12 @@
+name: daytona ssh
+synopsis: SSH into a project using the terminal
+usage: daytona ssh [WORKSPACE] [PROJECT] [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_start.yaml
+++ b/hack/docs/daytona_start.yaml
@@ -1,0 +1,20 @@
+name: daytona start
+synopsis: Start a workspace
+usage: daytona start [WORKSPACE] [flags]
+options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Start all workspaces
+    - name: project
+      shorthand: p
+      usage: Start a single project in the workspace (project name)
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_stop.yaml
+++ b/hack/docs/daytona_stop.yaml
@@ -1,0 +1,20 @@
+name: daytona stop
+synopsis: Stop a workspace
+usage: daytona stop [WORKSPACE] [flags]
+options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Stop all workspaces
+    - name: project
+      shorthand: p
+      usage: Stop a single project in the workspace (project name)
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_target.yaml
+++ b/hack/docs/daytona_target.yaml
@@ -1,0 +1,14 @@
+name: daytona target
+synopsis: Manage provider targets
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona target list - List targets
+    - daytona target remove - Remove target
+    - daytona target set - Set provider target

--- a/hack/docs/daytona_target_list.yaml
+++ b/hack/docs/daytona_target_list.yaml
@@ -1,0 +1,12 @@
+name: daytona target list
+synopsis: List targets
+usage: daytona target list [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona target - Manage provider targets

--- a/hack/docs/daytona_target_remove.yaml
+++ b/hack/docs/daytona_target_remove.yaml
@@ -1,0 +1,17 @@
+name: daytona target remove
+synopsis: Remove target
+usage: daytona target remove [TARGET_NAME] [flags]
+options:
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Confirm deletion of all workspaces without prompt
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona target - Manage provider targets

--- a/hack/docs/daytona_target_set.yaml
+++ b/hack/docs/daytona_target_set.yaml
@@ -1,0 +1,12 @@
+name: daytona target set
+synopsis: Set provider target
+usage: daytona target set [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona target - Manage provider targets

--- a/hack/docs/daytona_use.yaml
+++ b/hack/docs/daytona_use.yaml
@@ -1,0 +1,12 @@
+name: daytona use
+synopsis: Set the active profile
+usage: daytona use [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_version.yaml
+++ b/hack/docs/daytona_version.yaml
@@ -1,0 +1,12 @@
+name: daytona version
+synopsis: Print the version number
+usage: daytona version [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_whoami.yaml
+++ b/hack/docs/daytona_whoami.yaml
@@ -1,0 +1,12 @@
+name: daytona whoami
+synopsis: Display information about the active user
+usage: daytona whoami [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/workspace_mode/daytona.yaml
+++ b/hack/docs/workspace_mode/daytona.yaml
@@ -1,0 +1,21 @@
+name: daytona
+synopsis: Use the Daytona CLI to manage your project
+description: Use the Daytona CLI to manage your project
+usage: daytona [flags]
+options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona agent - Start the agent process
+    - daytona autocomplete - Adds completion script for your shell enviornment
+    - daytona docs - Opens the Daytona documentation in your default browser.
+    - daytona forward - Forward a port from the project to your local machine
+    - daytona info - Show project info
+    - daytona list - List workspaces
+    - daytona start - Start the project
+    - daytona stop - Stop the project
+    - daytona version - Print the version number

--- a/hack/docs/workspace_mode/daytona_agent.yaml
+++ b/hack/docs/workspace_mode/daytona_agent.yaml
@@ -1,0 +1,17 @@
+name: daytona agent
+synopsis: Start the agent process
+usage: daytona agent [flags]
+options:
+    - name: host
+      default_value: "false"
+      usage: Run the agent in host mode
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project
+    - daytona agent logs - Output Daytona Agent logs

--- a/hack/docs/workspace_mode/daytona_agent_logs.yaml
+++ b/hack/docs/workspace_mode/daytona_agent_logs.yaml
@@ -1,0 +1,17 @@
+name: daytona agent logs
+synopsis: Output Daytona Agent logs
+usage: daytona agent logs [flags]
+options:
+    - name: follow
+      shorthand: f
+      default_value: "false"
+      usage: Follow logs
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona agent - Start the agent process

--- a/hack/docs/workspace_mode/daytona_autocomplete.yaml
+++ b/hack/docs/workspace_mode/daytona_autocomplete.yaml
@@ -1,0 +1,12 @@
+name: daytona autocomplete
+synopsis: Adds completion script for your shell enviornment
+usage: daytona autocomplete [bash|zsh|fish|powershell] [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/hack/docs/workspace_mode/daytona_docs.yaml
+++ b/hack/docs/workspace_mode/daytona_docs.yaml
@@ -1,0 +1,12 @@
+name: daytona docs
+synopsis: Opens the Daytona documentation in your default browser.
+usage: daytona docs [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/hack/docs/workspace_mode/daytona_forward.yaml
+++ b/hack/docs/workspace_mode/daytona_forward.yaml
@@ -1,0 +1,16 @@
+name: daytona forward
+synopsis: Forward a port from the project to your local machine
+usage: daytona forward [PORT] [flags]
+options:
+    - name: public
+      default_value: "false"
+      usage: Should be port be available publicly via an URL
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/hack/docs/workspace_mode/daytona_info.yaml
+++ b/hack/docs/workspace_mode/daytona_info.yaml
@@ -1,0 +1,12 @@
+name: daytona info
+synopsis: Show project info
+usage: daytona info [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/hack/docs/workspace_mode/daytona_list.yaml
+++ b/hack/docs/workspace_mode/daytona_list.yaml
@@ -1,0 +1,17 @@
+name: daytona list
+synopsis: List workspaces
+usage: daytona list [flags]
+options:
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: Show verbose output
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/hack/docs/workspace_mode/daytona_start.yaml
+++ b/hack/docs/workspace_mode/daytona_start.yaml
@@ -1,0 +1,12 @@
+name: daytona start
+synopsis: Start the project
+usage: daytona start [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/hack/docs/workspace_mode/daytona_stop.yaml
+++ b/hack/docs/workspace_mode/daytona_stop.yaml
@@ -1,0 +1,12 @@
+name: daytona stop
+synopsis: Stop the project
+usage: daytona stop [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/hack/docs/workspace_mode/daytona_version.yaml
+++ b/hack/docs/workspace_mode/daytona_version.yaml
@@ -1,0 +1,12 @@
+name: daytona version
+synopsis: Print the version number
+usage: daytona version [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Use the Daytona CLI to manage your project

--- a/pkg/cmd/generatedocs.go
+++ b/pkg/cmd/generatedocs.go
@@ -6,12 +6,14 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
 
+var yamlDirectory = "hack"
 var defaultDirectory = "docs"
 
 var generateDocsCmd = &cobra.Command{
@@ -32,7 +34,17 @@ var generateDocsCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		err = os.MkdirAll(filepath.Join(yamlDirectory, directory), os.ModePerm)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		err = doc.GenMarkdownTree(cmd.Root(), directory)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = doc.GenYamlTree(cmd.Root(), filepath.Join(yamlDirectory, directory))
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
# Generate YAML docs

## Description

Generates documentation in YAML format to simplify parsing the files for the docs website.
Uses the same command and output directory flag as the human-readable MD docs but inside the "hack" folder.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation