### PR TITLE
Individual rows now have separate state

### DIFF
--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -23,16 +23,18 @@ import {
 } from './ui/dialog'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip'
 import { Pagination } from './Pagination'
+import { Loader2 } from 'lucide-react'
 
 interface DataTableProps {
   data: ApiKeyList[]
   loading: boolean
+  revokingKeys: string[]
   onRevoke: (keyName: string) => void
 }
 
-export function ApiKeyTable({ data, loading, onRevoke }: DataTableProps) {
+export function ApiKeyTable({ data, loading, revokingKeys, onRevoke }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
-  const columns = getColumns({ onRevoke, loading })
+  const columns = getColumns({ onRevoke, revokingKeys })
   const table = useReactTable({
     data,
     columns,
@@ -96,10 +98,10 @@ export function ApiKeyTable({ data, loading, onRevoke }: DataTableProps) {
 
 const getColumns = ({
   onRevoke,
-  loading,
+  revokingKeys,
 }: {
   onRevoke: (keyName: string) => void
-  loading: boolean
+  revokingKeys: string[]
 }): ColumnDef<ApiKeyList>[] => {
   const columns: ColumnDef<ApiKeyList>[] = [
     {
@@ -146,11 +148,20 @@ const getColumns = ({
         return <div className="px-4">Actions</div>
       },
       cell: ({ row }) => {
+        const isRevoking = revokingKeys.includes(row.original.name)
+
         return (
           <Dialog>
             <DialogTrigger asChild>
-              <Button variant="ghost" size="icon" disabled={loading} className="w-20" title="Revoke Key">
-                Revoke
+              <Button variant="ghost" size="icon" disabled={isRevoking} className="w-20" title="Revoke Key">
+                {isRevoking ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Revoking...
+                  </>
+                ) : (
+                  'Revoke'
+                )}
               </Button>
             </DialogTrigger>
             <DialogContent>

--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -28,13 +28,13 @@ import { Loader2 } from 'lucide-react'
 interface DataTableProps {
   data: ApiKeyList[]
   loading: boolean
-  revokingKeys: string[]
+  loadingKeys: Record<string, boolean>
   onRevoke: (keyName: string) => void
 }
 
-export function ApiKeyTable({ data, loading, revokingKeys, onRevoke }: DataTableProps) {
+export function ApiKeyTable({ data, loading, loadingKeys, onRevoke }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
-  const columns = getColumns({ onRevoke, revokingKeys })
+  const columns = getColumns({ onRevoke, loadingKeys })
   const table = useReactTable({
     data,
     columns,
@@ -73,7 +73,11 @@ export function ApiKeyTable({ data, loading, revokingKeys, onRevoke }: DataTable
               </TableRow>
             ) : table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && 'selected'}
+                  className={`${loadingKeys[row.original.name] ? 'opacity-50 pointer-events-none' : ''}`}
+                >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
                   ))}
@@ -98,10 +102,10 @@ export function ApiKeyTable({ data, loading, revokingKeys, onRevoke }: DataTable
 
 const getColumns = ({
   onRevoke,
-  revokingKeys,
+  loadingKeys,
 }: {
   onRevoke: (keyName: string) => void
-  revokingKeys: string[]
+  loadingKeys: Record<string, boolean>
 }): ColumnDef<ApiKeyList>[] => {
   const columns: ColumnDef<ApiKeyList>[] = [
     {
@@ -148,20 +152,13 @@ const getColumns = ({
         return <div className="px-4">Actions</div>
       },
       cell: ({ row }) => {
-        const isRevoking = revokingKeys.includes(row.original.name)
+        const isLoading = loadingKeys[row.original.name]
 
         return (
           <Dialog>
             <DialogTrigger asChild>
-              <Button variant="ghost" size="icon" disabled={isRevoking} className="w-20" title="Revoke Key">
-                {isRevoking ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    Revoking...
-                  </>
-                ) : (
-                  'Revoke'
-                )}
+              <Button variant="ghost" size="icon" disabled={isLoading} className="w-20" title="Revoke Key">
+                {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Revoke'}
               </Button>
             </DialogTrigger>
             <DialogContent>

--- a/apps/dashboard/src/pages/Keys.tsx
+++ b/apps/dashboard/src/pages/Keys.tsx
@@ -16,6 +16,7 @@ const Keys: React.FC = () => {
   const { apiKeyApi } = useApi()
   const [keys, setKeys] = useState<ApiKeyList[]>([])
   const [loading, setLoading] = useState(true)
+  const [revokingKeys, setRevokingKeys] = useState<string[]>([])
 
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
 
@@ -54,7 +55,7 @@ const Keys: React.FC = () => {
   }, [fetchKeys])
 
   const handleRevoke = async (keyName: string) => {
-    setLoading(true)
+    setRevokingKeys((prev) => [...prev, keyName])
     try {
       await apiKeyApi.deleteApiKey(keyName, selectedOrganization?.id)
       toast.success('API key revoked successfully')
@@ -62,7 +63,7 @@ const Keys: React.FC = () => {
     } catch (error) {
       handleApiError(error, 'Failed to revoke API key')
     } finally {
-      setLoading(false)
+      setRevokingKeys((prev) => prev.filter((key) => key !== keyName))
     }
   }
 
@@ -88,7 +89,7 @@ const Keys: React.FC = () => {
         <CreateApiKeyDialog availablePermissions={availablePermissions} onCreateApiKey={handleCreateKey} />
       </div>
 
-      <ApiKeyTable data={keys} loading={loading} onRevoke={handleRevoke} />
+      <ApiKeyTable data={keys} loading={loading} revokingKeys={revokingKeys} onRevoke={handleRevoke} />
     </div>
   )
 }

--- a/apps/dashboard/src/pages/Keys.tsx
+++ b/apps/dashboard/src/pages/Keys.tsx
@@ -16,7 +16,7 @@ const Keys: React.FC = () => {
   const { apiKeyApi } = useApi()
   const [keys, setKeys] = useState<ApiKeyList[]>([])
   const [loading, setLoading] = useState(true)
-  const [revokingKeys, setRevokingKeys] = useState<string[]>([])
+  const [loadingKeys, setLoadingKeys] = useState<Record<string, boolean>>({})
 
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
 
@@ -55,7 +55,7 @@ const Keys: React.FC = () => {
   }, [fetchKeys])
 
   const handleRevoke = async (keyName: string) => {
-    setRevokingKeys((prev) => [...prev, keyName])
+    setLoadingKeys((prev) => ({ ...prev, [keyName]: true }))
     try {
       await apiKeyApi.deleteApiKey(keyName, selectedOrganization?.id)
       toast.success('API key revoked successfully')
@@ -63,7 +63,7 @@ const Keys: React.FC = () => {
     } catch (error) {
       handleApiError(error, 'Failed to revoke API key')
     } finally {
-      setRevokingKeys((prev) => prev.filter((key) => key !== keyName))
+      setLoadingKeys((prev) => ({ ...prev, [keyName]: false }))
     }
   }
 
@@ -89,7 +89,7 @@ const Keys: React.FC = () => {
         <CreateApiKeyDialog availablePermissions={availablePermissions} onCreateApiKey={handleCreateKey} />
       </div>
 
-      <ApiKeyTable data={keys} loading={loading} revokingKeys={revokingKeys} onRevoke={handleRevoke} />
+      <ApiKeyTable data={keys} loading={loading} loadingKeys={loadingKeys} onRevoke={handleRevoke} />
     </div>
   )
 }


### PR DESCRIPTION
# Loading state applied only to the single API key which will get revoked.

## Description:
I've modified the code to apply loading states to individual API keys during revocation instead of blocking the entire table. This improves the user experience by allowing users to continue interacting with other keys while one is being revoked.

Changes Made: 
In `Keys.tsx`:
1- Added a new `revokingKeys` state array to track which specific keys are being revoked.

In `ApiKeyTable.tsx`:
1- Modified the "Revoke" button to show loading state only for specific keys being revoked.
2- Added visual indicators (spinner + "Revoking..." text) for keys in the process of revocation.

## Related Issue(s)

This PR addresses issue #1785 
@quest-bot loot #1785 


## Screenshots/ScreenRecord

https://github.com/user-attachments/assets/d72cb48e-feec-4dbd-a835-68ae00e3b2ef

## Notes

The changes maintain a responsive UI during API key operations and provide clearer feedback about which specific actions are in progress.