### PR TITLE
feat: builder image configuration

### DIFF
--- a/internal/testing/server/workspaces/mocks/container_registry_service.go
+++ b/internal/testing/server/workspaces/mocks/container_registry_service.go
@@ -1,0 +1,49 @@
+//go:build testing
+
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import (
+	"github.com/daytonaio/daytona/pkg/containerregistry"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockContainerRegistryService struct {
+	mock.Mock
+}
+
+func NewMockContainerRegistryService() *mockContainerRegistryService {
+	return &mockContainerRegistryService{}
+}
+
+func (m *mockContainerRegistryService) Delete(server string) error {
+	args := m.Called(server)
+	return args.Error(0)
+}
+
+func (m *mockContainerRegistryService) Find(server string) (*containerregistry.ContainerRegistry, error) {
+	args := m.Called(server)
+	return args.Get(0).(*containerregistry.ContainerRegistry), args.Error(1)
+}
+
+func (m *mockContainerRegistryService) FindByImageName(imageName string) (*containerregistry.ContainerRegistry, error) {
+	args := m.Called(imageName)
+	return args.Get(0).(*containerregistry.ContainerRegistry), args.Error(1)
+}
+
+func (m *mockContainerRegistryService) List() ([]*containerregistry.ContainerRegistry, error) {
+	args := m.Called()
+	return args.Get(0).([]*containerregistry.ContainerRegistry), args.Error(1)
+}
+
+func (m *mockContainerRegistryService) Map() (map[string]*containerregistry.ContainerRegistry, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]*containerregistry.ContainerRegistry), args.Error(1)
+}
+
+func (m *mockContainerRegistryService) Save(cr *containerregistry.ContainerRegistry) error {
+	args := m.Called(cr)
+	return args.Error(0)
+}

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1533,6 +1533,9 @@ const docTemplate = `{
                 "binariesPath": {
                     "type": "string"
                 },
+                "builderImage": {
+                    "type": "string"
+                },
                 "defaultProjectImage": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1530,6 +1530,9 @@
                 "binariesPath": {
                     "type": "string"
                 },
+                "builderImage": {
+                    "type": "string"
+                },
                 "defaultProjectImage": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -272,6 +272,8 @@ definitions:
         type: integer
       binariesPath:
         type: string
+      builderImage:
+        type: string
       defaultProjectImage:
         type: string
       defaultProjectPostStartCommands:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1295,6 +1295,7 @@ components:
         defaultProjectPostStartCommands:
         - defaultProjectPostStartCommands
         - defaultProjectPostStartCommands
+        builderImage: builderImage
         apiPort: 0
         headscalePort: 1
         serverDownloadUrl: serverDownloadUrl
@@ -1312,6 +1313,8 @@ components:
         apiPort:
           type: integer
         binariesPath:
+          type: string
+        builderImage:
           type: string
         defaultProjectImage:
           type: string

--- a/pkg/apiclient/docs/ServerConfig.md
+++ b/pkg/apiclient/docs/ServerConfig.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ApiPort** | Pointer to **int32** |  | [optional] 
 **BinariesPath** | Pointer to **string** |  | [optional] 
+**BuilderImage** | Pointer to **string** |  | [optional] 
 **DefaultProjectImage** | Pointer to **string** |  | [optional] 
 **DefaultProjectPostStartCommands** | Pointer to **[]string** |  | [optional] 
 **DefaultProjectUser** | Pointer to **string** |  | [optional] 
@@ -86,6 +87,31 @@ SetBinariesPath sets BinariesPath field to given value.
 `func (o *ServerConfig) HasBinariesPath() bool`
 
 HasBinariesPath returns a boolean if a field has been set.
+
+### GetBuilderImage
+
+`func (o *ServerConfig) GetBuilderImage() string`
+
+GetBuilderImage returns the BuilderImage field if non-nil, zero value otherwise.
+
+### GetBuilderImageOk
+
+`func (o *ServerConfig) GetBuilderImageOk() (*string, bool)`
+
+GetBuilderImageOk returns a tuple with the BuilderImage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetBuilderImage
+
+`func (o *ServerConfig) SetBuilderImage(v string)`
+
+SetBuilderImage sets BuilderImage field to given value.
+
+### HasBuilderImage
+
+`func (o *ServerConfig) HasBuilderImage() bool`
+
+HasBuilderImage returns a boolean if a field has been set.
 
 ### GetDefaultProjectImage
 

--- a/pkg/apiclient/model_server_config.go
+++ b/pkg/apiclient/model_server_config.go
@@ -21,6 +21,7 @@ var _ MappedNullable = &ServerConfig{}
 type ServerConfig struct {
 	ApiPort                         *int32      `json:"apiPort,omitempty"`
 	BinariesPath                    *string     `json:"binariesPath,omitempty"`
+	BuilderImage                    *string     `json:"builderImage,omitempty"`
 	DefaultProjectImage             *string     `json:"defaultProjectImage,omitempty"`
 	DefaultProjectPostStartCommands []string    `json:"defaultProjectPostStartCommands,omitempty"`
 	DefaultProjectUser              *string     `json:"defaultProjectUser,omitempty"`
@@ -113,6 +114,38 @@ func (o *ServerConfig) HasBinariesPath() bool {
 // SetBinariesPath gets a reference to the given string and assigns it to the BinariesPath field.
 func (o *ServerConfig) SetBinariesPath(v string) {
 	o.BinariesPath = &v
+}
+
+// GetBuilderImage returns the BuilderImage field value if set, zero value otherwise.
+func (o *ServerConfig) GetBuilderImage() string {
+	if o == nil || IsNil(o.BuilderImage) {
+		var ret string
+		return ret
+	}
+	return *o.BuilderImage
+}
+
+// GetBuilderImageOk returns a tuple with the BuilderImage field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetBuilderImageOk() (*string, bool) {
+	if o == nil || IsNil(o.BuilderImage) {
+		return nil, false
+	}
+	return o.BuilderImage, true
+}
+
+// HasBuilderImage returns a boolean if a field has been set.
+func (o *ServerConfig) HasBuilderImage() bool {
+	if o != nil && !IsNil(o.BuilderImage) {
+		return true
+	}
+
+	return false
+}
+
+// SetBuilderImage gets a reference to the given string and assigns it to the BuilderImage field.
+func (o *ServerConfig) SetBuilderImage(v string) {
+	o.BuilderImage = &v
 }
 
 // GetDefaultProjectImage returns the DefaultProjectImage field value if set, zero value otherwise.
@@ -482,6 +515,9 @@ func (o ServerConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.BinariesPath) {
 		toSerialize["binariesPath"] = o.BinariesPath
+	}
+	if !IsNil(o.BuilderImage) {
+		toSerialize["builderImage"] = o.BuilderImage
 	}
 	if !IsNil(o.DefaultProjectImage) {
 		toSerialize["defaultProjectImage"] = o.DefaultProjectImage

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/logger"
+	"github.com/daytonaio/daytona/pkg/server/containerregistries"
 	"github.com/daytonaio/daytona/pkg/workspace"
 )
 
@@ -22,6 +23,8 @@ type BuildResult struct {
 }
 
 type BuilderConfig struct {
+	Image                           string
+	ContainerRegistryService        containerregistries.IContainerRegistryService
 	ServerConfigFolder              string
 	LocalContainerRegistryServer    string
 	BasePath                        string
@@ -45,6 +48,8 @@ type Builder struct {
 	hash              string
 	projectVolumePath string
 
+	image                           string
+	containerRegistryService        containerregistries.IContainerRegistryService
 	serverConfigFolder              string
 	localContainerRegistryServer    string
 	basePath                        string

--- a/pkg/builder/factory.go
+++ b/pkg/builder/factory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/logger"
 	"github.com/daytonaio/daytona/pkg/ports"
+	"github.com/daytonaio/daytona/pkg/server/containerregistries"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -27,6 +28,8 @@ type BuilderFactory struct {
 	localContainerRegistryServer    string
 	basePath                        string
 	loggerFactory                   logger.LoggerFactory
+	image                           string
+	containerRegistryService        containerregistries.IContainerRegistryService
 	defaultProjectImage             string
 	defaultProjectUser              string
 	defaultProjectPostStartCommands []string
@@ -34,8 +37,10 @@ type BuilderFactory struct {
 
 func NewBuilderFactory(config BuilderConfig) IBuilderFactory {
 	return &BuilderFactory{
+		image:                           config.Image,
 		serverConfigFolder:              config.ServerConfigFolder,
 		localContainerRegistryServer:    config.LocalContainerRegistryServer,
+		containerRegistryService:        config.ContainerRegistryService,
 		basePath:                        config.BasePath,
 		loggerFactory:                   config.LoggerFactory,
 		defaultProjectImage:             config.DefaultProjectImage,
@@ -108,6 +113,8 @@ func (f *BuilderFactory) Create(p workspace.Project, gpc *gitprovider.GitProvide
 				gitProviderConfig:               gpc,
 				hash:                            hash,
 				projectVolumePath:               projectDir,
+				image:                           f.image,
+				containerRegistryService:        f.containerRegistryService,
 				serverConfigFolder:              f.serverConfigFolder,
 				localContainerRegistryServer:    f.localContainerRegistryServer,
 				basePath:                        f.basePath,

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -142,6 +142,8 @@ var ServeCmd = &cobra.Command{
 			DefaultProjectImage:             c.DefaultProjectImage,
 			DefaultProjectUser:              c.DefaultProjectUser,
 			DefaultProjectPostStartCommands: c.DefaultProjectPostStartCommands,
+			Image:                           c.BuilderImage,
+			ContainerRegistryService:        containerRegistryService,
 		})
 		provisioner := provisioner.NewProvisioner(provisioner.ProvisionerConfig{
 			ProviderManager: providerManager,
@@ -155,7 +157,7 @@ var ServeCmd = &cobra.Command{
 			TargetStore:                     providerTargetStore,
 			ApiKeyService:                   apiKeyService,
 			GitProviderService:              gitProviderService,
-			ContainerRegistryStore:          containerRegistryStore,
+			ContainerRegistryService:        containerRegistryService,
 			ServerApiUrl:                    util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
 			ServerUrl:                       util.GetFrpcServerUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
 			DefaultProjectImage:             c.DefaultProjectImage,

--- a/pkg/server/containerregistries/service.go
+++ b/pkg/server/containerregistries/service.go
@@ -3,11 +3,16 @@
 
 package containerregistries
 
-import "github.com/daytonaio/daytona/pkg/containerregistry"
+import (
+	"strings"
+
+	"github.com/daytonaio/daytona/pkg/containerregistry"
+)
 
 type IContainerRegistryService interface {
 	Delete(server string) error
 	Find(server string) (*containerregistry.ContainerRegistry, error)
+	FindByImageName(imageName string) (*containerregistry.ContainerRegistry, error)
 	List() ([]*containerregistry.ContainerRegistry, error)
 	Map() (map[string]*containerregistry.ContainerRegistry, error)
 	Save(cr *containerregistry.ContainerRegistry) error
@@ -49,6 +54,12 @@ func (s *ContainerRegistryService) Find(server string) (*containerregistry.Conta
 	return s.store.Find(server)
 }
 
+func (s *ContainerRegistryService) FindByImageName(imageName string) (*containerregistry.ContainerRegistry, error) {
+	server := getImageServer(imageName)
+
+	return s.Find(server)
+}
+
 func (s *ContainerRegistryService) Save(cr *containerregistry.ContainerRegistry) error {
 	return s.store.Save(cr)
 }
@@ -59,4 +70,14 @@ func (s *ContainerRegistryService) Delete(server string) error {
 		return err
 	}
 	return s.store.Delete(cr)
+}
+
+func getImageServer(imageName string) string {
+	parts := strings.Split(imageName, "/")
+
+	if len(parts) < 3 {
+		return "docker.io"
+	}
+
+	return parts[0]
 }

--- a/pkg/server/containerregistries/service_test.go
+++ b/pkg/server/containerregistries/service_test.go
@@ -35,4 +35,21 @@ func TestContainerRegistryService(t *testing.T) {
 		require.Nil(t, err)
 		require.EqualValues(t, crOrg, cr)
 	})
+
+	t.Run("FindByImageName", func(t *testing.T) {
+		var crOrg = &containerregistry.ContainerRegistry{
+			Server:   "example.com",
+			Username: "user",
+			Password: "password",
+		}
+
+		err := service.Save(crOrg)
+
+		require.Nil(t, err)
+
+		cr, err := service.FindByImageName("example.com/image/image")
+
+		require.Nil(t, err)
+		require.EqualValues(t, crOrg, cr)
+	})
 }

--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -21,6 +21,7 @@ const defaultServerDownloadUrl = "https://download.daytona.io/daytona/install.sh
 const defaultHeadscalePort = 3987
 const defaultApiPort = 3986
 const defaultRegistryPort = 3988
+const defaultBuilderImage = "daytonaio/workspace-builder:latest"
 const defaultProjectImage = "daytonaio/workspace-project:latest"
 const defaultProjectUser = "daytona"
 
@@ -111,6 +112,7 @@ func getDefaultConfig() (*Config, error) {
 		DefaultProjectImage:             defaultProjectImage,
 		DefaultProjectUser:              defaultProjectUser,
 		DefaultProjectPostStartCommands: defaultProjectPostStartCommands,
+		BuilderImage:                    defaultBuilderImage,
 	}
 
 	if os.Getenv("DEFAULT_REGISTRY_URL") != "" {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -43,4 +43,5 @@ type Config struct {
 	DefaultProjectImage             string      `json:"defaultProjectImage"`
 	DefaultProjectUser              string      `json:"defaultProjectUser"`
 	DefaultProjectPostStartCommands []string    `json:"defaultProjectPostStartCommands"`
+	BuilderImage                    string      `json:"builderImage"`
 } // @name ServerConfig

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -154,8 +154,8 @@ func (s *WorkspaceService) createBuild(project *workspace.Project, gc *gitprovid
 func (s *WorkspaceService) createProject(project *workspace.Project, target *provider.ProviderTarget, logWriter io.Writer) error {
 	logWriter.Write([]byte(fmt.Sprintf("Creating project %s\n", project.Name)))
 
-	cr, err := s.containerRegistryStore.Find(project.GetImageServer())
-	if !containerregistry.IsContainerRegistryNotFound(err) {
+	cr, err := s.containerRegistryService.FindByImageName(project.Image)
+	if err != nil && !containerregistry.IsContainerRegistryNotFound(err) {
 		return err
 	}
 

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -8,11 +8,11 @@ import (
 	"io"
 
 	"github.com/daytonaio/daytona/pkg/builder"
-	"github.com/daytonaio/daytona/pkg/containerregistry"
 	"github.com/daytonaio/daytona/pkg/logger"
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/server/apikeys"
+	"github.com/daytonaio/daytona/pkg/server/containerregistries"
 	"github.com/daytonaio/daytona/pkg/server/gitproviders"
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
 	"github.com/daytonaio/daytona/pkg/workspace"
@@ -39,7 +39,7 @@ type targetStore interface {
 type WorkspaceServiceConfig struct {
 	WorkspaceStore                  workspace.Store
 	TargetStore                     targetStore
-	ContainerRegistryStore          containerregistry.Store
+	ContainerRegistryService        containerregistries.IContainerRegistryService
 	ServerApiUrl                    string
 	ServerUrl                       string
 	Provisioner                     provisioner.IProvisioner
@@ -56,7 +56,7 @@ func NewWorkspaceService(config WorkspaceServiceConfig) IWorkspaceService {
 	return &WorkspaceService{
 		workspaceStore:                  config.WorkspaceStore,
 		targetStore:                     config.TargetStore,
-		containerRegistryStore:          config.ContainerRegistryStore,
+		containerRegistryService:        config.ContainerRegistryService,
 		serverApiUrl:                    config.ServerApiUrl,
 		serverUrl:                       config.ServerUrl,
 		defaultProjectImage:             config.DefaultProjectImage,
@@ -73,7 +73,7 @@ func NewWorkspaceService(config WorkspaceServiceConfig) IWorkspaceService {
 type WorkspaceService struct {
 	workspaceStore                  workspace.Store
 	targetStore                     targetStore
-	containerRegistryStore          containerregistry.Store
+	containerRegistryService        containerregistries.IContainerRegistryService
 	provisioner                     provisioner.IProvisioner
 	apiKeyService                   apikeys.IApiKeyService
 	serverApiUrl                    string

--- a/pkg/views/server/config.go
+++ b/pkg/views/server/config.go
@@ -33,11 +33,13 @@ func RenderConfig(config *server.Config) {
 
 	output += fmt.Sprintf("%s %d", views.GetPropertyKey("Headscale Port: "), config.HeadscalePort) + "\n\n"
 
-	output += fmt.Sprintf("%s %d", views.GetPropertyKey("Build Registry Port: "), config.RegistryPort) + "\n\n"
-
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Binaries Path: "), config.BinariesPath) + "\n\n"
 
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Logs Path: "), config.LogFilePath) + "\n\n"
+
+	output += fmt.Sprintf("%s %d", views.GetPropertyKey("Build Registry Port: "), config.RegistryPort) + "\n\n"
+
+	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Builder Image: "), config.BuilderImage) + "\n\n"
 
 	output += views.SeparatorString + "\n\n"
 

--- a/pkg/views/server/configure.go
+++ b/pkg/views/server/configure.go
@@ -51,6 +51,16 @@ func ConfigurationForm(config *apiclient.ServerConfig) *apiclient.ServerConfig {
 		),
 		huh.NewGroup(
 			huh.NewInput().
+				Title("Builder Image").
+				Description("Image dependencies: docker, @devcontainers/cli (node package)").
+				Value(config.BuilderImage),
+			huh.NewInput().
+				Title("Build Registry Port").
+				Value(&registryPortView).
+				Validate(createPortValidator(config, &registryPortView, config.RegistryPort)),
+		),
+		huh.NewGroup(
+			huh.NewInput().
 				Title("API Port").
 				Value(&apiPortView).
 				Validate(createPortValidator(config, &apiPortView, config.ApiPort)),
@@ -58,10 +68,6 @@ func ConfigurationForm(config *apiclient.ServerConfig) *apiclient.ServerConfig {
 				Title("Headscale Port").
 				Value(&headscalePortView).
 				Validate(createPortValidator(config, &headscalePortView, config.HeadscalePort)),
-			huh.NewInput().
-				Title("Build Registry Port").
-				Value(&registryPortView).
-				Validate(createPortValidator(config, &registryPortView, config.RegistryPort)),
 			huh.NewInput().
 				Title("Binaries Path").
 				Description("Directory will be created if it does not exist").

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/gitprovider"
@@ -87,16 +86,6 @@ const (
 	Copied             Status = "Copied"
 	UpdatedButUnmerged Status = "Updated but unmerged"
 )
-
-func (p *Project) GetImageServer() string {
-	parts := strings.Split(p.Image, "/")
-
-	if len(parts) < 3 {
-		return "docker.io"
-	}
-
-	return parts[0]
-}
 
 func GetProjectEnvVars(project *Project, apiUrl, serverUrl string) map[string]string {
 	envVars := map[string]string{


### PR DESCRIPTION
# Builder Image Configuration

## Description

This PR adds the `Builder Image` as a configuration option in `daytona server configure`. The user can now use any image as a builder image, including private images (this requires the user to add container registry credentials to the Daytona Server).

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #634 

## Screenshots
<img width="508" alt="Screenshot 2024-06-05 at 16 30 08" src="https://github.com/daytonaio/daytona/assets/26512078/ebf275fc-7260-447c-9917-aee8f93a2c01">
