### PR TITLE
fix: server start fails if systemd file exists 

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -46,6 +46,10 @@ var ServerCmd = &cobra.Command{
 		})
 
 		views.RenderInfoMessageBold("Starting the Daytona Server daemon...")
+		err = daemon.Stop()
+		if err != nil {
+			log.Fatal(err)
+		}
 		err = daemon.Start(c.LogFilePath)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/views/profile/create.go
+++ b/pkg/views/profile/create.go
@@ -6,6 +6,7 @@ package profile
 import (
 	"errors"
 	"log"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -65,6 +66,12 @@ func ProfileCreationView(c *config.Config, profileAddView *ProfileAddView, editi
 					if str == "" {
 						return errors.New("server API Key can not be blank")
 					}
+
+					_, err := url.ParseRequestURI(str)
+					if err != nil {
+						return errors.New("invalid URL url, must be of http/https/ssh format")
+					}
+
 					return nil
 				}),
 		),

--- a/pkg/views/profile/select.go
+++ b/pkg/views/profile/select.go
@@ -27,6 +27,7 @@ func GetProfileFromPrompt(profiles []config.Profile, activeProfileName string, w
 		name := NewProfileId
 		items = append(items, item{
 			profile: config.Profile{
+				Id:   NewProfileId,
 				Name: name,
 			},
 		})


### PR DESCRIPTION
# Fix server start fails if systemd file exists 
## Description

I have added daemon.Stop() before starting the server so that when systemd file exists it gets removed and then server starts

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #643 
closes #643
/claim #643
 
