### PR TITLE
fix: code of conduct link in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for taking the time to contribute! ❤️
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Daytona Code of Conduct](https://github.com/daytonaio/daytona/blob/contributing-update/CODE_OF_CONDUCT.md).
+[Daytona Code of Conduct](https://github.com/daytonaio/daytona/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to [info@daytona.io](mailto:info@daytona.io).
 


### PR DESCRIPTION
# fix broken code of conduct link in contributing guide

## Description
fix broken code of conduct link in contributing guide

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

fixes #1143
