### PR TITLE
Handle pagination in the CLI

### DIFF
--- a/apps/api/src/workspace/services/image.service.ts
+++ b/apps/api/src/workspace/services/image.service.ts
@@ -142,20 +142,22 @@ export class ImageService {
   }
 
   async getAllImages(organizationId: string, page = 1, limit = 10) {
+    const pageNum = Number(page)
+    const limitNum = Number(limit)
     const [items, total] = await this.imageRepository.findAndCount({
       where: { organizationId },
       order: {
         createdAt: 'DESC',
       },
-      skip: (page - 1) * limit,
-      take: limit,
+      skip: (pageNum - 1) * limitNum,
+      take: limitNum,
     })
 
     return {
       items,
       total,
-      page,
-      totalPages: Math.ceil(total / limit),
+      page: pageNum,
+      totalPages: Math.ceil(total / limitNum),
     }
   }
 

--- a/apps/cli/cmd/image/list.go
+++ b/apps/cli/cmd/image/list.go
@@ -26,7 +26,7 @@ var ListCmd = &cobra.Command{
 			return err
 		}
 
-		images, res, err := apiClient.ImagesAPI.GetAllImages(ctx).Execute()
+		images, res, err := apiClient.ImagesAPI.GetAllImages(ctx).Limit(float32(limitFlag)).Page(float32(pageFlag)).Execute()
 		if err != nil {
 			return apiclient.HandleErrorResponse(res, err)
 		}
@@ -52,6 +52,12 @@ var ListCmd = &cobra.Command{
 	},
 }
 
+var limitFlag int
+var pageFlag int
+
 func init() {
+	ListCmd.Flags().IntVarP(&limitFlag, "limit", "l", 10, "Number of images to list per page")
+	ListCmd.Flags().IntVarP(&pageFlag, "page", "p", 1, "Page number to retrive the data")
 	common.RegisterFormatFlag(ListCmd)
+
 }

--- a/apps/cli/cmd/sandbox/list.go
+++ b/apps/cli/cmd/sandbox/list.go
@@ -13,6 +13,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func paginate[T any](items []T, page, limit int) []T {
+	start := (page - 1) * limit
+	if start > len(items) {
+		return []T{}
+	}
+
+	end := start + limit
+	if end > len(items) {
+		end = len(items)
+	}
+
+	return items[start:end]
+}
+
 var ListCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List sandboxes",
@@ -46,15 +60,20 @@ var ListCmd = &cobra.Command{
 			}
 			activeOrganizationName = &name
 		}
+		paginatedSandBox := paginate(sandboxList, pageFlag, limitFlag)
 
-		sandbox.ListSandboxes(sandboxList, activeOrganizationName)
+		sandbox.ListSandboxes(paginatedSandBox, activeOrganizationName)
 		return nil
 	},
 }
 
 var verboseFlag bool
+var pageFlag int
+var limitFlag int
 
 func init() {
 	ListCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Include verbose output")
+	ListCmd.Flags().IntVarP(&limitFlag, "limit", "l", 10, "Number of images to list per page")
+	ListCmd.Flags().IntVarP(&pageFlag, "page", "p", 1, "Page number to retrive the data")
 	common.RegisterFormatFlag(ListCmd)
 }


### PR DESCRIPTION
# Handle pagination for images and sandbox in CLI

## Description
In cli list command of the sandbox and images are paginated. now we can have arguments which can be used to display pagination with the default value of 10 values per page. 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)
closes #1770
@quest-bot loot #1770

## Screenshots
![image](https://github.com/user-attachments/assets/01985abd-1e51-4eb9-a8f7-807b84ae37af)

## Notes

