### PR TITLE
Enhancement: add pagination for all GET apis' of git providers (#761)

### DIFF
--- a/internal/testing/gitprovider/mocks/git_provider.go
+++ b/internal/testing/gitprovider/mocks/git_provider.go
@@ -21,13 +21,13 @@ func (m *MockGitProvider) CanHandle(repoUrl string) (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockGitProvider) GetNamespaces() ([]*gitprovider.GitNamespace, error) {
-	args := m.Called()
+func (m *MockGitProvider) GetNamespaces(options gitprovider.ListOptions) ([]*gitprovider.GitNamespace, error) {
+	args := m.Called(options)
 	return args.Get(0).([]*gitprovider.GitNamespace), args.Error(1)
 }
 
-func (m *MockGitProvider) GetRepositories(namespace string) ([]*gitprovider.GitRepository, error) {
-	args := m.Called(namespace)
+func (m *MockGitProvider) GetRepositories(namespace string, options gitprovider.ListOptions) ([]*gitprovider.GitRepository, error) {
+	args := m.Called(namespace, options)
 	return args.Get(0).([]*gitprovider.GitRepository), args.Error(1)
 }
 
@@ -41,13 +41,13 @@ func (m *MockGitProvider) GetBranchByCommit(staticContext *gitprovider.StaticGit
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*gitprovider.GitBranch, error) {
-	args := m.Called(repositoryId, namespaceId)
+func (m *MockGitProvider) GetRepoBranches(repositoryId string, namespaceId string, options gitprovider.ListOptions) ([]*gitprovider.GitBranch, error) {
+	args := m.Called(repositoryId, namespaceId, options)
 	return args.Get(0).([]*gitprovider.GitBranch), args.Error(1)
 }
 
-func (m *MockGitProvider) GetRepoPRs(repositoryId string, namespaceId string) ([]*gitprovider.GitPullRequest, error) {
-	args := m.Called(repositoryId, namespaceId)
+func (m *MockGitProvider) GetRepoPRs(repositoryId string, namespaceId string, options gitprovider.ListOptions) ([]*gitprovider.GitPullRequest, error) {
+	args := m.Called(repositoryId, namespaceId, options)
 	return args.Get(0).([]*gitprovider.GitPullRequest), args.Error(1)
 }
 

--- a/internal/testing/server/workspaces/mocks/git_provider_service.go
+++ b/internal/testing/server/workspaces/mocks/git_provider_service.go
@@ -50,22 +50,22 @@ func (m *MockGitProviderService) GetGitUser(gitProviderId string) (*gitprovider.
 	return args.Get(0).(*gitprovider.GitUser), args.Error(1)
 }
 
-func (m *MockGitProviderService) GetNamespaces(gitProviderId string) ([]*gitprovider.GitNamespace, error) {
+func (m *MockGitProviderService) GetNamespaces(gitProviderId string, options gitprovider.ListOptions) ([]*gitprovider.GitNamespace, error) {
 	args := m.Called(gitProviderId)
 	return args.Get(0).([]*gitprovider.GitNamespace), args.Error(1)
 }
 
-func (m *MockGitProviderService) GetRepoBranches(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitBranch, error) {
+func (m *MockGitProviderService) GetRepoBranches(gitProviderId string, namespaceId string, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitBranch, error) {
 	args := m.Called(gitProviderId, namespaceId, repositoryId)
 	return args.Get(0).([]*gitprovider.GitBranch), args.Error(1)
 }
 
-func (m *MockGitProviderService) GetRepoPRs(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitPullRequest, error) {
+func (m *MockGitProviderService) GetRepoPRs(gitProviderId string, namespaceId string, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitPullRequest, error) {
 	args := m.Called(gitProviderId, namespaceId, repositoryId)
 	return args.Get(0).([]*gitprovider.GitPullRequest), args.Error(1)
 }
 
-func (m *MockGitProviderService) GetRepositories(gitProviderId string, namespaceId string, page, perPage int) ([]*gitprovider.GitRepository, error) {
+func (m *MockGitProviderService) GetRepositories(gitProviderId string, namespaceId string, options gitprovider.ListOptions) ([]*gitprovider.GitRepository, error) {
 	args := m.Called(gitProviderId, namespaceId)
 	return args.Get(0).([]*gitprovider.GitRepository), args.Error(1)
 }

--- a/internal/testing/server/workspaces/mocks/git_provider_service.go
+++ b/internal/testing/server/workspaces/mocks/git_provider_service.go
@@ -65,7 +65,7 @@ func (m *MockGitProviderService) GetRepoPRs(gitProviderId string, namespaceId st
 	return args.Get(0).([]*gitprovider.GitPullRequest), args.Error(1)
 }
 
-func (m *MockGitProviderService) GetRepositories(gitProviderId string, namespaceId string) ([]*gitprovider.GitRepository, error) {
+func (m *MockGitProviderService) GetRepositories(gitProviderId string, namespaceId string, page, perPage int) ([]*gitprovider.GitRepository, error) {
 	args := m.Called(gitProviderId, namespaceId)
 	return args.Get(0).([]*gitprovider.GitRepository), args.Error(1)
 }

--- a/internal/testing/server/workspaces/mocks/git_provider_service.go
+++ b/internal/testing/server/workspaces/mocks/git_provider_service.go
@@ -51,22 +51,22 @@ func (m *MockGitProviderService) GetGitUser(gitProviderId string) (*gitprovider.
 }
 
 func (m *MockGitProviderService) GetNamespaces(gitProviderId string, options gitprovider.ListOptions) ([]*gitprovider.GitNamespace, error) {
-	args := m.Called(gitProviderId)
+	args := m.Called(gitProviderId, options)
 	return args.Get(0).([]*gitprovider.GitNamespace), args.Error(1)
 }
 
 func (m *MockGitProviderService) GetRepoBranches(gitProviderId string, namespaceId string, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitBranch, error) {
-	args := m.Called(gitProviderId, namespaceId, repositoryId)
+	args := m.Called(gitProviderId, namespaceId, repositoryId, options)
 	return args.Get(0).([]*gitprovider.GitBranch), args.Error(1)
 }
 
 func (m *MockGitProviderService) GetRepoPRs(gitProviderId string, namespaceId string, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitPullRequest, error) {
-	args := m.Called(gitProviderId, namespaceId, repositoryId)
+	args := m.Called(gitProviderId, namespaceId, repositoryId, options)
 	return args.Get(0).([]*gitprovider.GitPullRequest), args.Error(1)
 }
 
 func (m *MockGitProviderService) GetRepositories(gitProviderId string, namespaceId string, options gitprovider.ListOptions) ([]*gitprovider.GitRepository, error) {
-	args := m.Called(gitProviderId, namespaceId)
+	args := m.Called(gitProviderId, namespaceId, options)
 	return args.Get(0).([]*gitprovider.GitRepository), args.Error(1)
 }
 

--- a/pkg/api/controllers/gitprovider/branches.go
+++ b/pkg/api/controllers/gitprovider/branches.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/daytonaio/daytona/pkg/api/controllers"
-	_ "github.com/daytonaio/daytona/pkg/gitprovider"
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -32,6 +33,8 @@ func GetRepoBranches(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
 	namespaceArg := ctx.Param("namespaceId")
 	repositoryArg := ctx.Param("repositoryId")
+	pageQuery := ctx.Query("page")
+	perPageQuery := ctx.Query("per_page")
 
 	namespaceId, err := url.QueryUnescape(namespaceArg)
 	if err != nil {
@@ -45,9 +48,33 @@ func GetRepoBranches(ctx *gin.Context) {
 		return
 	}
 
+	page := 1
+	perPage := 100
+
+	if pageQuery != "" {
+		page, err = strconv.Atoi(pageQuery)
+		if err != nil {
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'page' query param"))
+			return
+		}
+	}
+
+	if perPageQuery != "" {
+		perPage, err = strconv.Atoi(perPageQuery)
+		if err != nil {
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'per_page' query param"))
+			return
+		}
+	}
+
+	options := gitprovider.ListOptions{
+		Page:    page,
+		PerPage: perPage,
+	}
+
 	server := server.GetInstance(nil)
 
-	response, err := server.GitProviderService.GetRepoBranches(gitProviderId, namespaceId, repositoryId)
+	response, err := server.GitProviderService.GetRepoBranches(gitProviderId, namespaceId, repositoryId, options)
 	if err != nil {
 		statusCode, message, codeErr := controllers.GetHTTPStatusCodeAndMessageFromError(err)
 		if codeErr != nil {

--- a/pkg/api/controllers/gitprovider/branches.go
+++ b/pkg/api/controllers/gitprovider/branches.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/daytonaio/daytona/pkg/api/controllers"
-	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -35,8 +33,11 @@ func GetRepoBranches(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
 	namespaceArg := ctx.Param("namespaceId")
 	repositoryArg := ctx.Param("repositoryId")
-	pageQuery := ctx.Query("page")
-	perPageQuery := ctx.Query("per_page")
+	options, err := getListOptions(ctx)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
 
 	namespaceId, err := url.QueryUnescape(namespaceArg)
 	if err != nil {
@@ -48,30 +49,6 @@ func GetRepoBranches(ctx *gin.Context) {
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to parse repository: %w", err))
 		return
-	}
-
-	page := 1
-	perPage := 100
-
-	if pageQuery != "" {
-		page, err = strconv.Atoi(pageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'page' query param"))
-			return
-		}
-	}
-
-	if perPageQuery != "" {
-		perPage, err = strconv.Atoi(perPageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'per_page' query param"))
-			return
-		}
-	}
-
-	options := gitprovider.ListOptions{
-		Page:    page,
-		PerPage: perPage,
 	}
 
 	server := server.GetInstance(nil)

--- a/pkg/api/controllers/gitprovider/branches.go
+++ b/pkg/api/controllers/gitprovider/branches.go
@@ -24,6 +24,8 @@ import (
 //	@Param			gitProviderId	path	string	true	"Git provider"
 //	@Param			namespaceId		path	string	true	"Namespace"
 //	@Param			repositoryId	path	string	true	"Repository"
+//	@Param			page			query	int		false	"Page number"
+//	@Param			per_page		query	int		false	"Number of items per page"
 //	@Produce		json
 //	@Success		200	{array}	GitBranch
 //	@Router			/gitprovider/{gitProviderId}/{namespaceId}/{repositoryId}/branches [get]

--- a/pkg/api/controllers/gitprovider/gitprovider.go
+++ b/pkg/api/controllers/gitprovider/gitprovider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"net/url"
 
@@ -188,4 +189,33 @@ func RemoveGitProvider(ctx *gin.Context) {
 	}
 
 	ctx.JSON(200, nil)
+}
+
+// extract pagination related query params
+func getListOptions(ctx *gin.Context) (gitprovider.ListOptions, error) {
+	pageQuery := ctx.Query("page")
+	perPageQuery := ctx.Query("per_page")
+
+	page := 1
+	perPage := 100
+	var err error
+
+	if pageQuery != "" {
+		page, err = strconv.Atoi(pageQuery)
+		if err != nil {
+			return gitprovider.ListOptions{}, errors.New("invalid value for 'page' query param")
+		}
+	}
+
+	if perPageQuery != "" {
+		perPage, err = strconv.Atoi(perPageQuery)
+		if err != nil {
+			return gitprovider.ListOptions{}, errors.New("invalid value for 'per_page' query param")
+		}
+	}
+
+	return gitprovider.ListOptions{
+		Page:    page,
+		PerPage: perPage,
+	}, nil
 }

--- a/pkg/api/controllers/gitprovider/namespaces.go
+++ b/pkg/api/controllers/gitprovider/namespaces.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 
 	"net/http"
-	"strconv"
 
 	"github.com/daytonaio/daytona/pkg/api/controllers"
 
-	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -31,35 +29,13 @@ import (
 //	@id				GetNamespaces
 func GetNamespaces(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
-	pageQuery := ctx.Query("page")
-	perPageQuery := ctx.Query("per_page")
-
-	var err error
-	page := 1
-	perPage := 100
-
-	if pageQuery != "" {
-		page, err = strconv.Atoi(pageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'page' query param"))
-			return
-		}
-	}
-
-	if perPageQuery != "" {
-		perPage, err = strconv.Atoi(perPageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'per_page' query param"))
-			return
-		}
+	options, err := getListOptions(ctx)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, err)
+		return
 	}
 
 	server := server.GetInstance(nil)
-
-	options := gitprovider.ListOptions{
-		Page:    page,
-		PerPage: perPage,
-	}
 
 	response, err := server.GitProviderService.GetNamespaces(gitProviderId, options)
 	if err != nil {

--- a/pkg/api/controllers/gitprovider/namespaces.go
+++ b/pkg/api/controllers/gitprovider/namespaces.go
@@ -6,7 +6,12 @@ package gitprovider
 import (
 	"errors"
 
+	"net/http"
+	"strconv"
+
 	"github.com/daytonaio/daytona/pkg/api/controllers"
+
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -24,10 +29,37 @@ import (
 //	@id				GetNamespaces
 func GetNamespaces(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
+	pageQuery := ctx.Query("page")
+	perPageQuery := ctx.Query("per_page")
+
+	var err error
+	page := 1
+	perPage := 100
+
+	if pageQuery != "" {
+		page, err = strconv.Atoi(pageQuery)
+		if err != nil {
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'page' query param"))
+			return
+		}
+	}
+
+	if perPageQuery != "" {
+		perPage, err = strconv.Atoi(perPageQuery)
+		if err != nil {
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'per_page' query param"))
+			return
+		}
+	}
 
 	server := server.GetInstance(nil)
 
-	response, err := server.GitProviderService.GetNamespaces(gitProviderId)
+	options := gitprovider.ListOptions{
+		Page:    page,
+		PerPage: perPage,
+	}
+
+	response, err := server.GitProviderService.GetNamespaces(gitProviderId, options)
 	if err != nil {
 		statusCode, message, codeErr := controllers.GetHTTPStatusCodeAndMessageFromError(err)
 		if codeErr != nil {

--- a/pkg/api/controllers/gitprovider/namespaces.go
+++ b/pkg/api/controllers/gitprovider/namespaces.go
@@ -22,6 +22,8 @@ import (
 //	@Summary		Get Git namespaces
 //	@Description	Get Git namespaces
 //	@Param			gitProviderId	path	string	true	"Git provider"
+//	@Param			page			query	int		false	"Page number"
+//	@Param			per_page		query	int		false	"Number of items per page"
 //	@Produce		json
 //	@Success		200	{array}	GitNamespace
 //	@Router			/gitprovider/{gitProviderId}/namespaces [get]

--- a/pkg/api/controllers/gitprovider/pull_requests.go
+++ b/pkg/api/controllers/gitprovider/pull_requests.go
@@ -24,6 +24,8 @@ import (
 //	@Param			gitProviderId	path	string	true	"Git provider"
 //	@Param			namespaceId		path	string	true	"Namespace"
 //	@Param			repositoryId	path	string	true	"Repository"
+//	@Param			page			query	int		false	"Page number"
+//	@Param			per_page		query	int		false	"Number of items per page"
 //	@Produce		json
 //	@Success		200	{array}	GitPullRequest
 //	@Router			/gitprovider/{gitProviderId}/{namespaceId}/{repositoryId}/pull-requests [get]

--- a/pkg/api/controllers/gitprovider/pull_requests.go
+++ b/pkg/api/controllers/gitprovider/pull_requests.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/daytonaio/daytona/pkg/api/controllers"
-	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -35,8 +33,11 @@ func GetRepoPRs(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
 	namespaceArg := ctx.Param("namespaceId")
 	repositoryArg := ctx.Param("repositoryId")
-	pageQuery := ctx.Query("page")
-	perPageQuery := ctx.Query("per_page")
+	options, err := getListOptions(ctx)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
 
 	namespaceId, err := url.QueryUnescape(namespaceArg)
 	if err != nil {
@@ -48,30 +49,6 @@ func GetRepoPRs(ctx *gin.Context) {
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to parse repository: %w", err))
 		return
-	}
-
-	page := 1
-	perPage := 100
-
-	if pageQuery != "" {
-		page, err = strconv.Atoi(pageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'page' query param"))
-			return
-		}
-	}
-
-	if perPageQuery != "" {
-		perPage, err = strconv.Atoi(perPageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'per_page' query param"))
-			return
-		}
-	}
-
-	options := gitprovider.ListOptions{
-		Page:    page,
-		PerPage: perPage,
 	}
 
 	server := server.GetInstance(nil)

--- a/pkg/api/controllers/gitprovider/repositories.go
+++ b/pkg/api/controllers/gitprovider/repositories.go
@@ -7,11 +7,8 @@ import (
 	"errors"
 	"net/http"
 
-	"strconv"
-
 	"github.com/daytonaio/daytona/pkg/api/controllers"
 
-	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -33,32 +30,10 @@ import (
 func GetRepositories(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
 	namespaceId := ctx.Param("namespaceId")
-	pageQuery := ctx.Query("page")
-	perPageQuery := ctx.Query("per_page")
-
-	var err error
-	page := 1
-	perPage := 100
-
-	if pageQuery != "" {
-		page, err = strconv.Atoi(pageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'page' query param"))
-			return
-		}
-	}
-
-	if perPageQuery != "" {
-		perPage, err = strconv.Atoi(perPageQuery)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'per_page' query param"))
-			return
-		}
-	}
-
-	options := gitprovider.ListOptions{
-		Page:    page,
-		PerPage: perPage,
+	options, err := getListOptions(ctx)
+	if err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, err)
+		return
 	}
 
 	server := server.GetInstance(nil)

--- a/pkg/api/controllers/gitprovider/repositories.go
+++ b/pkg/api/controllers/gitprovider/repositories.go
@@ -6,7 +6,10 @@ package gitprovider
 import (
 	"errors"
 
+	"strconv"
+
 	"github.com/daytonaio/daytona/pkg/api/controllers"
+
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -26,10 +29,18 @@ import (
 func GetRepositories(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
 	namespaceId := ctx.Param("namespaceId")
+	page, err := strconv.Atoi(ctx.Param("page"))
+	if err != nil {
+		page = 1
+	}
+	perPage, err := strconv.Atoi(ctx.Param("perPage"))
+	if err != nil {
+		perPage = 100
+	}
 
 	server := server.GetInstance(nil)
 
-	response, err := server.GitProviderService.GetRepositories(gitProviderId, namespaceId)
+	response, err := server.GitProviderService.GetRepositories(gitProviderId, namespaceId, page, perPage)
 	if err != nil {
 		statusCode, message, codeErr := controllers.GetHTTPStatusCodeAndMessageFromError(err)
 		if codeErr != nil {

--- a/pkg/api/controllers/gitprovider/repositories.go
+++ b/pkg/api/controllers/gitprovider/repositories.go
@@ -5,6 +5,7 @@ package gitprovider
 
 import (
 	"errors"
+	"net/http"
 
 	"strconv"
 
@@ -21,6 +22,8 @@ import (
 //	@Description	Get Git repositories
 //	@Param			gitProviderId	path	string	true	"Git provider"
 //	@Param			namespaceId		path	string	true	"Namespace"
+//	@Param			page			query	integer	false	"Page"
+//	@Param			perPage			query	integer	false	"Per page"
 //	@Produce		json
 //	@Success		200	{array}	GitRepository
 //	@Router			/gitprovider/{gitProviderId}/{namespaceId}/repositories [get]
@@ -29,13 +32,27 @@ import (
 func GetRepositories(ctx *gin.Context) {
 	gitProviderId := ctx.Param("gitProviderId")
 	namespaceId := ctx.Param("namespaceId")
-	page, err := strconv.Atoi(ctx.Param("page"))
-	if err != nil {
-		page = 1
+	pageQuery := ctx.Query("page")
+	perPageQuery := ctx.Query("per_page")
+
+	var err error
+	page := 1
+	perPage := 100
+
+	if pageQuery != "" {
+		page, err = strconv.Atoi(pageQuery)
+		if err != nil {
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for page flag"))
+			return
+		}
 	}
-	perPage, err := strconv.Atoi(ctx.Param("perPage"))
-	if err != nil {
-		perPage = 100
+
+	if perPageQuery != "" {
+		perPage, err = strconv.Atoi(perPageQuery)
+		if err != nil {
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for per_page flag"))
+			return
+		}
 	}
 
 	server := server.GetInstance(nil)

--- a/pkg/api/controllers/gitprovider/repositories.go
+++ b/pkg/api/controllers/gitprovider/repositories.go
@@ -23,8 +23,8 @@ import (
 //	@Description	Get Git repositories
 //	@Param			gitProviderId	path	string	true	"Git provider"
 //	@Param			namespaceId		path	string	true	"Namespace"
-//	@Param			page			query	integer	false	"Page"
-//	@Param			perPage			query	integer	false	"Per page"
+//	@Param			page			query	int		false	"Page number"
+//	@Param			per_page		query	int		false	"Number of items per page"
 //	@Produce		json
 //	@Success		200	{array}	GitRepository
 //	@Router			/gitprovider/{gitProviderId}/{namespaceId}/repositories [get]

--- a/pkg/api/controllers/gitprovider/repositories.go
+++ b/pkg/api/controllers/gitprovider/repositories.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/daytonaio/daytona/pkg/api/controllers"
 
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -42,7 +43,7 @@ func GetRepositories(ctx *gin.Context) {
 	if pageQuery != "" {
 		page, err = strconv.Atoi(pageQuery)
 		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for page flag"))
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'page' query param"))
 			return
 		}
 	}
@@ -50,14 +51,19 @@ func GetRepositories(ctx *gin.Context) {
 	if perPageQuery != "" {
 		perPage, err = strconv.Atoi(perPageQuery)
 		if err != nil {
-			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for per_page flag"))
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for 'per_page' query param"))
 			return
 		}
 	}
 
+	options := gitprovider.ListOptions{
+		Page:    page,
+		PerPage: perPage,
+	}
+
 	server := server.GetInstance(nil)
 
-	response, err := server.GitProviderService.GetRepositories(gitProviderId, namespaceId, page, perPage)
+	response, err := server.GitProviderService.GetRepositories(gitProviderId, namespaceId, options)
 	if err != nil {
 		statusCode, message, codeErr := controllers.GetHTTPStatusCodeAndMessageFromError(err)
 		if codeErr != nil {

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -581,6 +581,18 @@ const docTemplate = `{
                         "name": "gitProviderId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -651,6 +663,18 @@ const docTemplate = `{
                         "name": "namespaceId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -698,6 +722,18 @@ const docTemplate = `{
                         "name": "repositoryId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -745,6 +781,18 @@ const docTemplate = `{
                         "name": "repositoryId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -578,6 +578,18 @@
                         "name": "gitProviderId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -707,6 +719,18 @@
                         "name": "repositoryId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -754,6 +778,18 @@
                         "name": "repositoryId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -648,6 +648,20 @@
                         "name": "namespaceId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query",
+                        "required": false
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items per page",
+                        "name": "per_page",
+                        "in": "query",
+                        "required": false
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -653,15 +653,13 @@
                         "type": "integer",
                         "description": "Page number",
                         "name": "page",
-                        "in": "query",
-                        "required": false
+                        "in": "query"
                     },
                     {
                         "type": "integer",
                         "description": "Number of items per page",
                         "name": "per_page",
-                        "in": "query",
-                        "required": false
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -1158,6 +1158,14 @@ paths:
         name: repositoryId
         required: true
         type: string
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Number of items per page
+        in: query
+        name: per_page
+        type: integer
       produces:
       - application/json
       responses:
@@ -1190,6 +1198,14 @@ paths:
         name: repositoryId
         required: true
         type: string
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Number of items per page
+        in: query
+        name: per_page
+        type: integer
       produces:
       - application/json
       responses:
@@ -1220,13 +1236,11 @@ paths:
       - description: Page number
         in: query
         name: page
-        schema:
-          type: integer
+        type: integer
       - description: Number of items per page
         in: query
         name: per_page
-        schema:
-          type: integer
+        type: integer
       produces:
       - application/json
       responses:
@@ -1249,6 +1263,14 @@ paths:
         name: gitProviderId
         required: true
         type: string
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Number of items per page
+        in: query
+        name: per_page
+        type: integer
       produces:
       - application/json
       responses:

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -1217,6 +1217,18 @@ paths:
         name: namespaceId
         required: true
         type: string
+      - description: Page
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+      - description: Per page
+        in: query
+        name: perPage
+        required: false
+        schema:
+          type: integer
       produces:
       - application/json
       responses:

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -1220,13 +1220,11 @@ paths:
       - description: Page number
         in: query
         name: page
-        required: false
         schema:
           type: integer
       - description: Number of items per page
         in: query
         name: per_page
-        required: false
         schema:
           type: integer
       produces:

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -1217,15 +1217,15 @@ paths:
         name: namespaceId
         required: true
         type: string
-      - description: Page
+      - description: Page number
         in: query
         name: page
         required: false
         schema:
           type: integer
-      - description: Per page
+      - description: Number of items per page
         in: query
-        name: perPage
+        name: per_page
         required: false
         schema:
           type: integer

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -461,17 +461,17 @@ paths:
         schema:
           type: string
       - description: Page
-        in: path
+        in: query
         name: page
-        required: true
+        required: false
         schema:
-          type: string
+          type: integer
       - description: Per page
-        in: path
+        in: query
         name: perPage
-        required: true
+        required: false
         schema:
-          type: string
+          type: integer
       responses:
         "200":
           content:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -410,6 +410,16 @@ paths:
         required: true
         schema:
           type: string
+      - description: Page number
+        in: query
+        name: page
+        schema:
+          type: integer
+      - description: Number of items per page
+        in: query
+        name: per_page
+        schema:
+          type: integer
       responses:
         "200":
           content:
@@ -505,6 +515,16 @@ paths:
         required: true
         schema:
           type: string
+      - description: Page number
+        in: query
+        name: page
+        schema:
+          type: integer
+      - description: Number of items per page
+        in: query
+        name: per_page
+        schema:
+          type: integer
       responses:
         "200":
           content:
@@ -540,6 +560,16 @@ paths:
         required: true
         schema:
           type: string
+      - description: Page number
+        in: query
+        name: page
+        schema:
+          type: integer
+      - description: Number of items per page
+        in: query
+        name: per_page
+        schema:
+          type: integer
       responses:
         "200":
           content:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -463,13 +463,11 @@ paths:
       - description: Page number
         in: query
         name: page
-        required: false
         schema:
           type: integer
       - description: Number of items per page
         in: query
         name: per_page
-        required: false
         schema:
           type: integer
       responses:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -460,15 +460,15 @@ paths:
         required: true
         schema:
           type: string
-      - description: Page
+      - description: Page number
         in: query
         name: page
         required: false
         schema:
           type: integer
-      - description: Per page
+      - description: Number of items per page
         in: query
-        name: perPage
+        name: per_page
         required: false
         schema:
           type: integer

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -460,6 +460,18 @@ paths:
         required: true
         schema:
           type: string
+      - description: Page
+        in: path
+        name: page
+        required: true
+        schema:
+          type: string
+      - description: Per page
+        in: path
+        name: perPage
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:

--- a/pkg/apiclient/api_git_provider.go
+++ b/pkg/apiclient/api_git_provider.go
@@ -877,6 +877,8 @@ type ApiGetRepositoriesRequest struct {
 	ApiService    *GitProviderAPIService
 	gitProviderId string
 	namespaceId   string
+	page          *int
+	perPage       *int
 }
 
 func (r ApiGetRepositoriesRequest) Execute() ([]GitRepository, *http.Response, error) {
@@ -893,12 +895,14 @@ Get Git repositories
 	@param namespaceId Namespace
 	@return ApiGetRepositoriesRequest
 */
-func (a *GitProviderAPIService) GetRepositories(ctx context.Context, gitProviderId string, namespaceId string) ApiGetRepositoriesRequest {
+func (a *GitProviderAPIService) GetRepositories(ctx context.Context, gitProviderId string, namespaceId string, page, perPage int) ApiGetRepositoriesRequest {
 	return ApiGetRepositoriesRequest{
 		ApiService:    a,
 		ctx:           ctx,
 		gitProviderId: gitProviderId,
 		namespaceId:   namespaceId,
+		page:          &page,
+		perPage:       &perPage,
 	}
 }
 

--- a/pkg/apiclient/api_git_provider.go
+++ b/pkg/apiclient/api_git_provider.go
@@ -503,10 +503,34 @@ func (a *GitProviderAPIService) GetGitUserExecute(r ApiGetGitUserRequest) (*GitU
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type ListOptions struct {
+	page    *int
+	perPage *int
+}
+
+func (l *ListOptions) SetPage(page int) {
+	l.page = &page
+}
+
+func (l *ListOptions) SetPerPage(perPage int) {
+	l.perPage = &perPage
+}
+
 type ApiGetNamespacesRequest struct {
 	ctx           context.Context
 	ApiService    *GitProviderAPIService
 	gitProviderId string
+	ListOptions
+}
+
+func (r ApiGetNamespacesRequest) Page(page int) ApiGetNamespacesRequest {
+	r.SetPage(page)
+	return r
+}
+
+func (r ApiGetNamespacesRequest) PerPage(perPage int) ApiGetNamespacesRequest {
+	r.SetPerPage(perPage)
+	return r
 }
 
 func (r ApiGetNamespacesRequest) Execute() ([]GitNamespace, *http.Response, error) {
@@ -552,6 +576,13 @@ func (a *GitProviderAPIService) GetNamespacesExecute(r ApiGetNamespacesRequest) 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+
+	if r.page != nil {
+		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+	}
+	if r.perPage != nil {
+		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -627,6 +658,17 @@ type ApiGetRepoBranchesRequest struct {
 	gitProviderId string
 	namespaceId   string
 	repositoryId  string
+	ListOptions
+}
+
+func (r ApiGetRepoBranchesRequest) Page(page int) ApiGetRepoBranchesRequest {
+	r.SetPage(page)
+	return r
+}
+
+func (r ApiGetRepoBranchesRequest) PerPage(perPage int) ApiGetRepoBranchesRequest {
+	r.SetPerPage(perPage)
+	return r
 }
 
 func (r ApiGetRepoBranchesRequest) Execute() ([]GitBranch, *http.Response, error) {
@@ -678,6 +720,13 @@ func (a *GitProviderAPIService) GetRepoBranchesExecute(r ApiGetRepoBranchesReque
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+
+	if r.page != nil {
+		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+	}
+	if r.perPage != nil {
+		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -753,6 +802,17 @@ type ApiGetRepoPRsRequest struct {
 	gitProviderId string
 	namespaceId   string
 	repositoryId  string
+	ListOptions
+}
+
+func (r ApiGetRepoPRsRequest) Page(page int) ApiGetRepoPRsRequest {
+	r.SetPage(page)
+	return r
+}
+
+func (r ApiGetRepoPRsRequest) PerPage(perPage int) ApiGetRepoPRsRequest {
+	r.SetPerPage(perPage)
+	return r
 }
 
 func (r ApiGetRepoPRsRequest) Execute() ([]GitPullRequest, *http.Response, error) {
@@ -804,6 +864,13 @@ func (a *GitProviderAPIService) GetRepoPRsExecute(r ApiGetRepoPRsRequest) ([]Git
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+
+	if r.page != nil {
+		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+	}
+	if r.perPage != nil {
+		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -878,17 +945,16 @@ type ApiGetRepositoriesRequest struct {
 	ApiService    *GitProviderAPIService
 	gitProviderId string
 	namespaceId   string
-	page          *int
-	perPage       *int
+	ListOptions
 }
 
 func (r ApiGetRepositoriesRequest) Page(page int) ApiGetRepositoriesRequest {
-	r.page = &page
+	r.SetPage(page)
 	return r
 }
 
 func (r ApiGetRepositoriesRequest) PerPage(perPage int) ApiGetRepositoriesRequest {
-	r.perPage = &perPage
+	r.SetPerPage(perPage)
 	return r
 }
 

--- a/pkg/apiclient/api_git_provider.go
+++ b/pkg/apiclient/api_git_provider.go
@@ -19,12 +19,11 @@ import (
 	"strings"
 )
 
-
 // GitProviderAPIService GitProviderAPI service
 type GitProviderAPIService service
 
 type ApiGetGitContextRequest struct {
-	ctx context.Context
+	ctx        context.Context
 	ApiService *GitProviderAPIService
 	repository *GetRepositoryContext
 }
@@ -55,7 +54,8 @@ func (a *GitProviderAPIService) GetGitContext(ctx context.Context) ApiGetGitCont
 }
 
 // Execute executes the request
-//  @return GitRepository
+//
+//	@return GitRepository
 func (a *GitProviderAPIService) GetGitContextExecute(r ApiGetGitContextRequest) (*GitRepository, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -149,9 +149,9 @@ func (a *GitProviderAPIService) GetGitContextExecute(r ApiGetGitContextRequest) 
 }
 
 type ApiGetGitProviderForUrlRequest struct {
-	ctx context.Context
+	ctx        context.Context
 	ApiService *GitProviderAPIService
-	url string
+	url        string
 }
 
 func (r ApiGetGitProviderForUrlRequest) Execute() (*GitProvider, *http.Response, error) {
@@ -163,26 +163,27 @@ GetGitProviderForUrl Get Git provider
 
 Get Git provider
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param url Url
- @return ApiGetGitProviderForUrlRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param url Url
+	@return ApiGetGitProviderForUrlRequest
 */
 func (a *GitProviderAPIService) GetGitProviderForUrl(ctx context.Context, url string) ApiGetGitProviderForUrlRequest {
 	return ApiGetGitProviderForUrlRequest{
 		ApiService: a,
-		ctx: ctx,
-		url: url,
+		ctx:        ctx,
+		url:        url,
 	}
 }
 
 // Execute executes the request
-//  @return GitProvider
+//
+//	@return GitProvider
 func (a *GitProviderAPIService) GetGitProviderForUrlExecute(r ApiGetGitProviderForUrlRequest) (*GitProvider, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *GitProvider
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *GitProvider
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetGitProviderForUrl")
@@ -384,8 +385,8 @@ func (a *GitProviderAPIService) GetGitProviderIdForUrlExecute(r ApiGetGitProvide
 }
 
 type ApiGetGitUserRequest struct {
-	ctx context.Context
-	ApiService *GitProviderAPIService
+	ctx           context.Context
+	ApiService    *GitProviderAPIService
 	gitProviderId string
 }
 
@@ -398,26 +399,27 @@ GetGitUser Get Git context
 
 Get Git context
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param gitProviderId Git Provider Id
- @return ApiGetGitUserRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param gitProviderId Git Provider Id
+	@return ApiGetGitUserRequest
 */
 func (a *GitProviderAPIService) GetGitUser(ctx context.Context, gitProviderId string) ApiGetGitUserRequest {
 	return ApiGetGitUserRequest{
-		ApiService: a,
-		ctx: ctx,
+		ApiService:    a,
+		ctx:           ctx,
 		gitProviderId: gitProviderId,
 	}
 }
 
 // Execute executes the request
-//  @return GitUser
+//
+//	@return GitUser
 func (a *GitProviderAPIService) GetGitUserExecute(r ApiGetGitUserRequest) (*GitUser, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  *GitUser
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *GitUser
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetGitUser")
@@ -501,11 +503,11 @@ func (a *GitProviderAPIService) GetGitUserExecute(r ApiGetGitUserRequest) (*GitU
 }
 
 type ApiGetNamespacesRequest struct {
-	ctx context.Context
-	ApiService *GitProviderAPIService
+	ctx           context.Context
+	ApiService    *GitProviderAPIService
 	gitProviderId string
-	page *int32
-	perPage *int32
+	page          *int32
+	perPage       *int32
 }
 
 // Page number
@@ -529,26 +531,27 @@ GetNamespaces Get Git namespaces
 
 Get Git namespaces
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param gitProviderId Git provider
- @return ApiGetNamespacesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param gitProviderId Git provider
+	@return ApiGetNamespacesRequest
 */
 func (a *GitProviderAPIService) GetNamespaces(ctx context.Context, gitProviderId string) ApiGetNamespacesRequest {
 	return ApiGetNamespacesRequest{
-		ApiService: a,
-		ctx: ctx,
+		ApiService:    a,
+		ctx:           ctx,
 		gitProviderId: gitProviderId,
 	}
 }
 
 // Execute executes the request
-//  @return []GitNamespace
+//
+//	@return []GitNamespace
 func (a *GitProviderAPIService) GetNamespacesExecute(r ApiGetNamespacesRequest) ([]GitNamespace, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  []GitNamespace
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue []GitNamespace
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetNamespaces")
@@ -638,13 +641,13 @@ func (a *GitProviderAPIService) GetNamespacesExecute(r ApiGetNamespacesRequest) 
 }
 
 type ApiGetRepoBranchesRequest struct {
-	ctx context.Context
-	ApiService *GitProviderAPIService
+	ctx           context.Context
+	ApiService    *GitProviderAPIService
 	gitProviderId string
-	namespaceId string
-	repositoryId string
-	page *int32
-	perPage *int32
+	namespaceId   string
+	repositoryId  string
+	page          *int32
+	perPage       *int32
 }
 
 // Page number
@@ -668,30 +671,31 @@ GetRepoBranches Get Git repository branches
 
 Get Git repository branches
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param gitProviderId Git provider
- @param namespaceId Namespace
- @param repositoryId Repository
- @return ApiGetRepoBranchesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param gitProviderId Git provider
+	@param namespaceId Namespace
+	@param repositoryId Repository
+	@return ApiGetRepoBranchesRequest
 */
 func (a *GitProviderAPIService) GetRepoBranches(ctx context.Context, gitProviderId string, namespaceId string, repositoryId string) ApiGetRepoBranchesRequest {
 	return ApiGetRepoBranchesRequest{
-		ApiService: a,
-		ctx: ctx,
+		ApiService:    a,
+		ctx:           ctx,
 		gitProviderId: gitProviderId,
-		namespaceId: namespaceId,
-		repositoryId: repositoryId,
+		namespaceId:   namespaceId,
+		repositoryId:  repositoryId,
 	}
 }
 
 // Execute executes the request
-//  @return []GitBranch
+//
+//	@return []GitBranch
 func (a *GitProviderAPIService) GetRepoBranchesExecute(r ApiGetRepoBranchesRequest) ([]GitBranch, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  []GitBranch
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue []GitBranch
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetRepoBranches")
@@ -783,13 +787,13 @@ func (a *GitProviderAPIService) GetRepoBranchesExecute(r ApiGetRepoBranchesReque
 }
 
 type ApiGetRepoPRsRequest struct {
-	ctx context.Context
-	ApiService *GitProviderAPIService
+	ctx           context.Context
+	ApiService    *GitProviderAPIService
 	gitProviderId string
-	namespaceId string
-	repositoryId string
-	page *int32
-	perPage *int32
+	namespaceId   string
+	repositoryId  string
+	page          *int32
+	perPage       *int32
 }
 
 // Page number
@@ -813,30 +817,31 @@ GetRepoPRs Get Git repository PRs
 
 Get Git repository PRs
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param gitProviderId Git provider
- @param namespaceId Namespace
- @param repositoryId Repository
- @return ApiGetRepoPRsRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param gitProviderId Git provider
+	@param namespaceId Namespace
+	@param repositoryId Repository
+	@return ApiGetRepoPRsRequest
 */
 func (a *GitProviderAPIService) GetRepoPRs(ctx context.Context, gitProviderId string, namespaceId string, repositoryId string) ApiGetRepoPRsRequest {
 	return ApiGetRepoPRsRequest{
-		ApiService: a,
-		ctx: ctx,
+		ApiService:    a,
+		ctx:           ctx,
 		gitProviderId: gitProviderId,
-		namespaceId: namespaceId,
-		repositoryId: repositoryId,
+		namespaceId:   namespaceId,
+		repositoryId:  repositoryId,
 	}
 }
 
 // Execute executes the request
-//  @return []GitPullRequest
+//
+//	@return []GitPullRequest
 func (a *GitProviderAPIService) GetRepoPRsExecute(r ApiGetRepoPRsRequest) ([]GitPullRequest, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  []GitPullRequest
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue []GitPullRequest
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetRepoPRs")
@@ -928,12 +933,12 @@ func (a *GitProviderAPIService) GetRepoPRsExecute(r ApiGetRepoPRsRequest) ([]Git
 }
 
 type ApiGetRepositoriesRequest struct {
-	ctx context.Context
-	ApiService *GitProviderAPIService
+	ctx           context.Context
+	ApiService    *GitProviderAPIService
 	gitProviderId string
-	namespaceId string
-	page *int32
-	perPage *int32
+	namespaceId   string
+	page          *int32
+	perPage       *int32
 }
 
 // Page number
@@ -957,28 +962,29 @@ GetRepositories Get Git repositories
 
 Get Git repositories
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param gitProviderId Git provider
- @param namespaceId Namespace
- @return ApiGetRepositoriesRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param gitProviderId Git provider
+	@param namespaceId Namespace
+	@return ApiGetRepositoriesRequest
 */
 func (a *GitProviderAPIService) GetRepositories(ctx context.Context, gitProviderId string, namespaceId string) ApiGetRepositoriesRequest {
 	return ApiGetRepositoriesRequest{
-		ApiService: a,
-		ctx: ctx,
+		ApiService:    a,
+		ctx:           ctx,
 		gitProviderId: gitProviderId,
-		namespaceId: namespaceId,
+		namespaceId:   namespaceId,
 	}
 }
 
 // Execute executes the request
-//  @return []GitRepository
+//
+//	@return []GitRepository
 func (a *GitProviderAPIService) GetRepositoriesExecute(r ApiGetRepositoriesRequest) ([]GitRepository, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  []GitRepository
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue []GitRepository
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetRepositories")
@@ -1195,7 +1201,7 @@ func (a *GitProviderAPIService) GetUrlFromRepositoryExecute(r ApiGetUrlFromRepos
 }
 
 type ApiListGitProvidersRequest struct {
-	ctx context.Context
+	ctx        context.Context
 	ApiService *GitProviderAPIService
 }
 
@@ -1208,24 +1214,25 @@ ListGitProviders List Git providers
 
 List Git providers
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiListGitProvidersRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiListGitProvidersRequest
 */
 func (a *GitProviderAPIService) ListGitProviders(ctx context.Context) ApiListGitProvidersRequest {
 	return ApiListGitProvidersRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
-//  @return []GitProvider
+//
+//	@return []GitProvider
 func (a *GitProviderAPIService) ListGitProvidersExecute(r ApiListGitProvidersRequest) ([]GitProvider, *http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodGet
-		localVarPostBody     interface{}
-		formFiles            []formFile
-		localVarReturnValue  []GitProvider
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue []GitProvider
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.ListGitProviders")
@@ -1308,8 +1315,8 @@ func (a *GitProviderAPIService) ListGitProvidersExecute(r ApiListGitProvidersReq
 }
 
 type ApiRemoveGitProviderRequest struct {
-	ctx context.Context
-	ApiService *GitProviderAPIService
+	ctx           context.Context
+	ApiService    *GitProviderAPIService
 	gitProviderId string
 }
 
@@ -1322,14 +1329,14 @@ RemoveGitProvider Remove Git provider
 
 Remove Git provider
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param gitProviderId Git provider
- @return ApiRemoveGitProviderRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param gitProviderId Git provider
+	@return ApiRemoveGitProviderRequest
 */
 func (a *GitProviderAPIService) RemoveGitProvider(ctx context.Context, gitProviderId string) ApiRemoveGitProviderRequest {
 	return ApiRemoveGitProviderRequest{
-		ApiService: a,
-		ctx: ctx,
+		ApiService:    a,
+		ctx:           ctx,
 		gitProviderId: gitProviderId,
 	}
 }
@@ -1337,9 +1344,9 @@ func (a *GitProviderAPIService) RemoveGitProvider(ctx context.Context, gitProvid
 // Execute executes the request
 func (a *GitProviderAPIService) RemoveGitProviderExecute(r ApiRemoveGitProviderRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodDelete
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.RemoveGitProvider")
@@ -1434,22 +1441,22 @@ SetGitProvider Set Git provider
 
 Set Git provider
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiSetGitProviderRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiSetGitProviderRequest
 */
 func (a *GitProviderAPIService) SetGitProvider(ctx context.Context) ApiSetGitProviderRequest {
 	return ApiSetGitProviderRequest{
 		ApiService: a,
-		ctx: ctx,
+		ctx:        ctx,
 	}
 }
 
 // Execute executes the request
 func (a *GitProviderAPIService) SetGitProviderExecute(r ApiSetGitProviderRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod   = http.MethodPut
-		localVarPostBody     interface{}
-		formFiles            []formFile
+		localVarHTTPMethod = http.MethodPut
+		localVarPostBody   interface{}
+		formFiles          []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.SetGitProvider")

--- a/pkg/apiclient/api_git_provider.go
+++ b/pkg/apiclient/api_git_provider.go
@@ -13,6 +13,7 @@ package apiclient
 import (
 	"bytes"
 	"context"
+	"strconv"
 	"io"
 	"net/http"
 	"net/url"
@@ -881,6 +882,16 @@ type ApiGetRepositoriesRequest struct {
 	perPage       *int
 }
 
+func (r ApiGetRepositoriesRequest) Page(page int) ApiGetRepositoriesRequest {
+	r.page = &page
+	return r
+}
+
+func (r ApiGetRepositoriesRequest) PerPage(perPage int) ApiGetRepositoriesRequest {
+	r.perPage = &perPage
+	return r
+}
+
 func (r ApiGetRepositoriesRequest) Execute() ([]GitRepository, *http.Response, error) {
 	return r.ApiService.GetRepositoriesExecute(r)
 }
@@ -895,14 +906,12 @@ Get Git repositories
 	@param namespaceId Namespace
 	@return ApiGetRepositoriesRequest
 */
-func (a *GitProviderAPIService) GetRepositories(ctx context.Context, gitProviderId string, namespaceId string, page, perPage int) ApiGetRepositoriesRequest {
+func (a *GitProviderAPIService) GetRepositories(ctx context.Context, gitProviderId string, namespaceId string) ApiGetRepositoriesRequest {
 	return ApiGetRepositoriesRequest{
 		ApiService:    a,
 		ctx:           ctx,
 		gitProviderId: gitProviderId,
 		namespaceId:   namespaceId,
-		page:          &page,
-		perPage:       &perPage,
 	}
 }
 
@@ -929,6 +938,13 @@ func (a *GitProviderAPIService) GetRepositoriesExecute(r ApiGetRepositoriesReque
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+
+	if r.page != nil {
+		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+	}
+	if r.perPage != nil {
+		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/pkg/apiclient/api_git_provider.go
+++ b/pkg/apiclient/api_git_provider.go
@@ -19,11 +19,12 @@ import (
 	"strings"
 )
 
+
 // GitProviderAPIService GitProviderAPI service
 type GitProviderAPIService service
 
 type ApiGetGitContextRequest struct {
-	ctx        context.Context
+	ctx context.Context
 	ApiService *GitProviderAPIService
 	repository *GetRepositoryContext
 }
@@ -54,8 +55,7 @@ func (a *GitProviderAPIService) GetGitContext(ctx context.Context) ApiGetGitCont
 }
 
 // Execute executes the request
-//
-//	@return GitRepository
+//  @return GitRepository
 func (a *GitProviderAPIService) GetGitContextExecute(r ApiGetGitContextRequest) (*GitRepository, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -149,9 +149,9 @@ func (a *GitProviderAPIService) GetGitContextExecute(r ApiGetGitContextRequest) 
 }
 
 type ApiGetGitProviderForUrlRequest struct {
-	ctx        context.Context
+	ctx context.Context
 	ApiService *GitProviderAPIService
-	url        string
+	url string
 }
 
 func (r ApiGetGitProviderForUrlRequest) Execute() (*GitProvider, *http.Response, error) {
@@ -170,20 +170,19 @@ Get Git provider
 func (a *GitProviderAPIService) GetGitProviderForUrl(ctx context.Context, url string) ApiGetGitProviderForUrlRequest {
 	return ApiGetGitProviderForUrlRequest{
 		ApiService: a,
-		ctx:        ctx,
-		url:        url,
+		ctx: ctx,
+		url: url,
 	}
 }
 
 // Execute executes the request
-//
-//	@return GitProvider
+//  @return GitProvider
 func (a *GitProviderAPIService) GetGitProviderForUrlExecute(r ApiGetGitProviderForUrlRequest) (*GitProvider, *http.Response, error) {
 	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue *GitProvider
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *GitProvider
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetGitProviderForUrl")
@@ -385,8 +384,8 @@ func (a *GitProviderAPIService) GetGitProviderIdForUrlExecute(r ApiGetGitProvide
 }
 
 type ApiGetGitUserRequest struct {
-	ctx           context.Context
-	ApiService    *GitProviderAPIService
+	ctx context.Context
+	ApiService *GitProviderAPIService
 	gitProviderId string
 }
 
@@ -405,21 +404,20 @@ Get Git context
 */
 func (a *GitProviderAPIService) GetGitUser(ctx context.Context, gitProviderId string) ApiGetGitUserRequest {
 	return ApiGetGitUserRequest{
-		ApiService:    a,
-		ctx:           ctx,
+		ApiService: a,
+		ctx: ctx,
 		gitProviderId: gitProviderId,
 	}
 }
 
 // Execute executes the request
-//
-//	@return GitUser
+//  @return GitUser
 func (a *GitProviderAPIService) GetGitUserExecute(r ApiGetGitUserRequest) (*GitUser, *http.Response, error) {
 	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue *GitUser
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *GitUser
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetGitUser")
@@ -503,19 +501,21 @@ func (a *GitProviderAPIService) GetGitUserExecute(r ApiGetGitUserRequest) (*GitU
 }
 
 type ApiGetNamespacesRequest struct {
-	ctx           context.Context
-	ApiService    *GitProviderAPIService
+	ctx context.Context
+	ApiService *GitProviderAPIService
 	gitProviderId string
-	page          *int
-	perPage       *int
+	page *int32
+	perPage *int32
 }
 
-func (r ApiGetNamespacesRequest) Page(page int) ApiGetNamespacesRequest {
+// Page number
+func (r ApiGetNamespacesRequest) Page(page int32) ApiGetNamespacesRequest {
 	r.page = &page
 	return r
 }
 
-func (r ApiGetNamespacesRequest) PerPage(perPage int) ApiGetNamespacesRequest {
+// Number of items per page
+func (r ApiGetNamespacesRequest) PerPage(perPage int32) ApiGetNamespacesRequest {
 	r.perPage = &perPage
 	return r
 }
@@ -535,21 +535,20 @@ Get Git namespaces
 */
 func (a *GitProviderAPIService) GetNamespaces(ctx context.Context, gitProviderId string) ApiGetNamespacesRequest {
 	return ApiGetNamespacesRequest{
-		ApiService:    a,
-		ctx:           ctx,
+		ApiService: a,
+		ctx: ctx,
 		gitProviderId: gitProviderId,
 	}
 }
 
 // Execute executes the request
-//
-//	@return []GitNamespace
+//  @return []GitNamespace
 func (a *GitProviderAPIService) GetNamespacesExecute(r ApiGetNamespacesRequest) ([]GitNamespace, *http.Response, error) {
 	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue []GitNamespace
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  []GitNamespace
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetNamespaces")
@@ -570,7 +569,6 @@ func (a *GitProviderAPIService) GetNamespacesExecute(r ApiGetNamespacesRequest) 
 	if r.perPage != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
 	}
-
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -640,21 +638,23 @@ func (a *GitProviderAPIService) GetNamespacesExecute(r ApiGetNamespacesRequest) 
 }
 
 type ApiGetRepoBranchesRequest struct {
-	ctx           context.Context
-	ApiService    *GitProviderAPIService
+	ctx context.Context
+	ApiService *GitProviderAPIService
 	gitProviderId string
-	namespaceId   string
-	repositoryId  string
-	page          *int
-	perPage       *int
+	namespaceId string
+	repositoryId string
+	page *int32
+	perPage *int32
 }
 
-func (r ApiGetRepoBranchesRequest) Page(page int) ApiGetRepoBranchesRequest {
+// Page number
+func (r ApiGetRepoBranchesRequest) Page(page int32) ApiGetRepoBranchesRequest {
 	r.page = &page
 	return r
 }
 
-func (r ApiGetRepoBranchesRequest) PerPage(perPage int) ApiGetRepoBranchesRequest {
+// Number of items per page
+func (r ApiGetRepoBranchesRequest) PerPage(perPage int32) ApiGetRepoBranchesRequest {
 	r.perPage = &perPage
 	return r
 }
@@ -676,23 +676,22 @@ Get Git repository branches
 */
 func (a *GitProviderAPIService) GetRepoBranches(ctx context.Context, gitProviderId string, namespaceId string, repositoryId string) ApiGetRepoBranchesRequest {
 	return ApiGetRepoBranchesRequest{
-		ApiService:    a,
-		ctx:           ctx,
+		ApiService: a,
+		ctx: ctx,
 		gitProviderId: gitProviderId,
-		namespaceId:   namespaceId,
-		repositoryId:  repositoryId,
+		namespaceId: namespaceId,
+		repositoryId: repositoryId,
 	}
 }
 
 // Execute executes the request
-//
-//	@return []GitBranch
+//  @return []GitBranch
 func (a *GitProviderAPIService) GetRepoBranchesExecute(r ApiGetRepoBranchesRequest) ([]GitBranch, *http.Response, error) {
 	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue []GitBranch
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  []GitBranch
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetRepoBranches")
@@ -715,7 +714,6 @@ func (a *GitProviderAPIService) GetRepoBranchesExecute(r ApiGetRepoBranchesReque
 	if r.perPage != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
 	}
-
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -785,21 +783,23 @@ func (a *GitProviderAPIService) GetRepoBranchesExecute(r ApiGetRepoBranchesReque
 }
 
 type ApiGetRepoPRsRequest struct {
-	ctx           context.Context
-	ApiService    *GitProviderAPIService
+	ctx context.Context
+	ApiService *GitProviderAPIService
 	gitProviderId string
-	namespaceId   string
-	repositoryId  string
-	page          *int
-	perPage       *int
+	namespaceId string
+	repositoryId string
+	page *int32
+	perPage *int32
 }
 
-func (r ApiGetRepoPRsRequest) Page(page int) ApiGetRepoPRsRequest {
+// Page number
+func (r ApiGetRepoPRsRequest) Page(page int32) ApiGetRepoPRsRequest {
 	r.page = &page
 	return r
 }
 
-func (r ApiGetRepoPRsRequest) PerPage(perPage int) ApiGetRepoPRsRequest {
+// Number of items per page
+func (r ApiGetRepoPRsRequest) PerPage(perPage int32) ApiGetRepoPRsRequest {
 	r.perPage = &perPage
 	return r
 }
@@ -821,23 +821,22 @@ Get Git repository PRs
 */
 func (a *GitProviderAPIService) GetRepoPRs(ctx context.Context, gitProviderId string, namespaceId string, repositoryId string) ApiGetRepoPRsRequest {
 	return ApiGetRepoPRsRequest{
-		ApiService:    a,
-		ctx:           ctx,
+		ApiService: a,
+		ctx: ctx,
 		gitProviderId: gitProviderId,
-		namespaceId:   namespaceId,
-		repositoryId:  repositoryId,
+		namespaceId: namespaceId,
+		repositoryId: repositoryId,
 	}
 }
 
 // Execute executes the request
-//
-//	@return []GitPullRequest
+//  @return []GitPullRequest
 func (a *GitProviderAPIService) GetRepoPRsExecute(r ApiGetRepoPRsRequest) ([]GitPullRequest, *http.Response, error) {
 	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue []GitPullRequest
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  []GitPullRequest
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetRepoPRs")
@@ -860,7 +859,6 @@ func (a *GitProviderAPIService) GetRepoPRsExecute(r ApiGetRepoPRsRequest) ([]Git
 	if r.perPage != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
 	}
-
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -930,20 +928,22 @@ func (a *GitProviderAPIService) GetRepoPRsExecute(r ApiGetRepoPRsRequest) ([]Git
 }
 
 type ApiGetRepositoriesRequest struct {
-	ctx           context.Context
-	ApiService    *GitProviderAPIService
+	ctx context.Context
+	ApiService *GitProviderAPIService
 	gitProviderId string
-	namespaceId   string
-	page          *int
-	perPage       *int
+	namespaceId string
+	page *int32
+	perPage *int32
 }
 
-func (r ApiGetRepositoriesRequest) Page(page int) ApiGetRepositoriesRequest {
+// Page number
+func (r ApiGetRepositoriesRequest) Page(page int32) ApiGetRepositoriesRequest {
 	r.page = &page
 	return r
 }
 
-func (r ApiGetRepositoriesRequest) PerPage(perPage int) ApiGetRepositoriesRequest {
+// Number of items per page
+func (r ApiGetRepositoriesRequest) PerPage(perPage int32) ApiGetRepositoriesRequest {
 	r.perPage = &perPage
 	return r
 }
@@ -964,22 +964,21 @@ Get Git repositories
 */
 func (a *GitProviderAPIService) GetRepositories(ctx context.Context, gitProviderId string, namespaceId string) ApiGetRepositoriesRequest {
 	return ApiGetRepositoriesRequest{
-		ApiService:    a,
-		ctx:           ctx,
+		ApiService: a,
+		ctx: ctx,
 		gitProviderId: gitProviderId,
-		namespaceId:   namespaceId,
+		namespaceId: namespaceId,
 	}
 }
 
 // Execute executes the request
-//
-//	@return []GitRepository
+//  @return []GitRepository
 func (a *GitProviderAPIService) GetRepositoriesExecute(r ApiGetRepositoriesRequest) ([]GitRepository, *http.Response, error) {
 	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue []GitRepository
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  []GitRepository
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetRepositories")
@@ -1196,7 +1195,7 @@ func (a *GitProviderAPIService) GetUrlFromRepositoryExecute(r ApiGetUrlFromRepos
 }
 
 type ApiListGitProvidersRequest struct {
-	ctx        context.Context
+	ctx context.Context
 	ApiService *GitProviderAPIService
 }
 
@@ -1215,19 +1214,18 @@ List Git providers
 func (a *GitProviderAPIService) ListGitProviders(ctx context.Context) ApiListGitProvidersRequest {
 	return ApiListGitProvidersRequest{
 		ApiService: a,
-		ctx:        ctx,
+		ctx: ctx,
 	}
 }
 
 // Execute executes the request
-//
-//	@return []GitProvider
+//  @return []GitProvider
 func (a *GitProviderAPIService) ListGitProvidersExecute(r ApiListGitProvidersRequest) ([]GitProvider, *http.Response, error) {
 	var (
-		localVarHTTPMethod  = http.MethodGet
-		localVarPostBody    interface{}
-		formFiles           []formFile
-		localVarReturnValue []GitProvider
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  []GitProvider
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.ListGitProviders")
@@ -1310,8 +1308,8 @@ func (a *GitProviderAPIService) ListGitProvidersExecute(r ApiListGitProvidersReq
 }
 
 type ApiRemoveGitProviderRequest struct {
-	ctx           context.Context
-	ApiService    *GitProviderAPIService
+	ctx context.Context
+	ApiService *GitProviderAPIService
 	gitProviderId string
 }
 
@@ -1330,8 +1328,8 @@ Remove Git provider
 */
 func (a *GitProviderAPIService) RemoveGitProvider(ctx context.Context, gitProviderId string) ApiRemoveGitProviderRequest {
 	return ApiRemoveGitProviderRequest{
-		ApiService:    a,
-		ctx:           ctx,
+		ApiService: a,
+		ctx: ctx,
 		gitProviderId: gitProviderId,
 	}
 }
@@ -1339,9 +1337,9 @@ func (a *GitProviderAPIService) RemoveGitProvider(ctx context.Context, gitProvid
 // Execute executes the request
 func (a *GitProviderAPIService) RemoveGitProviderExecute(r ApiRemoveGitProviderRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod = http.MethodDelete
-		localVarPostBody   interface{}
-		formFiles          []formFile
+		localVarHTTPMethod   = http.MethodDelete
+		localVarPostBody     interface{}
+		formFiles            []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.RemoveGitProvider")
@@ -1442,16 +1440,16 @@ Set Git provider
 func (a *GitProviderAPIService) SetGitProvider(ctx context.Context) ApiSetGitProviderRequest {
 	return ApiSetGitProviderRequest{
 		ApiService: a,
-		ctx:        ctx,
+		ctx: ctx,
 	}
 }
 
 // Execute executes the request
 func (a *GitProviderAPIService) SetGitProviderExecute(r ApiSetGitProviderRequest) (*http.Response, error) {
 	var (
-		localVarHTTPMethod = http.MethodPut
-		localVarPostBody   interface{}
-		formFiles          []formFile
+		localVarHTTPMethod   = http.MethodPut
+		localVarPostBody     interface{}
+		formFiles            []formFile
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.SetGitProvider")

--- a/pkg/apiclient/api_git_provider.go
+++ b/pkg/apiclient/api_git_provider.go
@@ -13,7 +13,6 @@ package apiclient
 import (
 	"bytes"
 	"context"
-	"strconv"
 	"io"
 	"net/http"
 	"net/url"
@@ -164,9 +163,9 @@ GetGitProviderForUrl Get Git provider
 
 Get Git provider
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param url Url
-	@return ApiGetGitProviderForUrlRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param url Url
+ @return ApiGetGitProviderForUrlRequest
 */
 func (a *GitProviderAPIService) GetGitProviderForUrl(ctx context.Context, url string) ApiGetGitProviderForUrlRequest {
 	return ApiGetGitProviderForUrlRequest{
@@ -400,9 +399,9 @@ GetGitUser Get Git context
 
 Get Git context
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param gitProviderId Git Provider Id
-	@return ApiGetGitUserRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param gitProviderId Git Provider Id
+ @return ApiGetGitUserRequest
 */
 func (a *GitProviderAPIService) GetGitUser(ctx context.Context, gitProviderId string) ApiGetGitUserRequest {
 	return ApiGetGitUserRequest{
@@ -503,33 +502,21 @@ func (a *GitProviderAPIService) GetGitUserExecute(r ApiGetGitUserRequest) (*GitU
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type ListOptions struct {
-	page    *int
-	perPage *int
-}
-
-func (l *ListOptions) SetPage(page int) {
-	l.page = &page
-}
-
-func (l *ListOptions) SetPerPage(perPage int) {
-	l.perPage = &perPage
-}
-
 type ApiGetNamespacesRequest struct {
 	ctx           context.Context
 	ApiService    *GitProviderAPIService
 	gitProviderId string
-	ListOptions
+	page          *int
+	perPage       *int
 }
 
 func (r ApiGetNamespacesRequest) Page(page int) ApiGetNamespacesRequest {
-	r.SetPage(page)
+	r.page = &page
 	return r
 }
 
 func (r ApiGetNamespacesRequest) PerPage(perPage int) ApiGetNamespacesRequest {
-	r.SetPerPage(perPage)
+	r.perPage = &perPage
 	return r
 }
 
@@ -542,9 +529,9 @@ GetNamespaces Get Git namespaces
 
 Get Git namespaces
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param gitProviderId Git provider
-	@return ApiGetNamespacesRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param gitProviderId Git provider
+ @return ApiGetNamespacesRequest
 */
 func (a *GitProviderAPIService) GetNamespaces(ctx context.Context, gitProviderId string) ApiGetNamespacesRequest {
 	return ApiGetNamespacesRequest{
@@ -578,10 +565,10 @@ func (a *GitProviderAPIService) GetNamespacesExecute(r ApiGetNamespacesRequest) 
 	localVarFormParams := url.Values{}
 
 	if r.page != nil {
-		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "page", r.page, "")
 	}
 	if r.perPage != nil {
-		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
 	}
 
 	// to determine the Content-Type header
@@ -658,16 +645,17 @@ type ApiGetRepoBranchesRequest struct {
 	gitProviderId string
 	namespaceId   string
 	repositoryId  string
-	ListOptions
+	page          *int
+	perPage       *int
 }
 
 func (r ApiGetRepoBranchesRequest) Page(page int) ApiGetRepoBranchesRequest {
-	r.SetPage(page)
+	r.page = &page
 	return r
 }
 
 func (r ApiGetRepoBranchesRequest) PerPage(perPage int) ApiGetRepoBranchesRequest {
-	r.SetPerPage(perPage)
+	r.perPage = &perPage
 	return r
 }
 
@@ -680,11 +668,11 @@ GetRepoBranches Get Git repository branches
 
 Get Git repository branches
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param gitProviderId Git provider
-	@param namespaceId Namespace
-	@param repositoryId Repository
-	@return ApiGetRepoBranchesRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param gitProviderId Git provider
+ @param namespaceId Namespace
+ @param repositoryId Repository
+ @return ApiGetRepoBranchesRequest
 */
 func (a *GitProviderAPIService) GetRepoBranches(ctx context.Context, gitProviderId string, namespaceId string, repositoryId string) ApiGetRepoBranchesRequest {
 	return ApiGetRepoBranchesRequest{
@@ -722,10 +710,10 @@ func (a *GitProviderAPIService) GetRepoBranchesExecute(r ApiGetRepoBranchesReque
 	localVarFormParams := url.Values{}
 
 	if r.page != nil {
-		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "page", r.page, "")
 	}
 	if r.perPage != nil {
-		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
 	}
 
 	// to determine the Content-Type header
@@ -802,16 +790,17 @@ type ApiGetRepoPRsRequest struct {
 	gitProviderId string
 	namespaceId   string
 	repositoryId  string
-	ListOptions
+	page          *int
+	perPage       *int
 }
 
 func (r ApiGetRepoPRsRequest) Page(page int) ApiGetRepoPRsRequest {
-	r.SetPage(page)
+	r.page = &page
 	return r
 }
 
 func (r ApiGetRepoPRsRequest) PerPage(perPage int) ApiGetRepoPRsRequest {
-	r.SetPerPage(perPage)
+	r.perPage = &perPage
 	return r
 }
 
@@ -824,11 +813,11 @@ GetRepoPRs Get Git repository PRs
 
 Get Git repository PRs
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param gitProviderId Git provider
-	@param namespaceId Namespace
-	@param repositoryId Repository
-	@return ApiGetRepoPRsRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param gitProviderId Git provider
+ @param namespaceId Namespace
+ @param repositoryId Repository
+ @return ApiGetRepoPRsRequest
 */
 func (a *GitProviderAPIService) GetRepoPRs(ctx context.Context, gitProviderId string, namespaceId string, repositoryId string) ApiGetRepoPRsRequest {
 	return ApiGetRepoPRsRequest{
@@ -866,10 +855,10 @@ func (a *GitProviderAPIService) GetRepoPRsExecute(r ApiGetRepoPRsRequest) ([]Git
 	localVarFormParams := url.Values{}
 
 	if r.page != nil {
-		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "page", r.page, "")
 	}
 	if r.perPage != nil {
-		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
 	}
 
 	// to determine the Content-Type header
@@ -945,16 +934,17 @@ type ApiGetRepositoriesRequest struct {
 	ApiService    *GitProviderAPIService
 	gitProviderId string
 	namespaceId   string
-	ListOptions
+	page          *int
+	perPage       *int
 }
 
 func (r ApiGetRepositoriesRequest) Page(page int) ApiGetRepositoriesRequest {
-	r.SetPage(page)
+	r.page = &page
 	return r
 }
 
 func (r ApiGetRepositoriesRequest) PerPage(perPage int) ApiGetRepositoriesRequest {
-	r.SetPerPage(perPage)
+	r.perPage = &perPage
 	return r
 }
 
@@ -967,10 +957,10 @@ GetRepositories Get Git repositories
 
 Get Git repositories
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param gitProviderId Git provider
-	@param namespaceId Namespace
-	@return ApiGetRepositoriesRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param gitProviderId Git provider
+ @param namespaceId Namespace
+ @return ApiGetRepositoriesRequest
 */
 func (a *GitProviderAPIService) GetRepositories(ctx context.Context, gitProviderId string, namespaceId string) ApiGetRepositoriesRequest {
 	return ApiGetRepositoriesRequest{
@@ -1006,12 +996,11 @@ func (a *GitProviderAPIService) GetRepositoriesExecute(r ApiGetRepositoriesReque
 	localVarFormParams := url.Values{}
 
 	if r.page != nil {
-		localVarQueryParams.Add("page", strconv.Itoa(*r.page))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "page", r.page, "")
 	}
 	if r.perPage != nil {
-		localVarQueryParams.Add("per_page", strconv.Itoa(*r.perPage))
+		parameterAddToHeaderOrQuery(localVarQueryParams, "per_page", r.perPage, "")
 	}
-
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -1220,8 +1209,8 @@ ListGitProviders List Git providers
 
 List Git providers
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiListGitProvidersRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiListGitProvidersRequest
 */
 func (a *GitProviderAPIService) ListGitProviders(ctx context.Context) ApiListGitProvidersRequest {
 	return ApiListGitProvidersRequest{
@@ -1335,9 +1324,9 @@ RemoveGitProvider Remove Git provider
 
 Remove Git provider
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@param gitProviderId Git provider
-	@return ApiRemoveGitProviderRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param gitProviderId Git provider
+ @return ApiRemoveGitProviderRequest
 */
 func (a *GitProviderAPIService) RemoveGitProvider(ctx context.Context, gitProviderId string) ApiRemoveGitProviderRequest {
 	return ApiRemoveGitProviderRequest{
@@ -1447,8 +1436,8 @@ SetGitProvider Set Git provider
 
 Set Git provider
 
-	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return ApiSetGitProviderRequest
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiSetGitProviderRequest
 */
 func (a *GitProviderAPIService) SetGitProvider(ctx context.Context) ApiSetGitProviderRequest {
 	return ApiSetGitProviderRequest{

--- a/pkg/apiclient/docs/GitProviderAPI.md
+++ b/pkg/apiclient/docs/GitProviderAPI.md
@@ -297,7 +297,7 @@ Name | Type | Description  | Notes
 
 ## GetNamespaces
 
-> []GitNamespace GetNamespaces(ctx, gitProviderId).Execute()
+> []GitNamespace GetNamespaces(ctx, gitProviderId).Page(page).PerPage(perPage).Execute()
 
 Get Git namespaces
 
@@ -317,6 +317,8 @@ import (
 
 func main() {
 	gitProviderId := "gitProviderId_example" // string | Git provider
+	page := int32(56) // int32 | Page number (optional)
+	perPage := int32(56) // int32 | Number of items per page (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -345,7 +347,8 @@ Other parameters are passed through a pointer to a apiGetNamespacesRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-
+**page** | **int32** | Page number | 
+**perPage** | **int32** | Number of items per page | 
 
 ### Return type
 
@@ -367,7 +370,7 @@ Name | Type | Description  | Notes
 
 ## GetRepoBranches
 
-> []GitBranch GetRepoBranches(ctx, gitProviderId, namespaceId, repositoryId).Execute()
+> []GitBranch GetRepoBranches(ctx, gitProviderId, namespaceId, repositoryId).Page(page).PerPage(perPage).Execute()
 
 Get Git repository branches
 
@@ -389,6 +392,8 @@ func main() {
 	gitProviderId := "gitProviderId_example" // string | Git provider
 	namespaceId := "namespaceId_example" // string | Namespace
 	repositoryId := "repositoryId_example" // string | Repository
+	page := int32(56) // int32 | Page number (optional)
+	perPage := int32(56) // int32 | Number of items per page (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -419,7 +424,8 @@ Other parameters are passed through a pointer to a apiGetRepoBranchesRequest str
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-
+**page** | **int32** | Page number | 
+**perPage** | **int32** | Number of items per page | 
 
 
 
@@ -443,7 +449,7 @@ Name | Type | Description  | Notes
 
 ## GetRepoPRs
 
-> []GitPullRequest GetRepoPRs(ctx, gitProviderId, namespaceId, repositoryId).Execute()
+> []GitPullRequest GetRepoPRs(ctx, gitProviderId, namespaceId, repositoryId).Page(page).PerPage(perPage).Execute()
 
 Get Git repository PRs
 
@@ -465,6 +471,8 @@ func main() {
 	gitProviderId := "gitProviderId_example" // string | Git provider
 	namespaceId := "namespaceId_example" // string | Namespace
 	repositoryId := "repositoryId_example" // string | Repository
+	page := int32(56) // int32 | Page number (optional)
+	perPage := int32(56) // int32 | Number of items per page (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -495,7 +503,8 @@ Other parameters are passed through a pointer to a apiGetRepoPRsRequest struct v
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-
+**page** | **int32** | Page number | 
+**perPage** | **int32** | Number of items per page | 
 
 
 
@@ -519,7 +528,7 @@ Name | Type | Description  | Notes
 
 ## GetRepositories
 
-> []GitRepository GetRepositories(ctx, gitProviderId, namespaceId).Execute()
+> []GitRepository GetRepositories(ctx, gitProviderId, namespaceId).Page(page).PerPage(perPage).Execute()
 
 Get Git repositories
 
@@ -540,10 +549,12 @@ import (
 func main() {
 	gitProviderId := "gitProviderId_example" // string | Git provider
 	namespaceId := "namespaceId_example" // string | Namespace
+	page := int32(56) // int32 | Page number (optional)
+	perPage := int32(56) // int32 | Number of items per page (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.GitProviderAPI.GetRepositories(context.Background(), gitProviderId, namespaceId).Execute()
+	resp, r, err := apiClient.GitProviderAPI.GetRepositories(context.Background(), gitProviderId, namespaceId).Page(page).PerPage(perPage).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `GitProviderAPI.GetRepositories``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -569,7 +580,8 @@ Other parameters are passed through a pointer to a apiGetRepositoriesRequest str
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-
+**page** | **int32** | Page number | 
+**perPage** | **int32** | Number of items per page | 
 
 
 ### Return type

--- a/pkg/apiclient/docs/GitProviderAPI.md
+++ b/pkg/apiclient/docs/GitProviderAPI.md
@@ -322,7 +322,7 @@ func main() {
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.GitProviderAPI.GetNamespaces(context.Background(), gitProviderId).Execute()
+	resp, r, err := apiClient.GitProviderAPI.GetNamespaces(context.Background(), gitProviderId).Page(page).PerPage(perPage).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `GitProviderAPI.GetNamespaces``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -347,8 +347,9 @@ Other parameters are passed through a pointer to a apiGetNamespacesRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**page** | **int32** | Page number | 
-**perPage** | **int32** | Number of items per page | 
+
+ **page** | **int32** | Page number | 
+ **perPage** | **int32** | Number of items per page | 
 
 ### Return type
 
@@ -397,7 +398,7 @@ func main() {
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.GitProviderAPI.GetRepoBranches(context.Background(), gitProviderId, namespaceId, repositoryId).Execute()
+	resp, r, err := apiClient.GitProviderAPI.GetRepoBranches(context.Background(), gitProviderId, namespaceId, repositoryId).Page(page).PerPage(perPage).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `GitProviderAPI.GetRepoBranches``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -424,10 +425,11 @@ Other parameters are passed through a pointer to a apiGetRepoBranchesRequest str
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**page** | **int32** | Page number | 
-**perPage** | **int32** | Number of items per page | 
 
 
+
+ **page** | **int32** | Page number | 
+ **perPage** | **int32** | Number of items per page | 
 
 ### Return type
 
@@ -476,7 +478,7 @@ func main() {
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.GitProviderAPI.GetRepoPRs(context.Background(), gitProviderId, namespaceId, repositoryId).Execute()
+	resp, r, err := apiClient.GitProviderAPI.GetRepoPRs(context.Background(), gitProviderId, namespaceId, repositoryId).Page(page).PerPage(perPage).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `GitProviderAPI.GetRepoPRs``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -503,10 +505,11 @@ Other parameters are passed through a pointer to a apiGetRepoPRsRequest struct v
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**page** | **int32** | Page number | 
-**perPage** | **int32** | Number of items per page | 
 
 
+
+ **page** | **int32** | Page number | 
+ **perPage** | **int32** | Number of items per page | 
 
 ### Return type
 
@@ -580,9 +583,10 @@ Other parameters are passed through a pointer to a apiGetRepositoriesRequest str
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**page** | **int32** | Page number | 
-**perPage** | **int32** | Number of items per page | 
 
+
+ **page** | **int32** | Page number | 
+ **perPage** | **int32** | Number of items per page | 
 
 ### Return type
 

--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -12,6 +12,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/common"
+	"github.com/daytonaio/daytona/pkg/views"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 )
@@ -31,7 +32,6 @@ func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWiza
 	var err error
 
 	for {
-		branchList = nil
 		err = views_util.WithSpinner("Loading Branches", func() error {
 			branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 			if err != nil {
@@ -52,12 +52,9 @@ func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWiza
 		// User will either choose a branch or navigate the pages
 		branch, navigate := selection.GetBranchFromPrompt(branchList, config.ProjectOrder, parentIdentifier, isPaginationDisabled, page, perPage)
 		if !isPaginationDisabled && navigate != "" {
-			if navigate == "next" {
+			if navigate == views.ListNavigationText {
 				page++
 				continue // Fetch the next page of branches
-			} else if navigate == "prev" && page > 1 {
-				page--
-				continue // Fetch the previous page of branches
 			}
 		} else if branch != nil {
 			config.ChosenRepo.Branch = branch.Name
@@ -162,7 +159,6 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 		page = 1
 		perPage = 100
 		for {
-			prList = nil
 			err = views_util.WithSpinner("Loading Pull Requests", func() error {
 				branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 				if err != nil {
@@ -183,11 +179,8 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 			// User will either choose a PR or navigate the pages
 			chosenPullRequest, navigate := selection.GetPullRequestFromPrompt(prList, config.ProjectOrder, parentIdentifier, isPaginationDisabled, page, perPage)
 			if !isPaginationDisabled && navigate != "" {
-				if navigate == "next" {
+				if navigate == views.ListNavigationText {
 					page++
-					continue
-				} else if navigate == "prev" && page > 1 {
-					page--
 					continue
 				}
 			} else if chosenPullRequest != nil {

--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -37,7 +37,7 @@ func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWiza
 
 	for {
 		err = views_util.WithSpinner("Loading Branches", func() error {
-			branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
+			branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 			if err != nil {
 				return err
 			}
@@ -52,7 +52,7 @@ func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWiza
 		}
 
 		// Check first if the git provider supports pagination
-		if isGitProviderWithUnsupportedPagination(config.ProviderId) {
+		if isGitProviderWithUnsupportedPagination(config.GitProviderConfigId) {
 			disablePagination = true
 		} else {
 			// Check if we have reached the end of the list
@@ -95,7 +95,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	ctx := context.Background()
 
 	err = views_util.WithSpinner("Loading", func() error {
-		branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
+		branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	perPage = 1
 
 	err = views_util.WithSpinner("Loading", func() error {
-		prs, _, err := config.ApiClient.GitProviderAPI.GetRepoPRs(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
+		prs, _, err := config.ApiClient.GitProviderAPI.GetRepoPRs(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 
 		for {
 			err = views_util.WithSpinner("Loading Pull Requests", func() error {
-				branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
+				branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -29,8 +29,8 @@ type BranchWizardConfig struct {
 func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, error) {
 	var branchList []apiclient.GitBranch
 	var checkoutOptions []selection.CheckoutOption
-	page := 1
-	perPage := 100
+	page := int32(1)
+	perPage := int32(100)
 	var err error
 	ctx := context.Background()
 
@@ -48,7 +48,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 		branchList = append(branchList, branches...)
 
 		// Break for git providers with unsupported pagination OR on reaching exhausted items.
-		if isPaginationUnsupportedGitProvider(config.ProviderId) || len(branches) < perPage {
+		if isGitProviderWithUnsupportedPagination(config.ProviderId) || int32(len(branches)) < perPage {
 			break
 		}
 
@@ -83,7 +83,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 		prList = append(prList, pullRequests...)
 
 		// Break for git providers with unsupported pagination OR on reaching exhausted items.
-		if isPaginationUnsupportedGitProvider(config.ProviderId) || len(pullRequests) < perPage {
+		if isGitProviderWithUnsupportedPagination(config.ProviderId) || int32(len(pullRequests)) < perPage {
 			break
 		}
 

--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -31,6 +31,8 @@ func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWiza
 	var branchList []apiclient.GitBranch
 	disablePagination := false
 	curPageItemsNum := 0
+	selectionListCursorIdx := 0
+	var selectionListOptions views.SelectionListOptions
 	var err error
 
 	for {
@@ -57,8 +59,15 @@ func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWiza
 			disablePagination = int32(curPageItemsNum) < perPage
 		}
 
+		selectionListCursorIdx = (int)(page-1) * int(perPage)
+		selectionListOptions = views.SelectionListOptions{
+			ParentIdentifier:     parentIdentifier,
+			IsPaginationDisabled: disablePagination,
+			CursorIndex:          selectionListCursorIdx,
+		}
+
 		// User will either choose a branch or navigate the pages
-		branch, navigate := selection.GetBranchFromPrompt(branchList, config.ProjectOrder, parentIdentifier, disablePagination)
+		branch, navigate := selection.GetBranchFromPrompt(branchList, config.ProjectOrder, selectionListOptions)
 		if !disablePagination && navigate != "" {
 			if navigate == views.ListNavigationText {
 				page++
@@ -168,6 +177,8 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 		perPage = 100
 		disablePagination := false
 		curPageItemsNum := 0
+		selectionListCursorIdx := 0
+		var selectionListOptions views.SelectionListOptions
 
 		for {
 			err = views_util.WithSpinner("Loading Pull Requests", func() error {
@@ -193,8 +204,15 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 				disablePagination = int32(curPageItemsNum) < perPage
 			}
 
+			selectionListCursorIdx = (int)(page-1) * int(perPage)
+			selectionListOptions = views.SelectionListOptions{
+				ParentIdentifier:     parentIdentifier,
+				IsPaginationDisabled: disablePagination,
+				CursorIndex:          selectionListCursorIdx,
+			}
+
 			// User will either choose a PR or navigate the pages
-			chosenPullRequest, navigate := selection.GetPullRequestFromPrompt(prList, config.ProjectOrder, parentIdentifier, disablePagination)
+			chosenPullRequest, navigate := selection.GetPullRequestFromPrompt(prList, config.ProjectOrder, selectionListOptions)
 			if !disablePagination && navigate != "" {
 				if navigate == views.ListNavigationText {
 					page++

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -113,6 +113,9 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 	perPage := int32(100)
 	disablePagination := false
 	curPageItemsNum := 0
+	selectionListCursorIdx := 0
+	var selectionListOptions views.SelectionListOptions
+
 	var namespaceList []apiclient.GitNamespace
 	namespace := ""
 
@@ -145,7 +148,14 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 			disablePagination = int32(curPageItemsNum) < perPage
 		}
 
-		namespaceId, navigate = selection.GetNamespaceIdFromPrompt(namespaceList, config.ProjectOrder, providerId, disablePagination)
+		selectionListCursorIdx = (int)(page-1) * int(perPage)
+		selectionListOptions = views.SelectionListOptions{
+			ParentIdentifier:     providerId,
+			IsPaginationDisabled: disablePagination,
+			CursorIndex:          selectionListCursorIdx,
+		}
+
+		namespaceId, navigate = selection.GetNamespaceIdFromPrompt(namespaceList, config.ProjectOrder, selectionListOptions)
 
 		if !disablePagination && navigate != "" {
 			if navigate == views.ListNavigationText {
@@ -202,8 +212,15 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 			disablePagination = int32(curPageItemsNum) < perPage
 		}
 
+		selectionListCursorIdx = (int)(page-1) * int(perPage)
+		selectionListOptions = views.SelectionListOptions{
+			ParentIdentifier:     parentIdentifier,
+			IsPaginationDisabled: disablePagination,
+			CursorIndex:          selectionListCursorIdx,
+		}
+
 		// User will either choose a repo or navigate the pages
-		chosenRepo, navigate = selection.GetRepositoryFromPrompt(providerRepos, config.ProjectOrder, config.SelectedRepos, parentIdentifier, disablePagination)
+		chosenRepo, navigate = selection.GetRepositoryFromPrompt(providerRepos, config.ProjectOrder, config.SelectedRepos, selectionListOptions)
 		if !disablePagination && navigate != "" {
 			if navigate == views.ListNavigationText {
 				page++

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -21,7 +21,7 @@ import (
 
 func isGitProviderWithUnsupportedPagination(providerId string) bool {
 	switch providerId {
-	case "azure-devops", "bitbucket", "gitness":
+	case "azure-devops", "bitbucket", "gitness", "aws-codecommit":
 		return true
 	default:
 		return false

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -125,13 +125,26 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 	}
 
 	var providerRepos []apiclient.GitRepository
-	err = views_util.WithSpinner("Loading", func() error {
-		providerRepos, _, err = config.ApiClient.GitProviderAPI.GetRepositories(ctx, gitProviderConfigId, namespaceId).Execute()
-		return err
-	})
+	page := 1
+	perPage := 100
 
-	if err != nil {
-		return nil, err
+	for {
+		var repos []apiclient.GitRepository
+		err = views_util.WithSpinner("Loading", func() error {
+			repos, _, err = config.ApiClient.GitProviderAPI.GetRepositories(ctx, providerId, namespaceId, page, perPage).Execute()
+			return err
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		providerRepos = append(providerRepos, repos...)
+
+		if len(repos) < perPage {
+			break
+		}
+
+		page++
 	}
 
 	parentIdentifier := fmt.Sprintf("%s/%s", providerId, namespace)

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -140,7 +140,8 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 
 		providerRepos = append(providerRepos, repos...)
 
-		if len(repos) < perPage {
+		// Break for git providers with unsupported pagination OR on reaching exhausted items.
+		if providerId == "azure-devops" || providerId == "bitbucket" || providerId == "gitness" || len(repos) < perPage {
 			break
 		}
 

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -130,7 +130,7 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 
 	for {
 		err = views_util.WithSpinner("Loading Namespaces", func() error {
-			namespaces, _, err := config.ApiClient.GitProviderAPI.GetNamespaces(ctx, providerId).Page(page).PerPage(perPage).Execute()
+			namespaces, _, err := config.ApiClient.GitProviderAPI.GetNamespaces(ctx, gitProviderConfigId).Page(page).PerPage(perPage).Execute()
 			if err != nil {
 				return err
 			}
@@ -199,7 +199,7 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 		// Fetch repos for the current page
 		err = views_util.WithSpinner("Loading Repositories", func() error {
 
-			repos, _, err := config.ApiClient.GitProviderAPI.GetRepositories(ctx, providerId, namespaceId).Page(page).PerPage(perPage).Execute()
+			repos, _, err := config.ApiClient.GitProviderAPI.GetRepositories(ctx, gitProviderConfigId, namespaceId).Page(page).PerPage(perPage).Execute()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func isPaginationUnsupportedGitProvider(providerId string) bool {
+func isGitProviderWithUnsupportedPagination(providerId string) bool {
 	switch providerId {
 	case "azure-devops", "bitbucket", "gitness":
 		return true
@@ -124,7 +124,7 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 		namespaceList = append(namespaceList, namespaces...)
 
 		// Break for git providers with unsupported pagination OR on reaching exhausted items.
-		if isPaginationUnsupportedGitProvider(providerId) || len(namespaces) < perPage {
+		if isGitProviderWithUnsupportedPagination(providerId) || len(namespaces) < perPage {
 			break
 		}
 
@@ -164,7 +164,7 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 		providerRepos = append(providerRepos, repos...)
 
 		// Break for git providers with unsupported pagination OR on reaching exhausted items.
-		if isPaginationUnsupportedGitProvider(providerId) || len(repos) < perPage {
+		if isGitProviderWithUnsupportedPagination(providerId) || len(repos) < perPage {
 			break
 		}
 

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -11,6 +11,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/common"
+	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
@@ -115,7 +116,6 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 	isOnlySingleNamespaceAvailable := true
 
 	for {
-		namespaceList = nil
 		err = views_util.WithSpinner("Loading Namespaces", func() error {
 			namespaces, _, err := config.ApiClient.GitProviderAPI.GetNamespaces(ctx, providerId).Page(page).PerPage(perPage).Execute()
 			if err != nil {
@@ -142,11 +142,8 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 
 		namespaceId, navigate = selection.GetNamespaceIdFromPrompt(namespaceList, config.ProjectOrder, providerId, isPaginationDisabled, page, perPage)
 		if !isPaginationDisabled && navigate != "" {
-			if navigate == "next" {
+			if navigate == views.ListNavigationText {
 				page++
-				continue
-			} else if navigate == "prev" && page > 1 {
-				page--
 				continue
 			}
 		} else if namespaceId != "" {
@@ -175,7 +172,6 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 	parentIdentifier := fmt.Sprintf("%s/%s", providerId, namespace)
 	for {
 		// Fetch repos for the current page
-		providerRepos = nil
 		err = views_util.WithSpinner("Loading Repositories", func() error {
 
 			repos, _, err := config.ApiClient.GitProviderAPI.GetRepositories(ctx, providerId, namespaceId).Page(page).PerPage(perPage).Execute()
@@ -197,12 +193,9 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 		// User will either choose a repo or navigate the pages
 		chosenRepo, navigate = selection.GetRepositoryFromPrompt(providerRepos, config.ProjectOrder, config.SelectedRepos, parentIdentifier, isPaginationDisabled, page, perPage)
 		if !isPaginationDisabled && navigate != "" {
-			if navigate == "next" {
+			if navigate == views.ListNavigationText {
 				page++
 				continue // Fetch the next page of repos
-			} else if navigate == "prev" && page > 1 {
-				page--
-				continue // Fetch the previous page of repos
 			}
 		} else if chosenRepo != nil {
 			break

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -108,8 +108,8 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 	}
 
 	var namespaceList []apiclient.GitNamespace
-	page := 1
-	perPage := 100
+	page := int32(1)
+	perPage := int32(100)
 
 	for {
 		var namespaces []apiclient.GitNamespace
@@ -124,7 +124,7 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 		namespaceList = append(namespaceList, namespaces...)
 
 		// Break for git providers with unsupported pagination OR on reaching exhausted items.
-		if isGitProviderWithUnsupportedPagination(providerId) || len(namespaces) < perPage {
+		if isGitProviderWithUnsupportedPagination(providerId) || int32(len(namespaces)) < perPage {
 			break
 		}
 
@@ -164,7 +164,7 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 		providerRepos = append(providerRepos, repos...)
 
 		// Break for git providers with unsupported pagination OR on reaching exhausted items.
-		if isGitProviderWithUnsupportedPagination(providerId) || len(repos) < perPage {
+		if isGitProviderWithUnsupportedPagination(providerId) || int32(len(repos)) < perPage {
 			break
 		}
 

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -163,6 +163,12 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 
 		providerRepos = append(providerRepos, repos...)
 
+		// For bitbucket, pagination is only supported for fetch repos api
+		if providerId == "bitbucket" {
+			page++
+			continue
+		}
+
 		// Break for git providers with unsupported pagination OR on reaching exhausted items.
 		if isGitProviderWithUnsupportedPagination(providerId) || int32(len(repos)) < perPage {
 			break

--- a/pkg/cmd/workspace/util/repository_wizard.go
+++ b/pkg/cmd/workspace/util/repository_wizard.go
@@ -131,7 +131,7 @@ func getRepositoryFromWizard(config RepositoryWizardConfig) (*apiclient.GitRepos
 	for {
 		var repos []apiclient.GitRepository
 		err = views_util.WithSpinner("Loading", func() error {
-			repos, _, err = config.ApiClient.GitProviderAPI.GetRepositories(ctx, providerId, namespaceId, page, perPage).Execute()
+			repos, _, err = config.ApiClient.GitProviderAPI.GetRepositories(ctx, providerId, namespaceId).Page(page).PerPage(perPage).Execute()
 			return err
 		})
 		if err != nil {

--- a/pkg/gitprovider/aws-codecommit.go
+++ b/pkg/gitprovider/aws-codecommit.go
@@ -48,7 +48,7 @@ func (g *AwsCodeCommitGitProvider) CanHandle(repoUrl string) (bool, error) {
 	return staticContext.Source == fmt.Sprintf("git-codecommit.%s.amazonaws.com", g.region) || fmt.Sprintf("%s.console.aws.amazon.com", g.region) == staticContext.Source, nil
 }
 
-func (g *AwsCodeCommitGitProvider) GetNamespaces() ([]*GitNamespace, error) {
+func (g *AwsCodeCommitGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace, error) {
 	// AWS CodeCommit does not have a project and repository structure similar to other git providers.
 	// Therefore, returning repositories as an array of type GitNamespace.
 	client, err := g.getApiClient()
@@ -119,7 +119,7 @@ func (g *AwsCodeCommitGitProvider) getApiClient() (*codecommit.Client, error) {
 	return client, nil
 }
 
-func (g *AwsCodeCommitGitProvider) GetRepositories(namespace string) ([]*GitRepository, error) {
+func (g *AwsCodeCommitGitProvider) GetRepositories(namespace string, options ListOptions) ([]*GitRepository, error) {
 	client, err := g.getApiClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)
@@ -150,7 +150,7 @@ func (g *AwsCodeCommitGitProvider) GetRepositories(namespace string) ([]*GitRepo
 	return repos, nil
 }
 
-func (g *AwsCodeCommitGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error) {
+func (g *AwsCodeCommitGitProvider) GetRepoBranches(repositoryId string, namespaceId string, options ListOptions) ([]*GitBranch, error) {
 	client, err := g.getApiClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)
@@ -210,7 +210,7 @@ func (g *AwsCodeCommitGitProvider) GetUser() (*GitUser, error) {
 
 }
 
-func (g *AwsCodeCommitGitProvider) GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error) {
+func (g *AwsCodeCommitGitProvider) GetRepoPRs(repositoryId string, namespaceId string, options ListOptions) ([]*GitPullRequest, error) {
 	client, err := g.getApiClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)

--- a/pkg/gitprovider/azure-devops.go
+++ b/pkg/gitprovider/azure-devops.go
@@ -77,7 +77,7 @@ func (g *AzureDevOpsGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	return nil, g.FormatError(err)
 }
 
-func (g *AzureDevOpsGitProvider) GetRepositories(namespace string) ([]*GitRepository, error) {
+func (g *AzureDevOpsGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
 	client, err := g.getGitClient()
 	if err != nil {
 		return nil, err

--- a/pkg/gitprovider/azure-devops.go
+++ b/pkg/gitprovider/azure-devops.go
@@ -51,7 +51,7 @@ func (g *AzureDevOpsGitProvider) CanHandle(repoUrl string) (bool, error) {
 	return strings.Contains(g.baseApiUrl, staticContext.Source), nil
 }
 
-func (g *AzureDevOpsGitProvider) GetNamespaces() ([]*GitNamespace, error) {
+func (g *AzureDevOpsGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace, error) {
 	client, _, err := g.getApiClient()
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (g *AzureDevOpsGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	return nil, g.FormatError(err)
 }
 
-func (g *AzureDevOpsGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
+func (g *AzureDevOpsGitProvider) GetRepositories(namespace string, options ListOptions) ([]*GitRepository, error) {
 	client, err := g.getGitClient()
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (g *AzureDevOpsGitProvider) GetUser() (*GitUser, error) {
 	return user, nil
 }
 
-func (g *AzureDevOpsGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error) {
+func (g *AzureDevOpsGitProvider) GetRepoBranches(repositoryId string, namespaceId string, options ListOptions) ([]*GitBranch, error) {
 	client, err := g.getGitClient()
 	if err != nil {
 		return nil, err
@@ -173,7 +173,7 @@ func (g *AzureDevOpsGitProvider) GetRepoBranches(repositoryId string, namespaceI
 	return response, nil
 }
 
-func (g *AzureDevOpsGitProvider) GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error) {
+func (g *AzureDevOpsGitProvider) GetRepoPRs(repositoryId string, namespaceId string, options ListOptions) ([]*GitPullRequest, error) {
 	client, err := g.getGitClient()
 	if err != nil {
 		return nil, err

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -45,7 +45,7 @@ func (g *BitbucketGitProvider) CanHandle(repoUrl string) (bool, error) {
 	return staticContext.Source == "bitbucket.org", nil
 }
 
-func (g *BitbucketGitProvider) GetNamespaces() ([]*GitNamespace, error) {
+func (g *BitbucketGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace, error) {
 	client := g.getApiClient()
 	wsList, err := client.Workspaces.List()
 	if err != nil {
@@ -64,7 +64,7 @@ func (g *BitbucketGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	return namespaces, nil
 }
 
-func (g *BitbucketGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
+func (g *BitbucketGitProvider) GetRepositories(namespace string, options ListOptions) ([]*GitRepository, error) {
 	client := g.getApiClient()
 	var response []*GitRepository
 
@@ -81,7 +81,7 @@ func (g *BitbucketGitProvider) GetRepositories(namespace string, page, perPage i
 	for {
 		repoList, err := client.Repositories.ListForAccount(&bitbucket.RepositoriesOptions{
 			Owner: namespace,
-			Page:  &page,
+			Page:  &options.Page,
 		})
 		if err != nil {
 			return nil, g.FormatError(err)
@@ -122,13 +122,13 @@ func (g *BitbucketGitProvider) GetRepositories(namespace string, page, perPage i
 			break
 		}
 
-		page++
+		options.Page++
 	}
 
 	return response, nil
 }
 
-func (g *BitbucketGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error) {
+func (g *BitbucketGitProvider) GetRepoBranches(repositoryId string, namespaceId string, options ListOptions) ([]*GitBranch, error) {
 	client := g.getApiClient()
 	var response []*GitBranch
 
@@ -165,7 +165,7 @@ func (g *BitbucketGitProvider) GetRepoBranches(repositoryId string, namespaceId 
 	return response, nil
 }
 
-func (g *BitbucketGitProvider) GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error) {
+func (g *BitbucketGitProvider) GetRepoPRs(repositoryId string, namespaceId string, options ListOptions) ([]*GitPullRequest, error) {
 	client := g.getApiClient()
 	var response []*GitPullRequest
 

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -84,23 +84,23 @@ func (g *BitbucketGitProvider) GetRepositories(namespace string, options ListOpt
 		Keyword: nil,
 	})
 	if err != nil {
-		return nil, err
+		return nil, g.FormatError(err)
 	}
 
 	for _, repo := range repoList.Items {
 		htmlLink, ok := repo.Links["html"].(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("invalid repo links")
+			return nil, errors.New("invalid repo links")
 		}
 
 		repoUrl, ok := htmlLink["href"].(string)
 		if !ok {
-			return nil, fmt.Errorf("invalid repo html link")
+			return nil, errors.New("invalid repo html link")
 		}
 
 		u, err := url.Parse(repoUrl)
 		if err != nil {
-			return nil, g.FormatError(err)
+			return nil, err
 		}
 
 		owner, name, err := g.getOwnerAndRepoFromFullName(repo.Full_name)

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -118,6 +118,7 @@ func (g *BitbucketGitProvider) GetRepositories(namespace string, options ListOpt
 		}
 
 		// If fewer than 10 items are returned, it indicates the last page
+		// refer to https://github.com/ktrysmt/go-bitbucket/blob/master/client.go#L23
 		if len(repoList.Items) < 10 {
 			break
 		}

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -26,7 +26,7 @@ type BitbucketServerGitProvider struct {
 	baseApiUrl string
 }
 
-func NewBitbucketServerGitProvider(username string, token string, baseApiUrl *string) *BitbucketServerGitProvider {
+func NewBitbucketServerGitProvider(username string, token string, baseApiUrl string) *BitbucketServerGitProvider {
 	provider := &BitbucketServerGitProvider{
 		username:            username,
 		token:               token,
@@ -137,7 +137,7 @@ func (g *BitbucketServerGitProvider) GetRepositories(namespace string, options L
 			ownerName = repo.Owner.Name
 		}
 
-		baseURL, err := url.Parse(*g.baseApiUrl)
+		baseURL, err := url.Parse(g.baseApiUrl)
 		if err != nil {
 			return nil, g.FormatError(repoList.StatusCode, repoList.Message)
 		}

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -92,72 +92,64 @@ func (g *BitbucketServerGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	return namespaces, nil
 }
 
-func (g *BitbucketServerGitProvider) GetRepositories(namespace string) ([]*GitRepository, error) {
+func (g *BitbucketServerGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
 	client, err := g.getApiClient()
 	if err != nil {
 		return nil, err
 	}
 
 	var response []*GitRepository
+	var repoList *bitbucketv1.APIResponse
 
-	start := 0
-	for {
-		var repoList *bitbucketv1.APIResponse
-		var err error
-		if namespace == personalNamespaceId {
-			repoList, err = client.DefaultApi.GetRepositories_19(nil)
-		} else {
-			repoList, err = client.DefaultApi.GetRepositoriesWithOptions(namespace, map[string]interface{}{
-				"start": start,
-			})
+	opts := map[string]interface{}{
+		"start": page,
+		"limit": perPage,
+	}
+	if namespace == personalNamespaceId {
+		repoList, err = client.DefaultApi.GetRepositories_19(opts)
+	} else {
+		repoList, err = client.DefaultApi.GetRepositoriesWithOptions(namespace, opts)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	pageRepos, err := bitbucketv1.GetRepositoriesResponse(repoList)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, repo := range pageRepos {
+		var repoUrl string
+		for _, link := range repo.Links.Clone {
+			if link.Name == "https" || link.Name == "http" {
+				repoUrl = link.Href
+				break
+			}
 		}
 
+		if len(repoUrl) == 0 && repo.Links != nil {
+			repoUrl = repo.Links.Self[0].Href
+		}
+
+		var ownerName string
+		if repo.Owner != nil {
+			ownerName = repo.Owner.Name
+		}
+
+		baseURL, err := url.Parse(*g.baseApiUrl)
 		if err != nil {
 			return nil, g.FormatError(repoList.StatusCode, repoList.Message)
 		}
 
-		pageRepos, err := bitbucketv1.GetRepositoriesResponse(repoList)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, repo := range pageRepos {
-			var repoUrl string
-			for _, link := range repo.Links.Clone {
-				if link.Name == "https" || link.Name == "http" {
-					repoUrl = link.Href
-					break
-				}
-			}
-
-			if len(repoUrl) == 0 && repo.Links != nil {
-				repoUrl = repo.Links.Self[0].Href
-			}
-
-			var ownerName string
-			if repo.Owner != nil {
-				ownerName = repo.Owner.Name
-			}
-
-			baseURL, err := url.Parse(g.baseApiUrl)
-			if err != nil {
-				return nil, err
-			}
-
-			response = append(response, &GitRepository{
-				Id:     repo.Slug,
-				Name:   repo.Name,
-				Url:    repoUrl,
-				Source: baseURL.Host,
-				Owner:  ownerName,
-			})
-		}
-
-		hasNextPage, nextPageStart := bitbucketv1.HasNextPage(repoList)
-		if !hasNextPage {
-			break
-		}
-		start = nextPageStart
+		response = append(response, &GitRepository{
+			Id:     repo.Slug,
+			Name:   repo.Name,
+			Url:    repoUrl,
+			Source: baseURL.Host,
+			Owner:  ownerName,
+		})
 	}
 
 	return response, nil

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -38,7 +38,7 @@ type GetRepositoryContext struct {
 	Path     *string `json:"path,omitempty" validate:"optional"`
 } // @name GetRepositoryContext
 
-// ListOptions holds additional parameters for api responses.
+// ListOptions holds additional parameters for list api responses.
 type ListOptions struct {
 	Page    int `json:"page,omitempty"`
 	PerPage int `json:"perPage,omitempty"`

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -38,12 +38,18 @@ type GetRepositoryContext struct {
 	Path     *string `json:"path,omitempty" validate:"optional"`
 } // @name GetRepositoryContext
 
+// ListOptions holds additional parameters for api responses.
+type ListOptions struct {
+	Page    int `json:"page,omitempty"`
+	PerPage int `json:"perPage,omitempty"`
+}
+
 type GitProvider interface {
-	GetNamespaces() ([]*GitNamespace, error)
-	GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error)
+	GetNamespaces(options ListOptions) ([]*GitNamespace, error)
+	GetRepositories(namespace string, options ListOptions) ([]*GitRepository, error)
 	GetUser() (*GitUser, error)
-	GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error)
-	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)
+	GetRepoBranches(repositoryId string, namespaceId string, options ListOptions) ([]*GitBranch, error)
+	GetRepoPRs(repositoryId string, namespaceId string, options ListOptions) ([]*GitPullRequest, error)
 
 	CanHandle(repoUrl string) (bool, error)
 	GetRepositoryContext(repoContext GetRepositoryContext) (*GitRepository, error)

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -40,7 +40,7 @@ type GetRepositoryContext struct {
 
 type GitProvider interface {
 	GetNamespaces() ([]*GitNamespace, error)
-	GetRepositories(namespace string) ([]*GitRepository, error)
+	GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error)
 	GetUser() (*GitUser, error)
 	GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error)
 	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)

--- a/pkg/gitprovider/gitea.go
+++ b/pkg/gitprovider/gitea.go
@@ -71,7 +71,10 @@ func (g *GiteaGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace, 
 		namespaces = append(namespaces, &GitNamespace{Id: org.UserName, Name: org.UserName})
 	}
 
-	namespaces = append([]*GitNamespace{{Id: personalNamespaceId, Name: user.Username}}, namespaces...)
+	// Append 'personal' namespace on first page
+	if options.Page == 1 {
+		namespaces = append([]*GitNamespace{{Id: personalNamespaceId, Name: user.Username}}, namespaces...)
+	}
 
 	return namespaces, nil
 }

--- a/pkg/gitprovider/gitea.go
+++ b/pkg/gitprovider/gitea.go
@@ -85,14 +85,14 @@ func (g *GiteaGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	return namespaces, nil
 }
 
-func (g *GiteaGitProvider) GetRepositories(namespace string) ([]*GitRepository, error) {
+func (g *GiteaGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
 	client, err := g.getApiClient()
 	if err != nil {
 		return nil, err
 	}
 
+	response := []*GitRepository{}
 	var repoList []*gitea.Repository
-	page := 1
 
 	for {
 		var repos []*gitea.Repository
@@ -135,8 +135,6 @@ func (g *GiteaGitProvider) GetRepositories(namespace string) ([]*GitRepository, 
 		repoList = repos
 	}
 
-	response := []*GitRepository{}
-
 	for _, repo := range repoList {
 		u, err := url.Parse(repo.HTMLURL)
 		if err != nil {
@@ -152,7 +150,7 @@ func (g *GiteaGitProvider) GetRepositories(namespace string) ([]*GitRepository, 
 		})
 	}
 
-	return response, err
+	return response, nil
 }
 
 func (g *GiteaGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error) {

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -77,7 +77,10 @@ func (g *GitHubGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace,
 		namespaces = append(namespaces, namespace)
 	}
 
-	namespaces = append([]*GitNamespace{{Id: personalNamespaceId, Name: user.Username}}, namespaces...)
+	// Append 'personal' namespace on first page
+	if options.Page == 1 {
+		namespaces = append([]*GitNamespace{{Id: personalNamespaceId, Name: user.Username}}, namespaces...)
+	}
 
 	return namespaces, nil
 }

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -108,13 +108,13 @@ func (g *GitHubGitProvider) GetRepositories(namespace string, options ListOption
 
 	repoList, _, err := client.Search.Repositories(ctx, query, opts)
 	if err != nil {
-		return nil, err
+		return nil, g.FormatError(err)
 	}
 
 	for _, repo := range repoList.Repositories {
 		u, err := url.Parse(*repo.HTMLURL)
 		if err != nil {
-			return nil, g.FormatError(err)
+			return nil, err
 		}
 
 		repos = append(repos, &GitRepository{

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -117,30 +117,17 @@ func (g *GitHubGitProvider) GetRepositories(namespace string, options ListOption
 			return nil, g.FormatError(err)
 		}
 
-		for _, repo := range repoList.Repositories {
-			u, err := url.Parse(*repo.HTMLURL)
-			if err != nil {
-				return nil, err
-			}
-			repos = append(repos, &GitRepository{
-				Id:     *repo.Name,
-				Name:   *repo.Name,
-				Url:    *repo.HTMLURL,
-				Branch: *repo.DefaultBranch,
-				Owner:  *repo.Owner.Login,
-				Source: u.Host,
-			})
-		}
-
-		// Break if there is no next page
-		if response.NextPage == 0 {
-			break
-		}
-
-		opts.Page = response.NextPage
+		repos = append(repos, &GitRepository{
+			Id:     *repo.Name,
+			Name:   *repo.Name,
+			Url:    *repo.HTMLURL,
+			Branch: *repo.DefaultBranch,
+			Owner:  *repo.Owner.Login,
+			Source: u.Host,
+		})
 	}
 
-	return repos, nil
+	return repos, err
 }
 
 func (g *GitHubGitProvider) GetRepoBranches(repositoryId string, namespaceId string, options ListOptions) ([]*GitBranch, error) {

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -87,37 +87,10 @@ func (g *GitLabGitProvider) GetRepositories(namespace string, options ListOption
 	var repoList []*gitlab.Project
 	var err error
 
-	page := 1
-
-	for {
-		var projects []*gitlab.Project
-		var response *gitlab.Response
-
-		if namespace == personalNamespaceId {
-			user, err := g.GetUser()
-			if err != nil {
-				return nil, err
-			}
-
-			projects, response, err = client.Projects.ListUserProjects(user.Id, &gitlab.ListProjectsOptions{
-				ListOptions: gitlab.ListOptions{
-					PerPage: 100,
-					Page:    page,
-				},
-			})
-			if err != nil {
-				return nil, g.FormatError(err)
-			}
-		} else {
-			projects, response, err = client.Groups.ListGroupProjects(namespace, &gitlab.ListGroupProjectsOptions{
-				ListOptions: gitlab.ListOptions{
-					PerPage: 100,
-					Page:    page,
-				},
-			})
-			if err != nil {
-				return nil, g.FormatError(err)
-			}
+	if namespace == personalNamespaceId {
+		user, err := g.GetUser()
+		if err != nil {
+			return nil, err
 		}
 
 		repoList, _, err = client.Projects.ListUserProjects(user.Id, &gitlab.ListProjectsOptions{
@@ -127,7 +100,7 @@ func (g *GitLabGitProvider) GetRepositories(namespace string, options ListOption
 			},
 		})
 		if err != nil {
-			return nil, err
+			return nil, g.FormatError(err)
 		}
 	} else {
 		repoList, _, err = client.Groups.ListGroupProjects(namespace, &gitlab.ListGroupProjectsOptions{
@@ -137,7 +110,7 @@ func (g *GitLabGitProvider) GetRepositories(namespace string, options ListOption
 			},
 		})
 		if err != nil {
-			return nil, err
+			return nil, g.FormatError(err)
 		}
 	}
 

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -50,14 +50,19 @@ func (g *GitLabGitProvider) CanHandle(repoUrl string) (bool, error) {
 	return strings.Contains(*g.baseApiUrl, staticContext.Source), nil
 }
 
-func (g *GitLabGitProvider) GetNamespaces() ([]*GitNamespace, error) {
+func (g *GitLabGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace, error) {
 	client := g.getApiClient()
 	user, err := g.GetUser()
 	if err != nil {
 		return nil, err
 	}
 
-	groupList, _, err := client.Groups.ListGroups(&gitlab.ListGroupsOptions{})
+	groupList, _, err := client.Groups.ListGroups(&gitlab.ListGroupsOptions{
+		ListOptions: gitlab.ListOptions{
+			Page:    options.Page,
+			PerPage: options.PerPage,
+		},
+	})
 	if err != nil {
 		return nil, g.FormatError(err)
 	}
@@ -76,7 +81,7 @@ func (g *GitLabGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	return namespaces, nil
 }
 
-func (g *GitLabGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
+func (g *GitLabGitProvider) GetRepositories(namespace string, options ListOptions) ([]*GitRepository, error) {
 	client := g.getApiClient()
 	var response []*GitRepository
 	var repoList []*gitlab.Project
@@ -117,8 +122,8 @@ func (g *GitLabGitProvider) GetRepositories(namespace string, page, perPage int)
 
 		repoList, _, err = client.Projects.ListUserProjects(user.Id, &gitlab.ListProjectsOptions{
 			ListOptions: gitlab.ListOptions{
-				PerPage: perPage,
-				Page:    page,
+				PerPage: options.PerPage,
+				Page:    options.Page,
 			},
 		})
 		if err != nil {
@@ -127,8 +132,8 @@ func (g *GitLabGitProvider) GetRepositories(namespace string, page, perPage int)
 	} else {
 		repoList, _, err = client.Groups.ListGroupProjects(namespace, &gitlab.ListGroupProjectsOptions{
 			ListOptions: gitlab.ListOptions{
-				PerPage: perPage,
-				Page:    page,
+				PerPage: options.PerPage,
+				Page:    options.Page,
 			},
 		})
 		if err != nil {
@@ -155,11 +160,16 @@ func (g *GitLabGitProvider) GetRepositories(namespace string, page, perPage int)
 	return response, nil
 }
 
-func (g *GitLabGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error) {
+func (g *GitLabGitProvider) GetRepoBranches(repositoryId string, namespaceId string, options ListOptions) ([]*GitBranch, error) {
 	client := g.getApiClient()
 	var response []*GitBranch
 
-	branches, _, err := client.Branches.ListBranches(repositoryId, &gitlab.ListBranchesOptions{})
+	branches, _, err := client.Branches.ListBranches(repositoryId, &gitlab.ListBranchesOptions{
+		ListOptions: gitlab.ListOptions{
+			Page:    options.Page,
+			PerPage: options.PerPage,
+		},
+	})
 	if err != nil {
 		return nil, g.FormatError(err)
 	}
@@ -177,11 +187,16 @@ func (g *GitLabGitProvider) GetRepoBranches(repositoryId string, namespaceId str
 	return response, nil
 }
 
-func (g *GitLabGitProvider) GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error) {
+func (g *GitLabGitProvider) GetRepoPRs(repositoryId string, namespaceId string, options ListOptions) ([]*GitPullRequest, error) {
 	client := g.getApiClient()
 	var response []*GitPullRequest
 
-	mergeRequests, _, err := client.MergeRequests.ListProjectMergeRequests(repositoryId, &gitlab.ListProjectMergeRequestsOptions{})
+	mergeRequests, _, err := client.MergeRequests.ListProjectMergeRequests(repositoryId, &gitlab.ListProjectMergeRequestsOptions{
+		ListOptions: gitlab.ListOptions{
+			Page:    options.Page,
+			PerPage: options.PerPage,
+		},
+	})
 	if err != nil {
 		return nil, g.FormatError(err)
 	}

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -76,7 +76,10 @@ func (g *GitLabGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace,
 		})
 	}
 
-	namespaces = append([]*GitNamespace{{Id: personalNamespaceId, Name: user.Username}}, namespaces...)
+	// Append 'personal' namespace on first page
+	if options.Page == 1 {
+		namespaces = append([]*GitNamespace{{Id: personalNamespaceId, Name: user.Username}}, namespaces...)
+	}
 
 	return namespaces, nil
 }

--- a/pkg/gitprovider/gitness.go
+++ b/pkg/gitprovider/gitness.go
@@ -39,7 +39,7 @@ func (g *GitnessGitProvider) CanHandle(repoUrl string) (bool, error) {
 	return strings.Contains(g.baseApiUrl, staticContext.Source), nil
 }
 
-func (g *GitnessGitProvider) GetNamespaces() ([]*GitNamespace, error) {
+func (g *GitnessGitProvider) GetNamespaces(options ListOptions) ([]*GitNamespace, error) {
 	client := g.getApiClient()
 	response, err := client.GetSpaces()
 	if err != nil {
@@ -61,7 +61,7 @@ func (g *GitnessGitProvider) getApiClient() *gitnessclient.GitnessClient {
 	return gitnessclient.NewGitnessClient(g.token, url)
 }
 
-func (g *GitnessGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
+func (g *GitnessGitProvider) GetRepositories(namespace string, options ListOptions) ([]*GitRepository, error) {
 	client := g.getApiClient()
 	response, err := client.GetRepositories(namespace)
 	if err != nil {
@@ -90,7 +90,7 @@ func (g *GitnessGitProvider) GetRepositories(namespace string, page, perPage int
 	return repos, nil
 }
 
-func (g *GitnessGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error) {
+func (g *GitnessGitProvider) GetRepoBranches(repositoryId string, namespaceId string, options ListOptions) ([]*GitBranch, error) {
 	client := g.getApiClient()
 	response, err := client.GetRepoBranches(repositoryId, namespaceId)
 	if err != nil {
@@ -107,7 +107,7 @@ func (g *GitnessGitProvider) GetRepoBranches(repositoryId string, namespaceId st
 	return branches, nil
 }
 
-func (g *GitnessGitProvider) GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error) {
+func (g *GitnessGitProvider) GetRepoPRs(repositoryId string, namespaceId string, options ListOptions) ([]*GitPullRequest, error) {
 	client := g.getApiClient()
 	response, err := client.GetRepoPRs(repositoryId, namespaceId)
 	if err != nil {

--- a/pkg/gitprovider/gitness.go
+++ b/pkg/gitprovider/gitness.go
@@ -61,7 +61,7 @@ func (g *GitnessGitProvider) getApiClient() *gitnessclient.GitnessClient {
 	return gitnessclient.NewGitnessClient(g.token, url)
 }
 
-func (g *GitnessGitProvider) GetRepositories(namespace string) ([]*GitRepository, error) {
+func (g *GitnessGitProvider) GetRepositories(namespace string, page, perPage int) ([]*GitRepository, error) {
 	client := g.getApiClient()
 	response, err := client.GetRepositories(namespace)
 	if err != nil {

--- a/pkg/server/gitproviders/branches.go
+++ b/pkg/server/gitproviders/branches.go
@@ -9,13 +9,13 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 )
 
-func (s *GitProviderService) GetRepoBranches(gitProviderId, namespaceId, repositoryId string) ([]*gitprovider.GitBranch, error) {
+func (s *GitProviderService) GetRepoBranches(gitProviderId, namespaceId, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitBranch, error) {
 	gitProvider, err := s.GetGitProvider(gitProviderId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git provider: %w", err)
 	}
 
-	response, err := gitProvider.GetRepoBranches(repositoryId, namespaceId)
+	response, err := gitProvider.GetRepoBranches(repositoryId, namespaceId, options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get branches: %w", err)
 	}

--- a/pkg/server/gitproviders/namespaces.go
+++ b/pkg/server/gitproviders/namespaces.go
@@ -9,13 +9,13 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 )
 
-func (s *GitProviderService) GetNamespaces(gitProviderId string) ([]*gitprovider.GitNamespace, error) {
+func (s *GitProviderService) GetNamespaces(gitProviderId string, options gitprovider.ListOptions) ([]*gitprovider.GitNamespace, error) {
 	gitProvider, err := s.GetGitProvider(gitProviderId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git provider: %w", err)
 	}
 
-	response, err := gitProvider.GetNamespaces()
+	response, err := gitProvider.GetNamespaces(options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get namespaces: %w", err)
 	}

--- a/pkg/server/gitproviders/pull_requests.go
+++ b/pkg/server/gitproviders/pull_requests.go
@@ -9,13 +9,13 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 )
 
-func (s *GitProviderService) GetRepoPRs(gitProviderId, namespaceId, repositoryId string) ([]*gitprovider.GitPullRequest, error) {
+func (s *GitProviderService) GetRepoPRs(gitProviderId, namespaceId, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitPullRequest, error) {
 	gitProvider, err := s.GetGitProvider(gitProviderId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git provider: %w", err)
 	}
 
-	response, err := gitProvider.GetRepoPRs(repositoryId, namespaceId)
+	response, err := gitProvider.GetRepoPRs(repositoryId, namespaceId, options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pull requests: %w", err)
 	}

--- a/pkg/server/gitproviders/repositories.go
+++ b/pkg/server/gitproviders/repositories.go
@@ -9,13 +9,13 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 )
 
-func (s *GitProviderService) GetRepositories(gitProviderId, namespaceId string) ([]*gitprovider.GitRepository, error) {
+func (s *GitProviderService) GetRepositories(gitProviderId, namespaceId string, page, perPage int) ([]*gitprovider.GitRepository, error) {
 	gitProvider, err := s.GetGitProvider(gitProviderId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git provider: %w", err)
 	}
 
-	response, err := gitProvider.GetRepositories(namespaceId)
+	response, err := gitProvider.GetRepositories(namespaceId, page, perPage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repositories: %w", err)
 	}

--- a/pkg/server/gitproviders/repositories.go
+++ b/pkg/server/gitproviders/repositories.go
@@ -9,13 +9,13 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 )
 
-func (s *GitProviderService) GetRepositories(gitProviderId, namespaceId string, page, perPage int) ([]*gitprovider.GitRepository, error) {
+func (s *GitProviderService) GetRepositories(gitProviderId, namespaceId string, options gitprovider.ListOptions) ([]*gitprovider.GitRepository, error) {
 	gitProvider, err := s.GetGitProvider(gitProviderId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git provider: %w", err)
 	}
 
-	response, err := gitProvider.GetRepositories(namespaceId, page, perPage)
+	response, err := gitProvider.GetRepositories(namespaceId, options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repositories: %w", err)
 	}

--- a/pkg/server/gitproviders/service.go
+++ b/pkg/server/gitproviders/service.go
@@ -19,10 +19,10 @@ type IGitProviderService interface {
 	GetGitProviderForUrl(url string) (gitprovider.GitProvider, string, error)
 	GetGitProviderForHttpRequest(req *http.Request) (gitprovider.GitProvider, error)
 	GetGitUser(gitProviderId string) (*gitprovider.GitUser, error)
-	GetNamespaces(gitProviderId string) ([]*gitprovider.GitNamespace, error)
-	GetRepoBranches(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitBranch, error)
-	GetRepoPRs(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitPullRequest, error)
-	GetRepositories(gitProviderId string, namespaceId string, page, perPage int) ([]*gitprovider.GitRepository, error)
+	GetNamespaces(gitProviderId string, options gitprovider.ListOptions) ([]*gitprovider.GitNamespace, error)
+	GetRepoBranches(gitProviderId string, namespaceId string, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitBranch, error)
+	GetRepoPRs(gitProviderId string, namespaceId string, repositoryId string, options gitprovider.ListOptions) ([]*gitprovider.GitPullRequest, error)
+	GetRepositories(gitProviderId string, namespaceId string, options gitprovider.ListOptions) ([]*gitprovider.GitRepository, error)
 	ListConfigs() ([]*gitprovider.GitProviderConfig, error)
 	RemoveGitProvider(gitProviderId string) error
 	SetGitProviderConfig(providerConfig *gitprovider.GitProviderConfig) error

--- a/pkg/server/gitproviders/service.go
+++ b/pkg/server/gitproviders/service.go
@@ -22,7 +22,7 @@ type IGitProviderService interface {
 	GetNamespaces(gitProviderId string) ([]*gitprovider.GitNamespace, error)
 	GetRepoBranches(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitBranch, error)
 	GetRepoPRs(gitProviderId string, namespaceId string, repositoryId string) ([]*gitprovider.GitPullRequest, error)
-	GetRepositories(gitProviderId string, namespaceId string) ([]*gitprovider.GitRepository, error)
+	GetRepositories(gitProviderId string, namespaceId string, page, perPage int) ([]*gitprovider.GitRepository, error)
 	ListConfigs() ([]*gitprovider.GitProviderConfig, error)
 	RemoveGitProvider(gitProviderId string) error
 	SetGitProviderConfig(providerConfig *gitprovider.GitProviderConfig) error

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -72,42 +72,44 @@ func GetStyledSelectList(items []list.Item, listOptions ...SelectionListOptions)
 
 	l := list.New(items, d, 0, 0)
 
-	if listOptions != nil && !listOptions[0].IsPaginationDisabled {
+	if listOptions != nil {
 		// Sets the mouse cursor to point to the first index of newly loaded items
 		if listOptions[0].CursorIndex > 0 {
 			l.Select(listOptions[0].CursorIndex)
 		}
 
-		// Add the 'Load More' option in search filter results
-		l.Filter = func(term string, targets []string) []list.Rank {
-			ranks := list.DefaultFilter(term, targets)
+		if !listOptions[0].IsPaginationDisabled {
+			// Add the 'Load More' option in search filter results
+			l.Filter = func(term string, targets []string) []list.Rank {
+				ranks := list.DefaultFilter(term, targets)
 
-			loadMoreIdx := -1
-			// Ideally 'Load More' option if present should be found at the last index
-			for i := len(targets) - 1; i >= 0; i-- {
-				if targets[i] == ListNavigationRenderText {
-					loadMoreIdx = i
-					break
+				loadMoreIdx := -1
+				// Ideally 'Load More' option if present should be found at the last index
+				for i := len(targets) - 1; i >= 0; i-- {
+					if targets[i] == ListNavigationRenderText {
+						loadMoreIdx = i
+						break
+					}
 				}
-			}
 
-			if loadMoreIdx == -1 {
-				return ranks
-			}
-
-			// Return if already present
-			for i := range ranks {
-				if ranks[i].Index == loadMoreIdx {
+				if loadMoreIdx == -1 {
 					return ranks
 				}
+
+				// Return if already present
+				for i := range ranks {
+					if ranks[i].Index == loadMoreIdx {
+						return ranks
+					}
+				}
+
+				// Append 'Load More' option in search filter results
+				ranks = append(ranks, list.Rank{
+					Index: loadMoreIdx,
+				})
+
+				return ranks
 			}
-
-			// Append 'Load More' option in search filter results
-			ranks = append(ranks, list.Rank{
-				Index: loadMoreIdx,
-			})
-
-			return ranks
 		}
 	}
 

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -82,24 +82,30 @@ func GetStyledSelectList(items []list.Item, listOptions ...SelectionListOptions)
 		l.Filter = func(term string, targets []string) []list.Rank {
 			ranks := list.DefaultFilter(term, targets)
 
-			lastIdx := len(targets) - 1
-			if targets[lastIdx] != ListNavigationRenderText {
+			loadMoreIdx := -1
+			// Ideally 'Load More' option if present should be found at the last index
+			for i := len(targets) - 1; i >= 0; i-- {
+				if targets[i] == ListNavigationRenderText {
+					loadMoreIdx = i
+					break
+				}
+			}
+
+			if loadMoreIdx == -1 {
 				return ranks
 			}
 
-			isLoadMoreOptionPresent := false
+			// Return if already present
 			for i := range ranks {
-				if ranks[i].Index == len(targets)-1 {
+				if ranks[i].Index == loadMoreIdx {
 					return ranks
 				}
 			}
 
-			if !isLoadMoreOptionPresent {
-				lastIdx := list.Rank{
-					Index: len(targets) - 1,
-				}
-				ranks = append(ranks, lastIdx)
-			}
+			// Append 'Load More' option in search filter results
+			ranks = append(ranks, list.Rank{
+				Index: loadMoreIdx,
+			})
 
 			return ranks
 		}
@@ -117,7 +123,7 @@ func GetStyledSelectList(items []list.Item, listOptions ...SelectionListOptions)
 	var pluralItemName string
 	if listOptions == nil {
 		pluralItemName = fmt.Sprintf("items\n\n%s", SeparatorString)
-	} else if listOptions != nil && len(listOptions[0].ParentIdentifier) > 0 {
+	} else if len(listOptions[0].ParentIdentifier) > 0 {
 		pluralItemName = fmt.Sprintf("items (%s)\n\n%s", listOptions[0].ParentIdentifier, SeparatorString)
 	}
 

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -12,9 +12,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-const (
+var (
 	ListNavigationText       = "load more"
-	ListNavigationRenderText = "Load more.."
+	ListNavigationRenderText = "+ Load more.."
 )
 
 var (

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -48,7 +48,12 @@ var LogPrefixColors = []lipgloss.AdaptiveColor{
 	Blue, Orange, Cyan, Yellow,
 }
 
-func GetStyledSelectList(items []list.Item, parentIdentifier ...string, curPage ...int32) list.Model {
+type ListOptions struct {
+	ParentIdentifier string
+	CurPage          int32
+}
+
+func GetStyledSelectList(items []list.Item, listOptions ...ListOptions) list.Model {
 
 	d := list.NewDefaultDelegate()
 
@@ -72,17 +77,17 @@ func GetStyledSelectList(items []list.Item, parentIdentifier ...string, curPage 
 	l.FilterInput.TextStyle = lipgloss.NewStyle().Foreground(Green)
 
 	singularItemName := "item " + SeparatorString
-	pluralItemName := "items "
+	pluralItemName := "items"
 
-	if curPage != nil {
-		pluralItemName += fmt.Sprintf("| Page %d", curPage[0])
+	if len(listOptions) > 0 && listOptions[0].CurPage > 0 {
+		pluralItemName += fmt.Sprintf(" | Page %d", listOptions[0].CurPage)
 	}
 
-	if len(parentIdentifier) > 0 {
-		pluralItemName += fmt.Sprintf(" (%s)", parentIdentifier[0])
+	if len(listOptions) > 0 && len(listOptions[0].ParentIdentifier) > 0 {
+		pluralItemName += fmt.Sprintf(" | (%s)", listOptions[0].ParentIdentifier)
 	}
 
-	pluralItemName += fmt.Sprintf("\n\n(%s)", SeparatorString)
+	pluralItemName += fmt.Sprintf(" \n\n%s", SeparatorString)
 
 	l.SetStatusBarItemName(singularItemName, pluralItemName)
 	return l

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -24,6 +24,7 @@ var (
 	Gray        = lipgloss.AdaptiveColor{Light: "243", Dark: "243"}
 	LightGray   = lipgloss.AdaptiveColor{Light: "#828282", Dark: "#828282"}
 	Red         = lipgloss.AdaptiveColor{Light: "#FF4672", Dark: "#ED567A"}
+	Purple      = lipgloss.AdaptiveColor{Light: "#800080", Dark: "#800080"}
 )
 
 var (
@@ -40,13 +41,14 @@ var (
 	DefaultRowDataStyle = lipgloss.NewStyle().Foreground(Gray)
 	BaseCellStyle       = lipgloss.NewRenderer(os.Stdout).NewStyle().Padding(0, 4, 1, 0)
 	TableHeaderStyle    = BaseCellStyle.Foreground(LightGray).Bold(false).Padding(0).MarginRight(4)
+	NavigationStyle     = lipgloss.NewStyle().Foreground(Purple)
 )
 
 var LogPrefixColors = []lipgloss.AdaptiveColor{
 	Blue, Orange, Cyan, Yellow,
 }
 
-func GetStyledSelectList(items []list.Item, parentIdentifier ...string) list.Model {
+func GetStyledSelectList(items []list.Item, parentIdentifier ...string, curPage ...int32) list.Model {
 
 	d := list.NewDefaultDelegate()
 
@@ -70,15 +72,19 @@ func GetStyledSelectList(items []list.Item, parentIdentifier ...string) list.Mod
 	l.FilterInput.TextStyle = lipgloss.NewStyle().Foreground(Green)
 
 	singularItemName := "item " + SeparatorString
-	var pluralItemName string
-	if len(parentIdentifier) == 0 {
-		pluralItemName = fmt.Sprintf("items\n\n%s", SeparatorString)
-	} else {
-		pluralItemName = fmt.Sprintf("items (%s)\n\n%s", parentIdentifier[0], SeparatorString)
+	pluralItemName := "items "
+
+	if curPage != nil {
+		pluralItemName += fmt.Sprintf("| Page %d", curPage[0])
 	}
 
-	l.SetStatusBarItemName(singularItemName, pluralItemName)
+	if len(parentIdentifier) > 0 {
+		pluralItemName += fmt.Sprintf(" (%s)", parentIdentifier[0])
+	}
 
+	pluralItemName += fmt.Sprintf("\n\n(%s)", SeparatorString)
+
+	l.SetStatusBarItemName(singularItemName, pluralItemName)
 	return l
 }
 

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -12,6 +12,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const (
+	ListNavigationText       = "load more"
+	ListNavigationRenderText = "Load more.."
+)
+
 var (
 	Green       = lipgloss.AdaptiveColor{Light: "#23cc71", Dark: "#23cc71"}
 	Blue        = lipgloss.AdaptiveColor{Light: "#017ffe", Dark: "#017ffe"}
@@ -48,12 +53,7 @@ var LogPrefixColors = []lipgloss.AdaptiveColor{
 	Blue, Orange, Cyan, Yellow,
 }
 
-type ListOptions struct {
-	ParentIdentifier string
-	CurPage          int32
-}
-
-func GetStyledSelectList(items []list.Item, listOptions ...ListOptions) list.Model {
+func GetStyledSelectList(items []list.Item, parentIdentifier ...string) list.Model {
 
 	d := list.NewDefaultDelegate()
 
@@ -77,19 +77,15 @@ func GetStyledSelectList(items []list.Item, listOptions ...ListOptions) list.Mod
 	l.FilterInput.TextStyle = lipgloss.NewStyle().Foreground(Green)
 
 	singularItemName := "item " + SeparatorString
-	pluralItemName := "items"
-
-	if len(listOptions) > 0 && listOptions[0].CurPage > 0 {
-		pluralItemName += fmt.Sprintf(" | Page %d", listOptions[0].CurPage)
+	var pluralItemName string
+	if len(parentIdentifier) == 0 {
+		pluralItemName = fmt.Sprintf("items\n\n%s", SeparatorString)
+	} else {
+		pluralItemName = fmt.Sprintf("items (%s)\n\n%s", parentIdentifier[0], SeparatorString)
 	}
-
-	if len(listOptions) > 0 && len(listOptions[0].ParentIdentifier) > 0 {
-		pluralItemName += fmt.Sprintf(" | (%s)", listOptions[0].ParentIdentifier)
-	}
-
-	pluralItemName += fmt.Sprintf(" \n\n%s", SeparatorString)
 
 	l.SetStatusBarItemName(singularItemName, pluralItemName)
+
 	return l
 }
 

--- a/pkg/views/workspace/selection/branch.go
+++ b/pkg/views/workspace/selection/branch.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
+func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -30,7 +30,11 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, choice
 		items = AddNavigationOptionsToList(items, len(branches), curPage, perPage)
 	}
 
-	l := views.GetStyledSelectList(items, curPage)
+	listOptions := views.ListOptions{
+		ParentIdentifier: parentIdentifier,
+		CurPage:          curPage,
+	}
+	l := views.GetStyledSelectList(items, listOptions)
 
 	title := "Choose a Branch"
 	if projectOrder > 1 {
@@ -59,11 +63,11 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, choice
 	}
 }
 
-func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitBranch, string) {
+func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitBranch, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectBranchPrompt(branches, projectOrder, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
+	go selectBranchPrompt(branches, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
 
 	select {
 	case branchName := <-choiceChan:

--- a/pkg/views/workspace/selection/branch.go
+++ b/pkg/views/workspace/selection/branch.go
@@ -27,14 +27,10 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 	}
 
 	if !isPaginationDisabled {
-		items = AddNavigationOptionsToList(items, len(branches), curPage, perPage)
+		items = AddLoadMoreOptionToList(items, len(branches), curPage, perPage)
 	}
 
-	listOptions := views.ListOptions{
-		ParentIdentifier: parentIdentifier,
-		CurPage:          curPage,
-	}
-	l := views.GetStyledSelectList(items, listOptions)
+	l := views.GetStyledSelectList(items, parentIdentifier)
 
 	title := "Choose a Branch"
 	if projectOrder > 1 {
@@ -53,7 +49,7 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == "next" || choice == "prev" {
+		if choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice

--- a/pkg/views/workspace/selection/branch.go
+++ b/pkg/views/workspace/selection/branch.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
+func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -27,7 +27,7 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 	}
 
 	if !isPaginationDisabled {
-		items = AddLoadMoreOptionToList(items, len(branches), curPage, perPage)
+		items = AddLoadMoreOptionToList(items)
 	}
 
 	l := views.GetStyledSelectList(items, parentIdentifier)
@@ -49,7 +49,7 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == views.ListNavigationText {
+		if !isPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice
@@ -59,11 +59,11 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 	}
 }
 
-func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitBranch, string) {
+func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, isPaginationDisabled bool) (*apiclient.GitBranch, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectBranchPrompt(branches, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
+	go selectBranchPrompt(branches, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled)
 
 	select {
 	case branchName := <-choiceChan:

--- a/pkg/views/workspace/selection/branch.go
+++ b/pkg/views/workspace/selection/branch.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, choiceChan chan<- string) {
+func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -26,7 +26,11 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 		items = append(items, newItem)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	if !isPaginationDisabled {
+		items = AddNavigationOptionsToList(items, len(branches), curPage, perPage)
+	}
+
+	l := views.GetStyledSelectList(items, curPage)
 
 	title := "Choose a Branch"
 	if projectOrder > 1 {
@@ -42,25 +46,34 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 		os.Exit(1)
 	}
 
+	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
-		choiceChan <- *m.choice
+		choice := *m.choice
+		if choice == "next" || choice == "prev" {
+			navChan <- choice
+		} else {
+			choiceChan <- choice
+		}
 	} else {
 		choiceChan <- ""
 	}
 }
 
-func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string) *apiclient.GitBranch {
+func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitBranch, string) {
 	choiceChan := make(chan string)
+	navChan := make(chan string)
 
-	go selectBranchPrompt(branches, projectOrder, parentIdentifier, choiceChan)
+	go selectBranchPrompt(branches, projectOrder, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
 
-	branchName := <-choiceChan
-
-	for _, b := range branches {
-		if b.Name == branchName {
-			return &b
+	select {
+	case branchName := <-choiceChan:
+		for _, b := range branches {
+			if b.Name == branchName {
+				return &b, ""
+			}
 		}
+		return nil, ""
+	case navigate := <-navChan:
+		return nil, navigate
 	}
-
-	return nil
 }

--- a/pkg/views/workspace/selection/branch.go
+++ b/pkg/views/workspace/selection/branch.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool) {
+func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, selectionListOptions views.SelectionListOptions, choiceChan chan<- string, navChan chan<- string) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -26,11 +26,11 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 		items = append(items, newItem)
 	}
 
-	if !isPaginationDisabled {
+	if !selectionListOptions.IsPaginationDisabled {
 		items = AddLoadMoreOptionToList(items)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	l := views.GetStyledSelectList(items, selectionListOptions)
 
 	title := "Choose a Branch"
 	if projectOrder > 1 {
@@ -49,7 +49,7 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if !isPaginationDisabled && choice == views.ListNavigationText {
+		if !selectionListOptions.IsPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice
@@ -59,11 +59,11 @@ func selectBranchPrompt(branches []apiclient.GitBranch, projectOrder int, parent
 	}
 }
 
-func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, parentIdentifier string, isPaginationDisabled bool) (*apiclient.GitBranch, string) {
+func GetBranchFromPrompt(branches []apiclient.GitBranch, projectOrder int, selectionListOptions views.SelectionListOptions) (*apiclient.GitBranch, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectBranchPrompt(branches, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled)
+	go selectBranchPrompt(branches, projectOrder, selectionListOptions, choiceChan, navChan)
 
 	select {
 	case branchName := <-choiceChan:

--- a/pkg/views/workspace/selection/checkout.go
+++ b/pkg/views/workspace/selection/checkout.go
@@ -32,7 +32,10 @@ func selectCheckoutPrompt(checkoutOptions []CheckoutOption, projectOrder int, pa
 		items = append(items, newItem)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	listOptions := views.ListOptions{
+		ParentIdentifier: parentIdentifier,
+	}
+	l := views.GetStyledSelectList(items, listOptions)
 
 	title := "Cloning Options"
 	if projectOrder > 1 {

--- a/pkg/views/workspace/selection/checkout.go
+++ b/pkg/views/workspace/selection/checkout.go
@@ -32,10 +32,7 @@ func selectCheckoutPrompt(checkoutOptions []CheckoutOption, projectOrder int, pa
 		items = append(items, newItem)
 	}
 
-	listOptions := views.ListOptions{
-		ParentIdentifier: parentIdentifier,
-	}
-	l := views.GetStyledSelectList(items, listOptions)
+	l := views.GetStyledSelectList(items, parentIdentifier)
 
 	title := "Cloning Options"
 	if projectOrder > 1 {

--- a/pkg/views/workspace/selection/checkout.go
+++ b/pkg/views/workspace/selection/checkout.go
@@ -32,7 +32,10 @@ func selectCheckoutPrompt(checkoutOptions []CheckoutOption, projectOrder int, pa
 		items = append(items, newItem)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	listOptions := views.SelectionListOptions{
+		ParentIdentifier: parentIdentifier,
+	}
+	l := views.GetStyledSelectList(items, listOptions)
 
 	title := "Cloning Options"
 	if projectOrder > 1 {

--- a/pkg/views/workspace/selection/common.go
+++ b/pkg/views/workspace/selection/common.go
@@ -34,20 +34,13 @@ func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perP
 
 // Adds 'Load more' option to a selection list for efficient pagination
 // totalItems count is exclusive of pagination options.
-func AddLoadMoreOptionToList(items []list.Item, totalItems int, curPage, perPage int32) []list.Item {
-	curPageItems := int32(totalItems)
-	if curPage > 1 {
-		curPageItems = (int32)(totalItems) - (perPage * curPage)
-	}
-
-	if curPageItems == perPage {
-		items = append(items, item[string]{
-			id:             views.ListNavigationText,
-			title:          views.NavigationStyle.Render(views.ListNavigationRenderText),
-			choiceProperty: views.ListNavigationText,
-			desc:           "Loads next set of remaining items",
-		})
-	}
+func AddLoadMoreOptionToList(items []list.Item) []list.Item {
+	items = append(items, item[string]{
+		id:             views.ListNavigationText,
+		title:          views.NavigationStyle.Render(views.ListNavigationRenderText),
+		choiceProperty: views.ListNavigationText,
+		desc:           "Loads next set of remaining items",
+	})
 
 	return items
 }

--- a/pkg/views/workspace/selection/common.go
+++ b/pkg/views/workspace/selection/common.go
@@ -8,7 +8,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-// Add navigation options for pagination to a selection list
+// Adds navigation options for pagination to a selection list
 // totalItems count is exclusive of pagination options.
 func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perPage int32) []list.Item {
 	if curPage > 1 {
@@ -26,6 +26,26 @@ func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perP
 			title:          views.NavigationStyle.Render("Next Page"),
 			choiceProperty: "next",
 			desc:           "Go to the next page",
+		})
+	}
+
+	return items
+}
+
+// Adds 'Load more' option to a selection list for efficient pagination
+// totalItems count is exclusive of pagination options.
+func AddLoadMoreOptionToList(items []list.Item, totalItems int, curPage, perPage int32) []list.Item {
+	curPageItems := int32(totalItems)
+	if curPage > 1 {
+		curPageItems = (int32)(totalItems) - (perPage * curPage)
+	}
+
+	if curPageItems == perPage {
+		items = append(items, item[string]{
+			id:             views.ListNavigationText,
+			title:          views.NavigationStyle.Render(views.ListNavigationRenderText),
+			choiceProperty: views.ListNavigationText,
+			desc:           "Loads next set of remaining items",
 		})
 	}
 

--- a/pkg/views/workspace/selection/common.go
+++ b/pkg/views/workspace/selection/common.go
@@ -14,7 +14,7 @@ func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perP
 	if curPage > 1 {
 		items = append([]list.Item{item[string]{
 			id:             "prev",
-			title:          views.NavigationStyle.Render("Previous Page"),
+			title:          "Previous Page",
 			choiceProperty: "prev",
 			desc:           "Go to the previous page",
 		}}, items...)
@@ -23,7 +23,7 @@ func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perP
 	if totalItems == int(perPage) {
 		items = append(items, item[string]{
 			id:             "next",
-			title:          views.NavigationStyle.Render("Next Page"),
+			title:          "Next Page",
 			choiceProperty: "next",
 			desc:           "Go to the next page",
 		})
@@ -37,7 +37,7 @@ func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perP
 func AddLoadMoreOptionToList(items []list.Item) []list.Item {
 	items = append(items, item[string]{
 		id:             views.ListNavigationText,
-		title:          views.NavigationStyle.Render(views.ListNavigationRenderText),
+		title:          views.ListNavigationRenderText,
 		choiceProperty: views.ListNavigationText,
 		desc:           "Loads next set of remaining items",
 	})

--- a/pkg/views/workspace/selection/common.go
+++ b/pkg/views/workspace/selection/common.go
@@ -8,30 +8,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-// Adds navigation options for pagination to a selection list
-// totalItems count is exclusive of pagination options.
-func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perPage int32) []list.Item {
-	if curPage > 1 {
-		items = append([]list.Item{item[string]{
-			id:             "prev",
-			title:          "Previous Page",
-			choiceProperty: "prev",
-			desc:           "Go to the previous page",
-		}}, items...)
-	}
-
-	if totalItems == int(perPage) {
-		items = append(items, item[string]{
-			id:             "next",
-			title:          "Next Page",
-			choiceProperty: "next",
-			desc:           "Go to the next page",
-		})
-	}
-
-	return items
-}
-
 // Adds 'Load more' option to a selection list for efficient pagination
 // totalItems count is exclusive of pagination options.
 func AddLoadMoreOptionToList(items []list.Item) []list.Item {

--- a/pkg/views/workspace/selection/common.go
+++ b/pkg/views/workspace/selection/common.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package selection
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/daytonaio/daytona/pkg/views"
+)
+
+// Add navigation options for pagination to a selection list
+// totalItems count is exclusive of pagination options.
+func AddNavigationOptionsToList(items []list.Item, totalItems int, curPage, perPage int32) []list.Item {
+	if curPage > 1 {
+		items = append([]list.Item{item[string]{
+			id:             "prev",
+			title:          views.NavigationStyle.Render("Previous Page"),
+			choiceProperty: "prev",
+			desc:           "Go to the previous page",
+		}}, items...)
+	}
+
+	if totalItems == int(perPage) {
+		items = append(items, item[string]{
+			id:             "next",
+			title:          views.NavigationStyle.Render("Next Page"),
+			choiceProperty: "next",
+			desc:           "Go to the next page",
+		})
+	}
+
+	return items
+}

--- a/pkg/views/workspace/selection/namespace.go
+++ b/pkg/views/workspace/selection/namespace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
+func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool) {
 	items := []list.Item{}
 	var desc string
 
@@ -29,7 +29,7 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	}
 
 	if !isPaginationDisabled {
-		items = AddLoadMoreOptionToList(items, len(namespaces), curPage, perPage)
+		items = AddLoadMoreOptionToList(items)
 	}
 
 	l := views.GetStyledSelectList(items, parentIdentifier)
@@ -51,7 +51,7 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == views.ListNavigationText {
+		if !isPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice
@@ -61,11 +61,11 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	}
 }
 
-func GetNamespaceIdFromPrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (string, string) {
+func GetNamespaceIdFromPrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, isPaginationDisabled bool) (string, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectNamespacePrompt(namespaces, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
+	go selectNamespacePrompt(namespaces, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled)
 
 	select {
 	case choice := <-choiceChan:

--- a/pkg/views/workspace/selection/namespace.go
+++ b/pkg/views/workspace/selection/namespace.go
@@ -29,14 +29,10 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	}
 
 	if !isPaginationDisabled {
-		items = AddNavigationOptionsToList(items, len(namespaces), curPage, perPage)
+		items = AddLoadMoreOptionToList(items, len(namespaces), curPage, perPage)
 	}
 
-	listOptions := views.ListOptions{
-		ParentIdentifier: parentIdentifier,
-		CurPage:          curPage,
-	}
-	l := views.GetStyledSelectList(items, listOptions)
+	l := views.GetStyledSelectList(items, parentIdentifier)
 
 	title := "Choose a Namespace"
 	if projectOrder > 1 {
@@ -55,7 +51,7 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == "next" || choice == "prev" {
+		if choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice

--- a/pkg/views/workspace/selection/namespace.go
+++ b/pkg/views/workspace/selection/namespace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool) {
+func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int, selectionListOptions views.SelectionListOptions, choiceChan chan<- string, navChan chan<- string) {
 	items := []list.Item{}
 	var desc string
 
@@ -28,11 +28,11 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 		items = append(items, newItem)
 	}
 
-	if !isPaginationDisabled {
+	if !selectionListOptions.IsPaginationDisabled {
 		items = AddLoadMoreOptionToList(items)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	l := views.GetStyledSelectList(items, selectionListOptions)
 
 	title := "Choose a Namespace"
 	if projectOrder > 1 {
@@ -51,7 +51,7 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if !isPaginationDisabled && choice == views.ListNavigationText {
+		if !selectionListOptions.IsPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice
@@ -61,11 +61,11 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	}
 }
 
-func GetNamespaceIdFromPrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, isPaginationDisabled bool) (string, string) {
+func GetNamespaceIdFromPrompt(namespaces []apiclient.GitNamespace, projectOrder int, selectionListOptions views.SelectionListOptions) (string, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectNamespacePrompt(namespaces, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled)
+	go selectNamespacePrompt(namespaces, projectOrder, selectionListOptions, choiceChan, navChan)
 
 	select {
 	case choice := <-choiceChan:

--- a/pkg/views/workspace/selection/namespace.go
+++ b/pkg/views/workspace/selection/namespace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
+func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
 	items := []list.Item{}
 	var desc string
 
@@ -32,7 +32,11 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 		items = AddNavigationOptionsToList(items, len(namespaces), curPage, perPage)
 	}
 
-	l := views.GetStyledSelectList(items, curPage)
+	listOptions := views.ListOptions{
+		ParentIdentifier: parentIdentifier,
+		CurPage:          curPage,
+	}
+	l := views.GetStyledSelectList(items, listOptions)
 
 	title := "Choose a Namespace"
 	if projectOrder > 1 {
@@ -61,11 +65,11 @@ func selectNamespacePrompt(namespaces []apiclient.GitNamespace, projectOrder int
 	}
 }
 
-func GetNamespaceIdFromPrompt(namespaces []apiclient.GitNamespace, projectOrder int, isPaginationDisabled bool, curPage, perPage int32) (string, string) {
+func GetNamespaceIdFromPrompt(namespaces []apiclient.GitNamespace, projectOrder int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (string, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectNamespacePrompt(namespaces, projectOrder, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
+	go selectNamespacePrompt(namespaces, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
 
 	select {
 	case choice := <-choiceChan:

--- a/pkg/views/workspace/selection/pullrequest.go
+++ b/pkg/views/workspace/selection/pullrequest.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
+func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -32,7 +32,12 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 		items = AddNavigationOptionsToList(items, len(pullRequests), curPage, perPage)
 	}
 
-	l := views.GetStyledSelectList(items, curPage)
+	listOptions := views.ListOptions{
+		ParentIdentifier: parentIdentifier,
+		CurPage:          curPage,
+	}
+
+	l := views.GetStyledSelectList(items, listOptions)
 
 	title := "Choose a Pull/Merge Request"
 	if projectOrder > 1 {
@@ -60,11 +65,11 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 	}
 }
 
-func GetPullRequestFromPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitPullRequest, string) {
+func GetPullRequestFromPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitPullRequest, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectPullRequestPrompt(pullRequests, projectOrder, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
+	go selectPullRequestPrompt(pullRequests, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
 
 	select {
 	case pullRequestName := <-choiceChan:

--- a/pkg/views/workspace/selection/pullrequest.go
+++ b/pkg/views/workspace/selection/pullrequest.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool) {
+func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, selectionListOptions views.SelectionListOptions, choiceChan chan<- string, navChan chan<- string) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -28,11 +28,11 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 		items = append(items, newItem)
 	}
 
-	if !isPaginationDisabled {
+	if !selectionListOptions.IsPaginationDisabled {
 		items = AddLoadMoreOptionToList(items)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	l := views.GetStyledSelectList(items, selectionListOptions)
 
 	title := "Choose a Pull/Merge Request"
 	if projectOrder > 1 {
@@ -50,7 +50,7 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if !isPaginationDisabled && choice == views.ListNavigationText {
+		if !selectionListOptions.IsPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice
@@ -60,11 +60,11 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 	}
 }
 
-func GetPullRequestFromPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, isPaginationDisabled bool) (*apiclient.GitPullRequest, string) {
+func GetPullRequestFromPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, selectionListOptions views.SelectionListOptions) (*apiclient.GitPullRequest, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectPullRequestPrompt(pullRequests, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled)
+	go selectPullRequestPrompt(pullRequests, projectOrder, selectionListOptions, choiceChan, navChan)
 
 	select {
 	case pullRequestName := <-choiceChan:

--- a/pkg/views/workspace/selection/pullrequest.go
+++ b/pkg/views/workspace/selection/pullrequest.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool, curPage, perPage int32) {
+func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, choiceChan chan<- string, navChan chan<- string, isPaginationDisabled bool) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -29,7 +29,7 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 	}
 
 	if !isPaginationDisabled {
-		items = AddLoadMoreOptionToList(items, len(pullRequests), curPage, perPage)
+		items = AddLoadMoreOptionToList(items)
 	}
 
 	l := views.GetStyledSelectList(items, parentIdentifier)
@@ -50,7 +50,7 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == views.ListNavigationText {
+		if !isPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice
@@ -60,11 +60,11 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 	}
 }
 
-func GetPullRequestFromPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitPullRequest, string) {
+func GetPullRequestFromPrompt(pullRequests []apiclient.GitPullRequest, projectOrder int, parentIdentifier string, isPaginationDisabled bool) (*apiclient.GitPullRequest, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectPullRequestPrompt(pullRequests, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled, curPage, perPage)
+	go selectPullRequestPrompt(pullRequests, projectOrder, parentIdentifier, choiceChan, navChan, isPaginationDisabled)
 
 	select {
 	case pullRequestName := <-choiceChan:

--- a/pkg/views/workspace/selection/pullrequest.go
+++ b/pkg/views/workspace/selection/pullrequest.go
@@ -29,15 +29,10 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 	}
 
 	if !isPaginationDisabled {
-		items = AddNavigationOptionsToList(items, len(pullRequests), curPage, perPage)
+		items = AddLoadMoreOptionToList(items, len(pullRequests), curPage, perPage)
 	}
 
-	listOptions := views.ListOptions{
-		ParentIdentifier: parentIdentifier,
-		CurPage:          curPage,
-	}
-
-	l := views.GetStyledSelectList(items, listOptions)
+	l := views.GetStyledSelectList(items, parentIdentifier)
 
 	title := "Choose a Pull/Merge Request"
 	if projectOrder > 1 {
@@ -55,7 +50,7 @@ func selectPullRequestPrompt(pullRequests []apiclient.GitPullRequest, projectOrd
 
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == "next" || choice == "prev" {
+		if choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			choiceChan <- choice

--- a/pkg/views/workspace/selection/repository.go
+++ b/pkg/views/workspace/selection/repository.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, navChan chan<- string, selectedRepos map[string]int, isPaginationDisabled bool, curPage, perPage int32) {
+func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, navChan chan<- string, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -32,7 +32,11 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 		items = AddNavigationOptionsToList(items, len(repositories), curPage, perPage)
 	}
 
-	l := views.GetStyledSelectList(items, curPage)
+	listOptions := views.ListOptions{
+		ParentIdentifier: parentIdentifier,
+		CurPage:          curPage,
+	}
+	l := views.GetStyledSelectList(items, listOptions)
 
 	title := "Choose a Repository"
 	if projectOrder > 1 {
@@ -62,11 +66,11 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	}
 }
 
-func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitRepository, string) {
+func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitRepository, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, navChan, selectedRepos, isPaginationDisabled, curPage, perPage)
+	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, navChan, selectedRepos, parentIdentifier, isPaginationDisabled, curPage, perPage)
 
 	select {
 	case choice := <-choiceChan:

--- a/pkg/views/workspace/selection/repository.go
+++ b/pkg/views/workspace/selection/repository.go
@@ -29,14 +29,10 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	}
 
 	if !isPaginationDisabled {
-		items = AddNavigationOptionsToList(items, len(repositories), curPage, perPage)
+		items = AddLoadMoreOptionToList(items, len(repositories), curPage, perPage)
 	}
 
-	listOptions := views.ListOptions{
-		ParentIdentifier: parentIdentifier,
-		CurPage:          curPage,
-	}
-	l := views.GetStyledSelectList(items, listOptions)
+	l := views.GetStyledSelectList(items, parentIdentifier)
 
 	title := "Choose a Repository"
 	if projectOrder > 1 {
@@ -55,7 +51,7 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == "next" || choice == "prev" {
+		if choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			selectedRepos[choice]++

--- a/pkg/views/workspace/selection/repository.go
+++ b/pkg/views/workspace/selection/repository.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, selectedRepos map[string]int, parentIdentifier string) {
+func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, navChan chan<- string, selectedRepos map[string]int, isPaginationDisabled bool, curPage, perPage int32) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -28,7 +28,11 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 		items = append(items, newItem)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	if !isPaginationDisabled {
+		items = AddNavigationOptionsToList(items, len(repositories), curPage, perPage)
+	}
+
+	l := views.GetStyledSelectList(items, curPage)
 
 	title := "Choose a Repository"
 	if projectOrder > 1 {
@@ -44,28 +48,35 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 		os.Exit(1)
 	}
 
+	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-
-		selectedRepos[choice]++
-		choiceChan <- choice
+		if choice == "next" || choice == "prev" {
+			navChan <- choice
+		} else {
+			selectedRepos[choice]++
+			choiceChan <- choice
+		}
 	} else {
 		choiceChan <- ""
 	}
 }
 
-func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, parentIdentifier string) *apiclient.GitRepository {
+func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitRepository, string) {
 	choiceChan := make(chan string)
+	navChan := make(chan string)
 
-	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, selectedRepos, parentIdentifier)
+	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, navChan, selectedRepos, isPaginationDisabled, curPage, perPage)
 
-	choice := <-choiceChan
-
-	for _, repository := range repositories {
-		if repository.Url == choice {
-			return &repository
+	select {
+	case choice := <-choiceChan:
+		for _, repository := range repositories {
+			if repository.Url == choice {
+				return &repository, ""
+			}
 		}
+		return nil, ""
+	case navigate := <-navChan:
+		return nil, navigate
 	}
-
-	return nil
 }

--- a/pkg/views/workspace/selection/repository.go
+++ b/pkg/views/workspace/selection/repository.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, navChan chan<- string, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) {
+func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, navChan chan<- string, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -29,7 +29,7 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	}
 
 	if !isPaginationDisabled {
-		items = AddLoadMoreOptionToList(items, len(repositories), curPage, perPage)
+		items = AddLoadMoreOptionToList(items)
 	}
 
 	l := views.GetStyledSelectList(items, parentIdentifier)
@@ -51,7 +51,7 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if choice == views.ListNavigationText {
+		if !isPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			selectedRepos[choice]++
@@ -62,11 +62,11 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	}
 }
 
-func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool, curPage, perPage int32) (*apiclient.GitRepository, string) {
+func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool) (*apiclient.GitRepository, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, navChan, selectedRepos, parentIdentifier, isPaginationDisabled, curPage, perPage)
+	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, navChan, selectedRepos, parentIdentifier, isPaginationDisabled)
 
 	select {
 	case choice := <-choiceChan:

--- a/pkg/views/workspace/selection/repository.go
+++ b/pkg/views/workspace/selection/repository.go
@@ -14,7 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, navChan chan<- string, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool) {
+func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder int, choiceChan chan<- string, navChan chan<- string, selectedRepos map[string]int, selectionListOptions views.SelectionListOptions) {
 	items := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
@@ -28,11 +28,11 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 		items = append(items, newItem)
 	}
 
-	if !isPaginationDisabled {
+	if !selectionListOptions.IsPaginationDisabled {
 		items = AddLoadMoreOptionToList(items)
 	}
 
-	l := views.GetStyledSelectList(items, parentIdentifier)
+	l := views.GetStyledSelectList(items, selectionListOptions)
 
 	title := "Choose a Repository"
 	if projectOrder > 1 {
@@ -51,7 +51,7 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	// Return either the choice or navigation
 	if m, ok := p.(model[string]); ok && m.choice != nil {
 		choice := *m.choice
-		if !isPaginationDisabled && choice == views.ListNavigationText {
+		if !selectionListOptions.IsPaginationDisabled && choice == views.ListNavigationText {
 			navChan <- choice
 		} else {
 			selectedRepos[choice]++
@@ -62,11 +62,11 @@ func selectRepositoryPrompt(repositories []apiclient.GitRepository, projectOrder
 	}
 }
 
-func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, parentIdentifier string, isPaginationDisabled bool) (*apiclient.GitRepository, string) {
+func GetRepositoryFromPrompt(repositories []apiclient.GitRepository, projectOrder int, selectedRepos map[string]int, selectionListOptions views.SelectionListOptions) (*apiclient.GitRepository, string) {
 	choiceChan := make(chan string)
 	navChan := make(chan string)
 
-	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, navChan, selectedRepos, parentIdentifier, isPaginationDisabled)
+	go selectRepositoryPrompt(repositories, projectOrder, choiceChan, navChan, selectedRepos, selectionListOptions)
 
 	select {
 	case choice := <-choiceChan:


### PR DESCRIPTION
# Enhancement: add pagination for all GET apis' of git providers (#761)


## Description
Almost every GET api results have been limited by a value of 100 items. Hence, we must enable pagination.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #761 
closes #761 
/claim #761 

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
