### PR TITLE
fix: use open instead of stat to check permissions

### DIFF
--- a/pkg/server/downloads.go
+++ b/pkg/server/downloads.go
@@ -33,8 +33,9 @@ func (s *Server) GetBinaryPath(binaryName, binaryVersion string) (string, error)
 	if *hostOs == binaryOs && binaryVersion == internal.Version {
 		executable, err := os.Executable()
 		if err == nil {
-			_, err := os.Stat(executable)
+			f, err := os.Open(executable)
 			if err == nil {
+				defer f.Close() // nolint: errcheck
 				return executable, nil
 			}
 		}


### PR DESCRIPTION
# Fix Checking Binary Permissions When Serving

## Description

Stat apparently doesn't throw if the user doesn't have permission to read the file so switched to checking with `os.Open`.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
