### PR TITLE
feat: port forward in workspacemode is public by default

### DIFF
--- a/docs/workspace_mode/daytona.md
+++ b/docs/workspace_mode/daytona.md
@@ -23,7 +23,7 @@ daytona [flags]
 * [daytona autocomplete](daytona_autocomplete.md)	 - Adds completion script for your shell enviornment
 * [daytona docs](daytona_docs.md)	 - Opens the Daytona documentation in your default browser.
 * [daytona expose](daytona_expose.md)	 - Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project
-* [daytona forward](daytona_forward.md)	 - Forward a port from the project to your local machine
+* [daytona forward](daytona_forward.md)	 - Forward a port publicly via an URL
 * [daytona info](daytona_info.md)	 - Show project info
 * [daytona list](daytona_list.md)	 - List workspaces
 * [daytona restart](daytona_restart.md)	 - Restart the project

--- a/docs/workspace_mode/daytona_forward.md
+++ b/docs/workspace_mode/daytona_forward.md
@@ -1,15 +1,9 @@
 ## daytona forward
 
-Forward a port from the project to your local machine
+Forward a port publicly via an URL
 
 ```
 daytona forward [PORT] [flags]
-```
-
-### Options
-
-```
-      --public   Should be port be available publicly via an URL
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/workspace_mode/daytona.yaml
+++ b/hack/docs/workspace_mode/daytona.yaml
@@ -15,7 +15,7 @@ see_also:
     - daytona autocomplete - Adds completion script for your shell enviornment
     - daytona docs - Opens the Daytona documentation in your default browser.
     - daytona expose - Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project
-    - daytona forward - Forward a port from the project to your local machine
+    - daytona forward - Forward a port publicly via an URL
     - daytona info - Show project info
     - daytona list - List workspaces
     - daytona restart - Restart the project

--- a/hack/docs/workspace_mode/daytona_forward.yaml
+++ b/hack/docs/workspace_mode/daytona_forward.yaml
@@ -1,10 +1,6 @@
 name: daytona forward
-synopsis: Forward a port from the project to your local machine
+synopsis: Forward a port publicly via an URL
 usage: daytona forward [PORT] [flags]
-options:
-    - name: public
-      default_value: "false"
-      usage: Should be port be available publicly via an URL
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/workspacemode/forward.go
+++ b/pkg/cmd/workspacemode/forward.go
@@ -4,58 +4,29 @@
 package workspacemode
 
 import (
-	"fmt"
 	"strconv"
 
-	"github.com/daytonaio/daytona/cmd/daytona/config"
-	"github.com/daytonaio/daytona/internal/cmd/tailscale"
 	"github.com/daytonaio/daytona/internal/util"
 	defaultPortForwardCmd "github.com/daytonaio/daytona/pkg/cmd/ports"
-	"github.com/daytonaio/daytona/pkg/views"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var publicPreview bool
-
 var portForwardCmd = &cobra.Command{
 	Use:     "forward [PORT]",
-	Short:   "Forward a port from the project to your local machine",
+	Short:   "Forward a port publicly via an URL",
 	Args:    cobra.ExactArgs(1),
 	GroupID: util.WORKSPACE_GROUP,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := config.GetConfig()
-		if err != nil {
-			return err
-		}
-		activeProfile, err := c.GetActiveProfile()
-		if err != nil {
-			return err
-		}
-
 		port, err := strconv.Atoi(args[0])
 		if err != nil {
 			return err
 		}
 
-		hostPort, errChan := tailscale.ForwardPort(workspaceId, projectName, uint16(port), activeProfile)
-
-		if hostPort == nil {
-			if err = <-errChan; err != nil {
-				return err
-			}
-		} else {
-			if *hostPort != uint16(port) {
-				views.RenderInfoMessage(fmt.Sprintf("Port %d already in use.", port))
-			}
-			views.RenderInfoMessage(fmt.Sprintf("Port available at http://localhost:%d\n", *hostPort))
-		}
-
-		if publicPreview {
-			go func() {
-				errChan <- defaultPortForwardCmd.ForwardPublicPort(workspaceId, projectName, *hostPort, uint16(port))
-			}()
-		}
+		errChan := make(chan error)
+		go func() {
+			errChan <- defaultPortForwardCmd.ForwardPublicPort(workspaceId, projectName, uint16(port), uint16(port))
+		}()
 
 		for {
 			err := <-errChan
@@ -64,8 +35,4 @@ var portForwardCmd = &cobra.Command{
 			}
 		}
 	},
-}
-
-func init() {
-	portForwardCmd.Flags().BoolVar(&publicPreview, "public", false, "Should be port be available publicly via an URL")
 }


### PR DESCRIPTION
# Pull Request Title

## Description

The tailscale forward inside a workspace/project was redundant so this PR removes that and makes public forwarding the default behavior.

### BREAKING CHANGE
removed the public flag from forward inside a workspace/project

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1156 