### PR TITLE
fix: remove presence of leftover data from previous page in TUI (#592)

### DIFF
--- a/pkg/views/workspace/selection/view.go
+++ b/pkg/views/workspace/selection/view.go
@@ -67,7 +67,6 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err != nil {
 			m.list.SetWidth(150)
 		}
-		m.initialWidthSet = true
 	}
 
 	switch msg := msg.(type) {
@@ -99,8 +98,8 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		h, v := views.DocStyle.GetFrameSize()
-		// The height here minus the height occupied by the title header
-		m.list.SetSize(msg.Width-h, msg.Height-v-3)
+		// The height here minus the height occupied by the title header and footer
+		m.list.SetSize(msg.Width-h, msg.Height-v-4)
 	}
 
 	var cmd tea.Cmd

--- a/pkg/views/workspace/selection/view.go
+++ b/pkg/views/workspace/selection/view.go
@@ -98,8 +98,7 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		h, v := views.DocStyle.GetFrameSize()
-		// The height here minus the height occupied by the title header and footer
-		m.list.SetSize(msg.Width-h, msg.Height-v-4)
+		m.list.SetSize(msg.Width-h, msg.Height-v)
 	}
 
 	var cmd tea.Cmd
@@ -127,7 +126,11 @@ func (m model[T]) View() string {
 		return ""
 	}
 
-	return views.DocStyle.MaxWidth(terminalWidth - 4).MaxHeight(terminalHeight - 4).Render(m.list.View() + m.footer)
+	if m.list.FilterState() == list.Filtering {
+		return views.DocStyle.MaxWidth(terminalWidth - 4).MaxHeight(terminalHeight - 4).Render(m.list.View() + m.footer)
+	}
+
+	return views.DocStyle.MaxWidth(terminalWidth - 4).Height(terminalHeight - 2).Render(m.list.View() + m.footer)
 }
 
 type ItemDelegate[T any] struct {

--- a/pkg/views/workspace/selection/view.go
+++ b/pkg/views/workspace/selection/view.go
@@ -128,7 +128,7 @@ func (m model[T]) View() string {
 		return ""
 	}
 
-	return views.DocStyle.Width(terminalWidth - 4).Height(terminalHeight - 4).Render(m.list.View() + m.footer)
+	return views.DocStyle.MaxWidth(terminalWidth - 4).MaxHeight(terminalHeight - 4).Render(m.list.View() + m.footer)
 }
 
 type ItemDelegate[T any] struct {

--- a/pkg/views/workspace/selection/view.go
+++ b/pkg/views/workspace/selection/view.go
@@ -67,6 +67,7 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err != nil {
 			m.list.SetWidth(150)
 		}
+		m.initialWidthSet = true
 	}
 
 	switch msg := msg.(type) {
@@ -98,7 +99,8 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		h, v := views.DocStyle.GetFrameSize()
-		m.list.SetSize(msg.Width-h, msg.Height-v)
+		// The height here minus the height occupied by the title header
+		m.list.SetSize(msg.Width-h, msg.Height-v-3)
 	}
 
 	var cmd tea.Cmd


### PR DESCRIPTION
fix: remove presence of leftover data from previous page in TUI (#592)
fix: filter input gets duplicated in full screen tui (#668)

1. consider height of other ui components ('title' header in this case) while setting window height for workspaces list.
2. set a max height for workspace selection view.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

This PR addresses issue #592 and #668 

closes #592 
closes #668 

/claim #592 