### PR TITLE
fix: project dir on windows

### DIFF
--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -5,7 +5,7 @@ package util
 
 import (
 	"os/exec"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
@@ -49,5 +49,5 @@ func GetProjectDir(activeProfile config.Profile, workspaceId string, projectName
 		return "", err
 	}
 
-	return filepath.Join(homeDir, projectName), nil
+	return path.Join(homeDir, projectName), nil
 }


### PR DESCRIPTION
# Fix Project Dir on Windows

## Description

Minor fix for opening a non-devcontainer project on Windows. Using `path` instead of `filepath` ensures that the path is constructed with slashes instead of backslashes.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #679 