### PR TITLE
fix: bitbucket server context parse

### DIFF
--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -422,7 +422,12 @@ func (g *BitbucketServerGitProvider) ParseStaticGitContext(repoUrl string) (*Sta
 	matches := re.FindStringSubmatch(repoUrl)
 
 	if len(matches) < 4 {
-		return nil, fmt.Errorf("could not extract project key and repo name from URL: %s", repoUrl)
+		// // Handle scm format
+		re = regexp.MustCompile(`(https?://[^/]+)/scm/([^/]+)/([^/.]+)(?:\.git)?(?:/([^/?#]+))?(?:/([^/?#\\]+))?(?:\?at=refs%2Fheads%2F([^/?#]+))?`)
+		matches = re.FindStringSubmatch(repoUrl)
+		if len(matches) < 4 {
+			return nil, fmt.Errorf("could not extract project key and repo name from URL: %s", repoUrl)
+		}
 	}
 
 	baseUrl := matches[1]


### PR DESCRIPTION
# Fix Bitbucket Server Context Parsing

## Description

Because, in the creation process, the gitprovider is expected to parse the clone url, the bitbucket context parsing would fail. This PR adds support for parsing the clone url as well. Additionally, refactored how git providers are fetched for URLs which was part of the issue.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
