### PR TITLE
fix: CLI target options and doc generation

### DIFF
--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -170,7 +170,7 @@ func init() {
 	CreateCmd.Flags().StringArrayVarP(&labelsFlag, "label", "l", []string{}, "Labels (format: KEY=VALUE)")
 	CreateCmd.Flags().BoolVar(&publicFlag, "public", false, "Make sandbox publicly accessible")
 	CreateCmd.Flags().StringVar(&classFlag, "class", "", "Workspace class type (small, medium, large)")
-	CreateCmd.Flags().StringVar(&targetFlag, "target", "", "Target region (eu, us, asia)")
+	CreateCmd.Flags().StringVar(&targetFlag, "target", "", "Target region (eu, us)")
 	CreateCmd.Flags().Int32Var(&cpuFlag, "cpu", 0, "CPU cores allocated to the sandbox")
 	CreateCmd.Flags().Int32Var(&gpuFlag, "gpu", 0, "GPU units allocated to the sandbox")
 	CreateCmd.Flags().Int32Var(&memoryFlag, "memory", 0, "Memory allocated to the sandbox in MB")

--- a/apps/cli/docs/daytona.md
+++ b/apps/cli/docs/daytona.md
@@ -19,12 +19,13 @@ daytona [flags]
 
 ### SEE ALSO
 
-- [daytona autocomplete](daytona_autocomplete.md) - Adds a completion script for your shell environment
-- [daytona docs](daytona_docs.md) - Opens the Daytona documentation in your default browser.
-- [daytona image](daytona_image.md) - Manage Daytona images
-- [daytona login](daytona_login.md) - Log in to Daytona
-- [daytona logout](daytona_logout.md) - Logout from Daytona
-- [daytona mcp](daytona_mcp.md) - Manage Daytona MCP Server
-- [daytona organization](daytona_organization.md) - Manage Daytona organizations
-- [daytona sandbox](daytona_sandbox.md) - Manage Daytona sandboxes
-- [daytona version](daytona_version.md) - Print the version number
+* [daytona autocomplete](daytona_autocomplete.md)  - Adds a completion script for your shell environment
+* [daytona docs](daytona_docs.md)  - Opens the Daytona documentation in your default browser.
+* [daytona image](daytona_image.md)  - Manage Daytona images
+* [daytona login](daytona_login.md)  - Log in to Daytona
+* [daytona logout](daytona_logout.md)  - Logout from Daytona
+* [daytona mcp](daytona_mcp.md)  - Manage Daytona MCP Server
+* [daytona organization](daytona_organization.md)  - Manage Daytona organizations
+* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes
+* [daytona version](daytona_version.md)  - Print the version number
+* [daytona volume](daytona_volume.md)  - Manage Daytona volumes

--- a/apps/cli/docs/daytona_autocomplete.md
+++ b/apps/cli/docs/daytona_autocomplete.md
@@ -14,4 +14,4 @@ daytona autocomplete [bash|zsh|fish|powershell] [flags]
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_docs.md
+++ b/apps/cli/docs/daytona_docs.md
@@ -14,4 +14,4 @@ daytona docs [flags]
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_image.md
+++ b/apps/cli/docs/daytona_image.md
@@ -14,9 +14,9 @@ Commands for managing Daytona images
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
-- [daytona image build](daytona_image_build.md) - Build an image from a Dockerfile
-- [daytona image create](daytona_image_create.md) - Create an image
-- [daytona image delete](daytona_image_delete.md) - Delete an image
-- [daytona image list](daytona_image_list.md) - List all images
-- [daytona image push](daytona_image_push.md) - Push local image
+* [daytona](daytona.md)  - Daytona CLI
+* [daytona image build](daytona_image_build.md)  - Build an image from a Dockerfile
+* [daytona image create](daytona_image_create.md)  - Create an image
+* [daytona image delete](daytona_image_delete.md)  - Delete an image
+* [daytona image list](daytona_image_list.md)  - List all images
+* [daytona image push](daytona_image_push.md)  - Push local image

--- a/apps/cli/docs/daytona_image_build.md
+++ b/apps/cli/docs/daytona_image_build.md
@@ -21,4 +21,4 @@ daytona image build [IMAGE] [flags]
 
 ### SEE ALSO
 
-- [daytona image](daytona_image.md) - Manage Daytona images
+* [daytona image](daytona_image.md)  - Manage Daytona images

--- a/apps/cli/docs/daytona_image_create.md
+++ b/apps/cli/docs/daytona_image_create.md
@@ -20,4 +20,4 @@ daytona image create [IMAGE] [flags]
 
 ### SEE ALSO
 
-- [daytona image](daytona_image.md) - Manage Daytona images
+* [daytona image](daytona_image.md)  - Manage Daytona images

--- a/apps/cli/docs/daytona_image_delete.md
+++ b/apps/cli/docs/daytona_image_delete.md
@@ -20,4 +20,4 @@ daytona image delete [IMAGE_ID] [flags]
 
 ### SEE ALSO
 
-- [daytona image](daytona_image.md) - Manage Daytona images
+* [daytona image](daytona_image.md)  - Manage Daytona images

--- a/apps/cli/docs/daytona_image_list.md
+++ b/apps/cli/docs/daytona_image_list.md
@@ -24,4 +24,4 @@ daytona image list [flags]
 
 ### SEE ALSO
 
-- [daytona image](daytona_image.md) - Manage Daytona images
+* [daytona image](daytona_image.md)  - Manage Daytona images

--- a/apps/cli/docs/daytona_image_push.md
+++ b/apps/cli/docs/daytona_image_push.md
@@ -4,18 +4,10 @@ Push local image
 
 ### Synopsis
 
-Push local image or build and push from Dockerfile. If building locally, the image will be built with an AMD architecture.
+Push a local image image to Daytona. To securely build it on our infastructure, use 'daytona image build'
 
 ```
 daytona image push [IMAGE] [flags]
-```
-
-### Options
-
-```
-  -c, --context string      Build context directory (defaults to Dockerfile directory)
-  -f, --dockerfile string   Path to Dockerfile to build before pushing
-  -e, --entrypoint string   The entrypoint command for the image
 ```
 
 ### Options inherited from parent commands
@@ -26,4 +18,4 @@ daytona image push [IMAGE] [flags]
 
 ### SEE ALSO
 
-- [daytona image](daytona_image.md) - Manage Daytona images
+* [daytona image](daytona_image.md)  - Manage Daytona images

--- a/apps/cli/docs/daytona_login.md
+++ b/apps/cli/docs/daytona_login.md
@@ -20,4 +20,4 @@ daytona login [flags]
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_logout.md
+++ b/apps/cli/docs/daytona_logout.md
@@ -14,4 +14,4 @@ daytona logout [flags]
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_mcp.md
+++ b/apps/cli/docs/daytona_mcp.md
@@ -14,7 +14,7 @@ Commands for managing Daytona MCP Server
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
-- [daytona mcp config](daytona_mcp_config.md) - Outputs JSON configuration for Daytona MCP Server
-- [daytona mcp init](daytona_mcp_init.md) - Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)
-- [daytona mcp start](daytona_mcp_start.md) - Start Daytona MCP Server
+* [daytona](daytona.md)  - Daytona CLI
+* [daytona mcp config](daytona_mcp_config.md)  - Outputs JSON configuration for Daytona MCP Server
+* [daytona mcp init](daytona_mcp_init.md)  - Initialize Daytona MCP Server with an agent (currently supported: claude, windsurf, cursor)
+* [daytona mcp start](daytona_mcp_start.md)  - Start Daytona MCP Server

--- a/apps/cli/docs/daytona_mcp_config.md
+++ b/apps/cli/docs/daytona_mcp_config.md
@@ -14,4 +14,4 @@ daytona mcp config [AGENT_NAME] [flags]
 
 ### SEE ALSO
 
-- [daytona mcp](daytona_mcp.md) - Manage Daytona MCP Server
+* [daytona mcp](daytona_mcp.md)  - Manage Daytona MCP Server

--- a/apps/cli/docs/daytona_mcp_init.md
+++ b/apps/cli/docs/daytona_mcp_init.md
@@ -14,4 +14,4 @@ daytona mcp init [AGENT_NAME] [flags]
 
 ### SEE ALSO
 
-- [daytona mcp](daytona_mcp.md) - Manage Daytona MCP Server
+* [daytona mcp](daytona_mcp.md)  - Manage Daytona MCP Server

--- a/apps/cli/docs/daytona_mcp_start.md
+++ b/apps/cli/docs/daytona_mcp_start.md
@@ -14,4 +14,4 @@ daytona mcp start [flags]
 
 ### SEE ALSO
 
-- [daytona mcp](daytona_mcp.md) - Manage Daytona MCP Server
+* [daytona mcp](daytona_mcp.md)  - Manage Daytona MCP Server

--- a/apps/cli/docs/daytona_organization.md
+++ b/apps/cli/docs/daytona_organization.md
@@ -14,8 +14,8 @@ Commands for managing Daytona organizations
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
-- [daytona organization create](daytona_organization_create.md) - Create a new organization and set it as active
-- [daytona organization delete](daytona_organization_delete.md) - Delete an organization
-- [daytona organization list](daytona_organization_list.md) - List all organizations
-- [daytona organization use](daytona_organization_use.md) - Set active organization
+* [daytona](daytona.md)  - Daytona CLI
+* [daytona organization create](daytona_organization_create.md)  - Create a new organization and set it as active
+* [daytona organization delete](daytona_organization_delete.md)  - Delete an organization
+* [daytona organization list](daytona_organization_list.md)  - List all organizations
+* [daytona organization use](daytona_organization_use.md)  - Set active organization

--- a/apps/cli/docs/daytona_organization_create.md
+++ b/apps/cli/docs/daytona_organization_create.md
@@ -14,4 +14,4 @@ daytona organization create [ORGANIZATION_NAME] [flags]
 
 ### SEE ALSO
 
-- [daytona organization](daytona_organization.md) - Manage Daytona organizations
+* [daytona organization](daytona_organization.md)  - Manage Daytona organizations

--- a/apps/cli/docs/daytona_organization_delete.md
+++ b/apps/cli/docs/daytona_organization_delete.md
@@ -14,4 +14,4 @@ daytona organization delete [ORGANIZATION] [flags]
 
 ### SEE ALSO
 
-- [daytona organization](daytona_organization.md) - Manage Daytona organizations
+* [daytona organization](daytona_organization.md)  - Manage Daytona organizations

--- a/apps/cli/docs/daytona_organization_list.md
+++ b/apps/cli/docs/daytona_organization_list.md
@@ -20,4 +20,4 @@ daytona organization list [flags]
 
 ### SEE ALSO
 
-- [daytona organization](daytona_organization.md) - Manage Daytona organizations
+* [daytona organization](daytona_organization.md)  - Manage Daytona organizations

--- a/apps/cli/docs/daytona_organization_use.md
+++ b/apps/cli/docs/daytona_organization_use.md
@@ -14,4 +14,4 @@ daytona organization use [ORGANIZATION] [flags]
 
 ### SEE ALSO
 
-- [daytona organization](daytona_organization.md) - Manage Daytona organizations
+* [daytona organization](daytona_organization.md)  - Manage Daytona organizations

--- a/apps/cli/docs/daytona_sandbox.md
+++ b/apps/cli/docs/daytona_sandbox.md
@@ -14,10 +14,10 @@ Commands for managing Daytona sandboxes
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
-- [daytona sandbox create](daytona_sandbox_create.md) - Create a new sandbox
-- [daytona sandbox delete](daytona_sandbox_delete.md) - Delete a sandbox
-- [daytona sandbox info](daytona_sandbox_info.md) - Get sandbox info
-- [daytona sandbox list](daytona_sandbox_list.md) - List sandboxes
-- [daytona sandbox start](daytona_sandbox_start.md) - Start a sandbox
-- [daytona sandbox stop](daytona_sandbox_stop.md) - Stop a sandbox
+* [daytona](daytona.md)  - Daytona CLI
+* [daytona sandbox create](daytona_sandbox_create.md)  - Create a new sandbox
+* [daytona sandbox delete](daytona_sandbox_delete.md)  - Delete a sandbox
+* [daytona sandbox info](daytona_sandbox_info.md)  - Get sandbox info
+* [daytona sandbox list](daytona_sandbox_list.md)  - List sandboxes
+* [daytona sandbox start](daytona_sandbox_start.md)  - Start a sandbox
+* [daytona sandbox stop](daytona_sandbox_stop.md)  - Stop a sandbox

--- a/apps/cli/docs/daytona_sandbox_create.md
+++ b/apps/cli/docs/daytona_sandbox_create.md
@@ -21,8 +21,9 @@ daytona sandbox create [flags]
   -l, --label stringArray     Labels (format: KEY=VALUE)
       --memory int32          Memory allocated to the sandbox in MB
       --public                Make sandbox publicly accessible
-      --target string         Target region (eu, us, asia)
+      --target string         Target region (eu, us)
       --user string           User associated with the sandbox
+  -v, --volume stringArray    Volumes to mount (format: VOLUME_NAME:MOUNT_PATH)
 ```
 
 ### Options inherited from parent commands
@@ -33,4 +34,4 @@ daytona sandbox create [flags]
 
 ### SEE ALSO
 
-- [daytona sandbox](daytona_sandbox.md) - Manage Daytona sandboxes
+* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes

--- a/apps/cli/docs/daytona_sandbox_delete.md
+++ b/apps/cli/docs/daytona_sandbox_delete.md
@@ -21,4 +21,4 @@ daytona sandbox delete [SANDBOX_ID] [flags]
 
 ### SEE ALSO
 
-- [daytona sandbox](daytona_sandbox.md) - Manage Daytona sandboxes
+* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes

--- a/apps/cli/docs/daytona_sandbox_list.md
+++ b/apps/cli/docs/daytona_sandbox_list.md
@@ -21,4 +21,4 @@ daytona sandbox list [flags]
 
 ### SEE ALSO
 
-- [daytona sandbox](daytona_sandbox.md) - Manage Daytona sandboxes
+* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes

--- a/apps/cli/docs/daytona_sandbox_start.md
+++ b/apps/cli/docs/daytona_sandbox_start.md
@@ -20,4 +20,4 @@ daytona sandbox start [SANDBOX_ID] [flags]
 
 ### SEE ALSO
 
-- [daytona sandbox](daytona_sandbox.md) - Manage Daytona sandboxes
+* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes

--- a/apps/cli/docs/daytona_sandbox_stop.md
+++ b/apps/cli/docs/daytona_sandbox_stop.md
@@ -20,4 +20,4 @@ daytona sandbox stop [SANDBOX_ID] [flags]
 
 ### SEE ALSO
 
-- [daytona sandbox](daytona_sandbox.md) - Manage Daytona sandboxes
+* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes

--- a/apps/cli/docs/daytona_version.md
+++ b/apps/cli/docs/daytona_version.md
@@ -14,4 +14,4 @@ daytona version [flags]
 
 ### SEE ALSO
 
-- [daytona](daytona.md) - Daytona CLI
+* [daytona](daytona.md)  - Daytona CLI

--- a/apps/cli/docs/daytona_volume.md
+++ b/apps/cli/docs/daytona_volume.md
@@ -1,0 +1,21 @@
+## daytona volume
+
+Manage Daytona volumes
+
+### Synopsis
+
+Commands for managing Daytona volumes
+
+### Options inherited from parent commands
+
+```
+      --help   help for daytona
+```
+
+### SEE ALSO
+
+* [daytona](daytona.md)  - Daytona CLI
+* [daytona volume create](daytona_volume_create.md)  - Create a volume
+* [daytona volume delete](daytona_volume_delete.md)  - Delete a volume
+* [daytona volume get](daytona_volume_get.md)  - Get volume details
+* [daytona volume list](daytona_volume_list.md)  - List all volumes

--- a/apps/cli/docs/daytona_volume_create.md
+++ b/apps/cli/docs/daytona_volume_create.md
@@ -1,0 +1,23 @@
+## daytona volume create
+
+Create a volume
+
+```
+daytona volume create [NAME] [flags]
+```
+
+### Options
+
+```
+  -s, --size int32   Size of the volume in GB (default 10)
+```
+
+### Options inherited from parent commands
+
+```
+      --help   help for daytona
+```
+
+### SEE ALSO
+
+* [daytona volume](daytona_volume.md)  - Manage Daytona volumes

--- a/apps/cli/docs/daytona_volume_delete.md
+++ b/apps/cli/docs/daytona_volume_delete.md
@@ -1,0 +1,17 @@
+## daytona volume delete
+
+Delete a volume
+
+```
+daytona volume delete [VOLUME_ID] [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --help   help for daytona
+```
+
+### SEE ALSO
+
+* [daytona volume](daytona_volume.md)  - Manage Daytona volumes

--- a/apps/cli/docs/daytona_volume_get.md
+++ b/apps/cli/docs/daytona_volume_get.md
@@ -1,16 +1,15 @@
-## daytona sandbox info
+## daytona volume get
 
-Get sandbox info
+Get volume details
 
 ```
-daytona sandbox info [SANDBOX_ID] [flags]
+daytona volume get [VOLUME_ID] [flags]
 ```
 
 ### Options
 
 ```
   -f, --format string   Output format. Must be one of (yaml, json)
-  -v, --verbose         Include verbose output
 ```
 
 ### Options inherited from parent commands
@@ -21,4 +20,4 @@ daytona sandbox info [SANDBOX_ID] [flags]
 
 ### SEE ALSO
 
-* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes
+* [daytona volume](daytona_volume.md)  - Manage Daytona volumes

--- a/apps/cli/docs/daytona_volume_list.md
+++ b/apps/cli/docs/daytona_volume_list.md
@@ -1,16 +1,15 @@
-## daytona sandbox info
+## daytona volume list
 
-Get sandbox info
+List all volumes
 
 ```
-daytona sandbox info [SANDBOX_ID] [flags]
+daytona volume list [flags]
 ```
 
 ### Options
 
 ```
   -f, --format string   Output format. Must be one of (yaml, json)
-  -v, --verbose         Include verbose output
 ```
 
 ### Options inherited from parent commands
@@ -21,4 +20,4 @@ daytona sandbox info [SANDBOX_ID] [flags]
 
 ### SEE ALSO
 
-* [daytona sandbox](daytona_sandbox.md)  - Manage Daytona sandboxes
+* [daytona volume](daytona_volume.md)  - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona.yaml
+++ b/apps/cli/hack/docs/daytona.yaml
@@ -20,3 +20,4 @@ see_also:
   - daytona organization - Manage Daytona organizations
   - daytona sandbox - Manage Daytona sandboxes
   - daytona version - Print the version number
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_image_push.yaml
+++ b/apps/cli/hack/docs/daytona_image_push.yaml
@@ -1,18 +1,8 @@
 name: daytona image push
 synopsis: Push local image
 description: |
-  Push local image or build and push from Dockerfile. If building locally, the image will be built with an AMD architecture.
+  Push a local image image to Daytona. To securely build it on our infastructure, use 'daytona image build'
 usage: daytona image push [IMAGE] [flags]
-options:
-  - name: context
-    shorthand: c
-    usage: Build context directory (defaults to Dockerfile directory)
-  - name: dockerfile
-    shorthand: f
-    usage: Path to Dockerfile to build before pushing
-  - name: entrypoint
-    shorthand: e
-    usage: The entrypoint command for the image
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/daytona_sandbox_create.yaml
+++ b/apps/cli/hack/docs/daytona_sandbox_create.yaml
@@ -41,9 +41,13 @@ options:
     default_value: 'false'
     usage: Make sandbox publicly accessible
   - name: target
-    usage: Target region (eu, us, asia)
+    usage: Target region (eu, us)
   - name: user
     usage: User associated with the sandbox
+  - name: volume
+    shorthand: v
+    default_value: '[]'
+    usage: 'Volumes to mount (format: VOLUME_NAME:MOUNT_PATH)'
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/daytona_volume.yaml
+++ b/apps/cli/hack/docs/daytona_volume.yaml
@@ -1,0 +1,13 @@
+name: daytona volume
+synopsis: Manage Daytona volumes
+description: Commands for managing Daytona volumes
+inherited_options:
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+see_also:
+  - daytona - Daytona CLI
+  - daytona volume create - Create a volume
+  - daytona volume delete - Delete a volume
+  - daytona volume get - Get volume details
+  - daytona volume list - List all volumes

--- a/apps/cli/hack/docs/daytona_volume_create.yaml
+++ b/apps/cli/hack/docs/daytona_volume_create.yaml
@@ -1,0 +1,14 @@
+name: daytona volume create
+synopsis: Create a volume
+usage: daytona volume create [NAME] [flags]
+options:
+  - name: size
+    shorthand: s
+    default_value: '10'
+    usage: Size of the volume in GB
+inherited_options:
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+see_also:
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_delete.yaml
+++ b/apps/cli/hack/docs/daytona_volume_delete.yaml
@@ -1,0 +1,9 @@
+name: daytona volume delete
+synopsis: Delete a volume
+usage: daytona volume delete [VOLUME_ID] [flags]
+inherited_options:
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+see_also:
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_get.yaml
+++ b/apps/cli/hack/docs/daytona_volume_get.yaml
@@ -1,0 +1,13 @@
+name: daytona volume get
+synopsis: Get volume details
+usage: daytona volume get [VOLUME_ID] [flags]
+options:
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+inherited_options:
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+see_also:
+  - daytona volume - Manage Daytona volumes

--- a/apps/cli/hack/docs/daytona_volume_list.yaml
+++ b/apps/cli/hack/docs/daytona_volume_list.yaml
@@ -1,0 +1,13 @@
+name: daytona volume list
+synopsis: List all volumes
+usage: daytona volume list [flags]
+options:
+  - name: format
+    shorthand: f
+    usage: Output format. Must be one of (yaml, json)
+inherited_options:
+  - name: help
+    default_value: 'false'
+    usage: help for daytona
+see_also:
+  - daytona volume - Manage Daytona volumes


### PR DESCRIPTION
# CLI target options and documentation generation

## Description

Fixes option list for `target` flag for `daytona sandbox create` and generates missing doc files

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation