### PR TITLE
fix: workspace target rename leftover

### DIFF
--- a/pkg/server/workspaces/list.go
+++ b/pkg/server/workspaces/list.go
@@ -47,23 +47,23 @@ func (s *WorkspaceService) ListWorkspaces(ctx context.Context, verbose bool) ([]
 			resultCh := make(chan provisioner.WorkspaceInfoResult, 1)
 
 			go func() {
-				targetInfo, err := s.provisioner.GetWorkspaceInfo(ctx, &ws.Workspace, &target.Target)
-				resultCh <- provisioner.WorkspaceInfoResult{Info: targetInfo, Err: err}
+				workspaceInfo, err := s.provisioner.GetWorkspaceInfo(ctx, &ws.Workspace, &target.Target)
+				resultCh <- provisioner.WorkspaceInfoResult{Info: workspaceInfo, Err: err}
 			}()
 
 			select {
 			case res := <-resultCh:
 				if res.Err != nil {
-					log.Error(fmt.Errorf("failed to get target info for %s: %v", ws.Name, res.Err))
+					log.Error(fmt.Errorf("failed to get workspace info for %s: %v", ws.Name, res.Err))
 					return
 				}
 
 				response[i].Info = res.Info
 			case <-ctx.Done():
 				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					log.Warn(fmt.Sprintf("timeout getting target info for %s", ws.Name))
+					log.Warn(fmt.Sprintf("timeout getting workspace info for %s", ws.Name))
 				} else {
-					log.Warn(fmt.Sprintf("cancelled getting target info for %s", ws.Name))
+					log.Warn(fmt.Sprintf("cancelled getting workspace info for %s", ws.Name))
 				}
 			}
 		}(i)


### PR DESCRIPTION
# Workspace target rename leftover
## Description

Workspace target rename leftover

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
