### PR TITLE
fix: prebuild run prompt if run flag is provided

### DIFF
--- a/docs/daytona_prebuild_add.md
+++ b/docs/daytona_prebuild_add.md
@@ -9,7 +9,7 @@ daytona prebuild add [flags]
 ### Options
 
 ```
-      --run   Run the prebuild once after adding it (default true)
+      --run   Run the prebuild once after adding it
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_prebuild_add.yaml
+++ b/hack/docs/daytona_prebuild_add.yaml
@@ -3,7 +3,7 @@ synopsis: Add a prebuild configuration
 usage: daytona prebuild add [flags]
 options:
     - name: run
-      default_value: "true"
+      default_value: "false"
       usage: Run the prebuild once after adding it
 inherited_options:
     - name: help

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -135,5 +135,5 @@ var prebuildAddCmd = &cobra.Command{
 var runOnAddFlag bool
 
 func init() {
-	prebuildAddCmd.Flags().BoolVar(&runOnAddFlag, "run", true, "Run the prebuild once after adding it")
+	prebuildAddCmd.Flags().BoolVar(&runOnAddFlag, "run", false, "Run the prebuild once after adding it")
 }

--- a/pkg/views/prebuild/add/add.go
+++ b/pkg/views/prebuild/add/add.go
@@ -40,41 +40,49 @@ func PrebuildCreationView(prebuildAddView *PrebuildAddView, editing bool) {
 		triggerFilesInput += triggerFile + "\n"
 	}
 
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewInput().
-				Title("Commit interval").
-				Description("Leave blank to ignore push events").
-				Value(&prebuildAddView.CommitInterval).
-				Validate(func(str string) error {
-					if str == "" {
-						return nil
-					}
-					num, err := strconv.Atoi(str)
-					if err != nil {
-						return err
-					}
-					if num == 0 {
-						return errors.New("commit interval cannot be 0")
-					}
+	formFields := []huh.Field{
+		huh.NewInput().
+			Title("Commit interval").
+			Description("Leave blank to ignore push events").
+			Value(&prebuildAddView.CommitInterval).
+			Validate(func(str string) error {
+				if str == "" {
 					return nil
-				}),
-			huh.NewText().
-				Title("Trigger files").
-				Description("Enter full paths for files whose changes you want to explicitly trigger a prebuild.\nUse newlines for multiple entries.").
-				Value(&triggerFilesInput).Lines(4),
-			huh.NewInput().
-				Title("Retention").
-				Description("Maximum number of resulting builds stored at a time").
-				Value(&prebuildAddView.Retention).
-				Validate(func(str string) error {
-					_, err := strconv.Atoi(str)
+				}
+				num, err := strconv.Atoi(str)
+				if err != nil {
 					return err
-				}),
-			huh.NewConfirm().
-				Title("Run the build once on submit?").
-				Value(&prebuildAddView.RunBuildOnAdd),
-		),
+				}
+				if num == 0 {
+					return errors.New("commit interval cannot be 0")
+				}
+				return nil
+			}),
+		huh.NewText().
+			Title("Trigger files").
+			Description("Enter full paths for files whose changes you want to explicitly trigger a prebuild.\nUse newlines for multiple entries.").
+			Value(&triggerFilesInput).Lines(4),
+		huh.NewInput().
+			Title("Retention").
+			Description("Maximum number of resulting builds stored at a time").
+			Value(&prebuildAddView.Retention).
+			Validate(func(str string) error {
+				_, err := strconv.Atoi(str)
+				return err
+			}),
+	}
+
+	if !prebuildAddView.RunBuildOnAdd {
+		// Set the default value to true if run flag is not passed
+		prebuildAddView.RunBuildOnAdd = true
+
+		formFields = append(formFields, huh.NewConfirm().
+			Title("Run the build once on submit?").
+			Value(&prebuildAddView.RunBuildOnAdd))
+	}
+
+	form := huh.NewForm(
+		huh.NewGroup(formFields...),
 	).WithTheme(views.GetCustomTheme())
 
 	keyMap := huh.NewDefaultKeyMap()


### PR DESCRIPTION
# don't show prebuild run prompt if run flag is provided

## Description
This PR resolves an issue where build run prompt was appearing even when the `--run` flag was specified

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1129

