### PR TITLE
fix: improve error handling for daytona code command

### DIFF
--- a/pkg/api/controllers/workspace/workspace.go
+++ b/pkg/api/controllers/workspace/workspace.go
@@ -31,7 +31,7 @@ func GetWorkspace(ctx *gin.Context) {
 
 	w, err := server.WorkspaceService.GetWorkspace(ctx.Request.Context(), workspaceId)
 	if err != nil {
-		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get workspace: %s", err.Error()))
+		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get workspace: %w", err))
 		return
 	}
 

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/jetbrains"
@@ -71,7 +70,7 @@ var CodeCmd = &cobra.Command{
 
 			workspace, err := apiclient_util.GetWorkspace(encodedWorkspaceName)
 			if err != nil {
-				if strings.Contains(err.Error(), workspaces.ErrWorkspaceNotFound.Error()) {
+				if errors.Is(err, workspaces.ErrWorkspaceNotFound) {
 					log.Debug(err)
 					log.Fatal("Workspace not found. You can see all workspace names by running the command `daytona list`")
 				} else {

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -72,7 +72,6 @@ var CodeCmd = &cobra.Command{
 			workspace, err := apiclient_util.GetWorkspace(encodedWorkspaceName)
 			if err != nil {
 				if strings.Contains(err.Error(), workspaces.ErrWorkspaceNotFound.Error()) {
-					log.Debug(err)
 					log.Fatal("Workspace not found. You can see all workspace names by running the command `daytona list`")
 				} else {
 					log.Fatal(err)

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -66,7 +66,7 @@ var CodeCmd = &cobra.Command{
 		} else {
 			workspace, err = apiclient_util.GetWorkspace(args[0])
 			if err != nil {
-				if err.Error() == "404 page not found" {
+				if err.Error() == "404 page not found" || err.Error() == "failed to get workspace: workspace not found"{
 					log.Debug(err)
 					log.Fatal("Workspace name required. Please provide a valid workspace name with the command. You can see all workspace names by running the command `daytona list`")
 				} else {

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/jetbrains"
@@ -70,7 +71,7 @@ var CodeCmd = &cobra.Command{
 
 			workspace, err := apiclient_util.GetWorkspace(encodedWorkspaceName)
 			if err != nil {
-				if errors.Is(err, workspaces.ErrWorkspaceNotFound) {
+				if strings.Contains(err.Error(), workspaces.ErrWorkspaceNotFound.Error()) {
 					log.Debug(err)
 					log.Fatal("Workspace not found. You can see all workspace names by running the command `daytona list`")
 				} else {

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -67,17 +67,20 @@ var CodeCmd = &cobra.Command{
 			}
 			workspaceId = workspace.Id
 		} else {
-			encodedWorkspaceName := url.PathEscape(args[0])
+			var workspaceName string
+			if _, err := url.ParseRequestURI(args[0]); err == nil {
+				workspaceName = url.PathEscape(args[0])
+			} else {
+				workspaceName = args[0]
+			}
 
-			workspace, err := apiclient_util.GetWorkspace(encodedWorkspaceName)
+			workspace, err = apiclient_util.GetWorkspace(workspaceName)
 			if err != nil {
 				if strings.Contains(err.Error(), workspaces.ErrWorkspaceNotFound.Error()) {
 					log.Fatal("Workspace not found. You can see all workspace names by running the command `daytona list`")
-				} else {
-					log.Fatal(err)
 				}
+				log.Fatal(err)
 			}
-
 			workspaceId = workspace.Id
 		}
 

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -67,14 +67,7 @@ var CodeCmd = &cobra.Command{
 			}
 			workspaceId = workspace.Id
 		} else {
-			var workspaceName string
-			if _, err := url.ParseRequestURI(args[0]); err == nil {
-				workspaceName = url.PathEscape(args[0])
-			} else {
-				workspaceName = args[0]
-			}
-
-			workspace, err = apiclient_util.GetWorkspace(workspaceName)
+			workspace, err = apiclient_util.GetWorkspace(url.PathEscape(args[0]))
 			if err != nil {
 				if strings.Contains(err.Error(), workspaces.ErrWorkspaceNotFound.Error()) {
 					log.Debug(err)

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -68,7 +68,7 @@ var CodeCmd = &cobra.Command{
 			if err != nil {
 				if err.Error() == "404 page not found" || err.Error() == "failed to get workspace: workspace not found"{
 					log.Debug(err)
-					log.Fatal("Workspace name required. Please provide a valid workspace name with the command. You can see all workspace names by running the command `daytona list`")
+					log.Fatal("Workspace not found. You can see all workspace names by running the command `daytona list`")
 				} else {
 					log.Fatal(err)
 				}

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -77,6 +77,7 @@ var CodeCmd = &cobra.Command{
 			workspace, err = apiclient_util.GetWorkspace(workspaceName)
 			if err != nil {
 				if strings.Contains(err.Error(), workspaces.ErrWorkspaceNotFound.Error()) {
+					log.Debug(err)
 					log.Fatal("Workspace not found. You can see all workspace names by running the command `daytona list`")
 				}
 				log.Fatal(err)

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -67,7 +67,8 @@ var CodeCmd = &cobra.Command{
 			workspace, err = apiclient_util.GetWorkspace(args[0])
 			if err != nil {
 				if err.Error() == "404 page not found" {
-					log.Fatalf("%s \nWorkspace name required. Please provide a valid workspace name with the command. You can see all workspace names by running the command `daytona list`",err.Error())
+					log.Debug(err)
+					log.Fatal("Workspace name required. Please provide a valid workspace name with the command. You can see all workspace names by running the command `daytona list`")
 				} else {
 					log.Fatal(err)
 				}


### PR DESCRIPTION
# Improve Error Handling for daytona code Command

## Description
- Adding validation for workspace names in the `daytona code` command.
- Enhancing error messages to provide clearer guidance, including suggesting the `daytona list` command for viewing available workspaces.

**Files changed:**

- **`pkg/cmd/workspace/code.go`**: Updated to include workspace validation and improved error handling.


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #859

## Screenshots
- Before
![terminal(dtn code non valid url or github link)](https://github.com/user-attachments/assets/5af55758-ec83-4d75-82d9-38245a9236ee)
-  After
![01](https://github.com/user-attachments/assets/060c9db5-d030-4b1a-98b5-7d527b2256c4)

