### PR TITLE
telemetry: track command errors

### DIFF
--- a/cmd/daytona/main.go
+++ b/cmd/daytona/main.go
@@ -20,11 +20,17 @@ import (
 
 func main() {
 	if internal.WorkspaceMode() {
-		workspacemode.Execute()
+		err := workspacemode.Execute()
+		if err != nil {
+			log.Fatal(err)
+		}
 		return
 	}
 
-	cmd.Execute()
+	err := cmd.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func init() {

--- a/pkg/cmd/agent/agent.go
+++ b/pkg/cmd/agent/agent.go
@@ -26,7 +26,7 @@ var AgentCmd = &cobra.Command{
 	Use:   "agent",
 	Short: "Start the agent process",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		setLogLevel()
 
 		agentMode := config.ModeProject
@@ -37,7 +37,7 @@ var AgentCmd = &cobra.Command{
 
 		c, err := config.GetConfig(agentMode)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		c.ProjectDir = filepath.Join(os.Getenv("HOME"), c.ProjectName)
 
@@ -50,7 +50,7 @@ var AgentCmd = &cobra.Command{
 		if c.LogFilePath != nil {
 			logFile, err := os.OpenFile(*c.LogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			defer logFile.Close()
 			gitLogWriter = io.MultiWriter(os.Stdout, logFile)
@@ -91,10 +91,7 @@ var AgentCmd = &cobra.Command{
 			TelemetryEnabled: telemetryEnabled,
 		}
 
-		err = agent.Start()
-		if err != nil {
-			log.Fatal(err)
-		}
+		return agent.Start()
 	},
 }
 

--- a/pkg/cmd/agent/logs.go
+++ b/pkg/cmd/agent/logs.go
@@ -5,13 +5,13 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/agent/config"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -20,16 +20,16 @@ var followFlag bool
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Output Daytona Agent logs",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		logFilePath := config.GetLogFilePath()
 
 		if logFilePath == nil {
-			log.Fatal("Log file path not set")
+			return errors.New("log file path not set")
 		}
 
 		file, err := os.Open(*logFilePath)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		defer file.Close()
 
@@ -41,13 +41,13 @@ var logsCmd = &cobra.Command{
 		for {
 			select {
 			case <-context.Background().Done():
-				return
+				return nil
 			case err := <-errChan:
 				if err != nil {
 					if err != io.EOF {
-						log.Fatal(err)
+						return err
 					}
-					return
+					return nil
 				}
 			case msg := <-msgChan:
 				fmt.Println(string(msg))

--- a/pkg/cmd/apikey/list.go
+++ b/pkg/cmd/apikey/list.go
@@ -9,7 +9,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/server/apikey"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -17,26 +16,27 @@ var listCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List API keys",
 	Aliases: []string{"ls"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
-		apiKeyList, _, err := apiClient.ApiKeyAPI.ListClientApiKeys(ctx).Execute()
+		apiKeyList, res, err := apiClient.ApiKeyAPI.ListClientApiKeys(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(nil, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(apiKeyList)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		apikey.ListApiKeys(apiKeyList)
+		return nil
 	},
 }
 

--- a/pkg/cmd/autocomplete.go
+++ b/pkg/cmd/autocomplete.go
@@ -16,12 +16,11 @@ var AutoCompleteCmd = &cobra.Command{
 	Use:   "autocomplete [bash|zsh|fish|powershell]",
 	Short: "Adds completion script for your shell enviornment",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		shell := args[0]
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			fmt.Printf("Error finding user home directory: %s\n", err)
-			return
+			return fmt.Errorf("Error finding user home directory: %s\n", err)
 		}
 
 		var filePath, profilePath string
@@ -39,14 +38,12 @@ var AutoCompleteCmd = &cobra.Command{
 			filePath = filepath.Join(homeDir, "daytona.completion_script.ps1")
 			profilePath = filepath.Join(homeDir, "Documents", "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1")
 		default:
-			fmt.Println("Unsupported shell type. Please use bash, zsh, fish, or powershell.")
-			return
+			return fmt.Errorf("Unsupported shell type. Please use bash, zsh, fish, or powershell.")
 		}
 
 		file, err := os.Create(filePath)
 		if err != nil {
-			fmt.Printf("Error creating completion script file: %s\n", err)
-			return
+			return fmt.Errorf("Error creating completion script file: %s\n", err)
 		}
 		defer file.Close()
 
@@ -62,8 +59,7 @@ var AutoCompleteCmd = &cobra.Command{
 		}
 
 		if err != nil {
-			fmt.Printf("Error generating completion script: %s\n", err)
-			return
+			return fmt.Errorf("Error generating completion script: %s\n", err)
 		}
 
 		sourceCommand := fmt.Sprintf("\nsource %s\n", filePath)
@@ -87,19 +83,19 @@ var AutoCompleteCmd = &cobra.Command{
 			// Append the source command to the shell's profile file if not present
 			profile, err := os.OpenFile(profilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 			if err != nil {
-				fmt.Printf("Error opening profile file (%s): %s\n", profilePath, err)
-				return
+				return fmt.Errorf("Error opening profile file (%s): %s\n", profilePath, err)
 			}
 			defer profile.Close()
 
 			if _, err := profile.WriteString(sourceCommand); err != nil {
-				fmt.Printf("Error writing to profile file (%s): %s\n", profilePath, err)
-				return
+				return fmt.Errorf("Error writing to profile file (%s): %s\n", profilePath, err)
 			}
 		}
 
 		fmt.Println("Autocomplete script generated and injected successfully.")
 		fmt.Printf("Please source your %s profile to apply the changes or restart your terminal.\n", shell)
 		fmt.Printf("For manual sourcing, use: source %s\n", profilePath)
+
+		return nil
 	},
 }

--- a/pkg/cmd/build/delete.go
+++ b/pkg/cmd/build/delete.go
@@ -6,7 +6,6 @@ package build
 import (
 	"context"
 	"fmt"
-	"log"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -19,44 +18,44 @@ var buildDeleteCmd = &cobra.Command{
 	Short:   "Delete a build",
 	Aliases: []string{"remove", "rm"},
 	Args:    cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		var buildId string
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if allFlag {
 			res, err := apiClient.BuildAPI.DeleteAllBuilds(ctx).Force(forceFlag).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			views.RenderInfoMessage("All builds have been marked for deletion")
-			return
+			return nil
 		}
 
 		if prebuildIdFlag != "" {
 			res, err := apiClient.BuildAPI.DeleteBuildsFromPrebuild(ctx, prebuildIdFlag).Force(forceFlag).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			views.RenderInfoMessage(fmt.Sprintf("All builds from prebuild %s have been marked for deletion\n", prebuildIdFlag))
-			return
+			return nil
 		}
 
 		if len(args) == 0 {
 			buildList, res, err := apiClient.BuildAPI.ListBuilds(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			build := selection.GetBuildFromPrompt(buildList, "Delete")
 			if build == nil {
-				return
+				return nil
 			}
 			buildId = build.Id
 		} else {
@@ -65,9 +64,10 @@ var buildDeleteCmd = &cobra.Command{
 
 		res, err := apiClient.BuildAPI.DeleteBuild(ctx, buildId).Force(forceFlag).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 		views.RenderInfoMessage(fmt.Sprintf("Build %s has been marked for deletion", buildId))
+		return nil
 	},
 }
 

--- a/pkg/cmd/build/info.go
+++ b/pkg/cmd/build/info.go
@@ -5,7 +5,6 @@ package build
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
@@ -21,24 +20,24 @@ var buildInfoCmd = &cobra.Command{
 	Short:   "Show build info",
 	Aliases: []string{"view", "inspect"},
 	Args:    cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		var build *apiclient.Build
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if len(args) == 0 {
 			buildList, res, err := apiClient.BuildAPI.ListBuilds(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			if format.FormatFlag != "" {
@@ -51,23 +50,24 @@ var buildInfoCmd = &cobra.Command{
 			}
 
 			if build == nil {
-				return
+				return nil
 			}
 		} else {
 			var res *http.Response
 			build, res, err = apiClient.BuildAPI.GetBuild(ctx, args[0]).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(build)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		info.Render(build, apiServerConfig, false)
+		return nil
 	},
 }
 

--- a/pkg/cmd/build/list.go
+++ b/pkg/cmd/build/list.go
@@ -5,7 +5,6 @@ package build
 
 import (
 	"context"
-	"log"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
@@ -19,36 +18,37 @@ var buildListCmd = &cobra.Command{
 	Short:   "List all builds",
 	Aliases: []string{"ls"},
 	Args:    cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		buildList, res, err := apiClient.BuildAPI.ListBuilds(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if len(buildList) == 0 {
 			views.RenderInfoMessage("No builds found.")
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(buildList)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		view.ListBuilds(buildList, apiServerConfig)
+		return nil
 	},
 }
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -43,10 +43,10 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:      true,
 	SilenceErrors:     true,
 	DisableAutoGenTag: true,
-	Run:               RunInitialScreenFlow,
+	RunE:              RunInitialScreenFlow,
 }
 
-func Execute() {
+func Execute() error {
 	rootCmd.AddGroup(&cobra.Group{ID: WORKSPACE_GROUP, Title: "Workspaces & Projects"})
 	rootCmd.AddGroup(&cobra.Group{ID: SERVER_GROUP, Title: "Server"})
 	rootCmd.AddGroup(&cobra.Group{ID: PROFILE_GROUP, Title: "Profile"})
@@ -108,10 +108,7 @@ func Execute() {
 			telemetryService.Close()
 		}
 
-		if helpErr != nil {
-			log.Fatal(err)
-		}
-		return
+		return helpErr
 	}
 
 	startTime := time.Now()
@@ -161,9 +158,7 @@ func Execute() {
 		telemetryService.Close()
 	}
 
-	if err != nil {
-		log.Fatal(err)
-	}
+	return err
 }
 
 func ValidateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command, err error) {
@@ -226,35 +221,34 @@ func SetupRootCommand(cmd *cobra.Command) {
 	}
 }
 
-func RunInitialScreenFlow(cmd *cobra.Command, args []string) {
+func RunInitialScreenFlow(cmd *cobra.Command, args []string) error {
 	command, err := view.GetCommand()
 	if err != nil {
 		if common.IsCtrlCAbort(err) {
-			return
+			return nil
 		} else {
-			log.Fatal(err)
+			return err
 		}
 	}
 
 	switch command {
 	case "server":
-		ServerCmd.Run(cmd, []string{})
+		return ServerCmd.RunE(cmd, []string{})
 	case "create":
-		CreateCmd.Run(cmd, []string{})
+		return CreateCmd.RunE(cmd, []string{})
 	case "code":
-		CodeCmd.Run(cmd, []string{})
+		return CodeCmd.RunE(cmd, []string{})
 	case "git-provider add":
-		GitProviderAddCmd.Run(cmd, []string{})
+		return GitProviderAddCmd.RunE(cmd, []string{})
 	case "target set":
-		TargetSetCmd.Run(cmd, []string{})
+		return TargetSetCmd.RunE(cmd, []string{})
 	case "docs":
-		DocsCmd.Run(cmd, []string{})
+		return DocsCmd.RunE(cmd, []string{})
 	case "help":
-		err := cmd.Help()
-		if err != nil {
-			log.Fatal(err)
-		}
+		return cmd.Help()
 	}
+
+	return nil
 }
 
 func GetCmdTelemetryData(cmd *cobra.Command) map[string]interface{} {

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	config_view "github.com/daytonaio/daytona/pkg/views/config"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,10 +17,10 @@ var configCmd = &cobra.Command{
 	Short:   "Output Daytona configuration",
 	Aliases: []string{"cfg"},
 	Args:    cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if format.FormatFlag != "" {
@@ -34,10 +33,11 @@ var configCmd = &cobra.Command{
 
 			formattedData := format.NewFormatter(&c)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		config_view.Render(c, showApiKeysFlag)
+		return nil
 	},
 }
 

--- a/pkg/cmd/containerregistry/list.go
+++ b/pkg/cmd/containerregistry/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views"
 	containerregistry_view "github.com/daytonaio/daytona/pkg/views/containerregistry/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -20,29 +19,30 @@ var containerRegistryListCmd = &cobra.Command{
 	Short:   "Lists container registries",
 	Aliases: []string{"ls"},
 	Args:    cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		containerRegistries, res, err := apiClient.ContainerRegistryAPI.ListContainerRegistries(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		if len(containerRegistries) == 0 {
 			views.RenderInfoMessage("No container registries found. Set a new container registry by running 'daytona container-registry set'")
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(containerRegistries)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		containerregistry_view.ListRegistries(containerRegistries)
+		return nil
 	},
 }
 

--- a/pkg/cmd/containerregistry/set.go
+++ b/pkg/cmd/containerregistry/set.go
@@ -14,8 +14,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	containerregistry_view "github.com/daytonaio/daytona/pkg/views/containerregistry"
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var containerRegistrySetCmd = &cobra.Command{
@@ -23,18 +21,18 @@ var containerRegistrySetCmd = &cobra.Command{
 	Short:   "Set container registry",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"add", "update", "register"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var registryDto *apiclient.ContainerRegistry
 		selectedServer := serverFlag
 
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		activeProfile, err := c.GetActiveProfile()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		registryView := containerregistry_view.RegistryView{
@@ -45,12 +43,12 @@ var containerRegistrySetCmd = &cobra.Command{
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		containerRegistries, res, err := apiClient.ContainerRegistryAPI.ListContainerRegistries(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if serverFlag == "" || usernameFlag == "" || passwordFlag == "" {
@@ -61,9 +59,9 @@ var containerRegistrySetCmd = &cobra.Command{
 				registryDto, err := containerregistry_view.GetRegistryFromPrompt(containerRegistries, activeProfile.Name, true)
 				if err != nil {
 					if common.IsCtrlCAbort(err) {
-						return
+						return nil
 					} else {
-						log.Fatal(err)
+						return err
 					}
 				}
 
@@ -91,10 +89,11 @@ var containerRegistrySetCmd = &cobra.Command{
 
 		res, err = apiClient.ContainerRegistryAPI.SetContainerRegistry(context.Background(), url.QueryEscape(selectedServer)).ContainerRegistry(*registryDto).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		views.RenderInfoMessage("Registry set successfully")
+		return nil
 	},
 }
 

--- a/pkg/cmd/docs.go
+++ b/pkg/cmd/docs.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -22,12 +21,9 @@ var DocsCmd = &cobra.Command{
 	Short:   "Opens the Daytona documentation in your default browser.",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"documentation", "doc"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		output := views.GetBoldedInfoMessage("Opening the Daytona documentation in your default browser. If opening fails, you can go to " + linkStyle.Render(docsURL) + " manually.")
 		fmt.Println(output)
-		err := browser.OpenURL(docsURL)
-		if err != nil {
-			log.Fatal(err)
-		}
+		return browser.OpenURL(docsURL)
 	},
 }

--- a/pkg/cmd/generatedocs.go
+++ b/pkg/cmd/generatedocs.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -19,10 +18,10 @@ var defaultDirectory = "docs"
 var generateDocsCmd = &cobra.Command{
 	Use:   "generate-docs",
 	Short: "Generate documentation for the Daytona CLI",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		directory, err := cmd.Flags().GetString("directory")
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if directory == "" {
@@ -31,25 +30,26 @@ var generateDocsCmd = &cobra.Command{
 
 		err = os.MkdirAll(directory, os.ModePerm)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = os.MkdirAll(filepath.Join(yamlDirectory, directory), os.ModePerm)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = doc.GenMarkdownTree(cmd.Root(), directory)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = doc.GenYamlTree(cmd.Root(), filepath.Join(yamlDirectory, directory))
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		fmt.Printf("Documentation generated at %s\n", directory)
+		return nil
 	},
 	Hidden: true,
 }

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -10,7 +10,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,12 +17,12 @@ var GitProviderAddCmd = &cobra.Command{
 	Use:     "add",
 	Aliases: []string{"new", "register", "update"},
 	Short:   "Register a Git providers",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		setGitProviderConfig := apiclient.SetGitProviderConfig{}
@@ -33,14 +32,15 @@ var GitProviderAddCmd = &cobra.Command{
 		gitprovider_view.GitProviderSelectionView(&setGitProviderConfig, nil, false)
 
 		if setGitProviderConfig.Id == "" {
-			return
+			return nil
 		}
 
 		res, err := apiClient.GitProviderAPI.SetGitProvider(ctx).GitProviderConfig(setGitProviderConfig).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		views.RenderInfoMessage("Git provider has been registered")
+		return nil
 	},
 }

--- a/pkg/cmd/gitprovider/delete.go
+++ b/pkg/cmd/gitprovider/delete.go
@@ -11,7 +11,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -44,12 +43,12 @@ var gitProviderDeleteCmd = &cobra.Command{
 		gitprovider_view.GitProviderSelectionView(&gitProviderData, gitProviders, true)
 
 		if gitProviderData.Id == "" {
-			return errors.New("Git provider id can not be blank")
+			return errors.New("git provider id can not be blank")
 		}
 
 		_, err = apiClient.GitProviderAPI.RemoveGitProvider(ctx, gitProviderData.Id).Execute()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		views.RenderInfoMessage("Git provider has been removed")

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -12,7 +12,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -20,20 +19,20 @@ var gitProviderListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "Lists your registered Git providers",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		gitProviders, res, err := apiClient.GitProviderAPI.ListGitProviders(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		if len(gitProviders) == 0 {
 			views.RenderInfoMessage("No git providers registered. Add a new git provider by\npreparing a Personal Access Token and running 'daytona git-providers add'")
-			return
+			return nil
 		}
 
 		views.RenderMainTitle("Registered Git Providers:")
@@ -58,12 +57,13 @@ var gitProviderListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(gitProviderViewList)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		for _, gitProviderView := range gitProviderViewList {
 			views.RenderListLine(fmt.Sprintf("%s (%s)", gitProviderView.Name, gitProviderView.Username))
 		}
+		return nil
 	},
 }
 

--- a/pkg/cmd/ide.go
+++ b/pkg/cmd/ide.go
@@ -22,10 +22,10 @@ var ideCmd = &cobra.Command{
 	Use:     "ide",
 	Short:   "Choose the default IDE",
 	GroupID: util.PROFILE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		ideList := config.GetIdeList()
@@ -34,7 +34,7 @@ var ideCmd = &cobra.Command{
 		chosenIdeId := ide.GetIdeIdFromPrompt(ideList)
 
 		if chosenIdeId == "" {
-			return
+			return nil
 		}
 
 		for _, ide := range ideList {
@@ -70,10 +70,11 @@ var ideCmd = &cobra.Command{
 
 		err = c.Save()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		content := fmt.Sprintf("%s %s", views.GetPropertyKey("Default IDE: "), chosenIde.Name)
 		views.RenderContainerLayout(views.GetInfoMessage(content))
+		return nil
 	},
 }

--- a/pkg/cmd/ports/forward.go
+++ b/pkg/cmd/ports/forward.go
@@ -32,23 +32,23 @@ var PortForwardCmd = &cobra.Command{
 	Short:   "Forward a port from a project to your local machine",
 	GroupID: util.WORKSPACE_GROUP,
 	Args:    cobra.RangeArgs(2, 3),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		activeProfile, err := c.GetActiveProfile()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		port, err := strconv.Atoi(args[0])
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		workspace, err := apiclient.GetWorkspace(args[1], true)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		workspaceId = workspace.Id
 
@@ -57,7 +57,7 @@ var PortForwardCmd = &cobra.Command{
 		} else {
 			projectName, err = apiclient.GetFirstWorkspaceProjectName(workspaceId, projectName, nil)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 		}
 
@@ -65,7 +65,7 @@ var PortForwardCmd = &cobra.Command{
 
 		if hostPort == nil {
 			if err = <-errChan; err != nil {
-				log.Fatal(err)
+				return err
 			}
 		} else {
 			if *hostPort != uint16(port) {

--- a/pkg/cmd/ports/forward.go
+++ b/pkg/cmd/ports/forward.go
@@ -119,7 +119,10 @@ func ForwardPublicPort(workspaceId, projectName string, hostPort, targetPort uin
 		time.Sleep(1 * time.Second)
 		var url = fmt.Sprintf("%s://%s.%s", serverConfig.Frps.Protocol, subDomain, serverConfig.Frps.Domain)
 		views.RenderInfoMessage(fmt.Sprintf("Port available at %s", url))
-		renderQr(url)
+		err := renderQr(url)
+		if err != nil {
+			log.Error(err)
+		}
 	}()
 
 	_, service, err := frpc.GetService(frpc.FrpcConnectParams{
@@ -136,10 +139,11 @@ func ForwardPublicPort(workspaceId, projectName string, hostPort, targetPort uin
 	return service.Run(context.Background())
 }
 
-func renderQr(s string) {
+func renderQr(s string) error {
 	q, err := qrcode.New(s, qrcode.Medium)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	fmt.Println(q.ToSmallString(true))
+	return nil
 }

--- a/pkg/cmd/prebuild/info.go
+++ b/pkg/cmd/prebuild/info.go
@@ -5,7 +5,6 @@ package prebuild
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
@@ -21,7 +20,7 @@ var prebuildInfoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Show prebuild configuration info",
 	Args:  cobra.MaximumNArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var prebuild *apiclient.PrebuildDTO
 		var res *http.Response
 
@@ -29,7 +28,7 @@ var prebuildInfoCmd = &cobra.Command{
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if len(args) < 2 {
@@ -40,18 +39,18 @@ var prebuildInfoCmd = &cobra.Command{
 				selectedProjectConfigName = args[0]
 				prebuilds, res, err = apiClient.PrebuildAPI.ListPrebuildsForProjectConfig(context.Background(), selectedProjectConfigName).Execute()
 				if err != nil {
-					log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+					return apiclient_util.HandleErrorResponse(res, err)
 				}
 			} else {
 				prebuilds, res, err = apiClient.PrebuildAPI.ListPrebuilds(context.Background()).Execute()
 				if err != nil {
-					log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+					return apiclient_util.HandleErrorResponse(res, err)
 				}
 			}
 
 			if len(prebuilds) == 0 {
 				views.RenderInfoMessage("No prebuilds found")
-				return
+				return nil
 			}
 
 			if format.FormatFlag != "" {
@@ -64,22 +63,23 @@ var prebuildInfoCmd = &cobra.Command{
 			}
 
 			if prebuild == nil {
-				return
+				return nil
 			}
 		} else {
 			prebuild, res, err = apiClient.PrebuildAPI.GetPrebuild(ctx, args[0], args[1]).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(prebuild)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		info.Render(prebuild, false)
+		return nil
 	},
 }
 

--- a/pkg/cmd/prebuild/list.go
+++ b/pkg/cmd/prebuild/list.go
@@ -5,7 +5,6 @@ package prebuild
 
 import (
 	"context"
-	"log"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
@@ -19,31 +18,32 @@ var prebuildListCmd = &cobra.Command{
 	Short:   "List prebuild configurations",
 	Aliases: []string{"ls"},
 	Args:    cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		prebuildList, res, err := apiClient.PrebuildAPI.ListPrebuilds(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if len(prebuildList) == 0 {
 			views.RenderInfoMessage("No prebuilds found. Add a new prebuild by running 'daytona prebuild add'")
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(prebuildList)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		view.ListPrebuilds(prebuildList)
+		return nil
 	},
 }
 

--- a/pkg/cmd/profile/add.go
+++ b/pkg/cmd/profile/add.go
@@ -8,7 +8,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/views/profile"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -17,11 +16,11 @@ var ProfileAddCmd = &cobra.Command{
 	Short:   "Add profile",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"new"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
 			if !config.IsNotExist(err) {
-				log.Fatal(err)
+				return err
 			}
 
 			c = &config.Config{
@@ -30,7 +29,7 @@ var ProfileAddCmd = &cobra.Command{
 			}
 
 			if err := c.Save(); err != nil {
-				log.Fatal(err)
+				return err
 			}
 		}
 
@@ -46,9 +45,7 @@ var ProfileAddCmd = &cobra.Command{
 			_, err = CreateProfile(c, &profileAddView, true)
 		}
 
-		if err != nil {
-			log.Fatal(err)
-		}
+		return err
 	},
 }
 

--- a/pkg/cmd/profile/delete.go
+++ b/pkg/cmd/profile/delete.go
@@ -4,6 +4,8 @@
 package profile
 
 import (
+	"errors"
+
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/views/profile"
 
@@ -16,10 +18,10 @@ var profileDeleteCmd = &cobra.Command{
 	Short:   "Delete profile [PROFILE_NAME]",
 	Args:    cobra.RangeArgs(0, 1),
 	Aliases: []string{"remove", "rm"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		var chosenProfileId string
@@ -30,11 +32,11 @@ var profileDeleteCmd = &cobra.Command{
 
 			chosenProfile, err = profile.GetProfileFromPrompt(profilesList, c.ActiveProfileId, false)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 
 			if chosenProfile == nil {
-				return
+				return nil
 			}
 
 			chosenProfileId = chosenProfile.Id
@@ -43,7 +45,7 @@ var profileDeleteCmd = &cobra.Command{
 		}
 
 		if chosenProfileId == "default" {
-			log.Fatal("Can not delete default profile")
+			return errors.New("can not delete default profile")
 		}
 
 		for _, profile := range c.Profiles {
@@ -54,8 +56,7 @@ var profileDeleteCmd = &cobra.Command{
 		}
 
 		if chosenProfile == nil {
-			log.Fatal("Profile does not exist")
-			return
+			return errors.New("profile does not exist")
 		}
 
 		if c.ActiveProfileId == chosenProfile.Id {
@@ -66,12 +67,13 @@ var profileDeleteCmd = &cobra.Command{
 			if profile.Name == chosenProfile.Name || profile.Id == chosenProfile.Id {
 				err = c.RemoveProfile(profile.Id)
 				if err != nil {
-					log.Fatal(err)
+					return err
 				}
 				break
 			}
 		}
 
 		log.Infof("Deleted profile %s", chosenProfile.Name)
+		return nil
 	},
 }

--- a/pkg/cmd/profile/edit.go
+++ b/pkg/cmd/profile/edit.go
@@ -9,7 +9,6 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/views/profile"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -17,10 +16,10 @@ var profileEditCmd = &cobra.Command{
 	Use:   "edit",
 	Short: "Edit profile [PROFILE_NAME]",
 	Args:  cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		var chosenProfileId string
@@ -29,11 +28,11 @@ var profileEditCmd = &cobra.Command{
 		if len(args) == 0 {
 			chosenProfile, err = profile.GetProfileFromPrompt(c.Profiles, c.ActiveProfileId, false)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 
 			if chosenProfile == nil {
-				return
+				return nil
 			}
 		} else {
 			chosenProfileId = args[0]
@@ -46,7 +45,7 @@ var profileEditCmd = &cobra.Command{
 		}
 
 		if chosenProfile == nil {
-			log.Fatal("Profile does not exist")
+			return errors.New("profile does not exist")
 		}
 
 		if profileNameFlag != "" {
@@ -60,11 +59,7 @@ var profileEditCmd = &cobra.Command{
 		}
 
 		if profileNameFlag == "" || apiUrlFlag == "" || apiKeyFlag == "" {
-			err = EditProfile(c, true, chosenProfile)
-			if err != nil {
-				log.Fatal(err)
-			}
-			return
+			return EditProfile(c, true, chosenProfile)
 		}
 
 		profileEditView := profile.ProfileAddView{
@@ -73,10 +68,7 @@ var profileEditCmd = &cobra.Command{
 			ApiKey:      apiKeyFlag,
 		}
 
-		err = editProfile(chosenProfile, profileEditView, c, true)
-		if err != nil {
-			log.Fatal(err)
-		}
+		return editProfile(chosenProfile, profileEditView, c, true)
 	},
 }
 

--- a/pkg/cmd/profile/list.go
+++ b/pkg/cmd/profile/list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/profile"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,24 +17,25 @@ var profileListCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List profiles",
 	Aliases: []string{"ls"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(c.Profiles)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		output, err := profile.ListProfiles(c.Profiles, c.ActiveProfileId, false)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		fmt.Print(output)
+		return nil
 	},
 }
 

--- a/pkg/cmd/profiledata/env/list.go
+++ b/pkg/cmd/profiledata/env/list.go
@@ -11,24 +11,22 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/env"
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var listCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List profile environment variables",
 	Aliases: []string{"ls"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		ctx := context.Background()
 
 		profileData, res, err := apiClient.ProfileAPI.GetProfileData(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		if format.FormatFlag != "" {
@@ -37,15 +35,16 @@ var listCmd = &cobra.Command{
 			}
 			formattedData := format.NewFormatter(profileData.EnvVars)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		if len(profileData.EnvVars) == 0 {
 			views.RenderInfoMessageBold("No environment variables set")
-			return
+			return nil
 		}
 
 		env.List(profileData.EnvVars)
+		return nil
 	},
 }
 

--- a/pkg/cmd/profiledata/env/set.go
+++ b/pkg/cmd/profiledata/env/set.go
@@ -5,14 +5,13 @@ package env
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var setCmd = &cobra.Command{
@@ -39,7 +38,7 @@ var setCmd = &cobra.Command{
 			for _, arg := range args {
 				kv := strings.Split(arg, "=")
 				if len(kv) != 2 {
-					log.Fatalf("Invalid key-value pair: %s", arg)
+					return fmt.Errorf("invalid key-value pair: %s", arg)
 				}
 				(profileData.EnvVars)[kv[0]] = kv[1]
 			}
@@ -52,7 +51,7 @@ var setCmd = &cobra.Command{
 
 			err = form.Run()
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 		}
 

--- a/pkg/cmd/profiledata/env/set.go
+++ b/pkg/cmd/profiledata/env/set.go
@@ -19,16 +19,16 @@ var setCmd = &cobra.Command{
 	Use:     "set [KEY=VALUE]...",
 	Short:   "Set profile environment variables",
 	Aliases: []string{"s", "update", "add", "delete", "rm"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		ctx := context.Background()
 
 		profileData, res, err := apiClient.ProfileAPI.GetProfileData(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		if profileData.EnvVars == nil {
@@ -58,9 +58,10 @@ var setCmd = &cobra.Command{
 
 		res, err = apiClient.ProfileAPI.SetProfileData(ctx).ProfileData(*profileData).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		views.RenderInfoMessageBold("Profile environment variables have been successfully set")
+		return nil
 	},
 }

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -16,7 +16,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +51,7 @@ var projectConfigAddCmd = &cobra.Command{
 		} else {
 			projectConfigName, err = processCmdArgument(args[0], apiClient, ctx)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 		}
 

--- a/pkg/cmd/projectconfig/delete.go
+++ b/pkg/cmd/projectconfig/delete.go
@@ -25,13 +25,13 @@ var projectConfigDeleteCmd = &cobra.Command{
 	Aliases: []string{"remove", "rm"},
 	Short:   "Delete a project config",
 	Args:    cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var selectedProjectConfig *apiclient.ProjectConfig
 		var selectedProjectConfigName string
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if allFlag {
@@ -47,23 +47,23 @@ var projectConfigDeleteCmd = &cobra.Command{
 
 				err := form.Run()
 				if err != nil {
-					log.Fatal(err)
+					return err
 				}
 
 				if !yesFlag {
 					fmt.Println("Operation canceled.")
-					return
+					return nil
 				}
 			}
 
 			projectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			if len(projectConfigs) == 0 {
 				views.RenderInfoMessage("No project configs found")
-				return
+				return nil
 			}
 
 			for _, projectConfig := range projectConfigs {
@@ -75,23 +75,23 @@ var projectConfigDeleteCmd = &cobra.Command{
 				}
 				views.RenderInfoMessage("Deleted project config: " + selectedProjectConfigName)
 			}
-			return
+			return nil
 		}
 
 		if len(args) == 0 {
 			projectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			if len(projectConfigs) == 0 {
 				views.RenderInfoMessage("No project configs found")
-				return
+				return nil
 			}
 
 			selectedProjectConfig = selection.GetProjectConfigFromPrompt(projectConfigs, 0, false, false, "Delete")
 			if selectedProjectConfig == nil {
-				return
+				return nil
 			}
 			selectedProjectConfigName = selectedProjectConfig.Name
 		} else {
@@ -100,10 +100,11 @@ var projectConfigDeleteCmd = &cobra.Command{
 
 		res, err := apiClient.ProjectConfigAPI.DeleteProjectConfig(context.Background(), selectedProjectConfigName).Force(forceFlag).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		views.RenderInfoMessage("Project config deleted successfully")
+		return nil
 	},
 }
 

--- a/pkg/cmd/projectconfig/info.go
+++ b/pkg/cmd/projectconfig/info.go
@@ -12,7 +12,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/projectconfig/info"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -21,17 +20,17 @@ var projectConfigInfoCmd = &cobra.Command{
 	Short:   "Show project config info",
 	Aliases: []string{"view", "inspect"},
 	Args:    cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		var projectConfig *apiclient.ProjectConfig
@@ -39,7 +38,7 @@ var projectConfigInfoCmd = &cobra.Command{
 		if len(args) == 0 {
 			projectConfigList, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			if format.FormatFlag != "" {
@@ -55,21 +54,22 @@ var projectConfigInfoCmd = &cobra.Command{
 			var res *http.Response
 			projectConfig, res, err = apiClient.ProjectConfigAPI.GetProjectConfig(ctx, args[0]).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 		}
 
 		if projectConfig == nil {
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(projectConfig)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		info.Render(projectConfig, apiServerConfig, false)
+		return nil
 	},
 }
 

--- a/pkg/cmd/projectconfig/list.go
+++ b/pkg/cmd/projectconfig/list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views"
 	projectconfig_view "github.com/daytonaio/daytona/pkg/views/projectconfig/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,18 +18,18 @@ var projectConfigListCmd = &cobra.Command{
 	Short:   "Lists project configs",
 	Aliases: []string{"ls"},
 	Args:    cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		var specifyGitProviders bool
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		gitProviders, res, err := apiClient.GitProviderAPI.ListGitProviders(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if len(gitProviders) > 1 {
@@ -39,26 +38,27 @@ var projectConfigListCmd = &cobra.Command{
 
 		apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		projectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if len(projectConfigs) == 0 {
 			views.RenderInfoMessage("No project configs found. Add a new project config by running 'daytona project-config add'")
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(projectConfigs)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		projectconfig_view.ListProjectConfigs(projectConfigs, apiServerConfig, specifyGitProviders)
+		return nil
 	},
 }
 

--- a/pkg/cmd/projectconfig/setdefault.go
+++ b/pkg/cmd/projectconfig/setdefault.go
@@ -10,7 +10,6 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,24 +17,24 @@ var projectConfigSetDefaultCmd = &cobra.Command{
 	Use:   "set-default",
 	Short: "Set project config info",
 	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectConfigName string
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if len(args) == 0 {
 			projectConfigList, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			projectConfig := selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Make Default")
 			if projectConfig == nil {
-				return
+				return nil
 			}
 			projectConfigName = projectConfig.Name
 		} else {
@@ -44,10 +43,11 @@ var projectConfigSetDefaultCmd = &cobra.Command{
 
 		res, err := apiClient.ProjectConfigAPI.SetDefaultProjectConfig(ctx, projectConfigName).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		views.RenderInfoMessage(fmt.Sprintf("Project config '%s' set as default", projectConfigName))
+		return nil
 	},
 }
 

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -13,7 +13,6 @@ import (
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -21,35 +20,35 @@ var projectConfigUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update a project config",
 	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var projectConfig *apiclient.ProjectConfig
 		var res *http.Response
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if len(args) == 0 {
 			projectConfigList, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Update")
 			if projectConfig == nil {
-				return
+				return nil
 			}
 		} else {
 			projectConfig, res, err = apiClient.ProjectConfigAPI.GetProjectConfig(ctx, args[0]).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 		}
 
 		if projectConfig == nil {
-			return
+			return nil
 		}
 
 		createDto := []apiclient.CreateProjectDTO{
@@ -77,7 +76,7 @@ var projectConfigUpdateCmd = &cobra.Command{
 
 		create.ProjectsConfigurationChanged, err = create.RunProjectConfiguration(&createDto, *projectDefaults)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		newProjectConfig := apiclient.CreateProjectConfigDTO{
@@ -91,9 +90,10 @@ var projectConfigUpdateCmd = &cobra.Command{
 
 		res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		views.RenderInfoMessage("Project config updated successfully")
+		return nil
 	},
 }

--- a/pkg/cmd/provider/list.go
+++ b/pkg/cmd/provider/list.go
@@ -13,8 +13,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/provider"
 	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var providerListCmd = &cobra.Command{
@@ -22,35 +20,36 @@ var providerListCmd = &cobra.Command{
 	Short:   "List installed providers",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"ls"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		providerList, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(providerList)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		provider.List(providerList)
+		return nil
 	},
 }
 
-func GetProviderViewOptions(apiClient *apiclient.APIClient, latestProviders []apiclient.Provider, ctx context.Context) []provider_view.ProviderView {
+func GetProviderViewOptions(apiClient *apiclient.APIClient, latestProviders []apiclient.Provider, ctx context.Context) ([]provider_view.ProviderView, error) {
 	var result []provider_view.ProviderView
 
 	installedProviders, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
 	if err != nil {
-		log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
 	providerMap := make(map[string]provider_view.ProviderView)
@@ -77,7 +76,7 @@ func GetProviderViewOptions(apiClient *apiclient.APIClient, latestProviders []ap
 		result = append(result, provider)
 	}
 
-	return result
+	return result, nil
 }
 
 func init() {

--- a/pkg/cmd/provider/uninstall.go
+++ b/pkg/cmd/provider/uninstall.go
@@ -13,8 +13,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/provider"
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var providerUninstallCmd = &cobra.Command{
@@ -22,37 +20,38 @@ var providerUninstallCmd = &cobra.Command{
 	Short:   "Uninstall provider",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"u"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		providerList, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		providerToUninstall, err := provider.GetProviderFromPrompt(provider.ProviderListToView(providerList), "Choose a Provider to Uninstall", false)
 		if err != nil {
 			if common.IsCtrlCAbort(err) {
-				return
+				return nil
 			} else {
-				log.Fatal(err)
+				return err
 			}
 		}
 
 		if providerToUninstall == nil {
-			return
+			return nil
 		}
 
 		res, err = apiClient.ProviderAPI.UninstallProvider(ctx, providerToUninstall.Name).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		views.RenderInfoMessageBold(fmt.Sprintf("Provider %s has been successfully uninstalled", providerToUninstall.Name))
+		return nil
 	},
 }

--- a/pkg/cmd/purge.go
+++ b/pkg/cmd/purge.go
@@ -134,7 +134,7 @@ var purgeCmd = &cobra.Command{
 
 		errs := server.Purge(ctx, forceFlag)
 		if len(errs) > 0 {
-			log.Fatal(errs[0])
+			return errs[0]
 		}
 
 		fmt.Println("Server purged.")

--- a/pkg/cmd/server/config.go
+++ b/pkg/cmd/server/config.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	view "github.com/daytonaio/daytona/pkg/views/server"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/daytonaio/daytona/pkg/cmd/format"
@@ -15,18 +14,20 @@ import (
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Output local Daytona Server config",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		config, err := server.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(config)
 			formattedData.Print()
+			return nil
 		}
 
 		view.RenderConfig(config)
+		return nil
 	},
 }
 

--- a/pkg/cmd/server/configure.go
+++ b/pkg/cmd/server/configure.go
@@ -9,39 +9,39 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	server_view "github.com/daytonaio/daytona/pkg/views/server"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var configureCmd = &cobra.Command{
 	Use:   "configure",
 	Short: "Configure Daytona Server",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		containerRegistries, res, err := apiClient.ContainerRegistryAPI.ListContainerRegistries(context.Background()).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		apiServerConfig, err = server_view.ConfigurationForm(apiServerConfig, containerRegistries)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		_, res, err = apiClient.ServerAPI.SetConfig(context.Background()).Config(*apiServerConfig).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		views.RenderContainerLayout(views.GetInfoMessage("Server configuration updated. You need to restart the server for the changes to take effect."))
+		return nil
 	},
 }

--- a/pkg/cmd/server/logs.go
+++ b/pkg/cmd/server/logs.go
@@ -25,15 +25,15 @@ var fileFlag bool
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Output Daytona Server logs",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		activeProfile, err := c.GetActiveProfile()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		query := ""
@@ -43,7 +43,7 @@ var logsCmd = &cobra.Command{
 
 		switch {
 		case fileFlag:
-			readServerLogFile()
+			return readServerLogFile()
 
 		default:
 			ws, res, err := apiclient.GetWebsocketConn(context.Background(), "/log/server", &activeProfile, &query)
@@ -52,7 +52,7 @@ var logsCmd = &cobra.Command{
 				log.Error(apiclient.HandleErrorResponse(res, err))
 
 				if activeProfile.Id != "default" {
-					return
+					return nil
 				}
 
 				readLogsFile := true
@@ -64,39 +64,38 @@ var logsCmd = &cobra.Command{
 				).WithTheme(views.GetCustomTheme())
 				formErr := form.Run()
 				if formErr != nil {
-					log.Fatal(formErr)
+					return formErr
 				}
 
 				if readLogsFile {
-					readServerLogFile()
+					return readServerLogFile()
 				}
-				return
+				return nil
 
 			}
 
 			for {
 				_, msg, err := ws.ReadMessage()
 				if err != nil {
-					return
+					return nil
 				}
 
 				fmt.Println(string(msg))
 			}
 		}
-
 	},
 }
 
-func readServerLogFile() {
+func readServerLogFile() error {
 	views.RenderBorderedMessage("Reading from server log file...")
 	cfg, err := server.GetConfig()
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to get server config: %w", err).Error())
+		return fmt.Errorf("failed to get server config: %w", err)
 	}
 
 	file, err := os.Open(cfg.LogFilePath)
 	if err != nil {
-		log.Fatal(fmt.Errorf("while opening server logs: %w", err).Error())
+		return fmt.Errorf("while opening server logs: %w", err)
 	}
 	defer file.Close()
 	msgChan := make(chan []byte)
@@ -107,13 +106,13 @@ func readServerLogFile() {
 	for {
 		select {
 		case <-context.Background().Done():
-			return
+			return nil
 		case err := <-errChan:
 			if err != nil {
 				if err != io.EOF {
-					log.Fatal(err)
+					return err
 				}
-				return
+				return nil
 			}
 		case msg := <-msgChan:
 			fmt.Println(string(msg))

--- a/pkg/cmd/server/restart.go
+++ b/pkg/cmd/server/restart.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/daytonaio/daytona/pkg/cmd/server/daemon"
@@ -15,23 +14,24 @@ import (
 var restartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "Restarts the Daytona Server daemon",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		views.RenderInfoMessage("Stopping the Daytona Server daemon...")
 		err := daemon.Stop()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		c, err := server.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		views.RenderInfoMessage("Starting the Daytona Server daemon...")
 		err = daemon.Start(c.LogFilePath)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		views.RenderContainerLayout(views.GetBoldedInfoMessage("Daytona Server daemon restarted successfully"))
+		return nil
 	},
 }

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -26,14 +26,14 @@ var ServerCmd = &cobra.Command{
 	Short:   "Start the server process in daemon mode",
 	GroupID: util.SERVER_GROUP,
 	Args:    cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		confirmCheck := true
 
 		if !yesFlag {
 			view.ConfirmPrompt(&confirmCheck)
 			if !confirmCheck {
 				views.RenderInfoMessage("Operation cancelled.")
-				return
+				return nil
 			}
 		}
 
@@ -44,7 +44,7 @@ var ServerCmd = &cobra.Command{
 
 		c, err := server.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		apiServer := api.NewApiServer(api.ApiServerConfig{
@@ -54,11 +54,11 @@ var ServerCmd = &cobra.Command{
 		views.RenderInfoMessageBold("Starting the Daytona Server daemon...")
 		err = daemon.Start(c.LogFilePath)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		err = waitForServerToStart(apiServer)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		printServerStartedMessage(c, true)
 
@@ -66,13 +66,14 @@ var ServerCmd = &cobra.Command{
 		case "linux":
 			fmt.Printf("Use `loginctl enable-linger %s` to allow the service to run after logging out.\n", os.Getenv("USER"))
 		}
+		return nil
 	},
 }
 
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the Daytona Server daemon",
-	Run:   ServerCmd.Run,
+	RunE:  ServerCmd.RunE,
 }
 
 func init() {

--- a/pkg/cmd/server/stop.go
+++ b/pkg/cmd/server/stop.go
@@ -4,7 +4,6 @@
 package server
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/daytonaio/daytona/pkg/cmd/server/daemon"
@@ -14,11 +13,8 @@ import (
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stops the Daytona Server daemon",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		views.RenderInfoMessageBold("Stopping the Daytona Server daemon...")
-		err := daemon.Stop()
-		if err != nil {
-			log.Fatal(err)
-		}
+		return daemon.Stop()
 	},
 }

--- a/pkg/cmd/target/list.go
+++ b/pkg/cmd/target/list.go
@@ -5,7 +5,6 @@ package target
 
 import (
 	"context"
-	"log"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
@@ -19,32 +18,33 @@ var targetListCmd = &cobra.Command{
 	Short:   "List targets",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"ls"},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		targetList, res, err := apiClient.TargetAPI.ListTargets(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
 		if len(targetList) == 0 {
 			views.RenderInfoMessageBold("No targets found")
 			views.RenderInfoMessage("Use 'daytona target set' to add a target")
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(targetList)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		list_view.ListTargets(targetList)
+		return nil
 	},
 }
 

--- a/pkg/cmd/telemetry/disable.go
+++ b/pkg/cmd/telemetry/disable.go
@@ -7,7 +7,6 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/views"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -15,17 +14,18 @@ var disableCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Disable telemetry collection",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = c.DisableTelemetry()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		views.RenderInfoMessage("Telemetry collection disabled")
+		return nil
 	},
 }

--- a/pkg/cmd/telemetry/enable.go
+++ b/pkg/cmd/telemetry/enable.go
@@ -7,7 +7,6 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/views"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -15,17 +14,18 @@ var enableCmd = &cobra.Command{
 	Use:   "enable",
 	Short: "Enable telemetry collection",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = c.EnableTelemetry()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		views.RenderInfoMessage("Telemetry collection enabled")
+		return nil
 	},
 }

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -13,7 +13,8 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Daytona version", internal.Version)
+		return nil
 	},
 }

--- a/pkg/cmd/whoami.go
+++ b/pkg/cmd/whoami.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	view "github.com/daytonaio/daytona/pkg/views/whoami"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,24 +18,25 @@ var whoamiCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Aliases: []string{"who", "user"},
 	GroupID: util.PROFILE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		profile, err := c.GetActiveProfile()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(profile)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		view.Render(profile)
+		return nil
 	},
 }
 

--- a/pkg/cmd/workspace/info.go
+++ b/pkg/cmd/workspace/info.go
@@ -12,7 +12,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/workspace/info"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -22,12 +21,12 @@ var InfoCmd = &cobra.Command{
 	Aliases: []string{"view", "inspect"},
 	Args:    cobra.RangeArgs(0, 1),
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		var workspace *apiclient.WorkspaceDTO
@@ -35,7 +34,7 @@ var InfoCmd = &cobra.Command{
 		if len(args) == 0 {
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Verbose(true).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			if format.FormatFlag != "" {
@@ -50,21 +49,22 @@ var InfoCmd = &cobra.Command{
 		} else {
 			workspace, err = apiclient_util.GetWorkspace(args[0], true)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 		}
 
 		if workspace == nil {
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(workspace)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		info.Render(workspace, "", false)
+		return nil
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {

--- a/pkg/cmd/workspace/list.go
+++ b/pkg/cmd/workspace/list.go
@@ -13,7 +13,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views"
 	list_view "github.com/daytonaio/daytona/pkg/views/workspace/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -25,24 +24,24 @@ var ListCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(0),
 	Aliases: []string{"ls"},
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		var specifyGitProviders bool
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Verbose(verbose).Execute()
 
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		gitProviders, res, err := apiClient.GitProviderAPI.ListGitProviders(ctx).Execute()
 		if err != nil {
-			log.Fatal(apiclient.HandleErrorResponse(res, err))
+			return apiclient.HandleErrorResponse(res, err)
 		}
 
 		if len(gitProviders) > 1 {
@@ -52,25 +51,27 @@ var ListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(workspaceList)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		if len(workspaceList) == 0 {
 			views.RenderInfoMessage("The workspace list is empty. Start off by running 'daytona create'.")
-			return
+			return nil
 		}
 
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		activeProfile, err := c.GetActiveProfile()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		list_view.ListWorkspaces(workspaceList, specifyGitProviders, verbose, activeProfile.Name)
+
+		return nil
 	},
 }
 

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -15,8 +15,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 
 	"github.com/spf13/cobra"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var SshCmd = &cobra.Command{
@@ -24,15 +22,15 @@ var SshCmd = &cobra.Command{
 	Short:   "SSH into a project using the terminal",
 	Args:    cobra.ArbitraryArgs,
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		activeProfile, err := c.GetActiveProfile()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		ctx := context.Background()
@@ -41,33 +39,33 @@ var SshCmd = &cobra.Command{
 
 		apiClient, err := apiclient_util.GetApiClient(&activeProfile)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if len(args) == 0 {
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
-				log.Fatal(apiclient_util.HandleErrorResponse(res, err))
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
 			workspace = selection.GetWorkspaceFromPrompt(workspaceList, "SSH Into")
 			if workspace == nil {
-				return
+				return nil
 			}
 		} else {
 			workspace, err = apiclient_util.GetWorkspace(args[0], true)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 		}
 
 		if len(args) == 0 || len(args) == 1 {
 			selectedProject, err := selectWorkspaceProject(workspace.Id, &activeProfile)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			if selectedProject == nil {
-				return
+				return nil
 			}
 			projectName = selectedProject.Name
 		}
@@ -79,10 +77,10 @@ var SshCmd = &cobra.Command{
 		if !workspace_util.IsProjectRunning(workspace, projectName) {
 			wsRunningStatus, err := AutoStartWorkspace(workspace.Name, projectName)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			if !wsRunningStatus {
-				return
+				return nil
 			}
 		}
 
@@ -91,10 +89,7 @@ var SshCmd = &cobra.Command{
 			sshArgs = append(sshArgs, args[2:]...)
 		}
 
-		err = ide.OpenTerminalSsh(activeProfile, workspace.Id, projectName, sshArgs...)
-		if err != nil {
-			log.Fatal(err)
-		}
+		return ide.OpenTerminalSsh(activeProfile, workspace.Id, projectName, sshArgs...)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) >= 2 {

--- a/pkg/cmd/workspacemode/expose.go
+++ b/pkg/cmd/workspacemode/expose.go
@@ -20,17 +20,17 @@ var exposeCmd = &cobra.Command{
 	Short:   "Expose a local port over stdout - Used by the Daytona CLI to make direct connections to the project",
 	Args:    cobra.ExactArgs(1),
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		port, err := strconv.Atoi(args[0])
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		targetUrl := fmt.Sprintf("localhost:%d", port)
 
 		dialConn, err := net.Dial("tcp", targetUrl)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		go func() {

--- a/pkg/cmd/workspacemode/forward.go
+++ b/pkg/cmd/workspacemode/forward.go
@@ -23,26 +23,26 @@ var portForwardCmd = &cobra.Command{
 	Short:   "Forward a port from the project to your local machine",
 	Args:    cobra.ExactArgs(1),
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		activeProfile, err := c.GetActiveProfile()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		port, err := strconv.Atoi(args[0])
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		hostPort, errChan := tailscale.ForwardPort(workspaceId, projectName, uint16(port), activeProfile)
 
 		if hostPort == nil {
 			if err = <-errChan; err != nil {
-				log.Fatal(err)
+				return err
 			}
 		} else {
 			if *hostPort != uint16(port) {

--- a/pkg/cmd/workspacemode/git_cred.go
+++ b/pkg/cmd/workspacemode/git_cred.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"strings"
@@ -21,21 +20,21 @@ var gitCredCmd = &cobra.Command{
 	Aliases: []string{"rev"},
 	Args:    cobra.ExactArgs(1),
 	Hidden:  true,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if args[0] != "get" {
-			return
+			return nil
 		}
 		ctx := context.Background()
 		result, err := parseFromStdin()
 		host := result["host"]
 		if err != nil || host == "" {
 			fmt.Println("error parsing 'host' from stdin")
-			return
+			return nil
 		}
 
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		encodedUrl := url.QueryEscape(host)
@@ -43,11 +42,11 @@ var gitCredCmd = &cobra.Command{
 		if gitProvider == nil {
 			fmt.Println("error: git provider not found")
 			os.Exit(1)
-			return
 		}
 
 		fmt.Println("username=" + gitProvider.Username)
 		fmt.Println("password=" + gitProvider.Token)
+		return nil
 	},
 }
 

--- a/pkg/cmd/workspacemode/info.go
+++ b/pkg/cmd/workspacemode/info.go
@@ -9,7 +9,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/workspace/info"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,25 +18,26 @@ var infoCmd = &cobra.Command{
 	Aliases: []string{"view", "inspect"},
 	Args:    cobra.ExactArgs(0),
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var workspace *apiclient.WorkspaceDTO
 
 		workspace, err := apiclient_util.GetWorkspace(workspaceId, true)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if workspace == nil {
-			return
+			return nil
 		}
 
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(workspace)
 			formattedData.Print()
-			return
+			return nil
 		}
 
 		info.Render(workspace, "", false)
+		return nil
 	},
 }
 

--- a/pkg/cmd/workspacemode/restart.go
+++ b/pkg/cmd/workspacemode/restart.go
@@ -10,7 +10,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	workspace_cmd "github.com/daytonaio/daytona/pkg/cmd/workspace"
 	"github.com/daytonaio/daytona/pkg/views"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,15 +18,15 @@ var restartCmd = &cobra.Command{
 	Short:   "Restart the project",
 	Args:    cobra.NoArgs,
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = workspace_cmd.RestartWorkspace(apiClient, workspaceId, projectName)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if projectName != "" {
@@ -35,5 +34,6 @@ var restartCmd = &cobra.Command{
 		} else {
 			views.RenderInfoMessage(fmt.Sprintf("Workspace '%s' successfully restarted", workspaceId))
 		}
+		return nil
 	},
 }

--- a/pkg/cmd/workspacemode/start.go
+++ b/pkg/cmd/workspacemode/start.go
@@ -8,7 +8,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	workspace_cmd "github.com/daytonaio/daytona/pkg/cmd/workspace"
 	"github.com/daytonaio/daytona/pkg/views"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -17,17 +16,18 @@ var startCmd = &cobra.Command{
 	Short:   "Start the project",
 	Args:    cobra.NoArgs,
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = workspace_cmd.StartWorkspace(apiClient, workspaceId, projectName)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		views.RenderInfoMessage("Project successfully started")
+		return nil
 	},
 }

--- a/pkg/cmd/workspacemode/stop.go
+++ b/pkg/cmd/workspacemode/stop.go
@@ -10,7 +10,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	workspace_cmd "github.com/daytonaio/daytona/pkg/cmd/workspace"
 	"github.com/daytonaio/daytona/pkg/views"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,15 +18,15 @@ var stopCmd = &cobra.Command{
 	Short:   "Stop the project",
 	Args:    cobra.NoArgs,
 	GroupID: util.WORKSPACE_GROUP,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		apiClient, err := apiclient.GetApiClient(nil)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		err = workspace_cmd.StopWorkspace(apiClient, workspaceId, projectName)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if projectName != "" {
@@ -35,5 +34,6 @@ var stopCmd = &cobra.Command{
 		} else {
 			views.RenderInfoMessage(fmt.Sprintf("Workspace '%s' successfully stopped", workspaceId))
 		}
+		return nil
 	},
 }

--- a/pkg/cmd/workspacemode/workspace_mode.go
+++ b/pkg/cmd/workspacemode/workspace_mode.go
@@ -30,15 +30,12 @@ var workspaceModeRootCmd = &cobra.Command{
 	DisableAutoGenTag: true,
 	SilenceUsage:      true,
 	SilenceErrors:     true,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := cmd.Help()
-		if err != nil {
-			log.Fatal(err)
-		}
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
 	},
 }
 
-func Execute() {
+func Execute() error {
 	cmd.SetupRootCommand(workspaceModeRootCmd)
 	workspaceModeRootCmd.AddGroup(&cobra.Group{ID: util.WORKSPACE_GROUP, Title: "Project & Workspace"})
 	workspaceModeRootCmd.AddCommand(gitCredCmd)
@@ -76,10 +73,7 @@ func Execute() {
 			telemetryService.Close()
 		}
 
-		if helpErr != nil {
-			log.Fatal(err)
-		}
-		return
+		return helpErr
 	}
 
 	if telemetryEnabled {
@@ -109,9 +103,7 @@ func Execute() {
 		telemetryService.Close()
 	}
 
-	if err != nil {
-		log.Fatal(err)
-	}
+	return err
 }
 
 func init() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -173,9 +173,7 @@ func (s *Server) Start(errCh chan error) error {
 		signal.Notify(interruptChannel, os.Interrupt)
 
 		for range interruptChannel {
-			log.Info("Shutting down")
 			plugin.CleanupClients()
-			os.Exit(0)
 		}
 	}()
 

--- a/pkg/telemetry/cli_events.go
+++ b/pkg/telemetry/cli_events.go
@@ -6,8 +6,9 @@ package telemetry
 type CliEvent string
 
 const (
-	CliEventCmdStart CliEvent = "cli_cmd_start"
-	CliEventCmdEnd   CliEvent = "cli_cmd_end"
+	CliEventCmdStart   CliEvent = "cli_cmd_start"
+	CliEventCmdEnd     CliEvent = "cli_cmd_end"
+	CliEventInvalidCmd CliEvent = "cli_invalid_cmd"
 )
 
 var AdditionalData map[string]interface{} = map[string]interface{}{}


### PR DESCRIPTION
# Telemetry: Track Command Errors

## Description

This PR adds proper tracking of CLI commands that ended with an error. To do this, all the commands needed to be refactored to return errors instead of throwing fatals. Additionally, fixed the tracking of user-interrupted commands (e.g. ctrl+c out of the workspace creation process)

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
