### PR TITLE
fix: handle daemon already running

### DIFF
--- a/pkg/cmd/server/daemon/daemon.go
+++ b/pkg/cmd/server/daemon/daemon.go
@@ -46,6 +46,17 @@ func Start(logFilePath string) error {
 		}
 	}
 
+	if runtime.GOOS == "darwin" {
+		status, err := s.Status()
+		if err != nil {
+			return err
+		}
+
+		if status == service.StatusRunning {
+			return errors.New("daemon already running. Run 'daytona server restart' to reload the daemon")
+		}
+	}
+
 	logFile, err := os.OpenFile(logFilePath, os.O_TRUNC|os.O_CREATE|os.O_RDONLY, 0644)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Handle daemon already running
## Description

Adds a daemon status check to `daytona server` that returns `daemon already running. Run "daytona server restart" to reload the daemon`
Relevant for MacOS's launchctl

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
Closes #1479 
