### PR TITLE
fix: info panic on git status

### DIFF
--- a/pkg/views/workspace/info/view.go
+++ b/pkg/views/workspace/info/view.go
@@ -121,7 +121,9 @@ func getProjectsOutputs(projects []apiclient.Project, isCreationView bool) strin
 	for i, project := range projects {
 		output += getInfoLine(fmt.Sprintf("Project #%d", i+1), *project.Name)
 		output += getInfoLineState("State", project.State)
-		output += getInfoLineGitStatus("Branch", project.State.GitStatus)
+		if project.State != nil && project.State.GitStatus != nil {
+			output += getInfoLineGitStatus("Branch", project.State.GitStatus)
+		}
 		if project.Target != nil && !isCreationView {
 			output += getInfoLine("Target", *project.Target)
 		}


### PR DESCRIPTION
# Fix info panic on git status
## Description

Adds pointer check for git status on `daytona info`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![image](https://github.com/daytonaio/daytona/assets/25279767/f91e4dda-59b7-49a6-8a4a-adc62196e1e8)
