### PR TITLE
fix: git provider config id when entering custom repo or sample

### DIFF
--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -152,6 +152,8 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 					return nil, err
 				}
 				gitProviderConfigId = gp.Id
+			} else {
+				gitProviderConfigId = ""
 			}
 		}
 


### PR DESCRIPTION
# Fix Git provider config id when entering custom repo or sample
## Description

Adding a Gitlab repo when only a Github provider is registered by selecting the "Enter a custom repository url" or "Create from Sample" option would result in an incorrect placeholder Git provider config in the project config.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![image](https://github.com/user-attachments/assets/ae8dfff7-2669-462b-8361-563158f13179)
