### PR TITLE
fix: fail cli await if deleting resource errors

### DIFF
--- a/pkg/cmd/common/delete_workspace.go
+++ b/pkg/cmd/common/delete_workspace.go
@@ -35,7 +35,7 @@ func DeleteWorkspace(ctx context.Context, apiClient *apiclient.APIClient, worksp
 			return err
 		}
 
-		err = AwaitWorkspaceDeleted(workspaceId)
+		err = AwaitWorkspaceState(workspaceId, apiclient.ResourceStateNameDeleted)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/target/delete.go
+++ b/pkg/cmd/target/delete.go
@@ -198,7 +198,7 @@ func deleteTarget(ctx context.Context, activeProfileId string, apiClient *apicli
 			return err
 		}
 
-		err = common.AwaitTargetDeleted(target.Id)
+		err = common.AwaitTargetState(target.Id, apiclient.ResourceStateNameDeleted)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Fail CLI await if deleting resource errors
## Description

Merges the "await resource deleted" helpers into "await resource state" so that the CLI now fails the await if deleting the resource had errored

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
