### PR TITLE
fix: creation of a new profile through <daytona profile>

### DIFF
--- a/pkg/views/profile/create.go
+++ b/pkg/views/profile/create.go
@@ -6,6 +6,7 @@ package profile
 import (
 	"errors"
 	"log"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -65,6 +66,12 @@ func ProfileCreationView(c *config.Config, profileAddView *ProfileAddView, editi
 					if str == "" {
 						return errors.New("server API Key can not be blank")
 					}
+
+					_, err := url.ParseRequestURI(str)
+					if err != nil {
+						return errors.New("invalid URL url, must be of http/https/ssh format")
+					}
+
 					return nil
 				}),
 		),

--- a/pkg/views/profile/select.go
+++ b/pkg/views/profile/select.go
@@ -27,6 +27,7 @@ func GetProfileFromPrompt(profiles []config.Profile, activeProfileName string, w
 		name := NewProfileId
 		items = append(items, item{
 			profile: config.Profile{
+				Id:   NewProfileId,
 				Name: name,
 			},
 		})


### PR DESCRIPTION
# fix: creation of a new profile through 'daytona profile' command

## Description

Resolved issues related to the daytona profile command:

- Ensures the creation of a new profile works correctly without abrupt closure or fatal errors.
- Adjusts the daytona profile command to always provide the option to create a new profile, regardless of the number of existing profiles.
- Adds validation for server API URL input to check for valid http/https/ssh URLs.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #778
closes #778 
/claim #778
