### PR TITLE
chore: mark git directory as safe in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,5 +8,6 @@
 		"DAYTONA_WS_ID": ""
 	},
 	"postCreateCommand": ".devcontainer/postcreate.sh",
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
 	"remoteUser": "daytona"
 }


### PR DESCRIPTION
# Mark Git Directroy as Safe in Devconainer

## Description

![Screenshot 2024-08-26 at 11 44 22](https://github.com/user-attachments/assets/e5749d31-6672-4c4b-a377-e92fb16ce9d3)

Resolves the above error that sometimes occurs when opening daytona in a devcontainer.


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
