### PR TITLE
chore: workspace mode tagline

### DIFF
--- a/docs/workspace_mode/daytona.md
+++ b/docs/workspace_mode/daytona.md
@@ -1,10 +1,10 @@
 ## daytona
 
-Use the Daytona CLI to manage your project
+Use the Daytona CLI to manage your workspace
 
 ### Synopsis
 
-Use the Daytona CLI to manage your project
+Use the Daytona CLI to manage your workspace
 
 ```
 daytona [flags]

--- a/docs/workspace_mode/daytona_agent.md
+++ b/docs/workspace_mode/daytona_agent.md
@@ -21,6 +21,6 @@ daytona agent [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 * [daytona agent logs](daytona_agent_logs.md)	 - Output Daytona Agent logs
 

--- a/docs/workspace_mode/daytona_autocomplete.md
+++ b/docs/workspace_mode/daytona_autocomplete.md
@@ -15,5 +15,5 @@ daytona autocomplete [bash|zsh|fish|powershell] [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/docs/workspace_mode/daytona_docs.md
+++ b/docs/workspace_mode/daytona_docs.md
@@ -15,5 +15,5 @@ daytona docs [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/docs/workspace_mode/daytona_forward.md
+++ b/docs/workspace_mode/daytona_forward.md
@@ -21,5 +21,5 @@ daytona forward [PORT] [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/docs/workspace_mode/daytona_info.md
+++ b/docs/workspace_mode/daytona_info.md
@@ -15,5 +15,5 @@ daytona info [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/docs/workspace_mode/daytona_list.md
+++ b/docs/workspace_mode/daytona_list.md
@@ -21,5 +21,5 @@ daytona list [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/docs/workspace_mode/daytona_start.md
+++ b/docs/workspace_mode/daytona_start.md
@@ -15,5 +15,5 @@ daytona start [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/docs/workspace_mode/daytona_stop.md
+++ b/docs/workspace_mode/daytona_stop.md
@@ -15,5 +15,5 @@ daytona stop [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/docs/workspace_mode/daytona_version.md
+++ b/docs/workspace_mode/daytona_version.md
@@ -15,5 +15,5 @@ daytona version [flags]
 
 ### SEE ALSO
 
-* [daytona](daytona.md)	 - Use the Daytona CLI to manage your project
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
 

--- a/hack/docs/workspace_mode/daytona.yaml
+++ b/hack/docs/workspace_mode/daytona.yaml
@@ -1,6 +1,6 @@
 name: daytona
-synopsis: Use the Daytona CLI to manage your project
-description: Use the Daytona CLI to manage your project
+synopsis: Use the Daytona CLI to manage your workspace
+description: Use the Daytona CLI to manage your workspace
 usage: daytona [flags]
 options:
     - name: help

--- a/hack/docs/workspace_mode/daytona_agent.yaml
+++ b/hack/docs/workspace_mode/daytona_agent.yaml
@@ -13,5 +13,5 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace
     - daytona agent logs - Output Daytona Agent logs

--- a/hack/docs/workspace_mode/daytona_autocomplete.yaml
+++ b/hack/docs/workspace_mode/daytona_autocomplete.yaml
@@ -9,4 +9,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/hack/docs/workspace_mode/daytona_docs.yaml
+++ b/hack/docs/workspace_mode/daytona_docs.yaml
@@ -9,4 +9,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/hack/docs/workspace_mode/daytona_forward.yaml
+++ b/hack/docs/workspace_mode/daytona_forward.yaml
@@ -13,4 +13,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/hack/docs/workspace_mode/daytona_info.yaml
+++ b/hack/docs/workspace_mode/daytona_info.yaml
@@ -9,4 +9,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/hack/docs/workspace_mode/daytona_list.yaml
+++ b/hack/docs/workspace_mode/daytona_list.yaml
@@ -14,4 +14,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/hack/docs/workspace_mode/daytona_start.yaml
+++ b/hack/docs/workspace_mode/daytona_start.yaml
@@ -9,4 +9,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/hack/docs/workspace_mode/daytona_stop.yaml
+++ b/hack/docs/workspace_mode/daytona_stop.yaml
@@ -9,4 +9,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/hack/docs/workspace_mode/daytona_version.yaml
+++ b/hack/docs/workspace_mode/daytona_version.yaml
@@ -9,4 +9,4 @@ inherited_options:
       shorthand: o
       usage: Output format. Must be one of (yaml, json)
 see_also:
-    - daytona - Use the Daytona CLI to manage your project
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/pkg/cmd/workspacemode/workspace_mode.go
+++ b/pkg/cmd/workspacemode/workspace_mode.go
@@ -18,8 +18,8 @@ var projectName = ""
 
 var workspaceModeRootCmd = &cobra.Command{
 	Use:               "daytona",
-	Short:             "Use the Daytona CLI to manage your project",
-	Long:              "Use the Daytona CLI to manage your project",
+	Short:             "Use the Daytona CLI to manage your workspace",
+	Long:              "Use the Daytona CLI to manage your workspace",
 	DisableAutoGenTag: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := cmd.Help()


### PR DESCRIPTION
# Workspace mode tagline

## Description

Changes the tagline for the CLI in workspace mode from
`Use the Daytona CLI to manage your project`
to
`Use the Daytona CLI to manage your workspace`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation