### PR TITLE
feat: suggest adding a target after provider install

### DIFF
--- a/docs/daytona_provider_install.md
+++ b/docs/daytona_provider_install.md
@@ -6,6 +6,12 @@ Install provider
 daytona provider install [flags]
 ```
 
+### Options
+
+```
+  -y, --yes   Automatically confirm any prompts
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/hack/docs/daytona_provider_install.yaml
+++ b/hack/docs/daytona_provider_install.yaml
@@ -1,6 +1,11 @@
 name: daytona provider install
 synopsis: Install provider
 usage: daytona provider install [flags]
+options:
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Automatically confirm any prompts
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/provider/install.go
+++ b/pkg/cmd/provider/install.go
@@ -4,8 +4,11 @@
 package provider
 
 import (
+	"context"
 	"fmt"
+	"slices"
 
+	"github.com/charmbracelet/huh"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/common"
@@ -14,11 +17,14 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/provider"
 	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
+	"github.com/daytonaio/daytona/pkg/views/target"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 
 	log "github.com/sirupsen/logrus"
 )
+
+var yesFlag bool
 
 var providerInstallCmd = &cobra.Command{
 	Use:     "install",
@@ -93,7 +99,72 @@ var providerInstallCmd = &cobra.Command{
 		}
 
 		views.RenderInfoMessageBold(fmt.Sprintf("Provider %s has been successfully installed", providerToInstall.Name))
+
+		targets, res, err := apiClient.TargetAPI.ListTargets(context.Background()).Execute()
+		if err != nil {
+			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+		}
+
+		if slices.ContainsFunc(targets, func(t apiclient.ProviderTarget) bool {
+			return t.ProviderInfo.Name == providerToInstall.Name
+		}) {
+			return
+		}
+
+		if !yesFlag {
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title("Add a Target?").
+						Value(&yesFlag),
+				),
+			).WithTheme(views.GetCustomTheme())
+
+			err := form.Run()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		if yesFlag {
+			targetManifest, res, err := apiClient.ProviderAPI.GetTargetManifest(context.Background(), providerToInstall.Name).Execute()
+			if err != nil {
+				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			}
+
+			targetToSet := &apiclient.ProviderTarget{
+				Options: "{}",
+				ProviderInfo: apiclient.ProviderProviderInfo{
+					Name:    providerToInstall.Name,
+					Version: providerToInstall.Version,
+				},
+			}
+
+			err = target.NewTargetNameInput(&targetToSet.Name, []string{})
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			err = target.SetTargetForm(targetToSet, *targetManifest)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(*targetToSet).Execute()
+			if err != nil {
+				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			views.RenderInfoMessage("Target set successfully")
+		}
 	},
+}
+
+func init() {
+	providerInstallCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Automatically confirm any prompts")
 }
 
 func GetProviderListFromManifest(manifest *manager.ProvidersManifest) []apiclient.Provider {


### PR DESCRIPTION
# Suggest Adding a Target After Provider Install

## Description

Added a suggestion to immediately add a target after installing a provider.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1070

## Screenshots
![Screenshot 2024-09-12 at 16 40 39](https://github.com/user-attachments/assets/61a73f7b-9274-4b6d-956b-c74d6890657e)


## Notes
The suggestion is not triggered if the provider has targets already set on the server (e.g. it comes with default targets).
