### PR TITLE
fix: check binary permissions before serving

### DIFF
--- a/pkg/server/downloads.go
+++ b/pkg/server/downloads.go
@@ -31,7 +31,13 @@ func (s *Server) GetBinaryPath(binaryName, binaryVersion string) (string, error)
 
 	// If the requested binary is the same as the host, return the current binary path
 	if *hostOs == binaryOs && binaryVersion == internal.Version {
-		return os.Executable()
+		executable, err := os.Executable()
+		if err == nil {
+			_, err := os.Stat(executable)
+			if err == nil {
+				return executable, nil
+			}
+		}
 	}
 
 	binaryPath := filepath.Join(s.config.BinariesPath, binaryVersion, binaryName)


### PR DESCRIPTION
# Check Binary Permissions Before Serving

## Description

Added a `Stat` check to the binary before serving it to projects. The stat check makes sure that the binary can be read so that the request doesn't fail with 403. If the file can not be read, the server will proceed to download the appropriate binary from our registry.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1034