### PR TITLE
fix: detach git provider config from project config on removal

### DIFF
--- a/internal/testing/server/projectconfig/store.go
+++ b/internal/testing/server/projectconfig/store.go
@@ -77,6 +77,13 @@ func (s *InMemoryProjectConfigStore) processFilters(filter *config.ProjectConfig
 				}
 			}
 		}
+		if filter.GitProviderConfigId != nil {
+			for _, projectConfig := range filteredProjectConfigs {
+				if projectConfig.GitProviderConfigId != nil && *projectConfig.GitProviderConfigId != *filter.GitProviderConfigId {
+					delete(filteredProjectConfigs, projectConfig.Name)
+				}
+			}
+		}
 	}
 
 	for _, projectConfig := range filteredProjectConfigs {

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -257,7 +257,8 @@ func GetInstance(c *server.Config, configDir string, version string, telemetrySe
 	})
 
 	gitProviderService := gitproviders.NewGitProviderService(gitproviders.GitProviderServiceConfig{
-		ConfigStore: gitProviderConfigStore,
+		ConfigStore:        gitProviderConfigStore,
+		ProjectConfigStore: projectConfigStore,
 	})
 
 	prebuildWebhookEndpoint := fmt.Sprintf("%s%s", util.GetFrpcApiUrl(c.Frps.Protocol, c.Id, c.Frps.Domain), constants.WEBHOOK_EVENT_ROUTE)

--- a/pkg/db/project_config_store.go
+++ b/pkg/db/project_config_store.go
@@ -85,6 +85,9 @@ func processProjectConfigFilters(tx *gorm.DB, filter *config.ProjectConfigFilter
 		if filter.Default != nil {
 			tx = tx.Where("is_default = ?", *filter.Default)
 		}
+		if filter.GitProviderConfigId != nil {
+			tx = tx.Where("git_provider_config_id = ?", *filter.GitProviderConfigId)
+		}
 	}
 
 	return tx

--- a/pkg/server/gitproviders/remove.go
+++ b/pkg/server/gitproviders/remove.go
@@ -3,10 +3,29 @@
 
 package gitproviders
 
+import "github.com/daytonaio/daytona/pkg/workspace/project/config"
+
 func (s *GitProviderService) RemoveGitProvider(gitProviderId string) error {
 	gitProvider, err := s.configStore.Find(gitProviderId)
 	if err != nil {
 		return err
+	}
+
+	// Check if project configs need to be updated
+	projectConfigs, err := s.projectConfigStore.List(&config.ProjectConfigFilter{
+		GitProviderConfigId: &gitProviderId,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	for _, projectConfig := range projectConfigs {
+		projectConfig.GitProviderConfigId = nil
+		err = s.projectConfigStore.Save(projectConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	return s.configStore.Delete(gitProvider)

--- a/pkg/server/gitproviders/service.go
+++ b/pkg/server/gitproviders/service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/daytonaio/daytona/pkg/gitprovider"
+	"github.com/daytonaio/daytona/pkg/workspace/project/config"
 )
 
 type IGitProviderService interface {
@@ -32,17 +33,25 @@ type IGitProviderService interface {
 	UnregisterPrebuildWebhook(gitProviderId string, repo *gitprovider.GitRepository, id string) error
 }
 
+type ProjectConfigStore interface {
+	Save(projectConfig *config.ProjectConfig) error
+	List(filter *config.ProjectConfigFilter) ([]*config.ProjectConfig, error)
+}
+
 type GitProviderServiceConfig struct {
-	ConfigStore gitprovider.ConfigStore
+	ConfigStore        gitprovider.ConfigStore
+	ProjectConfigStore ProjectConfigStore
 }
 
 type GitProviderService struct {
-	configStore gitprovider.ConfigStore
+	configStore        gitprovider.ConfigStore
+	projectConfigStore ProjectConfigStore
 }
 
 func NewGitProviderService(config GitProviderServiceConfig) IGitProviderService {
 	return &GitProviderService{
-		configStore: config.ConfigStore,
+		configStore:        config.ConfigStore,
+		projectConfigStore: config.ProjectConfigStore,
 	}
 }
 

--- a/pkg/workspace/project/config/store.go
+++ b/pkg/workspace/project/config/store.go
@@ -6,10 +6,11 @@ package config
 import "errors"
 
 type ProjectConfigFilter struct {
-	Name       *string
-	Url        *string
-	Default    *bool
-	PrebuildId *string
+	Name                *string
+	Url                 *string
+	Default             *bool
+	PrebuildId          *string
+	GitProviderConfigId *string
 }
 
 type PrebuildFilter struct {


### PR DESCRIPTION
# Detach Git Provider Config from Project Config on Removal

## Description

This PR fixes an issue where project configs would still retain the GitProviderId even after it was removed.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
