### PR TITLE
feat: flag for the project-config delete command to delete all project configurations

### DIFF
--- a/docs/daytona_project-config_delete.md
+++ b/docs/daytona_project-config_delete.md
@@ -6,6 +6,13 @@ Delete a project config
 daytona project-config delete [flags]
 ```
 
+### Options
+
+```
+  -a, --all   Delete all project configs
+  -y, --yes   Confirm deletion without prompt
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/hack/docs/daytona_project-config_delete.yaml
+++ b/hack/docs/daytona_project-config_delete.yaml
@@ -1,6 +1,15 @@
 name: daytona project-config delete
 synopsis: Delete a project config
 usage: daytona project-config delete [flags]
+options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Delete all project configs
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Confirm deletion without prompt
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/projectconfig/delete.go
+++ b/pkg/cmd/projectconfig/delete.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/charmbracelet/huh"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-	"github.com/charmbracelet/huh"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/pkg/cmd/projectconfig/delete.go
+++ b/pkg/cmd/projectconfig/delete.go
@@ -35,7 +35,6 @@ var projectConfigDeleteCmd = &cobra.Command{
 
 		if allFlag {
 			if !yesFlag {
-				// Added a confirmation prompt using huh.NewForm
 				form := huh.NewForm(
 					huh.NewGroup(
 						huh.NewConfirm().

--- a/pkg/cmd/projectconfig/delete.go
+++ b/pkg/cmd/projectconfig/delete.go
@@ -34,24 +34,26 @@ var projectConfigDeleteCmd = &cobra.Command{
 		}
 
 		if allFlag {
-			// Added a confirmation prompt using huh.NewForm
-			form := huh.NewForm(
-				huh.NewGroup(
-					huh.NewConfirm().
-						Title("Delete all project configs?").
-						Description("Are you sure you want to delete all project configs?").
-						Value(&yesFlag),
-				),
-			).WithTheme(views.GetCustomTheme())
-
-			err := form.Run()
-			if err != nil {
-				log.Fatal(err)
-			}
-
 			if !yesFlag {
-				fmt.Println("Operation canceled.")
-				return
+				// Added a confirmation prompt using huh.NewForm
+				form := huh.NewForm(
+					huh.NewGroup(
+						huh.NewConfirm().
+							Title("Delete all project configs?").
+							Description("Are you sure you want to delete all project configs?").
+							Value(&yesFlag),
+					),
+				).WithTheme(views.GetCustomTheme())
+
+				err := form.Run()
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				if !yesFlag {
+					fmt.Println("Operation canceled.")
+					return
+				}
 			}
 
 			projectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()


### PR DESCRIPTION
# Flag for the project-config delete command to delete all project configurations

## Description

This PR adds a `--all` flag to the `project-config delete` command so you can delete all project configurations at once. A confirmation prompt will now appear to make sure you really want to delete everything. You can also use the `--yes` flag to skip the prompt if you're sure.
Closes #890

### Files Changed:
- `/pkg/cmd/projectconfig/delete.go`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #890

## Screenshots

[Screencast_20240825_191600.webm](https://github.com/user-attachments/assets/33526f00-fae0-46fa-85fd-ca6cc5097292)

## Notes
Please add any relevant notes if necessary.
