### PR TITLE
Handle Pagination in CLI For Sandbox

### DIFF
--- a/apps/cli/apiclient/list_sandbox.go
+++ b/apps/cli/apiclient/list_sandbox.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package apiclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+type Sandbox struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (c Client) SandboxList(page, limit int) ([]Sandbox, int, error) {
+	url := fmt.Sprintf("%s/sandboxes?page=%d&limit=%d", c.baseURL, page, limit)
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Sandboxes []Sandbox `json:"data"`
+		Total     int       `json:"total"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, 0, err
+	}
+
+	return result.Sandboxes, result.Total, nil
+}

--- a/apps/cli/cmd/sandbox/sandbox.go
+++ b/apps/cli/cmd/sandbox/sandbox.go
@@ -4,6 +4,10 @@
 package sandbox
 
 import (
+	"fmt"
+	"net/http"
+
+	"github.com/daytonaio/daytona-ai-saas/cli/apiclient"
 	"github.com/daytonaio/daytona-ai-saas/cli/internal"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +20,15 @@ var SandboxCmd = &cobra.Command{
 	GroupID: internal.SANDBOX_GROUP,
 }
 
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+type Sandbox struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 func init() {
 	SandboxCmd.AddCommand(ListCmd)
 	SandboxCmd.AddCommand(CreateCmd)
@@ -23,4 +36,56 @@ func init() {
 	SandboxCmd.AddCommand(DeleteCmd)
 	SandboxCmd.AddCommand(StartCmd)
 	SandboxCmd.AddCommand(StopCmd)
+}
+
+// add more 10 sandboxes
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List sandboxes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			page, _ := cmd.Flags().GetInt("page")
+			limit, _ := cmd.Flags().GetInt("limit")
+
+			// Validate input
+			if page < 1 {
+				return fmt.Errorf("page must be a positive integer")
+			}
+			if limit < 1 {
+				return fmt.Errorf("limit must be a positive integer")
+			}
+
+			// Get paginated sandboxes from API
+			sandboxes, total, err := apiclient.Client{}.SandboxList(page, limit)
+
+			if err != nil {
+				return fmt.Errorf("failed to create API client: %w", err)
+			}
+
+			if err != nil {
+				return err
+			}
+
+			// Calculate display range
+			start := (page-1)*limit + 1
+			end := (page-1)*limit + len(sandboxes)
+			if len(sandboxes) == 0 {
+				start = 0
+				end = 0
+			}
+
+			// Format output
+			fmt.Printf("Sandboxes (Page %d, Showing %d-%d of %d):\n",
+				page, start, end, total)
+			for _, sb := range sandboxes {
+				fmt.Printf("ID: %s, Name: %s\n", sb.ID, sb.Name)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().IntP("page", "p", 1, "Page number")
+	cmd.Flags().IntP("limit", "l", 10, "Items per page")
+	return cmd
 }


### PR DESCRIPTION
# Handle Pagination in CLI For Sandbox

## Description
I make an improvement for the sandbox that right now it can be up to more 10 sandboxes and also it will be listed the active sandboxes if we try to do daytona sandbox ls and support for the flag using --page & --limit for the pagination and sandbox limit. The changes code are in the apps->cli->cmd->sandbox->apiclient->list_sandbox.go and apps->cli->cmd->sandbox->sandbox->sandbox.go
## Related Issue(s)
This PR is related to #1770 
@quest-bot loot #1770 
