### PR TITLE
fix: consider env variable while running `daytona server start`

### DIFF
--- a/internal/util/env_vars.go
+++ b/internal/util/env_vars.go
@@ -39,3 +39,15 @@ func MergeEnvVars(envVars ...map[string]string) map[string]string {
 
 	return vars
 }
+
+func GetEnvVarsFromShell() map[string]string {
+	envMap := map[string]string{}
+
+	for _, env := range os.Environ() {
+		kv := strings.SplitN(env, "=", 2)
+		if len(kv) == 2 {
+			envMap[kv[0]] = kv[1]
+		}
+	}
+	return envMap
+}

--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/kardianos/service"
 )
 
@@ -135,6 +136,7 @@ func getServiceConfig() (*service.Config, error) {
 			svcConfig.Option = service.KeyValue{"UserService": true}
 		}
 	}
+	svcConfig.EnvVars = util.GetEnvVarsFromShell()
 
 	return svcConfig, nil
 }


### PR DESCRIPTION
## Consider env variable while running `daytona server start`

## Description
1.Add `GetEnvVarsFromShell()` to retrieve environment variables 
2.Set EnvVars property in [config](https://pkg.go.dev/github.com/kardianos/service@v1.2.2#Config) of github.com/kardianos/service](https://pkg.go.dev/github.com/kardianos/service@v1.2.2) to consider env variables. 
- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1036 

## Screenshots
<img width="1000" alt="Screenshot 2024-09-02 at 9 32 31 PM" src="https://github.com/user-attachments/assets/409cf28a-7e63-45b1-a783-25a31e7cbedb">

## Notes
Please add any relevant notes if necessary.
