### PR TITLE
feat: apply devcontainer customizations to relevant IDEs

### DIFF
--- a/pkg/builder/devcontainer/customizations.go
+++ b/pkg/builder/devcontainer/customizations.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package devcontainer
+
+type Customizations struct {
+	Extensions []string               `json:"extensions"`
+	Settings   map[string]interface{} `json:"settings"`
+}
+
+type Tool string
+
+var (
+	Vscode     Tool = "vscode"
+	Browser    Tool = "browser"
+	Codespaces Tool = "codespaces"
+)
+
+func (c *Configuration) GetCustomizations(tool Tool) *Customizations {
+	if c.Customizations == nil {
+		return nil
+	}
+
+	customizations := []Customizations{}
+
+	// Common customizations
+	customizations = append(customizations, convertToCustomizations([]interface{}{c.Customizations})...)
+
+	customizations = append(customizations, getCustomizationsByTool(Vscode, c.Customizations)...)
+
+	if tool == Browser {
+		customizations = append(customizations, getCustomizationsByTool(Browser, c.Customizations)...)
+		customizations = append(customizations, getCustomizationsByTool(Codespaces, c.Customizations)...)
+	}
+
+	return MergeCustomizations(customizations)
+}
+
+func convertToCustomizations(customizations []interface{}) []Customizations {
+	result := []Customizations{}
+
+	for _, curr := range customizations {
+		c := Customizations{}
+
+		if curr.(map[string]interface{})["extensions"] != nil {
+			c.Extensions = interfaceListToStringList(curr.(map[string]interface{})["extensions"].([]interface{}))
+		}
+
+		if curr.(map[string]interface{})["settings"] != nil {
+			c.Settings = curr.(map[string]interface{})["settings"].(map[string]interface{})
+		}
+
+		result = append(result, c)
+	}
+
+	return result
+}
+
+func interfaceListToStringList(list []interface{}) []string {
+	result := []string{}
+
+	for _, curr := range list {
+		result = append(result, curr.(string))
+	}
+
+	return result
+}
+
+func getCustomizationsByTool(tool Tool, customizationsInterface map[string]interface{}) []Customizations {
+	customizations := []Customizations{}
+
+	if toolCustomization, ok := customizationsInterface[string(tool)]; ok {
+		if singleCustomization, ok := toolCustomization.(map[string]interface{}); ok {
+			customizations = append(customizations, convertToCustomizations([]interface{}{singleCustomization})...)
+		} else {
+			customizations = append(customizations, convertToCustomizations(toolCustomization.([]interface{}))...)
+		}
+	}
+
+	return customizations
+}
+
+func MergeCustomizations(customizations []Customizations) *Customizations {
+	if len(customizations) == 0 {
+		return nil
+	}
+
+	result := Customizations{
+		Extensions: []string{},
+		Settings:   map[string]interface{}{},
+	}
+
+	extensions := make(map[string]bool)
+	for _, curr := range customizations {
+		if curr.Extensions != nil {
+			for _, extension := range curr.Extensions {
+				if !extensions[extension] {
+					extensions[extension] = true
+					result.Extensions = append(result.Extensions, extension)
+				}
+			}
+		}
+
+		for key, value := range curr.Settings {
+			if result.Settings[key] == nil {
+				result.Settings[key] = value
+			}
+		}
+	}
+
+	return &result
+}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -193,7 +193,18 @@ var CreateCmd = &cobra.Command{
 
 		views.RenderCreationInfoMessage(fmt.Sprintf("Opening the workspace in %s ...", chosenIde.Name))
 
-		err = openIDE(chosenIdeId, activeProfile, *createdWorkspace.Id, *wsInfo.Projects[0].Name)
+		providerMetadata := ""
+		for _, project := range wsInfo.Info.Projects {
+			if *project.Name == *wsInfo.Projects[0].Name {
+				if project.ProviderMetadata == nil {
+					log.Fatal(errors.New("project provider metadata is missing"))
+				}
+				providerMetadata = *project.ProviderMetadata
+				break
+			}
+		}
+
+		err = openIDE(chosenIdeId, activeProfile, *createdWorkspace.Id, *wsInfo.Projects[0].Name, providerMetadata)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -66,7 +66,7 @@ var SshCmd = &cobra.Command{
 			if selectedProject == nil {
 				return
 			}
-			projectName = *selectedProject
+			projectName = *selectedProject.Name
 		}
 
 		if len(args) == 2 {

--- a/pkg/ide/browser.go
+++ b/pkg/ide/browser.go
@@ -13,6 +13,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/cmd/tailscale"
 	"github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/pkg/builder/devcontainer"
 	"github.com/daytonaio/daytona/pkg/ports"
 	"github.com/daytonaio/daytona/pkg/views"
 
@@ -22,7 +23,7 @@ import (
 
 const startVSCodeServerCommand = "$HOME/vscode-server/bin/openvscode-server --start-server --port=63000 --host=0.0.0.0 --without-connection-token --disable-workspace-trust --default-folder="
 
-func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectName string) error {
+func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectName string, projectProviderMetadata string) error {
 	// Download and start IDE
 	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
 	if err != nil {
@@ -81,6 +82,11 @@ func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectNam
 	err = browser.OpenURL(ideURL)
 	if err != nil {
 		log.Error("Error opening URL: " + err.Error())
+	}
+
+	err = setupIdeCustomizations(projectHostname, projectProviderMetadata, devcontainer.Browser, "*/vscode-server/bin/openvscode-server", "$HOME/.openvscode-server/data/Machine/settings.json")
+	if err != nil {
+		log.Errorf("Error setting up IDE customizations: %s", err)
 	}
 
 	for {

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -4,17 +4,22 @@
 package ide
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
+	"strings"
+	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/pkg/builder/devcontainer"
 
 	log "github.com/sirupsen/logrus"
 )
 
-func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName string) error {
+func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName string, projectProviderMetadata string) error {
 	checkAndAlertVSCodeInstalled()
 
 	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
@@ -26,9 +31,127 @@ func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName st
 
 	commandArgument := fmt.Sprintf("vscode-remote://ssh-remote+%s/%s", projectHostname, projectDir)
 
-	var vscCommand *exec.Cmd = exec.Command("code", "--folder-uri", commandArgument, "--disable-extension", "ms-vscode-remote.remote-containers")
+	vscCommand := exec.Command("code", "--folder-uri", commandArgument, "--disable-extension", "ms-vscode-remote.remote-containers")
 
-	return vscCommand.Run()
+	err = vscCommand.Run()
+	if err != nil {
+		return err
+	}
+
+	return setupIdeCustomizations(projectHostname, projectProviderMetadata, devcontainer.Vscode, "*/.vscode-server/*/bin/code-server", "$HOME/.vscode-server/data/Machine/settings.json")
+}
+
+func setupIdeCustomizations(projectHostname string, projectProviderMetadata string, tool devcontainer.Tool, codeServerPath string, settingsPath string) error {
+	// Check if customizations are already set up
+	err := exec.Command("ssh", projectHostname, "test", "-f", fmt.Sprintf("$HOME/.daytona-customizations-lock-%s", string(tool))).Run()
+	if err == nil {
+		return nil
+	}
+
+	fmt.Println("Setting up IDE customizations...")
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal([]byte(projectProviderMetadata), &metadata); err != nil {
+		return err
+	}
+
+	if devcontainerMetadata, ok := metadata["devcontainer.metadata"]; ok {
+		var configs []devcontainer.Configuration
+		if err := json.Unmarshal([]byte(devcontainerMetadata.(string)), &configs); err != nil {
+			return err
+		}
+
+		customizations := []devcontainer.Customizations{}
+
+		for _, config := range configs {
+			if config.Customizations != nil {
+				c := config.GetCustomizations(tool)
+				if c != nil {
+					customizations = append(customizations, *c)
+				}
+			}
+		}
+
+		mergedCustomizations := devcontainer.MergeCustomizations(customizations)
+
+		var vscodePath []byte
+
+		fmt.Println("Waiting for code server to install...")
+		for {
+			time.Sleep(2 * time.Second)
+			// Wait for code to be installed
+			var err error
+			if vscodePath, err = exec.Command("ssh", projectHostname, "find", "/home", "-path", fmt.Sprintf(`"%s"`, codeServerPath)).Output(); err == nil && len(vscodePath) > 0 {
+				break
+			}
+		}
+
+		if len(mergedCustomizations.Extensions) > 0 {
+			extensionArgs := []string{}
+			for _, extension := range mergedCustomizations.Extensions {
+				extensionArgs = append(extensionArgs, "--install-extension", extension)
+			}
+
+			args := []string{
+				projectHostname,
+				strings.TrimRight(string(vscodePath), "\n"),
+				"--accept-server-license-terms",
+			}
+
+			args = append(args, extensionArgs...)
+
+			installCmd := exec.Command("ssh", args...)
+			installCmd.Stdout = os.Stdout
+			installCmd.Stderr = os.Stderr
+			err := installCmd.Run()
+			if err != nil {
+				log.Errorf("Failed to install extensions: %s", err)
+			}
+		}
+
+		err := setIdeSettings(projectHostname, mergedCustomizations, settingsPath)
+		if err != nil {
+			log.Errorf("Failed to set IDE settings: %s", err)
+		}
+	}
+
+	// Create lock file to indicate that customizations are set up
+	return exec.Command("ssh", projectHostname, "touch", fmt.Sprintf("$HOME/.daytona-customizations-lock-%s", string(tool))).Run()
+}
+
+func setIdeSettings(projectHostname string, customizations *devcontainer.Customizations, settingsPath string) error {
+	if customizations == nil {
+		return nil
+	}
+
+	content, err := exec.Command("ssh", projectHostname, "cat", settingsPath).Output()
+	if err != nil {
+		content = []byte("{}")
+	}
+
+	settings := map[string]interface{}{}
+	err = json.Unmarshal(content, &settings)
+
+	if err != nil {
+		return err
+	}
+
+	if customizations.Settings != nil {
+		for key, value := range customizations.Settings {
+			if _, ok := settings[key]; !ok {
+				settings[key] = value
+			}
+		}
+	}
+
+	fmt.Println("Setting up IDE settings...")
+
+	settingsJson, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return exec.Command("ssh", projectHostname, "echo", fmt.Sprintf(`'%s'`, string(settingsJson)), ">", settingsPath).Run()
 }
 
 func checkAndAlertVSCodeInstalled() {

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -116,7 +116,13 @@ func setupIdeCustomizations(projectHostname string, projectProviderMetadata stri
 	}
 
 	// Create lock file to indicate that customizations are set up
-	return exec.Command("ssh", projectHostname, "touch", fmt.Sprintf("$HOME/.daytona-customizations-lock-%s", string(tool))).Run()
+	err = exec.Command("ssh", projectHostname, "touch", fmt.Sprintf("$HOME/.daytona-customizations-lock-%s", string(tool))).Run()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("IDE customizations set up successfully")
+	return nil
 }
 
 func setIdeSettings(projectHostname string, customizations *devcontainer.Customizations, settingsPath string) error {
@@ -151,7 +157,13 @@ func setIdeSettings(projectHostname string, customizations *devcontainer.Customi
 		return err
 	}
 
-	return exec.Command("ssh", projectHostname, "echo", fmt.Sprintf(`'%s'`, string(settingsJson)), ">", settingsPath).Run()
+	err = exec.Command("ssh", projectHostname, "echo", fmt.Sprintf(`'%s'`, string(settingsJson)), ">", settingsPath).Run()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("IDE settings set up successfully")
+	return nil
 }
 
 func checkAndAlertVSCodeInstalled() {


### PR DESCRIPTION
# Apply Devcontainer Customizations to relevant IDEs

## Description

With this PR, devcontainer vscode cusomizations (settings and extensions) are applied to relevant IDEs.

When the user uses VS Code Desktop, only `customizations["vscode"]` are used.
When the user uses VS Code Browser, `customizations["vscode", "browser", "codespaces"]` are used.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #712 