### PR TITLE
fix: implement correct multi-create output

### DIFF
--- a/pkg/api/controllers/workspace/create.go
+++ b/pkg/api/controllers/workspace/create.go
@@ -19,7 +19,7 @@ import (
 //	@Description	Create a workspace
 //	@Param			workspace	body	CreateWorkspaceDTO	true	"Create workspace"
 //	@Produce		json
-//	@Success		200	{object}	Workspace
+//	@Success		200	{object}	WorkspaceDTO
 //	@Router			/workspace [post]
 //
 //	@id				CreateWorkspace

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1513,7 +1513,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/Workspace"
+                            "$ref": "#/definitions/WorkspaceDTO"
                         }
                     }
                 }

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1510,7 +1510,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/Workspace"
+                            "$ref": "#/definitions/WorkspaceDTO"
                         }
                     }
                 }

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -2102,7 +2102,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/Workspace'
+            $ref: '#/definitions/WorkspaceDTO'
       summary: Create a workspace
       tags:
       - workspace

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1078,7 +1078,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workspace'
+                $ref: '#/components/schemas/WorkspaceDTO'
           description: OK
       summary: Create a workspace
       tags:

--- a/pkg/apiclient/api_workspace.go
+++ b/pkg/apiclient/api_workspace.go
@@ -34,7 +34,7 @@ func (r ApiCreateWorkspaceRequest) Workspace(workspace CreateWorkspaceDTO) ApiCr
 	return r
 }
 
-func (r ApiCreateWorkspaceRequest) Execute() (*Workspace, *http.Response, error) {
+func (r ApiCreateWorkspaceRequest) Execute() (*WorkspaceDTO, *http.Response, error) {
 	return r.ApiService.CreateWorkspaceExecute(r)
 }
 
@@ -55,13 +55,13 @@ func (a *WorkspaceAPIService) CreateWorkspace(ctx context.Context) ApiCreateWork
 
 // Execute executes the request
 //
-//	@return Workspace
-func (a *WorkspaceAPIService) CreateWorkspaceExecute(r ApiCreateWorkspaceRequest) (*Workspace, *http.Response, error) {
+//	@return WorkspaceDTO
+func (a *WorkspaceAPIService) CreateWorkspaceExecute(r ApiCreateWorkspaceRequest) (*WorkspaceDTO, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
 		localVarPostBody    interface{}
 		formFiles           []formFile
-		localVarReturnValue *Workspace
+		localVarReturnValue *WorkspaceDTO
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspaceAPIService.CreateWorkspace")

--- a/pkg/apiclient/docs/WorkspaceAPI.md
+++ b/pkg/apiclient/docs/WorkspaceAPI.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 ## CreateWorkspace
 
-> Workspace CreateWorkspace(ctx).Workspace(workspace).Execute()
+> WorkspaceDTO CreateWorkspace(ctx).Workspace(workspace).Execute()
 
 Create a workspace
 
@@ -44,7 +44,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error when calling `WorkspaceAPI.CreateWorkspace``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
 	}
-	// response from `CreateWorkspace`: Workspace
+	// response from `CreateWorkspace`: WorkspaceDTO
 	fmt.Fprintf(os.Stdout, "Response from `WorkspaceAPI.CreateWorkspace`: %v\n", resp)
 }
 ```
@@ -64,7 +64,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Workspace**](Workspace.md)
+[**WorkspaceDTO**](WorkspaceDTO.md)
 
 ### Authorization
 

--- a/pkg/cmd/workspace/create/cmd.go
+++ b/pkg/cmd/workspace/create/cmd.go
@@ -219,7 +219,7 @@ var CreateCmd = &cobra.Command{
 				SkipPrefixLengthSetup: true,
 			})
 
-			_, res, err = apiClient.WorkspaceAPI.CreateWorkspace(ctx).Workspace(createWorkspaceDtos[i]).Execute()
+			_, res, err := apiClient.WorkspaceAPI.CreateWorkspace(ctx).Workspace(createWorkspaceDtos[i]).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
 			}
@@ -264,12 +264,20 @@ var CreateCmd = &cobra.Command{
 
 		fmt.Println()
 
-		ws, _, err := apiclient_util.GetWorkspace(createWorkspaceDtos[0].Id, true)
-		if err != nil {
-			return err
+		createdWorkspaces := []apiclient.WorkspaceDTO{}
+		for _, createWorkspaceDto := range createWorkspaceDtos {
+			ws, _, err := apiclient_util.GetWorkspace(createWorkspaceDto.Id, true)
+			if err != nil {
+				return err
+			}
+			createdWorkspaces = append(createdWorkspaces, *ws)
 		}
 
-		info.Render(ws, chosenIde.Name, false)
+		if len(createdWorkspaces) > 1 {
+			info.RenderMulti(createdWorkspaces, chosenIde.Name, false)
+		} else {
+			info.Render(&createdWorkspaces[0], chosenIde.Name, false)
+		}
 
 		if noIdeFlag {
 			views.RenderCreationInfoMessage("Run 'daytona code' when you're ready to start developing")
@@ -278,7 +286,7 @@ var CreateCmd = &cobra.Command{
 
 		views.RenderCreationInfoMessage(fmt.Sprintf("Opening the workspace in %s ...", chosenIde.Name))
 
-		return cmd_common.OpenIDE(chosenIdeId, activeProfile, createWorkspaceDtos[0].Name, *ws.Info.ProviderMetadata, YesFlag, gpgKey)
+		return cmd_common.OpenIDE(chosenIdeId, activeProfile, createWorkspaceDtos[0].Name, *createdWorkspaces[0].Info.ProviderMetadata, YesFlag, gpgKey)
 	},
 }
 

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -178,7 +178,7 @@ func TestTargetService(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, workspace)
 
-		workspaceEquals(t, ws, workspace, defaultWorkspaceImage)
+		workspaceEquals(t, &services.WorkspaceDTO{Workspace: *ws}, workspace, defaultWorkspaceImage)
 
 		ws.EnvVars = nil
 	})
@@ -305,7 +305,7 @@ func TestTargetService(t *testing.T) {
 	})
 }
 
-func workspaceEquals(t *testing.T, ws1, ws2 *models.Workspace, workspaceImage string) {
+func workspaceEquals(t *testing.T, ws1, ws2 *services.WorkspaceDTO, workspaceImage string) {
 	t.Helper()
 
 	require.Equal(t, ws1.Id, ws2.Id)

--- a/pkg/services/workspace.go
+++ b/pkg/services/workspace.go
@@ -13,7 +13,7 @@ import (
 )
 
 type IWorkspaceService interface {
-	CreateWorkspace(ctx context.Context, req CreateWorkspaceDTO) (*models.Workspace, error)
+	CreateWorkspace(ctx context.Context, req CreateWorkspaceDTO) (*WorkspaceDTO, error)
 	GetWorkspace(ctx context.Context, workspaceId string, params WorkspaceRetrievalParams) (*WorkspaceDTO, error)
 	ListWorkspaces(ctx context.Context, params WorkspaceRetrievalParams) ([]WorkspaceDTO, error)
 	StartWorkspace(ctx context.Context, workspaceId string) error

--- a/pkg/views/workspace/info/multi.go
+++ b/pkg/views/workspace/info/multi.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package info
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/views"
+	"golang.org/x/term"
+)
+
+func RenderMulti(workspaces []apiclient.WorkspaceDTO, ide string, forceUnstyled bool) {
+	var output string
+
+	output += "\n"
+
+	output += getInfoLine("Using Target", workspaces[0].Target.Name) + "\n"
+	output += getInfoLine("Target ID", workspaces[0].TargetId) + "\n"
+
+	output += getInfoLine("Editor", ide) + "\n"
+
+	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		fmt.Println(output)
+		return
+	}
+	if terminalWidth < views.TUITableMinimumWidth || forceUnstyled {
+		renderUnstyledInfo(output)
+		return
+	}
+
+	output += fmt.Sprintf("%s\n\n", views.SeparatorString)
+	for index, workspace := range workspaces {
+		output += getInfoLine(fmt.Sprintf("Workspace #%d", index+1), fmt.Sprintf("%s (%s)", workspace.Name, workspace.Id)) + "\n"
+		output += getSingleWorkspaceOutput(&workspace, true)
+		if index < len(workspaces)-1 {
+			output += fmt.Sprintf("\n%s\n\n", views.SeparatorString)
+		}
+	}
+
+	renderTUIView(output, views.GetContainerBreakpointWidth(terminalWidth), true)
+}

--- a/pkg/views/workspace/list/view.go
+++ b/pkg/views/workspace/list/view.go
@@ -103,10 +103,10 @@ func getTableRowData(workspace apiclient.WorkspaceDTO, specifyGitProviders bool)
 }
 
 func renderUnstyledList(workspaceList []apiclient.WorkspaceDTO) {
-	for _, target := range workspaceList {
-		info_view.Render(&target, "", true)
+	for _, workspace := range workspaceList {
+		info_view.Render(&workspace, "", true)
 
-		if target.Id != workspaceList[len(workspaceList)-1].Id {
+		if workspace.Id != workspaceList[len(workspaceList)-1].Id {
 			fmt.Printf("\n%s\n\n", views.SeparatorString)
 		}
 


### PR DESCRIPTION
# Implement correct multi-create output

## Description

This PR fixes info output of the `daytona create --multi-workspace` command whereas now output is adapted to be similar as it was when daytona was using multi projects.

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
<img width="916" alt="Screenshot 2024-11-25 at 13 53 20" src="https://github.com/user-attachments/assets/b9bc0588-42c4-42f2-842b-24d529f6ccab">

## Notes
Not shown in the screenshot above, extra new line under `Editor` was removed.