### PR TITLE
fix: matching project config and build to repository

### DIFF
--- a/internal/testing/build/store.go
+++ b/internal/testing/build/store.go
@@ -127,7 +127,7 @@ func (s *InMemoryBuildStore) processFilters(filter *build.Filter) ([]*build.Buil
 		}
 		if filter.Branch != nil {
 			for _, b := range filteredBuilds {
-				if b.Repository == nil || b.Repository.Branch == nil || *b.Repository.Branch != *filter.Branch {
+				if b.Repository == nil || b.Repository.Branch != *filter.Branch {
 					delete(filteredBuilds, b.Id)
 				}
 			}

--- a/internal/testing/gitprovider/mocks/git_provider.go
+++ b/internal/testing/gitprovider/mocks/git_provider.go
@@ -51,8 +51,8 @@ func (m *MockGitProvider) GetRepositoryContext(repoContext gitprovider.GetReposi
 	return args.Get(0).(*gitprovider.GitRepository), args.Error(1)
 }
 
-func (m *MockGitProvider) GetUrlFromRepository(repository *gitprovider.GitRepository) string {
-	args := m.Called(repository)
+func (m *MockGitProvider) GetUrlFromContext(repoContext *gitprovider.GetRepositoryContext) string {
+	args := m.Called(repoContext)
 	return args.String(0)
 }
 

--- a/internal/util/env_vars.go
+++ b/internal/util/env_vars.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// MergeEnvVars merges multiple environment variables maps into one
+// and resolves environment variables that are referenced in the values.
+// If an environment variable is not found, a warning is logged.
+// The order of the maps is important. Latter maps will override
+// the values of the previous ones.
+func MergeEnvVars(envVars ...map[string]string) map[string]string {
+	vars := map[string]string{}
+
+	for _, env := range envVars {
+		for k, v := range env {
+			vars[k] = v
+		}
+	}
+
+	for k, v := range vars {
+		if strings.HasPrefix(v, "$") {
+			env, ok := os.LookupEnv(v[1:])
+			if ok {
+				vars[k] = env
+			} else {
+				log.Warnf("Environment variable %s not found", v[1:])
+			}
+		} else {
+			vars[k] = v
+		}
+	}
+
+	return vars
+}

--- a/pkg/api/controllers/build/build.go
+++ b/pkg/api/controllers/build/build.go
@@ -52,15 +52,12 @@ func CreateBuild(ctx *gin.Context) {
 	}
 
 	repo, err := gitProvider.GetRepositoryContext(gitprovider.GetRepositoryContext{
-		Url: projectConfig.RepositoryUrl,
+		Url:    projectConfig.RepositoryUrl,
+		Branch: &createBuildDto.Branch,
 	})
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get repository: %s", err.Error()))
 		return
-	}
-
-	if createBuildDto.Branch != nil {
-		repo.Branch = createBuildDto.Branch
 	}
 
 	newBuildDto := builds_dto.BuildCreationData{
@@ -68,7 +65,7 @@ func CreateBuild(ctx *gin.Context) {
 		User:        projectConfig.User,
 		BuildConfig: projectConfig.BuildConfig,
 		Repository:  repo,
-		EnvVars:     projectConfig.EnvVars,
+		EnvVars:     createBuildDto.EnvVars,
 	}
 
 	if createBuildDto.PrebuildId != nil {

--- a/pkg/api/controllers/build/dto/dto.go
+++ b/pkg/api/controllers/build/dto/dto.go
@@ -4,7 +4,8 @@
 package dto
 
 type CreateBuildDTO struct {
-	ProjectConfigName string  `json:"projectConfigName" validate:"required"`
-	Branch            *string `json:"branch" validate:"optional"`
-	PrebuildId        *string `json:"prebuildId" validate:"optional"`
+	ProjectConfigName string            `json:"projectConfigName" validate:"required"`
+	Branch            string            `json:"branch" validate:"required"`
+	PrebuildId        *string           `json:"prebuildId" validate:"optional"`
+	EnvVars           map[string]string `json:"envVars" validate:"required"`
 } // @name CreateBuildDTO

--- a/pkg/api/controllers/gitprovider/context.go
+++ b/pkg/api/controllers/gitprovider/context.go
@@ -60,21 +60,21 @@ func GetGitContext(ctx *gin.Context) {
 //
 //	@id				GetUrlFromRepository
 func GetUrlFromRepository(ctx *gin.Context) {
-	var gitRepository gitprovider.GitRepository
-	if err := ctx.ShouldBindJSON(&gitRepository); err != nil {
+	var repoContext gitprovider.GetRepositoryContext
+	if err := ctx.ShouldBindJSON(&repoContext); err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to bind json: %s", err.Error()))
 		return
 	}
 
 	server := server.GetInstance(nil)
 
-	gitProvider, _, err := server.GitProviderService.GetGitProviderForUrl(gitRepository.Url)
+	gitProvider, _, err := server.GitProviderService.GetGitProviderForUrl(repoContext.Url)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get git provider for url: %w", err))
 		return
 	}
 
-	url := gitProvider.GetUrlFromRepository(&gitRepository)
+	url := gitProvider.GetUrlFromContext(&repoContext)
 
 	response := dto.RepositoryUrl{
 		URL: url,

--- a/pkg/api/controllers/projectconfig/project_config.go
+++ b/pkg/api/controllers/projectconfig/project_config.go
@@ -77,6 +77,7 @@ func GetDefaultProjectConfig(ctx *gin.Context) {
 			statusCode = http.StatusNotFound
 		}
 		ctx.AbortWithError(statusCode, fmt.Errorf("failed to find project config by git url: %s", err.Error()))
+		return
 	}
 
 	ctx.JSON(200, projectConfigs)

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1713,6 +1713,7 @@ const docTemplate = `{
                 "id",
                 "image",
                 "prebuildId",
+                "repository",
                 "state",
                 "updatedAt",
                 "user"

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1812,11 +1812,19 @@ const docTemplate = `{
         "CreateBuildDTO": {
             "type": "object",
             "required": [
+                "branch",
+                "envVars",
                 "projectConfigName"
             ],
             "properties": {
                 "branch": {
                     "type": "string"
+                },
+                "envVars": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "prebuildId": {
                     "type": "string"
@@ -2129,6 +2137,7 @@ const docTemplate = `{
         "GitRepository": {
             "type": "object",
             "required": [
+                "branch",
                 "id",
                 "name",
                 "owner",

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1809,11 +1809,19 @@
         "CreateBuildDTO": {
             "type": "object",
             "required": [
+                "branch",
+                "envVars",
                 "projectConfigName"
             ],
             "properties": {
                 "branch": {
                     "type": "string"
+                },
+                "envVars": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "prebuildId": {
                     "type": "string"
@@ -2126,6 +2134,7 @@
         "GitRepository": {
             "type": "object",
             "required": [
+                "branch",
                 "id",
                 "name",
                 "owner",

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1710,6 +1710,7 @@
                 "id",
                 "image",
                 "prebuildId",
+                "repository",
                 "state",
                 "updatedAt",
                 "user"

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -90,11 +90,17 @@ definitions:
     properties:
       branch:
         type: string
+      envVars:
+        additionalProperties:
+          type: string
+        type: object
       prebuildId:
         type: string
       projectConfigName:
         type: string
     required:
+    - branch
+    - envVars
     - projectConfigName
     type: object
   CreatePrebuildDTO:
@@ -323,6 +329,7 @@ definitions:
       url:
         type: string
     required:
+    - branch
     - id
     - name
     - owner

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -44,6 +44,7 @@ definitions:
     - id
     - image
     - prebuildId
+    - repository
     - state
     - updatedAt
     - user

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1338,15 +1338,23 @@ components:
       example:
         prebuildId: prebuildId
         projectConfigName: projectConfigName
+        envVars:
+          key: envVars
         branch: branch
       properties:
         branch:
           type: string
+        envVars:
+          additionalProperties:
+            type: string
+          type: object
         prebuildId:
           type: string
         projectConfigName:
           type: string
       required:
+      - branch
+      - envVars
       - projectConfigName
       type: object
     CreatePrebuildDTO:
@@ -1734,6 +1742,7 @@ components:
         url:
           type: string
       required:
+      - branch
       - id
       - name
       - owner

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1279,6 +1279,7 @@ components:
       - id
       - image
       - prebuildId
+      - repository
       - state
       - updatedAt
       - user

--- a/pkg/apiclient/docs/Build.md
+++ b/pkg/apiclient/docs/Build.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **Id** | **string** |  | 
 **Image** | **string** |  | 
 **PrebuildId** | **string** |  | 
-**Repository** | Pointer to [**GitRepository**](GitRepository.md) |  | [optional] 
+**Repository** | [**GitRepository**](GitRepository.md) |  | 
 **State** | [**BuildBuildState**](BuildBuildState.md) |  | 
 **UpdatedAt** | **string** |  | 
 **User** | **string** |  | 
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 
 ### NewBuild
 
-`func NewBuild(createdAt string, envVars map[string]string, id string, image string, prebuildId string, state BuildBuildState, updatedAt string, user string, ) *Build`
+`func NewBuild(createdAt string, envVars map[string]string, id string, image string, prebuildId string, repository GitRepository, state BuildBuildState, updatedAt string, user string, ) *Build`
 
 NewBuild instantiates a new Build object
 This constructor will assign default values to properties that have it defined,
@@ -178,11 +178,6 @@ and a boolean to check if the value has been set.
 
 SetRepository sets Repository field to given value.
 
-### HasRepository
-
-`func (o *Build) HasRepository() bool`
-
-HasRepository returns a boolean if a field has been set.
 
 ### GetState
 

--- a/pkg/apiclient/docs/BuildAPI.md
+++ b/pkg/apiclient/docs/BuildAPI.md
@@ -34,7 +34,7 @@ import (
 )
 
 func main() {
-	createBuildDto := *openapiclient.NewCreateBuildDTO("ProjectConfigName_example") // CreateBuildDTO | Create Build DTO
+	createBuildDto := *openapiclient.NewCreateBuildDTO("Branch_example", map[string]string{"key": "Inner_example"}, "ProjectConfigName_example") // CreateBuildDTO | Create Build DTO
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/docs/CreateBuildDTO.md
+++ b/pkg/apiclient/docs/CreateBuildDTO.md
@@ -4,7 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Branch** | Pointer to **string** |  | [optional] 
+**Branch** | **string** |  | 
+**EnvVars** | **map[string]string** |  | 
 **PrebuildId** | Pointer to **string** |  | [optional] 
 **ProjectConfigName** | **string** |  | 
 
@@ -12,7 +13,7 @@ Name | Type | Description | Notes
 
 ### NewCreateBuildDTO
 
-`func NewCreateBuildDTO(projectConfigName string, ) *CreateBuildDTO`
+`func NewCreateBuildDTO(branch string, envVars map[string]string, projectConfigName string, ) *CreateBuildDTO`
 
 NewCreateBuildDTO instantiates a new CreateBuildDTO object
 This constructor will assign default values to properties that have it defined,
@@ -46,11 +47,26 @@ and a boolean to check if the value has been set.
 
 SetBranch sets Branch field to given value.
 
-### HasBranch
 
-`func (o *CreateBuildDTO) HasBranch() bool`
+### GetEnvVars
 
-HasBranch returns a boolean if a field has been set.
+`func (o *CreateBuildDTO) GetEnvVars() map[string]string`
+
+GetEnvVars returns the EnvVars field if non-nil, zero value otherwise.
+
+### GetEnvVarsOk
+
+`func (o *CreateBuildDTO) GetEnvVarsOk() (*map[string]string, bool)`
+
+GetEnvVarsOk returns a tuple with the EnvVars field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEnvVars
+
+`func (o *CreateBuildDTO) SetEnvVars(v map[string]string)`
+
+SetEnvVars sets EnvVars field to given value.
+
 
 ### GetPrebuildId
 

--- a/pkg/apiclient/docs/GitProviderAPI.md
+++ b/pkg/apiclient/docs/GitProviderAPI.md
@@ -611,7 +611,7 @@ import (
 )
 
 func main() {
-	repository := *openapiclient.NewGitRepository("Id_example", "Name_example", "Owner_example", "Sha_example", "Source_example", "Url_example") // GitRepository | Git repository
+	repository := *openapiclient.NewGitRepository("Branch_example", "Id_example", "Name_example", "Owner_example", "Sha_example", "Source_example", "Url_example") // GitRepository | Git repository
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/docs/GitRepository.md
+++ b/pkg/apiclient/docs/GitRepository.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Branch** | Pointer to **string** |  | [optional] 
+**Branch** | **string** |  | 
 **CloneTarget** | Pointer to [**CloneTarget**](CloneTarget.md) |  | [optional] 
 **Id** | **string** |  | 
 **Name** | **string** |  | 
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 
 ### NewGitRepository
 
-`func NewGitRepository(id string, name string, owner string, sha string, source string, url string, ) *GitRepository`
+`func NewGitRepository(branch string, id string, name string, owner string, sha string, source string, url string, ) *GitRepository`
 
 NewGitRepository instantiates a new GitRepository object
 This constructor will assign default values to properties that have it defined,
@@ -53,11 +53,6 @@ and a boolean to check if the value has been set.
 
 SetBranch sets Branch field to given value.
 
-### HasBranch
-
-`func (o *GitRepository) HasBranch() bool`
-
-HasBranch returns a boolean if a field has been set.
 
 ### GetCloneTarget
 

--- a/pkg/apiclient/docs/WorkspaceAPI.md
+++ b/pkg/apiclient/docs/WorkspaceAPI.md
@@ -37,7 +37,7 @@ import (
 )
 
 func main() {
-	workspace := *openapiclient.NewCreateWorkspaceDTO("Id_example", "Name_example", []openapiclient.CreateProjectDTO{*openapiclient.NewCreateProjectDTO(map[string]string{"key": "Inner_example"}, "Name_example", *openapiclient.NewCreateProjectSourceDTO(*openapiclient.NewGitRepository("Id_example", "Name_example", "Owner_example", "Sha_example", "Source_example", "Url_example")))}, "Target_example") // CreateWorkspaceDTO | Create workspace
+	workspace := *openapiclient.NewCreateWorkspaceDTO("Id_example", "Name_example", []openapiclient.CreateProjectDTO{*openapiclient.NewCreateProjectDTO(map[string]string{"key": "Inner_example"}, "Name_example", *openapiclient.NewCreateProjectSourceDTO(*openapiclient.NewGitRepository("Branch_example", "Id_example", "Name_example", "Owner_example", "Sha_example", "Source_example", "Url_example")))}, "Target_example") // CreateWorkspaceDTO | Create workspace
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/model_build.go
+++ b/pkg/apiclient/model_build.go
@@ -27,7 +27,7 @@ type Build struct {
 	Id          string            `json:"id"`
 	Image       string            `json:"image"`
 	PrebuildId  string            `json:"prebuildId"`
-	Repository  *GitRepository    `json:"repository,omitempty"`
+	Repository  GitRepository     `json:"repository"`
 	State       BuildBuildState   `json:"state"`
 	UpdatedAt   string            `json:"updatedAt"`
 	User        string            `json:"user"`
@@ -39,13 +39,14 @@ type _Build Build
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBuild(createdAt string, envVars map[string]string, id string, image string, prebuildId string, state BuildBuildState, updatedAt string, user string) *Build {
+func NewBuild(createdAt string, envVars map[string]string, id string, image string, prebuildId string, repository GitRepository, state BuildBuildState, updatedAt string, user string) *Build {
 	this := Build{}
 	this.CreatedAt = createdAt
 	this.EnvVars = envVars
 	this.Id = id
 	this.Image = image
 	this.PrebuildId = prebuildId
+	this.Repository = repository
 	this.State = state
 	this.UpdatedAt = updatedAt
 	this.User = user
@@ -212,36 +213,28 @@ func (o *Build) SetPrebuildId(v string) {
 	o.PrebuildId = v
 }
 
-// GetRepository returns the Repository field value if set, zero value otherwise.
+// GetRepository returns the Repository field value
 func (o *Build) GetRepository() GitRepository {
-	if o == nil || IsNil(o.Repository) {
+	if o == nil {
 		var ret GitRepository
 		return ret
 	}
-	return *o.Repository
+
+	return o.Repository
 }
 
-// GetRepositoryOk returns a tuple with the Repository field value if set, nil otherwise
+// GetRepositoryOk returns a tuple with the Repository field value
 // and a boolean to check if the value has been set.
 func (o *Build) GetRepositoryOk() (*GitRepository, bool) {
-	if o == nil || IsNil(o.Repository) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Repository, true
+	return &o.Repository, true
 }
 
-// HasRepository returns a boolean if a field has been set.
-func (o *Build) HasRepository() bool {
-	if o != nil && !IsNil(o.Repository) {
-		return true
-	}
-
-	return false
-}
-
-// SetRepository gets a reference to the given GitRepository and assigns it to the Repository field.
+// SetRepository sets field value
 func (o *Build) SetRepository(v GitRepository) {
-	o.Repository = &v
+	o.Repository = v
 }
 
 // GetState returns the State field value
@@ -334,9 +327,7 @@ func (o Build) ToMap() (map[string]interface{}, error) {
 	toSerialize["id"] = o.Id
 	toSerialize["image"] = o.Image
 	toSerialize["prebuildId"] = o.PrebuildId
-	if !IsNil(o.Repository) {
-		toSerialize["repository"] = o.Repository
-	}
+	toSerialize["repository"] = o.Repository
 	toSerialize["state"] = o.State
 	toSerialize["updatedAt"] = o.UpdatedAt
 	toSerialize["user"] = o.User
@@ -353,6 +344,7 @@ func (o *Build) UnmarshalJSON(data []byte) (err error) {
 		"id",
 		"image",
 		"prebuildId",
+		"repository",
 		"state",
 		"updatedAt",
 		"user",

--- a/pkg/apiclient/model_create_build_dto.go
+++ b/pkg/apiclient/model_create_build_dto.go
@@ -21,9 +21,10 @@ var _ MappedNullable = &CreateBuildDTO{}
 
 // CreateBuildDTO struct for CreateBuildDTO
 type CreateBuildDTO struct {
-	Branch            *string `json:"branch,omitempty"`
-	PrebuildId        *string `json:"prebuildId,omitempty"`
-	ProjectConfigName string  `json:"projectConfigName"`
+	Branch            string            `json:"branch"`
+	EnvVars           map[string]string `json:"envVars"`
+	PrebuildId        *string           `json:"prebuildId,omitempty"`
+	ProjectConfigName string            `json:"projectConfigName"`
 }
 
 type _CreateBuildDTO CreateBuildDTO
@@ -32,8 +33,10 @@ type _CreateBuildDTO CreateBuildDTO
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCreateBuildDTO(projectConfigName string) *CreateBuildDTO {
+func NewCreateBuildDTO(branch string, envVars map[string]string, projectConfigName string) *CreateBuildDTO {
 	this := CreateBuildDTO{}
+	this.Branch = branch
+	this.EnvVars = envVars
 	this.ProjectConfigName = projectConfigName
 	return &this
 }
@@ -46,36 +49,52 @@ func NewCreateBuildDTOWithDefaults() *CreateBuildDTO {
 	return &this
 }
 
-// GetBranch returns the Branch field value if set, zero value otherwise.
+// GetBranch returns the Branch field value
 func (o *CreateBuildDTO) GetBranch() string {
-	if o == nil || IsNil(o.Branch) {
+	if o == nil {
 		var ret string
 		return ret
 	}
-	return *o.Branch
+
+	return o.Branch
 }
 
-// GetBranchOk returns a tuple with the Branch field value if set, nil otherwise
+// GetBranchOk returns a tuple with the Branch field value
 // and a boolean to check if the value has been set.
 func (o *CreateBuildDTO) GetBranchOk() (*string, bool) {
-	if o == nil || IsNil(o.Branch) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Branch, true
+	return &o.Branch, true
 }
 
-// HasBranch returns a boolean if a field has been set.
-func (o *CreateBuildDTO) HasBranch() bool {
-	if o != nil && !IsNil(o.Branch) {
-		return true
+// SetBranch sets field value
+func (o *CreateBuildDTO) SetBranch(v string) {
+	o.Branch = v
+}
+
+// GetEnvVars returns the EnvVars field value
+func (o *CreateBuildDTO) GetEnvVars() map[string]string {
+	if o == nil {
+		var ret map[string]string
+		return ret
 	}
 
-	return false
+	return o.EnvVars
 }
 
-// SetBranch gets a reference to the given string and assigns it to the Branch field.
-func (o *CreateBuildDTO) SetBranch(v string) {
-	o.Branch = &v
+// GetEnvVarsOk returns a tuple with the EnvVars field value
+// and a boolean to check if the value has been set.
+func (o *CreateBuildDTO) GetEnvVarsOk() (*map[string]string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.EnvVars, true
+}
+
+// SetEnvVars sets field value
+func (o *CreateBuildDTO) SetEnvVars(v map[string]string) {
+	o.EnvVars = v
 }
 
 // GetPrebuildId returns the PrebuildId field value if set, zero value otherwise.
@@ -144,9 +163,8 @@ func (o CreateBuildDTO) MarshalJSON() ([]byte, error) {
 
 func (o CreateBuildDTO) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Branch) {
-		toSerialize["branch"] = o.Branch
-	}
+	toSerialize["branch"] = o.Branch
+	toSerialize["envVars"] = o.EnvVars
 	if !IsNil(o.PrebuildId) {
 		toSerialize["prebuildId"] = o.PrebuildId
 	}
@@ -159,6 +177,8 @@ func (o *CreateBuildDTO) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
+		"branch",
+		"envVars",
 		"projectConfigName",
 	}
 

--- a/pkg/apiclient/model_git_repository.go
+++ b/pkg/apiclient/model_git_repository.go
@@ -21,7 +21,7 @@ var _ MappedNullable = &GitRepository{}
 
 // GitRepository struct for GitRepository
 type GitRepository struct {
-	Branch      *string      `json:"branch,omitempty"`
+	Branch      string       `json:"branch"`
 	CloneTarget *CloneTarget `json:"cloneTarget,omitempty"`
 	Id          string       `json:"id"`
 	Name        string       `json:"name"`
@@ -39,8 +39,9 @@ type _GitRepository GitRepository
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewGitRepository(id string, name string, owner string, sha string, source string, url string) *GitRepository {
+func NewGitRepository(branch string, id string, name string, owner string, sha string, source string, url string) *GitRepository {
 	this := GitRepository{}
+	this.Branch = branch
 	this.Id = id
 	this.Name = name
 	this.Owner = owner
@@ -58,36 +59,28 @@ func NewGitRepositoryWithDefaults() *GitRepository {
 	return &this
 }
 
-// GetBranch returns the Branch field value if set, zero value otherwise.
+// GetBranch returns the Branch field value
 func (o *GitRepository) GetBranch() string {
-	if o == nil || IsNil(o.Branch) {
+	if o == nil {
 		var ret string
 		return ret
 	}
-	return *o.Branch
+
+	return o.Branch
 }
 
-// GetBranchOk returns a tuple with the Branch field value if set, nil otherwise
+// GetBranchOk returns a tuple with the Branch field value
 // and a boolean to check if the value has been set.
 func (o *GitRepository) GetBranchOk() (*string, bool) {
-	if o == nil || IsNil(o.Branch) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Branch, true
+	return &o.Branch, true
 }
 
-// HasBranch returns a boolean if a field has been set.
-func (o *GitRepository) HasBranch() bool {
-	if o != nil && !IsNil(o.Branch) {
-		return true
-	}
-
-	return false
-}
-
-// SetBranch gets a reference to the given string and assigns it to the Branch field.
+// SetBranch sets field value
 func (o *GitRepository) SetBranch(v string) {
-	o.Branch = &v
+	o.Branch = v
 }
 
 // GetCloneTarget returns the CloneTarget field value if set, zero value otherwise.
@@ -340,9 +333,7 @@ func (o GitRepository) MarshalJSON() ([]byte, error) {
 
 func (o GitRepository) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Branch) {
-		toSerialize["branch"] = o.Branch
-	}
+	toSerialize["branch"] = o.Branch
 	if !IsNil(o.CloneTarget) {
 		toSerialize["cloneTarget"] = o.CloneTarget
 	}
@@ -366,6 +357,7 @@ func (o *GitRepository) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
+		"branch",
 		"id",
 		"name",
 		"owner",

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,7 +30,7 @@ type Build struct {
 	Image       string                     `json:"image" validate:"required"`
 	User        string                     `json:"user" validate:"required"`
 	BuildConfig *buildconfig.BuildConfig   `json:"buildConfig" validate:"optional"`
-	Repository  *gitprovider.GitRepository `json:"repository" validate:"optional"`
+	Repository  *gitprovider.GitRepository `json:"repository" validate:"required"`
 	EnvVars     map[string]string          `json:"envVars" validate:"required"`
 	PrebuildId  string                     `json:"prebuildId" validate:"required"`
 	CreatedAt   time.Time                  `json:"createdAt" validate:"required"`

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -77,11 +77,8 @@ func (b *Build) GetBuildHash() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var branch string
-	if b.Repository != nil && b.Repository.Branch != nil {
-		branch = *b.Repository.Branch
-	}
-	data := string(buildJson) + b.Repository.Url + branch + string(envVarsJson)
+
+	data := string(buildJson) + b.Repository.Url + b.Repository.Branch + string(envVarsJson)
 	hash := sha256.Sum256([]byte(data))
 	hashStr := hex.EncodeToString(hash[:])
 	return hashStr, nil
@@ -96,12 +93,7 @@ func (b *Build) getBuildHashWithoutBuildConfig() (string, error) {
 		return "", err
 	}
 
-	var branch string
-	if b.Repository != nil && b.Repository.Branch != nil {
-		branch = *b.Repository.Branch
-	}
-
-	data := branch + b.Repository.Url + string(envVarsJson)
+	data := b.Repository.Branch + b.Repository.Url + string(envVarsJson)
 	hash := sha256.Sum256([]byte(data))
 	hashStr := hex.EncodeToString(hash[:])
 

--- a/pkg/build/devcontainer.go
+++ b/pkg/build/devcontainer.go
@@ -83,6 +83,7 @@ func (b *DevcontainerBuilder) buildDevcontainer(build Build) (string, string, er
 		},
 		ProjectDir: b.projectDir,
 		LogWriter:  buildLogger,
+		EnvVars:    build.EnvVars,
 	})
 	if err != nil {
 		return b.defaultProjectImage, b.defaultProjectUser, err

--- a/pkg/build/factory.go
+++ b/pkg/build/factory.go
@@ -55,12 +55,12 @@ func (f *BuilderFactory) Create(build Build, projectDir string) (IBuilder, error
 }
 
 func (f *BuilderFactory) CheckExistingBuild(b Build) (*Build, error) {
-	if b.Repository == nil || b.Repository.Branch == nil {
-		return nil, fmt.Errorf("repository and branch must be set")
+	if b.Repository == nil {
+		return nil, fmt.Errorf("repository must be set")
 	}
 
 	build, err := f.buildStore.Find(&Filter{
-		Branch:        b.Repository.Branch,
+		Branch:        &b.Repository.Branch,
 		RepositoryUrl: &b.Repository.Url,
 		BuildConfig:   b.BuildConfig,
 		EnvVars:       &b.EnvVars,

--- a/pkg/cmd/prebuild/update.go
+++ b/pkg/cmd/prebuild/update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/cmd/build"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/prebuild/add"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
@@ -126,13 +127,14 @@ var prebuildUpdateCmd = &cobra.Command{
 		views.RenderInfoMessage("Prebuild updated successfully")
 
 		if prebuildAddView.RunBuildOnAdd {
-			buildId, res, err := apiClient.BuildAPI.CreateBuild(ctx).CreateBuildDto(apiclient.CreateBuildDTO{
-				ProjectConfigName: prebuildAddView.ProjectConfigName,
-				Branch:            &prebuildAddView.Branch,
-				PrebuildId:        &prebuildId,
-			}).Execute()
+			projectConfig, res, err := apiClient.ProjectConfigAPI.GetProjectConfig(ctx, prebuildAddView.ProjectConfigName).Execute()
 			if err != nil {
 				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			}
+
+			buildId, err := build.CreateBuild(apiClient, projectConfig, *newPrebuild.Branch, &prebuildId)
+			if err != nil {
+				log.Fatal(err)
 			}
 
 			views.RenderViewBuildLogsMessage(buildId)

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -124,9 +124,8 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 		Image:         createDtos[0].Image,
 		User:          createDtos[0].User,
 		RepositoryUrl: createDtos[0].Source.Repository.Url,
+		EnvVars:       createDtos[0].EnvVars,
 	}
-
-	newProjectConfig.EnvVars = *workspace_util.GetEnvVariables(createDtos[0].EnvVars, nil)
 
 	res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()
 	if err != nil {

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -9,7 +9,6 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
-	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
@@ -86,9 +85,8 @@ var projectConfigUpdateCmd = &cobra.Command{
 			Image:         createDto[0].Image,
 			User:          createDto[0].User,
 			RepositoryUrl: createDto[0].Source.Repository.Url,
+			EnvVars:       createDto[0].EnvVars,
 		}
-
-		newProjectConfig.EnvVars = *workspace_util.GetEnvVariables(createDto[0].EnvVars, nil)
 
 		res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()
 		if err != nil {

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -107,7 +107,11 @@ var CreateCmd = &cobra.Command{
 
 		projectNames := []string{}
 		for i := range projects {
-			projects[i].EnvVars = *workspace_util.GetEnvVariables(projects[i].EnvVars, profileData)
+			if profileData != nil && profileData.EnvVars != nil {
+				projects[i].EnvVars = util.MergeEnvVars(profileData.EnvVars, projects[i].EnvVars)
+			} else {
+				projects[i].EnvVars = util.MergeEnvVars(projects[i].EnvVars)
+			}
 			projectNames = append(projectNames, projects[i].Name)
 		}
 

--- a/pkg/cmd/workspace/util/add_from_config.go
+++ b/pkg/cmd/workspace/util/add_from_config.go
@@ -8,6 +8,7 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/common"
 )
 
 func AddProjectFromConfig(projectConfig *apiclient.ProjectConfig, apiClient *apiclient.APIClient, projects *[]apiclient.CreateProjectDTO, branchFlag string) (*string, error) {
@@ -18,9 +19,11 @@ func AddProjectFromConfig(projectConfig *apiclient.ProjectConfig, apiClient *api
 		if err != nil {
 			return nil, err
 		}
-		if chosenBranch != nil {
-			chosenBranchName = chosenBranch.Name
+		if chosenBranch == nil {
+			return nil, common.ErrCtrlCAbort
 		}
+
+		chosenBranchName = chosenBranch.Name
 	}
 
 	configRepo, res, err := apiClient.GitProviderAPI.GetGitContext(context.Background()).Repository(apiclient.GetRepositoryContext{

--- a/pkg/db/dto/project.go
+++ b/pkg/db/dto/project.go
@@ -16,7 +16,7 @@ type RepositoryDTO struct {
 	Owner    string                  `json:"owner"`
 	Sha      string                  `json:"sha"`
 	Source   string                  `json:"source"`
-	Branch   *string                 `json:"branch,omitempty"`
+	Branch   string                  `json:"branch"`
 	PrNumber *uint32                 `json:"prNumber,omitempty"`
 	Path     *string                 `json:"path,omitempty"`
 	Target   gitprovider.CloneTarget `json:"cloneTarget,omitempty"`

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -68,9 +68,7 @@ func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.Ba
 		capability.ThinPack,
 	}
 
-	if repo.Branch != nil {
-		cloneOptions.ReferenceName = plumbing.ReferenceName("refs/heads/" + *repo.Branch)
-	}
+	cloneOptions.ReferenceName = plumbing.ReferenceName("refs/heads/" + repo.Branch)
 
 	_, err := git.PlainClone(s.ProjectDir, false, cloneOptions)
 	if err != nil {
@@ -100,11 +98,7 @@ func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.Ba
 }
 
 func (s *Service) CloneRepositoryCmd(repo *gitprovider.GitRepository, auth *http.BasicAuth) []string {
-	cloneCmd := []string{"git", "clone", "--single-branch"}
-
-	if repo.Branch != nil {
-		cloneCmd = append(cloneCmd, "--branch", *repo.Branch)
-	}
+	cloneCmd := []string{"git", "clone", "--single-branch", "--branch", repo.Branch}
 
 	if auth != nil {
 		repoUrl := strings.TrimPrefix(repo.Url, "https://")

--- a/pkg/gitprovider/aws-codecommit_test.go
+++ b/pkg/gitprovider/aws-codecommit_test.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -35,7 +36,7 @@ func (g *AwsCodeCommitGitProviderTestSuite) TestParseStaticGitContext_PR() {
 		Sha:      nil,
 		Source:   "ap-south-1.console.aws.amazon.com",
 		Path:     nil,
-		PrNumber: &[]uint32{1}[0],
+		PrNumber: util.Pointer(uint32(1)),
 	}
 
 	require := g.Require()
@@ -52,7 +53,7 @@ func (g *AwsCodeCommitGitProviderTestSuite) TestParseStaticGitContext_Files() {
 		Name:     "Test",
 		Owner:    "Test",
 		Url:      "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/Test",
-		Branch:   &[]string{"main"}[0],
+		Branch:   util.Pointer("main"),
 		Sha:      nil,
 		Source:   "ap-south-1.console.aws.amazon.com",
 		Path:     &branchpath,
@@ -72,7 +73,7 @@ func (g *AwsCodeCommitGitProviderTestSuite) TestParseStaticGitContext_Branch() {
 		Name:     "Test",
 		Owner:    "Test",
 		Url:      "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/Test",
-		Branch:   &[]string{"test2"}[0],
+		Branch:   util.Pointer("test2"),
 		Source:   "ap-south-1.console.aws.amazon.com",
 		Sha:      nil,
 		PrNumber: nil,
@@ -92,7 +93,7 @@ func (g *AwsCodeCommitGitProviderTestSuite) TestParseStaticGitContext_Commits() 
 		Name:     "Test",
 		Owner:    "Test",
 		Url:      "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/Test",
-		Branch:   &[]string{"main"}[0],
+		Branch:   util.Pointer("main"),
 		Source:   "ap-south-1.console.aws.amazon.com",
 		Sha:      nil,
 		Path:     nil,
@@ -114,8 +115,8 @@ func (g *AwsCodeCommitGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 		Owner:    "Test",
 		Url:      "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/Test",
 		Source:   "ap-south-1.console.aws.amazon.com",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		Path:     nil,
 		PrNumber: nil,
 	}
@@ -127,83 +128,76 @@ func (g *AwsCodeCommitGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 }
 
 func (g *AwsCodeCommitGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "demorepo",
-		Name:   "demorepo",
-		Owner:  "demorepo",
-		Source: "ap-south-1.console.aws.amazon.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("demorepo"),
+		Name:   util.Pointer("demorepo"),
+		Owner:  util.Pointer("demorepo"),
+		Source: util.Pointer("ap-south-1.console.aws.amazon.com"),
 		Url:    "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/demorepo",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/demorepo/browse", url)
 }
 
 func (g *AwsCodeCommitGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "demorepo",
-		Name:   "demorepo",
-		Owner:  "demorepo",
-		Source: "ap-south-1.console.aws.amazon.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("demorepo"),
+		Name:   util.Pointer("demorepo"),
+		Owner:  util.Pointer("demorepo"),
+		Source: util.Pointer("ap-south-1.console.aws.amazon.com"),
 		Url:    "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/demorepo",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/demorepo/browse/refs/heads/test-branch", url)
 }
 
 func (g *AwsCodeCommitGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "demorepo",
-		Name:   "demorepo",
-		Owner:  "demorepo",
-		Source: "ap-south-1.console.aws.amazon.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("demorepo"),
+		Name:   util.Pointer("demorepo"),
+		Owner:  util.Pointer("demorepo"),
+		Source: util.Pointer("ap-south-1.console.aws.amazon.com"),
 		Url:    "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/demorepo",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/demorepo/browse/refs/heads/test-branch/--/README.md", url)
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/demorepo/browse/refs/heads/main/--/README.md", url)
 }
 
 func (g *AwsCodeCommitGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "demorepo",
-		Name:   "demorepo",
-		Owner:  "demorepo",
-		Source: "ap-south-1.console.aws.amazon.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("demorepo"),
+		Name:   util.Pointer("demorepo"),
+		Owner:  util.Pointer("demorepo"),
+		Source: util.Pointer("ap-south-1.console.aws.amazon.com"),
 		Url:    "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/demorepo",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Branch: util.Pointer("COMMIT_SHA"),
+		Sha:    util.Pointer("COMMIT_SHA"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
-
-	require.Equal("https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/demorepo/commit/COMMIT_SHA", url)
-
-	repo.Path = nil
-
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/demorepo/commit/COMMIT_SHA", url)
 }

--- a/pkg/gitprovider/azure-devops.go
+++ b/pkg/gitprovider/azure-devops.go
@@ -90,7 +90,7 @@ func (g *AzureDevOpsGitProvider) GetRepositories(namespace string) ([]*GitReposi
 		gitRepo := &GitRepository{
 			Id:     repo.Id.String(),
 			Name:   *repo.Name,
-			Branch: &defaultBranch,
+			Branch: defaultBranch,
 			Url:    *repo.WebUrl,
 			Source: u.Host,
 		}
@@ -315,28 +315,30 @@ func (g *AzureDevOpsGitProvider) GetBranchByCommit(staticContext *StaticGitConte
 	return branchName, nil
 }
 
-func (g *AzureDevOpsGitProvider) GetUrlFromRepository(repo *GitRepository) string {
-	url := strings.TrimSuffix(repo.Url, ".git")
-	url = strings.TrimSuffix(url, repo.Name)
-	url += "_git/" + repo.Name
+func (g *AzureDevOpsGitProvider) GetUrlFromContext(repoContext *GetRepositoryContext) string {
+	url := strings.TrimSuffix(repoContext.Url, ".git")
+	if repoContext.Name != nil {
+		url = strings.TrimSuffix(url, *repoContext.Name)
+		url += "_git/" + *repoContext.Name
+	}
 	query := ""
 
-	if repo.Branch != nil && *repo.Branch != "" {
-		if repo.Sha == *repo.Branch {
-			query += "version=GC" + *repo.Branch
+	if repoContext.Branch != nil && *repoContext.Branch != "" {
+		if repoContext.Sha != nil && *repoContext.Sha == *repoContext.Branch {
+			query += "version=GC" + *repoContext.Branch
 		} else {
-			query += "version=GB" + *repo.Branch
+			query += "version=GB" + *repoContext.Branch
 		}
 
-		if repo.Path != nil && *repo.Path != "" {
+		if repoContext.Path != nil && *repoContext.Path != "" {
 			if query != "" {
 				query += "&"
 			}
 
-			query += "path=" + *repo.Path
+			query += "path=" + *repoContext.Path
 		}
-	} else if repo.Path != nil {
-		query = "version=GBmain&path=" + *repo.Path
+	} else if repoContext.Path != nil {
+		query = "version=GBmain&path=" + *repoContext.Path
 	} else {
 		url = strings.Replace(url, "/_git", "", 1)
 	}

--- a/pkg/gitprovider/azure-devops_test.go
+++ b/pkg/gitprovider/azure-devops_test.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -27,7 +28,7 @@ func TestAzureDevopsGitProvider(t *testing.T) {
 func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prUrl := "https://dev.azure.com/dotslashtarun/dot-1/_git/dot-1/pullrequest/4"
 	prContext := &StaticGitContext{
-		PrNumber: &[]uint32{4}[0],
+		PrNumber: util.Pointer(uint32(4)),
 		Source:   "dev.azure.com",
 		Owner:    "dotslashtarun",
 		Name:     "dot-1",
@@ -54,7 +55,7 @@ func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_Branch() {
 		Owner:    "dotslashtarun",
 		Url:      "https://dev.azure.com/dotslashtarun/dot-1/_git/dot-1",
 		Source:   "dev.azure.com",
-		Branch:   &[]string{"main"}[0],
+		Branch:   util.Pointer("main"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -76,8 +77,8 @@ func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 		Owner:    "dotslashtarun",
 		Url:      "https://dev.azure.com/dotslashtarun/dot-1/_git/dot-1",
 		Source:   "dev.azure.com",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -98,7 +99,7 @@ func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_Commits() {
 		Owner:    "dotslashtarun",
 		Url:      "https://dev.azure.com/dotslashtarun/dot-1/_git/dot-1",
 		Source:   "dev.azure.com",
-		Branch:   &[]string{"testbranch"}[0],
+		Branch:   util.Pointer("testbranch"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -123,7 +124,7 @@ func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 		Branch:   nil,
 		Sha:      nil,
 		PrNumber: nil,
-		Path:     &[]string{"README.md"}[0],
+		Path:     util.Pointer("README.md"),
 	}
 
 	require := g.Require()
@@ -135,83 +136,83 @@ func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 }
 
 func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "dev.azure.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("dev.azure.com"),
 		Url:    "https://dev.azure.com/daytonaio/daytona.git",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://dev.azure.com/daytonaio/daytona", url)
 }
 
 func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "dev.azure.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("dev.azure.com"),
 		Url:    "https://dev.azure.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GBtest-branch", url)
 }
 
 func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "dev.azure.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("dev.azure.com"),
 		Url:    "https://dev.azure.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GBtest-branch&path=README.md", url)
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GBmain&path=README.md", url)
 }
 
 func (g *AzureDevOpsGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "dev.azure.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("dev.azure.com"),
 		Url:    "https://dev.azure.com/daytonaio/daytona.git",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Branch: util.Pointer("COMMIT_SHA"),
+		Sha:    util.Pointer("COMMIT_SHA"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GCCOMMIT_SHA&path=README.md", url)
 
 	repo.Path = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://dev.azure.com/daytonaio/_git/daytona?version=GCCOMMIT_SHA", url)
 }

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -339,19 +339,19 @@ func (g *BitbucketGitProvider) GetBranchByCommit(staticContext *StaticGitContext
 	return branchName, nil
 }
 
-func (g *BitbucketGitProvider) GetUrlFromRepository(repository *GitRepository) string {
-	url := strings.TrimSuffix(repository.Url, ".git")
+func (g *BitbucketGitProvider) GetUrlFromContext(repoContext *GetRepositoryContext) string {
+	url := strings.TrimSuffix(repoContext.Url, ".git")
 
-	if repository.Branch != nil && *repository.Branch != "" {
-		if repository.Path != nil {
-			url += "/src/" + *repository.Branch + "/" + *repository.Path
-		} else if repository.Sha == *repository.Branch {
-			url += "/commit/" + *repository.Branch
+	if repoContext.Branch != nil && *repoContext.Branch != "" {
+		if repoContext.Path != nil {
+			url += "/src/" + *repoContext.Branch + "/" + *repoContext.Path
+		} else if repoContext.Sha != nil && *repoContext.Sha == *repoContext.Branch {
+			url += "/commit/" + *repoContext.Branch
 		} else {
-			url += "/branch/" + *repository.Branch
+			url += "/branch/" + *repoContext.Branch
 		}
-	} else if repository.Path != nil {
-		url += "/src/main/" + *repository.Path
+	} else if repoContext.Path != nil {
+		url += "/src/main/" + *repoContext.Path
 	}
 
 	return url

--- a/pkg/gitprovider/bitbucket_test.go
+++ b/pkg/gitprovider/bitbucket_test.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -30,7 +31,7 @@ func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_PR() {
 		Source:   "bitbucket.org",
 		Branch:   nil,
 		Sha:      nil,
-		PrNumber: &[]uint32{1}[0],
+		PrNumber: util.Pointer(uint32(1)),
 		Path:     nil,
 	}
 
@@ -50,10 +51,10 @@ func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 		Owner:    "atlassian",
 		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
 		Source:   "bitbucket.org",
-		Branch:   &[]string{"master"}[0],
+		Branch:   util.Pointer("master"),
 		Sha:      nil,
 		PrNumber: nil,
-		Path:     &[]string{"README.md"}[0],
+		Path:     util.Pointer("README.md"),
 	}
 
 	require := b.Require()
@@ -72,7 +73,7 @@ func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Branch() {
 		Owner:    "atlassian",
 		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
 		Source:   "bitbucket.org",
-		Branch:   &[]string{"master"}[0],
+		Branch:   util.Pointer("master"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -94,7 +95,7 @@ func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Commits() {
 		Owner:    "atlassian",
 		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
 		Source:   "bitbucket.org",
-		Branch:   &[]string{"master"}[0],
+		Branch:   util.Pointer("master"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -116,8 +117,8 @@ func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 		Owner:    "atlassian",
 		Url:      "https://bitbucket.org/atlassian/bitbucket-upload-file.git",
 		Source:   "bitbucket.org",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -131,83 +132,83 @@ func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 }
 
 func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.org",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.org"),
 		Url:    "https://bitbucket.org/daytonaio/daytona.git",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.org/daytonaio/daytona", url)
 }
 
 func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.org",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.org"),
 		Url:    "https://bitbucket.org/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.org/daytonaio/daytona/branch/test-branch", url)
 }
 
 func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.org",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.org"),
 		Url:    "https://bitbucket.org/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.org/daytonaio/daytona/src/test-branch/README.md", url)
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.org/daytonaio/daytona/src/main/README.md", url)
 }
 
 func (g *BitbucketGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.org",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.org"),
 		Url:    "https://bitbucket.org/daytonaio/daytona.git",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Branch: util.Pointer("COMMIT_SHA"),
+		Sha:    util.Pointer("COMMIT_SHA"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.org/daytonaio/daytona/src/COMMIT_SHA/README.md", url)
 
 	repo.Path = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.org/daytonaio/daytona/commit/COMMIT_SHA", url)
 }

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -362,18 +362,18 @@ func (g *BitbucketServerGitProvider) GetBranchByCommit(staticContext *StaticGitC
 	return branchName, nil
 }
 
-func (g *BitbucketServerGitProvider) GetUrlFromRepository(repository *GitRepository) string {
-	url := strings.TrimSuffix(repository.Url, ".git")
+func (g *BitbucketServerGitProvider) GetUrlFromContext(repoContext *GetRepositoryContext) string {
+	url := strings.TrimSuffix(repoContext.Url, ".git")
 	url = strings.Replace(url, "/scm/", "/", 1)
 
-	if repository.Branch != nil && *repository.Branch != "" {
-		url += "/src/" + *repository.Branch
+	if repoContext.Branch != nil && *repoContext.Branch != "" {
+		url += "/src/" + *repoContext.Branch
 
-		if repository.Path != nil && *repository.Path != "" {
-			url += "/" + *repository.Path
+		if repoContext.Path != nil && *repoContext.Path != "" {
+			url += "/" + *repoContext.Path
 		}
-	} else if repository.Path != nil && *repository.Path != "" {
-		url += "/src/main/" + *repository.Path
+	} else if repoContext.Path != nil && *repoContext.Path != "" {
+		url += "/src/main/" + *repoContext.Path
 	}
 
 	return url

--- a/pkg/gitprovider/bitbucketserver_test.go
+++ b/pkg/gitprovider/bitbucketserver_test.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -23,7 +24,6 @@ func NewBitbucketServerGitProviderTestSuite() *BitbucketServerGitProviderTestSui
 
 func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prUrl := "https://bitbucket.example.com/rest/api/latest/projects/PROJECT_KEY/repos/REPO_NAME/pull-requests/1"
-	prNumber := uint32(1)
 	prContext := &StaticGitContext{
 		Id:       "PROJECT_KEY",
 		Name:     "REPO_NAME",
@@ -32,7 +32,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_PR() {
 		Source:   "bitbucket.example.com",
 		Branch:   nil,
 		Sha:      nil,
-		PrNumber: &prNumber,
+		PrNumber: util.Pointer(uint32(1)),
 		Path:     nil,
 	}
 
@@ -55,7 +55,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 		Branch:   nil,
 		Sha:      nil,
 		PrNumber: nil,
-		Path:     &[]string{"README.md"}[0],
+		Path:     util.Pointer("README.md"),
 	}
 
 	require := b.Require()
@@ -74,7 +74,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Branch()
 		Owner:    "PROJECT_KEY",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
-		Branch:   &[]string{"main"}[0],
+		Branch:   util.Pointer("main"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -96,8 +96,8 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Commits(
 		Owner:    "PROJECT_KEY",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -118,8 +118,8 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Commit()
 		Owner:    "PROJECT_KEY",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -141,8 +141,8 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Repo_Url
 		Owner:    "PROJECT_KEY",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -156,83 +156,82 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Repo_Url
 }
 
 func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.example.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.example.com"),
 		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.example.com/daytonaio/daytona", url)
 }
 
 func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.example.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.example.com"),
 		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/test-branch", url)
 }
 
 func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.example.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.example.com"),
 		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/test-branch/README.md", url)
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/main/README.md", url)
 }
 
 func (g *BitbucketServerGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "bitbucket.example.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("bitbucket.example.com"),
 		Url:    "https://bitbucket.example.com/scm/daytonaio/daytona.git",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Branch: util.Pointer("COMMIT_SHA"),
+		Sha:    util.Pointer("COMMIT_SHA"),
+		Path:   util.Pointer("README.md"),
 	}
-
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/COMMIT_SHA/README.md", url)
 
 	repo.Path = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://bitbucket.example.com/daytonaio/daytona/src/COMMIT_SHA", url)
 }

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -46,7 +46,7 @@ type GitProvider interface {
 	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)
 
 	GetRepositoryContext(repoContext GetRepositoryContext) (*GitRepository, error)
-	GetUrlFromRepository(repository *GitRepository) string
+	GetUrlFromContext(repoContext *GetRepositoryContext) string
 	GetLastCommitSha(staticContext *StaticGitContext) (string, error)
 	GetBranchByCommit(staticContext *StaticGitContext) (string, error)
 	GetPrContext(staticContext *StaticGitContext) (*StaticGitContext, error)
@@ -116,7 +116,7 @@ func (a *AbstractGitProvider) GetRepositoryContext(repoContext GetRepositoryCont
 		Id:       staticContext.Id,
 		Name:     staticContext.Name,
 		Url:      staticContext.Url,
-		Branch:   staticContext.Branch,
+		Branch:   *staticContext.Branch,
 		Sha:      *staticContext.Sha,
 		Owner:    staticContext.Owner,
 		PrNumber: staticContext.PrNumber,

--- a/pkg/gitprovider/gitea.go
+++ b/pkg/gitprovider/gitea.go
@@ -108,7 +108,7 @@ func (g *GiteaGitProvider) GetRepositories(namespace string) ([]*GitRepository, 
 			Id:     repo.Name,
 			Name:   repo.Name,
 			Url:    repo.HTMLURL,
-			Branch: &repo.DefaultBranch,
+			Branch: repo.DefaultBranch,
 			Owner:  repo.Owner.UserName,
 			Source: u.Host,
 		})
@@ -312,21 +312,21 @@ func (g *GiteaGitProvider) getApiClient() (*gitea.Client, error) {
 	return gitea.NewClient(g.baseApiUrl, options...)
 }
 
-func (g *GiteaGitProvider) GetUrlFromRepository(repository *GitRepository) string {
-	url := strings.TrimSuffix(repository.Url, ".git")
+func (g *GiteaGitProvider) GetUrlFromContext(repoContext *GetRepositoryContext) string {
+	url := strings.TrimSuffix(repoContext.Url, ".git")
 
-	if repository.Branch != nil && *repository.Branch != "" {
-		if repository.Sha == *repository.Branch {
-			url += "/src/commit/" + *repository.Branch
+	if repoContext.Branch != nil && *repoContext.Branch != "" {
+		if repoContext.Sha != nil && *repoContext.Sha == *repoContext.Branch {
+			url += "/src/commit/" + *repoContext.Branch
 		} else {
-			url += "/src/branch/" + *repository.Branch
+			url += "/src/branch/" + *repoContext.Branch
 		}
 
-		if repository.Path != nil && *repository.Path != "" {
-			url += "/" + *repository.Path
+		if repoContext.Path != nil && *repoContext.Path != "" {
+			url += "/" + *repoContext.Path
 		}
-	} else if repository.Path != nil {
-		url += "/src/branch/main/" + *repository.Path
+	} else if repoContext.Path != nil {
+		url += "/src/branch/main/" + *repoContext.Path
 	}
 
 	return url

--- a/pkg/gitprovider/gitea_test.go
+++ b/pkg/gitprovider/gitea_test.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -30,7 +31,7 @@ func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_PR() {
 		Source:   "gitea.com",
 		Branch:   nil,
 		Sha:      nil,
-		PrNumber: &[]uint32{1}[0],
+		PrNumber: util.Pointer(uint32(1)),
 		Path:     nil,
 	}
 
@@ -50,10 +51,10 @@ func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 		Owner:    "gitea",
 		Url:      "https://gitea.com/gitea/go-sdk.git",
 		Source:   "gitea.com",
-		Branch:   &[]string{"main"}[0],
+		Branch:   util.Pointer("main"),
 		Sha:      nil,
 		PrNumber: nil,
-		Path:     &[]string{"README.md"}[0],
+		Path:     util.Pointer("README.md"),
 	}
 
 	require := g.Require()
@@ -72,7 +73,7 @@ func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Branch() {
 		Owner:    "gitea",
 		Url:      "https://gitea.com/gitea/go-sdk.git",
 		Source:   "gitea.com",
-		Branch:   &[]string{"test-branch"}[0],
+		Branch:   util.Pointer("test-branch"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -94,7 +95,7 @@ func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Commits() {
 		Owner:    "gitea",
 		Url:      "https://gitea.com/gitea/go-sdk.git",
 		Source:   "gitea.com",
-		Branch:   &[]string{"main"}[0],
+		Branch:   util.Pointer("main"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -116,8 +117,8 @@ func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 		Owner:    "gitea",
 		Url:      "https://gitea.com/gitea/go-sdk.git",
 		Source:   "gitea.com",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -131,83 +132,83 @@ func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 }
 
 func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitea.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitea.com"),
 		Url:    "https://gitea.com/daytonaio/daytona.git",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitea.com/daytonaio/daytona", url)
 }
 
 func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitea.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitea.com"),
 		Url:    "https://gitea.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitea.com/daytonaio/daytona/src/branch/test-branch", url)
 }
 
 func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitea.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitea.com"),
 		Url:    "https://gitea.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitea.com/daytonaio/daytona/src/branch/test-branch/README.md", url)
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitea.com/daytonaio/daytona/src/branch/main/README.md", url)
 }
 
 func (g *GiteaGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitea.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitea.com"),
 		Url:    "https://gitea.com/daytonaio/daytona.git",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Sha:    util.Pointer("COMMIT_SHA"),
+		Branch: util.Pointer("COMMIT_SHA"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitea.com/daytonaio/daytona/src/commit/COMMIT_SHA/README.md", url)
 
 	repo.Path = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitea.com/daytonaio/daytona/src/commit/COMMIT_SHA", url)
 }

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -103,7 +103,7 @@ func (g *GitHubGitProvider) GetRepositories(namespace string) ([]*GitRepository,
 			Id:     *repo.Name,
 			Name:   *repo.Name,
 			Url:    *repo.HTMLURL,
-			Branch: repo.DefaultBranch,
+			Branch: *repo.DefaultBranch,
 			Owner:  *repo.Owner.Login,
 			Source: u.Host,
 		})
@@ -236,21 +236,21 @@ func (g *GitHubGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (s
 	return *commits[0].SHA, nil
 }
 
-func (g *GitHubGitProvider) GetUrlFromRepository(repository *GitRepository) string {
-	url := strings.TrimSuffix(repository.Url, ".git")
+func (g *GitHubGitProvider) GetUrlFromContext(repoContext *GetRepositoryContext) string {
+	url := strings.TrimSuffix(repoContext.Url, ".git")
 
-	if repository.Branch != nil && *repository.Branch != "" {
-		if repository.Sha == *repository.Branch {
-			url += "/commit/" + *repository.Branch
+	if repoContext.Branch != nil && *repoContext.Branch != "" {
+		if repoContext.Sha != nil && *repoContext.Sha == *repoContext.Branch {
+			url += "/commit/" + *repoContext.Branch
 		} else {
-			url += "/tree/" + *repository.Branch
+			url += "/tree/" + *repoContext.Branch
 		}
 
-		if repository.Path != nil {
-			url += "/" + *repository.Path
+		if repoContext.Path != nil {
+			url += "/" + *repoContext.Path
 		}
-	} else if repository.Path != nil {
-		url += "/blob/main/" + *repository.Path
+	} else if repoContext.Path != nil {
+		url += "/blob/main/" + *repoContext.Path
 	}
 
 	return url

--- a/pkg/gitprovider/github_test.go
+++ b/pkg/gitprovider/github_test.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -30,7 +31,7 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_PR() {
 		Source:   "github.com",
 		Branch:   nil,
 		Sha:      nil,
-		PrNumber: &[]uint32{1}[0],
+		PrNumber: util.Pointer(uint32(1)),
 		Path:     nil,
 	}
 
@@ -50,10 +51,10 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 		Owner:    "daytonaio",
 		Source:   "github.com",
 		Url:      "https://github.com/daytonaio/daytona.git",
-		Branch:   &[]string{"main"}[0],
+		Branch:   util.Pointer("main"),
 		Sha:      nil,
 		PrNumber: nil,
-		Path:     &[]string{"README.md"}[0],
+		Path:     util.Pointer("README.md"),
 	}
 
 	require := g.Require()
@@ -72,7 +73,7 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Branch() {
 		Owner:    "daytonaio",
 		Source:   "github.com",
 		Url:      "https://github.com/daytonaio/daytona.git",
-		Branch:   &[]string{"test-branch"}[0],
+		Branch:   util.Pointer("test-branch"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -94,7 +95,7 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_BranchNameWithSla
 		Owner:    "daytonaio",
 		Source:   "github.com",
 		Url:      "https://github.com/daytonaio/daytona.git",
-		Branch:   &[]string{"test/test-branch"}[0],
+		Branch:   util.Pointer("test/test-branch"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -115,7 +116,7 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Commits() {
 		Owner:    "daytonaio",
 		Source:   "github.com",
 		Url:      "https://github.com/daytonaio/daytona.git",
-		Branch:   &[]string{"test-branch"}[0],
+		Branch:   util.Pointer("test-branch"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -137,8 +138,8 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 		Owner:    "daytonaio",
 		Source:   "github.com",
 		Url:      "https://github.com/daytonaio/daytona.git",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -152,83 +153,83 @@ func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 }
 
 func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "github.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("github.com"),
 		Url:    "https://github.com/daytonaio/daytona.git",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://github.com/daytonaio/daytona", url)
 }
 
 func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "github.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("github.com"),
 		Url:    "https://github.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://github.com/daytonaio/daytona/tree/test-branch", url)
 }
 
 func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "github.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("github.com"),
 		Url:    "https://github.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://github.com/daytonaio/daytona/tree/test-branch/README.md", url)
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://github.com/daytonaio/daytona/blob/main/README.md", url)
 }
 
 func (g *GitHubGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "github.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("github.com"),
 		Url:    "https://github.com/daytonaio/daytona.git",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Branch: util.Pointer("COMMIT_SHA"),
+		Sha:    util.Pointer("COMMIT_SHA"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://github.com/daytonaio/daytona/commit/COMMIT_SHA/README.md", url)
 
 	repo.Path = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://github.com/daytonaio/daytona/commit/COMMIT_SHA", url)
 }

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -100,7 +100,7 @@ func (g *GitLabGitProvider) GetRepositories(namespace string) ([]*GitRepository,
 			Id:     strconv.Itoa(repo.ID),
 			Name:   repo.Path,
 			Url:    repo.WebURL,
-			Branch: &repo.DefaultBranch,
+			Branch: repo.DefaultBranch,
 			Owner:  repo.Namespace.Path,
 			Source: u.Host,
 		})
@@ -260,21 +260,21 @@ func (g *GitLabGitProvider) GetLastCommitSha(staticContext *StaticGitContext) (s
 	return commits[0].ID, nil
 }
 
-func (g *GitLabGitProvider) GetUrlFromRepository(repository *GitRepository) string {
-	url := strings.TrimSuffix(repository.Url, ".git")
+func (g *GitLabGitProvider) GetUrlFromContext(repoContext *GetRepositoryContext) string {
+	url := strings.TrimSuffix(repoContext.Url, ".git")
 
-	if repository.Branch != nil && *repository.Branch != "" {
-		if repository.Sha == *repository.Branch {
-			url += "/-/commit/" + *repository.Branch
+	if repoContext.Branch != nil && *repoContext.Branch != "" {
+		if repoContext.Sha != nil && *repoContext.Sha == *repoContext.Branch {
+			url += "/-/commit/" + *repoContext.Branch
 		} else {
-			url += "/-/tree/" + *repository.Branch
+			url += "/-/tree/" + *repoContext.Branch
 		}
 
-		if repository.Path != nil {
-			url += "/" + *repository.Path
+		if repoContext.Path != nil {
+			url += "/" + *repoContext.Path
 		}
-	} else if repository.Path != nil {
-		url += "/-/blob/main/" + *repository.Path
+	} else if repoContext.Path != nil {
+		url += "/-/blob/main/" + *repoContext.Path
 	}
 
 	return url

--- a/pkg/gitprovider/gitlab_test.go
+++ b/pkg/gitprovider/gitlab_test.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -74,7 +75,7 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_MR() {
 		Source:   "gitlab.com",
 		Branch:   nil,
 		Sha:      nil,
-		PrNumber: &[]uint32{1}[0],
+		PrNumber: util.Pointer(uint32(1)),
 		Path:     nil,
 	}
 
@@ -94,10 +95,10 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 		Owner:    "gitlab-org",
 		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
 		Source:   "gitlab.com",
-		Branch:   &[]string{"master"}[0],
+		Branch:   util.Pointer("master"),
 		Sha:      nil,
 		PrNumber: nil,
-		Path:     &[]string{"README.md"}[0],
+		Path:     util.Pointer("README.md"),
 	}
 
 	require := g.Require()
@@ -116,7 +117,7 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Branch() {
 		Owner:    "gitlab-org",
 		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
 		Source:   "gitlab.com",
-		Branch:   &[]string{"test-branch"}[0],
+		Branch:   util.Pointer("test-branch"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -138,7 +139,7 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commits() {
 		Owner:    "gitlab-org",
 		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
 		Source:   "gitlab.com",
-		Branch:   &[]string{"master"}[0],
+		Branch:   util.Pointer("master"),
 		Sha:      nil,
 		PrNumber: nil,
 		Path:     nil,
@@ -160,8 +161,8 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 		Owner:    "gitlab-org",
 		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
 		Source:   "gitlab.com",
-		Branch:   &[]string{"COMMIT_SHA"}[0],
-		Sha:      &[]string{"COMMIT_SHA"}[0],
+		Branch:   util.Pointer("COMMIT_SHA"),
+		Sha:      util.Pointer("COMMIT_SHA"),
 		PrNumber: nil,
 		Path:     nil,
 	}
@@ -175,83 +176,83 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 }
 
 func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitlab.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitlab.com"),
 		Url:    "https://gitlab.com/daytonaio/daytona.git",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitlab.com/daytonaio/daytona", url)
 }
 
 func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitlab.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitlab.com"),
 		Url:    "https://gitlab.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitlab.com/daytonaio/daytona/-/tree/test-branch", url)
 }
 
 func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitlab.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitlab.com"),
 		Url:    "https://gitlab.com/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal(url, "https://gitlab.com/daytonaio/daytona/-/tree/test-branch/README.md")
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitlab.com/daytonaio/daytona/-/blob/main/README.md", url)
 }
 
 func (g *GitLabGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "gitlab.com",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("gitlab.com"),
 		Url:    "https://gitlab.com/daytonaio/daytona.git",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Branch: util.Pointer("COMMIT_SHA"),
+		Sha:    util.Pointer("COMMIT_SHA"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitlab.com/daytonaio/daytona/-/commit/COMMIT_SHA/README.md", url)
 
 	repo.Path = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://gitlab.com/daytonaio/daytona/-/commit/COMMIT_SHA", url)
 }

--- a/pkg/gitprovider/gitness.go
+++ b/pkg/gitprovider/gitness.go
@@ -71,7 +71,7 @@ func (g *GitnessGitProvider) GetRepositories(namespace string) ([]*GitRepository
 			Id:     repo.Identifier,
 			Name:   repo.Identifier,
 			Url:    repo.GitUrl,
-			Branch: &repo.DefaultBranch,
+			Branch: repo.DefaultBranch,
 			Source: u.Host,
 			Owner:  admin.Principal.DisplayName,
 		}
@@ -134,17 +134,17 @@ func (g *GitnessGitProvider) GetUser() (*GitUser, error) {
 	return user, nil
 }
 
-func (g *GitnessGitProvider) GetUrlFromRepository(repo *GitRepository) string {
-	url := strings.TrimSuffix(repo.Url, ".git")
+func (g *GitnessGitProvider) GetUrlFromContext(repoContext *GetRepositoryContext) string {
+	url := strings.TrimSuffix(repoContext.Url, ".git")
 
-	if repo.Branch != nil && *repo.Branch != "" {
-		url += "/files/" + *repo.Branch
+	if repoContext.Branch != nil && *repoContext.Branch != "" {
+		url += "/files/" + *repoContext.Branch
 
-		if repo.Path != nil && *repo.Path != "" {
-			url += "/~/" + *repo.Path
+		if repoContext.Path != nil && *repoContext.Path != "" {
+			url += "/~/" + *repoContext.Path
 		}
-	} else if repo.Path != nil {
-		url += "/files/main/~/" + *repo.Path
+	} else if repoContext.Path != nil {
+		url += "/files/main/~/" + *repoContext.Path
 	}
 
 	return url

--- a/pkg/gitprovider/gitness_test.go
+++ b/pkg/gitprovider/gitness_test.go
@@ -5,6 +5,7 @@ package gitprovider
 import (
 	"testing"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -119,83 +120,83 @@ func (g *GitnessGitProviderTestSuite) TestParseStaticGitContext_Commit() {
 }
 
 func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Bare() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "localhost:3000",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("localhost:3000"),
 		Url:    "https://localhost:3000/daytonaio/daytona.git",
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://localhost:3000/daytonaio/daytona", url)
 }
 
 func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Branch() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "localhost:3000",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("localhost:3000"),
 		Url:    "https://localhost:3000/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
+		Branch: util.Pointer("test-branch"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://localhost:3000/daytonaio/daytona/files/test-branch", url)
 }
 
 func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Path() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "localhost:3000",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("localhost:3000"),
 		Url:    "https://localhost:3000/daytonaio/daytona.git",
-		Branch: &[]string{"test-branch"}[0],
-		Path:   &[]string{"README.md"}[0],
+		Branch: util.Pointer("test-branch"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://localhost:3000/daytonaio/daytona/files/test-branch/~/README.md", url)
 
 	repo.Branch = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://localhost:3000/daytonaio/daytona/files/main/~/README.md", url)
 }
 
 func (g *GitnessGitProviderTestSuite) TestGetUrlFromRepo_Commit() {
-	repo := &GitRepository{
-		Id:     "daytona",
-		Name:   "daytona",
-		Owner:  "daytonaio",
-		Source: "localhost:3000",
+	repo := &GetRepositoryContext{
+		Id:     util.Pointer("daytona"),
+		Name:   util.Pointer("daytona"),
+		Owner:  util.Pointer("daytonaio"),
+		Source: util.Pointer("localhost:3000"),
 		Url:    "https://localhost:3000/daytonaio/daytona.git",
-		Path:   &[]string{"README.md"}[0],
-		Sha:    "COMMIT_SHA",
-		Branch: &[]string{"COMMIT_SHA"}[0],
+		Branch: util.Pointer("COMMIT_SHA"),
+		Sha:    util.Pointer("COMMIT_SHA"),
+		Path:   util.Pointer("README.md"),
 	}
 
 	require := g.Require()
 
-	url := g.gitProvider.GetUrlFromRepository(repo)
+	url := g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://localhost:3000/daytonaio/daytona/files/COMMIT_SHA/~/README.md", url)
 
 	repo.Path = nil
 
-	url = g.gitProvider.GetUrlFromRepository(repo)
+	url = g.gitProvider.GetUrlFromContext(repo)
 
 	require.Equal("https://localhost:3000/daytonaio/daytona/files/COMMIT_SHA", url)
 }

--- a/pkg/gitprovider/types.go
+++ b/pkg/gitprovider/types.go
@@ -28,7 +28,7 @@ type GitRepository struct {
 	Id       string      `json:"id" validate:"required"`
 	Url      string      `json:"url" validate:"required"`
 	Name     string      `json:"name" validate:"required"`
-	Branch   *string     `json:"branch,omitempty" validate:"optional"`
+	Branch   string      `json:"branch" validate:"required"`
 	Sha      string      `json:"sha" validate:"required"`
 	Owner    string      `json:"owner" validate:"required"`
 	PrNumber *uint32     `json:"prNumber,omitempty" validate:"optional"`

--- a/pkg/server/gitproviders/service.go
+++ b/pkg/server/gitproviders/service.go
@@ -141,7 +141,7 @@ func (s *GitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (
 		Id:       repo.Id,
 		Url:      repo.Url,
 		Name:     repo.Name,
-		Branch:   repo.Branch,
+		Branch:   &repo.Branch,
 		Sha:      &repo.Sha,
 		Owner:    repo.Owner,
 		PrNumber: repo.PrNumber,

--- a/pkg/server/projectconfig/prebuild_test.go
+++ b/pkg/server/projectconfig/prebuild_test.go
@@ -48,8 +48,8 @@ var prebuild1Dto *dto.PrebuildDTO = &dto.PrebuildDTO{
 }
 
 var repository1 *gitprovider.GitRepository = &gitprovider.GitRepository{
-	Url:    "url1",
-	Branch: util.Pointer("main"),
+	Url:    "https://github.com/daytonaio/daytona.git",
+	Branch: "main",
 	Sha:    "sha1",
 }
 
@@ -152,10 +152,10 @@ func (s *ProjectConfigServiceTestSuite) TestProcessGitEventCommitInterval() {
 	}, nil)
 
 	data := gitprovider.GitEventData{
-		Url:           "url1",
+		Url:           repository1.Url,
 		Branch:        "feat",
 		Sha:           "sha4",
-		Owner:         "idagelic",
+		Owner:         repository1.Owner,
 		AffectedFiles: []string{},
 	}
 
@@ -181,10 +181,10 @@ func (s *ProjectConfigServiceTestSuite) TestProcessGitEventTriggerFiles() {
 	}).Return("", nil)
 
 	data := gitprovider.GitEventData{
-		Url:    "url1",
+		Url:    repository1.Url,
 		Branch: "feat",
 		Sha:    "sha4",
-		Owner:  "idagelic",
+		Owner:  repository1.Owner,
 		AffectedFiles: []string{
 			"file1",
 		},

--- a/pkg/server/projectconfig/service.go
+++ b/pkg/server/projectconfig/service.go
@@ -4,6 +4,8 @@
 package projectconfig
 
 import (
+	"strings"
+
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/server/builds"
@@ -86,6 +88,13 @@ func (s *ProjectConfigService) SetDefault(projectConfigName string) error {
 }
 
 func (s *ProjectConfigService) Find(filter *config.ProjectConfigFilter) (*config.ProjectConfig, error) {
+	if filter != nil && filter.Url != nil {
+		cleanedUrl := util.CleanUpRepositoryUrl(*filter.Url)
+		if !strings.HasSuffix(cleanedUrl, ".git") {
+			cleanedUrl = cleanedUrl + ".git"
+		}
+		filter.Url = util.Pointer(cleanedUrl)
+	}
 	return s.configStore.Find(filter)
 }
 

--- a/pkg/server/projectconfig/service_test.go
+++ b/pkg/server/projectconfig/service_test.go
@@ -36,7 +36,7 @@ var projectConfig2 *config.ProjectConfig = &config.ProjectConfig{
 	Image:         "image2",
 	User:          "user2",
 	BuildConfig:   nil,
-	RepositoryUrl: "url1",
+	RepositoryUrl: "https://github.com/daytonaio/daytona.git",
 }
 
 var projectConfig3 *config.ProjectConfig = &config.ProjectConfig{
@@ -44,7 +44,7 @@ var projectConfig3 *config.ProjectConfig = &config.ProjectConfig{
 	Image:         "image3",
 	User:          "user3",
 	BuildConfig:   nil,
-	RepositoryUrl: "url3",
+	RepositoryUrl: "https://github.com/daytonaio/daytona3.git",
 }
 
 var projectConfig4 *config.ProjectConfig = &config.ProjectConfig{
@@ -52,7 +52,7 @@ var projectConfig4 *config.ProjectConfig = &config.ProjectConfig{
 	Image:         "image4",
 	User:          "user4",
 	BuildConfig:   nil,
-	RepositoryUrl: "url4",
+	RepositoryUrl: "https://github.com/daytonaio/daytona4.git",
 }
 
 var expectedProjectConfigs []*config.ProjectConfig
@@ -151,7 +151,7 @@ func (s *ProjectConfigServiceTestSuite) TestSetDefault() {
 	require.Nil(err)
 
 	projectConfig, err := s.projectConfigService.Find(&config.ProjectConfigFilter{
-		Url:     util.Pointer("url1"),
+		Url:     util.Pointer(projectConfig1.RepositoryUrl),
 		Default: util.Pointer(true),
 	})
 	require.Nil(err)

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -232,7 +232,7 @@ func (s *WorkspaceService) getCachedBuildForProject(p *project.Project) (*buildc
 	build, err := s.buildService.Find(&build.Filter{
 		States:        validStates,
 		RepositoryUrl: &p.Repository.Url,
-		Branch:        p.Repository.Branch,
+		Branch:        &p.Repository.Branch,
 		EnvVars:       &p.EnvVars,
 		BuildConfig:   p.BuildConfig,
 		GetNewest:     util.Pointer(true),

--- a/pkg/views/build/info/view.go
+++ b/pkg/views/build/info/view.go
@@ -35,9 +35,7 @@ func Render(b *apiclient.Build, apiServerConfig *apiclient.ServerConfig, forceUn
 
 	output += getInfoLine("State", string(b.State)) + "\n"
 
-	if b.Repository != nil {
-		output += getInfoLine("Repository", b.Repository.Url) + "\n"
-	}
+	output += getInfoLine("Repository", b.Repository.Url) + "\n"
 
 	output += getInfoLine("Image", b.Image) + "\n"
 

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -174,9 +174,7 @@ func getWorkspaceTableRowData(workspace apiclient.WorkspaceDTO, specifyGitProvid
 	rowData.Name = workspace.Name + views_util.AdditionalPropertyPadding
 	if len(workspace.Projects) > 0 {
 		rowData.Repository = util.GetRepositorySlugFromUrl(workspace.Projects[0].Repository.Url, specifyGitProviders)
-		if workspace.Projects[0].Repository.Branch != nil {
-			rowData.Branch = *workspace.Projects[0].Repository.Branch
-		}
+		rowData.Branch = workspace.Projects[0].Repository.Branch
 	}
 
 	rowData.Target = workspace.Target + views_util.AdditionalPropertyPadding
@@ -195,9 +193,7 @@ func getProjectTableRowData(workspaceDTO apiclient.WorkspaceDTO, project apiclie
 	rowData.Name = " └ " + project.Name
 
 	rowData.Repository = util.GetRepositorySlugFromUrl(project.Repository.Url, specifyGitProviders)
-	if project.Repository.Branch != nil {
-		rowData.Branch = *project.Repository.Branch
-	}
+	rowData.Branch = project.Repository.Branch
 
 	rowData.Target = project.Target + views_util.AdditionalPropertyPadding
 


### PR DESCRIPTION
# Fix Matching Project Config and Build to Repository

## Description

- Include env vars when creating a build on the API
- Include build env vars in the devcontainer creation process
- Fix matching the repo URL to a project config
- Make the branch property required in the git repository struct
- Set profile data env vars in builds

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #971 