### PR TITLE
fix(dashboard): move posthog user identification to App.tsx

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -44,8 +44,17 @@ const DocsRedirect = () => {
 function App() {
   const location = useLocation()
   const posthog = usePostHog()
-  const { error } = useAuth()
+  const { error, isAuthenticated, user } = useAuth()
   const [errorDialogOpen, setErrorDialogOpen] = useState(false)
+
+  useEffect(() => {
+    if (import.meta.env.PROD && isAuthenticated && user && posthog?.get_distinct_id() !== user.profile.sub) {
+      posthog?.identify(user.profile.sub, {
+        email: user.profile.email,
+        name: user.profile.name,
+      })
+    }
+  }, [isAuthenticated, user, posthog])
 
   // Hack for tracking PostHog pageviews in SPAs
   useEffect(() => {

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -3,24 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import LoadingFallback from '@/components/LoadingFallback'
-import { usePostHog } from 'posthog-js/react'
 
 const LandingPage: React.FC = () => {
-  const { signinRedirect, isAuthenticated, isLoading, user } = useAuth()
-  const posthog = usePostHog()
-
-  useEffect(() => {
-    if (import.meta.env.PROD && isAuthenticated && user && posthog?.get_distinct_id() !== user.profile.sub) {
-      posthog?.identify(user.profile.sub, {
-        email: user.profile.email,
-        name: user.profile.name,
-      })
-    }
-  }, [isAuthenticated, user, posthog])
+  const { signinRedirect, isAuthenticated, isLoading } = useAuth()
 
   if (isLoading) {
     return <LoadingFallback />


### PR DESCRIPTION
# Move PostHog user identification to App.tsx

## Description

Moves the logic for identifying a user in PostHog to the top-level component in the dashboard application. Previously, this action was triggered only if users visited the landing page.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
