### PR TITLE
fix: Handling and Logging of Missing Project Config on Repository Creation (#933)

### DIFF
--- a/pkg/api/controllers/projectconfig/project_config.go
+++ b/pkg/api/controllers/projectconfig/project_config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/server/projectconfig/dto"
 	"github.com/daytonaio/daytona/pkg/workspace/project/config"
 	"github.com/gin-gonic/gin"
-	"github.com/rs/zerolog/log"
+	log "github.com/sirupsen/logrus"
 )
 
 // GetProjectConfig godoc
@@ -77,9 +77,7 @@ func GetDefaultProjectConfig(ctx *gin.Context) {
 		if config.IsProjectConfigNotFound(err) {
 			statusCode = http.StatusNotFound
 			ctx.AbortWithStatus(statusCode)
-			go func() {
-				log.Printf("Project config not added for git url: %s", decodedURLParam)
-			}()
+			log.Debugf("Project config not added for git url: %s", decodedURLParam)
 			return
 		}
 		ctx.AbortWithError(statusCode, fmt.Errorf("failed to find project config by git url: %s", err.Error()))

--- a/pkg/api/controllers/projectconfig/project_config.go
+++ b/pkg/api/controllers/projectconfig/project_config.go
@@ -58,35 +58,35 @@ func GetProjectConfig(ctx *gin.Context) {
 //
 //	@id				GetDefaultProjectConfig
 func GetDefaultProjectConfig(ctx *gin.Context) {
-    gitUrl := ctx.Param("gitUrl")
+	gitUrl := ctx.Param("gitUrl")
 
-    decodedURLParam, err := url.QueryUnescape(gitUrl)
-    if err != nil {
-        ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to decode query param: %s", err.Error()))
-        return
-    }
+	decodedURLParam, err := url.QueryUnescape(gitUrl)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to decode query param: %s", err.Error()))
+		return
+	}
 
-    server := server.GetInstance(nil)
+	server := server.GetInstance(nil)
 
-    projectConfigs, err := server.ProjectConfigService.Find(&config.ProjectConfigFilter{
-        Url:     &decodedURLParam,
-        Default: util.Pointer(true),
-    })
-    if err != nil {
+	projectConfigs, err := server.ProjectConfigService.Find(&config.ProjectConfigFilter{
+		Url:     &decodedURLParam,
+		Default: util.Pointer(true),
+	})
+	if err != nil {
 		statusCode := http.StatusInternalServerError
-        if config.IsProjectConfigNotFound(err) {
+		if config.IsProjectConfigNotFound(err) {
 			statusCode = http.StatusNotFound
-            ctx.AbortWithStatus(statusCode)
+			ctx.AbortWithStatus(statusCode)
 			go func() {
-                log.Printf("Project config not found for URL: %s", decodedURLParam)
-            }()
-            return
-        }
-        ctx.AbortWithError(statusCode, fmt.Errorf("failed to find project config by git url: %s", err.Error()))
-        return
-    }
+				log.Printf("Project config not added for git url: %s", decodedURLParam)
+			}()
+			return
+		}
+		ctx.AbortWithError(statusCode, fmt.Errorf("failed to find project config by git url: %s", err.Error()))
+		return
+	}
 
-    ctx.JSON(200, projectConfigs)
+	ctx.JSON(200, projectConfigs)
 }
 
 // ListProjectConfigs godoc


### PR DESCRIPTION
# fix: Handling and Logging of Missing Project Config on Repository Creation (#933)
## Description

This pull request addresses issue #933, where the Daytona server improperly logs a 404 error when a repository is created without an existing project config. The current behavior is misleading, as the absence of a project config should not be treated as a failure.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #933 
/claim #933

## Screenshots
BEFORE 
![image](https://github.com/user-attachments/assets/7e5483e5-c42c-456a-a05a-496ea21abcb1)

AFTER
![image](https://github.com/user-attachments/assets/08892968-e08d-4615-a2c7-8344bfda375a)


## Notes
Please add any relevant notes if necessary.
