### PR TITLE
refactor: use errors new for simple strings

### DIFF
--- a/internal/cmd/tailscale/connection.go
+++ b/internal/cmd/tailscale/connection.go
@@ -4,6 +4,7 @@
 package tailscale
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -47,7 +48,7 @@ func GetConnection(profile *config.Profile) (*tsnet.Server, error) {
 		controlURL = fmt.Sprintf("http://localhost:%d", serverConfig.HeadscalePort)
 	} else {
 		if serverConfig.Frps == nil {
-			return nil, fmt.Errorf("frps config is missing")
+			return nil, errors.New("frps config is missing")
 		}
 		controlURL = util.GetFrpcHeadscaleUrl(serverConfig.Frps.Protocol, serverConfig.Id, serverConfig.Frps.Domain)
 	}

--- a/internal/testing/agent/mocks/apiserver.go
+++ b/internal/testing/agent/mocks/apiserver.go
@@ -6,7 +6,7 @@
 package mocks
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,7 +48,7 @@ func NewMockRestServer(t *testing.T, workspace *workspace.Workspace) *httptest.S
 	{
 		gitproviderController.GET("/for-url/:url", func(ctx *gin.Context) {
 			// This simulates a non-configured git provider
-			ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get git provider for url"))
+			ctx.AbortWithError(http.StatusInternalServerError, errors.New("failed to get git provider for url"))
 		})
 	}
 

