### PR TITLE
feat: add spinner to workspace start, stop and delete

### DIFF
--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -11,6 +11,7 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	workspace_cmd "github.com/daytonaio/daytona/pkg/cmd/workspace"
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/target"
@@ -120,14 +121,13 @@ func RemoveTargetWorkspaces(ctx context.Context, client *apiclient.APIClient, ta
 		if workspace.Target != target {
 			continue
 		}
-
-		res, err := client.WorkspaceAPI.RemoveWorkspace(ctx, workspace.Id).Execute()
+		err := workspace_cmd.RemoveWorkspace(ctx, client, &workspace, false)
 		if err != nil {
-			log.Errorf("Failed to delete workspace %s: %v", workspace.Name, apiclient_util.HandleErrorResponse(res, err))
+			log.Errorf("Failed to delete workspace %s: %v", workspace.Name, err)
 			continue
 		}
 
-		views.RenderLine(fmt.Sprintf("- Workspace %s successfully deleted\n", workspace.Name))
+		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' successfully deleted", workspace.Name))
 	}
 
 	return nil

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -19,7 +19,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/ide"
 	"github.com/daytonaio/daytona/pkg/server/workspaces"
 	"github.com/daytonaio/daytona/pkg/telemetry"
-	"github.com/daytonaio/daytona/pkg/views"
 	ide_views "github.com/daytonaio/daytona/pkg/views/ide"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
@@ -215,12 +214,9 @@ func AutoStartWorkspace(workspaceId string, projectName string) (bool, error) {
 		return false, err
 	}
 
-	views.RenderInfoMessage(fmt.Sprintf("Project '%s' from workspace '%s' is starting", projectName, workspaceId))
-
-	ctx := context.Background()
-	res, err := apiClient.WorkspaceAPI.StartProject(ctx, workspaceId, projectName).Execute()
+	err = StartWorkspace(apiClient, workspaceId, projectName)
 	if err != nil {
-		return false, apiclient_util.HandleErrorResponse(res, err)
+		return false, err
 	}
 
 	return true, nil

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
-	"github.com/daytonaio/daytona/internal/util/apiclient"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
 	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/views"
 	ide_views "github.com/daytonaio/daytona/pkg/views/ide"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
 	log "github.com/sirupsen/logrus"
@@ -36,7 +38,6 @@ var StartCmd = &cobra.Command{
 	GroupID: util.WORKSPACE_GROUP,
 	Run: func(cmd *cobra.Command, args []string) {
 		var workspaceIdOrName string
-		var message string
 		var activeProfile config.Profile
 		var ideId string
 		var workspaceId string
@@ -53,7 +54,7 @@ var StartCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		apiClient, err := apiclient.GetApiClient(nil)
+		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -68,7 +69,7 @@ var StartCmd = &cobra.Command{
 			}
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
+				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 			}
 
 			workspace := selection.GetWorkspaceFromPrompt(workspaceList, "Start")
@@ -96,7 +97,7 @@ var StartCmd = &cobra.Command{
 
 			wsInfo, res, err := apiClient.WorkspaceAPI.GetWorkspace(ctx, workspaceIdOrName).Execute()
 			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
+				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 			}
 			workspaceId = wsInfo.Id
 			if startProjectFlag == "" {
@@ -110,22 +111,15 @@ var StartCmd = &cobra.Command{
 			}
 		}
 
+		err = StartWorkspace(apiClient, workspaceIdOrName, startProjectFlag)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		if startProjectFlag == "" {
-			message = fmt.Sprintf("Workspace '%s' is starting", workspaceIdOrName)
-			res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, workspaceIdOrName).Execute()
-			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
-			}
-
-			views.RenderInfoMessage(message)
+			views.RenderInfoMessage(fmt.Sprintf("Workspace '%s' started successfully", workspaceIdOrName))
 		} else {
-			message = fmt.Sprintf("Project '%s' from workspace '%s' is starting", startProjectFlag, workspaceIdOrName)
-			res, err := apiClient.WorkspaceAPI.StartProject(ctx, workspaceIdOrName, startProjectFlag).Execute()
-			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
-			}
-
-			views.RenderInfoMessage(message)
+			views.RenderInfoMessage(fmt.Sprintf("Project '%s' from workspace '%s' started successfully", startProjectFlag, workspaceIdOrName))
 
 			if codeFlag {
 				ide_views.RenderIdeOpeningMessage(workspaceIdOrName, startProjectFlag, ideId, ideList)
@@ -159,30 +153,31 @@ func init() {
 
 func startAllWorkspaces() error {
 	ctx := context.Background()
-	apiClient, err := apiclient.GetApiClient(nil)
+	apiClient, err := apiclient_util.GetApiClient(nil)
 	if err != nil {
 		return err
 	}
 
 	workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 	if err != nil {
-		return apiclient.HandleErrorResponse(res, err)
+		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
 	for _, workspace := range workspaceList {
-		res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, workspace.Id).Execute()
+		err := StartWorkspace(apiClient, workspace.Name, "")
 		if err != nil {
-			log.Errorf("Failed to start workspace %s: %v", workspace.Name, apiclient.HandleErrorResponse(res, err))
+			log.Errorf("Failed to start workspace %s: %v\n\n", workspace.Name, err)
 			continue
 		}
-		fmt.Printf("Workspace '%s' is starting\n", workspace.Name)
+
+		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' started successfully", workspace.Name))
 	}
 	return nil
 }
 
 func getProjectNameCompletions(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	ctx := context.Background()
-	apiClient, err := apiclient.GetApiClient(nil)
+	apiClient, err := apiclient_util.GetApiClient(nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveDefault
 	}
@@ -202,7 +197,7 @@ func getProjectNameCompletions(cmd *cobra.Command, args []string, toComplete str
 
 func getWorkspaceNameCompletions() ([]string, cobra.ShellCompDirective) {
 	ctx := context.Background()
-	apiClient, err := apiclient.GetApiClient(nil)
+	apiClient, err := apiclient_util.GetApiClient(nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -222,7 +217,7 @@ func getWorkspaceNameCompletions() ([]string, cobra.ShellCompDirective) {
 
 func getAllWorkspacesByState(state WorkspaceState) ([]string, cobra.ShellCompDirective) {
 	ctx := context.Background()
-	apiClient, err := apiclient.GetApiClient(nil)
+	apiClient, err := apiclient_util.GetApiClient(nil)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -247,4 +242,37 @@ func getAllWorkspacesByState(state WorkspaceState) ([]string, cobra.ShellCompDir
 	}
 
 	return choices, cobra.ShellCompDirectiveNoFileComp
+}
+
+func StartWorkspace(apiClient *apiclient.APIClient, workspaceId, projectName string) error {
+	ctx := context.Background()
+	var message string
+	var startFunc func() error
+
+	if projectName == "" {
+		message = fmt.Sprintf("Workspace '%s' is starting", workspaceId)
+		startFunc = func() error {
+			res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, workspaceId).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+			return nil
+		}
+	} else {
+		message = fmt.Sprintf("Project '%s' from workspace '%s' is starting", projectName, workspaceId)
+		startFunc = func() error {
+			res, err := apiClient.WorkspaceAPI.StartProject(ctx, workspaceId, projectName).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+			return nil
+		}
+	}
+
+	err := views_util.WithInlineSpinner(message, startFunc)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 
 	"github.com/daytonaio/daytona/internal/util"
-	"github.com/daytonaio/daytona/internal/util/apiclient"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -24,7 +26,6 @@ var StopCmd = &cobra.Command{
 	Args:    cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
 		var workspaceId string
-		var message string
 
 		if allFlag {
 			err := stopAllWorkspaces()
@@ -36,7 +37,7 @@ var StopCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		apiClient, err := apiclient.GetApiClient(nil)
+		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -51,7 +52,7 @@ var StopCmd = &cobra.Command{
 			}
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
+				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 			}
 
 			workspace := selection.GetWorkspaceFromPrompt(workspaceList, "Stop")
@@ -63,21 +64,15 @@ var StopCmd = &cobra.Command{
 			workspaceId = args[0]
 		}
 
-		if stopProjectFlag == "" {
-			message = fmt.Sprintf("Workspace '%s' is stopping", workspaceId)
-			res, err := apiClient.WorkspaceAPI.StopWorkspace(ctx, workspaceId).Execute()
-			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
-			}
-		} else {
-			message = fmt.Sprintf("Project '%s' from workspace '%s' is stopping", stopProjectFlag, workspaceId)
-			res, err := apiClient.WorkspaceAPI.StopProject(ctx, workspaceId, stopProjectFlag).Execute()
-			if err != nil {
-				log.Fatal(apiclient.HandleErrorResponse(res, err))
-			}
+		err = StopWorkspace(apiClient, workspaceId, stopProjectFlag)
+		if err != nil {
+			log.Fatal(err)
 		}
-
-		views.RenderInfoMessage(message)
+		if stopProjectFlag != "" {
+			views.RenderInfoMessage(fmt.Sprintf("Project '%s' from workspace '%s' successfully stopped", stopProjectFlag, workspaceId))
+		} else {
+			views.RenderInfoMessage(fmt.Sprintf("Workspace '%s' successfully stopped", workspaceId))
+		}
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) >= 1 {
@@ -95,23 +90,56 @@ func init() {
 
 func stopAllWorkspaces() error {
 	ctx := context.Background()
-	apiClient, err := apiclient.GetApiClient(nil)
+	apiClient, err := apiclient_util.GetApiClient(nil)
 	if err != nil {
 		return err
 	}
 
 	workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 	if err != nil {
-		return apiclient.HandleErrorResponse(res, err)
+		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
 	for _, workspace := range workspaceList {
-		res, err := apiClient.WorkspaceAPI.StopWorkspace(ctx, workspace.Id).Execute()
+		err := StopWorkspace(apiClient, workspace.Name, "")
 		if err != nil {
-			log.Errorf("Failed to stop workspace %s: %v", workspace.Name, apiclient.HandleErrorResponse(res, err))
+			log.Errorf("Failed to stop workspace %s: %v\n\n", workspace.Name, err)
 			continue
 		}
-		fmt.Printf("Workspace '%s' is stopping\n", workspace.Name)
+		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' successfully stopped", workspace.Name))
 	}
+	return nil
+}
+
+func StopWorkspace(apiClient *apiclient.APIClient, workspaceId, projectName string) error {
+	ctx := context.Background()
+	var message string
+	var stopFunc func() error
+
+	if projectName == "" {
+		message = fmt.Sprintf("Workspace '%s' is stopping", workspaceId)
+		stopFunc = func() error {
+			res, err := apiClient.WorkspaceAPI.StopWorkspace(ctx, workspaceId).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+			return nil
+		}
+	} else {
+		message = fmt.Sprintf("Project '%s' from workspace '%s' is stopping", projectName, workspaceId)
+		stopFunc = func() error {
+			res, err := apiClient.WorkspaceAPI.StopProject(ctx, workspaceId, projectName).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+			return nil
+		}
+	}
+
+	err := views_util.WithInlineSpinner(message, stopFunc)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/cmd/workspacemode/start.go
+++ b/pkg/cmd/workspacemode/start.go
@@ -4,10 +4,9 @@
 package workspacemode
 
 import (
-	"context"
-
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
+	workspace_cmd "github.com/daytonaio/daytona/pkg/cmd/workspace"
 	"github.com/daytonaio/daytona/pkg/views"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -19,16 +18,14 @@ var startCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	GroupID: util.WORKSPACE_GROUP,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
-
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		res, err := apiClient.WorkspaceAPI.StartProject(ctx, workspaceId, projectName).Execute()
+		err = workspace_cmd.StartWorkspace(apiClient, workspaceId, projectName)
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			log.Fatal(err)
 		}
 
 		views.RenderInfoMessage("Project successfully started")

--- a/pkg/cmd/workspacemode/stop.go
+++ b/pkg/cmd/workspacemode/stop.go
@@ -4,10 +4,11 @@
 package workspacemode
 
 import (
-	"context"
+	"fmt"
 
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
+	workspace_cmd "github.com/daytonaio/daytona/pkg/cmd/workspace"
 	"github.com/daytonaio/daytona/pkg/views"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -19,18 +20,20 @@ var stopCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	GroupID: util.WORKSPACE_GROUP,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
-
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		res, err := apiClient.WorkspaceAPI.StopProject(ctx, workspaceId, projectName).Execute()
+		err = workspace_cmd.StopWorkspace(apiClient, workspaceId, projectName)
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			log.Fatal(err)
 		}
 
-		views.RenderInfoMessage("Project successfully stopped")
+		if projectName != "" {
+			views.RenderInfoMessage(fmt.Sprintf("Project '%s' from workspace '%s' successfully stopped", projectName, workspaceId))
+		} else {
+			views.RenderInfoMessage(fmt.Sprintf("Workspace '%s' successfully stopped", workspaceId))
+		}
 	},
 }


### PR DESCRIPTION
# add spinner to workspace start, stop and delete
## Description
This PR adds a spinner to `daytona start`, `daytona stop` and `daytona delete` commands 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #915
closes #915
/claim #915

## Screenshots

