### PR TITLE
refactor: server version from entrypoint

### DIFF
--- a/pkg/api/middlewares/version.go
+++ b/pkg/api/middlewares/version.go
@@ -4,14 +4,13 @@
 package middlewares
 
 import (
-	"github.com/daytonaio/daytona/internal"
 	"github.com/gin-gonic/gin"
 )
 
 const SERVER_VERSION_HEADER = "X-Server-Version"
 
-func SetVersionMiddleware() gin.HandlerFunc {
+func SetVersionMiddleware(version string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		ctx.Writer.Header().Add(SERVER_VERSION_HEADER, internal.Version)
+		ctx.Writer.Header().Add(SERVER_VERSION_HEADER, version)
 	}
 }

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -227,6 +227,7 @@ func PreRun(rootCmd *cobra.Command, args []string, telemetryEnabled bool, client
 		telemetryService = posthogservice.NewTelemetryService(posthogservice.PosthogServiceConfig{
 			ApiKey:   internal.PosthogApiKey,
 			Endpoint: internal.PosthogEndpoint,
+			Version:  internal.Version,
 		})
 	}
 

--- a/pkg/cmd/purge.go
+++ b/pkg/cmd/purge.go
@@ -100,12 +100,13 @@ var purgeCmd = &cobra.Command{
 		telemetryService := posthogservice.NewTelemetryService(posthogservice.PosthogServiceConfig{
 			ApiKey:   internal.PosthogApiKey,
 			Endpoint: internal.PosthogEndpoint,
+			Version:  internal.Version,
 		})
 
 		defer telemetryService.Close()
 
 		fmt.Println("Purging the server")
-		server, err := server_cmd.GetInstance(serverConfig, serverConfigDir, telemetryService)
+		server, err := server_cmd.GetInstance(serverConfig, serverConfigDir, internal.Version, telemetryService)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -72,6 +72,7 @@ var ServeCmd = &cobra.Command{
 		telemetryService := posthogservice.NewTelemetryService(posthogservice.PosthogServiceConfig{
 			ApiKey:   internal.PosthogApiKey,
 			Endpoint: internal.PosthogEndpoint,
+			Version:  internal.Version,
 		})
 
 		go func() {
@@ -86,9 +87,10 @@ var ServeCmd = &cobra.Command{
 		apiServer := api.NewApiServer(api.ApiServerConfig{
 			ApiPort:          int(c.ApiPort),
 			TelemetryService: telemetryService,
+			Version:          internal.Version,
 		})
 
-		server, err := GetInstance(c, configDir, telemetryService)
+		server, err := GetInstance(c, configDir, internal.Version, telemetryService)
 		if err != nil {
 			return err
 		}
@@ -146,7 +148,7 @@ var ServeCmd = &cobra.Command{
 	},
 }
 
-func GetInstance(c *server.Config, configDir string, telemetryService telemetry.TelemetryService) (*server.Server, error) {
+func GetInstance(c *server.Config, configDir string, version string, telemetryService telemetry.TelemetryService) (*server.Server, error) {
 	wsLogsDir, err := server.GetWorkspaceLogsDir(configDir)
 	if err != nil {
 		return nil, err
@@ -273,6 +275,7 @@ func GetInstance(c *server.Config, configDir string, telemetryService telemetry.
 		ApiUrl:                util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
 		DaytonaDownloadUrl:    getDaytonaScriptUrl(c),
 		ServerUrl:             headscaleUrl,
+		ServerVersion:         version,
 		RegistryUrl:           c.RegistryUrl,
 		BaseDir:               c.ProvidersDir,
 		CreateProviderNetworkKey: func(providerName string) (string, error) {
@@ -295,6 +298,7 @@ func GetInstance(c *server.Config, configDir string, telemetryService telemetry.
 		BuildService:             buildService,
 		ProjectConfigService:     projectConfigService,
 		ServerApiUrl:             util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain),
+		ServerVersion:            version,
 		ServerUrl:                headscaleUrl,
 		DefaultProjectImage:      c.DefaultProjectImage,
 		DefaultProjectUser:       c.DefaultProjectUser,
@@ -309,6 +313,7 @@ func GetInstance(c *server.Config, configDir string, telemetryService telemetry.
 
 	return server.GetInstance(&server.ServerInstanceConfig{
 		Config:                   *c,
+		Version:                  version,
 		TailscaleServer:          headscaleServer,
 		ProviderTargetService:    providerTargetService,
 		ContainerRegistryService: containerRegistryService,

--- a/pkg/posthogservice/service.go
+++ b/pkg/posthogservice/service.go
@@ -15,6 +15,7 @@ import (
 type PosthogServiceConfig struct {
 	ApiKey   string
 	Endpoint string
+	Version  string
 }
 
 func NewTelemetryService(config PosthogServiceConfig) telemetry.TelemetryService {
@@ -25,7 +26,7 @@ func NewTelemetryService(config PosthogServiceConfig) telemetry.TelemetryService
 	})
 	posthogService := &posthogService{
 		client:                   client,
-		AbstractTelemetryService: telemetry.NewAbstractTelemetryService(),
+		AbstractTelemetryService: telemetry.NewAbstractTelemetryService(config.Version),
 	}
 
 	posthogService.AbstractTelemetryService.TelemetryService = posthogService

--- a/pkg/provider/manager/manager.go
+++ b/pkg/provider/manager/manager.go
@@ -11,7 +11,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/internal/util"
 	os_util "github.com/daytonaio/daytona/pkg/os"
 	. "github.com/daytonaio/daytona/pkg/provider"
@@ -48,6 +47,7 @@ type IProviderManager interface {
 type ProviderManagerConfig struct {
 	DaytonaDownloadUrl       string
 	ServerUrl                string
+	ServerVersion            string
 	ApiUrl                   string
 	LogsDir                  string
 	ProviderTargetService    providertargets.IProviderTargetService
@@ -63,6 +63,7 @@ func NewProviderManager(config ProviderManagerConfig) *ProviderManager {
 		pluginRefs:               make(map[string]*pluginRef),
 		daytonaDownloadUrl:       config.DaytonaDownloadUrl,
 		serverUrl:                config.ServerUrl,
+		serverVersion:            config.ServerVersion,
 		apiUrl:                   config.ApiUrl,
 		logsDir:                  config.LogsDir,
 		providerTargetService:    config.ProviderTargetService,
@@ -78,6 +79,7 @@ type ProviderManager struct {
 	pluginRefs               map[string]*pluginRef
 	daytonaDownloadUrl       string
 	serverUrl                string
+	serverVersion            string
 	apiUrl                   string
 	serverPort               uint32
 	apiPort                  uint32
@@ -264,7 +266,7 @@ func (m *ProviderManager) initializeProvider(pluginPath string) (*pluginRef, err
 	_, err = (*p).Initialize(InitializeProviderRequest{
 		BasePath:           pluginBasePath,
 		DaytonaDownloadUrl: m.daytonaDownloadUrl,
-		DaytonaVersion:     internal.Version,
+		DaytonaVersion:     m.serverVersion,
 		ServerUrl:          m.serverUrl,
 		ApiUrl:             m.apiUrl,
 		LogsDir:            m.logsDir,

--- a/pkg/server/downloads.go
+++ b/pkg/server/downloads.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/daytonaio/daytona/internal"
 	daytona_os "github.com/daytonaio/daytona/pkg/os"
 )
 
@@ -30,7 +29,7 @@ func (s *Server) GetBinaryPath(binaryName, binaryVersion string) (string, error)
 	binaryOs = daytona_os.OperatingSystem(fmt.Sprintf("%s-%s", split[1], strings.TrimSuffix(split[2], ".exe")))
 
 	// If the requested binary is the same as the host, return the current binary path
-	if *hostOs == binaryOs && binaryVersion == internal.Version {
+	if *hostOs == binaryOs && binaryVersion == s.Version {
 		executable, err := os.Executable()
 		if err == nil {
 			f, err := os.Open(executable)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,6 +29,7 @@ import (
 
 type ServerInstanceConfig struct {
 	Config                   Config
+	Version                  string
 	TailscaleServer          TailscaleServer
 	ProviderTargetService    providertargets.IProviderTargetService
 	ContainerRegistryService containerregistries.IContainerRegistryService
@@ -57,6 +58,7 @@ func GetInstance(serverConfig *ServerInstanceConfig) *Server {
 		server = &Server{
 			Id:                       serverConfig.Config.Id,
 			config:                   serverConfig.Config,
+			Version:                  serverConfig.Version,
 			TailscaleServer:          serverConfig.TailscaleServer,
 			ProviderTargetService:    serverConfig.ProviderTargetService,
 			ContainerRegistryService: serverConfig.ContainerRegistryService,
@@ -78,6 +80,7 @@ func GetInstance(serverConfig *ServerInstanceConfig) *Server {
 type Server struct {
 	Id                       string
 	config                   Config
+	Version                  string
 	TailscaleServer          TailscaleServer
 	ProviderTargetService    providertargets.IProviderTargetService
 	ContainerRegistryService containerregistries.IContainerRegistryService

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -174,9 +174,10 @@ func (s *WorkspaceService) createWorkspace(ctx context.Context, ws *workspace.Wo
 	wsLogger.Write([]byte(fmt.Sprintf("Creating workspace %s (%s)\n", ws.Name, ws.Id)))
 
 	ws.EnvVars = workspace.GetWorkspaceEnvVars(ws, workspace.WorkspaceEnvVarParams{
-		ApiUrl:    s.serverApiUrl,
-		ServerUrl: s.serverUrl,
-		ClientId:  telemetry.ClientId(ctx),
+		ApiUrl:        s.serverApiUrl,
+		ServerUrl:     s.serverUrl,
+		ServerVersion: s.serverVersion,
+		ClientId:      telemetry.ClientId(ctx),
 	}, telemetry.TelemetryEnabled(ctx))
 
 	err := s.provisioner.CreateWorkspace(ws, target)
@@ -190,9 +191,10 @@ func (s *WorkspaceService) createWorkspace(ctx context.Context, ws *workspace.Wo
 
 		projectWithEnv := *p
 		projectWithEnv.EnvVars = project.GetProjectEnvVars(p, project.ProjectEnvVarParams{
-			ApiUrl:    s.serverApiUrl,
-			ServerUrl: s.serverUrl,
-			ClientId:  telemetry.ClientId(ctx),
+			ApiUrl:        s.serverApiUrl,
+			ServerUrl:     s.serverUrl,
+			ServerVersion: s.serverVersion,
+			ClientId:      telemetry.ClientId(ctx),
 		}, telemetry.TelemetryEnabled(ctx))
 
 		for k, v := range p.EnvVars {

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -49,6 +49,7 @@ type WorkspaceServiceConfig struct {
 	ProjectConfigService     projectconfig.IProjectConfigService
 	ServerApiUrl             string
 	ServerUrl                string
+	ServerVersion            string
 	Provisioner              provisioner.IProvisioner
 	DefaultProjectImage      string
 	DefaultProjectUser       string
@@ -67,6 +68,7 @@ func NewWorkspaceService(config WorkspaceServiceConfig) IWorkspaceService {
 		projectConfigService:     config.ProjectConfigService,
 		serverApiUrl:             config.ServerApiUrl,
 		serverUrl:                config.ServerUrl,
+		serverVersion:            config.ServerVersion,
 		defaultProjectImage:      config.DefaultProjectImage,
 		defaultProjectUser:       config.DefaultProjectUser,
 		provisioner:              config.Provisioner,
@@ -87,6 +89,7 @@ type WorkspaceService struct {
 	apiKeyService            apikeys.IApiKeyService
 	serverApiUrl             string
 	serverUrl                string
+	serverVersion            string
 	defaultProjectImage      string
 	defaultProjectUser       string
 	loggerFactory            logs.LoggerFactory

--- a/pkg/server/workspaces/start.go
+++ b/pkg/server/workspaces/start.go
@@ -82,9 +82,10 @@ func (s *WorkspaceService) startWorkspace(ctx context.Context, ws *workspace.Wor
 	wsLogWriter.Write([]byte("Starting workspace\n"))
 
 	ws.EnvVars = workspace.GetWorkspaceEnvVars(ws, workspace.WorkspaceEnvVarParams{
-		ApiUrl:    s.serverApiUrl,
-		ServerUrl: s.serverUrl,
-		ClientId:  telemetry.ClientId(ctx),
+		ApiUrl:        s.serverApiUrl,
+		ServerUrl:     s.serverUrl,
+		ServerVersion: s.serverVersion,
+		ClientId:      telemetry.ClientId(ctx),
 	}, telemetry.TelemetryEnabled(ctx))
 
 	err := s.provisioner.StartWorkspace(ws, target)
@@ -112,12 +113,13 @@ func (s *WorkspaceService) startProject(ctx context.Context, p *project.Project,
 
 	projectToStart := *p
 	projectToStart.EnvVars = project.GetProjectEnvVars(p, project.ProjectEnvVarParams{
-		ApiUrl:    s.serverApiUrl,
-		ServerUrl: s.serverUrl,
-		ClientId:  telemetry.ClientId(ctx),
+		ApiUrl:        s.serverApiUrl,
+		ServerUrl:     s.serverUrl,
+		ServerVersion: s.serverVersion,
+		ClientId:      telemetry.ClientId(ctx),
 	}, telemetry.TelemetryEnabled(ctx))
 
-	err := s.provisioner.StartProject(p, target)
+	err := s.provisioner.StartProject(&projectToStart, target)
 	if err != nil {
 		return err
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -63,9 +63,9 @@ type AbstractTelemetryService struct {
 	TelemetryService
 }
 
-func NewAbstractTelemetryService() *AbstractTelemetryService {
+func NewAbstractTelemetryService(version string) *AbstractTelemetryService {
 	return &AbstractTelemetryService{
-		daytonaVersion: internal.Version,
+		daytonaVersion: version,
 	}
 }
 

--- a/pkg/workspace/project/project.go
+++ b/pkg/workspace/project/project.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/workspace/project/buildconfig"
 )
@@ -69,9 +68,10 @@ const (
 )
 
 type ProjectEnvVarParams struct {
-	ApiUrl    string
-	ServerUrl string
-	ClientId  string
+	ApiUrl        string
+	ServerUrl     string
+	ServerVersion string
+	ClientId      string
 }
 
 func GetProjectEnvVars(project *Project, params ProjectEnvVarParams, telemetryEnabled bool) map[string]string {
@@ -80,7 +80,7 @@ func GetProjectEnvVars(project *Project, params ProjectEnvVarParams, telemetryEn
 		"DAYTONA_WS_PROJECT_NAME":           project.Name,
 		"DAYTONA_WS_PROJECT_REPOSITORY_URL": project.Repository.Url,
 		"DAYTONA_SERVER_API_KEY":            project.ApiKey,
-		"DAYTONA_SERVER_VERSION":            internal.Version,
+		"DAYTONA_SERVER_VERSION":            params.ServerVersion,
 		"DAYTONA_SERVER_URL":                params.ServerUrl,
 		"DAYTONA_SERVER_API_URL":            params.ApiUrl,
 		"DAYTONA_CLIENT_ID":                 params.ClientId,

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -6,7 +6,6 @@ package workspace
 import (
 	"errors"
 
-	"github.com/daytonaio/daytona/internal"
 	"github.com/daytonaio/daytona/pkg/workspace/project"
 )
 
@@ -35,16 +34,17 @@ func (w *Workspace) GetProject(projectName string) (*project.Project, error) {
 }
 
 type WorkspaceEnvVarParams struct {
-	ApiUrl    string
-	ServerUrl string
-	ClientId  string
+	ApiUrl        string
+	ServerUrl     string
+	ServerVersion string
+	ClientId      string
 }
 
 func GetWorkspaceEnvVars(workspace *Workspace, params WorkspaceEnvVarParams, telemetryEnabled bool) map[string]string {
 	envVars := map[string]string{
 		"DAYTONA_WS_ID":          workspace.Id,
 		"DAYTONA_SERVER_API_KEY": workspace.ApiKey,
-		"DAYTONA_SERVER_VERSION": internal.Version,
+		"DAYTONA_SERVER_VERSION": params.ServerVersion,
 		"DAYTONA_SERVER_URL":     params.ServerUrl,
 		"DAYTONA_SERVER_API_URL": params.ApiUrl,
 		"DAYTONA_CLIENT_ID":      params.ClientId,


### PR DESCRIPTION
# Refactor: Get Server Version from Entrypoint

## Description

Just a small refactor that sets the server version in the entrypoint (`serve`) instead of being hardcoded to `internal.Version`. This change makes it easier for tools implementing Daytona as a lib to set the version of the server.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
