### PR TITLE
fix: remove gin debug logs from workspaces

### DIFF
--- a/pkg/agent/toolbox/toolbox.go
+++ b/pkg/agent/toolbox/toolbox.go
@@ -38,6 +38,7 @@ func (s *Server) GetWorkspaceDir(ctx *gin.Context) {
 }
 
 func (s *Server) Start() error {
+	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middlewares.LoggingMiddleware())


### PR DESCRIPTION
# Remove Gin Debug Logs from Workspaces

## Description

Set the gin mode to release for the toolbox api server to remove the output from workspace logs

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
