### PR TITLE
feat: Add support for Bitbucket Webhook events

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -135,6 +135,8 @@ func GetWebhookEventHeaderKeyFromGitProvider(providerId string) string {
 		fallthrough
 	case "gitlab-self-managed":
 		return "X-Gitlab-Event"
+	case "bitbucket":
+		return "X-Event-Key"
 	default:
 		return ""
 	}

--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -123,7 +123,7 @@ func GetPrebuildScopesFromGitProviderId(providerId string) string {
 	case "github-enterprise-server":
 		return "admin:repo_hook"
 	case "bitbucket":
-		return "webhook"
+		return "webhooks"
 	default:
 		return ""
 	}

--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -122,10 +122,6 @@ func GetPrebuildScopesFromGitProviderId(providerId string) string {
 		fallthrough
 	case "github-enterprise-server":
 		return "admin:repo_hook"
-	case "gitlab":
-		fallthrough
-	case "gitlab-self-managed":
-		return "api,read_repository,write_repository"
 	case "bitbucket":
 		return "webhook"
 	default:

--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -122,6 +122,12 @@ func GetPrebuildScopesFromGitProviderId(providerId string) string {
 		fallthrough
 	case "github-enterprise-server":
 		return "admin:repo_hook"
+	case "gitlab":
+		fallthrough
+	case "gitlab-self-managed":
+		return "api,read_repository,write_repository"
+	case "bitbucket":
+		return "webhook"
 	default:
 		return ""
 	}

--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/webhooks/v6 v6.4.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -938,6 +938,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.19.0 h1:ol+5Fu+cSq9JD7SoSqe04GMI92cbn0+wvQ3bZ8b/AU4=
 github.com/go-playground/validator/v10 v10.19.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-playground/webhooks/v6 v6.4.0 h1:KLa6y7bD19N48rxJDHM0DpE3T4grV7GxMy1b/aHMWPY=
+github.com/go-playground/webhooks/v6 v6.4.0/go.mod h1:5lBxopx+cAJiBI4+kyRbuHrEi+hYRDdRHuRR4Ya5Ums=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -568,10 +568,9 @@ func (g *BitbucketGitProvider) UnregisterPrebuildWebhook(repo *GitRepository, id
 	return err
 }
 
-func (g *BitbucketGitProvider) GetCommitsRange(repo *GitRepository, owner string, initialSha string, currentSha string) (int, error) {
+func (g *BitbucketGitProvider) GetCommitsRange(repo *GitRepository, initialSha string, currentSha string) (int, error) {
 	client := g.getApiClient()
 
-	_ = owner
 	commits, err := client.Repositories.Diff.GetDiffStat(&bitbucket.DiffStatOptions{
 		Owner:    repo.Owner,
 		RepoSlug: repo.Id,

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -246,7 +246,7 @@ func (g *BitbucketServerGitProvider) GetUser() (*GitUser, error) {
 
 	username := res.Header.Get("X-Ausername")
 	if username == "" {
-		return nil, fmt.Errorf("header X-Ausername is missing")
+		return nil, fmt.Errorf("X-Ausername header is missing")
 	}
 
 	user, err := client.DefaultApi.GetUser(username)

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -246,7 +246,7 @@ func (g *BitbucketServerGitProvider) GetUser() (*GitUser, error) {
 
 	username := res.Header.Get("X-Ausername")
 	if username == "" {
-		return nil, fmt.Errorf("X-Ausername header is missing")
+		return nil, fmt.Errorf("header X-Ausername is missing")
 	}
 
 	user, err := client.DefaultApi.GetUser(username)

--- a/pkg/server/projectconfig/prebuild.go
+++ b/pkg/server/projectconfig/prebuild.go
@@ -239,14 +239,14 @@ func (s *ProjectConfigService) ProcessGitEvent(data gitprovider.GitEventData) er
 
 	gitProvider, _, err := s.gitProviderService.GetGitProviderForUrl(data.Url)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get git provider for URL: %s", err)
 	}
 
 	repo, err := gitProvider.GetRepositoryContext(gitprovider.GetRepositoryContext{
 		Url: data.Url,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get repository context: %s", err)
 	}
 
 	for _, projectConfig := range projectConfigs {
@@ -290,7 +290,7 @@ func (s *ProjectConfigService) ProcessGitEvent(data gitprovider.GitEventData) er
 
 		commitsRange, err := gitProvider.GetCommitsRange(repo, newestBuild.Repository.Sha, data.Sha)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get commits range: %s", err)
 		}
 
 		// Check if the commit interval has been reached
@@ -318,7 +318,7 @@ func (s *ProjectConfigService) ProcessGitEvent(data gitprovider.GitEventData) er
 
 		_, err = s.buildService.Create(createBuildDto)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create build: %s", err)
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR adds support for webhooks for Bitbucket prebuilds. It implements five methods namely webhook get, register, unregister, comparing commit ranges and parsing event data. Since the default Bitbucket package does not support parsing Push events, I have used `"github.com/go-playground/webhooks"` instead. Additionally, this PR enhances error handling by making it more detailed and addresses issues with capitalized error messages.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #994 
/claim #994

## Screenshots


https://github.com/user-attachments/assets/2fd121f0-282d-405a-8b65-33ebabdcc29d


## Notes
In the file pkg/gitprovider/bitbucket.go, I had to comment out 
```
owner, repo, err := g.getOwnerAndRepoFromFullName(repositoryId)
	if err != nil {
		return nil, err
	}
```
because it was causing this error: 

![error_getOwnerAndRepoFromFullName](https://github.com/user-attachments/assets/a4daae74-87f1-4795-b8ba-fbd08d6a7d5d)
