### PR TITLE
feat: always mark project dir as safe in git

### DIFF
--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -158,6 +158,17 @@ func (s *Service) SetGitConfig(userData *gitprovider.GitUser) error {
 		return err
 	}
 
+	if !cfg.HasSection("safe") {
+		_, err := cfg.NewSection("safe")
+		if err != nil {
+			return err
+		}
+	}
+	_, err = cfg.Section("safe").NewKey("directory", s.ProjectDir)
+	if err != nil {
+		return err
+	}
+
 	if userData != nil {
 		if !cfg.HasSection("user") {
 			_, err := cfg.NewSection("user")


### PR DESCRIPTION
# Always Mark Project Dir as Safe in Git

## Description

This PR sets the safe.directory value in the global gitconfig to the project dir. This way, users won't have to mark it themselves after creating a project in some scenarios.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
