### PR TITLE
fix: improve workspace creation summary view

### DIFF
--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -54,7 +54,11 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 		Source: &apiclient.CreateWorkspaceRequestProjectSource{
 			Repository: providerRepo,
 		},
-		Build: &apiclient.ProjectBuild{},
+		Build:             &apiclient.ProjectBuild{},
+		Image:             config.ApiServerConfig.DefaultProjectImage,
+		User:              config.ApiServerConfig.DefaultProjectUser,
+		PostStartCommands: config.ApiServerConfig.DefaultProjectPostStartCommands,
+		EnvVars:           &map[string]string{},
 	}}
 
 	if config.MultiProject {
@@ -91,7 +95,11 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 				Source: &apiclient.CreateWorkspaceRequestProjectSource{
 					Repository: providerRepo,
 				},
-				Build: &apiclient.ProjectBuild{},
+				Build:             &apiclient.ProjectBuild{},
+				Image:             config.ApiServerConfig.DefaultProjectImage,
+				User:              config.ApiServerConfig.DefaultProjectUser,
+				PostStartCommands: config.ApiServerConfig.DefaultProjectPostStartCommands,
+				EnvVars:           &map[string]string{},
 			})
 		}
 	}

--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -20,14 +20,14 @@ import (
 type ProjectDetail string
 
 const (
-	Build             ProjectDetail = "Build"
-	FilePath          ProjectDetail = "File Path"
-	Image             ProjectDetail = "Image"
-	User              ProjectDetail = "User"
-	PostStartCommands ProjectDetail = "Post Start Commands"
-	EnvVars           ProjectDetail = "Env Vars"
-	EMPTY_STRING                    = ""
-	DEFAULT_PADDING                 = 21
+	Build              ProjectDetail = "Build"
+	DevcontainerConfig ProjectDetail = "Devcontainer Config"
+	Image              ProjectDetail = "Image"
+	User               ProjectDetail = "User"
+	PostStartCommands  ProjectDetail = "Post Start Commands"
+	EnvVars            ProjectDetail = "Env Vars"
+	EMPTY_STRING                     = ""
+	DEFAULT_PADDING                  = 21
 )
 
 type SummaryModel struct {
@@ -76,8 +76,12 @@ func RunSubmissionForm(workspaceName *string, suggestedName string, workspaceNam
 }
 
 func RenderSummary(workspaceName string, projectList []apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) (string, error) {
-
-	output := views.GetStyledMainTitle(fmt.Sprintf("SUMMARY - Workspace %s", workspaceName))
+	var output string
+	if workspaceName == "" {
+		output = views.GetStyledMainTitle("SUMMARY")
+	} else {
+		output = views.GetStyledMainTitle(fmt.Sprintf("SUMMARY - Workspace %s", workspaceName))
+	}
 
 	for _, project := range projectList {
 		if project.Source == nil || project.Source.Repository == nil || project.Source.Repository.Url == nil {
@@ -88,11 +92,16 @@ func RenderSummary(workspaceName string, projectList []apiclient.CreateWorkspace
 	output += "\n\n"
 
 	for i := range projectList {
-		output += fmt.Sprintf("%s - %s\n", lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("%s #%d", "Project", i+1)), (*projectList[i].Source.Repository.Url))
+		if len(projectList) == 1 {
+			output += fmt.Sprintf("%s - %s\n", lipgloss.NewStyle().Foreground(views.Green).Render("Project"), (*projectList[i].Source.Repository.Url))
+		} else {
+			output += fmt.Sprintf("%s - %s\n", lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("%s #%d", "Project", i+1)), (*projectList[i].Source.Repository.Url))
+		}
+
 		projectBuildChoice, choiceName := getProjectBuildChoice(projectList[i], apiServerConfig)
 		output += renderProjectDetails(projectList[i], projectBuildChoice, choiceName)
 		if i < len(projectList)-1 {
-			output += "\n"
+			output += "\n\n"
 		}
 	}
 
@@ -107,7 +116,7 @@ func renderProjectDetails(project apiclient.CreateWorkspaceRequestProject, build
 			if project.Build.Devcontainer != nil {
 				if project.Build.Devcontainer.DevContainerFilePath != nil {
 					output += "\n"
-					output += projectDetailOutput(FilePath, *project.Build.Devcontainer.DevContainerFilePath)
+					output += projectDetailOutput(DevcontainerConfig, *project.Build.Devcontainer.DevContainerFilePath)
 				}
 			}
 		}

--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
@@ -16,23 +17,38 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
+type ProjectDetail string
+
+const (
+	Build             ProjectDetail = "Build"
+	FilePath          ProjectDetail = "File Path"
+	Image             ProjectDetail = "Image"
+	User              ProjectDetail = "User"
+	PostStartCommands ProjectDetail = "Post Start Commands"
+	EnvVars           ProjectDetail = "Env Vars"
+	EMPTY_STRING                    = ""
+	DEFAULT_PADDING                 = 21
+)
+
 type SummaryModel struct {
-	lg            *lipgloss.Renderer
-	styles        *Styles
-	form          *huh.Form
-	width         int
-	quitting      bool
-	workspaceName string
-	projectList   []apiclient.CreateWorkspaceRequestProject
+	lg              *lipgloss.Renderer
+	styles          *Styles
+	form            *huh.Form
+	width           int
+	quitting        bool
+	workspaceName   string
+	projectList     []apiclient.CreateWorkspaceRequestProject
+	apiServerConfig *apiclient.ServerConfig
 }
 
 var configureCheck bool
 var userCancelled bool
+var projectsConfigurationChanged bool
 
 func RunSubmissionForm(workspaceName *string, suggestedName string, workspaceNames []string, projectList *[]apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) error {
 	configureCheck = false
 
-	m := NewSummaryModel(workspaceName, suggestedName, workspaceNames, *projectList)
+	m := NewSummaryModel(workspaceName, suggestedName, workspaceNames, *projectList, apiServerConfig)
 
 	if _, err := tea.NewProgram(m).Run(); err != nil {
 		return err
@@ -50,35 +66,16 @@ func RunSubmissionForm(workspaceName *string, suggestedName string, workspaceNam
 		return fmt.Errorf("default project entries are not set")
 	}
 
-	for i := range *projectList {
-		if (*projectList)[i].Image == nil {
-			(*projectList)[i].Image = apiServerConfig.DefaultProjectImage
-		}
-		if (*projectList)[i].User == nil {
-			(*projectList)[i].User = apiServerConfig.DefaultProjectUser
-		}
-		if (*projectList)[i].PostStartCommands == nil {
-			(*projectList)[i].PostStartCommands = apiServerConfig.DefaultProjectPostStartCommands
-		}
-		if (*projectList)[i].EnvVars == nil {
-			(*projectList)[i].EnvVars = &map[string]string{}
-		}
-		if (*projectList)[i].Build == nil {
-			(*projectList)[i].Build = &apiclient.ProjectBuild{}
-		}
-	}
-
-	configuredProjects, err := ConfigureProjects(*projectList, *apiServerConfig)
+	var err error
+	projectsConfigurationChanged, err = ConfigureProjects(projectList, *apiServerConfig)
 	if err != nil {
 		return err
 	}
 
-	*projectList = configuredProjects
-
 	return RunSubmissionForm(workspaceName, suggestedName, workspaceNames, projectList, apiServerConfig)
 }
 
-func RenderSummary(workspaceName string, projectList []apiclient.CreateWorkspaceRequestProject) (string, error) {
+func RenderSummary(workspaceName string, projectList []apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) (string, error) {
 
 	output := views.GetStyledMainTitle(fmt.Sprintf("SUMMARY - Workspace %s", workspaceName))
 
@@ -91,7 +88,9 @@ func RenderSummary(workspaceName string, projectList []apiclient.CreateWorkspace
 	output += "\n\n"
 
 	for i := range projectList {
-		output += fmt.Sprintf("%s - %s", lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("%s #%d", "Project", i+1)), (*projectList[i].Source.Repository.Url))
+		output += fmt.Sprintf("%s - %s\n", lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("%s #%d", "Project", i+1)), (*projectList[i].Source.Repository.Url))
+		projectBuildChoice, choiceName := getProjectBuildChoice(projectList[i], apiServerConfig)
+		output += renderProjectDetails(projectList[i], projectBuildChoice, choiceName)
 		if i < len(projectList)-1 {
 			output += "\n"
 		}
@@ -100,12 +99,89 @@ func RenderSummary(workspaceName string, projectList []apiclient.CreateWorkspace
 	return output, nil
 }
 
-func NewSummaryModel(workspaceName *string, suggestedName string, workspaceNames []string, projectList []apiclient.CreateWorkspaceRequestProject) SummaryModel {
+func renderProjectDetails(project apiclient.CreateWorkspaceRequestProject, buildChoice BuildChoice, choiceName string) string {
+	output := projectDetailOutput(Build, choiceName)
+
+	if buildChoice == DEVCONTAINER {
+		if project.Build != nil {
+			if project.Build.Devcontainer != nil {
+				if project.Build.Devcontainer.DevContainerFilePath != nil {
+					output += "\n"
+					output += projectDetailOutput(FilePath, *project.Build.Devcontainer.DevContainerFilePath)
+				}
+			}
+		}
+	} else {
+		if project.Image != nil {
+			if output != "" {
+				output += "\n"
+			}
+			output += projectDetailOutput(Image, *project.Image)
+		}
+
+		if project.User != nil {
+			if output != "" {
+				output += "\n"
+			}
+			output += projectDetailOutput(User, *project.User)
+		}
+
+		if project.PostStartCommands != nil && len(project.PostStartCommands) > 0 {
+			if output != "" {
+				output += "\n"
+			}
+
+			var commands string
+			for _, command := range project.PostStartCommands {
+				commands += command
+				commands += "; "
+			}
+			output += projectDetailOutput(PostStartCommands, strings.TrimSuffix(commands, "; "))
+		}
+	}
+
+	if project.EnvVars != nil && len(*project.EnvVars) > 0 {
+		if output != "" {
+			output += "\n"
+		}
+
+		var envVars string
+		for key, val := range *project.EnvVars {
+			envVars += fmt.Sprintf("%s=%s; ", key, val)
+		}
+		output += projectDetailOutput(EnvVars, strings.TrimSuffix(envVars, "; "))
+	}
+
+	return output
+}
+
+func projectDetailOutput(projectDetailKey ProjectDetail, projectDetailValue string) string {
+	return fmt.Sprintf("\t%s%-*s%s", lipgloss.NewStyle().Foreground(views.Green).Render(string(projectDetailKey)), DEFAULT_PADDING-len(string(projectDetailKey)), EMPTY_STRING, projectDetailValue)
+}
+
+func getProjectBuildChoice(project apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) (BuildChoice, string) {
+	if project.Build == nil {
+		if *project.Image == *apiServerConfig.DefaultProjectImage && *project.User == *apiServerConfig.DefaultProjectUser {
+			return NONE, "None"
+		} else {
+			return CUSTOMIMAGE, "Custom Image"
+		}
+	} else {
+		if project.Build.Devcontainer != nil {
+			return DEVCONTAINER, "Devcontainer"
+		} else {
+			return AUTOMATIC, "Automatic"
+		}
+	}
+}
+
+func NewSummaryModel(workspaceName *string, suggestedName string, workspaceNames []string, projectList []apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) SummaryModel {
 	m := SummaryModel{width: maxWidth}
 	m.lg = lipgloss.DefaultRenderer()
 	m.styles = NewStyles(m.lg)
 	m.workspaceName = *workspaceName
 	m.projectList = projectList
+	m.apiServerConfig = apiServerConfig
 
 	if *workspaceName == "" {
 		*workspaceName = suggestedName
@@ -181,8 +257,8 @@ func (m SummaryModel) View() string {
 
 	view := m.form.View() + configurationHelpLine
 
-	if len(m.projectList) > 1 {
-		summary, err := RenderSummary(m.workspaceName, m.projectList)
+	if len(m.projectList) > 1 || len(m.projectList) == 1 && projectsConfigurationChanged {
+		summary, err := RenderSummary(m.workspaceName, m.projectList, m.apiServerConfig)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/views/workspace/selection/projectrequest.go
+++ b/pkg/views/workspace/selection/projectrequest.go
@@ -33,10 +33,10 @@ type projectRequestModel struct {
 	model[apiclient.CreateWorkspaceRequestProject]
 }
 
-func selectProjectRequestPrompt(projects []apiclient.CreateWorkspaceRequestProject, choiceChan chan<- *apiclient.CreateWorkspaceRequestProject) {
+func selectProjectRequestPrompt(projects *[]apiclient.CreateWorkspaceRequestProject, choiceChan chan<- *apiclient.CreateWorkspaceRequestProject) {
 	items := []list.Item{}
 
-	for _, project := range projects {
+	for _, project := range *projects {
 		var name string
 		var image string
 		var user string
@@ -107,7 +107,7 @@ func selectProjectRequestPrompt(projects []apiclient.CreateWorkspaceRequestProje
 	}
 }
 
-func GetProjectRequestFromPrompt(projects []apiclient.CreateWorkspaceRequestProject) *apiclient.CreateWorkspaceRequestProject {
+func GetProjectRequestFromPrompt(projects *[]apiclient.CreateWorkspaceRequestProject) *apiclient.CreateWorkspaceRequestProject {
 	choiceChan := make(chan *apiclient.CreateWorkspaceRequestProject)
 
 	go selectProjectRequestPrompt(projects, choiceChan)

--- a/pkg/views/workspace/selection/projectrequest.go
+++ b/pkg/views/workspace/selection/projectrequest.go
@@ -22,8 +22,8 @@ var DoneConfiguring = apiclient.CreateWorkspaceRequestProject{Name: "DoneConfigu
 
 type projectRequestItem struct {
 	item[apiclient.CreateWorkspaceRequestProject]
-	name, image, user, postStartCommands string
-	project                              apiclient.CreateWorkspaceRequestProject
+	name, image, user, postStartCommands, devcontainerConfig string
+	project                                                  apiclient.CreateWorkspaceRequestProject
 }
 
 type projectRequestItemDelegate struct {
@@ -41,6 +41,7 @@ func selectProjectRequestPrompt(projects *[]apiclient.CreateWorkspaceRequestProj
 		var image string
 		var user string
 		var postStartCommands string
+		var devcontainerConfig string
 
 		if project.Name != "" {
 			name = fmt.Sprintf("%s %s", "Project:", project.Name)
@@ -51,11 +52,11 @@ func selectProjectRequestPrompt(projects *[]apiclient.CreateWorkspaceRequestProj
 		if project.User != nil {
 			user = fmt.Sprintf("%s %s", "User:", *project.User)
 		}
-		if user == "" {
-			user = "User: not defined"
+		if project.Build != nil && project.Build.Devcontainer != nil && project.Build.Devcontainer.DevContainerFilePath != nil {
+			devcontainerConfig = fmt.Sprintf("%s %s", "Devcontainer Config:", *project.Build.Devcontainer.DevContainerFilePath)
 		}
 
-		newItem := projectRequestItem{name: name, image: image, user: user, project: project}
+		newItem := projectRequestItem{name: name, image: image, user: user, project: project, devcontainerConfig: devcontainerConfig}
 
 		newItem.SetId(name)
 
@@ -152,12 +153,14 @@ func (d projectRequestItemDelegate) Render(w io.Writer, m list.Model, index int,
 
 	name := baseStyles.Copy().Render(i.Name())
 	imageLine := baseStyles.Copy().Render(i.Image())
+	devcontainerConfigLine := baseStyles.Copy().Render(i.DevcontainerConfig())
 	userLine := baseStyles.Copy().Foreground(views.Gray).Render(i.User())
 	postStartCommandsLine := baseStyles.Copy().Foreground(views.Gray).Render(i.PostStartCommands())
 
 	// Adjust styles as the user moves through the menu
 	if isSelected {
 		name = selectedStyles.Copy().Foreground(views.Green).Render(i.Name())
+		devcontainerConfigLine = selectedStyles.Copy().Foreground(views.DimmedGreen).Render(i.DevcontainerConfig())
 		imageLine = selectedStyles.Copy().Foreground(views.DimmedGreen).Render(i.Image())
 		userLine = selectedStyles.Copy().Foreground(views.Gray).Render(i.User())
 		postStartCommandsLine = selectedStyles.Copy().Foreground(views.Gray).Render(i.PostStartCommands())
@@ -175,7 +178,11 @@ func (d projectRequestItemDelegate) Render(w io.Writer, m list.Model, index int,
 	} else {
 		s.WriteString(name)
 		s.WriteRune('\n')
-		s.WriteString(imageLine)
+		if i.DevcontainerConfig() != "" {
+			s.WriteString(devcontainerConfigLine)
+		} else {
+			s.WriteString(imageLine)
+		}
 		s.WriteRune('\n')
 		s.WriteString(userLine)
 		s.WriteRune('\n')
@@ -187,12 +194,13 @@ func (d projectRequestItemDelegate) Render(w io.Writer, m list.Model, index int,
 }
 
 func (d projectRequestItemDelegate) Height() int {
-	height := lipgloss.NewStyle().GetVerticalFrameSize() + 8
+	height := lipgloss.NewStyle().GetVerticalFrameSize() + 10
 	return height
 }
 
-func (i projectRequestItem) Name() string              { return i.name }
-func (i projectRequestItem) Image() string             { return i.image }
-func (i projectRequestItem) User() string              { return i.user }
-func (i projectRequestItem) PostStartCommands() string { return i.postStartCommands }
-func (i projectRequestItem) SetId(id string)           { i.id = id }
+func (i projectRequestItem) Name() string               { return i.name }
+func (i projectRequestItem) Image() string              { return i.image }
+func (i projectRequestItem) User() string               { return i.user }
+func (i projectRequestItem) PostStartCommands() string  { return i.postStartCommands }
+func (i projectRequestItem) DevcontainerConfig() string { return i.devcontainerConfig }
+func (i projectRequestItem) SetId(id string)            { i.id = id }


### PR DESCRIPTION
# Improve workspace creation summary view

## Description

On single project workspace creation summary is shown after the advanced configuration is opened.
On multi-project workspace creation summary is shown with detailed output after the advanced configuration is opened.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #512 

## Screenshots
![5](https://github.com/daytonaio/daytona/assets/116551028/a7e4d8d7-c64f-4b8d-be24-749752b51130)
![4](https://github.com/daytonaio/daytona/assets/116551028/570be83d-61c7-4303-a773-5d0f2ec85065)
![3](https://github.com/daytonaio/daytona/assets/116551028/2cd5a0ff-dd4a-4fd0-932a-9a478c4c4d5a)
![2](https://github.com/daytonaio/daytona/assets/116551028/a3a2f6d9-fab1-4075-b948-918017f756a0)
![1](https://github.com/daytonaio/daytona/assets/116551028/38c16a83-e006-42c6-96e8-6f2e03a892f2)
