### PR TITLE
feat: entrypoint execution for workspace image

### DIFF
--- a/pkg/docker/start_image.go
+++ b/pkg/docker/start_image.go
@@ -5,12 +5,20 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 )
+
+type FeatureItem struct {
+	ID         string `json:"id"`
+	Entrypoint string `json:"entrypoint,omitempty"`
+	// Add other fields as needed
+}
 
 func (d *DockerClient) startImageProject(opts *CreateProjectOptions) error {
 	containerName := d.GetProjectContainerName(opts.Project)
@@ -67,5 +75,63 @@ func (d *DockerClient) startImageProject(opts *CreateProjectOptions) error {
 		time.Sleep(1 * time.Second)
 	}
 
+	//	Find entrypoint metadata
+	//	These entrypoints are used to run commands after the container is started (e.g. dockerd)
+	c, err = d.apiClient.ContainerInspect(ctx, containerName)
+	if err != nil {
+		return err
+	}
+
+	//	First check if the image was built using devcontainer
+
+	// Check if the "devcontainer.metadata" label exists
+	metadata, ok := c.Config.Labels["devcontainer.metadata"]
+	if ok {
+		opts.LogWriter.Write([]byte("Found devcontainer.metadata label\n"))
+		// Parse the metadata JSON
+		var features []FeatureItem
+		err = json.Unmarshal([]byte(metadata), &features)
+		if err != nil {
+			opts.LogWriter.Write([]byte(fmt.Sprintf("Failed to parse devcontainer.metadata: %v", err)))
+			return nil
+		}
+
+		// Execute entrypoints
+		err = executeEntrypoints(ctx, d.apiClient, c.ID, features, opts)
+		if err != nil {
+			opts.LogWriter.Write([]byte(fmt.Sprintf("Failed to execute entrypoints: %v", err)))
+			return nil
+		}
+	}
+
+	//	TODO: add daytona metadata support for images that are not based on the devcontainer config
+
+	return nil
+}
+
+func executeEntrypoints(ctx context.Context, cli client.APIClient, containerID string, features []FeatureItem, opts *CreateProjectOptions) error {
+	for _, feature := range features {
+		if feature.Entrypoint != "" {
+			execConfig := container.ExecOptions{
+				Cmd:          []string{"/bin/sh", "-c", feature.Entrypoint},
+				AttachStdout: true,
+				AttachStderr: true,
+			}
+
+			// Create the exec instance
+			execIDResp, err := cli.ContainerExecCreate(ctx, containerID, execConfig)
+			if err != nil {
+				return fmt.Errorf("failed to create exec for feature %s: %v", feature.ID, err)
+			}
+
+			// Start the exec instance
+			err = cli.ContainerExecStart(ctx, execIDResp.ID, container.ExecStartOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to start exec for feature %s: %v", feature.ID, err)
+			}
+
+			opts.LogWriter.Write([]byte(fmt.Sprintf("Executed entrypoint for feature %s\n", feature.ID)))
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
# feat: entrypoint execution for workspace image

## Description

If the image contains devcontainer.metadata label, the provider will execute all the features entrypoints found in the label.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issues
Closes #1106 

## Notes
This PR requires updates to all the providers!

With this PR, only the image entry point logic is built using the devcontainer. The logic still needs to be implemented for the plain Docker images.
A new Issue should be created to resolve this.
