### PR TITLE
fix: support http protocol for git urls

### DIFF
--- a/pkg/git/service_test.go
+++ b/pkg/git/service_test.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package git_test
+
+import (
+	"testing"
+
+	"github.com/daytonaio/daytona/pkg/git"
+	"github.com/daytonaio/daytona/pkg/gitprovider"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/suite"
+)
+
+var repoHttp = &gitprovider.GitRepository{
+	Id:     "123",
+	Url:    "http://localhost:3000/daytonaio/daytona",
+	Name:   "daytona",
+	Branch: "main",
+	Target: gitprovider.CloneTargetBranch,
+}
+
+var repoHttps = &gitprovider.GitRepository{
+	Id:     "123",
+	Url:    "https://github.com/daytonaio/daytona",
+	Name:   "daytona",
+	Branch: "main",
+	Target: gitprovider.CloneTargetBranch,
+}
+
+var repoWithoutProtocol = &gitprovider.GitRepository{
+	Id:     "123",
+	Url:    "github.com/daytonaio/daytona",
+	Name:   "daytona",
+	Branch: "main",
+	Target: gitprovider.CloneTargetBranch,
+}
+
+var repoWithCloneTargetCommit = &gitprovider.GitRepository{
+	Id:     "123",
+	Url:    "https://github.com/daytonaio/daytona",
+	Name:   "daytona",
+	Branch: "main",
+	Sha:    "1234567890",
+	Target: gitprovider.CloneTargetCommit,
+}
+
+var creds = &http.BasicAuth{
+	Username: "daytonaio",
+	Password: "Daytona123",
+}
+
+type GitServiceTestSuite struct {
+	suite.Suite
+	gitService git.IGitService
+}
+
+func NewGitServiceTestSuite() *GitServiceTestSuite {
+	return &GitServiceTestSuite{}
+}
+
+func (s *GitServiceTestSuite) SetupTest() {
+	s.gitService = &git.Service{
+		ProjectDir: "/workdir",
+	}
+}
+
+func TestGitService(t *testing.T) {
+	suite.Run(t, NewGitServiceTestSuite())
+}
+
+func (s *GitServiceTestSuite) TestCloneRepositoryCmd_WithCreds() {
+	cloneCmd := s.gitService.CloneRepositoryCmd(repoHttps, creds)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "https://daytonaio:Daytona123@github.com/daytonaio/daytona", "/workdir"}, cloneCmd)
+
+	cloneCmd = s.gitService.CloneRepositoryCmd(repoHttp, creds)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "http://daytonaio:Daytona123@localhost:3000/daytonaio/daytona", "/workdir"}, cloneCmd)
+
+	cloneCmd = s.gitService.CloneRepositoryCmd(repoWithoutProtocol, creds)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "https://daytonaio:Daytona123@github.com/daytonaio/daytona", "/workdir"}, cloneCmd)
+
+	cloneCmd = s.gitService.CloneRepositoryCmd(repoWithCloneTargetCommit, creds)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "https://daytonaio:Daytona123@github.com/daytonaio/daytona", "/workdir", "&&", "cd", "/workdir", "&&", "git", "checkout", "1234567890"}, cloneCmd)
+}
+
+func (s *GitServiceTestSuite) TestCloneRepositoryCmd_WithoutCreds() {
+	cloneCmd := s.gitService.CloneRepositoryCmd(repoHttps, nil)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "https://github.com/daytonaio/daytona", "/workdir"}, cloneCmd)
+
+	cloneCmd = s.gitService.CloneRepositoryCmd(repoHttp, nil)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "http://localhost:3000/daytonaio/daytona", "/workdir"}, cloneCmd)
+
+	cloneCmd = s.gitService.CloneRepositoryCmd(repoWithoutProtocol, nil)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "https://github.com/daytonaio/daytona", "/workdir"}, cloneCmd)
+
+	cloneCmd = s.gitService.CloneRepositoryCmd(repoWithCloneTargetCommit, nil)
+	s.Require().Equal([]string{"git", "clone", "--single-branch", "--branch", "\"main\"", "https://github.com/daytonaio/daytona", "/workdir", "&&", "cd", "/workdir", "&&", "git", "checkout", "1234567890"}, cloneCmd)
+}


### PR DESCRIPTION
# Support HTTP protocol for git URLs
## Description

Adds support for the HTTP protocol for git URLs. Most relevant for local git providers.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation