### PR TITLE
feat: multi-profile support for git providers(#777)

### DIFF
--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -12,7 +12,6 @@ daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
       --blank                           Create a blank project without using existing configurations
       --branch strings                  Specify the Git branches to use in the projects
       --builder BuildChoice             Specify the builder (currently auto/devcontainer/none)
-  -c, --code                            Open the workspace in the IDE after workspace creation
       --custom-image string             Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string        Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
       --devcontainer-path string        Automatically assign the devcontainer builder with the path passed as the flag value
@@ -22,22 +21,9 @@ daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
       --manual                          Manually enter the Git repository
       --multi-project                   Workspace with multiple projects/repos
       --name string                     Specify the workspace name
+  -n, --no-ide                          Do not open the workspace in the IDE after workspace creation
   -t, --target string                   Specify the target (e.g. 'local')
   -y, --yes                             Automatically confirm any prompts
-      --blank                      Create a blank project without using existing configurations
-      --branch strings             Specify the Git branches to use in the projects
-      --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)
-      --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
-      --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
-      --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
-      --env stringArray            Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-  -i, --ide string                 Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
-      --manual                     Manually enter the Git repository
-      --multi-project              Workspace with multiple projects/repos
-      --name string                Specify the workspace name
-  -n, --no-ide                     Do not open the workspace in the IDE after workspace creation
-  -t, --target string              Specify the target (e.g. 'local')
-  -y, --yes                        Automatically confirm any prompts
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -9,6 +9,21 @@ daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
 ### Options
 
 ```
+      --blank                           Create a blank project without using existing configurations
+      --branch strings                  Specify the Git branches to use in the projects
+      --builder BuildChoice             Specify the builder (currently auto/devcontainer/none)
+  -c, --code                            Open the workspace in the IDE after workspace creation
+      --custom-image string             Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+      --custom-image-user string        Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+      --devcontainer-path string        Automatically assign the devcontainer builder with the path passed as the flag value
+      --env stringArray                 Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
+      --git-provider-config-id string   Specify the Git Provider Configuration Id
+  -i, --ide string                      Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+      --manual                          Manually enter the Git repository
+      --multi-project                   Workspace with multiple projects/repos
+      --name string                     Specify the workspace name
+  -t, --target string                   Specify the target (e.g. 'local')
+  -y, --yes                             Automatically confirm any prompts
       --blank                      Create a blank project without using existing configurations
       --branch strings             Specify the Git branches to use in the projects
       --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)

--- a/docs/daytona_project-config_add.md
+++ b/docs/daytona_project-config_add.md
@@ -9,13 +9,14 @@ daytona project-config add [flags]
 ### Options
 
 ```
-      --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)
-      --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
-      --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
-      --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
-      --env stringArray            Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-      --manual                     Manually enter the Git repository
-      --name string                Specify the project config name
+      --builder BuildChoice             Specify the builder (currently auto/devcontainer/none)
+      --custom-image string             Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+      --custom-image-user string        Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+      --devcontainer-path string        Automatically assign the devcontainer builder with the path passed as the flag value
+      --env stringArray                 Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
+      --git-provider-config-id string   Specify the Git Provider Configuration Id
+      --manual                          Manually enter the Git repository
+      --name string                     Specify the project config name
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -23,6 +23,8 @@ options:
       default_value: '[]'
       usage: |
         Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
+    - name: git-provider-config-id
+      usage: Specify the Git Provider Configuration Id
     - name: ide
       shorthand: i
       usage: |

--- a/hack/docs/daytona_project-config_add.yaml
+++ b/hack/docs/daytona_project-config_add.yaml
@@ -17,6 +17,8 @@ options:
       default_value: '[]'
       usage: |
         Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
+    - name: git-provider-config-id
+      usage: Specify the Git Provider Configuration Id
     - name: manual
       default_value: "false"
       usage: Manually enter the Git repository

--- a/internal/util/apiclient/conversion/project.go
+++ b/internal/util/apiclient/conversion/project.go
@@ -50,14 +50,15 @@ func ToProject(projectDTO *apiclient.Project) *project.Project {
 	}
 
 	project := &project.Project{
-		Name:        projectDTO.Name,
-		Image:       projectDTO.Image,
-		User:        projectDTO.User,
-		BuildConfig: projectBuild,
-		Repository:  repository,
-		Target:      projectDTO.Target,
-		WorkspaceId: projectDTO.WorkspaceId,
-		State:       projectState,
+		Name:                projectDTO.Name,
+		Image:               projectDTO.Image,
+		User:                projectDTO.User,
+		BuildConfig:         projectBuild,
+		Repository:          repository,
+		Target:              projectDTO.Target,
+		WorkspaceId:         projectDTO.WorkspaceId,
+		State:               projectState,
+		GitProviderConfigId: projectDTO.GitProviderConfigId,
 	}
 
 	if projectDTO.Repository.PrNumber != nil {
@@ -148,9 +149,10 @@ func ToGitStatusDTO(gitStatus *project.GitStatus) *apiclient.GitStatus {
 
 func ToProjectConfig(createProjectConfigDto pc_dto.CreateProjectConfigDTO) *config.ProjectConfig {
 	result := &config.ProjectConfig{
-		Name:        createProjectConfigDto.Name,
-		BuildConfig: createProjectConfigDto.BuildConfig,
-		EnvVars:     createProjectConfigDto.EnvVars,
+		Name:                createProjectConfigDto.Name,
+		BuildConfig:         createProjectConfigDto.BuildConfig,
+		EnvVars:             createProjectConfigDto.EnvVars,
+		GitProviderConfigId: createProjectConfigDto.GitProviderConfigId,
 	}
 
 	result.RepositoryUrl = createProjectConfigDto.RepositoryUrl
@@ -168,10 +170,11 @@ func ToProjectConfig(createProjectConfigDto pc_dto.CreateProjectConfigDTO) *conf
 
 func CreateDtoToProject(createProjectDto project_dto.CreateProjectDTO) *project.Project {
 	p := &project.Project{
-		Name:        createProjectDto.Name,
-		BuildConfig: createProjectDto.BuildConfig,
-		Repository:  createProjectDto.Source.Repository,
-		EnvVars:     createProjectDto.EnvVars,
+		Name:                createProjectDto.Name,
+		BuildConfig:         createProjectDto.BuildConfig,
+		Repository:          createProjectDto.Source.Repository,
+		EnvVars:             createProjectDto.EnvVars,
+		GitProviderConfigId: createProjectDto.GitProviderConfigId,
 	}
 
 	if createProjectDto.Image != nil {
@@ -187,10 +190,11 @@ func CreateDtoToProject(createProjectDto project_dto.CreateProjectDTO) *project.
 
 func CreateConfigDtoToProject(createProjectConfigDto pc_dto.CreateProjectConfigDTO) *project.Project {
 	return &project.Project{
-		Name:        createProjectConfigDto.Name,
-		Image:       *createProjectConfigDto.Image,
-		User:        *createProjectConfigDto.User,
-		BuildConfig: createProjectConfigDto.BuildConfig,
+		Name:                createProjectConfigDto.Name,
+		Image:               *createProjectConfigDto.Image,
+		User:                *createProjectConfigDto.User,
+		BuildConfig:         createProjectConfigDto.BuildConfig,
+		GitProviderConfigId: createProjectConfigDto.GitProviderConfigId,
 		Repository: &gitprovider.GitRepository{
 			Url: createProjectConfigDto.RepositoryUrl,
 		},

--- a/pkg/api/controllers/gitprovider/dto/dto.go
+++ b/pkg/api/controllers/gitprovider/dto/dto.go
@@ -8,8 +8,10 @@ type RepositoryUrl struct {
 } // @name RepositoryUrl
 
 type SetGitProviderConfig struct {
-	Id         string  `json:"id" validate:"required"`
-	Username   *string `json:"username" validate:"optional"`
+	Id         string  `json:"id" validate:"optional"`
+	ProviderId string  `json:"providerId" validate:"required"`
+	Username   *string `json:"username,omitempty" validate:"optional"`
 	Token      string  `json:"token" validate:"required"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty" validate:"optional"`
+	Alias      string  `json:"alias" validate:"optional"`
 } // @name SetGitProviderConfig

--- a/pkg/api/controllers/gitprovider/dto/dto.go
+++ b/pkg/api/controllers/gitprovider/dto/dto.go
@@ -13,5 +13,5 @@ type SetGitProviderConfig struct {
 	Username   *string `json:"username,omitempty" validate:"optional"`
 	Token      string  `json:"token" validate:"required"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty" validate:"optional"`
-	Alias      string  `json:"alias" validate:"optional"`
+	Alias      *string `json:"alias" validate:"optional"`
 } // @name SetGitProviderConfig

--- a/pkg/api/controllers/gitprovider/dto/dto.go
+++ b/pkg/api/controllers/gitprovider/dto/dto.go
@@ -13,5 +13,5 @@ type SetGitProviderConfig struct {
 	Username   *string `json:"username,omitempty" validate:"optional"`
 	Token      string  `json:"token" validate:"required"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty" validate:"optional"`
-	Alias      *string `json:"alias" validate:"optional"`
+	Alias      *string `json:"alias,omitempty" validate:"optional"`
 } // @name SetGitProviderConfig

--- a/pkg/api/controllers/gitprovider/gitprovider.go
+++ b/pkg/api/controllers/gitprovider/gitprovider.go
@@ -136,11 +136,14 @@ func SetGitProvider(ctx *gin.Context) {
 		ProviderId: setConfigDto.ProviderId,
 		Token:      setConfigDto.Token,
 		BaseApiUrl: setConfigDto.BaseApiUrl,
-		Alias:      *setConfigDto.Alias,
 	}
 
 	if setConfigDto.Username != nil {
 		gitProviderConfig.Username = *setConfigDto.Username
+	}
+
+	if setConfigDto.Alias != nil {
+		gitProviderConfig.Alias = *setConfigDto.Alias
 	}
 
 	server := server.GetInstance(nil)

--- a/pkg/api/controllers/gitprovider/gitprovider.go
+++ b/pkg/api/controllers/gitprovider/gitprovider.go
@@ -133,8 +133,10 @@ func SetGitProvider(ctx *gin.Context) {
 
 	gitProviderConfig := gitprovider.GitProviderConfig{
 		Id:         setConfigDto.Id,
+		ProviderId: setConfigDto.ProviderId,
 		Token:      setConfigDto.Token,
 		BaseApiUrl: setConfigDto.BaseApiUrl,
+		Alias:      setConfigDto.Alias,
 	}
 
 	if setConfigDto.Username != nil {

--- a/pkg/api/controllers/gitprovider/gitprovider.go
+++ b/pkg/api/controllers/gitprovider/gitprovider.go
@@ -136,7 +136,7 @@ func SetGitProvider(ctx *gin.Context) {
 		ProviderId: setConfigDto.ProviderId,
 		Token:      setConfigDto.Token,
 		BaseApiUrl: setConfigDto.BaseApiUrl,
-		Alias:      setConfigDto.Alias,
+		Alias:      *setConfigDto.Alias,
 	}
 
 	if setConfigDto.Username != nil {

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1953,6 +1953,7 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "envVars",
+                "gitProviderConfigId",
                 "name",
                 "repositoryUrl"
             ],
@@ -1965,6 +1966,9 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
                 },
                 "image": {
                     "type": "string"
@@ -1996,6 +2000,9 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
                 },
                 "image": {
                     "type": "string"
@@ -2169,15 +2176,23 @@ const docTemplate = `{
         "GitProvider": {
             "type": "object",
             "required": [
+                "alias",
                 "id",
+                "providerId",
                 "token",
                 "username"
             ],
             "properties": {
+                "alias": {
+                    "type": "string"
+                },
                 "baseApiUrl": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "providerId": {
                     "type": "string"
                 },
                 "token": {
@@ -2443,6 +2458,9 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "gitProviderConfigId": {
+                    "type": "string"
+                },
                 "image": {
                     "type": "string"
                 },
@@ -2488,6 +2506,9 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
                 },
                 "image": {
                     "type": "string"
@@ -2700,14 +2721,20 @@ const docTemplate = `{
         "SetGitProviderConfig": {
             "type": "object",
             "required": [
-                "id",
+                "providerId",
                 "token"
             ],
             "properties": {
+                "alias": {
+                    "type": "string"
+                },
                 "baseApiUrl": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "providerId": {
                     "type": "string"
                 },
                 "token": {

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1953,7 +1953,6 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "envVars",
-                "gitProviderConfigId",
                 "name",
                 "repositoryUrl"
             ],

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1950,7 +1950,6 @@
             "type": "object",
             "required": [
                 "envVars",
-                "gitProviderConfigId",
                 "name",
                 "repositoryUrl"
             ],

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1950,6 +1950,7 @@
             "type": "object",
             "required": [
                 "envVars",
+                "gitProviderConfigId",
                 "name",
                 "repositoryUrl"
             ],
@@ -1962,6 +1963,9 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
                 },
                 "image": {
                     "type": "string"
@@ -1993,6 +1997,9 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
                 },
                 "image": {
                     "type": "string"
@@ -2166,15 +2173,23 @@
         "GitProvider": {
             "type": "object",
             "required": [
+                "alias",
                 "id",
+                "providerId",
                 "token",
                 "username"
             ],
             "properties": {
+                "alias": {
+                    "type": "string"
+                },
                 "baseApiUrl": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "providerId": {
                     "type": "string"
                 },
                 "token": {
@@ -2440,6 +2455,9 @@
                         "type": "string"
                     }
                 },
+                "gitProviderConfigId": {
+                    "type": "string"
+                },
                 "image": {
                     "type": "string"
                 },
@@ -2485,6 +2503,9 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
                 },
                 "image": {
                     "type": "string"
@@ -2697,14 +2718,20 @@
         "SetGitProviderConfig": {
             "type": "object",
             "required": [
-                "id",
+                "providerId",
                 "token"
             ],
             "properties": {
+                "alias": {
+                    "type": "string"
+                },
                 "baseApiUrl": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "providerId": {
                     "type": "string"
                 },
                 "token": {

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -140,6 +140,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      gitProviderConfigId:
+        type: string
       image:
         type: string
       name:
@@ -150,6 +152,7 @@ definitions:
         type: string
     required:
     - envVars
+    - gitProviderConfigId
     - name
     - repositoryUrl
     type: object
@@ -161,6 +164,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      gitProviderConfigId:
+        type: string
       image:
         type: string
       name:
@@ -280,16 +285,22 @@ definitions:
     type: object
   GitProvider:
     properties:
+      alias:
+        type: string
       baseApiUrl:
         type: string
       id:
+        type: string
+      providerId:
         type: string
       token:
         type: string
       username:
         type: string
     required:
+    - alias
     - id
+    - providerId
     - token
     - username
     type: object
@@ -462,6 +473,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      gitProviderConfigId:
+        type: string
       image:
         type: string
       name:
@@ -495,6 +508,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      gitProviderConfigId:
+        type: string
       image:
         type: string
       name:
@@ -648,16 +663,20 @@ definitions:
     type: object
   SetGitProviderConfig:
     properties:
+      alias:
+        type: string
       baseApiUrl:
         type: string
       id:
+        type: string
+      providerId:
         type: string
       token:
         type: string
       username:
         type: string
     required:
-    - id
+    - providerId
     - token
     type: object
   SetProjectState:

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -152,7 +152,6 @@ definitions:
         type: string
     required:
     - envVars
-    - gitProviderConfigId
     - name
     - repositoryUrl
     type: object

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1485,7 +1485,6 @@ components:
           type: string
       required:
       - envVars
-      - gitProviderConfigId
       - name
       - repositoryUrl
       type: object

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1459,6 +1459,7 @@ components:
             user: user
           devcontainer:
             filePath: filePath
+        gitProviderConfigId: gitProviderConfigId
         image: image
         envVars:
           key: envVars
@@ -1472,6 +1473,8 @@ components:
           additionalProperties:
             type: string
           type: object
+        gitProviderConfigId:
+          type: string
         image:
           type: string
         name:
@@ -1482,6 +1485,7 @@ components:
           type: string
       required:
       - envVars
+      - gitProviderConfigId
       - name
       - repositoryUrl
       type: object
@@ -1493,6 +1497,7 @@ components:
             user: user
           devcontainer:
             filePath: filePath
+        gitProviderConfigId: gitProviderConfigId
         image: image
         envVars:
           key: envVars
@@ -1517,6 +1522,8 @@ components:
           additionalProperties:
             type: string
           type: object
+        gitProviderConfigId:
+          type: string
         image:
           type: string
         name:
@@ -1558,6 +1565,7 @@ components:
               user: user
             devcontainer:
               filePath: filePath
+          gitProviderConfigId: gitProviderConfigId
           image: image
           envVars:
             key: envVars
@@ -1581,6 +1589,7 @@ components:
               user: user
             devcontainer:
               filePath: filePath
+          gitProviderConfigId: gitProviderConfigId
           image: image
           envVars:
             key: envVars
@@ -1726,21 +1735,29 @@ components:
       type: object
     GitProvider:
       example:
+        providerId: providerId
         baseApiUrl: baseApiUrl
+        alias: alias
         id: id
         token: token
         username: username
       properties:
+        alias:
+          type: string
         baseApiUrl:
           type: string
         id:
+          type: string
+        providerId:
           type: string
         token:
           type: string
         username:
           type: string
       required:
+      - alias
       - id
+      - providerId
       - token
       - username
       type: object
@@ -1977,6 +1994,7 @@ components:
             user: user
           devcontainer:
             filePath: filePath
+        gitProviderConfigId: gitProviderConfigId
         image: image
         envVars:
           key: envVars
@@ -2019,6 +2037,8 @@ components:
           additionalProperties:
             type: string
           type: object
+        gitProviderConfigId:
+          type: string
         image:
           type: string
         name:
@@ -2065,6 +2085,7 @@ components:
             user: user
           devcontainer:
             filePath: filePath
+        gitProviderConfigId: gitProviderConfigId
         image: image
         default: true
         envVars:
@@ -2081,6 +2102,8 @@ components:
           additionalProperties:
             type: string
           type: object
+        gitProviderConfigId:
+          type: string
         image:
           type: string
         name:
@@ -2293,21 +2316,27 @@ components:
       type: object
     SetGitProviderConfig:
       example:
+        providerId: providerId
         baseApiUrl: baseApiUrl
+        alias: alias
         id: id
         token: token
         username: username
       properties:
+        alias:
+          type: string
         baseApiUrl:
           type: string
         id:
+          type: string
+        providerId:
           type: string
         token:
           type: string
         username:
           type: string
       required:
-      - id
+      - providerId
       - token
       type: object
     SetProjectState:
@@ -2364,6 +2393,7 @@ components:
               user: user
             devcontainer:
               filePath: filePath
+          gitProviderConfigId: gitProviderConfigId
           image: image
           envVars:
             key: envVars
@@ -2405,6 +2435,7 @@ components:
               user: user
             devcontainer:
               filePath: filePath
+          gitProviderConfigId: gitProviderConfigId
           image: image
           envVars:
             key: envVars
@@ -2469,6 +2500,7 @@ components:
               user: user
             devcontainer:
               filePath: filePath
+          gitProviderConfigId: gitProviderConfigId
           image: image
           envVars:
             key: envVars
@@ -2510,6 +2542,7 @@ components:
               user: user
             devcontainer:
               filePath: filePath
+          gitProviderConfigId: gitProviderConfigId
           image: image
           envVars:
             key: envVars

--- a/pkg/apiclient/docs/CreateProjectConfigDTO.md
+++ b/pkg/apiclient/docs/CreateProjectConfigDTO.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **BuildConfig** | Pointer to [**BuildConfig**](BuildConfig.md) |  | [optional] 
 **EnvVars** | **map[string]string** |  | 
-**GitProviderConfigId** | **string** |  | 
+**GitProviderConfigId** | Pointer to **string** |  | [optional] 
 **Image** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
 **RepositoryUrl** | **string** |  | 
@@ -16,7 +16,7 @@ Name | Type | Description | Notes
 
 ### NewCreateProjectConfigDTO
 
-`func NewCreateProjectConfigDTO(envVars map[string]string, gitProviderConfigId string, name string, repositoryUrl string, ) *CreateProjectConfigDTO`
+`func NewCreateProjectConfigDTO(envVars map[string]string, name string, repositoryUrl string, ) *CreateProjectConfigDTO`
 
 NewCreateProjectConfigDTO instantiates a new CreateProjectConfigDTO object
 This constructor will assign default values to properties that have it defined,
@@ -95,6 +95,11 @@ and a boolean to check if the value has been set.
 
 SetGitProviderConfigId sets GitProviderConfigId field to given value.
 
+### HasGitProviderConfigId
+
+`func (o *CreateProjectConfigDTO) HasGitProviderConfigId() bool`
+
+HasGitProviderConfigId returns a boolean if a field has been set.
 
 ### GetImage
 

--- a/pkg/apiclient/docs/CreateProjectConfigDTO.md
+++ b/pkg/apiclient/docs/CreateProjectConfigDTO.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **BuildConfig** | Pointer to [**BuildConfig**](BuildConfig.md) |  | [optional] 
 **EnvVars** | **map[string]string** |  | 
+**GitProviderConfigId** | **string** |  | 
 **Image** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
 **RepositoryUrl** | **string** |  | 
@@ -15,7 +16,7 @@ Name | Type | Description | Notes
 
 ### NewCreateProjectConfigDTO
 
-`func NewCreateProjectConfigDTO(envVars map[string]string, name string, repositoryUrl string, ) *CreateProjectConfigDTO`
+`func NewCreateProjectConfigDTO(envVars map[string]string, gitProviderConfigId string, name string, repositoryUrl string, ) *CreateProjectConfigDTO`
 
 NewCreateProjectConfigDTO instantiates a new CreateProjectConfigDTO object
 This constructor will assign default values to properties that have it defined,
@@ -73,6 +74,26 @@ and a boolean to check if the value has been set.
 `func (o *CreateProjectConfigDTO) SetEnvVars(v map[string]string)`
 
 SetEnvVars sets EnvVars field to given value.
+
+
+### GetGitProviderConfigId
+
+`func (o *CreateProjectConfigDTO) GetGitProviderConfigId() string`
+
+GetGitProviderConfigId returns the GitProviderConfigId field if non-nil, zero value otherwise.
+
+### GetGitProviderConfigIdOk
+
+`func (o *CreateProjectConfigDTO) GetGitProviderConfigIdOk() (*string, bool)`
+
+GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetGitProviderConfigId
+
+`func (o *CreateProjectConfigDTO) SetGitProviderConfigId(v string)`
+
+SetGitProviderConfigId sets GitProviderConfigId field to given value.
 
 
 ### GetImage

--- a/pkg/apiclient/docs/CreateProjectDTO.md
+++ b/pkg/apiclient/docs/CreateProjectDTO.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **BuildConfig** | Pointer to [**BuildConfig**](BuildConfig.md) |  | [optional] 
 **EnvVars** | **map[string]string** |  | 
+**GitProviderConfigId** | Pointer to **string** |  | [optional] 
 **Image** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
 **Source** | [**CreateProjectSourceDTO**](CreateProjectSourceDTO.md) |  | 
@@ -74,6 +75,31 @@ and a boolean to check if the value has been set.
 
 SetEnvVars sets EnvVars field to given value.
 
+
+### GetGitProviderConfigId
+
+`func (o *CreateProjectDTO) GetGitProviderConfigId() string`
+
+GetGitProviderConfigId returns the GitProviderConfigId field if non-nil, zero value otherwise.
+
+### GetGitProviderConfigIdOk
+
+`func (o *CreateProjectDTO) GetGitProviderConfigIdOk() (*string, bool)`
+
+GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetGitProviderConfigId
+
+`func (o *CreateProjectDTO) SetGitProviderConfigId(v string)`
+
+SetGitProviderConfigId sets GitProviderConfigId field to given value.
+
+### HasGitProviderConfigId
+
+`func (o *CreateProjectDTO) HasGitProviderConfigId() bool`
+
+HasGitProviderConfigId returns a boolean if a field has been set.
 
 ### GetImage
 

--- a/pkg/apiclient/docs/GitProvider.md
+++ b/pkg/apiclient/docs/GitProvider.md
@@ -4,8 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Alias** | **string** |  | 
 **BaseApiUrl** | Pointer to **string** |  | [optional] 
 **Id** | **string** |  | 
+**ProviderId** | **string** |  | 
 **Token** | **string** |  | 
 **Username** | **string** |  | 
 
@@ -13,7 +15,7 @@ Name | Type | Description | Notes
 
 ### NewGitProvider
 
-`func NewGitProvider(id string, token string, username string, ) *GitProvider`
+`func NewGitProvider(alias string, id string, providerId string, token string, username string, ) *GitProvider`
 
 NewGitProvider instantiates a new GitProvider object
 This constructor will assign default values to properties that have it defined,
@@ -27,6 +29,26 @@ will change when the set of required properties is changed
 NewGitProviderWithDefaults instantiates a new GitProvider object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAlias
+
+`func (o *GitProvider) GetAlias() string`
+
+GetAlias returns the Alias field if non-nil, zero value otherwise.
+
+### GetAliasOk
+
+`func (o *GitProvider) GetAliasOk() (*string, bool)`
+
+GetAliasOk returns a tuple with the Alias field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAlias
+
+`func (o *GitProvider) SetAlias(v string)`
+
+SetAlias sets Alias field to given value.
+
 
 ### GetBaseApiUrl
 
@@ -71,6 +93,26 @@ and a boolean to check if the value has been set.
 `func (o *GitProvider) SetId(v string)`
 
 SetId sets Id field to given value.
+
+
+### GetProviderId
+
+`func (o *GitProvider) GetProviderId() string`
+
+GetProviderId returns the ProviderId field if non-nil, zero value otherwise.
+
+### GetProviderIdOk
+
+`func (o *GitProvider) GetProviderIdOk() (*string, bool)`
+
+GetProviderIdOk returns a tuple with the ProviderId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetProviderId
+
+`func (o *GitProvider) SetProviderId(v string)`
+
+SetProviderId sets ProviderId field to given value.
 
 
 ### GetToken

--- a/pkg/apiclient/docs/GitProviderAPI.md
+++ b/pkg/apiclient/docs/GitProviderAPI.md
@@ -806,7 +806,7 @@ import (
 )
 
 func main() {
-	gitProviderConfig := *openapiclient.NewSetGitProviderConfig("Id_example", "Token_example") // SetGitProviderConfig | Git provider
+	gitProviderConfig := *openapiclient.NewSetGitProviderConfig("ProviderId_example", "Token_example") // SetGitProviderConfig | Git provider
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/docs/Project.md
+++ b/pkg/apiclient/docs/Project.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **BuildConfig** | Pointer to [**BuildConfig**](BuildConfig.md) |  | [optional] 
 **EnvVars** | **map[string]string** |  | 
+**GitProviderConfigId** | Pointer to **string** |  | [optional] 
 **Image** | **string** |  | 
 **Name** | **string** |  | 
 **Repository** | [**GitRepository**](GitRepository.md) |  | 
@@ -77,6 +78,31 @@ and a boolean to check if the value has been set.
 
 SetEnvVars sets EnvVars field to given value.
 
+
+### GetGitProviderConfigId
+
+`func (o *Project) GetGitProviderConfigId() string`
+
+GetGitProviderConfigId returns the GitProviderConfigId field if non-nil, zero value otherwise.
+
+### GetGitProviderConfigIdOk
+
+`func (o *Project) GetGitProviderConfigIdOk() (*string, bool)`
+
+GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetGitProviderConfigId
+
+`func (o *Project) SetGitProviderConfigId(v string)`
+
+SetGitProviderConfigId sets GitProviderConfigId field to given value.
+
+### HasGitProviderConfigId
+
+`func (o *Project) HasGitProviderConfigId() bool`
+
+HasGitProviderConfigId returns a boolean if a field has been set.
 
 ### GetImage
 

--- a/pkg/apiclient/docs/ProjectConfig.md
+++ b/pkg/apiclient/docs/ProjectConfig.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **BuildConfig** | Pointer to [**BuildConfig**](BuildConfig.md) |  | [optional] 
 **Default** | **bool** |  | 
 **EnvVars** | **map[string]string** |  | 
+**GitProviderConfigId** | Pointer to **string** |  | [optional] 
 **Image** | **string** |  | 
 **Name** | **string** |  | 
 **Prebuilds** | Pointer to [**[]PrebuildConfig**](PrebuildConfig.md) |  | [optional] 
@@ -96,6 +97,31 @@ and a boolean to check if the value has been set.
 
 SetEnvVars sets EnvVars field to given value.
 
+
+### GetGitProviderConfigId
+
+`func (o *ProjectConfig) GetGitProviderConfigId() string`
+
+GetGitProviderConfigId returns the GitProviderConfigId field if non-nil, zero value otherwise.
+
+### GetGitProviderConfigIdOk
+
+`func (o *ProjectConfig) GetGitProviderConfigIdOk() (*string, bool)`
+
+GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetGitProviderConfigId
+
+`func (o *ProjectConfig) SetGitProviderConfigId(v string)`
+
+SetGitProviderConfigId sets GitProviderConfigId field to given value.
+
+### HasGitProviderConfigId
+
+`func (o *ProjectConfig) HasGitProviderConfigId() bool`
+
+HasGitProviderConfigId returns a boolean if a field has been set.
 
 ### GetImage
 

--- a/pkg/apiclient/docs/ProjectConfigAPI.md
+++ b/pkg/apiclient/docs/ProjectConfigAPI.md
@@ -373,7 +373,7 @@ import (
 )
 
 func main() {
-	projectConfig := *openapiclient.NewCreateProjectConfigDTO(map[string]string{"key": "Inner_example"}, "GitProviderConfigId_example", "Name_example", "RepositoryUrl_example") // CreateProjectConfigDTO | Project config
+	projectConfig := *openapiclient.NewCreateProjectConfigDTO(map[string]string{"key": "Inner_example"}, "Name_example", "RepositoryUrl_example") // CreateProjectConfigDTO | Project config
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/docs/ProjectConfigAPI.md
+++ b/pkg/apiclient/docs/ProjectConfigAPI.md
@@ -373,7 +373,7 @@ import (
 )
 
 func main() {
-	projectConfig := *openapiclient.NewCreateProjectConfigDTO(map[string]string{"key": "Inner_example"}, "Name_example", "RepositoryUrl_example") // CreateProjectConfigDTO | Project config
+	projectConfig := *openapiclient.NewCreateProjectConfigDTO(map[string]string{"key": "Inner_example"}, "GitProviderConfigId_example", "Name_example", "RepositoryUrl_example") // CreateProjectConfigDTO | Project config
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/docs/SetGitProviderConfig.md
+++ b/pkg/apiclient/docs/SetGitProviderConfig.md
@@ -4,8 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Alias** | Pointer to **string** |  | [optional] 
 **BaseApiUrl** | Pointer to **string** |  | [optional] 
-**Id** | **string** |  | 
+**Id** | Pointer to **string** |  | [optional] 
+**ProviderId** | **string** |  | 
 **Token** | **string** |  | 
 **Username** | Pointer to **string** |  | [optional] 
 
@@ -13,7 +15,7 @@ Name | Type | Description | Notes
 
 ### NewSetGitProviderConfig
 
-`func NewSetGitProviderConfig(id string, token string, ) *SetGitProviderConfig`
+`func NewSetGitProviderConfig(providerId string, token string, ) *SetGitProviderConfig`
 
 NewSetGitProviderConfig instantiates a new SetGitProviderConfig object
 This constructor will assign default values to properties that have it defined,
@@ -27,6 +29,31 @@ will change when the set of required properties is changed
 NewSetGitProviderConfigWithDefaults instantiates a new SetGitProviderConfig object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAlias
+
+`func (o *SetGitProviderConfig) GetAlias() string`
+
+GetAlias returns the Alias field if non-nil, zero value otherwise.
+
+### GetAliasOk
+
+`func (o *SetGitProviderConfig) GetAliasOk() (*string, bool)`
+
+GetAliasOk returns a tuple with the Alias field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAlias
+
+`func (o *SetGitProviderConfig) SetAlias(v string)`
+
+SetAlias sets Alias field to given value.
+
+### HasAlias
+
+`func (o *SetGitProviderConfig) HasAlias() bool`
+
+HasAlias returns a boolean if a field has been set.
 
 ### GetBaseApiUrl
 
@@ -71,6 +98,31 @@ and a boolean to check if the value has been set.
 `func (o *SetGitProviderConfig) SetId(v string)`
 
 SetId sets Id field to given value.
+
+### HasId
+
+`func (o *SetGitProviderConfig) HasId() bool`
+
+HasId returns a boolean if a field has been set.
+
+### GetProviderId
+
+`func (o *SetGitProviderConfig) GetProviderId() string`
+
+GetProviderId returns the ProviderId field if non-nil, zero value otherwise.
+
+### GetProviderIdOk
+
+`func (o *SetGitProviderConfig) GetProviderIdOk() (*string, bool)`
+
+GetProviderIdOk returns a tuple with the ProviderId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetProviderId
+
+`func (o *SetGitProviderConfig) SetProviderId(v string)`
+
+SetProviderId sets ProviderId field to given value.
 
 
 ### GetToken

--- a/pkg/apiclient/model_create_project_config_dto.go
+++ b/pkg/apiclient/model_create_project_config_dto.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &CreateProjectConfigDTO{}
 type CreateProjectConfigDTO struct {
 	BuildConfig         *BuildConfig      `json:"buildConfig,omitempty"`
 	EnvVars             map[string]string `json:"envVars"`
-	GitProviderConfigId string            `json:"gitProviderConfigId"`
+	GitProviderConfigId *string           `json:"gitProviderConfigId,omitempty"`
 	Image               *string           `json:"image,omitempty"`
 	Name                string            `json:"name"`
 	RepositoryUrl       string            `json:"repositoryUrl"`
@@ -36,10 +36,9 @@ type _CreateProjectConfigDTO CreateProjectConfigDTO
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCreateProjectConfigDTO(envVars map[string]string, gitProviderConfigId string, name string, repositoryUrl string) *CreateProjectConfigDTO {
+func NewCreateProjectConfigDTO(envVars map[string]string, name string, repositoryUrl string) *CreateProjectConfigDTO {
 	this := CreateProjectConfigDTO{}
 	this.EnvVars = envVars
-	this.GitProviderConfigId = gitProviderConfigId
 	this.Name = name
 	this.RepositoryUrl = repositoryUrl
 	return &this
@@ -109,28 +108,36 @@ func (o *CreateProjectConfigDTO) SetEnvVars(v map[string]string) {
 	o.EnvVars = v
 }
 
-// GetGitProviderConfigId returns the GitProviderConfigId field value
+// GetGitProviderConfigId returns the GitProviderConfigId field value if set, zero value otherwise.
 func (o *CreateProjectConfigDTO) GetGitProviderConfigId() string {
-	if o == nil {
+	if o == nil || IsNil(o.GitProviderConfigId) {
 		var ret string
 		return ret
 	}
-
-	return o.GitProviderConfigId
+	return *o.GitProviderConfigId
 }
 
-// GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field value
+// GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *CreateProjectConfigDTO) GetGitProviderConfigIdOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.GitProviderConfigId) {
 		return nil, false
 	}
-	return &o.GitProviderConfigId, true
+	return o.GitProviderConfigId, true
 }
 
-// SetGitProviderConfigId sets field value
+// HasGitProviderConfigId returns a boolean if a field has been set.
+func (o *CreateProjectConfigDTO) HasGitProviderConfigId() bool {
+	if o != nil && !IsNil(o.GitProviderConfigId) {
+		return true
+	}
+
+	return false
+}
+
+// SetGitProviderConfigId gets a reference to the given string and assigns it to the GitProviderConfigId field.
 func (o *CreateProjectConfigDTO) SetGitProviderConfigId(v string) {
-	o.GitProviderConfigId = v
+	o.GitProviderConfigId = &v
 }
 
 // GetImage returns the Image field value if set, zero value otherwise.
@@ -259,7 +266,9 @@ func (o CreateProjectConfigDTO) ToMap() (map[string]interface{}, error) {
 		toSerialize["buildConfig"] = o.BuildConfig
 	}
 	toSerialize["envVars"] = o.EnvVars
-	toSerialize["gitProviderConfigId"] = o.GitProviderConfigId
+	if !IsNil(o.GitProviderConfigId) {
+		toSerialize["gitProviderConfigId"] = o.GitProviderConfigId
+	}
 	if !IsNil(o.Image) {
 		toSerialize["image"] = o.Image
 	}
@@ -277,7 +286,6 @@ func (o *CreateProjectConfigDTO) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"envVars",
-		"gitProviderConfigId",
 		"name",
 		"repositoryUrl",
 	}

--- a/pkg/apiclient/model_create_project_config_dto.go
+++ b/pkg/apiclient/model_create_project_config_dto.go
@@ -21,12 +21,13 @@ var _ MappedNullable = &CreateProjectConfigDTO{}
 
 // CreateProjectConfigDTO struct for CreateProjectConfigDTO
 type CreateProjectConfigDTO struct {
-	BuildConfig   *BuildConfig      `json:"buildConfig,omitempty"`
-	EnvVars       map[string]string `json:"envVars"`
-	Image         *string           `json:"image,omitempty"`
-	Name          string            `json:"name"`
-	RepositoryUrl string            `json:"repositoryUrl"`
-	User          *string           `json:"user,omitempty"`
+	BuildConfig         *BuildConfig      `json:"buildConfig,omitempty"`
+	EnvVars             map[string]string `json:"envVars"`
+	GitProviderConfigId string            `json:"gitProviderConfigId"`
+	Image               *string           `json:"image,omitempty"`
+	Name                string            `json:"name"`
+	RepositoryUrl       string            `json:"repositoryUrl"`
+	User                *string           `json:"user,omitempty"`
 }
 
 type _CreateProjectConfigDTO CreateProjectConfigDTO
@@ -35,9 +36,10 @@ type _CreateProjectConfigDTO CreateProjectConfigDTO
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCreateProjectConfigDTO(envVars map[string]string, name string, repositoryUrl string) *CreateProjectConfigDTO {
+func NewCreateProjectConfigDTO(envVars map[string]string, gitProviderConfigId string, name string, repositoryUrl string) *CreateProjectConfigDTO {
 	this := CreateProjectConfigDTO{}
 	this.EnvVars = envVars
+	this.GitProviderConfigId = gitProviderConfigId
 	this.Name = name
 	this.RepositoryUrl = repositoryUrl
 	return &this
@@ -105,6 +107,30 @@ func (o *CreateProjectConfigDTO) GetEnvVarsOk() (*map[string]string, bool) {
 // SetEnvVars sets field value
 func (o *CreateProjectConfigDTO) SetEnvVars(v map[string]string) {
 	o.EnvVars = v
+}
+
+// GetGitProviderConfigId returns the GitProviderConfigId field value
+func (o *CreateProjectConfigDTO) GetGitProviderConfigId() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.GitProviderConfigId
+}
+
+// GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field value
+// and a boolean to check if the value has been set.
+func (o *CreateProjectConfigDTO) GetGitProviderConfigIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.GitProviderConfigId, true
+}
+
+// SetGitProviderConfigId sets field value
+func (o *CreateProjectConfigDTO) SetGitProviderConfigId(v string) {
+	o.GitProviderConfigId = v
 }
 
 // GetImage returns the Image field value if set, zero value otherwise.
@@ -233,6 +259,7 @@ func (o CreateProjectConfigDTO) ToMap() (map[string]interface{}, error) {
 		toSerialize["buildConfig"] = o.BuildConfig
 	}
 	toSerialize["envVars"] = o.EnvVars
+	toSerialize["gitProviderConfigId"] = o.GitProviderConfigId
 	if !IsNil(o.Image) {
 		toSerialize["image"] = o.Image
 	}
@@ -250,6 +277,7 @@ func (o *CreateProjectConfigDTO) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"envVars",
+		"gitProviderConfigId",
 		"name",
 		"repositoryUrl",
 	}

--- a/pkg/apiclient/model_create_project_dto.go
+++ b/pkg/apiclient/model_create_project_dto.go
@@ -21,12 +21,13 @@ var _ MappedNullable = &CreateProjectDTO{}
 
 // CreateProjectDTO struct for CreateProjectDTO
 type CreateProjectDTO struct {
-	BuildConfig *BuildConfig           `json:"buildConfig,omitempty"`
-	EnvVars     map[string]string      `json:"envVars"`
-	Image       *string                `json:"image,omitempty"`
-	Name        string                 `json:"name"`
-	Source      CreateProjectSourceDTO `json:"source"`
-	User        *string                `json:"user,omitempty"`
+	BuildConfig         *BuildConfig           `json:"buildConfig,omitempty"`
+	EnvVars             map[string]string      `json:"envVars"`
+	GitProviderConfigId *string                `json:"gitProviderConfigId,omitempty"`
+	Image               *string                `json:"image,omitempty"`
+	Name                string                 `json:"name"`
+	Source              CreateProjectSourceDTO `json:"source"`
+	User                *string                `json:"user,omitempty"`
 }
 
 type _CreateProjectDTO CreateProjectDTO
@@ -105,6 +106,38 @@ func (o *CreateProjectDTO) GetEnvVarsOk() (*map[string]string, bool) {
 // SetEnvVars sets field value
 func (o *CreateProjectDTO) SetEnvVars(v map[string]string) {
 	o.EnvVars = v
+}
+
+// GetGitProviderConfigId returns the GitProviderConfigId field value if set, zero value otherwise.
+func (o *CreateProjectDTO) GetGitProviderConfigId() string {
+	if o == nil || IsNil(o.GitProviderConfigId) {
+		var ret string
+		return ret
+	}
+	return *o.GitProviderConfigId
+}
+
+// GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateProjectDTO) GetGitProviderConfigIdOk() (*string, bool) {
+	if o == nil || IsNil(o.GitProviderConfigId) {
+		return nil, false
+	}
+	return o.GitProviderConfigId, true
+}
+
+// HasGitProviderConfigId returns a boolean if a field has been set.
+func (o *CreateProjectDTO) HasGitProviderConfigId() bool {
+	if o != nil && !IsNil(o.GitProviderConfigId) {
+		return true
+	}
+
+	return false
+}
+
+// SetGitProviderConfigId gets a reference to the given string and assigns it to the GitProviderConfigId field.
+func (o *CreateProjectDTO) SetGitProviderConfigId(v string) {
+	o.GitProviderConfigId = &v
 }
 
 // GetImage returns the Image field value if set, zero value otherwise.
@@ -233,6 +266,9 @@ func (o CreateProjectDTO) ToMap() (map[string]interface{}, error) {
 		toSerialize["buildConfig"] = o.BuildConfig
 	}
 	toSerialize["envVars"] = o.EnvVars
+	if !IsNil(o.GitProviderConfigId) {
+		toSerialize["gitProviderConfigId"] = o.GitProviderConfigId
+	}
 	if !IsNil(o.Image) {
 		toSerialize["image"] = o.Image
 	}

--- a/pkg/apiclient/model_git_provider.go
+++ b/pkg/apiclient/model_git_provider.go
@@ -21,8 +21,10 @@ var _ MappedNullable = &GitProvider{}
 
 // GitProvider struct for GitProvider
 type GitProvider struct {
+	Alias      string  `json:"alias"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty"`
 	Id         string  `json:"id"`
+	ProviderId string  `json:"providerId"`
 	Token      string  `json:"token"`
 	Username   string  `json:"username"`
 }
@@ -33,9 +35,11 @@ type _GitProvider GitProvider
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewGitProvider(id string, token string, username string) *GitProvider {
+func NewGitProvider(alias string, id string, providerId string, token string, username string) *GitProvider {
 	this := GitProvider{}
+	this.Alias = alias
 	this.Id = id
+	this.ProviderId = providerId
 	this.Token = token
 	this.Username = username
 	return &this
@@ -47,6 +51,30 @@ func NewGitProvider(id string, token string, username string) *GitProvider {
 func NewGitProviderWithDefaults() *GitProvider {
 	this := GitProvider{}
 	return &this
+}
+
+// GetAlias returns the Alias field value
+func (o *GitProvider) GetAlias() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.Alias
+}
+
+// GetAliasOk returns a tuple with the Alias field value
+// and a boolean to check if the value has been set.
+func (o *GitProvider) GetAliasOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Alias, true
+}
+
+// SetAlias sets field value
+func (o *GitProvider) SetAlias(v string) {
+	o.Alias = v
 }
 
 // GetBaseApiUrl returns the BaseApiUrl field value if set, zero value otherwise.
@@ -103,6 +131,30 @@ func (o *GitProvider) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *GitProvider) SetId(v string) {
 	o.Id = v
+}
+
+// GetProviderId returns the ProviderId field value
+func (o *GitProvider) GetProviderId() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.ProviderId
+}
+
+// GetProviderIdOk returns a tuple with the ProviderId field value
+// and a boolean to check if the value has been set.
+func (o *GitProvider) GetProviderIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.ProviderId, true
+}
+
+// SetProviderId sets field value
+func (o *GitProvider) SetProviderId(v string) {
+	o.ProviderId = v
 }
 
 // GetToken returns the Token field value
@@ -163,10 +215,12 @@ func (o GitProvider) MarshalJSON() ([]byte, error) {
 
 func (o GitProvider) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	toSerialize["alias"] = o.Alias
 	if !IsNil(o.BaseApiUrl) {
 		toSerialize["baseApiUrl"] = o.BaseApiUrl
 	}
 	toSerialize["id"] = o.Id
+	toSerialize["providerId"] = o.ProviderId
 	toSerialize["token"] = o.Token
 	toSerialize["username"] = o.Username
 	return toSerialize, nil
@@ -177,7 +231,9 @@ func (o *GitProvider) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
+		"alias",
 		"id",
+		"providerId",
 		"token",
 		"username",
 	}

--- a/pkg/apiclient/model_project.go
+++ b/pkg/apiclient/model_project.go
@@ -21,15 +21,16 @@ var _ MappedNullable = &Project{}
 
 // Project struct for Project
 type Project struct {
-	BuildConfig *BuildConfig      `json:"buildConfig,omitempty"`
-	EnvVars     map[string]string `json:"envVars"`
-	Image       string            `json:"image"`
-	Name        string            `json:"name"`
-	Repository  GitRepository     `json:"repository"`
-	State       *ProjectState     `json:"state,omitempty"`
-	Target      string            `json:"target"`
-	User        string            `json:"user"`
-	WorkspaceId string            `json:"workspaceId"`
+	BuildConfig         *BuildConfig      `json:"buildConfig,omitempty"`
+	EnvVars             map[string]string `json:"envVars"`
+	GitProviderConfigId *string           `json:"gitProviderConfigId,omitempty"`
+	Image               string            `json:"image"`
+	Name                string            `json:"name"`
+	Repository          GitRepository     `json:"repository"`
+	State               *ProjectState     `json:"state,omitempty"`
+	Target              string            `json:"target"`
+	User                string            `json:"user"`
+	WorkspaceId         string            `json:"workspaceId"`
 }
 
 type _Project Project
@@ -112,6 +113,38 @@ func (o *Project) GetEnvVarsOk() (*map[string]string, bool) {
 // SetEnvVars sets field value
 func (o *Project) SetEnvVars(v map[string]string) {
 	o.EnvVars = v
+}
+
+// GetGitProviderConfigId returns the GitProviderConfigId field value if set, zero value otherwise.
+func (o *Project) GetGitProviderConfigId() string {
+	if o == nil || IsNil(o.GitProviderConfigId) {
+		var ret string
+		return ret
+	}
+	return *o.GitProviderConfigId
+}
+
+// GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Project) GetGitProviderConfigIdOk() (*string, bool) {
+	if o == nil || IsNil(o.GitProviderConfigId) {
+		return nil, false
+	}
+	return o.GitProviderConfigId, true
+}
+
+// HasGitProviderConfigId returns a boolean if a field has been set.
+func (o *Project) HasGitProviderConfigId() bool {
+	if o != nil && !IsNil(o.GitProviderConfigId) {
+		return true
+	}
+
+	return false
+}
+
+// SetGitProviderConfigId gets a reference to the given string and assigns it to the GitProviderConfigId field.
+func (o *Project) SetGitProviderConfigId(v string) {
+	o.GitProviderConfigId = &v
 }
 
 // GetImage returns the Image field value
@@ -304,6 +337,9 @@ func (o Project) ToMap() (map[string]interface{}, error) {
 		toSerialize["buildConfig"] = o.BuildConfig
 	}
 	toSerialize["envVars"] = o.EnvVars
+	if !IsNil(o.GitProviderConfigId) {
+		toSerialize["gitProviderConfigId"] = o.GitProviderConfigId
+	}
 	toSerialize["image"] = o.Image
 	toSerialize["name"] = o.Name
 	toSerialize["repository"] = o.Repository

--- a/pkg/apiclient/model_project_config.go
+++ b/pkg/apiclient/model_project_config.go
@@ -21,14 +21,15 @@ var _ MappedNullable = &ProjectConfig{}
 
 // ProjectConfig struct for ProjectConfig
 type ProjectConfig struct {
-	BuildConfig   *BuildConfig      `json:"buildConfig,omitempty"`
-	Default       bool              `json:"default"`
-	EnvVars       map[string]string `json:"envVars"`
-	Image         string            `json:"image"`
-	Name          string            `json:"name"`
-	Prebuilds     []PrebuildConfig  `json:"prebuilds,omitempty"`
-	RepositoryUrl string            `json:"repositoryUrl"`
-	User          string            `json:"user"`
+	BuildConfig         *BuildConfig      `json:"buildConfig,omitempty"`
+	Default             bool              `json:"default"`
+	EnvVars             map[string]string `json:"envVars"`
+	GitProviderConfigId *string           `json:"gitProviderConfigId,omitempty"`
+	Image               string            `json:"image"`
+	Name                string            `json:"name"`
+	Prebuilds           []PrebuildConfig  `json:"prebuilds,omitempty"`
+	RepositoryUrl       string            `json:"repositoryUrl"`
+	User                string            `json:"user"`
 }
 
 type _ProjectConfig ProjectConfig
@@ -134,6 +135,38 @@ func (o *ProjectConfig) GetEnvVarsOk() (*map[string]string, bool) {
 // SetEnvVars sets field value
 func (o *ProjectConfig) SetEnvVars(v map[string]string) {
 	o.EnvVars = v
+}
+
+// GetGitProviderConfigId returns the GitProviderConfigId field value if set, zero value otherwise.
+func (o *ProjectConfig) GetGitProviderConfigId() string {
+	if o == nil || IsNil(o.GitProviderConfigId) {
+		var ret string
+		return ret
+	}
+	return *o.GitProviderConfigId
+}
+
+// GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ProjectConfig) GetGitProviderConfigIdOk() (*string, bool) {
+	if o == nil || IsNil(o.GitProviderConfigId) {
+		return nil, false
+	}
+	return o.GitProviderConfigId, true
+}
+
+// HasGitProviderConfigId returns a boolean if a field has been set.
+func (o *ProjectConfig) HasGitProviderConfigId() bool {
+	if o != nil && !IsNil(o.GitProviderConfigId) {
+		return true
+	}
+
+	return false
+}
+
+// SetGitProviderConfigId gets a reference to the given string and assigns it to the GitProviderConfigId field.
+func (o *ProjectConfig) SetGitProviderConfigId(v string) {
+	o.GitProviderConfigId = &v
 }
 
 // GetImage returns the Image field value
@@ -279,6 +312,9 @@ func (o ProjectConfig) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["default"] = o.Default
 	toSerialize["envVars"] = o.EnvVars
+	if !IsNil(o.GitProviderConfigId) {
+		toSerialize["gitProviderConfigId"] = o.GitProviderConfigId
+	}
 	toSerialize["image"] = o.Image
 	toSerialize["name"] = o.Name
 	if !IsNil(o.Prebuilds) {

--- a/pkg/apiclient/model_set_git_provider_config.go
+++ b/pkg/apiclient/model_set_git_provider_config.go
@@ -21,8 +21,10 @@ var _ MappedNullable = &SetGitProviderConfig{}
 
 // SetGitProviderConfig struct for SetGitProviderConfig
 type SetGitProviderConfig struct {
+	Alias      *string `json:"alias,omitempty"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty"`
-	Id         string  `json:"id"`
+	Id         *string `json:"id,omitempty"`
+	ProviderId string  `json:"providerId"`
 	Token      string  `json:"token"`
 	Username   *string `json:"username,omitempty"`
 }
@@ -33,9 +35,9 @@ type _SetGitProviderConfig SetGitProviderConfig
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSetGitProviderConfig(id string, token string) *SetGitProviderConfig {
+func NewSetGitProviderConfig(providerId string, token string) *SetGitProviderConfig {
 	this := SetGitProviderConfig{}
-	this.Id = id
+	this.ProviderId = providerId
 	this.Token = token
 	return &this
 }
@@ -46,6 +48,38 @@ func NewSetGitProviderConfig(id string, token string) *SetGitProviderConfig {
 func NewSetGitProviderConfigWithDefaults() *SetGitProviderConfig {
 	this := SetGitProviderConfig{}
 	return &this
+}
+
+// GetAlias returns the Alias field value if set, zero value otherwise.
+func (o *SetGitProviderConfig) GetAlias() string {
+	if o == nil || IsNil(o.Alias) {
+		var ret string
+		return ret
+	}
+	return *o.Alias
+}
+
+// GetAliasOk returns a tuple with the Alias field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SetGitProviderConfig) GetAliasOk() (*string, bool) {
+	if o == nil || IsNil(o.Alias) {
+		return nil, false
+	}
+	return o.Alias, true
+}
+
+// HasAlias returns a boolean if a field has been set.
+func (o *SetGitProviderConfig) HasAlias() bool {
+	if o != nil && !IsNil(o.Alias) {
+		return true
+	}
+
+	return false
+}
+
+// SetAlias gets a reference to the given string and assigns it to the Alias field.
+func (o *SetGitProviderConfig) SetAlias(v string) {
+	o.Alias = &v
 }
 
 // GetBaseApiUrl returns the BaseApiUrl field value if set, zero value otherwise.
@@ -80,28 +114,60 @@ func (o *SetGitProviderConfig) SetBaseApiUrl(v string) {
 	o.BaseApiUrl = &v
 }
 
-// GetId returns the Id field value
+// GetId returns the Id field value if set, zero value otherwise.
 func (o *SetGitProviderConfig) GetId() string {
+	if o == nil || IsNil(o.Id) {
+		var ret string
+		return ret
+	}
+	return *o.Id
+}
+
+// GetIdOk returns a tuple with the Id field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SetGitProviderConfig) GetIdOk() (*string, bool) {
+	if o == nil || IsNil(o.Id) {
+		return nil, false
+	}
+	return o.Id, true
+}
+
+// HasId returns a boolean if a field has been set.
+func (o *SetGitProviderConfig) HasId() bool {
+	if o != nil && !IsNil(o.Id) {
+		return true
+	}
+
+	return false
+}
+
+// SetId gets a reference to the given string and assigns it to the Id field.
+func (o *SetGitProviderConfig) SetId(v string) {
+	o.Id = &v
+}
+
+// GetProviderId returns the ProviderId field value
+func (o *SetGitProviderConfig) GetProviderId() string {
 	if o == nil {
 		var ret string
 		return ret
 	}
 
-	return o.Id
+	return o.ProviderId
 }
 
-// GetIdOk returns a tuple with the Id field value
+// GetProviderIdOk returns a tuple with the ProviderId field value
 // and a boolean to check if the value has been set.
-func (o *SetGitProviderConfig) GetIdOk() (*string, bool) {
+func (o *SetGitProviderConfig) GetProviderIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Id, true
+	return &o.ProviderId, true
 }
 
-// SetId sets field value
-func (o *SetGitProviderConfig) SetId(v string) {
-	o.Id = v
+// SetProviderId sets field value
+func (o *SetGitProviderConfig) SetProviderId(v string) {
+	o.ProviderId = v
 }
 
 // GetToken returns the Token field value
@@ -170,10 +236,16 @@ func (o SetGitProviderConfig) MarshalJSON() ([]byte, error) {
 
 func (o SetGitProviderConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Alias) {
+		toSerialize["alias"] = o.Alias
+	}
 	if !IsNil(o.BaseApiUrl) {
 		toSerialize["baseApiUrl"] = o.BaseApiUrl
 	}
-	toSerialize["id"] = o.Id
+	if !IsNil(o.Id) {
+		toSerialize["id"] = o.Id
+	}
+	toSerialize["providerId"] = o.ProviderId
 	toSerialize["token"] = o.Token
 	if !IsNil(o.Username) {
 		toSerialize["username"] = o.Username
@@ -186,7 +258,7 @@ func (o *SetGitProviderConfig) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
-		"id",
+		"providerId",
 		"token",
 	}
 

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -28,10 +28,11 @@ var GitProviderAddCmd = &cobra.Command{
 		setGitProviderConfig := apiclient.SetGitProviderConfig{}
 		setGitProviderConfig.BaseApiUrl = new(string)
 		setGitProviderConfig.Username = new(string)
+		setGitProviderConfig.Alias = new(string)
 
-		gitprovider_view.GitProviderSelectionView(&setGitProviderConfig, nil, false)
+		gitprovider_view.GitProviderSelectionView(&setGitProviderConfig, apiClient, ctx)
 
-		if setGitProviderConfig.Id == "" {
+		if setGitProviderConfig.ProviderId == "" {
 			return nil
 		}
 

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -30,7 +30,7 @@ var GitProviderAddCmd = &cobra.Command{
 		setGitProviderConfig.Username = new(string)
 		setGitProviderConfig.Alias = new(string)
 
-		gitprovider_view.GitProviderSelectionView(&setGitProviderConfig, apiClient, ctx)
+		gitprovider_view.GitProviderSelectionView(ctx, &setGitProviderConfig, apiClient)
 
 		if setGitProviderConfig.ProviderId == "" {
 			return nil

--- a/pkg/cmd/gitprovider/delete.go
+++ b/pkg/cmd/gitprovider/delete.go
@@ -31,22 +31,24 @@ var gitProviderDeleteCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		var gitProviderData apiclient.SetGitProviderConfig
-		gitProviderData.BaseApiUrl = new(string)
-		gitProviderData.Username = new(string)
-
 		if len(gitProviders) == 0 {
 			views.RenderInfoMessage("No git providers registered")
 			return nil
 		}
 
-		gitprovider_view.GitProviderSelectionView(&gitProviderData, gitProviders, true)
+		var gitProviderData apiclient.SetGitProviderConfig
+		gitProviderData.Id = new(string)
+		gitProviderData.BaseApiUrl = new(string)
+		gitProviderData.Username = new(string)
+		gitProviderData.Alias = new(string)
 
-		if gitProviderData.Id == "" {
+		gitprovider_view.GitProviderDeleteView(&gitProviderData, gitProviders, apiClient, ctx)
+
+		if *gitProviderData.Id == "" {
 			return errors.New("git provider id can not be blank")
 		}
 
-		_, err = apiClient.GitProviderAPI.RemoveGitProvider(ctx, gitProviderData.Id).Execute()
+		_, err = apiClient.GitProviderAPI.RemoveGitProvider(ctx, *gitProviderData.Id).Execute()
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -42,12 +42,13 @@ var gitProviderListCmd = &cobra.Command{
 
 		for _, gitProvider := range gitProviders {
 			for _, supportedProvider := range supportedProviders {
-				if gitProvider.Id == supportedProvider.Id {
+				if gitProvider.ProviderId == supportedProvider.Id {
 					gitProviderViewList = append(gitProviderViewList,
 						gitprovider_view.GitProviderView{
-							Id:       gitProvider.Id,
+							Id:       gitProvider.ProviderId,
 							Name:     supportedProvider.Name,
 							Username: gitProvider.Username,
+							Alias:    gitProvider.Alias,
 						},
 					)
 				}
@@ -61,7 +62,7 @@ var gitProviderListCmd = &cobra.Command{
 		}
 
 		for _, gitProviderView := range gitProviderViewList {
-			views.RenderListLine(fmt.Sprintf("%s (%s)", gitProviderView.Name, gitProviderView.Username))
+			views.RenderListLine(fmt.Sprintf("%s (%s)", gitProviderView.Name, gitProviderView.Alias))
 		}
 		return nil
 	},

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -45,7 +45,7 @@ var gitProviderListCmd = &cobra.Command{
 				if gitProvider.ProviderId == supportedProvider.Id {
 					gitProviderViewList = append(gitProviderViewList,
 						gitprovider_view.GitProviderView{
-							Id:       gitProvider.ProviderId,
+							Id:       gitProvider.Id,
 							Name:     supportedProvider.Name,
 							Username: gitProvider.Username,
 							Alias:    gitProvider.Alias,

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -45,10 +45,11 @@ var gitProviderListCmd = &cobra.Command{
 				if gitProvider.ProviderId == supportedProvider.Id {
 					gitProviderViewList = append(gitProviderViewList,
 						gitprovider_view.GitProviderView{
-							Id:       gitProvider.Id,
-							Name:     supportedProvider.Name,
-							Username: gitProvider.Username,
-							Alias:    gitProvider.Alias,
+							Id:         gitProvider.Id,
+							ProviderId: gitProvider.ProviderId,
+							Name:       supportedProvider.Name,
+							Username:   gitProvider.Username,
+							Alias:      gitProvider.Alias,
 						},
 					)
 				}

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
@@ -136,12 +137,13 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 	}
 
 	createProjectConfig := apiclient.CreateProjectConfigDTO{
-		Name:          chosenName,
-		BuildConfig:   createDtos[0].BuildConfig,
-		Image:         createDtos[0].Image,
-		User:          createDtos[0].User,
-		RepositoryUrl: createDtos[0].Source.Repository.Url,
-		EnvVars:       createDtos[0].EnvVars,
+		Name:                chosenName,
+		BuildConfig:         createDtos[0].BuildConfig,
+		Image:               createDtos[0].Image,
+		User:                createDtos[0].User,
+		RepositoryUrl:       createDtos[0].Source.Repository.Url,
+		EnvVars:             createDtos[0].EnvVars,
+		GitProviderConfigId: *createDtos[0].GitProviderConfigId,
 	}
 
 	res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(createProjectConfig).Execute()
@@ -150,12 +152,13 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 	}
 
 	projectConfig := apiclient.ProjectConfig{
-		BuildConfig:   createProjectConfig.BuildConfig,
-		Default:       false,
-		EnvVars:       createProjectConfig.EnvVars,
-		Name:          createProjectConfig.Name,
-		Prebuilds:     nil,
-		RepositoryUrl: createProjectConfig.RepositoryUrl,
+		BuildConfig:         createProjectConfig.BuildConfig,
+		Default:             false,
+		EnvVars:             createProjectConfig.EnvVars,
+		Name:                createProjectConfig.Name,
+		Prebuilds:           nil,
+		RepositoryUrl:       createProjectConfig.RepositoryUrl,
+		GitProviderConfigId: &createProjectConfig.GitProviderConfigId,
 	}
 
 	if createProjectConfig.Image != nil {
@@ -164,6 +167,14 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 
 	if createProjectConfig.User != nil {
 		projectConfig.User = *createProjectConfig.User
+	}
+
+	if createProjectConfig.GitProviderConfigId == "" {
+		gitProviderConfigId, res, err := apiClient.GitProviderAPI.GetGitProviderIdForUrl(ctx, url.QueryEscape(createProjectConfig.RepositoryUrl)).Execute()
+		if err != nil {
+			return nil, apiclient_util.HandleErrorResponse(res, err)
+		}
+		projectConfig.GitProviderConfigId = &gitProviderConfigId
 	}
 
 	return &projectConfig, nil
@@ -209,13 +220,22 @@ func processCmdArgument(argument string, apiClient *apiclient.APIClient, ctx con
 		name = workspace_util.GetSuggestedName(projectName, existingProjectConfigNames)
 	}
 
+	if project.GitProviderConfigId == nil || *project.GitProviderConfigId == "" {
+		gitProviderConfigId, res, err := apiClient.GitProviderAPI.GetGitProviderIdForUrl(ctx, url.QueryEscape(repoUrl)).Execute()
+		if err != nil {
+			return nil, apiclient_util.HandleErrorResponse(res, err)
+		}
+		*project.GitProviderConfigId = gitProviderConfigId
+	}
+
 	newProjectConfig := apiclient.CreateProjectConfigDTO{
-		Name:          name,
-		BuildConfig:   project.BuildConfig,
-		Image:         project.Image,
-		User:          project.User,
-		RepositoryUrl: repoUrl,
-		EnvVars:       project.EnvVars,
+		Name:                name,
+		BuildConfig:         project.BuildConfig,
+		Image:               project.Image,
+		User:                project.User,
+		RepositoryUrl:       repoUrl,
+		EnvVars:             project.EnvVars,
+		GitProviderConfigId: *project.GitProviderConfigId,
 	}
 
 	if newProjectConfig.Image == nil {
@@ -252,12 +272,14 @@ func getExistingProjectConfigNames(apiClient *apiclient.APIClient) ([]string, er
 var nameFlag string
 
 var projectConfigurationFlags = workspace_util.ProjectConfigurationFlags{
-	Builder:          new(views_util.BuildChoice),
-	CustomImage:      new(string),
-	CustomImageUser:  new(string),
-	DevcontainerPath: new(string),
-	EnvVars:          new([]string),
-	Manual:           new(bool),
+	Builder:             new(views_util.BuildChoice),
+	CustomImage:         new(string),
+	CustomImageUser:     new(string),
+	Branches:            new([]string),
+	DevcontainerPath:    new(string),
+	EnvVars:             new([]string),
+	Manual:              new(bool),
+	GitProviderConfigId: new(string),
 }
 
 func init() {

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -143,7 +143,7 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 		User:                createDtos[0].User,
 		RepositoryUrl:       createDtos[0].Source.Repository.Url,
 		EnvVars:             createDtos[0].EnvVars,
-		GitProviderConfigId: *createDtos[0].GitProviderConfigId,
+		GitProviderConfigId: createDtos[0].GitProviderConfigId,
 	}
 
 	res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(createProjectConfig).Execute()
@@ -158,7 +158,7 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 		Name:                createProjectConfig.Name,
 		Prebuilds:           nil,
 		RepositoryUrl:       createProjectConfig.RepositoryUrl,
-		GitProviderConfigId: &createProjectConfig.GitProviderConfigId,
+		GitProviderConfigId: createProjectConfig.GitProviderConfigId,
 	}
 
 	if createProjectConfig.Image != nil {
@@ -169,7 +169,7 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 		projectConfig.User = *createProjectConfig.User
 	}
 
-	if createProjectConfig.GitProviderConfigId == "" {
+	if createProjectConfig.GitProviderConfigId == nil && *createProjectConfig.GitProviderConfigId == "" {
 		gitProviderConfigId, res, err := apiClient.GitProviderAPI.GetGitProviderIdForUrl(ctx, url.QueryEscape(createProjectConfig.RepositoryUrl)).Execute()
 		if err != nil {
 			return nil, apiclient_util.HandleErrorResponse(res, err)
@@ -235,7 +235,7 @@ func processCmdArgument(argument string, apiClient *apiclient.APIClient, ctx con
 		User:                project.User,
 		RepositoryUrl:       repoUrl,
 		EnvVars:             project.EnvVars,
-		GitProviderConfigId: *project.GitProviderConfigId,
+		GitProviderConfigId: project.GitProviderConfigId,
 	}
 
 	if newProjectConfig.Image == nil {

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -228,13 +228,14 @@ var blankFlag bool
 var multiProjectFlag bool
 
 var projectConfigurationFlags = workspace_util.ProjectConfigurationFlags{
-	Builder:          new(views_util.BuildChoice),
-	CustomImage:      new(string),
-	CustomImageUser:  new(string),
-	Branches:         new([]string),
-	DevcontainerPath: new(string),
-	EnvVars:          new([]string),
-	Manual:           new(bool),
+	Builder:             new(views_util.BuildChoice),
+	CustomImage:         new(string),
+	CustomImageUser:     new(string),
+	Branches:            new([]string),
+	DevcontainerPath:    new(string),
+	EnvVars:             new([]string),
+	Manual:              new(bool),
+	GitProviderConfigId: new(string),
 }
 
 func init() {
@@ -403,6 +404,7 @@ func processGitURL(ctx context.Context, repoUrl string, apiClient *apiclient.API
 	if !blankFlag {
 		projectConfig, res, err := apiClient.ProjectConfigAPI.GetDefaultProjectConfig(ctx, encodedURLParam).Execute()
 		if err == nil {
+			projectConfig.GitProviderConfigId = projectConfigurationFlags.GitProviderConfigId
 			return workspace_util.AddProjectFromConfig(projectConfig, apiClient, projects, branch)
 		}
 

--- a/pkg/cmd/workspace/util/add_from_config.go
+++ b/pkg/cmd/workspace/util/add_from_config.go
@@ -38,7 +38,8 @@ func AddProjectFromConfig(projectConfig *apiclient.ProjectConfig, apiClient *api
 	}
 
 	project := &apiclient.CreateProjectDTO{
-		Name: projectConfig.Name,
+		Name:                projectConfig.Name,
+		GitProviderConfigId: projectConfig.GitProviderConfigId,
 		Source: apiclient.CreateProjectSourceDTO{
 			Repository: *configRepo,
 		},

--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -17,12 +17,13 @@ import (
 )
 
 type BranchWizardConfig struct {
-	ApiClient    *apiclient.APIClient
-	ProviderId   string
-	NamespaceId  string
-	Namespace    string
-	ChosenRepo   *apiclient.GitRepository
-	ProjectOrder int
+	ApiClient           *apiclient.APIClient
+	GitProviderConfigId string
+	NamespaceId         string
+	Namespace           string
+	ChosenRepo          *apiclient.GitRepository
+	ProjectOrder        int
+	ProviderId          string
 }
 
 func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, error) {
@@ -32,7 +33,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	ctx := context.Background()
 
 	err = views_util.WithSpinner("Loading", func() error {
-		branchList, _, err = config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Execute()
+		branchList, _, err = config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Execute()
 		return err
 	})
 
@@ -52,7 +53,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 
 	var prList []apiclient.GitPullRequest
 	err = views_util.WithSpinner("Loading", func() error {
-		prList, _, err = config.ApiClient.GitProviderAPI.GetRepoPRs(ctx, config.ProviderId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Execute()
+		prList, _, err = config.ApiClient.GitProviderAPI.GetRepoPRs(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Execute()
 		return err
 	})
 

--- a/pkg/cmd/workspace/util/workspace.go
+++ b/pkg/cmd/workspace/util/workspace.go
@@ -13,13 +13,14 @@ import (
 )
 
 type ProjectConfigurationFlags struct {
-	Builder          *views_util.BuildChoice
-	CustomImage      *string
-	CustomImageUser  *string
-	Branches         *[]string
-	DevcontainerPath *string
-	EnvVars          *[]string
-	Manual           *bool
+	Builder             *views_util.BuildChoice
+	CustomImage         *string
+	CustomImageUser     *string
+	Branches            *[]string
+	DevcontainerPath    *string
+	EnvVars             *[]string
+	Manual              *bool
+	GitProviderConfigId *string
 }
 
 func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfigurationFlags, multiProjectFlagException bool) {
@@ -29,6 +30,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 	cmd.Flags().Var(flags.Builder, "builder", fmt.Sprintf("Specify the builder (currently %s/%s/%s)", views_util.AUTOMATIC, views_util.DEVCONTAINER, views_util.NONE))
 	cmd.Flags().StringArrayVar(flags.EnvVars, "env", []string{}, "Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')")
 	cmd.Flags().BoolVar(flags.Manual, "manual", false, "Manually enter the Git repository")
+	cmd.Flags().StringVar(flags.GitProviderConfigId, "git-provider-config-id", "", "Specify the Git Provider Configuration Id")
 
 	cmd.MarkFlagsMutuallyExclusive("builder", "custom-image")
 	cmd.MarkFlagsMutuallyExclusive("builder", "custom-image-user")
@@ -46,7 +48,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 }
 
 func CheckAnyProjectConfigurationFlagSet(flags ProjectConfigurationFlags) bool {
-	return *flags.CustomImage != "" || *flags.CustomImageUser != "" || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
+	return *flags.GitProviderConfigId != "" || *flags.CustomImage != "" || *flags.CustomImageUser != "" || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
 }
 
 func IsProjectRunning(workspace *apiclient.WorkspaceDTO, projectName string) bool {

--- a/pkg/db/dto/git_provider.go
+++ b/pkg/db/dto/git_provider.go
@@ -9,17 +9,21 @@ import (
 
 type GitProviderConfigDTO struct {
 	Id         string  `gorm:"primaryKey"`
+	ProviderId string  `json:"providerId"`
 	Username   string  `json:"username"`
 	Token      string  `json:"token"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty"`
+	Alias      string  `json:"alias"`
 }
 
 func ToGitProviderConfigDTO(gitProvider gitprovider.GitProviderConfig) GitProviderConfigDTO {
 	gitProviderDTO := GitProviderConfigDTO{
 		Id:         gitProvider.Id,
+		ProviderId: gitProvider.ProviderId,
 		Username:   gitProvider.Username,
 		Token:      gitProvider.Token,
 		BaseApiUrl: gitProvider.BaseApiUrl,
+		Alias:      gitProvider.Alias,
 	}
 
 	return gitProviderDTO
@@ -28,8 +32,10 @@ func ToGitProviderConfigDTO(gitProvider gitprovider.GitProviderConfig) GitProvid
 func ToGitProviderConfig(gitProviderDTO GitProviderConfigDTO) gitprovider.GitProviderConfig {
 	return gitprovider.GitProviderConfig{
 		Id:         gitProviderDTO.Id,
+		ProviderId: gitProviderDTO.ProviderId,
 		Username:   gitProviderDTO.Username,
 		Token:      gitProviderDTO.Token,
 		BaseApiUrl: gitProviderDTO.BaseApiUrl,
+		Alias:      gitProviderDTO.Alias,
 	}
 }

--- a/pkg/db/dto/project.go
+++ b/pkg/db/dto/project.go
@@ -52,28 +52,30 @@ type ProjectBuildDTO struct {
 }
 
 type ProjectDTO struct {
-	Name        string           `json:"name"`
-	Image       string           `json:"image"`
-	User        string           `json:"user"`
-	Build       *ProjectBuildDTO `json:"build,omitempty" gorm:"serializer:json"`
-	Repository  RepositoryDTO    `json:"repository" gorm:"serializer:json"`
-	WorkspaceId string           `json:"workspaceId"`
-	Target      string           `json:"target"`
-	ApiKey      string           `json:"apiKey"`
-	State       *ProjectStateDTO `json:"state,omitempty" gorm:"serializer:json"`
+	Name                string           `json:"name"`
+	Image               string           `json:"image"`
+	User                string           `json:"user"`
+	Build               *ProjectBuildDTO `json:"build,omitempty" gorm:"serializer:json"`
+	Repository          RepositoryDTO    `json:"repository" gorm:"serializer:json"`
+	WorkspaceId         string           `json:"workspaceId"`
+	Target              string           `json:"target"`
+	ApiKey              string           `json:"apiKey"`
+	State               *ProjectStateDTO `json:"state,omitempty" gorm:"serializer:json"`
+	GitProviderConfigId *string          `json:"gitProviderConfigId,omitempty"`
 }
 
 func ToProjectDTO(project *project.Project) ProjectDTO {
 	return ProjectDTO{
-		Name:        project.Name,
-		Image:       project.Image,
-		User:        project.User,
-		Build:       ToProjectBuildDTO(project.BuildConfig),
-		Repository:  ToRepositoryDTO(project.Repository),
-		WorkspaceId: project.WorkspaceId,
-		Target:      project.Target,
-		State:       ToProjectStateDTO(project.State),
-		ApiKey:      project.ApiKey,
+		Name:                project.Name,
+		Image:               project.Image,
+		User:                project.User,
+		Build:               ToProjectBuildDTO(project.BuildConfig),
+		Repository:          ToRepositoryDTO(project.Repository),
+		WorkspaceId:         project.WorkspaceId,
+		Target:              project.Target,
+		State:               ToProjectStateDTO(project.State),
+		ApiKey:              project.ApiKey,
+		GitProviderConfigId: project.GitProviderConfigId,
 	}
 }
 
@@ -156,15 +158,16 @@ func ToProjectBuildDTO(build *buildconfig.BuildConfig) *ProjectBuildDTO {
 
 func ToProject(projectDTO ProjectDTO) *project.Project {
 	return &project.Project{
-		Name:        projectDTO.Name,
-		Image:       projectDTO.Image,
-		User:        projectDTO.User,
-		BuildConfig: ToProjectBuild(projectDTO.Build),
-		Repository:  ToRepository(projectDTO.Repository),
-		WorkspaceId: projectDTO.WorkspaceId,
-		Target:      projectDTO.Target,
-		State:       ToProjectState(projectDTO.State),
-		ApiKey:      projectDTO.ApiKey,
+		Name:                projectDTO.Name,
+		Image:               projectDTO.Image,
+		User:                projectDTO.User,
+		BuildConfig:         ToProjectBuild(projectDTO.Build),
+		Repository:          ToRepository(projectDTO.Repository),
+		WorkspaceId:         projectDTO.WorkspaceId,
+		Target:              projectDTO.Target,
+		State:               ToProjectState(projectDTO.State),
+		ApiKey:              projectDTO.ApiKey,
+		GitProviderConfigId: projectDTO.GitProviderConfigId,
 	}
 }
 

--- a/pkg/db/dto/project_config.go
+++ b/pkg/db/dto/project_config.go
@@ -8,14 +8,15 @@ import (
 )
 
 type ProjectConfigDTO struct {
-	Name          string            `gorm:"primaryKey"`
-	Image         string            `json:"image"`
-	User          string            `json:"user"`
-	Build         *ProjectBuildDTO  `json:"build,omitempty" gorm:"serializer:json"`
-	RepositoryUrl string            `json:"repositoryUrl"`
-	EnvVars       map[string]string `json:"envVars" gorm:"serializer:json"`
-	Prebuilds     []PrebuildDTO     `gorm:"serializer:json"`
-	IsDefault     bool              `json:"isDefault"`
+	Name                string            `gorm:"primaryKey"`
+	Image               string            `json:"image"`
+	User                string            `json:"user"`
+	Build               *ProjectBuildDTO  `json:"build,omitempty" gorm:"serializer:json"`
+	RepositoryUrl       string            `json:"repositoryUrl"`
+	EnvVars             map[string]string `json:"envVars" gorm:"serializer:json"`
+	Prebuilds           []PrebuildDTO     `gorm:"serializer:json"`
+	IsDefault           bool              `json:"isDefault"`
+	GitProviderConfigId *string           `json:"gitProviderConfigId" validate:"optional"`
 }
 
 type PrebuildDTO struct {
@@ -33,14 +34,15 @@ func ToProjectConfigDTO(projectConfig *config.ProjectConfig) ProjectConfigDTO {
 	}
 
 	return ProjectConfigDTO{
-		Name:          projectConfig.Name,
-		Image:         projectConfig.Image,
-		User:          projectConfig.User,
-		Build:         ToProjectBuildDTO(projectConfig.BuildConfig),
-		RepositoryUrl: projectConfig.RepositoryUrl,
-		EnvVars:       projectConfig.EnvVars,
-		Prebuilds:     prebuilds,
-		IsDefault:     projectConfig.IsDefault,
+		Name:                projectConfig.Name,
+		Image:               projectConfig.Image,
+		User:                projectConfig.User,
+		Build:               ToProjectBuildDTO(projectConfig.BuildConfig),
+		RepositoryUrl:       projectConfig.RepositoryUrl,
+		EnvVars:             projectConfig.EnvVars,
+		Prebuilds:           prebuilds,
+		IsDefault:           projectConfig.IsDefault,
+		GitProviderConfigId: projectConfig.GitProviderConfigId,
 	}
 }
 
@@ -51,14 +53,15 @@ func ToProjectConfig(projectConfigDTO ProjectConfigDTO) *config.ProjectConfig {
 	}
 
 	return &config.ProjectConfig{
-		Name:          projectConfigDTO.Name,
-		Image:         projectConfigDTO.Image,
-		User:          projectConfigDTO.User,
-		BuildConfig:   ToProjectBuild(projectConfigDTO.Build),
-		RepositoryUrl: projectConfigDTO.RepositoryUrl,
-		EnvVars:       projectConfigDTO.EnvVars,
-		Prebuilds:     prebuilds,
-		IsDefault:     projectConfigDTO.IsDefault,
+		Name:                projectConfigDTO.Name,
+		Image:               projectConfigDTO.Image,
+		User:                projectConfigDTO.User,
+		BuildConfig:         ToProjectBuild(projectConfigDTO.Build),
+		RepositoryUrl:       projectConfigDTO.RepositoryUrl,
+		EnvVars:             projectConfigDTO.EnvVars,
+		Prebuilds:           prebuilds,
+		IsDefault:           projectConfigDTO.IsDefault,
+		GitProviderConfigId: projectConfigDTO.GitProviderConfigId,
 	}
 }
 

--- a/pkg/gitprovider/types.go
+++ b/pkg/gitprovider/types.go
@@ -5,9 +5,11 @@ package gitprovider
 
 type GitProviderConfig struct {
 	Id         string  `json:"id" validate:"required"`
+	ProviderId string  `json:"providerId" validate:"required"`
 	Username   string  `json:"username" validate:"required"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty" validate:"optional"`
 	Token      string  `json:"token" validate:"required"`
+	Alias      string  `json:"alias" validate:"required"`
 } // @name GitProvider
 
 type GitUser struct {

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -36,24 +36,11 @@ func (s *GitProviderService) GetGitProviderForUrl(repoUrl string) (gitprovider.G
 			}
 		}
 	}
-	supportedGitProviders := []string{
-		"github",
-		"github-enterprise-server",
-		"gitlab",
-		"gitlab-self-managed",
-		"bitbucket",
-		"bitbucket-server",
-		"codeberg",
-		"gitea",
-		"gitness",
-		"azure-devops",
-		"aws-codecommit",
-	}
 
-	for _, p := range supportedGitProviders {
+	for _, p := range config.GetSupportedGitProviders() {
 		gitProvider, err := s.newGitProvider(&gitprovider.GitProviderConfig{
-			ProviderId: p,
-			Id:         p,
+			ProviderId: p.Id,
+			Id:         p.Id,
 			Username:   "",
 			Token:      "",
 			BaseApiUrl: nil,
@@ -63,7 +50,7 @@ func (s *GitProviderService) GetGitProviderForUrl(repoUrl string) (gitprovider.G
 		}
 		canHandle, _ := gitProvider.CanHandle(repoUrl)
 		if canHandle {
-			return gitProvider, p, nil
+			return gitProvider, p.Id, nil
 		}
 	}
 

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/gitprovider"
+	"github.com/google/uuid"
 )
 
 func (s *GitProviderService) GetGitProviderForUrl(repoUrl string) (gitprovider.GitProvider, string, error) {
@@ -118,6 +119,13 @@ func (s *GitProviderService) SetGitProviderConfig(providerConfig *gitprovider.Gi
 		return err
 	}
 	providerConfig.Username = userData.Username
+	if providerConfig.Id == "" {
+		providerConfig.Id = uuid.NewString()
+	}
+
+	if providerConfig.Alias == "" {
+		providerConfig.Alias = userData.Username
+	}
 
 	return s.configStore.Save(providerConfig)
 }

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -53,7 +53,9 @@ func (s *GitProviderService) GetGitProviderForUrl(repoUrl string) (gitprovider.G
 		}
 	}
 
-	return selectedProvider[0].GitProvider, selectedProvider[0].Id, nil
+	if len(selectedProvider) > 0 {
+		return selectedProvider[0].GitProvider, selectedProvider[0].Id, nil
+	}
 
 	u, err := url.Parse(repoUrl)
 	if err != nil {

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -74,7 +74,12 @@ func (s *GitProviderService) GetConfigForUrl(repoUrl string) (*gitprovider.GitPr
 
 		canHandle, _ := gitProvider.CanHandle(repoUrl)
 		if canHandle {
-			return p, nil
+			_, err = gitProvider.GetRepositoryContext(gitprovider.GetRepositoryContext{
+				Url: repoUrl,
+			})
+			if err == nil {
+				return p, nil
+			}
 		}
 
 	}

--- a/pkg/server/gitproviders/service.go
+++ b/pkg/server/gitproviders/service.go
@@ -55,6 +55,7 @@ func (s *GitProviderService) GetGitProvider(id string) (gitprovider.GitProvider,
 		if gitprovider.IsGitProviderNotFound(err) {
 			providerConfig = &gitprovider.GitProviderConfig{
 				Id:         id,
+				ProviderId: id,
 				Username:   "",
 				Token:      "",
 				BaseApiUrl: nil,
@@ -88,8 +89,8 @@ func (s *GitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (
 	for _, p := range gitProviders {
 
 		isAwsUrl := strings.Contains(repo.Url, ".amazonaws.com/") || strings.Contains(repo.Url, ".console.aws.amazon.com/")
-		if p.Id == "aws-codecommit" && isAwsUrl {
-			provider, err = s.GetGitProvider(p.Id)
+		if p.ProviderId == "aws-codecommit" && isAwsUrl {
+			provider, err = s.GetGitProvider(p.ProviderId)
 			if err == nil {
 				return "", err
 			}
@@ -97,8 +98,8 @@ func (s *GitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (
 			break
 		}
 
-		if strings.Contains(repo.Url, fmt.Sprintf("%s.", p.Id)) {
-			provider, err = s.GetGitProvider(p.Id)
+		if strings.Contains(repo.Url, fmt.Sprintf("%s.", p.ProviderId)) {
+			provider, err = s.GetGitProvider(p.ProviderId)
 			if err == nil {
 				return "", err
 			}
@@ -112,7 +113,7 @@ func (s *GitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (
 		}
 
 		if p.BaseApiUrl != nil && strings.Contains(repo.Url, hostname) {
-			provider, err = s.GetGitProvider(p.Id)
+			provider, err = s.GetGitProvider(p.ProviderId)
 			if err == nil {
 				return "", err
 			}
@@ -127,7 +128,8 @@ func (s *GitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (
 		providerId := strings.Split(hostname, ".")[0]
 
 		provider, err = s.newGitProvider(&gitprovider.GitProviderConfig{
-			Id:         providerId,
+			Id:         "",
+			ProviderId: providerId,
 			Username:   "",
 			Token:      "",
 			BaseApiUrl: nil,
@@ -151,7 +153,7 @@ func (s *GitProviderService) GetLastCommitSha(repo *gitprovider.GitRepository) (
 }
 
 func (s *GitProviderService) newGitProvider(config *gitprovider.GitProviderConfig) (gitprovider.GitProvider, error) {
-	switch config.Id {
+	switch config.ProviderId {
 	case "github":
 		return gitprovider.NewGitHubGitProvider(config.Token, nil), nil
 	case "github-enterprise-server":

--- a/pkg/server/projectconfig/dto/projectconfig.go
+++ b/pkg/server/projectconfig/dto/projectconfig.go
@@ -8,12 +8,13 @@ import (
 )
 
 type CreateProjectConfigDTO struct {
-	Name          string                   `json:"name" validate:"required"`
-	Image         *string                  `json:"image,omitempty" validate:"optional"`
-	User          *string                  `json:"user,omitempty" validate:"optional"`
-	BuildConfig   *buildconfig.BuildConfig `json:"buildConfig,omitempty" validate:"optional"`
-	RepositoryUrl string                   `json:"repositoryUrl" validate:"required"`
-	EnvVars       map[string]string        `json:"envVars" validate:"required"`
+	Name                string                   `json:"name" validate:"required"`
+	Image               *string                  `json:"image,omitempty" validate:"optional"`
+	User                *string                  `json:"user,omitempty" validate:"optional"`
+	BuildConfig         *buildconfig.BuildConfig `json:"buildConfig,omitempty" validate:"optional"`
+	RepositoryUrl       string                   `json:"repositoryUrl" validate:"required"`
+	EnvVars             map[string]string        `json:"envVars" validate:"required"`
+	GitProviderConfigId *string                  `json:"gitProviderConfigId" validate:"required"`
 } // @name CreateProjectConfigDTO
 
 type PrebuildDTO struct {

--- a/pkg/server/projectconfig/dto/projectconfig.go
+++ b/pkg/server/projectconfig/dto/projectconfig.go
@@ -14,7 +14,7 @@ type CreateProjectConfigDTO struct {
 	BuildConfig         *buildconfig.BuildConfig `json:"buildConfig,omitempty" validate:"optional"`
 	RepositoryUrl       string                   `json:"repositoryUrl" validate:"required"`
 	EnvVars             map[string]string        `json:"envVars" validate:"required"`
-	GitProviderConfigId *string                  `json:"gitProviderConfigId" validate:"required"`
+	GitProviderConfigId *string                  `json:"gitProviderConfigId" validate:"optional"`
 } // @name CreateProjectConfigDTO
 
 type PrebuildDTO struct {

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -78,6 +78,15 @@ func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWo
 		}
 
 		p.Repository.Url = util.CleanUpRepositoryUrl(p.Repository.Url)
+		if p.GitProviderConfigId == nil || *p.GitProviderConfigId == "" {
+			_, id, err := s.gitProviderService.GetGitProviderForUrl(p.Repository.Url)
+			if err != nil {
+				return nil, err
+			}
+			p.GitProviderConfigId = &id
+
+		}
+
 		if p.Repository.Sha == "" {
 			sha, err := s.gitProviderService.GetLastCommitSha(p.Repository)
 			if err != nil {

--- a/pkg/server/workspaces/dto/workspace.go
+++ b/pkg/server/workspaces/dto/workspace.go
@@ -28,12 +28,13 @@ type CreateWorkspaceDTO struct {
 } //	@name	CreateWorkspaceDTO
 
 type CreateProjectDTO struct {
-	Name        string                   `json:"name" validate:"required"`
-	Image       *string                  `json:"image,omitempty" validate:"optional"`
-	User        *string                  `json:"user,omitempty" validate:"optional"`
-	BuildConfig *buildconfig.BuildConfig `json:"buildConfig,omitempty" validate:"optional"`
-	Source      CreateProjectSourceDTO   `json:"source" validate:"required"`
-	EnvVars     map[string]string        `json:"envVars" validate:"required"`
+	Name                string                   `json:"name" validate:"required"`
+	Image               *string                  `json:"image,omitempty" validate:"optional"`
+	User                *string                  `json:"user,omitempty" validate:"optional"`
+	BuildConfig         *buildconfig.BuildConfig `json:"buildConfig,omitempty" validate:"optional"`
+	Source              CreateProjectSourceDTO   `json:"source" validate:"required"`
+	EnvVars             map[string]string        `json:"envVars" validate:"required"`
+	GitProviderConfigId *string                  `json:"gitProviderConfigId" validate:"optional"`
 } //	@name	CreateProjectDTO
 
 type CreateProjectSourceDTO struct {

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -39,6 +39,18 @@ var target = provider.ProviderTarget{
 	},
 	Options: "test-options",
 }
+var gitProviderConfigId = "github"
+
+var baseApiUrl = "https://api.github.com"
+
+var gitProviderConfig = gitprovider.GitProviderConfig{
+	Id:         "github",
+	ProviderId: gitProviderConfigId,
+	Alias:      "test-alias",
+	Username:   "test-username",
+	Token:      "test-token",
+	BaseApiUrl: &baseApiUrl,
+}
 
 var createWorkspaceDto = dto.CreateWorkspaceDTO{
 	Name:   "test",
@@ -46,12 +58,15 @@ var createWorkspaceDto = dto.CreateWorkspaceDTO{
 	Target: target.Name,
 	Projects: []dto.CreateProjectDTO{
 		{
-			Name: "project1",
+			Name:                "project1",
+			GitProviderConfigId: &gitProviderConfig.Id,
 			Source: dto.CreateProjectSourceDTO{
 				Repository: &gitprovider.GitRepository{
-					Id:   "123",
-					Url:  "https://github.com/daytonaio/daytona",
-					Name: "daytona",
+					Id:     "123",
+					Url:    "https://github.com/daytonaio/daytona",
+					Name:   "daytona",
+					Branch: "main",
+					Sha:    "sha1",
 				},
 			},
 			Image: util.Pointer(defaultProjectImage),
@@ -117,14 +132,6 @@ func TestWorkspaceService(t *testing.T) {
 
 		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceDto.Id).Return(createWorkspaceDto.Id, nil)
 		gitProviderService.On("GetLastCommitSha", createWorkspaceDto.Projects[0].Source.Repository).Return("123", nil)
-
-		baseApiUrl := "https://api.github.com"
-		gitProviderConfig := gitprovider.GitProviderConfig{
-			Id:         "github",
-			Username:   "test-username",
-			Token:      "test-token",
-			BaseApiUrl: &baseApiUrl,
-		}
 
 		for _, project := range createWorkspaceDto.Projects {
 			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceDto.Id, project.Name)).Return(project.Name, nil)
@@ -260,13 +267,6 @@ func TestWorkspaceService(t *testing.T) {
 		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceDto.Id).Return(createWorkspaceDto.Id, nil)
 		gitProviderService.On("GetLastCommitSha", createWorkspaceDto.Projects[0].Source.Repository).Return("123", nil)
 
-		baseApiUrl := "https://api.github.com"
-		gitProviderConfig := gitprovider.GitProviderConfig{
-			Id:         "github",
-			Username:   "test-username",
-			Token:      "test-token",
-			BaseApiUrl: &baseApiUrl,
-		}
 		gitProviderService.On("GetConfigForUrl", "https://github.com/daytonaio/daytona").Return(&gitProviderConfig, nil)
 
 		for _, project := range createWorkspaceDto.Projects {

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -4,6 +4,7 @@
 package gitprovider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -16,34 +17,18 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-type GitProviderView struct {
-	Id         string
-	Name       string
-	Username   string
-	BaseApiUrl string
-	Token      string
-}
-
 var commonGitProviderIds = []string{"github", "gitlab", "bitbucket"}
 
-func GitProviderSelectionView(gitProviderAddView *apiclient.SetGitProviderConfig, userGitProviders []apiclient.GitProvider, isDeleting bool) {
+func GitProviderSelectionView(gitProviderAddView *apiclient.SetGitProviderConfig, apiClient *apiclient.APIClient, ctx context.Context) {
 	supportedProviders := config.GetSupportedGitProviders()
 
 	var gitProviderOptions []huh.Option[string]
 	var otherGitProviderOptions []huh.Option[string]
 	for _, supportedProvider := range supportedProviders {
-		if isDeleting {
-			for _, userProvider := range userGitProviders {
-				if userProvider.Id == supportedProvider.Id {
-					gitProviderOptions = append(gitProviderOptions, huh.Option[string]{Key: supportedProvider.Name, Value: supportedProvider.Id})
-				}
-			}
+		if slices.Contains(commonGitProviderIds, supportedProvider.Id) {
+			gitProviderOptions = append(gitProviderOptions, huh.Option[string]{Key: supportedProvider.Name, Value: supportedProvider.Id})
 		} else {
-			if slices.Contains(commonGitProviderIds, supportedProvider.Id) {
-				gitProviderOptions = append(gitProviderOptions, huh.Option[string]{Key: supportedProvider.Name, Value: supportedProvider.Id})
-			} else {
-				otherGitProviderOptions = append(otherGitProviderOptions, huh.Option[string]{Key: supportedProvider.Name, Value: supportedProvider.Id})
-			}
+			otherGitProviderOptions = append(otherGitProviderOptions, huh.Option[string]{Key: supportedProvider.Name, Value: supportedProvider.Id})
 		}
 	}
 
@@ -58,15 +43,15 @@ func GitProviderSelectionView(gitProviderAddView *apiclient.SetGitProviderConfig
 				Options(
 					gitProviderOptions...,
 				).
-				Value(&gitProviderAddView.Id)).WithHeight(8),
+				Value(&gitProviderAddView.ProviderId)).WithHeight(8),
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Choose a Git provider").
 				Options(
 					otherGitProviderOptions...,
 				).
-				Value(&gitProviderAddView.Id)).WithHeight(12).WithHideFunc(func() bool {
-			return gitProviderAddView.Id != "other"
+				Value(&gitProviderAddView.ProviderId)).WithHeight(12).WithHideFunc(func() bool {
+			return gitProviderAddView.ProviderId != "other"
 		}),
 	).WithTheme(views.GetCustomTheme())
 
@@ -87,13 +72,13 @@ func GitProviderSelectionView(gitProviderAddView *apiclient.SetGitProviderConfig
 					return nil
 				}),
 		).WithHeight(5).WithHideFunc(func() bool {
-			return isDeleting || !providerRequiresUsername(gitProviderAddView.Id)
+			return !providerRequiresUsername(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Self-managed API URL").
 				Value(gitProviderAddView.BaseApiUrl).
-				Description(getApiUrlDescription(gitProviderAddView.Id)).
+				Description(getApiUrlDescription(gitProviderAddView.ProviderId)).
 				Validate(func(str string) error {
 					if str == "" {
 						return errors.New("URL can not be blank")
@@ -101,7 +86,7 @@ func GitProviderSelectionView(gitProviderAddView *apiclient.SetGitProviderConfig
 					return nil
 				}),
 		).WithHeight(6).WithHideFunc(func() bool {
-			return isDeleting || !providerRequiresApiUrl(gitProviderAddView.Id)
+			return !providerRequiresApiUrl(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
@@ -114,17 +99,42 @@ func GitProviderSelectionView(gitProviderAddView *apiclient.SetGitProviderConfig
 					}
 					return nil
 				}),
-		).WithHeight(5).WithHide(isDeleting),
+		).WithHeight(5),
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Alias").
+				Description("Will default to username if left empty").
+				Value(gitProviderAddView.Alias),
+		).WithHeight(6),
 	).WithTheme(views.GetCustomTheme())
 
-	if !isDeleting {
-		views.RenderInfoMessage(getGitProviderHelpMessage(gitProviderAddView.Id))
-	}
-
+	views.RenderInfoMessage(getGitProviderHelpMessage(gitProviderAddView.ProviderId))
 	err = userDataForm.Run()
 	if err != nil {
 		log.Fatal(err)
 	}
+
+}
+
+func GitProviderDeleteView(gitProviderAddView *apiclient.SetGitProviderConfig, userGitProviders []apiclient.GitProvider, apiClient *apiclient.APIClient, ctx context.Context) {
+	var gitProviderOptions []huh.Option[string]
+	for _, userProvider := range userGitProviders {
+		gitProviderOptions = append(gitProviderOptions, huh.Option[string]{Key: fmt.Sprintf("%s   %s", userProvider.ProviderId, userProvider.Alias), Value: userProvider.Id})
+	}
+	gitProviderForm := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Choose a Git provider").
+				Options(
+					gitProviderOptions...,
+				).
+				Value(gitProviderAddView.Id)).WithHeight(8),
+	).WithTheme(views.GetCustomTheme())
+	err := gitProviderForm.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 }
 
 func providerRequiresUsername(gitProviderId string) bool {

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -19,7 +19,7 @@ import (
 
 var commonGitProviderIds = []string{"github", "gitlab", "bitbucket"}
 
-func GitProviderSelectionView(gitProviderAddView *apiclient.SetGitProviderConfig, apiClient *apiclient.APIClient, ctx context.Context) {
+func GitProviderSelectionView(ctx context.Context, gitProviderAddView *apiclient.SetGitProviderConfig, apiClient *apiclient.APIClient) {
 	supportedProviders := config.GetSupportedGitProviders()
 
 	var gitProviderOptions []huh.Option[string]

--- a/pkg/views/gitprovider/types.go
+++ b/pkg/views/gitprovider/types.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package gitprovider
+
+type GitProviderView struct {
+	Id         string
+	ProviderId string
+	Name       string
+	Username   string
+	BaseApiUrl string
+	Token      string
+	Alias      string
+}

--- a/pkg/views/workspace/selection/gitprovider.go
+++ b/pkg/views/workspace/selection/gitprovider.go
@@ -22,7 +22,7 @@ func selectGitProviderPrompt(gitProviders []gitprovider_view.GitProviderView, pr
 
 	// Populate items with titles and descriptions from workspaces.
 	for _, provider := range gitProviders {
-		newItem := item[string]{id: provider.Id, title: provider.Name, choiceProperty: provider.Id}
+		newItem := item[string]{id: provider.Id, title: fmt.Sprintf("%s (%s)", provider.Name, provider.Alias), choiceProperty: provider.Id}
 		items = append(items, newItem)
 	}
 
@@ -61,6 +61,5 @@ func GetProviderIdFromPrompt(gitProviders []gitprovider_view.GitProviderView, pr
 	choiceChan := make(chan string)
 
 	go selectGitProviderPrompt(gitProviders, projectOrder, choiceChan, samplesEnabled)
-
 	return <-choiceChan
 }

--- a/pkg/workspace/project/config/config.go
+++ b/pkg/workspace/project/config/config.go
@@ -10,14 +10,15 @@ import (
 )
 
 type ProjectConfig struct {
-	Name          string                   `json:"name" validate:"required"`
-	Image         string                   `json:"image" validate:"required"`
-	User          string                   `json:"user" validate:"required"`
-	BuildConfig   *buildconfig.BuildConfig `json:"buildConfig,omitempty" validate:"optional"`
-	RepositoryUrl string                   `json:"repositoryUrl" validate:"required"`
-	EnvVars       map[string]string        `json:"envVars" validate:"required"`
-	IsDefault     bool                     `json:"default" validate:"required"`
-	Prebuilds     []*PrebuildConfig        `json:"prebuilds" validate:"optional"`
+	Name                string                   `json:"name" validate:"required"`
+	Image               string                   `json:"image" validate:"required"`
+	User                string                   `json:"user" validate:"required"`
+	BuildConfig         *buildconfig.BuildConfig `json:"buildConfig,omitempty" validate:"optional"`
+	RepositoryUrl       string                   `json:"repositoryUrl" validate:"required"`
+	EnvVars             map[string]string        `json:"envVars" validate:"required"`
+	IsDefault           bool                     `json:"default" validate:"required"`
+	Prebuilds           []*PrebuildConfig        `json:"prebuilds" validate:"optional"`
+	GitProviderConfigId *string                  `json:"gitProviderConfigId" validate:"optional"`
 } // @name ProjectConfig
 
 func (pc *ProjectConfig) SetPrebuild(p *PrebuildConfig) error {

--- a/pkg/workspace/project/project.go
+++ b/pkg/workspace/project/project.go
@@ -12,16 +12,17 @@ import (
 )
 
 type Project struct {
-	Name        string                     `json:"name" validate:"required"`
-	Image       string                     `json:"image" validate:"required"`
-	User        string                     `json:"user" validate:"required"`
-	BuildConfig *buildconfig.BuildConfig   `json:"buildConfig,omitempty" validate:"optional"`
-	Repository  *gitprovider.GitRepository `json:"repository" validate:"required"`
-	EnvVars     map[string]string          `json:"envVars" validate:"required"`
-	WorkspaceId string                     `json:"workspaceId" validate:"required"`
-	ApiKey      string                     `json:"-"`
-	Target      string                     `json:"target" validate:"required"`
-	State       *ProjectState              `json:"state,omitempty" validate:"optional"`
+	Name                string                     `json:"name" validate:"required"`
+	Image               string                     `json:"image" validate:"required"`
+	User                string                     `json:"user" validate:"required"`
+	BuildConfig         *buildconfig.BuildConfig   `json:"buildConfig,omitempty" validate:"optional"`
+	Repository          *gitprovider.GitRepository `json:"repository" validate:"required"`
+	EnvVars             map[string]string          `json:"envVars" validate:"required"`
+	WorkspaceId         string                     `json:"workspaceId" validate:"required"`
+	ApiKey              string                     `json:"-"`
+	Target              string                     `json:"target" validate:"required"`
+	State               *ProjectState              `json:"state,omitempty" validate:"optional"`
+	GitProviderConfigId *string                    `json:"gitProviderConfigId,omitempty" validate:"optional"`
 } // @name Project
 
 type ProjectInfo struct {


### PR DESCRIPTION
#  Support for Multiple Git Provider Tokens and Auto-Selection

## Description

This update allows users to add multiple tokens for the same Git provider and specify which token to use with the `--git-provider-config-id="..."` flag or let the system auto-select the appropriate token.

### Key Changes:
1. **Git Provider Config Struct**:
   - **`Alias`**: Token alias for better identification.
   - **`ProviderId`**: Git provider name (e.g., GitHub, GitLab).
   - The **Git provider ID** is now a randomly generated `UUID`.

2. **Project and Project Config**:
   - Added `GitProviderConfigId` field to associate a specific Git provider config with the project or project config.

3. **Token Selection Logic**:
   - Fetch the repository context; if successful, it uses that token for the project. If an error occurs, it moves to the next token.

### Breaking Change:
- The `Id` of the Git provider config is now a randomly generated `UUID`.
- `ProviderId` now represents the Git provider name instead of an identifier.

--- 

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

This PR addresses issue #777
/claim #777

