### PR TITLE
feat: update project config git provider

### DIFF
--- a/pkg/cmd/gitprovider/delete.go
+++ b/pkg/cmd/gitprovider/delete.go
@@ -46,7 +46,10 @@ var gitProviderDeleteCmd = &cobra.Command{
 			return nil
 		}
 
-		selectedGitProvider := selection.GetGitProviderConfigFromPrompt(gitProviders, false, "Remove")
+		selectedGitProvider := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
+			GitProviderConfigs: gitProviders,
+			ActionVerb:         "Remove",
+		})
 
 		if selectedGitProvider == nil {
 			return nil

--- a/pkg/cmd/gitprovider/update.go
+++ b/pkg/cmd/gitprovider/update.go
@@ -36,7 +36,10 @@ var gitProviderUpdateCmd = &cobra.Command{
 			return nil
 		}
 
-		selectedGitProvider := selection.GetGitProviderConfigFromPrompt(gitProviders, false, "Update")
+		selectedGitProvider := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
+			GitProviderConfigs: gitProviders,
+			ActionVerb:         "Update",
+		})
 
 		if selectedGitProvider == nil {
 			return nil

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -88,9 +88,10 @@ var projectConfigUpdateCmd = &cobra.Command{
 
 		if len(eligibleGitProviders) > 0 {
 			selectedGitProvider := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
-				GitProviderConfigs: eligibleGitProviders,
-				ActionVerb:         "Use",
-				WithNoneOption:     true,
+				GitProviderConfigs:       eligibleGitProviders,
+				ActionVerb:               "Use",
+				WithNoneOption:           true,
+				PreselectedGitProviderId: projectConfig.GitProviderConfigId,
 			})
 
 			if selectedGitProvider == nil {

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -6,6 +6,7 @@ package projectconfig
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -59,8 +60,9 @@ var projectConfigUpdateCmd = &cobra.Command{
 						Url: projectConfig.RepositoryUrl,
 					},
 				},
-				BuildConfig: projectConfig.BuildConfig,
-				EnvVars:     projectConfig.EnvVars,
+				BuildConfig:         projectConfig.BuildConfig,
+				EnvVars:             projectConfig.EnvVars,
+				GitProviderConfigId: projectConfig.GitProviderConfigId,
 			},
 		}
 
@@ -74,18 +76,42 @@ var projectConfigUpdateCmd = &cobra.Command{
 			projectDefaults.DevcontainerFilePath = projectConfig.BuildConfig.Devcontainer.FilePath
 		}
 
-		create.ProjectsConfigurationChanged, err = create.RunProjectConfiguration(&createDto, *projectDefaults)
+		_, err = create.RunProjectConfiguration(&createDto, *projectDefaults)
 		if err != nil {
 			return err
 		}
 
+		eligibleGitProviders, res, err := apiClient.GitProviderAPI.ListGitProvidersForUrl(ctx, url.QueryEscape(projectConfig.RepositoryUrl)).Execute()
+		if err != nil {
+			return apiclient_util.HandleErrorResponse(res, err)
+		}
+
+		if len(eligibleGitProviders) > 0 {
+			selectedGitProvider := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
+				GitProviderConfigs: eligibleGitProviders,
+				ActionVerb:         "Use",
+				WithNoneOption:     true,
+			})
+
+			if selectedGitProvider == nil {
+				return nil
+			}
+
+			if selectedGitProvider.Id == selection.NoneGitProviderConfigIdentifier {
+				createDto[0].GitProviderConfigId = nil
+			} else {
+				createDto[0].GitProviderConfigId = &selectedGitProvider.Id
+			}
+		}
+
 		newProjectConfig := apiclient.CreateProjectConfigDTO{
-			Name:          projectConfig.Name,
-			BuildConfig:   createDto[0].BuildConfig,
-			Image:         createDto[0].Image,
-			User:          createDto[0].User,
-			RepositoryUrl: createDto[0].Source.Repository.Url,
-			EnvVars:       createDto[0].EnvVars,
+			Name:                projectConfig.Name,
+			BuildConfig:         createDto[0].BuildConfig,
+			Image:               createDto[0].Image,
+			User:                createDto[0].User,
+			RepositoryUrl:       createDto[0].Source.Repository.Url,
+			EnvVars:             createDto[0].EnvVars,
+			GitProviderConfigId: createDto[0].GitProviderConfigId,
 		}
 
 		res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -422,7 +422,10 @@ func processGitURL(ctx context.Context, repoUrl string, apiClient *apiclient.API
 	if len(gitProviderConfigs) == 1 {
 		projectConfigurationFlags.GitProviderConfig = &gitProviderConfigs[0].Id
 	} else if len(gitProviderConfigs) > 1 {
-		gp := selection.GetGitProviderConfigFromPrompt(gitProviderConfigs, false, "Use")
+		gp := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
+			GitProviderConfigs: gitProviderConfigs,
+			ActionVerb:         "Use",
+		})
 		projectConfigurationFlags.GitProviderConfig = &gp.Id
 	}
 

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -146,7 +146,10 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 			if len(gitProviderConfigs) == 1 {
 				gitProviderConfigId = gitProviderConfigs[0].Id
 			} else if len(gitProviderConfigs) > 1 {
-				gp := selection.GetGitProviderConfigFromPrompt(gitProviderConfigs, false, "Use")
+				gp := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
+					GitProviderConfigs: gitProviderConfigs,
+					ActionVerb:         "Use",
+				})
 				gitProviderConfigId = gp.Id
 			} else {
 				gitProviderConfigId = ""

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -150,6 +150,9 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 					GitProviderConfigs: gitProviderConfigs,
 					ActionVerb:         "Use",
 				})
+				if gp == nil {
+					return nil, common.ErrCtrlCAbort
+				}
 				gitProviderConfigId = gp.Id
 			} else {
 				gitProviderConfigId = ""


### PR DESCRIPTION
# Update Project Config Git Provider

## Description

This PR adds the option to update the attached git provider config on a project config. The user is only able to select from git providers that can handle the repository URL. Additionally, the user can choose `None` which will set the git provider config id to `nil`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
