### PR TITLE
fix(daemon): async backwards compatibility

### DIFF
--- a/apps/daemon/pkg/toolbox/process/session/execute.go
+++ b/apps/daemon/pkg/toolbox/process/session/execute.go
@@ -38,6 +38,10 @@ func SessionExecuteCommand(configDir string) func(c *gin.Context) {
 			return
 		}
 
+		if request.Async {
+			request.RunAsync = true
+		}
+
 		// Validate command is not empty (if not already handled by binding)
 		if strings.TrimSpace(request.Command) == "" {
 			c.AbortWithError(http.StatusBadRequest, errors.New("command cannot be empty"))

--- a/apps/daemon/pkg/toolbox/process/session/types.go
+++ b/apps/daemon/pkg/toolbox/process/session/types.go
@@ -19,6 +19,7 @@ type CreateSessionRequest struct {
 type SessionExecuteRequest struct {
 	Command  string `json:"command" validate:"required"`
 	RunAsync bool   `json:"runAsync" validate:"optional"`
+	Async    bool   `json:"async" validate:"optional"`
 } // @name SessionExecuteRequest
 
 type SessionExecuteResponse struct {


### PR DESCRIPTION
# Async Param Backwards Compatibility

## Description

Backwards compatibility for the async parameter

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
