### PR TITLE
fix(dashboard): preserve original query string on signinRedirect

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -34,7 +34,7 @@ SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASSWORD=
 SMTP_SECURE=
-EMAIL_FROM="Daytona Team <no-reply@daytona.io>"
+SMTP_EMAIL_FROM="Daytona Team <no-reply@daytona.io>"
 
 S3_ENDPOINT=http://minio:9000
 S3_REGION=us-east-1

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -121,7 +121,10 @@ function App() {
             </Suspense>
           }
         >
-          <Route index element={<Navigate to={getRouteSubPath(RoutePath.SANDBOXES)} replace />} />
+          <Route
+            index
+            element={<Navigate to={`${getRouteSubPath(RoutePath.SANDBOXES)}${location.search}`} replace />}
+          />
           <Route path={getRouteSubPath(RoutePath.KEYS)} element={<Keys />} />
           <Route path={getRouteSubPath(RoutePath.SANDBOXES)} element={<Workspaces />} />
           <Route path={getRouteSubPath(RoutePath.IMAGES)} element={<Images />} />

--- a/apps/dashboard/src/pages/LandingPage.tsx
+++ b/apps/dashboard/src/pages/LandingPage.tsx
@@ -4,24 +4,25 @@
  */
 
 import React from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import LoadingFallback from '@/components/LoadingFallback'
 import { RoutePath } from '@/enums/RoutePath'
 
 const LandingPage: React.FC = () => {
   const { signinRedirect, isAuthenticated, isLoading } = useAuth()
+  const location = useLocation()
 
   if (isLoading) {
     return <LoadingFallback />
   }
 
   if (isAuthenticated) {
-    return <Navigate to={RoutePath.DASHBOARD} replace />
+    return <Navigate to={`${RoutePath.DASHBOARD}${location.search}`} replace />
   } else {
     void signinRedirect({
       state: {
-        returnTo: window.location.pathname,
+        returnTo: location.pathname + location.search,
       },
     })
   }

--- a/apps/dashboard/src/providers/ApiProvider.tsx
+++ b/apps/dashboard/src/providers/ApiProvider.tsx
@@ -8,9 +8,11 @@ import { useEffect, useRef, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 import LoadingFallback from '@/components/LoadingFallback'
 import { ApiClient } from '@/api/apiClient'
+import { useLocation } from 'react-router-dom'
 
 export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isAuthenticated, isLoading, signinRedirect } = useAuth()
+  const location = useLocation()
 
   const apiRef = useRef<ApiClient | null>(null)
   const [isApiReady, setIsApiReady] = useState(false)
@@ -33,11 +35,11 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     if (!isLoading && !isAuthenticated) {
       void signinRedirect({
         state: {
-          returnTo: window.location.pathname,
+          returnTo: location.pathname + location.search,
         },
       })
     }
-  }, [isLoading, isAuthenticated, signinRedirect])
+  }, [isLoading, isAuthenticated, signinRedirect, location])
 
   if (isLoading || !isApiReady) {
     return <LoadingFallback />


### PR DESCRIPTION
# Preserve original query string on `signinRedirect`

## Description

Preserves original query string when the `signinRedirect` method from the authentication provider is called. This means that reloading a page will not strip away the URL search params. Also, the appropriate confirmation dialog will now be displayed when a user attempts to accept an invitation to join an organization:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/2fed000d-a96c-4443-9576-e56f538fd761" />


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
