### PR TITLE
fix: clone repo from context

### DIFF
--- a/internal/testing/git/mocks/gitservice.go
+++ b/internal/testing/git/mocks/gitservice.go
@@ -21,6 +21,11 @@ func (m *MockGitService) CloneRepository(project *workspace.Project, auth *http.
 	return args.Error(0)
 }
 
+func (m *MockGitService) CloneRepositoryCmd(project *workspace.Project, auth *http.BasicAuth) []string {
+	args := m.Called(project, auth)
+	return args.Get(0).([]string)
+}
+
 func (m *MockGitService) RepositoryExists(project *workspace.Project) (bool, error) {
 	args := m.Called(project)
 	return args.Bool(0), args.Error(1)

--- a/pkg/docker/create_test.go
+++ b/pkg/docker/create_test.go
@@ -63,6 +63,7 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 		Image:      "daytonaio/workspace-project",
 		Entrypoint: []string{"sleep"},
 		Cmd:        []string{"infinity"},
+		Env:        []string{"GIT_SSL_NO_VERIFY=true"},
 	}, &container.HostConfig{
 		Mounts: []mount.Mount{
 			{


### PR DESCRIPTION
# Clone Repo from Context

## Description

This PR fixes a regression introduced when moving project building to the target machine. The repo is now correctly cloned on the given context (branch/commit).

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #740 