### PR TITLE
fix: add project config during prebuilds add flow

### DIFF
--- a/pkg/cmd/build/run.go
+++ b/pkg/cmd/build/run.go
@@ -34,7 +34,7 @@ var buildRunCmd = &cobra.Command{
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
-		projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, "Update")
+		projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Update")
 		if projectConfig == nil {
 			return
 		}

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -5,6 +5,7 @@ package projectconfig
 
 import (
 	"context"
+	"errors"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -22,8 +23,6 @@ var projectConfigAddCmd = &cobra.Command{
 	Short:   "Add a project config",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		var createDtos []apiclient.CreateProjectDTO
-		var existingProjectConfigNames []string
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
@@ -36,91 +35,114 @@ var projectConfigAddCmd = &cobra.Command{
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
-		apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
-		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
-		}
-
-		existingProjectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()
-		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
-		}
-		for _, pc := range existingProjectConfigs {
-			existingProjectConfigNames = append(existingProjectConfigNames, pc.Name)
-		}
-
-		projectDefaults := &create.ProjectConfigDefaults{
-			BuildChoice:          create.AUTOMATIC,
-			Image:                &apiServerConfig.DefaultProjectImage,
-			ImageUser:            &apiServerConfig.DefaultProjectUser,
-			DevcontainerFilePath: create.DEVCONTAINER_FILEPATH,
-		}
-
-		createDtos, err = workspace_util.GetProjectsCreationDataFromPrompt(workspace_util.ProjectsDataPromptConfig{
-			UserGitProviders:    gitProviders,
-			Manual:              manualFlag,
-			MultiProject:        false,
-			SkipBranchSelection: true,
-			ApiClient:           apiClient,
-			Defaults:            projectDefaults,
-		},
-		)
-		if err != nil {
-			if common.IsCtrlCAbort(err) {
-				return
-			} else {
-				log.Fatal(err)
-			}
-		}
-
-		create.ProjectsConfigurationChanged, err = create.RunProjectConfiguration(&createDtos, *projectDefaults)
+		projectConfig, err := RunProjectConfigAddFlow(apiClient, gitProviders, ctx)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if len(createDtos) == 0 {
-			log.Fatal("no projects found")
+		if projectConfig != nil {
+			views.RenderInfoMessage("Project config added successfully")
 		}
-
-		if createDtos[0].Name == "" {
-			log.Fatal("project config name is required")
-		}
-
-		initialSuggestion := createDtos[0].Name
-
-		chosenName := workspace_util.GetSuggestedName(initialSuggestion, existingProjectConfigNames)
-
-		submissionFormConfig := create.SubmissionFormConfig{
-			ChosenName:    &chosenName,
-			SuggestedName: chosenName,
-			ExistingNames: existingProjectConfigNames,
-			ProjectList:   &createDtos,
-			NameLabel:     "Project config",
-			Defaults:      projectDefaults,
-		}
-
-		err = create.RunSubmissionForm(submissionFormConfig)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		newProjectConfig := apiclient.CreateProjectConfigDTO{
-			Name:          chosenName,
-			BuildConfig:   createDtos[0].BuildConfig,
-			Image:         createDtos[0].Image,
-			User:          createDtos[0].User,
-			RepositoryUrl: createDtos[0].Source.Repository.Url,
-		}
-
-		newProjectConfig.EnvVars = *workspace_util.GetEnvVariables(createDtos[0].EnvVars, nil)
-
-		res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()
-		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
-		}
-
-		views.RenderInfoMessage("Project config added successfully")
 	},
+}
+
+func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apiclient.GitProvider, ctx context.Context) (*apiclient.ProjectConfig, error) {
+	var createDtos []apiclient.CreateProjectDTO
+	var existingProjectConfigNames []string
+
+	apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
+	if err != nil {
+		return nil, apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	existingProjectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()
+	if err != nil {
+		return nil, apiclient_util.HandleErrorResponse(res, err)
+	}
+	for _, pc := range existingProjectConfigs {
+		existingProjectConfigNames = append(existingProjectConfigNames, pc.Name)
+	}
+
+	projectDefaults := &create.ProjectConfigDefaults{
+		BuildChoice:          create.AUTOMATIC,
+		Image:                &apiServerConfig.DefaultProjectImage,
+		ImageUser:            &apiServerConfig.DefaultProjectUser,
+		DevcontainerFilePath: create.DEVCONTAINER_FILEPATH,
+	}
+
+	createDtos, err = workspace_util.GetProjectsCreationDataFromPrompt(workspace_util.ProjectsDataPromptConfig{
+		UserGitProviders:    gitProviders,
+		Manual:              manualFlag,
+		MultiProject:        false,
+		SkipBranchSelection: true,
+		ApiClient:           apiClient,
+		Defaults:            projectDefaults,
+	},
+	)
+	if err != nil {
+		if common.IsCtrlCAbort(err) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	create.ProjectsConfigurationChanged, err = create.RunProjectConfiguration(&createDtos, *projectDefaults)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(createDtos) == 0 {
+		return nil, errors.New("no projects found")
+	}
+
+	if createDtos[0].Name == "" {
+		return nil, errors.New("project config name is required")
+	}
+
+	initialSuggestion := createDtos[0].Name
+
+	chosenName := workspace_util.GetSuggestedName(initialSuggestion, existingProjectConfigNames)
+
+	submissionFormConfig := create.SubmissionFormConfig{
+		ChosenName:    &chosenName,
+		SuggestedName: chosenName,
+		ExistingNames: existingProjectConfigNames,
+		ProjectList:   &createDtos,
+		NameLabel:     "Project config",
+		Defaults:      projectDefaults,
+	}
+
+	err = create.RunSubmissionForm(submissionFormConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	newProjectConfig := apiclient.CreateProjectConfigDTO{
+		Name:          chosenName,
+		BuildConfig:   createDtos[0].BuildConfig,
+		Image:         createDtos[0].Image,
+		User:          createDtos[0].User,
+		RepositoryUrl: createDtos[0].Source.Repository.Url,
+	}
+
+	newProjectConfig.EnvVars = *workspace_util.GetEnvVariables(createDtos[0].EnvVars, nil)
+
+	res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()
+	if err != nil {
+		return nil, apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	return &apiclient.ProjectConfig{
+		BuildConfig:   newProjectConfig.BuildConfig,
+		Default:       false,
+		EnvVars:       newProjectConfig.EnvVars,
+		Image:         *newProjectConfig.Image,
+		Name:          newProjectConfig.Name,
+		Prebuilds:     nil,
+		RepositoryUrl: newProjectConfig.RepositoryUrl,
+		User:          *newProjectConfig.User,
+	}, nil
 }
 
 var manualFlag bool

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -77,8 +77,8 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 		SkipBranchSelection: true,
 		ApiClient:           apiClient,
 		Defaults:            projectDefaults,
-	},
-	)
+	})
+
 	if err != nil {
 		if common.IsCtrlCAbort(err) {
 			return nil, nil

--- a/pkg/cmd/projectconfig/delete.go
+++ b/pkg/cmd/projectconfig/delete.go
@@ -89,7 +89,7 @@ var projectConfigDeleteCmd = &cobra.Command{
 				return
 			}
 
-			selectedProjectConfig = selection.GetProjectConfigFromPrompt(projectConfigs, 0, false, "Delete")
+			selectedProjectConfig = selection.GetProjectConfigFromPrompt(projectConfigs, 0, false, false, "Delete")
 			if selectedProjectConfig == nil {
 				return
 			}

--- a/pkg/cmd/projectconfig/info.go
+++ b/pkg/cmd/projectconfig/info.go
@@ -42,7 +42,7 @@ var projectConfigInfoCmd = &cobra.Command{
 				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 			}
 
-			projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, "View")
+			projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "View")
 		} else {
 			var res *http.Response
 			projectConfig, res, err = apiClient.ProjectConfigAPI.GetProjectConfig(ctx, args[0]).Execute()

--- a/pkg/cmd/projectconfig/setdefault.go
+++ b/pkg/cmd/projectconfig/setdefault.go
@@ -33,7 +33,7 @@ var projectConfigSetDefaultCmd = &cobra.Command{
 				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 			}
 
-			projectConfig := selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, "Make Default")
+			projectConfig := selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Make Default")
 			if projectConfig == nil {
 				return
 			}

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -37,7 +37,7 @@ var projectConfigUpdateCmd = &cobra.Command{
 				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 			}
 
-			projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, "Update")
+			projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Update")
 			if projectConfig == nil {
 				return
 			}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -313,8 +313,8 @@ func processPrompting(apiClient *apiclient.APIClient, workspaceName *string, pro
 		BlankProject:     blankFlag,
 		ApiClient:        apiClient,
 		Defaults:         projectDefaults,
-	},
-	)
+	})
+
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -54,7 +54,7 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 		}
 
 		if len(config.ProjectConfigs) > 0 && !config.BlankProject {
-			projectConfig := selection.GetProjectConfigFromPrompt(config.ProjectConfigs, i, true, "Use")
+			projectConfig := selection.GetProjectConfigFromPrompt(config.ProjectConfigs, i, true, false, "Use")
 			if projectConfig == nil {
 				return nil, common.ErrCtrlCAbort
 			}

--- a/pkg/views/workspace/selection/projectconfig.go
+++ b/pkg/views/workspace/selection/projectconfig.go
@@ -16,14 +16,15 @@ import (
 )
 
 var BlankProjectIdentifier = "<BLANK_PROJECT>"
+var NewProjectConfigIdentifier = "<NEW_PROJECT_CONFIG>"
 
-func GetProjectConfigFromPrompt(projectConfigs []apiclient.ProjectConfig, projectOrder int, showBlankOption bool, actionVerb string) *apiclient.ProjectConfig {
+func GetProjectConfigFromPrompt(projectConfigs []apiclient.ProjectConfig, projectOrder int, showBlankOption, withNewProjectConfig bool, actionVerb string) *apiclient.ProjectConfig {
 	choiceChan := make(chan *apiclient.ProjectConfig)
-	go selectProjectConfigPrompt(projectConfigs, projectOrder, showBlankOption, actionVerb, choiceChan)
+	go selectProjectConfigPrompt(projectConfigs, projectOrder, showBlankOption, withNewProjectConfig, actionVerb, choiceChan)
 	return <-choiceChan
 }
 
-func selectProjectConfigPrompt(projectConfigs []apiclient.ProjectConfig, projectOrder int, showBlankOption bool, actionVerb string, choiceChan chan<- *apiclient.ProjectConfig) {
+func selectProjectConfigPrompt(projectConfigs []apiclient.ProjectConfig, projectOrder int, showBlankOption, withNewProjectConfig bool, actionVerb string, choiceChan chan<- *apiclient.ProjectConfig) {
 	items := []list.Item{}
 
 	if showBlankOption {
@@ -40,6 +41,13 @@ func selectProjectConfigPrompt(projectConfigs []apiclient.ProjectConfig, project
 		}
 
 		newItem := item[apiclient.ProjectConfig]{title: projectConfigName, desc: pc.RepositoryUrl, choiceProperty: pc}
+		items = append(items, newItem)
+	}
+
+	if withNewProjectConfig {
+		newItem := item[apiclient.ProjectConfig]{title: "+ Create a new project configuration", desc: "", choiceProperty: apiclient.ProjectConfig{
+			Name: NewProjectConfigIdentifier,
+		}}
 		items = append(items, newItem)
 	}
 


### PR DESCRIPTION
# Add project config during prebuilds add flow

## Description

Adds an option to add a project config during `daytona prebuild add` and then continue on to set a prebuild

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #969 

## Screenshots

![image](https://github.com/user-attachments/assets/53db2f26-3c4f-48fc-a4dd-b7b186f8b461)


## Notes
Please add any relevant notes if necessary.
