### PR TITLE
feat: add custom installation loader to the install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -201,6 +201,10 @@ download_file() {
     sleep 0.1
   done
 
+  # Ensure the progress bar reaches 100% on successful completion
+  progress_bar_with_spinner "$total_size" "$total_size"
+  printf "\n"
+
   mv "$temp_output" "$output"
   echo ""
 }

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -160,7 +160,14 @@ download_file() {
   local temp_output=$(mktemp)
 
   # Start downloading the file with `curl` and pipe the output to `dd` to track progress
-  curl -L -s "$url" -o "$temp_output" &
+  #
+  # Flags:
+  # -f, --fail: Fail silently on server errors.
+  # -s, --silent: Silent mode. Don't show progress meter or error messages.
+  # -S, --show-error: When used with -s, show error even if silent mode is enabled.
+  # -L, --location: Follow redirects.
+  # -o, --output <file>: Write output to <file> instead of stdout.
+  curl -fsSL "$url" -o "$temp_output" &
   local curl_pid=$!
 
   while kill -0 $curl_pid 2>/dev/null; do
@@ -176,13 +183,7 @@ download_file() {
 # curl does not fail with a non-zero status code when the HTTP status
 # code is not successful (like 404 or 500). You can add -f flag to curl
 # command to fail silently on server errors.
-#
-# Flags:
-# -f, --fail: Fail silently on server errors.
-# -s, --silent: Silent mode. Don't show progress meter or error messages.
-# -S, --show-error: When used with -s, show error even if silent mode is enabled.
-# -L, --location: Follow redirects.
-# -o, --output <file>: Write output to <file> instead of stdout.
+
 if ! download_file "$DOWNLOAD_URL" "$temp_file"; then
   err "Daytona binary download failed"
 fi

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -134,6 +134,22 @@ temp_file="daytona-$RANDOM"
 # Ensure the temporary file is deleted on exit
 trap 'rm -f "$temp_file"' EXIT
 
+# Function to determine file size in a cross-platform way
+get_file_size() {
+  local file=$1
+  case "$(uname)" in
+    Darwin)
+      stat -f "%z" "$file" 2>/dev/null || echo "0"
+      ;;
+    Linux)
+      stat --printf="%s" "$file" 2>/dev/null || echo "0"
+      ;;
+    *)
+      echo "0"
+      ;;
+  esac
+}
+
 # Function to display a progress bar with a spinner
 progress_bar_with_spinner() {
   local current_size=$1
@@ -171,7 +187,7 @@ download_file() {
   local curl_pid=$!
 
   while kill -0 $curl_pid 2>/dev/null; do
-    local downloaded_size=$(stat --printf="%s" "$temp_output")
+    local downloaded_size=$(get_file_size "$temp_output")
     progress_bar_with_spinner "$downloaded_size" "$total_size"
     sleep 0.1
   done

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -138,15 +138,15 @@ trap 'rm -f "$temp_file"' EXIT
 get_file_size() {
   local file=$1
   case "$(uname)" in
-    Darwin)
-      stat -f "%z" "$file" 2>/dev/null || echo "0"
-      ;;
-    Linux)
-      stat --printf="%s" "$file" 2>/dev/null || echo "0"
-      ;;
-    *)
-      echo "0"
-      ;;
+  Darwin)
+    stat -f "%z" "$file" 2>/dev/null || echo "0"
+    ;;
+  Linux)
+    stat --printf="%s" "$file" 2>/dev/null || echo "0"
+    ;;
+  *)
+    echo "0"
+    ;;
   esac
 }
 
@@ -161,7 +161,7 @@ progress_bar_with_spinner() {
   local spinner="⠋⠙⠸⠴⠦⠧⠇⠏"
   local spin_char=${spinner:$(($RANDOM % 8)):1}
 
-  printf "\r[%s] Downloading... [%-${bar_width}s] %d%%" "$spin_char" "$(printf "%0.s#" $(seq 1 $filled))$(printf "%0.s-" $(seq 1 $empty))" "$percent"
+  printf "\r\033[K[%s] Downloading... [%-${bar_width}s] %d%%" "$spin_char" "$(printf "%0.s#" $(seq 1 $filled))$(printf "%0.s-" $(seq 1 $empty))" "$percent"
 }
 
 # Download the file while showing a progress bar with a spinner

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -16,7 +16,7 @@ CONFIRM_FLAG=false
 # Check for the -y flag
 for arg in "$@"; do
   case $arg in
-    -y)
+  -y)
     CONFIRM_FLAG=true
     shift
     ;;
@@ -31,21 +31,21 @@ err() {
 
 # Stop the Daytona server if it is running
 stop_daytona_server() {
-  if pgrep -x "daytona" > /dev/null; then
+  if pgrep -x "daytona" >/dev/null; then
     if [ "$CONFIRM_FLAG" = false ]; then
-      read -p "Daytona server is running. Do you want to stop it? (yes/no): " user_input < /dev/tty
+      read -p "Daytona server is running. Do you want to stop it? (yes/no): " user_input </dev/tty
       case $user_input in
-        [Yy][Ee][Ss] )
-          CONFIRM_FLAG=true
-          ;;
-        [Nn][Oo] )
-          echo "Please stop the Daytona server manually and rerun the script."
-          exit 0
-          ;;
-        * )
-          echo "Invalid input. Please enter 'yes' or 'no'."
-          exit 1
-          ;;
+      [Yy][Ee][Ss])
+        CONFIRM_FLAG=true
+        ;;
+      [Nn][Oo])
+        echo "Please stop the Daytona server manually and rerun the script."
+        exit 0
+        ;;
+      *)
+        echo "Invalid input. Please enter 'yes' or 'no'."
+        exit 1
+        ;;
       esac
     fi
 
@@ -134,6 +134,45 @@ temp_file="daytona-$RANDOM"
 # Ensure the temporary file is deleted on exit
 trap 'rm -f "$temp_file"' EXIT
 
+# Function to display a progress bar with a spinner
+progress_bar_with_spinner() {
+  local current_size=$1
+  local total_size=$2
+  local percent=$((current_size * 100 / total_size))
+  local bar_width=40
+  local filled=$((percent * bar_width / 100))
+  local empty=$((bar_width - filled))
+  local spinner="⠋⠙⠸⠴⠦⠧⠇⠏"
+  local spin_char=${spinner:$(($RANDOM % 8)):1}
+
+  printf "\r[%s] Downloading... [%-${bar_width}s] %d%%" "$spin_char" "$(printf "%0.s#" $(seq 1 $filled))$(printf "%0.s-" $(seq 1 $empty))" "$percent"
+}
+
+# Download the file while showing a progress bar with a spinner
+download_file() {
+  local url=$1
+  local output=$2
+
+  # Get the total size of the file to download
+  local total_size=$(curl -sI "$url" | grep -i Content-Length | awk '{print $2}' | tr -d '\r')
+
+  # Initialize a temporary file to hold the download
+  local temp_output=$(mktemp)
+
+  # Start downloading the file with `curl` and pipe the output to `dd` to track progress
+  curl -L -s "$url" -o "$temp_output" &
+  local curl_pid=$!
+
+  while kill -0 $curl_pid 2>/dev/null; do
+    local downloaded_size=$(stat --printf="%s" "$temp_output")
+    progress_bar_with_spinner "$downloaded_size" "$total_size"
+    sleep 0.1
+  done
+
+  mv "$temp_output" "$output"
+  echo ""
+}
+
 # curl does not fail with a non-zero status code when the HTTP status
 # code is not successful (like 404 or 500). You can add -f flag to curl
 # command to fail silently on server errors.
@@ -144,7 +183,7 @@ trap 'rm -f "$temp_file"' EXIT
 # -S, --show-error: When used with -s, show error even if silent mode is enabled.
 # -L, --location: Follow redirects.
 # -o, --output <file>: Write output to <file> instead of stdout.
-if ! curl -fsSL "$DOWNLOAD_URL" -o "$temp_file"; then
+if ! download_file "$DOWNLOAD_URL" "$temp_file"; then
   err "Daytona binary download failed"
 fi
 chmod +x "$temp_file"
@@ -161,3 +200,5 @@ if [[ ! :"$PATH:" == *":$DESTINATION:"* ]]; then
   echo "             export PATH=\$PATH:$DESTINATION"
   echo "         Source the configuration file to apply the changes (e.g., source ~/.bashrc)"
 fi
+
+echo -e "\nDaytona has been successfully installed to $DESTINATION!"


### PR DESCRIPTION
## Description
Added a combined progress bar and spinner to visually represent the download progress, displaying both percentage completion and a graphical progress bar.


## Related Issue(s)

This PR addresses issue #970
/claim #970

## Screenshots
```
(zulip-py3-venv) vamshi@LAPTOP-L0PR20E0:/mnt/c/Users/91970/Desktop/algora/daytona$ sudo hack/install.sh
Installing Daytona...

Default installation directory: /usr/local/bin
You can override this by setting the DAYTONA_PATH environment variable (ie. `| DAYTONA_PATH=/home/user/bin bash`)

Downloading Daytona binary from https://download.daytona.io/daytona/latest/daytona-linux-amd64
[⠏] Downloading... [####################################----] 91%
```
## Notes
To test it use:

```
curl -sf -L https://raw.githubusercontent.com/varshith257/daytona/add-custom-install-loader/hack/install.sh | sudo bash
```
