### PR TITLE
feat: server IP configuration

### DIFF
--- a/internal/util/apiclient/conversion/server_config.go
+++ b/internal/util/apiclient/conversion/server_config.go
@@ -1,0 +1,44 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package conversion
+
+import (
+	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/server"
+)
+
+func ToServerConfig(serverConfigDto *apiclient.ServerConfig) *server.Config {
+	if serverConfigDto == nil {
+		return nil
+	}
+
+	config := &server.Config{
+		Id:                              *serverConfigDto.Id,
+		ProvidersDir:                    *serverConfigDto.ProvidersDir,
+		RegistryUrl:                     *serverConfigDto.RegistryUrl,
+		ServerDownloadUrl:               *serverConfigDto.ServerDownloadUrl,
+		IpWithProtocol:                  serverConfigDto.IpWithProtocol,
+		ApiPort:                         uint32(*serverConfigDto.ApiPort),
+		LocalBuilderRegistryPort:        uint32(*serverConfigDto.LocalBuilderRegistryPort),
+		BuilderRegistryServer:           *serverConfigDto.BuilderRegistryServer,
+		BuildImageNamespace:             *serverConfigDto.BuildImageNamespace,
+		HeadscalePort:                   uint32(*serverConfigDto.HeadscalePort),
+		BinariesPath:                    *serverConfigDto.BinariesPath,
+		LogFilePath:                     *serverConfigDto.LogFilePath,
+		DefaultProjectImage:             *serverConfigDto.DefaultProjectImage,
+		DefaultProjectUser:              *serverConfigDto.DefaultProjectUser,
+		DefaultProjectPostStartCommands: serverConfigDto.DefaultProjectPostStartCommands,
+		BuilderImage:                    *serverConfigDto.BuilderImage,
+	}
+
+	if serverConfigDto.Frps != nil {
+		config.Frps = &server.FRPSConfig{
+			Domain:   *serverConfigDto.Frps.Domain,
+			Port:     uint32(*serverConfigDto.Frps.Port),
+			Protocol: *serverConfigDto.Frps.Protocol,
+		}
+	}
+
+	return config
+}

--- a/pkg/api/controllers/binary/get_daytona.go
+++ b/pkg/api/controllers/binary/get_daytona.go
@@ -4,22 +4,23 @@
 package binary
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/daytonaio/daytona/internal/constants"
+	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
 
 // Used in projects to download the Daytona binary
 func GetDaytonaScript(ctx *gin.Context) {
-	scheme := "http"
-	if ctx.Request.TLS != nil || ctx.GetHeader("X-Forwarded-Proto") == "https" {
-		scheme = "https"
+	c, err := server.GetConfig()
+	if err != nil {
+		ctx.String(http.StatusInternalServerError, err.Error())
+		return
 	}
 
-	downloadUrl, _ := url.JoinPath(fmt.Sprintf("%s://%s", scheme, ctx.Request.Host), "binary")
+	downloadUrl, _ := url.JoinPath(c.GetApiUrl(), "binary")
 	getServerScript := constants.GetDaytonaScript(downloadUrl)
 
 	ctx.String(http.StatusOK, getServerScript)

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1569,6 +1569,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "ipWithProtocol": {
+                    "type": "string"
+                },
                 "localBuilderRegistryPort": {
                     "type": "integer"
                 },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1566,6 +1566,9 @@
                 "id": {
                     "type": "string"
                 },
+                "ipWithProtocol": {
+                    "type": "string"
+                },
                 "localBuilderRegistryPort": {
                     "type": "integer"
                 },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -292,6 +292,8 @@ definitions:
         type: integer
       id:
         type: string
+      ipWithProtocol:
+        type: string
       localBuilderRegistryPort:
         type: integer
       logFilePath:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1306,6 +1306,7 @@ components:
         apiPort: 0
         headscalePort: 1
         buildImageNamespace: buildImageNamespace
+        ipWithProtocol: ipWithProtocol
         serverDownloadUrl: serverDownloadUrl
         binariesPath: binariesPath
         logFilePath: logFilePath
@@ -1340,6 +1341,8 @@ components:
         headscalePort:
           type: integer
         id:
+          type: string
+        ipWithProtocol:
           type: string
         localBuilderRegistryPort:
           type: integer

--- a/pkg/apiclient/docs/ServerConfig.md
+++ b/pkg/apiclient/docs/ServerConfig.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **Frps** | Pointer to [**FRPSConfig**](FRPSConfig.md) |  | [optional] 
 **HeadscalePort** | Pointer to **int32** |  | [optional] 
 **Id** | Pointer to **string** |  | [optional] 
+**IpWithProtocol** | Pointer to **string** |  | [optional] 
 **LocalBuilderRegistryPort** | Pointer to **int32** |  | [optional] 
 **LogFilePath** | Pointer to **string** |  | [optional] 
 **ProvidersDir** | Pointer to **string** |  | [optional] 
@@ -314,6 +315,31 @@ SetId sets Id field to given value.
 `func (o *ServerConfig) HasId() bool`
 
 HasId returns a boolean if a field has been set.
+
+### GetIpWithProtocol
+
+`func (o *ServerConfig) GetIpWithProtocol() string`
+
+GetIpWithProtocol returns the IpWithProtocol field if non-nil, zero value otherwise.
+
+### GetIpWithProtocolOk
+
+`func (o *ServerConfig) GetIpWithProtocolOk() (*string, bool)`
+
+GetIpWithProtocolOk returns a tuple with the IpWithProtocol field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetIpWithProtocol
+
+`func (o *ServerConfig) SetIpWithProtocol(v string)`
+
+SetIpWithProtocol sets IpWithProtocol field to given value.
+
+### HasIpWithProtocol
+
+`func (o *ServerConfig) HasIpWithProtocol() bool`
+
+HasIpWithProtocol returns a boolean if a field has been set.
 
 ### GetLocalBuilderRegistryPort
 

--- a/pkg/apiclient/model_server_config.go
+++ b/pkg/apiclient/model_server_config.go
@@ -30,6 +30,7 @@ type ServerConfig struct {
 	Frps                            *FRPSConfig `json:"frps,omitempty"`
 	HeadscalePort                   *int32      `json:"headscalePort,omitempty"`
 	Id                              *string     `json:"id,omitempty"`
+	IpWithProtocol                  *string     `json:"ipWithProtocol,omitempty"`
 	LocalBuilderRegistryPort        *int32      `json:"localBuilderRegistryPort,omitempty"`
 	LogFilePath                     *string     `json:"logFilePath,omitempty"`
 	ProvidersDir                    *string     `json:"providersDir,omitempty"`
@@ -406,6 +407,38 @@ func (o *ServerConfig) SetId(v string) {
 	o.Id = &v
 }
 
+// GetIpWithProtocol returns the IpWithProtocol field value if set, zero value otherwise.
+func (o *ServerConfig) GetIpWithProtocol() string {
+	if o == nil || IsNil(o.IpWithProtocol) {
+		var ret string
+		return ret
+	}
+	return *o.IpWithProtocol
+}
+
+// GetIpWithProtocolOk returns a tuple with the IpWithProtocol field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetIpWithProtocolOk() (*string, bool) {
+	if o == nil || IsNil(o.IpWithProtocol) {
+		return nil, false
+	}
+	return o.IpWithProtocol, true
+}
+
+// HasIpWithProtocol returns a boolean if a field has been set.
+func (o *ServerConfig) HasIpWithProtocol() bool {
+	if o != nil && !IsNil(o.IpWithProtocol) {
+		return true
+	}
+
+	return false
+}
+
+// SetIpWithProtocol gets a reference to the given string and assigns it to the IpWithProtocol field.
+func (o *ServerConfig) SetIpWithProtocol(v string) {
+	o.IpWithProtocol = &v
+}
+
 // GetLocalBuilderRegistryPort returns the LocalBuilderRegistryPort field value if set, zero value otherwise.
 func (o *ServerConfig) GetLocalBuilderRegistryPort() int32 {
 	if o == nil || IsNil(o.LocalBuilderRegistryPort) {
@@ -608,6 +641,9 @@ func (o ServerConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
+	}
+	if !IsNil(o.IpWithProtocol) {
+		toSerialize["ipWithProtocol"] = o.IpWithProtocol
 	}
 	if !IsNil(o.LocalBuilderRegistryPort) {
 		toSerialize["localBuilderRegistryPort"] = o.LocalBuilderRegistryPort

--- a/pkg/cmd/apikey/generate.go
+++ b/pkg/cmd/apikey/generate.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
-	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/internal/util/apiclient/conversion"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/server/apikey"
@@ -71,7 +71,7 @@ var GenerateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		apiUrl := util.GetFrpcApiUrl(*serverConfig.Frps.Protocol, *serverConfig.Id, *serverConfig.Frps.Domain)
+		apiUrl := conversion.ToServerConfig(serverConfig).GetApiUrl()
 
 		view.Render(key, apiUrl)
 	},

--- a/pkg/cmd/server/config.go
+++ b/pkg/cmd/server/config.go
@@ -8,7 +8,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/cmd/output"
 	"github.com/daytonaio/daytona/pkg/server"
 )
@@ -22,8 +21,7 @@ var configCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		apiUrl := util.GetFrpcApiUrl(config.Frps.Protocol, config.Id, config.Frps.Domain)
-		output.Output = apiUrl
+		output.Output = config.GetApiUrl()
 
 		view.RenderConfig(config)
 	},

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -96,11 +96,19 @@ var ServeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		var headscaleServerUrl string
+		if c.IpWithProtocol != nil {
+			headscaleServerUrl = fmt.Sprintf("%s:%d", *c.IpWithProtocol, c.HeadscalePort)
+			// FIXME
+			headscaleServerUrl = strings.Replace(headscaleServerUrl, "http://", "https://", 1)
+		} else if c.Frps != nil {
+			headscaleServerUrl = util.GetFrpcHeadscaleUrl(c.Frps.Protocol, c.Id, c.Frps.Domain)
+		}
+
 		headscaleServer := headscale.NewHeadscaleServer(&headscale.HeadscaleServerConfig{
-			ServerId:      c.Id,
-			FrpsDomain:    c.Frps.Domain,
-			FrpsProtocol:  c.Frps.Protocol,
-			HeadscalePort: c.HeadscalePort,
+			ServerId:  c.Id,
+			ServerUrl: headscaleServerUrl,
+			Port:      c.HeadscalePort,
 		})
 		err = headscaleServer.Init()
 		if err != nil {
@@ -137,14 +145,12 @@ var ServeCmd = &cobra.Command{
 			ApiKeyStore: apiKeyStore,
 		})
 
-		headscaleUrl := util.GetFrpcHeadscaleUrl(c.Frps.Protocol, c.Id, c.Frps.Domain)
-
 		providerManager := manager.NewProviderManager(manager.ProviderManagerConfig{
 			LogsDir:               logsDir,
 			ProviderTargetService: providerTargetService,
-			ApiUrl:                util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
+			ServerUrl:             headscaleServerUrl,
+			ApiUrl:                c.GetApiUrl(),
 			DaytonaDownloadUrl:    getDaytonaScriptUrl(c),
-			ServerUrl:             headscaleUrl,
 			RegistryUrl:           c.RegistryUrl,
 			BaseDir:               c.ProvidersDir,
 			CreateProviderNetworkKey: func(providerName string) (string, error) {
@@ -185,8 +191,8 @@ var ServeCmd = &cobra.Command{
 			ApiKeyService:                   apiKeyService,
 			GitProviderService:              gitProviderService,
 			ContainerRegistryService:        containerRegistryService,
-			ServerApiUrl:                    util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
-			ServerUrl:                       headscaleUrl,
+			ServerApiUrl:                    c.GetApiUrl(),
+			ServerUrl:                       headscaleServerUrl,
 			DefaultProjectImage:             c.DefaultProjectImage,
 			DefaultProjectUser:              c.DefaultProjectUser,
 			DefaultProjectPostStartCommands: c.DefaultProjectPostStartCommands,
@@ -268,12 +274,12 @@ func waitForServerToStart(apiServer *api.ApiServer) error {
 }
 
 func getDaytonaScriptUrl(config *server.Config) string {
-	url, _ := url.JoinPath(util.GetFrpcApiUrl(config.Frps.Protocol, config.Id, config.Frps.Domain), "binary", "script")
+	url, _ := url.JoinPath(config.GetApiUrl(), "binary", "script")
 	return url
 }
 
 func printServerStartedMessage(c *server.Config, runAsDaemon bool) {
-	started_view.Render(c.ApiPort, util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain), runAsDaemon)
+	started_view.Render(c.ApiPort, c.GetApiUrl(), runAsDaemon)
 }
 
 func getDbPath() (string, error) {

--- a/pkg/server/headscale/config.go
+++ b/pkg/server/headscale/config.go
@@ -27,8 +27,8 @@ func (s *HeadscaleServer) getHeadscaleConfig() (*hstypes.Config, error) {
 
 	cfg := &hstypes.Config{
 		DBtype:                         "sqlite3",
-		ServerURL:                      fmt.Sprintf("https://%s.%s", s.serverId, s.frpsDomain),
-		Addr:                           fmt.Sprintf("0.0.0.0:%d", s.headscalePort),
+		ServerURL:                      s.serverUrl,
+		Addr:                           fmt.Sprintf("0.0.0.0:%d", s.port),
 		EphemeralNodeInactivityTimeout: 5 * time.Minute,
 		NodeUpdateCheckInterval:        10 * time.Second,
 		BaseDomain:                     "daytona.local",

--- a/pkg/server/headscale/connect.go
+++ b/pkg/server/headscale/connect.go
@@ -27,7 +27,7 @@ func (s *HeadscaleServer) Connect() error {
 		log.Fatal(err)
 	}
 
-	tsNetServer.ControlURL = fmt.Sprintf("http://localhost:%d", s.headscalePort)
+	tsNetServer.ControlURL = s.serverUrl
 	tsNetServer.AuthKey = authKey
 
 	defer tsNetServer.Close()

--- a/pkg/server/headscale/server.go
+++ b/pkg/server/headscale/server.go
@@ -11,26 +11,23 @@ import (
 )
 
 type HeadscaleServerConfig struct {
-	ServerId      string
-	FrpsDomain    string
-	FrpsProtocol  string
-	HeadscalePort uint32
+	ServerId  string
+	Port      uint32
+	ServerUrl string
 }
 
 func NewHeadscaleServer(config *HeadscaleServerConfig) *HeadscaleServer {
 	return &HeadscaleServer{
-		serverId:      config.ServerId,
-		frpsDomain:    config.FrpsDomain,
-		frpsProtocol:  config.FrpsProtocol,
-		headscalePort: config.HeadscalePort,
+		serverId:  config.ServerId,
+		port:      config.Port,
+		serverUrl: config.ServerUrl,
 	}
 }
 
 type HeadscaleServer struct {
-	serverId      string
-	frpsDomain    string
-	frpsProtocol  string
-	headscalePort uint32
+	serverId  string
+	port      uint32
+	serverUrl string
 }
 
 func (s *HeadscaleServer) Init() error {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -4,7 +4,10 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
+
+	"github.com/daytonaio/daytona/internal/util"
 )
 
 type TailscaleServer interface {
@@ -35,6 +38,7 @@ type Config struct {
 	Id                              string      `json:"id"`
 	ServerDownloadUrl               string      `json:"serverDownloadUrl"`
 	Frps                            *FRPSConfig `json:"frps,omitempty"`
+	IpWithProtocol                  *string     `json:"ipWithProtocol,omitempty"`
 	ApiPort                         uint32      `json:"apiPort"`
 	HeadscalePort                   uint32      `json:"headscalePort"`
 	BinariesPath                    string      `json:"binariesPath"`
@@ -47,3 +51,13 @@ type Config struct {
 	BuilderRegistryServer           string      `json:"builderRegistryServer"`
 	BuildImageNamespace             string      `json:"buildImageNamespace"`
 } // @name ServerConfig
+
+func (config *Config) GetApiUrl() string {
+	apiUrl := util.GetFrpcApiUrl(config.Frps.Protocol, config.Id, config.Frps.Domain)
+
+	if config.IpWithProtocol != nil {
+		apiUrl = fmt.Sprintf("%s:%d", *config.IpWithProtocol, config.ApiPort)
+	}
+
+	return apiUrl
+}

--- a/pkg/views/server/config.go
+++ b/pkg/views/server/config.go
@@ -7,17 +7,20 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
 func RenderConfig(config *server.Config) {
-	apiUrl := util.GetFrpcApiUrl(config.Frps.Protocol, config.Id, config.Frps.Domain)
+	apiUrl := config.GetApiUrl()
 
 	output := views.GetStyledMainTitle("Daytona Server Config") + "\n\n"
 
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Server ID: "), config.Id) + "\n\n"
+
+	if config.IpWithProtocol != nil {
+		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Server IP: "), *config.IpWithProtocol) + "\n\n"
+	}
 
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("API URL: "), apiUrl) + "\n\n"
 


### PR DESCRIPTION
# Server IP configuration

## Description

If the server is running in a network with a static IP it can be directly accessed from the CLI and workspaces. This PR contributes a server configuration option that allows the user to configure direct server access through its IP

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #625 

## Notes
In draft until further testing
