### PR TITLE
feat: read server logs while starting as daemon

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -4,6 +4,7 @@
 package daemon
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"runtime"
@@ -17,7 +18,7 @@ type program struct {
 	service.Interface
 }
 
-func Start() error {
+func Start(logFilePath string) error {
 	cfg, err := getServiceConfig()
 	if err != nil {
 		return err
@@ -31,12 +32,26 @@ func Start() error {
 		return err
 	}
 
+	logFile, err := os.OpenFile(logFilePath, os.O_TRUNC|os.O_CREATE|os.O_RDONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+	go func() {
+		reader := bufio.NewReader(logFile)
+		for {
+			bytes := make([]byte, 1024)
+			_, err := reader.Read(bytes)
+			if err == nil {
+				fmt.Print(string(bytes))
+			}
+		}
+	}()
+
 	err = s.Start()
 	if err != nil {
 		return err
 	}
-
-	// logFilePath := server.GetLogFilePath()
 
 	time.Sleep(5 * time.Second)
 	status, err := s.Status()
@@ -52,13 +67,6 @@ func Start() error {
 	if err != nil {
 		return err
 	}
-
-	// TODO: return this
-	// logContent, err := os.ReadFile(*logFilePath)
-	// if err != nil {
-	// 	return err
-	// }
-	// fmt.Println(string(logContent))
 
 	if status == service.StatusStopped {
 		return fmt.Errorf("daemon stopped unexpectedly")

--- a/pkg/cmd/server/restart.go
+++ b/pkg/cmd/server/restart.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/daytonaio/daytona/pkg/cmd/server/daemon"
+	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
@@ -21,8 +22,13 @@ var restartCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		c, err := server.GetConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		views.RenderInfoMessage("Starting the Daytona Server daemon...")
-		err = daemon.Start()
+		err = daemon.Start(c.LogFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -46,7 +46,7 @@ var ServerCmd = &cobra.Command{
 		})
 
 		views.RenderInfoMessageBold("Starting the Daytona Server daemon...")
-		err = daemon.Start()
+		err = daemon.Start(c.LogFilePath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -46,15 +46,6 @@ func GetConfig() (*Config, error) {
 		return nil, err
 	}
 
-	if c.BinariesPath == "" {
-		binariesPath, err := getDefaultBinariesPath()
-		if err != nil {
-			return nil, err
-		}
-
-		c.BinariesPath = binariesPath
-	}
-
 	return &c, nil
 }
 


### PR DESCRIPTION
# Read Server Logs while Starting as Daemon

## Description

This PR adds server log reading while its starting in daemon mode (with `daytona server`). This change aims to improve UX while starting in daemon mode to let the user know what went wrong in the process.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #672 

## Screenshots
`daytona server -y`
![Screenshot 2024-06-12 at 11 31 13](https://github.com/daytonaio/daytona/assets/26512078/2d5b43e7-a720-4023-bb96-bcb9e109ded1)

`daytona server restart`
![Screenshot 2024-06-12 at 11 31 29](https://github.com/daytonaio/daytona/assets/26512078/9a409bf6-0808-44b9-b4ee-7ffd639943e0)

`daytona server -y` (with fatal error from the server)
![Screenshot 2024-06-12 at 11 32 38](https://github.com/daytonaio/daytona/assets/26512078/4a9aef2a-a487-4a1f-bba8-1076f57cd3cf)
