### PR TITLE
fix: apply consistent height to table rows

### DIFF
--- a/apps/dashboard/src/components/ui/table.tsx
+++ b/apps/dashboard/src/components/ui/table.tsx
@@ -23,7 +23,7 @@ TableHeader.displayName = 'TableHeader'
 
 const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
   ({ className, ...props }, ref) => (
-    <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+    <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', '[&_tr]:h-14', className)} {...props} />
   ),
 )
 TableBody.displayName = 'TableBody'


### PR DESCRIPTION
# Consistent table row heights across permission levels

## Description
This PR addresses an issue where table row heights were inconsistent between users with different permission levels. The problem occurred because users with permission to see action menus had taller rows than those without permission, causing visual inconsistency across the application's tables.

## Changes Made
- Added `[&_tr]:h-14` class to the TableBody component in `table.tsx`, ensuring consistent row height (56px) across all tables in the application
- This single change applies to all tables including:
  - WorkspaceTable
  - ImageTable
  - RegistryTable
  - ApiKeyTable
- The centralized approach in the base component avoids duplicating height classes in multiple places and ensures consistent height application

This fix ensures that all table rows maintain the same height (14 units/56px) regardless of user permissions or content, providing a more consistent visual experience throughout the dashboard.


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1784 
@quest-bot loot #1784

## Screenshots
This change is limited to styling and does not require screenshots.

## Notes

`This is a purely UI enhancement that doesn't change any functionality - it simply makes the tables look more consistent and professional when viewed by users with different permission levels.
`