### PR TITLE
refactor: replace target id with name in list cmd

### DIFF
--- a/internal/testing/server/workspaces/store.go
+++ b/internal/testing/server/workspaces/store.go
@@ -19,8 +19,8 @@ func NewInMemoryWorkspaceStore() workspace.Store {
 
 func (s *InMemoryWorkspaceStore) List() ([]*workspace.WorkspaceViewDTO, error) {
 	workspaceViewDTOs := []*workspace.WorkspaceViewDTO{}
-	for _, t := range s.workspaces {
-		workspaceViewDTOs = append(workspaceViewDTOs, &workspace.WorkspaceViewDTO{Workspace: *t})
+	for _, w := range s.workspaces {
+		workspaceViewDTOs = append(workspaceViewDTOs, &workspace.WorkspaceViewDTO{Workspace: *w})
 	}
 
 	return workspaceViewDTOs, nil

--- a/internal/testing/server/workspaces/store.go
+++ b/internal/testing/server/workspaces/store.go
@@ -17,27 +17,27 @@ func NewInMemoryWorkspaceStore() workspace.Store {
 	}
 }
 
-func (s *InMemoryWorkspaceStore) List() ([]*workspace.Workspace, error) {
-	workspaces := []*workspace.Workspace{}
+func (s *InMemoryWorkspaceStore) List() ([]*workspace.WorkspaceViewDTO, error) {
+	workspaceViewDTOs := []*workspace.WorkspaceViewDTO{}
 	for _, t := range s.workspaces {
-		workspaces = append(workspaces, t)
+		workspaceViewDTOs = append(workspaceViewDTOs, &workspace.WorkspaceViewDTO{Workspace: *t})
 	}
 
-	return workspaces, nil
+	return workspaceViewDTOs, nil
 }
 
-func (s *InMemoryWorkspaceStore) Find(idOrName string) (*workspace.Workspace, error) {
+func (s *InMemoryWorkspaceStore) Find(idOrName string) (*workspace.WorkspaceViewDTO, error) {
 	t, ok := s.workspaces[idOrName]
 	if !ok {
 		for _, w := range s.workspaces {
 			if w.Name == idOrName {
-				return w, nil
+				return &workspace.WorkspaceViewDTO{Workspace: *w}, nil
 			}
 		}
 		return nil, workspace.ErrWorkspaceNotFound
 	}
 
-	return t, nil
+	return &workspace.WorkspaceViewDTO{Workspace: *t}, nil
 }
 
 func (s *InMemoryWorkspaceStore) Save(workspace *workspace.Workspace) error {

--- a/pkg/api/controllers/workspace/create.go
+++ b/pkg/api/controllers/workspace/create.go
@@ -19,7 +19,7 @@ import (
 //	@Description	Create a workspace
 //	@Param			workspace	body	CreateWorkspaceDTO	true	"Create workspace"
 //	@Produce		json
-//	@Success		200	{object}	Workspace
+//	@Success		200	{object}	WorkspaceViewDTO
 //	@Router			/workspace [post]
 //
 //	@id				CreateWorkspace

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1453,7 +1453,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/Workspace"
+                            "$ref": "#/definitions/WorkspaceViewDTO"
                         }
                     }
                 }
@@ -2993,53 +2993,6 @@ const docTemplate = `{
                 }
             }
         },
-        "Workspace": {
-            "type": "object",
-            "required": [
-                "envVars",
-                "id",
-                "image",
-                "name",
-                "repository",
-                "targetId",
-                "user"
-            ],
-            "properties": {
-                "buildConfig": {
-                    "$ref": "#/definitions/BuildConfig"
-                },
-                "envVars": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "gitProviderConfigId": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "repository": {
-                    "$ref": "#/definitions/GitRepository"
-                },
-                "state": {
-                    "$ref": "#/definitions/WorkspaceState"
-                },
-                "targetId": {
-                    "type": "string"
-                },
-                "user": {
-                    "type": "string"
-                }
-            }
-        },
         "WorkspaceConfig": {
             "type": "object",
             "required": [
@@ -3095,6 +3048,7 @@ const docTemplate = `{
                 "name",
                 "repository",
                 "targetId",
+                "targetName",
                 "user"
             ],
             "properties": {
@@ -3129,6 +3083,9 @@ const docTemplate = `{
                     "$ref": "#/definitions/WorkspaceState"
                 },
                 "targetId": {
+                    "type": "string"
+                },
+                "targetName": {
                     "type": "string"
                 },
                 "user": {
@@ -3178,6 +3135,57 @@ const docTemplate = `{
                 },
                 "uptime": {
                     "type": "integer"
+                }
+            }
+        },
+        "WorkspaceViewDTO": {
+            "type": "object",
+            "required": [
+                "envVars",
+                "id",
+                "image",
+                "name",
+                "repository",
+                "targetId",
+                "targetName",
+                "user"
+            ],
+            "properties": {
+                "buildConfig": {
+                    "$ref": "#/definitions/BuildConfig"
+                },
+                "envVars": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "repository": {
+                    "$ref": "#/definitions/GitRepository"
+                },
+                "state": {
+                    "$ref": "#/definitions/WorkspaceState"
+                },
+                "targetId": {
+                    "type": "string"
+                },
+                "targetName": {
+                    "type": "string"
+                },
+                "user": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1450,7 +1450,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/Workspace"
+                            "$ref": "#/definitions/WorkspaceViewDTO"
                         }
                     }
                 }
@@ -2990,53 +2990,6 @@
                 }
             }
         },
-        "Workspace": {
-            "type": "object",
-            "required": [
-                "envVars",
-                "id",
-                "image",
-                "name",
-                "repository",
-                "targetId",
-                "user"
-            ],
-            "properties": {
-                "buildConfig": {
-                    "$ref": "#/definitions/BuildConfig"
-                },
-                "envVars": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "gitProviderConfigId": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "repository": {
-                    "$ref": "#/definitions/GitRepository"
-                },
-                "state": {
-                    "$ref": "#/definitions/WorkspaceState"
-                },
-                "targetId": {
-                    "type": "string"
-                },
-                "user": {
-                    "type": "string"
-                }
-            }
-        },
         "WorkspaceConfig": {
             "type": "object",
             "required": [
@@ -3092,6 +3045,7 @@
                 "name",
                 "repository",
                 "targetId",
+                "targetName",
                 "user"
             ],
             "properties": {
@@ -3126,6 +3080,9 @@
                     "$ref": "#/definitions/WorkspaceState"
                 },
                 "targetId": {
+                    "type": "string"
+                },
+                "targetName": {
                     "type": "string"
                 },
                 "user": {
@@ -3175,6 +3132,57 @@
                 },
                 "uptime": {
                     "type": "integer"
+                }
+            }
+        },
+        "WorkspaceViewDTO": {
+            "type": "object",
+            "required": [
+                "envVars",
+                "id",
+                "image",
+                "name",
+                "repository",
+                "targetId",
+                "targetName",
+                "user"
+            ],
+            "properties": {
+                "buildConfig": {
+                    "$ref": "#/definitions/BuildConfig"
+                },
+                "envVars": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "gitProviderConfigId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "repository": {
+                    "$ref": "#/definitions/GitRepository"
+                },
+                "state": {
+                    "$ref": "#/definitions/WorkspaceState"
+                },
+                "targetId": {
+                    "type": "string"
+                },
+                "targetName": {
+                    "type": "string"
+                },
+                "user": {
+                    "type": "string"
                 }
             }
         },

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -715,39 +715,6 @@ definitions:
     required:
     - name
     type: object
-  Workspace:
-    properties:
-      buildConfig:
-        $ref: '#/definitions/BuildConfig'
-      envVars:
-        additionalProperties:
-          type: string
-        type: object
-      gitProviderConfigId:
-        type: string
-      id:
-        type: string
-      image:
-        type: string
-      name:
-        type: string
-      repository:
-        $ref: '#/definitions/GitRepository'
-      state:
-        $ref: '#/definitions/WorkspaceState'
-      targetId:
-        type: string
-      user:
-        type: string
-    required:
-    - envVars
-    - id
-    - image
-    - name
-    - repository
-    - targetId
-    - user
-    type: object
   WorkspaceConfig:
     properties:
       buildConfig:
@@ -804,6 +771,8 @@ definitions:
         $ref: '#/definitions/WorkspaceState'
       targetId:
         type: string
+      targetName:
+        type: string
       user:
         type: string
     required:
@@ -813,6 +782,7 @@ definitions:
     - name
     - repository
     - targetId
+    - targetName
     - user
     type: object
   WorkspaceInfo:
@@ -845,6 +815,42 @@ definitions:
     - gitStatus
     - updatedAt
     - uptime
+    type: object
+  WorkspaceViewDTO:
+    properties:
+      buildConfig:
+        $ref: '#/definitions/BuildConfig'
+      envVars:
+        additionalProperties:
+          type: string
+        type: object
+      gitProviderConfigId:
+        type: string
+      id:
+        type: string
+      image:
+        type: string
+      name:
+        type: string
+      repository:
+        $ref: '#/definitions/GitRepository'
+      state:
+        $ref: '#/definitions/WorkspaceState'
+      targetId:
+        type: string
+      targetName:
+        type: string
+      user:
+        type: string
+    required:
+    - envVars
+    - id
+    - image
+    - name
+    - repository
+    - targetId
+    - targetName
+    - user
     type: object
   apikey.ApiKeyType:
     enum:
@@ -1872,7 +1878,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/Workspace'
+            $ref: '#/definitions/WorkspaceViewDTO'
       summary: Create a workspace
       tags:
       - workspace

--- a/pkg/apiclient/README.md
+++ b/pkg/apiclient/README.md
@@ -195,11 +195,11 @@ Class | Method | HTTP request | Description
  - [TargetConfigProperty](docs/TargetConfigProperty.md)
  - [TargetDTO](docs/TargetDTO.md)
  - [TargetInfo](docs/TargetInfo.md)
- - [Workspace](docs/Workspace.md)
  - [WorkspaceConfig](docs/WorkspaceConfig.md)
  - [WorkspaceDTO](docs/WorkspaceDTO.md)
  - [WorkspaceInfo](docs/WorkspaceInfo.md)
  - [WorkspaceState](docs/WorkspaceState.md)
+ - [WorkspaceViewDTO](docs/WorkspaceViewDTO.md)
 
 
 ## Documentation For Authorization

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1033,7 +1033,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workspace'
+                $ref: '#/components/schemas/WorkspaceViewDTO'
           description: OK
       summary: Create a workspace
       tags:
@@ -2429,82 +2429,6 @@ components:
       required:
       - name
       type: object
-    Workspace:
-      example:
-        buildConfig:
-          cachedBuild:
-            image: image
-            user: user
-          devcontainer:
-            filePath: filePath
-        gitProviderConfigId: gitProviderConfigId
-        image: image
-        targetId: targetId
-        envVars:
-          key: envVars
-        name: name
-        id: id
-        state:
-          gitStatus:
-            behind: 6
-            fileStatus:
-            - extra: extra
-              name: name
-              staging: null
-              worktree: null
-            - extra: extra
-              name: name
-              staging: null
-              worktree: null
-            ahead: 0
-            branchPublished: true
-            currentBranch: currentBranch
-          updatedAt: updatedAt
-          uptime: 1
-        repository:
-          owner: owner
-          path: path
-          name: name
-          id: id
-          source: source
-          prNumber: 0
-          branch: branch
-          cloneTarget: null
-          sha: sha
-          url: url
-        user: user
-      properties:
-        buildConfig:
-          $ref: '#/components/schemas/BuildConfig'
-        envVars:
-          additionalProperties:
-            type: string
-          type: object
-        gitProviderConfigId:
-          type: string
-        id:
-          type: string
-        image:
-          type: string
-        name:
-          type: string
-        repository:
-          $ref: '#/components/schemas/GitRepository'
-        state:
-          $ref: '#/components/schemas/WorkspaceState'
-        targetId:
-          type: string
-        user:
-          type: string
-      required:
-      - envVars
-      - id
-      - image
-      - name
-      - repository
-      - targetId
-      - user
-      type: object
     WorkspaceConfig:
       example:
         prebuilds:
@@ -2577,6 +2501,7 @@ components:
             filePath: filePath
         gitProviderConfigId: gitProviderConfigId
         image: image
+        targetName: targetName
         targetId: targetId
         envVars:
           key: envVars
@@ -2640,6 +2565,8 @@ components:
           $ref: '#/components/schemas/WorkspaceState'
         targetId:
           type: string
+        targetName:
+          type: string
         user:
           type: string
       required:
@@ -2649,6 +2576,7 @@ components:
       - name
       - repository
       - targetId
+      - targetName
       - user
       type: object
     WorkspaceInfo:
@@ -2704,6 +2632,86 @@ components:
       - gitStatus
       - updatedAt
       - uptime
+      type: object
+    WorkspaceViewDTO:
+      example:
+        buildConfig:
+          cachedBuild:
+            image: image
+            user: user
+          devcontainer:
+            filePath: filePath
+        gitProviderConfigId: gitProviderConfigId
+        image: image
+        targetName: targetName
+        targetId: targetId
+        envVars:
+          key: envVars
+        name: name
+        id: id
+        state:
+          gitStatus:
+            behind: 6
+            fileStatus:
+            - extra: extra
+              name: name
+              staging: null
+              worktree: null
+            - extra: extra
+              name: name
+              staging: null
+              worktree: null
+            ahead: 0
+            branchPublished: true
+            currentBranch: currentBranch
+          updatedAt: updatedAt
+          uptime: 1
+        repository:
+          owner: owner
+          path: path
+          name: name
+          id: id
+          source: source
+          prNumber: 0
+          branch: branch
+          cloneTarget: null
+          sha: sha
+          url: url
+        user: user
+      properties:
+        buildConfig:
+          $ref: '#/components/schemas/BuildConfig'
+        envVars:
+          additionalProperties:
+            type: string
+          type: object
+        gitProviderConfigId:
+          type: string
+        id:
+          type: string
+        image:
+          type: string
+        name:
+          type: string
+        repository:
+          $ref: '#/components/schemas/GitRepository'
+        state:
+          $ref: '#/components/schemas/WorkspaceState'
+        targetId:
+          type: string
+        targetName:
+          type: string
+        user:
+          type: string
+      required:
+      - envVars
+      - id
+      - image
+      - name
+      - repository
+      - targetId
+      - targetName
+      - user
       type: object
     apikey.ApiKeyType:
       enum:

--- a/pkg/apiclient/api_workspace.go
+++ b/pkg/apiclient/api_workspace.go
@@ -34,7 +34,7 @@ func (r ApiCreateWorkspaceRequest) Workspace(workspace CreateWorkspaceDTO) ApiCr
 	return r
 }
 
-func (r ApiCreateWorkspaceRequest) Execute() (*Workspace, *http.Response, error) {
+func (r ApiCreateWorkspaceRequest) Execute() (*WorkspaceViewDTO, *http.Response, error) {
 	return r.ApiService.CreateWorkspaceExecute(r)
 }
 
@@ -55,13 +55,13 @@ func (a *WorkspaceAPIService) CreateWorkspace(ctx context.Context) ApiCreateWork
 
 // Execute executes the request
 //
-//	@return Workspace
-func (a *WorkspaceAPIService) CreateWorkspaceExecute(r ApiCreateWorkspaceRequest) (*Workspace, *http.Response, error) {
+//	@return WorkspaceViewDTO
+func (a *WorkspaceAPIService) CreateWorkspaceExecute(r ApiCreateWorkspaceRequest) (*WorkspaceViewDTO, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *Workspace
+		localVarReturnValue *WorkspaceViewDTO
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspaceAPIService.CreateWorkspace")

--- a/pkg/apiclient/docs/WorkspaceAPI.md
+++ b/pkg/apiclient/docs/WorkspaceAPI.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 ## CreateWorkspace
 
-> Workspace CreateWorkspace(ctx).Workspace(workspace).Execute()
+> WorkspaceViewDTO CreateWorkspace(ctx).Workspace(workspace).Execute()
 
 Create a workspace
 
@@ -44,7 +44,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `WorkspaceAPI.CreateWorkspace``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `CreateWorkspace`: Workspace
+	// response from `CreateWorkspace`: WorkspaceViewDTO
 	fmt.Fprintf(os.Stdout, "Response from `WorkspaceAPI.CreateWorkspace`: %v\n", resp)
 }
 ```
@@ -64,7 +64,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Workspace**](Workspace.md)
+[**WorkspaceViewDTO**](WorkspaceViewDTO.md)
 
 ### Authorization
 

--- a/pkg/apiclient/docs/WorkspaceDTO.md
+++ b/pkg/apiclient/docs/WorkspaceDTO.md
@@ -14,13 +14,14 @@ Name | Type | Description | Notes
 **Repository** | [**GitRepository**](GitRepository.md) |  | 
 **State** | Pointer to [**WorkspaceState**](WorkspaceState.md) |  | [optional] 
 **TargetId** | **string** |  | 
+**TargetName** | **string** |  | 
 **User** | **string** |  | 
 
 ## Methods
 
 ### NewWorkspaceDTO
 
-`func NewWorkspaceDTO(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, user string, ) *WorkspaceDTO`
+`func NewWorkspaceDTO(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, targetName string, user string, ) *WorkspaceDTO`
 
 NewWorkspaceDTO instantiates a new WorkspaceDTO object
 This constructor will assign default values to properties that have it defined,
@@ -253,6 +254,26 @@ and a boolean to check if the value has been set.
 `func (o *WorkspaceDTO) SetTargetId(v string)`
 
 SetTargetId sets TargetId field to given value.
+
+
+### GetTargetName
+
+`func (o *WorkspaceDTO) GetTargetName() string`
+
+GetTargetName returns the TargetName field if non-nil, zero value otherwise.
+
+### GetTargetNameOk
+
+`func (o *WorkspaceDTO) GetTargetNameOk() (*string, bool)`
+
+GetTargetNameOk returns a tuple with the TargetName field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetTargetName
+
+`func (o *WorkspaceDTO) SetTargetName(v string)`
+
+SetTargetName sets TargetName field to given value.
 
 
 ### GetUser

--- a/pkg/apiclient/docs/WorkspaceViewDTO.md
+++ b/pkg/apiclient/docs/WorkspaceViewDTO.md
@@ -1,4 +1,4 @@
-# Workspace
+# WorkspaceViewDTO
 
 ## Properties
 
@@ -13,238 +13,259 @@ Name | Type | Description | Notes
 **Repository** | [**GitRepository**](GitRepository.md) |  | 
 **State** | Pointer to [**WorkspaceState**](WorkspaceState.md) |  | [optional] 
 **TargetId** | **string** |  | 
+**TargetName** | **string** |  | 
 **User** | **string** |  | 
 
 ## Methods
 
-### NewWorkspace
+### NewWorkspaceViewDTO
 
-`func NewWorkspace(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, user string, ) *Workspace`
+`func NewWorkspaceViewDTO(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, targetName string, user string, ) *WorkspaceViewDTO`
 
-NewWorkspace instantiates a new Workspace object
+NewWorkspaceViewDTO instantiates a new WorkspaceViewDTO object
 This constructor will assign default values to properties that have it defined,
 and makes sure properties required by API are set, but the set of arguments
 will change when the set of required properties is changed
 
-### NewWorkspaceWithDefaults
+### NewWorkspaceViewDTOWithDefaults
 
-`func NewWorkspaceWithDefaults() *Workspace`
+`func NewWorkspaceViewDTOWithDefaults() *WorkspaceViewDTO`
 
-NewWorkspaceWithDefaults instantiates a new Workspace object
+NewWorkspaceViewDTOWithDefaults instantiates a new WorkspaceViewDTO object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
 
 ### GetBuildConfig
 
-`func (o *Workspace) GetBuildConfig() BuildConfig`
+`func (o *WorkspaceViewDTO) GetBuildConfig() BuildConfig`
 
 GetBuildConfig returns the BuildConfig field if non-nil, zero value otherwise.
 
 ### GetBuildConfigOk
 
-`func (o *Workspace) GetBuildConfigOk() (*BuildConfig, bool)`
+`func (o *WorkspaceViewDTO) GetBuildConfigOk() (*BuildConfig, bool)`
 
 GetBuildConfigOk returns a tuple with the BuildConfig field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetBuildConfig
 
-`func (o *Workspace) SetBuildConfig(v BuildConfig)`
+`func (o *WorkspaceViewDTO) SetBuildConfig(v BuildConfig)`
 
 SetBuildConfig sets BuildConfig field to given value.
 
 ### HasBuildConfig
 
-`func (o *Workspace) HasBuildConfig() bool`
+`func (o *WorkspaceViewDTO) HasBuildConfig() bool`
 
 HasBuildConfig returns a boolean if a field has been set.
 
 ### GetEnvVars
 
-`func (o *Workspace) GetEnvVars() map[string]string`
+`func (o *WorkspaceViewDTO) GetEnvVars() map[string]string`
 
 GetEnvVars returns the EnvVars field if non-nil, zero value otherwise.
 
 ### GetEnvVarsOk
 
-`func (o *Workspace) GetEnvVarsOk() (*map[string]string, bool)`
+`func (o *WorkspaceViewDTO) GetEnvVarsOk() (*map[string]string, bool)`
 
 GetEnvVarsOk returns a tuple with the EnvVars field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetEnvVars
 
-`func (o *Workspace) SetEnvVars(v map[string]string)`
+`func (o *WorkspaceViewDTO) SetEnvVars(v map[string]string)`
 
 SetEnvVars sets EnvVars field to given value.
 
 
 ### GetGitProviderConfigId
 
-`func (o *Workspace) GetGitProviderConfigId() string`
+`func (o *WorkspaceViewDTO) GetGitProviderConfigId() string`
 
 GetGitProviderConfigId returns the GitProviderConfigId field if non-nil, zero value otherwise.
 
 ### GetGitProviderConfigIdOk
 
-`func (o *Workspace) GetGitProviderConfigIdOk() (*string, bool)`
+`func (o *WorkspaceViewDTO) GetGitProviderConfigIdOk() (*string, bool)`
 
 GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetGitProviderConfigId
 
-`func (o *Workspace) SetGitProviderConfigId(v string)`
+`func (o *WorkspaceViewDTO) SetGitProviderConfigId(v string)`
 
 SetGitProviderConfigId sets GitProviderConfigId field to given value.
 
 ### HasGitProviderConfigId
 
-`func (o *Workspace) HasGitProviderConfigId() bool`
+`func (o *WorkspaceViewDTO) HasGitProviderConfigId() bool`
 
 HasGitProviderConfigId returns a boolean if a field has been set.
 
 ### GetId
 
-`func (o *Workspace) GetId() string`
+`func (o *WorkspaceViewDTO) GetId() string`
 
 GetId returns the Id field if non-nil, zero value otherwise.
 
 ### GetIdOk
 
-`func (o *Workspace) GetIdOk() (*string, bool)`
+`func (o *WorkspaceViewDTO) GetIdOk() (*string, bool)`
 
 GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetId
 
-`func (o *Workspace) SetId(v string)`
+`func (o *WorkspaceViewDTO) SetId(v string)`
 
 SetId sets Id field to given value.
 
 
 ### GetImage
 
-`func (o *Workspace) GetImage() string`
+`func (o *WorkspaceViewDTO) GetImage() string`
 
 GetImage returns the Image field if non-nil, zero value otherwise.
 
 ### GetImageOk
 
-`func (o *Workspace) GetImageOk() (*string, bool)`
+`func (o *WorkspaceViewDTO) GetImageOk() (*string, bool)`
 
 GetImageOk returns a tuple with the Image field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetImage
 
-`func (o *Workspace) SetImage(v string)`
+`func (o *WorkspaceViewDTO) SetImage(v string)`
 
 SetImage sets Image field to given value.
 
 
 ### GetName
 
-`func (o *Workspace) GetName() string`
+`func (o *WorkspaceViewDTO) GetName() string`
 
 GetName returns the Name field if non-nil, zero value otherwise.
 
 ### GetNameOk
 
-`func (o *Workspace) GetNameOk() (*string, bool)`
+`func (o *WorkspaceViewDTO) GetNameOk() (*string, bool)`
 
 GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetName
 
-`func (o *Workspace) SetName(v string)`
+`func (o *WorkspaceViewDTO) SetName(v string)`
 
 SetName sets Name field to given value.
 
 
 ### GetRepository
 
-`func (o *Workspace) GetRepository() GitRepository`
+`func (o *WorkspaceViewDTO) GetRepository() GitRepository`
 
 GetRepository returns the Repository field if non-nil, zero value otherwise.
 
 ### GetRepositoryOk
 
-`func (o *Workspace) GetRepositoryOk() (*GitRepository, bool)`
+`func (o *WorkspaceViewDTO) GetRepositoryOk() (*GitRepository, bool)`
 
 GetRepositoryOk returns a tuple with the Repository field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetRepository
 
-`func (o *Workspace) SetRepository(v GitRepository)`
+`func (o *WorkspaceViewDTO) SetRepository(v GitRepository)`
 
 SetRepository sets Repository field to given value.
 
 
 ### GetState
 
-`func (o *Workspace) GetState() WorkspaceState`
+`func (o *WorkspaceViewDTO) GetState() WorkspaceState`
 
 GetState returns the State field if non-nil, zero value otherwise.
 
 ### GetStateOk
 
-`func (o *Workspace) GetStateOk() (*WorkspaceState, bool)`
+`func (o *WorkspaceViewDTO) GetStateOk() (*WorkspaceState, bool)`
 
 GetStateOk returns a tuple with the State field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetState
 
-`func (o *Workspace) SetState(v WorkspaceState)`
+`func (o *WorkspaceViewDTO) SetState(v WorkspaceState)`
 
 SetState sets State field to given value.
 
 ### HasState
 
-`func (o *Workspace) HasState() bool`
+`func (o *WorkspaceViewDTO) HasState() bool`
 
 HasState returns a boolean if a field has been set.
 
 ### GetTargetId
 
-`func (o *Workspace) GetTargetId() string`
+`func (o *WorkspaceViewDTO) GetTargetId() string`
 
 GetTargetId returns the TargetId field if non-nil, zero value otherwise.
 
 ### GetTargetIdOk
 
-`func (o *Workspace) GetTargetIdOk() (*string, bool)`
+`func (o *WorkspaceViewDTO) GetTargetIdOk() (*string, bool)`
 
 GetTargetIdOk returns a tuple with the TargetId field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetTargetId
 
-`func (o *Workspace) SetTargetId(v string)`
+`func (o *WorkspaceViewDTO) SetTargetId(v string)`
 
 SetTargetId sets TargetId field to given value.
 
 
+### GetTargetName
+
+`func (o *WorkspaceViewDTO) GetTargetName() string`
+
+GetTargetName returns the TargetName field if non-nil, zero value otherwise.
+
+### GetTargetNameOk
+
+`func (o *WorkspaceViewDTO) GetTargetNameOk() (*string, bool)`
+
+GetTargetNameOk returns a tuple with the TargetName field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetTargetName
+
+`func (o *WorkspaceViewDTO) SetTargetName(v string)`
+
+SetTargetName sets TargetName field to given value.
+
+
 ### GetUser
 
-`func (o *Workspace) GetUser() string`
+`func (o *WorkspaceViewDTO) GetUser() string`
 
 GetUser returns the User field if non-nil, zero value otherwise.
 
 ### GetUserOk
 
-`func (o *Workspace) GetUserOk() (*string, bool)`
+`func (o *WorkspaceViewDTO) GetUserOk() (*string, bool)`
 
 GetUserOk returns a tuple with the User field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetUser
 
-`func (o *Workspace) SetUser(v string)`
+`func (o *WorkspaceViewDTO) SetUser(v string)`
 
 SetUser sets User field to given value.
 

--- a/pkg/apiclient/model_workspace_dto.go
+++ b/pkg/apiclient/model_workspace_dto.go
@@ -31,6 +31,7 @@ type WorkspaceDTO struct {
 	Repository          GitRepository     `json:"repository"`
 	State               *WorkspaceState   `json:"state,omitempty"`
 	TargetId            string            `json:"targetId"`
+	TargetName          string            `json:"targetName"`
 	User                string            `json:"user"`
 }
 
@@ -40,7 +41,7 @@ type _WorkspaceDTO WorkspaceDTO
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewWorkspaceDTO(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, user string) *WorkspaceDTO {
+func NewWorkspaceDTO(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, targetName string, user string) *WorkspaceDTO {
 	this := WorkspaceDTO{}
 	this.EnvVars = envVars
 	this.Id = id
@@ -48,6 +49,7 @@ func NewWorkspaceDTO(envVars map[string]string, id string, image string, name st
 	this.Name = name
 	this.Repository = repository
 	this.TargetId = targetId
+	this.TargetName = targetName
 	this.User = user
 	return &this
 }
@@ -332,6 +334,30 @@ func (o *WorkspaceDTO) SetTargetId(v string) {
 	o.TargetId = v
 }
 
+// GetTargetName returns the TargetName field value
+func (o *WorkspaceDTO) GetTargetName() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.TargetName
+}
+
+// GetTargetNameOk returns a tuple with the TargetName field value
+// and a boolean to check if the value has been set.
+func (o *WorkspaceDTO) GetTargetNameOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.TargetName, true
+}
+
+// SetTargetName sets field value
+func (o *WorkspaceDTO) SetTargetName(v string) {
+	o.TargetName = v
+}
+
 // GetUser returns the User field value
 func (o *WorkspaceDTO) GetUser() string {
 	if o == nil {
@@ -384,6 +410,7 @@ func (o WorkspaceDTO) ToMap() (map[string]interface{}, error) {
 		toSerialize["state"] = o.State
 	}
 	toSerialize["targetId"] = o.TargetId
+	toSerialize["targetName"] = o.TargetName
 	toSerialize["user"] = o.User
 	return toSerialize, nil
 }
@@ -399,6 +426,7 @@ func (o *WorkspaceDTO) UnmarshalJSON(data []byte) (err error) {
 		"name",
 		"repository",
 		"targetId",
+		"targetName",
 		"user",
 	}
 

--- a/pkg/apiclient/model_workspace_view_dto.go
+++ b/pkg/apiclient/model_workspace_view_dto.go
@@ -16,11 +16,11 @@ import (
 	"fmt"
 )
 
-// checks if the Workspace type satisfies the MappedNullable interface at compile time
-var _ MappedNullable = &Workspace{}
+// checks if the WorkspaceViewDTO type satisfies the MappedNullable interface at compile time
+var _ MappedNullable = &WorkspaceViewDTO{}
 
-// Workspace struct for Workspace
-type Workspace struct {
+// WorkspaceViewDTO struct for WorkspaceViewDTO
+type WorkspaceViewDTO struct {
 	BuildConfig         *BuildConfig      `json:"buildConfig,omitempty"`
 	EnvVars             map[string]string `json:"envVars"`
 	GitProviderConfigId *string           `json:"gitProviderConfigId,omitempty"`
@@ -30,37 +30,39 @@ type Workspace struct {
 	Repository          GitRepository     `json:"repository"`
 	State               *WorkspaceState   `json:"state,omitempty"`
 	TargetId            string            `json:"targetId"`
+	TargetName          string            `json:"targetName"`
 	User                string            `json:"user"`
 }
 
-type _Workspace Workspace
+type _WorkspaceViewDTO WorkspaceViewDTO
 
-// NewWorkspace instantiates a new Workspace object
+// NewWorkspaceViewDTO instantiates a new WorkspaceViewDTO object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewWorkspace(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, user string) *Workspace {
-	this := Workspace{}
+func NewWorkspaceViewDTO(envVars map[string]string, id string, image string, name string, repository GitRepository, targetId string, targetName string, user string) *WorkspaceViewDTO {
+	this := WorkspaceViewDTO{}
 	this.EnvVars = envVars
 	this.Id = id
 	this.Image = image
 	this.Name = name
 	this.Repository = repository
 	this.TargetId = targetId
+	this.TargetName = targetName
 	this.User = user
 	return &this
 }
 
-// NewWorkspaceWithDefaults instantiates a new Workspace object
+// NewWorkspaceViewDTOWithDefaults instantiates a new WorkspaceViewDTO object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
-func NewWorkspaceWithDefaults() *Workspace {
-	this := Workspace{}
+func NewWorkspaceViewDTOWithDefaults() *WorkspaceViewDTO {
+	this := WorkspaceViewDTO{}
 	return &this
 }
 
 // GetBuildConfig returns the BuildConfig field value if set, zero value otherwise.
-func (o *Workspace) GetBuildConfig() BuildConfig {
+func (o *WorkspaceViewDTO) GetBuildConfig() BuildConfig {
 	if o == nil || IsNil(o.BuildConfig) {
 		var ret BuildConfig
 		return ret
@@ -70,7 +72,7 @@ func (o *Workspace) GetBuildConfig() BuildConfig {
 
 // GetBuildConfigOk returns a tuple with the BuildConfig field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetBuildConfigOk() (*BuildConfig, bool) {
+func (o *WorkspaceViewDTO) GetBuildConfigOk() (*BuildConfig, bool) {
 	if o == nil || IsNil(o.BuildConfig) {
 		return nil, false
 	}
@@ -78,7 +80,7 @@ func (o *Workspace) GetBuildConfigOk() (*BuildConfig, bool) {
 }
 
 // HasBuildConfig returns a boolean if a field has been set.
-func (o *Workspace) HasBuildConfig() bool {
+func (o *WorkspaceViewDTO) HasBuildConfig() bool {
 	if o != nil && !IsNil(o.BuildConfig) {
 		return true
 	}
@@ -87,12 +89,12 @@ func (o *Workspace) HasBuildConfig() bool {
 }
 
 // SetBuildConfig gets a reference to the given BuildConfig and assigns it to the BuildConfig field.
-func (o *Workspace) SetBuildConfig(v BuildConfig) {
+func (o *WorkspaceViewDTO) SetBuildConfig(v BuildConfig) {
 	o.BuildConfig = &v
 }
 
 // GetEnvVars returns the EnvVars field value
-func (o *Workspace) GetEnvVars() map[string]string {
+func (o *WorkspaceViewDTO) GetEnvVars() map[string]string {
 	if o == nil {
 		var ret map[string]string
 		return ret
@@ -103,7 +105,7 @@ func (o *Workspace) GetEnvVars() map[string]string {
 
 // GetEnvVarsOk returns a tuple with the EnvVars field value
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetEnvVarsOk() (*map[string]string, bool) {
+func (o *WorkspaceViewDTO) GetEnvVarsOk() (*map[string]string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -111,12 +113,12 @@ func (o *Workspace) GetEnvVarsOk() (*map[string]string, bool) {
 }
 
 // SetEnvVars sets field value
-func (o *Workspace) SetEnvVars(v map[string]string) {
+func (o *WorkspaceViewDTO) SetEnvVars(v map[string]string) {
 	o.EnvVars = v
 }
 
 // GetGitProviderConfigId returns the GitProviderConfigId field value if set, zero value otherwise.
-func (o *Workspace) GetGitProviderConfigId() string {
+func (o *WorkspaceViewDTO) GetGitProviderConfigId() string {
 	if o == nil || IsNil(o.GitProviderConfigId) {
 		var ret string
 		return ret
@@ -126,7 +128,7 @@ func (o *Workspace) GetGitProviderConfigId() string {
 
 // GetGitProviderConfigIdOk returns a tuple with the GitProviderConfigId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetGitProviderConfigIdOk() (*string, bool) {
+func (o *WorkspaceViewDTO) GetGitProviderConfigIdOk() (*string, bool) {
 	if o == nil || IsNil(o.GitProviderConfigId) {
 		return nil, false
 	}
@@ -134,7 +136,7 @@ func (o *Workspace) GetGitProviderConfigIdOk() (*string, bool) {
 }
 
 // HasGitProviderConfigId returns a boolean if a field has been set.
-func (o *Workspace) HasGitProviderConfigId() bool {
+func (o *WorkspaceViewDTO) HasGitProviderConfigId() bool {
 	if o != nil && !IsNil(o.GitProviderConfigId) {
 		return true
 	}
@@ -143,12 +145,12 @@ func (o *Workspace) HasGitProviderConfigId() bool {
 }
 
 // SetGitProviderConfigId gets a reference to the given string and assigns it to the GitProviderConfigId field.
-func (o *Workspace) SetGitProviderConfigId(v string) {
+func (o *WorkspaceViewDTO) SetGitProviderConfigId(v string) {
 	o.GitProviderConfigId = &v
 }
 
 // GetId returns the Id field value
-func (o *Workspace) GetId() string {
+func (o *WorkspaceViewDTO) GetId() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -159,7 +161,7 @@ func (o *Workspace) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetIdOk() (*string, bool) {
+func (o *WorkspaceViewDTO) GetIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -167,12 +169,12 @@ func (o *Workspace) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *Workspace) SetId(v string) {
+func (o *WorkspaceViewDTO) SetId(v string) {
 	o.Id = v
 }
 
 // GetImage returns the Image field value
-func (o *Workspace) GetImage() string {
+func (o *WorkspaceViewDTO) GetImage() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -183,7 +185,7 @@ func (o *Workspace) GetImage() string {
 
 // GetImageOk returns a tuple with the Image field value
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetImageOk() (*string, bool) {
+func (o *WorkspaceViewDTO) GetImageOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -191,12 +193,12 @@ func (o *Workspace) GetImageOk() (*string, bool) {
 }
 
 // SetImage sets field value
-func (o *Workspace) SetImage(v string) {
+func (o *WorkspaceViewDTO) SetImage(v string) {
 	o.Image = v
 }
 
 // GetName returns the Name field value
-func (o *Workspace) GetName() string {
+func (o *WorkspaceViewDTO) GetName() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -207,7 +209,7 @@ func (o *Workspace) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetNameOk() (*string, bool) {
+func (o *WorkspaceViewDTO) GetNameOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -215,12 +217,12 @@ func (o *Workspace) GetNameOk() (*string, bool) {
 }
 
 // SetName sets field value
-func (o *Workspace) SetName(v string) {
+func (o *WorkspaceViewDTO) SetName(v string) {
 	o.Name = v
 }
 
 // GetRepository returns the Repository field value
-func (o *Workspace) GetRepository() GitRepository {
+func (o *WorkspaceViewDTO) GetRepository() GitRepository {
 	if o == nil {
 		var ret GitRepository
 		return ret
@@ -231,7 +233,7 @@ func (o *Workspace) GetRepository() GitRepository {
 
 // GetRepositoryOk returns a tuple with the Repository field value
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetRepositoryOk() (*GitRepository, bool) {
+func (o *WorkspaceViewDTO) GetRepositoryOk() (*GitRepository, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -239,12 +241,12 @@ func (o *Workspace) GetRepositoryOk() (*GitRepository, bool) {
 }
 
 // SetRepository sets field value
-func (o *Workspace) SetRepository(v GitRepository) {
+func (o *WorkspaceViewDTO) SetRepository(v GitRepository) {
 	o.Repository = v
 }
 
 // GetState returns the State field value if set, zero value otherwise.
-func (o *Workspace) GetState() WorkspaceState {
+func (o *WorkspaceViewDTO) GetState() WorkspaceState {
 	if o == nil || IsNil(o.State) {
 		var ret WorkspaceState
 		return ret
@@ -254,7 +256,7 @@ func (o *Workspace) GetState() WorkspaceState {
 
 // GetStateOk returns a tuple with the State field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetStateOk() (*WorkspaceState, bool) {
+func (o *WorkspaceViewDTO) GetStateOk() (*WorkspaceState, bool) {
 	if o == nil || IsNil(o.State) {
 		return nil, false
 	}
@@ -262,7 +264,7 @@ func (o *Workspace) GetStateOk() (*WorkspaceState, bool) {
 }
 
 // HasState returns a boolean if a field has been set.
-func (o *Workspace) HasState() bool {
+func (o *WorkspaceViewDTO) HasState() bool {
 	if o != nil && !IsNil(o.State) {
 		return true
 	}
@@ -271,12 +273,12 @@ func (o *Workspace) HasState() bool {
 }
 
 // SetState gets a reference to the given WorkspaceState and assigns it to the State field.
-func (o *Workspace) SetState(v WorkspaceState) {
+func (o *WorkspaceViewDTO) SetState(v WorkspaceState) {
 	o.State = &v
 }
 
 // GetTargetId returns the TargetId field value
-func (o *Workspace) GetTargetId() string {
+func (o *WorkspaceViewDTO) GetTargetId() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -287,7 +289,7 @@ func (o *Workspace) GetTargetId() string {
 
 // GetTargetIdOk returns a tuple with the TargetId field value
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetTargetIdOk() (*string, bool) {
+func (o *WorkspaceViewDTO) GetTargetIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -295,12 +297,36 @@ func (o *Workspace) GetTargetIdOk() (*string, bool) {
 }
 
 // SetTargetId sets field value
-func (o *Workspace) SetTargetId(v string) {
+func (o *WorkspaceViewDTO) SetTargetId(v string) {
 	o.TargetId = v
 }
 
+// GetTargetName returns the TargetName field value
+func (o *WorkspaceViewDTO) GetTargetName() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.TargetName
+}
+
+// GetTargetNameOk returns a tuple with the TargetName field value
+// and a boolean to check if the value has been set.
+func (o *WorkspaceViewDTO) GetTargetNameOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.TargetName, true
+}
+
+// SetTargetName sets field value
+func (o *WorkspaceViewDTO) SetTargetName(v string) {
+	o.TargetName = v
+}
+
 // GetUser returns the User field value
-func (o *Workspace) GetUser() string {
+func (o *WorkspaceViewDTO) GetUser() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -311,7 +337,7 @@ func (o *Workspace) GetUser() string {
 
 // GetUserOk returns a tuple with the User field value
 // and a boolean to check if the value has been set.
-func (o *Workspace) GetUserOk() (*string, bool) {
+func (o *WorkspaceViewDTO) GetUserOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -319,11 +345,11 @@ func (o *Workspace) GetUserOk() (*string, bool) {
 }
 
 // SetUser sets field value
-func (o *Workspace) SetUser(v string) {
+func (o *WorkspaceViewDTO) SetUser(v string) {
 	o.User = v
 }
 
-func (o Workspace) MarshalJSON() ([]byte, error) {
+func (o WorkspaceViewDTO) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
@@ -331,7 +357,7 @@ func (o Workspace) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-func (o Workspace) ToMap() (map[string]interface{}, error) {
+func (o WorkspaceViewDTO) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.BuildConfig) {
 		toSerialize["buildConfig"] = o.BuildConfig
@@ -348,11 +374,12 @@ func (o Workspace) ToMap() (map[string]interface{}, error) {
 		toSerialize["state"] = o.State
 	}
 	toSerialize["targetId"] = o.TargetId
+	toSerialize["targetName"] = o.TargetName
 	toSerialize["user"] = o.User
 	return toSerialize, nil
 }
 
-func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
+func (o *WorkspaceViewDTO) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -363,6 +390,7 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 		"name",
 		"repository",
 		"targetId",
+		"targetName",
 		"user",
 	}
 
@@ -380,53 +408,53 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 		}
 	}
 
-	varWorkspace := _Workspace{}
+	varWorkspaceViewDTO := _WorkspaceViewDTO{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varWorkspace)
+	err = decoder.Decode(&varWorkspaceViewDTO)
 
 	if err != nil {
 		return err
 	}
 
-	*o = Workspace(varWorkspace)
+	*o = WorkspaceViewDTO(varWorkspaceViewDTO)
 
 	return err
 }
 
-type NullableWorkspace struct {
-	value *Workspace
+type NullableWorkspaceViewDTO struct {
+	value *WorkspaceViewDTO
 	isSet bool
 }
 
-func (v NullableWorkspace) Get() *Workspace {
+func (v NullableWorkspaceViewDTO) Get() *WorkspaceViewDTO {
 	return v.value
 }
 
-func (v *NullableWorkspace) Set(val *Workspace) {
+func (v *NullableWorkspaceViewDTO) Set(val *WorkspaceViewDTO) {
 	v.value = val
 	v.isSet = true
 }
 
-func (v NullableWorkspace) IsSet() bool {
+func (v NullableWorkspaceViewDTO) IsSet() bool {
 	return v.isSet
 }
 
-func (v *NullableWorkspace) Unset() {
+func (v *NullableWorkspaceViewDTO) Unset() {
 	v.value = nil
 	v.isSet = false
 }
 
-func NewNullableWorkspace(val *Workspace) *NullableWorkspace {
-	return &NullableWorkspace{value: val, isSet: true}
+func NewNullableWorkspaceViewDTO(val *WorkspaceViewDTO) *NullableWorkspaceViewDTO {
+	return &NullableWorkspaceViewDTO{value: val, isSet: true}
 }
 
-func (v NullableWorkspace) MarshalJSON() ([]byte, error) {
+func (v NullableWorkspaceViewDTO) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.value)
 }
 
-func (v *NullableWorkspace) UnmarshalJSON(src []byte) error {
+func (v *NullableWorkspaceViewDTO) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/pkg/db/dto/workspace.go
+++ b/pkg/db/dto/workspace.go
@@ -248,3 +248,10 @@ func ToWorkspaceBuild(buildDTO *WorkspaceBuildDTO) *buildconfig.BuildConfig {
 		},
 	}
 }
+
+func ToWorkspaceViewDTO(workspaceDTO WorkspaceDTO) *workspace.WorkspaceViewDTO {
+	return &workspace.WorkspaceViewDTO{
+		Workspace:  *ToWorkspace(workspaceDTO),
+		TargetName: workspaceDTO.Target.Name,
+	}
+}

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -42,7 +42,7 @@ func isValidWorkspaceName(name string) bool {
 	return true
 }
 
-func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWorkspaceDTO) (*workspace.Workspace, error) {
+func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWorkspaceDTO) (*workspace.WorkspaceViewDTO, error) {
 	_, err := s.workspaceStore.Find(req.Name)
 	if err == nil {
 		return s.handleCreateError(ctx, nil, ErrWorkspaceAlreadyExists)
@@ -160,9 +160,12 @@ func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req dto.CreateWo
 	return s.handleCreateError(ctx, w, err)
 }
 
-func (s *WorkspaceService) handleCreateError(ctx context.Context, w *workspace.Workspace, err error) (*workspace.Workspace, error) {
+func (s *WorkspaceService) handleCreateError(ctx context.Context, w *workspace.Workspace, err error) (*workspace.WorkspaceViewDTO, error) {
 	if !telemetry.TelemetryEnabled(ctx) {
-		return w, err
+		if w == nil {
+			return nil, err
+		}
+		return &workspace.WorkspaceViewDTO{Workspace: *w}, err
 	}
 
 	clientId := telemetry.ClientId(ctx)
@@ -178,7 +181,11 @@ func (s *WorkspaceService) handleCreateError(ctx context.Context, w *workspace.W
 		log.Trace(err)
 	}
 
-	return w, err
+	if w == nil {
+		return nil, err
+	}
+
+	return &workspace.WorkspaceViewDTO{Workspace: *w}, err
 }
 
 func (s *WorkspaceService) getCachedBuildForWorkspace(w *workspace.Workspace) (*buildconfig.CachedBuild, error) {

--- a/pkg/server/workspaces/dto/workspace.go
+++ b/pkg/server/workspaces/dto/workspace.go
@@ -10,7 +10,7 @@ import (
 )
 
 type WorkspaceDTO struct {
-	workspace.Workspace
+	workspace.WorkspaceViewDTO
 	Info *workspace.WorkspaceInfo `json:"info" validate:"optional"`
 } //	@name	WorkspaceDTO
 

--- a/pkg/server/workspaces/get.go
+++ b/pkg/server/workspaces/get.go
@@ -22,7 +22,7 @@ func (s *WorkspaceService) GetWorkspace(ctx context.Context, workspaceId string,
 	}
 
 	response := &dto.WorkspaceDTO{
-		Workspace: *ws,
+		WorkspaceViewDTO: *ws,
 	}
 
 	if !verbose {
@@ -45,7 +45,7 @@ func (s *WorkspaceService) GetWorkspace(ctx context.Context, workspaceId string,
 	resultCh := make(chan provisioner.WorkspaceInfoResult, 1)
 
 	go func() {
-		workspaceInfo, err := s.provisioner.GetWorkspaceInfo(ctx, ws, targetConfig)
+		workspaceInfo, err := s.provisioner.GetWorkspaceInfo(ctx, &ws.Workspace, targetConfig)
 		resultCh <- provisioner.WorkspaceInfoResult{Info: workspaceInfo, Err: err}
 	}()
 

--- a/pkg/server/workspaces/list.go
+++ b/pkg/server/workspaces/list.go
@@ -26,7 +26,7 @@ func (s *WorkspaceService) ListWorkspaces(ctx context.Context, verbose bool) ([]
 	response := []dto.WorkspaceDTO{}
 
 	for i, ws := range workspaces {
-		response = append(response, dto.WorkspaceDTO{Workspace: *ws})
+		response = append(response, dto.WorkspaceDTO{WorkspaceViewDTO: *ws})
 		if !verbose {
 			continue
 		}
@@ -53,7 +53,7 @@ func (s *WorkspaceService) ListWorkspaces(ctx context.Context, verbose bool) ([]
 			resultCh := make(chan provisioner.WorkspaceInfoResult, 1)
 
 			go func() {
-				targetInfo, err := s.provisioner.GetWorkspaceInfo(ctx, ws, targetConfig)
+				targetInfo, err := s.provisioner.GetWorkspaceInfo(ctx, &ws.Workspace, targetConfig)
 				resultCh <- provisioner.WorkspaceInfoResult{Info: targetInfo, Err: err}
 			}()
 

--- a/pkg/server/workspaces/remove.go
+++ b/pkg/server/workspaces/remove.go
@@ -17,24 +17,24 @@ import (
 func (s *WorkspaceService) RemoveWorkspace(ctx context.Context, workspaceId string) error {
 	ws, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
-		return s.handleRemoveError(ctx, ws, ErrWorkspaceNotFound)
+		return s.handleRemoveError(ctx, &ws.Workspace, ErrWorkspaceNotFound)
 	}
 
 	log.Infof("Destroying workspace %s", ws.Name)
 
 	target, err := s.targetStore.Find(ws.TargetId)
 	if err != nil {
-		return s.handleRemoveError(ctx, ws, err)
+		return s.handleRemoveError(ctx, &ws.Workspace, err)
 	}
 
 	targetConfig, err := s.targetConfigStore.Find(&provider.TargetConfigFilter{Name: &target.TargetConfig})
 	if err != nil {
-		return s.handleRemoveError(ctx, ws, err)
+		return s.handleRemoveError(ctx, &ws.Workspace, err)
 	}
 
-	err = s.provisioner.DestroyWorkspace(ws, targetConfig)
+	err = s.provisioner.DestroyWorkspace(&ws.Workspace, targetConfig)
 	if err != nil {
-		return s.handleRemoveError(ctx, ws, err)
+		return s.handleRemoveError(ctx, &ws.Workspace, err)
 	}
 
 	err = s.apiKeyService.Revoke(fmt.Sprintf("ws-%s", ws.Id))
@@ -49,31 +49,31 @@ func (s *WorkspaceService) RemoveWorkspace(ctx context.Context, workspaceId stri
 		log.Error(err)
 	}
 
-	err = s.workspaceStore.Delete(ws)
+	err = s.workspaceStore.Delete(&ws.Workspace)
 
-	return s.handleRemoveError(ctx, ws, err)
+	return s.handleRemoveError(ctx, &ws.Workspace, err)
 }
 
 // ForceRemoveWorkspace ignores provider errors and makes sure the workspace is removed from storage.
 func (s *WorkspaceService) ForceRemoveWorkspace(ctx context.Context, workspaceId string) error {
 	ws, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
-		return s.handleRemoveError(ctx, ws, ErrWorkspaceNotFound)
+		return s.handleRemoveError(ctx, &ws.Workspace, ErrWorkspaceNotFound)
 	}
 
 	log.Infof("Destroying workspace %s", ws.Name)
 
 	target, err := s.targetStore.Find(ws.TargetId)
 	if err != nil {
-		return s.handleRemoveError(ctx, ws, err)
+		return s.handleRemoveError(ctx, &ws.Workspace, err)
 	}
 
 	targetConfig, err := s.targetConfigStore.Find(&provider.TargetConfigFilter{Name: &target.TargetConfig})
 	if err != nil {
-		return s.handleRemoveError(ctx, ws, err)
+		return s.handleRemoveError(ctx, &ws.Workspace, err)
 	}
 
-	err = s.provisioner.DestroyWorkspace(ws, targetConfig)
+	err = s.provisioner.DestroyWorkspace(&ws.Workspace, targetConfig)
 	if err != nil {
 		log.Error(err)
 	}
@@ -90,9 +90,9 @@ func (s *WorkspaceService) ForceRemoveWorkspace(ctx context.Context, workspaceId
 		log.Error(err)
 	}
 
-	err = s.workspaceStore.Delete(ws)
+	err = s.workspaceStore.Delete(&ws.Workspace)
 
-	return s.handleRemoveError(ctx, ws, err)
+	return s.handleRemoveError(ctx, &ws.Workspace, err)
 }
 
 func (s *WorkspaceService) handleRemoveError(ctx context.Context, w *workspace.Workspace, err error) error {

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -22,7 +22,7 @@ import (
 )
 
 type IWorkspaceService interface {
-	CreateWorkspace(ctx context.Context, req dto.CreateWorkspaceDTO) (*workspace.Workspace, error)
+	CreateWorkspace(ctx context.Context, req dto.CreateWorkspaceDTO) (*workspace.WorkspaceViewDTO, error)
 	GetWorkspace(ctx context.Context, workspaceId string, verbose bool) (*dto.WorkspaceDTO, error)
 	ListWorkspaces(ctx context.Context, verbose bool) ([]dto.WorkspaceDTO, error)
 	StartWorkspace(ctx context.Context, workspaceId string) error
@@ -31,7 +31,7 @@ type IWorkspaceService interface {
 	ForceRemoveWorkspace(ctx context.Context, workspaceId string) error
 
 	GetWorkspaceLogReader(workspaceId string) (io.Reader, error)
-	SetWorkspaceState(workspaceId string, state *workspace.WorkspaceState) (*workspace.Workspace, error)
+	SetWorkspaceState(workspaceId string, state *workspace.WorkspaceState) (*workspace.WorkspaceViewDTO, error)
 }
 
 type targetStore interface {
@@ -101,14 +101,14 @@ type WorkspaceService struct {
 	telemetryService         telemetry.TelemetryService
 }
 
-func (s *WorkspaceService) SetWorkspaceState(workspaceId string, state *workspace.WorkspaceState) (*workspace.Workspace, error) {
+func (s *WorkspaceService) SetWorkspaceState(workspaceId string, state *workspace.WorkspaceState) (*workspace.WorkspaceViewDTO, error) {
 	ws, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
 		return nil, ErrWorkspaceNotFound
 	}
 
 	ws.State = state
-	return ws, s.workspaceStore.Save(ws)
+	return ws, s.workspaceStore.Save(&ws.Workspace)
 }
 
 func (s *WorkspaceService) GetWorkspaceLogReader(workspaceId string) (io.Reader, error) {

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -144,10 +144,10 @@ func TestTargetService(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, workspace)
 
-		ws = workspace
+		ws = &workspace.Workspace
 		ws.EnvVars = nil
 
-		workspaceEquals(t, createWorkspaceDTO, workspace, defaultWorkspaceImage)
+		workspaceEquals(t, createWorkspaceDTO, &workspace.Workspace, defaultWorkspaceImage)
 	})
 
 	t.Run("CreateWorkspace fails when workspace already exists", func(t *testing.T) {

--- a/pkg/server/workspaces/stop.go
+++ b/pkg/server/workspaces/stop.go
@@ -16,32 +16,32 @@ import (
 func (s *WorkspaceService) StopWorkspace(ctx context.Context, workspaceId string) error {
 	ws, err := s.workspaceStore.Find(workspaceId)
 	if err != nil {
-		return s.handleStopError(ctx, ws, ErrWorkspaceNotFound)
+		return s.handleStopError(ctx, &ws.Workspace, ErrWorkspaceNotFound)
 	}
 
 	target, err := s.targetStore.Find(ws.TargetId)
 	if err != nil {
-		return s.handleStopError(ctx, ws, err)
+		return s.handleStopError(ctx, &ws.Workspace, err)
 	}
 
 	targetConfig, err := s.targetConfigStore.Find(&provider.TargetConfigFilter{Name: &target.TargetConfig})
 	if err != nil {
-		return s.handleStopError(ctx, ws, err)
+		return s.handleStopError(ctx, &ws.Workspace, err)
 	}
 
 	//	todo: go routines
-	err = s.provisioner.StopWorkspace(ws, targetConfig)
+	err = s.provisioner.StopWorkspace(&ws.Workspace, targetConfig)
 	if err != nil {
-		return s.handleStopError(ctx, ws, err)
+		return s.handleStopError(ctx, &ws.Workspace, err)
 	}
 	if ws.State != nil {
 		ws.State.Uptime = 0
 		ws.State.UpdatedAt = time.Now().Format(time.RFC1123)
 	}
 
-	err = s.workspaceStore.Save(ws)
+	err = s.workspaceStore.Save(&ws.Workspace)
 
-	return s.handleStopError(ctx, ws, err)
+	return s.handleStopError(ctx, &ws.Workspace, err)
 }
 
 func (s *WorkspaceService) handleStopError(ctx context.Context, w *workspace.Workspace, err error) error {

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -18,7 +18,7 @@ import (
 type RowData struct {
 	Name       string
 	Repository string
-	TargetId   string
+	TargetName string
 	Status     string
 	Created    string
 	Branch     string
@@ -32,7 +32,7 @@ func ListWorkspaces(workspaceList []apiclient.WorkspaceDTO, specifyGitProviders 
 
 	SortWorkspaces(&workspaceList, verbose)
 
-	headers := []string{"Target", "Repository", "Target Id", "Status", "Created", "Branch"}
+	headers := []string{"Workspace", "Repository", "Target", "Status", "Created", "Branch"}
 
 	data := [][]string{}
 
@@ -93,7 +93,7 @@ func getRowFromRowData(rowData RowData, isMultiWorkspaceAccordion bool) []string
 	row := []string{
 		views.NameStyle.Render(rowData.Name),
 		views.DefaultRowDataStyle.Render(rowData.Repository),
-		views.DefaultRowDataStyle.Render(rowData.TargetId),
+		views.DefaultRowDataStyle.Render(rowData.TargetName),
 		state,
 		views.DefaultRowDataStyle.Render(rowData.Created),
 		views.DefaultRowDataStyle.Render(views.GetBranchNameLabel(rowData.Branch)),
@@ -136,7 +136,7 @@ func getTableRowData(workspace apiclient.WorkspaceDTO, specifyGitProviders bool)
 	rowData.Repository = util.GetRepositorySlugFromUrl(workspace.Repository.Url, specifyGitProviders)
 	rowData.Branch = workspace.Repository.Branch
 
-	rowData.TargetId = workspace.TargetId + views_util.AdditionalPropertyPadding
+	rowData.TargetName = workspace.TargetName + views_util.AdditionalPropertyPadding
 
 	if workspace.Info != nil {
 		rowData.Created = util.FormatTimestamp(workspace.Info.Created)

--- a/pkg/workspace/store.go
+++ b/pkg/workspace/store.go
@@ -6,11 +6,16 @@ package workspace
 import "errors"
 
 type Store interface {
-	List() ([]*Workspace, error)
-	Find(idOrName string) (*Workspace, error)
+	List() ([]*WorkspaceViewDTO, error)
+	Find(idOrName string) (*WorkspaceViewDTO, error)
 	Save(workspace *Workspace) error
 	Delete(workspace *Workspace) error
 }
+
+type WorkspaceViewDTO struct {
+	Workspace
+	TargetName string `json:"targetName" validate:"required"`
+} // @name WorkspaceViewDTO
 
 var (
 	ErrWorkspaceNotFound = errors.New("workspace not found")


### PR DESCRIPTION
# Replace target id with name in list cmd

## Description

This PR replaces target id with target name field in list workspaces command.
New DTO type `WorkspaceViewDTO` is introduced.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation