### PR TITLE
feat: add confirmation prompt for removing git providers

### DIFF
--- a/pkg/cmd/gitprovider/delete.go
+++ b/pkg/cmd/gitprovider/delete.go
@@ -5,8 +5,11 @@ package gitprovider
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/charmbracelet/huh"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
@@ -29,20 +32,41 @@ var gitProviderDeleteCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		if allFlag {
-			for _, gitProvider := range gitProviders {
-				_, err := apiClient.GitProviderAPI.RemoveGitProvider(ctx, gitProvider.Id).Execute()
-				if err != nil {
-					return err
-				}
-			}
-
-			views.RenderInfoMessage("All Git providers have been removed")
+		if len(gitProviders) == 0 {
+			views.RenderInfoMessage("No git providers registered")
 			return nil
 		}
 
-		if len(gitProviders) == 0 {
-			views.RenderInfoMessage("No git providers registered")
+		if allFlag {
+			if yesFlag {
+				err = removeAllGitProviders(gitProviders, apiClient)
+				if err != nil {
+					return err
+				}
+			} else {
+				form := huh.NewForm(
+					huh.NewGroup(
+						huh.NewConfirm().
+							Title("Remove all git providers?").
+							Description("Are you sure you want to remove all git providers?").
+							Value(&yesFlag),
+					),
+				).WithTheme(views.GetCustomTheme())
+				err := form.Run()
+				if err != nil {
+					return err
+				}
+
+				if yesFlag {
+					err = removeAllGitProviders(gitProviders, apiClient)
+					if err != nil {
+						return err
+					}
+				} else {
+					fmt.Println("Operation canceled.")
+				}
+			}
+
 			return nil
 		}
 
@@ -52,18 +76,54 @@ var gitProviderDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err = apiClient.GitProviderAPI.RemoveGitProvider(ctx, selectedGitProvider.Id).Execute()
-		if err != nil {
-			return err
+		selectedGitProviderText := fmt.Sprintf("%s (%s)", selectedGitProvider.ProviderId, selectedGitProvider.Alias)
+		if !yesFlag {
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title(fmt.Sprintf("Remove git provider: %s?", selectedGitProviderText)).
+						Description(fmt.Sprintf("Are you sure you want to remove the git provider: %s?", selectedGitProviderText)).
+						Value(&yesFlag),
+				),
+			).WithTheme(views.GetCustomTheme())
+
+			err := form.Run()
+			if err != nil {
+				return err
+			}
 		}
 
-		views.RenderInfoMessage("Git provider has been removed")
+		if !yesFlag {
+			fmt.Println("Operation canceled.")
+		} else {
+			_, err = apiClient.GitProviderAPI.RemoveGitProvider(ctx, selectedGitProvider.Id).Execute()
+			if err != nil {
+				return err
+			}
+
+			views.RenderInfoMessage("Git provider has been removed")
+		}
+
 		return nil
 	},
 }
 
 var allFlag bool
+var yesFlag bool
 
 func init() {
 	gitProviderDeleteCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Remove all Git providers")
+	gitProviderDeleteCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Confirm deletion without prompt")
+}
+
+func removeAllGitProviders(gitProviders []apiclient.GitProvider, apiClient *apiclient.APIClient) error {
+	ctx := context.Background()
+	for _, gitProvider := range gitProviders {
+		_, err := apiClient.GitProviderAPI.RemoveGitProvider(ctx, gitProvider.Id).Execute()
+		if err != nil {
+			return err
+		}
+	}
+	views.RenderInfoMessage("All Git providers have been removed")
+	return nil
 }


### PR DESCRIPTION
# add confirmation prompt for removing git providers

## Description

this PR adds a confirmation prompt for removing git providers. Prompt can be skipped by passing `--yes` flag

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1256

