### PR TITLE
feat: skip external clone with custom image

### DIFF
--- a/pkg/cmd/workspace/create.go
+++ b/pkg/cmd/workspace/create.go
@@ -488,7 +488,7 @@ func waitForDial(workspace *apiclient.Workspace, activeProfile *config.Profile, 
 				return nil
 			}
 
-			time.Sleep(time.Second)
+			time.Sleep(100 * time.Millisecond)
 		}
 	}
 
@@ -503,7 +503,7 @@ func waitForDial(workspace *apiclient.Workspace, activeProfile *config.Profile, 
 				connectChan <- dialConn.Close()
 				return
 			}
-			time.Sleep(time.Second)
+			time.Sleep(100 * time.Millisecond)
 		}
 	}()
 

--- a/pkg/docker/client_test.go
+++ b/pkg/docker/client_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/gitprovider"
 	"github.com/daytonaio/daytona/pkg/workspace"
 	"github.com/daytonaio/daytona/pkg/workspace/project"
+	"github.com/daytonaio/daytona/pkg/workspace/project/buildconfig"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -21,6 +22,7 @@ var project1 = &project.Project{
 		Url:  "https://github.com/daytonaio/daytona",
 		Name: "daytona",
 	},
+	BuildConfig: &buildconfig.BuildConfig{},
 	Image:       "test-image:tag",
 	User:        "test-user",
 	WorkspaceId: "123",

--- a/pkg/docker/create_test.go
+++ b/pkg/docker/create_test.go
@@ -55,7 +55,9 @@ func (s *DockerClientTestSuite) TestCreateProject() {
 	s.mockClient.On("ContainerRemove", mock.Anything, mock.Anything, container.RemoveOptions{RemoveVolumes: true, Force: true}).Return(nil)
 	s.mockClient.On("ContainerStart", mock.Anything, mock.Anything, container.StartOptions{}).Return(nil)
 	s.mockClient.On("ContainerExecCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.IDResponse{ID: "exec-id"}, nil)
-	s.mockClient.On("ContainerStop", mock.Anything, "123", container.StopOptions{}).Return(nil)
+	s.mockClient.On("ContainerStop", mock.Anything, "123", container.StopOptions{
+		Signal: "SIGKILL",
+	}).Return(nil)
 
 	_, client := net.Pipe()
 	s.mockClient.On("ContainerExecAttach", mock.Anything, "exec-id", container.ExecStartOptions{}).

--- a/pkg/docker/start_image.go
+++ b/pkg/docker/start_image.go
@@ -72,7 +72,7 @@ func (d *DockerClient) startImageProject(opts *CreateProjectOptions) error {
 			break
 		}
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	//	Find entrypoint metadata


### PR DESCRIPTION
# Skip External Clone with Custom Image

## Description

Cloning the repo first and mounting it into the project container is now skipped when a custom image is used.
This is unnecessary since daytona won't build a devcontainer.
This significantly improves creation time when a custom image is used.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
