### PR TITLE
fix: fetch branches with correct options provided from bitbucket

### DIFF
--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -108,15 +108,20 @@ func (g *BitbucketGitProvider) GetRepoBranches(repositoryId string, namespaceId 
 	client := g.getApiClient()
 	var response []*GitBranch
 
-	owner, repo, err := g.getOwnerAndRepoFromFullName(repositoryId)
-	if err != nil {
-		return nil, err
+	opts := &bitbucket.RepositoryBranchOptions{
+		RepoSlug: repositoryId,
+		Owner:    namespaceId,
 	}
 
-	branches, err := client.Repositories.Repository.ListBranches(&bitbucket.RepositoryBranchOptions{
-		RepoSlug: repo,
-		Owner:    owner,
-	})
+	owner, repo, err := g.getOwnerAndRepoFromFullName(repositoryId)
+	if err == nil {
+		opts = &bitbucket.RepositoryBranchOptions{
+			RepoSlug: repo,
+			Owner:    owner,
+		}
+	}
+
+	branches, err := client.Repositories.Repository.ListBranches(opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Fetch branches with correct options provided from bitbucket

## Description

This PR corrects options used for fetching repository branches for bitbucket as they are provided differently based on the type of creating project in daytona.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation