### PR TITLE
fix: run prompt on prebuild add/update

### DIFF
--- a/docs/daytona_prebuild_add.md
+++ b/docs/daytona_prebuild_add.md
@@ -9,7 +9,7 @@ daytona prebuild add [flags]
 ### Options
 
 ```
-      --run   Run the prebuild once after adding it
+      --run   Run the prebuild once after adding it (default true)
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_prebuild_add.yaml
+++ b/hack/docs/daytona_prebuild_add.yaml
@@ -3,7 +3,7 @@ synopsis: Add a prebuild configuration
 usage: daytona prebuild add [flags]
 options:
     - name: run
-      default_value: "false"
+      default_value: "true"
       usage: Run the prebuild once after adding it
 inherited_options:
     - name: help

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -68,6 +68,8 @@ var prebuildAddCmd = &cobra.Command{
 			prebuildAddView.Branch = chosenBranch.Name
 		}
 
+		prebuildAddView.RunBuildOnAdd = runOnAddFlag
+
 		add.PrebuildCreationView(&prebuildAddView, false)
 
 		var commitInterval int
@@ -104,7 +106,7 @@ var prebuildAddCmd = &cobra.Command{
 
 		views.RenderInfoMessage("Prebuild added successfully")
 
-		if runFlag {
+		if prebuildAddView.RunBuildOnAdd {
 			buildId, res, err := apiClient.BuildAPI.CreateBuild(ctx).CreateBuildDto(apiclient.CreateBuildDTO{
 				ProjectConfigName: prebuildAddView.ProjectConfigName,
 				Branch:            &prebuildAddView.Branch,
@@ -119,8 +121,8 @@ var prebuildAddCmd = &cobra.Command{
 	},
 }
 
-var runFlag bool
+var runOnAddFlag bool
 
 func init() {
-	prebuildAddCmd.Flags().BoolVar(&runFlag, "run", false, "Run the prebuild once after adding it")
+	prebuildAddCmd.Flags().BoolVar(&runOnAddFlag, "run", true, "Run the prebuild once after adding it")
 }

--- a/pkg/cmd/prebuild/update.go
+++ b/pkg/cmd/prebuild/update.go
@@ -87,6 +87,8 @@ var prebuildUpdateCmd = &cobra.Command{
 			prebuildAddView.TriggerFiles = prebuild.TriggerFiles
 		}
 
+		prebuildAddView.RunBuildOnAdd = runOnUpdateFlag
+
 		add.PrebuildCreationView(&prebuildAddView, true)
 
 		var commitInterval int
@@ -123,7 +125,7 @@ var prebuildUpdateCmd = &cobra.Command{
 
 		views.RenderInfoMessage("Prebuild updated successfully")
 
-		if runFlag {
+		if prebuildAddView.RunBuildOnAdd {
 			buildId, res, err := apiClient.BuildAPI.CreateBuild(ctx).CreateBuildDto(apiclient.CreateBuildDTO{
 				ProjectConfigName: prebuildAddView.ProjectConfigName,
 				Branch:            &prebuildAddView.Branch,
@@ -138,6 +140,8 @@ var prebuildUpdateCmd = &cobra.Command{
 	},
 }
 
+var runOnUpdateFlag bool
+
 func init() {
-	prebuildUpdateCmd.Flags().BoolVar(&runFlag, "run", false, "Run the prebuild once after updating it")
+	prebuildUpdateCmd.Flags().BoolVar(&runOnUpdateFlag, "run", false, "Run the prebuild once after updating it")
 }

--- a/pkg/views/prebuild/add/add.go
+++ b/pkg/views/prebuild/add/add.go
@@ -24,6 +24,7 @@ type PrebuildAddView struct {
 	CommitInterval    string
 	TriggerFiles      []string
 	Retention         string
+	RunBuildOnAdd     bool
 }
 
 func PrebuildCreationView(prebuildAddView *PrebuildAddView, editing bool) {
@@ -70,6 +71,9 @@ func PrebuildCreationView(prebuildAddView *PrebuildAddView, editing bool) {
 					_, err := strconv.Atoi(str)
 					return err
 				}),
+			huh.NewConfirm().
+				Title("Run the build once on submit?").
+				Value(&prebuildAddView.RunBuildOnAdd),
 		),
 	).WithTheme(views.GetCustomTheme())
 


### PR DESCRIPTION
# Run prompt on prebuild add/update
## Description

Adds a "Run the build once on submit?" TUI prompt when doing `daytona prebuild add` or `daytona prebuild update`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #972 

## Screenshots

![image](https://github.com/user-attachments/assets/ef807b72-e756-4d7e-9c03-bd01b7a1f2fb)
