### PR TITLE
fix: handle the error message for incorrect token

### DIFF
--- a/pkg/api/controllers/gitprovider/gitprovider.go
+++ b/pkg/api/controllers/gitprovider/gitprovider.go
@@ -97,7 +97,7 @@ func SetGitProvider(ctx *gin.Context) {
 
 	err = server.GitProviderService.SetGitProviderConfig(&gitProviderData)
 	if err != nil {
-		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to set git provider: %s", err.Error()))
+		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to set git provider: %s", err.Error()))
 		return
 	}
 

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -38,9 +38,9 @@ var GitProviderAddCmd = &cobra.Command{
 			return
 		}
 
-		_, err = apiClient.GitProviderAPI.SetGitProvider(ctx).GitProviderConfig(gitProviderData).Execute()
+		res, err := apiClient.GitProviderAPI.SetGitProvider(ctx).GitProviderConfig(gitProviderData).Execute()
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
 		views.RenderInfoMessage("Git provider has been registered")


### PR DESCRIPTION
# handle the error message for incorrect token

## Description
Handling the error message for incorrect token for the `gh add` command.


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
closes #727
/claim #727

## Screenshots
If relevant, please add screenshots.

![image](https://github.com/user-attachments/assets/ec4b531d-afc6-4d19-a3c8-59cb7013f9ee)


## Notes
Please add any relevant notes if necessary.
