### PR TITLE
fix: custom image builder select

### DIFF
--- a/pkg/views/workspace/create/configuration.go
+++ b/pkg/views/workspace/create/configuration.go
@@ -83,6 +83,11 @@ func ConfigureProjects(projectList []apiclient.CreateWorkspaceRequestProject, ap
 			projectList[i].PostStartCommands = projectConfigurationData.PostStartCommands
 			projectList[i].EnvVars = &projectConfigurationData.EnvVars
 
+			if projectConfigurationData.BuilderChoice == "custom-image" {
+				projectList[i].Build = nil
+				continue
+			}
+
 			if projectConfigurationData.BuilderChoice == "auto" {
 				projectList[i].Build = &apiclient.ProjectBuild{}
 				continue


### PR DESCRIPTION
# Custom Image Builder Select Fix

## Description

Just a minor fix for selecting the `Custom Image` builder in the advanced project view

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
