### PR TITLE
feat: uninteractive project config creation

### DIFF
--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -16,8 +16,9 @@ daytona create [REPOSITORY_URL] [flags]
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
       --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
+      --env strings                Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
   -i, --ide string                 Specify the IDE (vscode, browser, cursor, ssh, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
-      --manual                     Manually enter the Git repositories
+      --manual                     Manually enter the Git repository
       --multi-project              Workspace with multiple projects/repos
       --name string                Specify the workspace name
       --provider string            Specify the provider (e.g. 'docker-provider')

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -16,7 +16,7 @@ daytona create [REPOSITORY_URL] [flags]
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
       --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
-      --env strings                Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
+      --env stringArray            Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
   -i, --ide string                 Specify the IDE (vscode, browser, cursor, ssh, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
       --manual                     Manually enter the Git repository
       --multi-project              Workspace with multiple projects/repos

--- a/docs/daytona_project-config_add.md
+++ b/docs/daytona_project-config_add.md
@@ -9,7 +9,14 @@ daytona project-config add [flags]
 ### Options
 
 ```
-      --manual   Manually enter the Git repository
+      --branch string              Specify the Git branch to use in the project
+      --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)
+      --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+      --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+      --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
+      --env strings                Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
+      --manual                     Manually enter the Git repository
+      --name string                Specify the project config name
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_project-config_add.md
+++ b/docs/daytona_project-config_add.md
@@ -14,7 +14,7 @@ daytona project-config add [flags]
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
       --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
-      --env strings                Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
+      --env stringArray            Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
       --manual                     Manually enter the Git repository
       --name string                Specify the project config name
 ```

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -22,13 +22,17 @@ options:
     - name: devcontainer-path
       usage: |
         Automatically assign the devcontainer builder with the path passed as the flag value
+    - name: env
+      default_value: '[]'
+      usage: |
+        Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
     - name: ide
       shorthand: i
       usage: |
         Specify the IDE (vscode, browser, cursor, ssh, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
     - name: manual
       default_value: "false"
-      usage: Manually enter the Git repositories
+      usage: Manually enter the Git repository
     - name: multi-project
       default_value: "false"
       usage: Workspace with multiple projects/repos

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -25,7 +25,7 @@ options:
     - name: env
       default_value: '[]'
       usage: |
-        Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
+        Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
     - name: ide
       shorthand: i
       usage: |

--- a/hack/docs/daytona_project-config_add.yaml
+++ b/hack/docs/daytona_project-config_add.yaml
@@ -18,7 +18,7 @@ options:
     - name: env
       default_value: '[]'
       usage: |
-        Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
+        Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
     - name: manual
       default_value: "false"
       usage: Manually enter the Git repository

--- a/hack/docs/daytona_project-config_add.yaml
+++ b/hack/docs/daytona_project-config_add.yaml
@@ -2,9 +2,28 @@ name: daytona project-config add
 synopsis: Add a project config
 usage: daytona project-config add [flags]
 options:
+    - name: branch
+      usage: Specify the Git branch to use in the project
+    - name: builder
+      usage: Specify the builder (currently auto/devcontainer/none)
+    - name: custom-image
+      usage: |
+        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+    - name: custom-image-user
+      usage: |
+        Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+    - name: devcontainer-path
+      usage: |
+        Automatically assign the devcontainer builder with the path passed as the flag value
+    - name: env
+      default_value: '[]'
+      usage: |
+        Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')
     - name: manual
       default_value: "false"
       usage: Manually enter the Git repository
+    - name: name
+      usage: Specify the project config name
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -6,12 +6,15 @@ package projectconfig
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -21,8 +24,9 @@ var projectConfigAddCmd = &cobra.Command{
 	Use:     "add",
 	Aliases: []string{"new", "create"},
 	Short:   "Add a project config",
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		var projectConfig *apiclient.ProjectConfig
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
@@ -35,36 +39,40 @@ var projectConfigAddCmd = &cobra.Command{
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
-		projectConfig, err := RunProjectConfigAddFlow(apiClient, gitProviders, ctx)
-		if err != nil {
-			log.Fatal(err)
+		if len(args) == 0 {
+			projectConfig, err = RunProjectConfigAddFlow(apiClient, gitProviders, ctx)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if projectConfig == nil {
+				return
+			}
+		} else {
+			err = processCmdArgument(args[0], apiClient, ctx)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 
-		if projectConfig != nil {
-			views.RenderInfoMessage("Project config added successfully")
-		}
+		views.RenderInfoMessage("Project config added successfully")
 	},
 }
 
 func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apiclient.GitProvider, ctx context.Context) (*apiclient.ProjectConfig, error) {
+	if workspace_util.CheckAnyProjectConfigurationFlagSet(projectConfigurationFlags) {
+		return nil, fmt.Errorf("please provide the repository URL in order to set up custom project config details through the CLI")
+	}
+
 	var createDtos []apiclient.CreateProjectDTO
-	var existingProjectConfigNames []string
+	existingProjectConfigNames := getExistingProjectConfigNames(apiClient)
 
 	apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
 	if err != nil {
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	existingProjectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()
-	if err != nil {
-		return nil, apiclient_util.HandleErrorResponse(res, err)
-	}
-	for _, pc := range existingProjectConfigs {
-		existingProjectConfigNames = append(existingProjectConfigNames, pc.Name)
-	}
-
-	projectDefaults := &create.ProjectConfigDefaults{
-		BuildChoice:          create.AUTOMATIC,
+	projectDefaults := &views_util.ProjectConfigDefaults{
+		BuildChoice:          views_util.AUTOMATIC,
 		Image:                &apiServerConfig.DefaultProjectImage,
 		ImageUser:            &apiServerConfig.DefaultProjectUser,
 		DevcontainerFilePath: create.DEVCONTAINER_FILEPATH,
@@ -72,7 +80,7 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 
 	createDtos, err = workspace_util.GetProjectsCreationDataFromPrompt(workspace_util.ProjectsDataPromptConfig{
 		UserGitProviders:    gitProviders,
-		Manual:              manualFlag,
+		Manual:              *projectConfigurationFlags.Manual,
 		MultiProject:        false,
 		SkipBranchSelection: true,
 		ApiClient:           apiClient,
@@ -144,8 +152,93 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 	}, nil
 }
 
-var manualFlag bool
+func processCmdArgument(argument string, apiClient *apiclient.APIClient, ctx context.Context) error {
+	if *projectConfigurationFlags.Builder != "" && *projectConfigurationFlags.Builder != views_util.DEVCONTAINER && *projectConfigurationFlags.DevcontainerPath != "" {
+		return fmt.Errorf("can't set devcontainer file path if builder is not set to %s", views_util.DEVCONTAINER)
+	}
+
+	apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
+	if err != nil {
+		return apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	existingProjectConfigNames := getExistingProjectConfigNames(apiClient)
+
+	repoUrl, err := util.GetValidatedUrl(argument)
+	if err != nil {
+		return err
+	}
+
+	_, res, err = apiClient.GitProviderAPI.GetGitContext(ctx).Repository(apiclient.GetRepositoryContext{
+		Url: repoUrl,
+	}).Execute()
+	if err != nil {
+		return apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	project := workspace_util.GetCreateProjectDtoFromFlags(projectConfigurationFlags)
+
+	var name string
+	if nameFlag != "" {
+		name = nameFlag
+	} else {
+		projectName := workspace_util.GetProjectNameFromRepo(repoUrl)
+		name = workspace_util.GetSuggestedName(projectName, existingProjectConfigNames)
+	}
+
+	newProjectConfig := apiclient.CreateProjectConfigDTO{
+		Name:          name,
+		BuildConfig:   project.BuildConfig,
+		Image:         project.Image,
+		User:          project.User,
+		RepositoryUrl: repoUrl,
+		EnvVars:       project.EnvVars,
+	}
+
+	if newProjectConfig.Image == nil {
+		newProjectConfig.Image = &apiServerConfig.DefaultProjectImage
+	}
+
+	if newProjectConfig.User == nil {
+		newProjectConfig.User = &apiServerConfig.DefaultProjectUser
+	}
+
+	res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()
+	if err != nil {
+		return apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	return nil
+}
+
+func getExistingProjectConfigNames(apiClient *apiclient.APIClient) []string {
+	var existingProjectConfigNames []string
+
+	existingProjectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()
+	if err != nil {
+		log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+	}
+
+	for _, pc := range existingProjectConfigs {
+		existingProjectConfigNames = append(existingProjectConfigNames, pc.Name)
+	}
+
+	return existingProjectConfigNames
+}
+
+var nameFlag string
+
+var projectConfigurationFlags = workspace_util.ProjectConfigurationFlags{
+	Builder:          new(views_util.BuildChoice),
+	CustomImage:      new(string),
+	CustomImageUser:  new(string),
+	Branch:           new(string),
+	DevcontainerPath: new(string),
+	EnvVars:          new([]string),
+	Manual:           new(bool),
+}
 
 func init() {
-	projectConfigAddCmd.Flags().BoolVar(&manualFlag, "manual", false, "Manually enter the Git repository")
+	projectConfigAddCmd.Flags().StringVar(&nameFlag, "name", "", "Specify the project config name")
+	workspace_util.AddProjectConfigurationFlags(projectConfigAddCmd, projectConfigurationFlags, false)
 }

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -10,6 +10,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	log "github.com/sirupsen/logrus"
@@ -64,8 +65,8 @@ var projectConfigUpdateCmd = &cobra.Command{
 			},
 		}
 
-		projectDefaults := &create.ProjectConfigDefaults{
-			BuildChoice: create.AUTOMATIC,
+		projectDefaults := &views_util.ProjectConfigDefaults{
+			BuildChoice: views_util.AUTOMATIC,
 			Image:       &projectConfig.Image,
 			ImageUser:   &projectConfig.User,
 		}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -392,7 +392,10 @@ func processGitURL(repoUrl string, apiClient *apiclient.APIClient, projects *[]a
 		return nil, err
 	}
 
-	project := workspace_util.GetCreateProjectDtoFromFlags(projectConfigurationFlags)
+	project, err := workspace_util.GetCreateProjectDtoFromFlags(projectConfigurationFlags)
+	if err != nil {
+		return nil, err
+	}
 
 	project.Name = projectName
 	project.Source = apiclient.CreateProjectSourceDTO{

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -209,7 +209,7 @@ func GetBranchFromProjectConfig(projectConfig *apiclient.ProjectConfig, apiClien
 	}, nil
 }
 
-func GetCreateProjectDtoFromFlags(projectConfigurationFlags ProjectConfigurationFlags) *apiclient.CreateProjectDTO {
+func GetCreateProjectDtoFromFlags(projectConfigurationFlags ProjectConfigurationFlags) (*apiclient.CreateProjectDTO, error) {
 	project := &apiclient.CreateProjectDTO{
 		BuildConfig: &apiclient.BuildConfig{},
 	}
@@ -240,13 +240,13 @@ func GetCreateProjectDtoFromFlags(projectConfigurationFlags ProjectConfiguration
 		if len(parts) == 2 {
 			envVars[parts[0]] = parts[1]
 		} else {
-			fmt.Printf("Invalid environment variable format: %s\n", envVar)
+			return nil, fmt.Errorf("Invalid environment variable format: %s\n", envVar)
 		}
 	}
 
 	project.EnvVars = envVars
 
-	return project
+	return project, nil
 }
 
 func newCreateProjectConfigDTO(config ProjectsDataPromptConfig, providerRepo *apiclient.GitRepository, providerRepoName string) apiclient.CreateProjectDTO {

--- a/pkg/cmd/workspace/util/workspace.go
+++ b/pkg/cmd/workspace/util/workspace.go
@@ -3,7 +3,51 @@
 
 package util
 
-import "github.com/daytonaio/daytona/pkg/apiclient"
+import (
+	"fmt"
+
+	"github.com/daytonaio/daytona/pkg/apiclient"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
+	"github.com/spf13/cobra"
+)
+
+type ProjectConfigurationFlags struct {
+	Builder          *views_util.BuildChoice
+	CustomImage      *string
+	CustomImageUser  *string
+	Branch           *string
+	DevcontainerPath *string
+	EnvVars          *[]string
+	Manual           *bool
+}
+
+func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfigurationFlags, multiProjectFlagException bool) {
+	cmd.Flags().StringVar(flags.CustomImage, "custom-image", "", "Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well")
+	cmd.Flags().StringVar(flags.CustomImageUser, "custom-image-user", "", "Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well")
+	cmd.Flags().StringVar(flags.Branch, "branch", "", "Specify the Git branch to use in the project")
+	cmd.Flags().StringVar(flags.DevcontainerPath, "devcontainer-path", "", "Automatically assign the devcontainer builder with the path passed as the flag value")
+	cmd.Flags().Var(flags.Builder, "builder", fmt.Sprintf("Specify the builder (currently %s/%s/%s)", views_util.AUTOMATIC, views_util.DEVCONTAINER, views_util.NONE))
+	cmd.Flags().StringSliceVar(flags.EnvVars, "env", []string{}, "Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')")
+	cmd.Flags().BoolVar(flags.Manual, "manual", false, "Manually enter the Git repository")
+
+	cmd.MarkFlagsMutuallyExclusive("builder", "custom-image")
+	cmd.MarkFlagsMutuallyExclusive("builder", "custom-image-user")
+	cmd.MarkFlagsMutuallyExclusive("devcontainer-path", "custom-image")
+	cmd.MarkFlagsMutuallyExclusive("devcontainer-path", "custom-image-user")
+	cmd.MarkFlagsRequiredTogether("custom-image", "custom-image-user")
+
+	if multiProjectFlagException {
+		cmd.MarkFlagsMutuallyExclusive("multi-project", "custom-image")
+		cmd.MarkFlagsMutuallyExclusive("multi-project", "custom-image-user")
+		cmd.MarkFlagsMutuallyExclusive("multi-project", "devcontainer-path")
+		cmd.MarkFlagsMutuallyExclusive("multi-project", "builder")
+		cmd.MarkFlagsMutuallyExclusive("multi-project", "env")
+	}
+}
+
+func CheckAnyProjectConfigurationFlagSet(flags ProjectConfigurationFlags) bool {
+	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || *flags.Branch != "" || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
+}
 
 func IsProjectRunning(workspace *apiclient.WorkspaceDTO, projectName string) bool {
 	for _, project := range workspace.GetProjects() {

--- a/pkg/cmd/workspace/util/workspace.go
+++ b/pkg/cmd/workspace/util/workspace.go
@@ -27,7 +27,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 	cmd.Flags().StringVar(flags.Branch, "branch", "", "Specify the Git branch to use in the project")
 	cmd.Flags().StringVar(flags.DevcontainerPath, "devcontainer-path", "", "Automatically assign the devcontainer builder with the path passed as the flag value")
 	cmd.Flags().Var(flags.Builder, "builder", fmt.Sprintf("Specify the builder (currently %s/%s/%s)", views_util.AUTOMATIC, views_util.DEVCONTAINER, views_util.NONE))
-	cmd.Flags().StringSliceVar(flags.EnvVars, "env", []string{}, "Specify environment variables (e.g. --env 'KEY1=VALUE1,KEY2=VALUE2,...')")
+	cmd.Flags().StringArrayVar(flags.EnvVars, "env", []string{}, "Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')")
 	cmd.Flags().BoolVar(flags.Manual, "manual", false, "Manually enter the Git repository")
 
 	cmd.MarkFlagsMutuallyExclusive("builder", "custom-image")

--- a/pkg/views/build/info/view.go
+++ b/pkg/views/build/info/view.go
@@ -12,7 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	projectconfig_info "github.com/daytonaio/daytona/pkg/views/projectconfig/info"
-	"github.com/daytonaio/daytona/pkg/views/workspace/create"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"golang.org/x/term"
 )
 
@@ -42,12 +42,12 @@ func Render(b *apiclient.Build, apiServerConfig *apiclient.ServerConfig, forceUn
 	output += getInfoLine("User", b.User) + "\n"
 
 	if projectconfig_info.GetLabelFromBuild(b.BuildConfig) != "" {
-		projectDefaults := &create.ProjectConfigDefaults{
+		projectDefaults := &views_util.ProjectConfigDefaults{
 			Image:     &apiServerConfig.DefaultProjectImage,
 			ImageUser: &apiServerConfig.DefaultProjectUser,
 		}
 
-		_, buildChoice := create.GetProjectBuildChoice(apiclient.CreateProjectDTO{
+		_, buildChoice := views_util.GetProjectBuildChoice(apiclient.CreateProjectDTO{
 			BuildConfig: b.BuildConfig,
 		}, projectDefaults)
 		output += getInfoLine("Build", buildChoice) + "\n"

--- a/pkg/views/projectconfig/info/view.go
+++ b/pkg/views/projectconfig/info/view.go
@@ -12,7 +12,7 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
-	"github.com/daytonaio/daytona/pkg/views/workspace/create"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"golang.org/x/term"
 )
 
@@ -42,7 +42,7 @@ func Render(projectConfig *apiclient.ProjectConfig, apiServerConfig *apiclient.S
 	}
 
 	if GetLabelFromBuild(projectConfig.BuildConfig) != "" {
-		projectDefaults := &create.ProjectConfigDefaults{
+		projectDefaults := &views_util.ProjectConfigDefaults{
 			Image:     &apiServerConfig.DefaultProjectImage,
 			ImageUser: &apiServerConfig.DefaultProjectUser,
 		}
@@ -50,7 +50,7 @@ func Render(projectConfig *apiclient.ProjectConfig, apiServerConfig *apiclient.S
 		createProjectDto := apiclient.CreateProjectDTO{
 			BuildConfig: projectConfig.BuildConfig,
 		}
-		_, buildChoice := create.GetProjectBuildChoice(createProjectDto, projectDefaults)
+		_, buildChoice := views_util.GetProjectBuildChoice(createProjectDto, projectDefaults)
 		output += getInfoLine("Build", buildChoice) + "\n"
 	}
 

--- a/pkg/views/projectconfig/list/view.go
+++ b/pkg/views/projectconfig/list/view.go
@@ -14,7 +14,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/projectconfig/info"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
-	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 	"golang.org/x/term"
 )
 
@@ -110,7 +109,7 @@ func getTableRowData(projectConfig apiclient.ProjectConfig, apiServerConfig *api
 	rowData.Prebuilds = "None"
 	rowData.IsDefault = ""
 
-	projectDefaults := &create.ProjectConfigDefaults{
+	projectDefaults := &views_util.ProjectConfigDefaults{
 		Image:     &apiServerConfig.DefaultProjectImage,
 		ImageUser: &apiServerConfig.DefaultProjectUser,
 	}
@@ -119,7 +118,7 @@ func getTableRowData(projectConfig apiclient.ProjectConfig, apiServerConfig *api
 		BuildConfig: projectConfig.BuildConfig,
 	}
 
-	_, rowData.Build = create.GetProjectBuildChoice(createProjectDto, projectDefaults)
+	_, rowData.Build = views_util.GetProjectBuildChoice(createProjectDto, projectDefaults)
 
 	if projectConfig.Default {
 		rowData.IsDefault = "1"

--- a/pkg/views/util/build_choice.go
+++ b/pkg/views/util/build_choice.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package create
+package util
 
 import (
 	"fmt"
@@ -17,6 +17,13 @@ const (
 	CUSTOMIMAGE  BuildChoice = "custom-image"
 	NONE         BuildChoice = "none"
 )
+
+type ProjectConfigDefaults struct {
+	BuildChoice          BuildChoice
+	Image                *string
+	ImageUser            *string
+	DevcontainerFilePath string
+}
 
 func GetProjectBuildChoice(project apiclient.CreateProjectDTO, defaults *ProjectConfigDefaults) (BuildChoice, string) {
 	if project.BuildConfig == nil {

--- a/pkg/views/workspace/create/configuration.go
+++ b/pkg/views/workspace/create/configuration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 )
 
@@ -31,7 +32,7 @@ type ProjectConfigurationData struct {
 	EnvVars              map[string]string
 }
 
-func NewConfigurationData(buildChoice BuildChoice, devContainerFilePath string, currentProject *apiclient.CreateProjectDTO, defaults *ProjectConfigDefaults) *ProjectConfigurationData {
+func NewConfigurationData(buildChoice views_util.BuildChoice, devContainerFilePath string, currentProject *apiclient.CreateProjectDTO, defaults *views_util.ProjectConfigDefaults) *ProjectConfigurationData {
 	projectConfigurationData := &ProjectConfigurationData{
 		BuildChoice:          string(buildChoice),
 		DevcontainerFilePath: defaults.DevcontainerFilePath,
@@ -55,7 +56,7 @@ func NewConfigurationData(buildChoice BuildChoice, devContainerFilePath string, 
 	return projectConfigurationData
 }
 
-func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults ProjectConfigDefaults) (bool, error) {
+func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults views_util.ProjectConfigDefaults) (bool, error) {
 	var currentProject *apiclient.CreateProjectDTO
 
 	if len(*projectList) > 1 {
@@ -72,19 +73,19 @@ func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults
 	}
 
 	devContainerFilePath := defaults.DevcontainerFilePath
-	builderChoice := AUTOMATIC
+	builderChoice := views_util.AUTOMATIC
 
 	if currentProject.BuildConfig != nil {
 		if currentProject.BuildConfig.Devcontainer != nil {
-			builderChoice = DEVCONTAINER
+			builderChoice = views_util.DEVCONTAINER
 			devContainerFilePath = currentProject.BuildConfig.Devcontainer.FilePath
 		}
 	} else {
 		if currentProject.Image == nil && currentProject.User == nil ||
 			*currentProject.Image == *defaults.Image && *currentProject.User == *defaults.ImageUser {
-			builderChoice = NONE
+			builderChoice = views_util.NONE
 		} else {
-			builderChoice = CUSTOMIMAGE
+			builderChoice = views_util.CUSTOMIMAGE
 		}
 	}
 
@@ -98,25 +99,25 @@ func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults
 
 	for i := range *projectList {
 		if (*projectList)[i].Name == currentProject.Name {
-			if projectConfigurationData.BuildChoice == string(NONE) {
+			if projectConfigurationData.BuildChoice == string(views_util.NONE) {
 				(*projectList)[i].BuildConfig = nil
 				(*projectList)[i].Image = defaults.Image
 				(*projectList)[i].User = defaults.ImageUser
 			}
 
-			if projectConfigurationData.BuildChoice == string(CUSTOMIMAGE) {
+			if projectConfigurationData.BuildChoice == string(views_util.CUSTOMIMAGE) {
 				(*projectList)[i].BuildConfig = nil
 				(*projectList)[i].Image = &projectConfigurationData.Image
 				(*projectList)[i].User = &projectConfigurationData.User
 			}
 
-			if projectConfigurationData.BuildChoice == string(AUTOMATIC) {
+			if projectConfigurationData.BuildChoice == string(views_util.AUTOMATIC) {
 				(*projectList)[i].BuildConfig = &apiclient.BuildConfig{}
 				(*projectList)[i].Image = defaults.Image
 				(*projectList)[i].User = defaults.ImageUser
 			}
 
-			if projectConfigurationData.BuildChoice == string(DEVCONTAINER) {
+			if projectConfigurationData.BuildChoice == string(views_util.DEVCONTAINER) {
 				(*projectList)[i].BuildConfig = &apiclient.BuildConfig{
 					Devcontainer: &apiclient.DevcontainerConfig{
 						FilePath: projectConfigurationData.DevcontainerFilePath,
@@ -147,10 +148,10 @@ func validateDevcontainerFilename(filename string) error {
 
 func GetProjectConfigurationForm(projectConfiguration *ProjectConfigurationData) *huh.Form {
 	buildOptions := []huh.Option[string]{
-		{Key: "Automatic", Value: string(AUTOMATIC)},
-		{Key: "Devcontainer", Value: string(DEVCONTAINER)},
-		{Key: "Custom image", Value: string(CUSTOMIMAGE)},
-		{Key: "None", Value: string(NONE)},
+		{Key: "Automatic", Value: string(views_util.AUTOMATIC)},
+		{Key: "Devcontainer", Value: string(views_util.DEVCONTAINER)},
+		{Key: "Custom image", Value: string(views_util.CUSTOMIMAGE)},
+		{Key: "None", Value: string(views_util.NONE)},
 	}
 
 	form := huh.NewForm(
@@ -170,14 +171,14 @@ func GetProjectConfigurationForm(projectConfiguration *ProjectConfigurationData)
 				Title("Container user").
 				Value(&projectConfiguration.User),
 		).WithHideFunc(func() bool {
-			return projectConfiguration.BuildChoice != string(CUSTOMIMAGE)
+			return projectConfiguration.BuildChoice != string(views_util.CUSTOMIMAGE)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Devcontainer file path").
 				Value(&projectConfiguration.DevcontainerFilePath).Validate(validateDevcontainerFilename),
 		).WithHideFunc(func() bool {
-			return projectConfiguration.BuildChoice != string(DEVCONTAINER)
+			return projectConfiguration.BuildChoice != string(views_util.DEVCONTAINER)
 		}),
 		huh.NewGroup(
 			views.GetEnvVarsInput(&projectConfiguration.EnvVars),

--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -15,6 +15,7 @@ import (
 	util "github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
 type ProjectDetail string
@@ -29,13 +30,6 @@ const (
 	DEFAULT_PADDING                  = 21
 )
 
-type ProjectConfigDefaults struct {
-	BuildChoice          BuildChoice
-	Image                *string
-	ImageUser            *string
-	DevcontainerFilePath string
-}
-
 type SummaryModel struct {
 	lg          *lipgloss.Renderer
 	styles      *Styles
@@ -44,7 +38,7 @@ type SummaryModel struct {
 	quitting    bool
 	name        string
 	projectList []apiclient.CreateProjectDTO
-	defaults    *ProjectConfigDefaults
+	defaults    *views_util.ProjectConfigDefaults
 	nameLabel   string
 }
 
@@ -54,7 +48,7 @@ type SubmissionFormConfig struct {
 	ExistingNames []string
 	ProjectList   *[]apiclient.CreateProjectDTO
 	NameLabel     string
-	Defaults      *ProjectConfigDefaults
+	Defaults      *views_util.ProjectConfigDefaults
 }
 
 var configureCheck bool
@@ -91,7 +85,7 @@ func RunSubmissionForm(config SubmissionFormConfig) error {
 	return RunSubmissionForm(config)
 }
 
-func RenderSummary(name string, projectList []apiclient.CreateProjectDTO, defaults *ProjectConfigDefaults, nameLabel string) (string, error) {
+func RenderSummary(name string, projectList []apiclient.CreateProjectDTO, defaults *views_util.ProjectConfigDefaults, nameLabel string) (string, error) {
 	var output string
 	if name == "" {
 		output = views.GetStyledMainTitle("SUMMARY")
@@ -108,7 +102,7 @@ func RenderSummary(name string, projectList []apiclient.CreateProjectDTO, defaul
 			output += fmt.Sprintf("%s - %s\n", lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("%s #%d", "Project", i+1)), (projectList[i].Source.Repository.Url))
 		}
 
-		projectBuildChoice, choiceName := GetProjectBuildChoice(projectList[i], defaults)
+		projectBuildChoice, choiceName := views_util.GetProjectBuildChoice(projectList[i], defaults)
 		output += renderProjectDetails(projectList[i], projectBuildChoice, choiceName)
 		if i < len(projectList)-1 {
 			output += "\n\n"
@@ -118,10 +112,10 @@ func RenderSummary(name string, projectList []apiclient.CreateProjectDTO, defaul
 	return output, nil
 }
 
-func renderProjectDetails(project apiclient.CreateProjectDTO, buildChoice BuildChoice, choiceName string) string {
+func renderProjectDetails(project apiclient.CreateProjectDTO, buildChoice views_util.BuildChoice, choiceName string) string {
 	output := projectDetailOutput(Build, choiceName)
 
-	if buildChoice == DEVCONTAINER {
+	if buildChoice == views_util.DEVCONTAINER {
 		if project.BuildConfig != nil {
 			if project.BuildConfig.Devcontainer != nil {
 				output += "\n"


### PR DESCRIPTION
# Uninteractive project config creation
## Description

Allows for uninteractive creation of project configs by passing the same flags that work for `daytona create`.
Adds environment variables flag for both `daytona create` and `daytona project-config add`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/4c6dc3dd-255e-435d-b134-80371ed8649e)
