### PR TITLE
feat: notify users if server ports are taken

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -79,6 +79,11 @@ func (a *ApiServer) Start() error {
 	docs.SwaggerInfo.Description = "Daytona Server API"
 	docs.SwaggerInfo.Title = "Daytona Server API"
 
+	_, err := net.Dial("tcp", fmt.Sprintf(":%d", a.apiPort))
+	if err == nil {
+		return fmt.Errorf("cannot start API server, port %d is already in use", a.apiPort)
+	}
+
 	binding.Validator = new(defaultValidator)
 
 	if mode, ok := os.LookupEnv("DAYTONA_SERVER_MODE"); ok && mode == "development" {

--- a/pkg/server/headscale/server.go
+++ b/pkg/server/headscale/server.go
@@ -4,6 +4,8 @@
 package headscale
 
 import (
+	"fmt"
+	"net"
 	"os"
 
 	"github.com/juanfont/headscale/hscontrol"
@@ -40,6 +42,11 @@ func (s *HeadscaleServer) Init() error {
 }
 
 func (s *HeadscaleServer) Start() error {
+	_, err := net.Dial("tcp", fmt.Sprintf(":%d", s.headscalePort))
+	if err == nil {
+		return fmt.Errorf("cannot start Headscale server, port %d is already in use", s.headscalePort)
+	}
+
 	cfg, err := s.getHeadscaleConfig()
 	if err != nil {
 		return err

--- a/pkg/server/registry/service.go
+++ b/pkg/server/registry/service.go
@@ -6,6 +6,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/daytonaio/daytona/pkg/docker"
@@ -37,7 +38,12 @@ type LocalContainerRegistry struct {
 func (s *LocalContainerRegistry) Start() error {
 	ctx := context.Background()
 
-	_, err := os.Stat(s.dataPath)
+	_, err := net.Dial("tcp", fmt.Sprintf(":%d", s.port))
+	if err == nil {
+		return fmt.Errorf("cannot start registry, port %d is already in use", s.port)
+	}
+
+	_, err = os.Stat(s.dataPath)
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(s.dataPath, 0755)
 		if err != nil {


### PR DESCRIPTION
# Notify users if server ports are taken

## Description

If the server port is already taken, it will be logged during the startup
/claim #676 
Closes #676 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #676 

## Screenshots
![image](https://github.com/user-attachments/assets/7d135c22-72fb-44ec-881e-9bef1d80d590)


## Notes
Please add any relevant notes if necessary.
