### PR TITLE
feat: spinner during repo url validation

### DIFF
--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
 const maxWidth = 160
@@ -79,9 +80,11 @@ func GetRepositoryFromUrlInput(multiProject bool, projectOrder int, apiClient *a
 		Value(&initialRepoUrl).
 		Key("initialProjectRepo").
 		Validate(func(str string) error {
-			var err error
-			repo, err = validateRepoUrl(str, apiClient)
-			return err
+			return views_util.WithInlineSpinner("Validating", func() error {
+				var err error
+				repo, err = validateRepoUrl(str, apiClient)
+				return err
+			})
 		})
 
 	dTheme := views.GetCustomTheme()


### PR DESCRIPTION
# Spinner during repo URL validation

## Description

Adds a spinner to the "Enter a custom repository URL" form's validation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1155 

## Screenshots

![image](https://github.com/user-attachments/assets/6fd8ddb9-d463-492a-b039-11f463b10524)