### PR TITLE
fix: resolve the log returning empty slice

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -530,7 +530,7 @@ func dedupProjectNames(projects *[]apiclient.CreateProjectDTO) {
 }
 
 func GetGitProviderGpgKey(apiClient *apiclient.APIClient, ctx context.Context, providerConfigId *string) (string, error) {
-	if providerConfigId == nil {
+	if providerConfigId == nil || *providerConfigId == "" {
 		return "", nil
 	}
 


### PR DESCRIPTION
# fix: resolve the log returning empty slice

## Description
by adding a check for empty string this PR fixes the log.warn showing an empty slice

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1276 

## Screenshots
If relevant, please add screenshots.

## Notes
Please add any relevant notes if necessary.
