### PR TITLE
fix: add loginctl note for linux server daemon

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kardianos/service"
 )
 
+const serviceName = "DaytonaServerDaemon"
+
 type program struct {
 	service.Interface
 }
@@ -100,9 +102,9 @@ func getServiceConfig() (*service.Config, error) {
 	}
 
 	svcConfig := &service.Config{
-		Name:        "DaytonaServerDaemon",
+		Name:        serviceName,
 		DisplayName: "Daytona Server",
-		Description: "This is the Daytona Server daemon.",
+		Description: "Daytona Server daemon.",
 		Arguments:   []string{"serve"},
 	}
 
@@ -115,7 +117,7 @@ func getServiceConfig() (*service.Config, error) {
 			svcConfig.UserName = user
 		}
 		if !strings.HasSuffix(service.Platform(), "systemd") {
-			return nil, fmt.Errorf("on Linux, `server -d` is only supported with systemd. %s detected", service.Platform())
+			return nil, fmt.Errorf("on Linux, `server` is only supported with systemd. %s detected", service.Platform())
 		}
 		fallthrough
 	case "darwin":

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -4,6 +4,10 @@
 package server
 
 import (
+	"fmt"
+	"os"
+	"runtime"
+
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/api"
 	"github.com/daytonaio/daytona/pkg/cmd/server/daemon"
@@ -57,6 +61,11 @@ var ServerCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		printServerStartedMessage(c, true)
+
+		switch runtime.GOOS {
+		case "linux":
+			fmt.Printf("Use `loginctl enable-linger %s` to allow the service to run after logging out.\n", os.Getenv("USER"))
+		}
 	},
 }
 


### PR DESCRIPTION
# Add loginctl linger Note for Linux Server Daemon

## Description

Added a note that users on linux should run `loginctl enable-linger $USER` to enable the server daemon to continue running after logging out of the machine. This is especially useful for servers running on remote machines.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
