### PR TITLE
fix: devcontainer compose creation

### DIFF
--- a/internal/apikeys/functions.go
+++ b/internal/apikeys/functions.go
@@ -4,17 +4,16 @@
 package apikeys
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/google/uuid"
 )
 
 // returns the SHA-256 hash of a given key as a hexadecimal string.
 func HashKey(key string) string {
-	keyHash := sha256.Sum256([]byte(key))
-	return string(keyHash[:])
+	return util.Hash(key)
 }
 
 func GenerateRandomKey() string {

--- a/internal/util/hash.go
+++ b/internal/util/hash.go
@@ -1,0 +1,11 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import "crypto/sha256"
+
+func Hash(value string) string {
+	hash := sha256.Sum256([]byte(value))
+	return string(hash[:])
+}

--- a/pkg/docker/create_devcontainer.go
+++ b/pkg/docker/create_devcontainer.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/cli"
+	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/build/devcontainer"
 	"github.com/daytonaio/daytona/pkg/containerregistry"
 	"github.com/daytonaio/daytona/pkg/ssh"
@@ -150,7 +151,7 @@ func (d *DockerClient) CreateFromDevcontainer(opts CreateDevcontainerOptions) (s
 			return "", "", err
 		}
 
-		project.Name = fmt.Sprintf("%s-%s", opts.ProjectName, uuid.NewString())
+		project.Name = fmt.Sprintf("%s-%s", opts.ProjectName, util.Hash(opts.ProjectDir))
 
 		for _, service := range project.Services {
 			if service.Build != nil {


### PR DESCRIPTION
# Fix Devcontainer Compose Creation

## Description

Fix for creating devcontainer compose projects. Before, docker compose would get lifted twice because of the different project names.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes
All providers will need to be updated.
