### PR TITLE
fix: selection tui blocked by --o flag

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -40,8 +40,6 @@ var rootCmd = &cobra.Command{
 	Run:               RunInitialScreenFlow,
 }
 
-var originalStdout *os.File
-
 func Execute() {
 	rootCmd.AddGroup(&cobra.Group{ID: WORKSPACE_GROUP, Title: "Workspaces & Projects"})
 	rootCmd.AddGroup(&cobra.Group{ID: SERVER_GROUP, Title: "Server"})
@@ -163,7 +161,7 @@ func SetupRootCommand(cmd *cobra.Command) {
 		if output.FormatFlag == "" {
 			return
 		}
-		originalStdout = os.Stdout
+		output.OriginalStdout = os.Stdout
 		os.Stdout = nil
 	}
 
@@ -182,7 +180,7 @@ func SetupRootCommand(cmd *cobra.Command) {
 			}
 		}
 
-		os.Stdout = originalStdout
+		os.Stdout = output.OriginalStdout
 		output.Print(output.Output, output.FormatFlag)
 	}
 }

--- a/pkg/cmd/output/output.go
+++ b/pkg/cmd/output/output.go
@@ -13,6 +13,7 @@ import (
 
 var FormatFlag string
 var Output interface{}
+var OriginalStdout *os.File
 
 type Formatter interface {
 	Format(data interface{}) (string, error)

--- a/pkg/views/workspace/selection/workspace.go
+++ b/pkg/views/workspace/selection/workspace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/cmd/output"
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
@@ -100,6 +101,12 @@ func getWorkspaceProgramEssentials(modelTitle string, actionVerb string, workspa
 }
 
 func selectWorkspacePrompt(workspaces []apiclient.WorkspaceDTO, actionVerb string, choiceChan chan<- *apiclient.WorkspaceDTO) {
+	if os.Stdout == nil {
+		os.Stdout = output.OriginalStdout
+		defer func() {
+			os.Stdout = nil
+		}()
+	}
 
 	p := getWorkspaceProgramEssentials("Select a Workspace To ", actionVerb, workspaces, "")
 	if m, ok := p.(model[apiclient.WorkspaceDTO]); ok && m.choice != nil {
@@ -113,7 +120,6 @@ func GetWorkspaceFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb stri
 	choiceChan := make(chan *apiclient.WorkspaceDTO)
 
 	go selectWorkspacePrompt(workspaces, actionVerb, choiceChan)
-
 	return <-choiceChan
 }
 


### PR DESCRIPTION
# Fix: selection tui blocked by --o flag

## Description

I noticed that the setup for the daytona command had a persistent pre run command which set os.Stdout = nil, which blocked the routine anytime a command that required a form selection was run, i feel this would be a larger issue for almost all commands that require input if the -o flag is used by accident or where its not meant to be used but for this case i just added a check in the GetWorkspaceSelectionFunction to see if os.Stdout is nil, when nil it handles setting the correct output and also returning os.Stdout back to nil.
- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #688 
/claim #688

## Notes
- Might be a larger issue for all commands with tui forms if ran with -o flag.
