### PR TITLE
worked on 'daytona server start fails if systemd file exists #643' , …

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -29,7 +29,9 @@ func Start(logFilePath string) error {
 	}
 	err = s.Install()
 	if err != nil {
-		return err
+		if !strings.Contains(err.Error(), "Init already exists") {
+			return err
+		}
 	}
 
 	logFile, err := os.OpenFile(logFilePath, os.O_TRUNC|os.O_CREATE|os.O_RDONLY, 0644)


### PR DESCRIPTION
# Pull Request Title
worked on 'daytona server start fails if systemd file exists #643' 
## Description

i checked the error message that would have been returned if the daytona service exited but was still being recreated, the error will be ignored and the method flow would continue, other errors that happened during service creation will be thrown

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #643

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.

This PR addresses issue #643
closes #643
/claim #643

