### PR TITLE
feat: support to set the registry image

### DIFF
--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1554,6 +1554,9 @@ const docTemplate = `{
                 "providersDir": {
                     "type": "string"
                 },
+                "registryImage": {
+                    "type": "string"
+                },
                 "registryUrl": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1551,6 +1551,9 @@
                 "providersDir": {
                     "type": "string"
                 },
+                "registryImage": {
+                    "type": "string"
+                },
                 "registryUrl": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -282,6 +282,8 @@ definitions:
         type: string
       providersDir:
         type: string
+      registryImage:
+        type: string
       registryUrl:
         type: string
       serverDownloadUrl:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1272,6 +1272,7 @@ components:
         localBuilderRegistryPort: 5
         defaultProjectUser: defaultProjectUser
         builderRegistryServer: builderRegistryServer
+        registryImage: registryImage
         builderImage: builderImage
         apiPort: 0
         headscalePort: 1
@@ -1312,6 +1313,8 @@ components:
         logFilePath:
           type: string
         providersDir:
+          type: string
+        registryImage:
           type: string
         registryUrl:
           type: string

--- a/pkg/apiclient/docs/ServerConfig.md
+++ b/pkg/apiclient/docs/ServerConfig.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **LocalBuilderRegistryPort** | Pointer to **int32** |  | [optional] 
 **LogFilePath** | Pointer to **string** |  | [optional] 
 **ProvidersDir** | Pointer to **string** |  | [optional] 
+**RegistryImage** | Pointer to **string** |  | [optional] 
 **RegistryUrl** | Pointer to **string** |  | [optional] 
 **ServerDownloadUrl** | Pointer to **string** |  | [optional] 
 
@@ -363,6 +364,31 @@ SetProvidersDir sets ProvidersDir field to given value.
 `func (o *ServerConfig) HasProvidersDir() bool`
 
 HasProvidersDir returns a boolean if a field has been set.
+
+### GetRegistryImage
+
+`func (o *ServerConfig) GetRegistryImage() string`
+
+GetRegistryImage returns the RegistryImage field if non-nil, zero value otherwise.
+
+### GetRegistryImageOk
+
+`func (o *ServerConfig) GetRegistryImageOk() (*string, bool)`
+
+GetRegistryImageOk returns a tuple with the RegistryImage field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetRegistryImage
+
+`func (o *ServerConfig) SetRegistryImage(v string)`
+
+SetRegistryImage sets RegistryImage field to given value.
+
+### HasRegistryImage
+
+`func (o *ServerConfig) HasRegistryImage() bool`
+
+HasRegistryImage returns a boolean if a field has been set.
 
 ### GetRegistryUrl
 

--- a/pkg/apiclient/model_server_config.go
+++ b/pkg/apiclient/model_server_config.go
@@ -32,6 +32,7 @@ type ServerConfig struct {
 	LocalBuilderRegistryPort *int32      `json:"localBuilderRegistryPort,omitempty"`
 	LogFilePath              *string     `json:"logFilePath,omitempty"`
 	ProvidersDir             *string     `json:"providersDir,omitempty"`
+	RegistryImage            *string     `json:"registryImage,omitempty"`
 	RegistryUrl              *string     `json:"registryUrl,omitempty"`
 	ServerDownloadUrl        *string     `json:"serverDownloadUrl,omitempty"`
 }
@@ -469,6 +470,38 @@ func (o *ServerConfig) SetProvidersDir(v string) {
 	o.ProvidersDir = &v
 }
 
+// GetRegistryImage returns the RegistryImage field value if set, zero value otherwise.
+func (o *ServerConfig) GetRegistryImage() string {
+	if o == nil || IsNil(o.RegistryImage) {
+		var ret string
+		return ret
+	}
+	return *o.RegistryImage
+}
+
+// GetRegistryImageOk returns a tuple with the RegistryImage field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ServerConfig) GetRegistryImageOk() (*string, bool) {
+	if o == nil || IsNil(o.RegistryImage) {
+		return nil, false
+	}
+	return o.RegistryImage, true
+}
+
+// HasRegistryImage returns a boolean if a field has been set.
+func (o *ServerConfig) HasRegistryImage() bool {
+	if o != nil && !IsNil(o.RegistryImage) {
+		return true
+	}
+
+	return false
+}
+
+// SetRegistryImage gets a reference to the given string and assigns it to the RegistryImage field.
+func (o *ServerConfig) SetRegistryImage(v string) {
+	o.RegistryImage = &v
+}
+
 // GetRegistryUrl returns the RegistryUrl field value if set, zero value otherwise.
 func (o *ServerConfig) GetRegistryUrl() string {
 	if o == nil || IsNil(o.RegistryUrl) {
@@ -581,6 +614,9 @@ func (o ServerConfig) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ProvidersDir) {
 		toSerialize["providersDir"] = o.ProvidersDir
+	}
+	if !IsNil(o.RegistryImage) {
+		toSerialize["registryImage"] = o.RegistryImage
 	}
 	if !IsNil(o.RegistryUrl) {
 		toSerialize["registryUrl"] = o.RegistryUrl

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -130,8 +130,9 @@ var ServeCmd = &cobra.Command{
 
 		if c.BuilderRegistryServer == "local" {
 			localContainerRegistry = registry.NewLocalContainerRegistry(&registry.LocalContainerRegistryConfig{
-				DataPath: filepath.Join(configDir, "registry"),
-				Port:     c.LocalBuilderRegistryPort,
+				DataPath:      filepath.Join(configDir, "registry"),
+				Port:          c.LocalBuilderRegistryPort,
+				RegistryImage: c.RegistryImage,
 			})
 			c.BuilderRegistryServer = util.GetFrpcRegistryDomain(c.Id, c.Frps.Domain)
 		}

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -130,9 +130,9 @@ var ServeCmd = &cobra.Command{
 
 		if c.BuilderRegistryServer == "local" {
 			localContainerRegistry = registry.NewLocalContainerRegistry(&registry.LocalContainerRegistryConfig{
-				DataPath:      filepath.Join(configDir, "registry"),
-				Port:          c.LocalBuilderRegistryPort,
-				RegistryImage: c.RegistryImage,
+				DataPath: filepath.Join(configDir, "registry"),
+				Port:     c.LocalBuilderRegistryPort,
+				Image:    c.RegistryImage,
 			})
 			c.BuilderRegistryServer = util.GetFrpcRegistryDomain(c.Id, c.Frps.Domain)
 		}

--- a/pkg/server/registry/service.go
+++ b/pkg/server/registry/service.go
@@ -15,20 +15,27 @@ import (
 )
 
 type LocalContainerRegistryConfig struct {
-	DataPath string
-	Port     uint32
+	DataPath      string
+	Port          uint32
+	RegistryImage string
 }
 
 func NewLocalContainerRegistry(config *LocalContainerRegistryConfig) *LocalContainerRegistry {
+	registryImage := config.RegistryImage
+	if registryImage == "" {
+		registryImage = "registry:2.8.3"
+	}
 	return &LocalContainerRegistry{
-		dataPath: config.DataPath,
-		port:     config.Port,
+		dataPath:      config.DataPath,
+		port:          config.Port,
+		registryImage: registryImage,
 	}
 }
 
 type LocalContainerRegistry struct {
-	dataPath string
-	port     uint32
+	dataPath      string
+	port          uint32
+	registryImage string
 }
 
 func (s *LocalContainerRegistry) Start() error {
@@ -60,14 +67,14 @@ func (s *LocalContainerRegistry) Start() error {
 	}
 
 	// Pull the image
-	err = dockerClient.PullImage("registry:2.8.3", nil, os.Stdout)
+	err = dockerClient.PullImage(s.registryImage, nil, os.Stdout)
 	if err != nil {
 		return err
 	}
 
 	//	todo: enable TLS
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
-		Image: "registry:2.8.3",
+		Image: s.registryImage,
 		Env: []string{
 			fmt.Sprintf("REGISTRY_HTTP_ADDR=0.0.0.0:%d", s.port),
 		},

--- a/pkg/server/registry/service.go
+++ b/pkg/server/registry/service.go
@@ -15,27 +15,27 @@ import (
 )
 
 type LocalContainerRegistryConfig struct {
-	DataPath      string
-	Port          uint32
-	RegistryImage string
+	DataPath string
+	Port     uint32
+	Image    string
 }
 
 func NewLocalContainerRegistry(config *LocalContainerRegistryConfig) *LocalContainerRegistry {
-	registryImage := config.RegistryImage
+	registryImage := config.Image
 	if registryImage == "" {
 		registryImage = "registry:2.8.3"
 	}
 	return &LocalContainerRegistry{
-		dataPath:      config.DataPath,
-		port:          config.Port,
-		registryImage: registryImage,
+		dataPath: config.DataPath,
+		port:     config.Port,
+		image:    registryImage,
 	}
 }
 
 type LocalContainerRegistry struct {
-	dataPath      string
-	port          uint32
-	registryImage string
+	dataPath string
+	port     uint32
+	image    string
 }
 
 func (s *LocalContainerRegistry) Start() error {
@@ -67,14 +67,14 @@ func (s *LocalContainerRegistry) Start() error {
 	}
 
 	// Pull the image
-	err = dockerClient.PullImage(s.registryImage, nil, os.Stdout)
+	err = dockerClient.PullImage(s.image, nil, os.Stdout)
 	if err != nil {
 		return err
 	}
 
 	//	todo: enable TLS
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
-		Image: s.registryImage,
+		Image: s.image,
 		Env: []string{
 			fmt.Sprintf("REGISTRY_HTTP_ADDR=0.0.0.0:%d", s.port),
 		},

--- a/pkg/server/registry/service.go
+++ b/pkg/server/registry/service.go
@@ -21,14 +21,10 @@ type LocalContainerRegistryConfig struct {
 }
 
 func NewLocalContainerRegistry(config *LocalContainerRegistryConfig) *LocalContainerRegistry {
-	registryImage := config.Image
-	if registryImage == "" {
-		registryImage = "registry:2.8.3"
-	}
 	return &LocalContainerRegistry{
 		dataPath: config.DataPath,
 		port:     config.Port,
-		image:    registryImage,
+		image:    config.Image,
 	}
 }
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -32,6 +32,7 @@ type NetworkKey struct {
 type Config struct {
 	ProvidersDir             string      `json:"providersDir"`
 	RegistryUrl              string      `json:"registryUrl"`
+	RegistryImage            string      `json:"registryImage"`
 	Id                       string      `json:"id"`
 	ServerDownloadUrl        string      `json:"serverDownloadUrl"`
 	Frps                     *FRPSConfig `json:"frps,omitempty"`

--- a/pkg/views/server/config.go
+++ b/pkg/views/server/config.go
@@ -39,6 +39,8 @@ func RenderConfig(config *server.Config) {
 
 	if config.BuilderRegistryServer == "local" {
 		output += fmt.Sprintf("%s %d", views.GetPropertyKey("Local Builder Registry Port: "), config.LocalBuilderRegistryPort) + "\n\n"
+
+		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Local Builder Registry Image: "), config.RegistryImage) + "\n\n"
 	} else {
 		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Builder Registry: "), config.BuilderRegistryServer) + "\n\n"
 	}

--- a/pkg/views/server/configure.go
+++ b/pkg/views/server/configure.go
@@ -77,6 +77,9 @@ func ConfigurationForm(config *apiclient.ServerConfig, containerRegistries []api
 				Title("Local Builder Registry Port").
 				Value(&localBuilderRegistryPort).
 				Validate(createPortValidator(config, &localBuilderRegistryPort, config.LocalBuilderRegistryPort)),
+			huh.NewInput().
+				Title("Local Builder Registry Image").
+				Value(config.RegistryImage),
 		).WithHideFunc(func() bool {
 			return config.BuilderRegistryServer == nil || *config.BuilderRegistryServer != "local"
 		}),


### PR DESCRIPTION
# Support Setting Registry Image in Server Config

## Description

In some use cases, users need to change the image of `library/registry`. For instance:

* In a private network, they cannot pull images from the ineternet
* The `docker hub` is blocked in some areas

So, I propose to add a config item to allow users to change the image of `library/registry`.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## BREAKING CHANGE

Users will need to set the `registryImage` property in their server `config.json` file manually.
