### PR TITLE
fix: error message on non-started server stop

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -99,6 +99,14 @@ func Stop() error {
 		return err
 	}
 
+	serviceFilePath, err := getServiceFilePath(cfg)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(serviceFilePath); os.IsNotExist(err) {
+		return errors.New("daemon not installed. Run `daytona server` to start the server")
+	}
+
 	err = s.Stop()
 	if err != nil {
 		return err


### PR DESCRIPTION
# Fix Error Message on Non-started Server Stop

## Description

This PR makes the error message more readable when stopping the Daytona server when it's not even started.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1261 

## Screenshots
![Screenshot 2024-10-17 at 09 51 59](https://github.com/user-attachments/assets/fe703ca4-809d-4db9-8cdb-1ff756c5adaf)
