### PR TITLE
fix: disallow concurrent jobs

### DIFF
--- a/internal/testing/job/store.go
+++ b/internal/testing/job/store.go
@@ -97,6 +97,13 @@ func (s *InMemoryJobStore) processFilters(filter *stores.JobFilter) ([]*models.J
 				}
 			}
 		}
+		if filter.ResourceId != nil {
+			for _, job := range filteredJobs {
+				if job.ResourceId != *filter.ResourceId {
+					delete(filteredJobs, job.Id)
+				}
+			}
+		}
 	}
 
 	for _, job := range filteredJobs {

--- a/pkg/cmd/server/bootstrap/get_job_runner.go
+++ b/pkg/cmd/server/bootstrap/get_job_runner.go
@@ -47,7 +47,7 @@ func GetJobRunner(c *server.Config, configDir string, version string, telemetryS
 			if err != nil {
 				job.Error = util.Pointer((*err).Error())
 			}
-			return jobService.Save(job)
+			return jobService.Update(job)
 		},
 		WorkspaceJobFactory: workspaceJobFactory,
 		TargetJobFactory:    targetJobFactory,

--- a/pkg/cmd/server/bootstrap/get_server_instance.go
+++ b/pkg/cmd/server/bootstrap/get_server_instance.go
@@ -299,7 +299,7 @@ func GetInstance(c *server.Config, configDir string, version string, telemetrySe
 			return apiKeyService.Revoke(name)
 		},
 		CreateJob: func(ctx context.Context, targetId string, action models.JobAction) error {
-			return jobService.Save(&models.Job{
+			return jobService.Create(&models.Job{
 				ResourceId:   targetId,
 				ResourceType: models.ResourceTypeTarget,
 				Action:       action,
@@ -369,7 +369,7 @@ func GetInstance(c *server.Config, configDir string, version string, telemetrySe
 			return gitProviderService.GetLastCommitSha(repo)
 		},
 		CreateJob: func(ctx context.Context, workspaceId string, action models.JobAction) error {
-			return jobService.Save(&models.Job{
+			return jobService.Create(&models.Job{
 				ResourceId:   workspaceId,
 				ResourceType: models.ResourceTypeWorkspace,
 				Action:       action,

--- a/pkg/db/job_store.go
+++ b/pkg/db/job_store.go
@@ -79,6 +79,9 @@ func processJobFilters(tx *gorm.DB, filter *stores.JobFilter) *gorm.DB {
 		if filter.ResourceType != nil {
 			tx = tx.Where("resource_type = ?", *filter.ResourceType)
 		}
+		if filter.ResourceId != nil {
+			tx = tx.Where("resource_id = ?", *filter.ResourceId)
+		}
 		if filter.States != nil && len(*filter.States) > 0 {
 			placeholders := strings.Repeat("?,", len(*filter.States))
 			placeholders = placeholders[:len(placeholders)-1]

--- a/pkg/services/job.go
+++ b/pkg/services/job.go
@@ -9,7 +9,8 @@ import (
 )
 
 type IJobService interface {
-	Save(job *models.Job) error
+	Create(job *models.Job) error
+	Update(job *models.Job) error
 	Find(filter *stores.JobFilter) (*models.Job, error)
 	List(filter *stores.JobFilter) ([]*models.Job, error)
 	Delete(job *models.Job) error

--- a/pkg/stores/job_store.go
+++ b/pkg/stores/job_store.go
@@ -18,6 +18,7 @@ type JobStore interface {
 
 type JobFilter struct {
 	Id           *string
+	ResourceId   *string
 	ResourceType *models.ResourceType
 	States       *[]models.JobState
 	Actions      *[]models.JobAction
@@ -40,9 +41,14 @@ func (f *JobFilter) ActionsToInterface() []interface{} {
 }
 
 var (
-	ErrJobNotFound = errors.New("job not found")
+	ErrJobNotFound   = errors.New("job not found")
+	ErrJobInProgress = errors.New("another job is in progress")
 )
 
 func IsJobNotFound(err error) bool {
 	return err.Error() == ErrJobNotFound.Error()
+}
+
+func IsJobInProgress(err error) bool {
+	return err.Error() == ErrJobInProgress.Error()
 }


### PR DESCRIPTION
# Disallow concurrent jobs

## Description

The job service now disallows concurrent jobs. E.g. a workspace can't be deleted while being created.
Also, split the `Save` method into `Create` and `Update` in the user service to make this possible and to improve readability.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![Screenshot 2024-12-02 at 14 39 28](https://github.com/user-attachments/assets/cb2b0deb-db59-4dc7-b831-568bd8686545)
