### PR TITLE
feat: add a workspace start prompt in daytona code for stopped projects

### DIFF
--- a/docs/daytona_code.md
+++ b/docs/daytona_code.md
@@ -9,6 +9,7 @@ daytona code [WORKSPACE] [PROJECT] [flags]
 ### Options
 
 ```
+  -a, --auto-start   Automatically start the project if it is not running
   -i, --ide string   Specify the IDE (vscode, browser, cursor, ssh, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
 ```
 

--- a/docs/daytona_ssh.md
+++ b/docs/daytona_ssh.md
@@ -6,6 +6,12 @@ SSH into a project using the terminal
 daytona ssh [WORKSPACE] [PROJECT] [CMD...] [flags]
 ```
 
+### Options
+
+```
+  -a, --auto-start   Automatically start the project if it is not running
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/hack/docs/daytona_code.yaml
+++ b/hack/docs/daytona_code.yaml
@@ -2,6 +2,10 @@ name: daytona code
 synopsis: Open a workspace in your preferred IDE
 usage: daytona code [WORKSPACE] [PROJECT] [flags]
 options:
+    - name: auto-start
+      shorthand: a
+      default_value: "false"
+      usage: Automatically start the project if it is not running
     - name: ide
       shorthand: i
       usage: |

--- a/hack/docs/daytona_ssh.yaml
+++ b/hack/docs/daytona_ssh.yaml
@@ -1,6 +1,11 @@
 name: daytona ssh
 synopsis: SSH into a project using the terminal
 usage: daytona ssh [WORKSPACE] [PROJECT] [CMD...] [flags]
+options:
+    - name: auto-start
+      shorthand: a
+      default_value: "false"
+      usage: Automatically start the project if it is not running
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -5,7 +5,6 @@ package workspace
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
@@ -78,7 +77,13 @@ var SshCmd = &cobra.Command{
 		}
 
 		if !workspace_util.IsProjectRunning(workspace, projectName) {
-			log.Fatal(fmt.Sprintf("Project '%s' from workspace '%s' is not in running state", projectName, workspace.Name))
+			wsRunningStatus, err := AutoStartWorkspace(autoStartFlag, workspace.Name, projectName)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if !wsRunningStatus {
+				return
+			}
 		}
 
 		sshArgs := []string{}
@@ -101,4 +106,8 @@ var SshCmd = &cobra.Command{
 
 		return getWorkspaceNameCompletions()
 	},
+}
+
+func init() {
+	SshCmd.Flags().BoolVarP(&autoStartFlag, "auto-start", "a", false, "Automatically start the project if it is not running")
 }

--- a/pkg/views/ide/start_workspace.go
+++ b/pkg/views/ide/start_workspace.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ide
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/charmbracelet/huh"
+	"github.com/daytonaio/daytona/pkg/views"
+)
+
+func RunStartWorkspaceForm(workspaceName string) bool {
+	confirmCheck := true
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("The workspace %s is stopped, would you like to start it?", workspaceName)).
+				Value(&confirmCheck),
+		),
+	).WithTheme(views.GetCustomTheme())
+
+	err := form.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !confirmCheck {
+		fmt.Println("Operation canceled.")
+	}
+
+	return confirmCheck
+}


### PR DESCRIPTION
## add a workspace start prompt in daytona code for stopped projects

## Description
ask user to start workspace if daytona code or ssh cmd is run for a stopped project

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #914
/claim #914

## Screenshots
<img width="573" alt="image" src="https://github.com/user-attachments/assets/7b131694-71fc-4dd7-b2e4-08fbbb8709c6">
