### PR TITLE
fix: ssh edit command

### DIFF
--- a/pkg/cmd/workspace/logs.go
+++ b/pkg/cmd/workspace/logs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
-	cmd_common "github.com/daytonaio/daytona/pkg/cmd/common"
+	"github.com/daytonaio/daytona/pkg/cmd/common"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
@@ -24,7 +24,7 @@ var LogsCmd = &cobra.Command{
 	Short:   "View the logs of a workspace",
 	Args:    cobra.RangeArgs(0, 2),
 	GroupID: util.TARGET_GROUP,
-	Aliases: cmd_common.GetAliases("logs"),
+	Aliases: common.GetAliases("logs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
@@ -76,7 +76,7 @@ var LogsCmd = &cobra.Command{
 			return nil
 		}
 
-		cmd_common.ReadWorkspaceLogs(ctx, cmd_common.ReadLogParams{
+		common.ReadWorkspaceLogs(ctx, common.ReadLogParams{
 			Id:        ws.Id,
 			Label:     &ws.Name,
 			ServerUrl: activeProfile.Api.Url,
@@ -87,7 +87,7 @@ var LogsCmd = &cobra.Command{
 		return nil
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cmd_common.GetWorkspaceNameCompletions()
+		return common.GetWorkspaceNameCompletions()
 	},
 }
 

--- a/pkg/cmd/workspace/logs.go
+++ b/pkg/cmd/workspace/logs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
-	"github.com/daytonaio/daytona/pkg/cmd/common"
 	cmd_common "github.com/daytonaio/daytona/pkg/cmd/common"
 	"github.com/daytonaio/daytona/pkg/cmd/format"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
@@ -25,7 +24,7 @@ var LogsCmd = &cobra.Command{
 	Short:   "View the logs of a workspace",
 	Args:    cobra.RangeArgs(0, 2),
 	GroupID: util.TARGET_GROUP,
-	Aliases: common.GetAliases("logs"),
+	Aliases: cmd_common.GetAliases("logs"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
@@ -88,7 +87,7 @@ var LogsCmd = &cobra.Command{
 		return nil
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return common.GetWorkspaceNameCompletions()
+		return cmd_common.GetWorkspaceNameCompletions()
 	},
 }
 

--- a/pkg/cmd/workspace/ssh.go
+++ b/pkg/cmd/workspace/ssh.go
@@ -81,6 +81,7 @@ var SshCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+			return nil
 		}
 
 		if ws.State.Name == apiclient.ResourceStateNameStopped {

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -13,7 +13,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
-	"github.com/daytonaio/daytona/pkg/cmd/common"
 	cmd_common "github.com/daytonaio/daytona/pkg/cmd/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	ide_views "github.com/daytonaio/daytona/pkg/views/ide"
@@ -104,7 +103,7 @@ var StartCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			gpgKey, err := common.GetGitProviderGpgKey(apiClient, ctx, providerConfigId)
+			gpgKey, err := cmd_common.GetGitProviderGpgKey(apiClient, ctx, providerConfigId)
 			if err != nil {
 				log.Warn(err)
 			}
@@ -113,7 +112,7 @@ var StartCmd = &cobra.Command{
 
 			if codeFlag {
 				ide_views.RenderIdeOpeningMessage(ws.TargetId, ws.Name, ideId, ideList)
-				err = common.OpenIDE(ideId, activeProfile, ws.Id, workspaceProviderMetadata, yesFlag, gpgKey)
+				err = cmd_common.OpenIDE(ideId, activeProfile, ws.Id, workspaceProviderMetadata, yesFlag, gpgKey)
 				if err != nil {
 					return err
 				}
@@ -131,7 +130,7 @@ var StartCmd = &cobra.Command{
 		return nil
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return common.GetAllWorkspacesByState(apiclient.ResourceStateNameStopped)
+		return cmd_common.GetAllWorkspacesByState(apiclient.ResourceStateNameStopped)
 	},
 }
 
@@ -207,7 +206,7 @@ func StartWorkspace(apiClient *apiclient.APIClient, workspace apiclient.Workspac
 		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	err = common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStarted)
+	err = cmd_common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStarted)
 	if err != nil {
 		stopLogs()
 		return err

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
-	cmd_common "github.com/daytonaio/daytona/pkg/cmd/common"
+	"github.com/daytonaio/daytona/pkg/cmd/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	ide_views "github.com/daytonaio/daytona/pkg/views/ide"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
@@ -103,7 +103,7 @@ var StartCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			gpgKey, err := cmd_common.GetGitProviderGpgKey(apiClient, ctx, providerConfigId)
+			gpgKey, err := common.GetGitProviderGpgKey(apiClient, ctx, providerConfigId)
 			if err != nil {
 				log.Warn(err)
 			}
@@ -112,7 +112,7 @@ var StartCmd = &cobra.Command{
 
 			if codeFlag {
 				ide_views.RenderIdeOpeningMessage(ws.TargetId, ws.Name, ideId, ideList)
-				err = cmd_common.OpenIDE(ideId, activeProfile, ws.Id, workspaceProviderMetadata, yesFlag, gpgKey)
+				err = common.OpenIDE(ideId, activeProfile, ws.Id, workspaceProviderMetadata, yesFlag, gpgKey)
 				if err != nil {
 					return err
 				}
@@ -130,7 +130,7 @@ var StartCmd = &cobra.Command{
 		return nil
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cmd_common.GetAllWorkspacesByState(apiclient.ResourceStateNameStopped)
+		return common.GetAllWorkspacesByState(apiclient.ResourceStateNameStopped)
 	},
 }
 
@@ -183,7 +183,7 @@ func StartWorkspace(apiClient *apiclient.APIClient, workspace apiclient.Workspac
 	}
 
 	logsContext, stopLogs := context.WithCancel(context.Background())
-	go cmd_common.ReadWorkspaceLogs(logsContext, cmd_common.ReadLogParams{
+	go common.ReadWorkspaceLogs(logsContext, common.ReadLogParams{
 		Id:        workspace.Id,
 		Label:     &workspace.Name,
 		ServerUrl: activeProfile.Api.Url,
@@ -206,7 +206,7 @@ func StartWorkspace(apiClient *apiclient.APIClient, workspace apiclient.Workspac
 		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	err = cmd_common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStarted)
+	err = common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStarted)
 	if err != nil {
 		stopLogs()
 		return err

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -12,7 +12,7 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
-	cmd_common "github.com/daytonaio/daytona/pkg/cmd/common"
+	"github.com/daytonaio/daytona/pkg/cmd/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
 	"github.com/daytonaio/daytona/pkg/views/workspace/selection"
@@ -84,7 +84,7 @@ var StopCmd = &cobra.Command{
 		return nil
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cmd_common.GetAllWorkspacesByState(apiclient.ResourceStateNameStarted)
+		return common.GetAllWorkspacesByState(apiclient.ResourceStateNameStarted)
 	},
 }
 
@@ -136,7 +136,7 @@ func StopWorkspace(apiClient *apiclient.APIClient, workspace apiclient.Workspace
 	}
 
 	logsContext, stopLogs := context.WithCancel(context.Background())
-	go cmd_common.ReadWorkspaceLogs(logsContext, cmd_common.ReadLogParams{
+	go common.ReadWorkspaceLogs(logsContext, common.ReadLogParams{
 		Id:        workspace.Id,
 		Label:     &workspace.Name,
 		ServerUrl: activeProfile.Api.Url,
@@ -152,7 +152,7 @@ func StopWorkspace(apiClient *apiclient.APIClient, workspace apiclient.Workspace
 		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	err = cmd_common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStopped)
+	err = common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStopped)
 	if err != nil {
 		stopLogs()
 		return err

--- a/pkg/cmd/workspace/stop.go
+++ b/pkg/cmd/workspace/stop.go
@@ -12,7 +12,6 @@ import (
 	"github.com/daytonaio/daytona/internal/util"
 	apiclient_util "github.com/daytonaio/daytona/internal/util/apiclient"
 	"github.com/daytonaio/daytona/pkg/apiclient"
-	"github.com/daytonaio/daytona/pkg/cmd/common"
 	cmd_common "github.com/daytonaio/daytona/pkg/cmd/common"
 	"github.com/daytonaio/daytona/pkg/views"
 	views_util "github.com/daytonaio/daytona/pkg/views/util"
@@ -85,7 +84,7 @@ var StopCmd = &cobra.Command{
 		return nil
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return common.GetAllWorkspacesByState(apiclient.ResourceStateNameStarted)
+		return cmd_common.GetAllWorkspacesByState(apiclient.ResourceStateNameStarted)
 	},
 }
 
@@ -153,7 +152,7 @@ func StopWorkspace(apiClient *apiclient.APIClient, workspace apiclient.Workspace
 		return apiclient_util.HandleErrorResponse(res, err)
 	}
 
-	err = common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStopped)
+	err = cmd_common.AwaitWorkspaceState(workspace.Id, apiclient.ResourceStateNameStopped)
 	if err != nil {
 		stopLogs()
 		return err


### PR DESCRIPTION
# Fix SSH edit command

## Description

This PR fixes SSH command with edit flag provided as editing would proceed to ssh into workspace even though it shouldn't have.
Also, minor change of removing duplicated imports.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation