### PR TITLE
feat: default to single runner in prompt

### DIFF
--- a/pkg/cmd/common/get_runner.go
+++ b/pkg/cmd/common/get_runner.go
@@ -37,6 +37,13 @@ func GetRunnerFlow(apiClient *apiclient.APIClient, action string) (*runner.Runne
 		return nil, nil
 	}
 
+	if len(runners) == 1 {
+		return &runner.RunnerView{
+			Id:   runners[0].Id,
+			Name: runners[0].Name,
+		}, nil
+	}
+
 	selectedRunner, err := runner.GetRunnerFromPrompt(runners, activeProfile.Name, action)
 	if err != nil {
 		if common.IsCtrlCAbort(err) {


### PR DESCRIPTION
# Default to single runner in TUI prompt
## Description

Default to single runner in TUI prompt - `GetRunnerFlow`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
