### PR TITLE
fix: bitbucket repo list missing entries

### DIFF
--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -69,7 +69,6 @@ func (g *BitbucketGitProvider) GetRepositories(namespace string) ([]*GitReposito
 
 	repoList, err := client.Repositories.ListForAccount(&bitbucket.RepositoriesOptions{
 		Owner:   namespace,
-		Page:    &[]int{1}[0],
 		Keyword: nil,
 	})
 	if err != nil {


### PR DESCRIPTION
# Bitbucket repo list missing entries

## Description

Fixes missing repos when listing repos for Bitbucket in the TUI

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/23c4a93d-d02a-4ce2-b1ca-27938c272474)
