### PR TITLE
feat: improve CLI error messages

### DIFF
--- a/apps/cli/apiclient/error_handler.go
+++ b/apps/cli/apiclient/error_handler.go
@@ -18,7 +18,8 @@ import (
 const API_VERSION_HEADER = "X-Daytona-Api-Version"
 
 type ApiErrorResponse struct {
-	Error string `json:"error"`
+	Error   string `json:"error"`
+	Message any    `json:"message,omitempty"`
 }
 
 func HandleErrorResponse(res *http.Response, requestErr error) error {
@@ -45,6 +46,19 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 	if errMessage == "" {
 		// Fall back to raw body if error field is empty
 		errMessage = string(body)
+	} else {
+		if errResponse.Message != nil {
+			// Message field could be a string or an array
+			switch msg := errResponse.Message.(type) {
+			case string:
+				errMessage += ": " + msg
+			case []any:
+				if len(msg) > 0 {
+					msgStr := fmt.Sprintf("%v", msg)
+					errMessage += ": " + msgStr
+				}
+			}
+		}
 	}
 
 	if res.StatusCode == http.StatusUnauthorized {


### PR DESCRIPTION
# Improve CLI error messages

## Description

Improves error messages by adding the `message` field (string or array of strings) to the `error` property when displaying them to the user

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/a82609ee-e35f-4569-81c7-80252f4d55a2)


After:

![image](https://github.com/user-attachments/assets/2bfde9b4-c4fd-4023-af73-fc7e211cdcad)


