### PR TITLE
feat: add project config export/import

### DIFF
--- a/docs/daytona_project-config.md
+++ b/docs/daytona_project-config.md
@@ -13,6 +13,8 @@ Manage project configs
 * [daytona](daytona.md)	 - Daytona is a Dev Environment Manager
 * [daytona project-config add](daytona_project-config_add.md)	 - Add a project config
 * [daytona project-config delete](daytona_project-config_delete.md)	 - Delete a project config
+* [daytona project-config export](daytona_project-config_export.md)	 - Export a project config
+* [daytona project-config import](daytona_project-config_import.md)	 - Import project config from JSON
 * [daytona project-config info](daytona_project-config_info.md)	 - Show project config info
 * [daytona project-config list](daytona_project-config_list.md)	 - Lists project configs
 * [daytona project-config set-default](daytona_project-config_set-default.md)	 - Set project config info

--- a/docs/daytona_project-config_export.md
+++ b/docs/daytona_project-config_export.md
@@ -1,0 +1,24 @@
+## daytona project-config export
+
+Export a project config
+
+```
+daytona project-config export [flags]
+```
+
+### Options
+
+```
+  -a, --all   Export all project configs
+```
+
+### Options inherited from parent commands
+
+```
+      --help   help for daytona
+```
+
+### SEE ALSO
+
+* [daytona project-config](daytona_project-config.md)	 - Manage project configs
+

--- a/docs/daytona_project-config_export.md
+++ b/docs/daytona_project-config_export.md
@@ -9,7 +9,8 @@ daytona project-config export [flags]
 ### Options
 
 ```
-  -a, --all   Export all project configs
+  -a, --all             Export all project configs
+  -f, --format string   Output format. Must be one of (yaml, json)
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_project-config_import.md
+++ b/docs/daytona_project-config_import.md
@@ -2,8 +2,12 @@
 
 Import project config from JSON
 
+### Synopsis
+
+Import project config from a JSON input. Use '-' to read from stdin.
+
 ```
