### PR TITLE
fix: bitbucket context retrieval speed

### DIFF
--- a/pkg/gitprovider/bitbucket.go
+++ b/pkg/gitprovider/bitbucket.go
@@ -265,6 +265,7 @@ func (g *BitbucketGitProvider) GetLastCommitSha(staticContext *StaticGitContext)
 		RepoSlug:    staticContext.Id,
 		Branchortag: branch,
 		Include:     include,
+		Page:        util.Pointer(1),
 	})
 
 	if err != nil {


### PR DESCRIPTION
# Bitbucket context retrieval speed

## Description

Fixes the Bitbucket context retrieval being slow due to the speed of the API call for retrieving every commit and figuring out the last commit's SHA instead of getting just the one that is needed.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1258 
