### PR TITLE
feat: add logs command for workspaces and projects

### DIFF
--- a/docs/daytona.md
+++ b/docs/daytona.md
@@ -32,6 +32,7 @@ daytona [flags]
 * [daytona ide](daytona_ide.md)	 - Choose the default IDE
 * [daytona info](daytona_info.md)	 - Show workspace info
 * [daytona list](daytona_list.md)	 - List workspaces
+* [daytona logs](daytona_logs.md)	 - View logs for a workspace or project
 * [daytona profile](daytona_profile.md)	 - Manage profiles
 * [daytona project-config](daytona_project-config.md)	 - Manage project configs
 * [daytona provider](daytona_provider.md)	 - Manage providers

--- a/docs/daytona_logs.md
+++ b/docs/daytona_logs.md
@@ -1,0 +1,26 @@
+## daytona logs
+
+View logs for a workspace or project
+
+```
+daytona logs [WORKSPACE] [PROJECT] [flags]
+```
+
+### Options
+
+```
+  -f, --follow   Follow logs
+  -r, --retry    Retry connection
+```
+
+### Options inherited from parent commands
+
+```
+      --help            help for daytona
+  -o, --output string   Output format. Must be one of (yaml, json)
+```
+
+### SEE ALSO
+
+* [daytona](daytona.md)	 - Daytona is a Dev Environment Manager
+

