### PR TITLE
chore: cleanup existing cli docs before generation

### DIFF
--- a/hack/generate-cli-docs.sh
+++ b/hack/generate-cli-docs.sh
@@ -1,6 +1,9 @@
 # Copyright 2024 Daytona Platforms Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Clean up existing documentation files
+rm -rf docs hack/docs
+
 # Generate default CLI documentation files in folder "docs"
 go run cmd/daytona/main.go generate-docs
 


### PR DESCRIPTION
# Clean up existing CLI docs before generation

## Description

Removing CLI commands could previously result in leftovers

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation