### PR TITLE
fix: properly check if git provider can handle repo url

### DIFF
--- a/internal/testing/gitprovider/mocks/git_provider.go
+++ b/internal/testing/gitprovider/mocks/git_provider.go
@@ -16,6 +16,11 @@ type MockGitProvider struct {
 	mock.Mock
 }
 
+func (m *MockGitProvider) CanHandle(repoUrl string) (bool, error) {
+	args := m.Called(repoUrl)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockGitProvider) GetNamespaces() ([]*gitprovider.GitNamespace, error) {
 	args := m.Called()
 	return args.Get(0).([]*gitprovider.GitNamespace), args.Error(1)

--- a/pkg/gitprovider/aws-codecommit.go
+++ b/pkg/gitprovider/aws-codecommit.go
@@ -39,6 +39,15 @@ func NewAwsCodeCommitGitProvider(baseApiUrl string) *AwsCodeCommitGitProvider {
 	return gitProvider
 }
 
+func (g *AwsCodeCommitGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	return staticContext.Source == fmt.Sprintf("git-codecommit.%s.amazonaws.com", g.region) || fmt.Sprintf("%s.console.aws.amazon.com", g.region) == staticContext.Source, nil
+}
+
 func (g *AwsCodeCommitGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	// AWS CodeCommit does not have a project and repository structure similar to other git providers.
 	// Therefore, returning repositories as an array of type GitNamespace.

--- a/pkg/gitprovider/aws-codecommit_test.go
+++ b/pkg/gitprovider/aws-codecommit_test.go
@@ -25,6 +25,24 @@ func TestAwsCodeCommitGitProvider(t *testing.T) {
 	suite.Run(t, NewAwsCodeCommitGitProviderTestSuite())
 }
 
+func (g *AwsCodeCommitGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://git-codecommit.ap-south-1.amazonaws.com/v1/repos/Test"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+
+	repoUrl = "https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/Test/browse?region=ap-south-1"
+	canHandle, _ = g.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (g *AwsCodeCommitGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
+}
+
 func (g *AwsCodeCommitGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prUrl := "https://ap-south-1.console.aws.amazon.com/codesuite/codecommit/repositories/Test/pull-requests/1/details"
 	prContext := &StaticGitContext{

--- a/pkg/gitprovider/azure-devops.go
+++ b/pkg/gitprovider/azure-devops.go
@@ -42,6 +42,15 @@ func NewAzureDevOpsGitProvider(token string, baseApiUrl string) *AzureDevOpsGitP
 	return provider
 }
 
+func (g *AzureDevOpsGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.Contains(g.baseApiUrl, staticContext.Source), nil
+}
+
 func (g *AzureDevOpsGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	client, _, err := g.getApiClient()
 	if err != nil {

--- a/pkg/gitprovider/azure-devops_test.go
+++ b/pkg/gitprovider/azure-devops_test.go
@@ -25,6 +25,20 @@ func TestAzureDevopsGitProvider(t *testing.T) {
 	suite.Run(t, NewAzureDevOpsGitProviderTestSuite())
 }
 
+func (g *AzureDevOpsGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://dev.azure.com/dotslashtarun/dot-1/_git/dot-1"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (g *AzureDevOpsGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
+}
+
 func (g *AzureDevOpsGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prUrl := "https://dev.azure.com/dotslashtarun/dot-1/_git/dot-1/pullrequest/4"
 	prContext := &StaticGitContext{

--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -36,6 +36,15 @@ func NewBitbucketGitProvider(username string, token string) *BitbucketGitProvide
 	return provider
 }
 
+func (g *BitbucketGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	return staticContext.Source == "bitbucket.org", nil
+}
+
 func (g *BitbucketGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	client := g.getApiClient()
 	wsList, err := client.Workspaces.List()

--- a/pkg/gitprovider/bitbucket_test.go
+++ b/pkg/gitprovider/bitbucket_test.go
@@ -21,6 +21,20 @@ func NewBitbucketGitProviderTestSuite() *BitbucketGitProviderTestSuite {
 	}
 }
 
+func (b *BitbucketGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://bitbucket.org/daytonaio/daytona"
+	require := b.Require()
+	canHandle, _ := b.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (b *BitbucketGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := b.Require()
+	canHandle, _ := b.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
+}
+
 func (b *BitbucketGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prUrl := "https://bitbucket.org/atlassian/bitbucket-upload-file/pull-requests/1"
 	prContext := &StaticGitContext{

--- a/pkg/gitprovider/bitbucketserver.go
+++ b/pkg/gitprovider/bitbucketserver.go
@@ -23,12 +23,12 @@ type BitbucketServerGitProvider struct {
 
 	username   string
 	token      string
-	baseApiUrl *string
+	baseApiUrl string
 }
 
 const bitbucketServerResponseLimit = 100
 
-func NewBitbucketServerGitProvider(username string, token string, baseApiUrl *string) *BitbucketServerGitProvider {
+func NewBitbucketServerGitProvider(username string, token string, baseApiUrl string) *BitbucketServerGitProvider {
 	provider := &BitbucketServerGitProvider{
 		username:            username,
 		token:               token,
@@ -40,8 +40,17 @@ func NewBitbucketServerGitProvider(username string, token string, baseApiUrl *st
 	return provider
 }
 
+func (g *BitbucketServerGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.Contains(g.baseApiUrl, staticContext.Source), nil
+}
+
 func (g *BitbucketServerGitProvider) getApiClient() (*bitbucketv1.APIClient, error) {
-	conf := bitbucketv1.NewConfiguration(*g.baseApiUrl)
+	conf := bitbucketv1.NewConfiguration(g.baseApiUrl)
 	ctx := context.WithValue(context.Background(), bitbucketv1.ContextBasicAuth, bitbucketv1.BasicAuth{
 		UserName: g.username,
 		Password: g.token,
@@ -130,7 +139,7 @@ func (g *BitbucketServerGitProvider) GetRepositories(namespace string) ([]*GitRe
 				ownerName = repo.Owner.Name
 			}
 
-			baseURL, err := url.Parse(*g.baseApiUrl)
+			baseURL, err := url.Parse(g.baseApiUrl)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/gitprovider/bitbucketserver_test.go
+++ b/pkg/gitprovider/bitbucketserver_test.go
@@ -16,10 +16,23 @@ type BitbucketServerGitProviderTestSuite struct {
 }
 
 func NewBitbucketServerGitProviderTestSuite() *BitbucketServerGitProviderTestSuite {
-	baseApiUrl := "https://bitbucket.example.com"
 	return &BitbucketServerGitProviderTestSuite{
-		gitProvider: NewBitbucketServerGitProvider("username", "token", &baseApiUrl),
+		gitProvider: NewBitbucketServerGitProvider("username", "token", "https://bitbucket.example.com"),
 	}
+}
+
+func (b *BitbucketServerGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://bitbucket.example.com/scm/daytonaio/daytona.git"
+	require := b.Require()
+	canHandle, _ := b.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (b *BitbucketServerGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := b.Require()
+	canHandle, _ := b.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
 }
 
 func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_PR() {

--- a/pkg/gitprovider/git_provider.go
+++ b/pkg/gitprovider/git_provider.go
@@ -45,6 +45,7 @@ type GitProvider interface {
 	GetRepoBranches(repositoryId string, namespaceId string) ([]*GitBranch, error)
 	GetRepoPRs(repositoryId string, namespaceId string) ([]*GitPullRequest, error)
 
+	CanHandle(repoUrl string) (bool, error)
 	GetRepositoryContext(repoContext GetRepositoryContext) (*GitRepository, error)
 	GetUrlFromContext(repoContext *GetRepositoryContext) string
 	GetLastCommitSha(staticContext *StaticGitContext) (string, error)

--- a/pkg/gitprovider/gitea.go
+++ b/pkg/gitprovider/gitea.go
@@ -35,6 +35,15 @@ func NewGiteaGitProvider(token string, baseApiUrl string) *GiteaGitProvider {
 	return provider
 }
 
+func (g *GiteaGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.Contains(g.baseApiUrl, staticContext.Source), nil
+}
+
 func (g *GiteaGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	client, err := g.getApiClient()
 	if err != nil {

--- a/pkg/gitprovider/gitea_test.go
+++ b/pkg/gitprovider/gitea_test.go
@@ -17,8 +17,22 @@ type GiteaGitProviderTestSuite struct {
 
 func NewGiteaGitProviderTestSuite() *GiteaGitProviderTestSuite {
 	return &GiteaGitProviderTestSuite{
-		gitProvider: NewGiteaGitProvider("", ""),
+		gitProvider: NewGiteaGitProvider("", "https://gitea.com"),
 	}
+}
+
+func (g *GiteaGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://gitea.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (g *GiteaGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
 }
 
 func (g *GiteaGitProviderTestSuite) TestParseStaticGitContext_PR() {

--- a/pkg/gitprovider/github.go
+++ b/pkg/gitprovider/github.go
@@ -36,6 +36,19 @@ func NewGitHubGitProvider(token string, baseApiUrl *string) *GitHubGitProvider {
 	return gitProvider
 }
 
+func (g *GitHubGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	if g.baseApiUrl == nil {
+		return staticContext.Source == "github.com", nil
+	}
+
+	return strings.Contains(*g.baseApiUrl, staticContext.Source), nil
+}
+
 func (g *GitHubGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	client := g.getApiClient()
 	user, err := g.GetUser()

--- a/pkg/gitprovider/github_test.go
+++ b/pkg/gitprovider/github_test.go
@@ -21,6 +21,20 @@ func NewGitHubGitProviderTestSuite() *GitHubGitProviderTestSuite {
 	}
 }
 
+func (g *GitHubGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (g *GitHubGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://gitlab.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
+}
+
 func (g *GitHubGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prUrl := "https://github.com/daytonaio/daytona/pull/1"
 	prContext := &StaticGitContext{

--- a/pkg/gitprovider/gitlab.go
+++ b/pkg/gitprovider/gitlab.go
@@ -37,6 +37,19 @@ func NewGitLabGitProvider(token string, baseApiUrl *string) *GitLabGitProvider {
 	return gitProvider
 }
 
+func (g *GitLabGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	if g.baseApiUrl == nil {
+		return staticContext.Source == "gitlab.com", nil
+	}
+
+	return strings.Contains(*g.baseApiUrl, staticContext.Source), nil
+}
+
 func (g *GitLabGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 	client := g.getApiClient()
 	user, err := g.GetUser()

--- a/pkg/gitprovider/gitlab_test.go
+++ b/pkg/gitprovider/gitlab_test.go
@@ -21,6 +21,20 @@ func NewGitLabGitProviderTestSuite() *GitLabGitProviderTestSuite {
 	}
 }
 
+func (g *GitLabGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://gitlab.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (g *GitLabGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
+}
+
 func (g *GitLabGitProviderTestSuite) TestParseStaticGitContext_HTTP() {
 	httpSimple := "https://gitlab.com/gitlab-org/gitlab"
 	simpleContext := &StaticGitContext{

--- a/pkg/gitprovider/gitness.go
+++ b/pkg/gitprovider/gitness.go
@@ -16,10 +16,10 @@ import (
 type GitnessGitProvider struct {
 	*AbstractGitProvider
 	token      string
-	baseApiUrl *string
+	baseApiUrl string
 }
 
-func NewGitnessGitProvider(token string, baseApiUrl *string) *GitnessGitProvider {
+func NewGitnessGitProvider(token string, baseApiUrl string) *GitnessGitProvider {
 	gitProvider := &GitnessGitProvider{
 		token:               token,
 		baseApiUrl:          baseApiUrl,
@@ -28,6 +28,15 @@ func NewGitnessGitProvider(token string, baseApiUrl *string) *GitnessGitProvider
 	gitProvider.AbstractGitProvider.GitProvider = gitProvider
 
 	return gitProvider
+}
+
+func (g *GitnessGitProvider) CanHandle(repoUrl string) (bool, error) {
+	staticContext, err := g.ParseStaticGitContext(repoUrl)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.Contains(g.baseApiUrl, staticContext.Source), nil
 }
 
 func (g *GitnessGitProvider) GetNamespaces() ([]*GitNamespace, error) {
@@ -48,7 +57,7 @@ func (g *GitnessGitProvider) GetNamespaces() ([]*GitNamespace, error) {
 }
 
 func (g *GitnessGitProvider) getApiClient() *gitnessclient.GitnessClient {
-	url, _ := url.Parse(*g.baseApiUrl)
+	url, _ := url.Parse(g.baseApiUrl)
 	return gitnessclient.NewGitnessClient(g.token, url)
 }
 

--- a/pkg/gitprovider/gitness_test.go
+++ b/pkg/gitprovider/gitness_test.go
@@ -16,9 +16,24 @@ type GitnessGitProviderTestSuite struct {
 
 func NewGitnessGitProviderTestSuite() *GitnessGitProviderTestSuite {
 	return &GitnessGitProviderTestSuite{
-		gitProvider: NewGitnessGitProvider("", nil),
+		gitProvider: NewGitnessGitProvider("", "http://localhost:3000"),
 	}
 }
+
+func (g *GitnessGitProviderTestSuite) TestCanHandle() {
+	repoUrl := "https://localhost:3000/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.True(canHandle)
+}
+
+func (g *GitnessGitProviderTestSuite) TestCanHandle_False() {
+	repoUrl := "https://github.com/daytonaio/daytona"
+	require := g.Require()
+	canHandle, _ := g.gitProvider.CanHandle(repoUrl)
+	require.False(canHandle)
+}
+
 func (g *GitnessGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prUrl := "https://localhost:3000/test/test/pulls/1"
 	prContext := &StaticGitContext{

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -25,10 +25,8 @@ func (s *GitProviderService) GetGitProviderForUrl(repoUrl string) (gitprovider.G
 			return nil, "", err
 		}
 
-		_, err = gitProvider.GetRepositoryContext(gitprovider.GetRepositoryContext{
-			Url: repoUrl,
-		})
-		if err == nil {
+		canHandle, _ := gitProvider.CanHandle(repoUrl)
+		if canHandle {
 			return gitProvider, p.Id, nil
 		}
 	}
@@ -66,10 +64,8 @@ func (s *GitProviderService) GetConfigForUrl(repoUrl string) (*gitprovider.GitPr
 			return nil, err
 		}
 
-		_, err = gitProvider.GetRepositoryContext(gitprovider.GetRepositoryContext{
-			Url: repoUrl,
-		})
-		if err == nil {
+		canHandle, _ := gitProvider.CanHandle(repoUrl)
+		if canHandle {
 			return p, nil
 		}
 	}

--- a/pkg/server/gitproviders/service.go
+++ b/pkg/server/gitproviders/service.go
@@ -161,7 +161,7 @@ func (s *GitProviderService) newGitProvider(config *gitprovider.GitProviderConfi
 	case "bitbucket":
 		return gitprovider.NewBitbucketGitProvider(config.Username, config.Token), nil
 	case "bitbucket-server":
-		return gitprovider.NewBitbucketServerGitProvider(config.Username, config.Token, config.BaseApiUrl), nil
+		return gitprovider.NewBitbucketServerGitProvider(config.Username, config.Token, *config.BaseApiUrl), nil
 	case "gitlab-self-managed":
 		return gitprovider.NewGitLabGitProvider(config.Token, config.BaseApiUrl), nil
 	case "codeberg":
@@ -169,7 +169,7 @@ func (s *GitProviderService) newGitProvider(config *gitprovider.GitProviderConfi
 	case "gitea":
 		return gitprovider.NewGiteaGitProvider(config.Token, *config.BaseApiUrl), nil
 	case "gitness":
-		return gitprovider.NewGitnessGitProvider(config.Token, config.BaseApiUrl), nil
+		return gitprovider.NewGitnessGitProvider(config.Token, *config.BaseApiUrl), nil
 	case "azure-devops":
 		return gitprovider.NewAzureDevOpsGitProvider(config.Token, *config.BaseApiUrl), nil
 	case "aws-codecommit":


### PR DESCRIPTION
# Properly Check if Git Provider Can Handle Repo URL

## Description

This PR adds a `CanHandle` method to the `GitProvider` interface that is used to check if a git provider can handle a certain repo url. With this change, the appropriate provider is now always returned when requested for a certain URL.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
