### PR TITLE
fix: config client id getting

### DIFF
--- a/internal/util/apiclient/api_client.go
+++ b/internal/util/apiclient/api_client.go
@@ -68,7 +68,7 @@ func GetApiClient(profile *config.Profile) (*apiclient.APIClient, error) {
 	if c.TelemetryEnabled {
 		clientConfig.AddDefaultHeader(telemetry.ENABLED_HEADER, "true")
 		clientConfig.AddDefaultHeader(telemetry.SESSION_ID_HEADER, internal.SESSION_ID)
-		clientConfig.AddDefaultHeader(telemetry.CLIENT_ID_HEADER, c.Id)
+		clientConfig.AddDefaultHeader(telemetry.CLIENT_ID_HEADER, config.GetClientId())
 		if internal.WorkspaceMode() {
 			clientConfig.AddDefaultHeader(telemetry.SOURCE_HEADER, string(telemetry.CLI_PROJECT_SOURCE))
 		} else {

--- a/pkg/cmd/purge.go
+++ b/pkg/cmd/purge.go
@@ -109,7 +109,7 @@ var purgeCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		ctx = context.WithValue(ctx, telemetry.CLIENT_ID_CONTEXT_KEY, c.Id)
+		ctx = context.WithValue(ctx, telemetry.CLIENT_ID_CONTEXT_KEY, config.GetClientId())
 		ctx = context.WithValue(ctx, telemetry.ENABLED_CONTEXT_KEY, c.TelemetryEnabled)
 
 		errCh := make(chan error)

--- a/pkg/views/config/view.go
+++ b/pkg/views/config/view.go
@@ -15,7 +15,7 @@ import (
 func Render(cfg *config.Config, showApiKeysFlag bool) {
 	output := "\n"
 
-	output += fmt.Sprintf("%s %s", views.GetPropertyKey("ID: "), cfg.Id) + "\n\n"
+	output += fmt.Sprintf("%s %s", views.GetPropertyKey("ID: "), config.GetClientId()) + "\n\n"
 
 	output += fmt.Sprintf("%s %s", views.GetPropertyKey("Default IDE: "), cfg.DefaultIdeId) + "\n\n"
 


### PR DESCRIPTION
# Fix Config Client Id Getting

## Description

Fixes getting the config client ID so it's consistent everywhere. Before this PR, the client ID was correctly fetched only in the root command (which allowed overriding with `DAYTONA_CLIENT_ID`)

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
