### PR TITLE
fix: output error when purging autocompletion data

### DIFF
--- a/pkg/cmd/purge.go
+++ b/pkg/cmd/purge.go
@@ -148,7 +148,7 @@ var purgeCmd = &cobra.Command{
 		fmt.Println("Deleting autocompletion data")
 		err = config.DeleteAutocompletionData()
 		if err != nil {
-			return err
+			fmt.Printf("Error deleting autocompletion data: %s\n", err)
 		}
 
 		fmt.Println("Deleting the Daytona config directory")


### PR DESCRIPTION
# Output error when purging autocompletion data

## Description

If `daytona purge` fails upon deleting autocompletion data, only error is output to user instead of fataling.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #594 