### PR TITLE
Version mismatch warning displays wrong versions

### DIFF
--- a/internal/util/apiclient/error_handler.go
+++ b/internal/util/apiclient/error_handler.go
@@ -48,6 +48,6 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 func checkVersionsMismatch(res *http.Response) {
 	serverVersion := res.Header.Get(middlewares.SERVER_VERSION_HEADER)
 	if internal.Version != serverVersion {
-		log.Warn(fmt.Sprintf("Version mismatch detected. CLI is on version %s, Daytona Server is on version %s. To ensure maximum compatibility, please make sure the versions are aligned.", serverVersion, internal.Version))
+		log.Warn(fmt.Sprintf("Version mismatch detected. CLI is on version %s, Daytona Server is on version %s. To ensure maximum compatibility, please make sure the versions are aligned.", internal.Version, serverVersion))
 	}
 }


### PR DESCRIPTION
# Pull Request Title
Version mismatch warning displays wrong versions

## Description
The versions in the warning are swapped. I'm running the CLI on version `v0.25.1` and the server on `v0.0.0-dev`

## Related Issue(s)

This PR addresses issue #936 

/closes #936 