### PR TITLE
feat: expose server CLI version

### DIFF
--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -27,7 +27,7 @@ func main() {
 }
 
 func init() {
-	logLevel := log.ErrorLevel
+	logLevel := log.WarnLevel
 
 	logLevelEnv, logLevelSet := os.LookupEnv("LOG_LEVEL")
 	if logLevelSet {
@@ -41,7 +41,7 @@ func init() {
 		case "error":
 			logLevel = log.ErrorLevel
 		default:
-			logLevel = log.ErrorLevel
+			logLevel = log.WarnLevel
 		}
 	}
 

--- a/internal/util/apiclient/api_client.go
+++ b/internal/util/apiclient/api_client.go
@@ -17,6 +17,8 @@ import (
 	"github.com/daytonaio/daytona/pkg/server"
 )
 
+const CLIENT_VERSION_HEADER = "X-Client-Version"
+
 var apiClient *apiclient.APIClient
 
 func GetApiClient(profile *config.Profile) (*apiclient.APIClient, error) {
@@ -61,7 +63,7 @@ func GetApiClient(profile *config.Profile) (*apiclient.APIClient, error) {
 	}
 
 	clientConfig.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", apiKey))
-	clientConfig.AddDefaultHeader("X-Client-Version", internal.Version)
+	clientConfig.AddDefaultHeader(CLIENT_VERSION_HEADER, internal.Version)
 
 	apiClient = apiclient.NewAPIClient(clientConfig)
 
@@ -81,7 +83,7 @@ func GetAgentApiClient(apiUrl, apiKey string) (*apiclient.APIClient, error) {
 	}
 
 	clientConfig.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", apiKey))
-	clientConfig.AddDefaultHeader("X-Client-Version", internal.Version)
+	clientConfig.AddDefaultHeader(CLIENT_VERSION_HEADER, internal.Version)
 
 	apiClient = apiclient.NewAPIClient(clientConfig)
 

--- a/internal/util/apiclient/api_client.go
+++ b/internal/util/apiclient/api_client.go
@@ -52,7 +52,7 @@ func GetApiClient(profile *config.Profile) (*apiclient.APIClient, error) {
 
 	_, err = http.Head(healthUrl)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check server health at: %s. Make sure Daytona is running on the appropriate port", healthUrl)
+		return nil, ErrHealthCheckFailed(healthUrl)
 	}
 
 	clientConfig := apiclient.NewConfiguration()

--- a/internal/util/apiclient/api_client.go
+++ b/internal/util/apiclient/api_client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/api"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/server"
@@ -60,6 +61,7 @@ func GetApiClient(profile *config.Profile) (*apiclient.APIClient, error) {
 	}
 
 	clientConfig.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	clientConfig.AddDefaultHeader("X-Client-Version", internal.Version)
 
 	apiClient = apiclient.NewAPIClient(clientConfig)
 
@@ -79,6 +81,7 @@ func GetAgentApiClient(apiUrl, apiKey string) (*apiclient.APIClient, error) {
 	}
 
 	clientConfig.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	clientConfig.AddDefaultHeader("X-Client-Version", internal.Version)
 
 	apiClient = apiclient.NewAPIClient(clientConfig)
 

--- a/internal/util/apiclient/error.go
+++ b/internal/util/apiclient/error.go
@@ -1,0 +1,17 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package apiclient
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ErrHealthCheckFailed(healthUrl string) error {
+	return fmt.Errorf("failed to check server health at: %s. Make sure Daytona is running on the appropriate port", healthUrl)
+}
+
+func IsHealthCheckFailed(err error) bool {
+	return strings.HasPrefix(err.Error(), "failed to check server health at:")
+}

--- a/internal/util/apiclient/error_handler.go
+++ b/internal/util/apiclient/error_handler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/api/middlewares"
@@ -31,11 +32,6 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 		return err
 	}
 
-	serverVersion := res.Header.Get(middlewares.SERVER_VERSION_HEADER)
-	if internal.Version != serverVersion {
-		log.Warn(fmt.Sprintf("Version mismatch detected. CLI is on version %s, Daytona Server is on version %s. To ensure maximum compatibility, please make sure the versions are aligned.", serverVersion, internal.Version))
-	}
-
 	var errResponse ApiErrorResponse
 
 	err = json.Unmarshal(body, &errResponse)
@@ -43,5 +39,17 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 		return errors.New(string(body))
 	}
 
+	checkVersionsMismatch(res, errResponse)
+
 	return errors.New(errResponse.Error)
+}
+
+func checkVersionsMismatch(res *http.Response, err ApiErrorResponse) {
+	// Ignore check if error comes from health-check response
+	if !strings.Contains(err.Error, "failed to check server health at:") {
+		serverVersion := res.Header.Get(middlewares.SERVER_VERSION_HEADER)
+		if internal.Version != serverVersion {
+			log.Warn(fmt.Sprintf("Version mismatch detected. CLI is on version %s, Daytona Server is on version %s. To ensure maximum compatibility, please make sure the versions are aligned.", serverVersion, internal.Version))
+		}
+	}
 }

