### PR TITLE
feat: implement get url from repository API route

### DIFF
--- a/pkg/api/controllers/gitprovider/context.go
+++ b/pkg/api/controllers/gitprovider/context.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -47,4 +48,35 @@ func GetGitContext(ctx *gin.Context) {
 	}
 
 	ctx.JSON(200, repo)
+}
+
+// GetUrlFromRepository 			godoc
+//
+//	@Tags			gitProvider
+//	@Summary		Get URL from Git repository
+//	@Description	Get URL from Git repository
+//	@Produce		json
+//	@Param			repository	body		GitRepository	true	"Git repository"
+//	@Success		200			{string}	url
+//	@Router			/gitprovider/context/url [post]
+//
+//	@id				GetUrlFromRepository
+func GetUrlFromRepository(ctx *gin.Context) {
+	var gitRepository gitprovider.GitRepository
+	if err := ctx.ShouldBindJSON(&gitRepository); err != nil {
+		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to bind json: %s", err.Error()))
+		return
+	}
+
+	server := server.GetInstance(nil)
+
+	gitProvider, err := server.GitProviderService.GetGitProviderForUrl(gitRepository.Url)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get git provider for url: %s", err.Error()))
+		return
+	}
+
+	url := gitProvider.GetUrlFromRepository(&gitRepository)
+
+	ctx.String(200, url)
 }

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -249,6 +249,38 @@ const docTemplate = `{
                 }
             }
         },
+        "/gitprovider/context/url": {
+            "post": {
+                "description": "Get URL from Git repository",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "gitProvider"
+                ],
+                "summary": "Get URL from Git repository",
+                "operationId": "GetUrlFromRepository",
+                "parameters": [
+                    {
+                        "description": "Git repository",
+                        "name": "repository",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GitRepository"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/gitprovider/context/{gitUrl}": {
             "get": {
                 "description": "Get Git context",

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -246,6 +246,38 @@
                 }
             }
         },
+        "/gitprovider/context/url": {
+            "post": {
+                "description": "Get URL from Git repository",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "gitProvider"
+                ],
+                "summary": "Get URL from Git repository",
+                "operationId": "GetUrlFromRepository",
+                "parameters": [
+                    {
+                        "description": "Git repository",
+                        "name": "repository",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GitRepository"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/gitprovider/context/{gitUrl}": {
             "get": {
                 "description": "Get Git context",

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -749,6 +749,27 @@ paths:
       summary: Get Git context
       tags:
       - gitProvider
+  /gitprovider/context/url:
+    post:
+      description: Get URL from Git repository
+      operationId: GetUrlFromRepository
+      parameters:
+      - description: Git repository
+        in: body
+        name: repository
+        required: true
+        schema:
+          $ref: '#/definitions/GitRepository'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+      summary: Get URL from Git repository
+      tags:
+      - gitProvider
   /gitprovider/for-url/{url}:
     get:
       description: Get Git provider

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -170,6 +170,7 @@ func (a *ApiServer) Start() error {
 		gitProviderController.GET("/:gitProviderId/:namespaceId/:repositoryId/branches", gitprovider.GetRepoBranches)
 		gitProviderController.GET("/:gitProviderId/:namespaceId/:repositoryId/pull-requests", gitprovider.GetRepoPRs)
 		gitProviderController.GET("/context/:gitUrl", gitprovider.GetGitContext)
+		gitProviderController.POST("/context/url", gitprovider.GetUrlFromRepository)
 	}
 
 	apiKeyController := protected.Group("/apikey")

--- a/pkg/apiclient/README.md
+++ b/pkg/apiclient/README.md
@@ -91,6 +91,7 @@ Class | Method | HTTP request | Description
 *GitProviderAPI* | [**GetRepoBranches**](docs/GitProviderAPI.md#getrepobranches) | **Get** /gitprovider/{gitProviderId}/{namespaceId}/{repositoryId}/branches | Get Git repository branches
 *GitProviderAPI* | [**GetRepoPRs**](docs/GitProviderAPI.md#getrepoprs) | **Get** /gitprovider/{gitProviderId}/{namespaceId}/{repositoryId}/pull-requests | Get Git repository PRs
 *GitProviderAPI* | [**GetRepositories**](docs/GitProviderAPI.md#getrepositories) | **Get** /gitprovider/{gitProviderId}/{namespaceId}/repositories | Get Git repositories
+*GitProviderAPI* | [**GetUrlFromRepository**](docs/GitProviderAPI.md#geturlfromrepository) | **Post** /gitprovider/context/url | Get URL from Git repository
 *GitProviderAPI* | [**ListGitProviders**](docs/GitProviderAPI.md#listgitproviders) | **Get** /gitprovider | List Git providers
 *GitProviderAPI* | [**RemoveGitProvider**](docs/GitProviderAPI.md#removegitprovider) | **Delete** /gitprovider/{gitProviderId} | Remove Git provider
 *GitProviderAPI* | [**SetGitProvider**](docs/GitProviderAPI.md#setgitprovider) | **Put** /gitprovider | Set Git provider

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -176,6 +176,28 @@ paths:
       tags:
       - gitProvider
       x-codegen-request-body-name: gitProviderConfig
+  /gitprovider/context/url:
+    post:
+      description: Get URL from Git repository
+      operationId: GetUrlFromRepository
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/GitRepository'
+        description: Git repository
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: OK
+      summary: Get URL from Git repository
+      tags:
+      - gitProvider
+      x-codegen-request-body-name: repository
   /gitprovider/context/{gitUrl}:
     get:
       description: Get Git context

--- a/pkg/apiclient/api_git_provider.go
+++ b/pkg/apiclient/api_git_provider.go
@@ -868,6 +868,132 @@ func (a *GitProviderAPIService) GetRepositoriesExecute(r ApiGetRepositoriesReque
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type ApiGetUrlFromRepositoryRequest struct {
+	ctx        context.Context
+	ApiService *GitProviderAPIService
+	repository *GitRepository
+}
+
+// Git repository
+func (r ApiGetUrlFromRepositoryRequest) Repository(repository GitRepository) ApiGetUrlFromRepositoryRequest {
+	r.repository = &repository
+	return r
+}
+
+func (r ApiGetUrlFromRepositoryRequest) Execute() (string, *http.Response, error) {
+	return r.ApiService.GetUrlFromRepositoryExecute(r)
+}
+
+/*
+GetUrlFromRepository Get URL from Git repository
+
+Get URL from Git repository
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiGetUrlFromRepositoryRequest
+*/
+func (a *GitProviderAPIService) GetUrlFromRepository(ctx context.Context) ApiGetUrlFromRepositoryRequest {
+	return ApiGetUrlFromRepositoryRequest{
+		ApiService: a,
+		ctx:        ctx,
+	}
+}
+
+// Execute executes the request
+//
+//	@return string
+func (a *GitProviderAPIService) GetUrlFromRepositoryExecute(r ApiGetUrlFromRepositoryRequest) (string, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodPost
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue string
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "GitProviderAPIService.GetUrlFromRepository")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/gitprovider/context/url"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.repository == nil {
+		return localVarReturnValue, nil, reportError("repository is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.repository
+	if r.ctx != nil {
+		// API Key Authentication
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+			if apiKey, ok := auth["Bearer"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
+				}
+				localVarHeaderParams["Authorization"] = key
+			}
+		}
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type ApiListGitProvidersRequest struct {
 	ctx        context.Context
 	ApiService *GitProviderAPIService

--- a/pkg/apiclient/docs/GitProviderAPI.md
+++ b/pkg/apiclient/docs/GitProviderAPI.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**GetRepoBranches**](GitProviderAPI.md#GetRepoBranches) | **Get** /gitprovider/{gitProviderId}/{namespaceId}/{repositoryId}/branches | Get Git repository branches
 [**GetRepoPRs**](GitProviderAPI.md#GetRepoPRs) | **Get** /gitprovider/{gitProviderId}/{namespaceId}/{repositoryId}/pull-requests | Get Git repository PRs
 [**GetRepositories**](GitProviderAPI.md#GetRepositories) | **Get** /gitprovider/{gitProviderId}/{namespaceId}/repositories | Get Git repositories
+[**GetUrlFromRepository**](GitProviderAPI.md#GetUrlFromRepository) | **Post** /gitprovider/context/url | Get URL from Git repository
 [**ListGitProviders**](GitProviderAPI.md#ListGitProviders) | **Get** /gitprovider | List Git providers
 [**RemoveGitProvider**](GitProviderAPI.md#RemoveGitProvider) | **Delete** /gitprovider/{gitProviderId} | Remove Git provider
 [**SetGitProvider**](GitProviderAPI.md#SetGitProvider) | **Put** /gitprovider | Set Git provider
@@ -507,6 +508,72 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**[]GitRepository**](GitRepository.md)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## GetUrlFromRepository
+
+> string GetUrlFromRepository(ctx).Repository(repository).Execute()
+
+Get URL from Git repository
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID/apiclient"
+)
+
+func main() {
+	repository := *openapiclient.NewGitRepository() // GitRepository | Git repository
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.GitProviderAPI.GetUrlFromRepository(context.Background()).Repository(repository).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `GitProviderAPI.GetUrlFromRepository``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `GetUrlFromRepository`: string
+	fmt.Fprintf(os.Stdout, "Response from `GitProviderAPI.GetUrlFromRepository`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetUrlFromRepositoryRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **repository** | [**GitRepository**](GitRepository.md) | Git repository | 
+
+### Return type
+
+**string**
 
 ### Authorization
 

--- a/pkg/gitprovider/azure-devops.go
+++ b/pkg/gitprovider/azure-devops.go
@@ -254,6 +254,39 @@ func (g *AzureDevOpsGitProvider) GetLastCommitSha(staticContext *StaticGitContex
 	return *(*commits)[0].CommitId, nil
 }
 
+func (g *AzureDevOpsGitProvider) GetUrlFromRepository(repo *GitRepository) string {
+	url := strings.TrimSuffix(repo.Url, ".git")
+	url = strings.TrimSuffix(url, repo.Name)
+	url += "_git/" + repo.Name
+	query := ""
+
+	if repo.Branch != nil && *repo.Branch != "" {
+		if repo.Sha == *repo.Branch {
+			query += "version=GC" + *repo.Branch
+		} else {
+			query += "version=GB" + *repo.Branch
+		}
+
+		if repo.Path != nil && *repo.Path != "" {
+			if query != "" {
+				query += "&"
+			}
+
+			query += "path=" + *repo.Path
+		}
+	} else if repo.Path != nil {
+		query = "version=GBmain&path=" + *repo.Path
+	} else {
+		url = strings.Replace(url, "/_git", "", 1)
+	}
+
+	if query != "" {
+		url += "?" + query
+	}
+
+	return url
+}
+
 func (g *AzureDevOpsGitProvider) getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error) {
 	var pullRequestId int
 	if staticContext.PrNumber == nil {

--- a/pkg/gitprovider/azure-devops_test.go
+++ b/pkg/gitprovider/azure-devops_test.go
@@ -133,3 +133,85 @@ func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 	require.Nil(err)
 	require.Equal(httpContext, blobContext)
 }
+
+func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "dev.azure.com",
+		Url:    "https://dev.azure.com/daytonaio/daytona.git",
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://dev.azure.com/daytonaio/daytona", url)
+}
+
+func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "dev.azure.com",
+		Url:    "https://dev.azure.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GBtest-branch", url)
+}
+
+func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Path() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "dev.azure.com",
+		Url:    "https://dev.azure.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+		Path:   &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GBtest-branch&path=README.md", url)
+
+	repo.Branch = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GBmain&path=README.md", url)
+}
+
+func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "dev.azure.com",
+		Url:    "https://dev.azure.com/daytonaio/daytona.git",
+		Path:   &[]string{"README.md"}[0],
+		Sha:    "COMMIT_SHA",
+		Branch: &[]string{"COMMIT_SHA"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GCCOMMIT_SHA&path=README.md", url)
+
+	repo.Path = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GCCOMMIT_SHA", url)
+}

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -265,6 +265,24 @@ func (g *BitbucketGitProvider) GetLastCommitSha(staticContext *StaticGitContext)
 	return commitHash, nil
 }
 
