### PR TITLE
feat: support non-interactive mode in git provider add

### DIFF
--- a/docs/daytona_git-providers_add.md
+++ b/docs/daytona_git-providers_add.md
@@ -6,6 +6,17 @@ Register a Git provider
 daytona git-providers add [flags]
 ```
 
+### Options
+
+```
+  -a, --alias string            Alias
+  -b, --baseApiUrl string       BaseApiUrl
+  -k, --signing-key string      SigningKey
+  -s, --signing-method string   SigningMethod
+  -t, --token string            Token
+  -u, --username string         Username
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/docs/daytona_git-providers_add.md
+++ b/docs/daytona_git-providers_add.md
@@ -3,17 +3,17 @@
 Register a Git provider
 
 ```
-daytona git-providers add [flags]
+daytona git-providers add [GIT_PROVIDER_ID] [flags]
 ```
 
 ### Options
 
 ```
   -a, --alias string            Alias
-  -b, --baseApiUrl string       BaseApiUrl
-  -k, --signing-key string      SigningKey
-  -s, --signing-method string   SigningMethod
-  -t, --token string            Token
+  -b, --base-api-url string     Base API Url
+  -k, --signing-key string      Signing Key
+  -s, --signing-method string   Signing Method (ssh, gpg)
+  -t, --token string            Personal Access Token
   -u, --username string         Username
 ```
 

--- a/hack/docs/daytona_git-providers_add.yaml
+++ b/hack/docs/daytona_git-providers_add.yaml
@@ -1,22 +1,22 @@
 name: daytona git-providers add
 synopsis: Register a Git provider
-usage: daytona git-providers add [flags]
+usage: daytona git-providers add [GIT_PROVIDER_ID] [flags]
 options:
     - name: alias
       shorthand: a
       usage: Alias
-    - name: baseApiUrl
+    - name: base-api-url
       shorthand: b
-      usage: BaseApiUrl
+      usage: Base API Url
     - name: signing-key
       shorthand: k
-      usage: SigningKey
+      usage: Signing Key
     - name: signing-method
       shorthand: s
-      usage: SigningMethod
+      usage: Signing Method (ssh, gpg)
     - name: token
       shorthand: t
-      usage: Token
+      usage: Personal Access Token
     - name: username
       shorthand: u
       usage: Username

--- a/hack/docs/daytona_git-providers_add.yaml
+++ b/hack/docs/daytona_git-providers_add.yaml
@@ -1,6 +1,25 @@
 name: daytona git-providers add
 synopsis: Register a Git provider
 usage: daytona git-providers add [flags]
+options:
+    - name: alias
+      shorthand: a
+      usage: Alias
+    - name: baseApiUrl
+      shorthand: b
+      usage: BaseApiUrl
+    - name: signing-key
+      shorthand: k
+      usage: SigningKey
+    - name: signing-method
+      shorthand: s
+      usage: SigningMethod
+    - name: token
+      shorthand: t
+      usage: Token
+    - name: username
+      shorthand: u
+      usage: Username
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -92,6 +92,10 @@ var GitProviderAddCmd = &cobra.Command{
 					return fmt.Errorf("username is required for '%s' provider", providerId)
 				}
 				setGitProviderConfig.Username = &usernameFlag
