### PR TITLE
fix: Wrap text on the error

### DIFF
--- a/pkg/views/util/help.go
+++ b/pkg/views/util/help.go
@@ -6,8 +6,6 @@ package util
 import (
 	"fmt"
 	"os"
-	"strings"
-	"unicode/utf8"
 
 	"golang.org/x/term"
 )
@@ -68,42 +66,4 @@ func getLongDescriptionFull() string {
 			fmt.Sprintf("%s\n\n", "         @@@    @@@   ")
 
 	return response
-}
-
-func WrapText(text string, width int) string {
-	if width <= 0 {
-		return text
-	}
-
-	var wrappedText strings.Builder
-	var line strings.Builder
-
-	words := strings.Fields(text)
-
-	for _, word := range words {
-		if utf8.RuneCountInString(line.String())+utf8.RuneCountInString(word)+1 > width-2 {
-			wrappedText.WriteString(line.String() + "\n")
-			line.Reset()
-		}
-
-		if line.Len() > 0 {
-			line.WriteString(" ")
-		}
-		line.WriteString(word)
-	}
-
-	if line.Len() > 0 {
-		wrappedText.WriteString(line.String())
-	}
-
-	return wrappedText.String()
-}
-
-func GetTerminalWidth() int {
-	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	const maxWidth = 160
-	if err != nil {
-		return maxWidth
-	}
-	return width
 }

--- a/pkg/views/util/help.go
+++ b/pkg/views/util/help.go
@@ -6,6 +6,8 @@ package util
 import (
 	"fmt"
 	"os"
+	"strings"
+	"unicode/utf8"
 
 	"golang.org/x/term"
 )
@@ -66,4 +68,42 @@ func getLongDescriptionFull() string {
 			fmt.Sprintf("%s\n\n", "         @@@    @@@   ")
 
 	return response
+}
+
+func WrapText(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+
+	var wrappedText strings.Builder
+	var line strings.Builder
+
+	words := strings.Fields(text)
+
+	for _, word := range words {
+		if utf8.RuneCountInString(line.String())+utf8.RuneCountInString(word)+1 > width-2 {
+			wrappedText.WriteString(line.String() + "\n")
+			line.Reset()
+		}
+
+		if line.Len() > 0 {
+			line.WriteString(" ")
+		}
+		line.WriteString(word)
+	}
+
+	if line.Len() > 0 {
+		wrappedText.WriteString(line.String())
+	}
+
+	return wrappedText.String()
+}
+
+func GetTerminalWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	const maxWidth = 160
+	if err != nil {
+		return maxWidth
+	}
+	return width
 }

--- a/pkg/views/util/text_wrapper.go
+++ b/pkg/views/util/text_wrapper.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 package util
 
 import (

--- a/pkg/views/util/text_wrapper.go
+++ b/pkg/views/util/text_wrapper.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/term"
+)
+
+func WrapText(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+
+	var wrappedText strings.Builder
+	var line strings.Builder
+
+	words := strings.Fields(text)
+
+	for _, word := range words {
+		if utf8.RuneCountInString(line.String())+utf8.RuneCountInString(word)+1 > width-2 {
+			wrappedText.WriteString(line.String() + "\n")
+			line.Reset()
+		}
+
+		if line.Len() > 0 {
+			line.WriteString(" ")
+		}
+		line.WriteString(word)
+	}
+
+	if line.Len() > 0 {
+		wrappedText.WriteString(line.String())
+	}
+
+	return wrappedText.String()
+}
+
+func GetTerminalWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	const maxWidth = 160
+	if err != nil {
+		return maxWidth
+	}
+	return width
+}

--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/term"
 	"os"
 	"strings"
 	"unicode/utf8"
+
+	"golang.org/x/term"
 
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -183,7 +184,7 @@ func validateRepoUrl(repoUrl string, apiClient *apiclient.APIClient) (*apiclient
 		Url: result,
 	}).Execute()
 	if err != nil {
-		wrappedErr := fmt.Sprintf("Failed to fetch repository information. Please check the URL and try again.")
+		wrappedErr := "Failed to fetch repository information. Please check the URL and try again."
 		return nil, errors.New(WrapText(wrappedErr, GetTerminalWidth()))
 	}
 

--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -7,11 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"strings"
-	"unicode/utf8"
-
-	"golang.org/x/term"
 
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -185,45 +180,8 @@ func validateRepoUrl(repoUrl string, apiClient *apiclient.APIClient) (*apiclient
 	}).Execute()
 	if err != nil {
 		wrappedErr := "Failed to fetch repository information. Please check the URL and try again."
-		return nil, errors.New(WrapText(wrappedErr, GetTerminalWidth()))
+		return nil, errors.New(views_util.WrapText(wrappedErr, views_util.GetTerminalWidth()))
 	}
 
 	return repo, nil
-}
-
-func WrapText(text string, width int) string {
-	if width <= 0 {
-		return text
-	}
-
-	var wrappedText strings.Builder
-	var line strings.Builder
-
-	words := strings.Fields(text)
-
-	for _, word := range words {
-		if utf8.RuneCountInString(line.String())+utf8.RuneCountInString(word)+1 > width {
-			wrappedText.WriteString(line.String() + "\n")
-			line.Reset()
-		}
-
-		if line.Len() > 0 {
-			line.WriteString(" ")
-		}
-		line.WriteString(word)
-	}
-
-	if line.Len() > 0 {
-		wrappedText.WriteString(line.String())
-	}
-
-	return wrappedText.String()
-}
-
-func GetTerminalWidth() int {
-	width, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
-		return maxWidth
-	}
-	return width
 }

--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -7,6 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/term"
+	"os"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/daytonaio/daytona/internal/util"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -179,8 +183,46 @@ func validateRepoUrl(repoUrl string, apiClient *apiclient.APIClient) (*apiclient
 		Url: result,
 	}).Execute()
 	if err != nil {
-		return nil, errors.New("Failed to fetch repository information. Please check the URL and try again.")
+		wrappedErr := fmt.Sprintf("Failed to fetch repository information. Please check the URL and try again.")
+		return nil, errors.New(WrapText(wrappedErr, GetTerminalWidth()))
 	}
 
 	return repo, nil
+}
+
+func WrapText(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+
+	var wrappedText strings.Builder
+	var line strings.Builder
+
+	words := strings.Fields(text)
+
+	for _, word := range words {
+		if utf8.RuneCountInString(line.String())+utf8.RuneCountInString(word)+1 > width {
+			wrappedText.WriteString(line.String() + "\n")
+			line.Reset()
+		}
+
+		if line.Len() > 0 {
+			line.WriteString(" ")
+		}
+		line.WriteString(word)
+	}
+
+	if line.Len() > 0 {
+		wrappedText.WriteString(line.String())
+	}
+
+	return wrappedText.String()
+}
+
+func GetTerminalWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return maxWidth
+	}
+	return width
 }


### PR DESCRIPTION

# The Wrapping of the message to the error in the text 

## Description

In this issue #1166  we need to make the text wrapped so that for all the terminal sizes we can able to see it. It was added to it. 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1166 
@quest-bot loot #1166 

## Screenshots
![image](https://github.com/user-attachments/assets/2ee3bf9a-6e2f-4a2b-a349-690286512bf5)


## Notes
