### PR TITLE
feature: Added the support for the flags

### DIFF
--- a/docs/daytona_prebuild_add.md
+++ b/docs/daytona_prebuild_add.md
@@ -3,13 +3,17 @@
 Add a prebuild configuration
 
 ```
-daytona prebuild add [flags]
+daytona prebuild add [project-config] [flags]
 ```
 
 ### Options
 
 ```
-      --run   Run the prebuild once after adding it
+      --branch string           Git branch for the prebuild
+      --commit-interval int     Commit interval for the prebuild (in seconds)
+      --retention int           Retention period for the prebuild (in days)
+      --run                     Run the prebuild once after adding it
+      --trigger-files strings   Files that trigger the prebuild
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_prebuild_add.md
+++ b/docs/daytona_prebuild_add.md
@@ -3,7 +3,7 @@
 Add a prebuild configuration
 
 ```
-daytona prebuild add [project-config] [flags]
+daytona prebuild add [PROJECT_CONFIG] [flags]
 ```
 
 ### Options

--- a/docs/daytona_prebuild_add.md
+++ b/docs/daytona_prebuild_add.md
@@ -10,10 +10,10 @@ daytona prebuild add [PROJECT_CONFIG] [flags]
 
 ```
   -b, --branch string           Git branch for the prebuild
-  -c, --commit-interval int     Commit interval for the prebuild (in seconds)
-  -r, --retention int           Retention period for the prebuild (in days)
+  -c, --commit-interval int     Commit interval for running a prebuild - leave blank to ignore push events
+  -r, --retention int           Maximum number of resulting builds stored at a time
       --run                     Run the prebuild once after adding it
-  -t, --trigger-files strings   Files that trigger the prebuild
+  -t, --trigger-files strings   Full paths of files whose changes should explicitly trigger a  prebuild
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_prebuild_add.md
+++ b/docs/daytona_prebuild_add.md
@@ -9,11 +9,11 @@ daytona prebuild add [PROJECT_CONFIG] [flags]
 ### Options
 
 ```
-      --branch string           Git branch for the prebuild
-      --commit-interval int     Commit interval for the prebuild (in seconds)
-      --retention int           Retention period for the prebuild (in days)
+  -b, --branch string           Git branch for the prebuild
+  -c, --commit-interval int     Commit interval for the prebuild (in seconds)
+  -r, --retention int           Retention period for the prebuild (in days)
       --run                     Run the prebuild once after adding it
-      --trigger-files strings   Files that trigger the prebuild
+  -t, --trigger-files strings   Files that trigger the prebuild
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_prebuild_update.md
+++ b/docs/daytona_prebuild_update.md
@@ -3,7 +3,7 @@
 Update a prebuild configuration
 
 ```
-daytona prebuild update [project-config] [prebuild-id] [flags]
+daytona prebuild update [PROJECT_CONFIG] [PREBUILD_ID] [flags]
 ```
 
 ### Options
@@ -11,7 +11,6 @@ daytona prebuild update [project-config] [prebuild-id] [flags]
 ```
       --branch string           Git branch for the prebuild
       --commit-interval int     Commit interval for the prebuild
-      --project-config string   Project configuration name
       --retention int           Retention period for the prebuild
       --run                     Run the prebuild once after updating it
       --trigger-files strings   Files that trigger the prebuild

--- a/docs/daytona_prebuild_update.md
+++ b/docs/daytona_prebuild_update.md
@@ -9,11 +9,11 @@ daytona prebuild update [PROJECT_CONFIG] [PREBUILD_ID] [flags]
 ### Options
 
 ```
-      --branch string           Git branch for the prebuild
-      --commit-interval int     Commit interval for the prebuild
-      --retention int           Retention period for the prebuild
+  -b, --branch string           Git branch for the prebuild
+  -c, --commit-interval int     Commit interval for the prebuild
+  -r, --retention int           Retention period for the prebuild
       --run                     Run the prebuild once after updating it
-      --trigger-files strings   Files that trigger the prebuild
+  -t, --trigger-files strings   Files that trigger the prebuild
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_prebuild_update.md
+++ b/docs/daytona_prebuild_update.md
@@ -10,10 +10,10 @@ daytona prebuild update [PROJECT_CONFIG] [PREBUILD_ID] [flags]
 
 ```
   -b, --branch string           Git branch for the prebuild
-  -c, --commit-interval int     Commit interval for the prebuild
-  -r, --retention int           Retention period for the prebuild
+  -c, --commit-interval int     Commit interval for running a prebuild - leave blank to ignore push events
+  -r, --retention int           Maximum number of resulting builds stored at a time
       --run                     Run the prebuild once after updating it
-  -t, --trigger-files strings   Files that trigger the prebuild
+  -t, --trigger-files strings   Full paths of files whose changes should explicitly trigger a  prebuild
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_prebuild_update.md
+++ b/docs/daytona_prebuild_update.md
@@ -3,13 +3,18 @@
 Update a prebuild configuration
 
 ```
-daytona prebuild update [flags]
+daytona prebuild update [project-config] [prebuild-id] [flags]
 ```
 
 ### Options
 
 ```
-      --run   Run the prebuild once after updating it
+      --branch string           Git branch for the prebuild
+      --commit-interval int     Commit interval for the prebuild
+      --project-config string   Project configuration name
+      --retention int           Retention period for the prebuild
+      --run                     Run the prebuild once after updating it
+      --trigger-files strings   Files that trigger the prebuild
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_prebuild_add.yaml
+++ b/hack/docs/daytona_prebuild_add.yaml
@@ -8,18 +8,20 @@ options:
     - name: commit-interval
       shorthand: c
       default_value: "0"
-      usage: Commit interval for the prebuild (in seconds)
+      usage: |
+        Commit interval for running a prebuild - leave blank to ignore push events
     - name: retention
       shorthand: r
       default_value: "0"
-      usage: Retention period for the prebuild (in days)
+      usage: Maximum number of resulting builds stored at a time
     - name: run
       default_value: "false"
       usage: Run the prebuild once after adding it
     - name: trigger-files
       shorthand: t
       default_value: '[]'
-      usage: Files that trigger the prebuild
+      usage: |
+        Full paths of files whose changes should explicitly trigger a  prebuild
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/daytona_prebuild_add.yaml
+++ b/hack/docs/daytona_prebuild_add.yaml
@@ -1,6 +1,6 @@
 name: daytona prebuild add
 synopsis: Add a prebuild configuration
-usage: daytona prebuild add [project-config] [flags]
+usage: daytona prebuild add [PROJECT_CONFIG] [flags]
 options:
     - name: branch
       usage: Git branch for the prebuild

--- a/hack/docs/daytona_prebuild_add.yaml
+++ b/hack/docs/daytona_prebuild_add.yaml
@@ -3,17 +3,21 @@ synopsis: Add a prebuild configuration
 usage: daytona prebuild add [PROJECT_CONFIG] [flags]
 options:
     - name: branch
+      shorthand: b
       usage: Git branch for the prebuild
     - name: commit-interval
+      shorthand: c
       default_value: "0"
       usage: Commit interval for the prebuild (in seconds)
     - name: retention
+      shorthand: r
       default_value: "0"
       usage: Retention period for the prebuild (in days)
     - name: run
       default_value: "false"
       usage: Run the prebuild once after adding it
     - name: trigger-files
+      shorthand: t
       default_value: '[]'
       usage: Files that trigger the prebuild
 inherited_options:

--- a/hack/docs/daytona_prebuild_add.yaml
+++ b/hack/docs/daytona_prebuild_add.yaml
@@ -1,10 +1,21 @@
 name: daytona prebuild add
 synopsis: Add a prebuild configuration
-usage: daytona prebuild add [flags]
+usage: daytona prebuild add [project-config] [flags]
 options:
+    - name: branch
+      usage: Git branch for the prebuild
+    - name: commit-interval
+      default_value: "0"
+      usage: Commit interval for the prebuild (in seconds)
+    - name: retention
+      default_value: "0"
+      usage: Retention period for the prebuild (in days)
     - name: run
       default_value: "false"
       usage: Run the prebuild once after adding it
+    - name: trigger-files
+      default_value: '[]'
+      usage: Files that trigger the prebuild
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/daytona_prebuild_update.yaml
+++ b/hack/docs/daytona_prebuild_update.yaml
@@ -1,10 +1,23 @@
 name: daytona prebuild update
 synopsis: Update a prebuild configuration
-usage: daytona prebuild update [flags]
+usage: daytona prebuild update [project-config] [prebuild-id] [flags]
 options:
+    - name: branch
+      usage: Git branch for the prebuild
+    - name: commit-interval
+      default_value: "0"
+      usage: Commit interval for the prebuild
+    - name: project-config
+      usage: Project configuration name
+    - name: retention
+      default_value: "0"
+      usage: Retention period for the prebuild
     - name: run
       default_value: "false"
       usage: Run the prebuild once after updating it
+    - name: trigger-files
+      default_value: '[]'
+      usage: Files that trigger the prebuild
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/daytona_prebuild_update.yaml
+++ b/hack/docs/daytona_prebuild_update.yaml
@@ -8,18 +8,20 @@ options:
     - name: commit-interval
       shorthand: c
       default_value: "0"
-      usage: Commit interval for the prebuild
+      usage: |
+        Commit interval for running a prebuild - leave blank to ignore push events
     - name: retention
       shorthand: r
       default_value: "0"
-      usage: Retention period for the prebuild
+      usage: Maximum number of resulting builds stored at a time
     - name: run
       default_value: "false"
       usage: Run the prebuild once after updating it
     - name: trigger-files
       shorthand: t
       default_value: '[]'
-      usage: Files that trigger the prebuild
+      usage: |
+        Full paths of files whose changes should explicitly trigger a  prebuild
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/daytona_prebuild_update.yaml
+++ b/hack/docs/daytona_prebuild_update.yaml
@@ -3,17 +3,21 @@ synopsis: Update a prebuild configuration
 usage: daytona prebuild update [PROJECT_CONFIG] [PREBUILD_ID] [flags]
 options:
     - name: branch
+      shorthand: b
       usage: Git branch for the prebuild
     - name: commit-interval
+      shorthand: c
       default_value: "0"
       usage: Commit interval for the prebuild
     - name: retention
+      shorthand: r
       default_value: "0"
       usage: Retention period for the prebuild
     - name: run
       default_value: "false"
       usage: Run the prebuild once after updating it
     - name: trigger-files
+      shorthand: t
       default_value: '[]'
       usage: Files that trigger the prebuild
 inherited_options:

--- a/hack/docs/daytona_prebuild_update.yaml
+++ b/hack/docs/daytona_prebuild_update.yaml
@@ -1,14 +1,12 @@
 name: daytona prebuild update
 synopsis: Update a prebuild configuration
-usage: daytona prebuild update [project-config] [prebuild-id] [flags]
+usage: daytona prebuild update [PROJECT_CONFIG] [PREBUILD_ID] [flags]
 options:
     - name: branch
       usage: Git branch for the prebuild
     - name: commit-interval
       default_value: "0"
       usage: Commit interval for the prebuild
-    - name: project-config
-      usage: Project configuration name
     - name: retention
       default_value: "0"
       usage: Retention period for the prebuild

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -28,7 +28,7 @@ var (
 var prebuildAddCmd = &cobra.Command{
 	Use:     "add [PROJECT_CONFIG]",
 	Short:   "Add a prebuild configuration",
-	Args:    cobra.MaximumNArgs(1), // Maximum one argument allowed
+	Args:    cobra.MaximumNArgs(1), 
 	Aliases: []string{"new", "create"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var prebuildAddView add.PrebuildAddView

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -102,13 +102,14 @@ var prebuildAddCmd = &cobra.Command{
 				if err != nil {
 					return apiclient_util.HandleErrorResponse(res, err)
 				}
+				if projectConfigTemp == nil {
+					return errors.New("Invalid project config specified")
+				}
 
 				prebuildAddView.ProjectConfigName = projectConfigTemp.Name
 				projectConfig = projectConfigTemp
 
-				if projectConfig == nil {
-					return errors.New("Invalid project config specified")
-				}
+				
 			} else {
 				return errors.New("Project config must be specified when using flags")
 			}
@@ -171,7 +172,6 @@ var prebuildAddCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Printf(buildId)
 
 			views.RenderViewBuildLogsMessage(buildId)
 		}

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -184,7 +184,7 @@ var prebuildAddCmd = &cobra.Command{
 func init() {
 	prebuildAddCmd.Flags().BoolVar(&runOnAddFlag, "run", false, "Run the prebuild once after adding it")
 	prebuildAddCmd.Flags().StringVarP(&branchFlag, "branch", "b", "", "Git branch for the prebuild")
-	prebuildAddCmd.Flags().IntVarP(&retentionFlag, "retention", "r", 0, "Retention period for the prebuild (in days)")
-	prebuildAddCmd.Flags().IntVarP(&commitIntervalFlag, "commit-interval", "c", 0, "Commit interval for the prebuild (in seconds)")
-	prebuildAddCmd.Flags().StringSliceVarP(&triggerFilesFlag, "trigger-files", "t", nil, "Files that trigger the prebuild")
+	prebuildAddCmd.Flags().IntVarP(&retentionFlag, "retention", "r", 0, "Maximum number of resulting builds stored at a time")
+	prebuildAddCmd.Flags().IntVarP(&commitIntervalFlag, "commit-interval", "c", 0, "Commit interval for running a prebuild - leave blank to ignore push events")
+	prebuildAddCmd.Flags().StringSliceVarP(&triggerFilesFlag, "trigger-files", "t", nil, "Full paths of files whose changes should explicitly trigger a  prebuild")
 }

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -109,7 +109,6 @@ var prebuildAddCmd = &cobra.Command{
 				prebuildAddView.ProjectConfigName = projectConfigTemp.Name
 				projectConfig = projectConfigTemp
 
-				
 			} else {
 				return errors.New("Project config must be specified when using flags")
 			}

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -26,7 +26,7 @@ var (
 )
 
 var prebuildAddCmd = &cobra.Command{
-	Use:     "add [project-config]",
+	Use:     "add [PROJECT_CONFIG]",
 	Short:   "Add a prebuild configuration",
 	Args:    cobra.MaximumNArgs(1), // Maximum one argument allowed
 	Aliases: []string{"new", "create"},
@@ -41,8 +41,8 @@ var prebuildAddCmd = &cobra.Command{
 		}
 
 		// If no arguments and no flags are provided, run the interactive CLI
-		if len(args) == 0 && !cmd.Flags().Changed("branch") && !cmd.Flags().Changed("retention") &&
-			!cmd.Flags().Changed("commit-interval") && !cmd.Flags().Changed("trigger-files") {
+		if len(args) == 0 && branchFlag == "" && retentionFlag == 0 &&
+			commitIntervalFlag == 0 && triggerFilesFlag == nil {
 			// Interactive CLI logic
 			gitProviders, res, err := apiClient.GitProviderAPI.ListGitProviders(ctx).Execute()
 			if err != nil {

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -75,7 +75,6 @@ var prebuildAddCmd = &cobra.Command{
 			}
 
 			prebuildAddView.ProjectConfigName = projectConfig.Name
-
 			if projectConfig.BuildConfig == nil {
 				return errors.New("The chosen project config does not have a build configuration")
 			}
@@ -89,9 +88,9 @@ var prebuildAddCmd = &cobra.Command{
 				fmt.Println("Operation canceled")
 				return nil
 			}
-
 			prebuildAddView.RunBuildOnAdd = runOnAddFlag
 			prebuildAddView.Branch = chosenBranch.Name
+			add.PrebuildCreationView(&prebuildAddView, false)
 		} else {
 			// Non-interactive mode: use provided arguments and flags
 			if len(args) > 0 {
@@ -140,10 +139,13 @@ var prebuildAddCmd = &cobra.Command{
 				return errors.New("commit interval must be a number")
 			}
 		}
+		var retention int
 
-		retention, err := strconv.Atoi(prebuildAddView.Retention)
-		if err != nil {
-			return errors.New("retention must be a number")
+		if prebuildAddView.Retention != "" {
+			retention, err = strconv.Atoi(prebuildAddView.Retention)
+			if err != nil {
+				return errors.New("retention must be a number")
+			}
 		}
 
 		newPrebuild := apiclient.CreatePrebuildDTO{
@@ -181,8 +183,8 @@ var prebuildAddCmd = &cobra.Command{
 
 func init() {
 	prebuildAddCmd.Flags().BoolVar(&runOnAddFlag, "run", false, "Run the prebuild once after adding it")
-	prebuildAddCmd.Flags().StringVar(&branchFlag, "branch", "", "Git branch for the prebuild")
-	prebuildAddCmd.Flags().IntVar(&retentionFlag, "retention", 0, "Retention period for the prebuild (in days)")
-	prebuildAddCmd.Flags().IntVar(&commitIntervalFlag, "commit-interval", 0, "Commit interval for the prebuild (in seconds)")
-	prebuildAddCmd.Flags().StringSliceVar(&triggerFilesFlag, "trigger-files", nil, "Files that trigger the prebuild")
+	prebuildAddCmd.Flags().StringVarP(&branchFlag, "branch", "b", "", "Git branch for the prebuild")
+	prebuildAddCmd.Flags().IntVarP(&retentionFlag, "retention", "r", 0, "Retention period for the prebuild (in days)")
+	prebuildAddCmd.Flags().IntVarP(&commitIntervalFlag, "commit-interval", "c", 0, "Commit interval for the prebuild (in seconds)")
+	prebuildAddCmd.Flags().StringSliceVarP(&triggerFilesFlag, "trigger-files", "t", nil, "Files that trigger the prebuild")
 }

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -21,11 +21,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	runOnAddFlag bool
+)
+
 var prebuildAddCmd = &cobra.Command{
-	Use:     "add",
+	Use:     "add [flags]",
 	Short:   "Add a prebuild configuration",
 	Args:    cobra.NoArgs,
 	Aliases: []string{"new", "create"},
+	Long: `
+Add a prebuild configuration for your project.
+
+Flags:
+  --run                  Run the prebuild once after adding it.
+  --branch               Specify the Git branch for the prebuild.
+  --retention            Set the retention period for the prebuild (in days).
+  --commit-interval      Set the interval for commits (in seconds).
+  --trigger-files        Specify files that will trigger the prebuild.
+  --project-config       Specify the project configuration name.
+
+Examples:
+  daytona prebuild add --branch main --retention 30 --commit-interval 10 --trigger-files file1.go,file2.go --project-config myProject
+  daytona prebuild add --run --project-config myProject
+  `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var prebuildAddView add.PrebuildAddView
 		var projectConfig *apiclient.ProjectConfig
@@ -98,7 +117,6 @@ var prebuildAddCmd = &cobra.Command{
 		retention, err := strconv.Atoi(prebuildAddView.Retention)
 		if err != nil {
 			return errors.New("retention must be a number")
-
 		}
 
 		newPrebuild := apiclient.CreatePrebuildDTO{
@@ -134,8 +152,11 @@ var prebuildAddCmd = &cobra.Command{
 	},
 }
 
-var runOnAddFlag bool
-
 func init() {
 	prebuildAddCmd.Flags().BoolVar(&runOnAddFlag, "run", false, "Run the prebuild once after adding it")
+	prebuildAddCmd.Flags().StringVar(&branchFlag, "branch", "", "Git branch for the prebuild")
+	prebuildAddCmd.Flags().IntVar(&retentionFlag, "retention", 0, "Retention period for the prebuild (in days)")
+	prebuildAddCmd.Flags().IntVar(&commitIntervalFlag, "commit-interval", 0, "Commit interval for the prebuild (in seconds)")
+	prebuildAddCmd.Flags().StringSliceVar(&triggerFilesFlag, "trigger-files", nil, "Files that trigger the prebuild")
+	prebuildAddCmd.Flags().StringVar(&projectConfigFlag, "project-config", "", "Project configuration name")
 }

--- a/pkg/cmd/prebuild/update.go
+++ b/pkg/cmd/prebuild/update.go
@@ -18,18 +18,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	branchFlag         string
-	retentionFlag      int
-	commitIntervalFlag int
-	triggerFilesFlag   []string
-	runOnUpdateFlag    bool
-)
-
 var prebuildUpdateCmd = &cobra.Command{
 	Use:   "update [PROJECT_CONFIG] [PREBUILD_ID]",
 	Short: "Update a prebuild configuration",
-	Args:  cobra.MaximumNArgs(2), // Allow up to 2 arguments
+	Args:  cobra.MaximumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var prebuildAddView add.PrebuildAddView
 		var prebuild *apiclient.PrebuildDTO
@@ -84,14 +76,11 @@ var prebuildUpdateCmd = &cobra.Command{
 			if len(triggerFilesFlag) > 0 {
 				prebuild.TriggerFiles = triggerFilesFlag
 			}
-
-			prebuildAddView = add.PrebuildAddView{
-				Branch:            prebuild.Branch,
-				Retention:         strconv.Itoa(int(prebuild.Retention)),
-				ProjectConfigName: projectConfigRecieved,
-				TriggerFiles:      triggerFilesFlag,
-				CommitInterval:    strconv.Itoa(int(commitIntervalFlag)),
-			}
+			prebuildAddView.Branch = prebuild.Branch
+			prebuildAddView.Retention = strconv.Itoa(int(prebuild.Retention))
+			prebuildAddView.ProjectConfigName = projectConfigRecieved
+			prebuildAddView.TriggerFiles = triggerFilesFlag
+			prebuildAddView.CommitInterval = strconv.Itoa(int(commitIntervalFlag))
 			retention = int(prebuild.Retention)
 		} else {
 			// Interactive mode: Prompt for details
@@ -116,7 +105,6 @@ var prebuildUpdateCmd = &cobra.Command{
 				return nil
 			}
 
-			// Select prebuild from the prompt
 			prebuild = selection.GetPrebuildFromPrompt(prebuilds, "Update")
 			if prebuild == nil {
 				return nil
@@ -191,10 +179,18 @@ var prebuildUpdateCmd = &cobra.Command{
 	},
 }
 
+var (
+	branchFlag         string
+	retentionFlag      int
+	commitIntervalFlag int
+	triggerFilesFlag   []string
+	runOnUpdateFlag    bool
+)
+
 func init() {
 	prebuildUpdateCmd.Flags().StringVarP(&branchFlag, "branch", "b", "", "Git branch for the prebuild")
-	prebuildUpdateCmd.Flags().IntVarP(&retentionFlag, "retention", "r", 0, "Retention period for the prebuild")
-	prebuildUpdateCmd.Flags().IntVarP(&commitIntervalFlag, "commit-interval", "c", 0, "Commit interval for the prebuild")
-	prebuildUpdateCmd.Flags().StringSliceVarP(&triggerFilesFlag, "trigger-files", "t", nil, "Files that trigger the prebuild")
+	prebuildUpdateCmd.Flags().IntVarP(&retentionFlag, "retention", "r", 0, "Maximum number of resulting builds stored at a time")
+	prebuildUpdateCmd.Flags().IntVarP(&commitIntervalFlag, "commit-interval", "c", 0, "Commit interval for running a prebuild - leave blank to ignore push events")
+	prebuildUpdateCmd.Flags().StringSliceVarP(&triggerFilesFlag, "trigger-files", "t", nil, "Full paths of files whose changes should explicitly trigger a  prebuild")
 	prebuildUpdateCmd.Flags().BoolVar(&runOnUpdateFlag, "run", false, "Run the prebuild once after updating it")
 }

--- a/pkg/cmd/prebuild/update.go
+++ b/pkg/cmd/prebuild/update.go
@@ -79,8 +79,8 @@ var prebuildUpdateCmd = &cobra.Command{
 			prebuildAddView.Branch = prebuild.Branch
 			prebuildAddView.Retention = strconv.Itoa(int(prebuild.Retention))
 			prebuildAddView.ProjectConfigName = projectConfigRecieved
-			prebuildAddView.TriggerFiles = triggerFilesFlag
-			prebuildAddView.CommitInterval = strconv.Itoa(int(commitIntervalFlag))
+			prebuildAddView.TriggerFiles = prebuild.TriggerFiles
+			prebuildAddView.CommitInterval = strconv.Itoa(int(*prebuild.CommitInterval))
 			retention = int(prebuild.Retention)
 		} else {
 			// Interactive mode: Prompt for details
@@ -130,7 +130,7 @@ var prebuildUpdateCmd = &cobra.Command{
 			add.PrebuildCreationView(&prebuildAddView, false)
 		}
 
-		prebuildAddView.RunBuildOnAdd = runOnUpdateFlag
+		prebuildAddView.RunBuildOnAdd = runFlag
 
 		var commitInterval int
 		if prebuildAddView.CommitInterval != "" {
@@ -184,7 +184,7 @@ var (
 	retentionFlag      int
 	commitIntervalFlag int
 	triggerFilesFlag   []string
-	runOnUpdateFlag    bool
+	runFlag            bool
 )
 
 func init() {
@@ -192,5 +192,5 @@ func init() {
 	prebuildUpdateCmd.Flags().IntVarP(&retentionFlag, "retention", "r", 0, "Maximum number of resulting builds stored at a time")
 	prebuildUpdateCmd.Flags().IntVarP(&commitIntervalFlag, "commit-interval", "c", 0, "Commit interval for running a prebuild - leave blank to ignore push events")
 	prebuildUpdateCmd.Flags().StringSliceVarP(&triggerFilesFlag, "trigger-files", "t", nil, "Full paths of files whose changes should explicitly trigger a  prebuild")
-	prebuildUpdateCmd.Flags().BoolVar(&runOnUpdateFlag, "run", false, "Run the prebuild once after updating it")
+	prebuildUpdateCmd.Flags().BoolVar(&runFlag, "run", false, "Run the prebuild once after updating it")
 }

--- a/pkg/cmd/prebuild/update.go
+++ b/pkg/cmd/prebuild/update.go
@@ -28,7 +28,7 @@ var (
 )
 
 var prebuildUpdateCmd = &cobra.Command{
-	Use:   "update [project-config] [prebuild-id]",
+	Use:   "update [PROJECT_CONFIG] [PREBUILD_ID]",
 	Short: "Update a prebuild configuration",
 	Args:  cobra.MaximumNArgs(2), // Allow up to 2 arguments
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -193,6 +193,5 @@ func init() {
 	prebuildUpdateCmd.Flags().IntVar(&retentionFlag, "retention", 0, "Retention period for the prebuild")
 	prebuildUpdateCmd.Flags().IntVar(&commitIntervalFlag, "commit-interval", 0, "Commit interval for the prebuild")
 	prebuildUpdateCmd.Flags().StringSliceVar(&triggerFilesFlag, "trigger-files", nil, "Files that trigger the prebuild")
-	prebuildUpdateCmd.Flags().StringVar(&projectConfigFlag, "project-config", "", "Project configuration name") // New flag
 	prebuildUpdateCmd.Flags().BoolVar(&runOnUpdateFlag, "run", false, "Run the prebuild once after updating it")
 }

--- a/pkg/cmd/prebuild/update.go
+++ b/pkg/cmd/prebuild/update.go
@@ -6,7 +6,6 @@ package prebuild
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 
 	"github.com/daytonaio/daytona/internal/util"
@@ -62,10 +61,6 @@ var prebuildUpdateCmd = &cobra.Command{
 
 			projectConfigFlag = args[0]
 			prebuildID := args[1]
-			prebuilds, res, err := apiClient.PrebuildAPI.ListPrebuildsForProjectConfig(ctx, projectConfigFlag).Execute()
-			if err != nil {
-				return apiclient_util.HandleErrorResponse(res, err)
-			}
 
 			prebuild, res, err = apiClient.PrebuildAPI.GetPrebuild(ctx, projectConfigFlag, prebuildID).Execute()
 			if err != nil {

--- a/pkg/server/projectconfig/prebuild.go
+++ b/pkg/server/projectconfig/prebuild.go
@@ -28,8 +28,8 @@ func (s *ProjectConfigService) SetPrebuild(projectConfigName string, createPrebu
 
 	existingPrebuild, err := projectConfig.FindPrebuild(&config.PrebuildFilter{
 		Branch: &createPrebuildDto.Branch,
+		Id:     createPrebuildDto.Id,
 	})
-
 	if err == nil && createPrebuildDto.Id != nil && *createPrebuildDto.Id != existingPrebuild.Id {
 		return nil, errors.New("prebuild for the specified project config and branch already exists")
 	}

--- a/pkg/server/projectconfig/prebuild.go
+++ b/pkg/server/projectconfig/prebuild.go
@@ -29,6 +29,7 @@ func (s *ProjectConfigService) SetPrebuild(projectConfigName string, createPrebu
 	existingPrebuild, err := projectConfig.FindPrebuild(&config.PrebuildFilter{
 		Branch: &createPrebuildDto.Branch,
 	})
+
 	if err == nil && createPrebuildDto.Id != nil && *createPrebuildDto.Id != existingPrebuild.Id {
 		return nil, errors.New("prebuild for the specified project config and branch already exists")
 	}

--- a/pkg/server/projectconfig/prebuild.go
+++ b/pkg/server/projectconfig/prebuild.go
@@ -28,7 +28,6 @@ func (s *ProjectConfigService) SetPrebuild(projectConfigName string, createPrebu
 
 	existingPrebuild, err := projectConfig.FindPrebuild(&config.PrebuildFilter{
 		Branch: &createPrebuildDto.Branch,
-		Id:     createPrebuildDto.Id,
 	})
 	if err == nil && createPrebuildDto.Id != nil && *createPrebuildDto.Id != existingPrebuild.Id {
 		return nil, errors.New("prebuild for the specified project config and branch already exists")


### PR DESCRIPTION
# Added the feature for the flags in prebuild add/update

## Description

In the cobra command added the flags 

### Usage of update command after updating 

```  
daytona update <Project Config>  <PrebuildID>  --branch=main --retention=300 --commit-interval=60 --trigger-files="file1.go,file2.go" --run
```

### Usage of the add command after updating 

```
daytona prebuild add <Project Config>  --branch=main --retention=30 --commit-interval=60 --trigger-files="file1.go,file2.go" --run  
```


- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR fixes #985 

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.

@quest-bot loot #985
