### PR TITLE
fix: escape git namespace when fetching from API

### DIFF
--- a/pkg/cmd/workspace/util/branch_wizard.go
+++ b/pkg/cmd/workspace/util/branch_wizard.go
@@ -31,7 +31,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	ctx := context.Background()
 
 	err = views_util.WithSpinner("Loading", func() error {
-		branchList, _, err = config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Execute()
+		branchList, _, err = config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.ProviderId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Execute()
 		return err
 	})
 
@@ -51,7 +51,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 
 	var prList []apiclient.GitPullRequest
 	err = views_util.WithSpinner("Loading", func() error {
-		prList, _, err = config.ApiClient.GitProviderAPI.GetRepoPRs(ctx, config.ProviderId, config.NamespaceId, url.QueryEscape(config.ChosenRepo.Id)).Execute()
+		prList, _, err = config.ApiClient.GitProviderAPI.GetRepoPRs(ctx, config.ProviderId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Execute()
 		return err
 	})
 


### PR DESCRIPTION
# Escape Git Namespace When Fetching from API

## Description

Fixes an issue for namespaces that have `/` or when gitlab subgroups where used. The namespace is now correctly escaped before sending the request.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation