### PR TITLE
fix: devcontainer remote user fallback

### DIFF
--- a/pkg/build/devcontainer/types.go
+++ b/pkg/build/devcontainer/types.go
@@ -110,3 +110,10 @@ type MergedConfiguration struct {
 	PostStartCommands     interface{} `json:"postStartCommands"`
 	PostAttachCommands    interface{} `json:"postAttachCommands"`
 }
+
+type DevcontainerUpResult struct {
+	Outcome               string `json:"outcome"`
+	ContainerId           string `json:"containerId"`
+	RemoteUser            string `json:"remoteUser"`
+	RemoteWorkspaceFolder string `json:"remoteWorkspaceFolder"`
+}


### PR DESCRIPTION
# Devcontainer Remote User Fallback

## Description

If the remote user is not set in the config, it is read from the devcontainer up result.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #807 

## Notes
This will require a provider update.
