### PR TITLE
fix: vscode customizations panic

### DIFF
--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -94,7 +94,7 @@ func setupVSCodeCustomizations(projectHostname string, projectProviderMetadata s
 			}
 		}
 
-		if len(mergedCustomizations.Extensions) > 0 {
+		if mergedCustomizations != nil && len(mergedCustomizations.Extensions) > 0 {
 			extensionArgs := []string{}
 			for _, extension := range mergedCustomizations.Extensions {
 				extensionArgs = append(extensionArgs, "--install-extension", extension)


### PR DESCRIPTION
# VSCode customizations panic

## Description

Fixes a panic in VSCode customizations var property access

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![image](https://github.com/user-attachments/assets/04ed28f0-3fb5-46a9-9c4c-25de036b9345)