--- a/internal/util/workspace.go
+++ b/internal/util/workspace.go
@@ -4,7 +4,7 @@
 package util
 
 import (
-	"fmt"
+	"errors"
 	"net/url"
 	"regexp"
 	"strings"
@@ -22,7 +22,7 @@ func GetValidatedName(input string) (string, error) {
 	}
 
 	if !matched {
-		return "", fmt.Errorf("only letters, numbers, and dashes are allowed")
+		return "", errors.New("only letters, numbers, and dashes are allowed")
 	}
 
 	return input, nil
@@ -31,13 +31,13 @@ func GetValidatedName(input string) (string, error) {
 func GetValidatedUrl(input string) (string, error) {
 	// Check if the input starts with a scheme (e.g., http:// or https://)
 	if !strings.HasPrefix(input, "http://") && !strings.HasPrefix(input, "https://") {
-		return "", fmt.Errorf("input is missing http:// or https://")
+		return "", errors.New("input is missing http:// or https://")
 	}
 
 	// Try to parse the input as a URL
 	parsedURL, err := url.Parse(input)
 	if err != nil {
-		return "", fmt.Errorf("input is not a valid URL")
+		return "", errors.New("input is not a valid URL")
 	}
 
 	// If parsing was successful, return the fixed URL

--- a/pkg/build/devcontainer.go
+++ b/pkg/build/devcontainer.go
@@ -6,7 +6,6 @@ package build
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/daytonaio/daytona/pkg/build/detect"
@@ -35,7 +34,7 @@ func (b *DevcontainerBuilder) Build(build Build) (string, string, error) {
 	}
 
 	if builderType != detect.BuilderTypeDevcontainer {
-		return "", "", fmt.Errorf("failed to detect devcontainer config")
+		return "", "", errors.New("failed to detect devcontainer config")
 	}
 
 	return b.buildDevcontainer(build)

--- a/pkg/build/factory.go
+++ b/pkg/build/factory.go
@@ -4,6 +4,7 @@
 package build
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/daytonaio/daytona/pkg/containerregistry"
@@ -56,7 +57,7 @@ func (f *BuilderFactory) Create(build Build, projectDir string) (IBuilder, error
 
 func (f *BuilderFactory) CheckExistingBuild(b Build) (*Build, error) {
 	if b.Repository == nil {
-		return nil, fmt.Errorf("repository must be set")
+		return nil, errors.New("repository must be set")
 	}
 
 	build, err := f.buildStore.Find(&Filter{

--- a/pkg/cmd/ports/forward.go
+++ b/pkg/cmd/ports/forward.go
@@ -6,6 +6,7 @@ package ports
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"strconv"
@@ -111,7 +112,7 @@ func ForwardPublicPort(workspaceId, projectName string, hostPort, targetPort uin
 	subDomain := fmt.Sprintf("%d-%s", targetPort, base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprint(h.Sum64()))))
 
 	if serverConfig.Frps == nil {
-		return fmt.Errorf("frps config is missing")
+		return errors.New("frps config is missing")
 	}
 
 	go func() {

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -66,7 +66,7 @@ var projectConfigAddCmd = &cobra.Command{
 
 func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apiclient.GitProvider, ctx context.Context) (*apiclient.ProjectConfig, error) {
 	if workspace_util.CheckAnyProjectConfigurationFlagSet(projectConfigurationFlags) {
-		return nil, fmt.Errorf("please provide the repository URL in order to set up custom project config details through the CLI")
+		return nil, errors.New("please provide the repository URL in order to set up custom project config details through the CLI")
 	}
 
 	var createDtos []apiclient.CreateProjectDTO

--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -5,6 +5,7 @@ package daemon
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -82,9 +83,9 @@ func Start(logFilePath string) error {
 	}
 
 	if status == service.StatusStopped {
-		return fmt.Errorf("daemon stopped unexpectedly")
+		return errors.New("daemon stopped unexpectedly")
 	} else {
-		return fmt.Errorf("daemon status unknown")
+		return errors.New("daemon status unknown")
 	}
 }
 
@@ -109,7 +110,7 @@ func Stop() error {
 func getServiceConfig() (*service.Config, error) {
 	user, ok := os.LookupEnv("USER")
 	if !ok {
-		return nil, fmt.Errorf("could not determine user")
+		return nil, errors.New("could not determine user")
 	}
 
 	svcConfig := &service.Config{
@@ -121,7 +122,7 @@ func getServiceConfig() (*service.Config, error) {
 
 	switch runtime.GOOS {
 	case "windows":
-		return nil, fmt.Errorf("daemon mode not supported on Windows")
+		return nil, errors.New("daemon mode not supported on Windows")
 	case "linux":
 		// Fix for running as root on Linux
 		if user == "root" {
@@ -160,5 +161,5 @@ func getServiceFilePath(cfg *service.Config) (string, error) {
 		return fmt.Sprintf("%s/Library/LaunchAgents/%s.plist", homeDir, cfg.Name), nil
 	}
 
-	return "", fmt.Errorf("daemon mode not supported on current OS")
+	return "", errors.New("daemon mode not supported on current OS")
 }

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -5,6 +5,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -276,7 +277,7 @@ func getTarget(targetList []apiclient.ProviderTarget, activeProfileName string) 
 
 func processPrompting(apiClient *apiclient.APIClient, workspaceName *string, projects *[]apiclient.CreateProjectDTO, workspaceNames []string, ctx context.Context) error {
 	if workspace_util.CheckAnyProjectConfigurationFlagSet(projectConfigurationFlags) {
-		return fmt.Errorf("please provide the repository URL in order to set up custom project details through the CLI")
+		return errors.New("please provide the repository URL in order to set up custom project details through the CLI")
 	}
 
 	gitProviders, res, err := apiClient.GitProviderAPI.ListGitProviders(ctx).Execute()

--- a/pkg/docker/create_devcontainer.go
+++ b/pkg/docker/create_devcontainer.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -79,7 +80,7 @@ func (d *DockerClient) CreateFromDevcontainer(opts CreateDevcontainerOptions) (s
 
 	workspaceFolder := config.Workspace.WorkspaceFolder
 	if workspaceFolder == "" {
-		return "", "", fmt.Errorf("unable to determine workspace folder from devcontainer configuration")
+		return "", "", errors.New("unable to determine workspace folder from devcontainer configuration")
 	}
 
 	remoteUser := config.MergedConfiguration.RemoteUser
@@ -93,7 +94,7 @@ func (d *DockerClient) CreateFromDevcontainer(opts CreateDevcontainerOptions) (s
 
 	devcontainerConfig, ok := mergedConfig["configuration"].(map[string]interface{})
 	if !ok {
-		return "", "", fmt.Errorf("unable to find devcontainer configuration in merged configuration")
+		return "", "", errors.New("unable to find devcontainer configuration in merged configuration")
 	}
 
 	envVars := map[string]string{}
@@ -252,7 +253,7 @@ func (d *DockerClient) CreateFromDevcontainer(opts CreateDevcontainerOptions) (s
 
 	resultIndex := strings.LastIndex(output, "{")
 	if resultIndex == -1 {
-		return "", "", fmt.Errorf("unable to find result in devcontainer output")
+		return "", "", errors.New("unable to find result in devcontainer output")
 	}
 
 	resultRaw := output[resultIndex:]
@@ -365,7 +366,7 @@ func (d *DockerClient) readDevcontainerConfig(opts *CreateDevcontainerOptions, p
 
 	configStartIndex := strings.Index(output, "{")
 	if configStartIndex == -1 {
-		return "", nil, fmt.Errorf("unable to find start of JSON in devcontainer configuration")
+		return "", nil, errors.New("unable to find start of JSON in devcontainer configuration")
 	}
 
 	rawConfig := output[configStartIndex:]
@@ -542,7 +543,7 @@ func (d *DockerClient) getRemoteComposeContent(opts *CreateDevcontainerOptions, 
 
 	nameIndex := strings.Index(output, "name: ")
 	if nameIndex == -1 {
-		return "", fmt.Errorf("unable to find service name in compose config")
+		return "", errors.New("unable to find service name in compose config")
 	}
 
 	return output[nameIndex:], nil

--- a/pkg/gitprovider/aws-codecommit.go
+++ b/pkg/gitprovider/aws-codecommit.go
@@ -5,6 +5,7 @@ package gitprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -102,7 +103,7 @@ func (g *AwsCodeCommitGitProvider) GetUrlFromContext(repoContext *GetRepositoryC
 func (g *AwsCodeCommitGitProvider) getApiClient() (*codecommit.Client, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS SDK configuration")
+		return nil, errors.New("failed to load AWS SDK configuration")
 	}
 	client := codecommit.NewFromConfig(cfg)
 
@@ -180,7 +181,7 @@ func (g *AwsCodeCommitGitProvider) GetUser() (*GitUser, error) {
 	// No extra configuration is needed for the IAM service API.
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS SDK configuration")
+		return nil, errors.New("failed to load AWS SDK configuration")
 	}
 	iamclient := iam.NewFromConfig(cfg)
 	user, err := iamclient.GetUser(context.TODO(), &iam.GetUserInput{})

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -5,6 +5,7 @@ package gitprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -247,7 +248,7 @@ func (g *BitbucketServerGitProvider) GetUser() (*GitUser, error) {
 
 	username := res.Header.Get("X-Ausername")
 	if username == "" {
-		return nil, fmt.Errorf("X-Ausername header is missing")
+		return nil, errors.New("X-Ausername header is missing")
 	}
 
 	user, err := client.DefaultApi.GetUser(username)
@@ -256,7 +257,7 @@ func (g *BitbucketServerGitProvider) GetUser() (*GitUser, error) {
 	}
 
 	if user.Values == nil {
-		return nil, fmt.Errorf("user values are nil")
+		return nil, errors.New("user values are nil")
 	}
 	var userInfo bitbucketv1.User
 	err = mapstructure.Decode(user.Values, &userInfo)
@@ -293,7 +294,7 @@ func (g *BitbucketServerGitProvider) GetLastCommitSha(staticContext *StaticGitCo
 	}
 
 	if len(commits.Values) == 0 {
-		return "", fmt.Errorf("no commits found")
+		return "", errors.New("no commits found")
 	}
 
 	commitList, err := bitbucketv1.GetCommitsResponse(commits)
@@ -502,7 +503,7 @@ func (g *BitbucketServerGitProvider) GetDefaultBranch(staticContext *StaticGitCo
 		}
 	}
 
-	return nil, fmt.Errorf("default branch not found")
+	return nil, errors.New("default branch not found")
 }
 
 func (b *BitbucketServerGitProvider) FormatError(statusCode int, message string) error {

--- a/pkg/gitprovider/gitea.go
+++ b/pkg/gitprovider/gitea.go
@@ -5,6 +5,7 @@ package gitprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -516,7 +517,7 @@ func (g *GiteaGitProvider) GetCommitsRange(repo *GitRepository, initialSha strin
 
 func (g *GiteaGitProvider) ParseEventData(request *http.Request) (*GitEventData, error) {
 	if request.Header.Get("X-Gitea-Event") != "push" {
-		return nil, fmt.Errorf("invalid event key")
+		return nil, errors.New("invalid event key")
 	}
 
 	hook, err := giteaWebhook.New()

--- a/pkg/gitprovider/gitnessclient/gitness_client.go
+++ b/pkg/gitprovider/gitnessclient/gitness_client.go
@@ -6,6 +6,7 @@ package gitnessclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -289,7 +290,7 @@ func (g *GitnessClient) GetRepoRef(url string) (*string, error) {
 	repoUrl := strings.TrimSuffix(url, ".git")
 	parts := strings.Split(repoUrl, "/")
 	if len(parts) < 5 {
-		return nil, fmt.Errorf("failed to parse repository reference: invalid url passed")
+		return nil, errors.New("failed to parse repository reference: invalid url passed")
 	}
 	var path string
 	if parts[3] == "git" && len(parts) >= 6 {
@@ -312,7 +313,7 @@ func getLastCommit(jsonData []byte) (Commit, error) {
 	})
 
 	if len(commitsResponse.Commits) == 0 {
-		return Commit{}, fmt.Errorf("no commits found")
+		return Commit{}, errors.New("no commits found")
 	}
 
 	return commitsResponse.Commits[len(commitsResponse.Commits)-1], nil

--- a/pkg/ide/jetbrains.go
+++ b/pkg/ide/jetbrains.go
@@ -38,7 +38,7 @@ func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId, projectNam
 
 	jbIde, ok := jetbrains.GetIdes()[jetbrains.Id(ide)]
 	if !ok {
-		return fmt.Errorf("IDE not found")
+		return errors.New("IDE not found")
 	}
 
 	home, err := util.GetHomeDir(activeProfile, workspaceId, projectName)
@@ -66,7 +66,7 @@ func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId, projectNam
 	case ospkg.Linux_64_86:
 		downloadUrl = fmt.Sprintf(jbIde.UrlTemplates.Amd64, jbIdeVersion)
 	default:
-		return fmt.Errorf("JetBrains remote IDEs are only supported on Linux.")
+		return errors.New("JetBrains remote IDEs are only supported on Linux.")
 	}
 
 	err = downloadJetbrainsIDE(projectHostname, downloadUrl, downloadPath)

--- a/pkg/ide/jupyter.go
+++ b/pkg/ide/jupyter.go
@@ -5,6 +5,7 @@ package ide
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -85,7 +86,7 @@ func ensurePythonInstalled(hostname string, yesFlag bool) error {
 		if confirmInstall {
 			return installPython(hostname)
 		} else {
-			return fmt.Errorf("python3 is required but not installed")
+			return errors.New("python3 is required but not installed")
 		}
 	}
 	views.RenderInfoMessageBold("Python is already installed.")
@@ -128,7 +129,7 @@ func ensurePipInstalled(hostname string, yesFlag bool) error {
 		if confirmInstall {
 			return installPip(hostname)
 		} else {
-			return fmt.Errorf("pip is required but not installed")
+			return errors.New("pip is required but not installed")
 		}
 	}
 	views.RenderInfoMessageBold("pip is installed.")
@@ -167,7 +168,7 @@ func detectPackageManager(hostname string) (string, error) {
 			return manager, nil
 		}
 	}
-	return "", fmt.Errorf("no supported package manager found")
+	return "", errors.New("no supported package manager found")
 }
 
 // installPythonWithPackageManager installs Python using the detected package manager.

--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -4,7 +4,7 @@
 package os
 
 import (
-	"fmt"
+	"errors"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -24,7 +24,7 @@ const (
 func OSFromUnameA(unameA string) (*OperatingSystem, error) {
 	fields := strings.Fields(unameA)
 	if len(fields) < 3 {
-		return nil, fmt.Errorf("unexpected output format")
+		return nil, errors.New("unexpected output format")
 	}
 
 	if strings.Contains(unameA, "Darwin") && strings.Contains(unameA, "arm64") {
@@ -40,7 +40,7 @@ func OSFromUnameA(unameA string) (*OperatingSystem, error) {
 		arch := Linux_64_86
 		return &arch, nil
 	} else {
-		return nil, fmt.Errorf("unsupported architecture in uname -a output")
+		return nil, errors.New("unsupported architecture in uname -a output")
 	}
 }
 
@@ -52,7 +52,7 @@ func OSFromEchoProcessor(output string) (*OperatingSystem, error) {
 		arch := Windows_64_86
 		return &arch, nil
 	} else {
-		return nil, fmt.Errorf("unsupported architecture in echo PROCESSOR_ARCHITECTURE output")
+		return nil, errors.New("unsupported architecture in echo PROCESSOR_ARCHITECTURE output")
 	}
 }
 

--- a/pkg/server/projectconfig/prebuild.go
+++ b/pkg/server/projectconfig/prebuild.go
@@ -4,6 +4,7 @@
 package projectconfig
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -30,11 +31,11 @@ func (s *ProjectConfigService) SetPrebuild(projectConfigName string, createPrebu
 	})
 
 	if err == nil && createPrebuildDto.Id != nil && *createPrebuildDto.Id != existingPrebuild.Id {
-		return nil, fmt.Errorf("prebuild for the specified project config and branch already exists")
+		return nil, errors.New("prebuild for the specified project config and branch already exists")
 	}
 
 	if createPrebuildDto.CommitInterval == nil && len(createPrebuildDto.TriggerFiles) == 0 {
-		return nil, fmt.Errorf("either the commit interval or trigger files must be specified")
+		return nil, errors.New("either the commit interval or trigger files must be specified")
 	}
 
 	gitProvider, gitProviderId, err := s.gitProviderService.GetGitProviderForUrl(projectConfig.RepositoryUrl)

--- a/pkg/server/registry/service.go
+++ b/pkg/server/registry/service.go
@@ -5,6 +5,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -60,7 +61,7 @@ func (s *LocalContainerRegistry) Start() error {
 	}
 
 	if _, err := cli.Info(ctx); err != nil {
-		return fmt.Errorf("cannot connect to the Docker daemon. Is the Docker daemon running?\nIf Docker is not installed, please install it by following https://docs.docker.com/engine/install/ and try again")
+		return errors.New("cannot connect to the Docker daemon. Is the Docker daemon running?\nIf Docker is not installed, please install it by following https://docs.docker.com/engine/install/ and try again")
 	}
 
 	dockerClient := docker.NewDockerClient(docker.DockerClientConfig{

--- a/pkg/ssh/user.go
+++ b/pkg/ssh/user.go
@@ -4,7 +4,7 @@
 package ssh
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 )
 
@@ -23,7 +23,7 @@ func (c *Client) GetUserUidGid() (string, string, error) {
 	re := regexp.MustCompile(`uid=(\d+).*gid=(\d+)`)
 	matches := re.FindStringSubmatch(string(idResp))
 	if len(matches) < 3 {
-		return "", "", fmt.Errorf("could not parse uid and gid from id command")
+		return "", "", errors.New("could not parse uid and gid from id command")
 	}
 
 	return matches[1], matches[2], nil

--- a/pkg/tailscale/connection.go
+++ b/pkg/tailscale/connection.go
@@ -5,7 +5,7 @@ package tailscale
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"tailscale.com/tsnet"
@@ -27,7 +27,7 @@ func GetConnection(config *TsnetConnConfig) (*tsnet.Server, error) {
 	}
 
 	if config == nil {
-		return nil, fmt.Errorf("connection not initialized")
+		return nil, errors.New("connection not initialized")
 	}
 
 	conn = &tsnet.Server{

--- a/pkg/tailscale/tunnel/tunnel.go
+++ b/pkg/tailscale/tunnel/tunnel.go
@@ -94,7 +94,7 @@ func (tun *SshTunnel) Start(ctx context.Context) error {
 	tun.mutex.Lock()
 	if tun.started {
 		tun.mutex.Unlock()
-		return fmt.Errorf("already started")
+		return errors.New("already started")
 	}
 	tun.started = true
 	tun.ctx, tun.cancel = context.WithCancel(ctx)

--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -73,7 +73,7 @@ func RunSubmissionForm(config SubmissionFormConfig) error {
 	}
 
 	if config.Defaults.Image == nil || config.Defaults.ImageUser == nil {
-		return fmt.Errorf("default project entries are not set")
+		return errors.New("default project entries are not set")
 	}
 
 	var err error


### PR DESCRIPTION
# Refactor: use errors new for simple strings
## Description

Changes all call of `fmt.Errorf` that don't include any dynamic string formatting to instead use `errors.New` for consistency

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation