### PR TITLE
fix: don't log empty log entry

### DIFF
--- a/internal/util/apiclient/websocket_log_reader.go
+++ b/internal/util/apiclient/websocket_log_reader.go
@@ -95,7 +95,11 @@ func readJSONLog(ctx context.Context, ws *websocket.Conn, index int) {
 
 			err := ws.ReadJSON(&logEntry)
 
-			logEntriesChan <- logEntry
+			// An empty entry will be sent from the server on close/EOF
+			// We don't want to print that
+			if logEntry != (logs.LogEntry{}) {
+				logEntriesChan <- logEntry
+			}
 
 			if err != nil {
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {


### PR DESCRIPTION
# Don't Log Empty Log Entry

## Description

Minor fix for a regression introduced with https://github.com/daytonaio/daytona/pull/1182. This PR prevents logging empty log entries that are sent when the websocket connection closes.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
