### PR TITLE
fix: make prebuild ID optional for build

### DIFF
--- a/internal/testing/build/store.go
+++ b/internal/testing/build/store.go
@@ -76,7 +76,7 @@ func (s *InMemoryBuildStore) processFilters(filter *stores.BuildFilter) ([]*mode
 			for _, b := range filteredBuilds {
 				check := false
 				for _, prebuildId := range *filter.PrebuildIds {
-					if b.PrebuildId == prebuildId {
+					if b.PrebuildId != nil && *b.PrebuildId == prebuildId {
 						check = true
 						break
 					}

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -2496,7 +2496,6 @@ const docTemplate = `{
                 "createdAt",
                 "envVars",
                 "id",
-                "prebuildId",
                 "repository",
                 "state",
                 "updatedAt"

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -2493,7 +2493,6 @@
                 "createdAt",
                 "envVars",
                 "id",
-                "prebuildId",
                 "repository",
                 "state",
                 "updatedAt"

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -66,7 +66,6 @@ definitions:
     - createdAt
     - envVars
     - id
-    - prebuildId
     - repository
     - state
     - updatedAt

--- a/pkg/apiclient/api/openapi.yaml
+++ b/pkg/apiclient/api/openapi.yaml
@@ -1914,7 +1914,6 @@ components:
       - createdAt
       - envVars
       - id
-      - prebuildId
       - repository
       - state
       - updatedAt

--- a/pkg/apiclient/docs/BuildDTO.md
+++ b/pkg/apiclient/docs/BuildDTO.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **Id** | **string** |  | 
 **Image** | Pointer to **string** |  | [optional] 
 **LastJob** | Pointer to [**Job**](Job.md) |  | [optional] 
-**PrebuildId** | **string** |  | 
+**PrebuildId** | Pointer to **string** |  | [optional] 
 **Repository** | [**GitRepository**](GitRepository.md) |  | 
 **State** | [**ResourceState**](ResourceState.md) |  | 
 **UpdatedAt** | **string** |  | 
@@ -21,7 +21,7 @@ Name | Type | Description | Notes
 
 ### NewBuildDTO
 
-`func NewBuildDTO(containerConfig ContainerConfig, createdAt string, envVars map[string]string, id string, prebuildId string, repository GitRepository, state ResourceState, updatedAt string, ) *BuildDTO`
+`func NewBuildDTO(containerConfig ContainerConfig, createdAt string, envVars map[string]string, id string, repository GitRepository, state ResourceState, updatedAt string, ) *BuildDTO`
 
 NewBuildDTO instantiates a new BuildDTO object
 This constructor will assign default values to properties that have it defined,
@@ -210,6 +210,11 @@ and a boolean to check if the value has been set.
 
 SetPrebuildId sets PrebuildId field to given value.
 
+### HasPrebuildId
+
+`func (o *BuildDTO) HasPrebuildId() bool`
+
+HasPrebuildId returns a boolean if a field has been set.
 
 ### GetRepository
 

--- a/pkg/apiclient/model_build_dto.go
+++ b/pkg/apiclient/model_build_dto.go
@@ -28,7 +28,7 @@ type BuildDTO struct {
 	Id              string            `json:"id"`
 	Image           *string           `json:"image,omitempty"`
 	LastJob         *Job              `json:"lastJob,omitempty"`
-	PrebuildId      string            `json:"prebuildId"`
+	PrebuildId      *string           `json:"prebuildId,omitempty"`
 	Repository      GitRepository     `json:"repository"`
 	State           ResourceState     `json:"state"`
 	UpdatedAt       string            `json:"updatedAt"`
@@ -41,13 +41,12 @@ type _BuildDTO BuildDTO
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewBuildDTO(containerConfig ContainerConfig, createdAt string, envVars map[string]string, id string, prebuildId string, repository GitRepository, state ResourceState, updatedAt string) *BuildDTO {
+func NewBuildDTO(containerConfig ContainerConfig, createdAt string, envVars map[string]string, id string, repository GitRepository, state ResourceState, updatedAt string) *BuildDTO {
 	this := BuildDTO{}
 	this.ContainerConfig = containerConfig
 	this.CreatedAt = createdAt
 	this.EnvVars = envVars
 	this.Id = id
-	this.PrebuildId = prebuildId
 	this.Repository = repository
 	this.State = state
 	this.UpdatedAt = updatedAt
@@ -254,28 +253,36 @@ func (o *BuildDTO) SetLastJob(v Job) {
 	o.LastJob = &v
 }
 
-// GetPrebuildId returns the PrebuildId field value
+// GetPrebuildId returns the PrebuildId field value if set, zero value otherwise.
 func (o *BuildDTO) GetPrebuildId() string {
-	if o == nil {
+	if o == nil || IsNil(o.PrebuildId) {
 		var ret string
 		return ret
 	}
-
-	return o.PrebuildId
+	return *o.PrebuildId
 }
 
-// GetPrebuildIdOk returns a tuple with the PrebuildId field value
+// GetPrebuildIdOk returns a tuple with the PrebuildId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *BuildDTO) GetPrebuildIdOk() (*string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.PrebuildId) {
 		return nil, false
 	}
-	return &o.PrebuildId, true
+	return o.PrebuildId, true
 }
 
-// SetPrebuildId sets field value
+// HasPrebuildId returns a boolean if a field has been set.
+func (o *BuildDTO) HasPrebuildId() bool {
+	if o != nil && !IsNil(o.PrebuildId) {
+		return true
+	}
+
+	return false
+}
+
+// SetPrebuildId gets a reference to the given string and assigns it to the PrebuildId field.
 func (o *BuildDTO) SetPrebuildId(v string) {
-	o.PrebuildId = v
+	o.PrebuildId = &v
 }
 
 // GetRepository returns the Repository field value
@@ -405,7 +412,9 @@ func (o BuildDTO) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LastJob) {
 		toSerialize["lastJob"] = o.LastJob
 	}
-	toSerialize["prebuildId"] = o.PrebuildId
+	if !IsNil(o.PrebuildId) {
+		toSerialize["prebuildId"] = o.PrebuildId
+	}
 	toSerialize["repository"] = o.Repository
 	toSerialize["state"] = o.State
 	toSerialize["updatedAt"] = o.UpdatedAt
@@ -424,7 +433,6 @@ func (o *BuildDTO) UnmarshalJSON(data []byte) (err error) {
 		"createdAt",
 		"envVars",
 		"id",
-		"prebuildId",
 		"repository",
 		"state",
 		"updatedAt",

--- a/pkg/models/build.go
+++ b/pkg/models/build.go
@@ -20,7 +20,7 @@ type Build struct {
 	Repository      *gitprovider.GitRepository `json:"repository" validate:"required" gorm:"serializer:json;not null"`
 	EnvVars         map[string]string          `json:"envVars" validate:"required" gorm:"serializer:json;not null"`
 	LastJob         *Job                       `json:"lastJob" validate:"optional" gorm:"foreignKey:ResourceId;references:Id"`
-	PrebuildId      string                     `json:"prebuildId" validate:"required" gorm:"not null"`
+	PrebuildId      *string                    `json:"prebuildId" validate:"optional"`
 	CreatedAt       time.Time                  `json:"createdAt" validate:"required" gorm:"not null"`
 	UpdatedAt       time.Time                  `json:"updatedAt" validate:"required" gorm:"not null"`
 } // @name Build

--- a/pkg/server/builds/create.go
+++ b/pkg/server/builds/create.go
@@ -45,7 +45,7 @@ func (s *BuildService) Create(ctx context.Context, b services.CreateBuildDTO) (s
 	}
 
 	if b.PrebuildId != nil {
-		newBuild.PrebuildId = *b.PrebuildId
+		newBuild.PrebuildId = b.PrebuildId
 	}
 
 	err = s.buildStore.Save(ctx, &newBuild)

--- a/pkg/server/builds/service_test.go
+++ b/pkg/server/builds/service_test.go
@@ -150,7 +150,7 @@ func (s *BuildServiceTestSuite) TestSave() {
 	createBuildDto := services.CreateBuildDTO{
 		WorkspaceTemplateName: "workspaceTemplateName",
 		Branch:                "branch",
-		PrebuildId:            &build4.PrebuildId,
+		PrebuildId:            build4.PrebuildId,
 		EnvVars:               build4.EnvVars,
 	}
 

--- a/pkg/server/workspacetemplates/prebuild.go
+++ b/pkg/server/workspacetemplates/prebuild.go
@@ -143,7 +143,9 @@ func (s *WorkspaceTemplateService) EnforceRetentionPolicy(ctx context.Context) e
 
 	// Group builds by their prebuildId
 	for _, b := range existingBuilds {
-		buildMap[b.PrebuildId] = append(buildMap[b.PrebuildId], b.Build)
+		if b.PrebuildId != nil && *b.PrebuildId != "" {
+			buildMap[*b.PrebuildId] = append(buildMap[*b.PrebuildId], b.Build)
+		}
 	}
 
 	for _, prebuild := range prebuilds {

--- a/pkg/server/workspacetemplates/prebuild_test.go
+++ b/pkg/server/workspacetemplates/prebuild_test.go
@@ -147,7 +147,7 @@ func (s *WorkspaceTemplateServiceTestSuite) TestProcessGitEventCommitInterval() 
 		GetNewest:   util.Pointer(true),
 	}).Return(&models.Build{
 		Id:         "1",
-		PrebuildId: prebuild1.Id,
+		PrebuildId: &prebuild1.Id,
 		Repository: repository1,
 	}, nil)
 
@@ -202,22 +202,22 @@ func (s *WorkspaceTemplateServiceTestSuite) TestEnforceRetentionPolicy() {
 	}).Return([]*models.Build{
 		{
 			Id:         "1",
-			PrebuildId: "1",
+			PrebuildId: util.Pointer("1"),
 			CreatedAt:  time.Now().Add(time.Hour * -4),
 		},
 		{
 			Id:         "2",
-			PrebuildId: "1",
+			PrebuildId: util.Pointer("1"),
 			CreatedAt:  time.Now().Add(time.Hour * -3),
 		},
 		{
 			Id:         "3",
-			PrebuildId: "1",
+			PrebuildId: util.Pointer("1"),
 			CreatedAt:  time.Now().Add(time.Hour * -2),
 		},
 		{
 			Id:         "4",
-			PrebuildId: "1",
+			PrebuildId: util.Pointer("1"),
 			CreatedAt:  time.Now().Add(time.Hour * -1),
 		},
 	}, nil)

--- a/pkg/telemetry/build.go
+++ b/pkg/telemetry/build.go
@@ -40,7 +40,7 @@ func (e buildEvent) Props() map[string]interface{} {
 	}
 
 	props["build_id"] = e.build.Id
-	props["from_prebuild"] = e.build.PrebuildId != ""
+	props["from_prebuild"] = e.build.PrebuildId != nil && *e.build.PrebuildId != ""
 	if isImagePublic(e.build.ContainerConfig.Image) {
 		props["image"] = e.build.Image
 	}

--- a/pkg/views/build/info/view.go
+++ b/pkg/views/build/info/view.go
@@ -61,7 +61,9 @@ func Render(b *apiclient.BuildDTO, apiServerConfig *apiclient.ServerConfig, forc
 		output += getInfoLine("Devcontainer path", b.BuildConfig.Devcontainer.FilePath) + "\n"
 	}
 
-	output += getInfoLine("Prebuild ID", b.PrebuildId) + "\n"
+	if b.PrebuildId != nil {
+		output += getInfoLine("Prebuild ID", *b.PrebuildId) + "\n"
+	}
 
 	output += getInfoLine("Created", util.FormatTimestamp(b.CreatedAt)) + "\n"
 

--- a/pkg/views/build/list/view.go
+++ b/pkg/views/build/list/view.go
@@ -72,10 +72,13 @@ func getRowFromRowData(build apiclient.BuildDTO) []string {
 
 	data.Id = build.Id + views_util.AdditionalPropertyPadding
 	data.Status = views.GetStateLabel(build.State.Name)
-	data.PrebuildId = build.PrebuildId
-	if data.PrebuildId == "" {
+
+	if build.PrebuildId != nil && *build.PrebuildId != "" {
+		data.PrebuildId = *build.PrebuildId
+	} else {
 		data.PrebuildId = "/"
 	}
+
 	data.CreatedAt = util.FormatTimestamp(build.CreatedAt)
 	data.UpdatedAt = util.FormatTimestamp(build.UpdatedAt)
 


### PR DESCRIPTION
# Make prebuild ID optional for build

## Description

This PR makes prebuild ID on build optional so that builds ran regardless of prebuild configuration don't need to carry this information.

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation