### PR TITLE
fix(runner): add retries to container commit on snapshot create

### DIFF
--- a/apps/runner/pkg/docker/create_snapshot.go
+++ b/apps/runner/pkg/docker/create_snapshot.go
@@ -19,9 +19,7 @@ func (d *DockerClient) CreateSnapshot(ctx context.Context, containerId string, s
 
 	d.cache.SetSnapshotState(ctx, containerId, enums.SnapshotStateInProgress)
 
-	containerName := containerId
-
-	err := d.commitContainer(ctx, containerName, snapshotDto.Image)
+	err := d.commitContainer(ctx, containerId, snapshotDto.Image)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Add retries to container commit on snapshot create

## Description

This PR adds retries on container commit when creating snapshot

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
