### PR TITLE
fix: install code extensions on create

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -179,7 +179,7 @@ var CreateCmd = &cobra.Command{
 		// Make sure terminal cursor is reset
 		fmt.Print("\033[?25h")
 
-		wsInfo, res, err := apiClient.WorkspaceAPI.GetWorkspace(ctx, workspaceName).Execute()
+		wsInfo, res, err := apiClient.WorkspaceAPI.GetWorkspace(ctx, workspaceName).Verbose(true).Execute()
 		if err != nil {
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}

--- a/pkg/ide/browser.go
+++ b/pkg/ide/browser.go
@@ -84,6 +84,10 @@ func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, projectNam
 		log.Error("Error opening URL: " + err.Error())
 	}
 
+	if projectProviderMetadata == "" {
+		return nil
+	}
+
 	err = setupVSCodeCustomizations(projectHostname, projectProviderMetadata, devcontainer.Browser, "*/vscode-server/bin/openvscode-server", "$HOME/.openvscode-server/data/Machine/settings.json", ".daytona-customizations-lock-vscode-browser")
 	if err != nil {
 		log.Errorf("Error setting up IDE customizations: %s", err)

--- a/pkg/ide/cursor.go
+++ b/pkg/ide/cursor.go
@@ -36,6 +36,10 @@ func OpenCursor(activeProfile config.Profile, workspaceId string, projectName st
 		return err
 	}
 
+	if projectProviderMetadata == "" {
+		return nil
+	}
+
 	return setupVSCodeCustomizations(projectHostname, projectProviderMetadata, devcontainer.Vscode, "*/.cursor-server/*/bin/cursor-server", "$HOME/.cursor-server/data/Machine/settings.json", ".daytona-customizations-lock-cursor")
 }
 

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -38,6 +38,10 @@ func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName st
 		return err
 	}
 
+	if projectProviderMetadata == "" {
+		return nil
+	}
+
 	return setupVSCodeCustomizations(projectHostname, projectProviderMetadata, devcontainer.Vscode, "*/.vscode-server/*/bin/code-server", "$HOME/.vscode-server/data/Machine/settings.json", ".daytona-customizations-lock-vscode")
 }
 


### PR DESCRIPTION
# Fix Install Code Extensions on Create

## Description

Fixes a regression introduced with https://github.com/daytonaio/daytona/pull/1077 that broke extension installs if `--code` was used with `daytona create`.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1083
