### PR TITLE
feat: add support for editing ssh config files

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -321,10 +321,15 @@ func UpdateWorkspaceSshEntry(profileId, workspaceId, projectName, updatedContent
 		return err
 	}
 
-	regex := regexp.MustCompile(fmt.Sprintf(`(?m)^Host %s-%s-%s\s*\n(?:\s+[^\n]*\n?)*`, profileId, workspaceId, projectName))
-	newContent := regex.ReplaceAllString(existingContent, updatedContent)
+	hostLine := fmt.Sprintf("Host %s", GetProjectHostname(profileId, workspaceId, projectName))
+	regex := regexp.MustCompile(fmt.Sprintf(`%s\s*\n(?:\t.*\n?)*`, hostLine))
+	oldContent := regex.FindString(existingContent)
+	if oldContent == "" {
+		return fmt.Errorf("no SSH entry found for project %s", projectName)
+	}
+	existingContent = strings.ReplaceAll(existingContent, oldContent, updatedContent)
 
-	err = writeSshConfig(configPath, newContent)
+	err = writeSshConfig(configPath, existingContent)
 	if err != nil {
 		return err
 	}

--- a/docs/daytona_ssh.md
+++ b/docs/daytona_ssh.md
@@ -9,6 +9,7 @@ daytona ssh [WORKSPACE] [PROJECT] [CMD...] [flags]
 ### Options
 
 ```
+  -e, --edit                 Edit the project's SSH config
   -o, --option stringArray   Specify SSH options in KEY=VALUE format.
   -y, --yes                  Automatically confirm any prompts
 ```

--- a/hack/docs/daytona_ssh.yaml
+++ b/hack/docs/daytona_ssh.yaml
@@ -2,6 +2,10 @@ name: daytona ssh
 synopsis: SSH into a project using the terminal
 usage: daytona ssh [WORKSPACE] [PROJECT] [CMD...] [flags]
 options:
+    - name: edit
+      shorthand: e
+      default_value: "false"
+      usage: Edit the project's SSH config
     - name: option
       shorthand: o
       default_value: '[]'

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -183,9 +183,11 @@ func RemoveWorkspace(ctx context.Context, apiClient *apiclient.APIClient, worksp
 			return err
 		}
 
-		err = config.RemoveWorkspaceSshEntries(activeProfile.Id, workspace.Id)
-		if err != nil {
-			return err
+		for _, project := range workspace.Projects {
+			err = config.RemoveWorkspaceSshEntries(activeProfile.Id, workspace.Id, project.Name)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -105,8 +105,6 @@ var SshCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-
-			views.RenderInfoMessage(fmt.Sprintf("SSH configuration for %s updated successfully", projectName))
 			return nil
 		}
 
@@ -204,6 +202,15 @@ func editSSHConfig(activeProfile config.Profile, workspace *apiclient.WorkspaceD
 		return fmt.Errorf("operation canceled")
 	}
 
+	if modifiedContent == "" {
+		err = config.RemoveWorkspaceSshEntries(activeProfile.Id, workspace.Id, projectName)
+		if err != nil {
+			return err
+		}
+		views.RenderInfoMessage(fmt.Sprintf("SSH configuration for %s removed successfully", projectName))
+
+		return nil
+	}
 	updatedLines := strings.Split(modifiedContent, "\n")
 	modifiedContent = hostLine + "\n\t" + strings.Join(updatedLines, "\n\t")
 	modifiedContent = strings.TrimSuffix(modifiedContent, "\t")
@@ -215,6 +222,8 @@ func editSSHConfig(activeProfile config.Profile, workspace *apiclient.WorkspaceD
 	if err != nil {
 		return err
 	}
+
+	views.RenderInfoMessage(fmt.Sprintf("SSH configuration for %s updated successfully", projectName))
 
 	return nil
 }

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -222,7 +222,8 @@ func editSSHConfig(activeProfile config.Profile, workspace *apiclient.WorkspaceD
 		return nil
 	}
 
-	updatedLines := strings.Split(modifiedContent, "\n")
+	trimmedContent := strings.TrimSpace(modifiedContent)
+	updatedLines := strings.Split(trimmedContent, "\n")
 	updatedLines = append(updatedLines, proxyCommand)
 	modifiedContent = hostLine + "\n\t" + strings.Join(updatedLines, "\n\t")
 	modifiedContent = strings.TrimSuffix(modifiedContent, "\t")

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -225,7 +225,13 @@ func editSSHConfig(activeProfile config.Profile, workspace *apiclient.WorkspaceD
 	trimmedContent := strings.TrimSpace(modifiedContent)
 	updatedLines := strings.Split(trimmedContent, "\n")
 	updatedLines = append(updatedLines, proxyCommand)
-	modifiedContent = hostLine + "\n\t" + strings.Join(updatedLines, "\n\t")
+	var updatedLinesWithoutEmpty []string
+	for _, line := range updatedLines {
+		if line != "" {
+			updatedLinesWithoutEmpty = append(updatedLinesWithoutEmpty, line)
+		}
+	}
+	modifiedContent = hostLine + "\n\t" + strings.Join(updatedLinesWithoutEmpty, "\n\t")
 	modifiedContent = strings.TrimSuffix(modifiedContent, "\t")
 	if !strings.HasSuffix(modifiedContent, "\n") {
 		modifiedContent += "\n"

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -158,8 +158,7 @@ func editSSHConfig(activeProfile config.Profile, workspace *apiclient.WorkspaceD
 		return err
 	}
 
-	hostLine := fmt.Sprintf("Host %s-%s-%s", activeProfile.Id, workspace.Id, projectName)
-
+	hostLine := fmt.Sprintf("Host %s", config.GetProjectHostname(activeProfile.Id, workspace.Id, projectName))
 	regex := regexp.MustCompile(fmt.Sprintf(`%s\s*\n(?:\t.*\n?)*`, hostLine))
 	matchedEntry := regex.FindString(sshConfig)
 	if matchedEntry == "" {

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -167,10 +167,20 @@ func editSSHConfig(activeProfile config.Profile, workspace *apiclient.WorkspaceD
 	if len(lines) > 0 {
 		lines = lines[1:]
 	}
-	for i := range lines {
-		lines[i] = strings.TrimSpace(lines[i])
+
+	var proxyCommand string
+	var filteredLines []string
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "ProxyCommand") {
+			proxyCommand = trimmedLine
+		} else {
+			if trimmedLine != "" {
+				filteredLines = append(filteredLines, trimmedLine)
+			}
+		}
 	}
-	modifiedContent := strings.Join(lines, "\n")
+	modifiedContent := strings.Join(filteredLines, "\n")
 
 	isCorrect := true
 	formFields := []huh.Field{
@@ -211,7 +221,9 @@ func editSSHConfig(activeProfile config.Profile, workspace *apiclient.WorkspaceD
 
 		return nil
 	}
+
 	updatedLines := strings.Split(modifiedContent, "\n")
+	updatedLines = append(updatedLines, proxyCommand)
 	modifiedContent = hostLine + "\n\t" + strings.Join(updatedLines, "\n\t")
 	modifiedContent = strings.TrimSuffix(modifiedContent, "\t")
 	if !strings.HasSuffix(modifiedContent, "\n") {


### PR DESCRIPTION
## Description

This PR adds support for editing a workspace's project SSH config through the `daytona` CLI. Specifically it now supports `-e` to edit SSH config files.

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1207

## Screenshots
https://github.com/user-attachments/assets/49450ad9-b7ae-4abb-af07-eeabc43e7959

## Notes
This PR also fixes #1392 
![Screenshot from 2024-11-29 19-17-33](https://github.com/user-attachments/assets/0f811355-9632-4ce8-8f7f-d828ae08ce6a)

