### PR TITLE
fix: wrap no git providers found message

### DIFF
--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
 	"github.com/daytonaio/daytona/pkg/views/gitprovider/list"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,8 @@ var gitProviderListCmd = &cobra.Command{
 		}
 
 		if len(gitProviders) == 0 {
-			views.RenderInfoMessage("No git providers registered. Add a new git provider by\npreparing a Personal Access Token and running 'daytona git-providers add'")
+			message := "No git providers registered. Add a new git provider by preparing a Personal Access Token and running 'daytona git-providers add'"
+			views.RenderInfoMessage(views_util.WrapText(message, views_util.GetTerminalWidth()))
 			return nil
 		}
 


### PR DESCRIPTION
# fix: wrap no git providers found message

## Description

This PR adds wrapping to the no git provider found message

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1259 

## Screenshots
### Now 
![image](https://github.com/user-attachments/assets/89800c95-0161-42c7-a66e-278290919f15)

![image](https://github.com/user-attachments/assets/8f019a39-c52a-4147-ae64-ca1a52ea997a)



## Notes
Please add any relevant notes if necessary.
