### PR TITLE
fix: devcontainer metadata parsing

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -76,7 +76,7 @@ func TestAgent(t *testing.T) {
 	mockGitService := mock_git.NewMockGitService()
 	mockGitService.On("RepositoryExists").Return(true, nil)
 	mockGitService.On("SetGitConfig", mock.Anything, mock.Anything).Return(nil)
-	mockGitService.On("GetGitStatus").Return(gitStatus1, nil)
+	mockGitService.On("GetGitStatus").Return(gitStatus1, nil).Maybe()
 
 	mockSshServer := mocks.NewMockSshServer()
 	mockTailscaleServer := mocks.NewMockTailscaleServer()

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -66,7 +66,12 @@ func setupVSCodeCustomizations(projectHostname string, projectProviderMetadata s
 	if devcontainerMetadata, ok := metadata["devcontainer.metadata"]; ok {
 		var configs []devcontainer.Configuration
 		if err := json.Unmarshal([]byte(devcontainerMetadata.(string)), &configs); err != nil {
-			return err
+			// Metadata can sometimes be a single object
+			var config devcontainer.Configuration
+			if err := json.Unmarshal([]byte(devcontainerMetadata.(string)), &config); err != nil {
+				return err
+			}
+			configs = append(configs, config)
 		}
 
 		customizations := []devcontainer.Customizations{}


### PR DESCRIPTION
# Fix Devcontainer Metadata Parsing

## Description

Fixes parsing the devcontainer metadata when the metadata is a single object instead of an array of configurations

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1382 