### PR TITLE
fix: remote devcontainer compose creation

### DIFF
--- a/pkg/docker/create.go
+++ b/pkg/docker/create.go
@@ -211,7 +211,7 @@ func (d *DockerClient) toCreateDevcontainerOptions(opts *CreateProjectOptions, p
 			"daytona.workspace.id": opts.Project.WorkspaceId,
 			"daytona.project.name": opts.Project.Name,
 		},
-		Prebuild: true,
+		Prebuild: prebuild,
 	}
 }
 


### PR DESCRIPTION
# Fix Remote Devcontianer Compose Creation

## Description

Fixes an issue for creating compose devcontainers on remote environments (e.g. remote Docker target or any of the other providers).

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes https://github.com/daytonaio/daytona-provider-hetzner/issues/5

## Screenshots
If relevant, please add screenshots.

## Notes
Providers will need to be updated