### PR TITLE
feat: open IDE by default on daytona create

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ daytona serve;
 ### Create your first dev environment by opening a new terminal, and running:
 
 ```bash
-daytona create --code
+daytona create
 ```
 
 **Start coding.**
@@ -101,7 +101,7 @@ Setting up development environments has become increasingly challenging over tim
 
 This complexity is unnecessary.
 
-With Daytona, you need only to execute a single command: `daytona create --code`.
+With Daytona, you need only to execute a single command: `daytona create`.
 
 Daytona automates the entire process; provisioning the instance, interpreting and applying the configuration, setting up prebuilds, establishing a secure VPN connection, securely connecting your local or a Web IDE, and assigning a fully qualified domain name to the development environment for easy sharing and collaboration.
 
@@ -193,10 +193,10 @@ Now that you have installed and initialized Daytona, you can proceed to setting 
 ### Creating Dev Environments
 Creating development environments with Daytona is a straightforward process, accomplished with just one command:
 ```bash
-daytona create --code
+daytona create
 ```
 
-You can skip the `--code` flag if you don't wish to open the IDE immediately after creating the environment.
+You can add the `--no-ide` flag if you don't wish to open the IDE immediately after creating the environment.
 
 Upon executing this command, you will be prompted with two questions:
 1. Choose the provider to decide where to create a dev environment.
@@ -227,7 +227,7 @@ Daytona offers flexibility for extension through the creation of plugins and pro
 ### Providers
 Daytona is designed to be infrastructure-agnostic, capable of creating and managing development environments across various platforms. Providers are the components that encapsulate the logic for provisioning compute resources on a specific target platform. They allow for the configuration of different targets within a single provider, enabling, for instance, multiple AWS profiles within an AWS provider.
 
-How does it work? When executing the `daytona create --code` command, Daytona communicates the environment details to the selected provider, which then provisions the necessary compute resources. Once provisioned, Daytona sets up the environment on these resources, allowing the user to interact with the environment seamlessly.
+How does it work? When executing the `daytona create` command, Daytona communicates the environment details to the selected provider, which then provisions the necessary compute resources. Once provisioned, Daytona sets up the environment on these resources, allowing the user to interact with the environment seamlessly.
 
 Providers are independent projects that adhere to the Daytona Provider interface. They can be developed in nearly any major programming language. More details coming soon.
 

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -12,7 +12,6 @@ daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
       --blank                      Create a blank project without using existing configurations
       --branch strings             Specify the Git branches to use in the projects
       --builder BuildChoice        Specify the builder (currently auto/devcontainer/none)
-  -c, --code                       Open the workspace in the IDE after workspace creation
       --custom-image string        Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
       --custom-image-user string   Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
       --devcontainer-path string   Automatically assign the devcontainer builder with the path passed as the flag value
@@ -21,6 +20,7 @@ daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
       --manual                     Manually enter the Git repository
       --multi-project              Workspace with multiple projects/repos
       --name string                Specify the workspace name
+  -n, --no-ide                     Do not open the workspace in the IDE after workspace creation
   -t, --target string              Specify the target (e.g. 'local')
   -y, --yes                        Automatically confirm any prompts
 ```

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -10,10 +10,6 @@ options:
       usage: Specify the Git branches to use in the projects
     - name: builder
       usage: Specify the builder (currently auto/devcontainer/none)
-    - name: code
-      shorthand: c
-      default_value: "false"
-      usage: Open the workspace in the IDE after workspace creation
     - name: custom-image
       usage: |
         Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
@@ -39,6 +35,11 @@ options:
       usage: Workspace with multiple projects/repos
     - name: name
       usage: Specify the workspace name
+    - name: no-ide
+      shorthand: "n"
+      default_value: "false"
+      usage: |
+        Do not open the workspace in the IDE after workspace creation
     - name: target
       shorthand: t
       usage: Specify the target (e.g. 'local')

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -204,7 +204,7 @@ var CreateCmd = &cobra.Command{
 		fmt.Println()
 		info.Render(wsInfo, chosenIde.Name, false)
 
-		if !codeFlag {
+		if noIdeFlag {
 			views.RenderCreationInfoMessage("Run 'daytona code' when you're ready to start developing")
 			return nil
 		}
@@ -223,7 +223,7 @@ var CreateCmd = &cobra.Command{
 
 var nameFlag string
 var targetNameFlag string
-var codeFlag bool
+var noIdeFlag bool
 var blankFlag bool
 var multiProjectFlag bool
 
@@ -249,7 +249,7 @@ func init() {
 	CreateCmd.Flags().StringVarP(&ideFlag, "ide", "i", "", fmt.Sprintf("Specify the IDE (%s)", ideListStr))
 	CreateCmd.Flags().StringVarP(&targetNameFlag, "target", "t", "", "Specify the target (e.g. 'local')")
 	CreateCmd.Flags().BoolVar(&blankFlag, "blank", false, "Create a blank project without using existing configurations")
-	CreateCmd.Flags().BoolVarP(&codeFlag, "code", "c", false, "Open the workspace in the IDE after workspace creation")
+	CreateCmd.Flags().BoolVarP(&noIdeFlag, "no-ide", "n", false, "Do not open the workspace in the IDE after workspace creation")
 	CreateCmd.Flags().BoolVar(&multiProjectFlag, "multi-project", false, "Workspace with multiple projects/repos")
 	CreateCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Automatically confirm any prompts")
 	CreateCmd.Flags().StringSliceVar(projectConfigurationFlags.Branches, "branch", []string{}, "Specify the Git branches to use in the projects")

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -30,6 +30,7 @@ const (
 
 var startProjectFlag string
 var allFlag bool
+var codeFlag bool
 
 var StartCmd = &cobra.Command{
 	Use:     "start [WORKSPACE]",


### PR DESCRIPTION
# open IDE by default on daytona create

## Description

This PR makes daytona create open the IDE by default, replacing the `--code` flag with `--no-ide` to opt out.

### Breaking Change
Removed `--code` flag from the create command. The IDE now opens by default. Users can now pass `--no-ide` flag if they don't wish to open IDE immediately after workspace creation.



---
- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1203

