### PR TITLE
fix: devcontainer read config race condition

### DIFF
--- a/pkg/docker/create_devcontainer.go
+++ b/pkg/docker/create_devcontainer.go
@@ -326,6 +326,9 @@ func (d *DockerClient) readDevcontainerConfig(opts *CreateProjectOptions, paths 
 		"--config=" + paths.TargetConfigFilePath,
 		"--override-config=/tmp/devcontainer.json",
 		"--include-merged-configuration",
+		"&&",
+		"sleep",
+		"1",
 	}...)
 
 	output, err := d.execInContainer(strings.Join(devcontainerCmd, " "), opts, paths, paths.ProjectTarget, socketForwardId, false, nil)


### PR DESCRIPTION
# Fix Read Devcontainer Config Race Condition

## Description

A minor fix for a race condition that occurs when reading the devcontainer configuration of a project. The race condition occurs when reading container logs of the container that executes the read operation.
If the container exits before logs are read, the workspace creation process fails.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes
Providers will need to be updated with `daytona provider update`
