### PR TITLE
fix: narrow the gradient in logo

### DIFF
--- a/pkg/views/initial/view.go
+++ b/pkg/views/initial/view.go
@@ -46,14 +46,14 @@ var gradientColors = []lipgloss.AdaptiveColor{
 	{Light: "#000", Dark: "#fff"},
 	{Light: "#000", Dark: "#fff"},
 	{Light: "#000", Dark: "#fff"},
+	{Light: "#000", Dark: "#fff"},
+	{Light: "#000", Dark: "#fff"},
+	{Light: "#000", Dark: "#fff"},
 	{Light: "#4e4f4f", Dark: "#B9B9B9"},
 	{Light: "#686969", Dark: "#B2B2B2"},
 	{Light: "#686969", Dark: "#A4A4A4"},
 	{Light: "#a3a3a3", Dark: "#969696"},
 	{Light: "#a3a3a3", Dark: "#585858"},
-	{Light: "#bbbcbd", Dark: "#363636"},
-	{Light: "#bbbcbd", Dark: "#343434"},
-	{Light: "#d9d9d9", Dark: "#343434"},
 }
 
 var gradientSigil string


### PR DESCRIPTION
# Narrow the gradient in logo

## Description

Narrow the gradient in logo
/claim #619
Closes #619

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #619

## Screenshots
Attached below in comments


## Notes
Please add any relevant notes if necessary.
