### PR TITLE
fix: use conflict-http code (409) instead of 500

### DIFF
--- a/pkg/api/controllers/workspace/create.go
+++ b/pkg/api/controllers/workspace/create.go
@@ -35,7 +35,7 @@ func CreateWorkspace(ctx *gin.Context) {
 
 	w, err := server.WorkspaceService.CreateWorkspace(ctx.Request.Context(), createWorkspaceReq)
 	if err != nil {
-		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to create workspace: %w", err))
+		ctx.AbortWithError(http.StatusConflict, fmt.Errorf("failed to create workspace: %w", err))
 		return
 	}
 


### PR DESCRIPTION
# fix: use conflict-http code (409) instead of 500

## Description

Instead of using 500 http code which is for internal server code , we should now use 409 http code , which is for conflict

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1391

## Screenshots


## Notes
Please add any relevant notes if necessary.
