### PR TITLE
fix: sort build views by updatedat

### DIFF
--- a/pkg/views/build/list/view.go
+++ b/pkg/views/build/list/view.go
@@ -6,6 +6,7 @@ package list
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
@@ -26,6 +27,8 @@ type RowData struct {
 }
 
 func ListBuilds(buildList []apiclient.Build, apiServerConfig *apiclient.ServerConfig) {
+	SortBuilds(&buildList)
+
 	re := lipgloss.NewRenderer(os.Stdout)
 
 	headers := []string{"ID", "State", "Prebuild ID", "Created", "Updated"}
@@ -71,6 +74,14 @@ func ListBuilds(buildList []apiclient.Build, apiServerConfig *apiclient.ServerCo
 	fmt.Println(views.BaseTableStyle.Render(t.String()))
 }
 
+func SortBuilds(buildList *[]apiclient.Build) {
+	sort.Slice(*buildList, func(i, j int) bool {
+		b1 := (*buildList)[i]
+		b2 := (*buildList)[j]
+		return b1.UpdatedAt > b2.UpdatedAt
+	})
+}
+
 func renderUnstyledList(buildList []apiclient.Build, apiServerConfig *apiclient.ServerConfig) {
 	for _, b := range buildList {
 		info.Render(&b, apiServerConfig, true)
@@ -82,7 +93,6 @@ func renderUnstyledList(buildList []apiclient.Build, apiServerConfig *apiclient.
 }
 
 func getRowFromRowData(rowData RowData) []string {
-
 	row := []string{
 		views.NameStyle.Render(rowData.Id),
 		views.DefaultRowDataStyle.Render(rowData.State),

--- a/pkg/views/workspace/selection/build.go
+++ b/pkg/views/workspace/selection/build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	list_view "github.com/daytonaio/daytona/pkg/views/build/list"
 )
 
 func GetBuildFromPrompt(builds []apiclient.Build, actionVerb string) *apiclient.Build {
@@ -23,6 +24,8 @@ func GetBuildFromPrompt(builds []apiclient.Build, actionVerb string) *apiclient.
 }
 
 func selectBuildPrompt(builds []apiclient.Build, actionVerb string, choiceChan chan<- *apiclient.Build) {
+	list_view.SortBuilds(&builds)
+
 	items := []list.Item{}
 
 	for _, b := range builds {


### PR DESCRIPTION
# Sort build views by UpdatedAt property

## Description

Sorts `daytona build list` and daytona build selection screens (e.g. `daytona build info`) to start with the most recently updated ones

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

![image](https://github.com/user-attachments/assets/f6070d5d-ee1c-4290-b1b8-0d2e8ffb85c0)

![image](https://github.com/user-attachments/assets/5e8cb8e6-4321-40fc-9243-4a6b3af1ba22)