+			} else {
+				if usernameFlag != "" {
+					return fmt.Errorf("username is not required for '%s' provider", providerId)
+				}
 			}
 
 			if gitprovider_view.ProviderRequiresApiUrl(providerId) {
@@ -99,6 +103,10 @@ var GitProviderAddCmd = &cobra.Command{
 					return fmt.Errorf("base API URL is required for '%s' provider", providerId)
 				}
 				setGitProviderConfig.BaseApiUrl = &baseApiUrlFlag
+			} else {
+				if baseApiUrlFlag != "" {
+					return fmt.Errorf("base API URL is not required for '%s' provider", providerId)
+				}
 			}
 
 			if signingMethodFlag != "" || signingKeyFlag != "" {

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -6,6 +6,7 @@ package gitprovider
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
@@ -18,7 +19,7 @@ import (
 )
 
 var GitProviderAddCmd = &cobra.Command{
-	Use:     "add",
+	Use:     "add [GIT_PROVIDER_ID]",
 	Aliases: []string{"new", "register"},
 	Short:   "Register a Git provider",
 	Args:    cobra.RangeArgs(0, 1),
@@ -55,19 +56,17 @@ var GitProviderAddCmd = &cobra.Command{
 			}
 		} else {
 			supportedProviders := config.GetSupportedGitProviders()
-			for _, gp := range supportedProviders {
-				if gp.Id == args[0] {
-					setGitProviderConfig.ProviderId = gp.Id
-					break
-				}
+			supportedProviderIds := util.ArrayMap(supportedProviders, func(gp config.GitProvider) string {
+				return gp.Id
+			})
+
+			if slices.Contains(supportedProviderIds, args[0]) {
+				setGitProviderConfig.ProviderId = args[0]
 			}
 			providerId := setGitProviderConfig.ProviderId
 
 			if providerId == "" {
-				supportedProvidersStr := ""
-				for _, gp := range supportedProviders {
-					supportedProvidersStr += fmt.Sprintf("%s, ", gp.Id)
-				}
+				supportedProvidersStr := strings.Join(supportedProviderIds, ", ")
 				return fmt.Errorf("'%s' is invalid or not a supported git provider.\nSupported providers are: %s", args[0], strings.TrimSuffix(supportedProvidersStr, ", "))
 			}
 
@@ -154,9 +153,9 @@ var signingKeyFlag string
 func init() {
 	GitProviderAddCmd.Flags().StringVarP(&aliasFlag, "alias", "a", "", "Alias")
 	GitProviderAddCmd.Flags().StringVarP(&usernameFlag, "username", "u", "", "Username")
-	GitProviderAddCmd.Flags().StringVarP(&baseApiUrlFlag, "baseApiUrl", "b", "", "BaseApiUrl")
-	GitProviderAddCmd.Flags().StringVarP(&tokenFlag, "token", "t", "", "Token")
-	GitProviderAddCmd.Flags().StringVarP(&signingMethodFlag, "signing-method", "s", "", "SigningMethod")
-	GitProviderAddCmd.Flags().StringVarP(&signingKeyFlag, "signing-key", "k", "", "SigningKey")
+	GitProviderAddCmd.Flags().StringVarP(&baseApiUrlFlag, "base-api-url", "b", "", "Base API Url")
+	GitProviderAddCmd.Flags().StringVarP(&tokenFlag, "token", "t", "", "Personal Access Token")
+	GitProviderAddCmd.Flags().StringVarP(&signingMethodFlag, "signing-method", "s", "", "Signing Method (ssh, gpg)")
+	GitProviderAddCmd.Flags().StringVarP(&signingKeyFlag, "signing-key", "k", "", "Signing Key")
 	GitProviderAddCmd.MarkFlagsRequiredTogether("signing-method", "signing-key")
 }

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -67,7 +67,7 @@ var GitProviderAddCmd = &cobra.Command{
 
 			if providerId == "" {
 				supportedProvidersStr := strings.Join(supportedProviderIds, ", ")
-				return fmt.Errorf("'%s' is invalid or not a supported git provider.\nSupported providers are: %s", args[0], strings.TrimSuffix(supportedProvidersStr, ", "))
+				return fmt.Errorf("'%s' is invalid or not a supported git provider.\nSupported providers are: %s", args[0], supportedProvidersStr)
 			}
 
 			if tokenFlag == "" {

--- a/pkg/cmd/gitprovider/update.go
+++ b/pkg/cmd/gitprovider/update.go
@@ -61,7 +61,8 @@ var gitProviderUpdateCmd = &cobra.Command{
 			SigningKey:    selectedGitProvider.SigningKey,
 		}
 
-		err = gitprovider_view.GitProviderCreationView(ctx, apiClient, &setGitProviderConfig, existingAliases)
+		flags := map[string]string{}
+		err = gitprovider_view.GitProviderCreationView(ctx, apiClient, &setGitProviderConfig, existingAliases, flags)
 		if err != nil {
 			return err
 		}

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -19,7 +19,7 @@ import (
 
 var commonGitProviderIds = []string{"github", "gitlab", "bitbucket"}
 
-func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient, gitProviderAddView *apiclient.SetGitProviderConfig, existingAliases []string) error {
+func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient, gitProviderAddView *apiclient.SetGitProviderConfig, existingAliases []string, flags map[string]string) error {
 	supportedProviders := config.GetSupportedGitProviders()
 
 	var gitProviderOptions []huh.Option[string]
@@ -73,6 +73,39 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 		gitProviderAddView.SigningKey = nil
 	}
 
+	aliasFlag := flags["alias"]
+	tokenFlag := flags["token"]
+	baseApiUrlFlag := flags["base-api-url"]
+	usernameFlag := flags["username"]
+	signingMethodFlag := flags["signing-method"]
+	signingKeyFlag := flags["signing-key"]
+
+	if usernameFlag != "" {
+		if ProviderRequiresUsername(gitProviderAddView.ProviderId) {
+			gitProviderAddView.Username = &usernameFlag
+		} else {
+			return fmt.Errorf("username is not required for '%s' provider", gitProviderAddView.ProviderId)
+		}
+	}
+
+	if baseApiUrlFlag != "" {
+		if ProviderRequiresApiUrl(gitProviderAddView.ProviderId) {
+			gitProviderAddView.BaseApiUrl = &baseApiUrlFlag
+		} else {
+			return fmt.Errorf("base API URL is not required for '%s' provider", gitProviderAddView.ProviderId)
+		}
+	}
+
+	if signingMethodFlag != "" || signingKeyFlag != "" {
+		err := ValidateSigningMethodAndKey(signingMethodFlag, signingKeyFlag, gitProviderAddView.ProviderId)
+		if err != nil {
+			return err
+		}
+		signingMethod := apiclient.SigningMethod(signingMethodFlag)
+		gitProviderAddView.SigningMethod = &signingMethod
+		gitProviderAddView.SigningKey = &signingKeyFlag
+	}
+
 	userDataForm := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
@@ -85,7 +118,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					return nil
 				}),
 		).WithHeight(5).WithHideFunc(func() bool {
-			return !ProviderRequiresUsername(gitProviderAddView.ProviderId)
+			return usernameFlag != "" || !ProviderRequiresUsername(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
@@ -99,7 +132,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					return nil
 				}),
 		).WithHeight(6).WithHideFunc(func() bool {
-			return !ProviderRequiresApiUrl(gitProviderAddView.ProviderId)
+			return baseApiUrlFlag != "" || !ProviderRequiresApiUrl(gitProviderAddView.ProviderId)
 		}),
 
 		huh.NewGroup(
@@ -113,7 +146,9 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					}
 					return nil
 				}),
