### PR TITLE
fix: daytona code windows for vscode-like ides

### DIFF
--- a/pkg/ide/cursor.go
+++ b/pkg/ide/cursor.go
@@ -29,9 +29,9 @@ func OpenCursor(activeProfile config.Profile, workspaceId string, projectName st
 
 	commandArgument := fmt.Sprintf("vscode-remote://ssh-remote+%s/%s", projectHostname, projectDir)
 
-	vscCommand := exec.Command(path, "--folder-uri", commandArgument, "--disable-extension", "ms-vscode-remote.remote-containers")
+	cursorCommand := exec.Command(path, "--disable-extension", "ms-vscode-remote.remote-containers", "--folder-uri", commandArgument)
 
-	err = vscCommand.Run()
+	err = cursorCommand.Run()
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -31,7 +31,7 @@ func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName st
 
 	commandArgument := fmt.Sprintf("vscode-remote://ssh-remote+%s/%s", projectHostname, projectDir)
 
-	vscCommand := exec.Command("code", "--folder-uri", commandArgument, "--disable-extension", "ms-vscode-remote.remote-containers")
+	vscCommand := exec.Command("code", "--disable-extension", "ms-vscode-remote.remote-containers", "--folder-uri", commandArgument)
 
 	err = vscCommand.Run()
 	if err != nil {


### PR DESCRIPTION
# Fix daytona code command on Windows for VSCode/Cursor

## Description

Fixing the order of flags when calling the VSCode/Cursor CLI prevents the command from not doing anything

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation