### PR TITLE
feat: Added support for Azure DevOps Prebuild Webhooks

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -126,6 +126,8 @@ func GetPrebuildScopesFromGitProviderId(providerId string) string {
 		return "admin:repo_hook"
 	case "bitbucket":
 		return "webhooks"
+	case "azure-devops":
+		return "Work (Read, Write & Manage); Build (Read & Execute)"
 	default:
 		return ""
 	}
@@ -143,6 +145,8 @@ func GetWebhookEventHeaderKeyFromGitProvider(providerId string) string {
 		return "X-Event-Key"
 	case "gitea":
 		return "X-Gitea-Event"
+	case "azure-devops":
+		return "X-AzureDevops-Event"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Description

This PR adds support for webhooks for Azure DevOps prebuilds. It implements five methods: webhook get, register, unregister, comparing commit ranges and parsing event data.


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
closes #998 
/claim #998

## Screenrecord
https://github.com/user-attachments/assets/0cd9fed1-3c80-421c-a826-a5ff5288d858
