### PR TITLE
refactor: default config generation

### DIFF
--- a/cmd/daytona/config/config.go
+++ b/cmd/daytona/config/config.go
@@ -44,12 +44,6 @@ type GitProvider struct {
 	Name string
 }
 
-const configDoesntExistError = "config does not exist. Run `daytona serve` to create a default profile or `daytona profile add` to connect to a remote server."
-
-func IsNotExist(err error) bool {
-	return err.Error() == configDoesntExistError
-}
-
 func GetConfig() (*Config, error) {
 	configFilePath, err := getConfigPath()
 	if err != nil {
@@ -58,7 +52,12 @@ func GetConfig() (*Config, error) {
 
 	_, err = os.Stat(configFilePath)
 	if os.IsNotExist(err) {
-		return nil, errors.New(configDoesntExistError)
+		config := &Config{
+			Id:               uuid.NewString(),
+			DefaultIdeId:     DefaultIdeId,
+			TelemetryEnabled: true,
+		}
+		return config, config.Save()
 	}
 
 	if err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -49,7 +49,7 @@ func (a *Agent) Start() error {
 }
 
 func (a *Agent) startProjectMode() error {
-	err := a.setDefaultConfig()
+	err := a.ensureDefaultProfile()
 	if err != nil {
 		return err
 	}
@@ -188,38 +188,33 @@ func (a *Agent) getGitUser(gitProviderId string) (*apiclient.GitUser, error) {
 	return userData, nil
 }
 
-func (a *Agent) setDefaultConfig() error {
+func (a *Agent) ensureDefaultProfile() error {
 	existingConfig, err := config.GetConfig()
-	if err != nil && !config.IsNotExist(err) {
+	if err != nil {
 		return err
 	}
 
-	if existingConfig != nil {
-		for _, profile := range existingConfig.Profiles {
-			if profile.Id == "default" {
-				return nil
-			}
+	if existingConfig == nil {
+		return errors.New("config does not exist")
+	}
+
+	for _, profile := range existingConfig.Profiles {
+		if profile.Id == "default" {
+			return nil
 		}
 	}
 
-	config := &config.Config{
-		Id:              a.Config.ClientId,
-		ActiveProfileId: "default",
-		DefaultIdeId:    "vscode",
-		Profiles: []config.Profile{
-			{
-				Id:   "default",
-				Name: "default",
-				Api: config.ServerApi{
-					Url: a.Config.Server.ApiUrl,
-					Key: a.Config.Server.ApiKey,
-				},
-			},
-		},
-		TelemetryEnabled: a.TelemetryEnabled,
-	}
+	existingConfig.Id = a.Config.ClientId
+	existingConfig.TelemetryEnabled = a.TelemetryEnabled
 
-	return config.Save()
+	return existingConfig.AddProfile(config.Profile{
+		Id:   "default",
+		Name: "default",
+		Api: config.ServerApi{
+			Url: a.Config.Server.ApiUrl,
+			Key: a.Config.Server.ApiKey,
+		},
+	})
 }
 
 // Agent uptime in seconds

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -150,6 +150,8 @@ func validateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command
 
 func ensureProfiles(cmd *cobra.Command) error {
 	exemptions := []string{
+		"daytona",
+		"daytona docs",
 		"daytona version",
 		"daytona profile add",
 		"daytona serve",

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -151,6 +151,7 @@ func validateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command
 func ensureProfiles(cmd *cobra.Command) error {
 	exemptions := []string{
 		"daytona",
+		"daytona help",
 		"daytona docs",
 		"daytona version",
 		"daytona profile add",

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -4,9 +4,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"time"
 
@@ -92,6 +94,11 @@ func Execute() error {
 		return cmd.Help()
 	}
 
+	err = ensureProfiles(cmd)
+	if err != nil {
+		return err
+	}
+
 	err = rootCmd.Execute()
 
 	endTime := time.Now()
@@ -139,6 +146,33 @@ func validateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command
 	}
 
 	return currentCmd, flags, nil
+}
+
+func ensureProfiles(cmd *cobra.Command) error {
+	exemptions := []string{
+		"daytona version",
+		"daytona profile add",
+		"daytona serve",
+		"daytona server",
+		"daytona ide",
+		"daytona telemetry enable",
+		"daytona telemetry disable",
+	}
+
+	if slices.Contains(exemptions, cmd.CommandPath()) {
+		return nil
+	}
+
+	c, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(c.Profiles) == 0 {
+		return errors.New("no profiles found. Run `daytona serve` to create a default profile or `daytona profile add` to connect to a remote server.")
+	}
+
+	return nil
 }
 
 func SetupRootCommand(cmd *cobra.Command) {

--- a/pkg/cmd/profile/add.go
+++ b/pkg/cmd/profile/add.go
@@ -19,18 +19,7 @@ var ProfileAddCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := config.GetConfig()
 		if err != nil {
-			if !config.IsNotExist(err) {
-				return err
-			}
-
-			c = &config.Config{
-				DefaultIdeId: config.DefaultIdeId,
-				Profiles:     []config.Profile{},
-			}
-
-			if err := c.Save(); err != nil {
-				return err
-			}
+			return err
 		}
 
 		profileAddView := profile.ProfileAddView{

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -161,7 +162,7 @@ var ServeCmd = &cobra.Command{
 
 		printServerStartedMessage(c, false)
 
-		err = setDefaultConfig(server, c.ApiPort)
+		err = ensureDefaultProfile(server, c.ApiPort)
 		if err != nil {
 			return err
 		}
@@ -489,17 +490,19 @@ func getDbPath() (string, error) {
 	return filepath.Join(configDir, "db"), nil
 }
 
-func setDefaultConfig(server *server.Server, apiPort uint32) error {
+func ensureDefaultProfile(server *server.Server, apiPort uint32) error {
 	existingConfig, err := config.GetConfig()
-	if err != nil && !config.IsNotExist(err) {
+	if err != nil {
 		return err
 	}
 
-	if existingConfig != nil {
-		for _, profile := range existingConfig.Profiles {
-			if profile.Id == "default" {
-				return nil
-			}
+	if existingConfig == nil {
+		return errors.New("config does not exist")
+	}
+
+	for _, profile := range existingConfig.Profiles {
+		if profile.Id == "default" {
+			return nil
 		}
 	}
 
@@ -508,37 +511,12 @@ func setDefaultConfig(server *server.Server, apiPort uint32) error {
 		return err
 	}
 
-	if existingConfig != nil {
-		err := existingConfig.AddProfile(config.Profile{
-			Id:   "default",
-			Name: "default",
-			Api: config.ServerApi{
-				Url: fmt.Sprintf("http://localhost:%d", apiPort),
-				Key: apiKey,
-			},
-		})
-		if err != nil {
-			return err
-		}
-
-		return existingConfig.Save()
-	}
-
-	config := &config.Config{
-		ActiveProfileId: "default",
-		DefaultIdeId:    config.DefaultIdeId,
-		Profiles: []config.Profile{
-			{
-				Id:   "default",
-				Name: "default",
-				Api: config.ServerApi{
-					Url: fmt.Sprintf("http://localhost:%d", apiPort),
-					Key: apiKey,
-				},
-			},
+	return existingConfig.AddProfile(config.Profile{
+		Id:   "default",
+		Name: "default",
+		Api: config.ServerApi{
+			Url: fmt.Sprintf("http://localhost:%d", apiPort),
+			Key: apiKey,
 		},
-		TelemetryEnabled: true,
-	}
-
-	return config.Save()
+	})
 }


### PR DESCRIPTION
# Refactor Default Config Generation

## Description

Instead of the config being generated by `daytona serve` it is now generated whenever requested with `GetConfig`. This ensures that the config is always available without having to run `daytona serve` first.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
