### PR TITLE
Create target dto fix

### DIFF
--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -2612,7 +2612,7 @@ const docTemplate = `{
             "required": [
                 "id",
                 "name",
-                "targetConfigName"
+                "targetConfigId"
             ],
             "properties": {
                 "id": {
@@ -2621,7 +2621,7 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
-                "targetConfigName": {
+                "targetConfigId": {
                     "type": "string"
                 }
             }

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -2609,7 +2609,7 @@
             "required": [
                 "id",
                 "name",
-                "targetConfigName"
+                "targetConfigId"
             ],
             "properties": {
                 "id": {
@@ -2618,7 +2618,7 @@
                 "name": {
                     "type": "string"
                 },
-                "targetConfigName": {
+                "targetConfigId": {
                     "type": "string"
                 }
             }

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -153,12 +153,12 @@ definitions:
         type: string
       name:
         type: string
-      targetConfigName:
+      targetConfigId:
         type: string
     required:
     - id
     - name
-    - targetConfigName
+    - targetConfigId
     type: object
   CreateWorkspaceDTO:
     properties:

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1985,20 +1985,20 @@ components:
       type: object
     CreateTargetDTO:
       example:
-        targetConfigName: targetConfigName
         name: name
+        targetConfigId: targetConfigId
         id: id
       properties:
         id:
           type: string
         name:
           type: string
-        targetConfigName:
+        targetConfigId:
           type: string
       required:
       - id
       - name
-      - targetConfigName
+      - targetConfigId
       type: object
     CreateWorkspaceDTO:
       example:

--- a/pkg/apiclient/docs/CreateTargetDTO.md
+++ b/pkg/apiclient/docs/CreateTargetDTO.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | **string** |  | 
 **Name** | **string** |  | 
-**TargetConfigName** | **string** |  | 
+**TargetConfigId** | **string** |  | 
 
 ## Methods
 
 ### NewCreateTargetDTO
 
-`func NewCreateTargetDTO(id string, name string, targetConfigName string, ) *CreateTargetDTO`
+`func NewCreateTargetDTO(id string, name string, targetConfigId string, ) *CreateTargetDTO`
 
 NewCreateTargetDTO instantiates a new CreateTargetDTO object
 This constructor will assign default values to properties that have it defined,
@@ -67,24 +67,24 @@ and a boolean to check if the value has been set.
 SetName sets Name field to given value.
 
 
-### GetTargetConfigName
+### GetTargetConfigId
 
-`func (o *CreateTargetDTO) GetTargetConfigName() string`
+`func (o *CreateTargetDTO) GetTargetConfigId() string`
 
-GetTargetConfigName returns the TargetConfigName field if non-nil, zero value otherwise.
+GetTargetConfigId returns the TargetConfigId field if non-nil, zero value otherwise.
 
-### GetTargetConfigNameOk
+### GetTargetConfigIdOk
 
-`func (o *CreateTargetDTO) GetTargetConfigNameOk() (*string, bool)`
+`func (o *CreateTargetDTO) GetTargetConfigIdOk() (*string, bool)`
 
-GetTargetConfigNameOk returns a tuple with the TargetConfigName field if it's non-nil, zero value otherwise
+GetTargetConfigIdOk returns a tuple with the TargetConfigId field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetTargetConfigName
+### SetTargetConfigId
 
-`func (o *CreateTargetDTO) SetTargetConfigName(v string)`
+`func (o *CreateTargetDTO) SetTargetConfigId(v string)`
 
-SetTargetConfigName sets TargetConfigName field to given value.
+SetTargetConfigId sets TargetConfigId field to given value.
 
 
 

--- a/pkg/apiclient/docs/TargetAPI.md
+++ b/pkg/apiclient/docs/TargetAPI.md
@@ -38,7 +38,7 @@ import (
 )
 
 func main() {
-	target := *openapiclient.NewCreateTargetDTO("Id_example", "Name_example", "TargetConfigName_example") // CreateTargetDTO | Create target
+	target := *openapiclient.NewCreateTargetDTO("Id_example", "Name_example", "TargetConfigId_example") // CreateTargetDTO | Create target
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)

--- a/pkg/apiclient/model_create_target_dto.go
+++ b/pkg/apiclient/model_create_target_dto.go
@@ -21,9 +21,9 @@ var _ MappedNullable = &CreateTargetDTO{}
 
 // CreateTargetDTO struct for CreateTargetDTO
 type CreateTargetDTO struct {
-	Id               string `json:"id"`
-	Name             string `json:"name"`
-	TargetConfigName string `json:"targetConfigName"`
+	Id             string `json:"id"`
+	Name           string `json:"name"`
+	TargetConfigId string `json:"targetConfigId"`
 }
 
 type _CreateTargetDTO CreateTargetDTO
@@ -32,11 +32,11 @@ type _CreateTargetDTO CreateTargetDTO
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCreateTargetDTO(id string, name string, targetConfigName string) *CreateTargetDTO {
+func NewCreateTargetDTO(id string, name string, targetConfigId string) *CreateTargetDTO {
 	this := CreateTargetDTO{}
 	this.Id = id
 	this.Name = name
-	this.TargetConfigName = targetConfigName
+	this.TargetConfigId = targetConfigId
 	return &this
 }
 
@@ -96,28 +96,28 @@ func (o *CreateTargetDTO) SetName(v string) {
 	o.Name = v
 }
 
-// GetTargetConfigName returns the TargetConfigName field value
-func (o *CreateTargetDTO) GetTargetConfigName() string {
+// GetTargetConfigId returns the TargetConfigId field value
+func (o *CreateTargetDTO) GetTargetConfigId() string {
 	if o == nil {
 		var ret string
 		return ret
 	}
 
-	return o.TargetConfigName
+	return o.TargetConfigId
 }
 
-// GetTargetConfigNameOk returns a tuple with the TargetConfigName field value
+// GetTargetConfigIdOk returns a tuple with the TargetConfigId field value
 // and a boolean to check if the value has been set.
-func (o *CreateTargetDTO) GetTargetConfigNameOk() (*string, bool) {
+func (o *CreateTargetDTO) GetTargetConfigIdOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.TargetConfigName, true
+	return &o.TargetConfigId, true
 }
 
-// SetTargetConfigName sets field value
-func (o *CreateTargetDTO) SetTargetConfigName(v string) {
-	o.TargetConfigName = v
+// SetTargetConfigId sets field value
+func (o *CreateTargetDTO) SetTargetConfigId(v string) {
+	o.TargetConfigId = v
 }
 
 func (o CreateTargetDTO) MarshalJSON() ([]byte, error) {
@@ -132,7 +132,7 @@ func (o CreateTargetDTO) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["id"] = o.Id
 	toSerialize["name"] = o.Name
-	toSerialize["targetConfigName"] = o.TargetConfigName
+	toSerialize["targetConfigId"] = o.TargetConfigId
 	return toSerialize, nil
 }
 
@@ -143,7 +143,7 @@ func (o *CreateTargetDTO) UnmarshalJSON(data []byte) (err error) {
 	requiredProperties := []string{
 		"id",
 		"name",
-		"targetConfigName",
+		"targetConfigId",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/pkg/cmd/target/create.go
+++ b/pkg/cmd/target/create.go
@@ -162,8 +162,8 @@ func CreateTargetDtoFlow(ctx context.Context, params TargetCreationParams) (*api
 	id = stringid.TruncateID(id)
 
 	return &apiclient.CreateTargetDTO{
-		Id:               id,
-		Name:             targetName,
-		TargetConfigName: targetConfigView.Name,
+		Id:             id,
+		Name:           targetName,
+		TargetConfigId: targetConfigView.Id,
 	}, nil
 }

--- a/pkg/cmd/workspace/create/cmd.go
+++ b/pkg/cmd/workspace/create/cmd.go
@@ -169,11 +169,7 @@ var CreateCmd = &cobra.Command{
 				SkipPrefixLengthSetup: true,
 			})
 
-			t, res, err := apiClient.TargetAPI.CreateTarget(ctx).Target(apiclient.CreateTargetDTO{
-				Id:               createTargetDto.Id,
-				Name:             createTargetDto.Name,
-				TargetConfigName: createTargetDto.TargetConfigName,
-			}).Execute()
+			t, res, err := apiClient.TargetAPI.CreateTarget(ctx).Target(*createTargetDto).Execute()
 			if err != nil {
 				return apiclient_util.HandleErrorResponse(res, err)
 			}

--- a/pkg/models/target.go
+++ b/pkg/models/target.go
@@ -31,13 +31,19 @@ type TargetMetadata struct {
 	Uptime    uint64    `json:"uptime" validate:"required" gorm:"not null"`
 } // @name TargetMetadata
 
+var allowedAgentlessTargetStates = map[ResourceStateName]bool{
+	ResourceStateNamePendingCreate: true,
+	ResourceStateNameCreating:      true,
+	ResourceStateNameError:         true,
+	ResourceStateNameDeleted:       true,
+}
+
 func (t *Target) GetState() ResourceState {
 	state := getResourceStateFromJob(t.LastJob)
 
 	// Some providers do not utilize agents in target mode
 	if t.TargetConfig.ProviderInfo.AgentlessTarget {
-		if state.Name == ResourceStateNameDeleted || state.Name == ResourceStateNamePendingCreate ||
-			state.Name == ResourceStateNameCreating || state.Name == ResourceStateNameError {
+		if allowedAgentlessTargetStates[state.Name] {
 			return state
 		}
 

--- a/pkg/models/target.go
+++ b/pkg/models/target.go
@@ -36,7 +36,8 @@ func (t *Target) GetState() ResourceState {
 
 	// Some providers do not utilize agents in target mode
 	if t.TargetConfig.ProviderInfo.AgentlessTarget {
-		if state.Name == ResourceStateNameDeleted || state.Name == ResourceStateNamePendingCreate || state.Name == ResourceStateNameCreating {
+		if state.Name == ResourceStateNameDeleted || state.Name == ResourceStateNamePendingCreate ||
+			state.Name == ResourceStateNameCreating || state.Name == ResourceStateNameError {
 			return state
 		}
 

--- a/pkg/server/targets/create.go
+++ b/pkg/server/targets/create.go
@@ -30,7 +30,7 @@ func (s *TargetService) CreateTarget(ctx context.Context, req services.CreateTar
 		return nil, services.ErrTargetAlreadyExists
 	}
 
-	tc, err := s.findTargetConfig(ctx, req.TargetConfigName)
+	tc, err := s.findTargetConfig(ctx, req.TargetConfigId)
 	if err != nil {
 		return s.handleCreateError(ctx, nil, err)
 	}

--- a/pkg/server/targets/service_test.go
+++ b/pkg/server/targets/service_test.go
@@ -43,9 +43,9 @@ var tg = &models.Target{
 }
 
 var createTargetDTO = services.CreateTargetDTO{
-	Name:             "test",
-	Id:               "test",
-	TargetConfigName: "test",
+	Name:           "test",
+	Id:             "test",
+	TargetConfigId: "test",
 }
 
 func TestTargetService(t *testing.T) {

--- a/pkg/services/target.go
+++ b/pkg/services/target.go
@@ -36,9 +36,9 @@ type TargetDTO struct {
 } //	@name	TargetDTO
 
 type CreateTargetDTO struct {
-	Id               string `json:"id" validate:"required"`
-	Name             string `json:"name" validate:"required"`
-	TargetConfigName string `json:"targetConfigName" validate:"required"`
+	Id             string `json:"id" validate:"required"`
+	Name           string `json:"name" validate:"required"`
+	TargetConfigId string `json:"targetConfigId" validate:"required"`
 } //	@name	CreateTargetDTO
 
 type UpdateTargetProviderMetadataDTO struct {


### PR DESCRIPTION
# Create target dto fix

## Description

Fixes the target creation DTO to use target config ID instead of target config name to handle users deleting target configs and readding them using the same name. Another minor fix to allow "error" state for agentless target providers

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation