### PR TITLE
fix: only modify ssh config file when required

### DIFF
--- a/cmd/daytona/config/ssh_file.go
+++ b/cmd/daytona/config/ssh_file.go
@@ -60,9 +60,15 @@ func ensureSshFilesLinked() error {
 			return err
 		}
 
-		newContent := strings.ReplaceAll(string(content), "Include daytona_config\n\n", "")
-		newContent = strings.ReplaceAll(string(newContent), "Include daytona_config\n", "")
-		newContent = strings.ReplaceAll(string(newContent), "Include daytona_config", "")
+		contentStr := string(content)
+
+		if strings.HasPrefix(contentStr, "Include daytona_config") {
+			return nil
+		}
+
+		newContent := strings.ReplaceAll(contentStr, "Include daytona_config\n\n", "")
+		newContent = strings.ReplaceAll(newContent, "Include daytona_config\n", "")
+		newContent = strings.ReplaceAll(newContent, "Include daytona_config", "")
 		newContent = "Include daytona_config\n\n" + newContent
 		err = os.WriteFile(configFile, []byte(newContent), 0600)
 		if err != nil {


### PR DESCRIPTION
# Only Modify SSH Config File When Required

## Description

Currently, we always write to the ssh config file even if the `Include daytona_config` line is in the appropriate place. With this PR, we first check if a change is necessary.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1601 
