### PR TITLE
feat: add provider prefix option to logs

### DIFF
--- a/internal/util/apiclient/websocket_log_reader.go
+++ b/internal/util/apiclient/websocket_log_reader.go
@@ -60,7 +60,7 @@ func ReadWorkspaceLogs(ctx context.Context, activeProfile config.Profile, worksp
 			continue
 		}
 
-		readJSONLog(ctx, ws, logs_view.WORKSPACE_INDEX)
+		readJSONLog(ctx, ws, logs_view.STATIC_INDEX)
 		ws.Close()
 		break
 	}
@@ -111,7 +111,7 @@ func readJSONLog(ctx context.Context, ws *websocket.Conn, index int) {
 			logs_view.DisplayLogEntry(logEntry, index)
 		}
 
-		if !workspaceLogsStarted && index == logs_view.WORKSPACE_INDEX {
+		if !workspaceLogsStarted && index == logs_view.STATIC_INDEX {
 			workspaceLogsStarted = true
 		}
 	}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -121,7 +121,7 @@ var CreateCmd = &cobra.Command{
 
 		logs_view.DisplayLogEntry(logs.LogEntry{
 			Msg: "Request submitted\n",
-		}, logs_view.WORKSPACE_INDEX)
+		}, logs_view.STATIC_INDEX)
 
 		if existingProjectConfigName != nil {
 			logs_view.DisplayLogEntry(logs.LogEntry{

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -41,7 +41,7 @@ var (
 )
 
 var LogPrefixColors = []lipgloss.AdaptiveColor{
-	Blue, Yellow, Orange, Cyan,
+	Blue, Orange, Cyan, Yellow,
 }
 
 func GetStyledSelectList(items []list.Item) list.Model {


### PR DESCRIPTION
# Add provider option prefix to logs
## Description

Makes the logs print out "PROVIDER |" instead of "WORKSPACE |" and skip the checkmark when the source is the provider.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1029 
Closes #1031 

## Screenshots

![image](https://github.com/user-attachments/assets/5e367c51-d0b4-4939-ba44-600a8d860046)

![image](https://github.com/user-attachments/assets/dc877e03-1a6f-4abd-a2c6-569be3aa741f)

