### PR TITLE
fix: inform user if vscode ide is not installed locally (#654)

### DIFF
--- a/pkg/cmd/ide.go
+++ b/pkg/cmd/ide.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
+	ide_util "github.com/daytonaio/daytona/pkg/ide"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/ide"
 
@@ -37,6 +38,15 @@ var ideCmd = &cobra.Command{
 		for _, ide := range ideList {
 			if ide.Id == chosenIdeId {
 				chosenIde = ide
+			}
+		}
+
+		isChosenIdeInstalled := false
+		if chosenIde.Name == "VS Code" {
+			isChosenIdeInstalled = ide_util.CheckAndAlertVSCodeInstalled()
+
+			if !isChosenIdeInstalled {
+				return
 			}
 		}
 

--- a/pkg/cmd/ide.go
+++ b/pkg/cmd/ide.go
@@ -41,13 +41,8 @@ var ideCmd = &cobra.Command{
 			}
 		}
 
-		isChosenIdeInstalled := false
 		if chosenIde.Name == "VS Code" {
-			isChosenIdeInstalled = ide_util.CheckAndAlertVSCodeInstalled()
-
-			if !isChosenIdeInstalled {
-				return
-			}
+			ide_util.CheckAndAlertVSCodeInstalled()
 		}
 
 		c.DefaultIdeId = chosenIde.Id

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -166,7 +166,7 @@ func setIdeSettings(projectHostname string, customizations *devcontainer.Customi
 	return nil
 }
 
-func CheckAndAlertVSCodeInstalled() bool {
+func CheckAndAlertVSCodeInstalled() {
 	if err := isVSCodeInstalled(); err != nil {
 		redBold := "\033[1;31m" // ANSI escape code for red and bold
 		reset := "\033[0m"      // ANSI escape code to reset text formatting
@@ -179,10 +179,8 @@ func CheckAndAlertVSCodeInstalled() bool {
 
 		log.Error(redBold + errorMessage + reset + infoMessage)
 
-		return false
+		return
 	}
-
-	return true
 }
 
 func isVSCodeInstalled() error {

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -20,7 +20,7 @@ import (
 )
 
 func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName string, projectProviderMetadata string) error {
-	checkAndAlertVSCodeInstalled()
+	CheckAndAlertVSCodeInstalled()
 
 	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
 
@@ -166,7 +166,7 @@ func setIdeSettings(projectHostname string, customizations *devcontainer.Customi
 	return nil
 }
 
-func checkAndAlertVSCodeInstalled() {
+func CheckAndAlertVSCodeInstalled() bool {
 	if err := isVSCodeInstalled(); err != nil {
 		redBold := "\033[1;31m" // ANSI escape code for red and bold
 		reset := "\033[0m"      // ANSI escape code to reset text formatting
@@ -179,8 +179,10 @@ func checkAndAlertVSCodeInstalled() {
 
 		log.Error(redBold + errorMessage + reset + infoMessage)
 
-		return
+		return false
 	}
+
+	return true
 }
 
 func isVSCodeInstalled() error {


### PR DESCRIPTION
# fix: inform user if vscode ide is not installed locally (#654)

## Description
User should be provided with an error if chosen ide 'vscode' for project is not installed.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #654 
closes #654 
/claim #654 

## Screenshots

## Notes
