### PR TITLE
fix: custom image builder detection

### DIFF
--- a/pkg/build/detect/detect.go
+++ b/pkg/build/detect/detect.go
@@ -20,7 +20,11 @@ var (
 )
 
 func DetectProjectBuilderType(buildConfig *buildconfig.BuildConfig, projectDir string, sshClient *ssh.Client) (BuilderType, error) {
-	if buildConfig != nil && buildConfig.Devcontainer != nil {
+	if buildConfig == nil {
+		return BuilderTypeImage, nil
+	}
+
+	if buildConfig.Devcontainer != nil {
 		return BuilderTypeDevcontainer, nil
 	}
 


### PR DESCRIPTION
# Fix Custom Image Builder Detection

## Description

Fixes an issue where providers would panic because of a nil pointer exception in a scenario where the Custom Image builder was used in a devcontainer project.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


## Notes
All providers will need to be updated.
