### PR TITLE
refactor: target logger and create command output update

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -148,7 +148,8 @@ var CreateCmd = &cobra.Command{
 			return err
 		}
 
-		logs_view.CalculateLongestPrefixLength(workspaceNames)
+		names := append(workspaceNames, targetName)
+		logs_view.CalculateLongestPrefixLength(names)
 
 		logs_view.DisplayLogEntry(logs.LogEntry{
 			Msg: "Request submitted\n",
@@ -173,7 +174,7 @@ var CreateCmd = &cobra.Command{
 		logsContext, stopLogs := context.WithCancel(context.Background())
 		defer stopLogs()
 
-		logs_view.CalculateLongestPrefixLength(workspaceNames)
+		logs_view.CalculateLongestPrefixLength(names)
 
 		go apiclient_util.ReadTargetLogs(logsContext, activeProfile, id, true, nil)
 

--- a/pkg/logs/logger.go
+++ b/pkg/logs/logger.go
@@ -24,7 +24,7 @@ const (
 
 type LogEntry struct {
 	Source        string  `json:"source"`
-	TargetId      *string `json:"targetId,omitempty"`
+	TargetName    *string `json:"targetName,omitempty"`
 	WorkspaceName *string `json:"workspaceName,omitempty"`
 	BuildId       *string `json:"buildId,omitempty"`
 	Msg           string  `json:"msg"`
@@ -36,7 +36,7 @@ type LoggerFactory interface {
 	CreateBuildLogger(buildId string, source LogSource) Logger
 	CreateBuildLogReader(buildId string) (io.Reader, error)
 
-	CreateTargetLogger(targetId string, source LogSource) Logger
+	CreateTargetLogger(targetId, targetName string, source LogSource) Logger
 	CreateTargetLogReader(targetId string) (io.Reader, error)
 
 	CreateWorkspaceLogger(workspaceId, workspaceName string, source LogSource) Logger

--- a/pkg/logs/target.go
+++ b/pkg/logs/target.go
@@ -14,11 +14,12 @@ import (
 )
 
 type targetLogger struct {
-	logsDir  string
-	targetId string
-	logFile  *os.File
-	logger   *logrus.Logger
-	source   LogSource
+	logsDir    string
+	targetId   string
+	targetName string
+	logFile    *os.File
+	logger     *logrus.Logger
+	source     LogSource
 }
 
 func (w *targetLogger) Write(p []byte) (n int, err error) {
@@ -39,7 +40,7 @@ func (w *targetLogger) Write(p []byte) (n int, err error) {
 	var entry LogEntry
 	entry.Msg = string(p)
 	entry.Source = string(w.source)
-	entry.TargetId = &w.targetId
+	entry.TargetName = &w.targetName
 	entry.Time = time.Now().Format(time.RFC3339)
 
 	b, err := json.Marshal(entry)
@@ -79,14 +80,15 @@ func (w *targetLogger) Cleanup() error {
 	return os.RemoveAll(targetLogsDir)
 }
 
-func (l *loggerFactoryImpl) CreateTargetLogger(targetId string, source LogSource) Logger {
+func (l *loggerFactoryImpl) CreateTargetLogger(targetId, targetName string, source LogSource) Logger {
 	logger := logrus.New()
 
 	return &targetLogger{
-		targetId: targetId,
-		logsDir:  l.targetLogsDir,
-		logger:   logger,
-		source:   source,
+		targetId:   targetId,
+		targetName: targetName,
+		logsDir:    l.targetLogsDir,
+		logger:     logger,
+		source:     source,
 	}
 }
 

--- a/pkg/server/targets/create.go
+++ b/pkg/server/targets/create.go
@@ -68,7 +68,7 @@ func (s *TargetService) CreateTarget(ctx context.Context, req dto.CreateTargetDT
 		return s.handleCreateError(ctx, nil, err)
 	}
 
-	targetLogger := s.loggerFactory.CreateTargetLogger(tg.Id, logs.LogSourceServer)
+	targetLogger := s.loggerFactory.CreateTargetLogger(tg.Id, tg.Name, logs.LogSourceServer)
 	defer targetLogger.Close()
 
 	targetLogger.Write([]byte(fmt.Sprintf("Creating target %s (%s)\n", tg.Name, tg.Id)))

--- a/pkg/server/targets/remove.go
+++ b/pkg/server/targets/remove.go
@@ -37,7 +37,7 @@ func (s *TargetService) RemoveTarget(ctx context.Context, targetId string) error
 		log.Error(err)
 	}
 
-	logger := s.loggerFactory.CreateTargetLogger(target.Id, logs.LogSourceServer)
+	logger := s.loggerFactory.CreateTargetLogger(target.Id, target.Name, logs.LogSourceServer)
 	err = logger.Cleanup()
 	if err != nil {
 		// Should not fail the whole operation if the target logger cannot be cleaned up

--- a/pkg/server/targets/start.go
+++ b/pkg/server/targets/start.go
@@ -28,7 +28,7 @@ func (s *TargetService) StartTarget(ctx context.Context, targetId string) error 
 		return s.handleStartError(ctx, t, err)
 	}
 
-	targetLogger := s.loggerFactory.CreateTargetLogger(t.Id, logs.LogSourceServer)
+	targetLogger := s.loggerFactory.CreateTargetLogger(t.Id, t.Name, logs.LogSourceServer)
 	defer targetLogger.Close()
 
 	logger := io.MultiWriter(&util.InfoLogWriter{}, targetLogger)

--- a/pkg/views/logs/display.go
+++ b/pkg/views/logs/display.go
@@ -39,8 +39,8 @@ func DisplayLogEntry(logEntry logs.LogEntry, index int) {
 		prefixText = *logEntry.WorkspaceName
 	} else if logEntry.BuildId != nil {
 		prefixText = *logEntry.BuildId
-	} else if logEntry.TargetId != nil {
-		prefixText = *logEntry.TargetId
+	} else if logEntry.TargetName != nil {
+		prefixText = *logEntry.TargetName
 	}
 
 	if index == STATIC_INDEX && prefixText == "" {

--- a/pkg/views/workspace/info/view.go
+++ b/pkg/views/workspace/info/view.go
@@ -33,7 +33,7 @@ func Render(workspace *apiclient.WorkspaceDTO, ide string, forceUnstyled bool) {
 	}
 
 	if isCreationView {
-		nameLabel = "Worskpace"
+		nameLabel = "Workspace"
 	}
 
 	output += "\n"
@@ -55,7 +55,7 @@ func Render(workspace *apiclient.WorkspaceDTO, ide string, forceUnstyled bool) {
 		return
 	}
 
-	output = getSingleWorkspaceOutput(workspace, isCreationView)
+	output += getSingleWorkspaceOutput(workspace, isCreationView)
 
 	if !isCreationView {
 		output = views.GetStyledMainTitle("Workspace Info") + "\n" + output
@@ -100,6 +100,7 @@ func getSingleWorkspaceOutput(workspace *apiclient.WorkspaceDTO, isCreationView 
 	if !isCreationView {
 		output += getInfoLine("Target ID", workspace.TargetId) + "\n"
 	}
+
 	output += getInfoLine("Repository", repositoryUrl)
 
 	if !isCreationView {


### PR DESCRIPTION
# Target logger and info command update

## Description

This PR syncs output when running `daytona create` with what it was like before.
It also fixes target ID showing as a prefix in logs instead of target name.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
Note that even though output on `daytona create` looks like this:
<img width="736" alt="Screenshot 2024-10-29 at 14 42 39" src="https://github.com/user-attachments/assets/63067af4-fe59-49f5-bde9-f7c23957726c">

Output when running `daytona info` looks like this which needs refactor as well.
<img width="416" alt="Screenshot 2024-10-29 at 14 45 07" src="https://github.com/user-attachments/assets/6cc39d8a-da6f-4518-8d7e-3f6ce57bae45">
<img width="515" alt="Screenshot 2024-10-29 at 14 45 14" src="https://github.com/user-attachments/assets/4be06be1-b4f4-4640-943c-11db0a98015e">

## Notes
All of the providers need to be updated with expanding arguments of `CreateTargetLogger function` with `targetName string` argument as in [#42](https://github.com/daytonaio/daytona-provider-docker/pull/42).
