### PR TITLE
fix: set docker cred helper config

### DIFF
--- a/pkg/docker/credential_helper.go
+++ b/pkg/docker/credential_helper.go
@@ -62,7 +62,7 @@ func (d *DockerCredHelper) SetDockerConfig() error {
 		return err
 	}
 
-	return os.WriteFile(d.DockerConfigFileName, updatedConfigContent, 0644)
+	return os.WriteFile(d.DockerConfigFileName, updatedConfigContent, 0755)
 }
 
 func (d *DockerCredHelper) createDockerCredHelperExecutable() error {
@@ -76,7 +76,7 @@ func (d *DockerCredHelper) createDockerCredHelperExecutable() error {
 
 		_, ok := os.Stat(filePath)
 		if os.IsNotExist(ok) {
-			err := os.MkdirAll(filePath, 0757)
+			err := os.MkdirAll(filePath, 0755)
 			if err != nil {
 				return err
 			}
@@ -88,10 +88,10 @@ func (d *DockerCredHelper) createDockerCredHelperExecutable() error {
 		}
 	}
 
-	err = os.WriteFile(filepath.Join(filePath, fileName), []byte(content), 0555)
+	err = os.WriteFile(filepath.Join(filePath, fileName), []byte(content), 0755)
 	if err != nil {
 		return err
 	}
 
-	return os.Chmod(filepath.Join(filePath, fileName), 0555)
+	return os.Chmod(filepath.Join(filePath, fileName), 0755)
 }


### PR DESCRIPTION
# Fix setting docker cred-helper config

## Description

This PR fixes issue of Daytona not being able to set docker cred-helper config when workspace is restarded.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation