### PR TITLE
feat: add support to display unpushed commits

### DIFF
--- a/pkg/cmd/workspace/info.go
+++ b/pkg/cmd/workspace/info.go
@@ -6,6 +6,7 @@ package workspace
 import (
 	"context"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/daytonaio/daytona/internal/util"


### PR DESCRIPTION
fixes #532
/claim #532 

## Description

This PR improves the daytona info command to display the number of unpushed commits in the current branch by providing a message like:
```Your branch is ahead of origin/main by X commits```
