### PR TITLE
fix: server start fails if systemd file exists

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -46,6 +46,10 @@ var ServerCmd = &cobra.Command{
 		})
 
 		views.RenderInfoMessageBold("Starting the Daytona Server daemon...")
+		err = daemon.Stop()
+		if err != nil {
+			log.Trace(err)
+		}
 		err = daemon.Start(c.LogFilePath)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
# Server start fails if systemd file exists

## Description
I have added `daemon.Stop()` before starting the server so that when systemd file exists it gets removed and then server starts
/claim #643
Closes #643

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #643

## Screenshots

https://github.com/user-attachments/assets/df6d9cef-b1a0-4478-9216-4cb9c85ae584



## Notes
Please add any relevant notes if necessary.
