### PR TITLE
fix: version flag cmd RunE

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -156,7 +156,10 @@ func SetupRootCommand(cmd *cobra.Command) {
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		versionFlag, _ := cmd.Flags().GetBool("version")
 		if versionFlag {
-			versionCmd.Run(cmd, []string{})
+			err := versionCmd.RunE(cmd, []string{})
+			if err != nil {
+				log.Fatal(err)
+			}
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
# Fix Version flag cmd RunE

## Description

Fixes a leftover version command Run instead of RunE call

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1172 
