### PR TITLE
fix(gitlab): Configure SHA property for static git context

### DIFF
--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -416,7 +417,13 @@ func (g *GitLabGitProvider) ParseStaticGitContext(repoUrl string) (*StaticGitCon
 			return nil, fmt.Errorf("can not parse git URL: %s", repoUrl)
 		}
 
-		staticContext.Branch = &branchParts[0]
+		sha1Pattern := regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
+		if sha1Pattern.MatchString(branchParts[0]) {
+			staticContext.Sha = &branchParts[0]
+			staticContext.Branch = &branchParts[0]
+		} else {
+			staticContext.Branch = &branchParts[0]
+		}
 		staticContext.Path = nil
 	}
 

--- a/pkg/gitprovider/gitlab_test.go
+++ b/pkg/gitprovider/gitlab_test.go
@@ -151,6 +151,23 @@ func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commits() {
 
 	require.Nil(err)
 	require.Equal(httpContext, commitsContext)
+
+	shaUrl := "https://gitlab.com/gitlab-org/gitlab/-/commits/c87cfbb77c2cf36356d010d1c0b21817c42f70ef"
+	shaContext := &StaticGitContext{
+		Id:       "gitlab-org/gitlab",
+		Name:     "gitlab",
+		Owner:    "gitlab-org",
+		Url:      "https://gitlab.com/gitlab-org/gitlab.git",
+		Source:   "gitlab.com",
+		Branch:   util.Pointer("c87cfbb77c2cf36356d010d1c0b21817c42f70ef"),
+		Sha:      util.Pointer("c87cfbb77c2cf36356d010d1c0b21817c42f70ef"),
+		PrNumber: nil,
+		Path:     nil,
+	}
+
+	httpContext, err = g.gitProvider.ParseStaticGitContext(shaUrl)
+	require.Nil(err)
+	require.Equal(httpContext, shaContext)
 }
 
 func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_Commit() {


### PR DESCRIPTION
## Description

Adds SHA property to `StaticGitContext` if the section after`commits\` is a SHA hashcode

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #904
/claim #904