### PR TITLE
feat: add support for Vim IDE

### DIFF
--- a/cmd/daytona/config/const.go
+++ b/cmd/daytona/config/const.go
@@ -30,6 +30,7 @@ func GetIdeList() []Ide {
 		{"cursor", "Cursor"},
 		{"codium", "VSCodium"},
 		{"ssh", "Terminal SSH"},
+		{"vim", "Vim"},
 		{"jupyter", "Jupyter"},
 		{"fleet", "Fleet"},
 		{"zed", "Zed"},

--- a/docs/daytona_code.md
+++ b/docs/daytona_code.md
@@ -9,7 +9,7 @@ daytona code [WORKSPACE] [PROJECT] [flags]
 ### Options
 
 ```
-  -i, --ide string   Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+  -i, --ide string   Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, vim, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
   -y, --yes          Automatically confirm any prompts
 ```
 

--- a/docs/daytona_create.md
+++ b/docs/daytona_create.md
@@ -17,7 +17,7 @@ daytona create [REPOSITORY_URL | PROJECT_CONFIG_NAME]... [flags]
       --devcontainer-path string     Automatically assign the devcontainer builder with the path passed as the flag value
       --env stringArray              Specify environment variables (e.g. --env 'KEY1=VALUE1' --env 'KEY2=VALUE2' ...')
       --git-provider-config string   Specify the Git provider configuration ID or alias
-  -i, --ide string                   Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+  -i, --ide string                   Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, vim, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
       --manual                       Manually enter the Git repository
       --multi-project                Workspace with multiple projects/repos
       --name string                  Specify the workspace name

--- a/hack/docs/daytona_code.yaml
+++ b/hack/docs/daytona_code.yaml
@@ -5,7 +5,7 @@ options:
     - name: ide
       shorthand: i
       usage: |
-        Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+        Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, vim, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
     - name: "yes"
       shorthand: "y"
       default_value: "false"

--- a/hack/docs/daytona_create.yaml
+++ b/hack/docs/daytona_create.yaml
@@ -28,7 +28,7 @@ options:
     - name: ide
       shorthand: i
       usage: |
-        Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
+        Specify the IDE (vscode, code-insiders, browser, cursor, codium, ssh, vim, jupyter, fleet, zed, windsurf, clion, goland, intellij, phpstorm, pycharm, rider, rubymine, webstorm)
     - name: manual
       default_value: "false"
       usage: Manually enter the Git repository

--- a/pkg/cmd/ide.go
+++ b/pkg/cmd/ide.go
@@ -61,6 +61,11 @@ var ideCmd = &cobra.Command{
 			if err != nil {
 				log.Error(err)
 			}
+		case "vim":
+			_, err := ide_util.GetVimBinaryPath()
+			if err != nil {
+				log.Error(err)
+			}
 		case "fleet":
 			if err := ide_util.CheckFleetInstallation(); err != nil {
 				log.Error(err)

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -187,6 +187,8 @@ func openIDE(ideId string, activeProfile config.Profile, workspaceId string, pro
 		return ide.OpenTerminalSsh(activeProfile, workspaceId, projectName, gpgKey, nil)
 	case "browser":
 		return ide.OpenBrowserIDE(activeProfile, workspaceId, projectName, projectProviderMetadata, gpgKey)
+	case "vim":
+		return ide.OpenVim(activeProfile, workspaceId, projectName, gpgKey)
 	case "codium":
 		return ide.OpenVScodium(activeProfile, workspaceId, projectName, projectProviderMetadata, gpgKey)
 	case "cursor":

--- a/pkg/ide/vim.go
+++ b/pkg/ide/vim.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ide
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/daytonaio/daytona/cmd/daytona/config"
+	"github.com/daytonaio/daytona/internal/util"
+	"github.com/daytonaio/daytona/pkg/views"
+)
+
+func OpenVim(activeProfile config.Profile, workspaceId, projectName, gpgKey string) error {
+	path, err := GetVimBinaryPath()
+	if err != nil {
+		return err
+	}
+
+	printVimDisclaimer()
+	projectHostname := config.GetProjectHostname(activeProfile.Id, workspaceId, projectName)
+	projectDir, err := util.GetProjectDir(activeProfile, workspaceId, projectName, gpgKey)
+	if err != nil {
+		return err
+	}
+	// This suppresses the "Permanently added ... to the list of known hosts" message and reduce file listing errors
+	vimConfig := fmt.Sprintf(`:let g:netrw_list_cmd = "ssh -o LogLevel=QUIET %s ls -Fa"`, projectHostname)
+
+	// Both scp and sftp are supported by Vim's built-in netrw plugin
+	vimCmd := exec.Command(path, "-c", vimConfig, fmt.Sprintf("scp://%s/%s/", projectHostname, projectDir))
+	vimCmd.Stdin = os.Stdin
+	vimCmd.Stdout = os.Stdout
+	vimCmd.Stderr = os.Stderr
+
+	return vimCmd.Run()
+}
+
+func GetVimBinaryPath() (string, error) {
+	path, err := exec.LookPath("vim")
+	if err == nil {
+		return path, err
+	}
+
+	redBold := "\033[1;31m" // ANSI escape code for red and bold
+	reset := "\033[0m"      // ANSI escape code to reset text formatting
+
+	errorMessage := "Please install Vim and ensure it's in your PATH.\n"
+
+	return "", errors.New(redBold + errorMessage + reset)
+}
+
+func printVimDisclaimer() {
+	views.RenderTip(`Note: Vim only allows you to edit remote files using Netrw.
+For a better experience, consider using a dedicated IDE.
+If you need to run commands, please use the 'daytona ssh' command instead.`)
+}


### PR DESCRIPTION
# feat: add support for Vim IDE

## Description



- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

https://github.com/user-attachments/assets/5ade7398-edc7-405c-9483-9b9cb8ec9c5b



## Notes
Vim/Neovim allow you to edit remote files using [Netrw](https://www.vim.org/scripts/script.php?script_id=1075). You can connect it either from within vim :e scp://[user@]machine[[:#]port]/path or by starting vim with vim scp://[user@]machine[[:#]port]/path
