### PR TITLE
Introduce enum for page router paths 

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -29,6 +29,7 @@ import { NotificationSocketProvider } from '@/providers/NotificationSocketProvid
 import { ApiProvider } from './providers/ApiProvider'
 import LandingPage from './pages/LandingPage'
 import Logout from './pages/Logout'
+import { RoutePath } from './enums/RoutePath'
 
 // Docs redirect component
 const DocsRedirect = () => {
@@ -91,10 +92,10 @@ function App() {
         </DialogContent>
       </Dialog>
       <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/logout" element={<Logout />} />
+        <Route path={RoutePath.LandingPage} element={<LandingPage />} />
+        <Route path={RoutePath.Logout} element={<Logout />} />
         <Route
-          path="/dashboard"
+          path={RoutePath.Dashboard}
           element={
             <Suspense fallback={<LoadingFallback />}>
               <ApiProvider>
@@ -111,15 +112,15 @@ function App() {
             </Suspense>
           }
         >
-          <Route index element={<Navigate to="sandboxes" replace />} />
-          <Route path="keys" element={<Keys />} />
-          <Route path="sandboxes" element={<Workspaces />} />
-          <Route path="images" element={<Images />} />
-          <Route path="registries" element={<Registries />} />
-          <Route path="usage" element={<Usage />} />
+          <Route index element={<Navigate to={RoutePath.Sandboxes} replace />} />
+          <Route path={RoutePath.Keys} element={<Keys />} />
+          <Route path={RoutePath.Sandboxes} element={<Workspaces />} />
+          <Route path={RoutePath.Images} element={<Images />} />
+          <Route path={RoutePath.Registries} element={<Registries />} />
+          <Route path={RoutePath.Usage} element={<Usage />} />
           {import.meta.env.VITE_BILLING_API_URL && (
             <Route
-              path="billing"
+              path={RoutePath.Billing}
               element={
                 <OwnerAccessOrganizationPageWrapper>
                   <Billing />
@@ -128,7 +129,7 @@ function App() {
             />
           )}
           <Route
-            path="members"
+            path={RoutePath.Organizations}
             element={
               <NonPersonalOrganizationPageWrapper>
                 <OrganizationMembers />
@@ -148,10 +149,10 @@ function App() {
             }
           /> */
           }
-          <Route path="settings" element={<OrganizationSettings />} />
-          <Route path="user/invitations" element={<UserOrganizationInvitations />} />
+          <Route path={RoutePath.Settings} element={<OrganizationSettings />} />
+          <Route path={RoutePath.UserOrganizationInvitations} element={<UserOrganizationInvitations />} />
         </Route>
-        <Route path="/docs" element={<DocsRedirect />} />
+        <Route path={RoutePath.DocsRedirect} element={<DocsRedirect />} />
         {/* Add other routes as needed */}
       </Routes>
     </ThemeProvider>
@@ -162,7 +163,7 @@ function NonPersonalOrganizationPageWrapper({ children }: { children: React.Reac
   const { selectedOrganization } = useSelectedOrganization()
 
   if (selectedOrganization?.personal) {
-    return <Navigate to="/dashboard" replace />
+    return <Navigate to={RoutePath.Dashboard} replace />
   }
 
   return <>{children}</>
@@ -172,7 +173,7 @@ function OwnerAccessOrganizationPageWrapper({ children }: { children: React.Reac
   const { authenticatedUserOrganizationMember } = useSelectedOrganization()
 
   if (authenticatedUserOrganizationMember?.role !== OrganizationUserRoleEnum.OWNER) {
-    return <Navigate to="/dashboard" replace />
+    return <Navigate to={RoutePath.Dashboard} replace />
   }
 
   return <>{children}</>

--- a/apps/dashboard/src/components/GettingStarted.tsx
+++ b/apps/dashboard/src/components/GettingStarted.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsList, TabsTrigger } from './ui/tabs'
 import pythonIcon from '../assets/python.svg'
 import typescriptIcon from '../assets/typescript.svg'
 import CodeBlock from './CodeBlock'
+import { RoutePath } from '@/enums/RoutePath'
 
 const GettingStarted: React.FC = () => {
   const [language, setLanguage] = useState<'typescript' | 'python'>('python')
@@ -76,7 +77,7 @@ const GettingStarted: React.FC = () => {
               <h2 className="text-xl font-semibold mb-4">That's it</h2>
               <p className="text-muted-foreground">
                 It's as easy as that. For more examples check out the{' '}
-                <a href="https://daytona.io/docs" target="_blank" rel="noopener noreferrer" className="text-primary">
+                <a href={RoutePath.DaytonaDocs} target="_blank" rel="noopener noreferrer" className="text-primary">
                   Docs
                 </a>
                 .

--- a/apps/dashboard/src/components/Organizations/CreateOrganizationDialog.tsx
+++ b/apps/dashboard/src/components/Organizations/CreateOrganizationDialog.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Link } from 'react-router-dom'
 import { Label } from '@/components/ui/label'
+import { RoutePath } from '@/enums/RoutePath'
 
 interface CreateOrganizationDialogProps {
   open: boolean
@@ -99,7 +100,7 @@ export const CreateOrganizationDialog: React.FC<CreateOrganizationDialogProps> =
                   <>
                     To get started, add a payment method on the{' '}
                     <Link
-                      to="/dashboard/billing"
+                      to={RoutePath.DashboardBilling}
                       className="text-blue-500 hover:underline"
                       onClick={(e) => {
                         onOpenChange(false)

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -50,6 +50,7 @@ import { Card, CardDescription, CardHeader, CardTitle } from './ui/card'
 import { Tooltip, TooltipContent } from './ui/tooltip'
 import { TooltipProvider, TooltipTrigger } from './ui/tooltip'
 import { addHours, formatRelative } from 'date-fns'
+import { RoutePath } from '@/enums/RoutePath'
 
 export function Sidebar() {
   const { theme, setTheme } = useTheme()
@@ -179,12 +180,7 @@ export function Sidebar() {
           )}
           <SidebarMenuItem key="slack">
             <SidebarMenuButton asChild>
-              <a
-                href="https://go.daytona.io/slack"
-                className="text-xs h-8 py-0"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href={RoutePath.DaytonaSlack} className="text-xs h-8 py-0" target="_blank" rel="noopener noreferrer">
                 <Slack className="!w-4 !h-4 fill-foreground" />
                 <span>Slack</span>
               </a>

--- a/apps/dashboard/src/enums/RoutePath.ts
+++ b/apps/dashboard/src/enums/RoutePath.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export enum RoutePath {
+  Dashboard = '/dashboard',
+  Workspaces = '/workspaces',
+  Keys = '/keys',
+  Images = '/images',
+  Registries = '/registries',
+  Organizations = '/members',
+  UserOrganizationInvitations = '/user/invitations',
+  Usage = '/usage',
+  Billing = '/billing',
+  LandingPage = '/',
+  Logout = '/logout',
+  DocsRedirect = '/docs',
+  Sandboxes = '/sandboxes',
+  Settings = '/settings',
+  DashboardBilling = '/dashboard/billing',
+  DaytonaDocs = 'https://daytona.io/docs',
+  DaytonaSlack = 'https://go.daytona.io/slack',
+}

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import LoadingFallback from '@/components/LoadingFallback'
+import { RoutePath } from '@/enums/RoutePath'
 
 const LandingPage: React.FC = () => {
   const { signinRedirect, isAuthenticated, isLoading } = useAuth()
@@ -16,7 +17,7 @@ const LandingPage: React.FC = () => {
   }
 
   if (isAuthenticated) {
-    return <Navigate to="/dashboard" replace />
+    return <Navigate to={RoutePath.Dashboard} replace />
   } else {
     void signinRedirect({
       state: {


### PR DESCRIPTION
# Introduce enum for page router paths 

## Description
Hello. Today I make an implementation for the page router paths so it can make it easy to navigate from one page to another page using the enum page router. Also it can manage the router path better than do the hardcode route path anymore. Just import the module from RouterPath.tsx and everything will be done so easy.

## Related Issue(s)

This PR addresses issue #1783 
@quest-bot loot #1783 