### PR TITLE
fix: ctrl-c out of cloning option selection

### DIFF
--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -11,6 +11,7 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/common"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 )
@@ -78,6 +79,11 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	checkoutOptions = append(checkoutOptions, selection.CheckoutPR)
 
 	chosenCheckoutOption := selection.GetCheckoutOptionFromPrompt(config.ProjectOrder, checkoutOptions, parentIdentifier)
+
+	if chosenCheckoutOption == (selection.CheckoutOption{}) {
+		return nil, common.ErrCtrlCAbort
+	}
+
 	if chosenCheckoutOption == selection.CheckoutDefault {
 		// Get the default branch from context
 		repo, res, err := config.ApiClient.GitProviderAPI.GetGitContext(ctx).Repository(apiclient.GetRepositoryContext{

--- a/pkg/views/workspace/selection/checkout.go
+++ b/pkg/views/workspace/selection/checkout.go
@@ -67,5 +67,5 @@ func GetCheckoutOptionFromPrompt(projectOrder int, checkoutOptions []CheckoutOpt
 			return checkoutOption
 		}
 	}
-	return CheckoutDefault
+	return CheckoutOption{}
 }


### PR DESCRIPTION
# Ctrl-c out of cloning option selection
## Description

Ctrl-c-ing out of Cloning Options selection screen in the TUI used assume the default checkout option instead of cancelling the operation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/9f040740-2512-4c6d-96f2-89a6a9f0ccb9)

![image](https://github.com/user-attachments/assets/b24199aa-3b47-4623-a769-a99161dd0c90)