### PR TITLE
fix: Using git providers hosted without https fails to clone repositories

### DIFF
--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -6,10 +6,10 @@ package gitprovider
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
-	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -129,20 +129,7 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	return repo, nil
 }
 
-// isHttpsAvailable checks if the given URL is accessible via HTTPS
-func isHttpsAvailable(url string) bool {
-	resp, err := http.Head(url)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return false
-	}
-	return true
-}
-
 // getCloneUrl constructs the clone URL using the appropriate protocol
-func getCloneUrl(source, owner, repo string) string {
-	httpsUrl := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
-	if isHttpsAvailable(httpsUrl) {
-		return httpsUrl
-	}
-	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
+func getCloneUrl(protocol, source, owner, repo string) string {
+	return fmt.Sprintf("%s://%s/%s/%s.git", protocol, source, owner, repo)
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -6,10 +6,10 @@ package gitprovider
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
-	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -124,14 +124,13 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	repo.Name = matches[3]
 	repo.Id = matches[3]
 
-	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
+	repo.Url = getCloneUrl(fmt.Sprintf("https://%s/%s/%s", repo.Source, repo.Owner, repo.Name))
 
 	return repo, nil
 }
 
 // checkHTTPSAvailable checks if the given URL is accessible via HTTPS
-func checkHTTPSAvailable(source, owner, repo string) bool {
-	url := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+func checkHTTPSAvailable(url string) bool {
 	resp, err := http.Head(url)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return false
@@ -140,9 +139,9 @@ func checkHTTPSAvailable(source, owner, repo string) bool {
 }
 
 // getCloneUrl constructs the clone URL using the appropriate protocol
-func getCloneUrl(source, owner, repo string) string {
-	if checkHTTPSAvailable(source, owner, repo) {
-		return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+func getCloneUrl(url string) string {
+	if checkHTTPSAvailable(url) {
+		return url
 	}
-	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
+	return strings.Replace(url, "https://", "http://", 1)
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -128,6 +129,20 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	return repo, nil
 }
 
+// checkHTTPSAvailable checks if the given URL is accessible via HTTPS
+func checkHTTPSAvailable(source, owner, repo string) bool {
+	url := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	resp, err := http.Head(url)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return false
+	}
+	return true
+}
+
+// getCloneUrl constructs the clone URL using the appropriate protocol
 func getCloneUrl(source, owner, repo string) string {
-	return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	if checkHTTPSAvailable(source, owner, repo) {
+		return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	}
+	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -6,10 +6,10 @@ package gitprovider
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -124,13 +124,13 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	repo.Name = matches[3]
 	repo.Id = matches[3]
 
-	repo.Url = getCloneUrl(fmt.Sprintf("https://%s/%s/%s", repo.Source, repo.Owner, repo.Name))
+	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
 
 	return repo, nil
 }
 
-// checkHTTPSAvailable checks if the given URL is accessible via HTTPS
-func checkHTTPSAvailable(url string) bool {
+// isHttpsAvailable checks if the given URL is accessible via HTTPS
+func isHttpsAvailable(url string) bool {
 	resp, err := http.Head(url)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return false
@@ -139,9 +139,10 @@ func checkHTTPSAvailable(url string) bool {
 }
 
 // getCloneUrl constructs the clone URL using the appropriate protocol
-func getCloneUrl(url string) string {
-	if checkHTTPSAvailable(url) {
-		return url
+func getCloneUrl(source, owner, repo string) string {
+	httpsUrl := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	if isHttpsAvailable(httpsUrl) {
+		return httpsUrl
 	}
-	return strings.Replace(url, "https://", "http://", 1)
+	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
 }


### PR DESCRIPTION
# Pull Request Title
Bug Fix: Using git providers hosted without HTTPS fails to clone repositories

## Description

I included a few lines of code, that will solve the bug.

1. checkHTTPSAvailable Function:
- This function constructs the HTTPS URL and sends a HEAD request to check if the URL is accessible.
- If the HEAD request returns an error or a status code other than 200 OK, the function returns false, indicating that HTTPS is not available.

2. getCloneUrl Function:
- This function uses checkHTTPSAvailable to determine if HTTPS is accessible for the given repository.
- If HTTPS is available, it constructs the clone URL using HTTPS.
- If HTTPS is not available, it constructs the clone URL using HTTP.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

Closes #690 

## Notes
> This implementation assumes that the HEAD request is sufficient to determine the availability of HTTPS. In a production environment, you might want to handle more specific errors or edge cases.
