### PR TITLE
fix: update install.sh by removing unnecessary "continue"

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -52,7 +52,7 @@ stop_daytona_server() {
     if [ "$CONFIRM_FLAG" = true ]; then
       echo "Attempting to stop the Daytona server..."
       if daytona server stop; then
-        continue
+        echo -e "Stopping the daytona server"
       else
         pkill -x "daytona"
       fi


### PR DESCRIPTION
# Update install.sh by removing unnecessary "continue"
## Description

The install.sh script contained an unnecessary continue statement that has now been removed to improve the script’s functionality.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s):

This PR addresses issue #766
Closes #776
/claim #776
