### PR TITLE
fix: use 409 http code for workspace already exist

### DIFF
--- a/pkg/api/controllers/workspace/create.go
+++ b/pkg/api/controllers/workspace/create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/daytonaio/daytona/pkg/server"
 	"github.com/daytonaio/daytona/pkg/server/workspaces/dto"
+	"github.com/daytonaio/daytona/pkg/server/workspaces"
 	"github.com/gin-gonic/gin"
 )
 
@@ -35,6 +36,10 @@ func CreateWorkspace(ctx *gin.Context) {
 
 	w, err := server.WorkspaceService.CreateWorkspace(ctx.Request.Context(), createWorkspaceReq)
 	if err != nil {
+		if err == workspaces.ErrWorkspaceAlreadyExists {
+			ctx.AbortWithError(http.StatusConflict, fmt.Errorf("workspace already exists: %w", err))
+			return
+		}
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to create workspace: %w", err))
 		return
 	}


### PR DESCRIPTION
# fix: use 409 http code for workspace already exist

## Description

Instead of using 500 http code which is for internal server code , we should now use 409 http code , which is for conflict

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1397 

## Screenshots
![image](https://github.com/user-attachments/assets/fe64ded7-a767-4462-b9bc-66e36536a879)


## Notes
Please add any relevant notes if necessary.