-		).WithHeight(5),
+		).WithHeight(5).WithHideFunc(func() bool {
+			return tokenFlag != ""
+		}),
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Alias").
@@ -129,7 +164,9 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					}
 					return nil
 				}),
-		).WithHeight(6),
+		).WithHeight(6).WithHideFunc(func() bool {
+			return aliasFlag != ""
+		}),
 
 		huh.NewGroup(huh.NewSelect[string]().
 			Title("Commit Signing Method").
@@ -143,7 +180,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 			).
 			Value(&selectedSigningMethod).WithHeight(6),
 		).WithHeight(8).WithHideFunc(func() bool {
-			return CommitSigningNotSupported(gitProviderAddView.ProviderId)
+			return signingMethodFlag != "" || CommitSigningNotSupported(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
@@ -165,7 +202,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					return nil
 				}),
 		).WithHeight(5).WithHideFunc(func() bool {
-			return selectedSigningMethod == "none"
+			return signingKeyFlag != "" || selectedSigningMethod == "none"
 		}),
 	).WithTheme(views.GetCustomTheme())
 
@@ -279,4 +316,41 @@ func getGitProviderSigningHelpMessage(gitProviderId string) string {
 		return signingDocsLink
 	}
 	return ""
+}
+
+func CheckIfAliasExists(alias string, initialAlias *string, existingAliases []string) error {
+	for _, existingAlias := range existingAliases {
+		if alias == existingAlias {
+			if initialAlias == nil || *initialAlias != alias {
+				return fmt.Errorf("alias '%s' is already in use", alias)
+			}
+		}
+	}
+	return nil
+}
+
+func ValidateSigningMethodAndKey(signingMethod string, signingKey, providerId string) error {
+	if CommitSigningNotSupported(providerId) {
+		return fmt.Errorf("commit signing is not supported for '%s' provider", providerId)
+	} else {
+		if signingMethod == "" || signingKey == "" {
+			return fmt.Errorf("both signing method and key must be provided")
+		}
+		isValidSigningMethod := false
+		for _, signingMethod := range apiclient.AllowedSigningMethodEnumValues {
+			if signingMethod == apiclient.SigningMethod(signingMethod) {
+				isValidSigningMethod = true
+				break
+			}
+		}
+		if !isValidSigningMethod {
+			return fmt.Errorf("invalid signing method '%s'", signingMethod)
+		}
+		if signingMethod == "ssh" {
+			if err := IsValidSSHKey(signingKey); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -85,7 +85,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					return nil
 				}),
 		).WithHeight(5).WithHideFunc(func() bool {
-			return !providerRequiresUsername(gitProviderAddView.ProviderId)
+			return !ProviderRequiresUsername(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
@@ -99,7 +99,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					return nil
 				}),
 		).WithHeight(6).WithHideFunc(func() bool {
-			return !providerRequiresApiUrl(gitProviderAddView.ProviderId)
+			return !ProviderRequiresApiUrl(gitProviderAddView.ProviderId)
 		}),
 
 		huh.NewGroup(
@@ -143,7 +143,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 			).
 			Value(&selectedSigningMethod).WithHeight(6),
 		).WithHeight(8).WithHideFunc(func() bool {
-			return commitSigningNotSupported(gitProviderAddView.ProviderId)
+			return CommitSigningNotSupported(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
@@ -158,7 +158,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					}
 
 					if selectedSigningMethod == "ssh" {
-						if err := isValidSSHKey(str); err != nil {
+						if err := IsValidSSHKey(str); err != nil {
 							return err
 						}
 					}
@@ -186,7 +186,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 	return nil
 
 }
-func isValidSSHKey(key string) error {
+func IsValidSSHKey(key string) error {
 	sshKeyPattern := regexp.MustCompile(`^(ssh-(rsa|ed25519|dss|ecdsa-sha2-nistp(256|384|521)))\s+[A-Za-z0-9+/=]+(\s+.+)?$`)
 	if !sshKeyPattern.MatchString(key) {
 		return errors.New("invalid SSH key: must start with valid SSH key type (e.g., ssh-rsa, ssh-ed25519)")
@@ -195,11 +195,11 @@ func isValidSSHKey(key string) error {
 	return nil
 }
 
-func providerRequiresUsername(gitProviderId string) bool {
+func ProviderRequiresUsername(gitProviderId string) bool {
 	return gitProviderId == "bitbucket" || gitProviderId == "bitbucket-server" || gitProviderId == "aws-codecommit"
 }
 
-func providerRequiresApiUrl(gitProviderId string) bool {
+func ProviderRequiresApiUrl(gitProviderId string) bool {
 	providersRequiringApiUrl := []string{
 		"gitness",
 		"github-enterprise-server",
@@ -213,7 +213,7 @@ func providerRequiresApiUrl(gitProviderId string) bool {
 	return slices.Contains(providersRequiringApiUrl, gitProviderId)
 }
 
-func commitSigningNotSupported(gitProviderId string) bool {
+func CommitSigningNotSupported(gitProviderId string) bool {
 	return gitProviderId == "gitness" || gitProviderId == "bitbucket" || gitProviderId == "bitbucket-server"
 }
 


### PR DESCRIPTION
# support non-interactive mode in git provider add

## Description
currently, `daytona gp add` works only via TUI. This PR adds support for adding Git providers non-interactively.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1352

## Screenshots
<img width="929" alt="image" src="https://github.com/user-attachments/assets/71d83014-eb70-480b-9f75-4dd41fa74b40">

