### PR TITLE
fix(runner): fix swagger endpoint in development only

### DIFF
--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -87,7 +87,7 @@ func (a *ApiServer) Start() error {
 	public.GET("", controllers.HealthCheck)
 	public.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
-	if config.GetNodeEnv() != "production" {
+	if config.GetNodeEnv() == "development" {
 		public.GET("/api/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 	}
 


### PR DESCRIPTION
# Runner: fix swagger endpoint in development only

## Description

This PR introduces fix to setting swagger endpoint in development mode only

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation