### PR TITLE
refactor: add api key revoke on target/workspace removal

### DIFF
--- a/pkg/server/targets/remove.go
+++ b/pkg/server/targets/remove.go
@@ -34,6 +34,21 @@ func (s *TargetService) RemoveTarget(ctx context.Context, targetId string) error
 		return s.handleRemoveError(ctx, t, err)
 	}
 
+	err = s.revokeApiKey(ctx, targetId)
+	if err != nil {
+		return s.handleRemoveError(ctx, t, err)
+	}
+
+	metadata, err := s.targetMetadataStore.Find(ctx, &stores.TargetMetadataFilter{TargetId: &targetId})
+	if err != nil {
+		return s.handleRemoveError(ctx, t, err)
+	}
+
+	err = s.targetMetadataStore.Delete(ctx, metadata)
+	if err != nil {
+		return s.handleRemoveError(ctx, t, err)
+	}
+
 	err = s.createJob(ctx, t.Id, models.JobActionDelete)
 	if err != nil {
 		return s.handleRemoveError(ctx, t, err)
@@ -65,46 +80,25 @@ func (s *TargetService) ForceRemoveTarget(ctx context.Context, targetId string) 
 		return s.handleRemoveError(ctx, t, err)
 	}
 
-	err = s.createJob(ctx, t.Id, models.JobActionForceDelete)
-	if err != nil {
-		return s.handleRemoveError(ctx, t, err)
-	}
-
-	err = s.targetStore.CommitTransaction(ctx)
-	return s.handleRemoveError(ctx, t, err)
-}
-
-func (s *TargetService) HandleSuccessfulRemoval(ctx context.Context, targetId string) error {
-	var err error
-	ctx, err = s.targetStore.BeginTransaction(ctx)
-	if err != nil {
-		return s.handleRemoveError(ctx, nil, err)
-	}
-
-	defer stores.RecoverAndRollback(ctx, s.targetStore)
-
 	err = s.revokeApiKey(ctx, targetId)
 	if err != nil {
 		// Should not fail the whole operation if the API key cannot be revoked
 		log.Error(err)
 	}
 
-	t, err := s.targetStore.Find(ctx, &stores.TargetFilter{IdOrName: &targetId})
-	if err != nil {
-		return s.handleRemoveError(ctx, t, stores.ErrTargetNotFound)
-	}
-
 	metadata, err := s.targetMetadataStore.Find(ctx, &stores.TargetMetadataFilter{TargetId: &targetId})
 	if err != nil {
-		return s.handleRemoveError(ctx, t, err)
+		// Should not fail the whole operation if the metadata cannot be found
+		log.Error(err)
+	} else {
+		err = s.targetMetadataStore.Delete(ctx, metadata)
+		if err != nil {
+			// Should not fail the whole operation if the metadata cannot be deleted
+			log.Error(err)
+		}
 	}
 
-	err = s.targetMetadataStore.Delete(ctx, metadata)
-	if err != nil {
-		return s.handleRemoveError(ctx, t, err)
-	}
-
-	err = s.targetStore.Delete(ctx, t)
+	err = s.createJob(ctx, t.Id, models.JobActionForceDelete)
 	if err != nil {
 		return s.handleRemoveError(ctx, t, err)
 	}

--- a/pkg/server/workspaces/create.go
+++ b/pkg/server/workspaces/create.go
@@ -6,7 +6,6 @@ package workspaces
 import (
 	"context"
 	"errors"
-	"fmt"
 	"regexp"
 
 	"github.com/daytonaio/daytona/internal/util"
@@ -83,7 +82,7 @@ func (s *WorkspaceService) CreateWorkspace(ctx context.Context, req services.Cre
 		w.User = s.defaultWorkspaceUser
 	}
 
-	apiKey, err := s.generateApiKey(ctx, fmt.Sprintf("ws-%s", w.Id))
+	apiKey, err := s.generateApiKey(ctx, w.Id)
 	if err != nil {
 		return s.handleCreateError(ctx, w, err)
 	}

--- a/pkg/server/workspaces/service_test.go
+++ b/pkg/server/workspaces/service_test.go
@@ -5,7 +5,6 @@ package workspaces_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	t_targets "github.com/daytonaio/daytona/internal/testing/server/targets"
@@ -171,7 +170,7 @@ func TestTargetService(t *testing.T) {
 	t.Run("CreateWorkspace", func(t *testing.T) {
 		gitProviderService.On("GetLastCommitSha", createWorkspaceDTO.Source.Repository).Return("123", nil)
 
-		apiKeyService.On("Generate", models.ApiKeyTypeWorkspace, fmt.Sprintf("ws-%s", createWorkspaceDTO.Id)).Return(createWorkspaceDTO.Name, nil)
+		apiKeyService.On("Generate", models.ApiKeyTypeWorkspace, createWorkspaceDTO.Id).Return(createWorkspaceDTO.Name, nil)
 
 		ws := &models.Workspace{
 			Name:                createWorkspaceDTO.Name,

--- a/pkg/services/target.go
+++ b/pkg/services/target.go
@@ -23,7 +23,6 @@ type ITargetService interface {
 	RemoveTarget(ctx context.Context, targetId string) error
 	ForceRemoveTarget(ctx context.Context, targetId string) error
 	HandleSuccessfulCreation(ctx context.Context, targetId string) error
-	HandleSuccessfulRemoval(ctx context.Context, targetId string) error
 
 	SetTargetMetadata(ctx context.Context, targetId string, metadata *models.TargetMetadata) (*models.TargetMetadata, error)
 }

--- a/pkg/services/workspace.go
+++ b/pkg/services/workspace.go
@@ -20,7 +20,6 @@ type IWorkspaceService interface {
 	StopWorkspace(ctx context.Context, workspaceId string) error
 	RemoveWorkspace(ctx context.Context, workspaceId string) error
 	ForceRemoveWorkspace(ctx context.Context, workspaceId string) error
-	HandleSuccessfulRemoval(ctx context.Context, workspaceId string) error
 
 	GetWorkspaceLogReader(ctx context.Context, workspaceId string) (io.Reader, error)
 	SetWorkspaceMetadata(ctx context.Context, workspaceId string, metadata *models.WorkspaceMetadata) (*models.WorkspaceMetadata, error)


### PR DESCRIPTION
# Add api key revoke on target/workspace removal

## Description

This PR moves api-key revoke before target/workspace deletion job is started.
In this PR `ws-` prefix is removed from workspace api-keys as this was obsolete. (If there are any existing workspaces with this format of ID they won't be revoked)

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation