### PR TITLE
fix: bitbucket pr list options argument

### DIFF
--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -150,17 +150,20 @@ func (g *BitbucketGitProvider) GetRepoPRs(repositoryId string, namespaceId strin
 	client := g.getApiClient()
 	var response []*GitPullRequest
 
-	fullName := fmt.Sprintf("%s/%s", namespaceId, repositoryId)
-
-	owner, repo, err := g.getOwnerAndRepoFromFullName(fullName)
-	if err != nil {
-		return nil, err
+	opts := &bitbucket.PullRequestsOptions{
+		RepoSlug: repositoryId,
+		Owner:    namespaceId,
 	}
 
-	prList, err := client.Repositories.PullRequests.Get(&bitbucket.PullRequestsOptions{
-		Owner:    owner,
-		RepoSlug: repo,
-	})
+	owner, repo, err := g.getOwnerAndRepoFromFullName(repositoryId)
+	if err == nil {
+		opts = &bitbucket.PullRequestsOptions{
+			RepoSlug: repo,
+			Owner:    owner,
+		}
+	}
+
+	prList, err := client.Repositories.PullRequests.Get(opts)
 	if err != nil {
 		return nil, g.FormatError(err)
 	}
@@ -193,8 +196,8 @@ func (g *BitbucketGitProvider) GetRepoPRs(repositoryId string, namespaceId strin
 			Sha:             pr.Source.Commit.Hash,
 			SourceRepoId:    pr.Source.Repository.Full_name,
 			SourceRepoUrl:   repoUrl,
-			SourceRepoOwner: owner,
-			SourceRepoName:  repo,
+			SourceRepoOwner: opts.Owner,
+			SourceRepoName:  opts.RepoSlug,
 		})
 	}
 


### PR DESCRIPTION
# Bitbucket PR list options argument fix

## Description

Fixes an issue with incorrectly formed Bitbucket PR options argument properties that lead to 404 errors

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
