### PR TITLE
fix: server stop hanging

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -240,7 +240,7 @@ func PreRun(rootCmd *cobra.Command, args []string, telemetryEnabled bool, client
 			props["called_as"] = os.Args[1]
 			err := telemetryService.TrackCliEvent(telemetry.CliEventInvalidCmd, clientId, props)
 			if err != nil {
-				log.Error(err)
+				log.Trace(err)
 			}
 			telemetryService.Close()
 		}
@@ -251,7 +251,7 @@ func PreRun(rootCmd *cobra.Command, args []string, telemetryEnabled bool, client
 	if telemetryEnabled {
 		err := telemetryService.TrackCliEvent(telemetry.CliEventCmdStart, clientId, GetCmdTelemetryData(cmd, flags))
 		if err != nil {
-			log.Error(err)
+			log.Trace(err)
 		}
 
 		go func() {
@@ -267,7 +267,7 @@ func PreRun(rootCmd *cobra.Command, args []string, telemetryEnabled bool, client
 
 				err := telemetryService.TrackCliEvent(telemetry.CliEventCmdEnd, clientId, props)
 				if err != nil {
-					log.Error(err)
+					log.Trace(err)
 				}
 				telemetryService.Close()
 				os.Exit(0)
@@ -289,7 +289,7 @@ func PostRun(cmd *cobra.Command, cmdErr error, telemetryService telemetry.Teleme
 
 		err := telemetryService.TrackCliEvent(telemetry.CliEventCmdEnd, clientId, props)
 		if err != nil {
-			log.Error(err)
+			log.Trace(err)
 		}
 		telemetryService.Close()
 	}

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -176,8 +176,8 @@ var ServeCmd = &cobra.Command{
 			return err
 		case <-interruptChannel:
 			log.Info("Shutting down")
-			// Exit will be handled by command PreRun
-			select {}
+
+			return server.TailscaleServer.Stop()
 		}
 	},
 }

--- a/pkg/server/headscale/config.go
+++ b/pkg/server/headscale/config.go
@@ -58,7 +58,8 @@ func (s *HeadscaleServer) getHeadscaleConfig() (*hstypes.Config, error) {
 
 		Database: hstypes.DatabaseConfig{
 			Sqlite: hstypes.SqliteConfig{
-				Path: filepath.Join(s.configDir, "headscale.db"),
+				Path:          filepath.Join(s.configDir, "headscale.db"),
+				WriteAheadLog: true,
 			},
 			Type: "sqlite3",
 		},

--- a/pkg/server/headscale/connect.go
+++ b/pkg/server/headscale/connect.go
@@ -45,6 +45,12 @@ func (s *HeadscaleServer) Connect() error {
 	}
 	defer ln.Close()
 
+	go func() {
+		<-s.disconnectChan
+		tsNetServer.Close()
+		ln.Close()
+	}()
+
 	return http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Ok\n")
 	}))

--- a/pkg/server/headscale/server.go
+++ b/pkg/server/headscale/server.go
@@ -45,7 +45,8 @@ type HeadscaleServer struct {
 	configDir     string
 	frps          *server.FRPSConfig
 
-	stopChan chan struct{}
+	stopChan       chan struct{}
+	disconnectChan chan struct{}
 }
 
 func (s *HeadscaleServer) Init() error {
@@ -74,6 +75,7 @@ func (s *HeadscaleServer) Start(errChan chan error) error {
 	go func() {
 		select {
 		case <-s.stopChan:
+			s.disconnectChan <- struct{}{}
 			errChan <- nil
 			return
 		case errChan <- app.Serve():


### PR DESCRIPTION
# Fix Server Stop Hanging

## Description

Fix scenarios where the `daytona serve` command would hang forever after ctrl+C.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1209 