### PR TITLE
fix: gitprovider for url interface

### DIFF
--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -21,7 +21,11 @@ func (s *GitProviderService) GetGitProviderForUrl(repoUrl string) (gitprovider.G
 
 	for _, p := range gitProviders {
 		if p.Id == "aws-codecommit" && strings.Contains(repoUrl, "git-codecommit") {
-			return s.GetGitProvider(p.Id)
+			gitProvider, err := s.GetGitProvider(p.Id)
+			if err != nil {
+				return nil, "", err
+			}
+			return gitProvider, p.Id, nil
 		}
 
 		if strings.Contains(repoUrl, fmt.Sprintf("%s.", p.Id)) {


### PR DESCRIPTION
# Fix GitProviderForUrl interface return value

## Description

Minor fix to `GitProviderForUrl` interface return value for AWS CodeCommit conflict

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation