### PR TITLE
fix: remove FATAL error while pressing 'q' from profile TUI

### DIFF
--- a/pkg/cmd/profile/profile.go
+++ b/pkg/cmd/profile/profile.go
@@ -5,6 +5,7 @@ package profile
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -38,7 +39,7 @@ var ProfileCmd = &cobra.Command{
 
 		chosenProfile, err := profile.GetProfileFromPrompt(profilesList, c.ActiveProfileId, true)
 		if err != nil {
-			log.Fatal(err)
+			os.Exit(1)
 		}
 
 		if chosenProfile.Id == profile.NewProfileId {


### PR DESCRIPTION
# Make profile TUI to exit cleanly 

## Description

Removed fatal error on exiting the profiles with the 'q' key.

## Related Issue(s)

closes #646
/claim #646

## Screenshots

[Kazam_screencast_00001.webm](https://github.com/user-attachments/assets/31eb21ca-0f7c-482e-87ab-9ecc5baa522f)

