### PR TITLE
feat: set default target

### DIFF
--- a/docs/daytona_git-providers_delete.md
+++ b/docs/daytona_git-providers_delete.md
@@ -10,6 +10,7 @@ daytona git-providers delete [flags]
 
 ```
   -a, --all   Remove all Git providers
+  -y, --yes   Confirm deletion without prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_target.md
+++ b/docs/daytona_target.md
@@ -14,4 +14,5 @@ Manage provider targets
 * [daytona target list](daytona_target_list.md)	 - List targets
 * [daytona target remove](daytona_target_remove.md)	 - Remove target
 * [daytona target set](daytona_target_set.md)	 - Set provider target
+* [daytona target set-default](daytona_target_set-default.md)	 - Set target to be used by default
 

--- a/docs/daytona_target_set-default.md
+++ b/docs/daytona_target_set-default.md
@@ -1,0 +1,18 @@
+## daytona target set-default
+
+Set target to be used by default
+
+```
+daytona target set-default [TARGET_NAME] [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --help   help for daytona
+```
+
+### SEE ALSO
+
+* [daytona target](daytona_target.md)	 - Manage provider targets
+

--- a/hack/docs/daytona_git-providers_delete.yaml
+++ b/hack/docs/daytona_git-providers_delete.yaml
@@ -6,6 +6,10 @@ options:
       shorthand: a
       default_value: "false"
       usage: Remove all Git providers
+    - name: "yes"
+      shorthand: "y"
+      default_value: "false"
+      usage: Confirm deletion without prompt
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/daytona_target.yaml
+++ b/hack/docs/daytona_target.yaml
@@ -9,3 +9,4 @@ see_also:
     - daytona target list - List targets
     - daytona target remove - Remove target
     - daytona target set - Set provider target
+    - daytona target set-default - Set target to be used by default

--- a/hack/docs/daytona_target_set-default.yaml
+++ b/hack/docs/daytona_target_set-default.yaml
@@ -1,0 +1,9 @@
+name: daytona target set-default
+synopsis: Set target to be used by default
+usage: daytona target set-default [TARGET_NAME] [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+see_also:
+    - daytona target - Manage provider targets

--- a/internal/testing/provider/targets/store.go
+++ b/internal/testing/provider/targets/store.go
@@ -6,6 +6,8 @@
 package targets
 
 import (
+	"fmt"
+
 	"github.com/daytonaio/daytona/pkg/provider"
 )
 
@@ -19,22 +21,20 @@ func NewInMemoryTargetStore() provider.TargetStore {
 	}
 }
 
-func (s *InMemoryTargetStore) List() ([]*provider.ProviderTarget, error) {
-	targets := []*provider.ProviderTarget{}
-	for _, t := range s.targets {
-		targets = append(targets, t)
-	}
-
-	return targets, nil
+func (s *InMemoryTargetStore) List(filter *provider.TargetFilter) ([]*provider.ProviderTarget, error) {
+	return s.processFilters(filter)
 }
 
-func (s *InMemoryTargetStore) Find(targetName string) (*provider.ProviderTarget, error) {
-	target, ok := s.targets[targetName]
-	if !ok {
+func (s *InMemoryTargetStore) Find(filter *provider.TargetFilter) (*provider.ProviderTarget, error) {
+	targets, err := s.processFilters(filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
 		return nil, provider.ErrTargetNotFound
 	}
 
-	return target, nil
+	return targets[0], nil
 }
 
 func (s *InMemoryTargetStore) Save(target *provider.ProviderTarget) error {
@@ -45,4 +45,36 @@ func (s *InMemoryTargetStore) Save(target *provider.ProviderTarget) error {
 func (s *InMemoryTargetStore) Delete(target *provider.ProviderTarget) error {
 	delete(s.targets, target.Name)
 	return nil
+}
+
+func (s *InMemoryTargetStore) processFilters(filter *provider.TargetFilter) ([]*provider.ProviderTarget, error) {
+	var result []*provider.ProviderTarget
+	filteredTargets := make(map[string]*provider.ProviderTarget)
+	for k, v := range s.targets {
+		filteredTargets[k] = v
+	}
+
+	if filter != nil {
+		if filter.Name != nil {
+			target, ok := s.targets[*filter.Name]
+			if ok {
+				return []*provider.ProviderTarget{target}, nil
+			} else {
+				return []*provider.ProviderTarget{}, fmt.Errorf("target with name %s not found", *filter.Name)
+			}
+		}
+		if filter.Default != nil {
+			for _, target := range filteredTargets {
+				if target.IsDefault != *filter.Default {
+					delete(filteredTargets, target.Name)
+				}
+			}
+		}
+	}
+
+	for _, target := range filteredTargets {
+		result = append(result, target)
+	}
+
+	return result, nil
 }

--- a/internal/util/apiclient/conversion/target.go
+++ b/internal/util/apiclient/conversion/target.go
@@ -1,0 +1,17 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package conversion
+
+import (
+	"github.com/daytonaio/daytona/pkg/provider"
+	"github.com/daytonaio/daytona/pkg/server/providertargets/dto"
+)
+
+func ToProviderTarget(createProviderTargetDto dto.CreateProviderTargetDTO) *provider.ProviderTarget {
+	return &provider.ProviderTarget{
+		Name:         createProviderTargetDto.Name,
+		ProviderInfo: createProviderTargetDto.ProviderInfo,
+		Options:      createProviderTargetDto.Options,
+	}
+}

--- a/pkg/api/controllers/target/list.go
+++ b/pkg/api/controllers/target/list.go
@@ -24,7 +24,7 @@ import (
 func ListTargets(ctx *gin.Context) {
 	server := server.GetInstance(nil)
 
-	targets, err := server.ProviderTargetService.List()
+	targets, err := server.ProviderTargetService.List(nil)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to list targets: %w", err))
 		return

--- a/pkg/api/controllers/target/remove.go
+++ b/pkg/api/controllers/target/remove.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/gin-gonic/gin"
 )
@@ -26,7 +27,9 @@ func RemoveTarget(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	target, err := server.ProviderTargetService.Find(targetName)
+	target, err := server.ProviderTargetService.Find(&provider.TargetFilter{
+		Name: &targetName,
+	})
 	if err != nil {
 		ctx.AbortWithError(http.StatusNotFound, fmt.Errorf("failed to find target: %w", err))
 		return

--- a/pkg/api/controllers/target/set.go
+++ b/pkg/api/controllers/target/set.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/daytonaio/daytona/internal/util/apiclient/conversion"
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/server"
+	"github.com/daytonaio/daytona/pkg/server/providertargets/dto"
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,13 +19,13 @@ import (
 //	@Tags			target
 //	@Summary		Set a target
 //	@Description	Set a target
-//	@Param			target	body	ProviderTarget	true	"Target to set"
+//	@Param			target	body	CreateProviderTargetDTO	true	"Target to set"
 //	@Success		201
 //	@Router			/target [put]
 //
 //	@id				SetTarget
 func SetTarget(ctx *gin.Context) {
-	var req provider.ProviderTarget
+	var req dto.CreateProviderTargetDTO
 	err := ctx.BindJSON(&req)
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
@@ -32,13 +34,7 @@ func SetTarget(ctx *gin.Context) {
 
 	server := server.GetInstance(nil)
 
-	target, err := server.ProviderTargetService.Find(req.Name)
-	if err == nil {
-		target.Options = req.Options
-		target.ProviderInfo = req.ProviderInfo
-	} else {
-		target = &req
-	}
+	target := conversion.ToProviderTarget(req)
 
 	err = server.ProviderTargetService.Save(target)
 	if err != nil {
@@ -47,4 +43,36 @@ func SetTarget(ctx *gin.Context) {
 	}
 
 	ctx.Status(201)
+}
+
+// SetDefaultTarget godoc
+//
+//	@Tags			target
+//	@Summary		Set target to default
+//	@Description	Set target to default
+//	@Param			target	path	string	true	"Target name"
+//	@Success		200
+//	@Router			/target/{target}/set-default [patch]
+//
+//	@id				SetDefaultTarget
+func SetDefaultTarget(ctx *gin.Context) {
+	targetName := ctx.Param("target")
+
+	server := server.GetInstance(nil)
+
+	target, err := server.ProviderTargetService.Find(&provider.TargetFilter{
+		Name: &targetName,
+	})
+	if err != nil {
+		ctx.AbortWithError(http.StatusNotFound, fmt.Errorf("failed to find target: %w", err))
+		return
+	}
+
+	err = server.ProviderTargetService.SetDefault(target)
+	if err != nil {
+		ctx.AbortWithError(http.StatusNotFound, fmt.Errorf("failed to set project config to default: %s", err.Error()))
+		return
+	}
+
+	ctx.Status(200)
 }

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1522,7 +1522,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/ProviderTarget"
+                            "$ref": "#/definitions/CreateProviderTargetDTO"
                         }
                     }
                 ],
@@ -1553,6 +1553,30 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/target/{target}/set-default": {
+            "patch": {
+                "description": "Set target to default",
+                "tags": [
+                    "target"
+                ],
+                "summary": "Set target to default",
+                "operationId": "SetDefaultTarget",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target name",
+                        "name": "target",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -2104,6 +2128,25 @@ const docTemplate = `{
             "properties": {
                 "repository": {
                     "$ref": "#/definitions/GitRepository"
+                }
+            }
+        },
+        "CreateProviderTargetDTO": {
+            "type": "object",
+            "required": [
+                "name",
+                "options",
+                "providerInfo"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "options": {
+                    "type": "string"
+                },
+                "providerInfo": {
+                    "$ref": "#/definitions/provider.ProviderInfo"
                 }
             }
         },
@@ -2680,11 +2723,15 @@ const docTemplate = `{
         "ProviderTarget": {
             "type": "object",
             "required": [
+                "isDefault",
                 "name",
                 "options",
                 "providerInfo"
             ],
             "properties": {
+                "isDefault": {
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1519,7 +1519,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/ProviderTarget"
+                            "$ref": "#/definitions/CreateProviderTargetDTO"
                         }
                     }
                 ],
@@ -1550,6 +1550,30 @@
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/target/{target}/set-default": {
+            "patch": {
+                "description": "Set target to default",
+                "tags": [
+                    "target"
+                ],
+                "summary": "Set target to default",
+                "operationId": "SetDefaultTarget",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target name",
+                        "name": "target",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -2101,6 +2125,25 @@
             "properties": {
                 "repository": {
                     "$ref": "#/definitions/GitRepository"
+                }
+            }
+        },
+        "CreateProviderTargetDTO": {
+            "type": "object",
+            "required": [
+                "name",
+                "options",
+                "providerInfo"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "options": {
+                    "type": "string"
+                },
+                "providerInfo": {
+                    "$ref": "#/definitions/provider.ProviderInfo"
                 }
             }
         },
@@ -2677,11 +2720,15 @@
         "ProviderTarget": {
             "type": "object",
             "required": [
+                "isDefault",
                 "name",
                 "options",
                 "providerInfo"
             ],
             "properties": {
+                "isDefault": {
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -185,6 +185,19 @@ definitions:
     required:
     - repository
     type: object
+  CreateProviderTargetDTO:
+    properties:
+      name:
+        type: string
+      options:
+        type: string
+      providerInfo:
+        $ref: '#/definitions/provider.ProviderInfo'
+    required:
+    - name
+    - options
+    - providerInfo
+    type: object
   CreateWorkspaceDTO:
     properties:
       id:
@@ -578,6 +591,8 @@ definitions:
     type: object
   ProviderTarget:
     properties:
+      isDefault:
+        type: boolean
       name:
         type: string
       options:
@@ -586,6 +601,7 @@ definitions:
       providerInfo:
         $ref: '#/definitions/provider.ProviderInfo'
     required:
+    - isDefault
     - name
     - options
     - providerInfo
@@ -1883,7 +1899,7 @@ paths:
         name: target
         required: true
         schema:
-          $ref: '#/definitions/ProviderTarget'
+          $ref: '#/definitions/CreateProviderTargetDTO'
       responses:
         "201":
           description: Created
@@ -1904,6 +1920,22 @@ paths:
         "204":
           description: No Content
       summary: Remove a target
+      tags:
+      - target
+  /target/{target}/set-default:
+    patch:
+      description: Set target to default
+      operationId: SetDefaultTarget
+      parameters:
+      - description: Target name
+        in: path
+        name: target
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+      summary: Set target to default
       tags:
       - target
   /workspace:

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -208,6 +208,7 @@ func (a *ApiServer) Start() error {
 	{
 		targetController.GET("/", target.ListTargets)
 		targetController.PUT("/", target.SetTarget)
+		targetController.PATCH("/:target/set-default", target.SetDefaultTarget)
 		targetController.DELETE("/:target", target.RemoveTarget)
 	}
 

--- a/pkg/apiclient/README.md
+++ b/pkg/apiclient/README.md
@@ -129,6 +129,7 @@ Class | Method | HTTP request | Description
 *ServerAPI* | [**SetConfig**](docs/ServerAPI.md#setconfig) | **Post** /server/config | Set the server configuration
 *TargetAPI* | [**ListTargets**](docs/TargetAPI.md#listtargets) | **Get** /target | List targets
 *TargetAPI* | [**RemoveTarget**](docs/TargetAPI.md#removetarget) | **Delete** /target/{target} | Remove a target
+*TargetAPI* | [**SetDefaultTarget**](docs/TargetAPI.md#setdefaulttarget) | **Patch** /target/{target}/set-default | Set target to default
 *TargetAPI* | [**SetTarget**](docs/TargetAPI.md#settarget) | **Put** /target | Set a target
 *WorkspaceAPI* | [**CreateWorkspace**](docs/WorkspaceAPI.md#createworkspace) | **Post** /workspace | Create a workspace
 *WorkspaceAPI* | [**GetWorkspace**](docs/WorkspaceAPI.md#getworkspace) | **Get** /workspace/{workspaceId} | Get workspace info
@@ -157,6 +158,7 @@ Class | Method | HTTP request | Description
  - [CreateProjectConfigDTO](docs/CreateProjectConfigDTO.md)
  - [CreateProjectDTO](docs/CreateProjectDTO.md)
  - [CreateProjectSourceDTO](docs/CreateProjectSourceDTO.md)
+ - [CreateProviderTargetDTO](docs/CreateProviderTargetDTO.md)
  - [CreateWorkspaceDTO](docs/CreateWorkspaceDTO.md)
  - [DevcontainerConfig](docs/DevcontainerConfig.md)
  - [FRPSConfig](docs/FRPSConfig.md)

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1079,7 +1079,7 @@ paths:
         content:
           '*/*':
             schema:
-              $ref: '#/components/schemas/ProviderTarget'
+              $ref: '#/components/schemas/CreateProviderTargetDTO'
         description: Target to set
         required: true
       responses:
@@ -1106,6 +1106,24 @@ paths:
           content: {}
           description: No Content
       summary: Remove a target
+      tags:
+      - target
+  /target/{target}/set-default:
+    patch:
+      description: Set target to default
+      operationId: SetDefaultTarget
+      parameters:
+      - description: Target name
+        in: path
+        name: target
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content: {}
+          description: OK
+      summary: Set target to default
       tags:
       - target
   /workspace:
@@ -1616,6 +1634,26 @@ components:
           $ref: '#/components/schemas/GitRepository'
       required:
       - repository
+      type: object
+    CreateProviderTargetDTO:
+      example:
+        name: name
+        options: options
+        providerInfo:
+          name: name
+          label: label
+          version: version
+      properties:
+        name:
+          type: string
+        options:
+          type: string
+        providerInfo:
+          $ref: '#/components/schemas/provider.ProviderInfo'
+      required:
+      - name
+      - options
+      - providerInfo
       type: object
     CreateWorkspaceDTO:
       example:
@@ -2263,6 +2301,7 @@ components:
       type: object
     ProviderTarget:
       example:
+        isDefault: true
         name: name
         options: options
         providerInfo:
@@ -2270,6 +2309,8 @@ components:
           label: label
           version: version
       properties:
+        isDefault:
+          type: boolean
         name:
           type: string
         options:
@@ -2278,6 +2319,7 @@ components:
         providerInfo:
           $ref: '#/components/schemas/provider.ProviderInfo'
       required:
+      - isDefault
       - name
       - options
       - providerInfo

--- a/pkg/apiclient/api_target.go
+++ b/pkg/apiclient/api_target.go
@@ -242,14 +242,120 @@ func (a *TargetAPIService) RemoveTargetExecute(r ApiRemoveTargetRequest) (*http.
 	return localVarHTTPResponse, nil
 }
 
+type ApiSetDefaultTargetRequest struct {
+	ctx        context.Context
+	ApiService *TargetAPIService
+	target     string
+}
+
+func (r ApiSetDefaultTargetRequest) Execute() (*http.Response, error) {
+	return r.ApiService.SetDefaultTargetExecute(r)
+}
+
+/*
+SetDefaultTarget Set target to default
+
+Set target to default
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param target Target name
+	@return ApiSetDefaultTargetRequest
+*/
+func (a *TargetAPIService) SetDefaultTarget(ctx context.Context, target string) ApiSetDefaultTargetRequest {
+	return ApiSetDefaultTargetRequest{
+		ApiService: a,
+		ctx:        ctx,
+		target:     target,
+	}
+}
+
+// Execute executes the request
+func (a *TargetAPIService) SetDefaultTargetExecute(r ApiSetDefaultTargetRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodPatch
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TargetAPIService.SetDefaultTarget")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/target/{target}/set-default"
+	localVarPath = strings.Replace(localVarPath, "{"+"target"+"}", url.PathEscape(parameterValueToString(r.target, "target")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.ctx != nil {
+		// API Key Authentication
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+			if apiKey, ok := auth["Bearer"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
+				}
+				localVarHeaderParams["Authorization"] = key
+			}
+		}
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type ApiSetTargetRequest struct {
 	ctx        context.Context
 	ApiService *TargetAPIService
-	target     *ProviderTarget
+	target     *CreateProviderTargetDTO
 }
 
 // Target to set
-func (r ApiSetTargetRequest) Target(target ProviderTarget) ApiSetTargetRequest {
+func (r ApiSetTargetRequest) Target(target CreateProviderTargetDTO) ApiSetTargetRequest {
 	r.target = &target
 	return r
 }

--- a/pkg/apiclient/docs/CreateProviderTargetDTO.md
+++ b/pkg/apiclient/docs/CreateProviderTargetDTO.md
@@ -1,109 +1,88 @@
-# ProviderTarget
+# CreateProviderTargetDTO
 
 ## Properties
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**IsDefault** | **bool** |  | 
 **Name** | **string** |  | 
-**Options** | **string** | JSON encoded map of options | 
+**Options** | **string** |  | 
 **ProviderInfo** | [**ProviderProviderInfo**](ProviderProviderInfo.md) |  | 
 
 ## Methods
 
-### NewProviderTarget
+### NewCreateProviderTargetDTO
 
-`func NewProviderTarget(isDefault bool, name string, options string, providerInfo ProviderProviderInfo, ) *ProviderTarget`
+`func NewCreateProviderTargetDTO(name string, options string, providerInfo ProviderProviderInfo, ) *CreateProviderTargetDTO`
 
-NewProviderTarget instantiates a new ProviderTarget object
+NewCreateProviderTargetDTO instantiates a new CreateProviderTargetDTO object
 This constructor will assign default values to properties that have it defined,
 and makes sure properties required by API are set, but the set of arguments
 will change when the set of required properties is changed
 
-### NewProviderTargetWithDefaults
+### NewCreateProviderTargetDTOWithDefaults
 
-`func NewProviderTargetWithDefaults() *ProviderTarget`
+`func NewCreateProviderTargetDTOWithDefaults() *CreateProviderTargetDTO`
 
-NewProviderTargetWithDefaults instantiates a new ProviderTarget object
+NewCreateProviderTargetDTOWithDefaults instantiates a new CreateProviderTargetDTO object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
 
-### GetIsDefault
-
-`func (o *ProviderTarget) GetIsDefault() bool`
-
-GetIsDefault returns the IsDefault field if non-nil, zero value otherwise.
-
-### GetIsDefaultOk
-
-`func (o *ProviderTarget) GetIsDefaultOk() (*bool, bool)`
-
-GetIsDefaultOk returns a tuple with the IsDefault field if it's non-nil, zero value otherwise
-and a boolean to check if the value has been set.
-
-### SetIsDefault
-
-`func (o *ProviderTarget) SetIsDefault(v bool)`
-
-SetIsDefault sets IsDefault field to given value.
-
-
 ### GetName
 
-`func (o *ProviderTarget) GetName() string`
+`func (o *CreateProviderTargetDTO) GetName() string`
 
 GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *ProviderTarget) GetNameOk() (*string, bool)`
+`func (o *CreateProviderTargetDTO) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetName
 
-`func (o *ProviderTarget) SetName(v string)`
+`func (o *CreateProviderTargetDTO) SetName(v string)`
 
 SetName sets Name field to given value.
 
 
 ### GetOptions
 
-`func (o *ProviderTarget) GetOptions() string`
+`func (o *CreateProviderTargetDTO) GetOptions() string`
 
 GetOptions returns the Options field if non-nil, zero value otherwise.
 
 ### GetOptionsOk
 
-`func (o *ProviderTarget) GetOptionsOk() (*string, bool)`
+`func (o *CreateProviderTargetDTO) GetOptionsOk() (*string, bool)`
 
 GetOptionsOk returns a tuple with the Options field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetOptions
 
-`func (o *ProviderTarget) SetOptions(v string)`
+`func (o *CreateProviderTargetDTO) SetOptions(v string)`
 
 SetOptions sets Options field to given value.
 
 
 ### GetProviderInfo
 
-`func (o *ProviderTarget) GetProviderInfo() ProviderProviderInfo`
+`func (o *CreateProviderTargetDTO) GetProviderInfo() ProviderProviderInfo`
 
 GetProviderInfo returns the ProviderInfo field if non-nil, zero value otherwise.
 
 ### GetProviderInfoOk
 
-`func (o *ProviderTarget) GetProviderInfoOk() (*ProviderProviderInfo, bool)`
+`func (o *CreateProviderTargetDTO) GetProviderInfoOk() (*ProviderProviderInfo, bool)`
 
 GetProviderInfoOk returns a tuple with the ProviderInfo field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetProviderInfo
 
-`func (o *ProviderTarget) SetProviderInfo(v ProviderProviderInfo)`
+`func (o *CreateProviderTargetDTO) SetProviderInfo(v ProviderProviderInfo)`
 
 SetProviderInfo sets ProviderInfo field to given value.
 

--- a/pkg/apiclient/docs/TargetAPI.md
+++ b/pkg/apiclient/docs/TargetAPI.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**ListTargets**](TargetAPI.md#ListTargets) | **Get** /target | List targets
 [**RemoveTarget**](TargetAPI.md#RemoveTarget) | **Delete** /target/{target} | Remove a target
+[**SetDefaultTarget**](TargetAPI.md#SetDefaultTarget) | **Patch** /target/{target}/set-default | Set target to default
 [**SetTarget**](TargetAPI.md#SetTarget) | **Put** /target | Set a target
 
 
@@ -139,6 +140,74 @@ Name | Type | Description  | Notes
 [[Back to README]](../README.md)
 
 
+## SetDefaultTarget
+
+> SetDefaultTarget(ctx, target).Execute()
+
+Set target to default
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID/apiclient"
+)
+
+func main() {
+	target := "target_example" // string | Target name
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	r, err := apiClient.TargetAPI.SetDefaultTarget(context.Background(), target).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `TargetAPI.SetDefaultTarget``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**target** | **string** | Target name | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiSetDefaultTargetRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
 ## SetTarget
 
 > SetTarget(ctx).Target(target).Execute()
@@ -160,7 +229,7 @@ import (
 )
 
 func main() {
-	target := *openapiclient.NewProviderTarget("Name_example", "Options_example", *openapiclient.NewProviderProviderInfo("Name_example", "Version_example")) // ProviderTarget | Target to set
+	target := *openapiclient.NewCreateProviderTargetDTO("Name_example", "Options_example", *openapiclient.NewProviderProviderInfo("Name_example", "Version_example")) // CreateProviderTargetDTO | Target to set
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -183,7 +252,7 @@ Other parameters are passed through a pointer to a apiSetTargetRequest struct vi
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **target** | [**ProviderTarget**](ProviderTarget.md) | Target to set | 
+ **target** | [**CreateProviderTargetDTO**](CreateProviderTargetDTO.md) | Target to set | 
 
 ### Return type
 

--- a/pkg/apiclient/model_create_provider_target_dto.go
+++ b/pkg/apiclient/model_create_provider_target_dto.go
@@ -16,67 +16,40 @@ import (
 	"fmt"
 )
 
-// checks if the ProviderTarget type satisfies the MappedNullable interface at compile time
-var _ MappedNullable = &ProviderTarget{}
+// checks if the CreateProviderTargetDTO type satisfies the MappedNullable interface at compile time
+var _ MappedNullable = &CreateProviderTargetDTO{}
 
-// ProviderTarget struct for ProviderTarget
-type ProviderTarget struct {
-	IsDefault bool   `json:"isDefault"`
-	Name      string `json:"name"`
-	// JSON encoded map of options
+// CreateProviderTargetDTO struct for CreateProviderTargetDTO
+type CreateProviderTargetDTO struct {
+	Name         string               `json:"name"`
 	Options      string               `json:"options"`
 	ProviderInfo ProviderProviderInfo `json:"providerInfo"`
 }
 
-type _ProviderTarget ProviderTarget
+type _CreateProviderTargetDTO CreateProviderTargetDTO
 
-// NewProviderTarget instantiates a new ProviderTarget object
+// NewCreateProviderTargetDTO instantiates a new CreateProviderTargetDTO object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewProviderTarget(isDefault bool, name string, options string, providerInfo ProviderProviderInfo) *ProviderTarget {
-	this := ProviderTarget{}
-	this.IsDefault = isDefault
+func NewCreateProviderTargetDTO(name string, options string, providerInfo ProviderProviderInfo) *CreateProviderTargetDTO {
+	this := CreateProviderTargetDTO{}
 	this.Name = name
 	this.Options = options
 	this.ProviderInfo = providerInfo
 	return &this
 }
 
-// NewProviderTargetWithDefaults instantiates a new ProviderTarget object
+// NewCreateProviderTargetDTOWithDefaults instantiates a new CreateProviderTargetDTO object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
-func NewProviderTargetWithDefaults() *ProviderTarget {
-	this := ProviderTarget{}
+func NewCreateProviderTargetDTOWithDefaults() *CreateProviderTargetDTO {
+	this := CreateProviderTargetDTO{}
 	return &this
 }
 
-// GetIsDefault returns the IsDefault field value
-func (o *ProviderTarget) GetIsDefault() bool {
-	if o == nil {
-		var ret bool
-		return ret
-	}
-
-	return o.IsDefault
-}
-
-// GetIsDefaultOk returns a tuple with the IsDefault field value
-// and a boolean to check if the value has been set.
-func (o *ProviderTarget) GetIsDefaultOk() (*bool, bool) {
-	if o == nil {
-		return nil, false
-	}
-	return &o.IsDefault, true
-}
-
-// SetIsDefault sets field value
-func (o *ProviderTarget) SetIsDefault(v bool) {
-	o.IsDefault = v
-}
-
 // GetName returns the Name field value
-func (o *ProviderTarget) GetName() string {
+func (o *CreateProviderTargetDTO) GetName() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -87,7 +60,7 @@ func (o *ProviderTarget) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-func (o *ProviderTarget) GetNameOk() (*string, bool) {
+func (o *CreateProviderTargetDTO) GetNameOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -95,12 +68,12 @@ func (o *ProviderTarget) GetNameOk() (*string, bool) {
 }
 
 // SetName sets field value
-func (o *ProviderTarget) SetName(v string) {
+func (o *CreateProviderTargetDTO) SetName(v string) {
 	o.Name = v
 }
 
 // GetOptions returns the Options field value
-func (o *ProviderTarget) GetOptions() string {
+func (o *CreateProviderTargetDTO) GetOptions() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -111,7 +84,7 @@ func (o *ProviderTarget) GetOptions() string {
 
 // GetOptionsOk returns a tuple with the Options field value
 // and a boolean to check if the value has been set.
-func (o *ProviderTarget) GetOptionsOk() (*string, bool) {
+func (o *CreateProviderTargetDTO) GetOptionsOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -119,12 +92,12 @@ func (o *ProviderTarget) GetOptionsOk() (*string, bool) {
 }
 
 // SetOptions sets field value
-func (o *ProviderTarget) SetOptions(v string) {
+func (o *CreateProviderTargetDTO) SetOptions(v string) {
 	o.Options = v
 }
 
 // GetProviderInfo returns the ProviderInfo field value
-func (o *ProviderTarget) GetProviderInfo() ProviderProviderInfo {
+func (o *CreateProviderTargetDTO) GetProviderInfo() ProviderProviderInfo {
 	if o == nil {
 		var ret ProviderProviderInfo
 		return ret
@@ -135,7 +108,7 @@ func (o *ProviderTarget) GetProviderInfo() ProviderProviderInfo {
 
 // GetProviderInfoOk returns a tuple with the ProviderInfo field value
 // and a boolean to check if the value has been set.
-func (o *ProviderTarget) GetProviderInfoOk() (*ProviderProviderInfo, bool) {
+func (o *CreateProviderTargetDTO) GetProviderInfoOk() (*ProviderProviderInfo, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -143,11 +116,11 @@ func (o *ProviderTarget) GetProviderInfoOk() (*ProviderProviderInfo, bool) {
 }
 
 // SetProviderInfo sets field value
-func (o *ProviderTarget) SetProviderInfo(v ProviderProviderInfo) {
+func (o *CreateProviderTargetDTO) SetProviderInfo(v ProviderProviderInfo) {
 	o.ProviderInfo = v
 }
 
-func (o ProviderTarget) MarshalJSON() ([]byte, error) {
+func (o CreateProviderTargetDTO) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
@@ -155,21 +128,19 @@ func (o ProviderTarget) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-func (o ProviderTarget) ToMap() (map[string]interface{}, error) {
+func (o CreateProviderTargetDTO) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["isDefault"] = o.IsDefault
 	toSerialize["name"] = o.Name
 	toSerialize["options"] = o.Options
 	toSerialize["providerInfo"] = o.ProviderInfo
 	return toSerialize, nil
 }
 
-func (o *ProviderTarget) UnmarshalJSON(data []byte) (err error) {
+func (o *CreateProviderTargetDTO) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
-		"isDefault",
 		"name",
 		"options",
 		"providerInfo",
@@ -189,53 +160,53 @@ func (o *ProviderTarget) UnmarshalJSON(data []byte) (err error) {
 		}
 	}
 
-	varProviderTarget := _ProviderTarget{}
+	varCreateProviderTargetDTO := _CreateProviderTargetDTO{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varProviderTarget)
+	err = decoder.Decode(&varCreateProviderTargetDTO)
 
 	if err != nil {
 		return err
 	}
 
-	*o = ProviderTarget(varProviderTarget)
+	*o = CreateProviderTargetDTO(varCreateProviderTargetDTO)
 
 	return err
 }
 
-type NullableProviderTarget struct {
-	value *ProviderTarget
+type NullableCreateProviderTargetDTO struct {
+	value *CreateProviderTargetDTO
 	isSet bool
 }
 
-func (v NullableProviderTarget) Get() *ProviderTarget {
+func (v NullableCreateProviderTargetDTO) Get() *CreateProviderTargetDTO {
 	return v.value
 }
 
-func (v *NullableProviderTarget) Set(val *ProviderTarget) {
+func (v *NullableCreateProviderTargetDTO) Set(val *CreateProviderTargetDTO) {
 	v.value = val
 	v.isSet = true
 }
 
-func (v NullableProviderTarget) IsSet() bool {
+func (v NullableCreateProviderTargetDTO) IsSet() bool {
 	return v.isSet
 }
 
-func (v *NullableProviderTarget) Unset() {
+func (v *NullableCreateProviderTargetDTO) Unset() {
 	v.value = nil
 	v.isSet = false
 }
 
-func NewNullableProviderTarget(val *ProviderTarget) *NullableProviderTarget {
-	return &NullableProviderTarget{value: val, isSet: true}
+func NewNullableCreateProviderTargetDTO(val *CreateProviderTargetDTO) *NullableCreateProviderTargetDTO {
+	return &NullableCreateProviderTargetDTO{value: val, isSet: true}
 }
 
-func (v NullableProviderTarget) MarshalJSON() ([]byte, error) {
+func (v NullableCreateProviderTargetDTO) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.value)
 }
 
-func (v *NullableProviderTarget) UnmarshalJSON(src []byte) error {
+func (v *NullableCreateProviderTargetDTO) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -153,6 +153,7 @@ func ensureProfiles(cmd *cobra.Command) error {
 		"daytona",
 		"daytona help",
 		"daytona docs",
+		"daytona generate-docs",
 		"daytona version",
 		"daytona profile add",
 		"daytona serve",

--- a/pkg/cmd/provider/install.go
+++ b/pkg/cmd/provider/install.go
@@ -149,7 +149,7 @@ var providerInstallCmd = &cobra.Command{
 				return err
 			}
 
-			targetData := apiclient.ProviderTarget{
+			targetData := apiclient.CreateProviderTargetDTO{
 				Name:    targetToSet.Name,
 				Options: targetToSet.Options,
 				ProviderInfo: apiclient.ProviderProviderInfo{

--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -52,7 +52,7 @@ var targetRemoveCmd = &cobra.Command{
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
-			selectedTarget, err := target.GetTargetFromPrompt(targetList, activeProfile.Name, nil, false)
+			selectedTarget, err := target.GetTargetFromPrompt(targetList, activeProfile.Name, nil, false, "Remove")
 			if err != nil {
 				if common.IsCtrlCAbort(err) {
 					return nil

--- a/pkg/cmd/target/set.go
+++ b/pkg/cmd/target/set.go
@@ -165,7 +165,7 @@ var TargetSetCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		views.RenderInfoMessage("Target set successfully")
+		views.RenderInfoMessage("Target set successfully and will be used by default")
 		return nil
 	},
 }

--- a/pkg/cmd/target/set.go
+++ b/pkg/cmd/target/set.go
@@ -116,7 +116,7 @@ var TargetSetCmd = &cobra.Command{
 		var selectedTarget *target_view.TargetView
 
 		if !isNewProvider || len(filteredTargets) > 0 {
-			selectedTarget, err = target.GetTargetFromPrompt(filteredTargets, activeProfile.Name, nil, true)
+			selectedTarget, err = target.GetTargetFromPrompt(filteredTargets, activeProfile.Name, nil, true, "Set")
 			if err != nil {
 				if common.IsCtrlCAbort(err) {
 					return nil
@@ -151,7 +151,7 @@ var TargetSetCmd = &cobra.Command{
 			return err
 		}
 
-		targetData := apiclient.ProviderTarget{
+		targetData := apiclient.CreateProviderTargetDTO{
 			Name:    selectedTarget.Name,
 			Options: selectedTarget.Options,
 			ProviderInfo: apiclient.ProviderProviderInfo{

--- a/pkg/cmd/target/setdefault.go
+++ b/pkg/cmd/target/setdefault.go
@@ -1,0 +1,73 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/common"
+	"github.com/daytonaio/daytona/pkg/views"
+	target_view "github.com/daytonaio/daytona/pkg/views/target"
+	"github.com/spf13/cobra"
+)
+
+var targetSetDefaultCmd = &cobra.Command{
+	Use:   "set-default [TARGET_NAME]",
+	Short: "Set target to be used by default",
+	Args:  cobra.RangeArgs(0, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var targetName string
+		ctx := context.Background()
+
+		apiClient, err := apiclient_util.GetApiClient(nil)
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 0 {
+			targetList, res, err := apiClient.TargetAPI.ListTargets(ctx).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			c, err := config.GetConfig()
+			if err != nil {
+				return err
+			}
+
+			activeProfile, err := c.GetActiveProfile()
+			if err != nil {
+				return err
+			}
+
+			selectedTarget, err := target_view.GetTargetFromPrompt(targetList, activeProfile.Name, nil, false, "Make Default")
+			if err != nil {
+				if common.IsCtrlCAbort(err) {
+					return nil
+				} else {
+					return err
+				}
+			}
+
+			if selectedTarget == nil {
+				return nil
+			}
+
+			targetName = selectedTarget.Name
+		} else {
+			targetName = args[0]
+		}
+
+		res, err := apiClient.TargetAPI.SetDefaultTarget(ctx, targetName).Execute()
+		if err != nil {
+			return apiclient_util.HandleErrorResponse(res, err)
+		}
+
+		views.RenderInfoMessage(fmt.Sprintf("Target '%s' set as default", targetName))
+		return nil
+	},
+}

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -18,4 +18,5 @@ func init() {
 	TargetCmd.AddCommand(targetListCmd)
 	TargetCmd.AddCommand(TargetSetCmd)
 	TargetCmd.AddCommand(targetRemoveCmd)
+	TargetCmd.AddCommand(targetSetDefaultCmd)
 }

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -142,6 +142,9 @@ var CreateCmd = &cobra.Command{
 			PromptUsingTUI:    promptUsingTUI,
 		})
 		if err != nil {
+			if common.IsCtrlCAbort(err) {
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -48,6 +48,7 @@ var CreateCmd = &cobra.Command{
 		var workspaceName string
 		var existingWorkspaceNames []string
 		var existingProjectConfigNames []string
+		promptUsingTUI := len(args) == 0
 
 		apiClient, err := apiclient_util.GetApiClient(nil)
 		if err != nil {
@@ -81,7 +82,7 @@ var CreateCmd = &cobra.Command{
 			existingWorkspaceNames = append(existingWorkspaceNames, workspaceInfo.Name)
 		}
 
-		if len(args) == 0 {
+		if promptUsingTUI {
 			err = processPrompting(ctx, apiClient, &workspaceName, &projects, existingWorkspaceNames)
 			if err != nil {
 				if common.IsCtrlCAbort(err) {
@@ -132,7 +133,14 @@ var CreateCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		target, err := workspace_util.GetTarget(ctx, apiClient, targetList, activeProfile.Name, targetNameFlag)
+		target, err := workspace_util.GetTarget(workspace_util.GetTargetConfig{
+			Ctx:               ctx,
+			ApiClient:         apiClient,
+			TargetList:        targetList,
+			ActiveProfileName: activeProfile.Name,
+			TargetNameFlag:    targetNameFlag,
+			PromptUsingTUI:    promptUsingTUI,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/workspace/util/get_target.go
+++ b/pkg/cmd/workspace/util/get_target.go
@@ -12,7 +12,6 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/provider"
-	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/provider/manager"
 	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
 	target_view "github.com/daytonaio/daytona/pkg/views/target"
@@ -74,11 +73,7 @@ func GetTarget(config GetTargetConfig) (*target_view.TargetView, error) {
 
 	selectedTarget, err := target_view.GetTargetFromPrompt(config.TargetList, config.ActiveProfileName, &providerViewList, false, "Use")
 	if err != nil {
-		if common.IsCtrlCAbort(err) {
-			return nil, nil
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	if selectedTarget.ProviderInfo.Installed == nil || *selectedTarget.ProviderInfo.Installed || selectedTarget == nil {

--- a/pkg/cmd/workspace/util/get_target.go
+++ b/pkg/cmd/workspace/util/get_target.go
@@ -12,22 +12,40 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/provider"
+	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/provider/manager"
 	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
 	target_view "github.com/daytonaio/daytona/pkg/views/target"
 )
 
-func GetTarget(ctx context.Context, apiClient *apiclient.APIClient, targetList []apiclient.ProviderTarget, activeProfileName string, targetNameFlag string) (*target_view.TargetView, error) {
-	if targetNameFlag != "" {
-		for _, t := range targetList {
-			if t.Name == targetNameFlag {
+type GetTargetConfig struct {
+	Ctx               context.Context
+	ApiClient         *apiclient.APIClient
+	TargetList        []apiclient.ProviderTarget
+	ActiveProfileName string
+	TargetNameFlag    string
+	PromptUsingTUI    bool
+}
+
+func GetTarget(config GetTargetConfig) (*target_view.TargetView, error) {
+	if config.TargetNameFlag != "" {
+		for _, t := range config.TargetList {
+			if t.Name == config.TargetNameFlag {
 				return util.Pointer(target_view.GetTargetViewFromTarget(t)), nil
 			}
 		}
-		return nil, fmt.Errorf("target '%s' not found", targetNameFlag)
+		return nil, fmt.Errorf("target '%s' not found", config.TargetNameFlag)
 	}
 
-	serverConfig, res, err := apiClient.ServerAPI.GetConfigExecute(apiclient.ApiGetConfigRequest{})
+	if !config.PromptUsingTUI {
+		for _, t := range config.TargetList {
+			if t.IsDefault {
+				return util.Pointer(target_view.GetTargetViewFromTarget(t)), nil
+			}
+		}
+	}
+
+	serverConfig, res, err := config.ApiClient.ServerAPI.GetConfigExecute(apiclient.ApiGetConfigRequest{})
 	if err != nil {
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
@@ -48,22 +66,26 @@ func GetTarget(ctx context.Context, apiClient *apiclient.APIClient, targetList [
 
 		latestProviders := provider.GetProviderListFromManifest(providersManifestLatest)
 
-		providerViewList, err = provider.GetProviderViewOptions(apiClient, latestProviders, ctx)
+		providerViewList, err = provider.GetProviderViewOptions(config.ApiClient, latestProviders, config.Ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	selectedTarget, err := target_view.GetTargetFromPrompt(targetList, activeProfileName, &providerViewList, false)
+	selectedTarget, err := target_view.GetTargetFromPrompt(config.TargetList, config.ActiveProfileName, &providerViewList, false, "Use")
 	if err != nil {
-		return nil, err
+		if common.IsCtrlCAbort(err) {
+			return nil, nil
+		} else {
+			return nil, err
+		}
 	}
 
 	if selectedTarget.ProviderInfo.Installed == nil || *selectedTarget.ProviderInfo.Installed || selectedTarget == nil {
 		return selectedTarget, nil
 	}
 
-	err = provider.InstallProvider(apiClient, provider_view.ProviderView{
+	err = provider.InstallProvider(config.ApiClient, provider_view.ProviderView{
 		Name:    selectedTarget.ProviderInfo.Name,
 		Version: selectedTarget.ProviderInfo.Version,
 	}, providersManifest)
@@ -71,13 +93,13 @@ func GetTarget(ctx context.Context, apiClient *apiclient.APIClient, targetList [
 		return nil, err
 	}
 
-	targetManifest, res, err := apiClient.ProviderAPI.GetTargetManifest(context.Background(), selectedTarget.ProviderInfo.Name).Execute()
+	targetManifest, res, err := config.ApiClient.ProviderAPI.GetTargetManifest(context.Background(), selectedTarget.ProviderInfo.Name).Execute()
 	if err != nil {
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
 	selectedTarget.Name = ""
-	err = target_view.NewTargetNameInput(&selectedTarget.Name, util.ArrayMap(targetList, func(t apiclient.ProviderTarget) string {
+	err = target_view.NewTargetNameInput(&selectedTarget.Name, util.ArrayMap(config.TargetList, func(t apiclient.ProviderTarget) string {
 		return t.Name
 	}))
 	if err != nil {
@@ -89,7 +111,7 @@ func GetTarget(ctx context.Context, apiClient *apiclient.APIClient, targetList [
 		return nil, err
 	}
 
-	res, err = apiClient.TargetAPI.SetTarget(context.Background()).Target(apiclient.ProviderTarget{
+	res, err = config.ApiClient.TargetAPI.SetTarget(context.Background()).Target(apiclient.CreateProviderTargetDTO{
 		Name:    selectedTarget.Name,
 		Options: selectedTarget.Options,
 		ProviderInfo: apiclient.ProviderProviderInfo{

--- a/pkg/db/dto/provider_target.go
+++ b/pkg/db/dto/provider_target.go
@@ -11,6 +11,7 @@ type ProviderTargetDTO struct {
 	ProviderLabel   *string `json:"providerLabel,omitempty"`
 	ProviderVersion string  `json:"providerVersion"`
 	Options         string  `json:"options"`
+	IsDefault       bool    `json:"isDefault"`
 }
 
 func ToProviderTargetDTO(providerTarget *provider.ProviderTarget) ProviderTargetDTO {
@@ -20,6 +21,7 @@ func ToProviderTargetDTO(providerTarget *provider.ProviderTarget) ProviderTarget
 		ProviderLabel:   providerTarget.ProviderInfo.Label,
 		ProviderVersion: providerTarget.ProviderInfo.Version,
 		Options:         providerTarget.Options,
+		IsDefault:       providerTarget.IsDefault,
 	}
 }
 
@@ -31,6 +33,7 @@ func ToProviderTarget(providerTargetDTO ProviderTargetDTO) *provider.ProviderTar
 			Label:   providerTargetDTO.ProviderLabel,
 			Version: providerTargetDTO.ProviderVersion,
 		},
-		Options: providerTargetDTO.Options,
+		Options:   providerTargetDTO.Options,
+		IsDefault: providerTargetDTO.IsDefault,
 	}
 }

--- a/pkg/provider/manager/manager.go
+++ b/pkg/provider/manager/manager.go
@@ -147,13 +147,13 @@ func (m *ProviderManager) RegisterProvider(pluginPath string) error {
 		return errors.New("failed to get targets: " + err.Error())
 	}
 
-	defaultTargets, err := (*p).GetDefaultTargets()
+	presetTargets, err := (*p).GetPresetTargets()
 	if err != nil {
-		return errors.New("failed to get default targets: " + err.Error())
+		return errors.New("failed to get preset targets: " + err.Error())
 	}
 
-	log.Info("Setting default targets")
-	for _, target := range *defaultTargets {
+	log.Info("Setting preset targets")
+	for _, target := range *presetTargets {
 		if _, ok := existingTargets[target.Name]; ok {
 			log.Infof("Target %s already exists. Skipping...", target.Name)
 			continue
@@ -166,7 +166,7 @@ func (m *ProviderManager) RegisterProvider(pluginPath string) error {
 			log.Infof("Target %s set", target.Name)
 		}
 	}
-	log.Info("Default targets set")
+	log.Info("Preset targets set")
 
 	log.Infof("Provider %s initialized", pluginRef.name)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -17,7 +17,7 @@ type Provider interface {
 	GetInfo() (ProviderInfo, error)
 
 	GetTargetManifest() (*ProviderTargetManifest, error)
-	GetDefaultTargets() (*[]ProviderTarget, error)
+	GetPresetTargets() (*[]ProviderTarget, error)
 
 	CreateWorkspace(*WorkspaceRequest) (*util.Empty, error)
 	StartWorkspace(*WorkspaceRequest) (*util.Empty, error)

--- a/pkg/provider/rpc_client.go
+++ b/pkg/provider/rpc_client.go
@@ -33,9 +33,9 @@ func (m *ProviderRPCClient) GetTargetManifest() (*ProviderTargetManifest, error)
 	return &resp, err
 }
 
-func (m *ProviderRPCClient) GetDefaultTargets() (*[]ProviderTarget, error) {
+func (m *ProviderRPCClient) GetPresetTargets() (*[]ProviderTarget, error) {
 	var resp []ProviderTarget
-	err := m.client.Call("Plugin.GetDefaultTargets", new(interface{}), &resp)
+	err := m.client.Call("Plugin.GetPresetTargets", new(interface{}), &resp)
 	return &resp, err
 }
 

--- a/pkg/provider/rpc_server.go
+++ b/pkg/provider/rpc_server.go
@@ -38,8 +38,8 @@ func (m *ProviderRPCServer) GetTargetManifest(arg interface{}, resp *ProviderTar
 	return nil
 }
 
-func (m *ProviderRPCServer) GetDefaultTargets(arg interface{}, resp *[]ProviderTarget) error {
-	targets, err := m.Impl.GetDefaultTargets()
+func (m *ProviderRPCServer) GetPresetTargets(arg interface{}, resp *[]ProviderTarget) error {
+	targets, err := m.Impl.GetPresetTargets()
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/store.go
+++ b/pkg/provider/store.go
@@ -5,18 +5,20 @@ package provider
 
 import "errors"
 
-type Store interface {
+type TargetFilter struct {
+	Name    *string
+	Default *bool
 }
 
 type TargetStore interface {
-	List() ([]*ProviderTarget, error)
-	Find(targetName string) (*ProviderTarget, error)
+	List(filter *TargetFilter) ([]*ProviderTarget, error)
+	Find(filter *TargetFilter) (*ProviderTarget, error)
 	Save(target *ProviderTarget) error
 	Delete(target *ProviderTarget) error
 }
 
 var (
-	ErrTargetNotFound = errors.New("provider not found")
+	ErrTargetNotFound = errors.New("target not found")
 )
 
 func IsTargetNotFound(err error) bool {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -47,7 +47,8 @@ type ProviderTarget struct {
 	Name         string       `json:"name" validate:"required"`
 	ProviderInfo ProviderInfo `json:"providerInfo" validate:"required"`
 	// JSON encoded map of options
-	Options string `json:"options" validate:"required"`
+	Options   string `json:"options" validate:"required"`
+	IsDefault bool   `json:"isDefault" validate:"required"`
 } // @name ProviderTarget
 
 type ProviderTargetManifest map[string]ProviderTargetProperty // @name ProviderTargetManifest

--- a/pkg/server/providertargets/dto/providertargets.go
+++ b/pkg/server/providertargets/dto/providertargets.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package dto
+
+import "github.com/daytonaio/daytona/pkg/provider"
+
+type CreateProviderTargetDTO struct {
+	Name         string                `json:"name" validate:"required"`
+	ProviderInfo provider.ProviderInfo `json:"providerInfo" validate:"required"`
+	Options      string                `json:"options" validate:"required"`
+} // @name CreateProviderTargetDTO

--- a/pkg/server/providertargets/service_test.go
+++ b/pkg/server/providertargets/service_test.go
@@ -89,7 +89,7 @@ func TestProviderTargetService(t *testing.T) {
 func (s *ProviderTargetServiceTestSuite) TestList() {
 	require := s.Require()
 
-	providerTargets, err := s.providerTargetService.List()
+	providerTargets, err := s.providerTargetService.List(nil)
 	require.Nil(err)
 	require.ElementsMatch(expectedProviderTargets, providerTargets)
 }
@@ -105,9 +105,25 @@ func (s *ProviderTargetServiceTestSuite) TestMap() {
 func (s *ProviderTargetServiceTestSuite) TestFind() {
 	require := s.Require()
 
-	providerTarget, err := s.providerTargetService.Find(providerTarget1.Name)
+	providerTarget, err := s.providerTargetService.Find(&provider.TargetFilter{
+		Name: &providerTarget1.Name,
+	})
 	require.Nil(err)
 	require.Equal(providerTarget1, providerTarget)
+}
+
+func (s *ProviderTargetServiceTestSuite) TestSetDefault() {
+	require := s.Require()
+
+	err := s.providerTargetService.SetDefault(providerTarget2)
+	require.Nil(err)
+
+	providerTarget, err := s.providerTargetService.Find(&provider.TargetFilter{
+		Name: &providerTarget2.Name,
+	})
+	require.Nil(err)
+
+	require.Equal(providerTarget2, providerTarget)
 }
 
 func (s *ProviderTargetServiceTestSuite) TestSave() {
@@ -118,7 +134,7 @@ func (s *ProviderTargetServiceTestSuite) TestSave() {
 	err := s.providerTargetService.Save(providerTarget4)
 	require.Nil(err)
 
-	providerTargets, err := s.providerTargetService.List()
+	providerTargets, err := s.providerTargetService.List(nil)
 	require.Nil(err)
 	require.ElementsMatch(expectedProviderTargets, providerTargets)
 }
@@ -131,7 +147,7 @@ func (s *ProviderTargetServiceTestSuite) TestDelete() {
 	err := s.providerTargetService.Delete(providerTarget3)
 	require.Nil(err)
 
-	providerTargets, err := s.providerTargetService.List()
+	providerTargets, err := s.providerTargetService.List(nil)
 	require.Nil(err)
 	require.ElementsMatch(expectedProviderTargets, providerTargets)
 }

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -132,7 +132,7 @@ func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWo
 		return nil, err
 	}
 
-	target, err := s.targetStore.Find(w.Target)
+	target, err := s.targetStore.Find(&provider.TargetFilter{Name: &w.Target})
 	if err != nil {
 		return w, err
 	}

--- a/pkg/server/workspaces/get.go
+++ b/pkg/server/workspaces/get.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
 	log "github.com/sirupsen/logrus"
@@ -28,7 +29,7 @@ func (s *WorkspaceService) GetWorkspace(ctx context.Context, workspaceId string,
 		return &response, nil
 	}
 
-	target, err := s.targetStore.Find(ws.Target)
+	target, err := s.targetStore.Find(&provider.TargetFilter{Name: &ws.Target})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/workspaces/list.go
+++ b/pkg/server/workspaces/list.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
 	log "github.com/sirupsen/logrus"
@@ -34,7 +35,7 @@ func (s *WorkspaceService) ListWorkspaces(ctx context.Context, verbose bool) ([]
 		go func(i int) {
 			defer wg.Done()
 
-			target, err := s.targetStore.Find(w.Target)
+			target, err := s.targetStore.Find(&provider.TargetFilter{Name: &w.Target})
 			if err != nil {
 				log.Error(fmt.Errorf("failed to get target for %s", w.Target))
 				return

--- a/pkg/server/workspaces/remove.go
+++ b/pkg/server/workspaces/remove.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/daytonaio/daytona/pkg/logs"
+	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/telemetry"
 	log "github.com/sirupsen/logrus"
 )
@@ -20,7 +21,7 @@ func (s *WorkspaceService) RemoveWorkspace(ctx context.Context, workspaceId stri
 
 	log.Infof("Destroying workspace %s", workspace.Id)
 
-	target, err := s.targetStore.Find(workspace.Target)
+	target, err := s.targetStore.Find(&provider.TargetFilter{Name: &workspace.Target})
 	if err != nil {
 		return err
 	}
@@ -96,7 +97,7 @@ func (s *WorkspaceService) ForceRemoveWorkspace(ctx context.Context, workspaceId
 
 	log.Infof("Destroying workspace %s", workspace.Id)
 
-	target, _ := s.targetStore.Find(workspace.Target)
+	target, _ := s.targetStore.Find(&provider.TargetFilter{Name: &workspace.Target})
 
 	for _, project := range workspace.Projects {
 		//	todo: go routines

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -38,7 +38,7 @@ type IWorkspaceService interface {
 }
 
 type targetStore interface {
-	Find(targetName string) (*provider.ProviderTarget, error)
+	Find(filter *provider.TargetFilter) (*provider.ProviderTarget, error)
 }
 
 type WorkspaceServiceConfig struct {

--- a/pkg/server/workspaces/start.go
+++ b/pkg/server/workspaces/start.go
@@ -24,7 +24,7 @@ func (s *WorkspaceService) StartWorkspace(ctx context.Context, workspaceId strin
 		return ErrWorkspaceNotFound
 	}
 
-	target, err := s.targetStore.Find(w.Target)
+	target, err := s.targetStore.Find(&provider.TargetFilter{Name: &w.Target})
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (s *WorkspaceService) StartProject(ctx context.Context, workspaceId, projec
 		return ErrProjectNotFound
 	}
 
-	target, err := s.targetStore.Find(project.Target)
+	target, err := s.targetStore.Find(&provider.TargetFilter{Name: &w.Target})
 	if err != nil {
 		return err
 	}

--- a/pkg/server/workspaces/stop.go
+++ b/pkg/server/workspaces/stop.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/telemetry"
 	log "github.com/sirupsen/logrus"
 )
@@ -17,7 +18,7 @@ func (s *WorkspaceService) StopWorkspace(ctx context.Context, workspaceId string
 		return ErrWorkspaceNotFound
 	}
 
-	target, err := s.targetStore.Find(workspace.Target)
+	target, err := s.targetStore.Find(&provider.TargetFilter{Name: &workspace.Target})
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func (s *WorkspaceService) StopProject(ctx context.Context, workspaceId, project
 		return ErrProjectNotFound
 	}
 
-	target, err := s.targetStore.Find(w.Target)
+	target, err := s.targetStore.Find(&provider.TargetFilter{Name: &w.Target})
 	if err != nil {
 		return err
 	}

--- a/pkg/views/projectconfig/list/view.go
+++ b/pkg/views/projectconfig/list/view.go
@@ -54,7 +54,6 @@ func getRowFromData(projectConfig apiclient.ProjectConfig, apiServerConfig *apic
 	data.Name = projectConfig.Name + views_util.AdditionalPropertyPadding
 	data.Repository = util.GetRepositorySlugFromUrl(projectConfig.RepositoryUrl, specifyGitProviders)
 	data.Prebuilds = "None"
-	data.IsDefault = ""
 
 	projectDefaults := &views_util.ProjectConfigDefaults{
 		Image:     &apiServerConfig.DefaultProjectImage,
@@ -68,17 +67,13 @@ func getRowFromData(projectConfig apiclient.ProjectConfig, apiServerConfig *apic
 	_, data.Build = views_util.GetProjectBuildChoice(createProjectDto, projectDefaults)
 
 	if projectConfig.Default {
-		data.IsDefault = "1"
+		isDefault = views.ActiveStyle.Render("Yes")
+	} else {
+		isDefault = views.InactiveStyle.Render("/")
 	}
 
 	if len(projectConfig.Prebuilds) > 0 {
 		data.Prebuilds = fmt.Sprintf("%d", len(projectConfig.Prebuilds))
-	}
-
-	if data.IsDefault == "" {
-		isDefault = views.InactiveStyle.Render("/")
-	} else {
-		isDefault = views.ActiveStyle.Render("Yes")
 	}
 
 	return []string{

--- a/pkg/views/target/list/view.go
+++ b/pkg/views/target/list/view.go
@@ -13,9 +13,10 @@ import (
 )
 
 type rowData struct {
-	Target   string
-	Provider string
-	Options  string
+	Target    string
+	Provider  string
+	IsDefault string
+	Options   string
 }
 
 func ListTargets(targetList []apiclient.ProviderTarget) {
@@ -28,7 +29,7 @@ func ListTargets(targetList []apiclient.ProviderTarget) {
 	}
 
 	table := util.GetTableView(data, []string{
-		"Target", "Provider", "Options",
+		"Target", "Provider", "Default", "Options",
 	}, nil, func() {
 		renderUnstyledList(targetList)
 	})
@@ -37,15 +38,28 @@ func ListTargets(targetList []apiclient.ProviderTarget) {
 }
 
 func getRowFromRowData(target *apiclient.ProviderTarget) []string {
+	var isDefault string
 	var data rowData
 
 	data.Target = target.Name
 	data.Provider = target.ProviderInfo.Name
+	data.IsDefault = ""
 	data.Options = target.Options
+
+	if target.IsDefault {
+		data.IsDefault = "1"
+	}
+
+	if data.IsDefault == "" {
+		isDefault = views.InactiveStyle.Render("/")
+	} else {
+		isDefault = views.ActiveStyle.Render("Yes")
+	}
 
 	row := []string{
 		views.NameStyle.Render(data.Target),
 		views.DefaultRowDataStyle.Render(data.Provider),
+		isDefault,
 		views.DefaultRowDataStyle.Render(data.Options),
 	}
 
@@ -68,7 +82,11 @@ func renderUnstyledList(targetList []apiclient.ProviderTarget) {
 
 		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Target Provider: "), target.ProviderInfo.Name) + "\n\n"
 
-		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Target Options: "), target.Options) + "\n"
+		if target.IsDefault {
+			output += fmt.Sprintf("%s %s", views.GetPropertyKey("Default: "), "Yes") + "\n\n"
+		}
+
+		output += fmt.Sprintf("%s %s", views.GetPropertyKey("Target Options: "), target.Options) + "\n\n"
 
 		if target.Name != targetList[len(targetList)-1].Name {
 			output += views.SeparatorString + "\n\n"

--- a/pkg/views/target/list/view.go
+++ b/pkg/views/target/list/view.go
@@ -43,17 +43,12 @@ func getRowFromRowData(target *apiclient.ProviderTarget) []string {
 
 	data.Target = target.Name
 	data.Provider = target.ProviderInfo.Name
-	data.IsDefault = ""
 	data.Options = target.Options
 
 	if target.IsDefault {
-		data.IsDefault = "1"
-	}
-
-	if data.IsDefault == "" {
-		isDefault = views.InactiveStyle.Render("/")
-	} else {
 		isDefault = views.ActiveStyle.Render("Yes")
+	} else {
+		isDefault = views.InactiveStyle.Render("/")
 	}
 
 	row := []string{

--- a/pkg/views/target/select.go
+++ b/pkg/views/target/select.go
@@ -20,6 +20,7 @@ const NewTargetName = "+ New Target"
 type TargetView struct {
 	Name         string
 	Options      string
+	IsDefault    bool
 	ProviderInfo ProviderInfo
 }
 
@@ -29,7 +30,7 @@ type ProviderInfo struct {
 	Installed *bool
 }
 
-func GetTargetFromPrompt(targets []apiclient.ProviderTarget, activeProfileName string, providerViewList *[]provider.ProviderView, withNewTarget bool) (*TargetView, error) {
+func GetTargetFromPrompt(targets []apiclient.ProviderTarget, activeProfileName string, providerViewList *[]provider.ProviderView, withNewTarget bool, actionVerb string) (*TargetView, error) {
 	items := util.ArrayMap(targets, func(t apiclient.ProviderTarget) list.Item {
 		return item{
 			target: GetTargetViewFromTarget(t),
@@ -76,7 +77,7 @@ func GetTargetFromPrompt(targets []apiclient.ProviderTarget, activeProfileName s
 
 	l := views.GetStyledSelectList(items)
 	m := model{list: l}
-	m.list.Title = views.GetStyledMainTitle("Choose a Target")
+	m.list.Title = views.GetStyledMainTitle("Choose a Target To " + actionVerb)
 	m.footer = views.GetListFooter(activeProfileName, views.DefaultListFooterPadding)
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
@@ -93,8 +94,9 @@ func GetTargetFromPrompt(targets []apiclient.ProviderTarget, activeProfileName s
 
 func GetTargetViewFromTarget(target apiclient.ProviderTarget) TargetView {
 	return TargetView{
-		Name:    target.Name,
-		Options: target.Options,
+		Name:      target.Name,
+		Options:   target.Options,
+		IsDefault: target.IsDefault,
 		ProviderInfo: ProviderInfo{
 			Name:    target.ProviderInfo.Name,
 			Version: target.ProviderInfo.Version,

--- a/pkg/views/target/view.go
+++ b/pkg/views/target/view.go
@@ -16,7 +16,15 @@ type item struct {
 	target TargetView
 }
 
-func (i item) Title() string { return i.target.Name }
+func (i item) Title() string {
+	title := i.target.Name
+
+	if i.target.IsDefault {
+		title += " (default)"
+	}
+
+	return title
+}
 func (i item) Description() string {
 	desc := i.target.ProviderInfo.Name
 	if i.target.ProviderInfo.Installed != nil {


### PR DESCRIPTION
# Set default target

## Description

Adds `daytona target-set [TARGET_NAME]` which allows daytona create <REPO_URL> to work without prompting the user which target they want. The latest target to be created or updated is automatically set to default.
Minor refactors along the way.
The setting to default logic has been implemented the same way as it has been for project configs

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
Closes #1200 
Docs PR - https://github.com/daytonaio/docs/pull/180

## Screenshots
![image](https://github.com/user-attachments/assets/d292a784-b223-41e5-8a63-fc4cd2b3cdcb)

## Notes
Breaking change - before running the Server again, all providers will need to be removed by running the following command:

Linux: `rm -rf ~/.config/daytona/providers/*-provider/*-provider`
Mac: `rm -rf ~/Library/Application\ Support/daytona/providers/*-provider/*-provider`
Windows (PowerShell): 
`Remove-Item -Recurse -Force "C:\Users\<USERNAME>\AppData\Roaming\daytona\providers\*-provider\*-provider.exe"`