### PR TITLE
feat: direct api and headscale access

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1324,7 +1324,6 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=

--- a/internal/util/frpc.go
+++ b/internal/util/frpc.go
@@ -15,7 +15,7 @@ func GetFrpcServerDomain(serverId, frpsDomain string) string {
 	return fmt.Sprintf("%s.%s", serverId, frpsDomain)
 }
 
-func GetFrpcServerUrl(protocol, serverId, frpsDomain string) string {
+func GetFrpcHeadscaleUrl(protocol, serverId, frpsDomain string) string {
 	return fmt.Sprintf("%s://%s", protocol, GetFrpcServerDomain(serverId, frpsDomain))
 }
 

--- a/pkg/api/controllers/binary/get_daytona.go
+++ b/pkg/api/controllers/binary/get_daytona.go
@@ -4,19 +4,22 @@
 package binary
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/daytonaio/daytona/internal/constants"
-	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
 
 // Used in projects to download the Daytona binary
 func GetDaytonaScript(ctx *gin.Context) {
-	server := server.GetInstance(nil)
+	scheme := "http"
+	if ctx.Request.TLS != nil || ctx.GetHeader("X-Forwarded-Proto") == "https" {
+		scheme = "https"
+	}
 
-	downloadUrl, _ := url.JoinPath(server.GetApiUrl(), "binary")
+	downloadUrl, _ := url.JoinPath(fmt.Sprintf("%s://%s", scheme, ctx.Request.Host), "binary")
 	getServerScript := constants.GetDaytonaScript(downloadUrl)
 
 	ctx.String(http.StatusOK, getServerScript)

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -136,17 +136,22 @@ var ServeCmd = &cobra.Command{
 		apiKeyService := apikeys.NewApiKeyService(apikeys.ApiKeyServiceConfig{
 			ApiKeyStore: apiKeyStore,
 		})
+
+		headscaleUrl := util.GetFrpcHeadscaleUrl(c.Frps.Protocol, c.Id, c.Frps.Domain)
+
 		providerManager := manager.NewProviderManager(manager.ProviderManagerConfig{
 			LogsDir:               logsDir,
 			ProviderTargetService: providerTargetService,
-			ServerApiUrl:          util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
-			ServerDownloadUrl:     getDaytonaScriptUrl(c),
-			ServerUrl:             util.GetFrpcServerUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
+			ApiUrl:                util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
+			DaytonaDownloadUrl:    getDaytonaScriptUrl(c),
+			ServerUrl:             headscaleUrl,
 			RegistryUrl:           c.RegistryUrl,
 			BaseDir:               c.ProvidersDir,
 			CreateProviderNetworkKey: func(providerName string) (string, error) {
 				return headscaleServer.CreateAuthKey()
 			},
+			ServerPort: c.HeadscalePort,
+			ApiPort:    c.ApiPort,
 		})
 
 		buildImageNamespace := c.BuildImageNamespace
@@ -181,7 +186,7 @@ var ServeCmd = &cobra.Command{
 			GitProviderService:              gitProviderService,
 			ContainerRegistryService:        containerRegistryService,
 			ServerApiUrl:                    util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
-			ServerUrl:                       util.GetFrpcServerUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
+			ServerUrl:                       headscaleUrl,
 			DefaultProjectImage:             c.DefaultProjectImage,
 			DefaultProjectUser:              c.DefaultProjectUser,
 			DefaultProjectPostStartCommands: c.DefaultProjectPostStartCommands,

--- a/pkg/docker/create.go
+++ b/pkg/docker/create.go
@@ -38,6 +38,7 @@ func (d *DockerClient) CreateWorkspace(workspace *workspace.Workspace, logWriter
 
 	_, err = d.apiClient.NetworkCreate(ctx, workspace.Id, types.NetworkCreate{
 		Attachable: true,
+		Driver:     "bridge",
 	})
 	if err != nil {
 		return err
@@ -70,6 +71,9 @@ func (d *DockerClient) initProjectContainer(project *workspace.Project, daytonaD
 				Source: d.GetProjectVolumeName(project),
 				Target: fmt.Sprintf("/home/%s/%s", project.User, project.Name),
 			},
+		},
+		ExtraHosts: []string{
+			"host.docker.internal:host-gateway",
 		},
 	}, nil, nil, d.GetProjectContainerName(project))
 	if err != nil {

--- a/pkg/docker/create_test.go
+++ b/pkg/docker/create_test.go
@@ -24,6 +24,7 @@ func (s *DockerClientTestSuite) TestCreateWorkspace() {
 	s.mockClient.On("NetworkCreate", mock.Anything, workspace1.Id,
 		types.NetworkCreate{
 			Attachable: true,
+			Driver:     "bridge",
 		},
 	).Return(types.NetworkCreateResponse{}, nil)
 
@@ -55,6 +56,9 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 					Source: s.dockerClient.GetProjectVolumeName(project1),
 					Target: fmt.Sprintf("/home/%s/%s", project1.User, project1.Name),
 				},
+			},
+			ExtraHosts: []string{
+				"host.docker.internal:host-gateway",
 			},
 		},
 		networkingConfig,

--- a/pkg/provider/manager/manager.go
+++ b/pkg/provider/manager/manager.go
@@ -45,35 +45,41 @@ type IProviderManager interface {
 }
 
 type ProviderManagerConfig struct {
-	ServerDownloadUrl        string
+	DaytonaDownloadUrl       string
 	ServerUrl                string
-	ServerApiUrl             string
+	ApiUrl                   string
 	LogsDir                  string
 	ProviderTargetService    providertargets.IProviderTargetService
 	RegistryUrl              string
 	BaseDir                  string
 	CreateProviderNetworkKey func(providerName string) (string, error)
+	ServerPort               uint32
+	ApiPort                  uint32
 }
 
 func NewProviderManager(config ProviderManagerConfig) *ProviderManager {
 	return &ProviderManager{
 		pluginRefs:               make(map[string]*pluginRef),
-		serverDownloadUrl:        config.ServerDownloadUrl,
+		daytonaDownloadUrl:       config.DaytonaDownloadUrl,
 		serverUrl:                config.ServerUrl,
-		serverApiUrl:             config.ServerApiUrl,
+		apiUrl:                   config.ApiUrl,
 		logsDir:                  config.LogsDir,
 		providerTargetService:    config.ProviderTargetService,
 		registryUrl:              config.RegistryUrl,
 		baseDir:                  config.BaseDir,
 		createProviderNetworkKey: config.CreateProviderNetworkKey,
+		serverPort:               config.ServerPort,
+		apiPort:                  config.ApiPort,
 	}
 }
 
 type ProviderManager struct {
 	pluginRefs               map[string]*pluginRef
-	serverDownloadUrl        string
+	daytonaDownloadUrl       string
 	serverUrl                string
-	serverApiUrl             string
+	apiUrl                   string
+	serverPort               uint32
+	apiPort                  uint32
 	logsDir                  string
 	providerTargetService    providertargets.IProviderTargetService
 	registryUrl              string
@@ -242,13 +248,15 @@ func (m *ProviderManager) initializeProvider(pluginPath string) (*pluginRef, err
 	}
 
 	_, err = (*p).Initialize(InitializeProviderRequest{
-		BasePath:          pluginBasePath,
-		ServerDownloadUrl: m.serverDownloadUrl,
-		ServerVersion:     internal.Version,
-		ServerUrl:         m.serverUrl,
-		ServerApiUrl:      m.serverApiUrl,
-		LogsDir:           m.logsDir,
-		NetworkKey:        networkKey,
+		BasePath:           pluginBasePath,
+		DaytonaDownloadUrl: m.daytonaDownloadUrl,
+		DaytonaVersion:     internal.Version,
+		ServerUrl:          m.serverUrl,
+		ApiUrl:             m.apiUrl,
+		LogsDir:            m.logsDir,
+		NetworkKey:         networkKey,
+		ServerPort:         m.serverPort,
+		ApiPort:            m.apiPort,
 	})
 	if err != nil {
 		return nil, errors.New("failed to initialize provider: " + err.Error())

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -14,13 +14,18 @@ type ProviderInfo struct {
 }
 
 type InitializeProviderRequest struct {
-	BasePath          string
-	ServerDownloadUrl string
-	ServerVersion     string
-	ServerUrl         string
-	NetworkKey        string
-	ServerApiUrl      string
-	LogsDir           string
+	BasePath           string
+	DaytonaDownloadUrl string
+	DaytonaVersion     string
+	LogsDir            string
+
+	NetworkKey string
+	ServerUrl  string
+	ApiUrl     string
+	// ServerPort is used if the target supports direct server access
+	ServerPort uint32
+	// ApiPort is used if the target supports direct server access
+	ApiPort uint32
 }
 
 type WorkspaceRequest struct {

--- a/pkg/server/headscale/config.go
+++ b/pkg/server/headscale/config.go
@@ -28,7 +28,7 @@ func (s *HeadscaleServer) getHeadscaleConfig() (*hstypes.Config, error) {
 	cfg := &hstypes.Config{
 		DBtype:                         "sqlite3",
 		ServerURL:                      fmt.Sprintf("https://%s.%s", s.serverId, s.frpsDomain),
-		Addr:                           fmt.Sprintf("127.0.0.1:%d", s.headscalePort),
+		Addr:                           fmt.Sprintf("0.0.0.0:%d", s.headscalePort),
 		EphemeralNodeInactivityTimeout: 5 * time.Minute,
 		NodeUpdateCheckInterval:        10 * time.Second,
 		BaseDomain:                     "daytona.local",

--- a/pkg/server/headscale/connect.go
+++ b/pkg/server/headscale/connect.go
@@ -9,7 +9,6 @@ import (
 
 	"tailscale.com/tsnet"
 
-	"github.com/daytonaio/daytona/internal/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -28,7 +27,7 @@ func (s *HeadscaleServer) Connect() error {
 		log.Fatal(err)
 	}
 
-	tsNetServer.ControlURL = util.GetFrpcServerUrl(s.frpsProtocol, s.serverId, s.frpsDomain)
+	tsNetServer.ControlURL = fmt.Sprintf("http://localhost:%d", s.headscalePort)
 	tsNetServer.AuthKey = authKey
 
 	defer tsNetServer.Close()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,7 +10,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/frpc"
 	"github.com/daytonaio/daytona/pkg/provider/manager"
 	"github.com/daytonaio/daytona/pkg/server/apikeys"
@@ -227,8 +226,4 @@ func (s *Server) Start(errCh chan error) error {
 	}
 
 	return nil
-}
-
-func (s *Server) GetApiUrl() string {
-	return util.GetFrpcApiUrl(s.config.Frps.Protocol, s.config.Id, s.config.Frps.Domain)
 }


### PR DESCRIPTION
# Direct API and headscale access for local projects

## Description

With this PR, projects that are running locally will be able to access the Server without going through FRP. This change massively improves the binary download and SSH connection for those projects.

### BREAKING CHANGE
Since the provider interface changed, installed providers will need to be updated (with `daytona provider update`)

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Addresses #625 

## Notes
This PR is one of 2 that will address #625. The second part of the solution will be allowing users to add a static IP address of the server and avoid FRP altogether.
