### PR TITLE
fix: add selected project name to ssh on multi project workspace

### DIFF
--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -91,7 +91,7 @@ var SshCmd = &cobra.Command{
 			sshArgs = append(sshArgs, args[2:]...)
 		}
 
-		err = ide.OpenTerminalSsh(activeProfile, workspace.Id, workspace.Projects[0].Name, sshArgs...)
+		err = ide.OpenTerminalSsh(activeProfile, workspace.Id, projectName, sshArgs...)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
# Add selected project name to SSH on multi project workspace

## Description

This PR introduces a fix when selecting a project to SSH in from multi-project workspace.
Issue fixed is that no matter which project was chosen, always the first one was selected, now it is selected one.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1128 

## Screenshots

https://github.com/user-attachments/assets/aaee284e-0113-4d29-85b1-c44ee5b6ca34