### PR TITLE
feat: direct ssh access to local workspaces

### DIFF
--- a/docs/daytona_ssh.md
+++ b/docs/daytona_ssh.md
@@ -3,7 +3,7 @@
 SSH into a project using the terminal
 
 ```
-daytona ssh [WORKSPACE] [PROJECT] [flags]
+daytona ssh [WORKSPACE] [PROJECT] [CMD...] [flags]
 ```
 
 ### Options inherited from parent commands

--- a/docs/workspace_mode/daytona.md
+++ b/docs/workspace_mode/daytona.md
@@ -22,6 +22,7 @@ daytona [flags]
 * [daytona agent](daytona_agent.md)	 - Start the agent process
 * [daytona autocomplete](daytona_autocomplete.md)	 - Adds completion script for your shell enviornment
 * [daytona docs](daytona_docs.md)	 - Opens the Daytona documentation in your default browser.
+* [daytona expose](daytona_expose.md)	 - Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project
 * [daytona forward](daytona_forward.md)	 - Forward a port from the project to your local machine
 * [daytona info](daytona_info.md)	 - Show project info
 * [daytona list](daytona_list.md)	 - List workspaces

--- a/docs/workspace_mode/daytona_expose.md
+++ b/docs/workspace_mode/daytona_expose.md
@@ -1,0 +1,18 @@
+## daytona expose
+
+Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project
+
+```
+daytona expose [PORT] [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --help   help for daytona
+```
+
+### SEE ALSO
+
+* [daytona](daytona.md)	 - Use the Daytona CLI to manage your workspace
+

--- a/hack/docs/daytona_ssh.yaml
+++ b/hack/docs/daytona_ssh.yaml
@@ -1,6 +1,6 @@
 name: daytona ssh
 synopsis: SSH into a project using the terminal
-usage: daytona ssh [WORKSPACE] [PROJECT] [flags]
+usage: daytona ssh [WORKSPACE] [PROJECT] [CMD...] [flags]
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/workspace_mode/daytona.yaml
+++ b/hack/docs/workspace_mode/daytona.yaml
@@ -14,6 +14,7 @@ see_also:
     - daytona agent - Start the agent process
     - daytona autocomplete - Adds completion script for your shell enviornment
     - daytona docs - Opens the Daytona documentation in your default browser.
+    - daytona expose - Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project
     - daytona forward - Forward a port from the project to your local machine
     - daytona info - Show project info
     - daytona list - List workspaces

--- a/hack/docs/workspace_mode/daytona_expose.yaml
+++ b/hack/docs/workspace_mode/daytona_expose.yaml
@@ -1,0 +1,10 @@
+name: daytona expose
+synopsis: |
+    Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project
+usage: daytona expose [PORT] [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+see_also:
+    - daytona - Use the Daytona CLI to manage your workspace

--- a/internal/util/log_writer.go
+++ b/internal/util/log_writer.go
@@ -20,3 +20,10 @@ func (w *InfoLogWriter) Write(p []byte) (n int, err error) {
 	log.Info(string(p))
 	return len(p), nil
 }
+
+type TraceLogWriter struct{}
+
+func (w *TraceLogWriter) Write(p []byte) (n int, err error) {
+	log.Trace(string(p))
+	return len(p), nil
+}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -449,9 +449,9 @@ func waitForDial(workspace *apiclient.Workspace, activeProfile *config.Profile, 
 			return err
 		}
 
-		for {
-			projectHostname := config.GetProjectHostname(activeProfile.Id, workspace.Id, workspace.Projects[0].Name)
+		projectHostname := config.GetProjectHostname(activeProfile.Id, workspace.Id, workspace.Projects[0].Name)
 
+		for {
 			sshCommand := exec.Command("ssh", projectHostname, "daytona", "version")
 			sshCommand.Stdin = nil
 			sshCommand.Stdout = nil

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -139,9 +140,12 @@ var CreateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		tsConn, err := tailscale.GetConnection(&activeProfile)
-		if err != nil {
-			log.Fatal(err)
+		var tsConn *tsnet.Server
+		if target.Name != "local" {
+			tsConn, err = tailscale.GetConnection(&activeProfile)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 
 		id := stringid.GenerateRandomID()
@@ -160,7 +164,7 @@ var CreateCmd = &cobra.Command{
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
-		err = waitForDial(tsConn, createdWorkspace.Id, createdWorkspace.Projects[0].Name)
+		err = waitForDial(createdWorkspace, &activeProfile, tsConn)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -438,15 +442,36 @@ func processGitURL(repoUrl string, apiClient *apiclient.APIClient, projects *[]a
 	return nil, nil
 }
 
-func waitForDial(tsConn *tsnet.Server, workspaceId string, projectName string) error {
+func waitForDial(workspace *apiclient.Workspace, activeProfile *config.Profile, tsConn *tsnet.Server) error {
+	if workspace.Target == "local" {
+		err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspace.Id, workspace.Projects[0].Name)
+		if err != nil {
+			return err
+		}
+
+		for {
+			projectHostname := config.GetProjectHostname(activeProfile.Id, workspace.Id, workspace.Projects[0].Name)
+
+			sshCommand := exec.Command("ssh", projectHostname, "daytona", "version")
+			sshCommand.Stdin = nil
+			sshCommand.Stdout = nil
+			sshCommand.Stderr = &util.TraceLogWriter{}
+
+			err = sshCommand.Run()
+			if err == nil {
+				return nil
+			}
+
+			time.Sleep(time.Second)
+		}
+	}
+
 	for {
-		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:%d", project.GetProjectHostname(workspaceId, projectName), ssh_config.SSH_PORT))
+		dialConn, err := tsConn.Dial(context.Background(), "tcp", fmt.Sprintf("%s:%d", project.GetProjectHostname(workspace.Id, workspace.Projects[0].Name), ssh_config.SSH_PORT))
 		if err == nil {
-			defer dialConn.Close()
-			break
+			return dialConn.Close()
 		}
 
 		time.Sleep(time.Second)
 	}
-	return nil
 }

--- a/pkg/cmd/workspace/ssh-proxy.go
+++ b/pkg/cmd/workspace/ssh-proxy.go
@@ -8,12 +8,18 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/cmd/tailscale"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/internal/util/apiclient/conversion"
 	ssh_config "github.com/daytonaio/daytona/pkg/agent/ssh/config"
+	"github.com/daytonaio/daytona/pkg/docker"
 	"github.com/daytonaio/daytona/pkg/workspace/project"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,6 +50,85 @@ var SshProxyCmd = &cobra.Command{
 			projectName, err = apiclient.GetFirstWorkspaceProjectName(workspaceId, projectName, &profile)
 			if err != nil {
 				log.Fatal(err)
+			}
+		}
+
+		workspace, err := apiclient.GetWorkspace(workspaceId)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if workspace.Target == "local" {
+			// If the workspace is local, we directly access the ssh port through the container
+			project := workspace.Projects[0]
+
+			if project.Name != projectName {
+				for _, p := range workspace.Projects {
+					if p.Name == projectName {
+						project = p
+						break
+					}
+				}
+			}
+
+			cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			dockerClient := docker.NewDockerClient(docker.DockerClientConfig{
+				ApiClient: cli,
+			})
+
+			containerName := dockerClient.GetProjectContainerName(conversion.ToProject(&project))
+
+			ctx := context.Background()
+
+			config := container.ExecOptions{
+				AttachStdin:  true,
+				AttachStderr: true,
+				AttachStdout: true,
+				Cmd:          []string{"daytona", "expose", fmt.Sprint(ssh_config.SSH_PORT)},
+			}
+
+			response, err := cli.ContainerExecCreate(ctx, containerName, config)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			resp, err := cli.ContainerExecAttach(ctx, response.ID, container.ExecStartOptions{
+				Tty: config.Tty,
+			})
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			go func() {
+				_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, resp.Reader)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}()
+
+			go func() {
+				_, err := io.Copy(resp.Conn, os.Stdin)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}()
+
+			for {
+				res, err := cli.ContainerExecInspect(ctx, response.ID)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				if !res.Running {
+					os.Exit(res.ExitCode)
+				}
+
+				time.Sleep(100 * time.Millisecond)
 			}
 		}
 

--- a/pkg/cmd/workspacemode/expose.go
+++ b/pkg/cmd/workspacemode/expose.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package workspacemode
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/daytonaio/daytona/internal/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var exposeCmd = &cobra.Command{
+	Use:     "expose [PORT]",
+	Short:   "Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project",
+	Args:    cobra.ExactArgs(1),
+	GroupID: util.WORKSPACE_GROUP,
+	Run: func(cmd *cobra.Command, args []string) {
+		port, err := strconv.Atoi(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		targetUrl := fmt.Sprintf("localhost:%d", port)
+
+		dialConn, err := net.Dial("tcp", targetUrl)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		go func() {
+			_, err := io.Copy(os.Stdout, dialConn)
+			if err != nil {
+				log.Fatal(err)
+			}
+			dialConn.Close()
+		}()
+
+		go func() {
+			_, err := io.Copy(dialConn, os.Stdin)
+			if err != nil {
+				log.Fatal(err)
+			}
+			dialConn.Close()
+		}()
+
+		select {}
+	},
+}

--- a/pkg/cmd/workspacemode/workspace_mode.go
+++ b/pkg/cmd/workspacemode/workspace_mode.go
@@ -39,6 +39,7 @@ func Execute() {
 	workspaceModeRootCmd.AddCommand(stopCmd)
 	workspaceModeRootCmd.AddCommand(infoCmd)
 	workspaceModeRootCmd.AddCommand(portForwardCmd)
+	workspaceModeRootCmd.AddCommand(exposeCmd)
 
 	if err := workspaceModeRootCmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/pkg/ide/terminal.go
+++ b/pkg/ide/terminal.go
@@ -10,7 +10,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 )
 
-func OpenTerminalSsh(activeProfile config.Profile, workspaceId string, projectName string) error {
+func OpenTerminalSsh(activeProfile config.Profile, workspaceId string, projectName string, args ...string) error {
 	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, projectName)
 	if err != nil {
 		return err
@@ -18,7 +18,10 @@ func OpenTerminalSsh(activeProfile config.Profile, workspaceId string, projectNa
 
 	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
 
-	sshCommand := exec.Command("ssh", projectHostname)
+	cmdArgs := []string{projectHostname}
+	cmdArgs = append(cmdArgs, args...)
+
+	sshCommand := exec.Command("ssh", cmdArgs...)
 	sshCommand.Stdin = os.Stdin
 	sshCommand.Stdout = os.Stdout
 	sshCommand.Stderr = os.Stderr


### PR DESCRIPTION
# Direct SSH Access to Local Workspaces

## Description

- Local workspaces are now accessed directly by forward ssh traffic with docker exec
- The ssh command now allows direct command execution through its arguments

These changes represent a significant performance improvement when working with local workspaces.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #982
