### PR TITLE
telemetry: track used flag names

### DIFF
--- a/pkg/cmd/workspacemode/workspace_mode.go
+++ b/pkg/cmd/workspacemode/workspace_mode.go
@@ -46,7 +46,7 @@ func Execute() error {
 	telemetryEnabled := config.TelemetryEnabled()
 	startTime := time.Now()
 
-	telemetryService, command, err := cmd.PreRun(workspaceModeRootCmd, os.Args[1:], telemetryEnabled, clientId, startTime)
+	telemetryService, command, flags, err := cmd.PreRun(workspaceModeRootCmd, os.Args[1:], telemetryEnabled, clientId, startTime)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func Execute() error {
 	err = workspaceModeRootCmd.Execute()
 
 	endTime := time.Now()
-	cmd.PostRun(command, err, telemetryService, clientId, startTime, endTime)
+	cmd.PostRun(command, err, telemetryService, clientId, startTime, endTime, flags)
 
 	return err
 }


### PR DESCRIPTION
# Telemetry: Track Used Flag Names

## Description

This PR adds flag name tracking to our telemetry.

**NOTE:** Only flag names are tracked, not flag values.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
