### PR TITLE
feat: auto-copy api key to clipboard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -296,7 +296,7 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go v1.54.19
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.24.3
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/pkg/views/server/apikey/notify.go
+++ b/pkg/views/server/apikey/notify.go
@@ -5,41 +5,29 @@ package apikey
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/pkg/views"
-	"golang.org/x/term"
 )
-
-var minimumLayoutWidth = 80
 
 func Render(key, apiUrl string) {
 	var output string
 
-	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		fmt.Println("error: Unable to get terminal size")
-		return
-	}
-
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Generated API key: "), key) + "\n\n"
-
-	output += "Make sure to copy it as you will not be able to see it again." + "\n\n"
-
-	output += views.SeparatorString + "\n\n"
 
 	output += "You can connect to the Daytona Server from a client machine by running:"
 
-	formattedCommand := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a \\\n%s \\\n-k %s", apiUrl, key))
-	command := lipgloss.NewStyle().Foreground(views.Green).Render(fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key))
+	views.RenderContainerLayout(views.GetInfoMessage(output))
 
-	if terminalWidth >= minimumLayoutWidth {
-		output += "\n\n" + formattedCommand
-		views.RenderContainerLayout(views.GetInfoMessage(output))
+	command := fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key)
+	fmt.Println(lipgloss.NewStyle().Padding(0).Foreground(views.Green).Render(command) + "\n\n")
+
+	if err := clipboard.WriteAll(command); err == nil {
+		output = "The command has been copied to your clipboard."
 	} else {
-		views.RenderContainerLayout(views.GetInfoMessage(output))
-		fmt.Println(command + "\n\n")
+		output = "Make sure to copy it as you will not be able to see it again."
 	}
 
+	views.RenderContainerLayout(views.GetInfoMessage(output))
 }

--- a/pkg/views/server/apikey/notify.go
+++ b/pkg/views/server/apikey/notify.go
@@ -21,7 +21,7 @@ func Render(key, apiUrl string) {
 	views.RenderContainerLayout(views.GetInfoMessage(output))
 
 	command := fmt.Sprintf("daytona profile add -a %s -k %s", apiUrl, key)
-	fmt.Println(lipgloss.NewStyle().Padding(0).Foreground(views.Green).Render(command) + "\n\n")
+	fmt.Println(lipgloss.NewStyle().Padding(0).Foreground(views.Green).Render(command))
 
 	if err := clipboard.WriteAll(command); err == nil {
 		output = "The command has been copied to your clipboard."


### PR DESCRIPTION
# Auto-copy Api Key to Clipboard

## Description

With this PR, the command that is supposed to be run after `daytona api-key new` is automatically copied to the users clipboard.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #957 