### PR TITLE
fix(runner): add snapshot image removal from runner

### DIFF
--- a/apps/runner/pkg/docker/create_snapshot.go
+++ b/apps/runner/pkg/docker/create_snapshot.go
@@ -35,5 +35,10 @@ func (d *DockerClient) CreateSnapshot(ctx context.Context, containerId string, s
 
 	log.Infof("Snapshot (%s) for container %s created successfully", snapshotDto.Image, containerId)
 
+	err = d.RemoveImage(ctx, snapshotDto.Image, true)
+	if err != nil {
+		log.Errorf("Error removing image %s: %v", snapshotDto.Image, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
# Add snapshot image removal from runner

## Description

This PR introduces removal of snapshot images from runner node after snapshot is successfully pushed to the internal image registry.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
