### PR TITLE
refactor: reuse the list component across the cli

### DIFF
--- a/pkg/views/build/list/view.go
+++ b/pkg/views/build/list/view.go
@@ -33,7 +33,9 @@ func ListBuilds(buildList []apiclient.Build, apiServerConfig *apiclient.ServerCo
 
 	table := views_util.GetTableView(data, []string{
 		"ID", "State", "Prebuild ID", "Created", "Updated",
-	}, nil, renderUnstyledList, buildList, apiServerConfig)
+	}, nil, func() {
+		renderUnstyledList(buildList, apiServerConfig)
+	})
 
 	fmt.Println(table)
 }

--- a/pkg/views/build/list/view.go
+++ b/pkg/views/build/list/view.go
@@ -14,7 +14,7 @@ import (
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
-type RowData struct {
+type rowData struct {
 	Id         string
 	State      string
 	PrebuildId string
@@ -27,13 +27,8 @@ func ListBuilds(buildList []apiclient.Build, apiServerConfig *apiclient.ServerCo
 
 	data := [][]string{}
 
-	for _, pc := range buildList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getTableRowData(pc)
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
+	for _, b := range buildList {
+		data = append(data, getRowFromRowData(b))
 	}
 
 	table, success := views_util.GetTableView(data, []string{
@@ -66,29 +61,23 @@ func renderUnstyledList(buildList []apiclient.Build, apiServerConfig *apiclient.
 	}
 }
 
-func getRowFromRowData(rowData RowData) []string {
-	row := []string{
-		views.NameStyle.Render(rowData.Id),
-		views.DefaultRowDataStyle.Render(rowData.State),
-		views.DefaultRowDataStyle.Render(rowData.PrebuildId),
-		views.DefaultRowDataStyle.Render(rowData.CreatedAt),
-		views.DefaultRowDataStyle.Render(rowData.UpdatedAt),
+func getRowFromRowData(build apiclient.Build) []string {
+	var data rowData
+
+	data.Id = build.Id + views_util.AdditionalPropertyPadding
+	data.State = string(build.State)
+	data.PrebuildId = build.PrebuildId
+	if data.PrebuildId == "" {
+		data.PrebuildId = "/"
 	}
+	data.CreatedAt = util.FormatTimestamp(build.CreatedAt)
+	data.UpdatedAt = util.FormatTimestamp(build.UpdatedAt)
 
-	return row
-}
-
-func getTableRowData(build apiclient.Build) *RowData {
-	rowData := RowData{"", "", "", "", ""}
-
-	rowData.Id = build.Id + views_util.AdditionalPropertyPadding
-	rowData.State = string(build.State)
-	rowData.PrebuildId = build.PrebuildId
-	if rowData.PrebuildId == "" {
-		rowData.PrebuildId = "/"
+	return []string{
+		views.NameStyle.Render(data.Id),
+		views.DefaultRowDataStyle.Render(data.State),
+		views.DefaultRowDataStyle.Render(data.PrebuildId),
+		views.DefaultRowDataStyle.Render(data.CreatedAt),
+		views.DefaultRowDataStyle.Render(data.UpdatedAt),
 	}
-	rowData.CreatedAt = util.FormatTimestamp(build.CreatedAt)
-	rowData.UpdatedAt = util.FormatTimestamp(build.UpdatedAt)
-
-	return &rowData
 }

--- a/pkg/views/build/list/view.go
+++ b/pkg/views/build/list/view.go
@@ -31,14 +31,9 @@ func ListBuilds(buildList []apiclient.Build, apiServerConfig *apiclient.ServerCo
 		data = append(data, getRowFromRowData(b))
 	}
 
-	table, success := views_util.GetTableView(data, []string{
+	table := views_util.GetTableView(data, []string{
 		"ID", "State", "Prebuild ID", "Created", "Updated",
-	}, nil)
-
-	if !success {
-		renderUnstyledList(buildList, apiServerConfig)
-		return
-	}
+	}, nil, renderUnstyledList, buildList, apiServerConfig)
 
 	fmt.Println(table)
 }

--- a/pkg/views/containerregistry/list/view.go
+++ b/pkg/views/containerregistry/list/view.go
@@ -27,7 +27,9 @@ func ListRegistries(registryList []apiclient.ContainerRegistry) {
 
 	table := views_util.GetTableView(data, []string{
 		"Server", "Username", "Password",
-	}, nil, renderUnstyledList, registryList)
+	}, nil, func() {
+		renderUnstyledList(registryList)
+	})
 
 	fmt.Println(table)
 }

--- a/pkg/views/containerregistry/list/view.go
+++ b/pkg/views/containerregistry/list/view.go
@@ -22,15 +22,7 @@ func ListRegistries(registryList []apiclient.ContainerRegistry) {
 	data := [][]string{}
 
 	for _, registry := range registryList {
-		var rowData *rowData
-		var row []string
-
-		rowData = getRowData(&registry)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
+		data = append(data, getRowFromData(registry))
 	}
 
 	table, success := views_util.GetTableView(data, []string{
@@ -45,20 +37,15 @@ func ListRegistries(registryList []apiclient.ContainerRegistry) {
 	fmt.Println(table)
 }
 
-func getRowData(registry *apiclient.ContainerRegistry) *rowData {
-	rowData := rowData{"", "", ""}
+func getRowFromData(registry apiclient.ContainerRegistry) []string {
+	var data rowData
 
-	rowData.Server = registry.Server
-	rowData.Username = registry.Username
-	rowData.Password = registry.Password
+	data.Server = registry.Server
+	data.Username = registry.Username
 
-	return &rowData
-}
-
-func getRowFromRowData(rowData rowData) []string {
 	row := []string{
-		views.NameStyle.Render(rowData.Server),
-		views.DefaultRowDataStyle.Render(rowData.Username),
+		views.NameStyle.Render(data.Server),
+		views.DefaultRowDataStyle.Render(data.Username),
 		views.DefaultRowDataStyle.Render(strings.Repeat("*", 10)),
 	}
 

--- a/pkg/views/containerregistry/list/view.go
+++ b/pkg/views/containerregistry/list/view.go
@@ -25,14 +25,9 @@ func ListRegistries(registryList []apiclient.ContainerRegistry) {
 		data = append(data, getRowFromData(registry))
 	}
 
-	table, success := views_util.GetTableView(data, []string{
+	table := views_util.GetTableView(data, []string{
 		"Server", "Username", "Password",
-	}, nil)
-
-	if !success {
-		renderUnstyledList(registryList)
-		return
-	}
+	}, nil, renderUnstyledList, registryList)
 
 	fmt.Println(table)
 }

--- a/pkg/views/containerregistry/list/view.go
+++ b/pkg/views/containerregistry/list/view.go
@@ -5,22 +5,44 @@ package list
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
-
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
-	"golang.org/x/term"
 )
 
 type rowData struct {
 	Server   string
 	Username string
 	Password string
+}
+
+func ListRegistries(registryList []apiclient.ContainerRegistry) {
+	data := [][]string{}
+
+	for _, registry := range registryList {
+		var rowData *rowData
+		var row []string
+
+		rowData = getRowData(&registry)
+		if rowData == nil {
+			continue
+		}
+		row = getRowFromRowData(*rowData)
+		data = append(data, row)
+	}
+
+	table, success := views_util.GetTableView(data, []string{
+		"Server", "Username", "Password",
+	}, nil)
+
+	if !success {
+		renderUnstyledList(registryList)
+		return
+	}
+
+	fmt.Println(table)
 }
 
 func getRowData(registry *apiclient.ContainerRegistry) *rowData {
@@ -41,50 +63,6 @@ func getRowFromRowData(rowData rowData) []string {
 	}
 
 	return row
-}
-
-func ListRegistries(registryList []apiclient.ContainerRegistry) {
-	re := lipgloss.NewRenderer(os.Stdout)
-	headers := []string{"Server", "Username", "Password"}
-	data := [][]string{}
-
-	for _, registry := range registryList {
-		var rowData *rowData
-		var row []string
-
-		rowData = getRowData(&registry)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
-	}
-
-	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		fmt.Println(data)
-		return
-	}
-	breakpointWidth := views.GetContainerBreakpointWidth(terminalWidth)
-	minWidth := views_util.GetTableMinimumWidth(data)
-	if breakpointWidth == 0 || terminalWidth < views.TUITableMinimumWidth || minWidth > breakpointWidth {
-		renderUnstyledList(registryList)
-		return
-	}
-
-	t := table.New().
-		Headers(headers...).
-		Rows(data...).
-		BorderStyle(re.NewStyle().Foreground(views.LightGray)).
-		BorderRow(false).BorderColumn(false).BorderLeft(false).BorderRight(false).BorderTop(false).BorderBottom(false).
-		StyleFunc(func(row, col int) lipgloss.Style {
-			if row == 0 {
-				return views.TableHeaderStyle
-			}
-			return views.BaseCellStyle
-		}).Width(breakpointWidth - 2*views.BaseTableStyleHorizontalPadding)
-
-	fmt.Println(views.BaseTableStyle.Render(t.String()))
 }
 
 func renderUnstyledList(registryList []apiclient.ContainerRegistry) {

--- a/pkg/views/prebuild/list/view.go
+++ b/pkg/views/prebuild/list/view.go
@@ -16,7 +16,7 @@ import (
 
 var maxTriggerFilesStringLength = 24
 
-type RowData struct {
+type rowData struct {
 	ProjectConfigName string
 	Branch            string
 	CommitInterval    string
@@ -27,13 +27,8 @@ type RowData struct {
 func ListPrebuilds(prebuildList []apiclient.PrebuildDTO) {
 	data := [][]string{}
 
-	for _, pc := range prebuildList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getTableRowData(pc)
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
+	for _, p := range prebuildList {
+		data = append(data, getRowFromData(p))
 	}
 
 	table, success := util.GetTableView(data, []string{
@@ -58,32 +53,26 @@ func renderUnstyledList(prebuildList []apiclient.PrebuildDTO) {
 	}
 }
 
-func getRowFromRowData(rowData RowData) []string {
-	row := []string{
-		views.NameStyle.Render(rowData.ProjectConfigName),
-		views.DefaultRowDataStyle.Render(views.GetBranchNameLabel(rowData.Branch)),
-		views.ActiveStyle.Render(rowData.CommitInterval),
-		views.DefaultRowDataStyle.Render(rowData.TriggerFiles),
-		views.DefaultRowDataStyle.Render(rowData.Retention),
-	}
+func getRowFromData(prebuildConfig apiclient.PrebuildDTO) []string {
+	var data rowData
 
-	return row
-}
-
-func getTableRowData(prebuildConfig apiclient.PrebuildDTO) *RowData {
-	rowData := RowData{"", "", "", "", ""}
-
-	rowData.ProjectConfigName = prebuildConfig.ProjectConfigName + views_util.AdditionalPropertyPadding
-	rowData.Branch = prebuildConfig.Branch
+	data.ProjectConfigName = prebuildConfig.ProjectConfigName + views_util.AdditionalPropertyPadding
+	data.Branch = prebuildConfig.Branch
 	if prebuildConfig.CommitInterval != nil {
-		rowData.CommitInterval = strconv.Itoa(int(*prebuildConfig.CommitInterval))
+		data.CommitInterval = strconv.Itoa(int(*prebuildConfig.CommitInterval))
 	} else {
-		rowData.CommitInterval = views.InactiveStyle.Render("None")
+		data.CommitInterval = views.InactiveStyle.Render("None")
 	}
-	rowData.TriggerFiles = getTriggerFilesString(prebuildConfig.TriggerFiles)
-	rowData.Retention = strconv.Itoa(int(prebuildConfig.Retention))
+	data.TriggerFiles = getTriggerFilesString(prebuildConfig.TriggerFiles)
+	data.Retention = strconv.Itoa(int(prebuildConfig.Retention))
 
-	return &rowData
+	return []string{
+		views.NameStyle.Render(data.ProjectConfigName),
+		views.DefaultRowDataStyle.Render(views.GetBranchNameLabel(data.Branch)),
+		views.ActiveStyle.Render(data.CommitInterval),
+		views.DefaultRowDataStyle.Render(data.TriggerFiles),
+		views.DefaultRowDataStyle.Render(data.Retention),
+	}
 }
 
 func getTriggerFilesString(triggerFiles []string) string {

--- a/pkg/views/prebuild/list/view.go
+++ b/pkg/views/prebuild/list/view.go
@@ -33,7 +33,9 @@ func ListPrebuilds(prebuildList []apiclient.PrebuildDTO) {
 
 	table := util.GetTableView(data, []string{
 		"Project Config", "Branch", "Commit Interval", "Trigger files", "Build Retention",
-	}, nil, renderUnstyledList, prebuildList)
+	}, nil, func() {
+		renderUnstyledList(prebuildList)
+	})
 
 	fmt.Println(table)
 }

--- a/pkg/views/prebuild/list/view.go
+++ b/pkg/views/prebuild/list/view.go
@@ -31,14 +31,9 @@ func ListPrebuilds(prebuildList []apiclient.PrebuildDTO) {
 		data = append(data, getRowFromData(p))
 	}
 
-	table, success := util.GetTableView(data, []string{
+	table := util.GetTableView(data, []string{
 		"Project Config", "Branch", "Commit Interval", "Trigger files", "Build Retention",
-	}, nil)
-
-	if !success {
-		renderUnstyledList(prebuildList)
-		return
-	}
+	}, nil, renderUnstyledList, prebuildList)
 
 	fmt.Println(table)
 }

--- a/pkg/views/profile/list.go
+++ b/pkg/views/profile/list.go
@@ -31,11 +31,7 @@ func ListProfiles(profileList []config.Profile, activeProfileId string, showApiK
 		data = append(data, getRowFromData(&profile, activeProfileId, showApiKeysFlag))
 	}
 
-	table, success := views_util.GetTableView(data, headers, nil)
-
-	if !success {
-		return renderUnstyledList(profileList, activeProfileId, showApiKeysFlag), nil
-	}
+	table := views_util.GetTableView(data, headers, nil, renderUnstyledList, profileList, activeProfileId, showApiKeysFlag)
 
 	return table + "\n", nil
 }

--- a/pkg/views/profile/list.go
+++ b/pkg/views/profile/list.go
@@ -5,15 +5,10 @@ package profile
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/pkg/views"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
-
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
-	"golang.org/x/term"
 )
 
 type RowData struct {
@@ -22,6 +17,35 @@ type RowData struct {
 	Status string
 	ApiUrl string
 	ApiKey string
+}
+
+func ListProfiles(profileList []config.Profile, activeProfileId string, showApiKeysFlag bool) (string, error) {
+	headers := []string{"ID", "Name", "Status", "API URL"}
+	if showApiKeysFlag {
+		headers = append(headers, "API Key")
+	}
+
+	data := [][]string{}
+
+	for _, profile := range profileList {
+		var rowData *RowData
+		var row []string
+
+		rowData = getRowData(&profile, activeProfileId, showApiKeysFlag)
+		if rowData == nil {
+			continue
+		}
+		row = getRowFromRowData(*rowData, showApiKeysFlag)
+		data = append(data, row)
+	}
+
+	table, success := views_util.GetTableView(data, headers, nil)
+
+	if !success {
+		return renderUnstyledList(profileList, activeProfileId, showApiKeysFlag), nil
+	}
+
+	return table + "\n", nil
 }
 
 func getRowFromRowData(rowData RowData, showApiKeysFlag bool) []string {
@@ -59,56 +83,6 @@ func getRowData(profile *config.Profile, activeProfileId string, showApiKeysFlag
 	}
 
 	return &rowData
-}
-
-func ListProfiles(profileList []config.Profile, activeProfileId string, showApiKeysFlag bool) (string, error) {
-
-	re := lipgloss.NewRenderer(os.Stdout)
-
-	headers := []string{"ID", "Name", "Status", "API URL"}
-	if showApiKeysFlag {
-		headers = append(headers, "API Key")
-	}
-
-	data := [][]string{}
-
-	for _, profile := range profileList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getRowData(&profile, activeProfileId, showApiKeysFlag)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData, showApiKeysFlag)
-		data = append(data, row)
-	}
-
-	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		return "", err
-	}
-
-	breakpointWidth := views.GetContainerBreakpointWidth(terminalWidth)
-	minWidth := views_util.GetTableMinimumWidth(data)
-
-	if breakpointWidth == 0 || terminalWidth < views.TUITableMinimumWidth || minWidth > breakpointWidth {
-		return renderUnstyledList(profileList, activeProfileId, showApiKeysFlag), nil
-	}
-
-	t := table.New().
-		Headers(headers...).
-		Rows(data...).
-		BorderStyle(re.NewStyle().Foreground(views.LightGray)).
-		BorderRow(false).BorderColumn(false).BorderLeft(false).BorderRight(false).BorderTop(false).BorderBottom(false).
-		StyleFunc(func(row, col int) lipgloss.Style {
-			if row == 0 {
-				return views.TableHeaderStyle
-			}
-			return views.BaseCellStyle
-		}).Width(breakpointWidth - 2*views.BaseTableStyleHorizontalPadding)
-
-	return views.BaseTableStyle.Render(t.String()), nil
 }
 
 func renderUnstyledList(profileList []config.Profile, activeProfileId string, showApiKeysFlag bool) string {

--- a/pkg/views/profile/list.go
+++ b/pkg/views/profile/list.go
@@ -32,7 +32,7 @@ func ListProfiles(profileList []config.Profile, activeProfileId string, showApiK
 	}
 
 	table := views_util.GetTableView(data, headers, nil, func() {
-		fmt.Println(renderUnstyledList(profileList, activeProfileId, showApiKeysFlag))
+		renderUnstyledList(profileList, activeProfileId, showApiKeysFlag)
 	})
 
 	return table + "\n", nil
@@ -71,7 +71,7 @@ func getRowFromData(profile *config.Profile, activeProfileId string, showApiKeys
 	return row
 }
 
-func renderUnstyledList(profileList []config.Profile, activeProfileId string, showApiKeysFlag bool) string {
+func renderUnstyledList(profileList []config.Profile, activeProfileId string, showApiKeysFlag bool) {
 	var status string
 	var isActive bool
 
@@ -106,5 +106,5 @@ func renderUnstyledList(profileList []config.Profile, activeProfileId string, sh
 		isActive = false
 	}
 
-	return output
+	fmt.Print(output)
 }

--- a/pkg/views/profile/list.go
+++ b/pkg/views/profile/list.go
@@ -31,7 +31,9 @@ func ListProfiles(profileList []config.Profile, activeProfileId string, showApiK
 		data = append(data, getRowFromData(&profile, activeProfileId, showApiKeysFlag))
 	}
 
-	table := views_util.GetTableView(data, headers, nil, renderUnstyledList, profileList, activeProfileId, showApiKeysFlag)
+	table := views_util.GetTableView(data, headers, nil, func() {
+		fmt.Println(renderUnstyledList(profileList, activeProfileId, showApiKeysFlag))
+	})
 
 	return table + "\n", nil
 }

--- a/pkg/views/profile/list.go
+++ b/pkg/views/profile/list.go
@@ -11,7 +11,7 @@ import (
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
-type RowData struct {
+type rowData struct {
 	ID     string
 	Name   string
 	Status string
@@ -28,15 +28,7 @@ func ListProfiles(profileList []config.Profile, activeProfileId string, showApiK
 	data := [][]string{}
 
 	for _, profile := range profileList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getRowData(&profile, activeProfileId, showApiKeysFlag)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData, showApiKeysFlag)
-		data = append(data, row)
+		data = append(data, getRowFromData(&profile, activeProfileId, showApiKeysFlag))
 	}
 
 	table, success := views_util.GetTableView(data, headers, nil)
@@ -48,41 +40,37 @@ func ListProfiles(profileList []config.Profile, activeProfileId string, showApiK
 	return table + "\n", nil
 }
 
-func getRowFromRowData(rowData RowData, showApiKeysFlag bool) []string {
+func getRowFromData(profile *config.Profile, activeProfileId string, showApiKeysFlag bool) []string {
+	var data rowData
+
+	data.ID = profile.Id
+	data.Name = profile.Name
+	data.ApiUrl = profile.Api.Url
+	if profile.Id == activeProfileId {
+		data.Status = "1"
+	}
+	if showApiKeysFlag {
+		data.ApiKey = profile.Api.Key
+	}
+
 	var state string
-	if rowData.Status == "" {
+	if data.Status == "" {
 		state = views.InactiveStyle.Render("Inactive")
 	} else {
 		state = views.ActiveStyle.Render("Active")
 	}
 
 	row := []string{
-		views.NameStyle.Render(rowData.ID),
-		views.DefaultRowDataStyle.Render(rowData.Name),
+		views.NameStyle.Render(data.ID),
+		views.DefaultRowDataStyle.Render(data.Name),
 		state,
-		views.DefaultRowDataStyle.Render(rowData.ApiUrl),
+		views.DefaultRowDataStyle.Render(data.ApiUrl),
 	}
 	if showApiKeysFlag {
-		row = append(row, views.DefaultRowDataStyle.Render(rowData.ApiKey))
+		row = append(row, views.DefaultRowDataStyle.Render(data.ApiKey))
 	}
 
 	return row
-}
-
-func getRowData(profile *config.Profile, activeProfileId string, showApiKeysFlag bool) *RowData {
-	rowData := RowData{"", "", "", "", ""}
-
-	rowData.ID = profile.Id
-	rowData.Name = profile.Name
-	rowData.ApiUrl = profile.Api.Url
-	if profile.Id == activeProfileId {
-		rowData.Status = "1"
-	}
-	if showApiKeysFlag {
-		rowData.ApiKey = profile.Api.Key
-	}
-
-	return &rowData
 }
 
 func renderUnstyledList(profileList []config.Profile, activeProfileId string, showApiKeysFlag bool) string {

--- a/pkg/views/projectconfig/list/view.go
+++ b/pkg/views/projectconfig/list/view.go
@@ -5,16 +5,12 @@ package list
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/projectconfig/info"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
-	"golang.org/x/term"
 )
 
 type RowData struct {
@@ -26,10 +22,6 @@ type RowData struct {
 }
 
 func ListProjectConfigs(projectConfigList []apiclient.ProjectConfig, apiServerConfig *apiclient.ServerConfig, specifyGitProviders bool) {
-	re := lipgloss.NewRenderer(os.Stdout)
-
-	headers := []string{"Name", "Repository", "Build", "Prebuild rules", "Default"}
-
 	data := [][]string{}
 
 	for _, pc := range projectConfigList {
@@ -41,34 +33,16 @@ func ListProjectConfigs(projectConfigList []apiclient.ProjectConfig, apiServerCo
 		data = append(data, row)
 	}
 
-	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		fmt.Println(data)
-		return
-	}
+	table, success := views_util.GetTableView(data, []string{
+		"Name", "Repository", "Build", "Prebuild rules", "Default",
+	}, nil)
 
-	breakpointWidth := views.GetContainerBreakpointWidth(terminalWidth)
-
-	minWidth := views_util.GetTableMinimumWidth(data)
-
-	if breakpointWidth == 0 || minWidth > breakpointWidth {
+	if !success {
 		renderUnstyledList(projectConfigList, apiServerConfig)
 		return
 	}
 
-	t := table.New().
-		Headers(headers...).
-		Rows(data...).
-		BorderStyle(re.NewStyle().Foreground(views.LightGray)).
-		BorderRow(false).BorderColumn(false).BorderLeft(false).BorderRight(false).BorderTop(false).BorderBottom(false).
-		StyleFunc(func(row, col int) lipgloss.Style {
-			if row == 0 {
-				return views.TableHeaderStyle
-			}
-			return views.BaseCellStyle
-		}).Width(breakpointWidth - 2*views.BaseTableStyleHorizontalPadding - 1)
-
-	fmt.Println(views.BaseTableStyle.Render(t.String()))
+	fmt.Println(table)
 }
 
 func renderUnstyledList(projectConfigList []apiclient.ProjectConfig, apiServerConfig *apiclient.ServerConfig) {

--- a/pkg/views/projectconfig/list/view.go
+++ b/pkg/views/projectconfig/list/view.go
@@ -28,14 +28,9 @@ func ListProjectConfigs(projectConfigList []apiclient.ProjectConfig, apiServerCo
 		data = append(data, getRowFromData(pc, apiServerConfig, specifyGitProviders))
 	}
 
-	table, success := views_util.GetTableView(data, []string{
+	table := views_util.GetTableView(data, []string{
 		"Name", "Repository", "Build", "Prebuild rules", "Default",
-	}, nil)
-
-	if !success {
-		renderUnstyledList(projectConfigList, apiServerConfig)
-		return
-	}
+	}, nil, renderUnstyledList, projectConfigList, apiServerConfig)
 
 	fmt.Println(table)
 }

--- a/pkg/views/projectconfig/list/view.go
+++ b/pkg/views/projectconfig/list/view.go
@@ -30,7 +30,9 @@ func ListProjectConfigs(projectConfigList []apiclient.ProjectConfig, apiServerCo
 
 	table := views_util.GetTableView(data, []string{
 		"Name", "Repository", "Build", "Prebuild rules", "Default",
-	}, nil, renderUnstyledList, projectConfigList, apiServerConfig)
+	}, nil, func() {
+		renderUnstyledList(projectConfigList, apiServerConfig)
+	})
 
 	fmt.Println(table)
 }

--- a/pkg/views/provider/list.go
+++ b/pkg/views/provider/list.go
@@ -26,7 +26,9 @@ func List(providerList []apiclient.Provider) {
 
 	table := util.GetTableView(data, []string{
 		"Provider", "Name", "Version",
-	}, nil, renderUnstyledList, providerList)
+	}, nil, func() {
+		renderUnstyledList(providerList)
+	})
 
 	fmt.Println(table)
 }

--- a/pkg/views/provider/list.go
+++ b/pkg/views/provider/list.go
@@ -5,14 +5,10 @@ package provider
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
-
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
-	"golang.org/x/term"
+	"github.com/daytonaio/daytona/pkg/views/util"
 )
 
 type RowData struct {
@@ -46,11 +42,6 @@ func getRowData(provider *apiclient.Provider) *RowData {
 }
 
 func List(providerList []apiclient.Provider) {
-
-	re := lipgloss.NewRenderer(os.Stdout)
-
-	headers := []string{"Provider", "Name", "Version"}
-
 	data := [][]string{}
 
 	for _, provider := range providerList {
@@ -65,32 +56,16 @@ func List(providerList []apiclient.Provider) {
 		data = append(data, row)
 	}
 
-	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		fmt.Println(data)
-		return
-	}
+	table, success := util.GetTableView(data, []string{
+		"Provider", "Name", "Version",
+	}, nil)
 
-	breakpointWidth := views.GetContainerBreakpointWidth(terminalWidth)
-
-	if breakpointWidth == 0 || terminalWidth < views.TUITableMinimumWidth {
+	if !success {
 		renderUnstyledList(providerList)
 		return
 	}
 
-	t := table.New().
-		Headers(headers...).
-		Rows(data...).
-		BorderStyle(re.NewStyle().Foreground(views.LightGray)).
-		BorderRow(false).BorderColumn(false).BorderLeft(false).BorderRight(false).BorderTop(false).BorderBottom(false).
-		StyleFunc(func(row, col int) lipgloss.Style {
-			if row == 0 {
-				return views.TableHeaderStyle
-			}
-			return views.BaseCellStyle
-		}).Width(breakpointWidth - 2*views.BaseTableStyleHorizontalPadding)
-
-	fmt.Println(views.BaseTableStyle.Render(t.String()))
+	fmt.Println(table)
 }
 
 func renderUnstyledList(providerList []apiclient.Provider) {

--- a/pkg/views/provider/list.go
+++ b/pkg/views/provider/list.go
@@ -24,14 +24,9 @@ func List(providerList []apiclient.Provider) {
 		data = append(data, getRowFromData(&provider))
 	}
 
-	table, success := util.GetTableView(data, []string{
+	table := util.GetTableView(data, []string{
 		"Provider", "Name", "Version",
-	}, nil)
-
-	if !success {
-		renderUnstyledList(providerList)
-		return
-	}
+	}, nil, renderUnstyledList, providerList)
 
 	fmt.Println(table)
 }

--- a/pkg/views/provider/list.go
+++ b/pkg/views/provider/list.go
@@ -11,49 +11,17 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/util"
 )
 
-type RowData struct {
+type rowData struct {
 	Label   string
 	Name    string
 	Version string
-}
-
-func getRowFromRowData(rowData RowData) []string {
-	row := []string{
-		views.NameStyle.Render(rowData.Label),
-		views.DefaultRowDataStyle.Render(rowData.Name),
-		views.DefaultRowDataStyle.Render(rowData.Version),
-	}
-
-	return row
-}
-
-func getRowData(provider *apiclient.Provider) *RowData {
-	rowData := RowData{"", "", ""}
-
-	if provider.Label != nil {
-		rowData.Label = *provider.Label
-	} else {
-		rowData.Label = provider.Name
-	}
-	rowData.Name = provider.Name
-	rowData.Version = provider.Version
-
-	return &rowData
 }
 
 func List(providerList []apiclient.Provider) {
 	data := [][]string{}
 
 	for _, provider := range providerList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getRowData(&provider)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
+		data = append(data, getRowFromData(&provider))
 	}
 
 	table, success := util.GetTableView(data, []string{
@@ -66,6 +34,24 @@ func List(providerList []apiclient.Provider) {
 	}
 
 	fmt.Println(table)
+}
+
+func getRowFromData(provider *apiclient.Provider) []string {
+	var data rowData
+
+	if provider.Label != nil {
+		data.Label = *provider.Label
+	} else {
+		data.Label = provider.Name
+	}
+	data.Name = provider.Name
+	data.Version = provider.Version
+
+	return []string{
+		views.NameStyle.Render(data.Label),
+		views.DefaultRowDataStyle.Render(data.Name),
+		views.DefaultRowDataStyle.Render(data.Version),
+	}
 }
 
 func renderUnstyledList(providerList []apiclient.Provider) {

--- a/pkg/views/server/apikey/list.go
+++ b/pkg/views/server/apikey/list.go
@@ -25,7 +25,9 @@ func ListApiKeys(apiKeyList []apiclient.ApiKey) {
 
 	table := util.GetTableView(data, []string{
 		"Name", "Type",
-	}, nil, renderUnstyledList, apiKeyList)
+	}, nil, func() {
+		renderUnstyledList(apiKeyList)
+	})
 
 	fmt.Println(table)
 }

--- a/pkg/views/server/apikey/list.go
+++ b/pkg/views/server/apikey/list.go
@@ -20,15 +20,7 @@ func ListApiKeys(apiKeyList []apiclient.ApiKey) {
 	data := [][]string{}
 
 	for _, apiKey := range apiKeyList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getRowData(&apiKey)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
+		data = append(data, getRowFromRowData(apiKey))
 	}
 
 	table, success := util.GetTableView(data, []string{
@@ -43,22 +35,18 @@ func ListApiKeys(apiKeyList []apiclient.ApiKey) {
 	fmt.Println(table)
 }
 
-func getRowFromRowData(rowData RowData) []string {
+func getRowFromRowData(apiKey apiclient.ApiKey) []string {
+	rowData := RowData{"", ""}
+
+	rowData.Name = apiKey.Name
+	rowData.Type = string(apiKey.Type)
+
 	row := []string{
 		views.NameStyle.Render(rowData.Name),
 		views.DefaultRowDataStyle.Render(rowData.Type),
 	}
 
 	return row
-}
-
-func getRowData(apiKey *apiclient.ApiKey) *RowData {
-	rowData := RowData{"", ""}
-
-	rowData.Name = apiKey.Name
-	rowData.Type = string(apiKey.Type)
-
-	return &rowData
 }
 
 func renderUnstyledList(apiKeyList []apiclient.ApiKey) {

--- a/pkg/views/server/apikey/list.go
+++ b/pkg/views/server/apikey/list.go
@@ -5,19 +5,42 @@ package apikey
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
-
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
-	"golang.org/x/term"
+	"github.com/daytonaio/daytona/pkg/views/util"
 )
 
 type RowData struct {
 	Name string
 	Type string
+}
+
+func ListApiKeys(apiKeyList []apiclient.ApiKey) {
+	data := [][]string{}
+
+	for _, apiKey := range apiKeyList {
+		var rowData *RowData
+		var row []string
+
+		rowData = getRowData(&apiKey)
+		if rowData == nil {
+			continue
+		}
+		row = getRowFromRowData(*rowData)
+		data = append(data, row)
+	}
+
+	table, success := util.GetTableView(data, []string{
+		"Name", "Type",
+	}, nil)
+
+	if !success {
+		renderUnstyledList(apiKeyList)
+		return
+	}
+
+	fmt.Println(table)
 }
 
 func getRowFromRowData(rowData RowData) []string {
@@ -36,54 +59,6 @@ func getRowData(apiKey *apiclient.ApiKey) *RowData {
 	rowData.Type = string(apiKey.Type)
 
 	return &rowData
-}
-
-func ListApiKeys(apiKeyList []apiclient.ApiKey) {
-
-	re := lipgloss.NewRenderer(os.Stdout)
-
-	headers := []string{"Name", "Type"}
-
-	data := [][]string{}
-
-	for _, apiKey := range apiKeyList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getRowData(&apiKey)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
-	}
-
-	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		fmt.Println(data)
-		return
-	}
-
-	breakpointWidth := views.GetContainerBreakpointWidth(terminalWidth)
-
-	if breakpointWidth == 0 || terminalWidth < views.TUITableMinimumWidth {
-		renderUnstyledList(apiKeyList)
-		return
-	}
-
-	t := table.New().
-		Headers(headers...).
-		Rows(data...).
-		BorderStyle(re.NewStyle().Foreground(views.LightGray)).
-		BorderRow(false).BorderColumn(false).BorderLeft(false).BorderRight(false).BorderTop(false).BorderBottom(false).
-		StyleFunc(func(row, col int) lipgloss.Style {
-			if row == 0 {
-				return views.TableHeaderStyle
-			}
-			return views.BaseCellStyle
-		}).Width(breakpointWidth - 2*views.BaseTableStyleHorizontalPadding)
-
-	fmt.Println(views.BaseTableStyle.Render(t.String()))
 }
 
 func renderUnstyledList(apiKeyList []apiclient.ApiKey) {

--- a/pkg/views/server/apikey/list.go
+++ b/pkg/views/server/apikey/list.go
@@ -23,14 +23,9 @@ func ListApiKeys(apiKeyList []apiclient.ApiKey) {
 		data = append(data, getRowFromRowData(apiKey))
 	}
 
-	table, success := util.GetTableView(data, []string{
+	table := util.GetTableView(data, []string{
 		"Name", "Type",
-	}, nil)
-
-	if !success {
-		renderUnstyledList(apiKeyList)
-		return
-	}
+	}, nil, renderUnstyledList, apiKeyList)
 
 	fmt.Println(table)
 }

--- a/pkg/views/target/list/view.go
+++ b/pkg/views/target/list/view.go
@@ -27,14 +27,9 @@ func ListTargets(targetList []apiclient.ProviderTarget) {
 		data = append(data, getRowFromRowData(&target))
 	}
 
-	table, success := util.GetTableView(data, []string{
+	table := util.GetTableView(data, []string{
 		"Target", "Provider", "Options",
-	}, nil)
-
-	if !success {
-		renderUnstyledList(targetList)
-		return
-	}
+	}, nil, renderUnstyledList, targetList)
 
 	fmt.Println(table)
 }

--- a/pkg/views/target/list/view.go
+++ b/pkg/views/target/list/view.go
@@ -29,7 +29,9 @@ func ListTargets(targetList []apiclient.ProviderTarget) {
 
 	table := util.GetTableView(data, []string{
 		"Target", "Provider", "Options",
-	}, nil, renderUnstyledList, targetList)
+	}, nil, func() {
+		renderUnstyledList(targetList)
+	})
 
 	fmt.Println(table)
 }

--- a/pkg/views/target/list/view.go
+++ b/pkg/views/target/list/view.go
@@ -12,7 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/util"
 )
 
-type RowData struct {
+type rowData struct {
 	Target   string
 	Provider string
 	Options  string
@@ -24,15 +24,7 @@ func ListTargets(targetList []apiclient.ProviderTarget) {
 	data := [][]string{}
 
 	for _, target := range targetList {
-		var rowData *RowData
-		var row []string
-
-		rowData = getRowData(&target)
-		if rowData == nil {
-			continue
-		}
-		row = getRowFromRowData(*rowData)
-		data = append(data, row)
+		data = append(data, getRowFromRowData(&target))
 	}
 
 	table, success := util.GetTableView(data, []string{
@@ -47,24 +39,20 @@ func ListTargets(targetList []apiclient.ProviderTarget) {
 	fmt.Println(table)
 }
 
-func getRowFromRowData(rowData RowData) []string {
+func getRowFromRowData(target *apiclient.ProviderTarget) []string {
+	var data rowData
+
+	data.Target = target.Name
+	data.Provider = target.ProviderInfo.Name
+	data.Options = target.Options
+
 	row := []string{
-		views.NameStyle.Render(rowData.Target),
-		views.DefaultRowDataStyle.Render(rowData.Provider),
-		views.DefaultRowDataStyle.Render(rowData.Options),
+		views.NameStyle.Render(data.Target),
+		views.DefaultRowDataStyle.Render(data.Provider),
+		views.DefaultRowDataStyle.Render(data.Options),
 	}
 
 	return row
-}
-
-func getRowData(target *apiclient.ProviderTarget) *RowData {
-	rowData := RowData{"", "", ""}
-
-	rowData.Target = target.Name
-	rowData.Provider = target.ProviderInfo.Name
-	rowData.Options = target.Options
-
-	return &rowData
 }
 
 func sortTargets(targets *[]apiclient.ProviderTarget) {

--- a/pkg/views/util/table.go
+++ b/pkg/views/util/table.go
@@ -20,6 +20,7 @@ var AdditionalPropertyPadding = "  "
 var RowWhiteSpace = 1 + 4 + len(AdditionalPropertyPadding)*2 + 4 + 4 + 1
 var ArbitrarySpace = 10
 
+// Gets the table view string or falls back to an unstyled view for lower terminal widths
 func GetTableView(data [][]string, headers []string, footer *string, fallbackRender func()) string {
 	re := lipgloss.NewRenderer(os.Stdout)
 
@@ -34,7 +35,6 @@ func GetTableView(data [][]string, headers []string, footer *string, fallbackRen
 	minWidth := getMinimumWidth(data)
 
 	if breakpointWidth == 0 || minWidth > breakpointWidth {
-		// Fallback to unstyled view for lower terminal widths
 		fallbackRender()
 		return ""
 	}

--- a/pkg/views/util/table.go
+++ b/pkg/views/util/table.go
@@ -3,7 +3,16 @@
 
 package util
 
-import "regexp"
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/daytonaio/daytona/pkg/views"
+	"golang.org/x/term"
+)
 
 var AdditionalPropertyPadding = "  "
 
@@ -11,7 +20,45 @@ var AdditionalPropertyPadding = "  "
 var RowWhiteSpace = 1 + 4 + len(AdditionalPropertyPadding)*2 + 4 + 4 + 1
 var ArbitrarySpace = 10
 
-func GetTableMinimumWidth(data [][]string) int {
+func GetTableView(data [][]string, headers []string, footer *string) (string, bool) {
+	re := lipgloss.NewRenderer(os.Stdout)
+
+	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		fmt.Println(data)
+		return "", true
+	}
+
+	breakpointWidth := views.GetContainerBreakpointWidth(terminalWidth)
+
+	minWidth := getMinimumWidth(data)
+
+	if breakpointWidth == 0 || minWidth > breakpointWidth {
+		return "", false
+	}
+
+	t := table.New().
+		Headers(headers...).
+		Rows(data...).
+		BorderStyle(re.NewStyle().Foreground(views.LightGray)).
+		BorderRow(false).BorderColumn(false).BorderLeft(false).BorderRight(false).BorderTop(false).BorderBottom(false).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == 0 {
+				return views.TableHeaderStyle
+			}
+			return views.BaseCellStyle
+		}).Width(breakpointWidth - 2*views.BaseTableStyleHorizontalPadding - 1)
+
+	table := t.String()
+
+	if footer != nil {
+		table += "\n" + *footer
+	}
+
+	return views.BaseTableStyle.Render(table), true
+}
+
+func getMinimumWidth(data [][]string) int {
 	width := 0
 	widestRow := 0
 	for _, row := range data {

--- a/pkg/views/util/table.go
+++ b/pkg/views/util/table.go
@@ -6,7 +6,6 @@ package util
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"regexp"
 
 	"github.com/charmbracelet/lipgloss"
@@ -21,7 +20,7 @@ var AdditionalPropertyPadding = "  "
 var RowWhiteSpace = 1 + 4 + len(AdditionalPropertyPadding)*2 + 4 + 4 + 1
 var ArbitrarySpace = 10
 
-func GetTableView(data [][]string, headers []string, footer *string, fn interface{}, args ...interface{}) string {
+func GetTableView(data [][]string, headers []string, footer *string, fallbackRender func()) string {
 	re := lipgloss.NewRenderer(os.Stdout)
 
 	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
@@ -35,14 +34,8 @@ func GetTableView(data [][]string, headers []string, footer *string, fn interfac
 	minWidth := getMinimumWidth(data)
 
 	if breakpointWidth == 0 || minWidth > breakpointWidth {
-		// Fallback to unstyled view
-		function := reflect.ValueOf(fn)
-		var in []reflect.Value
-		for _, arg := range args {
-			in = append(in, reflect.ValueOf(arg))
-		}
-
-		function.Call(in)
+		// Fallback to unstyled view for lower terminal widths
+		fallbackRender()
 		return ""
 	}
 

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -68,12 +68,7 @@ func ListWorkspaces(workspaceList []apiclient.WorkspaceDTO, specifyGitProviders 
 
 	footer := lipgloss.NewStyle().Foreground(views.LightGray).Render(views.GetListFooter(activeProfileName, &views.Padding{}))
 
-	table, success := views_util.GetTableView(data, headers, &footer)
-
-	if !success {
-		renderUnstyledList(workspaceList)
-		return
-	}
+	table := views_util.GetTableView(data, headers, &footer, renderUnstyledList, workspaceList)
 
 	fmt.Println(table)
 }

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -68,7 +68,9 @@ func ListWorkspaces(workspaceList []apiclient.WorkspaceDTO, specifyGitProviders 
 
 	footer := lipgloss.NewStyle().Foreground(views.LightGray).Render(views.GetListFooter(activeProfileName, &views.Padding{}))
 
-	table := views_util.GetTableView(data, headers, &footer, renderUnstyledList, workspaceList)
+	table := views_util.GetTableView(data, headers, &footer, func() {
+		renderUnstyledList(workspaceList)
+	})
 
 	fmt.Println(table)
 }


### PR DESCRIPTION
# Reuse the list component across the CLI
## Description

Makes all 9 "list" components use the same util function for displaying the list

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/91dd6594-0a3f-4deb-84d0-df4ef93f8216)