### PR TITLE
fix: remove fatal on project config select ctrl-c

### DIFF
--- a/pkg/cmd/projectconfig/delete.go
+++ b/pkg/cmd/projectconfig/delete.go
@@ -40,6 +40,9 @@ var projectConfigDeleteCmd = &cobra.Command{
 			}
 
 			selectedProjectConfig = selection.GetProjectConfigFromPrompt(projectConfigs, 0, false, "Delete")
+			if selectedProjectConfig == nil {
+				return
+			}
 			selectedProjectConfigName = *selectedProjectConfig.Name
 		} else {
 			selectedProjectConfigName = args[0]

--- a/pkg/cmd/projectconfig/setdefault.go
+++ b/pkg/cmd/projectconfig/setdefault.go
@@ -34,6 +34,9 @@ var projectConfigSetDefaultCmd = &cobra.Command{
 			}
 
 			projectConfig := selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, "Make Default")
+			if projectConfig == nil {
+				return
+			}
 			projectConfigName = *projectConfig.Name
 		} else {
 			projectConfigName = args[0]

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -39,6 +39,9 @@ var projectConfigUpdateCmd = &cobra.Command{
 			}
 
 			projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, "Update")
+			if projectConfig == nil {
+				return
+			}
 		} else {
 			projectConfig, res, err = apiClient.ProjectConfigAPI.GetProjectConfig(ctx, args[0]).Execute()
 			if err != nil {

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -16,6 +16,7 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	log "github.com/sirupsen/logrus"
@@ -54,7 +55,7 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 		if len(config.ProjectConfigs) > 0 && !config.BlankProject {
 			projectConfig := selection.GetProjectConfigFromPrompt(config.ProjectConfigs, i, true, "Use")
 			if projectConfig == nil {
-				return nil, fmt.Errorf("must select a project config")
+				return nil, common.ErrCtrlCAbort
 			}
 
 			projectNames := []string{}


### PR DESCRIPTION
# Remove fatal err when ctrl-c-ing out of project config selection
## Description

Removes fatal err when ctrl-c-ing out of project config selection - delete, update, select

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
