### PR TITLE
Git provider non interactive

### DIFF
--- a/docs/daytona_git-providers_add.md
+++ b/docs/daytona_git-providers_add.md
@@ -6,6 +6,18 @@ Register a Git provider
 daytona git-providers add [flags]
 ```
 
+### Options
+
+```
+  -a, --alias string            Alias
+  -b, --base-api-url string     Base API URL
+  -g, --git-provider string     Git provider
+  -k, --signing-key string      Signing key
+  -m, --signing-method string   Signing method
+  -t, --token string            Token
+  -u, --username string         Username
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/hack/docs/daytona_git-providers_add.yaml
+++ b/hack/docs/daytona_git-providers_add.yaml
@@ -1,6 +1,28 @@
 name: daytona git-providers add
 synopsis: Register a Git provider
 usage: daytona git-providers add [flags]
+options:
+    - name: alias
+      shorthand: a
+      usage: Alias
+    - name: base-api-url
+      shorthand: b
+      usage: Base API URL
+    - name: git-provider
+      shorthand: g
+      usage: Git provider
+    - name: signing-key
+      shorthand: k
+      usage: Signing key
+    - name: signing-method
+      shorthand: m
+      usage: Signing method
+    - name: token
+      shorthand: t
+      usage: Token
+    - name: username
+      shorthand: u
+      usage: Username
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -5,7 +5,9 @@ package gitprovider
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
@@ -44,9 +46,79 @@ var GitProviderAddCmd = &cobra.Command{
 		setGitProviderConfig.Username = new(string)
 		setGitProviderConfig.Alias = new(string)
 
-		err = gitprovider_view.GitProviderCreationView(ctx, apiClient, &setGitProviderConfig, existingAliases)
-		if err != nil {
-			return err
+		if gitProviderFlag == "" {
+			err = gitprovider_view.GitProviderCreationView(ctx, apiClient, &setGitProviderConfig, existingAliases)
+			if err != nil {
+				return err
+			}
+		} else {
+			supportedProviders := config.GetSupportedGitProviders()
+			for _, gp := range supportedProviders {
+				if gp.Id == gitProviderFlag {
+					setGitProviderConfig.ProviderId = gp.Id
+					break
+				}
+			}
+			providerId := setGitProviderConfig.ProviderId
+			if providerId == "" {
+				supprotedProvidersString := ""
+				for _, gp := range supportedProviders {
+					supprotedProvidersString += fmt.Sprintf("%s  ", gp.Id)
+				}
+				return fmt.Errorf("Invalid git provider %s .",gitProviderFlag)
+			}
+			if tokenFlag == "" {
+				return fmt.Errorf("Token is required")
+			}
+			setGitProviderConfig.Token = tokenFlag
+			if aliasFlag != "" {
+				for _, alias := range existingAliases {
+					if alias == aliasFlag {
+						initialAliasValues := setGitProviderConfig.Alias
+						if initialAliasValues == nil || *initialAliasValues != aliasFlag {
+							return fmt.Errorf("Alias already exists")
+						}
+					}
+				}
+				setGitProviderConfig.Alias = &aliasFlag
+			}
+			if gitprovider_view.ProviderRequiresUsername(providerId) {
+				if usernameFlag == "" {
+					return fmt.Errorf("Username is required")
+				}
+				setGitProviderConfig.Username = &usernameFlag
+			}
+			if gitprovider_view.ProviderRequiresApiUrl(providerId) {
+				if baseApiUrlFlag == "" {
+					return fmt.Errorf("Base API URL is required")
+				}
+				setGitProviderConfig.BaseApiUrl = &baseApiUrlFlag
+			}
+			if signingKeyFlag != "" || signingMethodFlag != "" {
+				if gitprovider_view.CommitSigningNotSupported(providerId) {
+					return fmt.Errorf("Commit signing is not supported for this provider")
+				}
+				if signingKeyFlag == "" || signingMethodFlag == "" {
+					return fmt.Errorf("Signing key and signing method are required")
+				}
+				isValidSigningMethod := false
+				for _, method := range apiclient.AllowedSigningMethodEnumValues {
+					if method == apiclient.SigningMethod(signingMethodFlag) {
+						setGitProviderConfig.SigningMethod = &method
+						isValidSigningMethod = true
+						break
+					}
+				}
+				if !isValidSigningMethod {
+					return fmt.Errorf("Invalid signing method.")
+				}
+				if signingMethodFlag == "ssh" {
+					if err := gitprovider_view.IsValidSSHKey(signingKeyFlag); err != nil {
+						return err
+					}
+				}
+				setGitProviderConfig.SigningKey = &signingKeyFlag
+			}
 		}
 
 		if setGitProviderConfig.ProviderId == "" {
@@ -61,4 +133,23 @@ var GitProviderAddCmd = &cobra.Command{
 		views.RenderInfoMessage("Git provider has been registered")
 		return nil
 	},
+}
+
+var gitProviderFlag string
+var aliasFlag string
+var usernameFlag string
+var tokenFlag string
+var baseApiUrlFlag string
+var signingKeyFlag string
+var signingMethodFlag string
+
+func init() {
+	GitProviderAddCmd.Flags().StringVarP(&gitProviderFlag, "git-provider", "g", "", "Git provider")
+	GitProviderAddCmd.Flags().StringVarP(&aliasFlag, "alias", "a", "", "Alias")
+	GitProviderAddCmd.Flags().StringVarP(&usernameFlag, "username", "u", "", "Username")
+	GitProviderAddCmd.Flags().StringVarP(&tokenFlag, "token", "t", "", "Token")
+	GitProviderAddCmd.Flags().StringVarP(&baseApiUrlFlag, "base-api-url", "b", "", "Base API URL")
+	GitProviderAddCmd.Flags().StringVarP(&signingKeyFlag, "signing-key", "k", "", "Signing key")
+	GitProviderAddCmd.Flags().StringVarP(&signingMethodFlag, "signing-method", "m", "", "Signing method")
+	GitProviderAddCmd.MarkFlagsRequiredTogether("signing-key", "signing-method")
 }

--- a/pkg/cmd/gitprovider/add.go
+++ b/pkg/cmd/gitprovider/add.go
@@ -65,7 +65,7 @@ var GitProviderAddCmd = &cobra.Command{
 				for _, gp := range supportedProviders {
 					supprotedProvidersString += fmt.Sprintf("%s  ", gp.Id)
 				}
-				return fmt.Errorf("Invalid git provider %s .",gitProviderFlag)
+				return fmt.Errorf("Invalid git provider %s .", gitProviderFlag)
 			}
 			if tokenFlag == "" {
 				return fmt.Errorf("Token is required")

--- a/pkg/views/gitprovider/select.go
+++ b/pkg/views/gitprovider/select.go
@@ -85,7 +85,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					return nil
 				}),
 		).WithHeight(5).WithHideFunc(func() bool {
-			return !providerRequiresUsername(gitProviderAddView.ProviderId)
+			return !ProviderRequiresUsername(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
@@ -99,7 +99,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					return nil
 				}),
 		).WithHeight(6).WithHideFunc(func() bool {
-			return !providerRequiresApiUrl(gitProviderAddView.ProviderId)
+			return !ProviderRequiresApiUrl(gitProviderAddView.ProviderId)
 		}),
 
 		huh.NewGroup(
@@ -143,7 +143,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 			).
 			Value(&selectedSigningMethod).WithHeight(6),
 		).WithHeight(8).WithHideFunc(func() bool {
-			return commitSigningNotSupported(gitProviderAddView.ProviderId)
+			return CommitSigningNotSupported(gitProviderAddView.ProviderId)
 		}),
 		huh.NewGroup(
 			huh.NewInput().
@@ -158,7 +158,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 					}
 
 					if selectedSigningMethod == "ssh" {
-						if err := isValidSSHKey(str); err != nil {
+						if err := IsValidSSHKey(str); err != nil {
 							return err
 						}
 					}
@@ -186,7 +186,7 @@ func GitProviderCreationView(ctx context.Context, apiClient *apiclient.APIClient
 	return nil
 
 }
-func isValidSSHKey(key string) error {
+func IsValidSSHKey(key string) error {
 	sshKeyPattern := regexp.MustCompile(`^(ssh-(rsa|ed25519|dss|ecdsa-sha2-nistp(256|384|521)))\s+[A-Za-z0-9+/=]+(\s+.+)?$`)
 	if !sshKeyPattern.MatchString(key) {
 		return errors.New("invalid SSH key: must start with valid SSH key type (e.g., ssh-rsa, ssh-ed25519)")
@@ -195,11 +195,11 @@ func isValidSSHKey(key string) error {
 	return nil
 }
 
-func providerRequiresUsername(gitProviderId string) bool {
+func ProviderRequiresUsername(gitProviderId string) bool {
 	return gitProviderId == "bitbucket" || gitProviderId == "bitbucket-server" || gitProviderId == "aws-codecommit"
 }
 
-func providerRequiresApiUrl(gitProviderId string) bool {
+func ProviderRequiresApiUrl(gitProviderId string) bool {
 	providersRequiringApiUrl := []string{
 		"gitness",
 		"github-enterprise-server",
@@ -213,7 +213,7 @@ func providerRequiresApiUrl(gitProviderId string) bool {
 	return slices.Contains(providersRequiringApiUrl, gitProviderId)
 }
 
-func commitSigningNotSupported(gitProviderId string) bool {
+func CommitSigningNotSupported(gitProviderId string) bool {
 	return gitProviderId == "gitness" || gitProviderId == "bitbucket" || gitProviderId == "bitbucket-server"
 }
 


### PR DESCRIPTION
# Non-Interactive GitProvider

## Description
Added the flags to pass in non-interactive mode for the gitprovider add command. 


- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)
This PR fixes #1352 

## Screenshots
## Notes
