### PR TITLE
feat: display dialog for email address verification

### DIFF
--- a/apps/dashboard/src/components/VerifyEmailDialog.tsx
+++ b/apps/dashboard/src/components/VerifyEmailDialog.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import React from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface VerifyEmailDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export const VerifyEmailDialog: React.FC<VerifyEmailDialogProps> = ({ open, onOpenChange }) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Verify Your Account</DialogTitle>
+          <DialogDescription>
+            A verification email was sent to your registered email address. Please note that you must verify your email
+            before you can create sandboxes or new organizations.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="secondary">
+              Close
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -3,14 +3,28 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { Sidebar } from '@/components/Sidebar'
 import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { Toaster } from '@/components/ui/sonner'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { VerifyEmailDialog } from '@/components/VerifyEmailDialog'
 
 const Dashboard: React.FC = () => {
+  const { selectedOrganization } = useSelectedOrganization()
+  const [showVerifyEmailDialog, setShowVerifyEmailDialog] = useState(false)
+
+  useEffect(() => {
+    if (
+      selectedOrganization?.suspended &&
+      selectedOrganization.suspensionReason === 'Please verify your email address'
+    ) {
+      setShowVerifyEmailDialog(true)
+    }
+  }, [selectedOrganization])
+
   return (
     <div className="relative w-full">
       <SidebarProvider>
@@ -20,6 +34,7 @@ const Dashboard: React.FC = () => {
           <Outlet />
         </div>
         <Toaster />
+        <VerifyEmailDialog open={showVerifyEmailDialog} onOpenChange={setShowVerifyEmailDialog} />
       </SidebarProvider>
     </div>
   )


### PR DESCRIPTION
# Display dialog for email address verification

## Description

Adds a dialog which is displayed in the dashboard as a reminder to users that need to verify their registered email address.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/3f67a266-2eb8-4df9-b38b-e3d38bd920a5)

