### PR TITLE
fix: get git provider for http request

### DIFF
--- a/pkg/server/gitproviders/gitprovider.go
+++ b/pkg/server/gitproviders/gitprovider.go
@@ -106,7 +106,7 @@ func (s *GitProviderService) GetGitProviderForHttpRequest(req *http.Request) (gi
 	}
 
 	for _, p := range gitProviders {
-		header := req.Header.Get(config.GetWebhookEventHeaderKeyFromGitProvider(p.Id))
+		header := req.Header.Get(config.GetWebhookEventHeaderKeyFromGitProvider(p.ProviderId))
 		if header == "" {
 			continue
 		} else {


### PR DESCRIPTION
# Fix Get Git Provider for HTTP Request

## Description

Minor fix for getting the appropriate git provider for HTTP request. This influences only prebuilds.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
