### PR TITLE
fix: api-key list -o json

### DIFF
--- a/pkg/cmd/apikey/list.go
+++ b/pkg/cmd/apikey/list.go
@@ -6,11 +6,11 @@ package apikey
 import (
 	"context"
 
+	"github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/cmd/output"
+	"github.com/daytonaio/daytona/pkg/views/server/apikey"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"github.com/daytonaio/daytona/internal/util/apiclient"
-	"github.com/daytonaio/daytona/pkg/views/server/apikey"
 )
 
 var listCmd = &cobra.Command{
@@ -28,6 +28,11 @@ var listCmd = &cobra.Command{
 		apiKeyList, _, err := apiClient.ApiKeyAPI.ListClientApiKeys(ctx).Execute()
 		if err != nil {
 			log.Fatal(apiclient.HandleErrorResponse(nil, err))
+		}
+
+		if output.FormatFlag != "" {
+			output.Output = apiKeyList
+			return
 		}
 
 		apikey.ListApiKeys(apiKeyList)


### PR DESCRIPTION
# Fixed api-key list json/yaml output

## Description

`daytona api-key list -o json` works as expected
/claim #751
Closes #751

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #751

## Screenshots
![image](https://github.com/user-attachments/assets/8bc451d2-adf0-418c-a5f7-9cf4e3a2ca01)


## Notes
Please add any relevant notes if necessary.
