### PR TITLE
fix: hide registry password from API response

### DIFF
--- a/pkg/api/controllers/containerregistry/list.go
+++ b/pkg/api/controllers/containerregistry/list.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
@@ -41,7 +40,7 @@ func GetContainerRegistry(ctx *gin.Context) {
 		return
 	}
 
-	cr.Password = strings.Repeat("*", len(cr.Password))
+	cr.Password = ""
 
 	ctx.JSON(200, cr)
 }
@@ -66,7 +65,7 @@ func ListContainerRegistries(ctx *gin.Context) {
 	}
 
 	for _, cr := range crs {
-		cr.Password = strings.Repeat("*", len(cr.Password))
+		cr.Password = ""
 	}
 
 	ctx.JSON(200, crs)

--- a/pkg/views/containerregistry/list/view.go
+++ b/pkg/views/containerregistry/list/view.go
@@ -6,6 +6,7 @@ package list
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -36,7 +37,7 @@ func getRowFromRowData(rowData rowData) []string {
 	row := []string{
 		views.NameStyle.Render(rowData.Server),
 		views.DefaultRowDataStyle.Render(rowData.Username),
-		views.DefaultRowDataStyle.Render(rowData.Password),
+		views.DefaultRowDataStyle.Render(strings.Repeat("*", 10)),
 	}
 
 	return row


### PR DESCRIPTION
# Hide Container Registry Password from API response

## Description

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

Minor fix to completely hide the container registry password from the API response.