### PR TITLE
fix: opening cursor instead of vscode

### DIFF
--- a/pkg/cmd/ide.go
+++ b/pkg/cmd/ide.go
@@ -45,7 +45,10 @@ var ideCmd = &cobra.Command{
 		case "vscode":
 			ide_util.CheckAndAlertVSCodeInstalled()
 		case "cursor":
-			ide_util.GetCursorBinaryPath()
+			_, err := ide_util.GetCursorBinaryPath()
+			if err != nil {
+				log.Error(err)
+			}
 		}
 
 		c.DefaultIdeId = chosenIde.Id


### PR DESCRIPTION
# Fix Opening Cursor Instead of VS Code

## Description

Adds checking if the `code` binary is actually cursor and not VS Code. Additionally, improved error logging if Cursor is not found.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #966, #967 

## Screenshots
![Screenshot 2024-08-28 at 10 17 31](https://github.com/user-attachments/assets/f3eec5f1-8034-4138-978d-3aaffb2dcc9f)
