### PR TITLE
fix(runner): image and sandbox removal conflicts

### DIFF
--- a/apps/runner/pkg/docker/image_remove.go
+++ b/apps/runner/pkg/docker/image_remove.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/errdefs"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -17,6 +18,10 @@ func (d *DockerClient) RemoveImage(ctx context.Context, imageName string, force 
 	})
 	if err != nil {
 		return err
+	}
+
+	if errdefs.IsNotFound(err) {
+		return nil
 	}
 
 	log.Infof("Image %s deleted successfully", imageName)

--- a/apps/runner/pkg/services/sandbox.go
+++ b/apps/runner/pkg/services/sandbox.go
@@ -46,7 +46,7 @@ func (s *SandboxService) GetSandboxStatesInfo(ctx context.Context, sandboxId str
 func (s *SandboxService) RemoveDestroyedSandbox(ctx context.Context, sandboxId string) error {
 	info := s.GetSandboxStatesInfo(ctx, sandboxId)
 
-	if info != nil && info.SandboxState != enums.SandboxStateDestroyed {
+	if info != nil && info.SandboxState != enums.SandboxStateDestroyed && info.SandboxState != enums.SandboxStateDestroying {
 		err := s.docker.Destroy(ctx, sandboxId)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Fix Image and Sandbox Removal Conflicts

## Description

Fixes sandbox and image removal conflicts on the runner.
- if the image is not found, return from the function
- if the container is already removing, return from the function

