### PR TITLE
remove unnecessary 'continue' in install script (#766)

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -52,7 +52,7 @@ stop_daytona_server() {
     if [ "$CONFIRM_FLAG" = true ]; then
       echo "Attempting to stop the Daytona server..."
       if daytona server stop; then
-        continue
+        echo "Stopping Daytona server .."
       else
         pkill -x "daytona"
       fi


### PR DESCRIPTION
remove unnecessary 'continue' keyword in install script

## Description

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #766 
/claim #766 
closes #766 
## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
