### PR TITLE
fix: hide sensitive info when listing targets

### DIFF
--- a/pkg/api/controllers/target/list.go
+++ b/pkg/api/controllers/target/list.go
@@ -34,20 +34,20 @@ func ListTargets(ctx *gin.Context) {
 	for _, target := range targets {
 		p, err := server.ProviderManager.GetProvider(target.ProviderInfo.Name)
 		if err != nil {
-			target.Options = err.Error()
+			target.Options = fmt.Sprintf("Error: %s", err.Error())
 			continue
 		}
 
 		manifest, err := (*p).GetTargetManifest()
 		if err != nil {
-			target.Options = err.Error()
+			target.Options = fmt.Sprintf("Error: %s", err.Error())
 			continue
 		}
 
 		var opts map[string]interface{}
 		err = json.Unmarshal([]byte(target.Options), &opts)
 		if err != nil {
-			target.Options = err.Error()
+			target.Options = fmt.Sprintf("Error: %s", err.Error())
 			continue
 		}
 
@@ -59,7 +59,7 @@ func ListTargets(ctx *gin.Context) {
 
 		updatedOptions, err := json.MarshalIndent(opts, "", "  ")
 		if err != nil {
-			target.Options = err.Error()
+			target.Options = fmt.Sprintf("Error: %s", err.Error())
 			continue
 		}
 

--- a/pkg/api/controllers/target/list.go
+++ b/pkg/api/controllers/target/list.go
@@ -34,21 +34,21 @@ func ListTargets(ctx *gin.Context) {
 	for _, target := range targets {
 		p, err := server.ProviderManager.GetProvider(target.ProviderInfo.Name)
 		if err != nil {
-			ctx.AbortWithError(http.StatusNotFound, fmt.Errorf("provider not found: %w", err))
-			return
+			target.Options = err.Error()
+			continue
 		}
 
 		manifest, err := (*p).GetTargetManifest()
 		if err != nil {
-			ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get provider manifest: %w", err))
-			return
+			target.Options = err.Error()
+			continue
 		}
 
 		var opts map[string]interface{}
 		err = json.Unmarshal([]byte(target.Options), &opts)
 		if err != nil {
-			ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to unmarshal options: %w", err))
-			return
+			target.Options = err.Error()
+			continue
 		}
 
 		for name, property := range *manifest {
@@ -59,8 +59,8 @@ func ListTargets(ctx *gin.Context) {
 
 		updatedOptions, err := json.MarshalIndent(opts, "", "  ")
 		if err != nil {
-			ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to marshal updated options: %w", err))
-			return
+			target.Options = err.Error()
+			continue
 		}
 
 		target.Options = string(updatedOptions)


### PR DESCRIPTION
# Hide sensitive info when listing targets

## Description

This PR introduces hiding of sensitive information (e.g. access key IDs, Auth Tokens, etc.) when listing targets.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
Before
![Screenshot 2024-10-24 at 11 48 54](https://github.com/user-attachments/assets/0b527313-e405-485b-9fae-3cb387f7b91d)

After
![Screenshot 2024-10-24 at 11 49 07](https://github.com/user-attachments/assets/4af787ee-09bb-45fb-858c-1d1af87afdf6)