### PR TITLE
feat: custom builder image

### DIFF
--- a/hack/project_image/Dockerfile
+++ b/hack/project_image/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:22.04
 
 RUN apt update -y && \
-    apt install curl libgit2-1.1 -y
+    apt install curl socat libgit2-1.1 -y
 
 USER daytona
 

--- a/internal/testing/server/workspaces/mocks/provisioner.go
+++ b/internal/testing/server/workspaces/mocks/provisioner.go
@@ -8,9 +8,8 @@ package mocks
 import (
 	"context"
 
-	"github.com/daytonaio/daytona/pkg/containerregistry"
-	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/provider"
+	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/daytonaio/daytona/pkg/workspace/project"
 	"github.com/stretchr/testify/mock"
@@ -24,8 +23,8 @@ func NewMockProvisioner() *mockProvisioner {
 	return &mockProvisioner{}
 }
 
-func (p *mockProvisioner) CreateProject(proj *project.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry, gc *gitprovider.GitProviderConfig) error {
-	args := p.Called(proj, target, cr, gc)
+func (p *mockProvisioner) CreateProject(params provisioner.ProjectParams) error {
+	args := p.Called(params)
 	return args.Error(0)
 }
 
@@ -49,8 +48,8 @@ func (p *mockProvisioner) GetWorkspaceInfo(ctx context.Context, w *workspace.Wor
 	return args.Get(0).(*workspace.WorkspaceInfo), args.Error(1)
 }
 
-func (p *mockProvisioner) StartProject(proj *project.Project, target *provider.ProviderTarget) error {
-	args := p.Called(proj, target)
+func (p *mockProvisioner) StartProject(params provisioner.ProjectParams) error {
+	args := p.Called(params)
 	return args.Error(0)
 }
 

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -20,15 +20,16 @@ type IBuilder interface {
 }
 
 type Builder struct {
-	id                  string
-	projectDir          string
-	image               string
-	containerRegistry   *containerregistry.ContainerRegistry
-	buildStore          Store
-	buildImageNamespace string
-	loggerFactory       logs.LoggerFactory
-	defaultProjectImage string
-	defaultProjectUser  string
+	id                          string
+	projectDir                  string
+	image                       string
+	containerRegistry           *containerregistry.ContainerRegistry
+	buildImageContainerRegistry *containerregistry.ContainerRegistry
+	buildStore                  Store
+	buildImageNamespace         string
+	loggerFactory               logs.LoggerFactory
+	defaultProjectImage         string
+	defaultProjectUser          string
 }
 
 func (b *Builder) GetImageName(build Build) (string, error) {
@@ -43,7 +44,7 @@ func (b *Builder) GetImageName(build Build) (string, error) {
 	name := hex.EncodeToString(nameBytes[:])[:16]
 
 	namespace := b.buildImageNamespace
-	imageName := fmt.Sprintf("%s%s/p-%s:%s", b.containerRegistry.Server, namespace, name, tag)
+	imageName := fmt.Sprintf("%s%s/p-%s:%s", b.buildImageContainerRegistry.Server, namespace, name, tag)
 
 	return imageName, nil
 }

--- a/pkg/build/factory.go
+++ b/pkg/build/factory.go
@@ -19,34 +19,37 @@ type IBuilderFactory interface {
 }
 
 type BuilderFactory struct {
-	containerRegistry   *containerregistry.ContainerRegistry
-	buildImageNamespace string
-	buildStore          Store
-	loggerFactory       logs.LoggerFactory
-	image               string
-	defaultProjectImage string
-	defaultProjectUser  string
+	containerRegistry           *containerregistry.ContainerRegistry
+	buildImageContainerRegistry *containerregistry.ContainerRegistry
+	buildImageNamespace         string
+	buildStore                  Store
+	loggerFactory               logs.LoggerFactory
+	image                       string
+	defaultProjectImage         string
+	defaultProjectUser          string
 }
 
 type BuilderFactoryConfig struct {
-	Image               string
-	ContainerRegistry   *containerregistry.ContainerRegistry
-	BuildStore          Store
-	BuildImageNamespace string // Namespace to be used when tagging and pushing the build image
-	LoggerFactory       logs.LoggerFactory
-	DefaultProjectImage string
-	DefaultProjectUser  string
+	Image                       string
+	ContainerRegistry           *containerregistry.ContainerRegistry
+	BuildImageContainerRegistry *containerregistry.ContainerRegistry
+	BuildStore                  Store
+	BuildImageNamespace         string // Namespace to be used when tagging and pushing the build image
+	LoggerFactory               logs.LoggerFactory
+	DefaultProjectImage         string
+	DefaultProjectUser          string
 }
 
 func NewBuilderFactory(config BuilderFactoryConfig) IBuilderFactory {
 	return &BuilderFactory{
-		image:               config.Image,
-		containerRegistry:   config.ContainerRegistry,
-		buildImageNamespace: config.BuildImageNamespace,
-		buildStore:          config.BuildStore,
-		loggerFactory:       config.LoggerFactory,
-		defaultProjectImage: config.DefaultProjectImage,
-		defaultProjectUser:  config.DefaultProjectUser,
+		image:                       config.Image,
+		containerRegistry:           config.ContainerRegistry,
+		buildImageNamespace:         config.BuildImageNamespace,
+		buildImageContainerRegistry: config.BuildImageContainerRegistry,
+		buildStore:                  config.BuildStore,
+		loggerFactory:               config.LoggerFactory,
+		defaultProjectImage:         config.DefaultProjectImage,
+		defaultProjectUser:          config.DefaultProjectUser,
 	}
 }
 
@@ -85,15 +88,16 @@ func (f *BuilderFactory) newDevcontainerBuilder(projectDir string) (*Devcontaine
 
 	return &DevcontainerBuilder{
 		Builder: &Builder{
-			id:                  id,
-			projectDir:          projectDir,
-			image:               f.image,
-			containerRegistry:   f.containerRegistry,
-			buildImageNamespace: f.buildImageNamespace,
-			buildStore:          f.buildStore,
-			loggerFactory:       f.loggerFactory,
-			defaultProjectImage: f.defaultProjectImage,
-			defaultProjectUser:  f.defaultProjectUser,
+			id:                          id,
+			projectDir:                  projectDir,
+			image:                       f.image,
+			containerRegistry:           f.containerRegistry,
+			buildImageContainerRegistry: f.buildImageContainerRegistry,
+			buildImageNamespace:         f.buildImageNamespace,
+			buildStore:                  f.buildStore,
+			loggerFactory:               f.loggerFactory,
+			defaultProjectImage:         f.defaultProjectImage,
+			defaultProjectUser:          f.defaultProjectUser,
 		},
 		builderDockerPort: builderDockerPort,
 	}, nil

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -20,12 +20,14 @@ import (
 )
 
 type CreateProjectOptions struct {
-	Project    *project.Project
-	ProjectDir string
-	Cr         *containerregistry.ContainerRegistry
-	LogWriter  io.Writer
-	Gpc        *gitprovider.GitProviderConfig
-	SshClient  *ssh.Client
+	Project                  *project.Project
+	ProjectDir               string
+	ContainerRegistry        *containerregistry.ContainerRegistry
+	LogWriter                io.Writer
+	Gpc                      *gitprovider.GitProviderConfig
+	SshClient                *ssh.Client
+	BuilderImage             string
+	BuilderContainerRegistry *containerregistry.ContainerRegistry
 }
 
 type IDockerClient interface {

--- a/pkg/docker/create_image.go
+++ b/pkg/docker/create_image.go
@@ -22,7 +22,7 @@ func (d *DockerClient) createProjectFromImage(opts *CreateProjectOptions, pulled
 		return d.initProjectContainer(opts)
 	}
 
-	err := d.PullImage(opts.Project.Image, opts.Cr, opts.LogWriter)
+	err := d.PullImage(opts.Project.Image, opts.ContainerRegistry, opts.LogWriter)
 	if err != nil {
 		return err
 	}

--- a/pkg/docker/create_test.go
+++ b/pkg/docker/create_test.go
@@ -100,12 +100,13 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 	).Return(container.CreateResponse{ID: "123"}, nil)
 
 	err := s.dockerClient.CreateProject(&docker.CreateProjectOptions{
-		Project:    project1,
-		ProjectDir: projectDir,
-		Cr:         nil,
-		LogWriter:  nil,
-		Gpc:        nil,
-		SshClient:  nil,
+		Project:           project1,
+		ProjectDir:        projectDir,
+		ContainerRegistry: nil,
+		LogWriter:         nil,
+		Gpc:               nil,
+		SshClient:         nil,
+		BuilderImage:      "daytonaio/workspace-project",
 	})
 	require.Nil(s.T(), err)
 }

--- a/pkg/docker/start_devcontainer.go
+++ b/pkg/docker/start_devcontainer.go
@@ -24,7 +24,7 @@ func (d *DockerClient) startDevcontainerProject(opts *CreateProjectOptions) (Rem
 }
 
 func (d *DockerClient) runDevcontainerUserCommands(opts *CreateProjectOptions) error {
-	socketForwardId, err := d.ensureDockerSockForward(opts.LogWriter)
+	socketForwardId, err := d.ensureDockerSockForward(opts.BuilderImage, opts.BuilderContainerRegistry, opts.LogWriter)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -37,10 +37,12 @@ type WorkspaceRequest struct {
 }
 
 type ProjectRequest struct {
-	TargetOptions     string
-	ContainerRegistry *containerregistry.ContainerRegistry
-	Project           *project.Project
-	GitProviderConfig *gitprovider.GitProviderConfig
+	TargetOptions            string
+	ContainerRegistry        *containerregistry.ContainerRegistry
+	Project                  *project.Project
+	GitProviderConfig        *gitprovider.GitProviderConfig
+	BuilderImage             string
+	BuilderContainerRegistry *containerregistry.ContainerRegistry
 }
 
 type ProviderTarget struct {

--- a/pkg/provisioner/create.go
+++ b/pkg/provisioner/create.go
@@ -4,11 +4,8 @@
 package provisioner
 
 import (
-	"github.com/daytonaio/daytona/pkg/containerregistry"
-	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/workspace"
-	"github.com/daytonaio/daytona/pkg/workspace/project"
 )
 
 func (p *Provisioner) CreateWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error {
@@ -25,17 +22,19 @@ func (p *Provisioner) CreateWorkspace(workspace *workspace.Workspace, target *pr
 	return err
 }
 
-func (p *Provisioner) CreateProject(proj *project.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry, gc *gitprovider.GitProviderConfig) error {
-	targetProvider, err := p.providerManager.GetProvider(target.ProviderInfo.Name)
+func (p *Provisioner) CreateProject(params ProjectParams) error {
+	targetProvider, err := p.providerManager.GetProvider(params.Target.ProviderInfo.Name)
 	if err != nil {
 		return err
 	}
 
 	_, err = (*targetProvider).CreateProject(&provider.ProjectRequest{
-		TargetOptions:     target.Options,
-		Project:           proj,
-		ContainerRegistry: cr,
-		GitProviderConfig: gc,
+		TargetOptions:            params.Target.Options,
+		Project:                  params.Project,
+		ContainerRegistry:        params.ContainerRegistry,
+		GitProviderConfig:        params.GitProviderConfig,
+		BuilderImage:             params.BuilderImage,
+		BuilderContainerRegistry: params.BuilderImageContainerRegistry,
 	})
 
 	return err

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -14,13 +14,22 @@ import (
 	"github.com/daytonaio/daytona/pkg/workspace/project"
 )
 
+type ProjectParams struct {
+	Project                       *project.Project
+	Target                        *provider.ProviderTarget
+	ContainerRegistry             *containerregistry.ContainerRegistry
+	GitProviderConfig             *gitprovider.GitProviderConfig
+	BuilderImage                  string
+	BuilderImageContainerRegistry *containerregistry.ContainerRegistry
+}
+
 type IProvisioner interface {
-	CreateProject(project *project.Project, target *provider.ProviderTarget, cr *containerregistry.ContainerRegistry, gc *gitprovider.GitProviderConfig) error
+	CreateProject(params ProjectParams) error
 	CreateWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error
 	DestroyProject(project *project.Project, target *provider.ProviderTarget) error
 	DestroyWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error
 	GetWorkspaceInfo(ctx context.Context, workspace *workspace.Workspace, target *provider.ProviderTarget) (*workspace.WorkspaceInfo, error)
-	StartProject(project *project.Project, target *provider.ProviderTarget) error
+	StartProject(params ProjectParams) error
 	StartWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error
 	StopProject(project *project.Project, target *provider.ProviderTarget) error
 	StopWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error

--- a/pkg/provisioner/start.go
+++ b/pkg/provisioner/start.go
@@ -6,7 +6,6 @@ package provisioner
 import (
 	"github.com/daytonaio/daytona/pkg/provider"
 	"github.com/daytonaio/daytona/pkg/workspace"
-	"github.com/daytonaio/daytona/pkg/workspace/project"
 )
 
 func (p *Provisioner) StartWorkspace(workspace *workspace.Workspace, target *provider.ProviderTarget) error {
@@ -23,15 +22,19 @@ func (p *Provisioner) StartWorkspace(workspace *workspace.Workspace, target *pro
 	return err
 }
 
-func (p *Provisioner) StartProject(proj *project.Project, target *provider.ProviderTarget) error {
-	targetProvider, err := p.providerManager.GetProvider(target.ProviderInfo.Name)
+func (p *Provisioner) StartProject(params ProjectParams) error {
+	targetProvider, err := p.providerManager.GetProvider(params.Target.ProviderInfo.Name)
 	if err != nil {
 		return err
 	}
 
 	_, err = (*targetProvider).StartProject(&provider.ProjectRequest{
-		TargetOptions: target.Options,
-		Project:       proj,
+		TargetOptions:            params.Target.Options,
+		Project:                  params.Project,
+		ContainerRegistry:        params.ContainerRegistry,
+		GitProviderConfig:        params.GitProviderConfig,
+		BuilderImage:             params.BuilderImage,
+		BuilderContainerRegistry: params.BuilderImageContainerRegistry,
 	})
 
 	return err

--- a/pkg/server/registry/service.go
+++ b/pkg/server/registry/service.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/daytonaio/daytona/pkg/containerregistry"
 	"github.com/daytonaio/daytona/pkg/docker"
 	"github.com/daytonaio/daytona/pkg/frpc"
 	"github.com/daytonaio/daytona/pkg/server"
@@ -25,32 +26,35 @@ import (
 const registryContainerName = "daytona-registry"
 
 type LocalContainerRegistryConfig struct {
-	DataPath string
-	Port     uint32
-	Image    string
-	Logger   io.Writer
-	Frps     *server.FRPSConfig
-	ServerId string
+	DataPath          string
+	Port              uint32
+	Image             string
+	ContainerRegistry *containerregistry.ContainerRegistry
+	Logger            io.Writer
+	Frps              *server.FRPSConfig
+	ServerId          string
 }
 
 func NewLocalContainerRegistry(config *LocalContainerRegistryConfig) *LocalContainerRegistry {
 	return &LocalContainerRegistry{
-		dataPath: config.DataPath,
-		port:     config.Port,
-		image:    config.Image,
-		logger:   config.Logger,
-		frps:     config.Frps,
-		serverId: config.ServerId,
+		dataPath:          config.DataPath,
+		port:              config.Port,
+		image:             config.Image,
+		containerRegistry: config.ContainerRegistry,
+		logger:            config.Logger,
+		frps:              config.Frps,
+		serverId:          config.ServerId,
 	}
 }
 
 type LocalContainerRegistry struct {
-	dataPath string
-	port     uint32
-	image    string
-	logger   io.Writer
-	frps     *server.FRPSConfig
-	serverId string
+	dataPath          string
+	port              uint32
+	image             string
+	containerRegistry *containerregistry.ContainerRegistry
+	logger            io.Writer
+	frps              *server.FRPSConfig
+	serverId          string
 }
 
 func (s *LocalContainerRegistry) Start() error {
@@ -91,7 +95,7 @@ func (s *LocalContainerRegistry) Start() error {
 	}
 
 	// Pull the image
-	err = dockerClient.PullImage(s.image, nil, s.logger)
+	err = dockerClient.PullImage(s.image, s.containerRegistry, s.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/workspaces/service.go
+++ b/pkg/server/workspaces/service.go
@@ -53,6 +53,7 @@ type WorkspaceServiceConfig struct {
 	Provisioner              provisioner.IProvisioner
 	DefaultProjectImage      string
 	DefaultProjectUser       string
+	BuilderImage             string
 	ApiKeyService            apikeys.IApiKeyService
 	LoggerFactory            logs.LoggerFactory
 	GitProviderService       gitproviders.IGitProviderService
@@ -76,6 +77,7 @@ func NewWorkspaceService(config WorkspaceServiceConfig) IWorkspaceService {
 		apiKeyService:            config.ApiKeyService,
 		gitProviderService:       config.GitProviderService,
 		telemetryService:         config.TelemetryService,
+		builderImage:             config.BuilderImage,
 	}
 }
 
@@ -92,6 +94,7 @@ type WorkspaceService struct {
 	serverVersion            string
 	defaultProjectImage      string
 	defaultProjectUser       string
+	builderImage             string
 	loggerFactory            logs.LoggerFactory
 	gitProviderService       gitproviders.IGitProviderService
 	telemetryService         telemetry.TelemetryService

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -18,8 +18,10 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/logs"
 	"github.com/daytonaio/daytona/pkg/provider"
+	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/server/workspaces"
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
+	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/daytonaio/daytona/pkg/workspace/project"
 	"github.com/stretchr/testify/mock"
@@ -28,6 +30,7 @@ import (
 
 const serverApiUrl = "http://localhost:3986"
 const serverUrl = "http://localhost:3987"
+const serverVersion = "0.0.0-test"
 const defaultProjectUser = "daytona"
 const defaultProjectImage = "daytonaio/workspace-project:latest"
 
@@ -90,6 +93,9 @@ var workspaceInfo = workspace.WorkspaceInfo{
 }
 
 func TestWorkspaceService(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, telemetry.CLIENT_ID_CONTEXT_KEY, "test")
+
 	workspaceStore := t_workspaces.NewInMemoryWorkspaceStore()
 
 	containerRegistryService := mocks.NewMockContainerRegistryService()
@@ -102,7 +108,7 @@ func TestWorkspaceService(t *testing.T) {
 
 	apiKeyService := mocks.NewMockApiKeyService()
 	gitProviderService := mocks.NewMockGitProviderService()
-	provisioner := mocks.NewMockProvisioner()
+	mockProvisioner := mocks.NewMockProvisioner()
 
 	wsLogsDir := t.TempDir()
 	buildLogsDir := t.TempDir()
@@ -112,12 +118,14 @@ func TestWorkspaceService(t *testing.T) {
 		TargetStore:              targetStore,
 		ServerApiUrl:             serverApiUrl,
 		ServerUrl:                serverUrl,
+		ServerVersion:            serverVersion,
 		ContainerRegistryService: containerRegistryService,
 		ProjectConfigService:     projectConfigService,
 		DefaultProjectImage:      defaultProjectImage,
 		DefaultProjectUser:       defaultProjectUser,
+		BuilderImage:             defaultProjectImage,
 		ApiKeyService:            apiKeyService,
-		Provisioner:              provisioner,
+		Provisioner:              mockProvisioner,
 		LoggerFactory:            logs.NewLoggerFactory(&wsLogsDir, &buildLogsDir),
 		GitProviderService:       gitProviderService,
 	})
@@ -127,8 +135,8 @@ func TestWorkspaceService(t *testing.T) {
 
 		containerRegistryService.On("FindByImageName", defaultProjectImage).Return(containerRegistry, containerregistry.ErrContainerRegistryNotFound)
 
-		provisioner.On("CreateWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("CreateWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
 
 		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceDto.Id).Return(createWorkspaceDto.Id, nil)
 		gitProviderService.On("GetLastCommitSha", createWorkspaceDto.Projects[0].Source.Repository).Return("123", nil)
@@ -136,12 +144,46 @@ func TestWorkspaceService(t *testing.T) {
 		for _, project := range createWorkspaceDto.Projects {
 			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceDto.Id, project.Name)).Return(project.Name, nil)
 		}
-		provisioner.On("CreateProject", mock.Anything, &target, containerRegistry, &gitProviderConfig).Return(nil)
-		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
+
+		proj := &project.Project{
+			Name:                createWorkspaceDto.Projects[0].Name,
+			Image:               *createWorkspaceDto.Projects[0].Image,
+			User:                *createWorkspaceDto.Projects[0].User,
+			BuildConfig:         createWorkspaceDto.Projects[0].BuildConfig,
+			Repository:          createWorkspaceDto.Projects[0].Source.Repository,
+			ApiKey:              createWorkspaceDto.Projects[0].Name,
+			GitProviderConfigId: createWorkspaceDto.Projects[0].GitProviderConfigId,
+			WorkspaceId:         createWorkspaceDto.Id,
+			Target:              createWorkspaceDto.Target,
+		}
+
+		proj.EnvVars = project.GetProjectEnvVars(proj, project.ProjectEnvVarParams{
+			ApiUrl:        serverApiUrl,
+			ServerUrl:     serverUrl,
+			ServerVersion: serverVersion,
+			ClientId:      "test",
+		}, false)
+
+		mockProvisioner.On("CreateProject", provisioner.ProjectParams{
+			Project:                       proj,
+			Target:                        &target,
+			ContainerRegistry:             containerRegistry,
+			GitProviderConfig:             &gitProviderConfig,
+			BuilderImage:                  defaultProjectImage,
+			BuilderImageContainerRegistry: containerRegistry,
+		}).Return(nil)
+		mockProvisioner.On("StartProject", provisioner.ProjectParams{
+			Project:                       proj,
+			Target:                        &target,
+			ContainerRegistry:             containerRegistry,
+			GitProviderConfig:             &gitProviderConfig,
+			BuilderImage:                  defaultProjectImage,
+			BuilderImageContainerRegistry: containerRegistry,
+		}).Return(nil)
 
 		gitProviderService.On("GetConfig", "github").Return(&gitProviderConfig, nil)
 
-		workspace, err := service.CreateWorkspace(context.TODO(), createWorkspaceDto)
+		workspace, err := service.CreateWorkspace(ctx, createWorkspaceDto)
 
 		require.Nil(t, err)
 		require.NotNil(t, workspace)
@@ -150,7 +192,7 @@ func TestWorkspaceService(t *testing.T) {
 	})
 
 	t.Run("CreateWorkspace fails when workspace already exists", func(t *testing.T) {
-		_, err := service.CreateWorkspace(context.TODO(), createWorkspaceDto)
+		_, err := service.CreateWorkspace(ctx, createWorkspaceDto)
 		require.NotNil(t, err)
 		require.Equal(t, workspaces.ErrWorkspaceAlreadyExists, err)
 	})
@@ -159,15 +201,15 @@ func TestWorkspaceService(t *testing.T) {
 		invalidWorkspaceRequest := createWorkspaceDto
 		invalidWorkspaceRequest.Name = "invalid name"
 
-		_, err := service.CreateWorkspace(context.TODO(), invalidWorkspaceRequest)
+		_, err := service.CreateWorkspace(ctx, invalidWorkspaceRequest)
 		require.NotNil(t, err)
 		require.Equal(t, workspaces.ErrInvalidWorkspaceName, err)
 	})
 
 	t.Run("GetWorkspace", func(t *testing.T) {
-		provisioner.On("GetWorkspaceInfo", mock.Anything, mock.Anything, &target).Return(&workspaceInfo, nil)
+		mockProvisioner.On("GetWorkspaceInfo", mock.Anything, mock.Anything, &target).Return(&workspaceInfo, nil)
 
-		workspace, err := service.GetWorkspace(context.TODO(), createWorkspaceDto.Id, true)
+		workspace, err := service.GetWorkspace(ctx, createWorkspaceDto.Id, true)
 
 		require.Nil(t, err)
 		require.NotNil(t, workspace)
@@ -176,16 +218,16 @@ func TestWorkspaceService(t *testing.T) {
 	})
 
 	t.Run("GetWorkspace fails when workspace not found", func(t *testing.T) {
-		_, err := service.GetWorkspace(context.TODO(), "invalid-id", true)
+		_, err := service.GetWorkspace(ctx, "invalid-id", true)
 		require.NotNil(t, err)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
 
 	t.Run("ListWorkspaces", func(t *testing.T) {
 		verbose := false
-		provisioner.On("GetWorkspaceInfo", mock.Anything, mock.Anything, &target).Return(&workspaceInfo, nil)
+		mockProvisioner.On("GetWorkspaceInfo", mock.Anything, mock.Anything, &target).Return(&workspaceInfo, nil)
 
-		workspaces, err := service.ListWorkspaces(context.TODO(), verbose)
+		workspaces, err := service.ListWorkspaces(ctx, verbose)
 
 		require.Nil(t, err)
 		require.Len(t, workspaces, 1)
@@ -197,9 +239,9 @@ func TestWorkspaceService(t *testing.T) {
 
 	t.Run("ListWorkspaces - verbose", func(t *testing.T) {
 		verbose := true
-		provisioner.On("GetWorkspaceInfo", mock.Anything, mock.Anything, &target).Return(&workspaceInfo, nil)
+		mockProvisioner.On("GetWorkspaceInfo", mock.Anything, mock.Anything, &target).Return(&workspaceInfo, nil)
 
-		workspaces, err := service.ListWorkspaces(context.TODO(), verbose)
+		workspaces, err := service.ListWorkspaces(ctx, verbose)
 
 		require.Nil(t, err)
 		require.Len(t, workspaces, 1)
@@ -210,87 +252,72 @@ func TestWorkspaceService(t *testing.T) {
 	})
 
 	t.Run("StartWorkspace", func(t *testing.T) {
-		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StartProject", mock.Anything).Return(nil)
 
-		err := service.StartWorkspace(context.TODO(), createWorkspaceDto.Id)
+		err := service.StartWorkspace(ctx, createWorkspaceDto.Id)
 
 		require.Nil(t, err)
 	})
 
 	t.Run("StartProject", func(t *testing.T) {
-		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StartProject", mock.Anything).Return(nil)
 
-		err := service.StartProject(context.TODO(), createWorkspaceDto.Id, createWorkspaceDto.Projects[0].Name)
+		err := service.StartProject(ctx, createWorkspaceDto.Id, createWorkspaceDto.Projects[0].Name)
 
 		require.Nil(t, err)
 	})
 
 	t.Run("StopWorkspace", func(t *testing.T) {
-		provisioner.On("StopWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("StopProject", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StopWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StopProject", mock.Anything, &target).Return(nil)
 
-		err := service.StopWorkspace(context.TODO(), createWorkspaceDto.Id)
+		err := service.StopWorkspace(ctx, createWorkspaceDto.Id)
 
 		require.Nil(t, err)
 	})
 
 	t.Run("StopProject", func(t *testing.T) {
-		provisioner.On("StopWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("StopProject", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StopWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("StopProject", mock.Anything, &target).Return(nil)
 
-		err := service.StopProject(context.TODO(), createWorkspaceDto.Id, createWorkspaceDto.Projects[0].Name)
+		err := service.StopProject(ctx, createWorkspaceDto.Id, createWorkspaceDto.Projects[0].Name)
 
 		require.Nil(t, err)
 	})
 
 	t.Run("RemoveWorkspace", func(t *testing.T) {
-		provisioner.On("DestroyWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("DestroyProject", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("DestroyWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("DestroyProject", mock.Anything, &target).Return(nil)
 		apiKeyService.On("Revoke", mock.Anything).Return(nil)
 
-		err := service.RemoveWorkspace(context.TODO(), createWorkspaceDto.Id)
+		err := service.RemoveWorkspace(ctx, createWorkspaceDto.Id)
 
 		require.Nil(t, err)
 
-		_, err = service.GetWorkspace(context.TODO(), createWorkspaceDto.Id, true)
+		_, err = service.GetWorkspace(ctx, createWorkspaceDto.Id, true)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
 
 	t.Run("ForceRemoveWorkspace", func(t *testing.T) {
-		var containerRegistry *containerregistry.ContainerRegistry
+		err := workspaceStore.Save(&workspace.Workspace{Id: createWorkspaceDto.Id, Target: target.Name})
+		require.Nil(t, err)
 
-		provisioner.On("CreateWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("StartWorkspace", mock.Anything, &target).Return(nil)
-
-		apiKeyService.On("Generate", apikey.ApiKeyTypeWorkspace, createWorkspaceDto.Id).Return(createWorkspaceDto.Id, nil)
-		gitProviderService.On("GetLastCommitSha", createWorkspaceDto.Projects[0].Source.Repository).Return("123", nil)
-
-		gitProviderService.On("ListConfigsForUrl", "https://github.com/daytonaio/daytona").Return([]*gitprovider.GitProviderConfig{&gitProviderConfig}, nil)
-
-		for _, project := range createWorkspaceDto.Projects {
-			apiKeyService.On("Generate", apikey.ApiKeyTypeProject, fmt.Sprintf("%s/%s", createWorkspaceDto.Id, project.Name)).Return(project.Name, nil)
-		}
-		provisioner.On("CreateProject", mock.Anything, &target, containerRegistry, &gitProviderConfig).Return(nil)
-		provisioner.On("StartProject", mock.Anything, &target).Return(nil)
-
-		_, _ = service.CreateWorkspace(context.TODO(), createWorkspaceDto)
-
-		provisioner.On("DestroyWorkspace", mock.Anything, &target).Return(nil)
-		provisioner.On("DestroyProject", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("DestroyWorkspace", mock.Anything, &target).Return(nil)
+		mockProvisioner.On("DestroyProject", mock.Anything, &target).Return(nil)
 		apiKeyService.On("Revoke", mock.Anything).Return(nil)
 
-		err = service.ForceRemoveWorkspace(context.TODO(), createWorkspaceDto.Id)
+		err = service.ForceRemoveWorkspace(ctx, createWorkspaceDto.Id)
 
 		require.Nil(t, err)
 
-		_, err = service.GetWorkspace(context.TODO(), createWorkspaceDto.Id, true)
+		_, err = service.GetWorkspace(ctx, createWorkspaceDto.Id, true)
 		require.Equal(t, workspaces.ErrWorkspaceNotFound, err)
 	})
 
 	t.Run("SetProjectState", func(t *testing.T) {
-		ws, err := service.CreateWorkspace(context.TODO(), createWorkspaceDto)
+		ws, err := service.CreateWorkspace(ctx, createWorkspaceDto)
 		require.Nil(t, err)
 
 		projectName := ws.Projects[0].Name
@@ -311,7 +338,7 @@ func TestWorkspaceService(t *testing.T) {
 
 	t.Cleanup(func() {
 		apiKeyService.AssertExpectations(t)
-		provisioner.AssertExpectations(t)
+		mockProvisioner.AssertExpectations(t)
 	})
 }
 

--- a/pkg/server/workspaces/start.go
+++ b/pkg/server/workspaces/start.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/daytonaio/daytona/pkg/containerregistry"
+	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/logs"
 	"github.com/daytonaio/daytona/pkg/provider"
+	"github.com/daytonaio/daytona/pkg/provisioner"
 	"github.com/daytonaio/daytona/pkg/telemetry"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/daytonaio/daytona/pkg/workspace/project"
@@ -119,7 +122,33 @@ func (s *WorkspaceService) startProject(ctx context.Context, p *project.Project,
 		ClientId:      telemetry.ClientId(ctx),
 	}, telemetry.TelemetryEnabled(ctx))
 
-	err := s.provisioner.StartProject(&projectToStart, target)
+	cr, err := s.containerRegistryService.FindByImageName(p.Image)
+	if err != nil && !containerregistry.IsContainerRegistryNotFound(err) {
+		return err
+	}
+
+	builderCr, err := s.containerRegistryService.FindByImageName(s.builderImage)
+	if err != nil && !containerregistry.IsContainerRegistryNotFound(err) {
+		return err
+	}
+
+	var gc *gitprovider.GitProviderConfig
+
+	if p.GitProviderConfigId != nil {
+		gc, err = s.gitProviderService.GetConfig(*p.GitProviderConfigId)
+		if err != nil && !gitprovider.IsGitProviderNotFound(err) {
+			return err
+		}
+	}
+
+	err = s.provisioner.StartProject(provisioner.ProjectParams{
+		Project:                       &projectToStart,
+		Target:                        target,
+		ContainerRegistry:             cr,
+		GitProviderConfig:             gc,
+		BuilderImage:                  s.builderImage,
+		BuilderImageContainerRegistry: builderCr,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/views/server/configure.go
+++ b/pkg/views/server/configure.go
@@ -86,7 +86,7 @@ func (m *Model) createForm(containerRegistries []apiclient.ContainerRegistry) *h
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Builder Image").
-				Description("Image dependencies: docker, @devcontainers/cli (node package)").
+				Description("Image dependencies: docker, socat, git, @devcontainers/cli (node package)").
 				Value(&m.config.BuilderImage),
 			huh.NewSelect[string]().
 				Title("Builder Registry").


### PR DESCRIPTION
# Custom Builder Image

## Description

Added the option to configure the custom builder image. The option in the server existed before but wasn't used in the entire build process. The image, with the appropriate registry is used in the entire creation process now.

Additionally, added container registry credentials to the local container registry service. If the local registry fails to start, the serve command does not exit. Instead, it prints out the error and lets the user know they should restart the server to restart the registry.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes https://github.com/daytonaio/daytona/issues/1348

## Notes
All providers will need to be updated.