### PR TITLE
fix: update container user uid and gid

### DIFF
--- a/pkg/docker/create_image.go
+++ b/pkg/docker/create_image.go
@@ -6,10 +6,12 @@ package docker
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+	log "github.com/sirupsen/logrus"
 )
 
 func (d *DockerClient) createProjectFromImage(opts *CreateProjectOptions) error {
@@ -18,25 +20,47 @@ func (d *DockerClient) createProjectFromImage(opts *CreateProjectOptions) error 
 		return err
 	}
 
-	return d.initProjectContainer(opts.Project, opts.ProjectDir)
+	return d.initProjectContainer(opts)
 }
 
-func (d *DockerClient) initProjectContainer(project *workspace.Project, projectDir string) error {
+func (d *DockerClient) initProjectContainer(opts *CreateProjectOptions) error {
 	ctx := context.Background()
 
-	_, err := d.apiClient.ContainerCreate(ctx, GetContainerCreateConfig(project), &container.HostConfig{
+	c, err := d.apiClient.ContainerCreate(ctx, GetContainerCreateConfig(opts.Project), &container.HostConfig{
 		Privileged: true,
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,
-				Source: projectDir,
-				Target: fmt.Sprintf("/home/%s/%s", project.User, project.Name),
+				Source: opts.ProjectDir,
+				Target: fmt.Sprintf("/home/%s/%s", opts.Project.User, opts.Project.Name),
 			},
 		},
 		ExtraHosts: []string{
 			"host.docker.internal:host-gateway",
 		},
-	}, nil, nil, d.GetProjectContainerName(project))
+	}, nil, nil, d.GetProjectContainerName(opts.Project))
+	if err != nil {
+		return err
+	}
+
+	err = d.apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			err = d.GetContainerLogs(c.ID, opts.LogWriter)
+			if err == nil {
+				break
+			}
+			log.Error(err)
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	_, err = d.updateContainerUserUidGid(c.ID, opts)
+	err = d.apiClient.ContainerStop(ctx, c.ID, container.StopOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/docker/create_test.go
+++ b/pkg/docker/create_test.go
@@ -55,6 +55,7 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 	s.mockClient.On("ContainerRemove", mock.Anything, mock.Anything, container.RemoveOptions{RemoveVolumes: true, Force: true}).Return(nil)
 	s.mockClient.On("ContainerStart", mock.Anything, mock.Anything, container.StartOptions{}).Return(nil)
 	s.mockClient.On("ContainerExecCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.IDResponse{ID: "exec-id"}, nil)
+	s.mockClient.On("ContainerStop", mock.Anything, "123", container.StopOptions{}).Return(nil)
 
 	_, client := net.Pipe()
 	s.mockClient.On("ContainerExecAttach", mock.Anything, "exec-id", types.ExecStartCheck{}).


### PR DESCRIPTION
# Update container user UID and GID

## Description

This PR fixes the case where the user running Daytona does not have UID and GID set to 1000 and doesn't use a devcontainer project. Now the UID and GID is synced properly.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation