### PR TITLE
fix: validation for bitbucket' user credentials (#876)

### DIFF
--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -104,6 +104,18 @@ func (g *BitbucketGitProvider) GetRepositories(namespace string) ([]*GitReposito
 	return response, err
 }
 
+func (g *BitbucketGitProvider) IsValidUser(username, token string) (bool, error) {
+	client := bitbucket.NewBasicAuth(username, token)
+
+	// Fetch the user's profile to verify credentials
+	_, err := client.User.Profile()
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (g *BitbucketGitProvider) GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error) {
 	client := g.getApiClient()
 	var response []*GitBranch

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -31,6 +31,7 @@ type GitProvider interface {
 	GetUser() (*GitUser, error)
 	GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error)
 	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)
+	IsValidUser(username string, token string) (bool, error)
 
 	GetRepositoryFromUrl(repositoryUrl string) (*GitRepository, error)
 	GetUrlFromRepository(repository *GitRepository) string

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -96,6 +96,11 @@ func (s *GitProviderService) SetGitProviderConfig(providerConfig *gitprovider.Gi
 			return err
 		}
 		providerConfig.Username = userData.Username
+	} else {
+		_, err := gitProvider.IsValidUser(providerConfig.Username, providerConfig.Token)
+		if err != nil {
+			return err
+		}
 	}
 
 	return s.configStore.Save(providerConfig)


### PR DESCRIPTION
# fix: validation for bitbucket' user credentials (#876)

## Description
Add validation for bitbucket's creds.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #876 
closes #876 
/claim #876 

## Screenshots

## Notes

