### PR TITLE
feat: accept git provider aliases flag and make them unique

### DIFF
--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -9,21 +9,21 @@ daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
 ### Options
 
 ```
-      --blank                           Create a blank project without using existing configurations
-      --branch strings                  Specify the Git branches to use in the projects
-      --builder BuildChoice             Specify the builder (currently auto/devcontainer/none)
-      --custom-image string             Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
-      --custom-image-user string        Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
-      --devcontainer-path string        Automatically assign the devcontainer builder with the path passed as the flag value
-      --env stringArray                 Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-      --git-provider-config-id string   Specify the Git Provider Configuration Id
-  -i, --ide string                      Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
-      --manual                          Manually enter the Git repository
-      --multi-project                   Workspace with multiple projects/repos
-      --name string                     Specify the workspace name
-  -n, --no-ide                          Do not open the workspace in the IDE after workspace creation
-  -t, --target string                   Specify the target (e.g. 'local')
-  -y, --yes                             Automatically confirm any prompts
+      --blank                        Create a blank project without using existing configurations
+      --branch strings               Specify the Git branches to use in the projects
+      --builder BuildChoice          Specify the builder (currently auto/devcontainer/none)
+      --custom-image string          Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+      --custom-image-user string     Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+      --devcontainer-path string     Automatically assign the devcontainer builder with the path passed as the flag value
+      --env stringArray              Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
+      --git-provider-config string   Specify the Git provider configuration ID or alias
+  -i, --ide string                   Specify the IDE (vscode, browser, cursor, ssh, jupyter, fleet, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+      --manual                       Manually enter the Git repository
+      --multi-project                Workspace with multiple projects/repos
+      --name string                  Specify the workspace name
+  -n, --no-ide                       Do not open the workspace in the IDE after workspace creation
+  -t, --target string                Specify the target (e.g. 'local')
+  -y, --yes                          Automatically confirm any prompts
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_project-config_add.md
+++ b/docs/daytona_project-config_add.md
@@ -9,14 +9,14 @@ daytona project-config add [flags]
 ### Options
 
 ```
-      --builder BuildChoice             Specify the builder (currently auto/devcontainer/none)
-      --custom-image string             Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
-      --custom-image-user string        Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
-      --devcontainer-path string        Automatically assign the devcontainer builder with the path passed as the flag value
-      --env stringArray                 Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-      --git-provider-config-id string   Specify the Git Provider Configuration Id
-      --manual                          Manually enter the Git repository
-      --name string                     Specify the project config name
+      --builder BuildChoice          Specify the builder (currently auto/devcontainer/none)
+      --custom-image string          Create the project with the custom image passed as the flag value; Requires setting --custom-image-user flag as well
+      --custom-image-user string     Create the project with the custom image user passed as the flag value; Requires setting --custom-image flag as well
+      --devcontainer-path string     Automatically assign the devcontainer builder with the path passed as the flag value
+      --env stringArray              Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
+      --git-provider-config string   Specify the Git provider configuration ID or alias
+      --manual                       Manually enter the Git repository
+      --name string                  Specify the project config name
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -23,8 +23,8 @@ options:
       default_value: '[]'
       usage: |
         Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-    - name: git-provider-config-id
-      usage: Specify the Git Provider Configuration Id
+    - name: git-provider-config
+      usage: Specify the Git provider configuration ID or alias
     - name: ide
       shorthand: i
       usage: |

--- a/hack/docs/daytona_project-config_add.yaml
+++ b/hack/docs/daytona_project-config_add.yaml
@@ -17,8 +17,8 @@ options:
       default_value: '[]'
       usage: |
         Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
-    - name: git-provider-config-id
-      usage: Specify the Git Provider Configuration Id
+    - name: git-provider-config
+      usage: Specify the Git provider configuration ID or alias
     - name: manual
       default_value: "false"
       usage: Manually enter the Git repository

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"context"
 
+	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -18,7 +19,6 @@ var GitProviderAddCmd = &cobra.Command{
 	Aliases: []string{"new", "register"},
 	Short:   "Register a Git provider",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var existingAliases []string
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
@@ -30,6 +30,10 @@ var GitProviderAddCmd = &cobra.Command{
 		if err != nil {
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
+
+		existingAliases := util.ArrayMap(gitProviders, func(gp apiclient.GitProvider) string {
+			return gp.Alias
+		})
 
 		for _, gp := range gitProviders {
 			existingAliases = append(existingAliases, gp.Alias)

--- a/pkg/cmd/gitprovider/update.go
+++ b/pkg/cmd/gitprovider/update.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"context"
 
+	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
@@ -17,7 +18,6 @@ var gitProviderUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update a Git provider",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var existingAliases []string
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
@@ -44,9 +44,9 @@ var gitProviderUpdateCmd = &cobra.Command{
 			return nil
 		}
 
-		for _, gp := range gitProviders {
-			existingAliases = append(existingAliases, gp.Alias)
-		}
+		existingAliases := util.ArrayMap(gitProviders, func(gp apiclient.GitProvider) string {
+			return gp.Alias
+		})
 
 		setGitProviderConfig := apiclient.SetGitProviderConfig{
 			Id:         &selectedGitProvider.Id,

--- a/pkg/cmd/gitprovider/update.go
+++ b/pkg/cmd/gitprovider/update.go
@@ -17,6 +17,7 @@ var gitProviderUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update a Git provider",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var existingAliases []string
 		ctx := context.Background()
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
@@ -43,6 +44,10 @@ var gitProviderUpdateCmd = &cobra.Command{
 			return nil
 		}
 
+		for _, gp := range gitProviders {
+			existingAliases = append(existingAliases, gp.Alias)
+		}
+
 		setGitProviderConfig := apiclient.SetGitProviderConfig{
 			Id:         &selectedGitProvider.Id,
 			ProviderId: selectedGitProvider.ProviderId,
@@ -52,7 +57,7 @@ var gitProviderUpdateCmd = &cobra.Command{
 			Alias:      &selectedGitProvider.Alias,
 		}
 
-		err = gitprovider_view.GitProviderCreationView(ctx, &setGitProviderConfig, apiClient)
+		err = gitprovider_view.GitProviderCreationView(ctx, apiClient, &setGitProviderConfig, existingAliases)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -207,6 +207,11 @@ func processCmdArgument(argument string, apiClient *apiclient.APIClient, ctx con
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
+	projectConfigurationFlags.GitProviderConfig, err = workspace_util.GetGitProviderConfigIdFromFlag(ctx, apiClient, projectConfigurationFlags.GitProviderConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	project, err := workspace_util.GetCreateProjectDtoFromFlags(projectConfigurationFlags)
 	if err != nil {
 		return nil, err
@@ -272,14 +277,14 @@ func getExistingProjectConfigNames(apiClient *apiclient.APIClient) ([]string, er
 var nameFlag string
 
 var projectConfigurationFlags = workspace_util.ProjectConfigurationFlags{
-	Builder:             new(views_util.BuildChoice),
-	CustomImage:         new(string),
-	CustomImageUser:     new(string),
-	Branches:            new([]string),
-	DevcontainerPath:    new(string),
-	EnvVars:             new([]string),
-	Manual:              new(bool),
-	GitProviderConfigId: new(string),
+	Builder:           new(views_util.BuildChoice),
+	CustomImage:       new(string),
+	CustomImageUser:   new(string),
+	Branches:          new([]string),
+	DevcontainerPath:  new(string),
+	EnvVars:           new([]string),
+	Manual:            new(bool),
+	GitProviderConfig: new(string),
 }
 
 func init() {

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -227,14 +227,14 @@ var blankFlag bool
 var multiProjectFlag bool
 
 var projectConfigurationFlags = workspace_util.ProjectConfigurationFlags{
-	Builder:             new(views_util.BuildChoice),
-	CustomImage:         new(string),
-	CustomImageUser:     new(string),
-	Branches:            new([]string),
-	DevcontainerPath:    new(string),
-	EnvVars:             new([]string),
-	Manual:              new(bool),
-	GitProviderConfigId: new(string),
+	Builder:           new(views_util.BuildChoice),
+	CustomImage:       new(string),
+	CustomImageUser:   new(string),
+	Branches:          new([]string),
+	DevcontainerPath:  new(string),
+	EnvVars:           new([]string),
+	Manual:            new(bool),
+	GitProviderConfig: new(string),
 }
 
 func init() {
@@ -386,7 +386,7 @@ func processGitURL(ctx context.Context, repoUrl string, apiClient *apiclient.API
 	if !blankFlag {
 		projectConfig, res, err := apiClient.ProjectConfigAPI.GetDefaultProjectConfig(ctx, encodedURLParam).Execute()
 		if err == nil {
-			projectConfig.GitProviderConfigId = projectConfigurationFlags.GitProviderConfigId
+			projectConfig.GitProviderConfigId = projectConfigurationFlags.GitProviderConfig
 			return workspace_util.AddProjectFromConfig(projectConfig, apiClient, projects, branch)
 		}
 
@@ -404,6 +404,11 @@ func processGitURL(ctx context.Context, repoUrl string, apiClient *apiclient.API
 	}
 
 	projectName, err := workspace_util.GetSanitizedProjectName(repo.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	projectConfigurationFlags.GitProviderConfig, err = workspace_util.GetGitProviderConfigIdFromFlag(ctx, apiClient, projectConfigurationFlags.GitProviderConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/workspace/util/workspace.go
+++ b/pkg/cmd/workspace/util/workspace.go
@@ -13,14 +13,14 @@ import (
 )
 
 type ProjectConfigurationFlags struct {
-	Builder             *views_util.BuildChoice
-	CustomImage         *string
-	CustomImageUser     *string
-	Branches            *[]string
-	DevcontainerPath    *string
-	EnvVars             *[]string
-	Manual              *bool
-	GitProviderConfigId *string
+	Builder           *views_util.BuildChoice
+	CustomImage       *string
+	CustomImageUser   *string
+	Branches          *[]string
+	DevcontainerPath  *string
+	EnvVars           *[]string
+	Manual            *bool
+	GitProviderConfig *string
 }
 
 func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfigurationFlags, multiProjectFlagException bool) {
@@ -30,7 +30,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 	cmd.Flags().Var(flags.Builder, "builder", fmt.Sprintf("Specify the builder (currently %s/%s/%s)", views_util.AUTOMATIC, views_util.DEVCONTAINER, views_util.NONE))
 	cmd.Flags().StringArrayVar(flags.EnvVars, "env", []string{}, "Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')")
 	cmd.Flags().BoolVar(flags.Manual, "manual", false, "Manually enter the Git repository")
-	cmd.Flags().StringVar(flags.GitProviderConfigId, "git-provider-config-id", "", "Specify the Git Provider Configuration Id")
+	cmd.Flags().StringVar(flags.GitProviderConfig, "git-provider-config", "", "Specify the Git provider configuration ID or alias")
 
 	cmd.MarkFlagsMutuallyExclusive("builder", "custom-image")
 	cmd.MarkFlagsMutuallyExclusive("builder", "custom-image-user")
@@ -48,7 +48,7 @@ func AddProjectConfigurationFlags(cmd *cobra.Command, flags ProjectConfiguration
 }
 
 func CheckAnyProjectConfigurationFlagSet(flags ProjectConfigurationFlags) bool {
-	return *flags.GitProviderConfigId != "" || *flags.CustomImage != "" || *flags.CustomImageUser != "" || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
+	return *flags.GitProviderConfig != "" || *flags.CustomImage != "" || *flags.CustomImageUser != "" || *flags.DevcontainerPath != "" || *flags.Builder != "" || len(*flags.EnvVars) > 0
 }
 
 func IsProjectRunning(workspace *apiclient.WorkspaceDTO, projectName string) bool {

--- a/pkg/db/dto/git_provider.go
+++ b/pkg/db/dto/git_provider.go
@@ -13,7 +13,7 @@ type GitProviderConfigDTO struct {
 	Username   string  `json:"username"`
 	Token      string  `json:"token"`
 	BaseApiUrl *string `json:"baseApiUrl,omitempty"`
-	Alias      string  `json:"alias"`
+	Alias      string  `gorm:"uniqueIndex" json:"alias"`
 }
 
 func ToGitProviderConfigDTO(gitProvider gitprovider.GitProviderConfig) GitProviderConfigDTO {

--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
@@ -139,7 +140,25 @@ func (s *GitProviderService) SetGitProviderConfig(providerConfig *gitprovider.Gi
 	}
 
 	if providerConfig.Alias == "" {
-		providerConfig.Alias = userData.Username
+		gitProviderConfigs, err := s.ListConfigs()
+		if err != nil {
+			return err
+		}
+
+		uniqueAlias := userData.Username
+		aliases := make(map[string]bool)
+
+		for _, c := range gitProviderConfigs {
+			aliases[c.Alias] = true
+		}
+		counter := 2
+
+		for aliases[uniqueAlias] {
+			uniqueAlias = userData.Username + strconv.Itoa(counter)
+			counter++
+		}
+
+		providerConfig.Alias = uniqueAlias
 	}
 
 	return s.configStore.Save(providerConfig)

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -18,7 +18,7 @@ import (
 
 var commonGitProviderIds = []string{"github", "gitlab", "bitbucket"}
 
-func GitProviderCreationView(ctx context.Context, gitProviderAddView *apiclient.SetGitProviderConfig, apiClient *apiclient.APIClient) error {
+func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient, gitProviderAddView *apiclient.SetGitProviderConfig, existingAliases []string) error {
 	supportedProviders := config.GetSupportedGitProviders()
 
 	var gitProviderOptions []huh.Option[string]
@@ -106,7 +106,15 @@ func GitProviderCreationView(ctx context.Context, gitProviderAddView *apiclient.
 			huh.NewInput().
 				Title("Alias").
 				Description("Will default to username if left empty").
-				Value(gitProviderAddView.Alias),
+				Value(gitProviderAddView.Alias).
+				Validate(func(str string) error {
+					for _, alias := range existingAliases {
+						if alias == str {
+							return errors.New("alias is already in use")
+						}
+					}
+					return nil
+				}),
 		).WithHeight(6),
 	).WithTheme(views.GetCustomTheme())
 


### PR DESCRIPTION
# Accept git provider aliases flag and make them unique

## Description

Changes `daytona create`'s flag from `--git-provider-config-id` to `--git-provider-config`
`daytona create --git-provider-config` now accepts both Git provider config ID's and aliases.
Aliases are now globally unique - to-be-duplicates have a number appended to them to differentiate

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes
Flag rename would've been a "breaking change" but there hasn't been a release of it yet
Drafted until #1228 is merged - missing frontend alias validation and database uniqueness validation