### PR TITLE
fix: remove gin debug logs in production

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -103,14 +103,15 @@ func (a *ApiServer) Start() error {
 
 	binding.Validator = new(DefaultValidator)
 
+	gin.SetMode(gin.ReleaseMode)
+
 	a.router = gin.New()
 	a.router.Use(gin.Recovery())
 	if mode, ok := os.LookupEnv("DAYTONA_SERVER_MODE"); ok && mode == "development" {
 		a.router.Use(cors.New(cors.Config{
 			AllowAllOrigins: true,
 		}))
-	} else {
-		gin.SetMode(gin.ReleaseMode)
+		gin.SetMode(gin.DebugMode)
 	}
 
 	a.router.Use(middlewares.TelemetryMiddleware(a.telemetryService))


### PR DESCRIPTION
# Remove gin debug logs in production
## Description

Fixes the gin mode to be "release" in production and "debug" in development

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/3796632f-58b0-4bcf-bd0c-dc4dbd9142e4)