### PR TITLE
fix: ssh access with remote profiles

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -146,7 +146,7 @@ var CreateCmd = &cobra.Command{
 		}
 
 		var tsConn *tsnet.Server
-		if target.Name != "local" {
+		if target.Name != "local" || activeProfile.Id != "default" {
 			tsConn, err = tailscale.GetConnection(&activeProfile)
 			if err != nil {
 				log.Fatal(err)
@@ -406,7 +406,7 @@ func processGitURL(repoUrl string, apiClient *apiclient.APIClient, projects *[]a
 }
 
 func waitForDial(workspace *apiclient.Workspace, activeProfile *config.Profile, tsConn *tsnet.Server) error {
-	if workspace.Target == "local" {
+	if workspace.Target == "local" && (activeProfile != nil && activeProfile.Id == "default") {
 		err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspace.Id, workspace.Projects[0].Name)
 		if err != nil {
 			return err

--- a/pkg/cmd/workspace/ssh-proxy.go
+++ b/pkg/cmd/workspace/ssh-proxy.go
@@ -58,7 +58,7 @@ var SshProxyCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		if workspace.Target == "local" {
+		if workspace.Target == "local" && profile.Id == "default" {
 			// If the workspace is local, we directly access the ssh port through the container
 			project := workspace.Projects[0]
 


### PR DESCRIPTION
# Fix SSH Access with Remote Profiles

## Description

This PR fixes ssh access when using a remote profile. The bug was caused by the switch in directly accessing workspaces with docker exec but that should only be applied when using the default local profile.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
