### PR TITLE
fix: add a root user check on serve

### DIFF
--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -48,7 +48,7 @@ var ServeCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if os.Getenv("USER") == "root" {
-			views.RenderInfoMessageBold("Running the server as root is not recommended because\nDaytona will not be able to remap repository ownership.\nPlease run the server as a non-root user.")
+			views.RenderInfoMessageBold("Running the server as root is not recommended because\nDaytona will not be able to remap project directory ownership.\nPlease run the server as a non-root user.")
 		}
 
 		if log.GetLevel() < log.InfoLevel {

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -47,9 +47,7 @@ var ServeCmd = &cobra.Command{
 	GroupID: util.SERVER_GROUP,
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		user := os.Getenv("USER")
-		switch user {
-		case "root":
+		if os.Getenv("USER") == "root" {
 			views.RenderInfoMessageBold("Running the server as root is not recommended because\nDaytona will not be able to remap repository ownership.\nPlease run the server as a non-root user.")
 		}
 

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -34,6 +34,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/server/providertargets"
 	"github.com/daytonaio/daytona/pkg/server/registry"
 	"github.com/daytonaio/daytona/pkg/server/workspaces"
+	"github.com/daytonaio/daytona/pkg/views"
 	started_view "github.com/daytonaio/daytona/pkg/views/server/started"
 
 	log "github.com/sirupsen/logrus"
@@ -46,6 +47,12 @@ var ServeCmd = &cobra.Command{
 	GroupID: util.SERVER_GROUP,
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		user := os.Getenv("USER")
+		switch user {
+		case "root":
+			views.RenderInfoMessageBold("Running the server as root is not recommended because\nDaytona will not be able to remap repository ownership.\nPlease run the server as a non-root user.")
+		}
+
 		if log.GetLevel() < log.InfoLevel {
 			//	for now, force the log level to info when running the server
 			log.SetLevel(log.InfoLevel)


### PR DESCRIPTION
# Add a Root User Check on Serve

## Description

Added a root user check when starting the server to inform the user that we recommend running as a non-root user.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #749 