### PR TITLE
fix: server panic on invalid repo url

### DIFF
--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -148,6 +148,10 @@ func (a *AbstractGitProvider) ParseStaticGitContext(repoUrl string) (*StaticGitC
 	path := strings.TrimPrefix(u.Path, "/")
 	parts := strings.Split(path, "/")
 
+	if len(parts) < 2 {
+		return nil, errors.New("cannot parse git URL: " + repoUrl)
+	}
+
 	repo.Source = u.Host
 	repo.Owner = parts[0]
 	repo.Name = parts[1]


### PR DESCRIPTION
# Fix Server Panic on Invalid Repo URL

## Description

Adds a len check to the abstract git provider context parsing that would cause a server panic.

Before: 
![Screenshot 2024-09-26 at 14 56 49](https://github.com/user-attachments/assets/e73e76f2-0d48-4562-a906-8c2d737bb5da)

Now:
![Screenshot 2024-09-26 at 14 58 11](https://github.com/user-attachments/assets/92d986fd-8c3a-43cb-9387-82aa7b08c653)

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
