### PR TITLE
Introduced enum for page router paths

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -29,15 +29,23 @@ import { NotificationSocketProvider } from '@/providers/NotificationSocketProvid
 import { ApiProvider } from './providers/ApiProvider'
 import LandingPage from './pages/LandingPage'
 import Logout from './pages/Logout'
+import { RoutePath, getRouteSubPath } from './enums/RoutePath'
+import { DAYTONA_DOCS_URL, DAYTONA_SLACK_URL } from './constants/ExternalLinks'
 
-// Docs redirect component
+// Simple redirection components for external URLs
 const DocsRedirect = () => {
   React.useEffect(() => {
-    window.open('https://www.daytona.io/docs/', '_blank')
-    // Navigate back to dashboard after opening docs
-    window.location.href = '/dashboard'
+    window.open(DAYTONA_DOCS_URL, '_blank')
+    window.location.href = RoutePath.DASHBOARD
   }, [])
+  return null
+}
 
+const SlackRedirect = () => {
+  React.useEffect(() => {
+    window.open(DAYTONA_SLACK_URL, '_blank')
+    window.location.href = RoutePath.DASHBOARD
+  }, [])
   return null
 }
 
@@ -91,10 +99,12 @@ function App() {
         </DialogContent>
       </Dialog>
       <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/logout" element={<Logout />} />
+        <Route path={RoutePath.LANDING} element={<LandingPage />} />
+        <Route path={RoutePath.LOGOUT} element={<Logout />} />
+        <Route path={RoutePath.DOCS} element={<DocsRedirect />} />
+        <Route path={RoutePath.SLACK} element={<SlackRedirect />} />
         <Route
-          path="/dashboard"
+          path={RoutePath.DASHBOARD}
           element={
             <Suspense fallback={<LoadingFallback />}>
               <ApiProvider>
@@ -111,15 +121,15 @@ function App() {
             </Suspense>
           }
         >
-          <Route index element={<Navigate to="sandboxes" replace />} />
-          <Route path="keys" element={<Keys />} />
-          <Route path="sandboxes" element={<Workspaces />} />
-          <Route path="images" element={<Images />} />
-          <Route path="registries" element={<Registries />} />
-          <Route path="usage" element={<Usage />} />
+          <Route index element={<Navigate to={getRouteSubPath(RoutePath.SANDBOXES)} replace />} />
+          <Route path={getRouteSubPath(RoutePath.KEYS)} element={<Keys />} />
+          <Route path={getRouteSubPath(RoutePath.SANDBOXES)} element={<Workspaces />} />
+          <Route path={getRouteSubPath(RoutePath.IMAGES)} element={<Images />} />
+          <Route path={getRouteSubPath(RoutePath.REGISTRIES)} element={<Registries />} />
+          <Route path={getRouteSubPath(RoutePath.USAGE)} element={<Usage />} />
           {import.meta.env.VITE_BILLING_API_URL && (
             <Route
-              path="billing"
+              path={getRouteSubPath(RoutePath.BILLING)}
               element={
                 <OwnerAccessOrganizationPageWrapper>
                   <Billing />
@@ -128,7 +138,7 @@ function App() {
             />
           )}
           <Route
-            path="members"
+            path={getRouteSubPath(RoutePath.MEMBERS)}
             element={
               <NonPersonalOrganizationPageWrapper>
                 <OrganizationMembers />
@@ -138,7 +148,7 @@ function App() {
           {
             // TODO: uncomment when we allow creating custom roles
             /* <Route
-            path="roles"
+            path={getRouteSubPath(RoutePath.ROLES)}
             element={
               <NonPersonalOrganizationPageWrapper>
                 <OwnerAccessOrganizationPageWrapper>
@@ -148,10 +158,9 @@ function App() {
             }
           /> */
           }
-          <Route path="settings" element={<OrganizationSettings />} />
-          <Route path="user/invitations" element={<UserOrganizationInvitations />} />
+          <Route path={getRouteSubPath(RoutePath.SETTINGS)} element={<OrganizationSettings />} />
+          <Route path={getRouteSubPath(RoutePath.USER_INVITATIONS)} element={<UserOrganizationInvitations />} />
         </Route>
-        <Route path="/docs" element={<DocsRedirect />} />
         {/* Add other routes as needed */}
       </Routes>
     </ThemeProvider>
@@ -162,7 +171,7 @@ function NonPersonalOrganizationPageWrapper({ children }: { children: React.Reac
   const { selectedOrganization } = useSelectedOrganization()
 
   if (selectedOrganization?.personal) {
-    return <Navigate to="/dashboard" replace />
+    return <Navigate to={RoutePath.DASHBOARD} replace />
   }
 
   return <>{children}</>
@@ -172,7 +181,7 @@ function OwnerAccessOrganizationPageWrapper({ children }: { children: React.Reac
   const { authenticatedUserOrganizationMember } = useSelectedOrganization()
 
   if (authenticatedUserOrganizationMember?.role !== OrganizationUserRoleEnum.OWNER) {
-    return <Navigate to="/dashboard" replace />
+    return <Navigate to={RoutePath.DASHBOARD} replace />
   }
 
   return <>{children}</>

--- a/apps/dashboard/src/auth/oidc-config.ts
+++ b/apps/dashboard/src/auth/oidc-config.ts
@@ -5,6 +5,7 @@
 
 import { InMemoryWebStorage, WebStorageStateStore } from 'oidc-client-ts'
 import { AuthProviderProps } from 'react-oidc-context'
+import { RoutePath } from '@/enums/RoutePath'
 
 export const oidcConfig: AuthProviderProps = {
   authority: import.meta.env.VITE_OIDC_DOMAIN,
@@ -19,7 +20,7 @@ export const oidcConfig: AuthProviderProps = {
   userStore: new WebStorageStateStore({ store: new InMemoryWebStorage() }),
   onSigninCallback: (user) => {
     const state = user?.state as { returnTo?: string } | undefined
-    const targetUrl = state?.returnTo || '/dashboard'
+    const targetUrl = state?.returnTo || RoutePath.DASHBOARD
     window.history.replaceState({}, '', targetUrl)
     window.dispatchEvent(new PopStateEvent('popstate'))
   },

--- a/apps/dashboard/src/components/GettingStarted.tsx
+++ b/apps/dashboard/src/components/GettingStarted.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsList, TabsTrigger } from './ui/tabs'
 import pythonIcon from '../assets/python.svg'
 import typescriptIcon from '../assets/typescript.svg'
 import CodeBlock from './CodeBlock'
+import { DAYTONA_DOCS_URL } from '@/constants/ExternalLinks'
 
 const GettingStarted: React.FC = () => {
   const [language, setLanguage] = useState<'typescript' | 'python'>('python')
@@ -76,7 +77,7 @@ const GettingStarted: React.FC = () => {
               <h2 className="text-xl font-semibold mb-4">That's it</h2>
               <p className="text-muted-foreground">
                 It's as easy as that. For more examples check out the{' '}
-                <a href="https://daytona.io/docs" target="_blank" rel="noopener noreferrer" className="text-primary">
+                <a href={DAYTONA_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-primary">
                   Docs
                 </a>
                 .

--- a/apps/dashboard/src/components/Organizations/CreateOrganizationDialog.tsx
+++ b/apps/dashboard/src/components/Organizations/CreateOrganizationDialog.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Link } from 'react-router-dom'
 import { Label } from '@/components/ui/label'
+import { RoutePath } from '@/enums/RoutePath'
 
 interface CreateOrganizationDialogProps {
   open: boolean
@@ -99,7 +100,7 @@ export const CreateOrganizationDialog: React.FC<CreateOrganizationDialogProps> =
                   <>
                     To get started, add a payment method on the{' '}
                     <Link
-                      to="/dashboard/billing"
+                      to={RoutePath.BILLING}
                       className="text-blue-500 hover:underline"
                       onClick={(e) => {
                         onOpenChange(false)

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -50,6 +50,8 @@ import { Card, CardDescription, CardHeader, CardTitle } from './ui/card'
 import { Tooltip, TooltipContent } from './ui/tooltip'
 import { TooltipProvider, TooltipTrigger } from './ui/tooltip'
 import { addHours, formatRelative } from 'date-fns'
+import { RoutePath } from '@/enums/RoutePath'
+import { DAYTONA_DOCS_URL, DAYTONA_SLACK_URL } from '@/constants/ExternalLinks'
 
 export function Sidebar() {
   const { theme, setTheme } = useTheme()
@@ -61,33 +63,33 @@ export function Sidebar() {
 
   const sidebarItems = useMemo(() => {
     const arr = [
-      { icon: <Container className="w-5 h-5" />, label: 'Sandboxes', path: '/dashboard/sandboxes' },
-      { icon: <KeyRound className="w-5 h-5" />, label: 'Keys', path: '/dashboard/keys' },
+      { icon: <Container className="w-5 h-5" />, label: 'Sandboxes', path: RoutePath.SANDBOXES },
+      { icon: <KeyRound className="w-5 h-5" />, label: 'Keys', path: RoutePath.KEYS },
       {
         icon: <Box className="w-5 h-5" />,
         label: 'Images',
-        path: '/dashboard/images',
+        path: RoutePath.IMAGES,
       },
-      { icon: <PackageOpen className="w-5 h-5" />, label: 'Registries', path: '/dashboard/registries' },
-      { icon: <ChartColumn className="w-5 h-5" />, label: 'Usage', path: '/dashboard/usage' },
+      { icon: <PackageOpen className="w-5 h-5" />, label: 'Registries', path: RoutePath.REGISTRIES },
+      { icon: <ChartColumn className="w-5 h-5" />, label: 'Usage', path: RoutePath.USAGE },
     ]
 
     if (
       import.meta.env.VITE_BILLING_API_URL &&
       authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
     ) {
-      arr.push({ icon: <CreditCard className="w-5 h-5" />, label: 'Billing', path: '/dashboard/billing' })
+      arr.push({ icon: <CreditCard className="w-5 h-5" />, label: 'Billing', path: RoutePath.BILLING })
     }
 
     if (!selectedOrganization?.personal) {
-      arr.push({ icon: <Users className="w-5 h-5" />, label: 'Members', path: '/dashboard/members' })
+      arr.push({ icon: <Users className="w-5 h-5" />, label: 'Members', path: RoutePath.MEMBERS })
 
       // TODO: uncomment when we allow creating custom roles
       // if (authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER) {
-      //   arr.push({ icon: <UserCog className="w-5 h-5" />, label: 'Roles', path: '/dashboard/roles' })
+      //   arr.push({ icon: <UserCog className="w-5 h-5" />, label: 'Roles', path: RoutePath.ROLES })
       // }
     }
-    arr.push({ icon: <Settings className="w-5 h-5" />, label: 'Settings', path: '/dashboard/settings' })
+    arr.push({ icon: <Settings className="w-5 h-5" />, label: 'Settings', path: RoutePath.SETTINGS })
     return arr
   }, [authenticatedUserOrganizationMember?.role, selectedOrganization?.personal])
 
@@ -179,12 +181,7 @@ export function Sidebar() {
           )}
           <SidebarMenuItem key="slack">
             <SidebarMenuButton asChild>
-              <a
-                href="https://go.daytona.io/slack"
-                className="text-xs h-8 py-0"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href={DAYTONA_SLACK_URL} className="text-xs h-8 py-0" target="_blank" rel="noopener noreferrer">
                 <Slack className="!w-4 !h-4 fill-foreground" />
                 <span>Slack</span>
               </a>
@@ -192,7 +189,7 @@ export function Sidebar() {
           </SidebarMenuItem>
           <SidebarMenuItem key="docs">
             <SidebarMenuButton asChild>
-              <a href="https://daytona.io/docs" className="text-xs h-8 py-0" target="_blank" rel="noopener noreferrer">
+              <a href={DAYTONA_DOCS_URL} className="text-xs h-8 py-0" target="_blank" rel="noopener noreferrer">
                 <BookOpen className="!w-4 !h-4" />
                 <span>Docs</span>
               </a>
@@ -223,7 +220,7 @@ export function Sidebar() {
                   <Button
                     variant="ghost"
                     className="w-full cursor-pointer justify-start"
-                    onClick={() => navigate('/dashboard/user/invitations')}
+                    onClick={() => navigate(RoutePath.USER_INVITATIONS)}
                   >
                     <Mail className="w-4 h-4" />
                     Invitations

--- a/apps/dashboard/src/constants/ExternalLinks.ts
+++ b/apps/dashboard/src/constants/ExternalLinks.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * External URLs for Daytona resources
+ */
+export const DAYTONA_DOCS_URL = 'https://www.daytona.io/docs'
+export const DAYTONA_SLACK_URL = 'https://go.daytona.io/slack'

--- a/apps/dashboard/src/enums/RoutePath.ts
+++ b/apps/dashboard/src/enums/RoutePath.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * Enum for all route paths in the application
+ * Use this for consistent route references across the app
+ */
+export enum RoutePath {
+  // Main routes
+  LANDING = '/',
+  LOGOUT = '/logout',
+  DASHBOARD = '/dashboard',
+
+  // Dashboard sub-routes
+  KEYS = '/dashboard/keys',
+  SANDBOXES = '/dashboard/sandboxes',
+  IMAGES = '/dashboard/images',
+  REGISTRIES = '/dashboard/registries',
+  USAGE = '/dashboard/usage',
+  BILLING = '/dashboard/billing',
+  MEMBERS = '/dashboard/members',
+  ROLES = '/dashboard/roles',
+  SETTINGS = '/dashboard/settings',
+  DOCS = '/docs',
+  SLACK = '/slack',
+
+  // User routes
+  USER_INVITATIONS = '/dashboard/user/invitations',
+}
+
+/**
+ * Returns only the path segment for dashboard sub-routes
+ * Useful for nested routes under the dashboard
+ */
+export const getRouteSubPath = (path: RoutePath): string => {
+  return path.replace('/dashboard/', '')
+}

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -7,7 +7,6 @@ import React from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import LoadingFallback from '@/components/LoadingFallback'
-import { usePostHog } from 'posthog-js/react'
 import { RoutePath } from '@/enums/RoutePath'
 
 const LandingPage: React.FC = () => {

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -7,6 +7,8 @@ import React from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import LoadingFallback from '@/components/LoadingFallback'
+import { usePostHog } from 'posthog-js/react'
+import { RoutePath } from '@/enums/RoutePath'
 
 const LandingPage: React.FC = () => {
   const { signinRedirect, isAuthenticated, isLoading } = useAuth()
@@ -16,7 +18,7 @@ const LandingPage: React.FC = () => {
   }
 
   if (isAuthenticated) {
-    return <Navigate to="/dashboard" replace />
+    return <Navigate to={RoutePath.DASHBOARD} replace />
   } else {
     void signinRedirect({
       state: {

--- a/apps/dashboard/src/pages/Workspaces.tsx
+++ b/apps/dashboard/src/pages/Workspaces.tsx
@@ -24,6 +24,7 @@ import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { useNavigate } from 'react-router-dom'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
 import { handleApiError } from '@/lib/error-handling'
+import { RoutePath } from '@/enums/RoutePath'
 
 const Workspaces: React.FC = () => {
   const { workspaceApi } = useApi()
@@ -105,7 +106,7 @@ const Workspaces: React.FC = () => {
         error instanceof OrganizationSuspendedError &&
           import.meta.env.VITE_BILLING_API_URL &&
           authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER ? (
-          <Button variant="secondary" onClick={() => navigate('/dashboard/billing')}>
+          <Button variant="secondary" onClick={() => navigate(RoutePath.BILLING)}>
             Go to billing
           </Button>
         ) : undefined,

--- a/apps/dashboard/tsconfig.app.json
+++ b/apps/dashboard/tsconfig.app.json
@@ -4,6 +4,7 @@
     "outDir": "../../dist/out-tsc",
     "module": "ES2022",
     "allowImportingTsExtensions": true,
+    "noEmit": true,
     "types": ["node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts", "vite/client"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
# Introduced enum for page router paths

## Description:

I've completely overhauled the routing system in the Daytona dashboard application by implementing a TypeScript enum-based approach that provides better organization, type safety, and maintainability.

Key Features introduced:
1- Organized routes logically into categories `(main routes, dashboard sub-routes, user routes)`.
2- Added `external URL` constants for documentation and Slack integration.
3- Updated all routing references throughout the codebase to use the centralized enum.
4- The old routes.ts file was removed and replaced with a new `RoutePath` implementation.

- [ ] This change requires a documentation update

## Related Issue(s)

This PR addresses issue #1783 
@quest-bot loot #1783

## Screenshots

No Screenshots required, as only the enum introduced for route paths.

## Notes

`Note: The structured approach also improves developer experience by making it easy to locate, reference, and extend routes as the application grows.
`
