### PR TITLE
fix: git provider config flag on create

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -433,19 +433,24 @@ func processGitURL(ctx context.Context, repoUrl string, apiClient *apiclient.API
 		return nil, err
 	}
 
-	gitProviderConfigs, res, err := apiClient.GitProviderAPI.ListGitProvidersForUrl(context.Background(), url.QueryEscape(repoUrl)).Execute()
-	if err != nil {
-		return nil, apiclient_util.HandleErrorResponse(res, err)
-	}
+	if projectConfigurationFlags.GitProviderConfig == nil || *projectConfigurationFlags.GitProviderConfig == "" {
+		gitProviderConfigs, res, err := apiClient.GitProviderAPI.ListGitProvidersForUrl(context.Background(), url.QueryEscape(repoUrl)).Execute()
+		if err != nil {
+			return nil, apiclient_util.HandleErrorResponse(res, err)
+		}
 
-	if len(gitProviderConfigs) == 1 {
-		projectConfigurationFlags.GitProviderConfig = &gitProviderConfigs[0].Id
-	} else if len(gitProviderConfigs) > 1 {
-		gp := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
-			GitProviderConfigs: gitProviderConfigs,
-			ActionVerb:         "Use",
-		})
-		projectConfigurationFlags.GitProviderConfig = &gp.Id
+		if len(gitProviderConfigs) == 1 {
+			projectConfigurationFlags.GitProviderConfig = &gitProviderConfigs[0].Id
+		} else if len(gitProviderConfigs) > 1 {
+			gp := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
+				GitProviderConfigs: gitProviderConfigs,
+				ActionVerb:         "Use",
+			})
+			if gp == nil {
+				return nil, common.ErrCtrlCAbort
+			}
+			projectConfigurationFlags.GitProviderConfig = &gp.Id
+		}
 	}
 
 	project, err := workspace_util.GetCreateProjectDtoFromFlags(projectConfigurationFlags)


### PR DESCRIPTION
# Fix Git Provider Config Flag on Create

## Description

Fixes 2 issues:
- Null-pointer exception if a user ctrl+c's out of the Git Provider selection TUI
- Don't trigger TUI if the flag was provided

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![Screenshot 2024-11-05 at 09 47 28](https://github.com/user-attachments/assets/2e6aeb22-9aba-4fe7-b855-04310a803c3e)

![Screenshot 2024-11-05 at 09 50 49](https://github.com/user-attachments/assets/f6ca45e5-c56f-4d68-89b7-1191ac041dde)
