### PR TITLE
fix: update the swagger docs api version programatically

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/api/docs"
 	"github.com/daytonaio/daytona/pkg/api/middlewares"
 	"github.com/gin-contrib/cors"
@@ -68,7 +69,7 @@ type ApiServer struct {
 }
 
 func (a *ApiServer) Start() error {
-	docs.SwaggerInfo.Version = "0.1"
+	docs.SwaggerInfo.Version = internal.Version
 	docs.SwaggerInfo.BasePath = "/"
 	docs.SwaggerInfo.Description = "Daytona Server API"
 	docs.SwaggerInfo.Title = "Daytona Server API"


### PR DESCRIPTION
# Version number in swagger document differs from Daytona version number. #818 

## Description

This is a fix for a bug issue raised https://github.com/daytonaio/daytona/issues/818 where the API version number in swagger document differs from Daytona version number. Version number is fixed to 0.1.0. The solution is to make it dynamic based on the github release tag

- [ ] added `internal.Version` suggested by @Tpuljak in the `pkg/api/server.go` where the variable gets replaced in build time.

## Related Issue(s)

This PR addresses issue #818 

