### PR TITLE
fix: add descending sort on the `lastEvent` label in the sandbox dashboard

### DIFF
--- a/apps/dashboard/src/components/WorkspaceTable.tsx
+++ b/apps/dashboard/src/components/WorkspaceTable.tsx
@@ -82,7 +82,12 @@ export function WorkspaceTable({
     [authenticatedUserHasPermission],
   )
 
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: 'lastEvent',
+      desc: true,
+    },
+  ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
   const labelOptions: FacetedFilterOption[] = useMemo(() => {


### PR DESCRIPTION
# Pull Request Title

## Description

This PR adds a default descending sort on the `lastEvent` label in the Dashboard Sandboxes Table to improve the user experience.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1767 
