### PR TITLE
fix: prevent purge if server is active

### DIFF
--- a/pkg/cmd/purge.go
+++ b/pkg/cmd/purge.go
@@ -70,14 +70,20 @@ var purgeCmd = &cobra.Command{
 			return err
 		}
 
-		_, err = apiclient.GetApiClient(&defaultProfile)
+		apiClient, err := apiclient.GetApiClient(&defaultProfile)
 		if err != nil {
 			if !apiclient.IsHealthCheckFailed(err) {
 				return err
 			}
 		} else {
 			view.ServerStoppedPrompt(&serverStoppedCheck)
-			if !serverStoppedCheck {
+			if serverStoppedCheck {
+				_, _, err = apiClient.DefaultAPI.HealthCheck(context.Background()).Execute()
+				if err == nil {
+					views.RenderInfoMessage("The Daytona Server is still running. Please stop it before continuing.")
+					return nil
+				}
+			} else {
 				fmt.Println("Operation cancelled.")
 				return nil
 			}


### PR DESCRIPTION
# Prevent purge if server is active
## Description

Fixes an issue where there user can run `daytona purge` and ignore the "Please stop the Daytona Server" message which would lead to unexpected behavior

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/6442c010-28f1-4acb-aaeb-9887d729f7c2)