--- a/docs/daytona_logs.md
+++ b/docs/daytona_logs.md
@@ -9,8 +9,9 @@ daytona logs [WORKSPACE] [PROJECT] [flags]
 ### Options
 
 ```
-  -f, --follow   Follow logs
-  -r, --retry    Retry connection
+  -a, --all         Show logs for workspace and project together
+  -f, --follow      Follow logs
+  -w, --workspace   Show logs for workspace only
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona.yaml
+++ b/hack/docs/daytona.yaml
@@ -23,6 +23,7 @@ see_also:
     - daytona ide - Choose the default IDE
     - daytona info - Show workspace info
     - daytona list - List workspaces
+    - daytona logs - View logs for a workspace or project
     - daytona profile - Manage profiles
     - daytona project-config - Manage project configs
     - daytona provider - Manage providers

--- a/hack/docs/daytona_logs.yaml
+++ b/hack/docs/daytona_logs.yaml
@@ -1,0 +1,21 @@
+name: daytona logs
+synopsis: View logs for a workspace or project
+usage: daytona logs [WORKSPACE] [PROJECT] [flags]
+options:
+    - name: follow
+      shorthand: f
+      default_value: "false"
+      usage: Follow logs
+    - name: retry
+      shorthand: r
+      default_value: "false"
+      usage: Retry connection
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+    - name: output
+      shorthand: o
+      usage: Output format. Must be one of (yaml, json)
+see_also:
+    - daytona - Daytona is a Dev Environment Manager

--- a/hack/docs/daytona_logs.yaml
+++ b/hack/docs/daytona_logs.yaml
@@ -2,14 +2,18 @@ name: daytona logs
 synopsis: View logs for a workspace or project
 usage: daytona logs [WORKSPACE] [PROJECT] [flags]
 options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Show logs for workspace and project together
     - name: follow
       shorthand: f
       default_value: "false"
       usage: Follow logs
-    - name: retry
-      shorthand: r
+    - name: workspace
+      shorthand: w
       default_value: "false"
-      usage: Retry connection
+      usage: Show logs for workspace only
 inherited_options:
     - name: help
       default_value: "false"

--- a/internal/util/apiclient/websocket_log_reader.go
+++ b/internal/util/apiclient/websocket_log_reader.go
@@ -43,7 +43,7 @@ func ReadWorkspaceLogs(activeProfile config.Profile, workspaceId string, project
 					continue
 				}
 
-				ReadJSONLog(ws, index, stopLogs)
+				ReadJSONLog(ws, stopLogs, index)
 				ws.Close()
 				break
 			}
@@ -59,7 +59,7 @@ func ReadWorkspaceLogs(activeProfile config.Profile, workspaceId string, project
 			continue
 		}
 
-		ReadJSONLog(ws, logs_view.WORKSPACE_INDEX, stopLogs)
+		ReadJSONLog(ws, stopLogs, logs_view.WORKSPACE_INDEX)
 		ws.Close()
 		break
 	}
@@ -67,7 +67,7 @@ func ReadWorkspaceLogs(activeProfile config.Profile, workspaceId string, project
 	wg.Wait()
 }
 
-func ReadJSONLog(ws *websocket.Conn, index int, stopLogs ...*bool) {
+func ReadJSONLog(ws *websocket.Conn, stopLogs *bool, index int) {
 	logEntriesChan := make(chan logs.LogEntry)
 	go logs_view.DisplayLogs(logEntriesChan, index)
 	for {
@@ -80,7 +80,7 @@ func ReadJSONLog(ws *websocket.Conn, index int, stopLogs ...*bool) {
 		if !workspaceLogsStarted && index == logs_view.WORKSPACE_INDEX {
 			workspaceLogsStarted = true
 		}
-		if len(stopLogs) > 0 && stopLogs[0] != nil && *stopLogs[0] {
+		if *stopLogs {
 			return
 		}
 	}

--- a/internal/util/apiclient/websocket_log_reader.go
+++ b/internal/util/apiclient/websocket_log_reader.go
@@ -74,7 +74,6 @@ func ReadJSONLog(ws *websocket.Conn, index int, stopLogs ...*bool) {
 		var logEntry logs.LogEntry
 		err := ws.ReadJSON(&logEntry)
 		if err != nil {
-			fmt.Println(err.Error())
 			return
 		}
 		logEntriesChan <- logEntry

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -54,6 +54,7 @@ func Execute() {
 	rootCmd.AddCommand(SshProxyCmd)
 	rootCmd.AddCommand(CreateCmd)
 	rootCmd.AddCommand(DeleteCmd)
+	rootCmd.AddCommand(LogsCmd)
 	rootCmd.AddCommand(ProjectConfigCmd)
 	rootCmd.AddCommand(ServeCmd)
 	rootCmd.AddCommand(ServerCmd)

--- a/pkg/cmd/workspace/logs.go
+++ b/pkg/cmd/workspace/logs.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	logs_view "github.com/daytonaio/daytona/pkg/views/logs"
+	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+var followFlag bool
+var retryFlag bool
+
+var LogsCmd = &cobra.Command{
+	Use:     "logs [WORKSPACE] [PROJECT]",
+	Short:   "View logs for a workspace or project",
+	GroupID: util.WORKSPACE_GROUP,
+	Args:    cobra.RangeArgs(0, 2),
+	Aliases: []string{"log"},
+	Run: func(cmd *cobra.Command, args []string) {
+		c, err := config.GetConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		activeProfile, err := c.GetActiveProfile()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		query := ""
+		if retryFlag && followFlag {
+			query += "follow=true&retry=true"
+		} else if retryFlag {
+			query += "retry=true"
+		} else if followFlag {
+			query += "follow=true"
+		}
+
+		ctx := context.Background()
+		var workspaceId string
+		var projectName string
+
+		apiClient, err := apiclient_util.GetApiClient(&activeProfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if len(args) == 0 {
+			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
+			if err != nil {
+				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			}
+			workspace := selection.GetWorkspaceFromPrompt(workspaceList, "Get Logs for")
+			if workspace == nil {
+				return
+			}
+			workspaceId = *workspace.Id
+		} else {
+			workspace, err := apiclient_util.GetWorkspace(args[0])
+			if err != nil {
+				log.Fatal(err)
+			}
+			workspaceId = *workspace.Id
+		}
+
+		if len(args) == 2 {
+			projectName = args[1]
+
+		}
+		handleLogs(activeProfile, workspaceId, projectName, query)
+	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) >= 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return getWorkspaceNameCompletions()
+	},
+}
+
+func handleLogs(activeProfile config.Profile, workspaceId, projectName string, query string) {
+	logEndpoint := fmt.Sprintf("/log/workspace/%s", workspaceId)
+	logIndex := logs_view.WORKSPACE_INDEX
+	if projectName != "" {
+		logEndpoint = fmt.Sprintf("%s/%s", logEndpoint, projectName)
+		logIndex = logs_view.PROJECT_INDEX
+	}
+
+	ws, _, err := apiclient_util.GetWebsocketConn(logEndpoint, &activeProfile, &query)
+	if err != nil {
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	defer ws.Close()
+	apiclient_util.ReadJSONLog(ws, logIndex)
+
+}
+
+func init() {
+	LogsCmd.Flags().BoolVarP(&followFlag, "follow", "f", false, "Follow logs")
+	LogsCmd.Flags().BoolVarP(&retryFlag, "retry", "r", false, "Retry connection")
+}

--- a/pkg/cmd/workspace/logs.go
+++ b/pkg/cmd/workspace/logs.go
@@ -65,13 +65,13 @@ var LogsCmd = &cobra.Command{
 			if workspace == nil {
 				return
 			}
-			workspaceId = *workspace.Id
+			workspaceId = workspace.Id
 		} else {
 			workspace, err := apiclient_util.GetWorkspace(args[0])
 			if err != nil {
 				log.Fatal(err)
 			}
-			workspaceId = *workspace.Id
+			workspaceId = workspace.Id
 		}
 
 		if len(args) == 2 {

--- a/pkg/cmd/workspace/logs.go
+++ b/pkg/cmd/workspace/logs.go
@@ -6,6 +6,7 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
@@ -19,7 +20,7 @@ import (
 )
 
 var followFlag bool
-var retryFlag bool
+var workspaceFlag bool
 
 var LogsCmd = &cobra.Command{
 	Use:     "logs [WORKSPACE] [PROJECT]",
@@ -39,11 +40,7 @@ var LogsCmd = &cobra.Command{
 		}
 
 		query := ""
-		if retryFlag && followFlag {
-			query += "follow=true&retry=true"
-		} else if retryFlag {
-			query += "retry=true"
-		} else if followFlag {
+		if followFlag {
 			query += "follow=true"
 		}
 
@@ -74,11 +71,26 @@ var LogsCmd = &cobra.Command{
 			workspaceId = workspace.Id
 		}
 
-		if len(args) == 2 {
-			projectName = args[1]
-
+		if (len(args) == 0 || len(args) == 1) && !workspaceFlag {
+			selectedProject, err := selectWorkspaceProject(workspaceId, &activeProfile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if selectedProject == nil {
+				return
+			}
+			projectName = selectedProject.Name
 		}
-		handleLogs(activeProfile, workspaceId, projectName, query)
+
+		if len(args) == 2 && !workspaceFlag {
+			projectName = args[1]
+		}
+
+		if allFlag {
+			handleWorkspaceLogs(activeProfile, workspaceId, projectName, query)
+		} else {
+			handleLogs(activeProfile, workspaceId, projectName, query)
+		}
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) >= 1 {
@@ -88,25 +100,53 @@ var LogsCmd = &cobra.Command{
 	},
 }
 
+func handleWorkspaceLogs(activeProfile config.Profile, workspaceId string, projectName string, query string) {
+	workspaceLogsStarted := false
+	stopLogs := false
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if !workspaceLogsStarted {
+			time.Sleep(250 * time.Millisecond)
+		}
+		ws, res, err := apiclient_util.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s/%s", workspaceId, projectName), &activeProfile, &query)
+		if err != nil {
+			log.Error(apiclient_util.HandleErrorResponse(res, err))
+		}
+		apiclient_util.ReadJSONLog(ws, &stopLogs, logs_view.PROJECT_INDEX)
+
+	}()
+
+	ws, res, err := apiclient_util.GetWebsocketConn(fmt.Sprintf("/log/workspace/%s", workspaceId), &activeProfile, &query)
+	if err != nil {
+		log.Error(apiclient_util.HandleErrorResponse(res, err))
+	}
+	apiclient_util.ReadJSONLog(ws, &stopLogs, logs_view.WORKSPACE_INDEX)
+	workspaceLogsStarted = true
+	wg.Wait()
+
+}
+
 func handleLogs(activeProfile config.Profile, workspaceId, projectName string, query string) {
 	logEndpoint := fmt.Sprintf("/log/workspace/%s", workspaceId)
 	logIndex := logs_view.WORKSPACE_INDEX
+	stopLogs := false
 	if projectName != "" {
 		logEndpoint = fmt.Sprintf("%s/%s", logEndpoint, projectName)
 		logIndex = logs_view.PROJECT_INDEX
 	}
 
-	ws, _, err := apiclient_util.GetWebsocketConn(logEndpoint, &activeProfile, &query)
+	ws, res, err := apiclient_util.GetWebsocketConn(logEndpoint, &activeProfile, &query)
 	if err != nil {
-		time.Sleep(250 * time.Millisecond)
+		log.Error(apiclient_util.HandleErrorResponse(res, err))
 	}
 
-	defer ws.Close()
-	apiclient_util.ReadJSONLog(ws, logIndex)
-
+	apiclient_util.ReadJSONLog(ws, &stopLogs, logIndex)
 }
 
 func init() {
 	LogsCmd.Flags().BoolVarP(&followFlag, "follow", "f", false, "Follow logs")
-	LogsCmd.Flags().BoolVarP(&retryFlag, "retry", "r", false, "Retry connection")
+	LogsCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Show logs for workspace and project together")
+	LogsCmd.Flags().BoolVarP(&workspaceFlag, "workspace", "w", false, "Show logs for workspace only")
 }

--- a/pkg/views/logs/display.go
+++ b/pkg/views/logs/display.go
@@ -15,6 +15,7 @@ import (
 var FIRST_PROJECT_INDEX = 0
 var WORKSPACE_INDEX = -1
 var WORKSPACE_PREFIX = "WORKSPACE"
+var PROJECT_INDEX = 0
 
 var longestPrefixLength = len(WORKSPACE_PREFIX)
 var maxPrefixLength = 20


### PR DESCRIPTION
# feat: add logs command for workspaces and projects

## Description
Added the logs command to retrieve logs for workspaces and projects. Users can also follow the log in real-time using the -f flag.

closes #771 
/claim #771


Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #771 

## Screenshots
If relevant, please add screenshots.
![image](https://github.com/user-attachments/assets/1691db06-6bcb-4ad6-b9bd-3e8ecf809f90)
![image](https://github.com/user-attachments/assets/6992c894-ead6-4dbd-87c4-c28f24fe1ee5)


## Notes
Please add any relevant notes if necessary.

`websocket: close 1006 (abnormal closure): unexpected EOF`
