### PR TITLE
fix: check if devcontainer file exists before creating

### DIFF
--- a/pkg/docker/create_devcontainer.go
+++ b/pkg/docker/create_devcontainer.go
@@ -53,6 +53,19 @@ type CreateDevcontainerOptions struct {
 }
 
 func (d *DockerClient) CreateFromDevcontainer(opts CreateDevcontainerOptions) (string, RemoteUser, error) {
+	// Ensure that the devcontainer config exists
+	if opts.SshClient != nil {
+		_, err := opts.SshClient.ReadFile(path.Join(opts.ProjectDir, opts.BuildConfig.Devcontainer.FilePath))
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		_, err := os.Stat(filepath.Join(opts.ProjectDir, opts.BuildConfig.Devcontainer.FilePath))
+		if err != nil {
+			return "", "", err
+		}
+	}
+
 	socketForwardId, err := d.ensureDockerSockForward(opts.LogWriter)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
# Check if Devcontainer File Exists Before Creating

## Description

Adds a check to validate that the devcontainer config file exists before attempting to read and create the devcontainer. 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #917

## Screenshots
![Screenshot 2024-10-14 at 16 01 04](https://github.com/user-attachments/assets/c8282e66-5a6e-4de5-9b9c-c515064b6c40)

## Notes

All providers will need to be updated
