### PR TITLE
fix: properties missing from server config view

### DIFF
--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -23,9 +23,15 @@ type Profile struct {
 }
 
 type Config struct {
-	ActiveProfileId string    `json:"activeProfile"`
-	DefaultIdeId    string    `json:"defaultIde"`
-	Profiles        []Profile `json:"profiles"`
+	ActiveProfileId   string    `json:"activeProfile"`
+	DefaultIdeId      string    `json:"defaultIde"`
+	Profiles          []Profile `json:"profiles"`
+	ProvidersDir      string    `json:"providersDir"`
+	RegistryURL       string    `json:"registryUrl"`
+	ServerDownloadURL string    `json:"serverDownloadUrl"`
+	LogFilePath       string    `json:"logFilePath"`
+	FRPSPort          int       `json:"frpsPort"`
+	FRPSProtocol      string    `json:"frpsProtocol"`
 }
 
 type Ide struct {


### PR DESCRIPTION
# Pull Request Title
Added the missing properties

## Description
I've added all the missing properties that were not showing up on `daytona server config`

## Related Issue(s)

This PR addresses issue #780 

/closes #780
/claim #780
