### PR TITLE
fix: server configuration fails to make directory

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -70,6 +70,13 @@ func configFilePath() (string, error) {
 }
 
 func Save(c Config) error {
+	if err := directoryValidator(&c.BinariesPath); err != nil {
+		return err
+	}
+	if err := directoryValidator(&c.ProvidersDir); err != nil {
+		return err
+	}
+
 	configFilePath, err := configFilePath()
 	if err != nil {
 		return err
@@ -109,4 +116,12 @@ func GetWorkspaceLogsDir() (string, error) {
 	}
 
 	return filepath.Join(configDir, "logs"), nil
+}
+
+func directoryValidator(path *string) error {
+	_, err := os.Stat(*path)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(*path, 0700)
+	}
+	return err
 }

--- a/pkg/views/server/configure.go
+++ b/pkg/views/server/configure.go
@@ -59,8 +59,7 @@ func (m *Model) createForm(containerRegistries []apiclient.ContainerRegistry) *h
 			huh.NewInput().
 				Title("Providers Directory").
 				Description("Directory will be created if it does not exist").
-				Value(m.config.ProvidersDir).
-				Validate(directoryValidator(m.config.ProvidersDir)),
+				Value(m.config.ProvidersDir),
 			huh.NewInput().
 				Title("Registry URL").
 				Value(m.config.RegistryUrl),
@@ -116,8 +115,7 @@ func (m *Model) createForm(containerRegistries []apiclient.ContainerRegistry) *h
 			huh.NewInput().
 				Title("Binaries Path").
 				Description("Directory will be created if it does not exist").
-				Value(m.config.BinariesPath).
-				Validate(directoryValidator(m.config.BinariesPath)),
+				Value(m.config.BinariesPath),
 			huh.NewInput().
 				Title("Log File Path").
 				Description("File will be created if it does not exist").
@@ -233,16 +231,5 @@ func createPortValidator(config *apiclient.ServerConfig, portView *string, port 
 		}
 
 		return nil
-	}
-}
-
-func directoryValidator(path *string) func(string) error {
-	return func(string) error {
-		_, err := os.Stat(*path)
-		if os.IsNotExist(err) {
-			return os.MkdirAll(*path, 0700)
-		}
-
-		return err
 	}
 }


### PR DESCRIPTION
server configuration fails to make directory

## Description
`daytona server configure` fails because it attempts to create dir on the cli. This PR moves the directory creation logic to the server.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #618
/claim #618
closes #618 
