### PR TITLE
telemetry: disable telemetry on server daemon command

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -129,7 +129,7 @@ func getServiceConfig() (*service.Config, error) {
 		Name:        serviceName,
 		DisplayName: "Daytona Server",
 		Description: "Daytona Server daemon.",
-		Arguments:   []string{"serve"},
+		Arguments:   []string{"daemon-serve"},
 	}
 
 	switch runtime.GOOS {

--- a/pkg/cmd/server/serve.go
+++ b/pkg/cmd/server/serve.go
@@ -45,6 +45,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var DaemonServeCmd = &cobra.Command{
+	Use:    "daemon-serve",
+	Short:  "Used by the daemon to start the Daytona Server",
+	Args:   cobra.NoArgs,
+	Hidden: true,
+	RunE:   ServeCmd.RunE,
+}
+
 var ServeCmd = &cobra.Command{
 	Use:     "serve",
 	Short:   "Run the server process in the current terminal session",


### PR DESCRIPTION
# Disable Telemetry for Server Daemon Command

## Description

Disabled telemetry logging for the command used by the daemon to start the Daytona server.
The command is not relevant for telemetry and is called too many times.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation