### PR TITLE
fix: Using git providers hosted without HTTPS fails to clone repositories

### DIFF
--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -105,7 +105,11 @@ func (a *AbstractGitProvider) parseStaticGitContext(repoUrl string) (*StaticGitC
 		repo.Path = &branchPath
 	}
 
-	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
+	protocol := "https"
+	if !isHttpsAvailable(fmt.Sprintf("https://%s/%s/%s.git", repo.Source, repo.Owner, repo.Name)) {
+		protocol = "http"
+	}
+	repo.Url = getCloneUrl(protocol, repo.Source, repo.Owner, repo.Name)
 
 	return repo, nil
 }
@@ -124,7 +128,12 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	repo.Name = matches[3]
 	repo.Id = matches[3]
 
-	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
+	protocol := "https"
+	if !isHttpsAvailable(fmt.Sprintf("https://%s/%s/%s.git", repo.Source, repo.Owner, repo.Name)) {
+		protocol = "http"
+	}
+
+	repo.Url = getCloneUrl(protocol, repo.Source, repo.Owner, repo.Name)
 
 	return repo, nil
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -6,10 +6,10 @@ package gitprovider
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
-	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -129,20 +129,7 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	return repo, nil
 }
 
-// isHttpsAvailable checks if the given URL is accessible via HTTPS
-func isHttpsAvailable(url string) bool {
-	resp, err := http.Head(url)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return false
-	}
-	return true
-}
-
 // getCloneUrl constructs the clone URL using the appropriate protocol
-func getCloneUrl(source, owner, repo string) string {
-	httpsUrl := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
-	if isHttpsAvailable(httpsUrl) {
-		return httpsUrl
-	}
-	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
+func getCloneUrl(protocol, source, owner, repo string) string {
+	return fmt.Sprintf("%s://%s/%s/%s.git", protocol, source, owner, repo)
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -6,10 +6,10 @@ package gitprovider
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
-	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -124,14 +124,13 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	repo.Name = matches[3]
 	repo.Id = matches[3]
 
-	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
+	repo.Url = getCloneUrl(fmt.Sprintf("https://%s/%s/%s", repo.Source, repo.Owner, repo.Name))
 
 	return repo, nil
 }
 
 // checkHTTPSAvailable checks if the given URL is accessible via HTTPS
-func checkHTTPSAvailable(source, owner, repo string) bool {
-	url := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+func checkHTTPSAvailable(url string) bool {
 	resp, err := http.Head(url)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return false
@@ -140,9 +139,9 @@ func checkHTTPSAvailable(source, owner, repo string) bool {
 }
 
 // getCloneUrl constructs the clone URL using the appropriate protocol
-func getCloneUrl(source, owner, repo string) string {
-	if checkHTTPSAvailable(source, owner, repo) {
-		return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+func getCloneUrl(url string) string {
+	if checkHTTPSAvailable(url) {
+		return url
 	}
-	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
+	return strings.Replace(url, "https://", "http://", 1)
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -128,6 +129,20 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	return repo, nil
 }
 
+// checkHTTPSAvailable checks if the given URL is accessible via HTTPS
+func checkHTTPSAvailable(source, owner, repo string) bool {
+	url := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	resp, err := http.Head(url)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return false
+	}
+	return true
+}
+
+// getCloneUrl constructs the clone URL using the appropriate protocol
 func getCloneUrl(source, owner, repo string) string {
-	return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	if checkHTTPSAvailable(source, owner, repo) {
+		return fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	}
+	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -6,10 +6,10 @@ package gitprovider
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+	"net/http"
 )
 
 const personalNamespaceId = "<PERSONAL>"
@@ -124,13 +124,13 @@ func (a *AbstractGitProvider) parseSshGitUrl(gitURL string) (*StaticGitContext, 
 	repo.Name = matches[3]
 	repo.Id = matches[3]
 
-	repo.Url = getCloneUrl(fmt.Sprintf("https://%s/%s/%s", repo.Source, repo.Owner, repo.Name))
+	repo.Url = getCloneUrl(repo.Source, repo.Owner, repo.Name)
 
 	return repo, nil
 }
 
-// checkHTTPSAvailable checks if the given URL is accessible via HTTPS
-func checkHTTPSAvailable(url string) bool {
+// isHttpsAvailable checks if the given URL is accessible via HTTPS
+func isHttpsAvailable(url string) bool {
 	resp, err := http.Head(url)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return false
@@ -139,9 +139,10 @@ func checkHTTPSAvailable(url string) bool {
 }
 
 // getCloneUrl constructs the clone URL using the appropriate protocol
-func getCloneUrl(url string) string {
-	if checkHTTPSAvailable(url) {
-		return url
+func getCloneUrl(source, owner, repo string) string {
+	httpsUrl := fmt.Sprintf("https://%s/%s/%s.git", source, owner, repo)
+	if isHttpsAvailable(httpsUrl) {
+		return httpsUrl
 	}
-	return strings.Replace(url, "https://", "http://", 1)
+	return fmt.Sprintf("http://%s/%s/%s.git", source, owner, repo)
 }


### PR DESCRIPTION
# Pull Request Title
Bug Fix: Using git providers hosted without HTTPS fails to clone repositories

## Description


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #90 
