### PR TITLE
feat: start open workspace code

### DIFF
--- a/docs/daytona_start.md
+++ b/docs/daytona_start.md
@@ -10,6 +10,7 @@ daytona start [WORKSPACE] [flags]
 
 ```
   -a, --all              Start all workspaces
+  -c, --code             Open the workspace in the default IDE
   -p, --project string   Start a single project in the workspace (project name)
 ```
 

--- a/hack/docs/daytona_start.yaml
+++ b/hack/docs/daytona_start.yaml
@@ -6,6 +6,10 @@ options:
       shorthand: a
       default_value: "false"
       usage: Start all workspaces
+    - name: code
+      shorthand: c
+      default_value: "false"
+      usage: Open the workspace in the default IDE
     - name: project
       shorthand: p
       usage: Start a single project in the workspace (project name)

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -44,7 +44,11 @@ var StartCmd = &cobra.Command{
 		}
 
 		if wscodeFlag {
-			CodeCmd.Run(cmd, []string{args[0]})
+			if len(args) > 0 && args[0] != "" {
+				CodeCmd.Run(cmd, []string{args[0]})
+			}else {
+				log.Fatalf("Cannot found Workspace: Use daytona start %s", args[0])
+			}
 		}
 
 		ctx := context.Background()

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -46,7 +46,7 @@ var StartCmd = &cobra.Command{
 		if wscodeFlag {
 			if len(args) > 0 && args[0] != "" {
 				CodeCmd.Run(cmd, []string{args[0]})
-			}else {
+			} else {
 				log.Fatalf("Cannot found Workspace: Use daytona start %s", args[0])
 			}
 		}

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -24,6 +24,7 @@ const (
 
 var startProjectFlag string
 var allFlag bool
+var wscodeFlag bool
 
 var StartCmd = &cobra.Command{
 	Use:     "start [WORKSPACE]",
@@ -40,6 +41,10 @@ var StartCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 			return
+		}
+
+		if wscodeFlag {
+			CodeCmd.Run(cmd, []string{args[0]})
 		}
 
 		ctx := context.Background()
@@ -99,6 +104,7 @@ var StartCmd = &cobra.Command{
 func init() {
 	StartCmd.PersistentFlags().StringVarP(&startProjectFlag, "project", "p", "", "Start a single project in the workspace (project name)")
 	StartCmd.PersistentFlags().BoolVarP(&allFlag, "all", "a", false, "Start all workspaces")
+	StartCmd.PersistentFlags().BoolVarP(&wscodeFlag, "code", "c", false, "Open the workspace in the default IDE")
 
 	err := StartCmd.RegisterFlagCompletionFunc("project", getProjectNameCompletions)
 	if err != nil {

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -43,14 +43,6 @@ var StartCmd = &cobra.Command{
 			return
 		}
 
-		if wscodeFlag {
-			if len(args) > 0 && args[0] != "" {
-				CodeCmd.Run(cmd, []string{args[0]})
-			} else {
-				log.Fatalf("Cannot found Workspace: Use daytona start %s", args[0])
-			}
-		}
-
 		ctx := context.Background()
 
 		apiClient, err := apiclient.GetApiClient(nil)
@@ -83,6 +75,9 @@ var StartCmd = &cobra.Command{
 		if startProjectFlag == "" {
 			message = fmt.Sprintf("Workspace '%s' is starting", workspaceId)
 			res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, workspaceId).Execute()
+			if wscodeFlag {
+				CodeCmd.Run(cmd, []string{workspaceId})
+			}
 			if err != nil {
 				log.Fatal(apiclient.HandleErrorResponse(res, err))
 			}


### PR DESCRIPTION
# feat: start open workspace code

## Description
this pr adds support for 
start open workspace code
example -  for workspace 
daytona start xyz --code
for multi-project workspace
- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #986
/claim #986

## Screenshots

https://github.com/user-attachments/assets/06380e6e-009c-4cbd-b21f-a24550c9dfc9



## Notes
Please add any relevant notes if necessary.
