### PR TITLE
feat: show help menu on unknown command

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/daytonaio/daytona/pkg/cmd/apikey"
@@ -59,9 +60,46 @@ func Execute() {
 
 	SetupRootCommand(rootCmd)
 
+	cmd, err := validateCommands(rootCmd, os.Args[1:])
+	if err != nil {
+		fmt.Printf("Error: %v\n\n", err)
+		err := cmd.Help()
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func validateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command, err error) {
+	rootCmd.InitDefaultHelpCmd()
+	currentCmd := rootCmd
+
+	for len(args) > 0 {
+		subCmd, subArgs, err := currentCmd.Find(args)
+		if err != nil {
+			return currentCmd, err
+		}
+
+		if subCmd == currentCmd {
+			break
+		}
+
+		currentCmd = subCmd
+		args = subArgs
+	}
+
+	if len(args) > 0 {
+		if err := currentCmd.ValidateArgs(args); err != nil {
+			return currentCmd, err
+		}
+	}
+
+	return currentCmd, nil
 }
 
 func SetupRootCommand(cmd *cobra.Command) {


### PR DESCRIPTION
 show help menu on unknown command

## Description

remove fatal crash and show help menu on unknown command
 
- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #616
closes #616
/claim #616

## Screenshots
<img width="601" alt="image" src="https://github.com/user-attachments/assets/646b41a6-9036-46cf-815b-b6430a88ce87">
