### PR TITLE
fix: healthcheck not waiting for all services to start

### DIFF
--- a/internal/util/apiclient/error.go
+++ b/internal/util/apiclient/error.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ErrHealthCheckFailed(healthUrl string) error {
-	return fmt.Errorf("failed to check server health at: %s. Make sure Daytona is running on the appropriate port", healthUrl)
+	return fmt.Errorf("failed to check server health at: %s. Make sure all Daytona services are running on the appropriate ports", healthUrl)
 }
 
 func IsHealthCheckFailed(err error) bool {

--- a/pkg/server/providers.go
+++ b/pkg/server/providers.go
@@ -13,6 +13,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var AllProviderRegistered = false
+
 func (s *Server) downloadDefaultProviders() error {
 	manifest, err := s.ProviderManager.GetProvidersManifest()
 	if err != nil {
@@ -122,6 +124,7 @@ func (s *Server) registerProviders() error {
 	}
 
 	log.Info("Providers registered")
+	AllProviderRegistered = true
 
 	return nil
 }


### PR DESCRIPTION
# fix daytona healthcheck not waiting for all services to start

## Description

This PR updates the Daytona health check to ensure all services are ready before the command exits.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #1357 