### PR TITLE
fix: missing terminal cursor

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -161,6 +161,9 @@ var CreateCmd = &cobra.Command{
 
 		stopLogs = true
 
+		// Make sure terminal cursor is reset
+		fmt.Print("\033[?25h")
+
 		wsInfo, res, err := apiClient.WorkspaceAPI.GetWorkspace(ctx, workspaceName).Execute()
 		if err != nil {
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))


### PR DESCRIPTION
# Pull Request Title
fix: missing terminal cursor

## Description
Added a function that resets the terminal state

## Related Issue(s)

Closes #695
/closes #695
/claim #695
