### PR TITLE
fix: broken code of conduct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for taking the time to contribute! ❤️
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Daytona Code of Conduct](https://github.com/daytonaio/daytona/blob/contributing-update/CODE_OF_CONDUCT.md).
+[Daytona Code of Conduct](https://github.com/daytonaio/daytona?tab=coc-ov-file#readme).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to [info@daytona.io](mailto:info@daytona.io).
 


### PR DESCRIPTION
# Pull Request Title
Fixed broken Code of Conduct link

## Description
This pull request addresses the issue of a broken link in the repository’s documentation. The previous link to the Code of Conduct resulted in a 404 Page Not Found error.

Motivation and Context:
The Code of Conduct is an important document that outlines the expected behavior of contributors. Ensuring that this link works correctly is essential for maintaining a welcoming and informative environment for all contributors.

##Dependencies:
No additional dependencies are required for this change.

- [ ] This change requires a documentation update
- [✅ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1143 


