### PR TITLE
fix: set builder registry server to default frpc domain

### DIFF
--- a/pkg/cmd/build/run.go
+++ b/pkg/cmd/build/run.go
@@ -81,6 +81,7 @@ func CreateBuild(apiClient *apiclient.APIClient, workspaceTemplate *apiclient.Wo
 		WorkspaceTemplateName: workspaceTemplate.Name,
 		Branch:                branch,
 		PrebuildId:            prebuildId,
+		EnvVars:               workspaceTemplate.EnvVars,
 	}
 
 	buildId, res, err := apiClient.BuildAPI.CreateBuild(ctx).CreateBuildDto(createBuildDto).Execute()

--- a/pkg/cmd/server/bootstrap/get_job_runner.go
+++ b/pkg/cmd/server/bootstrap/get_job_runner.go
@@ -204,6 +204,12 @@ func GetBuildJobFactory(c *server.Config, configDir string, version string, tele
 		builderRegistry = envVars.FindContainerRegistry(c.BuilderRegistryServer)
 	}
 
+	if builderRegistry == nil {
+		builderRegistry = &models.ContainerRegistry{
+			Server: util.GetFrpcRegistryDomain(c.Id, c.Frps.Domain),
+		}
+	}
+
 	cr := envVars.FindContainerRegistryByImageName(c.BuilderImage)
 
 	return jobs_build.NewBuildJobFactory(jobs_build.BuildJobFactoryConfig{


### PR DESCRIPTION
# Set builder registry server to default frpc domain

## Description

This PR fixes env vars not being propagated from workspace templates to builds on running build as well as setting builder registry server to default frpc domain registry server to avoid nil pointer dereference bug.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation