### PR TITLE
feat: add -v flag to root cmds

### DIFF
--- a/docs/daytona.md
+++ b/docs/daytona.md
@@ -13,7 +13,8 @@ daytona [flags]
 ### Options
 
 ```
-      --help   help for daytona
+      --help      help for daytona
+  -v, --version   Display the version of Daytona
 ```
 
 ### SEE ALSO

--- a/docs/workspace_mode/daytona.md
+++ b/docs/workspace_mode/daytona.md
@@ -13,7 +13,8 @@ daytona [flags]
 ### Options
 
 ```
-      --help   help for daytona
+      --help      help for daytona
+  -v, --version   Display the version of Daytona
 ```
 
 ### SEE ALSO

--- a/hack/docs/daytona.yaml
+++ b/hack/docs/daytona.yaml
@@ -6,6 +6,10 @@ options:
     - name: help
       default_value: "false"
       usage: help for daytona
+    - name: version
+      shorthand: v
+      default_value: "false"
+      usage: Display the version of Daytona
 see_also:
     - daytona api-key - Api Key commands
     - daytona autocomplete - Adds completion script for your shell enviornment

--- a/hack/docs/workspace_mode/daytona.yaml
+++ b/hack/docs/workspace_mode/daytona.yaml
@@ -6,6 +6,10 @@ options:
     - name: help
       default_value: "false"
       usage: help for daytona
+    - name: version
+      shorthand: v
+      default_value: "false"
+      usage: Display the version of Daytona
 see_also:
     - daytona agent - Start the agent process
     - daytona autocomplete - Adds completion script for your shell enviornment

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -141,6 +141,7 @@ func SetupRootCommand(cmd *cobra.Command) {
 
 	cmd.CompletionOptions.HiddenDefaultCmd = true
 	cmd.PersistentFlags().BoolP("help", "", false, "help for daytona")
+	cmd.Flags().BoolP("version", "v", false, "Display the version of Daytona")
 
 	var telemetryService telemetry.TelemetryService
 	clientId := config.GetClientId()
@@ -154,6 +155,14 @@ func SetupRootCommand(cmd *cobra.Command) {
 	}
 
 	startTime := time.Now()
+
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		versionFlag, _ := cmd.Flags().GetBool("version")
+		if versionFlag {
+			versionCmd.Run(cmd, []string{})
+			os.Exit(0)
+		}
+	}
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if telemetryService != nil {


### PR DESCRIPTION
# Daytona -v
## Description

Adds `daytona -v` "alias" for `daytona version`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/2776a8b2-8019-4d22-ac28-79c9c64f57c2)