### PR TITLE
fix: entry not visible in initial screen

### DIFF
--- a/pkg/views/initial/view.go
+++ b/pkg/views/initial/view.go
@@ -94,7 +94,7 @@ func NewModel() Model {
 			huh.NewSelect[string]().
 				Key("command").
 				Options(options...).
-				Value(&m.choice).Height(10),
+				Value(&m.choice).Height(11),
 		),
 	).WithTheme(views.GetInitialCommandTheme()).WithShowHelp(false)
 


### PR DESCRIPTION
# Entry not visible in initial screen

## Description

Corrects the height of the initial screen so that the bottom option ("view all commands") is visible

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
Before:

![image](https://github.com/user-attachments/assets/042ae7a7-548f-4ce7-9ed2-ce6d07d6778b)

After:

![image](https://github.com/user-attachments/assets/b45e7e68-4260-42a8-ae72-fdda3b5b271e)