### PR TITLE
fix: move include daytona config to first line

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -56,9 +56,10 @@ func ensureSshFilesLinked() error {
 			return err
 		}
 
-		newContent := strings.ReplaceAll(string(content), "Include daytona_config\n", "")
+		newContent := strings.ReplaceAll(string(content), "Include daytona_config\n\n", "")
+		newContent = strings.ReplaceAll(string(newContent), "Include daytona_config\n", "")
 		newContent = strings.ReplaceAll(string(newContent), "Include daytona_config", "")
-		newContent = "Include daytona_config\n" + newContent
+		newContent = "Include daytona_config\n\n" + newContent
 		err = os.WriteFile(configFile, []byte(newContent), 0600)
 		if err != nil {
 			return err

--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -56,11 +56,19 @@ func ensureSshFilesLinked() error {
 			return err
 		}
 
-		if strings.Contains(string(content), "Include daytona_config") {
-			return nil
+		lines := strings.Split(string(content), "\n")
+		if !strings.Contains(string(content), "Include daytona_config") {
+			lines = append([]string{"Include daytona_config"}, lines...)
+		} else {
+			for i, line := range lines {
+				if strings.Contains(line, "Include daytona_config") {
+					lines = append([]string{"Include daytona_config"}, append(lines[:i], lines[i+1:]...)...)
+					break
+				}
+			}
 		}
 
-		newContent := "Include daytona_config\n\n" + string(content)
+		newContent := strings.Join(lines, "\n")
 		err = os.WriteFile(configFile, []byte(newContent), 0600)
 		if err != nil {
 			return err

--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -56,19 +56,9 @@ func ensureSshFilesLinked() error {
 			return err
 		}
 
-		lines := strings.Split(string(content), "\n")
-		if !strings.Contains(string(content), "Include daytona_config") {
-			lines = append([]string{"Include daytona_config"}, lines...)
-		} else {
-			for i, line := range lines {
-				if strings.Contains(line, "Include daytona_config") {
-					lines = append([]string{"Include daytona_config"}, append(lines[:i], lines[i+1:]...)...)
-					break
-				}
-			}
-		}
-
-		newContent := strings.Join(lines, "\n")
+		newContent := strings.ReplaceAll(string(content), "Include daytona_config\n", "")
+		newContent = strings.ReplaceAll(string(newContent), "Include daytona_config", "")
+		newContent = "Include daytona_config\n" + newContent
 		err = os.WriteFile(configFile, []byte(newContent), 0600)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Ensure that `Include daytona_config` is moved to the first line of .ssh/config file

## Description

Following the thread [here](https://arc.net/l/quote/jfcxvtpt) it was clear that `daytona ssh` command won't work properly if `Include dayonta_config` line was not at the top of the `.ssh/config` file. That's exactly what this PR ensures.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation