### PR TITLE
feat: display git provider config id in project config info view

### DIFF
--- a/pkg/views/projectconfig/info/view.go
+++ b/pkg/views/projectconfig/info/view.go
@@ -37,6 +37,13 @@ func Render(projectConfig *apiclient.ProjectConfig, apiServerConfig *apiclient.S
 
 	output += getInfoLine("Repository", projectConfig.RepositoryUrl) + "\n"
 
+	gitProviderConfig := "/"
+	if projectConfig.GitProviderConfigId != nil {
+		gitProviderConfig = *projectConfig.GitProviderConfigId
+	}
+
+	output += getInfoLine("Git Provider ID", gitProviderConfig) + "\n"
+
 	if projectConfig.Default {
 		output += getInfoLine("Default", "Yes") + "\n"
 	}


### PR DESCRIPTION
# Display Git provider config id in project config info view
## Description

Displays Git provider config ID in `project-config info `view

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/6d6daae6-3387-4644-a8d8-4908cbf29b64)

![image](https://github.com/user-attachments/assets/ec302e8c-62ab-4ebf-9c99-9d4b2c52e531)