### PR TITLE
fix: ghost default target

### DIFF
--- a/pkg/server/targets/delete.go
+++ b/pkg/server/targets/delete.go
@@ -28,6 +28,7 @@ func (s *TargetService) Delete(ctx context.Context, targetId string) error {
 	}
 
 	t.Name = util.AddDeletedToName(t.Name)
+	t.IsDefault = false
 
 	err = s.targetStore.Save(ctx, t)
 	if err != nil {

--- a/pkg/server/targets/set-default.go
+++ b/pkg/server/targets/set-default.go
@@ -29,7 +29,7 @@ func (s *TargetService) SetDefault(ctx context.Context, id string) error {
 
 	defaultTarget, err := s.Find(ctx, &stores.TargetFilter{
 		Default: util.Pointer(true),
-	}, services.TargetRetrievalParams{})
+	}, services.TargetRetrievalParams{ShowDeleted: true})
 	if err != nil && !stores.IsTargetNotFound(err) {
 		return s.targetStore.RollbackTransaction(ctx, err)
 	}


### PR DESCRIPTION
# Fix ghost default target

## Description

This PR fixes issue of default target not being set as non-default which resulted in other targets erroring on creation.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation