### PR TITLE
fix: timestamp with timezone

### DIFF
--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-var timeLayout = "2006-01-02T15:04:05.999999999Z"
+var timeLayout = "2006-01-02T15:04:05.999999999Z07:00"
 
 func FormatTimestamp(input string) string {
 	t, err := time.Parse(timeLayout, input)


### PR DESCRIPTION
# Fix timestamp with time zone
## Description

Fix for some instances to correctly display created/updated times where the timestamp in the database contains a time zone.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
Before:

![image](https://github.com/user-attachments/assets/5159dd06-5962-4620-9e24-ef1e48953140)


After:

![image](https://github.com/user-attachments/assets/c6962b13-47f8-4482-abb0-b3403e26db4c)

