### PR TITLE
fix: code cmd

### DIFF
--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -54,7 +54,7 @@ var CodeCmd = &cobra.Command{
 		}
 
 		if len(args) == 0 {
-			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Execute()
+			workspaceList, res, err := apiClient.WorkspaceAPI.ListWorkspaces(ctx).Verbose(true).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
 			}


### PR DESCRIPTION
# Fix code cmd

## Description

This PR adds verbosity to fetching workspace list for prompt selection of the workspace for which the user wants to run `daytona code` command.
Before this, `workspace.Info.ProviderMetadata` was missing and command would throw nil dereference error.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation