### PR TITLE
fix: show help on failed noargs commands

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -114,7 +114,7 @@ func validateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command
 	currentCmd := rootCmd
 
 	// Filter flags from args
-	sanitzedArgs := []string{}
+	sanitizedArgs := []string{}
 	for i := 0; i < len(args); i++ {
 		if strings.HasPrefix(args[i], "-") {
 			flags = append(flags, args[i])
@@ -123,11 +123,11 @@ func validateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command
 			}
 			continue
 		}
-		sanitzedArgs = append(sanitzedArgs, args[i])
+		sanitizedArgs = append(sanitizedArgs, args[i])
 	}
 
-	for len(sanitzedArgs) > 0 {
-		subCmd, subArgs, err := currentCmd.Find(sanitzedArgs)
+	for len(sanitizedArgs) > 0 {
+		subCmd, subArgs, err := currentCmd.Find(sanitizedArgs)
 		if err != nil {
 			return currentCmd, flags, false, err
 		}
@@ -137,16 +137,10 @@ func validateCommands(rootCmd *cobra.Command, args []string) (cmd *cobra.Command
 		}
 
 		currentCmd = subCmd
-		sanitzedArgs = subArgs
+		sanitizedArgs = subArgs
 	}
 
-	if len(sanitzedArgs) > 0 {
-		if err := currentCmd.ValidateArgs(sanitzedArgs); err != nil {
-			return currentCmd, flags, false, err
-		}
-	}
-
-	return currentCmd, flags, false, nil
+	return currentCmd, flags, false, currentCmd.ValidateArgs(sanitizedArgs)
 }
 
 func SetupRootCommand(cmd *cobra.Command) {


### PR DESCRIPTION
# Show help properly on failed noargs commands

## Description

Fixes showing "help" on failed commands for commands without extra arguments - e.g. `daytona autocomplete` and `daytona forward`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/fa03c510-2420-4988-951a-358bacae0770)

![image](https://github.com/user-attachments/assets/6e334eb9-80e4-48c0-9b28-d21688d0d1fe)