### PR TITLE
feat: Read Workspace and Project logs on Start-Stop

### DIFF
--- a/internal/util/apiclient/websocket_log_reader.go
+++ b/internal/util/apiclient/websocket_log_reader.go
@@ -18,7 +18,7 @@ import (
 
 var workspaceLogsStarted bool
 
-func ReadWorkspaceLogs(ctx context.Context, activeProfile config.Profile, workspaceId string, projectNames []string, follow, showWorkspaceLogs bool) {
+func ReadWorkspaceLogs(ctx context.Context, activeProfile config.Profile, workspaceId string, projectNames []string, follow, showWorkspaceLogs bool, timeNow time.Time) {
 	var wg sync.WaitGroup
 	query := ""
 	if follow {
@@ -32,7 +32,7 @@ func ReadWorkspaceLogs(ctx context.Context, activeProfile config.Profile, worksp
 
 	for index, projectName := range projectNames {
 		wg.Add(1)
-		go func(projectName string) {
+		go func(projectName string, timeNow time.Time) {
 			defer wg.Done()
 
 			for {
@@ -50,11 +50,11 @@ func ReadWorkspaceLogs(ctx context.Context, activeProfile config.Profile, worksp
 					continue
 				}
 
-				readJSONLog(ctx, ws, index)
+				readJSONLog(ctx, ws, index, timeNow)
 				ws.Close()
 				break
 			}
-		}(projectName)
+		}(projectName, timeNow)
 	}
 
 	if showWorkspaceLogs {
@@ -67,7 +67,7 @@ func ReadWorkspaceLogs(ctx context.Context, activeProfile config.Profile, worksp
 				continue
 			}
 
-			readJSONLog(ctx, ws, logs_view.STATIC_INDEX)
+			readJSONLog(ctx, ws, logs_view.STATIC_INDEX, timeNow)
 			ws.Close()
 			break
 		}
@@ -88,13 +88,13 @@ func ReadBuildLogs(ctx context.Context, activeProfile config.Profile, buildId st
 			continue
 		}
 
-		readJSONLog(ctx, ws, logs_view.FIRST_PROJECT_INDEX)
+		readJSONLog(ctx, ws, logs_view.FIRST_PROJECT_INDEX, time.Time{})
 		ws.Close()
 		break
 	}
 }
 
-func readJSONLog(ctx context.Context, ws *websocket.Conn, index int) {
+func readJSONLog(ctx context.Context, ws *websocket.Conn, index int, timeNow time.Time) {
 	logEntriesChan := make(chan logs.LogEntry)
 	readErr := make(chan error)
 	go func() {
@@ -124,7 +124,19 @@ func readJSONLog(ctx context.Context, ws *websocket.Conn, index int) {
 		case <-ctx.Done():
 			return
 		case logEntry := <-logEntriesChan:
-			logs_view.DisplayLogEntry(logEntry, index)
+			if !timeNow.Equal(time.Time{}) {
+				parsedTime, err := time.Parse(time.RFC3339Nano, logEntry.Time)
+				if err != nil {
+					log.Trace(err)
+				}
+
+				if parsedTime.After(timeNow) || parsedTime.Equal(timeNow) {
+					logs_view.DisplayLogEntry(logEntry, index)
+				}
+			} else {
+				logs_view.DisplayLogEntry(logEntry, index)
+			}
+
 		case err := <-readErr:
 			if err != nil {
 				err := ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(time.Second))

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
@@ -98,7 +97,7 @@ var logsCmd = &cobra.Command{
 			})
 		}
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, followFlag, showWorkspaceLogs, time.Time{})
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, followFlag, showWorkspaceLogs, nil)
 
 		return nil
 	},

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
@@ -97,7 +98,7 @@ var logsCmd = &cobra.Command{
 			})
 		}
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, followFlag, showWorkspaceLogs)
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, followFlag, showWorkspaceLogs, time.Time{})
 
 		return nil
 	},

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -158,7 +158,7 @@ var CreateCmd = &cobra.Command{
 		id = stringid.TruncateID(id)
 
 		logsContext, stopLogs := context.WithCancel(context.Background())
-		go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, id, projectNames, true, true)
+		go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, id, projectNames, true, true, time.Time{})
 
 		createdWorkspace, res, err := apiClient.WorkspaceAPI.CreateWorkspace(ctx).Workspace(apiclient.CreateWorkspaceDTO{
 			Id:       id,

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -158,7 +158,7 @@ var CreateCmd = &cobra.Command{
 		id = stringid.TruncateID(id)
 
 		logsContext, stopLogs := context.WithCancel(context.Background())
-		go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, id, projectNames, true, true, time.Time{})
+		go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, id, projectNames, true, true, nil)
 
 		createdWorkspace, res, err := apiClient.WorkspaceAPI.CreateWorkspace(ctx).Workspace(apiclient.CreateWorkspaceDTO{
 			Id:       id,

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -124,6 +124,10 @@ var StartCmd = &cobra.Command{
 
 		if startProjectFlag != "" {
 			projectNames = append(projectNames, startProjectFlag)
+		} else {
+			projectNames = util.ArrayMap(workspace.Projects, func(p apiclient.Project) string {
+				return p.Name
+			})
 		}
 
 		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, timeNow)
@@ -183,7 +187,11 @@ func startAllWorkspaces(activeProfile config.Profile, timeNow time.Time) error {
 			continue
 		}
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, []string{}, false, true, timeNow)
+		projectNames := util.ArrayMap(workspace.Projects, func(p apiclient.Project) string {
+			return p.Name
+		})
+
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, timeNow)
 
 		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' started successfully", workspace.Name))
 	}

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -242,7 +242,7 @@ func StartWorkspace(apiClient *apiclient.APIClient, workspaceId, projectName str
 	ctx := context.Background()
 	var projectNames []string
 	timeFormat := time.Now().Format("2006-01-02 15:04:05")
-	timeNow, err := time.Parse("2006-01-02 15:04:05", timeFormat)
+	from, err := time.Parse("2006-01-02 15:04:05", timeFormat)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func StartWorkspace(apiClient *apiclient.APIClient, workspaceId, projectName str
 	}
 
 	logsContext, stopLogs := context.WithCancel(context.Background())
-	go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, workspace.Id, projectNames, true, true, &timeNow)
+	go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, workspace.Id, projectNames, true, true, &from)
 
 	if projectName == "" {
 		res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, workspaceId).Execute()

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -270,7 +270,7 @@ func StartWorkspace(apiClient *apiclient.APIClient, workspaceId, projectName str
 	}
 
 	logsContext, stopLogs := context.WithCancel(context.Background())
-	go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, workspace.Id, projectNames, true, true, timeNow)
+	go apiclient_util.ReadWorkspaceLogs(logsContext, activeProfile, workspace.Id, projectNames, true, true, &timeNow)
 
 	if projectName == "" {
 		res, err := apiClient.WorkspaceAPI.StartWorkspace(ctx, workspaceId).Execute()

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -31,7 +31,7 @@ var StopCmd = &cobra.Command{
 		var projectNames []string
 
 		timeFormat := time.Now().Format("2006-01-02 15:04:05")
-		timeNow, err := time.Parse("2006-01-02 15:04:05", timeFormat)
+		from, err := time.Parse("2006-01-02 15:04:05", timeFormat)
 		if err != nil {
 			return err
 		}
@@ -47,7 +47,7 @@ var StopCmd = &cobra.Command{
 		}
 
 		if allFlag {
-			return stopAllWorkspaces(activeProfile, timeNow)
+			return stopAllWorkspaces(activeProfile, from)
 		}
 
 		ctx := context.Background()
@@ -93,7 +93,7 @@ var StopCmd = &cobra.Command{
 			})
 		}
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, &timeNow)
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, &from)
 
 		if stopProjectFlag != "" {
 			views.RenderInfoMessage(fmt.Sprintf("Project '%s' from workspace '%s' successfully stopped", stopProjectFlag, workspaceId))
@@ -116,7 +116,7 @@ func init() {
 	StopCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Stop all workspaces")
 }
 
-func stopAllWorkspaces(activeProfile config.Profile, timeNow time.Time) error {
+func stopAllWorkspaces(activeProfile config.Profile, from time.Time) error {
 	ctx := context.Background()
 	apiClient, err := apiclient_util.GetApiClient(nil)
 	if err != nil {
@@ -139,7 +139,7 @@ func stopAllWorkspaces(activeProfile config.Profile, timeNow time.Time) error {
 			return p.Name
 		})
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, &timeNow)
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, &from)
 		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' successfully stopped", workspace.Name))
 	}
 	return nil

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -87,6 +87,10 @@ var StopCmd = &cobra.Command{
 
 		if startProjectFlag != "" {
 			projectNames = append(projectNames, stopProjectFlag)
+		} else {
+			projectNames = util.ArrayMap(workspace.Projects, func(p apiclient.Project) string {
+				return p.Name
+			})
 		}
 
 		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, timeNow)
@@ -131,7 +135,11 @@ func stopAllWorkspaces(activeProfile config.Profile, timeNow time.Time) error {
 			continue
 		}
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, []string{}, false, true, timeNow)
+		projectNames := util.ArrayMap(workspace.Projects, func(p apiclient.Project) string {
+			return p.Name
+		})
+
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, timeNow)
 		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' successfully stopped", workspace.Name))
 	}
 	return nil

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -93,7 +93,7 @@ var StopCmd = &cobra.Command{
 			})
 		}
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, timeNow)
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, &timeNow)
 
 		if stopProjectFlag != "" {
 			views.RenderInfoMessage(fmt.Sprintf("Project '%s' from workspace '%s' successfully stopped", stopProjectFlag, workspaceId))
@@ -139,7 +139,7 @@ func stopAllWorkspaces(activeProfile config.Profile, timeNow time.Time) error {
 			return p.Name
 		})
 
-		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, timeNow)
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, &timeNow)
 		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' successfully stopped", workspace.Name))
 	}
 	return nil

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -6,7 +6,9 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -26,9 +28,26 @@ var StopCmd = &cobra.Command{
 	Args:    cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var workspaceId string
+		var projectNames []string
+
+		timeFormat := time.Now().Format("2006-01-02 15:04:05")
+		timeNow, err := time.Parse("2006-01-02 15:04:05", timeFormat)
+		if err != nil {
+			return err
+		}
+
+		c, err := config.GetConfig()
+		if err != nil {
+			return err
+		}
+
+		activeProfile, err := c.GetActiveProfile()
+		if err != nil {
+			return err
+		}
 
 		if allFlag {
-			return stopAllWorkspaces()
+			return stopAllWorkspaces(activeProfile, timeNow)
 		}
 
 		ctx := context.Background()
@@ -60,6 +79,18 @@ var StopCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		workspace, err := apiclient_util.GetWorkspace(workspaceId, false)
+		if err != nil {
+			return err
+		}
+
+		if startProjectFlag != "" {
+			projectNames = append(projectNames, stopProjectFlag)
+		}
+
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, projectNames, false, true, timeNow)
+
 		if stopProjectFlag != "" {
 			views.RenderInfoMessage(fmt.Sprintf("Project '%s' from workspace '%s' successfully stopped", stopProjectFlag, workspaceId))
 		} else {
@@ -81,7 +112,7 @@ func init() {
 	StopCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Stop all workspaces")
 }
 
-func stopAllWorkspaces() error {
+func stopAllWorkspaces(activeProfile config.Profile, timeNow time.Time) error {
 	ctx := context.Background()
 	apiClient, err := apiclient_util.GetApiClient(nil)
 	if err != nil {
@@ -99,6 +130,8 @@ func stopAllWorkspaces() error {
 			log.Errorf("Failed to stop workspace %s: %v\n\n", workspace.Name, err)
 			continue
 		}
+
+		apiclient_util.ReadWorkspaceLogs(ctx, activeProfile, workspace.Id, []string{}, false, true, timeNow)
 		views.RenderInfoMessage(fmt.Sprintf("- Workspace '%s' successfully stopped", workspace.Name))
 	}
 	return nil

--- a/pkg/logs/project.go
+++ b/pkg/logs/project.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -42,6 +43,7 @@ func (pl *projectLogger) Write(p []byte) (n int, err error) {
 	entry.Source = string(pl.source)
 	entry.WorkspaceId = &pl.workspaceId
 	entry.ProjectName = &pl.projectName
+	entry.Time = time.Now().Format(time.RFC3339)
 
 	b, err := json.Marshal(entry)
 	if err != nil {

--- a/pkg/logs/workspace.go
+++ b/pkg/logs/workspace.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -39,6 +40,7 @@ func (w *workspaceLogger) Write(p []byte) (n int, err error) {
 	entry.Msg = string(p)
 	entry.Source = string(w.source)
 	entry.WorkspaceId = &w.workspaceId
+	entry.Time = time.Now().Format(time.RFC3339)
 
 	b, err := json.Marshal(entry)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR enhances the UX by reading workspace and project logs on start and stop. I've implemented time-stamps to logs of workspace and project as [breakpoints](https://github.com/daytonaio/daytona/issues/593#issuecomment-2228009616) and logic to handle those.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #593
/claim #593

## Screenshots

![Screenshot from 2024-10-08 19-24-36](https://github.com/user-attachments/assets/c6022e2b-b52f-4d8b-ace6-0ba1cd504c8e)
![Screenshot from 2024-10-08 19-25-06](https://github.com/user-attachments/assets/9e3870c9-70eb-4c99-b240-f8385f94183c)

## Notes
The logs for ending a workspace/project do not function at this time because there is no implementation of logger for `daytona stop WS`, which is visible [here](https://github.com/daytonaio/daytona/blob/44dfd6118509b65ef5ac64722339a62a532fca79/pkg/server/workspaces/stop.go#L14).
