### PR TITLE
feat: skip workspace removal prompt when target has none

### DIFF
--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -74,27 +74,50 @@ var targetRemoveCmd = &cobra.Command{
 				return err
 			}
 		} else {
-			form := huh.NewForm(
-				huh.NewGroup(
-					huh.NewConfirm().
-						Title(fmt.Sprintf("Delete all workspaces within %s?", selectedTargetName)).
-						Description("You might not be able to easily remove these workspaces later.").
-						Value(&yesFlag),
-				),
-			).WithTheme(views.GetCustomTheme())
+			var targetWorkspaceCount int
 
-			err := form.Run()
+			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
-				return err
+				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
-			if yesFlag {
-				err := RemoveTargetWorkspaces(ctx, apiClient, selectedTargetName)
+			for _, workspace := range workspaceList {
+				if workspace.Target == selectedTargetName {
+					targetWorkspaceCount++
+				}
+			}
+
+			if targetWorkspaceCount > 0 {
+				title := fmt.Sprintf("Delete %d workspaces within %s?", targetWorkspaceCount, selectedTargetName)
+				description := "You might not be able to easily remove these workspaces later."
+
+				if targetWorkspaceCount == 1 {
+					title = fmt.Sprintf("Delete %d workspace within %s?", targetWorkspaceCount, selectedTargetName)
+					description = "You might not be able to easily remove this workspace later."
+				}
+
+				form := huh.NewForm(
+					huh.NewGroup(
+						huh.NewConfirm().
+							Title(title).
+							Description(description).
+							Value(&yesFlag),
+					),
+				).WithTheme(views.GetCustomTheme())
+
+				err := form.Run()
 				if err != nil {
 					return err
 				}
-			} else {
-				fmt.Println("Proceeding with target removal without deleting workspaces.")
+
+				if yesFlag {
+					err := RemoveTargetWorkspaces(ctx, apiClient, selectedTargetName)
+					if err != nil {
+						return err
+					}
+				} else {
+					fmt.Println("Proceeding with target removal without deleting workspaces.")
+				}
 			}
 		}
 


### PR DESCRIPTION
# Skip workspace removal prompt when target has none

## Description

When using `daytona target rm` the workspace removal prompt is skipped if there are no workspaces for the selected target.
If there are workspaces, prints out their number in the prompt.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![image](https://github.com/user-attachments/assets/8a0b10c4-c8d3-449a-9c3b-59254dfe4997)

