### PR TITLE
fix: fetch image user from project config on create

### DIFF
--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -90,7 +90,7 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 					return nil, apiclient_util.HandleErrorResponse(res, err)
 				}
 
-				projectList = append(projectList, apiclient.CreateProjectDTO{
+				createProjectDto := apiclient.CreateProjectDTO{
 					Name: projectName,
 					Source: apiclient.CreateProjectSourceDTO{
 						Repository: *configRepo,
@@ -99,7 +99,17 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 					Image:       config.Defaults.Image,
 					User:        config.Defaults.ImageUser,
 					EnvVars:     projectConfig.EnvVars,
-				})
+				}
+
+				if projectConfig.Image != "" {
+					createProjectDto.Image = &projectConfig.Image
+				}
+
+				if projectConfig.User != "" {
+					createProjectDto.User = &projectConfig.User
+				}
+
+				projectList = append(projectList, createProjectDto)
 				continue
 			}
 		}


### PR DESCRIPTION
# Fix fetching image/user from project config on daytona create
## Description

Daytona create now correctly fetches the custom image/user when a project config is selected instead of using the default ones

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation