### PR TITLE
fix: Pagination of Images Table

### DIFF
--- a/apps/dashboard/src/components/ImageTable.tsx
+++ b/apps/dashboard/src/components/ImageTable.tsx
@@ -3,7 +3,6 @@ import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
-  getPaginationRowModel,
   getSortedRowModel,
   SortingState,
   useReactTable,
@@ -29,9 +28,24 @@ interface DataTableProps {
   loadingImages: Record<string, boolean>
   onDelete: (image: ImageDto) => void
   onToggleEnabled: (image: ImageDto, enabled: boolean) => void
+  pagination: {
+    pageIndex: number
+    pageSize: number
+  }
+  pageCount: number
+  onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
 }
 
-export function ImageTable({ data, loading, loadingImages, onDelete, onToggleEnabled }: DataTableProps) {
+export function ImageTable({
+  data,
+  loading,
+  loadingImages,
+  onDelete,
+  onToggleEnabled,
+  pagination,
+  pageCount,
+  onPaginationChange,
+}: DataTableProps) {
   const { authenticatedUserHasPermission } = useSelectedOrganization()
 
   const writePermitted = useMemo(
@@ -53,13 +67,22 @@ export function ImageTable({ data, loading, loadingImages, onDelete, onToggleEna
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
-    autoResetPageIndex: false,
-    autoResetExpanded: false,
+    manualPagination: true,
+    pageCount: pageCount || 1,
+    onPaginationChange: pagination
+      ? (updater) => {
+          const newPagination = typeof updater === 'function' ? updater(table.getState().pagination) : updater
+          onPaginationChange(newPagination)
+        }
+      : undefined,
     state: {
       sorting,
+      pagination: {
+        pageIndex: pagination?.pageIndex || 0,
+        pageSize: pagination?.pageSize || 10,
+      },
     },
     getRowId: (row) => row.id,
   })

--- a/apps/dashboard/src/components/Pagination.tsx
+++ b/apps/dashboard/src/components/Pagination.tsx
@@ -42,7 +42,7 @@ export function Pagination<TData>({ table, selectionEnabled, className }: Pagina
           </Select>
         </div>
         <div className="flex w-[100px] items-center justify-center text-sm font-medium">
-          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount() || 1}
         </div>
         <div className="flex items-center space-x-2">
           <Button


### PR DESCRIPTION
## Description
This PR fixes an issue with the Image Table pagination where even with multiple pages of images, the pagination controls were not working properly and only showing "Page 1 of 1". The update introduces server-side pagination using the API’s pagination features, adds state management for the current page, page size, and total item count, and links the pagination UI controls directly to server data fetching. Additionally, it ensures that real-time updates keep the pagination state consistent, allowing users to navigate between pages and adjust the number of images displayed per page as expected.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1769 
@quest-bot loot #1769

## Screenshots
![Screenshot from 2025-04-30 13-04-46](https://github.com/user-attachments/assets/d7cbee2f-5b61-4a8f-86ec-70a492f0b8e5)
![Screenshot from 2025-04-30 13-04-58](https://github.com/user-attachments/assets/cda6ad6b-9645-4b64-a53f-872a189a1b2e)