### PR TITLE
fix: properly handle no target mode agent in providers

### DIFF
--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -3178,10 +3178,14 @@ const docTemplate = `{
         "TargetProviderInfo": {
             "type": "object",
             "required": [
+                "agentlessTarget",
                 "name",
                 "version"
             ],
             "properties": {
+                "agentlessTarget": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 },

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -3178,7 +3178,6 @@ const docTemplate = `{
         "TargetProviderInfo": {
             "type": "object",
             "required": [
-                "agentlessTarget",
                 "name",
                 "version"
             ],

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -3175,10 +3175,14 @@
         "TargetProviderInfo": {
             "type": "object",
             "required": [
+                "agentlessTarget",
                 "name",
                 "version"
             ],
             "properties": {
+                "agentlessTarget": {
+                    "type": "boolean"
+                },
                 "label": {
                     "type": "string"
                 },

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -3175,7 +3175,6 @@
         "TargetProviderInfo": {
             "type": "object",
             "required": [
-                "agentlessTarget",
                 "name",
                 "version"
             ],

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -862,7 +862,6 @@ definitions:
       version:
         type: string
     required:
-    - agentlessTarget
     - name
     - version
     type: object

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -853,6 +853,8 @@ definitions:
     type: object
   TargetProviderInfo:
     properties:
+      agentlessTarget:
+        type: boolean
       label:
         type: string
       name:
@@ -860,6 +862,7 @@ definitions:
       version:
         type: string
     required:
+    - agentlessTarget
     - name
     - version
     type: object

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -2846,7 +2846,6 @@ components:
         version:
           type: string
       required:
-      - agentlessTarget
       - name
       - version
       type: object

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1405,6 +1405,7 @@ components:
         name: name
         options: options
         providerInfo:
+          agentlessTarget: true
           name: name
           label: label
           version: version
@@ -2435,6 +2436,7 @@ components:
           options: options
           id: id
           providerInfo:
+            agentlessTarget: true
             name: name
             label: label
             version: version
@@ -2494,6 +2496,7 @@ components:
         options: options
         id: id
         providerInfo:
+          agentlessTarget: true
           name: name
           label: label
           version: version
@@ -2565,6 +2568,7 @@ components:
           options: options
           id: id
           providerInfo:
+            agentlessTarget: true
             name: name
             label: label
             version: version
@@ -2651,6 +2655,7 @@ components:
               options: options
               id: id
               providerInfo:
+                agentlessTarget: true
                 name: name
                 label: label
                 version: version
@@ -2735,6 +2740,7 @@ components:
               options: options
               id: id
               providerInfo:
+                agentlessTarget: true
                 name: name
                 label: label
                 version: version
@@ -2826,10 +2832,13 @@ components:
       type: object
     TargetProviderInfo:
       example:
+        agentlessTarget: true
         name: name
         label: label
         version: version
       properties:
+        agentlessTarget:
+          type: boolean
         label:
           type: string
         name:
@@ -2837,6 +2846,7 @@ components:
         version:
           type: string
       required:
+      - agentlessTarget
       - name
       - version
       type: object
@@ -2906,6 +2916,7 @@ components:
             options: options
             id: id
             providerInfo:
+              agentlessTarget: true
               name: name
               label: label
               version: version
@@ -3011,6 +3022,7 @@ components:
             options: options
             id: id
             providerInfo:
+              agentlessTarget: true
               name: name
               label: label
               version: version

--- a/pkg/apiclient/docs/TargetConfigAPI.md
+++ b/pkg/apiclient/docs/TargetConfigAPI.md
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	targetConfig := *openapiclient.NewAddTargetConfigDTO("Name_example", "Options_example", *openapiclient.NewTargetProviderInfo("Name_example", "Version_example")) // AddTargetConfigDTO | Target config to add
+	targetConfig := *openapiclient.NewAddTargetConfigDTO("Name_example", "Options_example", *openapiclient.NewTargetProviderInfo(false, "Name_example", "Version_example")) // AddTargetConfigDTO | Target config to add
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/docs/TargetConfigAPI.md
+++ b/pkg/apiclient/docs/TargetConfigAPI.md
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	targetConfig := *openapiclient.NewAddTargetConfigDTO("Name_example", "Options_example", *openapiclient.NewTargetProviderInfo(false, "Name_example", "Version_example")) // AddTargetConfigDTO | Target config to add
+	targetConfig := *openapiclient.NewAddTargetConfigDTO("Name_example", "Options_example", *openapiclient.NewTargetProviderInfo("Name_example", "Version_example")) // AddTargetConfigDTO | Target config to add
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/docs/TargetProviderInfo.md
+++ b/pkg/apiclient/docs/TargetProviderInfo.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**AgentlessTarget** | **bool** |  | 
 **Label** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
 **Version** | **string** |  | 
@@ -12,7 +13,7 @@ Name | Type | Description | Notes
 
 ### NewTargetProviderInfo
 
-`func NewTargetProviderInfo(name string, version string, ) *TargetProviderInfo`
+`func NewTargetProviderInfo(agentlessTarget bool, name string, version string, ) *TargetProviderInfo`
 
 NewTargetProviderInfo instantiates a new TargetProviderInfo object
 This constructor will assign default values to properties that have it defined,
@@ -26,6 +27,26 @@ will change when the set of required properties is changed
 NewTargetProviderInfoWithDefaults instantiates a new TargetProviderInfo object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
+
+### GetAgentlessTarget
+
+`func (o *TargetProviderInfo) GetAgentlessTarget() bool`
+
+GetAgentlessTarget returns the AgentlessTarget field if non-nil, zero value otherwise.
+
+### GetAgentlessTargetOk
+
+`func (o *TargetProviderInfo) GetAgentlessTargetOk() (*bool, bool)`
+
+GetAgentlessTargetOk returns a tuple with the AgentlessTarget field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetAgentlessTarget
+
+`func (o *TargetProviderInfo) SetAgentlessTarget(v bool)`
+
+SetAgentlessTarget sets AgentlessTarget field to given value.
+
 
 ### GetLabel
 

--- a/pkg/apiclient/docs/TargetProviderInfo.md
+++ b/pkg/apiclient/docs/TargetProviderInfo.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**AgentlessTarget** | **bool** |  | 
+**AgentlessTarget** | Pointer to **bool** |  | [optional] 
 **Label** | Pointer to **string** |  | [optional] 
 **Name** | **string** |  | 
 **Version** | **string** |  | 
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 
 ### NewTargetProviderInfo
 
-`func NewTargetProviderInfo(agentlessTarget bool, name string, version string, ) *TargetProviderInfo`
+`func NewTargetProviderInfo(name string, version string, ) *TargetProviderInfo`
 
 NewTargetProviderInfo instantiates a new TargetProviderInfo object
 This constructor will assign default values to properties that have it defined,
@@ -47,6 +47,11 @@ and a boolean to check if the value has been set.
 
 SetAgentlessTarget sets AgentlessTarget field to given value.
 
+### HasAgentlessTarget
+
+`func (o *TargetProviderInfo) HasAgentlessTarget() bool`
+
+HasAgentlessTarget returns a boolean if a field has been set.
 
 ### GetLabel
 

--- a/pkg/apiclient/model_target_provider_info.go
+++ b/pkg/apiclient/model_target_provider_info.go
@@ -21,7 +21,7 @@ var _ MappedNullable = &TargetProviderInfo{}
 
 // TargetProviderInfo struct for TargetProviderInfo
 type TargetProviderInfo struct {
-	AgentlessTarget bool    `json:"agentlessTarget"`
+	AgentlessTarget *bool   `json:"agentlessTarget,omitempty"`
 	Label           *string `json:"label,omitempty"`
 	Name            string  `json:"name"`
 	Version         string  `json:"version"`
@@ -33,9 +33,8 @@ type _TargetProviderInfo TargetProviderInfo
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTargetProviderInfo(agentlessTarget bool, name string, version string) *TargetProviderInfo {
+func NewTargetProviderInfo(name string, version string) *TargetProviderInfo {
 	this := TargetProviderInfo{}
-	this.AgentlessTarget = agentlessTarget
 	this.Name = name
 	this.Version = version
 	return &this
@@ -49,28 +48,36 @@ func NewTargetProviderInfoWithDefaults() *TargetProviderInfo {
 	return &this
 }
 
-// GetAgentlessTarget returns the AgentlessTarget field value
+// GetAgentlessTarget returns the AgentlessTarget field value if set, zero value otherwise.
 func (o *TargetProviderInfo) GetAgentlessTarget() bool {
-	if o == nil {
+	if o == nil || IsNil(o.AgentlessTarget) {
 		var ret bool
 		return ret
 	}
-
-	return o.AgentlessTarget
+	return *o.AgentlessTarget
 }
 
-// GetAgentlessTargetOk returns a tuple with the AgentlessTarget field value
+// GetAgentlessTargetOk returns a tuple with the AgentlessTarget field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *TargetProviderInfo) GetAgentlessTargetOk() (*bool, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.AgentlessTarget) {
 		return nil, false
 	}
-	return &o.AgentlessTarget, true
+	return o.AgentlessTarget, true
 }
 
-// SetAgentlessTarget sets field value
+// HasAgentlessTarget returns a boolean if a field has been set.
+func (o *TargetProviderInfo) HasAgentlessTarget() bool {
+	if o != nil && !IsNil(o.AgentlessTarget) {
+		return true
+	}
+
+	return false
+}
+
+// SetAgentlessTarget gets a reference to the given bool and assigns it to the AgentlessTarget field.
 func (o *TargetProviderInfo) SetAgentlessTarget(v bool) {
-	o.AgentlessTarget = v
+	o.AgentlessTarget = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -163,7 +170,9 @@ func (o TargetProviderInfo) MarshalJSON() ([]byte, error) {
 
 func (o TargetProviderInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["agentlessTarget"] = o.AgentlessTarget
+	if !IsNil(o.AgentlessTarget) {
+		toSerialize["agentlessTarget"] = o.AgentlessTarget
+	}
 	if !IsNil(o.Label) {
 		toSerialize["label"] = o.Label
 	}
@@ -177,7 +186,6 @@ func (o *TargetProviderInfo) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
-		"agentlessTarget",
 		"name",
 		"version",
 	}

--- a/pkg/apiclient/model_target_provider_info.go
+++ b/pkg/apiclient/model_target_provider_info.go
@@ -21,9 +21,10 @@ var _ MappedNullable = &TargetProviderInfo{}
 
 // TargetProviderInfo struct for TargetProviderInfo
 type TargetProviderInfo struct {
-	Label   *string `json:"label,omitempty"`
-	Name    string  `json:"name"`
-	Version string  `json:"version"`
+	AgentlessTarget bool    `json:"agentlessTarget"`
+	Label           *string `json:"label,omitempty"`
+	Name            string  `json:"name"`
+	Version         string  `json:"version"`
 }
 
 type _TargetProviderInfo TargetProviderInfo
@@ -32,8 +33,9 @@ type _TargetProviderInfo TargetProviderInfo
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTargetProviderInfo(name string, version string) *TargetProviderInfo {
+func NewTargetProviderInfo(agentlessTarget bool, name string, version string) *TargetProviderInfo {
 	this := TargetProviderInfo{}
+	this.AgentlessTarget = agentlessTarget
 	this.Name = name
 	this.Version = version
 	return &this
@@ -45,6 +47,30 @@ func NewTargetProviderInfo(name string, version string) *TargetProviderInfo {
 func NewTargetProviderInfoWithDefaults() *TargetProviderInfo {
 	this := TargetProviderInfo{}
 	return &this
+}
+
+// GetAgentlessTarget returns the AgentlessTarget field value
+func (o *TargetProviderInfo) GetAgentlessTarget() bool {
+	if o == nil {
+		var ret bool
+		return ret
+	}
+
+	return o.AgentlessTarget
+}
+
+// GetAgentlessTargetOk returns a tuple with the AgentlessTarget field value
+// and a boolean to check if the value has been set.
+func (o *TargetProviderInfo) GetAgentlessTargetOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.AgentlessTarget, true
+}
+
+// SetAgentlessTarget sets field value
+func (o *TargetProviderInfo) SetAgentlessTarget(v bool) {
+	o.AgentlessTarget = v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -137,6 +163,7 @@ func (o TargetProviderInfo) MarshalJSON() ([]byte, error) {
 
 func (o TargetProviderInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	toSerialize["agentlessTarget"] = o.AgentlessTarget
 	if !IsNil(o.Label) {
 		toSerialize["label"] = o.Label
 	}
@@ -150,6 +177,7 @@ func (o *TargetProviderInfo) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
+		"agentlessTarget",
 		"name",
 		"version",
 	}

--- a/pkg/cmd/common/await_state.go
+++ b/pkg/cmd/common/await_state.go
@@ -38,7 +38,7 @@ func AwaitTargetState(targetId string, stateName apiclient.ModelsResourceStateNa
 		if err != nil {
 			return err
 		}
-		if t.State.Name == stateName || t.TargetConfig.ProviderInfo.AgentlessTarget {
+		if t.State.Name == stateName || t.TargetConfig.ProviderInfo.AgentlessTarget != nil && *t.TargetConfig.ProviderInfo.AgentlessTarget {
 			time.Sleep(time.Second)
 			return nil
 		}

--- a/pkg/cmd/common/await_state.go
+++ b/pkg/cmd/common/await_state.go
@@ -38,9 +38,11 @@ func AwaitTargetState(targetId string, stateName apiclient.ModelsResourceStateNa
 		if err != nil {
 			return err
 		}
-		if t.State.Name == stateName || t.TargetConfig.ProviderInfo.AgentlessTarget != nil && *t.TargetConfig.ProviderInfo.AgentlessTarget {
+
+		if t.State.Name == stateName || t.State.Name == apiclient.ResourceStateNameUndefined {
 			return nil
 		}
+
 		if t.State.Name == apiclient.ResourceStateNameError {
 			var errorMessage string
 			if t.State.Error != nil {

--- a/pkg/cmd/common/await_state.go
+++ b/pkg/cmd/common/await_state.go
@@ -38,7 +38,8 @@ func AwaitTargetState(targetId string, stateName apiclient.ModelsResourceStateNa
 		if err != nil {
 			return err
 		}
-		if t.State.Name == stateName || t.State.Name == apiclient.ResourceStateNameUndefined {
+		if t.State.Name == stateName || t.TargetConfig.ProviderInfo.AgentlessTarget {
+			time.Sleep(time.Second)
 			return nil
 		}
 		if t.State.Name == apiclient.ResourceStateNameError {

--- a/pkg/cmd/common/await_state.go
+++ b/pkg/cmd/common/await_state.go
@@ -39,7 +39,6 @@ func AwaitTargetState(targetId string, stateName apiclient.ModelsResourceStateNa
 			return err
 		}
 		if t.State.Name == stateName || t.TargetConfig.ProviderInfo.AgentlessTarget != nil && *t.TargetConfig.ProviderInfo.AgentlessTarget {
-			time.Sleep(time.Second)
 			return nil
 		}
 		if t.State.Name == apiclient.ResourceStateNameError {

--- a/pkg/cmd/target/create.go
+++ b/pkg/cmd/target/create.go
@@ -6,6 +6,7 @@ package target
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/daytonaio/daytona/cmd/daytona/config"
 	"github.com/daytonaio/daytona/internal/util"
@@ -85,6 +86,9 @@ var targetCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		// Ensure reading remaining logs is completed
+		time.Sleep(100 * time.Millisecond)
 
 		views.RenderInfoMessage(fmt.Sprintf("Target '%s' set successfully and will be used by default", createTargetDto.Name))
 		return nil

--- a/pkg/cmd/target/create.go
+++ b/pkg/cmd/target/create.go
@@ -87,7 +87,7 @@ var targetCreateCmd = &cobra.Command{
 			return err
 		}
 
-		// Ensure reading remaining logs is completed
+		// Ensure reading remaining logs is complete
 		time.Sleep(100 * time.Millisecond)
 
 		views.RenderInfoMessage(fmt.Sprintf("Target '%s' set successfully and will be used by default", createTargetDto.Name))

--- a/pkg/cmd/target/ssh.go
+++ b/pkg/cmd/target/ssh.go
@@ -103,7 +103,7 @@ func autoStartTarget(target apiclient.TargetDTO) (bool, error) {
 		return false, err
 	}
 
-	err = StartTarget(apiClient, target.Id)
+	err = StartTarget(apiClient, target)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cmd/target/start.go
+++ b/pkg/cmd/target/start.go
@@ -190,7 +190,9 @@ func StartTarget(apiClient *apiclient.APIClient, targetId string) error {
 
 	err = cmd_common.AwaitTargetState(targetId, apiclient.ResourceStateNameStarted)
 
+	// Ensure reading remaining logs is completed
 	time.Sleep(100 * time.Millisecond)
+
 	stopLogs()
 	return err
 }

--- a/pkg/cmd/target/start.go
+++ b/pkg/cmd/target/start.go
@@ -169,6 +169,10 @@ func StartTarget(apiClient *apiclient.APIClient, targetId string) error {
 		return err
 	}
 
+	if target.TargetConfig.ProviderInfo.AgentlessTarget {
+		return agentlessTargetError(target.TargetConfig.ProviderInfo.Name)
+	}
+
 	logsContext, stopLogs := context.WithCancel(context.Background())
 	go apiclient_util.ReadTargetLogs(logsContext, apiclient_util.ReadLogParams{
 		Id:            target.Id,
@@ -189,4 +193,8 @@ func StartTarget(apiClient *apiclient.APIClient, targetId string) error {
 	time.Sleep(100 * time.Millisecond)
 	stopLogs()
 	return err
+}
+
+func agentlessTargetError(providerName string) error {
+	return fmt.Errorf("%s does not require target state management; you may continue without starting or stopping it", providerName)
 }

--- a/pkg/cmd/target/start.go
+++ b/pkg/cmd/target/start.go
@@ -169,7 +169,7 @@ func StartTarget(apiClient *apiclient.APIClient, targetId string) error {
 		return err
 	}
 
-	if target.TargetConfig.ProviderInfo.AgentlessTarget {
+	if target.TargetConfig.ProviderInfo.AgentlessTarget != nil && *target.TargetConfig.ProviderInfo.AgentlessTarget {
 		return agentlessTargetError(target.TargetConfig.ProviderInfo.Name)
 	}
 

--- a/pkg/cmd/target/stop.go
+++ b/pkg/cmd/target/stop.go
@@ -162,7 +162,7 @@ func StopTarget(apiClient *apiclient.APIClient, targetId string) error {
 		return err
 	}
 
-	if target.TargetConfig.ProviderInfo.AgentlessTarget {
+	if target.TargetConfig.ProviderInfo.AgentlessTarget != nil && *target.TargetConfig.ProviderInfo.AgentlessTarget {
 		return agentlessTargetError(target.TargetConfig.ProviderInfo.Name)
 	}
 

--- a/pkg/cmd/target/stop.go
+++ b/pkg/cmd/target/stop.go
@@ -157,7 +157,16 @@ func stopAllTargets(activeProfile config.Profile, from time.Time) error {
 func StopTarget(apiClient *apiclient.APIClient, targetId string) error {
 	ctx := context.Background()
 
-	err := views_util.WithInlineSpinner(fmt.Sprintf("Target '%s' is stopping", targetId), func() error {
+	target, _, err := apiclient_util.GetTarget(targetId, false)
+	if err != nil {
+		return err
+	}
+
+	if target.TargetConfig.ProviderInfo.AgentlessTarget {
+		return agentlessTargetError(target.TargetConfig.ProviderInfo.Name)
+	}
+
+	err = views_util.WithInlineSpinner(fmt.Sprintf("Target '%s' is stopping", targetId), func() error {
 		res, err := apiClient.TargetAPI.StopTarget(ctx, targetId).Execute()
 		if err != nil {
 			return apiclient_util.HandleErrorResponse(res, err)

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -157,6 +157,7 @@ func StopWorkspace(apiClient *apiclient.APIClient, workspace apiclient.Workspace
 		return err
 	}
 
+	// Ensure reading remaining logs is completed
 	time.Sleep(100 * time.Millisecond)
 
 	stopLogs()

--- a/pkg/jobs/target/create.go
+++ b/pkg/jobs/target/create.go
@@ -34,5 +34,10 @@ func (tj *TargetJob) create(ctx context.Context, j *models.Job) error {
 	}
 
 	targetLogger.Write([]byte(views.GetPrettyLogLine("Target creation complete")))
+
+	if tg.TargetConfig.ProviderInfo.AgentlessTarget {
+		return nil
+	}
+
 	return tj.start(ctx, j)
 }

--- a/pkg/models/target.go
+++ b/pkg/models/target.go
@@ -61,6 +61,6 @@ type TargetInfo struct {
 type ProviderInfo struct {
 	Name            string  `json:"name" validate:"required"`
 	Version         string  `json:"version" validate:"required"`
-	AgentlessTarget bool    `json:"agentlessTarget" validate:"required"`
+	AgentlessTarget bool    `json:"agentlessTarget" validate:"optional"`
 	Label           *string `json:"label" validate:"optional"`
 } // @name TargetProviderInfo

--- a/pkg/models/target.go
+++ b/pkg/models/target.go
@@ -4,15 +4,12 @@
 package models
 
 import (
-	"slices"
 	"time"
 
 	"github.com/daytonaio/daytona/internal/util"
 )
 
 const AGENT_UNRESPONSIVE_THRESHOLD = 30 * time.Second
-
-var providersWithoutTargetMode = []string{"docker-provider"}
 
 type Target struct {
 	Id             string            `json:"id" validate:"required" gorm:"primaryKey"`
@@ -37,7 +34,7 @@ func (t *Target) GetState() ResourceState {
 	state := getResourceStateFromJob(t.LastJob)
 
 	// Some providers do not utilize agents in target mode
-	if state.Name != ResourceStateNameDeleted && slices.Contains(providersWithoutTargetMode, t.TargetConfig.ProviderInfo.Name) {
+	if state.Name != ResourceStateNameDeleted && t.TargetConfig.ProviderInfo.AgentlessTarget {
 		return ResourceState{
 			Name:      ResourceStateNameUndefined,
 			UpdatedAt: time.Now(),
@@ -62,7 +59,8 @@ type TargetInfo struct {
 } // @name TargetInfo
 
 type ProviderInfo struct {
-	Name    string  `json:"name" validate:"required"`
-	Version string  `json:"version" validate:"required"`
-	Label   *string `json:"label" validate:"optional"`
+	Name            string  `json:"name" validate:"required"`
+	Version         string  `json:"version" validate:"required"`
+	AgentlessTarget bool    `json:"agentlessTarget" validate:"required"`
+	Label           *string `json:"label" validate:"optional"`
 } // @name TargetProviderInfo

--- a/pkg/models/target.go
+++ b/pkg/models/target.go
@@ -34,7 +34,11 @@ func (t *Target) GetState() ResourceState {
 	state := getResourceStateFromJob(t.LastJob)
 
 	// Some providers do not utilize agents in target mode
-	if state.Name != ResourceStateNameDeleted && t.TargetConfig.ProviderInfo.AgentlessTarget {
+	if t.TargetConfig.ProviderInfo.AgentlessTarget {
+		if state.Name == ResourceStateNameDeleted || state.Name == ResourceStateNamePendingCreate || state.Name == ResourceStateNameCreating {
+			return state
+		}
+
 		return ResourceState{
 			Name:      ResourceStateNameUndefined,
 			UpdatedAt: time.Now(),

--- a/pkg/provider/manager/manager.go
+++ b/pkg/provider/manager/manager.go
@@ -191,9 +191,10 @@ func (m *ProviderManager) RegisterProvider(pluginPath string, manualInstall bool
 
 			err = m.createTargetConfig(ctx, targetConfig.Name, targetConfig.Options,
 				models.ProviderInfo{
-					Name:    providerInfo.Name,
-					Version: providerInfo.Version,
-					Label:   providerInfo.Label,
+					Name:            providerInfo.Name,
+					Version:         providerInfo.Version,
+					Label:           providerInfo.Label,
+					AgentlessTarget: providerInfo.AgentlessTarget,
 				})
 			if err != nil {
 				log.Errorf("Failed to set target config %s: %s", targetConfig.Name, err)

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -37,7 +37,7 @@ type WorkspaceRequest struct {
 type ProviderInfo struct {
 	Name            string  `json:"name" validate:"required"`
 	Label           *string `json:"label" validate:"optional"`
-	AgentlessTarget bool    `json:"agentlessTarget" validate:"required"`
+	AgentlessTarget bool    `json:"agentlessTarget" validate:"optional"`
 	Version         string  `json:"version" validate:"required"`
 }
 

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -35,9 +35,10 @@ type WorkspaceRequest struct {
 }
 
 type ProviderInfo struct {
-	Name    string  `json:"name" validate:"required"`
-	Label   *string `json:"label" validate:"optional"`
-	Version string  `json:"version" validate:"required"`
+	Name            string  `json:"name" validate:"required"`
+	Label           *string `json:"label" validate:"optional"`
+	AgentlessTarget bool    `json:"agentlessTarget" validate:"required"`
+	Version         string  `json:"version" validate:"required"`
 }
 
 type TargetConfig struct {

--- a/pkg/server/targets/stop.go
+++ b/pkg/server/targets/stop.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/daytonaio/daytona/pkg/models"
+	"github.com/daytonaio/daytona/pkg/services"
 	"github.com/daytonaio/daytona/pkg/stores"
 	"github.com/daytonaio/daytona/pkg/telemetry"
 	log "github.com/sirupsen/logrus"
@@ -16,6 +17,10 @@ func (s *TargetService) StopTarget(ctx context.Context, targetId string) error {
 	target, err := s.targetStore.Find(ctx, &stores.TargetFilter{IdOrName: &targetId})
 	if err != nil {
 		return s.handleStopError(ctx, nil, stores.ErrTargetNotFound)
+	}
+
+	if target.TargetConfig.ProviderInfo.AgentlessTarget {
+		return s.handleStartError(ctx, target, services.ErrAgentlessTarget)
 	}
 
 	err = s.createJob(ctx, target.Id, models.JobActionStop)

--- a/pkg/services/target.go
+++ b/pkg/services/target.go
@@ -49,6 +49,7 @@ var (
 	ErrTargetAlreadyExists = errors.New("target already exists")
 	ErrInvalidTargetName   = errors.New("name is not a valid alphanumeric string")
 	ErrTargetDeleted       = errors.New("target is deleted")
+	ErrAgentlessTarget     = errors.New("provider uses an agentless target")
 )
 
 func IsTargetDeleted(err error) bool {


### PR DESCRIPTION
# Properly handle no target mode agent in providers
## Description

Frontend and backend validation for target mode agent in providers - currently only relevant for [Docker](https://github.com/daytonaio/daytona-provider-docker/pull/49), other providers need no changes

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