+func (g *BitbucketGitProvider) GetUrlFromRepository(repository *GitRepository) string {
+	url := strings.TrimSuffix(repository.Url, ".git")
+
+	if repository.Branch != nil && *repository.Branch != "" {
+		if repository.Path != nil {
+			url += "/src/" + *repository.Branch + "/" + *repository.Path
+		} else if repository.Sha == *repository.Branch {
+			url += "/commit/" + *repository.Branch
+		} else {
+			url += "/branch/" + *repository.Branch
+		}
+	} else if repository.Path != nil {
+		url += "/src/main/" + *repository.Path
+	}
+
+	return url
+}
+
 func (g *BitbucketGitProvider) getApiClient() *bitbucket.Client {
 	client := bitbucket.NewBasicAuth(g.username, g.token)
 	return client

--- a/pkg/gitprovider/bitbucket_test.go
+++ b/pkg/gitprovider/bitbucket_test.go
@@ -130,6 +130,88 @@ func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 	require.Equal(httpContext, commitContext)
 }
 
+func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.org",
+		Url:    "https://bitbucket.org/daytonaio/daytona.git",
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.org/daytonaio/daytona", url)
+}
+
+func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.org",
+		Url:    "https://bitbucket.org/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.org/daytonaio/daytona/branch/test-branch", url)
+}
+
+func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Path() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.org",
+		Url:    "https://bitbucket.org/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+		Path:   &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.org/daytonaio/daytona/src/test-branch/README.md", url)
+
+	repo.Branch = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.org/daytonaio/daytona/src/main/README.md", url)
+}
+
+func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.org",
+		Url:    "https://bitbucket.org/daytonaio/daytona.git",
+		Path:   &[]string{"README.md"}[0],
+		Sha:    "COMMIT_SHA",
+		Branch: &[]string{"COMMIT_SHA"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.org/daytonaio/daytona/src/COMMIT_SHA/README.md", url)
+
+	repo.Path = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.org/daytonaio/daytona/commit/COMMIT_SHA", url)
+}
+
 func TestBitbucketGitProvider(t *testing.T) {
 	suite.Run(t, NewBitbucketGitProviderTestSuite())
 }

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -303,6 +303,23 @@ func (g *BitbucketServerGitProvider) GetLastCommitSha(staticContext *StaticGitCo
 	return commitList[0].ID, nil
 }
 
+func (g *BitbucketServerGitProvider) GetUrlFromRepository(repository *GitRepository) string {
+	url := strings.TrimSuffix(repository.Url, ".git")
+	url = strings.Replace(url, "/scm/", "/", 1)
+
+	if repository.Branch != nil && *repository.Branch != "" {
+		url += "/src/" + *repository.Branch
+
+		if repository.Path != nil && *repository.Path != "" {
+			url += "/" + *repository.Path
+		}
+	} else if repository.Path != nil && *repository.Path != "" {
+		url += "/src/main/" + *repository.Path
+	}
+
+	return url
+}
+
 func (g *BitbucketServerGitProvider) getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error) {
 	if staticContext.PrNumber == nil {
 		return staticContext, nil

--- a/pkg/gitprovider/bitbucketserver_test.go
+++ b/pkg/gitprovider/bitbucketserver_test.go
@@ -155,6 +155,88 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Repo_Url
 	require.Equal(commitContext, httpContext)
 }
 
+func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.example.com",
+		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.example.com/daytonaio/daytona", url)
+}
+
+func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.example.com",
+		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/test-branch", url)
+}
+
+func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Path() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.example.com",
+		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+		Path:   &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/test-branch/README.md", url)
+
+	repo.Branch = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/main/README.md", url)
+}
+
+func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "bitbucket.example.com",
+		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
+		Path:   &[]string{"README.md"}[0],
+		Sha:    "COMMIT_SHA",
+		Branch: &[]string{"COMMIT_SHA"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/COMMIT_SHA/README.md", url)
+
+	repo.Path = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/COMMIT_SHA", url)
+}
+
 func TestBitbucketServerGitProvider(t *testing.T) {
 	suite.Run(t, NewBitbucketServerGitProviderTestSuite())
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -33,6 +33,7 @@ type GitProvider interface {
 	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)
 
 	GetRepositoryFromUrl(repositoryUrl string) (*GitRepository, error)
+	GetUrlFromRepository(repository *GitRepository) string
 	GetLastCommitSha(staticContext *StaticGitContext) (string, error)
 	getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error)
 	parseStaticGitContext(repoUrl string) (*StaticGitContext, error)

