### PR TITLE
refactor: adjust workspace info output

### DIFF
--- a/pkg/views/workspace/info/view.go
+++ b/pkg/views/workspace/info/view.go
@@ -98,15 +98,10 @@ func getSingleWorkspaceOutput(workspace *apiclient.WorkspaceDTO, isCreationView 
 	output += getInfoLinePrNumber(workspace.Repository.PrNumber, workspace.Repository, workspace.State)
 
 	if !isCreationView {
-		output += getInfoLine("Target ID", workspace.TargetId) + "\n"
+		output += getInfoLine("Target", fmt.Sprintf("%s (%s)", workspace.TargetName, workspace.TargetId)) + "\n"
 	}
 
 	output += getInfoLine("Repository", repositoryUrl)
-
-	if !isCreationView {
-		output += "\n"
-		output += getInfoLine("Workspace", workspace.Name)
-	}
 
 	return output
 }


### PR DESCRIPTION
# Pull Request Title

## Description

This PR syncs workspace info output as it was before the target refactor.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
Info now looks like this:
![Screenshot 2024-11-07 at 10 48 59](https://github.com/user-attachments/assets/043433e2-f88f-4d56-88c9-579f4a517692)