### PR TITLE
fix: logs prefix

### DIFF
--- a/pkg/cmd/workspace/create/cmd.go
+++ b/pkg/cmd/workspace/create/cmd.go
@@ -169,14 +169,13 @@ var CreateCmd = &cobra.Command{
 		logsContext, stopLogs := context.WithCancel(context.Background())
 		defer stopLogs()
 
-		logs_view.SetupLongestPrefixLength(names)
-
 		if !targetExisted {
 			go apiclient_util.ReadTargetLogs(logsContext, apiclient_util.ReadLogParams{
-				Id:            targetId,
-				Label:         &target.Name,
-				ActiveProfile: activeProfile,
-				Follow:        util.Pointer(true),
+				Id:                    targetId,
+				Label:                 &target.Name,
+				ActiveProfile:         activeProfile,
+				Follow:                util.Pointer(true),
+				SkipPrefixLengthSetup: true,
 			})
 
 			_, res, err := apiClient.TargetAPI.CreateTarget(ctx).Target(apiclient.CreateTargetDTO{


### PR DESCRIPTION
# Fix prefix logs create

## Description

Fixes prefix logs on `daytona create`

## Screenshots

Before
![image](https://github.com/user-attachments/assets/5fc91c20-9fc7-4c3d-a252-60aa47ed20ca)

After
![image](https://github.com/user-attachments/assets/2cb2b505-b7d0-4c2f-812b-85912b8ccf78)

## Notes
Please add any relevant notes if necessary.
