### PR TITLE
fix: (Dashboard) rows per page

### DIFF
--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -50,6 +50,11 @@ export function ApiKeyTable({ data, loading, loadingKeys, onRevoke }: DataTableP
     state: {
       sorting,
     },
+    initialState: {
+      pagination: {
+        pageSize: 25,
+      },
+    },
   })
 
   return (

--- a/apps/dashboard/src/components/ImageTable.tsx
+++ b/apps/dashboard/src/components/ImageTable.tsx
@@ -67,6 +67,11 @@ export function ImageTable({ data, loading, loadingImages, onDelete, onToggleEna
       sorting,
     },
     getRowId: (row) => row.id,
+    initialState: {
+      pagination: {
+        pageSize: 25,
+      },
+    },
   })
 
   return (

--- a/apps/dashboard/src/components/Pagination.tsx
+++ b/apps/dashboard/src/components/Pagination.tsx
@@ -34,11 +34,11 @@ export function Pagination<TData>({ table, selectionEnabled, className }: Pagina
               table.setPageSize(Number(value))
             }}
           >
-            <SelectTrigger className="h-8 w-[70px]">
+            <SelectTrigger className="h-8 w-[75px]">
               <SelectValue placeholder={table.getState().pagination.pageSize} />
             </SelectTrigger>
             <SelectContent side="top">
-              {[10, 20, 30, 40, 50].map((pageSize) => (
+              {[10, 25, 50, 100, 200].map((pageSize) => (
                 <SelectItem key={pageSize} value={`${pageSize}`}>
                   {pageSize}
                 </SelectItem>

--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -61,6 +61,11 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
     state: {
       sorting,
     },
+    initialState: {
+      pagination: {
+        pageSize: 25,
+      },
+    },
   })
 
   return (

--- a/apps/dashboard/src/components/WorkspaceTable.tsx
+++ b/apps/dashboard/src/components/WorkspaceTable.tsx
@@ -121,6 +121,11 @@ export function WorkspaceTable({
     },
     enableRowSelection: true,
     getRowId: (row) => row.id,
+    initialState: {
+      pagination: {
+        pageSize: 25,
+      },
+    },
   })
   const [bulkDeleteConfirmationOpen, setBulkDeleteConfirmationOpen] = useState(false)
 


### PR DESCRIPTION
## Description:

This PR improves the pagination component by providing more practical rows-per-page options, enhancing overall user experience.
1- Modified Row Size Options: `Previously the options include [10, 20, 30, 40, 50]` & now it was fixed to `[10, 25, 50, 100, 200]` which provides better scalability for viewing larger datasets.
2- Adjusted dropdown width to properly accommodate the three-digit number (100).
3- Default row per page value set to `25`.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1766 
@quest-bot loot #1766

## Screenshots

<img width="1190" alt="Screenshot 2025-04-30 at 4 31 14 PM" src="https://github.com/user-attachments/assets/5d3dd941-eb17-47cb-ba3a-93343a50efb8" />
<img width="1185" alt="Screenshot 2025-04-30 at 4 32 09 PM" src="https://github.com/user-attachments/assets/68a4789b-6fa7-4845-a4f4-856195d89748" />
<img width="1188" alt="Screenshot 2025-04-30 at 4 32 27 PM" src="https://github.com/user-attachments/assets/f0e67631-3b63-45e4-9b3e-d63e3f9853f8" />


## Notes

`These changes will make the tables more user-friendly by providing sensible pagination options with a reasonable default page size.`
