### PR TITLE
Fix: Randomization of Daytona Provider Install

### DIFF
--- a/pkg/cmd/provider/install.go
+++ b/pkg/cmd/provider/install.go
@@ -188,6 +188,16 @@ func GetProviderListFromManifest(manifest *manager.ProvidersManifest) []apiclien
 		}
 	}
 
+	slices.SortFunc(providerList, func(a, b apiclient.Provider) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+
 	return providerList
 }
 


### PR DESCRIPTION
## Description

This PR fixes the randomization of `daytona provider install` by sorting in ascending order by provider names.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1335 

## Screenshots
![image](https://github.com/user-attachments/assets/fedffba8-c6af-47c1-b42e-9e464fdde06a)

