### PR TITLE
feat: install provider during target set

### DIFF
--- a/internal/util/apiclient/api_client.go
+++ b/internal/util/apiclient/api_client.go
@@ -112,36 +112,6 @@ func GetAgentApiClient(apiUrl, apiKey, clientId string, telemetryEnabled bool) (
 	return apiClient, nil
 }
 
-func GetProviderList() ([]apiclient.Provider, error) {
-	apiClient, err := GetApiClient(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-
-	providersList, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
-	if err != nil {
-		return nil, HandleErrorResponse(res, err)
-	}
-
-	return providersList, nil
-}
-
-func GetTargetList() ([]apiclient.ProviderTarget, error) {
-	apiClient, err := GetApiClient(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	targets, resp, err := apiClient.TargetAPI.ListTargets(context.Background()).Execute()
-	if err != nil {
-		return nil, HandleErrorResponse(resp, err)
-	}
-
-	return targets, nil
-}
-
 func GetWorkspace(workspaceNameOrId string) (*apiclient.WorkspaceDTO, error) {
 	ctx := context.Background()
 

--- a/pkg/cmd/provider/install.go
+++ b/pkg/cmd/provider/install.go
@@ -131,10 +131,6 @@ func InstallProvider(apiClient *apiclient.APIClient, providerToInstall provider_
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		if err != nil {
-			return err
-		}
-
 		return nil
 	})
 

--- a/pkg/cmd/provider/install.go
+++ b/pkg/cmd/provider/install.go
@@ -110,7 +110,7 @@ func GetProviderListFromManifest(manifest *manager.ProvidersManifest) []apiclien
 	return pluginList
 }
 
-func ConvertToStringMap(downloadUrls map[os.OperatingSystem]string) map[string]string {
+func ConvertOSToStringMap(downloadUrls map[os.OperatingSystem]string) map[string]string {
 	stringMap := map[string]string{}
 	for os, url := range downloadUrls {
 		stringMap[string(os)] = url
@@ -120,7 +120,7 @@ func ConvertToStringMap(downloadUrls map[os.OperatingSystem]string) map[string]s
 }
 
 func InstallProvider(apiClient *apiclient.APIClient, providerToInstall provider_view.ProviderView, providersManifest *manager.ProvidersManifest) error {
-	downloadUrls := ConvertToStringMap((*providersManifest)[providerToInstall.Name].Versions[providerToInstall.Version].DownloadUrls)
+	downloadUrls := ConvertOSToStringMap((*providersManifest)[providerToInstall.Name].Versions[providerToInstall.Version].DownloadUrls)
 	err := views_util.WithSpinner("Installing", func() error {
 		res, err := apiClient.ProviderAPI.InstallProviderExecute(apiclient.ApiInstallProviderRequest{}.Provider(apiclient.InstallProviderRequest{
 			Name:         providerToInstall.Name,

--- a/pkg/cmd/provider/list.go
+++ b/pkg/cmd/provider/list.go
@@ -4,9 +4,14 @@
 package provider
 
 import (
-	"github.com/daytonaio/daytona/internal/util/apiclient"
+	"context"
+
+	"github.com/daytonaio/daytona/internal/util"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/provider"
+	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
 	"github.com/spf13/cobra"
 
 	log "github.com/sirupsen/logrus"
@@ -18,9 +23,16 @@ var providerListCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Aliases: []string{"ls"},
 	Run: func(cmd *cobra.Command, args []string) {
-		providerList, err := apiclient.GetProviderList()
+		ctx := context.Background()
+
+		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
+		}
+
+		providerList, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
+		if err != nil {
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
 		if format.FormatFlag != "" {
@@ -31,6 +43,41 @@ var providerListCmd = &cobra.Command{
 
 		provider.List(providerList)
 	},
+}
+
+func GetProviderViewOptions(apiClient *apiclient.APIClient, latestProviders []apiclient.Provider, ctx context.Context) []provider_view.ProviderView {
+	var result []provider_view.ProviderView
+
+	installedProviders, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
+	if err != nil {
+		log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+	}
+
+	providerMap := make(map[string]provider_view.ProviderView)
+
+	for _, installedProvider := range installedProviders {
+		providerMap[installedProvider.Name] = provider_view.ProviderView{
+			Name:      installedProvider.Name,
+			Version:   installedProvider.Version,
+			Installed: util.Pointer(true),
+		}
+	}
+
+	for _, latestProvider := range latestProviders {
+		if _, exists := providerMap[latestProvider.Name]; !exists {
+			providerMap[latestProvider.Name] = provider_view.ProviderView{
+				Name:      latestProvider.Name,
+				Version:   latestProvider.Version,
+				Installed: util.Pointer(false),
+			}
+		}
+	}
+
+	for _, provider := range providerMap {
+		result = append(result, provider)
+	}
+
+	return result
 }
 
 func init() {

--- a/pkg/cmd/provider/update.go
+++ b/pkg/cmd/provider/update.go
@@ -84,10 +84,10 @@ var providerUpdateCmd = &cobra.Command{
 	},
 }
 
-func updateProvider(providerToUpdateName string, providersManifest *manager.ProvidersManifest, apiClient *apiclient.APIClient) error {
-	providerManifest, ok := (*providersManifest)[providerToUpdateName]
+func updateProvider(providerName string, providersManifest *manager.ProvidersManifest, apiClient *apiclient.APIClient) error {
+	providerManifest, ok := (*providersManifest)[providerName]
 	if !ok {
-		return fmt.Errorf("Provider %s not found in manifest", providerToUpdateName)
+		return fmt.Errorf("Provider %s not found in manifest", providerName)
 	}
 
 	version, ok := providerManifest.Versions["latest"]
@@ -99,7 +99,7 @@ func updateProvider(providerToUpdateName string, providersManifest *manager.Prov
 	downloadUrls := ConvertToStringMap(version.DownloadUrls)
 
 	res, err := apiClient.ProviderAPI.InstallProviderExecute(apiclient.ApiInstallProviderRequest{}.Provider(apiclient.InstallProviderRequest{
-		Name:         providerToUpdateName,
+		Name:         providerName,
 		DownloadUrls: downloadUrls,
 	}))
 	if err != nil {

--- a/pkg/cmd/provider/update.go
+++ b/pkg/cmd/provider/update.go
@@ -96,7 +96,7 @@ func updateProvider(providerName string, providersManifest *manager.ProvidersMan
 		version = *latest
 	}
 
-	downloadUrls := ConvertToStringMap(version.DownloadUrls)
+	downloadUrls := ConvertOSToStringMap(version.DownloadUrls)
 
 	res, err := apiClient.ProviderAPI.InstallProviderExecute(apiclient.ApiInstallProviderRequest{}.Provider(apiclient.InstallProviderRequest{
 		Name:         providerName,

--- a/pkg/cmd/target/list.go
+++ b/pkg/cmd/target/list.go
@@ -4,9 +4,10 @@
 package target
 
 import (
+	"context"
 	"log"
 
-	"github.com/daytonaio/daytona/internal/util/apiclient"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views"
 	list_view "github.com/daytonaio/daytona/pkg/views/target/list"
@@ -19,24 +20,31 @@ var targetListCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Aliases: []string{"ls"},
 	Run: func(cmd *cobra.Command, args []string) {
-		targets, err := apiclient.GetTargetList()
+		ctx := context.Background()
+
+		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if len(targets) == 0 {
+		targetList, res, err := apiClient.TargetAPI.ListTargets(ctx).Execute()
+		if err != nil {
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+		}
+
+		if len(targetList) == 0 {
 			views.RenderInfoMessageBold("No targets found")
 			views.RenderInfoMessage("Use 'daytona target set' to add a target")
 			return
 		}
 
 		if format.FormatFlag != "" {
-			formattedData := format.NewFormatter(targets)
+			formattedData := format.NewFormatter(targetList)
 			formattedData.Print()
 			return
 		}
 
-		list_view.ListTargets(targets)
+		list_view.ListTargets(targetList)
 	},
 }
 

--- a/pkg/cmd/target/set.go
+++ b/pkg/cmd/target/set.go
@@ -10,9 +10,11 @@ import (
 	internal_util "github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/cmd/provider"
 	"github.com/daytonaio/daytona/pkg/common"
+	"github.com/daytonaio/daytona/pkg/provider/manager"
 	"github.com/daytonaio/daytona/pkg/views"
-	"github.com/daytonaio/daytona/pkg/views/provider"
+	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
 	"github.com/daytonaio/daytona/pkg/views/target"
 	"github.com/spf13/cobra"
 
@@ -25,6 +27,13 @@ var TargetSetCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Aliases: []string{"s", "add", "update", "register", "edit"},
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+
+		apiClient, err := apiclient_util.GetApiClient(nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		c, err := config.GetConfig()
 		if err != nil {
 			log.Fatal(err)
@@ -35,12 +44,31 @@ var TargetSetCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		pluginList, err := apiclient_util.GetProviderList()
+		serverConfig, res, err := apiClient.ServerAPI.GetConfigExecute(apiclient.ApiGetConfigRequest{})
+		if err != nil {
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+		}
+
+		providersManifest, err := manager.NewProviderManager(manager.ProviderManagerConfig{
+			RegistryUrl: serverConfig.RegistryUrl,
+		}).GetProvidersManifest()
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		selectedProvider, err := provider.GetProviderFromPrompt(pluginList, "Choose a provider", false)
+		if providersManifest == nil {
+			log.Fatal("Could not get providers manifest")
+		}
+
+		providersManifestLatest := providersManifest.GetLatestVersions()
+		if providersManifestLatest == nil {
+			log.Fatal("Could not get providers manifest")
+		}
+
+		latestProviders := provider.GetProviderListFromManifest(providersManifestLatest)
+		providerViewList := provider.GetProviderViewOptions(apiClient, latestProviders, ctx)
+
+		selectedProvider, err := provider_view.GetProviderFromPrompt(providerViewList, "Choose a Provider", false)
 		if err != nil {
 			if common.IsCtrlCAbort(err) {
 				return
@@ -53,9 +81,16 @@ var TargetSetCmd = &cobra.Command{
 			return
 		}
 
-		targets, err := apiclient_util.GetTargetList()
+		if selectedProvider.Installed != nil && !*selectedProvider.Installed {
+			err = provider.InstallProvider(apiClient, *selectedProvider, providersManifest)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		targets, res, err := apiClient.TargetAPI.ListTargets(ctx).Execute()
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
 		filteredTargets := []apiclient.ProviderTarget{}
@@ -74,12 +109,7 @@ var TargetSetCmd = &cobra.Command{
 			}
 		}
 
-		client, err := apiclient_util.GetApiClient(nil)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		targetManifest, res, err := client.ProviderAPI.GetTargetManifest(context.Background(), selectedProvider.Name).Execute()
+		targetManifest, res, err := apiClient.ProviderAPI.GetTargetManifest(context.Background(), selectedProvider.Name).Execute()
 		if err != nil {
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
@@ -104,7 +134,7 @@ var TargetSetCmd = &cobra.Command{
 			Version: selectedProvider.Version,
 		}
 
-		res, err = client.TargetAPI.SetTarget(context.Background()).Target(*selectedTarget).Execute()
+		res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(*selectedTarget).Execute()
 		if err != nil {
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}

--- a/pkg/cmd/target/set.go
+++ b/pkg/cmd/target/set.go
@@ -66,7 +66,7 @@ var TargetSetCmd = &cobra.Command{
 
 			latestProviders = provider.GetProviderListFromManifest(providersManifestLatest)
 		} else {
-			fmt.Println("Could not get providers manifest")
+			fmt.Println("Could not get provider manifest. Can't check for new providers to install")
 		}
 
 		providerViewList := provider.GetProviderViewOptions(apiClient, latestProviders, ctx)

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -129,7 +129,12 @@ var CreateCmd = &cobra.Command{
 			}, logs_view.FIRST_PROJECT_INDEX)
 		}
 
-		target, err := getTarget(activeProfile.Name)
+		targetList, res, err := apiClient.TargetAPI.ListTargets(ctx).Execute()
+		if err != nil {
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+		}
+
+		target, err := getTarget(targetList, activeProfile.Name)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -268,14 +273,9 @@ func init() {
 	CreateCmd.MarkFlagsRequiredTogether("custom-image", "custom-image-user")
 }
 
-func getTarget(activeProfileName string) (*apiclient.ProviderTarget, error) {
-	targets, err := apiclient_util.GetTargetList()
-	if err != nil {
-		return nil, err
-	}
-
+func getTarget(targetList []apiclient.ProviderTarget, activeProfileName string) (*apiclient.ProviderTarget, error) {
 	if targetNameFlag != "" {
-		for _, t := range targets {
+		for _, t := range targetList {
 			if t.Name == targetNameFlag {
 				return &t, nil
 			}
@@ -283,11 +283,11 @@ func getTarget(activeProfileName string) (*apiclient.ProviderTarget, error) {
 		return nil, fmt.Errorf("target '%s' not found", targetNameFlag)
 	}
 
-	if len(targets) == 1 {
-		return &targets[0], nil
+	if len(targetList) == 1 {
+		return &targetList[0], nil
 	}
 
-	return target.GetTargetFromPrompt(targets, activeProfileName, false)
+	return target.GetTargetFromPrompt(targetList, activeProfileName, false)
 }
 
 func processPrompting(apiClient *apiclient.APIClient, workspaceName *string, projects *[]apiclient.CreateProjectDTO, workspaceNames []string, ctx context.Context) error {

--- a/pkg/views/provider/select.go
+++ b/pkg/views/provider/select.go
@@ -4,6 +4,8 @@
 package provider
 
 import (
+	"sort"
+
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -11,9 +13,17 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
+type ProviderView struct {
+	Name      string
+	Version   string
+	Installed *bool
+}
+
 var NewProviderId = "+ New Provider"
 
-func GetProviderFromPrompt(providers []apiclient.Provider, title string, withNewProvider bool) (*apiclient.Provider, error) {
+func GetProviderFromPrompt(providers []ProviderView, title string, withNewProvider bool) (*ProviderView, error) {
+	sortProviders(&providers)
+
 	var items []list.Item
 
 	for _, p := range providers {
@@ -25,7 +35,7 @@ func GetProviderFromPrompt(providers []apiclient.Provider, title string, withNew
 	if withNewProvider {
 		name := NewProviderId
 		items = append(items, item{
-			provider: apiclient.Provider{
+			provider: ProviderView{
 				Name: name,
 			},
 		})
@@ -45,4 +55,30 @@ func GetProviderFromPrompt(providers []apiclient.Provider, title string, withNew
 	}
 
 	return nil, common.ErrCtrlCAbort
+}
+
+func ProviderListToView(providers []apiclient.Provider) []ProviderView {
+	var providerViews []ProviderView
+
+	for _, p := range providers {
+		providerViews = append(providerViews, ProviderView{
+			Name:      p.Name,
+			Version:   p.Version,
+			Installed: nil,
+		})
+	}
+
+	return providerViews
+}
+
+func sortProviders(providers *[]ProviderView) {
+	sort.Slice(*providers, func(i, j int) bool {
+		if (*providers)[i].Installed == nil {
+			return false
+		}
+		if (*providers)[j].Installed == nil {
+			return true
+		}
+		return *(*providers)[i].Installed
+	})
 }

--- a/pkg/views/provider/view.go
+++ b/pkg/views/provider/view.go
@@ -8,24 +8,30 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"golang.org/x/term"
 )
 
 type item struct {
-	provider apiclient.Provider
+	provider ProviderView
 }
 
 func (i item) Title() string { return i.provider.Name }
 func (i item) Description() string {
-	return i.provider.Version
+	desc := i.provider.Version
+	if i.provider.Installed != nil {
+		if !*i.provider.Installed {
+			desc += " (needs installing)"
+		}
+	}
+
+	return desc
 }
 func (i item) FilterValue() string { return i.provider.Name }
 
 type model struct {
 	list   list.Model
-	choice *apiclient.Provider
+	choice *ProviderView
 }
 
 func (m model) Init() tea.Cmd {


### PR DESCRIPTION
# Install provider during target set
## Description

During `daytona target set`, let users choose a provider that hasn't been installed yet. If selected, the provider will get installed right away as a part of the same TUI flow.
Minor overdue refactor/cleanups

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1030

## Screenshots

![image](https://github.com/user-attachments/assets/4ec73d79-cf6c-47f9-8ac8-82380d954f8f)

![image](https://github.com/user-attachments/assets/1bfd1666-1043-43cb-8c00-957041082218)
