### PR TITLE
fix(api): email service sender address

### DIFF
--- a/apps/api/src/email/services/email.service.ts
+++ b/apps/api/src/email/services/email.service.ts
@@ -31,7 +31,6 @@ export class EmailService {
       port,
       auth: user && password ? { user, pass: password } : undefined,
       secure,
-      from,
     })
   }
 
@@ -46,6 +45,7 @@ export class EmailService {
 
     try {
       await this.transporter.sendMail({
+        from: this.options.from,
         to: payload.inviteeEmail,
         subject: 'Invitation to join a Daytona organization',
         html: await renderFile(path.join(__dirname, 'assets/templates/organization-invitation.template.ejs'), {


### PR DESCRIPTION
# Fix email service sender address

## Description

Sets the email sender address in the mail options object instead of the transporter object.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
