### PR TITLE
Fixes: [Issue #1772] Better Handling for wrong API keys

### DIFF
--- a/apps/api/src/api-key/api-key.service.ts
+++ b/apps/api/src/api-key/api-key.service.ts
@@ -112,7 +112,7 @@ export class ApiKeyService {
     })
 
     if (!apiKey) {
-      throw new NotFoundException('API key not found')
+      throw new NotFoundException('401 Unauthorized')
     }
 
     const organizationUser = await this.organizationUserService.findOne(apiKey.organizationId, apiKey.userId)
@@ -128,7 +128,7 @@ export class ApiKeyService {
     const apiKey = await this.apiKeyRepository.findOne({ where: { organizationId, userId, name } })
 
     if (!apiKey) {
-      throw new NotFoundException('API key not found')
+      throw new NotFoundException('401 Unauthorized')
     }
 
     await this.apiKeyRepository.remove(apiKey)


### PR DESCRIPTION
# Resolved issue -  "API should return Unauthorized for wrong API keys"

## Description

  a summary of the change or the feature being introduced. 

- [ ] Change the file  `api-key.service.ts`  for better handling incase of wrong API keys usage.
- [ ] It now returns the required message.

## Related Issue

This PR addresses issue #1772 


