### PR TITLE
fix: remove obsolete provider flag from create command

### DIFF
--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -21,7 +21,6 @@ daytona create [REPOSITORY_URL] [flags]
       --manual                     Manually enter the Git repository
       --multi-project              Workspace with multiple projects/repos
       --name string                Specify the workspace name
-      --provider string            Specify the provider (e.g. 'docker-provider')
   -t, --target string              Specify the target (e.g. 'local')
 ```
 

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -38,8 +38,6 @@ options:
       usage: Workspace with multiple projects/repos
     - name: name
       usage: Specify the workspace name
-    - name: provider
-      usage: Specify the provider (e.g. 'docker-provider')
     - name: target
       shorthand: t
       usage: Specify the target (e.g. 'local')

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -221,7 +221,6 @@ var CreateCmd = &cobra.Command{
 	},
 }
 
-var providerFlag string
 var nameFlag string
 var targetNameFlag string
 var codeFlag bool
@@ -247,7 +246,6 @@ func init() {
 	ideListStr := strings.Join(ids, ", ")
 
 	CreateCmd.Flags().StringVar(&nameFlag, "name", "", "Specify the workspace name")
-	CreateCmd.Flags().StringVar(&providerFlag, "provider", "", "Specify the provider (e.g. 'docker-provider')")
 	CreateCmd.Flags().StringVarP(&ideFlag, "ide", "i", "", fmt.Sprintf("Specify the IDE (%s)", ideListStr))
 	CreateCmd.Flags().StringVarP(&targetNameFlag, "target", "t", "", "Specify the target (e.g. 'local')")
 	CreateCmd.Flags().BoolVar(&blankFlag, "blank", false, "Create a blank project without using existing configurations")


### PR DESCRIPTION
# Remove Obsolete Provider Flag from Create Command

## Description

Removed the obsolete `provider` flag from the `create` command.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1049