### PR TITLE
fix: hide env vars for nested target or workspace

### DIFF
--- a/pkg/api/controllers/target/target.go
+++ b/pkg/api/controllers/target/target.go
@@ -61,6 +61,10 @@ func GetTarget(ctx *gin.Context) {
 		t.TargetConfig.Options = maskedOptions
 	}
 
+	for i := range t.Workspaces {
+		util.HideDaytonaEnvVars(&t.Workspaces[i].EnvVars)
+	}
+
 	util.HideDaytonaEnvVars(&t.EnvVars)
 
 	ctx.JSON(200, t)
@@ -106,6 +110,11 @@ func ListTargets(ctx *gin.Context) {
 		}
 
 		targetList[i].TargetConfig.Options = maskedOptions
+
+		for j := range targetList[i].Workspaces {
+			util.HideDaytonaEnvVars(&targetList[i].Workspaces[j].EnvVars)
+		}
+
 		util.HideDaytonaEnvVars(&targetList[i].EnvVars)
 	}
 

--- a/pkg/api/controllers/workspace/workspace.go
+++ b/pkg/api/controllers/workspace/workspace.go
@@ -55,6 +55,7 @@ func GetWorkspace(ctx *gin.Context) {
 	}
 
 	util.HideDaytonaEnvVars(&w.EnvVars)
+	util.HideDaytonaEnvVars(&w.Target.EnvVars)
 
 	ctx.JSON(200, w)
 }
@@ -93,6 +94,7 @@ func ListWorkspaces(ctx *gin.Context) {
 
 	for i, _ := range workspaceList {
 		util.HideDaytonaEnvVars(&workspaceList[i].EnvVars)
+		util.HideDaytonaEnvVars(&workspaceList[i].Target.EnvVars)
 	}
 
 	ctx.JSON(200, workspaceList)


### PR DESCRIPTION
# Hide env vars for nested target or workspace
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
