### PR TITLE
fix: set spinner trigger time to 15 seconds

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -464,8 +464,8 @@ func waitForDial(workspace *apiclient.Workspace, activeProfile *config.Profile, 
 	}
 
 	connectChan := make(chan error)
-	spinner := time.After(3 * time.Second)
-	timeout := time.After(60 * time.Second)
+	spinner := time.After(15 * time.Second)
+	timeout := time.After(2 * time.Minute)
 
 	go func() {
 		for {


### PR DESCRIPTION
# Set spinner trigger time to 15 seconds

## Description

This PR fixes spinner trigger time by setting it to 15 seconds instead of 3 seconds and by setting timeout for tailscale connection upon workspace creation from 1 to 2 minutes.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation