### PR TITLE
fix: escape git credentials

### DIFF
--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -53,14 +53,17 @@ func (s *GitProviderService) GetGitProviderForUrl(repoUrl string) (gitprovider.G
 	})
 }
 
-func (s *GitProviderService) GetConfigForUrl(url string) (*gitprovider.GitProviderConfig, error) {
+func (s *GitProviderService) GetConfigForUrl(repoUrl string) (*gitprovider.GitProviderConfig, error) {
 	gitProviders, err := s.configStore.List()
 	if err != nil {
 		return nil, err
 	}
 
 	for _, p := range gitProviders {
-		if strings.Contains(url, fmt.Sprintf("%s.", p.Id)) {
+		p.Token = url.QueryEscape(p.Token)
+		p.Username = url.QueryEscape(p.Username)
+
+		if strings.Contains(repoUrl, fmt.Sprintf("%s.", p.Id)) {
 			return p, nil
 		}
 
@@ -73,7 +76,7 @@ func (s *GitProviderService) GetConfigForUrl(url string) (*gitprovider.GitProvid
 			return nil, err
 		}
 
-		if p.BaseApiUrl != nil && strings.Contains(url, hostname) {
+		if p.BaseApiUrl != nil && strings.Contains(repoUrl, hostname) {
 			return p, nil
 		}
 	}


### PR DESCRIPTION
# Escape Git Credentials

## Description

If git credentials have "illegal" URL chars, relevant git operations will fail. This PR simply adds `url.QueryEscape` when getting the token and username.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #837 