### PR TITLE
fix: wrong regex rules for repo names

### DIFF
--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -20,10 +20,10 @@ import (
 
 func isValidWorkspaceName(name string) bool {
 	// The repository name can only contain ASCII letters, digits, and the characters ., -, and _.
-	var validRepoName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	var validName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 	// Check if the name matches the basic regex
-	if !validRepoName.MatchString(name) {
+	if !validName.MatchString(name) {
 		return false
 	}
 

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -18,7 +18,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/workspace"
 )
 
-func isValidRepoName(name string) bool {
+func isValidWorkspaceName(name string) bool {
 	// The repository name can only contain ASCII letters, digits, and the characters ., -, and _.
 	var validRepoName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
@@ -42,7 +42,7 @@ func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*wor
 	}
 
 	// Repo name is taken as the name for workspace by default
-	if !isValidRepoName(req.Name) {
+	if !isValidWorkspaceName(req.Name) {
 		return nil, ErrInvalidWorkspaceName
 	}
 

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -18,14 +18,31 @@ import (
 	"github.com/daytonaio/daytona/pkg/workspace"
 )
 
+func isValidRepoName(name string) bool {
+	// The repository name can only contain ASCII letters, digits, and the characters ., -, and _.
+	var validRepoName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+	// Check if the name matches the basic regex
+	if !validRepoName.MatchString(name) {
+		return false
+	}
+
+	// Names starting with a period must have atleast one char appended to it.
+	if name == "." || name == "" {
+		return false
+	}
+
+	return true
+}
+
 func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*workspace.Workspace, error) {
 	_, err := s.workspaceStore.Find(req.Name)
 	if err == nil {
 		return nil, ErrWorkspaceAlreadyExists
 	}
 
-	isAlphaNumeric := regexp.MustCompile(`^[a-zA-Z0-9-]+$`).MatchString
-	if !isAlphaNumeric(req.Name) {
+	// Repo name is taken as the name for workspace by default
+	if !isValidRepoName(req.Name) {
 		return nil, ErrInvalidWorkspaceName
 	}
 

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/gitprovider"
@@ -102,6 +103,12 @@ func GetProjectEnvVars(project *Project, apiUrl, serverUrl string) map[string]st
 }
 
 func GetProjectHostname(workspaceId string, projectName string) string {
+	// Replace special chars with hyphen to form valid hostname
+	// String resulting in consecutive hyphens is also valid
+	projectName = strings.ReplaceAll(projectName, "_", "-")
+	projectName = strings.ReplaceAll(projectName, "*", "-")
+	projectName = strings.ReplaceAll(projectName, ".", "-")
+
 	hostname := fmt.Sprintf("%s-%s", workspaceId, projectName)
 
 	if len(hostname) > 63 {


### PR DESCRIPTION
# Wrong regex rules for repo names

## Description

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #767 
/claim #767 