### PR TITLE
fix: handle logging build deletion errors

### DIFF
--- a/pkg/api/controllers/build/build.go
+++ b/pkg/api/controllers/build/build.go
@@ -97,15 +97,19 @@ func GetBuild(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	build, err := server.BuildService.Find(&build.Filter{
+	b, err := server.BuildService.Find(&build.Filter{
 		Id: &buildId,
 	})
 	if err != nil {
-		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get build: %s", err.Error()))
+		statusCode := http.StatusInternalServerError
+		if build.IsBuildNotFound(err) {
+			statusCode = http.StatusNotFound
+		}
+		ctx.AbortWithError(statusCode, fmt.Errorf("failed to find build: %w", err))
 		return
 	}
 
-	ctx.JSON(200, build)
+	ctx.JSON(200, b)
 }
 
 // ListBuilds godoc

--- a/pkg/build/runner.go
+++ b/pkg/build/runner.go
@@ -305,9 +305,11 @@ func (r *BuildRunner) handleBuildError(b Build, builder IBuilder, err error, bui
 		errMsg += fmt.Sprintf("Error saving build: %s\n", err.Error())
 	}
 
-	cleanupErr := builder.CleanUp()
-	if cleanupErr != nil {
-		errMsg += fmt.Sprintf("Error cleaning up build: %s\n", cleanupErr.Error())
+	if builder != nil {
+		cleanupErr := builder.CleanUp()
+		if cleanupErr != nil {
+			errMsg += fmt.Sprintf("Error cleaning up build: %s\n", cleanupErr.Error())
+		}
 	}
 
 	buildLogger.Write([]byte(errMsg + "\n"))

--- a/pkg/build/runner.go
+++ b/pkg/build/runner.go
@@ -206,12 +206,14 @@ func (r *BuildRunner) DeleteBuilds() {
 
 			err := dockerClient.DeleteImage(b.Image, true, nil)
 			if err != nil {
-				log.Error(err)
+				r.handleBuildError(*b, nil, err, buildLogger)
+				return
 			}
 
 			err = r.buildStore.Delete(b.Id)
 			if err != nil {
-				log.Error(err)
+				r.handleBuildError(*b, nil, err, buildLogger)
+				return
 			}
 		}(b)
 	}

--- a/pkg/cmd/build/logs.go
+++ b/pkg/cmd/build/logs.go
@@ -89,7 +89,6 @@ func waitForBuildToComplete(buildId string, apiClient *apiclient.APIClient) erro
 		completedStates := []apiclient.BuildBuildState{
 			apiclient.BuildStatePublished,
 			apiclient.BuildStateError,
-			apiclient.BuildStateDeleting,
 		}
 
 		if slices.Contains(completedStates, build.State) {


### PR DESCRIPTION
# Handle logging build deletion errors
## Description

Handle logging build deletion errors for docker image and db entity deletion.
Also removes "deleting" from being a completed state regarding pausing build log reading

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
