### PR TITLE
fix: move request submitted message after target selection screen

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -115,12 +115,6 @@ var CreateCmd = &cobra.Command{
 			projectNames = append(projectNames, projects[i].Name)
 		}
 
-		logs_view.CalculateLongestPrefixLength(projectNames)
-
-		logs_view.DisplayLogEntry(logs.LogEntry{
-			Msg: "Request submitted\n",
-		}, logs_view.STATIC_INDEX)
-
 		for i, projectConfigName := range existingProjectConfigNames {
 			if projectConfigName == "" {
 				continue
@@ -140,6 +134,12 @@ var CreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		logs_view.CalculateLongestPrefixLength(projectNames)
+
+		logs_view.DisplayLogEntry(logs.LogEntry{
+			Msg: "Request submitted\n",
+		}, logs_view.STATIC_INDEX)
 
 		activeProfile, err = c.GetActiveProfile()
 		if err != nil {


### PR DESCRIPTION
# Daytona create move request submitted message after target selection screen
## Description

Moves the "Request submitted" message during `daytona create` to after the target selection screen.
The reason is that if the user exited the target selection screen, it would seem the request had been submitted regardless

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation