### PR TITLE
fix: add git provider id to cloning options output

### DIFF
--- a/pkg/cmd/workspace/create/creation_data.go
+++ b/pkg/cmd/workspace/create/creation_data.go
@@ -227,12 +227,19 @@ func GetBranchFromWorkspaceTemplate(ctx context.Context, workspaceTemplate *apic
 		return nil, apiclient_util.HandleErrorResponse(res, err)
 	}
 
+	gitProviderId := gitProviderConfigId
+	gitProvider, _, err := apiClient.GitProviderAPI.GetGitProvider(ctx, gitProviderConfigId).Execute()
+	if err == nil && gitProvider != nil {
+		gitProviderId = gitProvider.ProviderId
+	}
+
 	branchWizardConfig := BranchWizardParams{
 		ApiClient:           apiClient,
 		GitProviderConfigId: gitProviderConfigId,
 		NamespaceId:         repoResponse.Owner,
 		ChosenRepo:          repoResponse,
 		WorkspaceOrder:      workspaceOrder,
+		ProviderId:          gitProviderId,
 	}
 
 	repo, err := SetBranchFromWizard(branchWizardConfig)
@@ -282,7 +289,7 @@ func GetCreateWorkspaceDtoFromFlags(workspaceConfigurationFlags cmd_common.Works
 		if len(parts) == 2 {
 			envVars[parts[0]] = parts[1]
 		} else {
-			return nil, fmt.Errorf("Invalid environment variable format: %s\n", envVar)
+			return nil, fmt.Errorf("invalid environment variable format: %s", envVar)
 		}
 	}
 


### PR DESCRIPTION
# Add git provider id to cloning options output

## Description

This PR adds missing git provider id in the title of selection cloning options (and others) when running builds.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
Before:
![Screenshot 2024-12-04 at 11 54 30](https://github.com/user-attachments/assets/7b760820-0a58-4dcb-a64e-29ff73cbd241)

After:
![Screenshot 2024-12-11 at 14 14 09](https://github.com/user-attachments/assets/304db2db-2933-4e96-91d2-f208e425e07a)
