### PR TITLE
fix: ensure prebuild is unique per branch

### DIFF
--- a/pkg/server/projectconfig/prebuild.go
+++ b/pkg/server/projectconfig/prebuild.go
@@ -26,11 +26,11 @@ func (s *ProjectConfigService) SetPrebuild(projectConfigName string, createPrebu
 		return nil, err
 	}
 
-	existingPrebuild, err := projectConfig.FindPrebuild(&config.PrebuildFilter{
+	existingPrebuild, _ := projectConfig.FindPrebuild(&config.PrebuildFilter{
 		Branch: &createPrebuildDto.Branch,
 	})
 
-	if err == nil && createPrebuildDto.Id != nil && *createPrebuildDto.Id != existingPrebuild.Id {
+	if existingPrebuild != nil && createPrebuildDto.Id == nil {
 		return nil, errors.New("prebuild for the specified project config and branch already exists")
 	}
 


### PR DESCRIPTION
# Ensure prebuild is unique per branch
## Description

Fixes validation to ensure prebuilds are unique per branch

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation