### PR TITLE
feat: support creating multiple projects non-interactively

### DIFF
--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -3,14 +3,14 @@
 Create a workspace
 
 ```
-daytona create [REPOSITORY_URL] [flags]
+daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
 ```
 
 ### Options
 
 ```
       --blank                      Create a blank project without using existing configurations
-      --branch string              Specify the Git branch to use in the project
+      --branch strings             Specify the Git branches to use in the projects
       --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)
   -c, --code                       Open the workspace in the IDE after workspace creation
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well

--- a/docs/daytona_project-config_add.md
+++ b/docs/daytona_project-config_add.md
@@ -9,7 +9,6 @@ daytona project-config add [flags]
 ### Options
 
 ```
-      --branch string              Specify the Git branch to use in the project
       --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -1,12 +1,13 @@
 name: daytona create
 synopsis: Create a workspace
-usage: daytona create [REPOSITORY_URL] [flags]
+usage: daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
 options:
     - name: blank
       default_value: "false"
       usage: Create a blank project without using existing configurations
     - name: branch
-      usage: Specify the Git branch to use in the project
+      default_value: '[]'
+      usage: Specify the Git branches to use in the projects
     - name: builder
       usage: Specify the builder (currently auto/devcontainer/none)
     - name: code

--- a/hack/docs/daytona_project-config_add.yaml
+++ b/hack/docs/daytona_project-config_add.yaml
@@ -2,8 +2,6 @@ name: daytona project-config add
 synopsis: Add a project config
 usage: daytona project-config add [flags]
 options:
-    - name: branch
-      usage: Specify the Git branch to use in the project
     - name: builder
       usage: Specify the builder (currently auto/devcontainer/none)
     - name: custom-image

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -249,7 +249,6 @@ var projectConfigurationFlags = workspace_util.ProjectConfigurationFlags{
 	Builder:          new(views_util.BuildChoice),
 	CustomImage:      new(string),
 	CustomImageUser:  new(string),
-	Branch:           new(string),
 	DevcontainerPath: new(string),
 	EnvVars:          new([]string),
 	Manual:           new(bool),

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -279,7 +279,7 @@ func getTarget(targetList []apiclient.ProviderTarget, activeProfileName string) 
 }
 
 func processPrompting(apiClient *apiclient.APIClient, workspaceName *string, projects *[]apiclient.CreateProjectDTO, workspaceNames []string, ctx context.Context) error {
-	if workspace_util.CheckAnyProjectConfigurationFlagSet(projectConfigurationFlags) {
+	if workspace_util.CheckAnyProjectConfigurationFlagSet(projectConfigurationFlags) || (projectConfigurationFlags.Branches != nil && len(*projectConfigurationFlags.Branches) > 0) {
 		return errors.New("please provide the repository URL in order to set up custom project details through the CLI")
 	}
 

--- a/pkg/cmd/workspace/util/add_from_config.go
+++ b/pkg/cmd/workspace/util/add_from_config.go
@@ -11,8 +11,11 @@ import (
 	"github.com/daytonaio/daytona/pkg/common"
 )
 
-func AddProjectFromConfig(projectConfig *apiclient.ProjectConfig, apiClient *apiclient.APIClient, projects *[]apiclient.CreateProjectDTO, branchFlag string) (*string, error) {
-	chosenBranchName := branchFlag
+func AddProjectFromConfig(projectConfig *apiclient.ProjectConfig, apiClient *apiclient.APIClient, projects *[]apiclient.CreateProjectDTO, branchFlag *string) (*string, error) {
+	chosenBranchName := ""
+	if branchFlag != nil {
+		chosenBranchName = *branchFlag
+	}
 
 	if chosenBranchName == "" {
 		chosenBranch, err := GetBranchFromProjectConfig(projectConfig, apiClient, 0)

--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -61,7 +61,12 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	}
 
 	var branch *apiclient.GitBranch
-	parentIdentifier := fmt.Sprintf("%s/%s/%s", config.ProviderId, config.Namespace, config.ChosenRepo.Name)
+	namespace := config.Namespace
+	if namespace == "" {
+		namespace = config.ChosenRepo.Owner
+	}
+
+	parentIdentifier := fmt.Sprintf("%s/%s/%s", config.ProviderId, namespace, config.ChosenRepo.Name)
 	if len(prList) == 0 {
 		branch = selection.GetBranchFromPrompt(branchList, config.ProjectOrder, parentIdentifier)
 		if branch == nil {

--- a/pkg/cmd/workspace/util/workspace.go
+++ b/pkg/cmd/workspace/util/workspace.go
@@ -46,7 +46,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 }
 
 func CheckAnyProjectConfigurationFlagSet(flags ProjectConfigurationFlags) bool {
-	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || (flags.Branches != nil && len(*flags.Branches) > 0) || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
+	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
 }
 
 func IsProjectRunning(workspace *apiclient.WorkspaceDTO, projectName string) bool {

--- a/pkg/cmd/workspace/util/workspace.go
+++ b/pkg/cmd/workspace/util/workspace.go
@@ -16,7 +16,7 @@ type ProjectConfigurationFlags struct {
 	Builder          *views_util.BuildChoice
 	CustomImage      *string
 	CustomImageUser  *string
-	Branch           *string
+	Branches         *[]string
 	DevcontainerPath *string
 	EnvVars          *[]string
 	Manual           *bool
@@ -25,7 +25,6 @@ type ProjectConfigurationFlags struct {
 func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfigurationFlags, multiProjectFlagException bool) {
 	cmd.Flags().StringVar(flags.CustomImage, "custom-image", "", "Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well")
 	cmd.Flags().StringVar(flags.CustomImageUser, "custom-image-user", "", "Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well")
-	cmd.Flags().StringVar(flags.Branch, "branch", "", "Specify the Git branch to use in the project")
 	cmd.Flags().StringVar(flags.DevcontainerPath, "devcontainer-path", "", "Automatically assign the devcontainer builder with the path passed as the flag value")
 	cmd.Flags().Var(flags.Builder, "builder", fmt.Sprintf("Specify the builder (currently %s/%s/%s)", views_util.AUTOMATIC, views_util.DEVCONTAINER, views_util.NONE))
 	cmd.Flags().StringArrayVar(flags.EnvVars, "env", []string{}, "Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')")
@@ -47,7 +46,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 }
 
 func CheckAnyProjectConfigurationFlagSet(flags ProjectConfigurationFlags) bool {
-	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || *flags.Branch != "" || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
+	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || (*flags.Branches != nil && len(*flags.Branches) > 0) || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
 }
 
 func IsProjectRunning(workspace *apiclient.WorkspaceDTO, projectName string) bool {

--- a/pkg/cmd/workspace/util/workspace.go
+++ b/pkg/cmd/workspace/util/workspace.go
@@ -46,7 +46,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 }
 
 func CheckAnyProjectConfigurationFlagSet(flags ProjectConfigurationFlags) bool {
-	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || (*flags.Branches != nil && len(*flags.Branches) > 0) || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
+	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || (flags.Branches != nil && len(*flags.Branches) > 0) || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
 }
 
 func IsProjectRunning(workspace *apiclient.WorkspaceDTO, projectName string) bool {


### PR DESCRIPTION
# Support Creating Multiple Projects Non-interactively

## Description

This PR adds the ability to pass multiple repository urls (or project config names) to the `daytona create` command. This adds the ability to create a multi-project workspace non-interactively.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
