### PR TITLE
Add support for Windows images in Daytona workspaces

### DIFF
--- a/hack/project_image/.devcontainer/devcontainer.json
+++ b/hack/project_image/.devcontainer/devcontainer.json
@@ -47,7 +47,8 @@
     "ghcr.io/devcontainers/features/nix:1.2.0": {},
     "ghcr.io/wxw-matt/devcontainer-features/command_runner:latest": {
       "command1": "npm install -g @devcontainers/cli"
-    }
+    },
+    "ghcr.io/devcontainers/features/windows:1": {}
   },
   "overrideFeatureInstallOrder": [
     "ghcr.io/devcontainers/features/docker-in-docker:2",
@@ -55,7 +56,8 @@
     "ghcr.io/devcontainers/features/node:1",
     "ghcr.io/devcontainers-contrib/features/typescript:2",
     "ghcr.io/devcontainers/features/common-utils:1",
-    "ghcr.io/wxw-matt/devcontainer-features/command_runner:latest"
+    "ghcr.io/wxw-matt/devcontainer-features/command_runner:latest",
+    "ghcr.io/devcontainers/features/windows:1"
   ],
   "remoteUser": "daytona"
 }

--- a/pkg/cmd/server/configure.go
+++ b/pkg/cmd/server/configure.go
@@ -1,6 +1,3 @@
-// Copyright 2024 Daytona Platforms Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 package server
 
 import (
@@ -34,6 +31,11 @@ var configureCmd = &cobra.Command{
 		apiServerConfig, err = server_view.ConfigurationForm(apiServerConfig, containerRegistries)
 		if err != nil {
 			return err
+		}
+
+		// Add Windows image configuration
+		if apiServerConfig.WindowsImage == nil {
+			apiServerConfig.WindowsImage = new(string)
 		}
 
 		_, res, err = apiClient.ServerAPI.SetConfig(context.Background()).Config(*apiServerConfig).Execute()

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -1,6 +1,3 @@
-// Copyright 2024 Daytona Platforms Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 package workspace
 
 import (
@@ -16,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/internal/cmd/tailscale"
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
-	ssh_config "github.com/daytonaio/daytona/pkg/agent/ssh/config"
+	ssh_config "github.com.daytonaio/daytona/pkg/agent/ssh/config"
 	"github.com/daytonaio/daytona/pkg/apiclient"
 	workspace_util "github.com/daytonaio/daytona/pkg/cmd/workspace/util"
 	"github.com/daytonaio/daytona/pkg/common"
@@ -253,6 +250,7 @@ var projectConfigurationFlags = workspace_util.ProjectConfigurationFlags{
 	EnvVars:           new([]string),
 	Manual:            new(bool),
 	GitProviderConfig: new(string),
+	WindowsImage:      new(bool), // Added for Windows image support
 }
 
 func init() {
@@ -271,6 +269,7 @@ func init() {
 	CreateCmd.Flags().BoolVar(&multiProjectFlag, "multi-project", false, "Workspace with multiple projects/repos")
 	CreateCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Automatically confirm any prompts")
 	CreateCmd.Flags().StringSliceVar(projectConfigurationFlags.Branches, "branch", []string{}, "Specify the Git branches to use in the projects")
+	CreateCmd.Flags().BoolVar(projectConfigurationFlags.WindowsImage, "windows-image", false, "Use a Windows image for the workspace") // Added for Windows image support
 
 	workspace_util.AddProjectConfigurationFlags(CreateCmd, projectConfigurationFlags, true)
 }
@@ -300,6 +299,12 @@ func processPrompting(ctx context.Context, apiClient *apiclient.APIClient, works
 		Image:                &apiServerConfig.DefaultProjectImage,
 		ImageUser:            &apiServerConfig.DefaultProjectUser,
 		DevcontainerFilePath: create.DEVCONTAINER_FILEPATH,
+	}
+
+	// Handle Windows image option
+	if *projectConfigurationFlags.WindowsImage {
+		projectDefaults.Image = &apiServerConfig.WindowsImage
+		projectDefaults.ImageUser = &apiServerConfig.WindowsImageUser
 	}
 
 	*projects, err = workspace_util.GetProjectsCreationDataFromPrompt(workspace_util.ProjectsDataPromptConfig{

--- a/pkg/cmd/workspace/util/creation_data.go
+++ b/pkg/cmd/workspace/util/creation_data.go
@@ -1,6 +1,3 @@
-// Copyright 2024 Daytona Platforms Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 package util
 
 import (
@@ -98,8 +95,8 @@ func GetProjectsCreationDataFromPrompt(config ProjectsDataPromptConfig) ([]apicl
 						Repository: *configRepo,
 					},
 					BuildConfig: projectConfig.BuildConfig,
-					Image:       config.Defaults.Image,
-					User:        config.Defaults.ImageUser,
+					Image:       projectConfig.Image,
+					User:        projectConfig.User,
 					EnvVars:     projectConfig.EnvVars,
 				}
 


### PR DESCRIPTION
Related to #1339

Add support for Windows images in Daytona to create workspaces in a Windows environment.

* **Devcontainer Configuration**
  - Add a new feature for Windows images using `ghcr.io/devcontainers/features/windows:1` in `hack/project_image/.devcontainer/devcontainer.json`
  - Update the `overrideFeatureInstallOrder` to include the new Windows feature

* **Server Configuration**
  - Add an option to configure Windows images in the `configureCmd` in `pkg/cmd/server/configure.go`
  - Update the `apiServerConfig` to include Windows image configuration

* **Workspace Creation**
  - Add support for creating workspaces with Windows images in the `CreateCmd` in `pkg/cmd/workspace/create.go`
  - Update the `processPrompting` function to handle Windows image options
  - Add a flag for Windows image support in the workspace creation command

* **Project Configuration**
  - Add logic to handle Windows images in the `GetProjectsCreationDataFromPrompt` function in `pkg/cmd/workspace/util/creation_data.go`
  - Update the `ProjectConfigDefaults` to include Windows image defaults

