### PR TITLE
fix: add verbose arg to get ws info

### DIFF
--- a/internal/util/apiclient/api_client.go
+++ b/internal/util/apiclient/api_client.go
@@ -112,7 +112,7 @@ func GetAgentApiClient(apiUrl, apiKey, clientId string, telemetryEnabled bool) (
 	return apiClient, nil
 }
 
-func GetWorkspace(workspaceNameOrId string) (*apiclient.WorkspaceDTO, error) {
+func GetWorkspace(workspaceNameOrId string, verbose bool) (*apiclient.WorkspaceDTO, error) {
 	ctx := context.Background()
 
 	apiClient, err := GetApiClient(nil)
@@ -120,7 +120,7 @@ func GetWorkspace(workspaceNameOrId string) (*apiclient.WorkspaceDTO, error) {
 		return nil, err
 	}
 
-	workspace, res, err := apiClient.WorkspaceAPI.GetWorkspace(ctx, workspaceNameOrId).Execute()
+	workspace, res, err := apiClient.WorkspaceAPI.GetWorkspace(ctx, workspaceNameOrId).Verbose(verbose).Execute()
 	if err != nil {
 		return nil, HandleErrorResponse(res, err)
 	}

--- a/pkg/api/controllers/workspace/workspace.go
+++ b/pkg/api/controllers/workspace/workspace.go
@@ -20,16 +20,28 @@ import (
 //	@Description	Get workspace info
 //	@Produce		json
 //	@Param			workspaceId	path		string	true	"Workspace ID or Name"
+//	@Param			verbose		query		bool	false	"Verbose"
 //	@Success		200			{object}	WorkspaceDTO
 //	@Router			/workspace/{workspaceId} [get]
 //
 //	@id				GetWorkspace
 func GetWorkspace(ctx *gin.Context) {
 	workspaceId := ctx.Param("workspaceId")
+	verboseQuery := ctx.Query("verbose")
+	verbose := false
+	var err error
+
+	if verboseQuery != "" {
+		verbose, err = strconv.ParseBool(verboseQuery)
+		if err != nil {
+			ctx.AbortWithError(http.StatusBadRequest, errors.New("invalid value for verbose flag"))
+			return
+		}
+	}
 
 	server := server.GetInstance(nil)
 
-	w, err := server.WorkspaceService.GetWorkspace(ctx.Request.Context(), workspaceId)
+	w, err := server.WorkspaceService.GetWorkspace(ctx.Request.Context(), workspaceId, verbose)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get workspace: %w", err))
 		return

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1517,6 +1517,12 @@ const docTemplate = `{
                         "name": "workspaceId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Verbose",
+                        "name": "verbose",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1514,6 +1514,12 @@
                         "name": "workspaceId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Verbose",
+                        "name": "verbose",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -1833,6 +1833,10 @@ paths:
         name: workspaceId
         required: true
         type: string
+      - description: Verbose
+        in: query
+        name: verbose
+        type: boolean
       produces:
       - application/json
       responses:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1092,6 +1092,11 @@ paths:
         required: true
         schema:
           type: string
+      - description: Verbose
+        in: query
+        name: verbose
+        schema:
+          type: boolean
       responses:
         "200":
           content:

--- a/pkg/apiclient/api_workspace.go
+++ b/pkg/apiclient/api_workspace.go
@@ -152,6 +152,13 @@ type ApiGetWorkspaceRequest struct {
 	ctx         context.Context
 	ApiService  *WorkspaceAPIService
 	workspaceId string
+	verbose     *bool
+}
+
+// Verbose
+func (r ApiGetWorkspaceRequest) Verbose(verbose bool) ApiGetWorkspaceRequest {
+	r.verbose = &verbose
+	return r
 }
 
 func (r ApiGetWorkspaceRequest) Execute() (*WorkspaceDTO, *http.Response, error) {
@@ -198,6 +205,9 @@ func (a *WorkspaceAPIService) GetWorkspaceExecute(r ApiGetWorkspaceRequest) (*Wo
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.verbose != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "verbose", r.verbose, "")
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/pkg/apiclient/docs/WorkspaceAPI.md
+++ b/pkg/apiclient/docs/WorkspaceAPI.md
@@ -84,7 +84,7 @@ Name | Type | Description  | Notes
 
 ## GetWorkspace
 
-> WorkspaceDTO GetWorkspace(ctx, workspaceId).Execute()
+> WorkspaceDTO GetWorkspace(ctx, workspaceId).Verbose(verbose).Execute()
 
 Get workspace info
 
@@ -104,10 +104,11 @@ import (
 
 func main() {
 	workspaceId := "workspaceId_example" // string | Workspace ID or Name
+	verbose := true // bool | Verbose (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.WorkspaceAPI.GetWorkspace(context.Background(), workspaceId).Execute()
+	resp, r, err := apiClient.WorkspaceAPI.GetWorkspace(context.Background(), workspaceId).Verbose(verbose).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `WorkspaceAPI.GetWorkspace``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -133,6 +134,7 @@ Other parameters are passed through a pointer to a apiGetWorkspaceRequest struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
+ **verbose** | **bool** | Verbose | 
 
 ### Return type
 

--- a/pkg/cmd/ports/forward.go
+++ b/pkg/cmd/ports/forward.go
@@ -45,7 +45,7 @@ var PortForwardCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		workspace, err := apiclient.GetWorkspace(args[1])
+		workspace, err := apiclient.GetWorkspace(args[1], true)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -69,7 +69,7 @@ var CodeCmd = &cobra.Command{
 			}
 			workspaceId = workspace.Id
 		} else {
-			workspace, err = apiclient_util.GetWorkspace(url.PathEscape(args[0]))
+			workspace, err = apiclient_util.GetWorkspace(url.PathEscape(args[0]), true)
 			if err != nil {
 				if strings.Contains(err.Error(), workspaces.ErrWorkspaceNotFound.Error()) {
 					log.Debug(err)

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -83,7 +83,7 @@ var DeleteCmd = &cobra.Command{
 			}
 		} else {
 			for _, arg := range args {
-				workspace, err := apiclient_util.GetWorkspace(arg)
+				workspace, err := apiclient_util.GetWorkspace(arg, false)
 				if err != nil {
 					log.Error(fmt.Sprintf("[ %s ] : %v", arg, err))
 					continue

--- a/pkg/cmd/workspace/info.go
+++ b/pkg/cmd/workspace/info.go
@@ -48,7 +48,7 @@ var InfoCmd = &cobra.Command{
 			}
 
 		} else {
-			workspace, err = apiclient_util.GetWorkspace(args[0])
+			workspace, err = apiclient_util.GetWorkspace(args[0], true)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/cmd/workspace/ssh-proxy.go
+++ b/pkg/cmd/workspace/ssh-proxy.go
@@ -53,7 +53,7 @@ var SshProxyCmd = &cobra.Command{
 			}
 		}
 
-		workspace, err := apiclient.GetWorkspace(workspaceId)
+		workspace, err := apiclient.GetWorkspace(workspaceId, true)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -55,7 +55,7 @@ var SshCmd = &cobra.Command{
 				return
 			}
 		} else {
-			workspace, err = apiclient_util.GetWorkspace(args[0])
+			workspace, err = apiclient_util.GetWorkspace(args[0], true)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/cmd/workspacemode/info.go
+++ b/pkg/cmd/workspacemode/info.go
@@ -22,7 +22,7 @@ var infoCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var workspace *apiclient.WorkspaceDTO
 
-		workspace, err := apiclient_util.GetWorkspace(workspaceId)
+		workspace, err := apiclient_util.GetWorkspace(workspaceId, true)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/server/workspaces/get.go
+++ b/pkg/server/workspaces/get.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *WorkspaceService) GetWorkspace(ctx context.Context, workspaceId string) (*dto.WorkspaceDTO, error) {
+func (s *WorkspaceService) GetWorkspace(ctx context.Context, workspaceId string, verbose bool) (*dto.WorkspaceDTO, error) {
 	ws, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
 		return nil, ErrWorkspaceNotFound
@@ -22,6 +22,10 @@ func (s *WorkspaceService) GetWorkspace(ctx context.Context, workspaceId string)
 
 	response := dto.WorkspaceDTO{
 		Workspace: *ws,
+	}
+
+	if !verbose {
+		return &response, nil
 	}
 
 	target, err := s.targetStore.Find(ws.Target)

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -24,7 +24,7 @@ import (
 
 type IWorkspaceService interface {
 	CreateWorkspace(ctx context.Context, req dto.CreateWorkspaceDTO) (*workspace.Workspace, error)
-	GetWorkspace(ctx context.Context, workspaceId string) (*dto.WorkspaceDTO, error)
+	GetWorkspace(ctx context.Context, workspaceId string, verbose bool) (*dto.WorkspaceDTO, error)
 	GetWorkspaceLogReader(workspaceId string) (io.Reader, error)
 	GetProjectLogReader(workspaceId, projectName string) (io.Reader, error)
 	ListWorkspaces(ctx context.Context, verbose bool) ([]dto.WorkspaceDTO, error)

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -160,7 +160,7 @@ func TestWorkspaceService(t *testing.T) {
 	t.Run("GetWorkspace", func(t *testing.T) {
 		provisioner.On("GetWorkspaceInfo", mock.Anything, mock.Anything, &target).Return(&workspaceInfo, nil)
 
-		workspace, err := service.GetWorkspace(context.TODO(), createWorkspaceDto.Id)
+		workspace, err := service.GetWorkspace(context.TODO(), createWorkspaceDto.Id, true)
 
 		require.Nil(t, err)
 		require.NotNil(t, workspace)
@@ -169,7 +169,7 @@ func TestWorkspaceService(t *testing.T) {
 	})
 
 	t.Run("GetWorkspace fails when workspace not found", func(t *testing.T) {
-		_, err := service.GetWorkspace(context.TODO(), "invalid-id")
+		_, err := service.GetWorkspace(context.TODO(), "invalid-id", true)
 		require.NotNil(t, err)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
@@ -247,7 +247,7 @@ func TestWorkspaceService(t *testing.T) {
 
 		require.Nil(t, err)
 
-		_, err = service.GetWorkspace(context.TODO(), createWorkspaceDto.Id)
+		_, err = service.GetWorkspace(context.TODO(), createWorkspaceDto.Id, true)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
 
@@ -285,7 +285,7 @@ func TestWorkspaceService(t *testing.T) {
 
 		require.Nil(t, err)
 
-		_, err = service.GetWorkspace(context.TODO(), createWorkspaceDto.Id)
+		_, err = service.GetWorkspace(context.TODO(), createWorkspaceDto.Id, true)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
 


### PR DESCRIPTION
# Add verbose arg to get ws info

## Description

This PR adds verbose argument to get workspace info command which consequently fixes `daytona delete -f` command.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1074 