### PR TITLE
fix: don't throw when ssh entry not found on removal

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -335,7 +335,7 @@ func RemoveWorkspaceSshEntries(profileId, workspaceId, projectName string) error
 	regex := regexp.MustCompile(fmt.Sprintf(`%s\s*\n(?:\t.*\n?)*`, hostLine))
 	contentToDelete := regex.FindString(existingContent)
 	if contentToDelete == "" {
-		return fmt.Errorf("no SSH entry found for project %s", projectName)
+		return nil
 	}
 
 	newContent := strings.ReplaceAll(existingContent, contentToDelete, "")


### PR DESCRIPTION
# Fix SSH entry not found on workspace removal

## Description

<img width="869" alt="Screenshot 2024-12-12 at 08 43 21" src="https://github.com/user-attachments/assets/8abadb10-77a6-4a5b-a868-7d6c6952afd8" />
Fixes the above error that occurred when removing a workspace that doesn't have an ssh config entry


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation