### PR TITLE
feat: all flag for git provider remove command

### DIFF
--- a/docs/daytona_git-providers_delete.md
+++ b/docs/daytona_git-providers_delete.md
@@ -6,6 +6,12 @@ Unregister a Git providers
 daytona git-providers delete [flags]
 ```
 
+### Options
+
+```
+  -a, --all   Remove all Git providers
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/hack/docs/daytona_git-providers_delete.yaml
+++ b/hack/docs/daytona_git-providers_delete.yaml
@@ -1,6 +1,11 @@
 name: daytona git-providers delete
 synopsis: Unregister a Git providers
 usage: daytona git-providers delete [flags]
+options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Remove all Git providers
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/gitprovider/delete.go
+++ b/pkg/cmd/gitprovider/delete.go
@@ -31,6 +31,18 @@ var gitProviderDeleteCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
+		if allFlag {
+			for _, gitProvider := range gitProviders {
+				_, err := apiClient.GitProviderAPI.RemoveGitProvider(ctx, gitProvider.Id).Execute()
+				if err != nil {
+					return err
+				}
+			}
+
+			views.RenderInfoMessage("All Git providers have been removed")
+			return nil
+		}
+
 		if len(gitProviders) == 0 {
 			views.RenderInfoMessage("No git providers registered")
 			return nil
@@ -56,4 +68,10 @@ var gitProviderDeleteCmd = &cobra.Command{
 		views.RenderInfoMessage("Git provider has been removed")
 		return nil
 	},
+}
+
+var allFlag bool
+
+func init() {
+	gitProviderDeleteCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Remove all Git providers")
 }


### PR DESCRIPTION
# All flag for Git provider remove command
## Description

Adds `daytona git-provider remove --all` flag

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
