### PR TITLE
fix: devcontainer read config environment variables

### DIFF
--- a/pkg/ssh/env.go
+++ b/pkg/ssh/env.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ssh
+
+import (
+	"io"
+	"strings"
+)
+
+func (c *Client) GetEnv(logWriter io.Writer) ([]string, error) {
+	session, err := c.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	session.Stdout = logWriter
+	session.Stderr = logWriter
+
+	out, err := session.CombinedOutput("env")
+	if err != nil {
+		return nil, err
+	}
+
+	output := strings.TrimRight(string(out), "\n")
+	return strings.Split(output, "\n"), nil
+}


### PR DESCRIPTION
# Fix Env Variables when Reading Devcontainer Config

## Description

Env variables are now passed from the host machine when reading the devcontainer config.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes
This change is applied to providers, not Daytona directly.
