### PR TITLE
fix: add tsnet directory for proper purge

### DIFF
--- a/pkg/agent/tailscale/server.go
+++ b/pkg/agent/tailscale/server.go
@@ -10,8 +10,10 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"path/filepath"
 	"time"
 
+	cfg "github.com/daytonaio/daytona/cmd/daytona/config"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/agent/config"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -98,10 +100,16 @@ func (s *Server) getNetworkKey() (string, error) {
 }
 
 func (s *Server) getTsnetServer() (*tsnet.Server, error) {
+	configDir, err := cfg.GetConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
 	tsnetServer := &tsnet.Server{
 		Hostname:   s.Hostname,
 		ControlURL: s.Server.Url,
 		Ephemeral:  true,
+		Dir:        filepath.Join(configDir, "tsnet"),
 	}
 
 	networkKey, err := s.getNetworkKey()

--- a/pkg/server/headscale/connect.go
+++ b/pkg/server/headscale/connect.go
@@ -6,9 +6,11 @@ package headscale
 import (
 	"fmt"
 	"net/http"
+	"path/filepath"
 
 	"tailscale.com/tsnet"
 
+	"github.com/daytonaio/daytona/cmd/daytona/config"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -29,6 +31,12 @@ func (s *HeadscaleServer) Connect() error {
 
 	tsNetServer.ControlURL = fmt.Sprintf("http://localhost:%d", s.headscalePort)
 	tsNetServer.AuthKey = authKey
+
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return err
+	}
+	tsNetServer.Dir = filepath.Join(configDir, "tsnet")
 
 	defer tsNetServer.Close()
 	ln, err := tsNetServer.Listen("tcp", ":80")


### PR DESCRIPTION
# Add tsnet directory for proper purge

## Description

This PR fixes an issue where tsnet files were not properly purged because tsnet server was creating its own directory by default due to server directory not being set

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #764 

## Notes
Users can delete the old tailscale directory found at:
Linux: `~/.config/tsnet-daytona`
Mac: `~/Library/Application\ Support/tsnet-daytona`
Windows: `C:\Users\[USER]\AppData\Roaming\tsnet-daytona`