### PR TITLE
feat: auto install remote SSH extension in vscode

### DIFF
--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -21,6 +21,10 @@ import (
 
 func OpenVSCode(activeProfile config.Profile, workspaceId string, projectName string, projectProviderMetadata string) error {
 	CheckAndAlertVSCodeInstalled()
+	err := installRemoteSSHExtension()
+	if err != nil {
+		return err
+	}
 
 	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
 
@@ -190,4 +194,21 @@ func CheckAndAlertVSCodeInstalled() {
 func isVSCodeInstalled() error {
 	_, err := exec.LookPath("code")
 	return err
+}
+
+func installRemoteSSHExtension() error {
+	output, err := exec.Command("code", "--list-extensions").Output()
+	if err != nil {
+		return err
+	}
+
+	if !strings.Contains(string(output), "ms-vscode-remote.remote-ssh") {
+		fmt.Println("Installing Remote SSH extension...")
+		err = exec.Command("code", "--install-extension", "ms-vscode-remote.remote-ssh").Run()
+		if err != nil {
+			return err
+		}
+		fmt.Println("Remote SSH extension successfully installed")
+	}
+	return nil
 }


### PR DESCRIPTION
# auto install remote SSH extension in vscode

## Description

auto install remote SSH extension if it is not already installed in user's `vscode`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1094