### PR TITLE
feat: allow user to override workspace image at creation

### DIFF
--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -9,13 +9,17 @@ daytona create [REPOSITORY_URL] [flags]
 ### Options
 
 ```
-  -c, --code              Open the workspace in the IDE after workspace creation
-  -i, --ide string        Specify the IDE ('vscode' or 'browser')
-      --manual            Manually enter the git repositories
-      --multi-project     Workspace with multiple projects/repos
-      --name string       Specify the workspace name
-      --provider string   Specify the provider (e.g. 'docker-provider')
-  -t, --target string     Specify the target (e.g. 'local')
+      --builder string             Specify the builder (currently Automatic/Devcontainer/None)
+  -c, --code                       Open the workspace in the IDE after workspace creation
+      --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+      --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+      --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
+  -i, --ide string                 Specify the IDE ('vscode' or 'browser')
+      --manual                     Manually enter the git repositories
+      --multi-project              Workspace with multiple projects/repos
+      --name string                Specify the workspace name
+      --provider string            Specify the provider (e.g. 'docker-provider')
+  -t, --target string              Specify the target (e.g. 'local')
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -9,7 +9,7 @@ daytona create [REPOSITORY_URL] [flags]
 ### Options
 
 ```
-      --builder string             Specify the builder (currently auto/devcontainer/none)
+      --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)
   -c, --code                       Open the workspace in the IDE after workspace creation
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -9,7 +9,7 @@ daytona create [REPOSITORY_URL] [flags]
 ### Options
 
 ```
-      --builder string             Specify the builder (currently Automatic/Devcontainer/None)
+      --builder string             Specify the builder (currently auto/devcontainer/none)
   -c, --code                       Open the workspace in the IDE after workspace creation
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -3,7 +3,7 @@ synopsis: Create a workspace
 usage: daytona create [REPOSITORY_URL] [flags]
 options:
     - name: builder
-      usage: Specify the builder (currently Automatic/Devcontainer/None)
+      usage: Specify the builder (currently auto/devcontainer/none)
     - name: code
       shorthand: c
       default_value: "false"

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -2,10 +2,21 @@ name: daytona create
 synopsis: Create a workspace
 usage: daytona create [REPOSITORY_URL] [flags]
 options:
+    - name: builder
+      usage: Specify the builder (currently Automatic/Devcontainer/None)
     - name: code
       shorthand: c
       default_value: "false"
       usage: Open the workspace in the IDE after workspace creation
+    - name: custom-image
+      usage: |
+        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+    - name: custom-image-user
+      usage: |
+        Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+    - name: devcontainer-path
+      usage: |
+        Automatically assign the devcontainer builder with the path passed as the flag value
     - name: ide
       shorthand: i
       usage: Specify the IDE ('vscode' or 'browser')

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -43,34 +43,9 @@ var CreateCmd = &cobra.Command{
 		var workspaceName string
 		var existingWorkspaceNames []string
 
-		if multiProjectFlag && (builderFlag != "" || devcontainerPathFlag != "" || customImageFlag != "" || customImageUserFlag != "") {
-			log.Fatal("Can't use single project only flags (--builder, --devcontainer, --custom-image, --custom-image-user) with --multi-project flag.")
-			return
-		}
-
-		if devcontainerPathFlag != "" && (customImageFlag != "" || customImageUserFlag != "") {
-			log.Fatal("Can't declare devcontainer file path with custom image and user flags. Choose either.")
-			return
-		}
-
-		if builderFlag != "" && builderFlag != "Automatic" && builderFlag != "Devcontainer" && builderFlag != "None" {
-			log.Fatal("Can't specify unsupported builder type! Please specify one of the following: Automatic/Devcontainer/None.")
-			return
-		}
-
-		if builderFlag != "" && builderFlag != "Devcontainer" && devcontainerPathFlag != "" {
-			log.Fatal("Can't set devcontainer file path if builder is not set to Devcontainer.")
-			return
-		}
-
-		if builderFlag == "Devcontainer" && (customImageFlag != "" || customImageUserFlag != "") {
-			log.Fatal("Can't choose Devcontainer as builder type and set custom image and user for it.")
-			return
-		}
-
-		if (customImageFlag != "" && customImageUserFlag == "") || (customImageFlag == "" && customImageUserFlag != "") {
-			log.Fatal("Must specify both: custom image and custom image user.")
-			return
+		err := validateFlags()
+		if err != nil {
+			log.Fatal(err)
 		}
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
@@ -276,6 +251,34 @@ func init() {
 	CreateCmd.Flags().BoolVar(&manualFlag, "manual", false, "Manually enter the git repositories")
 	CreateCmd.Flags().BoolVar(&multiProjectFlag, "multi-project", false, "Workspace with multiple projects/repos")
 	CreateCmd.Flags().BoolVarP(&codeFlag, "code", "c", false, "Open the workspace in the IDE after workspace creation")
+}
+
+func validateFlags() error {
+	if multiProjectFlag && (builderFlag != "" || devcontainerPathFlag != "" || customImageFlag != "" || customImageUserFlag != "") {
+		return errors.New("Can't use single project only flags (--builder, --devcontainer, --custom-image, --custom-image-user) with --multi-project flag.")
+	}
+
+	if devcontainerPathFlag != "" && (customImageFlag != "" || customImageUserFlag != "") {
+		return errors.New("Can't declare devcontainer file path with custom image and user flags. Choose either.")
+	}
+
+	if builderFlag != "" && builderFlag != "Automatic" && builderFlag != "Devcontainer" && builderFlag != "None" {
+		return errors.New("Can't specify unsupported builder type! Please specify one of the following: Automatic/Devcontainer/None.")
+	}
+
+	if builderFlag != "" && builderFlag != "Devcontainer" && devcontainerPathFlag != "" {
+		return errors.New("Can't set devcontainer file path if builder is not set to Devcontainer.")
+	}
+
+	if builderFlag == "Devcontainer" && (customImageFlag != "" || customImageUserFlag != "") {
+		return errors.New("Can't choose Devcontainer as builder type and set custom image and user for it.")
+	}
+
+	if (customImageFlag != "" && customImageUserFlag == "") || (customImageFlag == "" && customImageUserFlag != "") {
+		return errors.New("Must specify both: custom image and custom image user.")
+	}
+
+	return nil
 }
 
 func getTarget(activeProfileName string) (*apiclient.ProviderTarget, error) {

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -108,29 +108,6 @@ var CreateCmd = &cobra.Command{
 			}
 			visited[*projects[i].Source.Repository.Url] = true
 			projects[i].EnvVars = getEnvVariables(&projects[i], profileData)
-
-			if builderFlag == create.DEVCONTAINER || devcontainerPathFlag != "" {
-				projects[i].Build = &apiclient.ProjectBuild{
-					Devcontainer: &apiclient.ProjectBuildDevcontainer{},
-				}
-				if devcontainerPathFlag != "" {
-					projects[i].Build.Devcontainer.DevContainerFilePath = &devcontainerPathFlag
-				}
-			}
-
-			if builderFlag == create.AUTOMATIC {
-				projects[i].Build = &apiclient.ProjectBuild{}
-			}
-
-			if builderFlag == create.NONE {
-				projects[i].Build = nil
-			}
-
-			if customImageFlag != "" || customImageUserFlag != "" {
-				projects[i].Build = nil
-				projects[i].Image = &customImageFlag
-				projects[i].User = &customImageUserFlag
-			}
 		}
 
 		projectNames := []string{}
@@ -339,6 +316,21 @@ func processCmdArguments(args []string, apiClient *apiclient.APIClient, projects
 			Repository: repoResponse,
 		},
 		Build: &apiclient.ProjectBuild{},
+	}
+
+	if builderFlag == create.DEVCONTAINER || devcontainerPathFlag != "" {
+		project.Build.Devcontainer = &apiclient.ProjectBuildDevcontainer{}
+		if devcontainerPathFlag != "" {
+			project.Build.Devcontainer.DevContainerFilePath = &devcontainerPathFlag
+		}
+	}
+
+	if builderFlag == create.NONE || customImageFlag != "" || customImageUserFlag != "" {
+		project.Build = nil
+		if customImageFlag != "" || customImageUserFlag != "" {
+			project.Image = &customImageFlag
+			project.User = &customImageUserFlag
+		}
 	}
 
 	*projects = append(*projects, *project)

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -108,6 +108,25 @@ var CreateCmd = &cobra.Command{
 			}
 			visited[*projects[i].Source.Repository.Url] = true
 			projects[i].EnvVars = getEnvVariables(&projects[i], profileData)
+
+			if builderFlag == create.AUTOMATIC {
+				projects[i].Build = &apiclient.ProjectBuild{}
+			}
+
+			if builderFlag == create.DEVCONTAINER || devcontainerPathFlag != "" {
+				projects[i].Build.Devcontainer = &apiclient.ProjectBuildDevcontainer{}
+				if devcontainerPathFlag != "" {
+					projects[i].Build.Devcontainer.DevContainerFilePath = &devcontainerPathFlag
+				}
+			}
+
+			if builderFlag == create.NONE || customImageFlag != "" || customImageUserFlag != "" {
+				projects[i].Build = nil
+				if customImageFlag != "" || customImageUserFlag != "" {
+					projects[i].Image = &customImageFlag
+					projects[i].User = &customImageUserFlag
+				}
+			}
 		}
 
 		projectNames := []string{}
@@ -316,21 +335,6 @@ func processCmdArguments(args []string, apiClient *apiclient.APIClient, projects
 			Repository: repoResponse,
 		},
 		Build: &apiclient.ProjectBuild{},
-	}
-
-	if builderFlag == create.DEVCONTAINER || devcontainerPathFlag != "" {
-		project.Build.Devcontainer = &apiclient.ProjectBuildDevcontainer{}
-		if devcontainerPathFlag != "" {
-			project.Build.Devcontainer.DevContainerFilePath = &devcontainerPathFlag
-		}
-	}
-
-	if builderFlag == create.NONE || customImageFlag != "" || customImageUserFlag != "" {
-		project.Build = nil
-		if customImageFlag != "" || customImageUserFlag != "" {
-			project.Image = &customImageFlag
-			project.User = &customImageUserFlag
-		}
 	}
 
 	*projects = append(*projects, *project)

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -49,7 +49,7 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 		return "", nil, err
 	}
 
-	projectList = initializeProjectList(config, providerRepo, providerRepoName)
+	projectList = []apiclient.CreateWorkspaceRequestProject{newCreateProjectRequest(config, providerRepo, providerRepoName)}
 
 	if config.MultiProject {
 		addMore := true
@@ -80,17 +80,7 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 				return "", nil, err
 			}
 
-			projectList = append(projectList, apiclient.CreateWorkspaceRequestProject{
-				Name: providerRepoName,
-				Source: &apiclient.CreateWorkspaceRequestProjectSource{
-					Repository: providerRepo,
-				},
-				Build:             &apiclient.ProjectBuild{},
-				Image:             config.Defaults.Image,
-				User:              config.Defaults.ImageUser,
-				PostStartCommands: config.Defaults.PostStartCommands,
-				EnvVars:           &map[string]string{},
-			})
+			projectList = append(projectList, newCreateProjectRequest(config, providerRepo, providerRepoName))
 		}
 	}
 
@@ -104,7 +94,7 @@ func GetCreationDataFromPrompt(config CreateDataPromptConfig) (string, []apiclie
 	return workspaceName, projectList, nil
 }
 
-func initializeProjectList(config CreateDataPromptConfig, providerRepo *apiclient.GitRepository, providerRepoName string) []apiclient.CreateWorkspaceRequestProject {
+func newCreateProjectRequest(config CreateDataPromptConfig, providerRepo *apiclient.GitRepository, providerRepoName string) apiclient.CreateWorkspaceRequestProject {
 	project := apiclient.CreateWorkspaceRequestProject{
 		Name: providerRepoName,
 		Source: &apiclient.CreateWorkspaceRequestProjectSource{
@@ -117,20 +107,7 @@ func initializeProjectList(config CreateDataPromptConfig, providerRepo *apiclien
 		EnvVars:           &map[string]string{},
 	}
 
-	if config.Defaults.BuildChoice == create.DEVCONTAINER || config.Defaults.DevcontainerFilePath != "" {
-		project.Image = nil
-		project.User = nil
-		project.PostStartCommands = nil
-		project.Build.Devcontainer = &apiclient.ProjectBuildDevcontainer{
-			DevContainerFilePath: &config.Defaults.DevcontainerFilePath,
-		}
-	}
-
-	if config.Defaults.BuildChoice == create.NONE || config.Defaults.BuildChoice == create.CUSTOMIMAGE {
-		project.Build = nil
-	}
-
-	return []apiclient.CreateWorkspaceRequestProject{project}
+	return project
 
 }
 

--- a/pkg/views/workspace/create/build_choice.go
+++ b/pkg/views/workspace/create/build_choice.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package create
+
+import "fmt"
+
+type BuildChoice string
+
+const (
+	AUTOMATIC    BuildChoice = "auto"
+	DEVCONTAINER BuildChoice = "devcontainer"
+	CUSTOMIMAGE  BuildChoice = "custom-image"
+	NONE         BuildChoice = "none"
+)
+
+// String is used both by fmt.Print and by Cobra in help text
+func (c *BuildChoice) String() string {
+	return string(*c)
+}
+
+// Set must have pointer receiver so it doesn't change the value of a copy
+func (c *BuildChoice) Set(v string) error {
+	switch v {
+	case string(AUTOMATIC), string(DEVCONTAINER), string(CUSTOMIMAGE), string(NONE):
+		*c = BuildChoice(v)
+		return nil
+	default:
+		return fmt.Errorf("Build type must be one of %s/%s/%s", AUTOMATIC, DEVCONTAINER, NONE)
+	}
+}
+
+// Type is only used in help text
+func (c *BuildChoice) Type() string {
+	return "BuildChoice"
+}

--- a/pkg/views/workspace/create/build_choice.go
+++ b/pkg/views/workspace/create/build_choice.go
@@ -5,25 +5,25 @@ package create
 
 import "fmt"
 
-type BuilderChoice string
+type BuildChoice string
 
 const (
-	AUTOMATIC    BuilderChoice = "auto"
-	DEVCONTAINER BuilderChoice = "devcontainer"
-	CUSTOMIMAGE  BuilderChoice = "custom-image"
-	NONE         BuilderChoice = "none"
+	AUTOMATIC    BuildChoice = "auto"
+	DEVCONTAINER BuildChoice = "devcontainer"
+	CUSTOMIMAGE  BuildChoice = "custom-image"
+	NONE         BuildChoice = "none"
 )
 
 // String is used both by fmt.Print and by Cobra in help text
-func (c *BuilderChoice) String() string {
+func (c *BuildChoice) String() string {
 	return string(*c)
 }
 
 // Set must have pointer receiver so it doesn't change the value of a copy
-func (c *BuilderChoice) Set(v string) error {
+func (c *BuildChoice) Set(v string) error {
 	switch v {
 	case string(AUTOMATIC), string(DEVCONTAINER), string(CUSTOMIMAGE), string(NONE):
-		*c = BuilderChoice(v)
+		*c = BuildChoice(v)
 		return nil
 	default:
 		return fmt.Errorf("Build type must be one of %s/%s/%s", AUTOMATIC, DEVCONTAINER, NONE)
@@ -31,6 +31,6 @@ func (c *BuilderChoice) Set(v string) error {
 }
 
 // Type is only used in help text
-func (c *BuilderChoice) Type() string {
+func (c *BuildChoice) Type() string {
 	return "BuildChoice"
 }

--- a/pkg/views/workspace/create/build_choice.go
+++ b/pkg/views/workspace/create/build_choice.go
@@ -5,25 +5,25 @@ package create
 
 import "fmt"
 
-type BuildChoice string
+type BuilderChoice string
 
 const (
-	AUTOMATIC    BuildChoice = "auto"
-	DEVCONTAINER BuildChoice = "devcontainer"
-	CUSTOMIMAGE  BuildChoice = "custom-image"
-	NONE         BuildChoice = "none"
+	AUTOMATIC    BuilderChoice = "auto"
+	DEVCONTAINER BuilderChoice = "devcontainer"
+	CUSTOMIMAGE  BuilderChoice = "custom-image"
+	NONE         BuilderChoice = "none"
 )
 
 // String is used both by fmt.Print and by Cobra in help text
-func (c *BuildChoice) String() string {
+func (c *BuilderChoice) String() string {
 	return string(*c)
 }
 
 // Set must have pointer receiver so it doesn't change the value of a copy
-func (c *BuildChoice) Set(v string) error {
+func (c *BuilderChoice) Set(v string) error {
 	switch v {
 	case string(AUTOMATIC), string(DEVCONTAINER), string(CUSTOMIMAGE), string(NONE):
-		*c = BuildChoice(v)
+		*c = BuilderChoice(v)
 		return nil
 	default:
 		return fmt.Errorf("Build type must be one of %s/%s/%s", AUTOMATIC, DEVCONTAINER, NONE)
@@ -31,6 +31,6 @@ func (c *BuildChoice) Set(v string) error {
 }
 
 // Type is only used in help text
-func (c *BuildChoice) Type() string {
+func (c *BuilderChoice) Type() string {
 	return "BuildChoice"
 }

--- a/pkg/views/workspace/create/configuration.go
+++ b/pkg/views/workspace/create/configuration.go
@@ -16,14 +16,8 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 )
 
-type BuildChoice string
-
 const (
-	AUTOMATIC             BuildChoice = "auto"
-	DEVCONTAINER          BuildChoice = "devcontainer"
-	CUSTOMIMAGE           BuildChoice = "custom-image"
-	NONE                  BuildChoice = "none"
-	DEVCONTAINER_FILEPATH             = ".devcontainer/devcontainer.json"
+	DEVCONTAINER_FILEPATH = ".devcontainer/devcontainer.json"
 )
 
 var configurationHelpLine = lipgloss.NewStyle().Foreground(views.Gray).Render("enter: next  f10: advanced configuration")

--- a/pkg/views/workspace/create/configuration.go
+++ b/pkg/views/workspace/create/configuration.go
@@ -32,35 +32,32 @@ type ProjectConfigurationData struct {
 }
 
 func NewProjectConfigurationData(buildChoice BuildChoice, devContainerFilePath string, currentProject *apiclient.CreateWorkspaceRequestProject, defaults *ProjectDefaults) *ProjectConfigurationData {
-	image := *defaults.Image
-	user := *defaults.ImageUser
-	commands := []string{}
-	envVars := map[string]string{}
+	projectConfigurationData := &ProjectConfigurationData{
+		BuildChoice:          string(buildChoice),
+		DevcontainerFilePath: defaults.DevcontainerFilePath,
+		Image:                *defaults.Image,
+		User:                 *defaults.ImageUser,
+		PostStartCommands:    defaults.PostStartCommands,
+		EnvVars:              map[string]string{},
+	}
 
 	if currentProject.Image != nil {
-		image = *currentProject.Image
+		projectConfigurationData.Image = *currentProject.Image
 	}
 
 	if currentProject.User != nil {
-		user = *currentProject.User
+		projectConfigurationData.User = *currentProject.User
 	}
 
 	if currentProject.PostStartCommands != nil {
-		commands = currentProject.PostStartCommands
+		projectConfigurationData.PostStartCommands = currentProject.PostStartCommands
 	}
 
 	if currentProject.EnvVars != nil {
-		envVars = *currentProject.EnvVars
+		projectConfigurationData.EnvVars = *currentProject.EnvVars
 	}
 
-	return &ProjectConfigurationData{
-		BuildChoice:          string(buildChoice),
-		DevcontainerFilePath: devContainerFilePath,
-		Image:                image,
-		User:                 user,
-		PostStartCommands:    commands,
-		EnvVars:              envVars,
-	}
+	return projectConfigurationData
 }
 
 func ConfigureProjects(projectList *[]apiclient.CreateWorkspaceRequestProject, defaults ProjectDefaults) (bool, error) {
@@ -79,7 +76,7 @@ func ConfigureProjects(projectList *[]apiclient.CreateWorkspaceRequestProject, d
 		return false, nil
 	}
 
-	devContainerFilePath := DEVCONTAINER_FILEPATH
+	devContainerFilePath := defaults.DevcontainerFilePath
 	builderChoice := AUTOMATIC
 
 	if currentProject.Build != nil {

--- a/pkg/views/workspace/create/configuration.go
+++ b/pkg/views/workspace/create/configuration.go
@@ -31,7 +31,7 @@ type ProjectConfigurationData struct {
 	EnvVars              map[string]string
 }
 
-func NewProjectConfigurationData(builderChoice BuildChoice, devContainerFilePath string, currentProject *apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) *ProjectConfigurationData {
+func NewProjectConfigurationData(builderChoice BuilderChoice, devContainerFilePath string, currentProject *apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) *ProjectConfigurationData {
 	image := *apiServerConfig.DefaultProjectImage
 	user := *apiServerConfig.DefaultProjectUser
 	commands := []string{}

--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -108,7 +108,7 @@ func RenderSummary(workspaceName string, projectList []apiclient.CreateWorkspace
 	return output, nil
 }
 
-func renderProjectDetails(project apiclient.CreateWorkspaceRequestProject, buildChoice BuildChoice, choiceName string) string {
+func renderProjectDetails(project apiclient.CreateWorkspaceRequestProject, buildChoice BuilderChoice, choiceName string) string {
 	output := projectDetailOutput(Build, choiceName)
 
 	if buildChoice == DEVCONTAINER {
@@ -168,7 +168,7 @@ func projectDetailOutput(projectDetailKey ProjectDetail, projectDetailValue stri
 	return fmt.Sprintf("\t%s%-*s%s", lipgloss.NewStyle().Foreground(views.Green).Render(string(projectDetailKey)), DEFAULT_PADDING-len(string(projectDetailKey)), EMPTY_STRING, projectDetailValue)
 }
 
-func getProjectBuildChoice(project apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) (BuildChoice, string) {
+func getProjectBuildChoice(project apiclient.CreateWorkspaceRequestProject, apiServerConfig *apiclient.ServerConfig) (BuilderChoice, string) {
 	if project.Build == nil {
 		if *project.Image == *apiServerConfig.DefaultProjectImage && *project.User == *apiServerConfig.DefaultProjectUser {
 			return NONE, "None"


### PR DESCRIPTION
# Allow user to override workspace image at creation

## Description

Added following single-project-only flags with short description:
`--custom-image` - create the project with the custom image passed as the flag value
this requires setting `--custom-image-user` and vice versa
`--devcontainer-path` - automatically assign the devcontainer builder with the path passed as the flag value
`--builder` - allows the user to specify the builder (currently Automatic/Devcontainer/None)

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #620 
