### PR TITLE
feat: disable items for selection when in invalid state

### DIFF
--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -82,7 +82,7 @@ var DeleteCmd = &cobra.Command{
 				return nil
 			}
 
-			workspaceDeleteList = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.DeleteActionVerb))
+			workspaceDeleteList = selection.GetWorkspacesFromPrompt(workspaceList, selection.DeleteActionVerb)
 		} else {
 			for _, arg := range args {
 				workspace, _, err := apiclient_util.GetWorkspace(arg, false)

--- a/pkg/cmd/workspace/delete.go
+++ b/pkg/cmd/workspace/delete.go
@@ -82,7 +82,7 @@ var DeleteCmd = &cobra.Command{
 				return nil
 			}
 
-			workspaceDeleteList = selection.GetWorkspacesFromPrompt(workspaceList, "Delete")
+			workspaceDeleteList = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.DeleteActionVerb))
 		} else {
 			for _, arg := range args {
 				workspace, _, err := apiclient_util.GetWorkspace(arg, false)

--- a/pkg/cmd/workspace/restart.go
+++ b/pkg/cmd/workspace/restart.go
@@ -44,7 +44,7 @@ var RestartCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, "Restart")
+			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.RestartActionVerb))
 			if selectedWorkspaces == nil {
 				return nil
 			}

--- a/pkg/cmd/workspace/restart.go
+++ b/pkg/cmd/workspace/restart.go
@@ -44,7 +44,7 @@ var RestartCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.RestartActionVerb))
+			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, selection.RestartActionVerb)
 			if selectedWorkspaces == nil {
 				return nil
 			}

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -60,7 +60,7 @@ var StartCmd = &cobra.Command{
 				return nil
 			}
 
-			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.StartActionVerb))
+			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, selection.StartActionVerb)
 		} else {
 			for _, arg := range args {
 				workspace, _, err := apiclient_util.GetWorkspace(arg, false)

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -60,7 +60,7 @@ var StartCmd = &cobra.Command{
 				return nil
 			}
 
-			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, "Start")
+			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.StartActionVerb))
 		} else {
 			for _, arg := range args {
 				workspace, _, err := apiclient_util.GetWorkspace(arg, false)

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -50,7 +50,7 @@ var StopCmd = &cobra.Command{
 				return nil
 			}
 
-			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, "Stop")
+			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.StopActionVerb))
 		} else {
 			for _, arg := range args {
 				workspace, _, err := apiclient_util.GetWorkspace(arg, false)

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -50,7 +50,7 @@ var StopCmd = &cobra.Command{
 				return nil
 			}
 
-			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, string(selection.StopActionVerb))
+			selectedWorkspaces = selection.GetWorkspacesFromPrompt(workspaceList, selection.StopActionVerb)
 		} else {
 			for _, arg := range args {
 				workspace, _, err := apiclient_util.GetWorkspace(arg, false)

--- a/pkg/views/workspace/selection/view.go
+++ b/pkg/views/workspace/selection/view.go
@@ -76,6 +76,53 @@ func (m model[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
+		case "down", "j":
+			for {
+				isSubsequentItemsDisabled := true
+				curIndex := m.list.Index()
+				lastIndex := len(m.list.Items()) - 1
+				for i := curIndex + 1; i <= lastIndex; i++ {
+					if !m.list.Items()[i].(item[T]).isDisabled {
+						isSubsequentItemsDisabled = false
+						break
+					}
+				}
+				// no need of moving cursor down if all subsequent items after current index have
+				// disabled property true.
+				if isSubsequentItemsDisabled {
+					break
+				}
+				m.list.CursorDown()
+				item := m.list.SelectedItem().(item[T])
+				if !item.isDisabled {
+					break
+				}
+			}
+			return m, nil
+
+		case "up", "k":
+			for {
+				isPrecedingItemsDisabled := true
+				curIndex := m.list.Index()
+				for i := curIndex - 1; i >= 0; i-- {
+					if !m.list.Items()[i].(item[T]).isDisabled {
+						isPrecedingItemsDisabled = false
+						break
+					}
+				}
+				// no need of moving cursor up if all preceding items before current index have
+				// disabled property true.
+				if isPrecedingItemsDisabled {
+					break
+				}
+				m.list.CursorUp()
+				item := m.list.SelectedItem().(item[T])
+				if !item.isDisabled {
+					break
+				}
+			}
+			return m, nil
+
 		case "ctrl+c":
 			return m, tea.Quit
 

--- a/pkg/views/workspace/selection/workspace.go
+++ b/pkg/views/workspace/selection/workspace.go
@@ -19,6 +19,13 @@ import (
 
 var NewWorkspaceIdentifier = "<NEW_WORKSPACE>"
 
+type ActionVerb string
+
+var StartActionVerb ActionVerb = "Start"
+var StopActionVerb ActionVerb = "Stop"
+var RestartActionVerb ActionVerb = "Restart"
+var DeleteActionVerb ActionVerb = "Delete"
+
 func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect bool, action string) []list.Item {
 	// Initialize an empty list of items.
 	items := []list.Item{}
@@ -39,6 +46,18 @@ func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect
 
 		stateLabel := views.GetStateLabel(workspace.State.Name)
 
+		isDisabled := false
+		switch action {
+		case string(StartActionVerb):
+			if workspace.State.Name == apiclient.ResourceStateNameStarted {
+				isDisabled = true
+			}
+		case string(StopActionVerb), string(RestartActionVerb):
+			if workspace.State.Name == apiclient.ResourceStateNameStopped {
+				isDisabled = true
+			}
+		}
+
 		if workspace.Metadata != nil {
 			views_util.CheckAndAppendTimeLabel(&stateLabel, workspace.State, workspace.Metadata.Uptime)
 		}
@@ -53,6 +72,7 @@ func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect
 			state:          stateLabel,
 			workspace:      &workspace,
 			choiceProperty: workspace,
+			isDisabled:     isDisabled,
 		}
 
 		if isMultipleSelect {

--- a/pkg/views/workspace/selection/workspace.go
+++ b/pkg/views/workspace/selection/workspace.go
@@ -26,9 +26,11 @@ var StopActionVerb ActionVerb = "Stop"
 var RestartActionVerb ActionVerb = "Restart"
 var DeleteActionVerb ActionVerb = "Delete"
 
-func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect bool, action string) []list.Item {
+func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect bool, action ActionVerb) []list.Item {
 	// Initialize an empty list of items.
 	items := []list.Item{}
+	enabledItems := []list.Item{}
+	disabledItems := []list.Item{}
 
 	// Populate items with titles and descriptions from workspaces.
 	for _, workspace := range workspaces {
@@ -48,11 +50,11 @@ func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect
 
 		isDisabled := false
 		switch action {
-		case string(StartActionVerb):
+		case StartActionVerb:
 			if workspace.State.Name == apiclient.ResourceStateNameStarted {
 				isDisabled = true
 			}
-		case string(StopActionVerb), string(RestartActionVerb):
+		case StopActionVerb, RestartActionVerb:
 			if workspace.State.Name == apiclient.ResourceStateNameStopped {
 				isDisabled = true
 			}
@@ -77,16 +79,23 @@ func generateWorkspaceList(workspaces []apiclient.WorkspaceDTO, isMultipleSelect
 
 		if isMultipleSelect {
 			newItem.isMultipleSelect = true
-			newItem.action = action
+			newItem.action = string(action)
 		}
 
-		items = append(items, newItem)
+		if isDisabled {
+			disabledItems = append(disabledItems, newItem)
+		} else {
+			enabledItems = append(enabledItems, newItem)
+		}
 	}
+
+	items = append(items, enabledItems...)
+	items = append(items, disabledItems...)
 
 	return items
 }
 
-func getWorkspaceProgramEssentials(modelTitle string, actionVerb string, workspaces []apiclient.WorkspaceDTO, footerText string, isMultipleSelect bool) tea.Model {
+func getWorkspaceProgramEssentials(modelTitle string, actionVerb ActionVerb, workspaces []apiclient.WorkspaceDTO, footerText string, isMultipleSelect bool) tea.Model {
 
 	items := generateWorkspaceList(workspaces, isMultipleSelect, actionVerb)
 
@@ -102,7 +111,7 @@ func getWorkspaceProgramEssentials(modelTitle string, actionVerb string, workspa
 
 	m := model[apiclient.WorkspaceDTO]{list: l}
 
-	m.list.Title = views.GetStyledMainTitle(modelTitle + actionVerb)
+	m.list.Title = views.GetStyledMainTitle(modelTitle + string(actionVerb))
 	m.list.Styles.Title = lipgloss.NewStyle().Foreground(views.Green).Bold(true)
 	m.footer = footerText
 
@@ -116,7 +125,7 @@ func getWorkspaceProgramEssentials(modelTitle string, actionVerb string, workspa
 	return p
 }
 
-func selectWorkspacePrompt(workspaces []apiclient.WorkspaceDTO, actionVerb string, choiceChan chan<- *apiclient.WorkspaceDTO) {
+func selectWorkspacePrompt(workspaces []apiclient.WorkspaceDTO, actionVerb ActionVerb, choiceChan chan<- *apiclient.WorkspaceDTO) {
 	list_view.SortWorkspaces(&workspaces, true)
 
 	p := getWorkspaceProgramEssentials("Select a Workspace To ", actionVerb, workspaces, "", false)
@@ -127,7 +136,7 @@ func selectWorkspacePrompt(workspaces []apiclient.WorkspaceDTO, actionVerb strin
 	}
 }
 
-func GetWorkspaceFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb string) *apiclient.WorkspaceDTO {
+func GetWorkspaceFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb ActionVerb) *apiclient.WorkspaceDTO {
 	choiceChan := make(chan *apiclient.WorkspaceDTO)
 
 	go selectWorkspacePrompt(workspaces, actionVerb, choiceChan)
@@ -135,7 +144,7 @@ func GetWorkspaceFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb stri
 	return <-choiceChan
 }
 
-func selectWorkspacesFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb string, choiceChan chan<- []*apiclient.WorkspaceDTO) {
+func selectWorkspacesFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb ActionVerb, choiceChan chan<- []*apiclient.WorkspaceDTO) {
 	list_view.SortWorkspaces(&workspaces, true)
 
 	footerText := lipgloss.NewStyle().Bold(true).PaddingLeft(2).Render(fmt.Sprintf("\n\nPress 'x' to mark a workspace.\nPress 'enter' to %s the current/marked workspaces.", actionVerb))
@@ -151,7 +160,7 @@ func selectWorkspacesFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb 
 	}
 }
 
-func GetWorkspacesFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb string) []*apiclient.WorkspaceDTO {
+func GetWorkspacesFromPrompt(workspaces []apiclient.WorkspaceDTO, actionVerb ActionVerb) []*apiclient.WorkspaceDTO {
 	choiceChan := make(chan []*apiclient.WorkspaceDTO)
 
 	go selectWorkspacesFromPrompt(workspaces, actionVerb, choiceChan)


### PR DESCRIPTION
# Disable items for selection when in invalid state

## Description

This PR introduces selection of items in improper state for commands such as `daytona start`, `daytona stop`, `daytona restart` and `daytona delete`.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenrecording
https://github.com/user-attachments/assets/9b5910e0-a28d-4f78-b03e-72706616c416