### PR TITLE
chore: use different config dir in development mode

### DIFF
--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
+echo 'alias dtn="DAYTONA_DEV=1 DAYTONA_CONFIG_DIR=$HOME/.config/daytona-dev go run cmd/daytona/main.go"' >> ~/.zshrc
+
 go install github.com/swaggo/swag/cmd/swag@v1.16.3
 
 go mod tidy
-
-echo 'alias dtn="DAYTONA_DEV=1 go run cmd/daytona/main.go"' >> ~/.zshrc

--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -188,6 +188,11 @@ func getConfigPath() (string, error) {
 }
 
 func GetConfigDir() (string, error) {
+	daytonaConfigDir := os.Getenv("DAYTONA_CONFIG_DIR")
+	if daytonaConfigDir != "" {
+		return daytonaConfigDir, nil
+	}
+
 	userConfigDir, err := os.UserConfigDir()
 	if err != nil {
 		return "", err

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -126,6 +126,7 @@ var ServeCmd = &cobra.Command{
 			FrpsDomain:    c.Frps.Domain,
 			FrpsProtocol:  c.Frps.Protocol,
 			HeadscalePort: c.HeadscalePort,
+			ConfigDir:     filepath.Join(configDir, "headscale"),
 		})
 		err = headscaleServer.Init()
 		if err != nil {
@@ -316,19 +317,17 @@ func printServerStartedMessage(c *server.Config, runAsDaemon bool) {
 }
 
 func getDbPath() (string, error) {
-	userConfigDir, err := os.UserConfigDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
 		return "", err
 	}
 
-	dir := filepath.Join(userConfigDir, "daytona")
-
-	err = os.MkdirAll(dir, 0755)
+	err = os.MkdirAll(configDir, 0755)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(dir, "db"), nil
+	return filepath.Join(configDir, "db"), nil
 }
 
 func setDefaultConfig(server *server.Server, apiPort uint32) error {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/google/uuid"
 )
 
@@ -93,12 +94,12 @@ func Save(c Config) error {
 }
 
 func GetConfigDir() (string, error) {
-	userConfigDir, err := os.UserConfigDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(userConfigDir, "daytona", "server"), nil
+	return filepath.Join(configDir, "server"), nil
 }
 
 func GetWorkspaceLogsDir() (string, error) {

--- a/pkg/server/defaults.go
+++ b/pkg/server/defaults.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/google/uuid"
 
 	log "github.com/sirupsen/logrus"
@@ -164,12 +165,12 @@ func parsePort(port string) (uint32, error) {
 }
 
 func getDefaultProvidersDir() (string, error) {
-	userConfigDir, err := os.UserConfigDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(userConfigDir, "daytona", "providers"), nil
+	return filepath.Join(configDir, "providers"), nil
 }
 
 func getDefaultLogFilePath() (string, error) {

--- a/pkg/server/headscale/config.go
+++ b/pkg/server/headscale/config.go
@@ -20,11 +20,6 @@ import (
 )
 
 func (s *HeadscaleServer) getHeadscaleConfig() (*hstypes.Config, error) {
-	headscaleConfigDir, err := s.getHeadscaleConfigDir()
-	if err != nil {
-		return nil, err
-	}
-
 	cfg := &hstypes.Config{
 		DBtype:                         "sqlite3",
 		ServerURL:                      fmt.Sprintf("https://%s.%s", s.serverId, s.frpsDomain),
@@ -39,7 +34,7 @@ func (s *HeadscaleServer) getHeadscaleConfig() (*hstypes.Config, error) {
 			ServerRegionCode:                   "local",
 			ServerRegionName:                   "Daytona embedded DERP",
 			Paths:                              []string{},
-			ServerPrivateKeyPath:               filepath.Join(headscaleConfigDir, "derp_server_private.key"),
+			ServerPrivateKeyPath:               filepath.Join(s.configDir, "derp_server_private.key"),
 			UpdateFrequency:                    24 * time.Hour,
 			AutoUpdate:                         true,
 			STUNAddr:                           "0.0.0.0:3478",
@@ -66,10 +61,10 @@ func (s *HeadscaleServer) getHeadscaleConfig() (*hstypes.Config, error) {
 				},
 			},
 		},
-		DBpath:               filepath.Join(headscaleConfigDir, "headscale.db"),
-		UnixSocket:           filepath.Join(headscaleConfigDir, "headscale.sock"),
+		DBpath:               filepath.Join(s.configDir, "headscale.db"),
+		UnixSocket:           filepath.Join(s.configDir, "headscale.sock"),
 		UnixSocketPermission: fs.FileMode.Perm(0700),
-		NoisePrivateKeyPath:  filepath.Join(headscaleConfigDir, "noise_private.key"),
+		NoisePrivateKeyPath:  filepath.Join(s.configDir, "noise_private.key"),
 		CLI: hstypes.CLIConfig{
 			Timeout: 10 * time.Second,
 		},
@@ -77,6 +72,7 @@ func (s *HeadscaleServer) getHeadscaleConfig() (*hstypes.Config, error) {
 
 	logLevelEnv, logLevelSet := os.LookupEnv("LOG_LEVEL")
 	if logLevelSet {
+		var err error
 		cfg.Log.Level, err = zerolog.ParseLevel(logLevelEnv)
 		if err != nil {
 			cfg.Log.Level = zerolog.ErrorLevel

--- a/pkg/server/headscale/server.go
+++ b/pkg/server/headscale/server.go
@@ -5,7 +5,6 @@ package headscale
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/juanfont/headscale/hscontrol"
 )
@@ -15,6 +14,7 @@ type HeadscaleServerConfig struct {
 	FrpsDomain    string
 	FrpsProtocol  string
 	HeadscalePort uint32
+	ConfigDir     string
 }
 
 func NewHeadscaleServer(config *HeadscaleServerConfig) *HeadscaleServer {
@@ -23,6 +23,7 @@ func NewHeadscaleServer(config *HeadscaleServerConfig) *HeadscaleServer {
 		frpsDomain:    config.FrpsDomain,
 		frpsProtocol:  config.FrpsProtocol,
 		headscalePort: config.HeadscalePort,
+		configDir:     config.ConfigDir,
 	}
 }
 
@@ -31,15 +32,11 @@ type HeadscaleServer struct {
 	frpsDomain    string
 	frpsProtocol  string
 	headscalePort uint32
+	configDir     string
 }
 
 func (s *HeadscaleServer) Init() error {
-	headscaleConfigDir, err := s.getHeadscaleConfigDir()
-	if err != nil {
-		return err
-	}
-
-	return os.MkdirAll(headscaleConfigDir, 0700)
+	return os.MkdirAll(s.configDir, 0700)
 }
 
 func (s *HeadscaleServer) Start() error {
@@ -54,12 +51,4 @@ func (s *HeadscaleServer) Start() error {
 	}
 
 	return app.Serve()
-}
-
-func (s *HeadscaleServer) getHeadscaleConfigDir() (string, error) {
-	userConfigDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(userConfigDir, "daytona", "server", "headscale"), nil
 }


### PR DESCRIPTION
# Use Different Config Dir in Development Mode

## Description

A small fix to use a different config dir when inside a devcontainer. This makes it easier to run Daytona in Daytona.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #882 

## Screenshots

![Screenshot 2024-08-01 at 17 51 46](https://github.com/user-attachments/assets/3571a64c-66f4-49f0-8799-23c7cb1c0076)

