### PR TITLE
telemetry: track IDE id

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -236,9 +236,11 @@ func getCmdTelemetryData(cmd *cobra.Command) map[string]interface{} {
 	}
 
 	calledAs := cmd.CalledAs()
-	return map[string]interface{}{
-		"command":   path,
-		"called_as": calledAs,
-		"source":    source,
-	}
+
+	data := telemetry.AdditionalData
+	data["command"] = path
+	data["called_as"] = calledAs
+	data["source"] = source
+
+	return data
 }

--- a/pkg/cmd/ide.go
+++ b/pkg/cmd/ide.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
 	ide_util "github.com/daytonaio/daytona/pkg/ide"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/ide"
 
@@ -52,6 +53,8 @@ var ideCmd = &cobra.Command{
 		}
 
 		c.DefaultIdeId = chosenIde.Id
+
+		telemetry.AdditionalData["ide"] = chosenIde.Id
 
 		err = c.Save()
 		if err != nil {

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -18,6 +18,7 @@ import (
 	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/ide"
 	"github.com/daytonaio/daytona/pkg/server/workspaces"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
@@ -174,6 +175,8 @@ func selectWorkspaceProject(workspaceId string, profile *config.Profile) (*apicl
 }
 
 func openIDE(ideId string, activeProfile config.Profile, workspaceId string, projectName string, projectProviderMetadata string) error {
+	telemetry.AdditionalData["ide"] = ideId
+
 	switch ideId {
 	case "vscode":
 		return ide.OpenVSCode(activeProfile, workspaceId, projectName, projectProviderMetadata)

--- a/pkg/telemetry/cli_events.go
+++ b/pkg/telemetry/cli_events.go
@@ -9,3 +9,5 @@ const (
 	CliEventCmdStart CliEvent = "cli_cmd_start"
 	CliEventCmdEnd   CliEvent = "cli_cmd_end"
 )
+
+var AdditionalData map[string]interface{} = map[string]interface{}{}


### PR DESCRIPTION
# Telemetry: Track IDE id

## Description

- track which IDE is used when opening a project
- track which IDE is set when changing the default

This will give us more insight into which IDEs are used with Daytona. The insights that comes from this will prove valuable in shaping and prioritizing roadmap targets.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
