### PR TITLE
feat(ide): Support for JetBrains Fleet IDE

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -29,6 +29,7 @@ func GetIdeList() []Ide {
 		{"cursor", "Cursor"},
 		{"ssh", "Terminal SSH"},
 		{"jupyter", "Jupyter"},
+		{"fleet", "Fleet"},
 	}
 
 	sortedJbIdes := []Ide{}

--- a/docs/daytona_code.md
+++ b/docs/daytona_code.md
@@ -9,7 +9,7 @@ daytona code [WORKSPACE] [PROJECT] [flags]
 ### Options
 
 ```
-  -i, --ide string   Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+  -i, --ide string   Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
   -y, --yes          Automatically confirm any prompts
 ```
 

--- a/docs/daytona_code.md
+++ b/docs/daytona_code.md
@@ -9,7 +9,7 @@ daytona code [WORKSPACE] [PROJECT] [flags]
 ### Options
 
 ```
-  -i, --ide string   Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
+  -i, --ide string   Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
   -y, --yes          Automatically confirm any prompts
 ```
 

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -17,7 +17,7 @@ daytona create [REPOSITORY_URL] [flags]
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
       --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
       --env stringArray            Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-  -i, --ide string                 Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
+  -i, --ide string                 Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
       --manual                     Manually enter the Git repository
       --multi-project              Workspace with multiple projects/repos
       --name string                Specify the workspace name

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -17,7 +17,7 @@ daytona create [REPOSITORY_URL] [flags]
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
       --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
       --env stringArray            Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-  -i, --ide string                 Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+  -i, --ide string                 Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
       --manual                     Manually enter the Git repository
       --multi-project              Workspace with multiple projects/repos
       --name string                Specify the workspace name

--- a/hack/docs/daytona_code.yaml
+++ b/hack/docs/daytona_code.yaml
@@ -5,7 +5,7 @@ options:
     - name: ide
       shorthand: i
       usage: |
-        Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+        Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
     - name: "yes"
       shorthand: "y"
       default_value: "false"

--- a/hack/docs/daytona_code.yaml
+++ b/hack/docs/daytona_code.yaml
@@ -5,7 +5,7 @@ options:
     - name: ide
       shorthand: i
       usage: |
-        Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
+        Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
     - name: "yes"
       shorthand: "y"
       default_value: "false"

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -29,7 +29,7 @@ options:
     - name: ide
       shorthand: i
       usage: |
-        Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
+        Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
     - name: manual
       default_value: "false"
       usage: Manually enter the Git repository

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -29,7 +29,7 @@ options:
     - name: ide
       shorthand: i
       usage: |
-        Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+        Specify the IDE (vscode, browser, cursor, ssh, jupyter, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm, fleet)
     - name: manual
       default_value: "false"
       usage: Manually enter the Git repository

--- a/pkg/cmd/ide.go
+++ b/pkg/cmd/ide.go
@@ -50,6 +50,10 @@ var ideCmd = &cobra.Command{
 			if err != nil {
 				log.Error(err)
 			}
+		case "fleet":
+			if err := ide_util.CheckFleetInstallation(); err != nil {
+				log.Error(err)
+			}
 		}
 
 		c.DefaultIdeId = chosenIde.Id

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -176,6 +176,8 @@ func openIDE(ideId string, activeProfile config.Profile, workspaceId string, pro
 		return ide.OpenCursor(activeProfile, workspaceId, projectName, projectProviderMetadata)
 	case "jupyter":
 		return ide.OpenJupyterIDE(activeProfile, workspaceId, projectName, projectProviderMetadata, yesFlag)
+	case "fleet":
+		return ide.OpenFleet(activeProfile, workspaceId, projectName)
 	default:
 		_, ok := jetbrains.GetIdes()[jetbrains.Id(ideId)]
 		if ok {

--- a/pkg/ide/fleet.go
+++ b/pkg/ide/fleet.go
@@ -14,7 +14,7 @@ import (
 )
 
 func OpenFleet(activeProfile config.Profile, workspaceId string, projectName string) error {
-	if err := checkFleetInstallation(); err != nil {
+	if err := CheckFleetInstallation(); err != nil {
 		return err
 	}
 
@@ -34,7 +34,7 @@ func OpenFleet(activeProfile config.Profile, workspaceId string, projectName str
 	return nil
 }
 
-func checkFleetInstallation() error {
+func CheckFleetInstallation() error {
 	_, err := exec.LookPath("fleet")
 	if err != nil {
 		redBold := "\033[1;31m" // ANSI escape code for red and bold

--- a/pkg/ide/fleet.go
+++ b/pkg/ide/fleet.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ide
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util"
+	"github.com/pkg/browser"
+	log "github.com/sirupsen/logrus"
+)
+
+func OpenFleet(activeProfile config.Profile, workspaceId string, projectName string) error {
+	if err := checkFleetInstallation(); err != nil {
+		return err
+	}
+
+	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
+	projectDir, err := util.GetProjectDir(activeProfile, workspaceId, projectName)
+	if err != nil {
+		return err
+	}
+
+	ideURL := fmt.Sprintf("fleet://fleet.ssh/%s?pwd=%s", projectHostname, projectDir)
+
+	err = browser.OpenURL(ideURL)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkFleetInstallation() error {
+	_, err := exec.LookPath("fleet")
+	if err != nil {
+		redBold := "\033[1;31m" // ANSI escape code for red and bold
+		reset := "\033[0m"      // ANSI escape code to reset text formatting
+
+		errorMessage := "Please install Fleet using JetBrains Toolbox and ensure it's in your PATH. "
+		infoMessage := "\nMore information: \n1) Install JetBrains Toolbox: 'https://www.jetbrains.com/toolbox-app/'\n2) Install Fleet: Using JetBrains Toolbox, search for 'Fleet' and install it. \n3) Ensure Fleet is in your PATH and keep your 'Shell script name' as 'fleet': 'https://www.jetbrains.com/help/fleet/launch-from-cli.html'"
+
+		log.Error(redBold + errorMessage + reset + infoMessage)
+
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

This PR adds support for JetBrains Fleet IDE. The SSH connection is set up via the URI provided by the [Fleet CLI](https://www.jetbrains.com/help/fleet/launch-from-cli.html#connecting-to-ssh-with-fleet-uri-handler) through the browser route.

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1001 
/claim #1001

## Screenshots

https://github.com/user-attachments/assets/f37558c0-7111-45fb-8ad3-de2a0d6fc329

