### PR TITLE
fix: list all user github orgs

### DIFF
--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -38,7 +38,7 @@ func (g *GitHubGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 		return nil, err
 	}
 
-	orgList, _, err := client.Organizations.List(context.Background(), user.Username, &github.ListOptions{
+	orgList, _, err := client.Organizations.List(context.Background(), "", &github.ListOptions{
 		PerPage: 100,
 		Page:    1,
 	})


### PR DESCRIPTION
# Fix Listing All User GitHub Orgs

## Description

Minor fix to list all users GitHub Orgs.

![Screenshot 2024-07-08 at 09 58 46](https://github.com/daytonaio/daytona/assets/26512078/77c7dbf4-6d82-4d92-9b40-e5d5e4e8ad88)

As per their API docs, the username needs to be left out if we want to list all users github orgs. If the username is provided, then only public org relations are listed.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #728 