### PR TITLE
fix: multi ws select marking

### DIFF
--- a/pkg/views/workspace/selection/view.go
+++ b/pkg/views/workspace/selection/view.go
@@ -41,6 +41,7 @@ type item[T any] struct {
 	id, title, desc, createdTime, uptime, target string
 	choiceProperty                               T
 	markForDeletion                              bool
+	isMultipleSelect                             bool
 }
 
 func (i item[T]) Title() string       { return i.title }
@@ -204,6 +205,9 @@ func (d ItemDelegate[T]) Update(msg tea.Msg, m *list.Model) tea.Cmd {
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
 		case "x":
+			if !i.isMultipleSelect {
+				return nil
+			}
 			if i.markForDeletion {
 				i.title = strings.TrimPrefix(i.title, statusMessageDangerStyle("Delete: "))
 				i.markForDeletion = false

--- a/pkg/views/workspace/selection/workspace.go
+++ b/pkg/views/workspace/selection/workspace.go
@@ -17,7 +17,7 @@ import (
 	list_view "github.com/daytonaio/daytona/pkg/views/workspace/list"
 )
 
-func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO) []list.Item {
+func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect bool) []list.Item {
 
 	// Initialize an empty list of items.
 	items := []list.Item{}
@@ -62,15 +62,19 @@ func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO) []list.Item {
 			choiceProperty: workspace,
 		}
 
+		if isMultipleSelect {
+			newItem.isMultipleSelect = true
+		}
+
 		items = append(items, newItem)
 	}
 
 	return items
 }
 
-func getWorkspaceProgramEssentials(modelTitle string, actionVerb string, workspaces []apiclient.WorkspaceDTO, footerText string) tea.Model {
+func getWorkspaceProgramEssentials(modelTitle string, actionVerb string, workspaces []apiclient.WorkspaceDTO, footerText string, isMultipleSelect bool) tea.Model {
 
-	items := generateWorkspaceList(workspaces)
+	items := generateWorkspaceList(workspaces, isMultipleSelect)
 
 	d := ItemDelegate[apiclient.WorkspaceDTO]{}
 
@@ -101,7 +105,7 @@ func getWorkspaceProgramEssentials(modelTitle string, actionVerb string, workspa
 func selectWorkspacePrompt(workspaces []apiclient.WorkspaceDTO, actionVerb string, choiceChan chan<- *apiclient.WorkspaceDTO) {
 	list_view.SortWorkspaces(&workspaces, true)
 
-	p := getWorkspaceProgramEssentials("Select a Workspace To ", actionVerb, workspaces, "")
+	p := getWorkspaceProgramEssentials("Select a Workspace To ", actionVerb, workspaces, "", false)
 	if m, ok := p.(model[apiclient.WorkspaceDTO]); ok && m.choice != nil {
 		choiceChan <- m.choice
 	} else {
@@ -121,7 +125,7 @@ func selectWorkspacesFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb 
 	list_view.SortWorkspaces(&workspaces, true)
 
 	footerText := lipgloss.NewStyle().Bold(true).PaddingLeft(2).Render("\n\nPress 'x' to mark workspace for deletion.\nPress 'enter' to delete the current/marked workspaces.")
-	p := getWorkspaceProgramEssentials("Select Workspaces To ", actionVerb, workspaces, footerText)
+	p := getWorkspaceProgramEssentials("Select Workspaces To ", actionVerb, workspaces, footerText, true)
 
 	m, ok := p.(model[apiclient.WorkspaceDTO])
 	if ok && m.choices != nil {


### PR DESCRIPTION
# Multi workspace select marking fix
## Description

Pressing "x" during daytona start/stop/code/info workspace selections would still visually "mark" workspaces for deletion because a check was missing for this being a multi-workspace selection action

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1042 
