### PR TITLE
fix: remove env vars input char limit

### DIFF
--- a/pkg/views/common.go
+++ b/pkg/views/common.go
@@ -160,6 +160,7 @@ func GetEnvVarsInput(envVars *map[string]string) *huh.Text {
 	return huh.NewText().
 		Title("Environment Variables").
 		Description("Enter environment variables in the format KEY=VALUE\nTo pass machine env variables at runtime, use $VALUE").
+		CharLimit(-1).
 		Value(&inputText).
 		Validate(func(str string) error {
 			tempEnvVars := map[string]string{}


### PR DESCRIPTION
# remove env vars input char limit

## Description

This PR removes env vars input character limit.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1316

