### PR TITLE
fix: code command runtime error on select workspace

### DIFF
--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -50,7 +50,7 @@ var CodeCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
+			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Verbose(true).Execute()
 			if err != nil {
 				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 			}
@@ -99,13 +99,15 @@ var CodeCmd = &cobra.Command{
 		views.RenderInfoMessage(fmt.Sprintf("Opening the project '%s' from workspace '%s' in %s", projectName, *workspace.Name, ideName))
 
 		providerMetadata := ""
-		for _, project := range workspace.Info.Projects {
-			if *project.Name == projectName {
-				if project.ProviderMetadata == nil {
-					log.Fatal(errors.New("project provider metadata is missing"))
+		if workspace.Info != nil {
+			for _, project := range workspace.Info.Projects {
+				if *project.Name == projectName {
+					if project.ProviderMetadata == nil {
+						log.Fatal(errors.New("project provider metadata is missing"))
+					}
+					providerMetadata = *project.ProviderMetadata
+					break
 				}
-				providerMetadata = *project.ProviderMetadata
-				break
 			}
 		}
 


### PR DESCRIPTION
# Fix code command runtime error on select workspace

## Description

This PR adds a workspace info nil check in order to fix the runtime error upon daytona code command workspace select

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #782