### PR TITLE
fix: inconsistency with non-follow log reading

### DIFF
--- a/docs/daytona_build_logs.md
+++ b/docs/daytona_build_logs.md
@@ -9,8 +9,7 @@ daytona build logs [flags]
 ### Options
 
 ```
-      --continue-on-completed   Continue streaming logs after the build is completed
-  -f, --follow                  Follow logs
+  -f, --follow   Follow logs
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_build_logs.yaml
+++ b/hack/docs/daytona_build_logs.yaml
@@ -2,9 +2,6 @@ name: daytona build logs
 synopsis: View logs for build
 usage: daytona build logs [flags]
 options:
-    - name: continue-on-completed
-      default_value: "false"
-      usage: Continue streaming logs after the build is completed
     - name: follow
       shorthand: f
       default_value: "false"

--- a/internal/util/log_reader.go
+++ b/internal/util/log_reader.go
@@ -5,12 +5,14 @@ package util
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 
 	"github.com/daytonaio/daytona/pkg/logs"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func ReadLog(ctx context.Context, logReader io.Reader, follow bool, c chan []byte, errChan chan error) {
@@ -38,44 +40,33 @@ func ReadLog(ctx context.Context, logReader io.Reader, follow bool, c chan []byt
 }
 
 func ReadJSONLog(ctx context.Context, logReader io.Reader, follow bool, c chan interface{}, errChan chan error) {
-	var buffer bytes.Buffer
 	reader := bufio.NewReader(logReader)
-	delimiter := []byte(logs.LogDelimiter)
-
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			byteChunk := make([]byte, 1024)
-
-			n, err := reader.Read(byteChunk)
-			if err != nil {
-				if err != io.EOF {
-					errChan <- err
-				} else if !follow {
-					errChan <- io.EOF
-					return
-				}
-			}
-			buffer.Write(byteChunk[:n])
-
-			data := buffer.Bytes()
-
-			index := bytes.Index(data, delimiter)
-
-			if index != -1 { // if the delimiter is found, process the log entry
-
+			line, readErr := reader.ReadString('\n')
+			if line != "" {
+				stripped := strings.TrimSuffix(line, logs.LogDelimiter)
 				var logEntry logs.LogEntry
 
-				err = json.Unmarshal(data[:index], &logEntry)
+				err := json.Unmarshal([]byte(stripped), &logEntry)
 				if err != nil {
-					return
+					log.Trace("Failed to parse log entry: ", err, string(stripped))
 				}
 
 				c <- logEntry
-				buffer.Reset()
-				buffer.Write(data[index+len(delimiter):]) // write remaining data to buffer
+			}
+			if readErr != nil {
+				if readErr != io.EOF {
+					c <- logs.LogEntry{}
+					errChan <- readErr
+				} else if !follow {
+					c <- logs.LogEntry{}
+					errChan <- io.EOF
+					return
+				}
 			}
 		}
 	}

--- a/pkg/api/controllers/log/websocket.go
+++ b/pkg/api/controllers/log/websocket.go
@@ -5,6 +5,7 @@ package log
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -34,62 +35,9 @@ func writeToWs(ws *websocket.Conn, c chan []byte, errChan chan error) {
 	}
 }
 
-func readLog(ginCtx *gin.Context, logReader io.Reader) {
-	followQuery := ginCtx.Query("follow")
-	follow := followQuery == "true"
-
-	ws, err := upgrader.Upgrade(ginCtx.Writer, ginCtx.Request, nil)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-	defer ws.Close()
-
-	msgChannel := make(chan []byte)
-	errChannel := make(chan error)
-	ctx, cancel := context.WithCancel(context.Background())
-
-	defer cancel()
-	go util.ReadLog(ctx, logReader, follow, msgChannel, errChannel)
-	go writeToWs(ws, msgChannel, errChannel)
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				err := <-errChannel
-				if err != nil {
-					if err.Error() != "EOF" {
-						log.Error(err)
-					}
-					ws.Close()
-					cancel()
-				}
-			}
-		}
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			_, _, err := ws.ReadMessage()
-			if err != nil {
-				ws.Close()
-				cancel()
-				return
-			}
-		}
-	}
-}
-
 func writeJSONToWs(ws *websocket.Conn, c chan interface{}, errChan chan error) {
 	for {
-		value := <-c
-		err := ws.WriteJSON(value)
+		err := ws.WriteJSON(<-c)
 		if err != nil {
 			errChan <- err
 			break
@@ -97,7 +45,9 @@ func writeJSONToWs(ws *websocket.Conn, c chan interface{}, errChan chan error) {
 	}
 }
 
-func readJSONLog(ginCtx *gin.Context, logReader io.Reader) {
+// readLog reads from the logReader and writes to the websocket.
+// T is the type of the message to be read from the logReader
+func readLog[T any](ginCtx *gin.Context, logReader io.Reader, readFunc func(context.Context, io.Reader, bool, chan T, chan error), wsWriteFunc func(*websocket.Conn, chan T, chan error)) {
 	followQuery := ginCtx.Query("follow")
 	follow := followQuery == "true"
 
@@ -106,31 +56,32 @@ func readJSONLog(ginCtx *gin.Context, logReader io.Reader) {
 		log.Error(err)
 		return
 	}
-	defer ws.Close()
 
-	msgChannel := make(chan interface{})
+	defer func() {
+		closeErr := websocket.CloseNormalClosure
+		if !errors.Is(err, io.EOF) {
+			closeErr = websocket.CloseInternalServerErr
+		}
+		err := ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(closeErr, ""), time.Now().Add(time.Second))
+		if err != nil {
+			log.Trace(err)
+		}
+		ws.Close()
+	}()
+
+	msgChannel := make(chan T)
 	errChannel := make(chan error)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ginCtx.Request.Context())
 
 	defer cancel()
-	go util.ReadJSONLog(ctx, logReader, follow, msgChannel, errChannel)
-	go writeJSONToWs(ws, msgChannel, errChannel)
+	go readFunc(ctx, logReader, follow, msgChannel, errChannel)
+	go wsWriteFunc(ws, msgChannel, errChannel)
 
+	readErr := make(chan error)
 	go func() {
 		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				err := <-errChannel
-				if err != nil {
-					if err.Error() != "EOF" {
-						log.Error(err)
-					}
-					ws.Close()
-					cancel()
-				}
-			}
+			_, _, err := ws.ReadMessage()
+			readErr <- err
 		}
 	}()
 
@@ -138,11 +89,19 @@ func readJSONLog(ginCtx *gin.Context, logReader io.Reader) {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			_, _, err := ws.ReadMessage()
+		case err = <-errChannel:
 			if err != nil {
-				ws.Close()
+				if !errors.Is(err, io.EOF) {
+					log.Error(err)
+				}
 				cancel()
+				return
+			}
+		case err := <-readErr:
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure) {
+				log.Error(err)
+			}
+			if err != nil {
 				return
 			}
 		}
@@ -158,7 +117,7 @@ func ReadServerLog(ginCtx *gin.Context) {
 		for {
 			reader, err := server.GetLogReader()
 			if err == nil {
-				readLog(ginCtx, reader)
+				readLog(ginCtx, reader, util.ReadLog, writeToWs)
 				return
 			}
 			time.Sleep(TIMEOUT)
@@ -171,7 +130,7 @@ func ReadServerLog(ginCtx *gin.Context) {
 		return
 	}
 
-	readLog(ginCtx, reader)
+	readLog(ginCtx, reader, util.ReadLog, writeToWs)
 }
 
 func ReadWorkspaceLog(ginCtx *gin.Context) {
@@ -185,7 +144,7 @@ func ReadWorkspaceLog(ginCtx *gin.Context) {
 		for {
 			wsLogReader, err := server.WorkspaceService.GetWorkspaceLogReader(workspaceId)
 			if err == nil {
-				readJSONLog(ginCtx, wsLogReader)
+				readLog(ginCtx, wsLogReader, util.ReadJSONLog, writeJSONToWs)
 				return
 			}
 			time.Sleep(TIMEOUT)
@@ -198,7 +157,7 @@ func ReadWorkspaceLog(ginCtx *gin.Context) {
 		return
 	}
 
-	readJSONLog(ginCtx, wsLogReader)
+	readLog(ginCtx, wsLogReader, util.ReadJSONLog, writeJSONToWs)
 }
 
 func ReadProjectLog(ginCtx *gin.Context) {
@@ -213,7 +172,7 @@ func ReadProjectLog(ginCtx *gin.Context) {
 		for {
 			projectLogReader, err := server.WorkspaceService.GetProjectLogReader(workspaceId, projectName)
 			if err == nil {
-				readJSONLog(ginCtx, projectLogReader)
+				readLog(ginCtx, projectLogReader, util.ReadJSONLog, writeJSONToWs)
 				return
 			}
 			time.Sleep(TIMEOUT)
@@ -226,7 +185,7 @@ func ReadProjectLog(ginCtx *gin.Context) {
 		return
 	}
 
-	readJSONLog(ginCtx, projectLogReader)
+	readLog(ginCtx, projectLogReader, util.ReadJSONLog, writeJSONToWs)
 }
 
 func ReadBuildLog(ginCtx *gin.Context) {
@@ -241,7 +200,7 @@ func ReadBuildLog(ginCtx *gin.Context) {
 			buildLogReader, err := server.BuildService.GetBuildLogReader(buildId)
 
 			if err == nil {
-				readJSONLog(ginCtx, buildLogReader)
+				readLog(ginCtx, buildLogReader, util.ReadJSONLog, writeJSONToWs)
 				return
 			}
 			time.Sleep(TIMEOUT)
@@ -254,5 +213,5 @@ func ReadBuildLog(ginCtx *gin.Context) {
 		return
 	}
 
-	readJSONLog(ginCtx, buildLogReader)
+	readLog(ginCtx, buildLogReader, util.ReadJSONLog, writeJSONToWs)
 }


### PR DESCRIPTION
# Fix inconsistency with Non-follow Log Reading

## Description

This PR fixes log websocket log reading. Now the logs are correctly read and the connection correctly cleaned up when the `--follow` flag is not used. This ensures a consistent behavior where the logs are always correctly stopped once the file is fully read.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1174 

## Breaking Change

Removed `continue-on-completed` flag from the `build logs` command. Because the logs are now read correctly, the flag 
becomes obsolete
