### PR TITLE
fix: detect correct user when opening jetbrains IDEs

### DIFF
--- a/pkg/ide/jetbrains.go
+++ b/pkg/ide/jetbrains.go
@@ -35,7 +35,12 @@ func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId, projectNam
 		return fmt.Errorf("IDE not found")
 	}
 
-	downloadPath := filepath.ToSlash(filepath.Join("/home/daytona/.cache/JetBrains", ide))
+	home, err := util.GetHomeDir(activeProfile, workspaceId, projectName)
+	if err != nil {
+		return err
+	}
+
+	downloadPath := filepath.ToSlash(filepath.Join(home, "/.cache/JetBrains", ide))
 
 	downloadUrl := ""
 


### PR DESCRIPTION
# Detect Correct User When Opening Jetbrains IDEs

## Description

Before this PR, we assumed that the user inside the project is `daytona`.  Now we correctly detect the home folder of the user inside the container.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1079 