### PR TITLE
fix: ssh proxycommand file location windows

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -117,7 +117,7 @@ func generateSshConfigEntry(profileId, workspaceId, projectName, knownHostsPath 
 		tab+"User daytona\n"+
 		tab+"StrictHostKeyChecking no\n"+
 		tab+"UserKnownHostsFile %s\n"+
-		tab+"ProxyCommand %s ssh-proxy %s %s %s\n"+
+		tab+"ProxyCommand \"%s\" ssh-proxy %s %s %s\n"+
 		tab+"ForwardAgent yes\n\n", projectHostname, knownHostsPath, daytonaPath, profileId, workspaceId, projectName)
 
 	return config, nil


### PR DESCRIPTION
# SSH ProxyCommand file location Windows fix

## Description

Adds double quotes to ProxyCommand's binary file location to fix ssh-ing on Windows

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation