### PR TITLE
fix: set importHelpers to false for api-client

### DIFF
--- a/libs/api-client/tsconfig.json
+++ b/libs/api-client/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
# Pull Request Title

## Description

Set `importHelpers` to false in the` api-client` package to ensure all necessary TypeScript helpers are included in the compiled output, so end users don't need to install `tslib` separately.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
