### PR TITLE
fix: add unique project names while creating multi-project ws

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -320,6 +320,8 @@ func processPrompting(ctx context.Context, apiClient *apiclient.APIClient, works
 
 	suggestedName := workspace_util.GetSuggestedName(initialSuggestion, workspaceNames)
 
+	dedupProjectNames(projects)
+
 	submissionFormConfig := create.SubmissionFormConfig{
 		ChosenName:    workspaceName,
 		SuggestedName: suggestedName,


### PR DESCRIPTION
## Description

This PR ensures that each project is assigned a unique name when creating workspaces, allowing for successful API key generation.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1301 

## Screenrecord

https://github.com/user-attachments/assets/c042f529-9b48-4cd9-a273-da7b68ff4c7e