### PR TITLE
fix: correctly parse branch names with slashes in GitHub Urls

### DIFF
--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -301,7 +301,8 @@ func (g *GitHubGitProvider) parseStaticGitContext(repoUrl string) (*StaticGitCon
 		staticContext.PrNumber = &prUint
 		staticContext.Path = nil
 	case len(parts) >= 1 && parts[0] == "tree":
-		staticContext.Branch = &parts[1]
+		branchPath := strings.Join(parts[1:], "/")
+		staticContext.Branch = &branchPath
 		staticContext.Path = nil
 	case len(parts) >= 2 && parts[0] == "blob":
 		staticContext.Branch = &parts[1]

--- a/pkg/gitprovider/github_test.go
+++ b/pkg/gitprovider/github_test.go
@@ -86,6 +86,27 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Branch() {
 	require.Equal(httpContext, branchContext)
 }
 
+func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_BranchNameWithSlash() {
+	commitUrl := "https://github.com/daytonaio/daytona/tree/test/test-branch"
+	commitContext := &StaticGitContext{
+		Id:       "daytona",
+		Name:     "daytona",
+		Owner:    "daytonaio",
+		Source:   "github.com",
+		Url:      "https://github.com/daytonaio/daytona.git",
+		Branch:   &[]string{"test/test-branch"}[0],
+		Sha:      nil,
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	require := g.Require()
+
+	httpContext, err := g.gitProvider.parseStaticGitContext(commitUrl)
+
+	require.Nil(err)
+	require.Equal(httpContext, commitContext)
+}
 func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Commits() {
 	commitsUrl := "https://github.com/daytonaio/daytona/commits/test-branch"
 	commitsContext := &StaticGitContext{


### PR DESCRIPTION
# Pull Request Title

## Description
correctly parse branch names with slashes in GitHub Urls.
closes #843

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
