### PR TITLE
fix: build logs UX

### DIFF
--- a/docs/daytona_build_logs.md
+++ b/docs/daytona_build_logs.md
@@ -9,7 +9,8 @@ daytona build logs [flags]
 ### Options
 
 ```
-  -f, --follow   Follow logs
+      --continue-on-completed   Continue streaming logs after the build is completed
+  -f, --follow                  Follow logs
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_build_logs.yaml
+++ b/hack/docs/daytona_build_logs.yaml
@@ -2,6 +2,9 @@ name: daytona build logs
 synopsis: View logs for build
 usage: daytona build logs [flags]
 options:
+    - name: continue-on-completed
+      default_value: "false"
+      usage: Continue streaming logs after the build is completed
     - name: follow
       shorthand: f
       default_value: "false"

--- a/pkg/build/runner.go
+++ b/pkg/build/runner.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/pkg/containerregistry"
 	"github.com/daytonaio/daytona/pkg/docker"
 	"github.com/daytonaio/daytona/pkg/git"
@@ -283,7 +284,7 @@ func (r *BuildRunner) RunBuildProcess(config BuildProcessConfig) {
 		config.BuildLogger.Write([]byte(errMsg + "\n"))
 	}
 
-	config.BuildLogger.Write([]byte("\nBuild completed successfully\n"))
+	config.BuildLogger.Write([]byte("\n \n" + lipgloss.NewStyle().Bold(true).Render("Build completed successfully")))
 
 	if r.telemetryEnabled {
 		r.logTelemetry(context.Background(), *config.Build, err)


### PR DESCRIPTION
# Build logs UX

## Description

Adds a polling function to stop reading logs once the build is published or has errored
Adds `--continue-on-completed` flag to continue reading logs and ignore the poll
Adds a newline and bolds the build success message

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #968 

## Screenshots

![image](https://github.com/user-attachments/assets/36376f3e-ce5f-412d-9730-9ba456d9c7fe)