### PR TITLE
fix: ctrl-c out of daytona command

### DIFF
--- a/pkg/views/initial/view.go
+++ b/pkg/views/initial/view.go
@@ -114,6 +114,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
 		case "ctrl+c":
+			m.choice = ""
 			return m, tea.Quit
 		}
 	}


### PR DESCRIPTION
# Fix ctrl-c-ing out of daytona command

## Description
Fixes ctrl-c-ing out of the `daytona` command to simply exit instead of defaulting to the first command in the list

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
