### PR TITLE
fix: .devcontainer.json detection

### DIFF
--- a/pkg/build/detect/detect.go
+++ b/pkg/build/detect/detect.go
@@ -54,7 +54,7 @@ func DetectProjectBuilderType(project *project.Project, projectDir string, sshCl
 func findDevcontainerConfigFilePath(projectDir string) (string, error) {
 	devcontainerPath := ".devcontainer/devcontainer.json"
 	isDevcontainer, err := fileExists(filepath.Join(projectDir, devcontainerPath))
-	if err != nil {
+	if !isDevcontainer || err != nil {
 		devcontainerPath = ".devcontainer.json"
 		isDevcontainer, err = fileExists(filepath.Join(projectDir, devcontainerPath))
 		if err != nil {


### PR DESCRIPTION
# Fix .devcontainer.json Detection

## Description

Fixes devcontainer auto-detect if `.devcontainer.json` should be detected

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #938 

## Notes
Providers will need to be updated with `daytona provider update`