-daytona project-config import [flags]
+daytona project-config import [-]
 ```
 
 ### Options inherited from parent commands

--- a/docs/daytona_project-config_import.md
+++ b/docs/daytona_project-config_import.md
@@ -1,0 +1,18 @@
+## daytona project-config import
+
+Import project config from JSON
+
+```
+daytona project-config import [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --help   help for daytona
+```
+
+### SEE ALSO
+
+* [daytona project-config](daytona_project-config.md)	 - Manage project configs
+

--- a/docs/daytona_project-config_import.md
+++ b/docs/daytona_project-config_import.md
@@ -2,12 +2,14 @@
 
 Import project config from JSON
 
-### Synopsis
+```
+daytona project-config import [flags]
+```
 
-Import project config from a JSON input. Use '-' to read from stdin.
+### Options
 
 ```
-daytona project-config import [-]
+  -f, --file string   Import project config from a JSON file. Use '-' to read from stdin.
 ```
 
 ### Options inherited from parent commands

--- a/hack/docs/daytona_project-config.yaml
+++ b/hack/docs/daytona_project-config.yaml
@@ -8,6 +8,8 @@ see_also:
     - daytona - Daytona is a Dev Environment Manager
     - daytona project-config add - Add a project config
     - daytona project-config delete - Delete a project config
+    - daytona project-config export - Export a project config
+    - daytona project-config import - Import project config from JSON
     - daytona project-config info - Show project config info
     - daytona project-config list - Lists project configs
     - daytona project-config set-default - Set project config info

--- a/hack/docs/daytona_project-config_export.yaml
+++ b/hack/docs/daytona_project-config_export.yaml
@@ -1,0 +1,14 @@
+name: daytona project-config export
+synopsis: Export a project config
+usage: daytona project-config export [flags]
+options:
+    - name: all
+      shorthand: a
+      default_value: "false"
+      usage: Export all project configs
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+see_also:
+    - daytona project-config - Manage project configs

--- a/hack/docs/daytona_project-config_export.yaml
+++ b/hack/docs/daytona_project-config_export.yaml
@@ -6,6 +6,9 @@ options:
       shorthand: a
       default_value: "false"
       usage: Export all project configs
+    - name: format
+      shorthand: f
+      usage: Output format. Must be one of (yaml, json)
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/daytona_project-config_import.yaml
+++ b/hack/docs/daytona_project-config_import.yaml
@@ -1,8 +1,11 @@
 name: daytona project-config import
 synopsis: Import project config from JSON
-description: |
-    Import project config from a JSON input. Use '-' to read from stdin.
-usage: daytona project-config import [-]
+usage: daytona project-config import [flags]
+options:
+    - name: file
+      shorthand: f
+      usage: |
+        Import project config from a JSON file. Use '-' to read from stdin.
 inherited_options:
     - name: help
       default_value: "false"

--- a/hack/docs/daytona_project-config_import.yaml
+++ b/hack/docs/daytona_project-config_import.yaml
@@ -1,0 +1,9 @@
+name: daytona project-config import
+synopsis: Import project config from JSON
+usage: daytona project-config import [flags]
+inherited_options:
+    - name: help
+      default_value: "false"
+      usage: help for daytona
+see_also:
+    - daytona project-config - Manage project configs

--- a/hack/docs/daytona_project-config_import.yaml
+++ b/hack/docs/daytona_project-config_import.yaml
@@ -1,6 +1,8 @@
 name: daytona project-config import
 synopsis: Import project config from JSON
-usage: daytona project-config import [flags]
+description: |
+    Import project config from a JSON input. Use '-' to read from stdin.
+usage: daytona project-config import [-]
 inherited_options:
     - name: help
       default_value: "false"

--- a/pkg/cmd/projectconfig/add.go
+++ b/pkg/cmd/projectconfig/add.go
@@ -71,7 +71,7 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 	}
 
 	var createDtos []apiclient.CreateProjectDTO
-	existingProjectConfigNames, err := getExistingProjectConfigNames(apiClient)
+	existingProjectConfigNames, err := GetExistingProjectConfigNames(apiClient)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 		}
 	}
 
-	create.ProjectsConfigurationChanged, err = create.RunProjectConfiguration(&createDtos, *projectDefaults)
+	create.ProjectsConfigurationChanged, err = create.RunProjectConfiguration(&createDtos, *projectDefaults, false)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,8 @@ func RunProjectConfigAddFlow(apiClient *apiclient.APIClient, gitProviders []apic
 		Defaults:      projectDefaults,
 	}
 
-	err = create.RunSubmissionForm(submissionFormConfig)
+	pcFlag := false
+	err = create.RunSubmissionForm(submissionFormConfig, &pcFlag)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func processCmdArgument(argument string, apiClient *apiclient.APIClient, ctx con
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	existingProjectConfigNames, err := getExistingProjectConfigNames(apiClient)
+	existingProjectConfigNames, err := GetExistingProjectConfigNames(apiClient)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +260,7 @@ func processCmdArgument(argument string, apiClient *apiclient.APIClient, ctx con
 	return &newProjectConfig.Name, nil
 }
 
-func getExistingProjectConfigNames(apiClient *apiclient.APIClient) ([]string, error) {
+func GetExistingProjectConfigNames(apiClient *apiclient.APIClient) ([]string, error) {
 	var existingProjectConfigNames []string
 
 	existingProjectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(context.Background()).Execute()

--- a/pkg/cmd/projectconfig/export.go
+++ b/pkg/cmd/projectconfig/export.go
@@ -44,8 +44,14 @@ var projectConfigExportCmd = &cobra.Command{
 				return nil
 			}
 
+			var pbFlag bool
+
 			for i := range projectConfigs {
 				projectConfigs[i].GitProviderConfigId = nil
+				if projectConfigs[i].Prebuilds != nil {
+					projectConfigs[i].Prebuilds = nil
+					pbFlag = true
+				}
 			}
 
 			data, err := json.MarshalIndent(projectConfigs, "", "  ")
@@ -54,6 +60,10 @@ var projectConfigExportCmd = &cobra.Command{
 			}
 
 			fmt.Println(string(data))
+
+			if pbFlag {
+				views.RenderContainerLayout("Prebuilds have been removed from your configs.")
+			}
 
 			if err := clipboard.WriteAll(string(data)); err == nil {
 				output = "The configs have been copied to your clipboard."
@@ -89,6 +99,10 @@ var projectConfigExportCmd = &cobra.Command{
 		}
 
 		selectedProjectConfig.GitProviderConfigId = nil
+		if selectedProjectConfig.Prebuilds != nil {
+			selectedProjectConfig.Prebuilds = nil
+			views.RenderContainerLayout("Prebuilds have been removed from the config.")
+		}
 
 		data, err := json.MarshalIndent(selectedProjectConfig, "", "  ")
 		if err != nil {

--- a/pkg/cmd/projectconfig/export.go
+++ b/pkg/cmd/projectconfig/export.go
@@ -1,0 +1,114 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package projectconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/atotto/clipboard"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/views"
+	views_util "github.com/daytonaio/daytona/pkg/views/util"
+	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
+	"github.com/spf13/cobra"
+)
+
+var projectConfigExportCmd = &cobra.Command{
+	Use:     "export",
+	Aliases: []string{"exp"},
+	Short:   "Export a project config",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var selectedProjectConfig *apiclient.ProjectConfig
+		var output string
+		ctx := context.Background()
+
+		apiClient, err := apiclient_util.GetApiClient(nil)
+		if err != nil {
+			return err
+		}
+
+		if allFlag {
+			projectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(ctx).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(projectConfigs) == 0 {
+				views_util.NotifyEmptyProjectConfigList(true)
+				return nil
+			}
+
+			for i := range projectConfigs {
+				projectConfigs[i].GitProviderConfigId = nil
+			}
+
+			data, err := json.MarshalIndent(projectConfigs, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(data))
+
+			if err := clipboard.WriteAll(string(data)); err == nil {
+				output = "The configs have been copied to your clipboard."
+			} else {
+				output = "Could not copy the configs to your clipboard."
+			}
+			views.RenderContainerLayout(views.GetInfoMessage(output))
+
+			return nil
+		}
+
+		if len(args) == 0 {
+			projectConfigs, res, err := apiClient.ProjectConfigAPI.ListProjectConfigs(ctx).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			if len(projectConfigs) == 0 {
+				views_util.NotifyEmptyProjectConfigList(true)
+				return nil
+			}
+
+			selectedProjectConfig = selection.GetProjectConfigFromPrompt(projectConfigs, 0, false, false, "Export")
+			if selectedProjectConfig == nil {
+				return nil
+			}
+		} else {
+			var res *http.Response
+			selectedProjectConfig, res, err = apiClient.ProjectConfigAPI.GetProjectConfig(ctx, args[0]).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+		}
+
+		selectedProjectConfig.GitProviderConfigId = nil
+
+		data, err := json.MarshalIndent(selectedProjectConfig, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(data))
+
+		if err := clipboard.WriteAll(string(data)); err == nil {
+			output = "The config has been copied to your clipboard."
+		} else {
+			output = "Could not copy the config to your clipboard."
+		}
+		views.RenderContainerLayout(views.GetInfoMessage(output))
+
+		return nil
+	},
+}
+
+func init() {
+	ProjectConfigCmd.AddCommand(projectConfigExportCmd)
+	projectConfigExportCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Export all project configs")
+}

--- a/pkg/cmd/projectconfig/export.go
+++ b/pkg/cmd/projectconfig/export.go
@@ -78,6 +78,10 @@ func init() {
 }
 
 func exportProjectConfig(projectConfigs []apiclient.ProjectConfig) error {
+	if len(projectConfigs) == 0 {
+		return nil
+	}
+
 	var pbFlag bool
 
 	for i := range projectConfigs {

--- a/pkg/cmd/projectconfig/export.go
+++ b/pkg/cmd/projectconfig/export.go
@@ -109,6 +109,5 @@ var projectConfigExportCmd = &cobra.Command{
 }
 
 func init() {
-	ProjectConfigCmd.AddCommand(projectConfigExportCmd)
 	projectConfigExportCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Export all project configs")
 }

--- a/pkg/cmd/projectconfig/import.go
+++ b/pkg/cmd/projectconfig/import.go
@@ -59,7 +59,6 @@ var projectConfigImportCmd = &cobra.Command{
 			// 	}
 			// }
 
-			// GitProviderConfigId is not set or does not exist, fetch it using the repo URL
 			gitProviders, _, err := apiClient.GitProviderAPI.ListGitProvidersForUrl(ctx, url.QueryEscape(config.RepositoryUrl)).Execute()
 			if err != nil {
 				return fmt.Errorf("error fetching Git providers: %v", err)
@@ -72,7 +71,6 @@ var projectConfigImportCmd = &cobra.Command{
 			if len(gitProviders) == 1 {
 				config.GitProviderConfigId = &gitProviders[0].Id
 			} else {
-				// Multiple Git providers available, prompt the user to select one
 				selectedGitProvider := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
 					GitProviderConfigs: gitProviders,
 					ActionVerb:         "Use",
@@ -122,8 +120,4 @@ var projectConfigImportCmd = &cobra.Command{
 
 		return nil
 	},
-}
-
-func init() {
-	ProjectConfigCmd.AddCommand(projectConfigImportCmd)
 }

--- a/pkg/cmd/projectconfig/import.go
+++ b/pkg/cmd/projectconfig/import.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package projectconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/charmbracelet/huh"
+	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
+	"github.com/daytonaio/daytona/pkg/apiclient"
+	"github.com/daytonaio/daytona/pkg/views"
+	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
+	"github.com/spf13/cobra"
+)
+
+var projectConfigImportCmd = &cobra.Command{
+	Use:     "import",
+	Aliases: []string{"imp"},
+	Short:   "Import project config from JSON",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var inputText string
+		ctx := context.Background()
+
+		apiClient, err := apiclient_util.GetApiClient(nil)
+		if err != nil {
+			return err
+		}
+
+		form := huh.NewForm(
+			huh.NewGroup(
+				huh.NewText().
+					Title("Import Project-Config").
+					Description("Enter Project-Config as a JSON or an array of JSON objects").
+					CharLimit(-1).
+					Value(&inputText),
+			),
+		).WithTheme(views.GetCustomTheme()).WithHeight(20)
+		err = form.Run()
+		if err != nil {
+			return err
+		}
+
+		var config apiclient.ProjectConfig
+		err = json.Unmarshal([]byte(inputText), &config)
+		if err == nil {
+			fmt.Printf("Single Project Config: %+v\n", config)
+
+			// if config.GitProviderConfigId != nil {
+			// 	// Verify if the Git provider config exists
+			// 	_, _, err := apiClient.GitProviderAPI.GetGitProvider(ctx, *config.GitProviderConfigId).Execute()
+			// 	if err == nil {
+			// 		// Git provider config exists, proceed with import
+			// 		return nil
+			// 	}
+			// }
+
+			// GitProviderConfigId is not set or does not exist, fetch it using the repo URL
+			gitProviders, _, err := apiClient.GitProviderAPI.ListGitProvidersForUrl(ctx, url.QueryEscape(config.RepositoryUrl)).Execute()
+			if err != nil {
+				return fmt.Errorf("error fetching Git providers: %v", err)
+			}
+
+			if len(gitProviders) == 0 {
+				return fmt.Errorf("no Git providers found for URL: %s", config.RepositoryUrl)
+			}
+
+			if len(gitProviders) == 1 {
+				config.GitProviderConfigId = &gitProviders[0].Id
+			} else {
+				// Multiple Git providers available, prompt the user to select one
+				selectedGitProvider := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
+					GitProviderConfigs: gitProviders,
+					ActionVerb:         "Use",
+				})
+				config.GitProviderConfigId = &selectedGitProvider.Id
+			}
+
+			apiServerConfig, res, err := apiClient.ServerAPI.GetConfig(context.Background()).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+
+			newProjectConfig := apiclient.CreateProjectConfigDTO{
+				Name:                config.Name,
+				BuildConfig:         config.BuildConfig,
+				Image:               &config.Image,
+				User:                &config.User,
+				RepositoryUrl:       config.RepositoryUrl,
+				EnvVars:             config.EnvVars,
+				GitProviderConfigId: config.GitProviderConfigId,
+			}
+
+			if newProjectConfig.Image == nil {
+				newProjectConfig.Image = &apiServerConfig.DefaultProjectImage
+			}
+
+			if newProjectConfig.User == nil {
+				newProjectConfig.User = &apiServerConfig.DefaultProjectUser
+			}
+
+			res, err = apiClient.ProjectConfigAPI.SetProjectConfig(ctx).ProjectConfig(newProjectConfig).Execute()
+			if err != nil {
+				return apiclient_util.HandleErrorResponse(res, err)
+			}
+		} else {
+			var configs []apiclient.ProjectConfig
+			err = json.Unmarshal([]byte(inputText), &configs)
+			if err != nil {
+				return fmt.Errorf("invalid JSON input: %v", err)
+			}
+
+			fmt.Println("Multiple Project Configs:")
+			for i, config := range configs {
+				fmt.Printf("Project Config %d: %+v\n", i+1, config)
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	ProjectConfigCmd.AddCommand(projectConfigImportCmd)
+}

--- a/pkg/cmd/projectconfig/import.go
+++ b/pkg/cmd/projectconfig/import.go
@@ -28,7 +28,7 @@ var (
 )
 
 var projectConfigImportCmd = &cobra.Command{
-	Use:     "import [-]",
+	Use:     "import",
 	Aliases: []string{"imp"},
 	Short:   "Import project config from JSON",
 	Args:    cobra.MaximumNArgs(1),

--- a/pkg/cmd/projectconfig/import.go
+++ b/pkg/cmd/projectconfig/import.go
@@ -25,10 +25,12 @@ import (
 var projectConfigList []apiclient.ProjectConfig
 
 var projectConfigImportCmd = &cobra.Command{
-	Use:     "import",
-	Aliases: []string{"imp"},
-	Short:   "Import project config from JSON",
-	Args:    cobra.MaximumNArgs(1),
+	Use:                   "import [-]",
+	Aliases:               []string{"imp"},
+	Short:                 "Import project config from JSON",
+	Long:                  "Import project config from a JSON input. Use '-' to read from stdin.",
+	Args:                  cobra.MaximumNArgs(1),
+	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var inputText string
 		var res *http.Response

--- a/pkg/cmd/projectconfig/import.go
+++ b/pkg/cmd/projectconfig/import.go
@@ -78,7 +78,7 @@ var projectConfigImportCmd = &cobra.Command{
 		if err == nil {
 			err = importProjectConfig(ctx, apiClient, config, &projectConfigList)
 			if err != nil {
-				return err
+				return fmt.Errorf("error importing project config: %v", err)
 			}
 		} else {
 			var configs []apiclient.ProjectConfig
@@ -90,7 +90,7 @@ var projectConfigImportCmd = &cobra.Command{
 			for _, config := range configs {
 				err = importProjectConfig(ctx, apiClient, config, &projectConfigList)
 				if err != nil {
-					return err
+					return fmt.Errorf("error importing project config: %v", err)
 				}
 			}
 		}
@@ -113,8 +113,7 @@ func isProjectConfigAlreadyExists(configName string, projectConfigList *[]apicli
 
 func importProjectConfig(ctx context.Context, apiClient *apiclient.APIClient, config apiclient.ProjectConfig, projectConfigList *[]apiclient.ProjectConfig) error {
 	if isProjectConfigAlreadyExists(config.Name, projectConfigList) {
-		views.RenderInfoMessage(fmt.Sprintf("Project config already present with name \"%s\"", config.Name))
-		return nil
+		return fmt.Errorf("project config already present with name \"%s\"", config.Name)
 	}
 
 	var verifiedGitProvider bool

--- a/pkg/cmd/projectconfig/import.go
+++ b/pkg/cmd/projectconfig/import.go
@@ -120,12 +120,16 @@ func importProjectConfig(ctx context.Context, apiClient *apiclient.APIClient, co
 		}
 
 		if len(gitProviders) == 0 {
-			return fmt.Errorf("no Git providers found for URL: %s", config.RepositoryUrl)
+			gitProviderConfigId, _, err := apiClient.GitProviderAPI.GetGitProviderIdForUrl(ctx, url.QueryEscape(config.RepositoryUrl)).Execute()
+			if err != nil {
+				return fmt.Errorf("error fetching Git provider: %v", err)
+			}
+			config.GitProviderConfigId = &gitProviderConfigId
 		}
 
-		if len(gitProviders) == 1 {
+		if len(gitProviders) == 1 && config.GitProviderConfigId == nil {
 			config.GitProviderConfigId = &gitProviders[0].Id
-		} else {
+		} else if len(gitProviders) > 1 && config.GitProviderConfigId == nil {
 			selectedGitProvider := selection.GetGitProviderConfigFromPrompt(selection.GetGitProviderConfigParams{
 				GitProviderConfigs: gitProviders,
 				ActionVerb:         "Use",

--- a/pkg/cmd/projectconfig/projectconfig.go
+++ b/pkg/cmd/projectconfig/projectconfig.go
@@ -22,4 +22,6 @@ func init() {
 	ProjectConfigCmd.AddCommand(projectConfigUpdateCmd)
 	ProjectConfigCmd.AddCommand(projectConfigSetDefaultCmd)
 	ProjectConfigCmd.AddCommand(projectConfigDeleteCmd)
+	ProjectConfigCmd.AddCommand(projectConfigExportCmd)
+	ProjectConfigCmd.AddCommand(projectConfigImportCmd)
 }

--- a/pkg/cmd/projectconfig/update.go
+++ b/pkg/cmd/projectconfig/update.go
@@ -81,7 +81,7 @@ var projectConfigUpdateCmd = &cobra.Command{
 			projectDefaults.DevcontainerFilePath = projectConfig.BuildConfig.Devcontainer.FilePath
 		}
 
-		_, err = create.RunProjectConfiguration(&createDto, *projectDefaults)
+		_, err = create.RunProjectConfiguration(&createDto, *projectDefaults, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -331,7 +331,8 @@ func processPrompting(ctx context.Context, apiClient *apiclient.APIClient, works
 		Defaults:      projectDefaults,
 	}
 
-	err = create.RunSubmissionForm(submissionFormConfig)
+	pcImportFlag := false
+	err = create.RunSubmissionForm(submissionFormConfig, &pcImportFlag)
 	if err != nil {
 		return err
 	}

--- a/pkg/views/workspace/create/configuration.go
+++ b/pkg/views/workspace/create/configuration.go
@@ -57,7 +57,7 @@ func NewConfigurationData(buildChoice views_util.BuildChoice, devContainerFilePa
 	return projectConfigurationData
 }
 
-func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults views_util.ProjectConfigDefaults) (bool, error) {
+func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults views_util.ProjectConfigDefaults, isConfigImport bool) (bool, error) {
 	var currentProject *apiclient.CreateProjectDTO
 
 	if len(*projectList) > 1 {
@@ -92,10 +92,12 @@ func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults
 
 	projectConfigurationData := NewConfigurationData(builderChoice, devContainerFilePath, currentProject, &defaults)
 
-	form := GetProjectConfigurationForm(projectConfigurationData)
-	err := form.WithProgramOptions(tea.WithAltScreen()).Run()
-	if err != nil {
-		log.Fatal(err)
+	if !isConfigImport {
+		form := GetProjectConfigurationForm(projectConfigurationData)
+		err := form.WithProgramOptions(tea.WithAltScreen()).Run()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	for i := range *projectList {
@@ -136,7 +138,7 @@ func RunProjectConfiguration(projectList *[]apiclient.CreateProjectDTO, defaults
 		return true, nil
 	}
 
-	return RunProjectConfiguration(projectList, defaults)
+	return RunProjectConfiguration(projectList, defaults, isConfigImport)
 }
 
 func validateDevcontainerFilename(filename string) error {


### PR DESCRIPTION
## Description

This PR allows users to import and export project configurations by adding two new commands `daytona pc export` & `daytona pc import`. When a project-config is exported it's by default copied to the clipboard also while exporting prebuilds(if any) are set to empty. 

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1202

## Screenshots
https://github.com/user-attachments/assets/61abd178-32dc-4c6c-98f3-6e7a538212bc

