### PR TITLE
fix: pull image before building

### DIFF
--- a/pkg/build/devcontainer.go
+++ b/pkg/build/devcontainer.go
@@ -77,6 +77,12 @@ func (b *DevcontainerBuilder) buildDevcontainer(build Build) (string, string, er
 		ApiClient: cli,
 	})
 
+	// TODO: The image should be configurable
+	err = dockerClient.PullImage("daytonaio/workspace-project", nil, buildLogger)
+	if err != nil {
+		return b.defaultProjectImage, b.defaultProjectUser, err
+	}
+
 	containerId, remoteUser, err := dockerClient.CreateFromDevcontainer(docker.CreateDevcontainerOptions{
 		BuildConfig:       build.BuildConfig,
 		ProjectName:       build.Id,


### PR DESCRIPTION
# Pull Image Before Building

## Description

Small fix for running builds. The `daytonaio/workspace-project` image is now pulled before starting the building process.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1120 