### PR TITLE
fix: bitbucket get repo prs

### DIFF
--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -145,7 +145,9 @@ func (g *BitbucketGitProvider) GetRepoPRs(repositoryId string, namespaceId strin
 	client := g.getApiClient()
 	var response []*GitPullRequest
 
-	owner, repo, err := g.getOwnerAndRepoFromFullName(repositoryId)
+	fullName := fmt.Sprintf("%s/%s", namespaceId, repositoryId)
+
+	owner, repo, err := g.getOwnerAndRepoFromFullName(fullName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Bitbucket get repository pull requests fix
## Description

Getting repository pull requests would fail due to the poorly constructed full repository name

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/6a5e1926-7544-4ba1-ae4b-bc152f51980c)