### PR TITLE
feat: read server logs directly from file

### DIFF
--- a/docs/daytona_server_logs.md
+++ b/docs/daytona_server_logs.md
@@ -9,6 +9,7 @@ daytona server logs [flags]
 ### Options
 
 ```
+      --file     Read logs from local server log file
   -f, --follow   Follow logs
 ```
 

--- a/hack/docs/daytona_server_logs.yaml
+++ b/hack/docs/daytona_server_logs.yaml
@@ -2,6 +2,9 @@ name: daytona server logs
 synopsis: Output Daytona Server logs
 usage: daytona server logs [flags]
 options:
+    - name: file
+      default_value: "false"
+      usage: Read logs from local server log file
     - name: follow
       shorthand: f
       default_value: "false"

--- a/pkg/cmd/server/logs.go
+++ b/pkg/cmd/server/logs.go
@@ -4,15 +4,23 @@
 package server
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"os"
 
+	"github.com/charmbracelet/huh"
 	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/server"
+	"github.com/daytonaio/daytona/pkg/views"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var followFlag bool
+var fileFlag bool
 
 var logsCmd = &cobra.Command{
 	Use:   "logs",
@@ -33,22 +41,87 @@ var logsCmd = &cobra.Command{
 			query = "follow=true"
 		}
 
-		ws, res, err := apiclient.GetWebsocketConn("/log/server", &activeProfile, &query)
-		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
-		}
+		switch {
+		case fileFlag:
+			readServerLogFile()
 
-		for {
-			_, msg, err := ws.ReadMessage()
+		default:
+			ws, res, err := apiclient.GetWebsocketConn("/log/server", &activeProfile, &query)
+
 			if err != nil {
+				log.Error(apiclient.HandleErrorResponse(res, err))
+
+				if activeProfile.Id != "default" {
+					return
+				}
+
+				readLogsFile := true
+				form := huh.NewForm(
+					huh.NewGroup(
+						huh.NewConfirm().Description("An error occurred while connecting to the server. Would you like to read from local log file instead?").
+							Value(&readLogsFile),
+					),
+				).WithTheme(views.GetCustomTheme())
+				formErr := form.Run()
+				if formErr != nil {
+					log.Fatal(formErr)
+				}
+
+				if readLogsFile {
+					readServerLogFile()
+				}
 				return
+
 			}
 
+			for {
+				_, msg, err := ws.ReadMessage()
+				if err != nil {
+					return
+				}
+
+				fmt.Println(string(msg))
+			}
+		}
+
+	},
+}
+
+func readServerLogFile() {
+	views.RenderBorderedMessage("Reading from server log file...")
+	cfg, err := server.GetConfig()
+	if err != nil {
+		log.Fatal(fmt.Errorf("failed to get server config: %w", err).Error())
+	}
+
+	file, err := os.Open(cfg.LogFilePath)
+	if err != nil {
+		log.Fatal(fmt.Errorf("while opening server logs: %v", err).Error())
+	}
+	defer file.Close()
+	msgChan := make(chan []byte)
+	errChan := make(chan error)
+
+	go util.ReadLog(context.Background(), file, followFlag, msgChan, errChan)
+
+	for {
+		select {
+		case <-context.Background().Done():
+			return
+		case err := <-errChan:
+			if err != nil {
+				if err != io.EOF {
+					log.Fatal(err)
+				}
+				return
+			}
+		case msg := <-msgChan:
 			fmt.Println(string(msg))
 		}
-	},
+	}
 }
 
 func init() {
 	logsCmd.Flags().BoolVarP(&followFlag, "follow", "f", false, "Follow logs")
+	logsCmd.Flags().BoolVar(&fileFlag, "file", false, "Read logs from local server log file")
 }


### PR DESCRIPTION
# Add [daytona server logs --file] flag to read logs from local file

## Description
Solution to [Allow daytona logs to read straight from the log file](https://github.com/daytonaio/daytona/issues/772#top)
/claim #772

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)
Closes #772 
