### PR TITLE
bug fix: sudo dockerd removed

### DIFF
--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -28,7 +28,7 @@ const defaultLocalBuilderRegistryPort = 3988
 const defaultBuilderRegistryServer = "local"
 const defaultBuildImageNamespace = ""
 
-var defaultProjectPostStartCommands = []string{"sudo dockerd"}
+var defaultProjectPostStartCommands = []string{}
 
 var us_defaultFrpsConfig = FRPSConfig{
 	Domain:   "try-us.daytona.app",

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -28,7 +28,7 @@ const serverUrl = "http://localhost:3987"
 const defaultProjectImage = "daytonaio/workspace-project:latest"
 const defaultProjectUser = "daytona"
 
-var defaultProjectPostStartCommands = []string{"sudo dockerd"}
+var defaultProjectPostStartCommands = []string{}
 
 var target = provider.ProviderTarget{
 	Name: "test-target",


### PR DESCRIPTION
# Pull Request Title
bug fix: sudo dockerd removed

## Description
Atm. sudo dockerd is the default post-start command. This is no longer needed and should be removed.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #716 
