### PR TITLE
fix: pagination of sandbox and images in the CLI

### DIFF
--- a/apps/api/src/workspace/services/image.service.ts
+++ b/apps/api/src/workspace/services/image.service.ts
@@ -142,19 +142,22 @@ export class ImageService {
   }
 
   async getAllImages(organizationId: string, page = 1, limit = 10) {
+    const pageNum = Number(page)
+    const limitNum = Number(limit)
+
     const [items, total] = await this.imageRepository.findAndCount({
       where: { organizationId },
       order: {
         createdAt: 'DESC',
       },
-      skip: (page - 1) * limit,
-      take: limit,
+      skip: (pageNum - 1) * limitNum,
+      take: limitNum,
     })
 
     return {
       items,
       total,
-      page,
+      page: pageNum,
       totalPages: Math.ceil(total / limit),
     }
   }

--- a/apps/cli/cmd/image/list.go
+++ b/apps/cli/cmd/image/list.go
@@ -5,12 +5,18 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/daytonaio/daytona-ai-saas/cli/apiclient"
 	"github.com/daytonaio/daytona-ai-saas/cli/cmd/common"
 	"github.com/daytonaio/daytona-ai-saas/cli/config"
 	"github.com/daytonaio/daytona-ai-saas/cli/views/image"
 	"github.com/spf13/cobra"
