### PR TITLE
feat: Add Clipboard functionality to api-key new cmd

### DIFF
--- a/pkg/views/server/apikey/notify.go
+++ b/pkg/views/server/apikey/notify.go
@@ -38,11 +38,12 @@ func Render(key, apiUrl string) {
 	clipboardMessage := copyToClipboard(command)
 
 	if terminalWidth >= minimumLayoutWidth {
-		output += "\n\n" + formattedCommand + "\n\n" + clipboardMessage
+		output += "\n\n" + formattedCommand
+		output += "\n\n" + clipboardMessage
 		views.RenderContainerLayout(views.GetInfoMessage(output))
 	} else {
 		views.RenderContainerLayout(views.GetInfoMessage(output))
-		fmt.Println(formattedCommand + "\n\n")
+		fmt.Println(command + "\n\n")
 		fmt.Println(clipboardMessage)
 	}
 }

--- a/pkg/views/server/apikey/notify.go
+++ b/pkg/views/server/apikey/notify.go
@@ -32,18 +32,25 @@ func Render(key, apiUrl string) {
 
 	output += "You can connect to the Daytona Server from a client machine by running:"
 
-	formattedCommand := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
-	command := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
-	clipboard.WriteAll(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
+	formattedCommand := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a \\\n%s \\\n-k %s", apiUrl, key))
+	command := fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key)
+
+	clipboardMessage := copyToClipboard(command)
 
 	if terminalWidth >= minimumLayoutWidth {
-		output += "\n\n" + formattedCommand
-		output += "\n\n" +"The following command is copied to your clipboard."
+		output += "\n\n" + formattedCommand + "\n\n" + clipboardMessage
 		views.RenderContainerLayout(views.GetInfoMessage(output))
-		} else {
-			views.RenderContainerLayout(views.GetInfoMessage(output))
-			fmt.Println(command + "\n\n")
-			fmt.Println("The following command is copied to your clipboard.")
-		}
+	} else {
+		views.RenderContainerLayout(views.GetInfoMessage(output))
+		fmt.Println(formattedCommand + "\n\n")
+		fmt.Println(clipboardMessage)
+	}
+}
 
+func copyToClipboard(command string) string {
+	err := clipboard.WriteAll(command)
+	if err != nil {
+		return "Error: Unable to copy the command to the clipboard. Please copy it manually."
+	}
+	return "The command has been successfully copied to your clipboard."
 }

--- a/pkg/views/server/apikey/notify.go
+++ b/pkg/views/server/apikey/notify.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/pkg/views"
 	"golang.org/x/term"
@@ -31,15 +32,18 @@ func Render(key, apiUrl string) {
 
 	output += "You can connect to the Daytona Server from a client machine by running:"
 
-	formattedCommand := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a \\\n%s \\\n-k %s", apiUrl, key))
+	formattedCommand := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
 	command := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
+	clipboard.WriteAll(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
 
 	if terminalWidth >= minimumLayoutWidth {
 		output += "\n\n" + formattedCommand
+		output += "\n\n" +"The following command is copied to your clipboard."
 		views.RenderContainerLayout(views.GetInfoMessage(output))
-	} else {
-		views.RenderContainerLayout(views.GetInfoMessage(output))
-		fmt.Println(command + "\n\n")
-	}
+		} else {
+			views.RenderContainerLayout(views.GetInfoMessage(output))
+			fmt.Println(command + "\n\n")
+			fmt.Println("The following command is copied to your clipboard.")
+		}
 
 }


### PR DESCRIPTION
# feat: Add Clipboard functionality to api-key new cmd

## Description
This PR introduces a clipboard functionality to the api-key new command in the Daytona project. The new feature automatically copies the generated command to the system clipboard, addressing issues with trailing whitespaces and improving usability. The change leverages the ```github.com/atotto/clipboard``` package

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #957 

## Screenshots
![today](https://github.com/user-attachments/assets/3e0fcebd-3b34-4c74-a192-d145f5e87df7)


https://github.com/user-attachments/assets/69d89664-8d59-43cf-8435-640e929f2576





## Notes
Please add any relevant notes if necessary.
