### PR TITLE
refactor: server start

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/daytonaio/daytona/pkg/api/docs"
 	"github.com/daytonaio/daytona/pkg/api/middlewares"
+	"github.com/daytonaio/daytona/pkg/frpc"
 	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/gin-contrib/cors"
 
@@ -52,6 +53,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/daytonaio/daytona/internal/constants"
+	daytonaServer "github.com/daytonaio/daytona/pkg/server"
 	swaggerfiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
@@ -60,6 +62,8 @@ type ApiServerConfig struct {
 	ApiPort          int
 	Version          string
 	TelemetryService telemetry.TelemetryService
+	Frps             *daytonaServer.FRPSConfig
+	ServerId         string
 }
 
 func NewApiServer(config ApiServerConfig) *ApiServer {
@@ -67,6 +71,8 @@ func NewApiServer(config ApiServerConfig) *ApiServer {
 		apiPort:          config.ApiPort,
 		telemetryService: config.TelemetryService,
 		version:          config.Version,
+		frps:             config.Frps,
+		serverId:         config.ServerId,
 	}
 }
 
@@ -76,6 +82,8 @@ type ApiServer struct {
 	httpServer       *http.Server
 	router           *gin.Engine
 	version          string
+	frps             *daytonaServer.FRPSConfig
+	serverId         string
 }
 
 func (a *ApiServer) Start() error {
@@ -262,8 +270,44 @@ func (a *ApiServer) Start() error {
 		return err
 	}
 
-	log.Infof("Starting api server on port %d", a.apiPort)
-	return a.httpServer.Serve(listener)
+	errChan := make(chan error)
+	go func() {
+		errChan <- a.httpServer.Serve(listener)
+	}()
+
+	if a.frps != nil {
+		frpcHealthCheck, frpcService, err := frpc.GetService(frpc.FrpcConnectParams{
+			ServerDomain: a.frps.Domain,
+			ServerPort:   int(a.frps.Port),
+			Name:         fmt.Sprintf("daytona-server-api-%s", a.serverId),
+			Port:         int(a.apiPort),
+			SubDomain:    fmt.Sprintf("api-%s", a.serverId),
+		})
+		if err != nil {
+			return err
+		}
+
+		go func() {
+			err := frpcService.Run(context.Background())
+			if err != nil {
+				errChan <- err
+			}
+		}()
+
+		for i := 0; i < 5; i++ {
+			if err = frpcHealthCheck(); err != nil {
+				log.Debugf("Failed to connect to api frpc: %s", err)
+				time.Sleep(2 * time.Second)
+			} else {
+				break
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return <-errChan
 }
 
 func (a *ApiServer) HealthCheck() error {

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -75,29 +75,15 @@ var ServeCmd = &cobra.Command{
 			Version:  internal.Version,
 		})
 
-		go func() {
-			interruptChannel := make(chan os.Signal, 1)
-			signal.Notify(interruptChannel, os.Interrupt)
-
-			for range interruptChannel {
-				log.Info("Shutting down")
-			}
-		}()
-
 		apiServer := api.NewApiServer(api.ApiServerConfig{
 			ApiPort:          int(c.ApiPort),
 			TelemetryService: telemetryService,
 			Version:          internal.Version,
+			ServerId:         c.Id,
+			Frps:             c.Frps,
 		})
 
 		server, err := GetInstance(c, configDir, internal.Version, telemetryService)
-		if err != nil {
-			return err
-		}
-
-		errCh := make(chan error)
-
-		err = server.Start(errCh)
 		if err != nil {
 			return err
 		}
@@ -117,22 +103,58 @@ var ServeCmd = &cobra.Command{
 			return err
 		}
 
+		apiServerErrChan := make(chan error)
+
 		go func() {
-			err := apiServer.Start()
+			log.Infof("Starting api server on port %d", c.ApiPort)
+			apiServerErrChan <- apiServer.Start()
+		}()
+
+		headscaleServerStartedChan := make(chan struct{})
+		headscaleServerErrChan := make(chan error)
+
+		go func() {
+			log.Info("Starting headscale server...")
+			err := server.TailscaleServer.Start(headscaleServerErrChan)
 			if err != nil {
-				errCh <- err
+				headscaleServerErrChan <- err
+				return
+			}
+			headscaleServerStartedChan <- struct{}{}
+		}()
+
+		localContainerRegistryErrChan := make(chan error)
+
+		go func() {
+			if server.LocalContainerRegistry != nil {
+				log.Info("Starting local container registry...")
+				localContainerRegistryErrChan <- server.LocalContainerRegistry.Start()
+			} else {
+				localContainerRegistryErrChan <- registry.RemoveRegistryContainer()
 			}
 		}()
 
-		go func() {
-			err := <-errCh
-			if err != nil {
-				buildRunner.Stop()
-			}
-		}()
+		select {
+		case <-headscaleServerStartedChan:
+			log.Info("Headscale server started")
+			go func() {
+				headscaleServerErrChan <- server.TailscaleServer.Connect()
+			}()
+		case err := <-headscaleServerErrChan:
+			return err
+		}
 
-		err = waitForServerToStart(apiServer)
+		err = server.Start()
+		if err != nil {
+			return err
+		}
 
+		err = waitForApiServerToStart(apiServer)
+		if err != nil {
+			return err
+		}
+
+		err = <-localContainerRegistryErrChan
 		if err != nil {
 			return err
 		}
@@ -144,7 +166,19 @@ var ServeCmd = &cobra.Command{
 			return err
 		}
 
-		return <-errCh
+		interruptChannel := make(chan os.Signal, 1)
+		signal.Notify(interruptChannel, os.Interrupt)
+
+		select {
+		case err := <-apiServerErrChan:
+			return err
+		case err := <-headscaleServerErrChan:
+			return err
+		case <-interruptChannel:
+			log.Info("Shutting down")
+			// Exit will be handled by command PreRun
+			select {}
+		}
 	},
 }
 
@@ -205,6 +239,7 @@ func GetInstance(c *server.Config, configDir string, version string, telemetrySe
 		FrpsProtocol:  c.Frps.Protocol,
 		HeadscalePort: c.HeadscalePort,
 		ConfigDir:     filepath.Join(configDir, "headscale"),
+		Frps:          c.Frps,
 	})
 	err = headscaleServer.Init()
 	if err != nil {
@@ -255,6 +290,8 @@ func GetInstance(c *server.Config, configDir string, version string, telemetrySe
 			Port:     c.LocalBuilderRegistryPort,
 			Image:    c.LocalBuilderRegistryImage,
 			Logger:   log.StandardLogger().Writer(),
+			Frps:     c.Frps,
+			ServerId: c.Id,
 		})
 		c.BuilderRegistryServer = util.GetFrpcRegistryDomain(c.Id, c.Frps.Domain)
 	}
@@ -311,7 +348,7 @@ func GetInstance(c *server.Config, configDir string, version string, telemetrySe
 		ProfileDataStore: profileDataStore,
 	})
 
-	return server.GetInstance(&server.ServerInstanceConfig{
+	s := server.GetInstance(&server.ServerInstanceConfig{
 		Config:                   *c,
 		Version:                  version,
 		TailscaleServer:          headscaleServer,
@@ -326,7 +363,9 @@ func GetInstance(c *server.Config, configDir string, version string, telemetrySe
 		ProviderManager:          providerManager,
 		ProfileDataService:       profileDataService,
 		TelemetryService:         telemetryService,
-	}), nil
+	})
+
+	return s, s.Initialize()
 }
 
 func GetBuildRunner(c *server.Config, buildRunnerConfig *build.Config, telemetryService telemetry.TelemetryService) (*build.BuildRunner, error) {
@@ -412,7 +451,7 @@ func GetBuildRunner(c *server.Config, buildRunnerConfig *build.Config, telemetry
 	}), nil
 }
 
-func waitForServerToStart(apiServer *api.ApiServer) error {
+func waitForApiServerToStart(apiServer *api.ApiServer) error {
 	var err error
 	for i := 0; i < 30; i++ {
 		time.Sleep(1 * time.Second)

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -56,7 +56,7 @@ var ServerCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = waitForServerToStart(apiServer)
+		err = waitForApiServerToStart(apiServer)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/purge.go
+++ b/pkg/server/purge.go
@@ -30,9 +30,7 @@ func (s *Server) Purge(ctx context.Context, force bool) []error {
 
 	fmt.Println("Deleting all workspaces...")
 
-	errCh := make(chan error)
-
-	err := server.Start(errCh)
+	err := server.Start()
 	if err != nil {
 		s.trackPurgeError(ctx, force, err)
 		return []error{err}
@@ -62,30 +60,6 @@ func (s *Server) Purge(ctx context.Context, force bool) []error {
 		}
 	} else {
 		fmt.Printf("Failed to list workspaces: %v\n", err)
-	}
-
-	if s.LocalContainerRegistry != nil {
-		fmt.Println("Purging local container registry...")
-		err := s.LocalContainerRegistry.Purge()
-		if err != nil {
-			s.trackPurgeError(ctx, force, err)
-			if !force {
-				return []error{err}
-			} else {
-				fmt.Printf("Failed to purge local container registry: %v\n", err)
-			}
-		}
-	}
-
-	fmt.Println("Purging Tailscale server...")
-	err = s.TailscaleServer.Purge()
-	if err != nil {
-		s.trackPurgeError(ctx, force, err)
-		if !force {
-			return []error{err}
-		} else {
-			fmt.Printf("Failed to purge Tailscale server: %v\n", err)
-		}
 	}
 
 	fmt.Println("Purging providers...")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,13 +4,9 @@
 package server
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"os/signal"
-	"time"
 
-	"github.com/daytonaio/daytona/pkg/frpc"
 	"github.com/daytonaio/daytona/pkg/provider/manager"
 	"github.com/daytonaio/daytona/pkg/server/apikeys"
 	"github.com/daytonaio/daytona/pkg/server/builds"
@@ -19,7 +15,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/server/profiledata"
 	"github.com/daytonaio/daytona/pkg/server/projectconfig"
 	"github.com/daytonaio/daytona/pkg/server/providertargets"
-	"github.com/daytonaio/daytona/pkg/server/registry"
 	"github.com/daytonaio/daytona/pkg/server/workspaces"
 	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/hashicorp/go-plugin"
@@ -95,81 +90,12 @@ type Server struct {
 	TelemetryService         telemetry.TelemetryService
 }
 
-func (s *Server) Start(errCh chan error) error {
-	err := s.initLogs()
-	if err != nil {
-		return err
-	}
+func (s *Server) Initialize() error {
+	return s.initLogs()
+}
 
+func (s *Server) Start() error {
 	log.Info("Starting Daytona server")
-
-	headscaleFrpcHealthCheck, headscaleFrpcService, err := frpc.GetService(frpc.FrpcConnectParams{
-		ServerDomain: s.config.Frps.Domain,
-		ServerPort:   int(s.config.Frps.Port),
-		Name:         fmt.Sprintf("daytona-server-%s", s.config.Id),
-		Port:         int(s.config.HeadscalePort),
-		SubDomain:    s.config.Id,
-	})
-	if err != nil {
-		return err
-	}
-
-	if s.LocalContainerRegistry != nil {
-		log.Info("Starting local container registry")
-		err = s.LocalContainerRegistry.Start()
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		err := registry.RemoveRegistryContainer()
-		if err != nil {
-			log.Fatalf("Failed to remove local container registry: %s", err.Error())
-		}
-	}
-
-	go func() {
-		err := headscaleFrpcService.Run(context.Background())
-		if err != nil {
-			errCh <- err
-		}
-	}()
-
-	apiFrpcHealthCheck, apiFrpcService, err := frpc.GetService(frpc.FrpcConnectParams{
-		ServerDomain: s.config.Frps.Domain,
-		ServerPort:   int(s.config.Frps.Port),
-		Name:         fmt.Sprintf("daytona-server-api-%s", s.config.Id),
-		Port:         int(s.config.ApiPort),
-		SubDomain:    fmt.Sprintf("api-%s", s.config.Id),
-	})
-	if err != nil {
-		return err
-	}
-
-	go func() {
-		err := apiFrpcService.Run(context.Background())
-		if err != nil {
-			errCh <- err
-		}
-	}()
-
-	if s.LocalContainerRegistry != nil {
-		_, registryFrpcService, err := frpc.GetService(frpc.FrpcConnectParams{
-			ServerDomain: s.config.Frps.Domain,
-			ServerPort:   int(s.config.Frps.Port),
-			Name:         fmt.Sprintf("daytona-server-registry-%s", s.config.Id),
-			Port:         int(s.config.LocalBuilderRegistryPort),
-			SubDomain:    fmt.Sprintf("registry-%s", s.config.Id),
-		})
-		if err != nil {
-			return err
-		}
-		go func() {
-			err := registryFrpcService.Run(context.Background())
-			if err != nil {
-				errCh <- err
-			}
-		}()
-	}
 
 	go func() {
 		interruptChannel := make(chan os.Signal, 1)
@@ -180,52 +106,8 @@ func (s *Server) Start(errCh chan error) error {
 		}
 	}()
 
-	go func() {
-		errChan := make(chan error)
-		go func() {
-			errChan <- s.TailscaleServer.Start()
-		}()
-
-		select {
-		case err := <-errChan:
-			errCh <- err
-		case <-time.After(1 * time.Second):
-			go func() {
-				errChan <- s.TailscaleServer.Connect()
-			}()
-		}
-
-		if err := <-errChan; err != nil {
-			errCh <- err
-		}
-	}()
-
-	for i := 0; i < 5; i++ {
-		if err = headscaleFrpcHealthCheck(); err != nil {
-			log.Debugf("Failed to connect to headscale frpc: %s", err)
-			time.Sleep(2 * time.Second)
-		} else {
-			break
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	for i := 0; i < 5; i++ {
-		if err = apiFrpcHealthCheck(); err != nil {
-			log.Debugf("Failed to connect to api frpc: %s", err)
-			time.Sleep(2 * time.Second)
-		} else {
-			break
-		}
-	}
-	if err != nil {
-		return err
-	}
-
 	// Terminate orphaned provider processes
-	err = s.ProviderManager.TerminateProviderProcesses(s.config.ProvidersDir)
+	err := s.ProviderManager.TerminateProviderProcesses(s.config.ProvidersDir)
 	if err != nil {
 		log.Errorf("Failed to terminate orphaned provider processes: %s", err)
 	}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -12,7 +12,7 @@ type TailscaleServer interface {
 	CreateAuthKey() (string, error)
 	CreateUser() error
 	HTTPClient() *http.Client
-	Start() error
+	Start(errChan chan error) error
 	Stop() error
 	Purge() error
 }


### PR DESCRIPTION
# Refactor: Server Start

## Description

This is a small logical refactor that moves responsibility of starting the FRP connection into their respective components. Additionally, starting the headscale server and local CR is now done in the entrypoint (`serve`) rather than in the server start method. Since those components are self-contained, they should be started outside of the server and provided as a dependency to the server itself. This will also enable us to connect to external headscale servers since the Daytona server won't manage one by itself.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
