### PR TITLE
feat: custom builder registry configuration

### DIFF
--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1533,7 +1533,13 @@ const docTemplate = `{
                 "binariesPath": {
                     "type": "string"
                 },
+                "buildImageNamespace": {
+                    "type": "string"
+                },
                 "builderImage": {
+                    "type": "string"
+                },
+                "builderRegistryServer": {
                     "type": "string"
                 },
                 "defaultProjectImage": {
@@ -1557,14 +1563,14 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "localBuilderRegistryPort": {
+                    "type": "integer"
+                },
                 "logFilePath": {
                     "type": "string"
                 },
                 "providersDir": {
                     "type": "string"
-                },
-                "registryPort": {
-                    "type": "integer"
                 },
                 "registryUrl": {
                     "type": "string"

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1530,7 +1530,13 @@
                 "binariesPath": {
                     "type": "string"
                 },
+                "buildImageNamespace": {
+                    "type": "string"
+                },
                 "builderImage": {
+                    "type": "string"
+                },
+                "builderRegistryServer": {
                     "type": "string"
                 },
                 "defaultProjectImage": {
@@ -1554,14 +1560,14 @@
                 "id": {
                     "type": "string"
                 },
+                "localBuilderRegistryPort": {
+                    "type": "integer"
+                },
                 "logFilePath": {
                     "type": "string"
                 },
                 "providersDir": {
                     "type": "string"
-                },
-                "registryPort": {
-                    "type": "integer"
                 },
                 "registryUrl": {
                     "type": "string"

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -272,7 +272,11 @@ definitions:
         type: integer
       binariesPath:
         type: string
+      buildImageNamespace:
+        type: string
       builderImage:
+        type: string
+      builderRegistryServer:
         type: string
       defaultProjectImage:
         type: string
@@ -288,12 +292,12 @@ definitions:
         type: integer
       id:
         type: string
+      localBuilderRegistryPort:
+        type: integer
       logFilePath:
         type: string
       providersDir:
         type: string
-      registryPort:
-        type: integer
       registryUrl:
         type: string
       serverDownloadUrl:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1291,20 +1291,22 @@ components:
     ServerConfig:
       example:
         registryUrl: registryUrl
+        localBuilderRegistryPort: 5
         defaultProjectUser: defaultProjectUser
+        builderRegistryServer: builderRegistryServer
         defaultProjectPostStartCommands:
         - defaultProjectPostStartCommands
         - defaultProjectPostStartCommands
         builderImage: builderImage
         apiPort: 0
         headscalePort: 1
+        buildImageNamespace: buildImageNamespace
         serverDownloadUrl: serverDownloadUrl
         binariesPath: binariesPath
         logFilePath: logFilePath
         defaultProjectImage: defaultProjectImage
         providersDir: providersDir
         id: id
-        registryPort: 5
         frps:
           protocol: protocol
           port: 6
@@ -1314,7 +1316,11 @@ components:
           type: integer
         binariesPath:
           type: string
+        buildImageNamespace:
+          type: string
         builderImage:
+          type: string
+        builderRegistryServer:
           type: string
         defaultProjectImage:
           type: string
@@ -1330,12 +1336,12 @@ components:
           type: integer
         id:
           type: string
+        localBuilderRegistryPort:
+          type: integer
         logFilePath:
           type: string
         providersDir:
           type: string
-        registryPort:
-          type: integer
         registryUrl:
           type: string
         serverDownloadUrl:

--- a/pkg/apiclient/docs/ServerConfig.md
+++ b/pkg/apiclient/docs/ServerConfig.md
@@ -6,16 +6,18 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ApiPort** | Pointer to **int32** |  | [optional] 
 **BinariesPath** | Pointer to **string** |  | [optional] 
+**BuildImageNamespace** | Pointer to **string** |  | [optional] 
 **BuilderImage** | Pointer to **string** |  | [optional] 
+**BuilderRegistryServer** | Pointer to **string** |  | [optional] 
 **DefaultProjectImage** | Pointer to **string** |  | [optional] 
 **DefaultProjectPostStartCommands** | Pointer to **[]string** |  | [optional] 
 **DefaultProjectUser** | Pointer to **string** |  | [optional] 
 **Frps** | Pointer to [**FRPSConfig**](FRPSConfig.md) |  | [optional] 
 **HeadscalePort** | Pointer to **int32** |  | [optional] 
 **Id** | Pointer to **string** |  | [optional] 
+**LocalBuilderRegistryPort** | Pointer to **int32** |  | [optional] 
 **LogFilePath** | Pointer to **string** |  | [optional] 
 **ProvidersDir** | Pointer to **string** |  | [optional] 
-**RegistryPort** | Pointer to **int32** |  | [optional] 
 **RegistryUrl** | Pointer to **string** |  | [optional] 
 **ServerDownloadUrl** | Pointer to **string** |  | [optional] 
 
@@ -88,6 +90,31 @@ SetBinariesPath sets BinariesPath field to given value.
 
 HasBinariesPath returns a boolean if a field has been set.
 
+### GetBuildImageNamespace
+
+`func (o *ServerConfig) GetBuildImageNamespace() string`
+
+GetBuildImageNamespace returns the BuildImageNamespace field if non-nil, zero value otherwise.
+
+### GetBuildImageNamespaceOk
+
+`func (o *ServerConfig) GetBuildImageNamespaceOk() (*string, bool)`
+
+GetBuildImageNamespaceOk returns a tuple with the BuildImageNamespace field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetBuildImageNamespace
+
+`func (o *ServerConfig) SetBuildImageNamespace(v string)`
+
+SetBuildImageNamespace sets BuildImageNamespace field to given value.
+
+### HasBuildImageNamespace
+
+`func (o *ServerConfig) HasBuildImageNamespace() bool`
+
+HasBuildImageNamespace returns a boolean if a field has been set.
+
 ### GetBuilderImage
 
 `func (o *ServerConfig) GetBuilderImage() string`
@@ -112,6 +139,31 @@ SetBuilderImage sets BuilderImage field to given value.
 `func (o *ServerConfig) HasBuilderImage() bool`
 
 HasBuilderImage returns a boolean if a field has been set.
+
+### GetBuilderRegistryServer
+
+`func (o *ServerConfig) GetBuilderRegistryServer() string`
+
+GetBuilderRegistryServer returns the BuilderRegistryServer field if non-nil, zero value otherwise.
+
+### GetBuilderRegistryServerOk
+
+`func (o *ServerConfig) GetBuilderRegistryServerOk() (*string, bool)`
+
+GetBuilderRegistryServerOk returns a tuple with the BuilderRegistryServer field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetBuilderRegistryServer
+
+`func (o *ServerConfig) SetBuilderRegistryServer(v string)`
+
+SetBuilderRegistryServer sets BuilderRegistryServer field to given value.
+
+### HasBuilderRegistryServer
+
+`func (o *ServerConfig) HasBuilderRegistryServer() bool`
+
+HasBuilderRegistryServer returns a boolean if a field has been set.
 
 ### GetDefaultProjectImage
 
@@ -263,6 +315,31 @@ SetId sets Id field to given value.
 
 HasId returns a boolean if a field has been set.
 
+### GetLocalBuilderRegistryPort
+
+`func (o *ServerConfig) GetLocalBuilderRegistryPort() int32`
+
+GetLocalBuilderRegistryPort returns the LocalBuilderRegistryPort field if non-nil, zero value otherwise.
+
+### GetLocalBuilderRegistryPortOk
+
+`func (o *ServerConfig) GetLocalBuilderRegistryPortOk() (*int32, bool)`
+
+GetLocalBuilderRegistryPortOk returns a tuple with the LocalBuilderRegistryPort field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLocalBuilderRegistryPort
+
+`func (o *ServerConfig) SetLocalBuilderRegistryPort(v int32)`
+
+SetLocalBuilderRegistryPort sets LocalBuilderRegistryPort field to given value.
+
+### HasLocalBuilderRegistryPort
+
+`func (o *ServerConfig) HasLocalBuilderRegistryPort() bool`
+
+HasLocalBuilderRegistryPort returns a boolean if a field has been set.
+
 ### GetLogFilePath
 
 `func (o *ServerConfig) GetLogFilePath() string`
@@ -312,31 +389,6 @@ SetProvidersDir sets ProvidersDir field to given value.
 `func (o *ServerConfig) HasProvidersDir() bool`
 
 HasProvidersDir returns a boolean if a field has been set.
-
-### GetRegistryPort
-
-`func (o *ServerConfig) GetRegistryPort() int32`
-
-GetRegistryPort returns the RegistryPort field if non-nil, zero value otherwise.
-
-### GetRegistryPortOk
-
-`func (o *ServerConfig) GetRegistryPortOk() (*int32, bool)`
-
-GetRegistryPortOk returns a tuple with the RegistryPort field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetRegistryPort
-
-`func (o *ServerConfig) SetRegistryPort(v int32)`
-
-SetRegistryPort sets RegistryPort field to given value.
-
-### HasRegistryPort
-
-`func (o *ServerConfig) HasRegistryPort() bool`
-
-HasRegistryPort returns a boolean if a field has been set.
 
 ### GetRegistryUrl
 

--- a/pkg/apiclient/model_server_config.go
+++ b/pkg/apiclient/model_server_config.go
@@ -21,16 +21,18 @@ var _ MappedNullable = &ServerConfig{}
 type ServerConfig struct {
 	ApiPort                         *int32      `json:"apiPort,omitempty"`
 	BinariesPath                    *string     `json:"binariesPath,omitempty"`
+	BuildImageNamespace             *string     `json:"buildImageNamespace,omitempty"`
 	BuilderImage                    *string     `json:"builderImage,omitempty"`
+	BuilderRegistryServer           *string     `json:"builderRegistryServer,omitempty"`
 	DefaultProjectImage             *string     `json:"defaultProjectImage,omitempty"`
 	DefaultProjectPostStartCommands []string    `json:"defaultProjectPostStartCommands,omitempty"`
 	DefaultProjectUser              *string     `json:"defaultProjectUser,omitempty"`
 	Frps                            *FRPSConfig `json:"frps,omitempty"`
 	HeadscalePort                   *int32      `json:"headscalePort,omitempty"`
 	Id                              *string     `json:"id,omitempty"`
+	LocalBuilderRegistryPort        *int32      `json:"localBuilderRegistryPort,omitempty"`
 	LogFilePath                     *string     `json:"logFilePath,omitempty"`
 	ProvidersDir                    *string     `json:"providersDir,omitempty"`
-	RegistryPort                    *int32      `json:"registryPort,omitempty"`
 	RegistryUrl                     *string     `json:"registryUrl,omitempty"`
 	ServerDownloadUrl               *string     `json:"serverDownloadUrl,omitempty"`
 }
@@ -116,6 +118,38 @@ func (o *ServerConfig) SetBinariesPath(v string) {
 	o.BinariesPath = &v
 }
 
+// GetBuildImageNamespace returns the BuildImageNamespace field value if set, zero value otherwise.
+func (o *ServerConfig) GetBuildImageNamespace() string {
+	if o == nil || IsNil(o.BuildImageNamespace) {
+		var ret string
+		return ret
+	}
+	return *o.BuildImageNamespace
+}
+
+// GetBuildImageNamespaceOk returns a tuple with the BuildImageNamespace field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetBuildImageNamespaceOk() (*string, bool) {
+	if o == nil || IsNil(o.BuildImageNamespace) {
+		return nil, false
+	}
+	return o.BuildImageNamespace, true
+}
+
+// HasBuildImageNamespace returns a boolean if a field has been set.
+func (o *ServerConfig) HasBuildImageNamespace() bool {
+	if o != nil && !IsNil(o.BuildImageNamespace) {
+		return true
+	}
+
+	return false
+}
+
+// SetBuildImageNamespace gets a reference to the given string and assigns it to the BuildImageNamespace field.
+func (o *ServerConfig) SetBuildImageNamespace(v string) {
+	o.BuildImageNamespace = &v
+}
+
 // GetBuilderImage returns the BuilderImage field value if set, zero value otherwise.
 func (o *ServerConfig) GetBuilderImage() string {
 	if o == nil || IsNil(o.BuilderImage) {
@@ -146,6 +180,38 @@ func (o *ServerConfig) HasBuilderImage() bool {
 // SetBuilderImage gets a reference to the given string and assigns it to the BuilderImage field.
 func (o *ServerConfig) SetBuilderImage(v string) {
 	o.BuilderImage = &v
+}
+
+// GetBuilderRegistryServer returns the BuilderRegistryServer field value if set, zero value otherwise.
+func (o *ServerConfig) GetBuilderRegistryServer() string {
+	if o == nil || IsNil(o.BuilderRegistryServer) {
+		var ret string
+		return ret
+	}
+	return *o.BuilderRegistryServer
+}
+
+// GetBuilderRegistryServerOk returns a tuple with the BuilderRegistryServer field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetBuilderRegistryServerOk() (*string, bool) {
+	if o == nil || IsNil(o.BuilderRegistryServer) {
+		return nil, false
+	}
+	return o.BuilderRegistryServer, true
+}
+
+// HasBuilderRegistryServer returns a boolean if a field has been set.
+func (o *ServerConfig) HasBuilderRegistryServer() bool {
+	if o != nil && !IsNil(o.BuilderRegistryServer) {
+		return true
+	}
+
+	return false
+}
+
+// SetBuilderRegistryServer gets a reference to the given string and assigns it to the BuilderRegistryServer field.
+func (o *ServerConfig) SetBuilderRegistryServer(v string) {
+	o.BuilderRegistryServer = &v
 }
 
 // GetDefaultProjectImage returns the DefaultProjectImage field value if set, zero value otherwise.
@@ -340,6 +406,38 @@ func (o *ServerConfig) SetId(v string) {
 	o.Id = &v
 }
 
+// GetLocalBuilderRegistryPort returns the LocalBuilderRegistryPort field value if set, zero value otherwise.
+func (o *ServerConfig) GetLocalBuilderRegistryPort() int32 {
+	if o == nil || IsNil(o.LocalBuilderRegistryPort) {
+		var ret int32
+		return ret
+	}
+	return *o.LocalBuilderRegistryPort
+}
+
+// GetLocalBuilderRegistryPortOk returns a tuple with the LocalBuilderRegistryPort field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetLocalBuilderRegistryPortOk() (*int32, bool) {
+	if o == nil || IsNil(o.LocalBuilderRegistryPort) {
+		return nil, false
+	}
+	return o.LocalBuilderRegistryPort, true
+}
+
+// HasLocalBuilderRegistryPort returns a boolean if a field has been set.
+func (o *ServerConfig) HasLocalBuilderRegistryPort() bool {
+	if o != nil && !IsNil(o.LocalBuilderRegistryPort) {
+		return true
+	}
+
+	return false
+}
+
+// SetLocalBuilderRegistryPort gets a reference to the given int32 and assigns it to the LocalBuilderRegistryPort field.
+func (o *ServerConfig) SetLocalBuilderRegistryPort(v int32) {
+	o.LocalBuilderRegistryPort = &v
+}
+
 // GetLogFilePath returns the LogFilePath field value if set, zero value otherwise.
 func (o *ServerConfig) GetLogFilePath() string {
 	if o == nil || IsNil(o.LogFilePath) {
@@ -402,38 +500,6 @@ func (o *ServerConfig) HasProvidersDir() bool {
 // SetProvidersDir gets a reference to the given string and assigns it to the ProvidersDir field.
 func (o *ServerConfig) SetProvidersDir(v string) {
 	o.ProvidersDir = &v
-}
-
-// GetRegistryPort returns the RegistryPort field value if set, zero value otherwise.
-func (o *ServerConfig) GetRegistryPort() int32 {
-	if o == nil || IsNil(o.RegistryPort) {
-		var ret int32
-		return ret
-	}
-	return *o.RegistryPort
-}
-
-// GetRegistryPortOk returns a tuple with the RegistryPort field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ServerConfig) GetRegistryPortOk() (*int32, bool) {
-	if o == nil || IsNil(o.RegistryPort) {
-		return nil, false
-	}
-	return o.RegistryPort, true
-}
-
-// HasRegistryPort returns a boolean if a field has been set.
-func (o *ServerConfig) HasRegistryPort() bool {
-	if o != nil && !IsNil(o.RegistryPort) {
-		return true
-	}
-
-	return false
-}
-
-// SetRegistryPort gets a reference to the given int32 and assigns it to the RegistryPort field.
-func (o *ServerConfig) SetRegistryPort(v int32) {
-	o.RegistryPort = &v
 }
 
 // GetRegistryUrl returns the RegistryUrl field value if set, zero value otherwise.
@@ -516,8 +582,14 @@ func (o ServerConfig) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.BinariesPath) {
 		toSerialize["binariesPath"] = o.BinariesPath
 	}
+	if !IsNil(o.BuildImageNamespace) {
+		toSerialize["buildImageNamespace"] = o.BuildImageNamespace
+	}
 	if !IsNil(o.BuilderImage) {
 		toSerialize["builderImage"] = o.BuilderImage
+	}
+	if !IsNil(o.BuilderRegistryServer) {
+		toSerialize["builderRegistryServer"] = o.BuilderRegistryServer
 	}
 	if !IsNil(o.DefaultProjectImage) {
 		toSerialize["defaultProjectImage"] = o.DefaultProjectImage
@@ -537,14 +609,14 @@ func (o ServerConfig) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
+	if !IsNil(o.LocalBuilderRegistryPort) {
+		toSerialize["localBuilderRegistryPort"] = o.LocalBuilderRegistryPort
+	}
 	if !IsNil(o.LogFilePath) {
 		toSerialize["logFilePath"] = o.LogFilePath
 	}
 	if !IsNil(o.ProvidersDir) {
 		toSerialize["providersDir"] = o.ProvidersDir
-	}
-	if !IsNil(o.RegistryPort) {
-		toSerialize["registryPort"] = o.RegistryPort
 	}
 	if !IsNil(o.RegistryUrl) {
 		toSerialize["registryUrl"] = o.RegistryUrl

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -23,10 +23,12 @@ type BuildResult struct {
 }
 
 type BuilderConfig struct {
-	Image                           string
-	ContainerRegistryService        containerregistries.IContainerRegistryService
-	ServerConfigFolder              string
-	LocalContainerRegistryServer    string
+	Image                    string
+	ContainerRegistryService containerregistries.IContainerRegistryService
+	ServerConfigFolder       string
+	ContainerRegistryServer  string
+	// Namespace to be used when tagging and pushing the build image
+	BuildImageNamespace             string
 	BasePath                        string
 	LoggerFactory                   logger.LoggerFactory
 	DefaultProjectImage             string
@@ -50,8 +52,9 @@ type Builder struct {
 
 	image                           string
 	containerRegistryService        containerregistries.IContainerRegistryService
+	containerRegistryServer         string
+	buildImageNamespace             string
 	serverConfigFolder              string
-	localContainerRegistryServer    string
 	basePath                        string
 	loggerFactory                   logger.LoggerFactory
 	defaultProjectImage             string

--- a/pkg/cmd/server/configure.go
+++ b/pkg/cmd/server/configure.go
@@ -27,7 +27,12 @@ var configureCmd = &cobra.Command{
 			log.Fatal(apiclient.HandleErrorResponse(res, err))
 		}
 
-		apiServerConfig = server_view.ConfigurationForm(apiServerConfig)
+		containerRegistries, res, err := apiClient.ContainerRegistryAPI.ListContainerRegistries(context.Background()).Execute()
+		if err != nil {
+			log.Fatal(apiclient.HandleErrorResponse(res, err))
+		}
+
+		apiServerConfig = server_view.ConfigurationForm(apiServerConfig, containerRegistries)
 
 		_, res, err = apiClient.ServerAPI.SetConfig(context.Background()).Config(*apiServerConfig).Execute()
 		if err != nil {

--- a/pkg/containerregistry/container_registry.go
+++ b/pkg/containerregistry/container_registry.go
@@ -3,9 +3,27 @@
 
 package containerregistry
 
+import (
+	"errors"
+	"strings"
+)
+
 // ContainerRegistry represents a container registry credentials
 type ContainerRegistry struct {
 	Server   string `json:"server"`
 	Username string `json:"username"`
 	Password string `json:"password"`
 } // @name ContainerRegistry
+
+func GetServerHostname(server string) (string, error) {
+	server = strings.TrimPrefix(server, "https://")
+	server = strings.TrimPrefix(server, "http://")
+
+	parts := strings.Split(server, "/")
+
+	if len(parts) == 0 {
+		return "", errors.New("invalid container registry server URL")
+	}
+
+	return parts[0], nil
+}

--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -20,10 +20,13 @@ const defaultRegistryUrl = "https://download.daytona.io/daytona"
 const defaultServerDownloadUrl = "https://download.daytona.io/daytona/install.sh"
 const defaultHeadscalePort = 3987
 const defaultApiPort = 3986
-const defaultRegistryPort = 3988
 const defaultBuilderImage = "daytonaio/workspace-project:latest"
 const defaultProjectImage = "daytonaio/workspace-project:latest"
 const defaultProjectUser = "daytona"
+
+const defaultLocalBuilderRegistryPort = 3988
+const defaultBuilderRegistryServer = "local"
+const defaultBuildImageNamespace = ""
 
 var defaultProjectPostStartCommands = []string{"sudo dockerd"}
 
@@ -104,7 +107,6 @@ func getDefaultConfig() (*Config, error) {
 		ProvidersDir:                    providersDir,
 		ServerDownloadUrl:               defaultServerDownloadUrl,
 		ApiPort:                         defaultApiPort,
-		RegistryPort:                    defaultRegistryPort,
 		HeadscalePort:                   defaultHeadscalePort,
 		BinariesPath:                    binariesPath,
 		Frps:                            getDefaultFRPSConfig(),
@@ -113,6 +115,9 @@ func getDefaultConfig() (*Config, error) {
 		DefaultProjectUser:              defaultProjectUser,
 		DefaultProjectPostStartCommands: defaultProjectPostStartCommands,
 		BuilderImage:                    defaultBuilderImage,
+		LocalBuilderRegistryPort:        defaultLocalBuilderRegistryPort,
+		BuilderRegistryServer:           defaultBuilderRegistryServer,
+		BuildImageNamespace:             defaultBuildImageNamespace,
 	}
 
 	if os.Getenv("DEFAULT_REGISTRY_URL") != "" {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -36,7 +36,6 @@ type Config struct {
 	ServerDownloadUrl               string      `json:"serverDownloadUrl"`
 	Frps                            *FRPSConfig `json:"frps,omitempty"`
 	ApiPort                         uint32      `json:"apiPort"`
-	RegistryPort                    uint32      `json:"registryPort"`
 	HeadscalePort                   uint32      `json:"headscalePort"`
 	BinariesPath                    string      `json:"binariesPath"`
 	LogFilePath                     string      `json:"logFilePath"`
@@ -44,4 +43,7 @@ type Config struct {
 	DefaultProjectUser              string      `json:"defaultProjectUser"`
 	DefaultProjectPostStartCommands []string    `json:"defaultProjectPostStartCommands"`
 	BuilderImage                    string      `json:"builderImage"`
+	LocalBuilderRegistryPort        uint32      `json:"localBuilderRegistryPort"`
+	BuilderRegistryServer           string      `json:"builderRegistryServer"`
+	BuildImageNamespace             string      `json:"buildImageNamespace"`
 } // @name ServerConfig

--- a/pkg/views/server/config.go
+++ b/pkg/views/server/config.go
@@ -37,9 +37,15 @@ func RenderConfig(config *server.Config) {
 
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Logs Path: "), config.LogFilePath) + "\n\n"
 
-	output += fmt.Sprintf("%s %d", views.GetPropertyKey("Build Registry Port: "), config.RegistryPort) + "\n\n"
-
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Builder Image: "), config.BuilderImage) + "\n\n"
+
+	if config.BuilderRegistryServer == "local" {
+		output += fmt.Sprintf("%s %d", views.GetPropertyKey("Local Builder Registry Port: "), config.LocalBuilderRegistryPort) + "\n\n"
+	} else {
+		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Builder Registry: "), config.BuilderRegistryServer) + "\n\n"
+	}
+
+	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Build Image Namespace: "), config.BuildImageNamespace) + "\n\n"
 
 	output += views.SeparatorString + "\n\n"
 


### PR DESCRIPTION
# Custom Builder Registry Configuration

## Description

This PR introduces the option to choose a custom builder registry that was added to Daytona with `daytona cr set`. The registry will be used to store build images. Additionally, the `Build Image Namespace` option was introduced that is used when tagging and pushing build images.

### BREAKING CHANGE
Before starting the server, users will need to add 'localBuilderRegistryPort' and 'builderRegistryServer' properties to their server configuration.
The following properties should be added:
```
  "localBuilderRegistryPort": 3988,
  "builderRegistryServer": "local",
```

(Note: `"registryPort"` can be removed from the config file)

> **On Mac**
The file is located at: `~/Library/Application\ Support/daytona/server/config.json`.

> **On Linux**
The file is located at: `~/.config/daytona/server/config.json`

> **On Windows**
The file is located at: `C:\Users\YOUR_USERNAME\AppData\Roaming\daytona\server\config.json`


- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #635 