### PR TITLE
fix: windows check for daytona server

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -116,6 +116,10 @@ func Stop() error {
 }
 
 func getServiceConfig() (*service.Config, error) {
+	if runtime.GOOS == "windows" {
+		return nil, errors.New("daemon mode not supported on Windows")
+	}
+
 	user, ok := os.LookupEnv("USER")
 	if !ok {
 		return nil, errors.New("could not determine user")
@@ -129,8 +133,6 @@ func getServiceConfig() (*service.Config, error) {
 	}
 
 	switch runtime.GOOS {
-	case "windows":
-		return nil, errors.New("daemon mode not supported on Windows")
 	case "linux":
 		// Fix for running as root on Linux
 		if user == "root" {


### PR DESCRIPTION
# Windows check for daytona server
## Description

Moves the GOOS check further up so that 'daytona server' does not try getting the e.g. USER env var before returning an error on Windows

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
Closes #1310 

## Screenshots

![image](https://github.com/user-attachments/assets/7433898e-8acf-415a-99d1-004f44e00bc5)


## Notes
Daemon mode is not yet supported for Windows
