### PR TITLE
fix: gitlab remove fatal error when getting project from MR

### DIFF
--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -7,12 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/xanzy/go-gitlab"
@@ -149,7 +150,8 @@ func (g *GitLabGitProvider) GetRepoPRs(repositoryId string, namespaceId string) 
 	for _, mergeRequest := range mergeRequests {
 		sourceRepo, _, err := client.Projects.GetProject(mergeRequest.SourceProjectID, nil)
 		if err != nil {
-			return nil, g.FormatError(err)
+			log.Warn(g.FormatError(err))
+			continue
 		}
 
 		response = append(response, &GitPullRequest{


### PR DESCRIPTION
# GitLab - remove fatal error when getting project from MR

## Description

Removes the fatal error when getting GitLab project from merge request - relevant when user does not have access to the MR.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1117 