### PR TITLE
feat: number of unpushed commits in dtn info cmd

### DIFF
--- a/internal/testing/git/mocks/gitservice.go
+++ b/internal/testing/git/mocks/gitservice.go
@@ -41,6 +41,11 @@ func (m *MockGitService) GetGitStatus() (*project.GitStatus, error) {
 	return args.Get(0).(*project.GitStatus), args.Error(1)
 }
 
+func (m *MockGitService) GetUnpushedCommitsCount(branchName string) (int, error) {
+	args := m.Called(branchName)
+	return args.Int(0), args.Error(1)
+}
+
 func NewMockGitService() *MockGitService {
 	gitService := new(MockGitService)
 	return gitService

--- a/internal/util/apiclient/conversion/project.go
+++ b/internal/util/apiclient/conversion/project.go
@@ -82,9 +82,15 @@ func ToGitStatus(gitStatusDTO apiclient.GitStatus) *project.GitStatus {
 		files = append(files, file)
 	}
 
+	var unpushedCommits int
+	if gitStatusDTO.UnpushedCommits != nil {
+		unpushedCommits = int(*gitStatusDTO.UnpushedCommits)
+	}
+
 	return &project.GitStatus{
-		CurrentBranch: gitStatusDTO.CurrentBranch,
-		Files:         files,
+		CurrentBranch:   gitStatusDTO.CurrentBranch,
+		Files:           files,
+		UnpushedCommits: unpushedCommits,
 	}
 }
 
@@ -105,10 +111,16 @@ func ToGitStatusDTO(gitStatus *project.GitStatus) *apiclient.GitStatus {
 		}
 		fileStatusDTO = append(fileStatusDTO, fileDTO)
 	}
+	var unpushedCommits *int32
+	if gitStatus.UnpushedCommits != 0 {
+		value := int32(gitStatus.UnpushedCommits)
+		unpushedCommits = &value
+	}
 
 	return &apiclient.GitStatus{
-		CurrentBranch: gitStatus.CurrentBranch,
-		FileStatus:    fileStatusDTO,
+		CurrentBranch:   gitStatus.CurrentBranch,
+		FileStatus:      fileStatusDTO,
+		UnpushedCommits: unpushedCommits,
 	}
 }
 

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -2218,6 +2218,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/FileStatus"
                     }
+                },
+                "unpushedCommits": {
+                    "type": "integer"
                 }
             }
         },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -2215,6 +2215,9 @@
                     "items": {
                         "$ref": "#/definitions/FileStatus"
                     }
+                },
+                "unpushedCommits": {
+                    "type": "integer"
                 }
             }
         },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -346,6 +346,8 @@ definitions:
         items:
           $ref: '#/definitions/FileStatus'
         type: array
+      unpushedCommits:
+        type: integer
     required:
     - currentBranch
     - fileStatus

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1778,6 +1778,7 @@ components:
           name: name
           staging: null
           worktree: null
+        unpushedCommits: 0
         currentBranch: currentBranch
       properties:
         currentBranch:
@@ -1786,6 +1787,8 @@ components:
           items:
             $ref: '#/components/schemas/FileStatus'
           type: array
+        unpushedCommits:
+          type: integer
       required:
       - currentBranch
       - fileStatus
@@ -1931,9 +1934,10 @@ components:
               name: name
               staging: null
               worktree: null
+            unpushedCommits: 0
             currentBranch: currentBranch
           updatedAt: updatedAt
-          uptime: 0
+          uptime: 6
         repository:
           owner: owner
           path: path
@@ -2073,9 +2077,10 @@ components:
             name: name
             staging: null
             worktree: null
+          unpushedCommits: 0
           currentBranch: currentBranch
         updatedAt: updatedAt
-        uptime: 0
+        uptime: 6
       properties:
         gitStatus:
           $ref: '#/components/schemas/GitStatus'
@@ -2255,6 +2260,7 @@ components:
             name: name
             staging: null
             worktree: null
+          unpushedCommits: 0
           currentBranch: currentBranch
         uptime: 0
       properties:
@@ -2309,9 +2315,10 @@ components:
                 name: name
                 staging: null
                 worktree: null
+              unpushedCommits: 0
               currentBranch: currentBranch
             updatedAt: updatedAt
-            uptime: 0
+            uptime: 6
           repository:
             owner: owner
             path: path
@@ -2347,9 +2354,10 @@ components:
                 name: name
                 staging: null
                 worktree: null
+              unpushedCommits: 0
               currentBranch: currentBranch
             updatedAt: updatedAt
-            uptime: 0
+            uptime: 6
           repository:
             owner: owner
             path: path
@@ -2408,9 +2416,10 @@ components:
                 name: name
                 staging: null
                 worktree: null
+              unpushedCommits: 0
               currentBranch: currentBranch
             updatedAt: updatedAt
-            uptime: 0
+            uptime: 6
           repository:
             owner: owner
             path: path
@@ -2446,9 +2455,10 @@ components:
                 name: name
                 staging: null
                 worktree: null
+              unpushedCommits: 0
               currentBranch: currentBranch
             updatedAt: updatedAt
-            uptime: 0
+            uptime: 6
           repository:
             owner: owner
             path: path

--- a/pkg/apiclient/docs/GitStatus.md
+++ b/pkg/apiclient/docs/GitStatus.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **CurrentBranch** | **string** |  | 
 **FileStatus** | [**[]FileStatus**](FileStatus.md) |  | 
+**UnpushedCommits** | Pointer to **int32** |  | [optional] 
 
 ## Methods
 
@@ -65,6 +66,31 @@ and a boolean to check if the value has been set.
 
 SetFileStatus sets FileStatus field to given value.
 
+
+### GetUnpushedCommits
+
+`func (o *GitStatus) GetUnpushedCommits() int32`
+
+GetUnpushedCommits returns the UnpushedCommits field if non-nil, zero value otherwise.
+
+### GetUnpushedCommitsOk
+
+`func (o *GitStatus) GetUnpushedCommitsOk() (*int32, bool)`
+
+GetUnpushedCommitsOk returns a tuple with the UnpushedCommits field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetUnpushedCommits
+
+`func (o *GitStatus) SetUnpushedCommits(v int32)`
+
+SetUnpushedCommits sets UnpushedCommits field to given value.
+
+### HasUnpushedCommits
+
+`func (o *GitStatus) HasUnpushedCommits() bool`
+
+HasUnpushedCommits returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/pkg/apiclient/model_git_status.go
+++ b/pkg/apiclient/model_git_status.go
@@ -21,8 +21,9 @@ var _ MappedNullable = &GitStatus{}
 
 // GitStatus struct for GitStatus
 type GitStatus struct {
-	CurrentBranch string       `json:"currentBranch"`
-	FileStatus    []FileStatus `json:"fileStatus"`
+	CurrentBranch   string       `json:"currentBranch"`
+	FileStatus      []FileStatus `json:"fileStatus"`
+	UnpushedCommits *int32       `json:"unpushedCommits,omitempty"`
 }
 
 type _GitStatus GitStatus
@@ -94,6 +95,38 @@ func (o *GitStatus) SetFileStatus(v []FileStatus) {
 	o.FileStatus = v
 }
 
+// GetUnpushedCommits returns the UnpushedCommits field value if set, zero value otherwise.
+func (o *GitStatus) GetUnpushedCommits() int32 {
+	if o == nil || IsNil(o.UnpushedCommits) {
+		var ret int32
+		return ret
+	}
+	return *o.UnpushedCommits
+}
+
+// GetUnpushedCommitsOk returns a tuple with the UnpushedCommits field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitStatus) GetUnpushedCommitsOk() (*int32, bool) {
+	if o == nil || IsNil(o.UnpushedCommits) {
+		return nil, false
+	}
+	return o.UnpushedCommits, true
+}
+
+// HasUnpushedCommits returns a boolean if a field has been set.
+func (o *GitStatus) HasUnpushedCommits() bool {
+	if o != nil && !IsNil(o.UnpushedCommits) {
+		return true
+	}
+
+	return false
+}
+
+// SetUnpushedCommits gets a reference to the given int32 and assigns it to the UnpushedCommits field.
+func (o *GitStatus) SetUnpushedCommits(v int32) {
+	o.UnpushedCommits = &v
+}
+
 func (o GitStatus) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -106,6 +139,9 @@ func (o GitStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["currentBranch"] = o.CurrentBranch
 	toSerialize["fileStatus"] = o.FileStatus
+	if !IsNil(o.UnpushedCommits) {
+		toSerialize["unpushedCommits"] = o.UnpushedCommits
+	}
 	return toSerialize, nil
 }
 

--- a/pkg/db/dto/project.go
+++ b/pkg/db/dto/project.go
@@ -30,8 +30,9 @@ type FileStatusDTO struct {
 }
 
 type GitStatusDTO struct {
-	CurrentBranch string           `json:"currentBranch"`
-	Files         []*FileStatusDTO `json:"fileStatus"`
+	CurrentBranch   string           `json:"currentBranch"`
+	Files           []*FileStatusDTO `json:"fileStatus"`
+	UnpushedCommits *int32           `json:"unpushedCommits,omitempty"`
 }
 
 type ProjectStateDTO struct {
@@ -117,6 +118,11 @@ func ToGitStatusDTO(status *project.GitStatus) *GitStatusDTO {
 		statusDTO.Files = append(statusDTO.Files, ToFileStatusDTO(file))
 	}
 
+	if status.UnpushedCommits != 0 {
+		value := int32(status.UnpushedCommits)
+		statusDTO.UnpushedCommits = &value
+	}
+
 	return statusDTO
 }
 
@@ -186,6 +192,10 @@ func ToGitStatus(statusDTO *GitStatusDTO) *project.GitStatus {
 
 	for _, file := range statusDTO.Files {
 		status.Files = append(status.Files, ToFileStatus(file))
+	}
+
+	if statusDTO.UnpushedCommits != nil {
+		status.UnpushedCommits = int(*statusDTO.UnpushedCommits)
 	}
 
 	return status

--- a/pkg/views/workspace/info/view.go
+++ b/pkg/views/workspace/info/view.go
@@ -159,17 +159,27 @@ func getInfoLineGitStatus(key string, status *apiclient.GitStatus) string {
 	output += propertyNameStyle.Foreground(views.Gray).Render(fmt.Sprintf("%-*s", propertyNameWidth, status.CurrentBranch))
 
 	changesOutput := ""
-	if status.FileStatus == nil {
-		return output + "\n"
+
+	if status.FileStatus != nil {
+		filesNum := len(status.FileStatus)
+		if filesNum == 1 {
+			changesOutput = " (1 uncommitted change)"
+		} else if filesNum > 1 {
+			changesOutput = fmt.Sprintf(" (%d uncommitted changes)", filesNum)
+		}
 	}
 
-	filesNum := len(status.FileStatus)
-	if filesNum == 1 {
-		changesOutput = " (" + fmt.Sprint(filesNum) + " uncommited change)"
-	} else if filesNum > 1 {
-		changesOutput = " (" + fmt.Sprint(filesNum) + " uncommited changes)"
+	unpushedOutput := ""
+	if status.UnpushedCommits != nil {
+		unpushedCommitsNum := *status.UnpushedCommits
+		if unpushedCommitsNum == 1 {
+			unpushedOutput = " (1 unpushed commit)"
+		} else if unpushedCommitsNum > 1 {
+			unpushedOutput = fmt.Sprintf(" (%d unpushed commits)", unpushedCommitsNum)
+		}
 	}
-	output += changesOutput + propertyValueStyle.Foreground(views.Light).Render("\n")
+
+	output += changesOutput + unpushedOutput + propertyValueStyle.Foreground(views.Light).Render("\n")
 
 	return output
 }

--- a/pkg/workspace/project/project.go
+++ b/pkg/workspace/project/project.go
@@ -40,8 +40,9 @@ type ProjectState struct {
 } // @name ProjectState
 
 type GitStatus struct {
-	CurrentBranch string        `json:"currentBranch" validate:"required"`
-	Files         []*FileStatus `json:"fileStatus" validate:"required"`
+	CurrentBranch   string        `json:"currentBranch" validate:"required"`
+	Files           []*FileStatus `json:"fileStatus" validate:"required"`
+	UnpushedCommits int           `json:"unpushedCommits" validate:"optional"`
 } // @name GitStatus
 
 type FileStatus struct {


### PR DESCRIPTION
# feat: number of unpushed commits in dtn info cmd

## Description

This PR enhances the daytona info command by adding a feature similar to git status, which checks the project's difference from the origin branch. It displays the number of unpushed commits, with changes made to info.go, service.go, tests, and documentation.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #532
/claim #532

## Screenshots
![Screenshot from 2024-09-08 15-21-36](https://github.com/user-attachments/assets/c7176c67-f8ef-411d-b6bf-2b0e71acb220)


## Notes
I AM DIVANSHU GROVER 
@rajivkuma45
@divgro9
@Divanshu-Grover
all are my accounts
