### PR TITLE
fix: remove duplicate image pulling on project create

### DIFF
--- a/pkg/docker/create.go
+++ b/pkg/docker/create.go
@@ -35,11 +35,15 @@ func (d *DockerClient) CreateWorkspace(workspace *workspace.Workspace, workspace
 }
 
 func (d *DockerClient) CreateProject(opts *CreateProjectOptions) error {
+	pulledImages := map[string]bool{}
+
 	// TODO: The image should be configurable
 	err := d.PullImage("daytonaio/workspace-project", nil, opts.LogWriter)
 	if err != nil {
 		return err
 	}
+	pulledImages["daytonaio/workspace-project"] = true
+	pulledImages["daytonaio/workspace-project:latest"] = true
 
 	err = d.cloneProjectRepository(opts)
 	if err != nil {
@@ -56,7 +60,7 @@ func (d *DockerClient) CreateProject(opts *CreateProjectOptions) error {
 		_, _, err := d.CreateFromDevcontainer(d.toCreateDevcontainerOptions(opts, true))
 		return err
 	case detect.BuilderTypeImage:
-		return d.createProjectFromImage(opts)
+		return d.createProjectFromImage(opts, pulledImages)
 	default:
 		return fmt.Errorf("unknown builder type: %s", builderType)
 	}

--- a/pkg/docker/create_image.go
+++ b/pkg/docker/create_image.go
@@ -14,11 +14,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (d *DockerClient) createProjectFromImage(opts *CreateProjectOptions) error {
+func (d *DockerClient) createProjectFromImage(opts *CreateProjectOptions, pulledImages map[string]bool) error {
+	if pulledImages[opts.Project.Image] {
+		return d.initProjectContainer(opts)
+	}
+
 	err := d.PullImage(opts.Project.Image, opts.Cr, opts.LogWriter)
 	if err != nil {
 		return err
 	}
+	pulledImages[opts.Project.Image] = true
 
 	return d.initProjectContainer(opts)
 }


### PR DESCRIPTION
# Remove duplicate image pulling on project create

## Description

This PR fixes a duplicate pull of the same (already pulled) image upon project creation.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1059