### PR TITLE
feat: improve git provider config list view

### DIFF
--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -5,13 +5,13 @@ package gitprovider
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
+	"github.com/daytonaio/daytona/pkg/views/gitprovider/list"
 	"github.com/spf13/cobra"
 )
 
@@ -35,23 +35,25 @@ var gitProviderListCmd = &cobra.Command{
 			return nil
 		}
 
-		views.RenderMainTitle("Registered Git Providers:")
-
 		supportedProviders := config.GetSupportedGitProviders()
 		var gitProviderViewList []gitprovider_view.GitProviderView
 
 		for _, gitProvider := range gitProviders {
 			for _, supportedProvider := range supportedProviders {
 				if gitProvider.ProviderId == supportedProvider.Id {
-					gitProviderViewList = append(gitProviderViewList,
-						gitprovider_view.GitProviderView{
-							Id:         gitProvider.Id,
-							ProviderId: gitProvider.ProviderId,
-							Name:       supportedProvider.Name,
-							Username:   gitProvider.Username,
-							Alias:      gitProvider.Alias,
-						},
-					)
+					gitProviderView := gitprovider_view.GitProviderView{
+						Id:         gitProvider.Id,
+						ProviderId: gitProvider.ProviderId,
+						Name:       supportedProvider.Name,
+						Username:   gitProvider.Username,
+						Alias:      gitProvider.Alias,
+					}
+
+					if gitProvider.BaseApiUrl != nil {
+						gitProviderView.BaseApiUrl = *gitProvider.BaseApiUrl
+					}
+
+					gitProviderViewList = append(gitProviderViewList, gitProviderView)
 				}
 			}
 		}
@@ -62,9 +64,7 @@ var gitProviderListCmd = &cobra.Command{
 			return nil
 		}
 
-		for _, gitProviderView := range gitProviderViewList {
-			views.RenderListLine(fmt.Sprintf("%s (%s)", gitProviderView.Name, gitProviderView.Alias))
-		}
+		list.ListGitProviders(gitProviderViewList)
 		return nil
 	},
 }

--- a/pkg/views/gitprovider/info/view.go
+++ b/pkg/views/gitprovider/info/view.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package info
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/daytonaio/daytona/pkg/views"
+	"github.com/daytonaio/daytona/pkg/views/gitprovider"
+	"golang.org/x/term"
+)
+
+const propertyNameWidth = 20
+
+var propertyNameStyle = lipgloss.NewStyle().
+	Foreground(views.LightGray)
+
+var propertyValueStyle = lipgloss.NewStyle().
+	Foreground(views.Light).
+	Bold(true)
+
+func Render(gp *gitprovider.GitProviderView, forceUnstyled bool) {
+	var output string
+	output += "\n\n"
+
+	output += views.GetStyledMainTitle("Git Provider Info") + "\n\n"
+
+	output += getInfoLine("ID", gp.Id) + "\n"
+
+	output += getInfoLine("Name", gp.Name) + "\n"
+
+	output += getInfoLine("Alias", gp.Alias) + "\n"
+
+	output += getInfoLine("Username", gp.Username) + "\n"
+
+	if gp.BaseApiUrl != "" {
+		output += getInfoLine("Base API URL", gp.BaseApiUrl) + "\n"
+	}
+
+	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		fmt.Println(output)
+		return
+	}
+	if terminalWidth < views.TUITableMinimumWidth || forceUnstyled {
+		renderUnstyledInfo(output)
+		return
+	}
+
+	renderTUIView(output, views.GetContainerBreakpointWidth(terminalWidth))
+}
+
+func renderUnstyledInfo(output string) {
+	fmt.Println(output)
+}
+
+func renderTUIView(output string, width int) {
+	output = lipgloss.NewStyle().PaddingLeft(3).Render(output)
+
+	content := lipgloss.
+		NewStyle().Width(width).
+		Render(output)
+
+	fmt.Println(content)
+}
+
+func getInfoLine(key, value string) string {
+	return propertyNameStyle.Render(fmt.Sprintf("%-*s", propertyNameWidth, key)) + propertyValueStyle.Render(value) + "\n"
+}

--- a/pkg/views/gitprovider/list/view.go
+++ b/pkg/views/gitprovider/list/view.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package list
+
+import (
+	"fmt"
+
+	"github.com/daytonaio/daytona/pkg/views"
+	"github.com/daytonaio/daytona/pkg/views/gitprovider"
+	"github.com/daytonaio/daytona/pkg/views/gitprovider/info"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
+)
+
+type rowData struct {
+	Name       string
+	Alias      string
+	Username   string
+	BaseApiUrl string
+}
+
+func ListGitProviders(gitProviderViewList []gitprovider.GitProviderView) {
+	var showBaseApiUrlColumn bool
+	headers := []string{"Name", "Alias", "Username", "Base API URL"}
+
+	for _, gp := range gitProviderViewList {
+		if gp.BaseApiUrl != "" {
+			showBaseApiUrlColumn = true
+			break
+		}
+	}
+
+	data := [][]string{}
+
+	for _, b := range gitProviderViewList {
+		data = append(data, getRowFromRowData(b))
+	}
+
+	if !showBaseApiUrlColumn {
+		headers = headers[:len(headers)-1]
+		for value := range data {
+			data[value] = data[value][:len(data[value])-1]
+		}
+	}
+
+	table := views_util.GetTableView(data, headers, nil, func() {
+		renderUnstyledList(gitProviderViewList)
+	})
+
+	fmt.Println(table)
+}
+
+func renderUnstyledList(gitProviderViewList []gitprovider.GitProviderView) {
+	for _, b := range gitProviderViewList {
+		info.Render(&b, true)
+
+		if b.Id != gitProviderViewList[len(gitProviderViewList)-1].Id {
+			fmt.Printf("\n%s\n\n", views.SeparatorString)
+		}
+	}
+}
+
+func getRowFromRowData(build gitprovider.GitProviderView) []string {
+	var data rowData
+
+	data.Name = build.Name + views_util.AdditionalPropertyPadding
+	data.Alias = build.Alias
+	data.Username = build.Username
+	data.BaseApiUrl = build.BaseApiUrl
+
+	return []string{
+		views.NameStyle.Render(data.Name),
+		views.DefaultRowDataStyle.Render(data.Alias),
+		views.DefaultRowDataStyle.Render(data.Username),
+		views.DefaultRowDataStyle.Render(data.BaseApiUrl),
+	}
+}


### PR DESCRIPTION
# Improve git provider config list view

## Description

Git provider config list view now uses the same table layout as other commands allowing us to display missing information - username/base API URL

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![image](https://github.com/user-attachments/assets/e114c5a0-a5ca-4dc4-bf7f-f5e640b8b1a5)