### PR TITLE
fix(runner): remove old daemon binary on embed init

### DIFF
--- a/apps/runner/pkg/daemon/util.go
+++ b/apps/runner/pkg/daemon/util.go
@@ -16,6 +16,17 @@ func WriteDaemonBinary() (string, error) {
 
 	tmpDir := os.TempDir()
 	daemonPath := filepath.Join(tmpDir, "daemon-amd64")
+
+	_, err = os.Stat(daemonPath)
+	if err == nil {
+		err = os.Remove(daemonPath)
+		if err != nil {
+			return "", err
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
 	err = os.WriteFile(daemonPath, daemonBinary, 0755)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Remove old daemon binary on embed init

## Description

This PR introduces removal of old daemon binaries when reinitializing new runner

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
