### PR TITLE
selecting multiple sandboxes prompt fixed

### DIFF
--- a/apps/dashboard/src/components/WorkspaceTable.tsx
+++ b/apps/dashboard/src/components/WorkspaceTable.tsx
@@ -340,22 +340,31 @@ const getColumns = ({
   const columns: ColumnDef<Workspace>[] = [
     {
       id: 'select',
-      header: ({ table }) => (
-        <Checkbox
-          checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
-          onCheckedChange={(value) => {
-            for (const row of table.getRowModel().rows) {
-              if (loadingWorkspaces[row.original.id]) {
-                row.toggleSelected(false)
-              } else {
-                row.toggleSelected(!!value)
+      header: ({ table }) => {
+        const allRows = table.getFilteredRowModel().rows
+        const isAllSelected = table.getIsAllRowsSelected()
+
+        return (
+          <Checkbox
+            checked={isAllSelected}
+            onCheckedChange={(value) => {
+              if (value && allRows.length > 10) {
+                const confirmed = window.confirm(`Select ALL ${allRows.length} Sandboxes?`)
+                if (!confirmed) return
               }
-            }
-          }}
-          aria-label="Select all"
-          className="translate-y-[2px]"
-        />
-      ),
+              for (const row of allRows) {
+                if (loadingWorkspaces[row.original.id]) {
+                  row.toggleSelected(false)
+                } else {
+                  row.toggleSelected(!!value)
+                }
+              }
+            }}
+            aria-label="Select all"
+            className="translate-y-[2px]"
+          />
+        )
+      },
       cell: ({ row }) => {
         if (loadingWorkspaces[row.original.id]) {
           return <Loader2 className="w-4 h-4 animate-spin" />


### PR DESCRIPTION
# Added 'Select ALL X Sandboxes?' Prompt for Bulk Selection in Workspace Table

## Description

This PR introduces a confirmation prompt when users attempt to bulk-select all visible sandboxes in the Workspace table. If the total number of selectable sandboxes exceeds a defined threshold (e.g., 10), a popover appears asking the user to confirm whether they want to "Select ALL X Sandboxes?". This helps prevent accidental selection of a large number of sandboxes.

The logic is added in the checkbox column of the table.

Selection respects loading and disabled sandbox states.

This feature enhances UX and safety around bulk actions like deletion.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1764 
@quest-bot loot #1764 
