### PR TITLE
fix: api failure on repeated validation of repo url

### DIFF
--- a/pkg/views/workspace/create/view.go
+++ b/pkg/views/workspace/create/view.go
@@ -75,16 +75,32 @@ func GetRepositoryFromUrlInput(multiProject bool, projectOrder int, apiClient *a
 	var initialRepoUrl string
 	var repo *apiclient.GitRepository
 
+	var previousRepoUrl string
+	var previousError error
+
 	initialRepoInput := huh.NewInput().
 		Title(title).
 		Value(&initialRepoUrl).
 		Key("initialProjectRepo").
 		Validate(func(str string) error {
-			return views_util.WithInlineSpinner("Validating", func() error {
+			if str == previousRepoUrl && previousError != nil {
+				return previousError
+			}
+
+			previousRepoUrl = str
+			previousError = nil
+
+			err := views_util.WithInlineSpinner("Validating", func() error {
 				var err error
 				repo, err = validateRepoUrl(str, apiClient)
 				return err
 			})
+
+			if err != nil {
+				previousError = err
+			}
+
+			return err
 		})
 
 	dTheme := views.GetCustomTheme()


### PR DESCRIPTION
# fix: api failure on repeated validation of repo url

## Description

This PR fixes the API failure on repeated validation of Repo URL.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1257

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
