### PR TITLE
refactord ImageTable.tsx (fixed the imageState icon size) 

### DIFF
--- a/apps/dashboard/src/components/ImageTable.tsx
+++ b/apps/dashboard/src/components/ImageTable.tsx
@@ -180,9 +180,9 @@ const getColumns = ({
         }
 
         return (
-          <div className={`flex gap-2 ${color}`}>
-            <div className="flex-shrink-0 w-5 h-5">{getStateIcon(image.state)}</div>
-            <span className="whitespace-nowrap text-sm">{getStateLabel(image.state)}</span>
+          <div className={`flex items-center gap-2 ${color}`}>
+            {getStateIcon(image.state)}
+            {getStateLabel(image.state)}
           </div>
         )
       },
@@ -260,13 +260,11 @@ const getColumns = ({
 const getStateIcon = (state: ImageState) => {
   switch (state) {
     case ImageState.ACTIVE:
-      return <CheckCircle className="w-4 h-4" />
+      return <CheckCircle className="w-4 h-4 flex-shrink-0" />
     case ImageState.ERROR:
-      return <AlertTriangle className="w-4 h-4" />
-    case ImageState.PULLING_IMAGE:
-      return <CheckCircle className="w-4 h-4" />
+      return <AlertTriangle className="w-4 h-4 flex-shrink-0" />
     default:
-      return <Timer className="w-4 h-4" />
+      return <Timer className="w-4 h-4 flex-shrink-0" />
   }
 }
 

--- a/apps/dashboard/src/components/ImageTable.tsx
+++ b/apps/dashboard/src/components/ImageTable.tsx
@@ -180,9 +180,9 @@ const getColumns = ({
         }
 
         return (
-          <div className={`flex items-center gap-2 ${color}`}>
-            {getStateIcon(image.state)}
-            {getStateLabel(image.state)}
+          <div className={`flex gap-2 ${color}`}>
+            <div className="flex-shrink-0 w-5 h-5">{getStateIcon(image.state)}</div>
+            <span className="whitespace-nowrap text-sm">{getStateLabel(image.state)}</span>
           </div>
         )
       },
@@ -263,6 +263,8 @@ const getStateIcon = (state: ImageState) => {
       return <CheckCircle className="w-4 h-4" />
     case ImageState.ERROR:
       return <AlertTriangle className="w-4 h-4" />
+    case ImageState.PULLING_IMAGE:
+      return <CheckCircle className="w-4 h-4" />
     default:
       return <Timer className="w-4 h-4" />
   }


### PR DESCRIPTION
# Fix icon and label layout for responsive ImageState display
## Description

This PR resolves a UI responsiveness issue where the icon size would shrink when the label (e.g., "Pulling Image") wrapped onto multiple lines in smaller viewports. The layout is updated to keep the icon size consistent and prevent text wrapping by:

Wrapping the icon in a fixed-size, non-shrinking container (flex-shrink-0 w-5 h-5)

Applying whitespace-nowrap to the label text to maintain layout integrity

Ensuring better responsive behavior across screen sizes


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1781
@quest-bot loot #1781

## Screenshots
<img width="246" alt="Screenshot 2025-04-30 at 4 36 42 PM" src="https://github.com/user-attachments/assets/35110af4-28fe-42a7-9887-464dfe672b68" />