### PR TITLE
fix: build run project config selection verb

### DIFF
--- a/pkg/cmd/build/run.go
+++ b/pkg/cmd/build/run.go
@@ -37,7 +37,7 @@ var buildRunCmd = &cobra.Command{
 			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
 		}
 
-		projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Update")
+		projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Build")
 		if projectConfig == nil {
 			return
 		}


### PR DESCRIPTION
# Fix build run project config selection verb

## Description
Fixes the verb in the title when running `daytona build run` from "Update" to "Build"

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/ad5c5f03-0281-483c-8c47-d61c742d2f67)

![image](https://github.com/user-attachments/assets/0f779642-9ec0-4528-97d5-decb29616ce0)
