### PR TITLE
fix: bitbucket branch list pagination

### DIFF
--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -127,14 +127,14 @@ func (g *BitbucketGitProvider) GetRepoBranches(repositoryId string, namespaceId 
 	opts := &bitbucket.RepositoryBranchOptions{
 		RepoSlug: repositoryId,
 		Owner:    namespaceId,
+		PageNum:  options.Page,
+		Pagelen:  options.PerPage,
 	}
 
 	owner, repo, err := g.getOwnerAndRepoFromFullName(repositoryId)
 	if err == nil {
-		opts = &bitbucket.RepositoryBranchOptions{
-			RepoSlug: repo,
-			Owner:    owner,
-		}
+		opts.RepoSlug = repo
+		opts.Owner = owner
 	}
 
 	branches, err := client.Repositories.Repository.ListBranches(opts)


### PR DESCRIPTION
# Bitbucket branch list pagination

## Description

Fixes Bitbucket branch retrieval to use the recently implemented pagination support. Previously, the TUI would list only 10 branches in total instead of listing up to 100 plus a "Load more" option.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation