### PR TITLE
feat: Add Bitbucket-Server Prebuilds Webhook

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -148,6 +148,8 @@ func GetPrebuildScopesFromGitProviderId(providerId string) string {
 		return "admin:repo_hook"
 	case "bitbucket":
 		return "webhooks"
+	case "bitbucket-server":
+		return "REPO_ADMIN"
 	case "azure-devops":
 		return "Work (Read, Write & Manage); Build (Read & Execute)"
 	default:

--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -165,6 +165,8 @@ func GetWebhookEventHeaderKeyFromGitProvider(providerId string) string {
 		return "X-Gitlab-Event"
 	case "bitbucket":
 		return "X-Event-Key"
+	case "bitbucket-server":
+		return "X-Event-Key"
 	case "gitea":
 		return "X-Gitea-Event"
 	case "azure-devops":

--- a/pkg/gitprovider/bitbucketserver_test.go
+++ b/pkg/gitprovider/bitbucketserver_test.go
@@ -40,7 +40,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_PR() {
 	prContext := &StaticGitContext{
 		Id:       "PROJECT_KEY",
 		Name:     "REPO_NAME",
-		Owner:    "PROJECT_KEY",
+		Owner:    "REPO_NAME",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
 		Branch:   nil,
@@ -62,7 +62,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Blob() {
 	blobContext := &StaticGitContext{
 		Id:       "PROJECT_KEY",
 		Name:     "REPO_NAME",
-		Owner:    "PROJECT_KEY",
+		Owner:    "REPO_NAME",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
 		Branch:   nil,
@@ -84,7 +84,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Branch()
 	branchContext := &StaticGitContext{
 		Id:       "PROJECT_KEY",
 		Name:     "REPO_NAME",
-		Owner:    "PROJECT_KEY",
+		Owner:    "REPO_NAME",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
 		Branch:   util.Pointer("main"),
@@ -106,7 +106,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Commits(
 	commitsContext := &StaticGitContext{
 		Id:       "PROJECT_KEY",
 		Name:     "REPO_NAME",
-		Owner:    "PROJECT_KEY",
+		Owner:    "REPO_NAME",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
 		Branch:   util.Pointer("COMMIT_SHA"),
@@ -128,7 +128,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Commit()
 	commitContext := &StaticGitContext{
 		Id:       "PROJECT_KEY",
 		Name:     "REPO_NAME",
-		Owner:    "PROJECT_KEY",
+		Owner:    "REPO_NAME",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
 		Branch:   util.Pointer("COMMIT_SHA"),
@@ -151,7 +151,7 @@ func (b *BitbucketServerGitProviderTestSuite) TestParseStaticGitContext_Repo_Url
 	commitContext := &StaticGitContext{
 		Id:       "PROJECT_KEY",
 		Name:     "REPO_NAME",
-		Owner:    "PROJECT_KEY",
+		Owner:    "REPO_NAME",
 		Url:      "https://bitbucket.example.com/scm/PROJECT_KEY/REPO_NAME.git",
 		Source:   "bitbucket.example.com",
 		Branch:   util.Pointer("COMMIT_SHA"),


### PR DESCRIPTION
## Description

This PR adds support for webhooks for Bitbucket Server prebuilds. It implements five methods: webhook get, register, unregister, comparing commit ranges and parsing event data.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
closes #995 
/claim #995

## Screenrecord

https://github.com/user-attachments/assets/795542cb-d52d-4d48-aea9-158b5bc97342


## Notes
While fetching [RepoBranches](https://github.com/daytonaio/daytona/blob/5973ccc3d53363e781252f664f972d39718e801f/pkg/gitprovider/bitbucketserver.go#L166), the namespaceId and repositoryId was same that's why it was throwing this error:
```
ERRO[4348] API ERROR                                     URI=/gitprovider/bitbucket-server/so
m/som/branches error="Error #01: Request failed with Status: 404 , Body: {errors:[{message:Repository som/som does not exist.,exceptionName:com.atlassian.bitbucket.repository.NoSuchRepositoryException}]}\n" latency=19.242749ms method=GET status=404
```
I have fixed that in this PR itself, everything seems to be working fine but let me know after you test it!