### PR TITLE
feat: Support for Webhook events for GitLab/GitLab self-managed prebuilds

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -131,6 +131,10 @@ func GetWebhookEventHeaderKeyFromGitProvider(providerId string) string {
 	switch providerId {
 	case "github":
 		return "X-GitHub-Event"
+	case "gitlab":
+		fallthrough
+	case "gitlab-self-managed":
+		return "X-Gitlab-Event"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Description

This PR adds support for webhooks for GitLab / GitLab self-managed prebuilds. It implements five methods namely webhook get, register, unregister, comparing commit ranges and parsing event data. 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #993 
/claim #993

## Screenshots

https://github.com/user-attachments/assets/53ebe944-88f5-44bc-afa1-f2c4ef3dc467

