### PR TITLE
refactor: remove owner param from get commits range

### DIFF
--- a/internal/testing/gitprovider/mocks/git_provider.go
+++ b/internal/testing/gitprovider/mocks/git_provider.go
@@ -91,8 +91,8 @@ func (m *MockGitProvider) UnregisterPrebuildWebhook(repo *gitprovider.GitReposit
 	return args.Error(0)
 }
 
-func (m *MockGitProvider) GetCommitsRange(repo *gitprovider.GitRepository, owner string, initialSha string, currentSha string) (int, error) {
-	args := m.Called(repo, owner, initialSha, currentSha)
+func (m *MockGitProvider) GetCommitsRange(repo *gitprovider.GitRepository, initialSha string, currentSha string) (int, error) {
+	args := m.Called(repo, initialSha, currentSha)
 	return args.Int(0), args.Error(1)
 }
 

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -56,7 +56,7 @@ type GitProvider interface {
 	RegisterPrebuildWebhook(repo *GitRepository, endpointUrl string) (string, error)
 	GetPrebuildWebhook(repo *GitRepository, endpointUrl string) (*string, error)
 	UnregisterPrebuildWebhook(repo *GitRepository, id string) error
-	GetCommitsRange(repo *GitRepository, owner string, initialSha string, currentSha string) (int, error)
+	GetCommitsRange(repo *GitRepository, initialSha string, currentSha string) (int, error)
 	ParseEventData(request *http.Request) (*GitEventData, error)
 }
 
@@ -175,7 +175,7 @@ func (g *AbstractGitProvider) UnregisterPrebuildWebhook(repo *GitRepository, id 
 	return errors.New("prebuilds not yet implemented for this git provider")
 }
 
-func (g *AbstractGitProvider) GetCommitsRange(repo *GitRepository, owner string, initialSha string, currentSha string) (int, error) {
+func (g *AbstractGitProvider) GetCommitsRange(repo *GitRepository, initialSha string, currentSha string) (int, error) {
 	return 0, errors.New("prebuilds not yet implemented for this git provider")
 }
 

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -424,10 +424,10 @@ func (g *GitHubGitProvider) UnregisterPrebuildWebhook(repo *GitRepository, id st
 	return err
 }
 
-func (g *GitHubGitProvider) GetCommitsRange(repo *GitRepository, owner string, initialSha string, currentSha string) (int, error) {
+func (g *GitHubGitProvider) GetCommitsRange(repo *GitRepository, initialSha string, currentSha string) (int, error) {
 	client := g.getApiClient()
 
-	commits, _, err := client.Repositories.CompareCommits(context.Background(), owner, repo.Name, initialSha, currentSha)
+	commits, _, err := client.Repositories.CompareCommits(context.Background(), repo.Owner, repo.Name, initialSha, currentSha)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -524,7 +524,7 @@ func (g *GitLabGitProvider) UnregisterPrebuildWebhook(repo *GitRepository, hookI
 	return nil
 }
 
-func (g *GitLabGitProvider) GetCommitsRange(repo *GitRepository, owner string, initialSha string, currentSha string) (int, error) {
+func (g *GitLabGitProvider) GetCommitsRange(repo *GitRepository, initialSha string, currentSha string) (int, error) {
 	client := g.getApiClient()
 
 	projectID := fmt.Sprintf("%s/%s", repo.Owner, repo.Name)

--- a/pkg/server/projectconfig/prebuild.go
+++ b/pkg/server/projectconfig/prebuild.go
@@ -288,7 +288,7 @@ func (s *ProjectConfigService) ProcessGitEvent(data gitprovider.GitEventData) er
 			continue
 		}
 
-		commitsRange, err := gitProvider.GetCommitsRange(repo, data.Owner, newestBuild.Repository.Sha, data.Sha)
+		commitsRange, err := gitProvider.GetCommitsRange(repo, newestBuild.Repository.Sha, data.Sha)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/projectconfig/prebuild_test.go
+++ b/pkg/server/projectconfig/prebuild_test.go
@@ -159,7 +159,7 @@ func (s *ProjectConfigServiceTestSuite) TestProcessGitEventCommitInterval() {
 		AffectedFiles: []string{},
 	}
 
-	s.gitProvider.On("GetCommitsRange", repository1, data.Owner, repository1.Sha, data.Sha).Return(3, nil)
+	s.gitProvider.On("GetCommitsRange", repository1, repository1.Sha, data.Sha).Return(3, nil)
 
 	err := s.projectConfigService.ProcessGitEvent(data)
 	require.Nil(err)


### PR DESCRIPTION
# Remove owner param from get commits range
## Description

Removes the owner param string from get commits range and changes GitHub's implementation to use repo.Owner instead

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