--- a/pkg/gitprovider/gitea.go
+++ b/pkg/gitprovider/gitea.go
@@ -256,6 +256,26 @@ func (g *GiteaGitProvider) getApiClient() (*gitea.Client, error) {
 	return gitea.NewClient(g.baseApiUrl, options...)
 }
 
+func (g *GiteaGitProvider) GetUrlFromRepository(repository *GitRepository) string {
+	url := strings.TrimSuffix(repository.Url, ".git")
+
+	if repository.Branch != nil && *repository.Branch != "" {
+		if repository.Sha == *repository.Branch {
+			url += "/src/commit/" + *repository.Branch
+		} else {
+			url += "/src/branch/" + *repository.Branch
+		}
+
+		if repository.Path != nil && *repository.Path != "" {
+			url += "/" + *repository.Path
+		}
+	} else if repository.Path != nil {
+		url += "/src/branch/main/" + *repository.Path
+	}
+
+	return url
+}
+
 func (g *GiteaGitProvider) getPrContext(staticContext *StaticGitContext) (*StaticGitContext, error) {
 	if staticContext.PrNumber == nil {
 		return staticContext, nil

--- a/pkg/gitprovider/gitea_test.go
+++ b/pkg/gitprovider/gitea_test.go
@@ -130,6 +130,88 @@ func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 	require.Equal(httpContext, commitContext)
 }
 
+func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitea.com",
+		Url:    "https://gitea.com/daytonaio/daytona.git",
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitea.com/daytonaio/daytona", url)
+}
+
+func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitea.com",
+		Url:    "https://gitea.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitea.com/daytonaio/daytona/src/branch/test-branch", url)
+}
+
+func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Path() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitea.com",
+		Url:    "https://gitea.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+		Path:   &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitea.com/daytonaio/daytona/src/branch/test-branch/README.md", url)
+
+	repo.Branch = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitea.com/daytonaio/daytona/src/branch/main/README.md", url)
+}
+
+func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitea.com",
+		Url:    "https://gitea.com/daytonaio/daytona.git",
+		Path:   &[]string{"README.md"}[0],
+		Sha:    "COMMIT_SHA",
+		Branch: &[]string{"COMMIT_SHA"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitea.com/daytonaio/daytona/src/commit/COMMIT_SHA/README.md", url)
+
+	repo.Path = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitea.com/daytonaio/daytona/src/commit/COMMIT_SHA", url)
+}
+
 func TestGiteaGitProvider(t *testing.T) {
 	suite.Run(t, NewGiteaGitProviderTestSuite())
 }

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -232,6 +232,26 @@ func (g *GitHubGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (s
 	return *commits[0].SHA, nil
 }
 
+func (g *GitHubGitProvider) GetUrlFromRepository(repository *GitRepository) string {
+	url := strings.TrimSuffix(repository.Url, ".git")
+
+	if repository.Branch != nil && *repository.Branch != "" {
+		if repository.Sha == *repository.Branch {
+			url += "/commit/" + *repository.Branch
+		} else {
+			url += "/tree/" + *repository.Branch
+		}
+
+		if repository.Path != nil {
+			url += "/" + *repository.Path
+		}
+	} else if repository.Path != nil {
+		url += "/blob/main/" + *repository.Path
+	}
+
+	return url
+}
+
 func (g *GitHubGitProvider) getApiClient() *github.Client {
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(

--- a/pkg/gitprovider/github_test.go
+++ b/pkg/gitprovider/github_test.go
@@ -151,6 +151,88 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 	require.Equal(httpContext, commitContext)
 }
 
+func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "github.com",
+		Url:    "https://github.com/daytonaio/daytona.git",
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://github.com/daytonaio/daytona", url)
+}
+
+func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "github.com",
+		Url:    "https://github.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://github.com/daytonaio/daytona/tree/test-branch", url)
+}
+
+func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Path() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "github.com",
+		Url:    "https://github.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+		Path:   &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://github.com/daytonaio/daytona/tree/test-branch/README.md", url)
+
+	repo.Branch = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://github.com/daytonaio/daytona/blob/main/README.md", url)
+}
+
+func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "github.com",
+		Url:    "https://github.com/daytonaio/daytona.git",
+		Path:   &[]string{"README.md"}[0],
+		Sha:    "COMMIT_SHA",
+		Branch: &[]string{"COMMIT_SHA"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://github.com/daytonaio/daytona/commit/COMMIT_SHA/README.md", url)
+
+	repo.Path = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://github.com/daytonaio/daytona/commit/COMMIT_SHA", url)
+}
+
 func TestGitHubGitProvider(t *testing.T) {
 	suite.Run(t, NewGitHubGitProviderTestSuite())
 }

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -209,6 +209,26 @@ func (g *GitLabGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (s
 	return commits[0].ID, nil
 }
 
+func (g *GitLabGitProvider) GetUrlFromRepository(repository *GitRepository) string {
+	url := strings.TrimSuffix(repository.Url, ".git")
+
+	if repository.Branch != nil && *repository.Branch != "" {
+		if repository.Sha == *repository.Branch {
+			url += "/-/commit/" + *repository.Branch
+		} else {
+			url += "/-/tree/" + *repository.Branch
+		}
+
+		if repository.Path != nil {
+			url += "/" + *repository.Path
+		}
+	} else if repository.Path != nil {
+		url += "/-/blob/main/" + *repository.Path
+	}
+
+	return url
+}
+
 func (g *GitLabGitProvider) getApiClient() *gitlab.Client {
 	var client *gitlab.Client
 	var err error

--- a/pkg/gitprovider/gitlab_test.go
+++ b/pkg/gitprovider/gitlab_test.go
@@ -174,6 +174,88 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 	require.Equal(httpContext, commitContext)
 }
 
+func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitlab.com",
+		Url:    "https://gitlab.com/daytonaio/daytona.git",
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitlab.com/daytonaio/daytona", url)
+}
+
+func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitlab.com",
+		Url:    "https://gitlab.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitlab.com/daytonaio/daytona/-/tree/test-branch", url)
+}
+
+func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Path() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitlab.com",
+		Url:    "https://gitlab.com/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+		Path:   &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal(url, "https://gitlab.com/daytonaio/daytona/-/tree/test-branch/README.md")
+
+	repo.Branch = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitlab.com/daytonaio/daytona/-/blob/main/README.md", url)
+}
+
+func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "gitlab.com",
+		Url:    "https://gitlab.com/daytonaio/daytona.git",
+		Path:   &[]string{"README.md"}[0],
+		Sha:    "COMMIT_SHA",
+		Branch: &[]string{"COMMIT_SHA"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitlab.com/daytonaio/daytona/-/commit/COMMIT_SHA/README.md", url)
+
+	repo.Path = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://gitlab.com/daytonaio/daytona/-/commit/COMMIT_SHA", url)
+}
+
 func TestGitLabGitProvider(t *testing.T) {
 	suite.Run(t, NewGitLabGitProviderTestSuite())
 }

--- a/pkg/gitprovider/gitness.go
+++ b/pkg/gitprovider/gitness.go
@@ -134,6 +134,22 @@ func (g *GitnessGitProvider) GetUser() (*GitUser, error) {
 	return user, nil
 }
 
+func (g *GitnessGitProvider) GetUrlFromRepository(repo *GitRepository) string {
+	url := strings.TrimSuffix(repo.Url, ".git")
+
+	if repo.Branch != nil && *repo.Branch != "" {
+		url += "/files/" + *repo.Branch
+
+		if repo.Path != nil && *repo.Path != "" {
+			url += "/~/" + *repo.Path
+		}
+	} else if repo.Path != nil {
+		url += "/files/main/~/" + *repo.Path
+	}
+
+	return url
+}
+
 func (g *GitnessGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (string, error) {
 	client := g.getApiClient()
 	return client.GetLastCommitSha(staticContext.Url, staticContext.Branch)

--- a/pkg/gitprovider/gitness_test.go
+++ b/pkg/gitprovider/gitness_test.go
@@ -118,6 +118,88 @@ func (g *GitnessGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 	require.Equal(commitContext, httpContext)
 }
 
+func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "localhost:3000",
+		Url:    "https://localhost:3000/daytonaio/daytona.git",
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://localhost:3000/daytonaio/daytona", url)
+}
+
+func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "localhost:3000",
+		Url:    "https://localhost:3000/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://localhost:3000/daytonaio/daytona/files/test-branch", url)
+}
+
+func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Path() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "localhost:3000",
+		Url:    "https://localhost:3000/daytonaio/daytona.git",
+		Branch: &[]string{"test-branch"}[0],
+		Path:   &[]string{"README.md"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://localhost:3000/daytonaio/daytona/files/test-branch/~/README.md", url)
+
+	repo.Branch = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://localhost:3000/daytonaio/daytona/files/main/~/README.md", url)
+}
+
+func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
+	repo := &GitRepository{
+		Id:     "daytona",
+		Name:   "daytona",
+		Owner:  "daytonaio",
+		Source: "localhost:3000",
+		Url:    "https://localhost:3000/daytonaio/daytona.git",
+		Path:   &[]string{"README.md"}[0],
+		Sha:    "COMMIT_SHA",
+		Branch: &[]string{"COMMIT_SHA"}[0],
+	}
+
+	require := g.Require()
+
+	url := g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://localhost:3000/daytonaio/daytona/files/COMMIT_SHA/~/README.md", url)
+
+	repo.Path = nil
+
+	url = g.gitProvider.GetUrlFromRepository(repo)
+
+	require.Equal("https://localhost:3000/daytonaio/daytona/files/COMMIT_SHA", url)
+}
+
 func TestGitnessGitProvider(t *testing.T) {
 	suite.Run(t, NewGitnessGitProviderTestSuite())
 }


### PR DESCRIPTION
# Implement Get URL From Repository API Route

## Description

Added a get URL from repository API route that allows passing a git repo (context) to the API to get the appropriate URL from the appropriate git provider.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #865 