### PR TITLE
fix: no TUI for daytona profile use

### DIFF
--- a/docs/daytona.md
+++ b/docs/daytona.md
@@ -41,7 +41,7 @@ daytona [flags]
 * [daytona start](daytona_start.md)	 - Start a workspace
 * [daytona stop](daytona_stop.md)	 - Stop a workspace
 * [daytona target](daytona_target.md)	 - Manage provider targets
-* [daytona use](daytona_use.md)	 - Set the active profile
+* [daytona use](daytona_use.md)	 - Use profile [PROFILE_NAME]
 * [daytona version](daytona_version.md)	 - Print the version number
 * [daytona whoami](daytona_whoami.md)	 - Display information about the active user
 

--- a/docs/daytona_profile.md
+++ b/docs/daytona_profile.md
@@ -2,10 +2,6 @@
 
 Manage profiles
 
-```
-daytona profile [flags]
-```
-
 ### Options inherited from parent commands
 
 ```
@@ -20,5 +16,5 @@ daytona profile [flags]
 * [daytona profile delete](daytona_profile_delete.md)	 - Delete profile [PROFILE_NAME]
 * [daytona profile edit](daytona_profile_edit.md)	 - Edit profile [PROFILE_NAME]
 * [daytona profile list](daytona_profile_list.md)	 - List profiles
-* [daytona profile use](daytona_profile_use.md)	 - Set the active profile
+* [daytona profile use](daytona_profile_use.md)	 - Use profile [PROFILE_NAME]
 

--- a/docs/daytona_use.md
+++ b/docs/daytona_use.md
@@ -1,6 +1,6 @@
 ## daytona use
 
-Set the active profile
+Use profile [PROFILE_NAME]
 
 ```
 daytona use [flags]

--- a/hack/docs/daytona.yaml
+++ b/hack/docs/daytona.yaml
@@ -32,6 +32,6 @@ see_also:
     - daytona start - Start a workspace
     - daytona stop - Stop a workspace
     - daytona target - Manage provider targets
-    - daytona use - Set the active profile
+    - daytona use - Use profile [PROFILE_NAME]
     - daytona version - Print the version number
     - daytona whoami - Display information about the active user

--- a/hack/docs/daytona_profile.yaml
+++ b/hack/docs/daytona_profile.yaml
@@ -1,6 +1,5 @@
 name: daytona profile
 synopsis: Manage profiles
-usage: daytona profile [flags]
 inherited_options:
     - name: help
       default_value: "false"
@@ -14,4 +13,4 @@ see_also:
     - daytona profile delete - Delete profile [PROFILE_NAME]
     - daytona profile edit - Edit profile [PROFILE_NAME]
     - daytona profile list - List profiles
-    - daytona use - Set the active profile
+    - daytona use - Use profile [PROFILE_NAME]

--- a/hack/docs/daytona_use.yaml
+++ b/hack/docs/daytona_use.yaml
@@ -1,5 +1,5 @@
 name: daytona use
-synopsis: Set the active profile
+synopsis: Use profile [PROFILE_NAME]
 usage: daytona use [flags]
 inherited_options:
     - name: help

--- a/pkg/cmd/profile/profile.go
+++ b/pkg/cmd/profile/profile.go
@@ -4,69 +4,12 @@
 package profile
 
 import (
-	"fmt"
-
-	"github.com/daytonaio/daytona/cmd/daytona/config"
-	"github.com/daytonaio/daytona/pkg/views"
-	"github.com/daytonaio/daytona/pkg/views/profile"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var ProfileCmd = &cobra.Command{
 	Use:   "profile",
 	Short: "Manage profiles",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		c, err := config.GetConfig()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		profilesList := c.Profiles
-
-		if len(profilesList) == 0 {
-			views.RenderInfoMessage("Add a profile by running `daytona profile add`")
-			return
-		}
-
-		if len(profilesList) == 1 {
-			views.RenderInfoMessage(fmt.Sprintf("You are using profile %s. Add a new profile by running `daytona profile add`", profilesList[0].Name))
-			return
-		}
-
-		chosenProfile, err := profile.GetProfileFromPrompt(profilesList, c.ActiveProfileId, true)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if chosenProfile.Id == profile.NewProfileId {
-			_, err = CreateProfile(c, nil, true)
-			if err != nil {
-				log.Fatal(err)
-			}
-			return
-		}
-
-		if chosenProfile.Id == "" {
-			return
-		}
-
-		profile, err := c.GetProfile(chosenProfile.Id)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		c.ActiveProfileId = profile.Id
-
-		err = c.Save()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		views.RenderInfoMessage(fmt.Sprintf("Active profile set to: %s", profile.Name))
-	},
 }
 
 func init() {

--- a/pkg/cmd/profile/use.go
+++ b/pkg/cmd/profile/use.go
@@ -12,13 +12,14 @@ import (
 
 	"github.com/daytonaio/daytona/pkg/cmd/output"
 	"github.com/daytonaio/daytona/pkg/views"
+	"github.com/daytonaio/daytona/pkg/views/profile"
 	"github.com/spf13/cobra"
 )
 
 var ProfileUseCmd = &cobra.Command{
 	Use:   "use",
-	Short: "Set the active profile",
-	Args:  cobra.ExactArgs(1),
+	Short: "Use profile [PROFILE_NAME]",
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		c, err := config.GetConfig()
 		if err != nil {
@@ -26,36 +27,77 @@ var ProfileUseCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			log.Fatal("Please provide the profile name")
-		}
+			profilesList := c.Profiles
 
-		profileArg := args[0]
-
-		var chosenProfile config.Profile
-
-		for _, profile := range c.Profiles {
-			if profile.Name == profileArg || profile.Id == profileArg {
-				chosenProfile = profile
-				break
+			if len(profilesList) == 0 {
+				views.RenderInfoMessage("Add a profile by running `daytona profile add`")
+				return
 			}
+
+			if len(profilesList) == 1 {
+				views.RenderInfoMessage(fmt.Sprintf("You are using profile %s. Add a new profile by running `daytona profile add`", profilesList[0].Name))
+				return
+			}
+
+			chosenProfile, err := profile.GetProfileFromPrompt(profilesList, c.ActiveProfileId, true)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if chosenProfile.Id == profile.NewProfileId {
+				_, err = CreateProfile(c, nil, true)
+				if err != nil {
+					log.Fatal(err)
+				}
+				return
+			}
+
+			if chosenProfile.Id == "" {
+				return
+			}
+
+			profile, err := c.GetProfile(chosenProfile.Id)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			c.ActiveProfileId = profile.Id
+
+			err = c.Save()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			views.RenderInfoMessage(fmt.Sprintf("Active profile set to: %s", profile.Name))
+		} else {
+			profileArg := args[0]
+
+			var chosenProfile config.Profile
+
+			for _, profile := range c.Profiles {
+				if profile.Name == profileArg || profile.Id == profileArg {
+					chosenProfile = profile
+					break
+				}
+			}
+
+			if chosenProfile == (config.Profile{}) {
+				log.Fatal("Profile does not exist: ", profileArg)
+			}
+
+			c.ActiveProfileId = chosenProfile.Id
+
+			err = c.Save()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if output.FormatFlag != "" {
+				output.Output = chosenProfile.Id
+				return
+			}
+
+			views.RenderInfoMessage(fmt.Sprintf("Active profile set to: %s", chosenProfile.Name))
 		}
-
-		if chosenProfile == (config.Profile{}) {
-			log.Fatal("Profile does not exist: ", profileArg)
-		}
-
-		c.ActiveProfileId = chosenProfile.Id
-
-		err = c.Save()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if output.FormatFlag != "" {
-			output.Output = chosenProfile.Id
-			return
-		}
-
-		views.RenderInfoMessage(fmt.Sprintf("Active profile set to %s", chosenProfile.Name))
 	},
 }


### PR DESCRIPTION
# Added TUI for daytona profile use

## Description

`daytona profile` opens the help and `daytona profile use` open the TUI to switch the active profile when called without arguments or simply take the first argument -> `daytona profile use p1`
/claim #806 
Closes #806 

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #806 

## Screenshots

https://github.com/user-attachments/assets/2c19e7d7-952d-46ee-9acd-4ac24891d849

## Notes
Please add any relevant notes if necessary.
