### PR TITLE
fix(daemon): session exec persistence

### DIFF
--- a/apps/daemon/pkg/toolbox/process/session/execute.go
+++ b/apps/daemon/pkg/toolbox/process/session/execute.go
@@ -78,7 +78,7 @@ func SessionExecuteCommand(configDir string) func(c *gin.Context) {
 			return
 		}
 
-		cmdToExec := fmt.Sprintf("(%s) > %s 2>&1 ; echo \"DTN_EXIT: $?\" >> %s\n", request.Command, logFile.Name(), logFile.Name())
+		cmdToExec := fmt.Sprintf("{ %s; } > %s 2>&1 ; echo \"DTN_EXIT: $?\" >> %s\n", request.Command, logFile.Name(), logFile.Name())
 
 		type execResult struct {
 			out      string


### PR DESCRIPTION
# Fix Session Exec Persistance

## Description

Fixes session command persistence between executions. Because of `(%s)` before, all commands were executed in a sub-shell that didn't persist context.

Now this flow should work correctly:
```typescript
  await sandbox.process.createSession('sess');
  await sandbox.process.executeSessionCommand('sess', {
    command: `cd /`,
  });

  await sandbox.process.executeSessionCommand(agentSessionId, {
    command: `export VAR=123 && echo $VAR && export VAR2=456 && echo $VAR2`,
  });

  const response = await sandbox.process.executeSessionCommand(agentSessionId, {
    command: `pwd && echo $VAR1 && echo $VAR2`,
  });

```

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