--- a/internal/util/apiclient/error_handler.go
+++ b/internal/util/apiclient/error_handler.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"io"
 	"net/http"
+
+	"github.com/daytonaio/daytona/internal"
+	log "github.com/sirupsen/logrus"
 )
 
 type ApiErrorResponse struct {
@@ -24,6 +27,11 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
+	}
+
+	version := res.Header.Get("X-Server-Version")
+	if internal.Version != version {
+		log.Warn("Version mismatch! Server and client version are not the same. Please, update your Daytona versions.")
 	}
 
 	var errResponse ApiErrorResponse

--- a/internal/util/apiclient/error_handler.go
+++ b/internal/util/apiclient/error_handler.go
@@ -6,10 +6,12 @@ package apiclient
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/daytonaio/daytona/internal"
+	"github.com/daytonaio/daytona/pkg/api/middlewares"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -29,9 +31,9 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 		return err
 	}
 
-	version := res.Header.Get("X-Server-Version")
-	if internal.Version != version {
-		log.Warn("Version mismatch! Server and client version are not the same. Please, update your Daytona versions.")
+	serverVersion := res.Header.Get(middlewares.SERVER_VERSION_HEADER)
+	if internal.Version != serverVersion {
+		log.Warn(fmt.Sprintf("Version mismatch detected. CLI is on version %s, Daytona Server is on version %s. To ensure maximum compatibility, please make sure the versions are aligned.", serverVersion, internal.Version))
 	}
 
 	var errResponse ApiErrorResponse

--- a/pkg/api/middlewares/version.go
+++ b/pkg/api/middlewares/version.go
@@ -8,8 +8,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func VersionCheckMiddleware() gin.HandlerFunc {
+const SERVER_VERSION_HEADER = "X-Server-Version"
+
+func SetVersionMiddleware() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		ctx.Writer.Header().Add("X-Server-Version", internal.Version)
+		ctx.Writer.Header().Add(SERVER_VERSION_HEADER, internal.Version)
 	}
 }

--- a/pkg/api/middlewares/version.go
+++ b/pkg/api/middlewares/version.go
@@ -1,0 +1,15 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package middlewares
+
+import (
+	"github.com/daytonaio/daytona/internal"
+	"github.com/gin-gonic/gin"
+)
+
+func VersionCheckMiddleware() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ctx.Writer.Header().Add("X-Server-Version", internal.Version)
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -87,6 +87,7 @@ func (a *ApiServer) Start() error {
 	}
 
 	a.router.Use(middlewares.LoggingMiddleware())
+	a.router.Use(middlewares.VersionCheckMiddleware())
 
 	public := a.router.Group("/")
 	public.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -87,7 +87,7 @@ func (a *ApiServer) Start() error {
 	}
 
 	a.router.Use(middlewares.LoggingMiddleware())
-	a.router.Use(middlewares.VersionCheckMiddleware())
+	a.router.Use(middlewares.SetVersionMiddleware())
 
 	public := a.router.Group("/")
 	public.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -292,10 +292,11 @@ func readWorkspaceLogs(activeProfile config.Profile, workspaceId string, project
 			query := "follow=true"
 
 			for {
-				ws, res, err := apiclient_util.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s/%s", workspaceId, project.Name), &activeProfile, &query)
+				ws, _, err := apiclient_util.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s/%s", workspaceId, project.Name), &activeProfile, &query)
 				// We want to retry getting the logs if it fails
 				if err != nil {
-					log.Trace(apiclient_util.HandleErrorResponse(res, err))
+					// TODO: return log.Trace once https://github.com/daytonaio/daytona/issues/696 is resolved
+					// log.Trace(apiclient_util.HandleErrorResponse(res, err))
 					time.Sleep(500 * time.Millisecond)
 					continue
 				}
@@ -310,10 +311,11 @@ func readWorkspaceLogs(activeProfile config.Profile, workspaceId string, project
 	query := "follow=true"
 
 	for {
-		ws, res, err := apiclient_util.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s", workspaceId), &activeProfile, &query)
+		ws, _, err := apiclient_util.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s", workspaceId), &activeProfile, &query)
 		// We want to retry getting the logs if it fails
 		if err != nil {
-			log.Trace(apiclient_util.HandleErrorResponse(res, err))
+			// TODO: return log.Trace once https://github.com/daytonaio/daytona/issues/696 is resolved
+			// log.Trace(apiclient_util.HandleErrorResponse(res, err))
 			time.Sleep(500 * time.Millisecond)
 			continue
 		}


### PR DESCRIPTION
# Expose server CLI version

## Description

Expose server and client versions through response/request headers (`X-Server-Version` & `X-Client-Version`). If version mismatch is detected, user is warn of it.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #666

## Screenshots

![2024-06-18_14-59](https://github.com/daytonaio/daytona/assets/116551028/ad957672-60f3-42fa-bf41-7b7f286c8efe)

