### PR TITLE
feat: improve empty list handling structure

### DIFF
--- a/pkg/cmd/build/delete.go
+++ b/pkg/cmd/build/delete.go
@@ -9,6 +9,7 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -51,6 +52,11 @@ var buildDeleteCmd = &cobra.Command{
 			buildList, res, err := apiClient.BuildAPI.ListBuilds(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(buildList) == 0 {
+				views_util.NotifyEmptyBuildList(false)
+				return nil
 			}
 
 			build := selection.GetBuildFromPrompt(buildList, "Delete")

--- a/pkg/cmd/build/info.go
+++ b/pkg/cmd/build/info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/build/info"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -38,6 +39,11 @@ var buildInfoCmd = &cobra.Command{
 			buildList, res, err := apiClient.BuildAPI.ListBuilds(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(buildList) == 0 {
+				views_util.NotifyEmptyBuildList(true)
+				return nil
 			}
 
 			if format.FormatFlag != "" {

--- a/pkg/cmd/build/list.go
+++ b/pkg/cmd/build/list.go
@@ -9,7 +9,6 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	view "github.com/daytonaio/daytona/pkg/views/build/list"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -39,11 +38,6 @@ var buildListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(buildList)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(buildList) == 0 {
-			views_util.NotifyEmptyBuildList(true)
 			return nil
 		}
 

--- a/pkg/cmd/build/list.go
+++ b/pkg/cmd/build/list.go
@@ -8,8 +8,8 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	view "github.com/daytonaio/daytona/pkg/views/build/list"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -36,14 +36,14 @@ var buildListCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		if len(buildList) == 0 {
-			views.RenderInfoMessage("No builds found.")
-			return nil
-		}
-
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(buildList)
 			formattedData.Print()
+			return nil
+		}
+
+		if len(buildList) == 0 {
+			views_util.NotifyEmptyBuildList(true)
 			return nil
 		}
 

--- a/pkg/cmd/build/logs.go
+++ b/pkg/cmd/build/logs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +48,12 @@ var buildLogsCmd = &cobra.Command{
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
+
+			if len(buildList) == 0 {
+				views_util.NotifyEmptyBuildList(false)
+				return nil
+			}
+
 			build := selection.GetBuildFromPrompt(buildList, "Get Logs For")
 			if build == nil {
 				return nil

--- a/pkg/cmd/containerregistry/delete.go
+++ b/pkg/cmd/containerregistry/delete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	containerregistry_view "github.com/daytonaio/daytona/pkg/views/containerregistry"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +48,7 @@ var containerRegistryDeleteCmd = &cobra.Command{
 			}
 
 			if len(containerRegistries) == 0 {
-				views.RenderInfoMessage("No container registries found")
+				views_util.NotifyEmptyContainerRegistryList(false)
 				return nil
 			}
 

--- a/pkg/cmd/containerregistry/list.go
+++ b/pkg/cmd/containerregistry/list.go
@@ -9,8 +9,8 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	containerregistry_view "github.com/daytonaio/daytona/pkg/views/containerregistry/list"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -30,14 +30,14 @@ var containerRegistryListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if len(containerRegistries) == 0 {
-			views.RenderInfoMessage("No container registries found. Set a new container registry by running 'daytona container-registry set'")
-			return nil
-		}
-
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(containerRegistries)
 			formattedData.Print()
+			return nil
+		}
+
+		if len(containerRegistries) == 0 {
+			views_util.NotifyEmptyContainerRegistryList(true)
 			return nil
 		}
 

--- a/pkg/cmd/containerregistry/list.go
+++ b/pkg/cmd/containerregistry/list.go
@@ -10,7 +10,6 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	containerregistry_view "github.com/daytonaio/daytona/pkg/views/containerregistry/list"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -33,11 +32,6 @@ var containerRegistryListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(containerRegistries)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(containerRegistries) == 0 {
-			views_util.NotifyEmptyContainerRegistryList(true)
 			return nil
 		}
 

--- a/pkg/cmd/gitprovider/delete.go
+++ b/pkg/cmd/gitprovider/delete.go
@@ -11,6 +11,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,7 @@ var gitProviderDeleteCmd = &cobra.Command{
 		}
 
 		if len(gitProviders) == 0 {
-			views.RenderInfoMessage("No git providers registered")
+			views_util.NotifyEmptyGitProviderList(true)
 			return nil
 		}
 

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
 	"github.com/daytonaio/daytona/pkg/views/gitprovider/list"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -60,11 +59,6 @@ var gitProviderListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(gitProviderViewList)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(gitProviderViewList) == 0 {
-			views_util.NotifyEmptyGitProviderList(true)
 			return nil
 		}
 

--- a/pkg/cmd/gitprovider/list.go
+++ b/pkg/cmd/gitprovider/list.go
@@ -9,7 +9,6 @@ import (
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
 	"github.com/daytonaio/daytona/pkg/views/gitprovider/list"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
@@ -31,14 +30,8 @@ var gitProviderListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if len(gitProviders) == 0 {
-			message := "No git providers registered. Add a new git provider by preparing a Personal Access Token and running 'daytona git-providers add'"
-			views.RenderInfoMessage(views_util.WrapText(message, views_util.GetTerminalWidth()))
-			return nil
-		}
-
 		supportedProviders := config.GetSupportedGitProviders()
-		var gitProviderViewList []gitprovider_view.GitProviderView
+		gitProviderViewList := []gitprovider_view.GitProviderView{}
 
 		for _, gitProvider := range gitProviders {
 			for _, supportedProvider := range supportedProviders {
@@ -67,6 +60,11 @@ var gitProviderListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(gitProviderViewList)
 			formattedData.Print()
+			return nil
+		}
+
+		if len(gitProviderViewList) == 0 {
+			views_util.NotifyEmptyGitProviderList(true)
 			return nil
 		}
 

--- a/pkg/cmd/gitprovider/update.go
+++ b/pkg/cmd/gitprovider/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	gitprovider_view "github.com/daytonaio/daytona/pkg/views/gitprovider"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +33,7 @@ var gitProviderUpdateCmd = &cobra.Command{
 		}
 
 		if len(gitProviders) == 0 {
-			views.RenderInfoMessage("No git providers registered")
+			views_util.NotifyEmptyGitProviderList(true)
 			return nil
 		}
 

--- a/pkg/cmd/prebuild/delete.go
+++ b/pkg/cmd/prebuild/delete.go
@@ -10,6 +10,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +50,7 @@ var prebuildDeleteCmd = &cobra.Command{
 			}
 
 			if len(prebuilds) == 0 {
-				views.RenderInfoMessage("No prebuilds found")
+				views_util.NotifyEmptyPrebuildList(false)
 				return nil
 			}
 

--- a/pkg/cmd/prebuild/info.go
+++ b/pkg/cmd/prebuild/info.go
@@ -10,8 +10,8 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/prebuild/info"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +49,7 @@ var prebuildInfoCmd = &cobra.Command{
 			}
 
 			if len(prebuilds) == 0 {
-				views.RenderInfoMessage("No prebuilds found")
+				views_util.NotifyEmptyPrebuildList(true)
 				return nil
 			}
 

--- a/pkg/cmd/prebuild/list.go
+++ b/pkg/cmd/prebuild/list.go
@@ -8,8 +8,8 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	view "github.com/daytonaio/daytona/pkg/views/prebuild/list"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -31,14 +31,14 @@ var prebuildListCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		if len(prebuildList) == 0 {
-			views.RenderInfoMessage("No prebuilds found. Add a new prebuild by running 'daytona prebuild add'")
-			return nil
-		}
-
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(prebuildList)
 			formattedData.Print()
+			return nil
+		}
+
+		if len(prebuildList) == 0 {
+			views_util.NotifyEmptyPrebuildList(true)
 			return nil
 		}
 

--- a/pkg/cmd/prebuild/list.go
+++ b/pkg/cmd/prebuild/list.go
@@ -9,7 +9,6 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	view "github.com/daytonaio/daytona/pkg/views/prebuild/list"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -34,11 +33,6 @@ var prebuildListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(prebuildList)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(prebuildList) == 0 {
-			views_util.NotifyEmptyPrebuildList(true)
 			return nil
 		}
 

--- a/pkg/cmd/prebuild/update.go
+++ b/pkg/cmd/prebuild/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/build"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/prebuild/add"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -101,7 +102,7 @@ var prebuildUpdateCmd = &cobra.Command{
 			}
 
 			if len(prebuilds) == 0 {
-				views.RenderInfoMessage("No prebuilds found")
+				views_util.NotifyEmptyPrebuildList(true)
 				return nil
 			}
 

--- a/pkg/cmd/profiledata/env/list.go
+++ b/pkg/cmd/profiledata/env/list.go
@@ -9,7 +9,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/env"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -35,11 +34,6 @@ var listCmd = &cobra.Command{
 			}
 			formattedData := format.NewFormatter(profileData.EnvVars)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(profileData.EnvVars) == 0 {
-			views_util.NotifyEmptyEnvVarList(true)
 			return nil
 		}
 

--- a/pkg/cmd/profiledata/env/list.go
+++ b/pkg/cmd/profiledata/env/list.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/env"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +39,7 @@ var listCmd = &cobra.Command{
 		}
 
 		if len(profileData.EnvVars) == 0 {
-			views.RenderInfoMessageBold("No environment variables set")
+			views_util.NotifyEmptyEnvVarList(true)
 			return nil
 		}
 

--- a/pkg/cmd/projectconfig/delete.go
+++ b/pkg/cmd/projectconfig/delete.go
@@ -11,6 +11,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -62,7 +63,7 @@ var projectConfigDeleteCmd = &cobra.Command{
 			}
 
 			if len(projectConfigs) == 0 {
-				views.RenderInfoMessage("No project configs found")
+				views_util.NotifyEmptyProjectConfigList(false)
 				return nil
 			}
 

--- a/pkg/cmd/projectconfig/info.go
+++ b/pkg/cmd/projectconfig/info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/projectconfig/info"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -39,6 +40,11 @@ var projectConfigInfoCmd = &cobra.Command{
 			projectConfigList, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(projectConfigList) == 0 {
+				views_util.NotifyEmptyProjectConfigList(true)
+				return nil
 			}
 
 			if format.FormatFlag != "" {

--- a/pkg/cmd/projectconfig/list.go
+++ b/pkg/cmd/projectconfig/list.go
@@ -8,8 +8,8 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	projectconfig_view "github.com/daytonaio/daytona/pkg/views/projectconfig/list"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -46,14 +46,14 @@ var projectConfigListCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		if len(projectConfigs) == 0 {
-			views.RenderInfoMessage("No project configs found. Add a new project config by running 'daytona project-config add'")
-			return nil
-		}
-
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(projectConfigs)
 			formattedData.Print()
+			return nil
+		}
+
+		if len(projectConfigs) == 0 {
+			views_util.NotifyEmptyProjectConfigList(true)
 			return nil
 		}
 

--- a/pkg/cmd/projectconfig/list.go
+++ b/pkg/cmd/projectconfig/list.go
@@ -9,7 +9,6 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	projectconfig_view "github.com/daytonaio/daytona/pkg/views/projectconfig/list"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -49,11 +48,6 @@ var projectConfigListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(projectConfigs)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(projectConfigs) == 0 {
-			views_util.NotifyEmptyProjectConfigList(true)
 			return nil
 		}
 

--- a/pkg/cmd/projectconfig/setdefault.go
+++ b/pkg/cmd/projectconfig/setdefault.go
@@ -9,6 +9,7 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,11 @@ var projectConfigSetDefaultCmd = &cobra.Command{
 			projectConfigList, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(projectConfigList) == 0 {
+				views_util.NotifyEmptyProjectConfigList(true)
+				return nil
 			}
 
 			projectConfig := selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Make Default")

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -37,6 +37,11 @@ var projectConfigUpdateCmd = &cobra.Command{
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
+			if len(projectConfigList) == 0 {
+				views_util.NotifyEmptyProjectConfigList(true)
+				return nil
+			}
+
 			projectConfig = selection.GetProjectConfigFromPrompt(projectConfigList, 0, false, false, "Update")
 			if projectConfig == nil {
 				return nil

--- a/pkg/cmd/provider/list.go
+++ b/pkg/cmd/provider/list.go
@@ -12,7 +12,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/provider"
 	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -37,11 +36,6 @@ var providerListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(providerList)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(providerList) == 0 {
-			views_util.NotifyEmptyProviderList(true)
 			return nil
 		}
 

--- a/pkg/cmd/provider/list.go
+++ b/pkg/cmd/provider/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	"github.com/daytonaio/daytona/pkg/views/provider"
 	provider_view "github.com/daytonaio/daytona/pkg/views/provider"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,11 @@ var providerListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(providerList)
 			formattedData.Print()
+			return nil
+		}
+
+		if len(providerList) == 0 {
+			views_util.NotifyEmptyProviderList(true)
 			return nil
 		}
 

--- a/pkg/cmd/provider/uninstall.go
+++ b/pkg/cmd/provider/uninstall.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/provider"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,11 @@ var providerUninstallCmd = &cobra.Command{
 		providerList, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
 		if err != nil {
 			return apiclient_util.HandleErrorResponse(res, err)
+		}
+
+		if len(providerList) == 0 {
+			views_util.NotifyEmptyProviderList(false)
+			return nil
 		}
 
 		providerToUninstall, err := provider.GetProviderFromPrompt(provider.ProviderListToView(providerList), "Choose a Provider to Uninstall", false)

--- a/pkg/cmd/provider/update.go
+++ b/pkg/cmd/provider/update.go
@@ -12,9 +12,9 @@ import (
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/provider/manager"
 	"github.com/daytonaio/daytona/pkg/views/provider"
-	"github.com/spf13/cobra"
-
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var allFlag bool
@@ -35,6 +35,11 @@ var providerUpdateCmd = &cobra.Command{
 		providerList, res, err := apiClient.ProviderAPI.ListProviders(ctx).Execute()
 		if err != nil {
 			return apiclient_util.HandleErrorResponse(res, err)
+		}
+
+		if len(providerList) == 0 {
+			views_util.NotifyEmptyProviderList(true)
+			return nil
 		}
 
 		serverConfig, res, err := apiClient.ServerAPI.GetConfigExecute(apiclient.ApiGetConfigRequest{})

--- a/pkg/cmd/target/list.go
+++ b/pkg/cmd/target/list.go
@@ -8,8 +8,8 @@ import (
 
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
 	list_view "github.com/daytonaio/daytona/pkg/views/target/list"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -31,15 +31,14 @@ var targetListCmd = &cobra.Command{
 			return apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		if len(targetList) == 0 {
-			views.RenderInfoMessageBold("No targets found")
-			views.RenderInfoMessage("Use 'daytona target set' to add a target")
-			return nil
-		}
-
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(targetList)
 			formattedData.Print()
+			return nil
+		}
+
+		if len(targetList) == 0 {
+			views_util.NotifyEmptyTargetList(true)
 			return nil
 		}
 

--- a/pkg/cmd/target/list.go
+++ b/pkg/cmd/target/list.go
@@ -9,7 +9,6 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	list_view "github.com/daytonaio/daytona/pkg/views/target/list"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -34,11 +33,6 @@ var targetListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(targetList)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(targetList) == 0 {
-			views_util.NotifyEmptyTargetList(true)
 			return nil
 		}
 

--- a/pkg/cmd/target/remove.go
+++ b/pkg/cmd/target/remove.go
@@ -15,9 +15,9 @@ import (
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/target"
-	"github.com/spf13/cobra"
-
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var yesFlag bool
@@ -50,6 +50,11 @@ var targetRemoveCmd = &cobra.Command{
 			targetList, res, err := apiClient.TargetAPI.ListTargets(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(targetList) == 0 {
+				views_util.NotifyEmptyTargetList(false)
+				return nil
 			}
 
 			selectedTarget, err := target.GetTargetFromPrompt(targetList, activeProfile.Name, nil, false, "Remove")

--- a/pkg/cmd/target/setdefault.go
+++ b/pkg/cmd/target/setdefault.go
@@ -12,6 +12,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	target_view "github.com/daytonaio/daytona/pkg/views/target"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,11 @@ var targetSetDefaultCmd = &cobra.Command{
 			targetList, res, err := apiClient.TargetAPI.ListTargets(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(targetList) == 0 {
+				views_util.NotifyEmptyTargetList(true)
+				return nil
 			}
 
 			c, err := config.GetConfig()

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -20,8 +20,8 @@ import (
 	"github.com/daytonaio/daytona/pkg/server/workspaces"
 	"github.com/daytonaio/daytona/pkg/telemetry"
 	ide_views "github.com/daytonaio/daytona/pkg/views/ide"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -61,6 +61,11 @@ var CodeCmd = &cobra.Command{
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Verbose(true).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(workspaceList) == 0 {
+				views_util.NotifyEmptyWorkspaceList(true)
+				return nil
 			}
 
 			workspace = selection.GetWorkspaceFromPrompt(workspaceList, "Open")

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -16,7 +16,6 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -78,6 +77,12 @@ var DeleteCmd = &cobra.Command{
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
+
+			if len(workspaceList) == 0 {
+				views_util.NotifyEmptyWorkspaceList(false)
+				return nil
+			}
+
 			workspaceDeleteList = selection.GetWorkspacesFromPrompt(workspaceList, "Delete")
 			for _, workspace := range workspaceDeleteList {
 				workspaceDeleteListNames = append(workspaceDeleteListNames, workspace.Name)

--- a/pkg/cmd/workspace/info.go
+++ b/pkg/cmd/workspace/info.go
@@ -10,6 +10,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/info"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
@@ -35,6 +36,11 @@ var InfoCmd = &cobra.Command{
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Verbose(true).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(workspaceList) == 0 {
+				views_util.NotifyEmptyWorkspaceList(true)
+				return nil
 			}
 
 			if format.FormatFlag != "" {

--- a/pkg/cmd/workspace/list.go
+++ b/pkg/cmd/workspace/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	list_view "github.com/daytonaio/daytona/pkg/views/workspace/list"
 	"github.com/spf13/cobra"
 )
@@ -51,11 +50,6 @@ var ListCmd = &cobra.Command{
 		if format.FormatFlag != "" {
 			formattedData := format.NewFormatter(workspaceList)
 			formattedData.Print()
-			return nil
-		}
-
-		if len(workspaceList) == 0 {
-			views_util.NotifyEmptyWorkspaceList(true)
 			return nil
 		}
 

--- a/pkg/cmd/workspace/list.go
+++ b/pkg/cmd/workspace/list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/daytonaio/daytona/internal/util/apiclient"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
-	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	list_view "github.com/daytonaio/daytona/pkg/views/workspace/list"
 	"github.com/spf13/cobra"
 )
@@ -55,7 +55,7 @@ var ListCmd = &cobra.Command{
 		}
 
 		if len(workspaceList) == 0 {
-			views.RenderInfoMessage("The workspace list is empty. Start off by running 'daytona create'.")
+			views_util.NotifyEmptyWorkspaceList(true)
 			return nil
 		}
 

--- a/pkg/cmd/workspace/restart.go
+++ b/pkg/cmd/workspace/restart.go
@@ -11,6 +11,7 @@ import (
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	"github.com/spf13/cobra"
 )
@@ -44,6 +45,11 @@ var RestartCmd = &cobra.Command{
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(workspaceList) == 0 {
+				views_util.NotifyEmptyWorkspaceList(true)
+				return nil
 			}
 
 			workspace := selection.GetWorkspaceFromPrompt(workspaceList, "Restart")

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -12,9 +12,9 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/ide"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +50,11 @@ var SshCmd = &cobra.Command{
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(workspaceList) == 0 {
+				views_util.NotifyEmptyWorkspaceList(true)
+				return nil
 			}
 
 			workspace = selection.GetWorkspaceFromPrompt(workspaceList, "SSH Into")

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -15,8 +15,8 @@ import (
 	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/views"
 	ide_views "github.com/daytonaio/daytona/pkg/views/ide"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -63,6 +63,11 @@ var StartCmd = &cobra.Command{
 			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(workspaceList) == 0 {
+				views_util.NotifyEmptyWorkspaceList(true)
+				return nil
 			}
 
 			selectedWorkspaces := selection.GetWorkspacesFromPrompt(workspaceList, "Start")

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -63,6 +63,11 @@ var StopCmd = &cobra.Command{
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
 
+			if len(workspaceList) == 0 {
+				views_util.NotifyEmptyWorkspaceList(true)
+				return nil
+			}
+
 			selectedWorkspaces := selection.GetWorkspacesFromPrompt(workspaceList, "Stop")
 
 			for _, workspace := range selectedWorkspaces {

--- a/pkg/views/build/list/view.go
+++ b/pkg/views/build/list/view.go
@@ -23,6 +23,11 @@ type rowData struct {
 }
 
 func ListBuilds(buildList []apiclient.Build, apiServerConfig *apiclient.ServerConfig) {
+	if len(buildList) == 0 {
+		views_util.NotifyEmptyBuildList(true)
+		return
+	}
+
 	SortBuilds(&buildList)
 
 	data := [][]string{}

--- a/pkg/views/common.go
+++ b/pkg/views/common.go
@@ -52,8 +52,8 @@ func RenderMainTitle(title string) {
 	fmt.Println(lipgloss.NewStyle().Foreground(Green).Bold(true).Padding(1, 0, 1, 0).Render(title))
 }
 
-func RenderLine(message string) {
-	fmt.Println(lipgloss.NewStyle().PaddingLeft(1).Render(message))
+func RenderTip(message string) {
+	fmt.Println(lipgloss.NewStyle().Padding(0, 0, 1, 1).Render(message))
 }
 
 func RenderInfoMessage(message string) {

--- a/pkg/views/containerregistry/list/view.go
+++ b/pkg/views/containerregistry/list/view.go
@@ -19,6 +19,11 @@ type rowData struct {
 }
 
 func ListRegistries(registryList []apiclient.ContainerRegistry) {
+	if len(registryList) == 0 {
+		views_util.NotifyEmptyContainerRegistryList(true)
+		return
+	}
+
 	data := [][]string{}
 
 	for _, registry := range registryList {

--- a/pkg/views/env/list.go
+++ b/pkg/views/env/list.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"golang.org/x/term"
 )
 
@@ -34,6 +35,11 @@ func getRowData(key, value string) *RowData {
 }
 
 func List(envVars map[string]string) {
+	if len(envVars) == 0 {
+		views_util.NotifyEmptyEnvVarList(true)
+		return
+	}
+
 	re := lipgloss.NewRenderer(os.Stdout)
 
 	headers := []string{"Key", "Value"}

--- a/pkg/views/gitprovider/list/view.go
+++ b/pkg/views/gitprovider/list/view.go
@@ -21,6 +21,11 @@ type rowData struct {
 }
 
 func ListGitProviders(gitProviderViewList []gitprovider.GitProviderView) {
+	if len(gitProviderViewList) == 0 {
+		views_util.NotifyEmptyGitProviderList(true)
+		return
+	}
+
 	var showBaseApiUrlColumn bool
 	var showSigningMethodColumn bool
 	headers := []string{"Name", "Alias", "Username", "Base API URL", "Signing Method"}

--- a/pkg/views/prebuild/list/view.go
+++ b/pkg/views/prebuild/list/view.go
@@ -25,6 +25,11 @@ type rowData struct {
 }
 
 func ListPrebuilds(prebuildList []apiclient.PrebuildDTO) {
+	if len(prebuildList) == 0 {
+		views_util.NotifyEmptyPrebuildList(true)
+		return
+	}
+
 	data := [][]string{}
 
 	for _, p := range prebuildList {

--- a/pkg/views/projectconfig/list/view.go
+++ b/pkg/views/projectconfig/list/view.go
@@ -22,6 +22,11 @@ type rowData struct {
 }
 
 func ListProjectConfigs(projectConfigList []apiclient.ProjectConfig, apiServerConfig *apiclient.ServerConfig, specifyGitProviders bool) {
+	if len(projectConfigList) == 0 {
+		views_util.NotifyEmptyProjectConfigList(true)
+		return
+	}
+
 	data := [][]string{}
 
 	for _, pc := range projectConfigList {

--- a/pkg/views/provider/list.go
+++ b/pkg/views/provider/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/util"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
 type rowData struct {
@@ -18,6 +19,11 @@ type rowData struct {
 }
 
 func List(providerList []apiclient.Provider) {
+	if len(providerList) == 0 {
+		views_util.NotifyEmptyProviderList(true)
+		return
+	}
+
 	data := [][]string{}
 
 	for _, provider := range providerList {

--- a/pkg/views/target/list/view.go
+++ b/pkg/views/target/list/view.go
@@ -10,6 +10,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	"github.com/daytonaio/daytona/pkg/views"
 	"github.com/daytonaio/daytona/pkg/views/util"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
 type rowData struct {
@@ -20,6 +21,11 @@ type rowData struct {
 }
 
 func ListTargets(targetList []apiclient.ProviderTarget) {
+	if len(targetList) == 0 {
+		views_util.NotifyEmptyTargetList(true)
+		return
+	}
+
 	sortTargets(&targetList)
 
 	data := [][]string{}

--- a/pkg/views/util/empty_list.go
+++ b/pkg/views/util/empty_list.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import "github.com/daytonaio/daytona/pkg/views"
+
+func NotifyEmptyProviderList(tip bool) {
+	views.RenderInfoMessageBold("No providers found")
+	if tip {
+		views.RenderTip("Use 'daytona provider install' to install a provider")
+	}
+}
+
+func NotifyEmptyGitProviderList(tip bool) {
+	views.RenderInfoMessageBold("No Git providers found")
+	if tip {
+		views.RenderTip("Use 'daytona git-provider add' to add a Git provider")
+	}
+}
+
+func NotifyEmptyTargetList(tip bool) {
+	views.RenderInfoMessageBold("No targets found")
+	if tip {
+		views.RenderTip("Use 'daytona target set' to add a target")
+	}
+}
+
+func NotifyEmptyProjectConfigList(tip bool) {
+	views.RenderInfoMessageBold("No project configs found")
+	if tip {
+		views.RenderTip("Use 'daytona project-config add' to add a project config")
+	}
+}
+
+func NotifyEmptyWorkspaceList(tip bool) {
+	views.RenderInfoMessageBold("No workspaces found")
+	if tip {
+		views.RenderTip("Use 'daytona create' to create a workspace")
+	}
+}
+
+func NotifyEmptyContainerRegistryList(tip bool) {
+	views.RenderInfoMessageBold("No container registries found")
+	if tip {
+		views.RenderTip("Use 'daytona container-registry add' to add a container registry")
+	}
+}
+
+func NotifyEmptyProfileList(tip bool) {
+	views.RenderInfoMessageBold("No profiles found")
+	if tip {
+		views.RenderTip("Use 'daytona profile add' to add a profile")
+	}
+}
+
+func NotifyEmptyPrebuildList(tip bool) {
+	views.RenderInfoMessageBold("No prebuilds found")
+	if tip {
+		views.RenderTip("Use 'daytona prebuild add' to add a prebuild")
+	}
+}
+
+func NotifyEmptyApiKeyList(tip bool) {
+	views.RenderInfoMessageBold("No API keys found")
+	if tip {
+		views.RenderTip("Use 'daytona api-key new' to create an API key")
+	}
+}
+
+func NotifyEmptyBuildList(tip bool) {
+	views.RenderInfoMessageBold("No builds found")
+	if tip {
+		views.RenderTip("Use 'daytona build run' to run a build or 'daytona prebuild add' to configure a prebuild rule")
+	}
+}
+
+func NotifyEmptyEnvVarList(tip bool) {
+	views.RenderInfoMessageBold("No environment variables found")
+	if tip {
+		views.RenderTip("Use 'daytona env set' to set environment variables")
+	}
+}

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -25,6 +25,11 @@ type RowData struct {
 }
 
 func ListWorkspaces(workspaceList []apiclient.WorkspaceDTO, specifyGitProviders bool, verbose bool, activeProfileName string) {
+	if len(workspaceList) == 0 {
+		views_util.NotifyEmptyWorkspaceList(true)
+		return
+	}
+
 	SortWorkspaces(&workspaceList, verbose)
 
 	headers := []string{"Workspace", "Repository", "Target", "Status", "Created", "Branch"}


### PR DESCRIPTION
# Improve empty list handling structure
## Description

Adds some missing empty list checks to the CLI like `daytona provider list`, `daytona build info`, `daytona code/start/stop` etc.
Moves some handling directly to the views package including a "tip" option when not deleting the resource
Moves formatting flag check above the empty list handling views to make sure the responses are empty arrays instead of e.g. "null"

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/15625498-8f54-46f8-b65c-77fb8dd06150)

![image](https://github.com/user-attachments/assets/883cec4b-7a0a-42f8-88b9-294ceac21abd)

![image](https://github.com/user-attachments/assets/a5f2d59e-8374-4165-ac23-1f1e78c7689d)

![image](https://github.com/user-attachments/assets/11eafc03-de9d-4f74-81b6-fdf5080b85aa)