### PR TITLE
fix: git provider update alias

### DIFF
--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -35,6 +35,8 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 		gitProviderOptions = append(gitProviderOptions, huh.Option[string]{Key: "Other", Value: "other"})
 	}
 
+	initialAlias := gitProviderAddView.Alias
+
 	if gitProviderAddView.ProviderId == "" {
 		gitProviderForm := huh.NewForm(
 			huh.NewGroup(
@@ -110,7 +112,9 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 				Validate(func(str string) error {
 					for _, alias := range existingAliases {
 						if alias == str {
-							return errors.New("alias is already in use")
+							if initialAlias == nil || *initialAlias != str {
+								return errors.New("alias is already in use")
+							}
 						}
 					}
 					return nil


### PR DESCRIPTION
# Fix git provider update alias
## Description

Fixes `daytona git-provider update` frontend validation for "Alias" failing when being left unchanged

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![image](https://github.com/user-attachments/assets/95bb3d49-47ba-436d-a3e9-721e6962a64e)
