### PR TITLE
refactor: move get daytona script to common

### DIFF
--- a/pkg/api/controllers/binary/get_daytona.go
+++ b/pkg/api/controllers/binary/get_daytona.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/daytonaio/daytona/internal/constants"
+	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/gin-gonic/gin"
 )
 
@@ -20,7 +20,7 @@ func GetDaytonaScript(ctx *gin.Context) {
 	}
 
 	downloadUrl, _ := url.JoinPath(fmt.Sprintf("%s://%s", scheme, ctx.Request.Host), "binary")
-	getServerScript := constants.GetDaytonaScript(downloadUrl)
+	getServerScript := common.GetDaytonaScript(downloadUrl)
 
 	ctx.String(http.StatusOK, getServerScript)
 }

--- a/pkg/common/get_daytona_script.go
+++ b/pkg/common/get_daytona_script.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package constants
+package common
 
 import (
 	"strings"

--- a/pkg/common/get_daytona_script_test.go
+++ b/pkg/common/get_daytona_script_test.go
@@ -3,7 +3,7 @@
 // Copyright 2024 Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package constants
+package common
 
 import (
 	"testing"


### PR DESCRIPTION
# Refactor: Move get Daytona script to common

## Description

Minor refactor that moves the `GetDaytonaScript` function to the `common` package so it can be reused by other applications.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