+)
+
+var (
+	pageFlag  int
+	limitFlag int
 )
 
 var ListCmd = &cobra.Command{
@@ -26,8 +32,20 @@ var ListCmd = &cobra.Command{
 			return err
 		}
 
-		images, res, err := apiClient.ImagesAPI.GetAllImages(ctx).Execute()
+		page := float32(1.0)
+		limit := float32(100.0)
+
+		if cmd.Flags().Changed("page") {
+			page = float32(pageFlag)
+		}
+
+		if cmd.Flags().Changed("limit") {
+			limit = float32(limitFlag)
+		}
+
+		images, res, err := apiClient.ImagesAPI.GetAllImages(ctx).Page(page).Limit(limit).Execute()
 		if err != nil {
+			fmt.Printf("Error: %v\n", err)
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
@@ -54,4 +72,6 @@ var ListCmd = &cobra.Command{
 
 func init() {
 	common.RegisterFormatFlag(ListCmd)
+	ListCmd.Flags().IntVarP(&pageFlag, "page", "p", 1, "Page number for pagination (starting from 1)")
+	ListCmd.Flags().IntVarP(&limitFlag, "limit", "l", 100, "Maximum number of items per page")
 }

--- a/apps/cli/cmd/sandbox/list.go
+++ b/apps/cli/cmd/sandbox/list.go
@@ -13,6 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	verboseFlag bool
+	pageFlag    int
+	limitFlag   int
+)
+
 var ListCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List sandboxes",
@@ -31,6 +37,18 @@ var ListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
+		sandbox.SortSandboxes(&sandboxList)
+
+		start := (pageFlag - 1) * limitFlag
+		end := start + limitFlag
+		if start > len(sandboxList) {
+			start = len(sandboxList)
+		}
+		if end > len(sandboxList) {
+			end = len(sandboxList)
+		}
+		paginatedList := sandboxList[start:end]
+
 		if common.FormatFlag != "" {
 			formattedData := common.NewFormatter(sandboxList)
 			formattedData.Print()
@@ -47,14 +65,14 @@ var ListCmd = &cobra.Command{
 			activeOrganizationName = &name
 		}
 
-		sandbox.ListSandboxes(sandboxList, activeOrganizationName)
+		sandbox.ListSandboxes(paginatedList, activeOrganizationName)
 		return nil
 	},
 }
 
-var verboseFlag bool
-
 func init() {
 	ListCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Include verbose output")
+	ListCmd.Flags().IntVarP(&pageFlag, "page", "p", 1, "Page number for pagination (starting from 1)")
+	ListCmd.Flags().IntVarP(&limitFlag, "limit", "l", 100, "Maximum number of items per page")
 	common.RegisterFormatFlag(ListCmd)
 }

--- a/apps/cli/views/sandbox/list.go
+++ b/apps/cli/views/sandbox/list.go
@@ -27,8 +27,6 @@ func ListSandboxes(sandboxList []daytonaapiclient.Workspace, activeOrganizationN
 		return
 	}
 
-	SortSandboxes(&sandboxList)
-
 	headers := []string{"Sandbox", "State", "Region", "Class", "Last Event"}
 
 	data := [][]string{}


### PR DESCRIPTION
## Description
This PR fixes the pagination of images and sandboxes in the CLI. While implementing pagination for images was straightforward, manual handling was required to paginate sandboxes.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1770
@quest-bot loot #1770

## Screenshots
```
daytona ➜ /workspaces/daytona (fix/pagination-cli) $ ./dtn sandbox ls
                                                                                                                     
                                                                                                                     
    Sandbox                                       State          Region        Class        Last Event               
    ─────────────────────────────────────────────────────────────────────────────────────────────────────────────    
    8aee3da9-5f03-4264-b3b4-18aefa1a0763          STARTED        us            small        < 1 minute ago           
                                                                                                                     
    ce148916-11b6-4597-a397-7e1d13e10d61          STARTED        us            small        30 minutes ago           
                                                                                                                     
    fb33566e-5f12-4390-ae06-49ed7f10332f          STARTED        us            small        30 minutes ago           
                                                                                                                     
    e997dabc-1caa-4075-8450-5ebbcc475e6b          STARTED        us            small        30 minutes ago           
                                                                                                                     
    501ccd49-812d-4c44-9450-e5cf3050b06d          ERROR          us            small        8 minutes ago            
                                                                                                                     
    77410d7a-5319-416d-a7ce-40f861b63606          STOPPED        us            small        2 minutes ago            
                                                                                                                     
    0ba9b0c2-c806-4245-92cd-2104dccfb499          STOPPED        us            small        12 minutes ago           
                                                                                                                     
    7a8f3359-7699-4f0a-90ef-7a2756f58c16          STOPPED        us            small        < 1 minute ago           
                                                                                                                     
    07fc4ff6-f528-4723-98f2-61a8ca73c863          STOPPED        us            small        8 minutes ago            
                                                                                                                     
    bf66752e-6a44-4958-95c9-b0979d200b63          STOPPED        us            small        < 1 minute ago           
                                                                                                                     
    3441ca42-3dfd-473b-9e51-097891f7a619          STOPPED        us            small        9 minutes ago            
                                                                                                                     
    4a37f1de-0510-45d2-b1b5-c57b5f58ff21          STOPPED        us            small        9 minutes ago            
                                                                                                                     
    9b9645b8-349c-4fa4-9f96-5d6778a2f7dc          STOPPED        us            small        < 1 minute ago           
                                                                                                                     
    5634f2bd-cb30-4937-bb05-59810cd807ab          STOPPED        us            small        5 minutes ago            
                                                                                                                     
                                                                                                                     
                                                                                                                     
daytona ➜ /workspaces/daytona (fix/pagination-cli) $ ./dtn sandbox ls --limit=4 --page=3
                                                                                                                     
                                                                                                                     
    Sandbox                                       State          Region        Class        Last Event               
    ─────────────────────────────────────────────────────────────────────────────────────────────────────────────    
    07fc4ff6-f528-4723-98f2-61a8ca73c863          STOPPED        us            small        8 minutes ago            
                                                                                                                     
    bf66752e-6a44-4958-95c9-b0979d200b63          STOPPED        us            small        < 1 minute ago           
                                                                                                                     
    3441ca42-3dfd-473b-9e51-097891f7a619          STOPPED        us            small        10 minutes ago           
                                                                                                                     
    4a37f1de-0510-45d2-b1b5-c57b5f58ff21          STOPPED        us            small        9 minutes ago            
                                                                                                                     
                                                                                                                     
                                                                                                                     
daytona ➜ /workspaces/daytona (fix/pagination-cli) $ ./dtn images ls
                                                                                                                     
                                                                                                                     
    Image                      State             Enabled            Size               Created                       
    ─────────────────────────────────────────────────────────────────────────────────────────────────────────────    
    postgres:16                ERROR             Yes                0.41 GB            12 minutes ago                
                                                                                                                     
    mysql:8.0                  ERROR             Yes                0.72 GB            12 minutes ago                
                                                                                                                     
    debian:11                  ERROR             Yes                0.12 GB            13 minutes ago                
                                                                                                                     
    debian:12                  ERROR             Yes                0.11 GB            13 minutes ago                
                                                                                                                     
    golang:1.22                ACTIVE            Yes                0.77 GB            12 minutes ago                
                                                                                                                     
    python:3.12                ACTIVE            Yes                0.95 GB            13 minutes ago                
                                                                                                                     
    alpine:3.18                ACTIVE            Yes                0.01 GB            13 minutes ago                
                                                                                                                     
    alpine:3.19                ACTIVE            Yes                0.01 GB            13 minutes ago                
                                                                                                                     
    fedora:39                  ACTIVE            Yes                0.17 GB            13 minutes ago                
                                                                                                                     
    centos:8                   ACTIVE            Yes                0.22 GB            13 minutes ago                
                                                                                                                     
    centos:7                   ACTIVE            Yes                0.19 GB            13 minutes ago                
                                                                                                                     
    ubuntu:18.04               ACTIVE            Yes                0.06 GB            13 minutes ago                
                                                                                                                     
    ubuntu:22.04               ACTIVE            Yes                0.07 GB            36 minutes ago                
                                                                                                                     
                                                                                                                     
                                                                                                                     
daytona ➜ /workspaces/daytona (fix/pagination-cli) $ ./dtn images ls --limit=6 --page=2
                                                                                                                     
                                                                                                                     
    Image                      State             Enabled            Size               Created                       
    ─────────────────────────────────────────────────────────────────────────────────────────────────────────────    
    debian:11                  ERROR             Yes                0.12 GB            13 minutes ago                
                                                                                                                     
    debian:12                  ERROR             Yes                0.11 GB            14 minutes ago                
                                                                                                                     
    fedora:39                  ACTIVE            Yes                0.17 GB            13 minutes ago                
                                                                                                                     
    centos:8                   ACTIVE            Yes                0.22 GB            13 minutes ago                
                                                                                                                     
    centos:7                   ACTIVE            Yes                0.19 GB            13 minutes ago                
                                                                                                                     
    ubuntu:18.04               ACTIVE            Yes                0.06 GB            14 minutes ago      
```          
                                                                                                                     
                                                                                                                     


## Notes
![Screenshot from 2025-04-30 13-37-23](https://github.com/user-attachments/assets/f47e6286-c884-4ab1-b33f-899f1c10be82)
I had to also change `apps/api/src/workspace/services/image.service.ts` file because I was encountering this issue.
