### PR TITLE
feat: add provider and target during create, provider labels

### DIFF
--- a/pkg/api/controllers/provider/dto/dto.go
+++ b/pkg/api/controllers/provider/dto/dto.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Provider struct {
-	Name    string `json:"name" validate:"required"`
-	Version string `json:"version" validate:"required"`
+	Name    string  `json:"name" validate:"required"`
+	Label   *string `json:"label" validate:"optional"`
+	Version string  `json:"version" validate:"required"`
 } //	@name	Provider
 
 type InstallProviderRequest struct {

--- a/pkg/api/controllers/provider/list.go
+++ b/pkg/api/controllers/provider/list.go
@@ -36,6 +36,7 @@ func ListProviders(ctx *gin.Context) {
 
 		result = append(result, dto.Provider{
 			Name:    info.Name,
+			Label:   info.Label,
 			Version: info.Version,
 		})
 	}

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -2561,6 +2561,9 @@ const docTemplate = `{
                 "version"
             ],
             "properties": {
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -2874,6 +2877,9 @@ const docTemplate = `{
                 "version"
             ],
             "properties": {
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -2558,6 +2558,9 @@
                 "version"
             ],
             "properties": {
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -2871,6 +2874,9 @@
                 "version"
             ],
             "properties": {
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -548,6 +548,8 @@ definitions:
     type: object
   Provider:
     properties:
+      label:
+        type: string
       name:
         type: string
       version:
@@ -773,6 +775,8 @@ definitions:
     - BuildStateDeleting
   provider.ProviderInfo:
     properties:
+      label:
+        type: string
       name:
         type: string
       version:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -2158,8 +2158,11 @@ components:
     Provider:
       example:
         name: name
+        label: label
         version: version
       properties:
+        label:
+          type: string
         name:
           type: string
         version:
@@ -2174,6 +2177,7 @@ components:
         options: options
         providerInfo:
           name: name
+          label: label
           version: version
       properties:
         name:
@@ -2642,8 +2646,11 @@ components:
     provider.ProviderInfo:
       example:
         name: name
+        label: label
         version: version
       properties:
+        label:
+          type: string
         name:
           type: string
         version:

--- a/pkg/apiclient/docs/Provider.md
+++ b/pkg/apiclient/docs/Provider.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Label** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
 **Version** | **string** |  | 
 
@@ -25,6 +26,31 @@ will change when the set of required properties is changed
 NewProviderWithDefaults instantiates a new Provider object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetLabel
+
+`func (o *Provider) GetLabel() string`
+
+GetLabel returns the Label field if non-nil, zero value otherwise.
+
+### GetLabelOk
+
+`func (o *Provider) GetLabelOk() (*string, bool)`
+
+GetLabelOk returns a tuple with the Label field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLabel
+
+`func (o *Provider) SetLabel(v string)`
+
+SetLabel sets Label field to given value.
+
+### HasLabel
+
+`func (o *Provider) HasLabel() bool`
+
+HasLabel returns a boolean if a field has been set.
 
 ### GetName
 

--- a/pkg/apiclient/docs/ProviderProviderInfo.md
+++ b/pkg/apiclient/docs/ProviderProviderInfo.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Label** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
 **Version** | **string** |  | 
 
@@ -25,6 +26,31 @@ will change when the set of required properties is changed
 NewProviderProviderInfoWithDefaults instantiates a new ProviderProviderInfo object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetLabel
+
+`func (o *ProviderProviderInfo) GetLabel() string`
+
+GetLabel returns the Label field if non-nil, zero value otherwise.
+
+### GetLabelOk
+
+`func (o *ProviderProviderInfo) GetLabelOk() (*string, bool)`
+
+GetLabelOk returns a tuple with the Label field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetLabel
+
+`func (o *ProviderProviderInfo) SetLabel(v string)`
+
+SetLabel sets Label field to given value.
+
+### HasLabel
+
+`func (o *ProviderProviderInfo) HasLabel() bool`
+
+HasLabel returns a boolean if a field has been set.
 
 ### GetName
 

--- a/pkg/apiclient/model_provider.go
+++ b/pkg/apiclient/model_provider.go
@@ -21,8 +21,9 @@ var _ MappedNullable = &Provider{}
 
 // Provider struct for Provider
 type Provider struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Label   *string `json:"label,omitempty"`
+	Name    string  `json:"name"`
+	Version string  `json:"version"`
 }
 
 type _Provider Provider
@@ -44,6 +45,38 @@ func NewProvider(name string, version string) *Provider {
 func NewProviderWithDefaults() *Provider {
 	this := Provider{}
 	return &this
+}
+
+// GetLabel returns the Label field value if set, zero value otherwise.
+func (o *Provider) GetLabel() string {
+	if o == nil || IsNil(o.Label) {
+		var ret string
+		return ret
+	}
+	return *o.Label
+}
+
+// GetLabelOk returns a tuple with the Label field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Provider) GetLabelOk() (*string, bool) {
+	if o == nil || IsNil(o.Label) {
+		return nil, false
+	}
+	return o.Label, true
+}
+
+// HasLabel returns a boolean if a field has been set.
+func (o *Provider) HasLabel() bool {
+	if o != nil && !IsNil(o.Label) {
+		return true
+	}
+
+	return false
+}
+
+// SetLabel gets a reference to the given string and assigns it to the Label field.
+func (o *Provider) SetLabel(v string) {
+	o.Label = &v
 }
 
 // GetName returns the Name field value
@@ -104,6 +137,9 @@ func (o Provider) MarshalJSON() ([]byte, error) {
 
 func (o Provider) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Label) {
+		toSerialize["label"] = o.Label
+	}
 	toSerialize["name"] = o.Name
 	toSerialize["version"] = o.Version
 	return toSerialize, nil

--- a/pkg/apiclient/model_provider_provider_info.go
+++ b/pkg/apiclient/model_provider_provider_info.go
@@ -21,8 +21,9 @@ var _ MappedNullable = &ProviderProviderInfo{}
 
 // ProviderProviderInfo struct for ProviderProviderInfo
 type ProviderProviderInfo struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Label   *string `json:"label,omitempty"`
+	Name    string  `json:"name"`
+	Version string  `json:"version"`
 }
 
 type _ProviderProviderInfo ProviderProviderInfo
@@ -44,6 +45,38 @@ func NewProviderProviderInfo(name string, version string) *ProviderProviderInfo 
 func NewProviderProviderInfoWithDefaults() *ProviderProviderInfo {
 	this := ProviderProviderInfo{}
 	return &this
+}
+
+// GetLabel returns the Label field value if set, zero value otherwise.
+func (o *ProviderProviderInfo) GetLabel() string {
+	if o == nil || IsNil(o.Label) {
+		var ret string
+		return ret
+	}
+	return *o.Label
+}
+
+// GetLabelOk returns a tuple with the Label field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ProviderProviderInfo) GetLabelOk() (*string, bool) {
+	if o == nil || IsNil(o.Label) {
+		return nil, false
+	}
+	return o.Label, true
+}
+
+// HasLabel returns a boolean if a field has been set.
+func (o *ProviderProviderInfo) HasLabel() bool {
+	if o != nil && !IsNil(o.Label) {
+		return true
+	}
+
+	return false
+}
+
+// SetLabel gets a reference to the given string and assigns it to the Label field.
+func (o *ProviderProviderInfo) SetLabel(v string) {
+	o.Label = &v
 }
 
 // GetName returns the Name field value
@@ -104,6 +137,9 @@ func (o ProviderProviderInfo) MarshalJSON() ([]byte, error) {
 
 func (o ProviderProviderInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.Label) {
+		toSerialize["label"] = o.Label
+	}
 	toSerialize["name"] = o.Name
 	toSerialize["version"] = o.Version
 	return toSerialize, nil

--- a/pkg/cmd/provider/install.go
+++ b/pkg/cmd/provider/install.go
@@ -60,7 +60,7 @@ var providerInstallCmd = &cobra.Command{
 		providerList := GetProviderListFromManifest(providersManifestLatest)
 		specificProviderName := "Select a specific version"
 		specificProviderVersion := ""
-		providerList = append(providerList, apiclient.Provider{Name: specificProviderName, Version: specificProviderVersion})
+		providerList = append(providerList, apiclient.Provider{Name: specificProviderName, Label: &specificProviderName, Version: specificProviderVersion})
 
 		providerToInstall, err := provider.GetProviderFromPrompt(provider.ProviderListToView(providerList), "Choose a Provider to Install", false)
 		if err != nil {
@@ -131,9 +131,9 @@ var providerInstallCmd = &cobra.Command{
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
-			targetToSet := &apiclient.ProviderTarget{
+			targetToSet := &target.TargetView{
 				Options: "{}",
-				ProviderInfo: apiclient.ProviderProviderInfo{
+				ProviderInfo: target.ProviderInfo{
 					Name:    providerToInstall.Name,
 					Version: providerToInstall.Version,
 				},
@@ -149,7 +149,16 @@ var providerInstallCmd = &cobra.Command{
 				return err
 			}
 
-			res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(*targetToSet).Execute()
+			targetData := apiclient.ProviderTarget{
+				Name:    targetToSet.Name,
+				Options: targetToSet.Options,
+				ProviderInfo: apiclient.ProviderProviderInfo{
+					Name:    targetToSet.ProviderInfo.Name,
+					Version: targetToSet.ProviderInfo.Version,
+				},
+			}
+
+			res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(targetData).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
@@ -168,17 +177,18 @@ func init() {
 }
 
 func GetProviderListFromManifest(manifest *manager.ProvidersManifest) []apiclient.Provider {
-	pluginList := []apiclient.Provider{}
-	for pluginName, pluginManifest := range *manifest {
-		for version := range pluginManifest.Versions {
-			pluginList = append(pluginList, apiclient.Provider{
-				Name:    pluginName,
+	providerList := []apiclient.Provider{}
+	for providerName, providerManifest := range *manifest {
+		for version := range providerManifest.Versions {
+			providerList = append(providerList, apiclient.Provider{
+				Name:    providerName,
+				Label:   &providerManifest.Label,
 				Version: version,
 			})
 		}
 	}
 
-	return pluginList
+	return providerList
 }
 
 func ConvertOSToStringMap(downloadUrls map[os.OperatingSystem]string) map[string]string {

--- a/pkg/cmd/provider/install.go
+++ b/pkg/cmd/provider/install.go
@@ -182,7 +182,7 @@ func GetProviderListFromManifest(manifest *manager.ProvidersManifest) []apiclien
 		for version := range providerManifest.Versions {
 			providerList = append(providerList, apiclient.Provider{
 				Name:    providerName,
-				Label:   &providerManifest.Label,
+				Label:   providerManifest.Label,
 				Version: version,
 			})
 		}

--- a/pkg/cmd/provider/list.go
+++ b/pkg/cmd/provider/list.go
@@ -57,6 +57,7 @@ func GetProviderViewOptions(apiClient *apiclient.APIClient, latestProviders []ap
 	for _, installedProvider := range installedProviders {
 		providerMap[installedProvider.Name] = provider_view.ProviderView{
 			Name:      installedProvider.Name,
+			Label:     installedProvider.Label,
 			Version:   installedProvider.Version,
 			Installed: util.Pointer(true),
 		}
@@ -66,6 +67,7 @@ func GetProviderViewOptions(apiClient *apiclient.APIClient, latestProviders []ap
 		if _, exists := providerMap[latestProvider.Name]; !exists {
 			providerMap[latestProvider.Name] = provider_view.ProviderView{
 				Name:      latestProvider.Name,
+				Label:     latestProvider.Label,
 				Version:   latestProvider.Version,
 				Installed: util.Pointer(false),
 			}

--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -52,7 +52,7 @@ var targetRemoveCmd = &cobra.Command{
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
-			selectedTarget, err := target.GetTargetFromPrompt(targetList, activeProfile.Name, false)
+			selectedTarget, err := target.GetTargetFromPrompt(targetList, activeProfile.Name, nil, false)
 			if err != nil {
 				if common.IsCtrlCAbort(err) {
 					return nil

--- a/pkg/cmd/target/set.go
+++ b/pkg/cmd/target/set.go
@@ -110,7 +110,7 @@ var TargetSetCmd = &cobra.Command{
 			}
 		}
 
-		selectedTarget, err := target.GetTargetFromPrompt(filteredTargets, activeProfile.Name, true)
+		selectedTarget, err := target.GetTargetFromPrompt(filteredTargets, activeProfile.Name, nil, true)
 		if err != nil {
 			if common.IsCtrlCAbort(err) {
 				return nil
@@ -139,12 +139,16 @@ var TargetSetCmd = &cobra.Command{
 			return err
 		}
 
-		selectedTarget.ProviderInfo = apiclient.ProviderProviderInfo{
-			Name:    selectedProvider.Name,
-			Version: selectedProvider.Version,
+		targetData := apiclient.ProviderTarget{
+			Name:    selectedTarget.Name,
+			Options: selectedTarget.Options,
+			ProviderInfo: apiclient.ProviderProviderInfo{
+				Name:    selectedProvider.Name,
+				Version: selectedProvider.Version,
+			},
 		}
 
-		res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(*selectedTarget).Execute()
+		res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(targetData).Execute()
 		if err != nil {
 			return apiclient_util.HandleErrorResponse(res, err)
 		}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -23,7 +23,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/logs"
 	"github.com/daytonaio/daytona/pkg/views"
 	logs_view "github.com/daytonaio/daytona/pkg/views/logs"
-	"github.com/daytonaio/daytona/pkg/views/target"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 	"github.com/daytonaio/daytona/pkg/views/workspace/info"
@@ -136,7 +135,7 @@ var CreateCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		target, err := getTarget(targetList, activeProfile.Name)
+		target, err := workspace_util.GetTarget(ctx, apiClient, targetList, activeProfile.Name, targetNameFlag)
 		if err != nil {
 			return err
 		}
@@ -255,23 +254,6 @@ func init() {
 	CreateCmd.Flags().StringSliceVar(projectConfigurationFlags.Branches, "branch", []string{}, "Specify the Git branches to use in the projects")
 
 	workspace_util.AddProjectConfigurationFlags(CreateCmd, projectConfigurationFlags, true)
-}
-
-func getTarget(targetList []apiclient.ProviderTarget, activeProfileName string) (*apiclient.ProviderTarget, error) {
-	if targetNameFlag != "" {
-		for _, t := range targetList {
-			if t.Name == targetNameFlag {
-				return &t, nil
-			}
-		}
-		return nil, fmt.Errorf("target '%s' not found", targetNameFlag)
-	}
-
-	if len(targetList) == 1 {
-		return &targetList[0], nil
-	}
-
-	return target.GetTargetFromPrompt(targetList, activeProfileName, false)
 }
 
 func processPrompting(ctx context.Context, apiClient *apiclient.APIClient, workspaceName *string, projects *[]apiclient.CreateProjectDTO, workspaceNames []string) error {

--- a/pkg/cmd/workspace/util/get_target.go
+++ b/pkg/cmd/workspace/util/get_target.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/daytonaio/daytona/internal/util"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/cmd/provider"
+	"github.com/daytonaio/daytona/pkg/provider/manager"
+	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
+	target_view "github.com/daytonaio/daytona/pkg/views/target"
+)
+
+func GetTarget(ctx context.Context, apiClient *apiclient.APIClient, targetList []apiclient.ProviderTarget, activeProfileName string, targetNameFlag string) (*target_view.TargetView, error) {
+	if targetNameFlag != "" {
+		for _, t := range targetList {
+			if t.Name == targetNameFlag {
+				return util.Pointer(target_view.GetTargetViewFromTarget(t)), nil
+			}
+		}
+		return nil, fmt.Errorf("target '%s' not found", targetNameFlag)
+	}
+
+	serverConfig, res, err := apiClient.ServerAPI.GetConfigExecute(apiclient.ApiGetConfigRequest{})
+	if err != nil {
+		return nil, apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	providersManifest, err := manager.NewProviderManager(manager.ProviderManagerConfig{
+		RegistryUrl: serverConfig.RegistryUrl,
+	}).GetProvidersManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	var providerViewList []provider_view.ProviderView
+	if providersManifest != nil {
+		providersManifestLatest := providersManifest.GetLatestVersions()
+		if providersManifestLatest == nil {
+			return nil, errors.New("could not get latest provider versions")
+		}
+
+		latestProviders := provider.GetProviderListFromManifest(providersManifestLatest)
+
+		providerViewList, err = provider.GetProviderViewOptions(apiClient, latestProviders, ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	selectedTarget, err := target_view.GetTargetFromPrompt(targetList, activeProfileName, &providerViewList, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if selectedTarget.ProviderInfo.Installed == nil || *selectedTarget.ProviderInfo.Installed || selectedTarget == nil {
+		return selectedTarget, nil
+	}
+
+	err = provider.InstallProvider(apiClient, provider_view.ProviderView{
+		Name:    selectedTarget.ProviderInfo.Name,
+		Version: selectedTarget.ProviderInfo.Version,
+	}, providersManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	targetManifest, res, err := apiClient.ProviderAPI.GetTargetManifest(context.Background(), selectedTarget.ProviderInfo.Name).Execute()
+	if err != nil {
+		return nil, apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	selectedTarget.Name = ""
+	err = target_view.NewTargetNameInput(&selectedTarget.Name, util.ArrayMap(targetList, func(t apiclient.ProviderTarget) string {
+		return t.Name
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	err = target_view.SetTargetForm(selectedTarget, *targetManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(apiclient.ProviderTarget{
+		Name:    selectedTarget.Name,
+		Options: selectedTarget.Options,
+		ProviderInfo: apiclient.ProviderProviderInfo{
+			Name:    selectedTarget.ProviderInfo.Name,
+			Version: selectedTarget.ProviderInfo.Version,
+		},
+	}).Execute()
+	if err != nil {
+		return nil, apiclient_util.HandleErrorResponse(res, err)
+	}
+
+	return selectedTarget, nil
+}

--- a/pkg/db/dto/provider_target.go
+++ b/pkg/db/dto/provider_target.go
@@ -6,16 +6,18 @@ package dto
 import "github.com/daytonaio/daytona/pkg/provider"
 
 type ProviderTargetDTO struct {
-	Name            string `json:"name" gorm:"primaryKey"`
-	ProviderName    string `json:"providerName"`
-	ProviderVersion string `json:"providerVersion"`
-	Options         string `json:"options"`
+	Name            string  `json:"name" gorm:"primaryKey"`
+	ProviderName    string  `json:"providerName"`
+	ProviderLabel   *string `json:"providerLabel,omitempty"`
+	ProviderVersion string  `json:"providerVersion"`
+	Options         string  `json:"options"`
 }
 
 func ToProviderTargetDTO(providerTarget *provider.ProviderTarget) ProviderTargetDTO {
 	return ProviderTargetDTO{
 		Name:            providerTarget.Name,
 		ProviderName:    providerTarget.ProviderInfo.Name,
+		ProviderLabel:   providerTarget.ProviderInfo.Label,
 		ProviderVersion: providerTarget.ProviderInfo.Version,
 		Options:         providerTarget.Options,
 	}
@@ -26,6 +28,7 @@ func ToProviderTarget(providerTargetDTO ProviderTargetDTO) *provider.ProviderTar
 		Name: providerTargetDTO.Name,
 		ProviderInfo: provider.ProviderInfo{
 			Name:    providerTargetDTO.ProviderName,
+			Label:   providerTargetDTO.ProviderLabel,
 			Version: providerTargetDTO.ProviderVersion,
 		},
 		Options: providerTargetDTO.Options,

--- a/pkg/provider/manager/manifest.go
+++ b/pkg/provider/manager/manifest.go
@@ -16,7 +16,7 @@ type ProvidersManifest map[string]ProviderManifest
 
 type ProviderManifest struct {
 	Default  bool               `json:"default"`
-	Label    string             `json:"label"`
+	Label    *string            `json:"label"`
 	Versions map[string]Version `json:"versions"`
 }
 

--- a/pkg/provider/manager/manifest.go
+++ b/pkg/provider/manager/manifest.go
@@ -16,6 +16,7 @@ type ProvidersManifest map[string]ProviderManifest
 
 type ProviderManifest struct {
 	Default  bool               `json:"default"`
+	Label    string             `json:"label"`
 	Versions map[string]Version `json:"versions"`
 }
 
@@ -80,7 +81,7 @@ func (p *ProvidersManifest) HasUpdateAvailable(providerName string, currentVersi
 func (m *ProvidersManifest) GetLatestVersions() *ProvidersManifest {
 	var latestManifest ProvidersManifest = make(map[string]ProviderManifest, 0)
 	for provider, manifest := range *m {
-		latestManifest[provider] = ProviderManifest{Default: manifest.Default, Versions: make(map[string]Version)}
+		latestManifest[provider] = ProviderManifest{Default: manifest.Default, Label: manifest.Label, Versions: make(map[string]Version)}
 		versionName, version := manifest.FindLatestVersion()
 		latestManifest[provider].Versions[versionName] = *version
 	}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -11,8 +11,9 @@ import (
 )
 
 type ProviderInfo struct {
-	Name    string `json:"name" validate:"required"`
-	Version string `json:"version" validate:"required"`
+	Name    string  `json:"name" validate:"required"`
+	Label   *string `json:"label" validate:"optional"`
+	Version string  `json:"version" validate:"required"`
 }
 
 type InitializeProviderRequest struct {

--- a/pkg/views/provider/list.go
+++ b/pkg/views/provider/list.go
@@ -16,13 +16,15 @@ import (
 )
 
 type RowData struct {
+	Label   string
 	Name    string
 	Version string
 }
 
 func getRowFromRowData(rowData RowData) []string {
 	row := []string{
-		views.NameStyle.Render(rowData.Name),
+		views.NameStyle.Render(rowData.Label),
+		views.DefaultRowDataStyle.Render(rowData.Name),
 		views.DefaultRowDataStyle.Render(rowData.Version),
 	}
 
@@ -30,8 +32,13 @@ func getRowFromRowData(rowData RowData) []string {
 }
 
 func getRowData(provider *apiclient.Provider) *RowData {
-	rowData := RowData{"", ""}
+	rowData := RowData{"", "", ""}
 
+	if provider.Label != nil {
+		rowData.Label = *provider.Label
+	} else {
+		rowData.Label = provider.Name
+	}
 	rowData.Name = provider.Name
 	rowData.Version = provider.Version
 
@@ -42,7 +49,7 @@ func List(providerList []apiclient.Provider) {
 
 	re := lipgloss.NewRenderer(os.Stdout)
 
-	headers := []string{"Name", "Version"}
+	headers := []string{"Provider", "Name", "Version"}
 
 	data := [][]string{}
 
@@ -90,9 +97,11 @@ func renderUnstyledList(providerList []apiclient.Provider) {
 	output := "\n"
 
 	for _, provider := range providerList {
-		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Provider Name: "), provider.Name) + "\n\n"
-
-		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Provider Version: "), provider.Version) + "\n"
+		if provider.Label != nil {
+			output += fmt.Sprintf("%s %s", views.GetPropertyKey("Provider: "), *provider.Label) + "\n\n"
+		}
+		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Name: "), provider.Name) + "\n\n"
+		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Version: "), provider.Version) + "\n"
 
 		if provider.Name != providerList[len(providerList)-1].Name {
 			output += views.SeparatorString + "\n\n"

--- a/pkg/views/provider/select.go
+++ b/pkg/views/provider/select.go
@@ -15,6 +15,7 @@ import (
 
 type ProviderView struct {
 	Name      string
+	Label     *string
 	Version   string
 	Installed *bool
 }
@@ -63,6 +64,7 @@ func ProviderListToView(providers []apiclient.Provider) []ProviderView {
 	for _, p := range providers {
 		providerViews = append(providerViews, ProviderView{
 			Name:      p.Name,
+			Label:     p.Label,
 			Version:   p.Version,
 			Installed: nil,
 		})

--- a/pkg/views/provider/view.go
+++ b/pkg/views/provider/view.go
@@ -16,7 +16,13 @@ type item struct {
 	provider ProviderView
 }
 
-func (i item) Title() string { return i.provider.Name }
+func (i item) Title() string {
+	if i.provider.Label != nil {
+		return *i.provider.Label
+	} else {
+		return i.provider.Name
+	}
+}
 func (i item) Description() string {
 	desc := i.provider.Version
 	if i.provider.Installed != nil {
@@ -27,7 +33,13 @@ func (i item) Description() string {
 
 	return desc
 }
-func (i item) FilterValue() string { return i.provider.Name }
+func (i item) FilterValue() string {
+	if i.provider.Label != nil {
+		return *i.provider.Label
+	} else {
+		return i.provider.Name
+	}
+}
 
 type model struct {
 	list   list.Model

--- a/pkg/views/target/set.go
+++ b/pkg/views/target/set.go
@@ -44,7 +44,7 @@ func NewTargetNameInput(targetName *string, existingTargetNames []string) error 
 	return nil
 }
 
-func SetTargetForm(target *apiclient.ProviderTarget, targetManifest map[string]apiclient.ProviderProviderTargetProperty) error {
+func SetTargetForm(target *TargetView, targetManifest map[string]apiclient.ProviderProviderTargetProperty) error {
 	fields := make([]huh.Field, 0, len(targetManifest))
 	groups := []*huh.Group{}
 	options := make(map[string]interface{})

--- a/pkg/views/target/view.go
+++ b/pkg/views/target/view.go
@@ -8,24 +8,30 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"golang.org/x/term"
 )
 
 type item struct {
-	target apiclient.ProviderTarget
+	target TargetView
 }
 
 func (i item) Title() string { return i.target.Name }
 func (i item) Description() string {
-	return i.target.ProviderInfo.Name
+	desc := i.target.ProviderInfo.Name
+	if i.target.ProviderInfo.Installed != nil {
+		if !*i.target.ProviderInfo.Installed {
+			desc += " (needs installing)"
+		}
+	}
+
+	return desc
 }
 func (i item) FilterValue() string { return i.target.Name }
 
 type model struct {
 	list   list.Model
-	choice *apiclient.ProviderTarget
+	choice *TargetView
 	footer string
 }
 


### PR DESCRIPTION
# Add provider and target during create, provider labels
## Description

Allow installing new provider and adding a target as a part of the `daytona create` flow.
Adds provider labels to all provider views (the manifest has been updated).

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1204 

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
