### PR TITLE
feat: build projects on the target machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,12 @@ require (
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/charmbracelet/huh v0.2.3
 	github.com/charmbracelet/lipgloss v0.9.1
-	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240131155556-0b41d7863037
+	github.com/compose-spec/compose-go/v2 v2.1.3
 	github.com/creack/pty v1.1.21
 	github.com/docker/docker v26.0.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/fatedier/frp v0.54.0
+	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240131155556-0b41d7863037
 	github.com/gin-contrib/cors v1.5.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/glebarez/sqlite v1.10.0
@@ -27,6 +28,7 @@ require (
 	github.com/kardianos/service v1.2.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pkg/sftp v1.13.6
 	github.com/rs/zerolog v1.31.0
@@ -38,6 +40,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.3
+	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	golang.org/x/crypto v0.23.0
 	golang.org/x/mod v0.17.0
 	golang.org/x/oauth2 v0.17.0
@@ -120,6 +123,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+	github.com/go-viper/mapstructure/v2 v2.0.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 // indirect
 	github.com/gofrs/uuid/v5 v5.0.0 // indirect
@@ -166,6 +170,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/mdlayher/genetlink v1.3.2 // indirect
 	github.com/mdlayher/netlink v1.7.2 // indirect
@@ -174,7 +179,6 @@ require (
 	github.com/miekg/dns v1.1.57 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -216,7 +220,6 @@ require (
 	github.com/tailscale/go-winio v0.0.0-20231025203758-c4f33415bf55 // indirect
 	github.com/tailscale/golang-x-crypto v0.0.0-20240108194725-7ce1f622c780 // indirect
 	github.com/tailscale/goupnp v1.0.1-0.20210804011211-c64d0f06ea05 // indirect
-	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a // indirect
 	github.com/tailscale/netlink v1.1.1-0.20211101221916-cabfb018fe85 // indirect
 	github.com/tailscale/setec v0.0.0-20230926024544-07dde05889e7 // indirect
 	github.com/tailscale/tailsql v0.0.0-20231216172832-51483e0c711b // indirect
@@ -235,6 +238,9 @@ require (
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.50.0 // indirect
 	go.opentelemetry.io/otel v1.25.0 // indirect
@@ -247,7 +253,7 @@ require (
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13 // indirect
 	go4.org/netipx v0.0.0-20230824141953-6213f710f925 // indirect
 	golang.org/x/arch v0.5.0 // indirect
-	golang.org/x/exp v0.0.0-20231127185646-65229373498e // indirect
+	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect
 	golang.org/x/tools v0.21.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -748,6 +748,8 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/compose-spec/compose-go/v2 v2.1.3 h1:bD67uqLuL/XgkAK6ir3xZvNLFPxPScEi1KW7R5esrLE=
+github.com/compose-spec/compose-go/v2 v2.1.3/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
@@ -836,6 +838,7 @@ github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uq
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20240131155556-0b41d7863037 h1:F1O6v+jmHAJErLdTevHtDuZwx3Upd3JA0RQLyhdl0wc=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20240131155556-0b41d7863037/go.mod h1:ZEXoTRQmw7DEoiVE18I3ESWtdbevIr31GjQTv58Ptns=
+github.com/gfleury/go-bitbucket-v1/test/bb-mock-server v0.0.0-20230825095122-9bc1711434ab h1:BeG9dDWckFi/p5Gvqq3wTEDXsUV4G6bdvjEHMOT2B8E=
 github.com/gfleury/go-bitbucket-v1/test/bb-mock-server v0.0.0-20230825095122-9bc1711434ab/go.mod h1:VssB0kb1cETNaFFC/0mHVCj+7i5TS2xraYq+tl9JLwE=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/cors v1.5.0 h1:DgGKV7DDoOn36DFkNtbHrjoRiT5ExCe+PC9/xp7aKvk=
@@ -909,6 +912,8 @@ github.com/go-playground/validator/v10 v10.18.0/go.mod h1:dbuPbCMFw/DrkbEynArYaC
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+github.com/go-viper/mapstructure/v2 v2.0.0 h1:dhn8MZ1gZ0mzeodTG3jt5Vj/o87xZKuNAprG2mQfMfc=
+github.com/go-viper/mapstructure/v2 v2.0.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
@@ -1191,6 +1196,8 @@ github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRC
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
@@ -1441,6 +1448,13 @@ github.com/xanzy/go-gitlab v0.97.0 h1:StMqJ1Kvt00X43pYIBBjj52dFlghwSeBhRDRfzaZ7x
 github.com/xanzy/go-gitlab v0.97.0/go.mod h1:ETg8tcj4OhrB84UEgeE8dSuV/0h4BBL1uOV/qK0vlyI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xtaci/lossyconn v0.0.0-20200209145036-adba10fffc37 h1:EWU6Pktpas0n8lLQwDsRyZfmkPeRbdgPtW609es+/9E=
 github.com/xtaci/lossyconn v0.0.0-20200209145036-adba10fffc37/go.mod h1:HpMP7DB2CyokmAh4lp0EQnnWhmycP/TvwBGzvuie+H0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -1542,8 +1556,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
-golang.org/x/exp v0.0.0-20231127185646-65229373498e h1:Gvh4YaCaXNs6dKTlfgismwWZKyjVZXwOPfIyUaqU3No=
-golang.org/x/exp v0.0.0-20231127185646-65229373498e/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
+golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=
+golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
 golang.org/x/exp/typeparams v0.0.0-20230905200255-921286631fa9 h1:j3D9DvWRpUfIyFfDPws7LoIZ2MAI1OJHdQXtTnYtN+k=
 golang.org/x/exp/typeparams v0.0.0-20230905200255-921286631fa9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
@@ -1841,7 +1855,6 @@ golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/hack/project_image/Dockerfile
+++ b/hack/project_image/Dockerfile
@@ -8,4 +8,4 @@ RUN apt update -y && \
 
 USER daytona
 
-ENTRYPOINT ["tail", "-f", "/dev/null"]
+ENTRYPOINT ["sudo", "dockerd"]

--- a/internal/constants/get_daytona_script.go
+++ b/internal/constants/get_daytona_script.go
@@ -20,6 +20,12 @@ err() {
   exit 1
 }
 
+# Check if daytona is already installed
+if [ -x "$(command -v daytona)" ]; then
+  echo "Daytona already installed. Skipping installation..."
+  exit 0
+fi
+
 # Check machine architecture
 ARCH=$(uname -m)
 # Check operating system

--- a/internal/testing/docker/mocks/api_client.go
+++ b/internal/testing/docker/mocks/api_client.go
@@ -102,6 +102,11 @@ func (m *MockApiClient) ContainerInspect(ctx context.Context, container string) 
 	return args.Get(0).(types.ContainerJSON), args.Error(1)
 }
 
+func (m *MockApiClient) ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+	args := m.Called(ctx, options)
+	return args.Get(0).([]types.Container), args.Error(1)
+}
+
 func (m *MockApiClient) VolumeRemove(ctx context.Context, volume string, force bool) error {
 	args := m.Called(ctx, volume, force)
 	return args.Error(0)

--- a/internal/testing/server/workspaces/mocks/provisioner.go
+++ b/internal/testing/server/workspaces/mocks/provisioner.go
@@ -7,6 +7,7 @@ package mocks
 
 import (
 	"github.com/daytonaio/daytona/pkg/containerregistry"
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/stretchr/testify/mock"
@@ -20,8 +21,8 @@ func NewMockProvisioner() *mockProvisioner {
 	return &mockProvisioner{}
 }
 
-func (p *mockProvisioner) CreateProject(project *workspace.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry) error {
-	args := p.Called(project, target, cr)
+func (p *mockProvisioner) CreateProject(project *workspace.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry, gc *gitprovider.GitProviderConfig) error {
+	args := p.Called(project, target, cr, gc)
 	return args.Error(0)
 }
 

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -28,6 +28,22 @@ func GetHomeDir(activeProfile config.Profile, workspaceId string, projectName st
 }
 
 func GetProjectDir(activeProfile config.Profile, workspaceId string, projectName string) (string, error) {
+	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
+	if err != nil {
+		return "", err
+	}
+
+	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
+
+	daytonaProjectDir, err := exec.Command("ssh", projectHostname, "echo", "$DAYTONA_PROJECT_DIR").Output()
+	if err != nil {
+		return "", err
+	}
+
+	if strings.TrimRight(string(daytonaProjectDir), "\n") != "" {
+		return strings.TrimRight(string(daytonaProjectDir), "\n"), nil
+	}
+
 	homeDir, err := GetHomeDir(activeProfile, workspaceId, projectName)
 	if err != nil {
 		return "", err

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -79,7 +79,7 @@ func GetLogFilePath() *string {
 		return nil
 	}
 
-	logFilePath = strings.Replace(logFilePath, "$HOME", os.Getenv("HOME"), 1)
+	logFilePath = strings.Replace(logFilePath, "(HOME)", os.Getenv("HOME"), 1)
 
 	return &logFilePath
 }

--- a/pkg/builder/detect/detect.go
+++ b/pkg/builder/detect/detect.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package detect
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/daytonaio/daytona/pkg/ssh"
+	"github.com/daytonaio/daytona/pkg/workspace"
+)
+
+type BuilderType string
+
+var (
+	BuilderTypeDevcontainer BuilderType = "devcontainer"
+	BuilderTypeImage        BuilderType = "image"
+)
+
+func DetectProjectBuilderType(project *workspace.Project, projectDir string, sshClient *ssh.Client) (BuilderType, error) {
+	if project.Build != nil && project.Build.Devcontainer != nil {
+		return BuilderTypeDevcontainer, nil
+	}
+
+	if sshClient != nil {
+		if _, err := sshClient.ReadFile(path.Join(projectDir, ".devcontainer/devcontainer.json")); err == nil {
+			project.Build.Devcontainer = &workspace.ProjectBuildDevcontainer{
+				DevContainerFilePath: ".devcontainer/devcontainer.json",
+			}
+			return BuilderTypeDevcontainer, nil
+		}
+		if _, err := sshClient.ReadFile(path.Join(projectDir, ".devcontainer.json")); err == nil {
+			project.Build.Devcontainer = &workspace.ProjectBuildDevcontainer{
+				DevContainerFilePath: ".devcontainer.json",
+			}
+			return BuilderTypeDevcontainer, nil
+		}
+	} else {
+		if devcontainerFilePath, pathError := findDevcontainerConfigFilePath(projectDir); pathError == nil {
+			project.Build.Devcontainer = &workspace.ProjectBuildDevcontainer{
+				DevContainerFilePath: devcontainerFilePath,
+			}
+
+			return BuilderTypeDevcontainer, nil
+		}
+	}
+
+	return BuilderTypeImage, nil
+}
+
+func findDevcontainerConfigFilePath(projectDir string) (string, error) {
+	devcontainerPath := ".devcontainer/devcontainer.json"
+	isDevcontainer, err := fileExists(filepath.Join(projectDir, devcontainerPath))
+	if err != nil {
+		devcontainerPath = ".devcontainer.json"
+		isDevcontainer, err = fileExists(filepath.Join(projectDir, devcontainerPath))
+		if err != nil {
+			return devcontainerPath, nil
+		}
+	}
+
+	if isDevcontainer {
+		return devcontainerPath, nil
+	}
+
+	return "", os.ErrNotExist
+}
+
+func fileExists(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		// There was an error checking for the file
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/builder/devcontainer.go
+++ b/pkg/builder/devcontainer.go
@@ -259,12 +259,12 @@ func (b *DevcontainerBuilder) readConfiguration() error {
 		return err
 	}
 
-	postCreateCommands, err := devcontainer.ConvertCommands(root.MergedConfiguration.PostCreateCommands)
+	postCreateCommands, err := devcontainer.ConvertToArray(root.MergedConfiguration.PostCreateCommands)
 	if err != nil {
 		projectLogger.Write([]byte(fmt.Sprintf("Error converting post create commands: %v\n", err)))
 	}
 
-	postStartCommands, err := devcontainer.ConvertCommands(root.MergedConfiguration.PostStartCommands)
+	postStartCommands, err := devcontainer.ConvertToArray(root.MergedConfiguration.PostStartCommands)
 	if err != nil {
 		projectLogger.Write([]byte(fmt.Sprintf("Error converting post start commands: %v\n", err)))
 	}

--- a/pkg/builder/devcontainer/config.go
+++ b/pkg/builder/devcontainer/config.go
@@ -3,145 +3,45 @@
 
 package devcontainer
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
-type Configuration struct {
-	Name              string                    `json:"name"`
-	DockerFile        string                    `json:"dockerFile"`
-	RunArgs           []string                  `json:"runArgs"`
-	InitializeCommand string                    `json:"initializeCommand"`
-	PostCreateCommand string                    `json:"postCreateCommand"`
-	RemoteUser        string                    `json:"remoteUser"`
-	Features          map[string]interface{}    `json:"features"`
-	ForwardPorts      map[string]PortAttributes `json:"forwardPorts"`
-	Customizations    map[string]interface{}    `json:"customizations"`
-	ConfigFilePath    ConfigFilePath            `json:"configFilePath"`
-}
-
-type PortAttributes struct {
-	Label            *string
-	OnAutoForward    *string
-	Protocol         *string
-	RequireLocalPort *bool
-	ElevateIfNeeded  *bool
-}
-
-type ConfigFilePath struct {
-	Mid    int    `json:"$mid"`
-	FsPath string `json:"fsPath"`
-	Path   string `json:"path"`
-	Scheme string `json:"scheme"`
-}
-
-type Workspace struct {
-	WorkspaceFolder string `json:"workspaceFolder"`
-	WorkspaceMount  string `json:"workspaceMount"`
-}
-
-type FeatureRef struct {
-	Id        string `json:"id"`
-	Owner     string `json:"owner"`
-	Namespace string `json:"namespace"`
-	Registry  string `json:"registry"`
-	Resource  string `json:"resource"`
-	Path      string `json:"path"`
-	Version   string `json:"version"`
-	Tag       string `json:"tag"`
-}
-
-type Feature struct {
-	Id               string                 `json:"id"`
-	Version          string                 `json:"version"`
-	Name             string                 `json:"name"`
-	DocumentationURL string                 `json:"documentationURL"`
-	Description      string                 `json:"description"`
-	Options          map[string]interface{} `json:"options"`
-	LicenceURL       string                 `json:"licenceURL"`
-	Keywords         string                 `json:"keywords"`
-	Entrypoint       string                 `json:"entrypoint"`
-	Privileged       bool                   `json:"privileged"`
-	ContainerEnv     map[string]string      `json:"containerEnv"`
-	Customizations   map[string]interface{} `json:"customizations"`
-	Mounts           []Mount                `json:"mounts"`
-	InstallsAfter    []string               `json:"installsAfter"`
-	Included         bool                   `json:"included"`
-	Value            string                 `json:"value"`
-	CachePath        string                 `json:"cachePath"`
-	ConsecutiveId    string                 `json:"consecutiveId"`
-	Init             bool                   `json:"init"`
-	CapAdd           []string               `json:"capAdd"`
-	SecurityOpt      []string               `json:"securityOpt"`
-	LegacyIds        []string               `json:"legacyIds"`
-	Deprecated       bool                   `json:"deprecated"`
-}
-
-type Mount struct {
-	Source string `json:"source"`
-	Target string `json:"target"`
-	Type   string `json:"type"`
-}
-
-type Root struct {
-	/*
-		Configuration         Configuration         `json:"configuration"`
-		Workspace             Workspace             `json:"workspace"`
-		FeaturesConfiguration FeaturesConfiguration `json:"featuresConfiguration"`
-	*/
-	MergedConfiguration MergedConfiguration `json:"mergedConfiguration"`
-}
-
-type MergedConfiguration struct {
-	Name            string                    `json:"name"`
-	DockerFile      string                    `json:"dockerFile"`
-	RunArgs         []string                  `json:"runArgs"`
-	RemoteUser      string                    `json:"remoteUser"`
-	Features        map[string]interface{}    `json:"features"`
-	ForwardPorts    []int                     `json:"forwardPorts"`
-	ConfigFilePath  ConfigFilePath            `json:"configFilePath"`
-	Init            bool                      `json:"init"`
-	Privileged      bool                      `json:"privileged"`
-	Entrypoints     []string                  `json:"entrypoints"`
-	Mounts          []Mount                   `json:"mounts"`
-	RemoteEnv       map[string]string         `json:"remoteEnv"`
-	ContainerEnv    map[string]string         `json:"containerEnv"`
-	PortsAttributes map[string]PortAttributes `json:"portsAttributes"`
-
-	// Commands
-	InitializeCommand     []interface{} `json:"initializeCommand"`
-	OnCreateCommands      []interface{} `json:"onCreateCommands"`
-	UpdateContentCommands []interface{} `json:"updateContentCommands"`
-	PostCreateCommands    []interface{} `json:"postCreateCommands"`
-	PostStartCommands     []interface{} `json:"postStartCommands"`
-	PostAttachCommands    []interface{} `json:"postAttachCommands"`
-}
-
-func ConvertCommands(mergedCommands []interface{}) ([]string, error) {
-	// Convert the commands to a string array
-	var commandArray []string
-	for _, commands := range mergedCommands {
-		switch commands := commands.(type) {
-		case []interface{}:
-			for _, command := range commands {
-				commandString, ok := command.(string)
-				if !ok {
-					return nil, fmt.Errorf("invalid command type: %v", command)
-				}
-				commandArray = append(commandArray, commandString)
+func ConvertToArray(mergedCommands interface{}) ([]string, error) {
+	switch mergedCommands := mergedCommands.(type) {
+	case string:
+		return []string{mergedCommands}, nil
+	case []interface{}:
+		var commandArray []string
+		for _, arg := range mergedCommands {
+			argString, ok := arg.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid command type: %v", arg)
 			}
-		case map[string]interface{}:
-			for _, command := range commands {
-				commandString, ok := command.(string)
-				if !ok {
-					return nil, fmt.Errorf("invalid command type: %v", command)
-				}
-				commandArray = append(commandArray, commandString)
-			}
-		case string:
-			commandArray = append(commandArray, commands)
-		default:
-			return nil, fmt.Errorf("invalid command type")
+			commandArray = append(commandArray, argString)
 		}
+		return []string{strings.Join(commandArray, " ")}, nil
+	case map[string]interface{}:
+		var commandArray []string
+		for _, command := range mergedCommands {
+			switch command := command.(type) {
+			case string:
+				commandArray = append(commandArray, command)
+			case []interface{}:
+				var cmd []string
+				for _, arg := range command {
+					argString, ok := arg.(string)
+					if !ok {
+						return nil, fmt.Errorf("invalid command type: %v", command)
+					}
+					cmd = append(cmd, argString)
+				}
+				commandArray = append(commandArray, strings.Join(cmd, " "))
+			}
+		}
+		return commandArray, nil
 	}
 
-	return commandArray, nil
+	return nil, fmt.Errorf("invalid command type: %v", mergedCommands)
 }

--- a/pkg/builder/devcontainer/types.go
+++ b/pkg/builder/devcontainer/types.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package devcontainer
+
+type Configuration struct {
+	Name              string                 `json:"name"`
+	DockerFile        string                 `json:"dockerFile"`
+	RunArgs           []string               `json:"runArgs"`
+	InitializeCommand string                 `json:"initializeCommand"`
+	PostCreateCommand string                 `json:"postCreateCommand"`
+	RemoteUser        string                 `json:"remoteUser"`
+	Features          map[string]interface{} `json:"features"`
+	ForwardPorts      []int                  `json:"forwardPorts"`
+	Customizations    map[string]interface{} `json:"customizations"`
+	ConfigFilePath    ConfigFilePath         `json:"configFilePath"`
+}
+
+type PortAttributes struct {
+	Label            *string
+	OnAutoForward    *string
+	Protocol         *string
+	RequireLocalPort *bool
+	ElevateIfNeeded  *bool
+}
+
+type ConfigFilePath struct {
+	Mid    int    `json:"$mid"`
+	FsPath string `json:"fsPath"`
+	Path   string `json:"path"`
+	Scheme string `json:"scheme"`
+}
+
+type Workspace struct {
+	WorkspaceFolder string `json:"workspaceFolder"`
+	WorkspaceMount  string `json:"workspaceMount"`
+}
+
+type FeatureRef struct {
+	Id        string `json:"id"`
+	Owner     string `json:"owner"`
+	Namespace string `json:"namespace"`
+	Registry  string `json:"registry"`
+	Resource  string `json:"resource"`
+	Path      string `json:"path"`
+	Version   string `json:"version"`
+	Tag       string `json:"tag"`
+}
+
+type Feature struct {
+	Id               string                 `json:"id"`
+	Version          string                 `json:"version"`
+	Name             string                 `json:"name"`
+	DocumentationURL string                 `json:"documentationURL"`
+	Description      string                 `json:"description"`
+	Options          map[string]interface{} `json:"options"`
+	LicenceURL       string                 `json:"licenceURL"`
+	Keywords         string                 `json:"keywords"`
+	Entrypoint       string                 `json:"entrypoint"`
+	Privileged       bool                   `json:"privileged"`
+	ContainerEnv     map[string]string      `json:"containerEnv"`
+	Customizations   map[string]interface{} `json:"customizations"`
+	Mounts           []Mount                `json:"mounts"`
+	InstallsAfter    []string               `json:"installsAfter"`
+	Included         bool                   `json:"included"`
+	Value            string                 `json:"value"`
+	CachePath        string                 `json:"cachePath"`
+	ConsecutiveId    string                 `json:"consecutiveId"`
+	Init             bool                   `json:"init"`
+	CapAdd           []string               `json:"capAdd"`
+	SecurityOpt      []string               `json:"securityOpt"`
+	LegacyIds        []string               `json:"legacyIds"`
+	Deprecated       bool                   `json:"deprecated"`
+}
+
+type Mount struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Type   string `json:"type"`
+}
+
+type Root struct {
+	// FeaturesConfiguration FeaturesConfiguration `json:"featuresConfiguration"`
+	Configuration       Configuration       `json:"configuration"`
+	Workspace           Workspace           `json:"workspace"`
+	MergedConfiguration MergedConfiguration `json:"mergedConfiguration"`
+}
+
+type MergedConfiguration struct {
+	Name            string                    `json:"name"`
+	DockerFile      string                    `json:"dockerFile"`
+	RunArgs         []string                  `json:"runArgs"`
+	RemoteUser      string                    `json:"remoteUser"`
+	Features        map[string]interface{}    `json:"features"`
+	ForwardPorts    []int                     `json:"forwardPorts"`
+	ConfigFilePath  ConfigFilePath            `json:"configFilePath"`
+	Init            bool                      `json:"init"`
+	Privileged      bool                      `json:"privileged"`
+	Entrypoints     []string                  `json:"entrypoints"`
+	Mounts          []Mount                   `json:"mounts"`
+	RemoteEnv       map[string]string         `json:"remoteEnv"`
+	ContainerEnv    map[string]string         `json:"containerEnv"`
+	PortsAttributes map[string]PortAttributes `json:"portsAttributes"`
+
+	// Commands
+	InitializeCommand     interface{} `json:"initializeCommand"`
+	OnCreateCommands      interface{} `json:"onCreateCommands"`
+	UpdateContentCommands interface{} `json:"updateContentCommands"`
+	PostCreateCommands    interface{} `json:"postCreateCommands"`
+	PostStartCommands     interface{} `json:"postStartCommands"`
+	PostAttachCommands    interface{} `json:"postAttachCommands"`
+}

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -43,6 +43,10 @@ var AgentCmd = &cobra.Command{
 		}
 		c.ProjectDir = filepath.Join(os.Getenv("HOME"), c.ProjectName)
 
+		if projectDir := os.Getenv("DAYTONA_PROJECT_DIR"); projectDir != "" {
+			c.ProjectDir = projectDir
+		}
+
 		gitLogWriter := io.MultiWriter(os.Stdout)
 		var agentLogWriter io.Writer
 		if c.LogFilePath != nil {

--- a/pkg/docker/container_logs.go
+++ b/pkg/docker/container_logs.go
@@ -16,6 +16,11 @@ func (d *DockerClient) GetContainerLogs(containerName string, logWriter io.Write
 		return nil
 	}
 
+	inspect, err := d.apiClient.ContainerInspect(context.Background(), containerName)
+	if err != nil {
+		return err
+	}
+
 	logs, err := d.apiClient.ContainerLogs(context.Background(), containerName, container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
@@ -25,6 +30,11 @@ func (d *DockerClient) GetContainerLogs(containerName string, logWriter io.Write
 		return err
 	}
 	defer logs.Close()
+
+	if inspect.Config.Tty {
+		_, err = io.Copy(logWriter, logs)
+		return err
+	}
 
 	_, err = stdcopy.StdCopy(logWriter, logWriter, logs)
 

--- a/pkg/docker/container_logs_test.go
+++ b/pkg/docker/container_logs_test.go
@@ -8,14 +8,23 @@ import (
 
 	t_docker "github.com/daytonaio/daytona/internal/testing/docker"
 	"github.com/daytonaio/daytona/internal/util"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func (s *DockerClientTestSuite) TestGetContainerLogs() {
+	s.mockClient.On("ContainerList", mock.Anything, mock.Anything).Return([]types.Container{}, nil)
+
 	containerName := s.dockerClient.GetProjectContainerName(project1)
 	logWriter := io.MultiWriter(&util.DebugLogWriter{})
+
+	s.mockClient.On("ContainerInspect", mock.Anything, containerName).Return(types.ContainerJSON{
+		Config: &container.Config{
+			Tty: false,
+		},
+	}, nil)
 
 	s.mockClient.On("ContainerLogs", mock.Anything, containerName,
 		container.LogsOptions{
@@ -27,5 +36,4 @@ func (s *DockerClientTestSuite) TestGetContainerLogs() {
 
 	err := s.dockerClient.GetContainerLogs(containerName, logWriter)
 	require.Nil(s.T(), err)
-
 }

--- a/pkg/docker/create.go
+++ b/pkg/docker/create.go
@@ -7,101 +7,175 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os/user"
+	"path/filepath"
+	"time"
 
-	"github.com/daytonaio/daytona/pkg/containerregistry"
-	"github.com/daytonaio/daytona/pkg/provider/util"
+	"github.com/daytonaio/daytona/pkg/builder/detect"
+	"github.com/daytonaio/daytona/pkg/ssh"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+	log "github.com/sirupsen/logrus"
 )
 
 func (d *DockerClient) CreateWorkspace(workspace *workspace.Workspace, logWriter io.Writer) error {
-	if logWriter != nil {
-		logWriter.Write([]byte("Initializing network\n"))
-	}
-	ctx := context.Background()
+	return nil
+}
 
-	networks, err := d.apiClient.NetworkList(ctx, types.NetworkListOptions{})
+func (d *DockerClient) CreateProject(opts *CreateProjectOptions) error {
+	// TODO: The image should be configurable
+	err := d.PullImage("daytonaio/workspace-project", nil, opts.LogWriter)
 	if err != nil {
 		return err
 	}
 
-	for _, network := range networks {
-		if network.Name == workspace.Id {
-			if logWriter != nil {
-				logWriter.Write([]byte("Network already exists\n"))
+	var sshClient *ssh.Client
+	if opts.SshSessionConfig != nil {
+		sshClient, err = ssh.NewClient(opts.SshSessionConfig)
+		if err != nil {
+			return err
+		}
+		defer sshClient.Close()
+	}
+
+	err = d.cloneProjectRepository(opts, sshClient)
+	if err != nil {
+		return err
+	}
+
+	builderType, err := detect.DetectProjectBuilderType(opts.Project, opts.ProjectDir, sshClient)
+	if err != nil {
+		return err
+	}
+
+	switch builderType {
+	case detect.BuilderTypeDevcontainer:
+		_, err := d.createProjectFromDevcontainer(opts, true, sshClient)
+		return err
+	case detect.BuilderTypeImage:
+		return d.createProjectFromImage(opts)
+	default:
+		return fmt.Errorf("unknown builder type: %s", builderType)
+	}
+}
+
+func (d *DockerClient) cloneProjectRepository(opts *CreateProjectOptions, sshClient *ssh.Client) error {
+	ctx := context.Background()
+
+	cloneUrl := opts.Project.Repository.Url
+	if opts.Gpc != nil {
+		cloneUrl = fmt.Sprintf("https://%s:%s@%s", opts.Gpc.Username, opts.Gpc.Token, opts.Project.Repository.Url)
+	}
+
+	cloneCmd := []string{"git", "clone", cloneUrl, fmt.Sprintf("/workdir/%s-%s", opts.Project.WorkspaceId, opts.Project.Name)}
+
+	c, err := d.apiClient.ContainerCreate(ctx, &container.Config{
+		Image:      "daytonaio/workspace-project",
+		Entrypoint: []string{"sleep"},
+		Cmd:        []string{"infinity"},
+	}, &container.HostConfig{
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: filepath.Dir(opts.ProjectDir),
+				Target: "/workdir",
+			},
+		},
+	}, nil, nil, fmt.Sprintf("git-clone-%s-%s", opts.Project.WorkspaceId, opts.Project.Name))
+	if err != nil {
+		return err
+	}
+
+	defer d.removeContainer(c.ID) // nolint:errcheck
+
+	err = d.apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			err = d.GetContainerLogs(c.ID, opts.LogWriter)
+			if err == nil {
+				break
 			}
-			return nil
+			log.Error(err)
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	containerUser := "daytona"
+	newUid := currentUser.Uid
+	newGid := currentUser.Gid
+
+	if sshClient != nil {
+		newUid, newGid, err = sshClient.GetUserUidGid()
+		if err != nil {
+			return err
 		}
 	}
 
-	_, err = d.apiClient.NetworkCreate(ctx, workspace.Id, types.NetworkCreate{
-		Attachable: true,
-		Driver:     "bridge",
-	})
-	if err != nil {
-		return err
+	if newUid == "0" && newGid == "0" {
+		containerUser = "root"
 	}
 
-	if logWriter != nil {
-		logWriter.Write([]byte("Network initialized\n"))
-	}
-	return nil
-}
-
-func (d *DockerClient) CreateProject(project *workspace.Project, daytonaDownloadUrl string, cr *containerregistry.ContainerRegistry, logWriter io.Writer) error {
-	err := d.PullImage(project.Image, cr, logWriter)
-	if err != nil {
-		return err
-	}
-
-	return d.initProjectContainer(project, daytonaDownloadUrl)
-}
-
-func (d *DockerClient) initProjectContainer(project *workspace.Project, daytonaDownloadUrl string) error {
-	ctx := context.Background()
-
-	_, err := d.apiClient.ContainerCreate(ctx, GetContainerCreateConfig(project, daytonaDownloadUrl), &container.HostConfig{
-		Privileged:  true,
-		NetworkMode: container.NetworkMode(project.WorkspaceId),
-		Mounts: []mount.Mount{
-			{
-				Type:   mount.TypeVolume,
-				Source: d.GetProjectVolumeName(project),
-				Target: fmt.Sprintf("/home/%s/%s", project.User, project.Name),
+	/*
+		Patch UID and GID of the user cloning the repository
+	*/
+	if containerUser != "root" {
+		_, err = d.ExecSync(c.ID, types.ExecConfig{
+			User: "root",
+			Cmd:  []string{"sh", "-c", UPDATE_UID_GID_SCRIPT},
+			Env: []string{
+				fmt.Sprintf("REMOTE_USER=%s", containerUser),
+				fmt.Sprintf("NEW_UID=%s", newUid),
+				fmt.Sprintf("NEW_GID=%s", newGid),
 			},
-		},
-		ExtraHosts: []string{
-			"host.docker.internal:host-gateway",
-		},
-	}, nil, nil, d.GetProjectContainerName(project))
+		}, opts.LogWriter)
+		if err != nil {
+			return err
+		}
+	}
+
+	res, err := d.ExecSync(c.ID, types.ExecConfig{
+		User: containerUser,
+		Cmd:  cloneCmd,
+	}, opts.LogWriter)
 	if err != nil {
 		return err
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("git clone failed with exit code %d", res.ExitCode)
 	}
 
 	return nil
 }
 
-func GetContainerCreateConfig(project *workspace.Project, daytonaDownloadUrl string) *container.Config {
-	envVars := []string{}
-
-	for key, value := range project.EnvVars {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
-	}
-
-	return &container.Config{
-		Hostname: project.Name,
-		Image:    project.Image,
-		Labels: map[string]string{
-			"daytona.workspace.id":                     project.WorkspaceId,
-			"daytona.workspace.project.name":           project.Name,
-			"daytona.workspace.project.repository.url": project.Repository.Url,
-		},
-		User:         project.User,
-		Env:          envVars,
-		Entrypoint:   []string{"bash", "-c", util.GetProjectStartScript(daytonaDownloadUrl, project.ApiKey)},
-		AttachStdout: true,
-		AttachStderr: true,
-	}
-}
+const UPDATE_UID_GID_SCRIPT = `eval $(sed -n "s/${REMOTE_USER}:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/OLD_UID=\1;OLD_GID=\2;HOME_FOLDER=\3/p" /etc/passwd); \
+eval $(sed -n "s/\([^:]*\):[^:]*:${NEW_UID}:.*/EXISTING_USER=\1/p" /etc/passwd); \
+eval $(sed -n "s/\([^:]*\):[^:]*:${NEW_GID}:.*/EXISTING_GROUP=\1/p" /etc/group); \
+if [ -z "$OLD_UID" ]; then \
+	echo "Remote user not found in /etc/passwd ($REMOTE_USER)."; \
+elif [ "$OLD_UID" = "$NEW_UID" -a "$OLD_GID" = "$NEW_GID" ]; then \
+	echo "UIDs and GIDs are the same ($NEW_UID:$NEW_GID)."; \
+elif [ "$OLD_UID" != "$NEW_UID" -a -n "$EXISTING_USER" ]; then \
+	echo "User with UID exists ($EXISTING_USER=$NEW_UID)."; \
+else \
+	if [ "$OLD_GID" != "$NEW_GID" -a -n "$EXISTING_GROUP" ]; then \
+		echo "Group with GID exists ($EXISTING_GROUP=$NEW_GID)."; \
+		NEW_GID="$OLD_GID"; \
+	fi; \
+	echo "Updating UID:GID from $OLD_UID:$OLD_GID to $NEW_UID:$NEW_GID."; \
+	sed -i -e "s/\(${REMOTE_USER}:[^:]*:\)[^:]*:[^:]*/\1${NEW_UID}:${NEW_GID}/" /etc/passwd; \
+	if [ "$OLD_GID" != "$NEW_GID" ]; then \
+		sed -i -e "s/\([^:]*:[^:]*:\)${OLD_GID}:/\1${NEW_GID}:/" /etc/group; \
+	fi; \
+	chown -R $NEW_UID:$NEW_GID $HOME_FOLDER; \
+fi;`

--- a/pkg/docker/create.go
+++ b/pkg/docker/create.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/daytonaio/daytona/pkg/builder/detect"
@@ -66,7 +67,9 @@ func (d *DockerClient) cloneProjectRepository(opts *CreateProjectOptions, sshCli
 
 	cloneUrl := opts.Project.Repository.Url
 	if opts.Gpc != nil {
-		cloneUrl = fmt.Sprintf("https://%s:%s@%s", opts.Gpc.Username, opts.Gpc.Token, opts.Project.Repository.Url)
+		repoUrl := strings.TrimPrefix(cloneUrl, "https://")
+		repoUrl = strings.TrimPrefix(repoUrl, "http://")
+		cloneUrl = fmt.Sprintf("https://%s:%s@%s", opts.Gpc.Username, opts.Gpc.Token, repoUrl)
 	}
 
 	cloneCmd := []string{"git", "clone", cloneUrl, fmt.Sprintf("/workdir/%s-%s", opts.Project.WorkspaceId, opts.Project.Name)}

--- a/pkg/docker/create_devcontainer.go
+++ b/pkg/docker/create_devcontainer.go
@@ -1,0 +1,555 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/compose-spec/compose-go/v2/cli"
+	"github.com/daytonaio/daytona/pkg/builder/devcontainer"
+	"github.com/daytonaio/daytona/pkg/ssh"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/google/uuid"
+	"github.com/tailscale/hujson"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const dockerSockForwardContainer = "daytona-sock-forward"
+
+type RemoteUser string
+
+func (d *DockerClient) createProjectFromDevcontainer(opts *CreateProjectOptions, prebuild bool, sshClient *ssh.Client) (RemoteUser, error) {
+	socketForwardId, err := d.ensureDockerSockForward(opts.LogWriter)
+	if err != nil {
+		return "", err
+	}
+
+	ctx := context.Background()
+
+	overridesDir := filepath.Join(filepath.Dir(opts.ProjectDir), fmt.Sprintf("%s-data", filepath.Base(opts.ProjectDir)))
+	overridesTarget := "/tmp/overrides"
+
+	if sshClient != nil {
+		err = sshClient.Exec(fmt.Sprintf("mkdir -p %s", overridesDir), opts.LogWriter)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		err = os.MkdirAll(overridesDir, 0755)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	projectTarget := path.Join("/project", filepath.Base(opts.ProjectDir))
+	targetConfigFilePath := path.Join(projectTarget, opts.Project.Build.Devcontainer.DevContainerFilePath)
+
+	config, err := d.readDevcontainerConfig(opts, socketForwardId, projectTarget, targetConfigFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	workspaceFolder := config.Workspace.WorkspaceFolder
+	if workspaceFolder == "" {
+		return "", fmt.Errorf("unable to determine workspace folder from devcontainer configuration")
+	}
+
+	remoteUser := config.MergedConfiguration.RemoteUser
+	if remoteUser == "" {
+		return "", fmt.Errorf("unable to determine remote user from devcontainer configuration")
+	}
+
+	var devcontainerConfigContent []byte
+	if sshClient != nil {
+		configFilePath := path.Join(opts.ProjectDir, opts.Project.Build.Devcontainer.DevContainerFilePath)
+		devcontainerConfigContent, err = sshClient.ReadFile(configFilePath)
+	} else {
+		configFilePath := filepath.Join(opts.ProjectDir, opts.Project.Build.Devcontainer.DevContainerFilePath)
+		devcontainerConfigContent, err = os.ReadFile(configFilePath)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	var devcontainerConfig map[string]interface{}
+
+	standardized, err := hujson.Standardize(devcontainerConfigContent)
+	if err != nil {
+		return "", err
+	}
+
+	err = json.Unmarshal(standardized, &devcontainerConfig)
+	if err != nil {
+		return "", err
+	}
+
+	envVars := map[string]string{}
+
+	if _, ok := devcontainerConfig["containerEnv"]; ok {
+		if containerEnv, ok := devcontainerConfig["containerEnv"].(map[string]interface{}); ok {
+			for k, v := range containerEnv {
+				envVars[k] = v.(string)
+			}
+		}
+	}
+
+	for k, v := range opts.Project.EnvVars {
+		envVars[k] = v
+	}
+
+	// If the workspaceFolder is not set in the devcontainer.json, we set it to /workspaces/<project-name>
+	if _, ok := devcontainerConfig["workspaceFolder"].(string); !ok {
+		workspaceFolder = fmt.Sprintf("/workspaces/%s", opts.Project.Name)
+		devcontainerConfig["workspaceFolder"] = workspaceFolder
+	}
+	devcontainerConfig["workspaceMount"] = fmt.Sprintf("source=%s,target=%s,type=bind", opts.ProjectDir, workspaceFolder)
+
+	delete(devcontainerConfig, "initializeCommand")
+
+	if _, ok := devcontainerConfig["dockerComposeFile"]; ok {
+		composeFilePath := devcontainerConfig["dockerComposeFile"].(string)
+
+		if opts.SshSessionConfig != nil {
+			composeFilePath = path.Join(opts.ProjectDir, filepath.Dir(opts.Project.Build.Devcontainer.DevContainerFilePath), composeFilePath)
+
+			composeFileContent, err := d.getRemoteComposeContent(opts, socketForwardId, opts.ProjectDir, composeFilePath)
+			if err != nil {
+				return "", err
+			}
+
+			composeFilePath = filepath.Join(os.TempDir(), fmt.Sprintf("daytona-compose-%s-%s.yml", opts.Project.WorkspaceId, opts.Project.Name))
+			err = os.WriteFile(composeFilePath, []byte(composeFileContent), 0644)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			composeFilePath = filepath.Join(opts.ProjectDir, filepath.Dir(opts.Project.Build.Devcontainer.DevContainerFilePath), composeFilePath)
+		}
+
+		options, err := cli.NewProjectOptions([]string{composeFilePath}, cli.WithOsEnv, cli.WithDotEnv)
+		if err != nil {
+			return "", err
+		}
+
+		project, err := cli.ProjectFromOptions(ctx, options)
+		if err != nil {
+			return "", err
+		}
+
+		project.Name = fmt.Sprintf("%s-%s", opts.Project.WorkspaceId, opts.Project.Name)
+
+		for _, service := range project.Services {
+			if service.Build != nil {
+				if strings.HasPrefix(service.Build.Context, opts.ProjectDir) {
+					service.Build.Context = strings.Replace(service.Build.Context, opts.ProjectDir, projectTarget, 1)
+				}
+			}
+		}
+
+		overrideComposeContent, err := project.MarshalYAML()
+		if err != nil {
+			return "", err
+		}
+
+		if sshClient != nil {
+			err = os.RemoveAll(composeFilePath)
+			if err != nil {
+				opts.LogWriter.Write([]byte(fmt.Sprintf("Error removing override compose file: %v\n", err)))
+				return "", err
+			}
+			res, err := sshClient.WriteFile(string(overrideComposeContent), filepath.Join(overridesDir, "daytona-compose-override.yml"))
+			if err != nil {
+				opts.LogWriter.Write([]byte(fmt.Sprintf("Error writing override compose file: %s\n", string(res))))
+				return "", err
+			}
+		} else {
+			err = os.WriteFile(filepath.Join(overridesDir, "daytona-compose-override.yml"), overrideComposeContent, 0644)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		devcontainerConfig["dockerComposeFile"] = path.Join(overridesTarget, "daytona-compose-override.yml")
+	}
+
+	envVars["DAYTONA_PROJECT_DIR"] = workspaceFolder
+
+	devcontainerConfig["containerEnv"] = envVars
+
+	configString, err := json.MarshalIndent(devcontainerConfig, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	if sshClient != nil {
+		res, err := sshClient.WriteFile(string(configString), path.Join(overridesDir, "devcontainer.json"))
+		if err != nil {
+			opts.LogWriter.Write([]byte(fmt.Sprintf("Error writing override compose file: %s\n", string(res))))
+			return "", err
+		}
+	} else {
+		err = os.WriteFile(path.Join(overridesDir, "devcontainer.json"), configString, 0644)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	devcontainerCmd := []string{
+		"devcontainer",
+		"up",
+		"--workspace-folder=" + projectTarget,
+		"--config=" + targetConfigFilePath,
+		"--override-config=" + path.Join(overridesTarget, "devcontainer.json"),
+		"--id-label=daytona.workspace.id=" + opts.Project.WorkspaceId,
+		"--id-label=daytona.project.name=" + opts.Project.Name,
+	}
+
+	if prebuild {
+		devcontainerCmd = append(devcontainerCmd, "--prebuild")
+	}
+
+	cmd := []string{"-c", strings.Join(devcontainerCmd, " ")}
+
+	if prebuild {
+		err = d.runInitializeCommand(config.MergedConfiguration.InitializeCommand, opts.LogWriter, sshClient)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	c, err := d.apiClient.ContainerCreate(ctx, &container.Config{
+		Image:        "daytonaio/workspace-project",
+		Entrypoint:   []string{"sh"},
+		Env:          []string{"DOCKER_HOST=tcp://localhost:2375"},
+		Cmd:          cmd,
+		AttachStdout: true,
+		AttachStderr: true,
+		Tty:          true,
+	}, &container.HostConfig{
+		Privileged:  true,
+		NetworkMode: container.NetworkMode(fmt.Sprintf("container:%s", socketForwardId)),
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: opts.ProjectDir,
+				Target: projectTarget,
+			},
+			{
+				Type:   mount.TypeBind,
+				Source: overridesDir,
+				Target: overridesTarget,
+			},
+		},
+	}, nil, nil, uuid.NewString())
+	if err != nil {
+		return "", err
+	}
+
+	defer d.removeContainer(c.ID) // nolint:errcheck
+
+	waitResponse, errChan := d.apiClient.ContainerWait(ctx, c.ID, container.WaitConditionNextExit)
+
+	err = d.apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	go func() {
+		for {
+			err = d.GetContainerLogs(c.ID, opts.LogWriter)
+			if err == nil {
+				break
+			}
+			log.Error(err)
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			return "", err
+		}
+	case resp := <-waitResponse:
+		if resp.StatusCode != 0 {
+			return "", fmt.Errorf("container exited with status %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			return "", fmt.Errorf("container exited with error: %s", resp.Error.Message)
+		}
+	}
+
+	return RemoteUser(remoteUser), nil
+}
+
+func (d *DockerClient) ensureDockerSockForward(logWriter io.Writer) (string, error) {
+	ctx := context.Background()
+
+	containers, err := d.apiClient.ContainerList(ctx, container.ListOptions{
+		Filters: filters.NewArgs(filters.Arg("name", dockerSockForwardContainer)),
+		All:     true,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(containers) > 1 {
+		return "", fmt.Errorf("multiple containers with name %s found", dockerSockForwardContainer)
+	}
+
+	if len(containers) == 1 {
+		if containers[0].State == "running" {
+			return containers[0].ID, nil
+		}
+		err := d.removeContainer(containers[0].ID)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// TODO: This image should be configurable because it might be hosted on an alternative registry
+	err = d.PullImage("alpine/socat", nil, logWriter)
+	if err != nil {
+		return "", err
+	}
+
+	c, err := d.apiClient.ContainerCreate(ctx, &container.Config{
+		Image: "alpine/socat",
+		User:  "root",
+		Cmd:   []string{"tcp-listen:2375,fork,reuseaddr", "unix-connect:/var/run/docker.sock"},
+	}, &container.HostConfig{
+		Privileged: true,
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: "/var/run/docker.sock",
+				Target: "/var/run/docker.sock",
+			},
+		},
+	}, nil, nil, dockerSockForwardContainer)
+	if err != nil {
+		return "", err
+	}
+
+	return c.ID, d.apiClient.ContainerStart(ctx, dockerSockForwardContainer, container.StartOptions{})
+}
+
+func (d *DockerClient) readDevcontainerConfig(opts *CreateProjectOptions, socketForwardId, projectTarget, configFilePath string) (*devcontainer.Root, error) {
+	opts.LogWriter.Write([]byte("Reading devcontainer configuration...\n"))
+
+	devcontainerCmd := []string{
+		"devcontainer",
+		"read-configuration",
+		"--workspace-folder=" + projectTarget,
+		"--config=" + configFilePath,
+		"--include-merged-configuration",
+	}
+
+	cmd := strings.Join(devcontainerCmd, " ")
+
+	output, err := d.execInContainer(cmd, opts, projectTarget, socketForwardId, projectTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	configStartIndex := strings.Index(output, "{")
+	if configStartIndex == -1 {
+		return nil, fmt.Errorf("unable to find start of JSON in devcontainer configuration")
+	}
+
+	var rootConfig devcontainer.Root
+	err = json.Unmarshal([]byte(output[configStartIndex:]), &rootConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rootConfig, nil
+}
+
+func (d *DockerClient) runInitializeCommand(initializeCommand interface{}, logWriter io.Writer, sshClient *ssh.Client) error {
+	if initializeCommand == nil {
+		return nil
+	}
+
+	logWriter.Write([]byte("Running initialize command...\n"))
+
+	switch initializeCommand := initializeCommand.(type) {
+	case string:
+		cmd := []string{"sh", "-c", initializeCommand}
+		return execDevcontainerCommand(cmd, logWriter, sshClient)
+	case []interface{}:
+		var commandArray []string
+		for _, arg := range initializeCommand {
+			argString, ok := arg.(string)
+			if !ok {
+				return fmt.Errorf("invalid command type: %v", arg)
+			}
+			commandArray = append(commandArray, argString)
+		}
+		return execDevcontainerCommand(commandArray, logWriter, sshClient)
+	case map[string]interface{}:
+		commands := map[string][]string{}
+		for name, command := range initializeCommand {
+			switch command := command.(type) {
+			case string:
+				commands[name] = []string{"sh", "-c", command}
+			case []interface{}:
+				var cmd []string
+				for _, arg := range command {
+					argString, ok := arg.(string)
+					if !ok {
+						return fmt.Errorf("invalid command type: %v", command)
+					}
+					cmd = append(cmd, argString)
+				}
+				commands[name] = cmd
+			}
+		}
+		errChan := make(chan error)
+		for name, command := range commands {
+			go func() {
+				logWriter.Write([]byte(fmt.Sprintf("Running %s\n", name)))
+				err := execDevcontainerCommand(command, logWriter, sshClient)
+				if err != nil {
+					logWriter.Write([]byte(fmt.Sprintf("Error running %s: %v\n", name, err)))
+					errChan <- err
+				} else {
+					errChan <- nil
+				}
+			}()
+		}
+
+		errs := []error{}
+		for range commands {
+			err := <-errChan
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		if len(errs) > 0 {
+			return fmt.Errorf("errors running initialize commands: %v", errs)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("invalid command type: %v", initializeCommand)
+}
+
+func (d *DockerClient) execInContainer(cmd string, opts *CreateProjectOptions, workDir, socketForwardId, projectTarget string) (string, error) {
+	ctx := context.Background()
+
+	c, err := d.apiClient.ContainerCreate(ctx, &container.Config{
+		Image:      "daytonaio/workspace-project",
+		Entrypoint: []string{"sh"},
+		Env:        []string{"DOCKER_HOST=tcp://localhost:2375"},
+		Cmd:        append([]string{"-c"}, cmd),
+		Tty:        true,
+		WorkingDir: workDir,
+	}, &container.HostConfig{
+		Privileged:  true,
+		NetworkMode: container.NetworkMode(fmt.Sprintf("container:%s", socketForwardId)),
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: opts.ProjectDir,
+				Target: projectTarget,
+			},
+		},
+	}, nil, nil, uuid.NewString())
+	if err != nil {
+		return "", err
+	}
+
+	defer d.removeContainer(c.ID) // nolint:errcheck
+
+	waitResponse, errChan := d.apiClient.ContainerWait(ctx, c.ID, container.WaitConditionNextExit)
+
+	err = d.apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	output := ""
+
+	r, w := io.Pipe()
+
+	go func() {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			output += scanner.Text() + "\n"
+		}
+	}()
+
+	go func() {
+		err = d.GetContainerLogs(c.ID, w)
+		if err != nil {
+			opts.LogWriter.Write([]byte(fmt.Sprintf("Error reading devcontainer configuration: %v\n", err)))
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			return "", err
+		}
+	case resp := <-waitResponse:
+		if resp.StatusCode != 0 {
+			return "", fmt.Errorf("container exited with status %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			return "", fmt.Errorf("container exited with error: %s", resp.Error.Message)
+		}
+	}
+
+	return output, nil
+}
+
+func (d *DockerClient) getRemoteComposeContent(opts *CreateProjectOptions, socketForwardId, projectTarget, composePath string) (string, error) {
+	if opts.SshSessionConfig == nil {
+		return "", nil
+	}
+
+	output, err := d.execInContainer("docker compose config", opts, filepath.Dir(composePath), socketForwardId, projectTarget)
+	if err != nil {
+		return "", err
+	}
+
+	nameIndex := strings.Index(output, "name: ")
+	if nameIndex == -1 {
+		return "", fmt.Errorf("unable to find service name in compose config")
+	}
+
+	return output[nameIndex:], nil
+}
+
+func execDevcontainerCommand(command []string, logWriter io.Writer, sshClient *ssh.Client) error {
+	if sshClient != nil {
+		if command[0] == "sh" {
+			cmd := fmt.Sprintf(`sh -c "%s"`, strings.Join(command[2:], " "))
+			return sshClient.Exec(cmd, logWriter)
+		}
+		return sshClient.Exec(strings.Join(command, " "), logWriter)
+	}
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Stdout = logWriter
+	cmd.Stderr = logWriter
+	cmd.Env = os.Environ()
+	return cmd.Run()
+}

--- a/pkg/docker/create_image.go
+++ b/pkg/docker/create_image.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/daytonaio/daytona/pkg/workspace"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+)
+
+func (d *DockerClient) createProjectFromImage(opts *CreateProjectOptions) error {
+	err := d.PullImage(opts.Project.Image, opts.Cr, opts.LogWriter)
+	if err != nil {
+		return err
+	}
+
+	return d.initProjectContainer(opts.Project, opts.ProjectDir)
+}
+
+func (d *DockerClient) initProjectContainer(project *workspace.Project, projectDir string) error {
+	ctx := context.Background()
+
+	_, err := d.apiClient.ContainerCreate(ctx, GetContainerCreateConfig(project), &container.HostConfig{
+		Privileged: true,
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: projectDir,
+				Target: fmt.Sprintf("/home/%s/%s", project.User, project.Name),
+			},
+		},
+		ExtraHosts: []string{
+			"host.docker.internal:host-gateway",
+		},
+	}, nil, nil, d.GetProjectContainerName(project))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetContainerCreateConfig(project *workspace.Project) *container.Config {
+	envVars := []string{}
+
+	for key, value := range project.EnvVars {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	return &container.Config{
+		Hostname: project.Name,
+		Image:    project.Image,
+		Labels: map[string]string{
+			"daytona.workspace.id":                     project.WorkspaceId,
+			"daytona.workspace.project.name":           project.Name,
+			"daytona.workspace.project.repository.url": project.Repository.Url,
+		},
+		User:         project.User,
+		Env:          envVars,
+		Entrypoint:   []string{"sleep", "infinity"},
+		AttachStdout: true,
+		AttachStderr: true,
+	}
+}

--- a/pkg/docker/create_test.go
+++ b/pkg/docker/create_test.go
@@ -4,7 +4,11 @@
 package docker_test
 
 import (
+	"bufio"
 	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 
 	t_docker "github.com/daytonaio/daytona/internal/testing/docker"
 	"github.com/daytonaio/daytona/pkg/docker"
@@ -20,21 +24,17 @@ import (
 )
 
 func (s *DockerClientTestSuite) TestCreateWorkspace() {
-	s.mockClient.On("NetworkList", mock.Anything, types.NetworkListOptions{}).Return([]types.NetworkResource{}, nil)
-	s.mockClient.On("NetworkCreate", mock.Anything, workspace1.Id,
-		types.NetworkCreate{
-			Attachable: true,
-			Driver:     "bridge",
-		},
-	).Return(types.NetworkCreateResponse{}, nil)
-
 	err := s.dockerClient.CreateWorkspace(workspace1, nil)
 	require.Nil(s.T(), err)
 }
 
 func (s *DockerClientTestSuite) TestCreateProject() {
+	s.mockClient.On("ContainerList", mock.Anything, mock.Anything).Return([]types.Container{}, nil)
+
 	var networkingConfig *network.NetworkingConfig
 	var platform *v1.Platform
+
+	projectDir := os.TempDir()
 
 	containerName := s.dockerClient.GetProjectContainerName(project1)
 
@@ -45,20 +45,46 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 	).Return([]image.Summary{}, nil)
 
 	s.mockClient.On("ImagePull", mock.Anything, project1.Image, mock.Anything).Return(t_docker.NewPipeReader(""), nil)
+	s.mockClient.On("ImagePull", mock.Anything, "daytonaio/workspace-project", mock.Anything).Return(t_docker.NewPipeReader(""), nil)
 
-	s.mockClient.On("ContainerCreate", mock.Anything, docker.GetContainerCreateConfig(project1, "download-url"),
-		&container.HostConfig{
-			Privileged:  true,
-			NetworkMode: container.NetworkMode(project1.WorkspaceId),
-			Mounts: []mount.Mount{
-				{
-					Type:   mount.TypeVolume,
-					Source: s.dockerClient.GetProjectVolumeName(project1),
-					Target: fmt.Sprintf("/home/%s/%s", project1.User, project1.Name),
-				},
+	s.mockClient.On("ContainerRemove", mock.Anything, mock.Anything, container.RemoveOptions{RemoveVolumes: true, Force: true}).Return(nil)
+	s.mockClient.On("ContainerStart", mock.Anything, mock.Anything, container.StartOptions{}).Return(nil)
+	s.mockClient.On("ContainerExecCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.IDResponse{ID: "exec-id"}, nil)
+
+	_, client := net.Pipe()
+	s.mockClient.On("ContainerExecAttach", mock.Anything, "exec-id", types.ExecStartCheck{}).
+		Return(types.HijackedResponse{
+			Conn:   client,
+			Reader: bufio.NewReader(t_docker.NewPipeReader("")),
+		}, nil)
+	s.mockClient.On("ContainerExecInspect", mock.Anything, "exec-id").Return(types.ContainerExecInspect{}, nil)
+
+	s.mockClient.On("ContainerCreate", mock.Anything, &container.Config{
+		Image:      "daytonaio/workspace-project",
+		Entrypoint: []string{"sleep"},
+		Cmd:        []string{"infinity"},
+	}, &container.HostConfig{
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: filepath.Dir(projectDir),
+				Target: "/workdir",
 			},
+		},
+	}, networkingConfig, platform, fmt.Sprintf("git-clone-%s-%s", project1.WorkspaceId, project1.Name),
+	).Return(container.CreateResponse{ID: "123"}, nil)
+	s.mockClient.On("ContainerCreate", mock.Anything, docker.GetContainerCreateConfig(project1),
+		&container.HostConfig{
+			Privileged: true,
 			ExtraHosts: []string{
 				"host.docker.internal:host-gateway",
+			},
+			Mounts: []mount.Mount{
+				{
+					Type:   mount.TypeBind,
+					Source: projectDir,
+					Target: fmt.Sprintf("/home/%s/%s", project1.User, project1.Name),
+				},
 			},
 		},
 		networkingConfig,
@@ -66,6 +92,13 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 		containerName,
 	).Return(container.CreateResponse{ID: "123"}, nil)
 
-	err := s.dockerClient.CreateProject(project1, "download-url", nil, nil)
+	err := s.dockerClient.CreateProject(&docker.CreateProjectOptions{
+		Project:          project1,
+		ProjectDir:       projectDir,
+		Cr:               nil,
+		LogWriter:        nil,
+		Gpc:              nil,
+		SshSessionConfig: nil,
+	})
 	require.Nil(s.T(), err)
 }

--- a/pkg/docker/destroy_test.go
+++ b/pkg/docker/destroy_test.go
@@ -11,22 +11,18 @@ import (
 )
 
 func (s *DockerClientTestSuite) TestDestroyWorkspace() {
-	networks := []types.NetworkResource{
-		{
-			ID:   workspace1.Id,
-			Name: workspace1.Id,
-		},
-	}
-
-	s.mockClient.On("NetworkList", mock.Anything, types.NetworkListOptions{}).Return(networks, nil)
-	s.mockClient.On("NetworkRemove", mock.Anything, workspace1.Id).Return(nil)
-
 	err := s.dockerClient.DestroyWorkspace(workspace1)
 	require.Nil(s.T(), err)
 }
 
 func (s *DockerClientTestSuite) TestDestroyProject() {
+	s.mockClient.On("ContainerList", mock.Anything, mock.Anything).Return([]types.Container{}, nil)
+
 	containerName := s.dockerClient.GetProjectContainerName(project1)
+
+	s.mockClient.On("ContainerInspect", mock.Anything, containerName).Return(types.ContainerJSON{
+		Config: &container.Config{},
+	}, nil)
 
 	s.mockClient.On("ContainerRemove", mock.Anything, containerName,
 		container.RemoveOptions{

--- a/pkg/docker/exec.go
+++ b/pkg/docker/exec.go
@@ -25,7 +25,7 @@ func (d *DockerClient) ExecSync(containerID string, config types.ExecConfig, out
 	config.AttachStdout = true
 	config.AttachStdin = false
 
-	config.Env = append(config.Env, "DEBIAN_FRONTEND=noninteractive")
+	config.Env = append([]string{"DEBIAN_FRONTEND=noninteractive"}, config.Env...)
 
 	response, err := d.apiClient.ContainerExecCreate(ctx, containerID, config)
 	if err != nil {

--- a/pkg/docker/info_test.go
+++ b/pkg/docker/info_test.go
@@ -4,19 +4,19 @@
 package docker_test
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/daytonaio/daytona/pkg/docker"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func (s *DockerClientTestSuite) TestGetProjectInfo() {
+	s.mockClient.On("ContainerList", mock.Anything, mock.Anything).Return([]types.Container{}, nil)
+
 	containerName := s.dockerClient.GetProjectContainerName(project1)
 
 	inspectResult := types.ContainerJSON{
@@ -42,19 +42,6 @@ func (s *DockerClientTestSuite) TestGetProjectInfo() {
 	require.Equal(s.T(), projectInfo.IsRunning, inspectResult.State.Running)
 	require.Equal(s.T(), projectInfo.Created, inspectResult.Created)
 	require.Equal(s.T(), projectInfo.ProviderMetadata, metadata)
-}
-
-func (s *DockerClientTestSuite) TestGetProjectInfoNotFound() {
-	containerName := s.dockerClient.GetProjectContainerName(project1)
-
-	s.mockClient.On("ContainerInspect", mock.Anything, containerName).Return(types.ContainerJSON{}, errdefs.NotFound(errors.New("not found")))
-
-	projectInfo, err := s.dockerClient.GetProjectInfo(project1)
-	require.Nil(s.T(), err)
-	require.Equal(s.T(), project1.Name, projectInfo.Name)
-	require.Equal(s.T(), projectInfo.IsRunning, false)
-	require.Equal(s.T(), projectInfo.Created, "")
-	require.Equal(s.T(), projectInfo.ProviderMetadata, docker.ContainerNotFoundMetadata)
 }
 
 func (s *DockerClientTestSuite) TestGetWorkspaceInfo() {

--- a/pkg/docker/start_devcontainer.go
+++ b/pkg/docker/start_devcontainer.go
@@ -1,0 +1,10 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import "github.com/daytonaio/daytona/pkg/ssh"
+
+func (d *DockerClient) startDevcontainerProject(opts *CreateProjectOptions, sshClient *ssh.Client) (RemoteUser, error) {
+	return d.createProjectFromDevcontainer(opts, false, sshClient)
+}

--- a/pkg/docker/start_image.go
+++ b/pkg/docker/start_image.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+func (d *DockerClient) startImageProject(opts *CreateProjectOptions) error {
+	containerName := d.GetProjectContainerName(opts.Project)
+	ctx := context.Background()
+
+	c, err := d.apiClient.ContainerInspect(ctx, containerName)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Add logging
+	_, composeContainers, err := d.getComposeContainers(c)
+	if err != nil {
+		return err
+	}
+
+	if composeContainers != nil {
+		if opts.LogWriter != nil {
+			opts.LogWriter.Write([]byte("Starting compose containers\n"))
+		}
+
+		for _, c := range composeContainers {
+			err = d.apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
+			if err != nil {
+				return err
+			}
+			if opts.LogWriter != nil {
+				opts.LogWriter.Write([]byte(fmt.Sprintf("Started %s\n", strings.TrimPrefix(c.Names[0], "/"))))
+			}
+		}
+	}
+
+	if err == nil && c.State.Running {
+		return nil
+	}
+
+	err = d.apiClient.ContainerStart(ctx, containerName, container.StartOptions{})
+	if err != nil {
+		return err
+	}
+
+	// make sure container is running
+	//	TODO: timeout
+	for {
+		c, err = d.apiClient.ContainerInspect(ctx, containerName)
+		if err != nil {
+			return err
+		}
+
+		if c.State.Running {
+			break
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return nil
+}

--- a/pkg/docker/stop.go
+++ b/pkg/docker/stop.go
@@ -5,17 +5,21 @@ package docker
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"strings"
 	"time"
 
 	"github.com/daytonaio/daytona/pkg/workspace"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 )
 
-func (d *DockerClient) StopProject(project *workspace.Project) error {
-	return d.stopProjectContainer(project)
+func (d *DockerClient) StopProject(project *workspace.Project, logWriter io.Writer) error {
+	return d.stopProjectContainer(project, logWriter)
 }
 
-func (d *DockerClient) stopProjectContainer(project *workspace.Project) error {
+func (d *DockerClient) stopProjectContainer(project *workspace.Project, logWriter io.Writer) error {
 	containerName := d.GetProjectContainerName(project)
 	ctx := context.Background()
 
@@ -24,18 +28,44 @@ func (d *DockerClient) stopProjectContainer(project *workspace.Project) error {
 		return err
 	}
 
+	var c types.ContainerJSON
+
 	//	TODO: timeout
 	for {
-		inspect, err := d.apiClient.ContainerInspect(ctx, containerName)
+		c, err = d.apiClient.ContainerInspect(ctx, containerName)
 		if err != nil {
 			return err
 		}
 
-		if !inspect.State.Running {
+		if !c.State.Running {
 			break
 		}
 
 		time.Sleep(1 * time.Second)
+	}
+
+	// TODO: Add logging
+	_, composeContainers, err := d.getComposeContainers(c)
+	if err != nil {
+		return err
+	}
+
+	if composeContainers == nil {
+		return nil
+	}
+
+	if logWriter != nil {
+		logWriter.Write([]byte("Stopping compose containers\n"))
+	}
+
+	for _, c := range composeContainers {
+		err = d.apiClient.ContainerStop(ctx, c.ID, container.StopOptions{})
+		if err != nil {
+			return err
+		}
+		if logWriter != nil {
+			logWriter.Write([]byte(fmt.Sprintf("Stopped %s\n", strings.TrimPrefix(c.Names[0], "/"))))
+		}
 	}
 
 	return nil

--- a/pkg/docker/stop_test.go
+++ b/pkg/docker/stop_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func (s *DockerClientTestSuite) TestStopProject() {
+	s.mockClient.On("ContainerList", mock.Anything, mock.Anything).Return([]types.Container{}, nil)
+
 	containerName := s.dockerClient.GetProjectContainerName(project1)
 
 	s.mockClient.On("ContainerStop", mock.Anything, containerName, container.StopOptions{}).Return(nil)
@@ -20,8 +22,11 @@ func (s *DockerClientTestSuite) TestStopProject() {
 				Running: false,
 			},
 		},
+		Config: &container.Config{
+			Labels: map[string]string{},
+		},
 	}, nil)
 
-	err := s.dockerClient.StopProject(project1)
+	err := s.dockerClient.StopProject(project1, nil)
 	require.Nil(s.T(), err)
 }

--- a/pkg/ide/browser.go
+++ b/pkg/ide/browser.go
@@ -20,7 +20,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const startVSCodeServerCommand = "$HOME/vscode-server/bin/openvscode-server --start-server --port=63000 --host=0.0.0.0 --without-connection-token --disable-workspace-trust --default-folder=$HOME/$DAYTONA_WS_PROJECT_NAME"
+const startVSCodeServerCommand = "$HOME/vscode-server/bin/openvscode-server --start-server --port=63000 --host=0.0.0.0 --without-connection-token --disable-workspace-trust --default-folder="
 
 func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectName string) error {
 	// Download and start IDE
@@ -41,10 +41,15 @@ func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectNam
 		return err
 	}
 
+	projectDir, err := util.GetProjectDir(activeProfile, workspaceId, projectName)
+	if err != nil {
+		return err
+	}
+
 	views.RenderInfoMessageBold("Starting OpenVSCode Server...")
 
 	go func() {
-		startServerCommand := exec.CommandContext(context.Background(), "ssh", projectHostname, startVSCodeServerCommand)
+		startServerCommand := exec.CommandContext(context.Background(), "ssh", projectHostname, fmt.Sprintf("%s%s", startVSCodeServerCommand, projectDir))
 		startServerCommand.Stdout = io.Writer(&util.DebugLogWriter{})
 		startServerCommand.Stderr = io.Writer(&util.DebugLogWriter{})
 

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -25,7 +25,7 @@ func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName st
 
 	commandArgument := fmt.Sprintf("vscode-remote://ssh-remote+%s/%s", projectHostname, projectDir)
 
-	var vscCommand *exec.Cmd = exec.Command("code", "--folder-uri", commandArgument)
+	var vscCommand *exec.Cmd = exec.Command("code", "--folder-uri", commandArgument, "--disable-extension", "ms-vscode-remote.remote-containers")
 
 	return vscCommand.Run()
 }

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"github.com/daytonaio/daytona/pkg/containerregistry"
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/workspace"
 )
 
@@ -37,6 +38,7 @@ type ProjectRequest struct {
 	TargetOptions     string
 	ContainerRegistry *containerregistry.ContainerRegistry
 	Project           *workspace.Project
+	GitProviderConfig *gitprovider.GitProviderConfig
 }
 
 type ProviderTarget struct {

--- a/pkg/provisioner/create.go
+++ b/pkg/provisioner/create.go
@@ -5,6 +5,7 @@ package provisioner
 
 import (
 	"github.com/daytonaio/daytona/pkg/containerregistry"
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/workspace"
 )
@@ -23,7 +24,7 @@ func (p *Provisioner) CreateWorkspace(workspace *workspace.Workspace, target *pr
 	return err
 }
 
-func (p *Provisioner) CreateProject(project *workspace.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry) error {
+func (p *Provisioner) CreateProject(project *workspace.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry, gc *gitprovider.GitProviderConfig) error {
 	targetProvider, err := p.providerManager.GetProvider(target.ProviderInfo.Name)
 	if err != nil {
 		return err
@@ -33,6 +34,7 @@ func (p *Provisioner) CreateProject(project *workspace.Project, target *provider
 		TargetOptions:     target.Options,
 		Project:           project,
 		ContainerRegistry: cr,
+		GitProviderConfig: gc,
 	})
 
 	return err

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -5,13 +5,14 @@ package provisioner
 
 import (
 	"github.com/daytonaio/daytona/pkg/containerregistry"
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/provider/manager"
 	"github.com/daytonaio/daytona/pkg/workspace"
 )
 
 type IProvisioner interface {
-	CreateProject(project *workspace.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry) error
+	CreateProject(project *workspace.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry, gc *gitprovider.GitProviderConfig) error
 	CreateWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error
 	DestroyProject(project *workspace.Project, target *provider.ProviderTarget) error
 	DestroyWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -168,7 +168,12 @@ func (s *WorkspaceService) createProject(project *workspace.Project, target *pro
 		return err
 	}
 
-	err = s.provisioner.CreateProject(project, target, cr)
+	gc, err := s.gitProviderService.GetConfigForUrl(project.Repository.Url)
+	if err != nil && !gitprovider.IsGitProviderNotFound(err) {
+		return err
+	}
+
+	err = s.provisioner.CreateProject(project, target, cr, gc)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -101,7 +101,10 @@ func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*wor
 }
 
 func (s *WorkspaceService) createBuild(project *workspace.Project, gc *gitprovider.GitProviderConfig, logWriter io.Writer) (*workspace.Project, error) {
-	if project.Build != nil {
+	// FIXME: skip build completely for now
+	return project, nil
+
+	if project.Build != nil { // nolint:govet
 		lastBuildResult, err := s.builderFactory.CheckExistingBuild(*project)
 		if err != nil {
 			return nil, err

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -115,12 +115,6 @@ func TestWorkspaceService(t *testing.T) {
 		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceRequest.Id).Return(createWorkspaceRequest.Id, nil)
 		gitProviderService.On("GetLastCommitSha", createWorkspaceRequest.Projects[0].Source.Repository).Return("123", nil)
 
-		for _, project := range createWorkspaceRequest.Projects {
-			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceRequest.Id, project.Name)).Return(project.Name, nil)
-		}
-		provisioner.On("CreateProject", mock.Anything, &target, containerRegistry).Return(nil)
-		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
-
 		baseApiUrl := "https://api.github.com"
 		gitProviderConfig := gitprovider.GitProviderConfig{
 			Id:         "github",
@@ -128,6 +122,12 @@ func TestWorkspaceService(t *testing.T) {
 			Token:      "test-token",
 			BaseApiUrl: &baseApiUrl,
 		}
+
+		for _, project := range createWorkspaceRequest.Projects {
+			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceRequest.Id, project.Name)).Return(project.Name, nil)
+		}
+		provisioner.On("CreateProject", mock.Anything, &target, containerRegistry, &gitProviderConfig).Return(nil)
+		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
 
 		gitProviderService.On("GetConfigForUrl", "https://github.com/daytonaio/daytona").Return(&gitProviderConfig, nil)
 
@@ -257,10 +257,19 @@ func TestWorkspaceService(t *testing.T) {
 		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceRequest.Id).Return(createWorkspaceRequest.Id, nil)
 		gitProviderService.On("GetLastCommitSha", createWorkspaceRequest.Projects[0].Source.Repository).Return("123", nil)
 
+		baseApiUrl := "https://api.github.com"
+		gitProviderConfig := gitprovider.GitProviderConfig{
+			Id:         "github",
+			Username:   "test-username",
+			Token:      "test-token",
+			BaseApiUrl: &baseApiUrl,
+		}
+		gitProviderService.On("GetConfigForUrl", "https://github.com/daytonaio/daytona").Return(&gitProviderConfig, nil)
+
 		for _, project := range createWorkspaceRequest.Projects {
 			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceRequest.Id, project.Name)).Return(project.Name, nil)
 		}
-		provisioner.On("CreateProject", mock.Anything, &target, containerRegistry).Return(nil)
+		provisioner.On("CreateProject", mock.Anything, &target, containerRegistry, &gitProviderConfig).Return(nil)
 		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
 
 		_, _ = service.CreateWorkspace(createWorkspaceRequest)

--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type SessionConfig struct {
+	Hostname       string
+	Port           int
+	Username       string
+	Password       *string
+	PrivateKeyPath *string
+}
+
+type Client struct {
+	*ssh.Client
+}
+
+func NewClient(config *SessionConfig) (*Client, error) {
+	server := fmt.Sprintf("%s:%d", config.Hostname, config.Port)
+	sshConfig := &ssh.ClientConfig{
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			return nil
+		},
+		Timeout: time.Second * 30,
+		User:    config.Username,
+	}
+
+	if config.Password != nil {
+		sshConfig.Auth = []ssh.AuthMethod{
+			ssh.Password(*config.Password),
+		}
+	} else if config.PrivateKeyPath != nil {
+		buf, err := os.ReadFile(*config.PrivateKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading SSH key file %s: %w", *config.PrivateKeyPath, err)
+		}
+
+		privateKey, err := ssh.ParsePrivateKey(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		sshConfig.Auth = []ssh.AuthMethod{
+			ssh.PublicKeys(privateKey),
+		}
+	}
+
+	client, err := ssh.Dial("tcp", server, sshConfig)
+	if err != nil {
+		return nil, fmt.Errorf("dialing SSH server: %w", err)
+	}
+
+	return &Client{
+		Client: client,
+	}, nil
+}

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"io"
+)
+
+func (c *Client) Exec(command string, logWriter io.Writer) error {
+	session, err := c.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	session.Stdout = logWriter
+	session.Stderr = logWriter
+
+	return session.Run(command)
+}

--- a/pkg/ssh/read_file.go
+++ b/pkg/ssh/read_file.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"fmt"
+)
+
+func (c *Client) ReadFile(filePath string) ([]byte, error) {
+	session, err := c.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	output, err := session.CombinedOutput(fmt.Sprintf("cat %s", filePath))
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/pkg/ssh/user.go
+++ b/pkg/ssh/user.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func (c *Client) GetUserUidGid() (string, string, error) {
+	session, err := c.NewSession()
+	if err != nil {
+		return "", "", err
+	}
+	defer session.Close()
+
+	idResp, err := session.Output("id")
+	if err != nil {
+		return "", "", err
+	}
+
+	re := regexp.MustCompile(`uid=(\d+).*gid=(\d+)`)
+	matches := re.FindStringSubmatch(string(idResp))
+	if len(matches) < 3 {
+		return "", "", fmt.Errorf("could not parse uid and gid from id command")
+	}
+
+	return matches[1], matches[2], nil
+}

--- a/pkg/ssh/write_file.go
+++ b/pkg/ssh/write_file.go
@@ -1,0 +1,18 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"fmt"
+)
+
+func (c *Client) WriteFile(content, filePath string) ([]byte, error) {
+	session, err := c.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	return session.CombinedOutput(fmt.Sprintf("echo '%s' > %s", content, filePath))
+}

--- a/pkg/tailscale/exec_cmd.go
+++ b/pkg/tailscale/exec_cmd.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"tailscale.com/tsnet"
+)
+
+type ExecConfig struct {
+	Ctx       context.Context
+	TsnetConn *tsnet.Server
+	Hostname  string
+	SshPort   int
+	LogWriter io.Writer
+	Command   string
+}
+
+func ExecCommand(config ExecConfig) error {
+	server := fmt.Sprintf("%s:%d", config.Hostname, config.SshPort)
+	sshConfig := &ssh.ClientConfig{
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			return nil
+		},
+		Timeout: time.Second * 30,
+	}
+
+	conn, err := config.TsnetConn.Dial(config.Ctx, "tcp", server)
+	if err != nil {
+		return err
+	}
+	c, chans, reqs, err := ssh.NewClientConn(conn, server, sshConfig)
+	if err != nil {
+		return err
+	}
+
+	sshClient := ssh.NewClient(c, chans, reqs)
+	defer sshClient.Close()
+
+	session, err := sshClient.NewSession()
+	if err != nil {
+		return err
+	}
+
+	session.Stdout = config.LogWriter
+	session.Stderr = config.LogWriter
+
+	return session.Run(config.Command)
+}

--- a/pkg/views/logs/display.go
+++ b/pkg/views/logs/display.go
@@ -49,14 +49,22 @@ func DisplayLogEntry(logEntry logs.LogEntry, index int) {
 	line = strings.ReplaceAll(line, "\r", fmt.Sprintf("\u001b[%dG", cursorOffset))
 	line = strings.ReplaceAll(line, "\u001b[0G", fmt.Sprintf("\u001b[%dG", cursorOffset))
 
+	if line == "\n" {
+		fmt.Print(line)
+		return
+	}
+
 	parts := strings.Split(line, "\n")
 
-	result := prefix
+	var result string
 	for _, part := range parts {
 		if part == "" {
 			continue
 		}
-		result += fmt.Sprintf("\r%s%s%s\n", prefixPadding, prefix, strings.TrimSuffix(part, "\r"))
+		result = fmt.Sprintf("%s\r%s%s%s", result, prefixPadding, prefix, part)
+		if len(parts) > 1 {
+			result = fmt.Sprintf("%s\n", result)
+		}
 	}
 
 	fmt.Print(result)

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -96,8 +96,8 @@ func GetProjectEnvVars(project *Project, apiUrl, serverUrl string) map[string]st
 		"DAYTONA_SERVER_VERSION":            internal.Version,
 		"DAYTONA_SERVER_URL":                serverUrl,
 		"DAYTONA_SERVER_API_URL":            apiUrl,
-		// $HOME will be replaced at runtime
-		"DAYTONA_AGENT_LOG_FILE_PATH": "$HOME/.daytona-agent.log",
+		// (HOME) will be replaced at runtime
+		"DAYTONA_AGENT_LOG_FILE_PATH": "(HOME)/.daytona-agent.log",
 	}
 
 	return envVars

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -44,8 +44,8 @@ func GetWorkspaceEnvVars(workspace *Workspace, params WorkspaceEnvVarParams) map
 		"DAYTONA_SERVER_VERSION": params.ServerVersion,
 		"DAYTONA_SERVER_URL":     params.ServerUrl,
 		"DAYTONA_SERVER_API_URL": params.ApiUrl,
-		// $HOME will be replaced at runtime
-		"DAYTONA_AGENT_LOG_FILE_PATH": "$HOME/.daytona-agent.log",
+		// (HOME) will be replaced at runtime
+		"DAYTONA_AGENT_LOG_FILE_PATH": "(HOME)/.daytona-agent.log",
 	}
 
 	return envVars


### PR DESCRIPTION
# Build Projects on the Target Machine

## Description

In this PR, a significant refactor is made to how the workspace creation process is run. The process is now ran on the target machine (local or remote) and directly on the host (before the process was ran inside a container). With this change, the creation process will see a significant performance improvement, especially on subsequent builds, because it will be cached on the hosts docker registry. Additionally, devcontainer Docker specific capabilities (e.g. gpu support) are now supported alongside full support for devcontainers that leverage docker compose projects.

### Breaking change

The provider interface was changed so they will need to be updated by the user

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #697 

## Notes

1. The most significant portion of the changes are made in the `docker` pkg which means that all providers will benefit from this change.
2. The building process we have implemented beforehand is now ignored during the creation process. The builders will be using during the prebuilding process which will be tackled in a separate issue.
3. Because of the change to the workspace-project entrypoint, users can remove `sudo dockerd` from the default post start commands with `daytona server configure`.

### Testing
`daytona serve`
`daytona server configure` -> change Registry URL to https://download.daytona.io/daytona-providers-pre-release
`daytona provider install` -> select `v0.7.0-alpha.1`
restart the `daytona serve` process
`daytona create <DEVCONTAINER_REPO_URL>`
Additionally, test remote docker targets.
