### PR TITLE
refactor: fix passing ctx and config params naming

### DIFF
--- a/pkg/cmd/build/run.go
+++ b/pkg/cmd/build/run.go
@@ -45,7 +45,7 @@ var buildRunCmd = &cobra.Command{
 			return errors.New("The chosen workspace config does not have a build configuration")
 		}
 
-		chosenBranch, err := create.GetBranchFromWorkspaceConfig(workspaceConfig, apiClient, 0)
+		chosenBranch, err := create.GetBranchFromWorkspaceConfig(ctx, workspaceConfig, apiClient, 0)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/prebuild/add.go
+++ b/pkg/cmd/prebuild/add.go
@@ -75,7 +75,7 @@ var prebuildAddCmd = &cobra.Command{
 				return errors.New("The chosen workspace config does not have a build configuration")
 			}
 
-			chosenBranch, err := create.GetBranchFromWorkspaceConfig(workspaceConfig, apiClient, 0)
+			chosenBranch, err := create.GetBranchFromWorkspaceConfig(ctx, workspaceConfig, apiClient, 0)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/workspace/create/branch_wizard.go
+++ b/pkg/cmd/workspace/create/branch_wizard.go
@@ -17,7 +17,7 @@ import (
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
-type BranchWizardConfig struct {
+type BranchWizardParams struct {
 	ApiClient           *apiclient.APIClient
 	GitProviderConfigId string
 	NamespaceId         string
@@ -27,7 +27,7 @@ type BranchWizardConfig struct {
 	ProviderId          string
 }
 
-func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, error) {
+func SetBranchFromWizard(params BranchWizardParams) (*apiclient.GitRepository, error) {
 	var branchList []apiclient.GitBranch
 	var checkoutOptions []selection.CheckoutOption
 	page := int32(1)
@@ -37,7 +37,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	ctx := context.Background()
 
 	err = views_util.WithSpinner("Loading", func() error {
-		branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
+		branches, _, err := params.ApiClient.GitProviderAPI.GetRepoBranches(ctx, params.GitProviderConfigId, url.QueryEscape(params.NamespaceId), url.QueryEscape(params.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 		if err != nil {
 			return err
 		}
@@ -55,9 +55,9 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	}
 
 	if len(branchList) == 1 {
-		config.ChosenRepo.Branch = branchList[0].Name
-		config.ChosenRepo.Sha = branchList[0].Sha
-		return config.ChosenRepo, nil
+		params.ChosenRepo.Branch = branchList[0].Name
+		params.ChosenRepo.Sha = branchList[0].Sha
+		return params.ChosenRepo, nil
 	}
 
 	var prList []apiclient.GitPullRequest
@@ -66,7 +66,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 	perPage = 1
 
 	err = views_util.WithSpinner("Loading", func() error {
-		prs, _, err := config.ApiClient.GitProviderAPI.GetRepoPRs(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
+		prs, _, err := params.ApiClient.GitProviderAPI.GetRepoPRs(ctx, params.GitProviderConfigId, url.QueryEscape(params.NamespaceId), url.QueryEscape(params.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 		if err != nil {
 			return err
 		}
@@ -79,20 +79,20 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 		return nil, err
 	}
 
-	namespace := config.Namespace
+	namespace := params.Namespace
 	if namespace == "" {
-		namespace = config.ChosenRepo.Owner
+		namespace = params.ChosenRepo.Owner
 	}
-	parentIdentifier := fmt.Sprintf("%s/%s/%s", config.ProviderId, namespace, config.ChosenRepo.Name)
+	parentIdentifier := fmt.Sprintf("%s/%s/%s", params.ProviderId, namespace, params.ChosenRepo.Name)
 	if len(prList) == 0 {
-		return runGetBranchFromPromptWithPagination(ctx, config, parentIdentifier, 1, 100)
+		return runGetBranchFromPromptWithPagination(ctx, params, parentIdentifier, 1, 100)
 	}
 
 	checkoutOptions = append(checkoutOptions, selection.CheckoutDefault)
 	checkoutOptions = append(checkoutOptions, selection.CheckoutBranch)
 	checkoutOptions = append(checkoutOptions, selection.CheckoutPR)
 
-	chosenCheckoutOption := selection.GetCheckoutOptionFromPrompt(config.WorkspaceOrder, checkoutOptions, parentIdentifier)
+	chosenCheckoutOption := selection.GetCheckoutOptionFromPrompt(params.WorkspaceOrder, checkoutOptions, parentIdentifier)
 
 	if chosenCheckoutOption == (selection.CheckoutOption{}) {
 		return nil, common.ErrCtrlCAbort
@@ -100,20 +100,20 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 
 	if chosenCheckoutOption == selection.CheckoutDefault {
 		// Get the default branch from context
-		repo, res, err := config.ApiClient.GitProviderAPI.GetGitContext(ctx).Repository(apiclient.GetRepositoryContext{
-			Url: config.ChosenRepo.Url,
+		repo, res, err := params.ApiClient.GitProviderAPI.GetGitContext(ctx).Repository(apiclient.GetRepositoryContext{
+			Url: params.ChosenRepo.Url,
 		}).Execute()
 		if err != nil {
 			return nil, apiclient_util.HandleErrorResponse(res, err)
 		}
 
-		config.ChosenRepo.Branch = repo.Branch
+		params.ChosenRepo.Branch = repo.Branch
 
-		return config.ChosenRepo, nil
+		return params.ChosenRepo, nil
 	}
 
 	if chosenCheckoutOption == selection.CheckoutBranch {
-		return runGetBranchFromPromptWithPagination(ctx, config, parentIdentifier, 1, 100)
+		return runGetBranchFromPromptWithPagination(ctx, params, parentIdentifier, 1, 100)
 	} else if chosenCheckoutOption == selection.CheckoutPR {
 		page = 1
 		perPage = 100
@@ -124,7 +124,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 
 		for {
 			err = views_util.WithSpinner("Loading Pull Requests", func() error {
-				branches, _, err := config.ApiClient.GitProviderAPI.GetRepoBranches(ctx, config.GitProviderConfigId, url.QueryEscape(config.NamespaceId), url.QueryEscape(config.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
+				branches, _, err := params.ApiClient.GitProviderAPI.GetRepoBranches(ctx, params.GitProviderConfigId, url.QueryEscape(params.NamespaceId), url.QueryEscape(params.ChosenRepo.Id)).Page(page).PerPage(perPage).Execute()
 				if err != nil {
 					return err
 				}
@@ -139,7 +139,7 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 			}
 
 			// Check first if the git provider supports pagination
-			if isGitProviderWithUnsupportedPagination(config.ProviderId) {
+			if isGitProviderWithUnsupportedPagination(params.ProviderId) {
 				disablePagination = true
 			} else {
 				// Check if we have reached the end of the list
@@ -154,21 +154,21 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 			}
 
 			// User will either choose a PR or navigate the pages
-			chosenPullRequest, navigate := selection.GetPullRequestFromPrompt(prList, config.WorkspaceOrder, selectionListOptions)
+			chosenPullRequest, navigate := selection.GetPullRequestFromPrompt(prList, params.WorkspaceOrder, selectionListOptions)
 			if !disablePagination && navigate != "" {
 				if navigate == views.ListNavigationText {
 					page++
 					continue
 				}
 			} else if chosenPullRequest != nil {
-				config.ChosenRepo.Branch = chosenPullRequest.Branch
-				config.ChosenRepo.Sha = chosenPullRequest.Sha
-				config.ChosenRepo.Id = chosenPullRequest.SourceRepoId
-				config.ChosenRepo.Name = chosenPullRequest.SourceRepoName
-				config.ChosenRepo.Owner = chosenPullRequest.SourceRepoOwner
-				config.ChosenRepo.Url = chosenPullRequest.SourceRepoUrl
+				params.ChosenRepo.Branch = chosenPullRequest.Branch
+				params.ChosenRepo.Sha = chosenPullRequest.Sha
+				params.ChosenRepo.Id = chosenPullRequest.SourceRepoId
+				params.ChosenRepo.Name = chosenPullRequest.SourceRepoName
+				params.ChosenRepo.Owner = chosenPullRequest.SourceRepoOwner
+				params.ChosenRepo.Url = chosenPullRequest.SourceRepoUrl
 
-				return config.ChosenRepo, nil
+				return params.ChosenRepo, nil
 			} else {
 				// If user aborts or there's no selection
 				return nil, errors.New("must select a pull request")
@@ -176,10 +176,10 @@ func SetBranchFromWizard(config BranchWizardConfig) (*apiclient.GitRepository, e
 		}
 	}
 
-	return config.ChosenRepo, nil
+	return params.ChosenRepo, nil
 }
 
-func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWizardConfig, parentIdentifier string, page, perPage int32) (*apiclient.GitRepository, error) {
+func runGetBranchFromPromptWithPagination(ctx context.Context, config BranchWizardParams, parentIdentifier string, page, perPage int32) (*apiclient.GitRepository, error) {
 	var branchList []apiclient.GitBranch
 	disablePagination := false
 	curPageItemsNum := 0

--- a/pkg/cmd/workspace/create/cmd.go
+++ b/pkg/cmd/workspace/create/cmd.go
@@ -89,7 +89,7 @@ var CreateCmd = &cobra.Command{
 		}
 
 		if promptUsingTUI {
-			err = ProcessPrompting(ctx, ProcessPromptingConfig{
+			err = ProcessPrompting(ctx, ProcessPromptingParams{
 				ApiClient:                   apiClient,
 				CreateWorkspaceDtos:         &createWorkspaceDtos,
 				ExistingWorkspaces:          &existingWorkspaces,
@@ -106,7 +106,7 @@ var CreateCmd = &cobra.Command{
 				}
 			}
 		} else {
-			existingWorkspaceConfigNames, err = ProcessCmdArguments(ctx, ProcessCmdArgumentsConfig{
+			existingWorkspaceConfigNames, err = ProcessCmdArguments(ctx, ProcessCmdArgumentsParams{
 				ApiClient:                   apiClient,
 				RepoUrls:                    args,
 				CreateWorkspaceDtos:         &createWorkspaceDtos,

--- a/pkg/cmd/workspace/create/creation_data.go
+++ b/pkg/cmd/workspace/create/creation_data.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 )
 
-type WorkspacesDataPromptConfig struct {
+type WorkspacesDataPromptParams struct {
 	UserGitProviders    []apiclient.GitProvider
 	WorkspaceConfigs    []apiclient.WorkspaceConfig
 	Manual              bool
@@ -35,13 +35,13 @@ type WorkspacesDataPromptConfig struct {
 	Defaults            *views_util.WorkspaceConfigDefaults
 }
 
-func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]apiclient.CreateWorkspaceDTO, error) {
+func GetWorkspacesCreationDataFromPrompt(ctx context.Context, params WorkspacesDataPromptParams) ([]apiclient.CreateWorkspaceDTO, error) {
 	var workspaceList []apiclient.CreateWorkspaceDTO
 	// keep track of visited repos, will help in keeping workspace names unique
 	// since these are later saved into the db under a unique constraint field.
 	selectedRepos := make(map[string]int)
 
-	for i := 1; config.MultiWorkspace || i == 1; i++ {
+	for i := 1; params.MultiWorkspace || i == 1; i++ {
 		var err error
 
 		if i > 2 {
@@ -54,8 +54,8 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 			}
 		}
 
-		if len(config.WorkspaceConfigs) > 0 && !config.BlankWorkspace {
-			workspaceConfig := selection.GetWorkspaceConfigFromPrompt(config.WorkspaceConfigs, i, true, false, "Use")
+		if len(params.WorkspaceConfigs) > 0 && !params.BlankWorkspace {
+			workspaceConfig := selection.GetWorkspaceConfigFromPrompt(params.WorkspaceConfigs, i, true, false, "Use")
 			if workspaceConfig == nil {
 				return nil, common.ErrCtrlCAbort
 			}
@@ -78,7 +78,7 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 					Url: workspaceConfig.RepositoryUrl,
 				}
 
-				branch, err := GetBranchFromWorkspaceConfig(workspaceConfig, config.ApiClient, i)
+				branch, err := GetBranchFromWorkspaceConfig(ctx, workspaceConfig, params.ApiClient, i)
 				if err != nil {
 					return nil, err
 				}
@@ -88,7 +88,7 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 					getRepoContext.Sha = &branch.Sha
 				}
 
-				configRepo, res, err := config.ApiClient.GitProviderAPI.GetGitContext(context.Background()).Repository(getRepoContext).Execute()
+				configRepo, res, err := params.ApiClient.GitProviderAPI.GetGitContext(ctx).Repository(getRepoContext).Execute()
 				if err != nil {
 					return nil, apiclient_util.HandleErrorResponse(res, err)
 				}
@@ -100,8 +100,8 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 						Repository: *configRepo,
 					},
 					BuildConfig: workspaceConfig.BuildConfig,
-					Image:       config.Defaults.Image,
-					User:        config.Defaults.ImageUser,
+					Image:       params.Defaults.Image,
+					User:        params.Defaults.ImageUser,
 					EnvVars:     workspaceConfig.EnvVars,
 				}
 
@@ -114,7 +114,7 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 				}
 
 				if workspaceConfig.GitProviderConfigId == nil || *workspaceConfig.GitProviderConfigId == "" {
-					gitProviderConfigId, res, err := config.ApiClient.GitProviderAPI.GetGitProviderIdForUrl(context.Background(), url.QueryEscape(workspaceConfig.RepositoryUrl)).Execute()
+					gitProviderConfigId, res, err := params.ApiClient.GitProviderAPI.GetGitProviderIdForUrl(ctx, url.QueryEscape(workspaceConfig.RepositoryUrl)).Execute()
 					if err != nil {
 						return nil, apiclient_util.HandleErrorResponse(res, err)
 					}
@@ -126,12 +126,12 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 			}
 		}
 
-		providerRepo, gitProviderConfigId, err := getRepositoryFromWizard(RepositoryWizardConfig{
-			ApiClient:           config.ApiClient,
-			UserGitProviders:    config.UserGitProviders,
-			Manual:              config.Manual,
-			MultiWorkspace:      config.MultiWorkspace,
-			SkipBranchSelection: config.SkipBranchSelection,
+		providerRepo, gitProviderConfigId, err := getRepositoryFromWizard(ctx, RepositoryWizardParams{
+			ApiClient:           params.ApiClient,
+			UserGitProviders:    params.UserGitProviders,
+			Manual:              params.Manual,
+			MultiWorkspace:      params.MultiWorkspace,
+			SkipBranchSelection: params.SkipBranchSelection,
 			WorkspaceOrder:      i,
 			SelectedRepos:       selectedRepos,
 		})
@@ -140,7 +140,7 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 		}
 
 		if gitProviderConfigId == selection.CustomRepoIdentifier || gitProviderConfigId == selection.CREATE_FROM_SAMPLE {
-			gitProviderConfigs, res, err := config.ApiClient.GitProviderAPI.ListGitProvidersForUrl(context.Background(), url.QueryEscape(providerRepo.Url)).Execute()
+			gitProviderConfigs, res, err := params.ApiClient.GitProviderAPI.ListGitProvidersForUrl(ctx, url.QueryEscape(providerRepo.Url)).Execute()
 			if err != nil {
 				return nil, apiclient_util.HandleErrorResponse(res, err)
 			}
@@ -164,7 +164,7 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 		getRepoContext := createGetRepoContextFromRepository(providerRepo)
 
 		var res *http.Response
-		providerRepo, res, err = config.ApiClient.GitProviderAPI.GetGitContext(context.Background()).Repository(getRepoContext).Execute()
+		providerRepo, res, err = params.ApiClient.GitProviderAPI.GetGitContext(ctx).Repository(getRepoContext).Execute()
 		if err != nil {
 			return nil, apiclient_util.HandleErrorResponse(res, err)
 		}
@@ -174,7 +174,7 @@ func GetWorkspacesCreationDataFromPrompt(config WorkspacesDataPromptConfig) ([]a
 			return nil, err
 		}
 
-		workspaceList = append(workspaceList, newCreateWorkspaceConfigDTO(config, providerRepo, providerRepoName, gitProviderConfigId))
+		workspaceList = append(workspaceList, newCreateWorkspaceConfigDTO(params, providerRepo, providerRepoName, gitProviderConfigId))
 	}
 
 	return workspaceList, nil
@@ -212,9 +212,7 @@ func GetSanitizedWorkspaceName(workspaceName string) (string, error) {
 	return workspaceName, nil
 }
 
-func GetBranchFromWorkspaceConfig(workspaceConfig *apiclient.WorkspaceConfig, apiClient *apiclient.APIClient, workspaceOrder int) (*apiclient.GitBranch, error) {
-	ctx := context.Background()
-
+func GetBranchFromWorkspaceConfig(ctx context.Context, workspaceConfig *apiclient.WorkspaceConfig, apiClient *apiclient.APIClient, workspaceOrder int) (*apiclient.GitBranch, error) {
 	encodedURLParam := url.QueryEscape(workspaceConfig.RepositoryUrl)
 
 	repoResponse, res, err := apiClient.GitProviderAPI.GetGitContext(ctx).Repository(apiclient.GetRepositoryContext{
@@ -229,7 +227,7 @@ func GetBranchFromWorkspaceConfig(workspaceConfig *apiclient.WorkspaceConfig, ap
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	branchWizardConfig := BranchWizardConfig{
+	branchWizardConfig := BranchWizardParams{
 		ApiClient:           apiClient,
 		GitProviderConfigId: gitProviderConfigId,
 		NamespaceId:         repoResponse.Owner,
@@ -315,7 +313,7 @@ func GetGitProviderConfigIdFromFlag(ctx context.Context, apiClient *apiclient.AP
 	return nil, fmt.Errorf("git provider config '%s' not found", *gitProviderConfigFlag)
 }
 
-func newCreateWorkspaceConfigDTO(config WorkspacesDataPromptConfig, providerRepo *apiclient.GitRepository, providerRepoName string, gitProviderConfigId string) apiclient.CreateWorkspaceDTO {
+func newCreateWorkspaceConfigDTO(config WorkspacesDataPromptParams, providerRepo *apiclient.GitRepository, providerRepoName string, gitProviderConfigId string) apiclient.CreateWorkspaceDTO {
 	workspace := apiclient.CreateWorkspaceDTO{
 		Name:                providerRepoName,
 		GitProviderConfigId: &gitProviderConfigId,

--- a/pkg/cmd/workspace/create/creation_data.go
+++ b/pkg/cmd/workspace/create/creation_data.go
@@ -313,7 +313,7 @@ func GetGitProviderConfigIdFromFlag(ctx context.Context, apiClient *apiclient.AP
 	return nil, fmt.Errorf("git provider config '%s' not found", *gitProviderConfigFlag)
 }
 
-func newCreateWorkspaceConfigDTO(config WorkspacesDataPromptParams, providerRepo *apiclient.GitRepository, providerRepoName string, gitProviderConfigId string) apiclient.CreateWorkspaceDTO {
+func newCreateWorkspaceConfigDTO(params WorkspacesDataPromptParams, providerRepo *apiclient.GitRepository, providerRepoName string, gitProviderConfigId string) apiclient.CreateWorkspaceDTO {
 	workspace := apiclient.CreateWorkspaceDTO{
 		Name:                providerRepoName,
 		GitProviderConfigId: &gitProviderConfigId,
@@ -321,8 +321,8 @@ func newCreateWorkspaceConfigDTO(config WorkspacesDataPromptParams, providerRepo
 			Repository: *providerRepo,
 		},
 		BuildConfig: &apiclient.BuildConfig{},
-		Image:       config.Defaults.Image,
-		User:        config.Defaults.ImageUser,
+		Image:       params.Defaults.Image,
+		User:        params.Defaults.ImageUser,
 		EnvVars:     map[string]string{},
 	}
 

--- a/pkg/cmd/workspace/create/process_cmd_arguments.go
+++ b/pkg/cmd/workspace/create/process_cmd_arguments.go
@@ -17,7 +17,7 @@ import (
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 )
 
-type ProcessCmdArgumentsConfig struct {
+type ProcessCmdArgumentsParams struct {
 	ApiClient                   *apiclient.APIClient
 	RepoUrls                    []string
 	CreateWorkspaceDtos         *[]apiclient.CreateWorkspaceDTO
@@ -26,7 +26,7 @@ type ProcessCmdArgumentsConfig struct {
 	BlankFlag                   bool
 }
 
-type ProcessGitUrlConfig struct {
+type ProcessGitUrlParams struct {
 	ApiClient                   *apiclient.APIClient
 	RepoUrl                     string
 	CreateWorkspaceDtos         *[]apiclient.CreateWorkspaceDTO
@@ -35,16 +35,16 @@ type ProcessGitUrlConfig struct {
 	BlankFlag                   bool
 }
 
-func ProcessCmdArguments(ctx context.Context, config ProcessCmdArgumentsConfig) ([]string, error) {
-	if len(config.RepoUrls) == 0 {
+func ProcessCmdArguments(ctx context.Context, params ProcessCmdArgumentsParams) ([]string, error) {
+	if len(params.RepoUrls) == 0 {
 		return nil, fmt.Errorf("no repository URLs provided")
 	}
 
-	if len(config.RepoUrls) > 1 && workspace_common.CheckAnyWorkspaceConfigurationFlagSet(config.WorkspaceConfigurationFlags) {
+	if len(params.RepoUrls) > 1 && workspace_common.CheckAnyWorkspaceConfigurationFlagSet(params.WorkspaceConfigurationFlags) {
 		return nil, fmt.Errorf("can't set custom workspace configuration properties for multiple workspaces")
 	}
 
-	if *config.WorkspaceConfigurationFlags.Builder != "" && *config.WorkspaceConfigurationFlags.Builder != views_util.DEVCONTAINER && *config.WorkspaceConfigurationFlags.DevcontainerPath != "" {
+	if *params.WorkspaceConfigurationFlags.Builder != "" && *params.WorkspaceConfigurationFlags.Builder != views_util.DEVCONTAINER && *params.WorkspaceConfigurationFlags.DevcontainerPath != "" {
 		return nil, fmt.Errorf("can't set devcontainer file path if builder is not set to %s", views_util.DEVCONTAINER)
 	}
 
@@ -52,22 +52,22 @@ func ProcessCmdArguments(ctx context.Context, config ProcessCmdArgumentsConfig) 
 
 	existingWorkspaceConfigNames := []string{}
 
-	for i, repoUrl := range config.RepoUrls {
+	for i, repoUrl := range params.RepoUrls {
 		var branch *string
-		if len(*config.WorkspaceConfigurationFlags.Branches) > i {
-			branch = &(*config.WorkspaceConfigurationFlags.Branches)[i]
+		if len(*params.WorkspaceConfigurationFlags.Branches) > i {
+			branch = &(*params.WorkspaceConfigurationFlags.Branches)[i]
 		}
 
 		validatedUrl, err := util.GetValidatedUrl(repoUrl)
 		if err == nil {
 			// The argument is a Git URL
-			existingWorkspaceConfigName, err := processGitURL(ctx, ProcessGitUrlConfig{
-				ApiClient:                   config.ApiClient,
+			existingWorkspaceConfigName, err := processGitURL(ctx, ProcessGitUrlParams{
+				ApiClient:                   params.ApiClient,
 				RepoUrl:                     validatedUrl,
-				CreateWorkspaceDtos:         config.CreateWorkspaceDtos,
-				WorkspaceConfigurationFlags: config.WorkspaceConfigurationFlags,
+				CreateWorkspaceDtos:         params.CreateWorkspaceDtos,
+				WorkspaceConfigurationFlags: params.WorkspaceConfigurationFlags,
 				Branch:                      branch,
-				BlankFlag:                   config.BlankFlag,
+				BlankFlag:                   params.BlankFlag,
 			})
 			if err != nil {
 				return nil, err
@@ -82,12 +82,17 @@ func ProcessCmdArguments(ctx context.Context, config ProcessCmdArgumentsConfig) 
 		}
 
 		// The argument is not a Git URL - try getting the workspace config
-		workspaceConfig, _, err = config.ApiClient.WorkspaceConfigAPI.GetWorkspaceConfig(ctx, repoUrl).Execute()
+		workspaceConfig, _, err = params.ApiClient.WorkspaceConfigAPI.GetWorkspaceConfig(ctx, repoUrl).Execute()
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse the URL or fetch the workspace config for '%s'", repoUrl)
 		}
 
-		existingWorkspaceConfigName, err := AddWorkspaceFromConfig(workspaceConfig, config.ApiClient, config.CreateWorkspaceDtos, branch)
+		existingWorkspaceConfigName, err := AddWorkspaceFromConfig(ctx, AddWorkspaceFromConfigParams{
+			WorkspaceConfig: workspaceConfig,
+			ApiClient:       params.ApiClient,
+			Workspaces:      params.CreateWorkspaceDtos,
+			BranchFlag:      branch,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -98,20 +103,25 @@ func ProcessCmdArguments(ctx context.Context, config ProcessCmdArgumentsConfig) 
 		}
 	}
 
-	generateWorkspaceIds(config.CreateWorkspaceDtos)
-	setInitialWorkspaceNames(config.CreateWorkspaceDtos, *config.ExistingWorkspaces)
+	generateWorkspaceIds(params.CreateWorkspaceDtos)
+	setInitialWorkspaceNames(params.CreateWorkspaceDtos, *params.ExistingWorkspaces)
 
 	return existingWorkspaceConfigNames, nil
 }
 
-func processGitURL(ctx context.Context, config ProcessGitUrlConfig) (*string, error) {
-	encodedURLParam := url.QueryEscape(config.RepoUrl)
+func processGitURL(ctx context.Context, params ProcessGitUrlParams) (*string, error) {
+	encodedURLParam := url.QueryEscape(params.RepoUrl)
 
-	if !config.BlankFlag {
-		workspaceConfig, res, err := config.ApiClient.WorkspaceConfigAPI.GetDefaultWorkspaceConfig(ctx, encodedURLParam).Execute()
+	if !params.BlankFlag {
+		workspaceConfig, res, err := params.ApiClient.WorkspaceConfigAPI.GetDefaultWorkspaceConfig(ctx, encodedURLParam).Execute()
 		if err == nil {
-			workspaceConfig.GitProviderConfigId = config.WorkspaceConfigurationFlags.GitProviderConfig
-			return AddWorkspaceFromConfig(workspaceConfig, config.ApiClient, config.CreateWorkspaceDtos, config.Branch)
+			workspaceConfig.GitProviderConfigId = params.WorkspaceConfigurationFlags.GitProviderConfig
+			return AddWorkspaceFromConfig(ctx, AddWorkspaceFromConfigParams{
+				WorkspaceConfig: workspaceConfig,
+				ApiClient:       params.ApiClient,
+				Workspaces:      params.CreateWorkspaceDtos,
+				BranchFlag:      params.Branch,
+			})
 		}
 
 		if res.StatusCode != http.StatusNotFound {
@@ -119,9 +129,9 @@ func processGitURL(ctx context.Context, config ProcessGitUrlConfig) (*string, er
 		}
 	}
 
-	repo, res, err := config.ApiClient.GitProviderAPI.GetGitContext(ctx).Repository(apiclient.GetRepositoryContext{
-		Url:    config.RepoUrl,
-		Branch: config.Branch,
+	repo, res, err := params.ApiClient.GitProviderAPI.GetGitContext(ctx).Repository(apiclient.GetRepositoryContext{
+		Url:    params.RepoUrl,
+		Branch: params.Branch,
 	}).Execute()
 	if err != nil {
 		return nil, apiclient_util.HandleErrorResponse(res, err)
@@ -132,27 +142,27 @@ func processGitURL(ctx context.Context, config ProcessGitUrlConfig) (*string, er
 		return nil, err
 	}
 
-	config.WorkspaceConfigurationFlags.GitProviderConfig, err = GetGitProviderConfigIdFromFlag(ctx, config.ApiClient, config.WorkspaceConfigurationFlags.GitProviderConfig)
+	params.WorkspaceConfigurationFlags.GitProviderConfig, err = GetGitProviderConfigIdFromFlag(ctx, params.ApiClient, params.WorkspaceConfigurationFlags.GitProviderConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	gitProviderConfigs, res, err := config.ApiClient.GitProviderAPI.ListGitProvidersForUrl(context.Background(), url.QueryEscape(config.RepoUrl)).Execute()
+	gitProviderConfigs, res, err := params.ApiClient.GitProviderAPI.ListGitProvidersForUrl(ctx, url.QueryEscape(params.RepoUrl)).Execute()
 	if err != nil {
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
 	if len(gitProviderConfigs) == 1 {
-		config.WorkspaceConfigurationFlags.GitProviderConfig = &gitProviderConfigs[0].Id
+		params.WorkspaceConfigurationFlags.GitProviderConfig = &gitProviderConfigs[0].Id
 	} else if len(gitProviderConfigs) > 1 {
 		gp := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
 			GitProviderConfigs: gitProviderConfigs,
 			ActionVerb:         "Use",
 		})
-		config.WorkspaceConfigurationFlags.GitProviderConfig = &gp.Id
+		params.WorkspaceConfigurationFlags.GitProviderConfig = &gp.Id
 	}
 
-	workspace, err := GetCreateWorkspaceDtoFromFlags(config.WorkspaceConfigurationFlags)
+	workspace, err := GetCreateWorkspaceDtoFromFlags(params.WorkspaceConfigurationFlags)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +172,7 @@ func processGitURL(ctx context.Context, config ProcessGitUrlConfig) (*string, er
 		Repository: *repo,
 	}
 
-	*config.CreateWorkspaceDtos = append(*config.CreateWorkspaceDtos, *workspace)
+	*params.CreateWorkspaceDtos = append(*params.CreateWorkspaceDtos, *workspace)
 
 	return nil, nil
 }

--- a/pkg/cmd/workspace/create/process_prompting.go
+++ b/pkg/cmd/workspace/create/process_prompting.go
@@ -15,7 +15,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views/workspace/create"
 )
 
-type ProcessPromptingConfig struct {
+type ProcessPromptingParams struct {
 	ApiClient                   *apiclient.APIClient
 	CreateWorkspaceDtos         *[]apiclient.CreateWorkspaceDTO
 	ExistingWorkspaces          *[]apiclient.WorkspaceDTO
@@ -25,7 +25,7 @@ type ProcessPromptingConfig struct {
 	TargetName                  string
 }
 
-func ProcessPrompting(ctx context.Context, config ProcessPromptingConfig) error {
+func ProcessPrompting(ctx context.Context, config ProcessPromptingParams) error {
 	if workspace_common.CheckAnyWorkspaceConfigurationFlagSet(config.WorkspaceConfigurationFlags) || (config.WorkspaceConfigurationFlags.Branches != nil && len(*config.WorkspaceConfigurationFlags.Branches) > 0) {
 		return errors.New("please provide the repository URL in order to set up custom workspace details through the CLI")
 	}
@@ -40,7 +40,7 @@ func ProcessPrompting(ctx context.Context, config ProcessPromptingConfig) error 
 		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	apiServerConfig, res, err := config.ApiClient.ServerAPI.GetConfig(context.Background()).Execute()
+	apiServerConfig, res, err := config.ApiClient.ServerAPI.GetConfig(ctx).Execute()
 	if err != nil {
 		return apiclient_util.HandleErrorResponse(res, err)
 	}
@@ -52,7 +52,7 @@ func ProcessPrompting(ctx context.Context, config ProcessPromptingConfig) error 
 		DevcontainerFilePath: create.DEVCONTAINER_FILEPATH,
 	}
 
-	*config.CreateWorkspaceDtos, err = GetWorkspacesCreationDataFromPrompt(WorkspacesDataPromptConfig{
+	*config.CreateWorkspaceDtos, err = GetWorkspacesCreationDataFromPrompt(ctx, WorkspacesDataPromptParams{
 		UserGitProviders: gitProviders,
 		WorkspaceConfigs: workspaceConfigs,
 		Manual:           *config.WorkspaceConfigurationFlags.Manual,
@@ -69,7 +69,7 @@ func ProcessPrompting(ctx context.Context, config ProcessPromptingConfig) error 
 	generateWorkspaceIds(config.CreateWorkspaceDtos)
 	setInitialWorkspaceNames(config.CreateWorkspaceDtos, *config.ExistingWorkspaces)
 
-	submissionFormConfig := create.SubmissionFormConfig{
+	submissionFormConfig := create.SubmissionFormParams{
 		ChosenName:    &config.TargetName,
 		WorkspaceList: config.CreateWorkspaceDtos,
 		NameLabel:     config.TargetName,

--- a/pkg/cmd/workspaceconfig/add.go
+++ b/pkg/cmd/workspaceconfig/add.go
@@ -89,7 +89,7 @@ func RunWorkspaceConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []ap
 		DevcontainerFilePath: create.DEVCONTAINER_FILEPATH,
 	}
 
-	createDtos, err = create_cmd.GetWorkspacesCreationDataFromPrompt(create_cmd.WorkspacesDataPromptConfig{
+	createDtos, err = create_cmd.GetWorkspacesCreationDataFromPrompt(ctx, create_cmd.WorkspacesDataPromptParams{
 		UserGitProviders:    gitProviders,
 		Manual:              *workspaceConfigurationFlags.Manual,
 		MultiWorkspace:      false,
@@ -123,7 +123,7 @@ func RunWorkspaceConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []ap
 
 	chosenName := create_cmd.GetSuggestedName(initialSuggestion, existingWorkspaceConfigNames)
 
-	submissionFormConfig := create.SubmissionFormConfig{
+	submissionFormConfig := create.SubmissionFormParams{
 		ChosenName:             &chosenName,
 		SuggestedName:          chosenName,
 		ExistingWorkspaceNames: existingWorkspaceConfigNames,

--- a/pkg/views/workspace/create/summary.go
+++ b/pkg/views/workspace/create/summary.go
@@ -43,7 +43,7 @@ type SummaryModel struct {
 	nameLabel     string
 }
 
-type SubmissionFormConfig struct {
+type SubmissionFormParams struct {
 	ChosenName             *string
 	SuggestedName          string
 	WorkspaceList          *[]apiclient.CreateWorkspaceDTO
@@ -56,10 +56,10 @@ var doneCheck bool
 var userCancelled bool
 var WorkspacesConfigurationChanged bool
 
-func RunSubmissionForm(config SubmissionFormConfig) error {
+func RunSubmissionForm(params SubmissionFormParams) error {
 	doneCheck = true
 
-	m := NewSummaryModel(config)
+	m := NewSummaryModel(params)
 
 	if _, err := tea.NewProgram(m, tea.WithAltScreen()).Run(); err != nil {
 		return err
@@ -73,17 +73,17 @@ func RunSubmissionForm(config SubmissionFormConfig) error {
 		return nil
 	}
 
-	if config.Defaults.Image == nil || config.Defaults.ImageUser == nil {
+	if params.Defaults.Image == nil || params.Defaults.ImageUser == nil {
 		return errors.New("default workspace entries are not set")
 	}
 
 	var err error
-	WorkspacesConfigurationChanged, err = RunWorkspaceConfiguration(config.WorkspaceList, *config.Defaults)
+	WorkspacesConfigurationChanged, err = RunWorkspaceConfiguration(params.WorkspaceList, *params.Defaults)
 	if err != nil {
 		return err
 	}
 
-	return RunSubmissionForm(config)
+	return RunSubmissionForm(params)
 }
 
 func RenderSummary(name string, workspaceList []apiclient.CreateWorkspaceDTO, defaults *views_util.WorkspaceConfigDefaults, nameLabel string) (string, error) {
@@ -160,16 +160,16 @@ func workspaceDetailOutput(workspaceDetailKey WorkspaceDetail, workspaceDetailVa
 	return fmt.Sprintf("\t%s%-*s%s", lipgloss.NewStyle().Foreground(views.Green).Render(string(workspaceDetailKey)), DEFAULT_PADDING-len(string(workspaceDetailKey)), EMPTY_STRING, workspaceDetailValue)
 }
 
-func NewSummaryModel(config SubmissionFormConfig) SummaryModel {
+func NewSummaryModel(params SubmissionFormParams) SummaryModel {
 	m := SummaryModel{width: maxWidth}
 	m.lg = lipgloss.DefaultRenderer()
 	m.styles = NewStyles(m.lg)
-	m.workspaceList = *config.WorkspaceList
-	m.defaults = config.Defaults
-	m.nameLabel = config.NameLabel
+	m.workspaceList = *params.WorkspaceList
+	m.defaults = params.Defaults
+	m.nameLabel = params.NameLabel
 
-	if config.ChosenName != nil && *config.ChosenName == "" {
-		*config.ChosenName = config.SuggestedName
+	if params.ChosenName != nil && *params.ChosenName == "" {
+		*params.ChosenName = params.SuggestedName
 	}
 
 	m.form = huh.NewForm(


### PR DESCRIPTION
# Fix passing ctx and config params naming
## Description

Fixes passing the context to certain functions and improves naming consistency for "Params" types

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation