### PR TITLE
fix: restart methods

### DIFF
--- a/pkg/api/controllers/target/restart.go
+++ b/pkg/api/controllers/target/restart.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/daytonaio/daytona/pkg/server"
+	"github.com/gin-gonic/gin"
+)
+
+// RestartTarget 			godoc
+//
+//	@Tags			target
+//	@Summary		Restart target
+//	@Description	Restart target
+//	@Param			targetId	path	string	true	"Target ID or Name"
+//	@Success		200
+//	@Router			/target/{targetId}/restart [post]
+//
+//	@id				RestartTarget
+func RestartTarget(ctx *gin.Context) {
+	targetId := ctx.Param("targetId")
+
+	server := server.GetInstance(nil)
+
+	err := server.TargetService.RestartTarget(ctx.Request.Context(), targetId)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to restart target %s: %w", targetId, err))
+		return
+	}
+
+	ctx.Status(200)
+}

--- a/pkg/api/controllers/workspace/restart.go
+++ b/pkg/api/controllers/workspace/restart.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package workspace
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/daytonaio/daytona/pkg/server"
+	"github.com/gin-gonic/gin"
+)
+
+// RestartWorkspace 			godoc
+//
+//	@Tags			workspace
+//	@Summary		Restart workspace
+//	@Description	Restart workspace
+//	@Param			workspaceId	path	string	true	"Workspace ID or Name"
+//	@Success		200
+//	@Router			/workspace/{workspaceId}/restart [post]
+//
+//	@id				RestartWorkspace
+func RestartWorkspace(ctx *gin.Context) {
+	workspaceId := ctx.Param("workspaceId")
+
+	server := server.GetInstance(nil)
+
+	err := server.WorkspaceService.RestartWorkspace(ctx.Request.Context(), workspaceId)
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to restart workspace %s: %w", workspaceId, err))
+		return
+	}
+
+	ctx.Status(200)
+}

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -1734,6 +1734,30 @@ const docTemplate = `{
                 }
             }
         },
+        "/target/{targetId}/restart": {
+            "post": {
+                "description": "Restart target",
+                "tags": [
+                    "target"
+                ],
+                "summary": "Restart target",
+                "operationId": "RestartTarget",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target ID or Name",
+                        "name": "targetId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/target/{targetId}/set-default": {
             "patch": {
                 "description": "Set target to be used by default",
@@ -2333,6 +2357,30 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/UpdateWorkspaceProviderMetadataDTO"
                         }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/workspace/{workspaceId}/restart": {
+            "post": {
+                "description": "Restart workspace",
+                "tags": [
+                    "workspace"
+                ],
+                "summary": "Restart workspace",
+                "operationId": "RestartWorkspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID or Name",
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -1731,6 +1731,30 @@
                 }
             }
         },
+        "/target/{targetId}/restart": {
+            "post": {
+                "description": "Restart target",
+                "tags": [
+                    "target"
+                ],
+                "summary": "Restart target",
+                "operationId": "RestartTarget",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Target ID or Name",
+                        "name": "targetId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/target/{targetId}/set-default": {
             "patch": {
                 "description": "Set target to be used by default",
@@ -2330,6 +2354,30 @@
                         "schema": {
                             "$ref": "#/definitions/UpdateWorkspaceProviderMetadataDTO"
                         }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/workspace/{workspaceId}/restart": {
+            "post": {
+                "description": "Restart workspace",
+                "tags": [
+                    "workspace"
+                ],
+                "summary": "Restart workspace",
+                "operationId": "RestartWorkspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID or Name",
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -2360,6 +2360,22 @@ paths:
       summary: Update target provider metadata
       tags:
       - target
+  /target/{targetId}/restart:
+    post:
+      description: Restart target
+      operationId: RestartTarget
+      parameters:
+      - description: Target ID or Name
+        in: path
+        name: targetId
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+      summary: Restart target
+      tags:
+      - target
   /target/{targetId}/set-default:
     patch:
       description: Set target to be used by default
@@ -2765,6 +2781,22 @@ paths:
         "200":
           description: OK
       summary: Update workspace provider metadata
+      tags:
+      - workspace
+  /workspace/{workspaceId}/restart:
+    post:
+      description: Restart workspace
+      operationId: RestartWorkspace
+      parameters:
+      - description: Workspace ID or Name
+        in: path
+        name: workspaceId
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+      summary: Restart workspace
       tags:
       - workspace
   /workspace/{workspaceId}/start:

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -148,6 +148,7 @@ func (a *ApiServer) Start() error {
 		targetController.POST("/", target.CreateTarget)
 		targetController.POST("/:targetId/start", target.StartTarget)
 		targetController.POST("/:targetId/stop", target.StopTarget)
+		targetController.POST("/:targetId/restart", target.RestartTarget)
 		targetController.PATCH("/:targetId/set-default", target.SetDefaultTarget)
 		targetController.POST("/:targetId/handle-successful-creation", target.HandleSuccessfulCreation)
 		targetController.POST("/:targetId/provider-metadata", target.UpdateTargetProviderMetadata)
@@ -162,6 +163,7 @@ func (a *ApiServer) Start() error {
 		workspaceController.DELETE("/:workspaceId", workspace.RemoveWorkspace)
 		workspaceController.POST("/:workspaceId/start", workspace.StartWorkspace)
 		workspaceController.POST("/:workspaceId/stop", workspace.StopWorkspace)
+		workspaceController.POST("/:workspaceId/restart", workspace.RestartWorkspace)
 		workspaceController.POST("/:workspaceId/provider-metadata", workspace.UpdateWorkspaceProviderMetadata)
 	}
 

--- a/pkg/apiclient/README.md
+++ b/pkg/apiclient/README.md
@@ -133,6 +133,7 @@ Class | Method | HTTP request | Description
 *TargetAPI* | [**HandleSuccessfulCreation**](docs/TargetAPI.md#handlesuccessfulcreation) | **Post** /target/{targetId}/handle-successful-creation | Handles successful creation of the target
 *TargetAPI* | [**ListTargets**](docs/TargetAPI.md#listtargets) | **Get** /target | List targets
 *TargetAPI* | [**RemoveTarget**](docs/TargetAPI.md#removetarget) | **Delete** /target/{targetId} | Remove target
+*TargetAPI* | [**RestartTarget**](docs/TargetAPI.md#restarttarget) | **Post** /target/{targetId}/restart | Restart target
 *TargetAPI* | [**SetDefaultTarget**](docs/TargetAPI.md#setdefaulttarget) | **Patch** /target/{targetId}/set-default | Set target to be used by default
 *TargetAPI* | [**SetTargetMetadata**](docs/TargetAPI.md#settargetmetadata) | **Post** /target/{targetId}/metadata | Set target metadata
 *TargetAPI* | [**StartTarget**](docs/TargetAPI.md#starttarget) | **Post** /target/{targetId}/start | Start target
@@ -145,6 +146,7 @@ Class | Method | HTTP request | Description
 *WorkspaceAPI* | [**GetWorkspace**](docs/WorkspaceAPI.md#getworkspace) | **Get** /workspace/{workspaceId} | Get workspace info
 *WorkspaceAPI* | [**ListWorkspaces**](docs/WorkspaceAPI.md#listworkspaces) | **Get** /workspace | List workspaces
 *WorkspaceAPI* | [**RemoveWorkspace**](docs/WorkspaceAPI.md#removeworkspace) | **Delete** /workspace/{workspaceId} | Remove workspace
+*WorkspaceAPI* | [**RestartWorkspace**](docs/WorkspaceAPI.md#restartworkspace) | **Post** /workspace/{workspaceId}/restart | Restart workspace
 *WorkspaceAPI* | [**SetWorkspaceMetadata**](docs/WorkspaceAPI.md#setworkspacemetadata) | **Post** /workspace/{workspaceId}/metadata | Set workspace metadata
 *WorkspaceAPI* | [**StartWorkspace**](docs/WorkspaceAPI.md#startworkspace) | **Post** /workspace/{workspaceId}/start | Start workspace
 *WorkspaceAPI* | [**StopWorkspace**](docs/WorkspaceAPI.md#stopworkspace) | **Post** /workspace/{workspaceId}/stop | Stop workspace

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1254,6 +1254,24 @@ paths:
       tags:
       - target
       x-codegen-request-body-name: metadata
+  /target/{targetId}/restart:
+    post:
+      description: Restart target
+      operationId: RestartTarget
+      parameters:
+      - description: Target ID or Name
+        in: path
+        name: targetId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content: {}
+          description: OK
+      summary: Restart target
+      tags:
+      - target
   /target/{targetId}/set-default:
     patch:
       description: Set target to be used by default
@@ -1697,6 +1715,24 @@ paths:
       tags:
       - workspace
       x-codegen-request-body-name: metadata
+  /workspace/{workspaceId}/restart:
+    post:
+      description: Restart workspace
+      operationId: RestartWorkspace
+      parameters:
+      - description: Workspace ID or Name
+        in: path
+        name: workspaceId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content: {}
+          description: OK
+      summary: Restart workspace
+      tags:
+      - workspace
   /workspace/{workspaceId}/start:
     post:
       description: Start workspace

--- a/pkg/apiclient/api_target.go
+++ b/pkg/apiclient/api_target.go
@@ -622,6 +622,112 @@ func (a *TargetAPIService) RemoveTargetExecute(r ApiRemoveTargetRequest) (*http.
 	return localVarHTTPResponse, nil
 }
 
+type ApiRestartTargetRequest struct {
+	ctx        context.Context
+	ApiService *TargetAPIService
+	targetId   string
+}
+
+func (r ApiRestartTargetRequest) Execute() (*http.Response, error) {
+	return r.ApiService.RestartTargetExecute(r)
+}
+
+/*
+RestartTarget Restart target
+
+Restart target
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param targetId Target ID or Name
+	@return ApiRestartTargetRequest
+*/
+func (a *TargetAPIService) RestartTarget(ctx context.Context, targetId string) ApiRestartTargetRequest {
+	return ApiRestartTargetRequest{
+		ApiService: a,
+		ctx:        ctx,
+		targetId:   targetId,
+	}
+}
+
+// Execute executes the request
+func (a *TargetAPIService) RestartTargetExecute(r ApiRestartTargetRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TargetAPIService.RestartTarget")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/target/{targetId}/restart"
+	localVarPath = strings.Replace(localVarPath, "{"+"targetId"+"}", url.PathEscape(parameterValueToString(r.targetId, "targetId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.ctx != nil {
+		// API Key Authentication
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+			if apiKey, ok := auth["Bearer"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
+				}
+				localVarHeaderParams["Authorization"] = key
+			}
+		}
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type ApiSetDefaultTargetRequest struct {
 	ctx        context.Context
 	ApiService *TargetAPIService

--- a/pkg/apiclient/api_workspace.go
+++ b/pkg/apiclient/api_workspace.go
@@ -496,6 +496,112 @@ func (a *WorkspaceAPIService) RemoveWorkspaceExecute(r ApiRemoveWorkspaceRequest
 	return localVarHTTPResponse, nil
 }
 
+type ApiRestartWorkspaceRequest struct {
+	ctx         context.Context
+	ApiService  *WorkspaceAPIService
+	workspaceId string
+}
+
+func (r ApiRestartWorkspaceRequest) Execute() (*http.Response, error) {
+	return r.ApiService.RestartWorkspaceExecute(r)
+}
+
+/*
+RestartWorkspace Restart workspace
+
+Restart workspace
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param workspaceId Workspace ID or Name
+	@return ApiRestartWorkspaceRequest
+*/
+func (a *WorkspaceAPIService) RestartWorkspace(ctx context.Context, workspaceId string) ApiRestartWorkspaceRequest {
+	return ApiRestartWorkspaceRequest{
+		ApiService:  a,
+		ctx:         ctx,
+		workspaceId: workspaceId,
+	}
+}
+
+// Execute executes the request
+func (a *WorkspaceAPIService) RestartWorkspaceExecute(r ApiRestartWorkspaceRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodPost
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WorkspaceAPIService.RestartWorkspace")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/workspace/{workspaceId}/restart"
+	localVarPath = strings.Replace(localVarPath, "{"+"workspaceId"+"}", url.PathEscape(parameterValueToString(r.workspaceId, "workspaceId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.ctx != nil {
+		// API Key Authentication
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+			if apiKey, ok := auth["Bearer"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
+				}
+				localVarHeaderParams["Authorization"] = key
+			}
+		}
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type ApiSetWorkspaceMetadataRequest struct {
 	ctx               context.Context
 	ApiService        *WorkspaceAPIService

--- a/pkg/apiclient/docs/TargetAPI.md
+++ b/pkg/apiclient/docs/TargetAPI.md
@@ -9,6 +9,7 @@ Method | HTTP request | Description
 [**HandleSuccessfulCreation**](TargetAPI.md#HandleSuccessfulCreation) | **Post** /target/{targetId}/handle-successful-creation | Handles successful creation of the target
 [**ListTargets**](TargetAPI.md#ListTargets) | **Get** /target | List targets
 [**RemoveTarget**](TargetAPI.md#RemoveTarget) | **Delete** /target/{targetId} | Remove target
+[**RestartTarget**](TargetAPI.md#RestartTarget) | **Post** /target/{targetId}/restart | Restart target
 [**SetDefaultTarget**](TargetAPI.md#SetDefaultTarget) | **Patch** /target/{targetId}/set-default | Set target to be used by default
 [**SetTargetMetadata**](TargetAPI.md#SetTargetMetadata) | **Post** /target/{targetId}/metadata | Set target metadata
 [**StartTarget**](TargetAPI.md#StartTarget) | **Post** /target/{targetId}/start | Start target
@@ -340,6 +341,74 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
  **force** | **bool** | Force | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## RestartTarget
+
+> RestartTarget(ctx, targetId).Execute()
+
+Restart target
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID/apiclient"
+)
+
+func main() {
+	targetId := "targetId_example" // string | Target ID or Name
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	r, err := apiClient.TargetAPI.RestartTarget(context.Background(), targetId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `TargetAPI.RestartTarget``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**targetId** | **string** | Target ID or Name | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiRestartTargetRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 

--- a/pkg/apiclient/docs/WorkspaceAPI.md
+++ b/pkg/apiclient/docs/WorkspaceAPI.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**GetWorkspace**](WorkspaceAPI.md#GetWorkspace) | **Get** /workspace/{workspaceId} | Get workspace info
 [**ListWorkspaces**](WorkspaceAPI.md#ListWorkspaces) | **Get** /workspace | List workspaces
 [**RemoveWorkspace**](WorkspaceAPI.md#RemoveWorkspace) | **Delete** /workspace/{workspaceId} | Remove workspace
+[**RestartWorkspace**](WorkspaceAPI.md#RestartWorkspace) | **Post** /workspace/{workspaceId}/restart | Restart workspace
 [**SetWorkspaceMetadata**](WorkspaceAPI.md#SetWorkspaceMetadata) | **Post** /workspace/{workspaceId}/metadata | Set workspace metadata
 [**StartWorkspace**](WorkspaceAPI.md#StartWorkspace) | **Post** /workspace/{workspaceId}/start | Start workspace
 [**StopWorkspace**](WorkspaceAPI.md#StopWorkspace) | **Post** /workspace/{workspaceId}/stop | Stop workspace
@@ -263,6 +264,74 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
  **force** | **bool** | Force | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+[Bearer](../README.md#Bearer)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## RestartWorkspace
+
+> RestartWorkspace(ctx, workspaceId).Execute()
+
+Restart workspace
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID/apiclient"
+)
+
+func main() {
+	workspaceId := "workspaceId_example" // string | Workspace ID or Name
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	r, err := apiClient.WorkspaceAPI.RestartWorkspace(context.Background(), workspaceId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `WorkspaceAPI.RestartWorkspace``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**workspaceId** | **string** | Workspace ID or Name | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiRestartWorkspaceRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 

--- a/pkg/cmd/target/restart.go
+++ b/pkg/cmd/target/restart.go
@@ -51,7 +51,7 @@ var restartCmd = &cobra.Command{
 			}
 		}
 
-		err = RestartTarget(apiClient, *target)
+		err = StartTarget(apiClient, *target, true)
 		if err != nil {
 			return err
 		}
@@ -61,12 +61,4 @@ var restartCmd = &cobra.Command{
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return getAllTargetsByState(util.Pointer(apiclient.ResourceStateNameStarted))
 	},
-}
-
-func RestartTarget(apiClient *apiclient.APIClient, target apiclient.TargetDTO) error {
-	err := StopTarget(apiClient, target)
-	if err != nil {
-		return err
-	}
-	return StartTarget(apiClient, target)
 }

--- a/pkg/cmd/target/ssh.go
+++ b/pkg/cmd/target/ssh.go
@@ -107,7 +107,7 @@ func autoStartTarget(target apiclient.TargetDTO) (bool, error) {
 		return false, err
 	}
 
-	err = StartTarget(apiClient, target)
+	err = StartTarget(apiClient, target, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -134,7 +134,7 @@ func AutoStartWorkspace(workspace apiclient.WorkspaceDTO) (bool, error) {
 		return false, err
 	}
 
-	err = StartWorkspace(apiClient, workspace)
+	err = StartWorkspace(apiClient, workspace, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cmd/workspace/restart.go
+++ b/pkg/cmd/workspace/restart.go
@@ -62,7 +62,7 @@ var RestartCmd = &cobra.Command{
 		if len(selectedWorkspaces) == 1 {
 			workspace := selectedWorkspaces[0]
 
-			err = RestartWorkspace(apiClient, *workspace)
+			err = StartWorkspace(apiClient, *workspace, true)
 			if err != nil {
 				return err
 			}
@@ -70,7 +70,7 @@ var RestartCmd = &cobra.Command{
 			views.RenderInfoMessage(fmt.Sprintf("Workspace '%s' restarted successfully", workspace.Name))
 		} else {
 			for _, ws := range selectedWorkspaces {
-				err := RestartWorkspace(apiClient, *ws)
+				err := StartWorkspace(apiClient, *ws, true)
 				if err != nil {
 					log.Errorf("Failed to restart workspace %s: %v\n\n", ws.Name, err)
 					continue
@@ -84,12 +84,4 @@ var RestartCmd = &cobra.Command{
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return common.GetAllWorkspacesByState(apiclient.ResourceStateNameStarted)
 	},
-}
-
-func RestartWorkspace(apiClient *apiclient.APIClient, workspace apiclient.WorkspaceDTO) error {
-	err := StopWorkspace(apiClient, workspace)
-	if err != nil {
-		return err
-	}
-	return StartWorkspace(apiClient, workspace)
 }

--- a/pkg/jobs/workspace/restart.go
+++ b/pkg/jobs/workspace/restart.go
@@ -9,7 +9,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/models"
 )
 
-func (wj *WorkspaceJob) Restart(ctx context.Context, j *models.Job) error {
+func (wj *WorkspaceJob) restart(ctx context.Context, j *models.Job) error {
 	err := wj.stop(ctx, j)
 	if err != nil {
 		return err

--- a/pkg/jobs/workspace/workspace.go
+++ b/pkg/jobs/workspace/workspace.go
@@ -36,6 +36,8 @@ func (wj *WorkspaceJob) Execute(ctx context.Context) error {
 		return wj.start(ctx, &wj.Job)
 	case models.JobActionStop:
 		return wj.stop(ctx, &wj.Job)
+	case models.JobActionRestart:
+		return wj.restart(ctx, &wj.Job)
 	case models.JobActionDelete:
 		return wj.delete(ctx, &wj.Job, false)
 	case models.JobActionForceDelete:

--- a/pkg/server/targets/restart.go
+++ b/pkg/server/targets/restart.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package targets
+
+import (
+	"context"
+
+	"github.com/daytonaio/daytona/pkg/models"
+	"github.com/daytonaio/daytona/pkg/services"
+	"github.com/daytonaio/daytona/pkg/stores"
+	"github.com/daytonaio/daytona/pkg/telemetry"
+	log "github.com/sirupsen/logrus"
+)
+
+func (s *TargetService) RestartTarget(ctx context.Context, targetId string) error {
+	target, err := s.targetStore.Find(ctx, &stores.TargetFilter{IdOrName: &targetId})
+	if err != nil {
+		return s.handleRestartError(ctx, nil, stores.ErrTargetNotFound)
+	}
+
+	if target.TargetConfig.ProviderInfo.AgentlessTarget {
+		return s.handleRestartError(ctx, target, services.ErrAgentlessTarget)
+	}
+
+	err = s.createJob(ctx, target.Id, target.TargetConfig.ProviderInfo.RunnerId, models.JobActionRestart)
+	return s.handleRestartError(ctx, target, err)
+}
+
+func (s *TargetService) handleRestartError(ctx context.Context, target *models.Target, err error) error {
+	if !telemetry.TelemetryEnabled(ctx) {
+		return err
+	}
+
+	clientId := telemetry.ClientId(ctx)
+
+	telemetryProps := telemetry.NewTargetEventProps(ctx, target)
+	event := telemetry.ServerEventTargetRestarted
+	if err != nil {
+		telemetryProps["error"] = err.Error()
+		event = telemetry.ServerEventTargetRestartError
+	}
+	telemetryError := s.telemetryService.TrackServerEvent(event, clientId, telemetryProps)
+	if telemetryError != nil {
+		log.Trace(telemetryError)
+	}
+
+	return err
+}

--- a/pkg/server/workspaces/restart.go
+++ b/pkg/server/workspaces/restart.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package workspaces
+
+import (
+	"context"
+
+	"github.com/daytonaio/daytona/pkg/models"
+	"github.com/daytonaio/daytona/pkg/stores"
+	"github.com/daytonaio/daytona/pkg/telemetry"
+	log "github.com/sirupsen/logrus"
+)
+
+func (s *WorkspaceService) RestartWorkspace(ctx context.Context, workspaceId string) error {
+	w, err := s.workspaceStore.Find(ctx, workspaceId)
+	if err != nil {
+		return s.handleRestartError(ctx, w, stores.ErrWorkspaceNotFound)
+	}
+
+	err = s.createJob(ctx, w.Id, w.Target.TargetConfig.ProviderInfo.RunnerId, models.JobActionStart)
+	if err != nil {
+		return s.handleRestartError(ctx, w, err)
+	}
+
+	return s.handleRestartError(ctx, w, err)
+}
+
+func (s *WorkspaceService) handleRestartError(ctx context.Context, w *models.Workspace, err error) error {
+	if !telemetry.TelemetryEnabled(ctx) {
+		return err
+	}
+
+	clientId := telemetry.ClientId(ctx)
+
+	telemetryProps := telemetry.NewWorkspaceEventProps(ctx, w)
+	event := telemetry.ServerEventWorkspaceRestarted
+	if err != nil {
+		telemetryProps["error"] = err.Error()
+		event = telemetry.ServerEventWorkspaceRestartError
+	}
+	telemetryError := s.trackTelemetryEvent(event, clientId, telemetryProps)
+	if telemetryError != nil {
+		log.Trace(err)
+	}
+
+	return err
+}

--- a/pkg/services/target.go
+++ b/pkg/services/target.go
@@ -19,6 +19,7 @@ type ITargetService interface {
 	ListTargets(ctx context.Context, filter *stores.TargetFilter, params TargetRetrievalParams) ([]TargetDTO, error)
 	StartTarget(ctx context.Context, targetId string) error
 	StopTarget(ctx context.Context, targetId string) error
+	RestartTarget(ctx context.Context, targetId string) error
 	SetDefault(ctx context.Context, targetId string) error
 	UpdateTargetProviderMetadata(ctx context.Context, targetId, metadata string) error
 	RemoveTarget(ctx context.Context, targetId string) error

--- a/pkg/services/workspace.go
+++ b/pkg/services/workspace.go
@@ -18,6 +18,7 @@ type IWorkspaceService interface {
 	ListWorkspaces(ctx context.Context, params WorkspaceRetrievalParams) ([]WorkspaceDTO, error)
 	StartWorkspace(ctx context.Context, workspaceId string) error
 	StopWorkspace(ctx context.Context, workspaceId string) error
+	RestartWorkspace(ctx context.Context, workspaceId string) error
 	RemoveWorkspace(ctx context.Context, workspaceId string) error
 	ForceRemoveWorkspace(ctx context.Context, workspaceId string) error
 	UpdateWorkspaceProviderMetadata(ctx context.Context, workspaceId, metadata string) error

--- a/pkg/telemetry/server_events.go
+++ b/pkg/telemetry/server_events.go
@@ -26,20 +26,24 @@ const (
 	ServerEventTargetDestroyed    ServerEvent = "server_target_destroyed"
 	ServerEventTargetStarted      ServerEvent = "server_target_started"
 	ServerEventTargetStopped      ServerEvent = "server_target_stopped"
+	ServerEventTargetRestarted    ServerEvent = "server_target_restarted"
 	ServerEventTargetCreateError  ServerEvent = "server_target_created_error"
 	ServerEventTargetDestroyError ServerEvent = "server_target_destroyed_error"
 	ServerEventTargetStartError   ServerEvent = "server_target_started_error"
 	ServerEventTargetStopError    ServerEvent = "server_target_stopped_error"
+	ServerEventTargetRestartError ServerEvent = "server_target_restarted_error"
 
 	// Workspace events
 	ServerEventWorkspaceCreated      ServerEvent = "server_workspace_created"
 	ServerEventWorkspaceDestroyed    ServerEvent = "server_workspace_destroyed"
 	ServerEventWorkspaceStarted      ServerEvent = "server_workspace_started"
 	ServerEventWorkspaceStopped      ServerEvent = "server_workspace_stopped"
+	ServerEventWorkspaceRestarted    ServerEvent = "server_workspace_restarted"
 	ServerEventWorkspaceCreateError  ServerEvent = "server_workspace_created_error"
 	ServerEventWorkspaceDestroyError ServerEvent = "server_workspace_destroyed_error"
 	ServerEventWorkspaceStartError   ServerEvent = "server_workspace_started_error"
 	ServerEventWorkspaceStopError    ServerEvent = "server_workspace_stopped_error"
+	ServerEventWorkspaceRestartError ServerEvent = "server_workspace_restarted_error"
 )
 
 func NewTargetEventProps(ctx context.Context, target *models.Target) map[string]interface{} {


### PR DESCRIPTION
# Restart methods

## Description

Fixes the services to properly use the "restart" job. Adds api endpoints for restarting which are in turn now used by the CLI - includes both workspaces and targets

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation