### PR TITLE
fix: code command opening wrong directory

### DIFF
--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -27,7 +27,7 @@ func GetHomeDir(activeProfile config.Profile, workspaceId string, gpgKey *string
 	return strings.TrimRight(string(homeDir), "\n"), nil
 }
 
-func GetWorkspaceDir(activeProfile config.Profile, workspaceId string, gpgKey *string) (string, error) {
+func GetWorkspaceDir(activeProfile config.Profile, workspaceId, repoName string, gpgKey *string) (string, error) {
 	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, gpgKey)
 	if err != nil {
 		return "", err
@@ -49,5 +49,5 @@ func GetWorkspaceDir(activeProfile config.Profile, workspaceId string, gpgKey *s
 		return "", err
 	}
 
-	return path.Join(homeDir, workspaceId), nil
+	return path.Join(homeDir, repoName), nil
 }

--- a/pkg/cmd/common/open_ide.go
+++ b/pkg/cmd/common/open_ide.go
@@ -14,37 +14,37 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func OpenIDE(ideId string, activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, yesFlag bool, gpgKey *string) error {
+func OpenIDE(ideId string, activeProfile config.Profile, workspaceId, repoName, workspaceProviderMetadata string, yesFlag bool, gpgKey *string) error {
 	var err error
 	switch ideId {
 	case "vscode":
-		err = ide.OpenVSCode(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenVSCode(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	case "code-insiders":
-		err = ide.OpenVSCodeInsiders(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenVSCodeInsiders(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	case "ssh":
 		err = ide.OpenTerminalSsh(activeProfile, workspaceId, gpgKey, nil)
 	case "browser":
-		err = ide.OpenBrowserIDE(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenBrowserIDE(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	case "codium":
-		err = ide.OpenVScodium(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenVScodium(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	case "codium-insiders":
-		err = ide.OpenVScodiumInsiders(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenVScodiumInsiders(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	case "cursor":
-		err = ide.OpenCursor(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenCursor(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	case "jupyter":
-		err = ide.OpenJupyterIDE(activeProfile, workspaceId, workspaceProviderMetadata, yesFlag, gpgKey)
+		err = ide.OpenJupyterIDE(activeProfile, workspaceId, repoName, workspaceProviderMetadata, yesFlag, gpgKey)
 	case "fleet":
-		err = ide.OpenFleet(activeProfile, workspaceId, gpgKey)
+		err = ide.OpenFleet(activeProfile, workspaceId, repoName, gpgKey)
 	case "positron":
-		err = ide.OpenPositron(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenPositron(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	case "zed":
-		err = ide.OpenZed(activeProfile, workspaceId, gpgKey)
+		err = ide.OpenZed(activeProfile, workspaceId, repoName, gpgKey)
 	case "windsurf":
-		err = ide.OpenWindsurf(activeProfile, workspaceId, workspaceProviderMetadata, gpgKey)
+		err = ide.OpenWindsurf(activeProfile, workspaceId, repoName, workspaceProviderMetadata, gpgKey)
 	default:
 		_, ok := jetbrains.GetIdes()[jetbrains.Id(ideId)]
 		if ok {
-			err = ide.OpenJetbrainsIDE(activeProfile, ideId, workspaceId, gpgKey)
+			err = ide.OpenJetbrainsIDE(activeProfile, ideId, workspaceId, repoName, gpgKey)
 		} else {
 			return errors.New("invalid IDE. Please choose one by running `daytona ide`")
 		}

--- a/pkg/cmd/workspace/code.go
+++ b/pkg/cmd/workspace/code.go
@@ -102,7 +102,7 @@ var CodeCmd = &cobra.Command{
 		yesFlag, _ := cmd.Flags().GetBool("yes")
 		ideList := config.GetIdeList()
 		ide_views.RenderIdeOpeningMessage(ws.TargetId, ws.Name, ideId, ideList)
-		return common.OpenIDE(ideId, activeProfile, ws.Id, providerMetadata, yesFlag, gpgKey)
+		return common.OpenIDE(ideId, activeProfile, ws.Id, ws.Repository.Name, providerMetadata, yesFlag, gpgKey)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return common.GetWorkspaceNameCompletions()

--- a/pkg/cmd/workspace/create/cmd.go
+++ b/pkg/cmd/workspace/create/cmd.go
@@ -272,7 +272,7 @@ var CreateCmd = &cobra.Command{
 
 		views.RenderCreationInfoMessage(fmt.Sprintf("Opening the workspace in %s ...", chosenIde.Name))
 
-		return cmd_common.OpenIDE(chosenIdeId, activeProfile, createWorkspaceDtos[0].Name, *createdWorkspaces[0].ProviderMetadata, YesFlag, gpgKey)
+		return cmd_common.OpenIDE(chosenIdeId, activeProfile, createWorkspaceDtos[0].Id, createWorkspaceDtos[0].Source.Repository.Name, *createdWorkspaces[0].ProviderMetadata, YesFlag, gpgKey)
 	},
 }
 

--- a/pkg/cmd/workspace/start.go
+++ b/pkg/cmd/workspace/start.go
@@ -112,7 +112,7 @@ var StartCmd = &cobra.Command{
 
 			if codeFlag {
 				ide_views.RenderIdeOpeningMessage(ws.TargetId, ws.Name, ideId, ideList)
-				err = common.OpenIDE(ideId, activeProfile, ws.Id, workspaceProviderMetadata, yesFlag, gpgKey)
+				err = common.OpenIDE(ideId, activeProfile, ws.Id, ws.Repository.Name, workspaceProviderMetadata, yesFlag, gpgKey)
 				if err != nil {
 					return err
 				}

--- a/pkg/ide/browser.go
+++ b/pkg/ide/browser.go
@@ -23,7 +23,7 @@ import (
 
 const startVSCodeServerCommand = "$HOME/vscode-server/bin/openvscode-server --start-server --port=63000 --host=0.0.0.0 --without-connection-token --disable-workspace-trust --default-folder="
 
-func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgKey *string) error {
+func OpenBrowserIDE(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgKey *string) error {
 	// Download and start IDE
 	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, gpgKey)
 	if err != nil {
@@ -42,7 +42,7 @@ func OpenBrowserIDE(activeProfile config.Profile, workspaceId string, workspaceP
 		return err
 	}
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/cursor.go
+++ b/pkg/ide/cursor.go
@@ -14,7 +14,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/build/devcontainer"
 )
 
-func OpenCursor(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgKey *string) error {
+func OpenCursor(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgKey *string) error {
 	path, err := GetCursorBinaryPath()
 	if err != nil {
 		return err
@@ -22,7 +22,7 @@ func OpenCursor(activeProfile config.Profile, workspaceId string, workspaceProvi
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/fleet.go
+++ b/pkg/ide/fleet.go
@@ -13,13 +13,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func OpenFleet(activeProfile config.Profile, workspaceId string, gpgKey *string) error {
+func OpenFleet(activeProfile config.Profile, workspaceId, repoName string, gpgKey *string) error {
 	if err := CheckFleetInstallation(); err != nil {
 		return err
 	}
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/jetbrains.go
+++ b/pkg/ide/jetbrains.go
@@ -23,13 +23,13 @@ import (
 	"github.com/pkg/browser"
 )
 
-func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId string, gpgKey *string) error {
+func OpenJetbrainsIDE(activeProfile config.Profile, ide, workspaceId, repoName string, gpgKey *string) error {
 	err := IsJetBrainsGatewayInstalled()
 	if err != nil {
 		return err
 	}
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/jupyter.go
+++ b/pkg/ide/jupyter.go
@@ -26,7 +26,7 @@ import (
 const startJupyterCommand = "notebook --no-browser --port=8888 --ip=0.0.0.0 --NotebookApp.token='' --NotebookApp.password=''"
 
 // OpenJupyterIDE manages the installation and startup of a Jupyter IDE on a remote target.
-func OpenJupyterIDE(activeProfile config.Profile, workspaceId, workspaceProviderMetadata string, yesFlag bool, gpgKey *string) error {
+func OpenJupyterIDE(activeProfile config.Profile, workspaceId, repoName, workspaceProviderMetadata string, yesFlag bool, gpgKey *string) error {
 	// Ensure SSH config entry is added
 	err := config.EnsureSshConfigEntryAdded(activeProfile.Id, workspaceId, gpgKey)
 	if err != nil {
@@ -51,7 +51,7 @@ func OpenJupyterIDE(activeProfile config.Profile, workspaceId, workspaceProvider
 	}
 
 	// Start Jupyter Notebook server
-	if err := startJupyterServer(workspaceHostname, activeProfile, workspaceId, gpgKey); err != nil {
+	if err := startJupyterServer(workspaceHostname, activeProfile, workspaceId, repoName, gpgKey); err != nil {
 		return err
 	}
 
@@ -216,8 +216,8 @@ func ensureJupyterInstalled(hostname string) error {
 }
 
 // startJupyterServer starts the Jupyter Notebook server on the remote target.
-func startJupyterServer(hostname string, activeProfile config.Profile, workspaceId string, gpgKey *string) error {
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+func startJupyterServer(hostname string, activeProfile config.Profile, workspaceId, repoName string, gpgKey *string) error {
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/positron.go
+++ b/pkg/ide/positron.go
@@ -15,7 +15,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-func OpenPositron(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgkey *string) error {
+func OpenPositron(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgkey *string) error {
 	path, err := GetPositronBinaryPath()
 	if err != nil {
 		return err
@@ -23,7 +23,7 @@ func OpenPositron(activeProfile config.Profile, workspaceId string, workspacePro
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgkey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgkey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/vscode-insiders.go
+++ b/pkg/ide/vscode-insiders.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/build/devcontainer"
 )
 
-func OpenVSCodeInsiders(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgKey *string) error {
+func OpenVSCodeInsiders(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgKey *string) error {
 	path, err := GetVSCodeInsidersBinaryPath()
 	if err != nil {
 		return err
@@ -25,7 +25,7 @@ func OpenVSCodeInsiders(activeProfile config.Profile, workspaceId string, worksp
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/vscode.go
+++ b/pkg/ide/vscode.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func OpenVSCode(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgKey *string) error {
+func OpenVSCode(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgKey *string) error {
 	CheckAndAlertVSCodeInstalled()
 	err := installRemoteSSHExtension("code")
 	if err != nil {
@@ -28,7 +28,7 @@ func OpenVSCode(activeProfile config.Profile, workspaceId string, workspaceProvi
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/vscodium-insiders.go
+++ b/pkg/ide/vscodium-insiders.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/build/devcontainer"
 )
 
-func OpenVScodiumInsiders(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgkey *string) error {
+func OpenVScodiumInsiders(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgkey *string) error {
 	path, err := GetCodiumInsidersBinaryPath()
 	if err != nil {
 		return err
@@ -26,7 +26,7 @@ func OpenVScodiumInsiders(activeProfile config.Profile, workspaceId string, work
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgkey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgkey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/vscodium.go
+++ b/pkg/ide/vscodium.go
@@ -16,7 +16,7 @@ import (
 
 const requiredExtension = "jeanp413.open-remote-ssh"
 
-func OpenVScodium(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgkey *string) error {
+func OpenVScodium(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgkey *string) error {
 	path, err := GetCodiumBinaryPath()
 	if err != nil {
 		return err
@@ -29,7 +29,7 @@ func OpenVScodium(activeProfile config.Profile, workspaceId string, workspacePro
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgkey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgkey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/windsurf.go
+++ b/pkg/ide/windsurf.go
@@ -13,7 +13,7 @@ import (
 	"github.com/daytonaio/daytona/pkg/build/devcontainer"
 )
 
-func OpenWindsurf(activeProfile config.Profile, workspaceId string, workspaceProviderMetadata string, gpgkey *string) error {
+func OpenWindsurf(activeProfile config.Profile, workspaceId, repoName string, workspaceProviderMetadata string, gpgkey *string) error {
 	path, err := GetWindsurfBinaryPath()
 	if err != nil {
 		return err
@@ -21,7 +21,7 @@ func OpenWindsurf(activeProfile config.Profile, workspaceId string, workspacePro
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
 
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgkey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgkey)
 	if err != nil {
 		return err
 	}

--- a/pkg/ide/zed.go
+++ b/pkg/ide/zed.go
@@ -14,14 +14,14 @@ import (
 	"github.com/daytonaio/daytona/pkg/views"
 )
 
-func OpenZed(activeProfile config.Profile, workspaceId string, gpgKey *string) error {
+func OpenZed(activeProfile config.Profile, workspaceId, repoName string, gpgKey *string) error {
 	path, err := GetZedBinaryPath()
 	if err != nil {
 		return err
 	}
 
 	workspaceHostname := config.GetHostname(activeProfile.Id, workspaceId)
-	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, gpgKey)
+	workspaceDir, err := util.GetWorkspaceDir(activeProfile, workspaceId, repoName, gpgKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Fix Code Command Opening Wrong Directory

## Description

Minor fix for the `code` command which was opening the wrong directory of a workspace for non-devcontainer workspaces.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
