### PR TITLE
fix: execute devcontainer user commands in the background

### DIFF
--- a/pkg/docker/start_devcontainer.go
+++ b/pkg/docker/start_devcontainer.go
@@ -3,8 +3,55 @@
 
 package docker
 
-import "github.com/daytonaio/daytona/pkg/ssh"
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/daytonaio/daytona/pkg/ssh"
+	"github.com/docker/docker/api/types/mount"
+)
 
 func (d *DockerClient) startDevcontainerProject(opts *CreateProjectOptions, sshClient *ssh.Client) (RemoteUser, error) {
+	go func() {
+		err := d.runDevcontainerUserCommands(opts)
+		if err != nil {
+			opts.LogWriter.Write([]byte(fmt.Sprintf("Error running devcontainer user commands: %s\n", err)))
+		}
+	}()
+
 	return d.createProjectFromDevcontainer(opts, false, sshClient)
+}
+
+func (d *DockerClient) runDevcontainerUserCommands(opts *CreateProjectOptions) error {
+	socketForwardId, err := d.ensureDockerSockForward(opts.LogWriter)
+	if err != nil {
+		return err
+	}
+
+	opts.LogWriter.Write([]byte("Running devcontainer user commands...\n"))
+
+	paths := d.getDevcontainerPaths(opts)
+
+	devcontainerCmd := []string{
+		"devcontainer",
+		"run-user-commands",
+		"--workspace-folder=" + paths.ProjectTarget,
+		"--config=" + paths.TargetConfigFilePath,
+		"--override-config=" + path.Join(paths.OverridesTarget, "devcontainer.json"),
+		"--id-label=daytona.workspace.id=" + opts.Project.WorkspaceId,
+		"--id-label=daytona.project.name=" + opts.Project.Name,
+	}
+
+	cmd := strings.Join(devcontainerCmd, " ")
+
+	_, err = d.execInContainer(cmd, opts, paths, paths.ProjectTarget, socketForwardId, true, []mount.Mount{
+		{
+			Type:   mount.TypeBind,
+			Source: paths.OverridesDir,
+			Target: paths.OverridesTarget,
+		},
+	})
+
+	return err
 }


### PR DESCRIPTION
# Execute Devcontainer User Commands in the Background

## Description

With this PR, devcontainer user commands are executed in the background when a project is started. This makes the creation process more efficient as it now skips non-blocking commands.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #733 