### PR TITLE
fix: run socat container as root

### DIFF
--- a/pkg/docker/create_devcontainer.go
+++ b/pkg/docker/create_devcontainer.go
@@ -349,6 +349,7 @@ func (d *DockerClient) ensureDockerSockForward(builderImage string, builderConta
 	c, err := d.apiClient.ContainerCreate(ctx, &container.Config{
 		Image:      builderImage,
 		Entrypoint: []string{"socat"},
+		User:       "root",
 		Cmd:        []string{"tcp-listen:2375,fork,reuseaddr", "unix-connect:/var/run/docker.sock"},
 	}, &container.HostConfig{
 		Privileged: true,


### PR DESCRIPTION
# Run Socat Container as Root

## Description

Fixes an issue for creating devcontainer on MacOS. The socat container is now ran as the root user.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes
Providers will need to be updated.
