### PR TITLE
fix: home folder when installing vscode extensions

### DIFF
--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -81,7 +81,7 @@ func setupIdeCustomizations(projectHostname string, projectProviderMetadata stri
 			time.Sleep(2 * time.Second)
 			// Wait for code to be installed
 			var err error
-			if vscodePath, err = exec.Command("ssh", projectHostname, "find", "/home", "-path", fmt.Sprintf(`"%s"`, codeServerPath)).Output(); err == nil && len(vscodePath) > 0 {
+			if vscodePath, err = exec.Command("ssh", projectHostname, "find", "$HOME", "-path", fmt.Sprintf(`"%s"`, codeServerPath)).Output(); err == nil && len(vscodePath) > 0 {
 				break
 			}
 		}


### PR DESCRIPTION
# Fix Home Folder Path When Installing VS Code Extensions

## Description

Minor fix for the home folder path when installing vscode extensions. This fixes the installation when the project is ran with the `root` user.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
