### PR TITLE
fix: panic output flag breaks the stdout

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -42,8 +42,6 @@ var rootCmd = &cobra.Command{
 	Run:               RunInitialScreenFlow,
 }
 
-var originalStdout *os.File
-
 func Execute() {
 	rootCmd.AddGroup(&cobra.Group{ID: WORKSPACE_GROUP, Title: "Workspaces & Projects"})
 	rootCmd.AddGroup(&cobra.Group{ID: SERVER_GROUP, Title: "Server"})
@@ -162,12 +160,6 @@ func SetupRootCommand(cmd *cobra.Command) {
 				log.Error(err)
 			}
 		}
-
-		if output.FormatFlag == "" {
-			return
-		}
-		originalStdout = os.Stdout
-		os.Stdout = nil
 	}
 
 	cmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
@@ -185,7 +177,6 @@ func SetupRootCommand(cmd *cobra.Command) {
 			}
 		}
 
-		os.Stdout = originalStdout
 		output.Print(output.Output, output.FormatFlag)
 	}
 }

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -36,8 +36,6 @@ var gitProviderListCmd = &cobra.Command{
 			return
 		}
 
-		views.RenderMainTitle("Registered Git Providers:")
-
 		supportedProviders := config.GetSupportedGitProviders()
 		var gitProviderViewList []gitprovider_view.GitProviderView
 
@@ -59,6 +57,8 @@ var gitProviderListCmd = &cobra.Command{
 			output.Output = gitProviderViewList
 			return
 		}
+
+		views.RenderMainTitle("Registered Git Providers:")
 
 		for _, gitProviderView := range gitProviderViewList {
 			views.RenderListLine(fmt.Sprintf("%s (%s)", gitProviderView.Name, gitProviderView.Username))


### PR DESCRIPTION
# fix: panic output flag breaks the stdout

## Description

The output flag breaks stdout, causing the TUI selection to fail or a blank screen to appear in the terminal. This happens because stdout is set to nil, which can cause problems in other parts of the code that rely on standard output.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
closes #688 
/claim #688 
## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
