### PR TITLE
fix: update profile name validation to match workspace name

### DIFF
--- a/internal/constants/profile.go
+++ b/internal/constants/profile.go
@@ -1,0 +1,6 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+const PROFILE_NAME_VALIDATION = "^[a-zA-Z0-9._-]+$"

--- a/pkg/views/profile/create.go
+++ b/pkg/views/profile/create.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/constants"
 	"github.com/daytonaio/daytona/pkg/views"
 
 	"github.com/charmbracelet/huh"
@@ -29,8 +30,8 @@ func ProfileCreationView(c *config.Config, profileAddView *ProfileAddView, editi
 			if str == "" {
 				return errors.New("profile name can not be blank")
 			}
-			if match, _ := regexp.MatchString("^[a-zA-Z0-9]+$", str); !match {
-				return errors.New("profile name must be alphanumeric only")
+			if match, _ := regexp.MatchString(constants.PROFILE_NAME_VALIDATION, str); !match {
+				return errors.New("only letters, digits, dashes, underscores and periods are allowed")
 			}
 
 			if !editing {


### PR DESCRIPTION
# Update profile name validation

## Description

Update profile name validation to match workspace name [a-zA-Z0-9._-] (as in https://github.com/daytonaio/daytona/pull/775)


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #956
/claim #956
