### PR TITLE
feat: collect telemetry data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
       "program": "${workspaceFolder}/cmd/daytona",
       "console": "integratedTerminal",
       "args": [
-        "serve"
+        "serve",
       ]
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
       "program": "${workspaceFolder}/cmd/daytona",
       "console": "integratedTerminal",
       "args": [
-        "serve",
+        "serve"
       ]
     },
     {

--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/google/uuid"
 )
 
 type ServerApi struct {
@@ -23,9 +25,11 @@ type Profile struct {
 }
 
 type Config struct {
-	ActiveProfileId string    `json:"activeProfile"`
-	DefaultIdeId    string    `json:"defaultIde"`
-	Profiles        []Profile `json:"profiles"`
+	Id               string    `json:"id"`
+	ActiveProfileId  string    `json:"activeProfile"`
+	DefaultIdeId     string    `json:"defaultIde"`
+	Profiles         []Profile `json:"profiles"`
+	TelemetryEnabled bool      `json:"telemetryEnabled"`
 }
 
 type Ide struct {
@@ -70,6 +74,14 @@ func GetConfig() (*Config, error) {
 	err = json.Unmarshal(configContent, &c)
 	if err != nil {
 		return nil, err
+	}
+
+	if c.Id == "" {
+		c.Id = uuid.NewString()
+		err := c.Save()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &c, nil
@@ -154,6 +166,18 @@ func (c *Config) GetProfile(profileId string) (Profile, error) {
 	return Profile{}, errors.New("profile not found")
 }
 
+func (c *Config) EnableTelemetry() error {
+	c.TelemetryEnabled = true
+
+	return c.Save()
+}
+
+func (c *Config) DisableTelemetry() error {
+	c.TelemetryEnabled = false
+
+	return c.Save()
+}
+
 func getConfigPath() (string, error) {
 	configDir, err := GetConfigDir()
 	if err != nil {
@@ -184,4 +208,32 @@ func DeleteConfigDir() error {
 	}
 
 	return nil
+}
+
+func TelemetryEnabled() bool {
+	telemetryEnabled := os.Getenv("DAYTONA_TELEMETRY_ENABLED")
+	if telemetryEnabled != "" {
+		return telemetryEnabled == "true"
+	}
+
+	c, err := GetConfig()
+	if err != nil {
+		return false
+	}
+
+	return c.TelemetryEnabled
+}
+
+func GetCliId() string {
+	cliId := os.Getenv("DAYTONA_CLI_ID")
+	if cliId != "" {
+		return cliId
+	}
+
+	c, err := GetConfig()
+	if err != nil {
+		return ""
+	}
+
+	return c.Id
 }

--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -224,10 +224,10 @@ func TelemetryEnabled() bool {
 	return c.TelemetryEnabled
 }
 
-func GetCliId() string {
-	cliId := os.Getenv("DAYTONA_CLI_ID")
-	if cliId != "" {
-		return cliId
+func GetClientId() string {
+	clientId := os.Getenv("DAYTONA_CLIENT_ID")
+	if clientId != "" {
+		return clientId
 	}
 
 	c, err := GetConfig()

--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -9,6 +9,7 @@ import (
 
 	golog "log"
 
+	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/cmd"
 	"github.com/daytonaio/daytona/pkg/cmd/workspacemode"
@@ -18,7 +19,7 @@ import (
 )
 
 func main() {
-	if util.WorkspaceMode() {
+	if internal.WorkspaceMode() {
 		workspacemode.Execute()
 		return
 	}
@@ -30,17 +31,11 @@ func init() {
 	logLevel := log.WarnLevel
 
 	logLevelEnv, logLevelSet := os.LookupEnv("LOG_LEVEL")
+
 	if logLevelSet {
-		switch logLevelEnv {
-		case "debug":
-			logLevel = log.DebugLevel
-		case "info":
-			logLevel = log.InfoLevel
-		case "warn":
-			logLevel = log.WarnLevel
-		case "error":
-			logLevel = log.ErrorLevel
-		default:
+		var err error
+		logLevel, err = log.ParseLevel(logLevelEnv)
+		if err != nil {
 			logLevel = log.WarnLevel
 		}
 	}

--- a/docs/daytona.md
+++ b/docs/daytona.md
@@ -41,6 +41,7 @@ daytona [flags]
 * [daytona start](daytona_start.md)	 - Start a workspace
 * [daytona stop](daytona_stop.md)	 - Stop a workspace
 * [daytona target](daytona_target.md)	 - Manage provider targets
+* [daytona telemetry](daytona_telemetry.md)	 - Manage telemetry collection
 * [daytona use](daytona_use.md)	 - Use profile [PROFILE_NAME]
 * [daytona version](daytona_version.md)	 - Print the version number
 * [daytona whoami](daytona_whoami.md)	 - Display information about the active user

--- a/docs/daytona_telemetry.md
+++ b/docs/daytona_telemetry.md
@@ -1,0 +1,17 @@
+## daytona telemetry
+
+Manage telemetry collection
+
+### Options inherited from parent commands
+
+```
+      --help            help for daytona
+  -o, --output string   Output format. Must be one of (yaml, json)
+```
+
+### SEE ALSO
+
+* [daytona](daytona.md)	 - Daytona is a Dev Environment Manager
+* [daytona telemetry disable](daytona_telemetry_disable.md)	 - Disable telemetry collection
+* [daytona telemetry enable](daytona_telemetry_enable.md)	 - Enable telemetry collection
+

--- a/docs/daytona_telemetry_disable.md
+++ b/docs/daytona_telemetry_disable.md
@@ -1,0 +1,19 @@
+## daytona telemetry disable
+
+Disable telemetry collection
+
+```
+daytona telemetry disable [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --help            help for daytona
+  -o, --output string   Output format. Must be one of (yaml, json)
+```
+
+### SEE ALSO
+
+* [daytona telemetry](daytona_telemetry.md)	 - Manage telemetry collection
+

--- a/docs/daytona_telemetry_enable.md
+++ b/docs/daytona_telemetry_enable.md
@@ -1,0 +1,19 @@
+## daytona telemetry enable
+
+Enable telemetry collection
+
+```
+daytona telemetry enable [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --help            help for daytona
+  -o, --output string   Output format. Must be one of (yaml, json)
+```
+
+### SEE ALSO
+
+* [daytona telemetry](daytona_telemetry.md)	 - Manage telemetry collection
+

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pkg/sftp v1.13.6
+	github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103
 	github.com/rs/zerolog v1.31.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -1297,6 +1297,8 @@ github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Q
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103 h1:YEWdfKVtz5Db85b8RLIZ1IY3PLSB1fW49hvK2yIL6JU=
+github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103/go.mod h1:QjlpryJtfYLrZF2GUkAhejH4E7WlDbdKkvOi5hLmkdg=
 github.com/prometheus/client_golang v1.17.0 h1:rl2sfwZMtSthVU752MqfjQozy7blglC+1SOtjMAMh+Q=
 github.com/prometheus/client_golang v1.17.0/go.mod h1:VeL+gMmOAxkS2IqfCq0ZmHSL+LjWfWDUmp1mBz9JgUY=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/hack/docs/daytona.yaml
+++ b/hack/docs/daytona.yaml
@@ -32,6 +32,7 @@ see_also:
     - daytona start - Start a workspace
     - daytona stop - Stop a workspace
     - daytona target - Manage provider targets
+    - daytona telemetry - Manage telemetry collection
     - daytona use - Use profile [PROFILE_NAME]
     - daytona version - Print the version number
     - daytona whoami - Display information about the active user

--- a/hack/docs/daytona_telemetry.yaml
+++ b/hack/docs/daytona_telemetry.yaml
@@ -1,0 +1,13 @@
+name: daytona telemetry
+synopsis: Manage telemetry collection
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager
+    - daytona telemetry disable - Disable telemetry collection
+    - daytona telemetry enable - Enable telemetry collection

--- a/hack/docs/daytona_telemetry_disable.yaml
+++ b/hack/docs/daytona_telemetry_disable.yaml
@@ -1,0 +1,12 @@
+name: daytona telemetry disable
+synopsis: Disable telemetry collection
+usage: daytona telemetry disable [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona telemetry - Manage telemetry collection

--- a/hack/docs/daytona_telemetry_enable.yaml
+++ b/hack/docs/daytona_telemetry_enable.yaml
@@ -1,0 +1,12 @@
+name: daytona telemetry enable
+synopsis: Enable telemetry collection
+usage: daytona telemetry enable [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona telemetry - Manage telemetry collection

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import "github.com/google/uuid"
+
+var SESSION_ID = uuid.NewString()

--- a/internal/posthog.go
+++ b/internal/posthog.go
@@ -1,0 +1,9 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+var (
+	PosthogApiKey   = "phc_BJyojqMOQdkR0I9cHRsHETVgYDQJU6ftsXO6HKtrpKu"
+	PosthogEndpoint = "https://eu.posthog.com"
+)

--- a/internal/util/apiclient/api_client.go
+++ b/internal/util/apiclient/api_client.go
@@ -68,11 +68,11 @@ func GetApiClient(profile *config.Profile) (*apiclient.APIClient, error) {
 	if c.TelemetryEnabled {
 		clientConfig.AddDefaultHeader(telemetry.ENABLED_HEADER, "true")
 		clientConfig.AddDefaultHeader(telemetry.SESSION_ID_HEADER, internal.SESSION_ID)
-		clientConfig.AddDefaultHeader(telemetry.CLI_ID_HEADER, c.Id)
+		clientConfig.AddDefaultHeader(telemetry.CLIENT_ID_HEADER, c.Id)
 		if internal.WorkspaceMode() {
-			clientConfig.AddDefaultHeader(telemetry.SOURCE_HEADER, "cli-project")
+			clientConfig.AddDefaultHeader(telemetry.SOURCE_HEADER, string(telemetry.CLI_PROJECT_SOURCE))
 		} else {
-			clientConfig.AddDefaultHeader(telemetry.SOURCE_HEADER, "cli")
+			clientConfig.AddDefaultHeader(telemetry.SOURCE_HEADER, string(telemetry.CLI_SOURCE))
 		}
 	}
 
@@ -85,7 +85,7 @@ func GetApiClient(profile *config.Profile) (*apiclient.APIClient, error) {
 	return apiClient, nil
 }
 
-func GetAgentApiClient(apiUrl, apiKey, cliId string, telemetryEnabled bool) (*apiclient.APIClient, error) {
+func GetAgentApiClient(apiUrl, apiKey, clientId string, telemetryEnabled bool) (*apiclient.APIClient, error) {
 	clientConfig := apiclient.NewConfiguration()
 	clientConfig.Servers = apiclient.ServerConfigurations{
 		{
@@ -99,8 +99,8 @@ func GetAgentApiClient(apiUrl, apiKey, cliId string, telemetryEnabled bool) (*ap
 	if telemetryEnabled {
 		clientConfig.AddDefaultHeader(telemetry.ENABLED_HEADER, "true")
 		clientConfig.AddDefaultHeader(telemetry.SESSION_ID_HEADER, internal.SESSION_ID)
-		clientConfig.AddDefaultHeader(telemetry.CLI_ID_HEADER, cliId)
-		clientConfig.AddDefaultHeader(telemetry.SOURCE_HEADER, "agent")
+		clientConfig.AddDefaultHeader(telemetry.CLIENT_ID_HEADER, clientId)
+		clientConfig.AddDefaultHeader(telemetry.SOURCE_HEADER, string(telemetry.AGENT_SOURCE))
 	}
 
 	apiClient = apiclient.NewAPIClient(clientConfig)

--- a/internal/util/workspace.go
+++ b/internal/util/workspace.go
@@ -6,22 +6,9 @@ package util
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
 )
-
-func WorkspaceMode() bool {
-	_, devEnv := os.LookupEnv("DAYTONA_DEV")
-	if devEnv {
-		return false
-	}
-	val, wsMode := os.LookupEnv("DAYTONA_WS_ID")
-	if wsMode && val != "" {
-		return true
-	}
-	return false
-}
 
 func GetValidatedWorkspaceName(input string) (string, error) {
 	// input = strings.ToLower(input)

--- a/internal/workspace_mode.go
+++ b/internal/workspace_mode.go
@@ -1,0 +1,18 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import "os"
+
+func WorkspaceMode() bool {
+	_, devEnv := os.LookupEnv("DAYTONA_DEV")
+	if devEnv {
+		return false
+	}
+	val, wsMode := os.LookupEnv("DAYTONA_WS_ID")
+	if wsMode && val != "" {
+		return true
+	}
+	return false
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -137,7 +137,7 @@ func (a *Agent) startProjectMode() error {
 func (a *Agent) getProject() (*workspace.Project, error) {
 	ctx := context.Background()
 
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.ClientId, a.TelemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (a *Agent) getProject() (*workspace.Project, error) {
 func (a *Agent) getGitProvider(repoUrl string) (*apiclient.GitProvider, error) {
 	ctx := context.Background()
 
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.ClientId, a.TelemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (a *Agent) getGitProvider(repoUrl string) (*apiclient.GitProvider, error) {
 }
 
 func (a *Agent) getGitUser(gitProviderId string) (*apiclient.GitUser, error) {
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.ClientId, a.TelemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (a *Agent) setDefaultConfig() error {
 	}
 
 	config := &config.Config{
-		Id:              a.Config.CliId,
+		Id:              a.Config.ClientId,
 		ActiveProfileId: "default",
 		DefaultIdeId:    "vscode",
 		Profiles: []config.Profile{
@@ -231,7 +231,7 @@ func (a *Agent) uptime() int32 {
 }
 
 func (a *Agent) updateProjectState() error {
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.ClientId, a.TelemetryEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -137,7 +137,7 @@ func (a *Agent) startProjectMode() error {
 func (a *Agent) getProject() (*workspace.Project, error) {
 	ctx := context.Background()
 
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (a *Agent) getProject() (*workspace.Project, error) {
 func (a *Agent) getGitProvider(repoUrl string) (*apiclient.GitProvider, error) {
 	ctx := context.Background()
 
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (a *Agent) getGitProvider(repoUrl string) (*apiclient.GitProvider, error) {
 }
 
 func (a *Agent) getGitUser(gitProviderId string) (*apiclient.GitUser, error) {
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -206,6 +206,7 @@ func (a *Agent) setDefaultConfig() error {
 	}
 
 	config := &config.Config{
+		Id:              a.Config.CliId,
 		ActiveProfileId: "default",
 		DefaultIdeId:    "vscode",
 		Profiles: []config.Profile{
@@ -218,6 +219,7 @@ func (a *Agent) setDefaultConfig() error {
 				},
 			},
 		},
+		TelemetryEnabled: a.TelemetryEnabled,
 	}
 
 	return config.Save()
@@ -229,7 +231,7 @@ func (a *Agent) uptime() int32 {
 }
 
 func (a *Agent) updateProjectState() error {
-	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey)
+	apiClient, err := apiclient_util.GetAgentApiClient(a.Config.Server.ApiUrl, a.Config.Server.ApiKey, a.Config.CliId, a.TelemetryEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -22,6 +22,7 @@ type DaytonaServerConfig struct {
 
 type Config struct {
 	ProjectDir  string
+	CliId       string  `envconfig:"DAYTONA_CLI_ID" validate:"required"`
 	ProjectName string  `envconfig:"DAYTONA_WS_PROJECT_NAME"`
 	WorkspaceId string  `envconfig:"DAYTONA_WS_ID" validate:"required"`
 	LogFilePath *string `envconfig:"DAYTONA_AGENT_LOG_FILE_PATH"`

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -22,7 +22,7 @@ type DaytonaServerConfig struct {
 
 type Config struct {
 	ProjectDir  string
-	CliId       string  `envconfig:"DAYTONA_CLI_ID" validate:"required"`
+	ClientId    string  `envconfig:"DAYTONA_CLIENT_ID" validate:"required"`
 	ProjectName string  `envconfig:"DAYTONA_WS_PROJECT_NAME"`
 	WorkspaceId string  `envconfig:"DAYTONA_WS_ID" validate:"required"`
 	LogFilePath *string `envconfig:"DAYTONA_AGENT_LOG_FILE_PATH"`

--- a/pkg/agent/tailscale/server.go
+++ b/pkg/agent/tailscale/server.go
@@ -21,8 +21,10 @@ import (
 )
 
 type Server struct {
-	Hostname string
-	Server   config.DaytonaServerConfig
+	Hostname         string
+	Server           config.DaytonaServerConfig
+	TelemetryEnabled bool
+	CliId            string
 }
 
 func (s *Server) Start() error {
@@ -63,7 +65,7 @@ func (s *Server) Start() error {
 }
 
 func (s *Server) getNetworkKey() (string, error) {
-	apiClient, err := apiclient_util.GetAgentApiClient(s.Server.ApiUrl, s.Server.ApiKey)
+	apiClient, err := apiclient_util.GetAgentApiClient(s.Server.ApiUrl, s.Server.ApiKey, s.CliId, s.TelemetryEnabled)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/agent/tailscale/server.go
+++ b/pkg/agent/tailscale/server.go
@@ -24,7 +24,7 @@ type Server struct {
 	Hostname         string
 	Server           config.DaytonaServerConfig
 	TelemetryEnabled bool
-	CliId            string
+	ClientId         string
 }
 
 func (s *Server) Start() error {
@@ -65,7 +65,7 @@ func (s *Server) Start() error {
 }
 
 func (s *Server) getNetworkKey() (string, error) {
-	apiClient, err := apiclient_util.GetAgentApiClient(s.Server.ApiUrl, s.Server.ApiKey, s.CliId, s.TelemetryEnabled)
+	apiClient, err := apiclient_util.GetAgentApiClient(s.Server.ApiUrl, s.Server.ApiKey, s.ClientId, s.TelemetryEnabled)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -20,10 +20,11 @@ type TailscaleServer interface {
 }
 
 type Agent struct {
-	Config    *config.Config
-	Git       git.IGitService
-	Ssh       SshServer
-	Tailscale TailscaleServer
-	LogWriter io.Writer
-	startTime time.Time
+	Config           *config.Config
+	Git              git.IGitService
+	Ssh              SshServer
+	Tailscale        TailscaleServer
+	LogWriter        io.Writer
+	TelemetryEnabled bool
+	startTime        time.Time
 }

--- a/pkg/api/controllers/workspace/create.go
+++ b/pkg/api/controllers/workspace/create.go
@@ -33,7 +33,7 @@ func CreateWorkspace(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	w, err := server.WorkspaceService.CreateWorkspace(createWorkspaceReq)
+	w, err := server.WorkspaceService.CreateWorkspace(ctx.Request.Context(), createWorkspaceReq)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to create workspace: %s", err.Error()))
 		return

--- a/pkg/api/controllers/workspace/start.go
+++ b/pkg/api/controllers/workspace/start.go
@@ -26,7 +26,7 @@ func StartWorkspace(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	err := server.WorkspaceService.StartWorkspace(workspaceId)
+	err := server.WorkspaceService.StartWorkspace(ctx.Request.Context(), workspaceId)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to start workspace %s: %s", workspaceId, err.Error()))
 		return
@@ -52,7 +52,7 @@ func StartProject(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	err := server.WorkspaceService.StartProject(workspaceId, projectId)
+	err := server.WorkspaceService.StartProject(ctx.Request.Context(), workspaceId, projectId)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to start project %s: %s", projectId, err.Error()))
 		return

--- a/pkg/api/controllers/workspace/stop.go
+++ b/pkg/api/controllers/workspace/stop.go
@@ -26,7 +26,7 @@ func StopWorkspace(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	err := server.WorkspaceService.StopWorkspace(workspaceId)
+	err := server.WorkspaceService.StopWorkspace(ctx.Request.Context(), workspaceId)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to stop workspace %s: %s", workspaceId, err.Error()))
 		return
@@ -52,7 +52,7 @@ func StopProject(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	err := server.WorkspaceService.StopProject(workspaceId, projectId)
+	err := server.WorkspaceService.StopProject(ctx.Request.Context(), workspaceId, projectId)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to stop project %s: %s", projectId, err.Error()))
 		return

--- a/pkg/api/controllers/workspace/workspace.go
+++ b/pkg/api/controllers/workspace/workspace.go
@@ -29,7 +29,7 @@ func GetWorkspace(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	w, err := server.WorkspaceService.GetWorkspace(workspaceId)
+	w, err := server.WorkspaceService.GetWorkspace(ctx.Request.Context(), workspaceId)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get workspace: %s", err.Error()))
 		return
@@ -101,9 +101,9 @@ func RemoveWorkspace(ctx *gin.Context) {
 	server := server.GetInstance(nil)
 
 	if force {
-		err = server.WorkspaceService.ForceRemoveWorkspace(workspaceId)
+		err = server.WorkspaceService.ForceRemoveWorkspace(ctx.Request.Context(), workspaceId)
 	} else {
-		err = server.WorkspaceService.RemoveWorkspace(workspaceId)
+		err = server.WorkspaceService.RemoveWorkspace(ctx.Request.Context(), workspaceId)
 	}
 
 	if err != nil {

--- a/pkg/api/middlewares/telemetry.go
+++ b/pkg/api/middlewares/telemetry.go
@@ -1,0 +1,96 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package middlewares
+
+import (
+	"context"
+	"time"
+
+	"github.com/daytonaio/daytona/internal"
+	"github.com/daytonaio/daytona/pkg/server"
+	"github.com/daytonaio/daytona/pkg/telemetry"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+func TelemetryMiddleware(telemetryService telemetry.TelemetryService) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		if telemetryService == nil {
+			ctx.Next()
+			return
+		}
+
+		if ctx.GetHeader(telemetry.ENABLED_HEADER) != "true" {
+			ctx.Next()
+			return
+		}
+
+		cliId := ctx.GetHeader(telemetry.CLI_ID_HEADER)
+		if cliId == "" {
+			cliId = uuid.NewString()
+		}
+
+		sessionId := ctx.GetHeader(telemetry.SESSION_ID_HEADER)
+		if sessionId == "" {
+			sessionId = internal.SESSION_ID
+		}
+
+		server := server.GetInstance(nil)
+
+		telemetryCtx := context.WithValue(ctx.Request.Context(), telemetry.ENABLED_CONTEXT_KEY, true)
+		telemetryCtx = context.WithValue(telemetryCtx, telemetry.CLI_ID_CONTEXT_KEY, cliId)
+		telemetryCtx = context.WithValue(telemetryCtx, telemetry.SESSION_ID_CONTEXT_KEY, sessionId)
+		telemetryCtx = context.WithValue(telemetryCtx, telemetry.SERVER_ID_CONTEXT_KEY, server.Id)
+
+		ctx.Request = ctx.Request.WithContext(telemetryCtx)
+
+		source := ctx.GetHeader(telemetry.SOURCE_HEADER)
+
+		reqMethod := ctx.Request.Method
+		reqUri := ctx.FullPath()
+
+		query := ctx.Request.URL.RawQuery
+
+		err := telemetryService.TrackServerEvent(telemetry.ServerEventApiRequestStarted, cliId, map[string]interface{}{
+			"method":     reqMethod,
+			"URI":        reqUri,
+			"query":      query,
+			"source":     source,
+			"server_id":  server.Id,
+			"session_id": sessionId,
+		})
+		if err != nil {
+			log.Trace(err)
+		}
+
+		startTime := time.Now()
+		ctx.Next()
+		endTime := time.Now()
+		execTime := endTime.Sub(startTime)
+		statusCode := ctx.Writer.Status()
+
+		properties := map[string]interface{}{
+			"method":         reqMethod,
+			"URI":            reqUri,
+			"query":          query,
+			"status":         statusCode,
+			"source":         source,
+			"exec time (µs)": execTime.Microseconds(),
+			"server_id":      server.Id,
+			"session_id":     sessionId,
+		}
+
+		if len(ctx.Errors) > 0 {
+			properties["error"] = ctx.Errors.String()
+		}
+
+		err = telemetryService.TrackServerEvent(telemetry.ServerEventApiResponseSent, cliId, properties)
+		if err != nil {
+			log.Trace(err)
+		}
+
+		ctx.Next()
+	}
+}

--- a/pkg/api/middlewares/telemetry.go
+++ b/pkg/api/middlewares/telemetry.go
@@ -27,9 +27,9 @@ func TelemetryMiddleware(telemetryService telemetry.TelemetryService) gin.Handle
 			return
 		}
 
-		cliId := ctx.GetHeader(telemetry.CLI_ID_HEADER)
-		if cliId == "" {
-			cliId = uuid.NewString()
+		clientId := ctx.GetHeader(telemetry.CLIENT_ID_HEADER)
+		if clientId == "" {
+			clientId = uuid.NewString()
 		}
 
 		sessionId := ctx.GetHeader(telemetry.SESSION_ID_HEADER)
@@ -40,7 +40,7 @@ func TelemetryMiddleware(telemetryService telemetry.TelemetryService) gin.Handle
 		server := server.GetInstance(nil)
 
 		telemetryCtx := context.WithValue(ctx.Request.Context(), telemetry.ENABLED_CONTEXT_KEY, true)
-		telemetryCtx = context.WithValue(telemetryCtx, telemetry.CLI_ID_CONTEXT_KEY, cliId)
+		telemetryCtx = context.WithValue(telemetryCtx, telemetry.CLIENT_ID_CONTEXT_KEY, clientId)
 		telemetryCtx = context.WithValue(telemetryCtx, telemetry.SESSION_ID_CONTEXT_KEY, sessionId)
 		telemetryCtx = context.WithValue(telemetryCtx, telemetry.SERVER_ID_CONTEXT_KEY, server.Id)
 
@@ -53,7 +53,7 @@ func TelemetryMiddleware(telemetryService telemetry.TelemetryService) gin.Handle
 
 		query := ctx.Request.URL.RawQuery
 
-		err := telemetryService.TrackServerEvent(telemetry.ServerEventApiRequestStarted, cliId, map[string]interface{}{
+		err := telemetryService.TrackServerEvent(telemetry.ServerEventApiRequestStarted, clientId, map[string]interface{}{
 			"method":     reqMethod,
 			"URI":        reqUri,
 			"query":      query,
@@ -86,7 +86,7 @@ func TelemetryMiddleware(telemetryService telemetry.TelemetryService) gin.Handle
 			properties["error"] = ctx.Errors.String()
 		}
 
-		err = telemetryService.TrackServerEvent(telemetry.ServerEventApiResponseSent, cliId, properties)
+		err = telemetryService.TrackServerEvent(telemetry.ServerEventApiResponseSent, clientId, properties)
 		if err != nil {
 			log.Trace(err)
 		}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/api/docs"
 	"github.com/daytonaio/daytona/pkg/api/middlewares"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/gin-contrib/cors"
 
 	"github.com/daytonaio/daytona/pkg/api/controllers/apikey"
@@ -51,21 +52,24 @@ import (
 )
 
 type ApiServerConfig struct {
-	ApiPort int
+	ApiPort          int
+	TelemetryService telemetry.TelemetryService
 }
 
 const HEALTH_CHECK_ROUTE = "/health"
 
 func NewApiServer(config ApiServerConfig) *ApiServer {
 	return &ApiServer{
-		apiPort: config.ApiPort,
+		apiPort:          config.ApiPort,
+		telemetryService: config.TelemetryService,
 	}
 }
 
 type ApiServer struct {
-	apiPort    int
-	httpServer *http.Server
-	router     *gin.Engine
+	apiPort          int
+	telemetryService telemetry.TelemetryService
+	httpServer       *http.Server
+	router           *gin.Engine
 }
 
 func (a *ApiServer) Start() error {
@@ -87,6 +91,7 @@ func (a *ApiServer) Start() error {
 		a.router.Use(gin.Recovery())
 	}
 
+	a.router.Use(middlewares.TelemetryMiddleware(a.telemetryService))
 	a.router.Use(middlewares.LoggingMiddleware())
 	a.router.Use(middlewares.SetVersionMiddleware())
 

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -81,7 +81,7 @@ var AgentCmd = &cobra.Command{
 			Hostname:         tailscaleHostname,
 			Server:           c.Server,
 			TelemetryEnabled: telemetryEnabled,
-			CliId:            c.CliId,
+			ClientId:         c.ClientId,
 		}
 
 		agent := agent.Agent{

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -75,17 +75,22 @@ var AgentCmd = &cobra.Command{
 			tailscaleHostname = c.WorkspaceId
 		}
 
+		telemetryEnabled := os.Getenv("DAYTONA_TELEMETRY_ENABLED") == "true"
+
 		tailscaleServer := &tailscale.Server{
-			Hostname: tailscaleHostname,
-			Server:   c.Server,
+			Hostname:         tailscaleHostname,
+			Server:           c.Server,
+			TelemetryEnabled: telemetryEnabled,
+			CliId:            c.CliId,
 		}
 
 		agent := agent.Agent{
-			Config:    c,
-			Git:       git,
-			Ssh:       sshServer,
-			Tailscale: tailscaleServer,
-			LogWriter: agentLogWriter,
+			Config:           c,
+			Git:              git,
+			Ssh:              sshServer,
+			Tailscale:        tailscaleServer,
+			LogWriter:        agentLogWriter,
+			TelemetryEnabled: telemetryEnabled,
 		}
 
 		err = agent.Start()

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -90,7 +90,7 @@ func SetupRootCommand(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&output.FormatFlag, "output", "o", output.FormatFlag, `Output format. Must be one of (yaml, json)`)
 
 	var telemetryService telemetry.TelemetryService
-	cliId := config.GetCliId()
+	clientId := config.GetClientId()
 	telemetryEnabled := config.TelemetryEnabled()
 
 	if telemetryEnabled {
@@ -104,7 +104,7 @@ func SetupRootCommand(cmd *cobra.Command) {
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if telemetryService != nil {
-			err := telemetryService.TrackCliEvent(telemetry.CliEventCmdStart, cliId, getCmdTelemetryData(cmd))
+			err := telemetryService.TrackCliEvent(telemetry.CliEventCmdStart, clientId, getCmdTelemetryData(cmd))
 			if err != nil {
 				log.Error(err)
 			}
@@ -126,7 +126,7 @@ func SetupRootCommand(cmd *cobra.Command) {
 			props := getCmdTelemetryData(cmd)
 			props["exec time (µs)"] = execTime.Microseconds()
 
-			err := telemetryService.TrackCliEvent(telemetry.CliEventCmdEnd, cliId, props)
+			err := telemetryService.TrackCliEvent(telemetry.CliEventCmdEnd, clientId, props)
 			if err != nil {
 				log.Error(err)
 			}
@@ -173,9 +173,9 @@ func getCmdTelemetryData(cmd *cobra.Command) map[string]interface{} {
 		path = strings.TrimPrefix(path, "daytona ")
 	}
 
-	source := "cli"
+	source := telemetry.CLI_SOURCE
 	if internal.WorkspaceMode() {
-		source = "cli-project"
+		source = telemetry.CLI_PROJECT_SOURCE
 	}
 
 	calledAs := cmd.CalledAs()

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -5,7 +5,11 @@ package cmd
 
 import (
 	"os"
+	"strings"
+	"time"
 
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal"
 	. "github.com/daytonaio/daytona/internal/util"
 	. "github.com/daytonaio/daytona/pkg/cmd/apikey"
 	. "github.com/daytonaio/daytona/pkg/cmd/containerregistry"
@@ -17,7 +21,10 @@ import (
 	. "github.com/daytonaio/daytona/pkg/cmd/provider"
 	. "github.com/daytonaio/daytona/pkg/cmd/server"
 	. "github.com/daytonaio/daytona/pkg/cmd/target"
+	. "github.com/daytonaio/daytona/pkg/cmd/telemetry"
 	. "github.com/daytonaio/daytona/pkg/cmd/workspace"
+	"github.com/daytonaio/daytona/pkg/posthogservice"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	view "github.com/daytonaio/daytona/pkg/views/initial"
 	log "github.com/sirupsen/logrus"
 
@@ -61,6 +68,7 @@ func Execute() {
 	rootCmd.AddCommand(InfoCmd)
 	rootCmd.AddCommand(PortForwardCmd)
 	rootCmd.AddCommand(EnvCmd)
+	rootCmd.AddCommand(TelemetryCmd)
 
 	SetupRootCommand(rootCmd)
 
@@ -81,7 +89,27 @@ func SetupRootCommand(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP("help", "", false, "help for daytona")
 	cmd.PersistentFlags().StringVarP(&output.FormatFlag, "output", "o", output.FormatFlag, `Output format. Must be one of (yaml, json)`)
 
+	var telemetryService telemetry.TelemetryService
+	cliId := config.GetCliId()
+	telemetryEnabled := config.TelemetryEnabled()
+
+	if telemetryEnabled {
+		telemetryService = posthogservice.NewTelemetryService(posthogservice.PosthogServiceConfig{
+			ApiKey:   internal.PosthogApiKey,
+			Endpoint: internal.PosthogEndpoint,
+		})
+	}
+
+	startTime := time.Now()
+
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if telemetryService != nil {
+			err := telemetryService.TrackCliEvent(telemetry.CliEventCmdStart, cliId, getCmdTelemetryData(cmd))
+			if err != nil {
+				log.Error(err)
+			}
+		}
+
 		if output.FormatFlag == "" {
 			return
 		}
@@ -90,6 +118,20 @@ func SetupRootCommand(cmd *cobra.Command) {
 	}
 
 	cmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+		endTime := time.Now()
+
+		if telemetryService != nil {
+			defer telemetryService.Close()
+			execTime := endTime.Sub(startTime)
+			props := getCmdTelemetryData(cmd)
+			props["exec time (µs)"] = execTime.Microseconds()
+
+			err := telemetryService.TrackCliEvent(telemetry.CliEventCmdEnd, cliId, props)
+			if err != nil {
+				log.Error(err)
+			}
+		}
+
 		os.Stdout = originalStdout
 		output.Print(output.Output, output.FormatFlag)
 	}
@@ -119,5 +161,27 @@ func RunInitialScreenFlow(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
+	}
+}
+
+func getCmdTelemetryData(cmd *cobra.Command) map[string]interface{} {
+	path := cmd.CommandPath()
+
+	// Trim daytona from the path if a non-root command was invoked
+	// This prevents a `daytona` pileup in the telemetry data
+	if path != "daytona" {
+		path = strings.TrimPrefix(path, "daytona ")
+	}
+
+	source := "cli"
+	if internal.WorkspaceMode() {
+		source = "cli-project"
+	}
+
+	calledAs := cmd.CalledAs()
+	return map[string]interface{}{
+		"command":   path,
+		"called_as": calledAs,
+		"source":    source,
 	}
 }

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -70,7 +70,7 @@ var ServeCmd = &cobra.Command{
 			signal.Notify(interruptChannel, os.Interrupt)
 
 			for range interruptChannel {
-				log.Info("Shutting down2")
+				log.Info("Shutting down")
 				telemetryService.Close()
 			}
 		}()
@@ -379,6 +379,7 @@ func setDefaultConfig(server *server.Server, apiPort uint32) error {
 				},
 			},
 		},
+		TelemetryEnabled: true,
 	}
 
 	return config.Save()

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -8,11 +8,13 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/api"
 	"github.com/daytonaio/daytona/pkg/apikey"
@@ -20,6 +22,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/db"
 	"github.com/daytonaio/daytona/pkg/git"
 	"github.com/daytonaio/daytona/pkg/logs"
+	"github.com/daytonaio/daytona/pkg/posthogservice"
 	"github.com/daytonaio/daytona/pkg/provider/manager"
 	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/server"
@@ -58,8 +61,23 @@ var ServeCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		telemetryService := posthogservice.NewTelemetryService(posthogservice.PosthogServiceConfig{
+			ApiKey:   internal.PosthogApiKey,
+			Endpoint: internal.PosthogEndpoint,
+		})
+		go func() {
+			interruptChannel := make(chan os.Signal, 1)
+			signal.Notify(interruptChannel, os.Interrupt)
+
+			for range interruptChannel {
+				log.Info("Shutting down2")
+				telemetryService.Close()
+			}
+		}()
+
 		apiServer := api.NewApiServer(api.ApiServerConfig{
-			ApiPort: int(c.ApiPort),
+			ApiPort:          int(c.ApiPort),
+			TelemetryService: telemetryService,
 		})
 
 		logsDir, err := server.GetWorkspaceLogsDir()
@@ -212,6 +230,7 @@ var ServeCmd = &cobra.Command{
 			Provisioner:              provisioner,
 			LoggerFactory:            loggerFactory,
 			BuilderFactory:           builderFactory,
+			TelemetryService:         telemetryService,
 		})
 		profileDataService := profiledata.NewProfileDataService(profiledata.ProfileDataServiceConfig{
 			ProfileDataStore: profileDataStore,
@@ -228,6 +247,7 @@ var ServeCmd = &cobra.Command{
 			GitProviderService:       gitProviderService,
 			ProviderManager:          providerManager,
 			ProfileDataService:       profileDataService,
+			TelemetryService:         telemetryService,
 		})
 
 		errCh := make(chan error)

--- a/pkg/cmd/telemetry/disable.go
+++ b/pkg/cmd/telemetry/disable.go
@@ -1,0 +1,31 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/pkg/views"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var disableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable telemetry collection",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		c, err := config.GetConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = c.DisableTelemetry()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		views.RenderInfoMessage("Telemetry collection disabled")
+	},
+}

--- a/pkg/cmd/telemetry/enable.go
+++ b/pkg/cmd/telemetry/enable.go
@@ -1,0 +1,31 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/pkg/views"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var enableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable telemetry collection",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		c, err := config.GetConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = c.EnableTelemetry()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		views.RenderInfoMessage("Telemetry collection enabled")
+	},
+}

--- a/pkg/cmd/telemetry/telemetry.go
+++ b/pkg/cmd/telemetry/telemetry.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var TelemetryCmd = &cobra.Command{
+	Use:   "telemetry",
+	Short: "Manage telemetry collection",
+	Args:  cobra.NoArgs,
+}
+
+func init() {
+	TelemetryCmd.AddCommand(enableCmd)
+	TelemetryCmd.AddCommand(disableCmd)
+}

--- a/pkg/posthogservice/service.go
+++ b/pkg/posthogservice/service.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package posthogservice
+
+import (
+	"log"
+
+	"github.com/daytonaio/daytona/pkg/telemetry"
+	"github.com/posthog/posthog-go"
+	"github.com/sirupsen/logrus"
+)
+
+type PosthogServiceConfig struct {
+	ApiKey   string
+	Endpoint string
+}
+
+func NewTelemetryService(config PosthogServiceConfig) telemetry.TelemetryService {
+	client, _ := posthog.NewWithConfig(config.ApiKey, posthog.Config{
+		Endpoint: config.Endpoint,
+		Logger:   posthog.StdLogger(log.New(logrus.StandardLogger().WriterLevel(logrus.TraceLevel), "", 0)),
+		Verbose:  true,
+	})
+	posthogService := &posthogService{
+		client:                   client,
+		AbstractTelemetryService: telemetry.NewAbstractTelemetryService(),
+	}
+
+	posthogService.AbstractTelemetryService.TelemetryService = posthogService
+
+	return posthogService
+}
+
+type posthogService struct {
+	*telemetry.AbstractTelemetryService
+
+	client posthog.Client
+}
+
+func (p *posthogService) Close() error {
+	return p.client.Close()
+}
+
+func (p *posthogService) TrackCliEvent(event telemetry.CliEvent, cliId string, properties map[string]interface{}) error {
+	p.AbstractTelemetryService.SetCommonProps(properties)
+	return p.client.Enqueue(posthog.Capture{
+		DistinctId: cliId,
+		Event:      string(event),
+		Properties: properties,
+	})
+}
+
+func (p *posthogService) TrackServerEvent(event telemetry.ServerEvent, cliId string, properties map[string]interface{}) error {
+	p.AbstractTelemetryService.SetCommonProps(properties)
+	return p.client.Enqueue(posthog.Capture{
+		DistinctId: cliId,
+		Event:      string(event),
+		Properties: properties,
+	})
+}

--- a/pkg/posthogservice/service.go
+++ b/pkg/posthogservice/service.go
@@ -42,19 +42,19 @@ func (p *posthogService) Close() error {
 	return p.client.Close()
 }
 
-func (p *posthogService) TrackCliEvent(event telemetry.CliEvent, cliId string, properties map[string]interface{}) error {
+func (p *posthogService) TrackCliEvent(event telemetry.CliEvent, clientId string, properties map[string]interface{}) error {
 	p.AbstractTelemetryService.SetCommonProps(properties)
 	return p.client.Enqueue(posthog.Capture{
-		DistinctId: cliId,
+		DistinctId: clientId,
 		Event:      string(event),
 		Properties: properties,
 	})
 }
 
-func (p *posthogService) TrackServerEvent(event telemetry.ServerEvent, cliId string, properties map[string]interface{}) error {
+func (p *posthogService) TrackServerEvent(event telemetry.ServerEvent, clientId string, properties map[string]interface{}) error {
 	p.AbstractTelemetryService.SetCommonProps(properties)
 	return p.client.Enqueue(posthog.Capture{
-		DistinctId: cliId,
+		DistinctId: clientId,
 		Event:      string(event),
 		Properties: properties,
 	})

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/google/uuid"
 )
 
 func GetConfig() (*Config, error) {
@@ -42,6 +44,14 @@ func GetConfig() (*Config, error) {
 	}
 
 	err = json.Unmarshal(configContent, &c)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Id == "" {
+		c.Id = uuid.NewString()
+	}
+	err = Save(c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -101,7 +101,7 @@ func getDefaultConfig() (*Config, error) {
 	}
 
 	c := Config{
-		Id:                        generateUuid(),
+		Id:                        uuid.NewString(),
 		RegistryUrl:               defaultRegistryUrl,
 		ProvidersDir:              providersDir,
 		ServerDownloadUrl:         defaultServerDownloadUrl,
@@ -188,9 +188,4 @@ func getDefaultBinariesPath() (string, error) {
 	}
 
 	return filepath.Join(configDir, "binaries"), nil
-}
-
-func generateUuid() string {
-	uuid := uuid.New()
-	return uuid.String()
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/server/providertargets"
 	"github.com/daytonaio/daytona/pkg/server/registry"
 	"github.com/daytonaio/daytona/pkg/server/workspaces"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/hashicorp/go-plugin"
 
 	log "github.com/sirupsen/logrus"
@@ -35,6 +36,7 @@ type ServerInstanceConfig struct {
 	GitProviderService       gitproviders.IGitProviderService
 	ProviderManager          manager.IProviderManager
 	ProfileDataService       profiledata.IProfileDataService
+	TelemetryService         telemetry.TelemetryService
 }
 
 var server *Server
@@ -49,6 +51,7 @@ func GetInstance(serverConfig *ServerInstanceConfig) *Server {
 			log.Fatal("Server not initialized")
 		}
 		server = &Server{
+			Id:                       serverConfig.Config.Id,
 			config:                   serverConfig.Config,
 			TailscaleServer:          serverConfig.TailscaleServer,
 			ProviderTargetService:    serverConfig.ProviderTargetService,
@@ -59,6 +62,7 @@ func GetInstance(serverConfig *ServerInstanceConfig) *Server {
 			GitProviderService:       serverConfig.GitProviderService,
 			ProviderManager:          serverConfig.ProviderManager,
 			ProfileDataService:       serverConfig.ProfileDataService,
+			TelemetryService:         serverConfig.TelemetryService,
 		}
 	}
 
@@ -66,6 +70,7 @@ func GetInstance(serverConfig *ServerInstanceConfig) *Server {
 }
 
 type Server struct {
+	Id                       string
 	config                   Config
 	TailscaleServer          TailscaleServer
 	ProviderTargetService    providertargets.IProviderTargetService
@@ -76,6 +81,7 @@ type Server struct {
 	GitProviderService       gitproviders.IGitProviderService
 	ProviderManager          manager.IProviderManager
 	ProfileDataService       profiledata.IProfileDataService
+	TelemetryService         telemetry.TelemetryService
 }
 
 func (s *Server) Start(errCh chan error) error {

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -123,7 +123,7 @@ func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWo
 		return w, err
 	}
 
-	cliId := telemetry.CliId(ctx)
+	clientId := telemetry.ClientId(ctx)
 
 	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, w, target)
 	event := telemetry.ServerEventWorkspaceCreated
@@ -131,7 +131,7 @@ func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWo
 		telemetryProps["error"] = err.Error()
 		event = telemetry.ServerEventWorkspaceCreateError
 	}
-	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	telemetryError := s.telemetryService.TrackServerEvent(event, clientId, telemetryProps)
 	if telemetryError != nil {
 		log.Trace(err)
 	}
@@ -232,7 +232,7 @@ func (s *WorkspaceService) createWorkspace(ctx context.Context, ws *workspace.Wo
 	ws.EnvVars = workspace.GetWorkspaceEnvVars(ws, workspace.WorkspaceEnvVarParams{
 		ApiUrl:    s.serverApiUrl,
 		ServerUrl: s.serverUrl,
-		CliId:     telemetry.CliId(ctx),
+		ClientId:  telemetry.ClientId(ctx),
 	}, telemetry.TelemetryEnabled(ctx))
 
 	for i, project := range ws.Projects {
@@ -245,7 +245,7 @@ func (s *WorkspaceService) createWorkspace(ctx context.Context, ws *workspace.Wo
 		projectWithEnv.EnvVars = workspace.GetProjectEnvVars(project, workspace.ProjectEnvVarParams{
 			ApiUrl:    s.serverApiUrl,
 			ServerUrl: s.serverUrl,
-			CliId:     telemetry.CliId(ctx),
+			ClientId:  telemetry.ClientId(ctx),
 		}, telemetry.TelemetryEnabled(ctx))
 
 		for k, v := range project.EnvVars {

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -4,6 +4,7 @@
 package workspaces
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -15,7 +16,10 @@ import (
 	"github.com/daytonaio/daytona/pkg/logs"
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/daytonaio/daytona/pkg/workspace"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func isValidWorkspaceName(name string) bool {
@@ -35,7 +39,7 @@ func isValidWorkspaceName(name string) bool {
 	return true
 }
 
-func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*workspace.Workspace, error) {
+func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWorkspaceRequest) (*workspace.Workspace, error) {
 	_, err := s.workspaceStore.Find(req.Name)
 	if err == nil {
 		return nil, ErrWorkspaceAlreadyExists
@@ -108,7 +112,31 @@ func (s *WorkspaceService) CreateWorkspace(req dto.CreateWorkspaceRequest) (*wor
 		return nil, err
 	}
 
-	return s.createWorkspace(w)
+	target, err := s.targetStore.Find(w.Target)
+	if err != nil {
+		return w, err
+	}
+
+	w, err = s.createWorkspace(ctx, w, target)
+
+	if !telemetry.TelemetryEnabled(ctx) {
+		return w, err
+	}
+
+	cliId := telemetry.CliId(ctx)
+
+	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, w, target)
+	event := telemetry.ServerEventWorkspaceCreated
+	if err != nil {
+		telemetryProps["error"] = err.Error()
+		event = telemetry.ServerEventWorkspaceCreateError
+	}
+	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	if telemetryError != nil {
+		log.Trace(err)
+	}
+
+	return w, err
 }
 
 func (s *WorkspaceService) createBuild(project *workspace.Project, gc *gitprovider.GitProviderConfig, logWriter io.Writer) (*workspace.Project, error) {
@@ -190,21 +218,22 @@ func (s *WorkspaceService) createProject(project *workspace.Project, target *pro
 	return nil
 }
 
-func (s *WorkspaceService) createWorkspace(ws *workspace.Workspace) (*workspace.Workspace, error) {
-	target, err := s.targetStore.Find(ws.Target)
-	if err != nil {
-		return ws, err
-	}
-
+func (s *WorkspaceService) createWorkspace(ctx context.Context, ws *workspace.Workspace, target *provider.ProviderTarget) (*workspace.Workspace, error) {
 	wsLogger := s.loggerFactory.CreateWorkspaceLogger(ws.Id, logs.LogSourceServer)
 	defer wsLogger.Close()
 
 	wsLogger.Write([]byte(fmt.Sprintf("Creating workspace %s (%s)\n", ws.Name, ws.Id)))
 
-	err = s.provisioner.CreateWorkspace(ws, target)
+	err := s.provisioner.CreateWorkspace(ws, target)
 	if err != nil {
 		return nil, err
 	}
+
+	ws.EnvVars = workspace.GetWorkspaceEnvVars(ws, workspace.WorkspaceEnvVarParams{
+		ApiUrl:    s.serverApiUrl,
+		ServerUrl: s.serverUrl,
+		CliId:     telemetry.CliId(ctx),
+	}, telemetry.TelemetryEnabled(ctx))
 
 	for i, project := range ws.Projects {
 		projectLogger := s.loggerFactory.CreateProjectLogger(ws.Id, project.Name, logs.LogSourceServer)
@@ -213,7 +242,11 @@ func (s *WorkspaceService) createWorkspace(ws *workspace.Workspace) (*workspace.
 		gc, _ := s.gitProviderService.GetConfigForUrl(project.Repository.Url)
 
 		projectWithEnv := *project
-		projectWithEnv.EnvVars = workspace.GetProjectEnvVars(project, s.serverApiUrl, s.serverUrl)
+		projectWithEnv.EnvVars = workspace.GetProjectEnvVars(project, workspace.ProjectEnvVarParams{
+			ApiUrl:    s.serverApiUrl,
+			ServerUrl: s.serverUrl,
+			CliId:     telemetry.CliId(ctx),
+		}, telemetry.TelemetryEnabled(ctx))
 
 		for k, v := range project.EnvVars {
 			projectWithEnv.EnvVars[k] = v
@@ -240,7 +273,7 @@ func (s *WorkspaceService) createWorkspace(ws *workspace.Workspace) (*workspace.
 
 	wsLogger.Write([]byte("Workspace creation complete. Pending start...\n"))
 
-	err = s.startWorkspace(ws, target, wsLogger)
+	err = s.startWorkspace(ctx, ws, target, wsLogger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/workspaces/get.go
+++ b/pkg/server/workspaces/get.go
@@ -4,10 +4,12 @@
 package workspaces
 
 import (
+	"context"
+
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
 )
 
-func (s *WorkspaceService) GetWorkspace(workspaceId string) (*dto.WorkspaceDTO, error) {
+func (s *WorkspaceService) GetWorkspace(ctx context.Context, workspaceId string) (*dto.WorkspaceDTO, error) {
 	workspace, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
 		return nil, ErrWorkspaceNotFound

--- a/pkg/server/workspaces/remove.go
+++ b/pkg/server/workspaces/remove.go
@@ -71,7 +71,7 @@ func (s *WorkspaceService) RemoveWorkspace(ctx context.Context, workspaceId stri
 		return err
 	}
 
-	cliId := telemetry.CliId(ctx)
+	clientId := telemetry.ClientId(ctx)
 
 	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, workspace, target)
 	event := telemetry.ServerEventWorkspaceDestroyed
@@ -79,7 +79,7 @@ func (s *WorkspaceService) RemoveWorkspace(ctx context.Context, workspaceId stri
 		telemetryProps["error"] = err.Error()
 		event = telemetry.ServerEventWorkspaceDestroyError
 	}
-	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	telemetryError := s.telemetryService.TrackServerEvent(event, clientId, telemetryProps)
 	if telemetryError != nil {
 		log.Trace(telemetryError)
 	}
@@ -135,7 +135,7 @@ func (s *WorkspaceService) ForceRemoveWorkspace(ctx context.Context, workspaceId
 		return err
 	}
 
-	cliId := telemetry.CliId(ctx)
+	clientId := telemetry.ClientId(ctx)
 
 	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, workspace, target)
 	event := telemetry.ServerEventWorkspaceDestroyed
@@ -143,7 +143,7 @@ func (s *WorkspaceService) ForceRemoveWorkspace(ctx context.Context, workspaceId
 		telemetryProps["error"] = err.Error()
 		event = telemetry.ServerEventWorkspaceDestroyError
 	}
-	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	telemetryError := s.telemetryService.TrackServerEvent(event, clientId, telemetryProps)
 	if telemetryError != nil {
 		log.Trace(telemetryError)
 	}

--- a/pkg/server/workspaces/remove.go
+++ b/pkg/server/workspaces/remove.go
@@ -4,13 +4,15 @@
 package workspaces
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/daytonaio/daytona/pkg/logs"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *WorkspaceService) RemoveWorkspace(workspaceId string) error {
+func (s *WorkspaceService) RemoveWorkspace(ctx context.Context, workspaceId string) error {
 	workspace, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
 		return ErrWorkspaceNotFound
@@ -64,16 +66,29 @@ func (s *WorkspaceService) RemoveWorkspace(workspaceId string) error {
 	}
 
 	err = s.workspaceStore.Delete(workspace)
-	if err != nil {
+
+	if !telemetry.TelemetryEnabled(ctx) {
 		return err
 	}
 
-	log.Infof("Workspace %s destroyed", workspace.Id)
-	return nil
+	cliId := telemetry.CliId(ctx)
+
+	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, workspace, target)
+	event := telemetry.ServerEventWorkspaceDestroyed
+	if err != nil {
+		telemetryProps["error"] = err.Error()
+		event = telemetry.ServerEventWorkspaceDestroyError
+	}
+	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	if telemetryError != nil {
+		log.Trace(telemetryError)
+	}
+
+	return err
 }
 
 // ForceRemoveWorkspace ignores provider errors and makes sure the workspace is removed from storage.
-func (s *WorkspaceService) ForceRemoveWorkspace(workspaceId string) error {
+func (s *WorkspaceService) ForceRemoveWorkspace(ctx context.Context, workspaceId string) error {
 	workspace, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
 		return ErrWorkspaceNotFound
@@ -115,10 +130,23 @@ func (s *WorkspaceService) ForceRemoveWorkspace(workspaceId string) error {
 	}
 
 	err = s.workspaceStore.Delete(workspace)
-	if err != nil {
+
+	if !telemetry.TelemetryEnabled(ctx) {
 		return err
 	}
 
-	log.Infof("Workspace %s destroyed", workspace.Id)
-	return nil
+	cliId := telemetry.CliId(ctx)
+
+	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, workspace, target)
+	event := telemetry.ServerEventWorkspaceDestroyed
+	if err != nil {
+		telemetryProps["error"] = err.Error()
+		event = telemetry.ServerEventWorkspaceDestroyError
+	}
+	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	if telemetryError != nil {
+		log.Trace(telemetryError)
+	}
+
+	return err
 }

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -4,6 +4,7 @@
 package workspaces_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -128,7 +129,7 @@ func TestWorkspaceService(t *testing.T) {
 
 		gitProviderService.On("GetConfigForUrl", "https://github.com/daytonaio/daytona").Return(&gitProviderConfig, nil)
 
-		workspace, err := service.CreateWorkspace(createWorkspaceRequest)
+		workspace, err := service.CreateWorkspace(context.TODO(), createWorkspaceRequest)
 
 		require.Nil(t, err)
 		require.NotNil(t, workspace)
@@ -137,7 +138,7 @@ func TestWorkspaceService(t *testing.T) {
 	})
 
 	t.Run("CreateWorkspace fails when workspace already exists", func(t *testing.T) {
-		_, err := service.CreateWorkspace(createWorkspaceRequest)
+		_, err := service.CreateWorkspace(context.TODO(), createWorkspaceRequest)
 		require.NotNil(t, err)
 		require.Equal(t, workspaces.ErrWorkspaceAlreadyExists, err)
 	})
@@ -146,7 +147,7 @@ func TestWorkspaceService(t *testing.T) {
 		invalidWorkspaceRequest := createWorkspaceRequest
 		invalidWorkspaceRequest.Name = "invalid name"
 
-		_, err := service.CreateWorkspace(invalidWorkspaceRequest)
+		_, err := service.CreateWorkspace(context.TODO(), invalidWorkspaceRequest)
 		require.NotNil(t, err)
 		require.Equal(t, workspaces.ErrInvalidWorkspaceName, err)
 	})
@@ -154,7 +155,7 @@ func TestWorkspaceService(t *testing.T) {
 	t.Run("GetWorkspace", func(t *testing.T) {
 		provisioner.On("GetWorkspaceInfo", mock.Anything, &target).Return(&workspaceInfo, nil)
 
-		workspace, err := service.GetWorkspace(createWorkspaceRequest.Id)
+		workspace, err := service.GetWorkspace(context.TODO(), createWorkspaceRequest.Id)
 
 		require.Nil(t, err)
 		require.NotNil(t, workspace)
@@ -163,7 +164,7 @@ func TestWorkspaceService(t *testing.T) {
 	})
 
 	t.Run("GetWorkspace fails when workspace not found", func(t *testing.T) {
-		_, err := service.GetWorkspace("invalid-id")
+		_, err := service.GetWorkspace(context.TODO(), "invalid-id")
 		require.NotNil(t, err)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
@@ -200,7 +201,7 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
 		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
 
-		err := service.StartWorkspace(createWorkspaceRequest.Id)
+		err := service.StartWorkspace(context.TODO(), createWorkspaceRequest.Id)
 
 		require.Nil(t, err)
 	})
@@ -209,7 +210,7 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
 		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
 
-		err := service.StartProject(createWorkspaceRequest.Id, createWorkspaceRequest.Projects[0].Name)
+		err := service.StartProject(context.TODO(), createWorkspaceRequest.Id, createWorkspaceRequest.Projects[0].Name)
 
 		require.Nil(t, err)
 	})
@@ -218,7 +219,7 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("StopWorkspace", mock.Anything, &target).Return(nil)
 		provisioner.On("StopProject", mock.Anything, &target).Return(nil)
 
-		err := service.StopWorkspace(createWorkspaceRequest.Id)
+		err := service.StopWorkspace(context.TODO(), createWorkspaceRequest.Id)
 
 		require.Nil(t, err)
 	})
@@ -227,7 +228,7 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("StopWorkspace", mock.Anything, &target).Return(nil)
 		provisioner.On("StopProject", mock.Anything, &target).Return(nil)
 
-		err := service.StopProject(createWorkspaceRequest.Id, createWorkspaceRequest.Projects[0].Name)
+		err := service.StopProject(context.TODO(), createWorkspaceRequest.Id, createWorkspaceRequest.Projects[0].Name)
 
 		require.Nil(t, err)
 	})
@@ -237,11 +238,11 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("DestroyProject", mock.Anything, &target).Return(nil)
 		apiKeyService.On("Revoke", mock.Anything).Return(nil)
 
-		err := service.RemoveWorkspace(createWorkspaceRequest.Id)
+		err := service.RemoveWorkspace(context.TODO(), createWorkspaceRequest.Id)
 
 		require.Nil(t, err)
 
-		_, err = service.GetWorkspace(createWorkspaceRequest.Id)
+		_, err = service.GetWorkspace(context.TODO(), createWorkspaceRequest.Id)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
 
@@ -269,22 +270,22 @@ func TestWorkspaceService(t *testing.T) {
 		provisioner.On("CreateProject", mock.Anything, &target, containerRegistry, &gitProviderConfig).Return(nil)
 		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
 
-		_, _ = service.CreateWorkspace(createWorkspaceRequest)
+		_, _ = service.CreateWorkspace(context.TODO(), createWorkspaceRequest)
 
 		provisioner.On("DestroyWorkspace", mock.Anything, &target).Return(nil)
 		provisioner.On("DestroyProject", mock.Anything, &target).Return(nil)
 		apiKeyService.On("Revoke", mock.Anything).Return(nil)
 
-		err = service.ForceRemoveWorkspace(createWorkspaceRequest.Id)
+		err = service.ForceRemoveWorkspace(context.TODO(), createWorkspaceRequest.Id)
 
 		require.Nil(t, err)
 
-		_, err = service.GetWorkspace(createWorkspaceRequest.Id)
+		_, err = service.GetWorkspace(context.TODO(), createWorkspaceRequest.Id)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
 
 	t.Run("SetProjectState", func(t *testing.T) {
-		ws, err := service.CreateWorkspace(createWorkspaceRequest)
+		ws, err := service.CreateWorkspace(context.TODO(), createWorkspaceRequest)
 		require.Nil(t, err)
 
 		projectName := ws.Projects[0].Name

--- a/pkg/server/workspaces/start.go
+++ b/pkg/server/workspaces/start.go
@@ -39,7 +39,7 @@ func (s *WorkspaceService) StartWorkspace(ctx context.Context, workspaceId strin
 		return err
 	}
 
-	cliId := telemetry.CliId(ctx)
+	clientId := telemetry.ClientId(ctx)
 
 	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, w, target)
 	event := telemetry.ServerEventWorkspaceStarted
@@ -47,7 +47,7 @@ func (s *WorkspaceService) StartWorkspace(ctx context.Context, workspaceId strin
 		telemetryProps["error"] = err.Error()
 		event = telemetry.ServerEventWorkspaceStartError
 	}
-	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	telemetryError := s.telemetryService.TrackServerEvent(event, clientId, telemetryProps)
 	if telemetryError != nil {
 		log.Trace(telemetryError)
 	}
@@ -83,7 +83,7 @@ func (s *WorkspaceService) startWorkspace(ctx context.Context, ws *workspace.Wor
 	ws.EnvVars = workspace.GetWorkspaceEnvVars(ws, workspace.WorkspaceEnvVarParams{
 		ApiUrl:    s.serverApiUrl,
 		ServerUrl: s.serverUrl,
-		CliId:     telemetry.CliId(ctx),
+		ClientId:  telemetry.ClientId(ctx),
 	}, telemetry.TelemetryEnabled(ctx))
 
 	err := s.provisioner.StartWorkspace(ws, target)
@@ -113,7 +113,7 @@ func (s *WorkspaceService) startProject(ctx context.Context, project *workspace.
 	projectToStart.EnvVars = workspace.GetProjectEnvVars(project, workspace.ProjectEnvVarParams{
 		ApiUrl:    s.serverApiUrl,
 		ServerUrl: s.serverUrl,
-		CliId:     telemetry.CliId(ctx),
+		ClientId:  telemetry.ClientId(ctx),
 	}, telemetry.TelemetryEnabled(ctx))
 
 	err := s.provisioner.StartProject(project, target)

--- a/pkg/server/workspaces/stop.go
+++ b/pkg/server/workspaces/stop.go
@@ -4,10 +4,14 @@
 package workspaces
 
 import (
+	"context"
 	"time"
+
+	"github.com/daytonaio/daytona/pkg/telemetry"
+	log "github.com/sirupsen/logrus"
 )
 
-func (s *WorkspaceService) StopWorkspace(workspaceId string) error {
+func (s *WorkspaceService) StopWorkspace(ctx context.Context, workspaceId string) error {
 	workspace, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
 		return ErrWorkspaceNotFound
@@ -31,6 +35,24 @@ func (s *WorkspaceService) StopWorkspace(workspaceId string) error {
 	}
 
 	err = s.provisioner.StopWorkspace(workspace, target)
+
+	if !telemetry.TelemetryEnabled(ctx) {
+		return err
+	}
+
+	cliId := telemetry.CliId(ctx)
+
+	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, workspace, target)
+	event := telemetry.ServerEventWorkspaceStopped
+	if err != nil {
+		telemetryProps["error"] = err.Error()
+		event = telemetry.ServerEventWorkspaceStopError
+	}
+	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	if telemetryError != nil {
+		log.Trace(telemetryError)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -38,7 +60,7 @@ func (s *WorkspaceService) StopWorkspace(workspaceId string) error {
 	return s.workspaceStore.Save(workspace)
 }
 
-func (s *WorkspaceService) StopProject(workspaceId, projectName string) error {
+func (s *WorkspaceService) StopProject(ctx context.Context, workspaceId, projectName string) error {
 	w, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
 		return ErrWorkspaceNotFound

--- a/pkg/server/workspaces/stop.go
+++ b/pkg/server/workspaces/stop.go
@@ -40,7 +40,7 @@ func (s *WorkspaceService) StopWorkspace(ctx context.Context, workspaceId string
 		return err
 	}
 
-	cliId := telemetry.CliId(ctx)
+	clientId := telemetry.ClientId(ctx)
 
 	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, workspace, target)
 	event := telemetry.ServerEventWorkspaceStopped
@@ -48,7 +48,7 @@ func (s *WorkspaceService) StopWorkspace(ctx context.Context, workspaceId string
 		telemetryProps["error"] = err.Error()
 		event = telemetry.ServerEventWorkspaceStopError
 	}
-	telemetryError := s.telemetryService.TrackServerEvent(event, cliId, telemetryProps)
+	telemetryError := s.telemetryService.TrackServerEvent(event, clientId, telemetryProps)
 	if telemetryError != nil {
 		log.Trace(telemetryError)
 	}

--- a/pkg/telemetry/cli_events.go
+++ b/pkg/telemetry/cli_events.go
@@ -1,0 +1,11 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+type CliEvent string
+
+const (
+	CliEventCmdStart CliEvent = "cli_cmd_start"
+	CliEventCmdEnd   CliEvent = "cli_cmd_end"
+)

--- a/pkg/telemetry/contants.go
+++ b/pkg/telemetry/contants.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+const ENABLED_HEADER = "X-Daytona-Telemetry-Enabled"
+const SESSION_ID_HEADER = "X-Daytona-Session-Id"
+const SOURCE_HEADER = "X-Daytona-Source"
+const CLIENT_ID_HEADER = "X-Daytona-Client-Id"
+
+type TelemetryContextKey string
+
+var (
+	ENABLED_CONTEXT_KEY    TelemetryContextKey = "telemetry-enabled"
+	CLIENT_ID_CONTEXT_KEY  TelemetryContextKey = "cli-id"
+	SESSION_ID_CONTEXT_KEY TelemetryContextKey = "session-id"
+	SERVER_ID_CONTEXT_KEY  TelemetryContextKey = "server-id"
+)
+
+type TelemetrySource string
+
+var (
+	CLI_SOURCE         TelemetrySource = "cli"
+	CLI_PROJECT_SOURCE TelemetrySource = "cli-project"
+	AGENT_SOURCE       TelemetrySource = "agent"
+)

--- a/pkg/telemetry/server_events.go
+++ b/pkg/telemetry/server_events.go
@@ -1,0 +1,96 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/daytonaio/daytona/pkg/provider"
+	"github.com/daytonaio/daytona/pkg/workspace"
+)
+
+type ServerEvent string
+
+const (
+	ServerEventApiRequestStarted ServerEvent = "server_api_request_started"
+	ServerEventApiResponseSent   ServerEvent = "server_api_response_sent"
+
+	// Workspace events
+	ServerEventWorkspaceCreated      ServerEvent = "server_workspace_created"
+	ServerEventWorkspaceDestroyed    ServerEvent = "server_workspace_destroyed"
+	ServerEventWorkspaceStarted      ServerEvent = "server_workspace_started"
+	ServerEventWorkspaceStopped      ServerEvent = "server_workspace_stopped"
+	ServerEventWorkspaceCreateError  ServerEvent = "server_workspace_created_error"
+	ServerEventWorkspaceDestroyError ServerEvent = "server_workspace_destroyed_error"
+	ServerEventWorkspaceStartError   ServerEvent = "server_workspace_started_error"
+	ServerEventWorkspaceStopError    ServerEvent = "server_workspace_stopped_error"
+)
+
+func NewWorkspaceEventProps(ctx context.Context, workspace *workspace.Workspace, target *provider.ProviderTarget) map[string]interface{} {
+	props := map[string]interface{}{}
+
+	sessionId := SessionId(ctx)
+	serverId := ServerId(ctx)
+
+	props["session_id"] = sessionId
+	props["server_id"] = serverId
+
+	if workspace != nil {
+		props["workspace_id"] = workspace.Id
+		props["workspace_n_projects"] = len(workspace.Projects)
+		publicRepos := []string{}
+		publicImages := []string{}
+		builders := map[string]int{}
+
+		for _, project := range workspace.Projects {
+			if isImagePublic(project.Image) {
+				publicImages = append(publicImages, project.Image)
+			}
+			if project.Repository != nil && isPublic(project.Repository.Url) {
+				publicRepos = append(publicRepos, project.Repository.Url)
+			}
+			if project.Build == nil {
+				builders["none"]++
+			} else if project.Build.Devcontainer != nil {
+				builders["devcontainer"]++
+			} else {
+				builders["automatic"]++
+			}
+		}
+
+		props["workspace_public_repos"] = publicRepos
+		props["workspace_public_images"] = publicImages
+		props["workspace_builders"] = builders
+	}
+
+	if target != nil {
+		props["target_name"] = target.Name
+		props["target_provider"] = target.ProviderInfo.Name
+		props["target_provider_version"] = target.ProviderInfo.Version
+	}
+
+	return props
+}
+
+func isImagePublic(imageName string) bool {
+	if strings.Count(imageName, "/") < 2 {
+		if strings.Count(imageName, "/") == 0 {
+			return isPublic("https://hub.docker.com/_/" + imageName)
+		}
+
+		return isPublic("https://hub.docker.com/r/" + imageName)
+	}
+
+	return isPublic(imageName)
+}
+
+func isPublic(url string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	_, err := http.NewRequestWithContext(ctx, "HEAD", url, nil)
+	cancel()
+	return err == nil
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -12,24 +12,10 @@ import (
 	"github.com/google/uuid"
 )
 
-const ENABLED_HEADER = "X-Daytona-Telemetry-Enabled"
-const SESSION_ID_HEADER = "X-Daytona-Session-Id"
-const SOURCE_HEADER = "X-Daytona-Source"
-const CLI_ID_HEADER = "X-Daytona-CLI-Id"
-
-type TelemetryContextKey string
-
-var (
-	ENABLED_CONTEXT_KEY    TelemetryContextKey = "telemetry-enabled"
-	CLI_ID_CONTEXT_KEY     TelemetryContextKey = "cli-id"
-	SESSION_ID_CONTEXT_KEY TelemetryContextKey = "session-id"
-	SERVER_ID_CONTEXT_KEY  TelemetryContextKey = "server-id"
-)
-
 type TelemetryService interface {
 	io.Closer
-	TrackCliEvent(event CliEvent, cliId string, properties map[string]interface{}) error
-	TrackServerEvent(event ServerEvent, cliId string, properties map[string]interface{}) error
+	TrackCliEvent(event CliEvent, clientId string, properties map[string]interface{}) error
+	TrackServerEvent(event ServerEvent, clientId string, properties map[string]interface{}) error
 	SetCommonProps(properties map[string]interface{})
 }
 
@@ -42,11 +28,11 @@ func TelemetryEnabled(ctx context.Context) bool {
 	return enabled
 }
 
-func CliId(ctx context.Context) string {
-	id, ok := ctx.Value(CLI_ID_CONTEXT_KEY).(string)
+func ClientId(ctx context.Context) string {
+	id, ok := ctx.Value(CLIENT_ID_CONTEXT_KEY).(string)
 	if !ok {
-		// To identify requests that had no CLI ID set
-		return fmt.Sprintf("%s-invalid-cli-id", uuid.NewString()[0:16])
+		// To identify requests that had no client ID set
+		return fmt.Sprintf("%s-invalid-client-id", uuid.NewString()[0:16])
 	}
 
 	return id

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,87 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/daytonaio/daytona/internal"
+	"github.com/google/uuid"
+)
+
+const ENABLED_HEADER = "X-Daytona-Telemetry-Enabled"
+const SESSION_ID_HEADER = "X-Daytona-Session-Id"
+const SOURCE_HEADER = "X-Daytona-Source"
+const CLI_ID_HEADER = "X-Daytona-CLI-Id"
+
+type TelemetryContextKey string
+
+var (
+	ENABLED_CONTEXT_KEY    TelemetryContextKey = "telemetry-enabled"
+	CLI_ID_CONTEXT_KEY     TelemetryContextKey = "cli-id"
+	SESSION_ID_CONTEXT_KEY TelemetryContextKey = "session-id"
+	SERVER_ID_CONTEXT_KEY  TelemetryContextKey = "server-id"
+)
+
+type TelemetryService interface {
+	io.Closer
+	TrackCliEvent(event CliEvent, cliId string, properties map[string]interface{}) error
+	TrackServerEvent(event ServerEvent, cliId string, properties map[string]interface{}) error
+	SetCommonProps(properties map[string]interface{})
+}
+
+func TelemetryEnabled(ctx context.Context) bool {
+	enabled, ok := ctx.Value(ENABLED_CONTEXT_KEY).(bool)
+	if !ok {
+		return false
+	}
+
+	return enabled
+}
+
+func CliId(ctx context.Context) string {
+	id, ok := ctx.Value(CLI_ID_CONTEXT_KEY).(string)
+	if !ok {
+		// To identify requests that had no CLI ID set
+		return fmt.Sprintf("%s-invalid-cli-id", uuid.NewString()[0:16])
+	}
+
+	return id
+}
+
+func SessionId(ctx context.Context) string {
+	id, ok := ctx.Value(SESSION_ID_CONTEXT_KEY).(string)
+	if !ok {
+		return internal.SESSION_ID
+	}
+
+	return id
+}
+
+func ServerId(ctx context.Context) string {
+	id, ok := ctx.Value(SERVER_ID_CONTEXT_KEY).(string)
+	if !ok {
+		// To identify requests that had no server ID set
+		return fmt.Sprintf("%s-invalid-server-id", uuid.NewString()[0:16])
+	}
+
+	return id
+}
+
+type AbstractTelemetryService struct {
+	daytonaVersion string
+	TelemetryService
+}
+
+func NewAbstractTelemetryService() *AbstractTelemetryService {
+	return &AbstractTelemetryService{
+		daytonaVersion: internal.Version,
+	}
+}
+
+func (t *AbstractTelemetryService) SetCommonProps(properties map[string]interface{}) {
+	properties["daytona_version"] = t.daytonaVersion
+}

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -86,17 +86,28 @@ const (
 	UpdatedButUnmerged Status = "Updated but unmerged"
 )
 
-func GetProjectEnvVars(project *Project, apiUrl, serverUrl string) map[string]string {
+type ProjectEnvVarParams struct {
+	ApiUrl    string
+	ServerUrl string
+	CliId     string
+}
+
+func GetProjectEnvVars(project *Project, params ProjectEnvVarParams, telemetryEnabled bool) map[string]string {
 	envVars := map[string]string{
 		"DAYTONA_WS_ID":                     project.WorkspaceId,
 		"DAYTONA_WS_PROJECT_NAME":           project.Name,
 		"DAYTONA_WS_PROJECT_REPOSITORY_URL": project.Repository.Url,
 		"DAYTONA_SERVER_API_KEY":            project.ApiKey,
 		"DAYTONA_SERVER_VERSION":            internal.Version,
-		"DAYTONA_SERVER_URL":                serverUrl,
-		"DAYTONA_SERVER_API_URL":            apiUrl,
+		"DAYTONA_SERVER_URL":                params.ServerUrl,
+		"DAYTONA_SERVER_API_URL":            params.ApiUrl,
+		"DAYTONA_CLI_ID":                    params.CliId,
 		// (HOME) will be replaced at runtime
 		"DAYTONA_AGENT_LOG_FILE_PATH": "(HOME)/.daytona-agent.log",
+	}
+
+	if telemetryEnabled {
+		envVars["DAYTONA_TELEMETRY_ENABLED"] = "true"
 	}
 
 	return envVars

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -89,7 +89,7 @@ const (
 type ProjectEnvVarParams struct {
 	ApiUrl    string
 	ServerUrl string
-	CliId     string
+	ClientId  string
 }
 
 func GetProjectEnvVars(project *Project, params ProjectEnvVarParams, telemetryEnabled bool) map[string]string {
@@ -101,7 +101,7 @@ func GetProjectEnvVars(project *Project, params ProjectEnvVarParams, telemetryEn
 		"DAYTONA_SERVER_VERSION":            internal.Version,
 		"DAYTONA_SERVER_URL":                params.ServerUrl,
 		"DAYTONA_SERVER_API_URL":            params.ApiUrl,
-		"DAYTONA_CLI_ID":                    params.CliId,
+		"DAYTONA_CLIENT_ID":                 params.ClientId,
 		// (HOME) will be replaced at runtime
 		"DAYTONA_AGENT_LOG_FILE_PATH": "(HOME)/.daytona-agent.log",
 	}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -36,7 +36,7 @@ func (w *Workspace) GetProject(projectName string) (*Project, error) {
 type WorkspaceEnvVarParams struct {
 	ApiUrl    string
 	ServerUrl string
-	CliId     string
+	ClientId  string
 }
 
 func GetWorkspaceEnvVars(workspace *Workspace, params WorkspaceEnvVarParams, telemetryEnabled bool) map[string]string {
@@ -46,7 +46,7 @@ func GetWorkspaceEnvVars(workspace *Workspace, params WorkspaceEnvVarParams, tel
 		"DAYTONA_SERVER_VERSION": internal.Version,
 		"DAYTONA_SERVER_URL":     params.ServerUrl,
 		"DAYTONA_SERVER_API_URL": params.ApiUrl,
-		"DAYTONA_CLI_ID":         params.CliId,
+		"DAYTONA_CLIENT_ID":      params.ClientId,
 		// (HOME) will be replaced at runtime
 		"DAYTONA_AGENT_LOG_FILE_PATH": "(HOME)/.daytona-agent.log",
 	}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -5,14 +5,17 @@ package workspace
 
 import (
 	"errors"
+
+	"github.com/daytonaio/daytona/internal"
 )
 
 type Workspace struct {
-	Id       string     `json:"id"`
-	Name     string     `json:"name"`
-	Projects []*Project `json:"projects"`
-	Target   string     `json:"target"`
-	ApiKey   string     `json:"-"`
+	Id       string            `json:"id"`
+	Name     string            `json:"name"`
+	Projects []*Project        `json:"projects"`
+	Target   string            `json:"target"`
+	ApiKey   string            `json:"-"`
+	EnvVars  map[string]string `json:"-"`
 } // @name Workspace
 
 type WorkspaceInfo struct {
@@ -31,21 +34,25 @@ func (w *Workspace) GetProject(projectName string) (*Project, error) {
 }
 
 type WorkspaceEnvVarParams struct {
-	ApiUrl        string
-	ApiKey        string
-	ServerUrl     string
-	ServerVersion string
+	ApiUrl    string
+	ServerUrl string
+	CliId     string
 }
 
-func GetWorkspaceEnvVars(workspace *Workspace, params WorkspaceEnvVarParams) map[string]string {
+func GetWorkspaceEnvVars(workspace *Workspace, params WorkspaceEnvVarParams, telemetryEnabled bool) map[string]string {
 	envVars := map[string]string{
 		"DAYTONA_WS_ID":          workspace.Id,
-		"DAYTONA_SERVER_API_KEY": params.ApiKey,
-		"DAYTONA_SERVER_VERSION": params.ServerVersion,
+		"DAYTONA_SERVER_API_KEY": workspace.ApiKey,
+		"DAYTONA_SERVER_VERSION": internal.Version,
 		"DAYTONA_SERVER_URL":     params.ServerUrl,
 		"DAYTONA_SERVER_API_URL": params.ApiUrl,
+		"DAYTONA_CLI_ID":         params.CliId,
 		// (HOME) will be replaced at runtime
 		"DAYTONA_AGENT_LOG_FILE_PATH": "(HOME)/.daytona-agent.log",
+	}
+
+	if telemetryEnabled {
+		envVars["DAYTONA_TELEMETRY_ENABLED"] = "true"
 	}
 
 	return envVars


### PR DESCRIPTION
# Start Gathering Anonymous Telemetry Data

## Description

This PR introduces telemetry data gathering to the Daytona CLI. 
**All telemetry data is completely anonymous and does not include any personally identifiable information (PII) or user secrets.**

### Goal of gathering telemetry data
The goal of gathering telemetry data in the CLI is exclusively for the purpose of improving the Daytona ecosystem. Data gathered from the CLI will allow us to gain more insights into the usage of the binary, help us track errors and improve user experience.

The data **DOES** include:
- CLI command usage
  - name of the command that was ran, how was it called (was an alias used?), the source (e.g. local CLI or inside of a project), the version of the binary and the execution time
- API server request and response data
  - In the request and response payloads, only public data is included. This data may include: any public git repositories used to create workspaces, any public container images used to create workspaces.
  - The data also includes the path of the request - note: the path is stripped of any URL params that might include PII (e.g. data URI: `/workspace/:workspaceId/:projectName/state` => the URI is provided as is - `workspaceId` and `projectName` are not provided to the telemetry service)
  - Additionally, the request method, binary version, query and source are gathered
 - Relevant server events
   - Currently, only workspace lifecycle events are gathered (creation, stop, start, delete, etc.)
   - This might be expanded upon in the future

The data does **NOT** include:
- CLI command arguments
  - arguments might contain PII or user secrets so they are left out
- Full API request and response payloads
  - payloads may contain PII or user secrets so only public data is shared to the telemetry collection service
- Any environment variables set on projects created by the user, including Daytona-set environment variables
- Geolocation information about the user nor their IP address

CLI command telemetry data can be found [here](https://github.com/daytonaio/daytona/blob/telemetry/pkg/cmd/cmd.go#L94).
Telemetry data gathered from the workspace creation payload can be found [here](https://github.com/daytonaio/daytona/blob/telemetry/pkg/telemetry/server_events.go#L33).
API telemetry middleware can be found [here](https://github.com/daytonaio/daytona/blob/telemetry/pkg/api/middlewares/telemetry.go).

### Gathering policy
Telemetry gathering in the CLI will be **opt out**. This means that telemetry data will be gathered by default because it does not include any PII. 
To disable telemetry, users can run `daytona telemetry disable`.

### CLI ID
All telemetry events contain a unique identifier. The ID is set in the CLI configuration. The purpose of this identifier is to provide a way to aggregate telemetry data from the same CLI across different sessions and workspaces. This means that the CLI ID is shared between the CLI and any workspaces the user might create.

### Note
For current CLI users, telemetry will be disabled by default because of how the flag is stored in the CLI. This means that users, who have already installed Daytona, can run `daytona telemetry enable`.

### Telemetry Service
We use [Posthog](https://posthog.com/) as the Telemetry service of choice.

### Debugging
Telemetry events can be debugged by setting `LOG_LEVEL=trace` which will output information about the telemetry event queue.

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #257 