### PR TITLE
feat(api,dashboard): last used timestamp for api keys and images

### DIFF
--- a/apps/api/src/api-key/api-key.entity.ts
+++ b/apps/api/src/api-key/api-key.entity.ts
@@ -41,4 +41,7 @@ export class ApiKey {
 
   @Column()
   createdAt: Date
+
+  @Column({ nullable: true })
+  lastUsedAt?: Date
 }

--- a/apps/api/src/api-key/api-key.service.ts
+++ b/apps/api/src/api-key/api-key.service.ts
@@ -67,7 +67,16 @@ export class ApiKeyService {
   }
 
   async getApiKeys(organizationId: string, userId: string): Promise<ApiKey[]> {
-    const apiKeys = await this.apiKeyRepository.find({ where: { organizationId, userId } })
+    const apiKeys = await this.apiKeyRepository.find({
+      where: { organizationId, userId },
+      order: {
+        lastUsedAt: {
+          direction: 'DESC',
+          nulls: 'LAST',
+        },
+        createdAt: 'DESC',
+      },
+    })
 
     const organizationUser = await this.organizationUserService.findOne(organizationId, userId)
     if (!organizationUser) {
@@ -132,6 +141,17 @@ export class ApiKeyService {
     }
 
     await this.apiKeyRepository.remove(apiKey)
+  }
+
+  async updateLastUsedAt(organizationId: string, userId: string, name: string, lastUsedAt: Date): Promise<void> {
+    await this.apiKeyRepository.update(
+      {
+        organizationId,
+        userId,
+        name,
+      },
+      { lastUsedAt },
+    )
   }
 
   private getEffectivePermissions(

--- a/apps/api/src/api-key/dto/api-key-list.dto.ts
+++ b/apps/api/src/api-key/dto/api-key-list.dto.ts
@@ -34,6 +34,9 @@ export class ApiKeyListDto {
   })
   permissions: OrganizationResourcePermission[]
 
+  @ApiProperty({ nullable: true })
+  lastUsedAt?: Date
+
   constructor(partial: Partial<ApiKeyListDto>) {
     Object.assign(this, partial)
   }
@@ -46,6 +49,7 @@ export class ApiKeyListDto {
       value: maskedValue,
       createdAt: apiKey.createdAt,
       permissions: apiKey.permissions,
+      lastUsedAt: apiKey.lastUsedAt,
     })
   }
 }

--- a/apps/api/src/auth/api-key.strategy.ts
+++ b/apps/api/src/auth/api-key.strategy.ts
@@ -34,6 +34,9 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') implem
       const apiKey = await this.apiKeyService.getApiKeyByValue(token)
       this.logger.debug(`API key found for userId: ${apiKey.userId}`)
 
+      this.logger.debug(`Updating last used timestamp for API key: ${token.substring(0, 8)}...`)
+      await this.apiKeyService.updateLastUsedAt(apiKey.organizationId, apiKey.userId, apiKey.name, new Date())
+
       let user = await this.userService.findOne(apiKey.userId)
       if (!user) {
         this.logger.debug(`Creating new user for userId: ${apiKey.userId}`)

--- a/apps/api/src/migrations/1747658203010-migration.ts
+++ b/apps/api/src/migrations/1747658203010-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1747658203010 implements MigrationInterface {
+  name = 'Migration1747658203010'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "api_key" ADD "lastUsedAt" TIMESTAMP`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "api_key" DROP COLUMN "lastUsedAt"`)
+  }
+}

--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -30,6 +30,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/t
 import { Pagination } from './Pagination'
 import { Loader2 } from 'lucide-react'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { getRelativeTimeString } from '@/lib/utils'
 
 interface DataTableProps {
   data: ApiKeyList[]
@@ -154,7 +155,14 @@ const getColumns = ({
       accessorKey: 'createdAt',
       header: 'Created',
       cell: ({ row }) => {
-        return new Date(row.original.createdAt).toLocaleDateString()
+        return getRelativeTimeString(row.original.createdAt).relativeTimeString
+      },
+    },
+    {
+      accessorKey: 'lastUsedAt',
+      header: 'Last Used',
+      cell: ({ row }) => {
+        return getRelativeTimeString(row.original.lastUsedAt).relativeTimeString
       },
     },
     {

--- a/apps/dashboard/src/components/ImageTable.tsx
+++ b/apps/dashboard/src/components/ImageTable.tsx
@@ -26,6 +26,7 @@ import {
 import { Pagination } from './Pagination'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { getRelativeTimeString } from '@/lib/utils'
 
 interface DataTableProps {
   data: ImageDto[]
@@ -226,12 +227,12 @@ const getColumns = ({
     {
       accessorKey: 'createdAt',
       header: 'Created',
-      cell: ({ row }) => new Date(row.original.createdAt).toLocaleDateString(),
+      cell: ({ row }) => getRelativeTimeString(row.original.createdAt).relativeTimeString,
     },
     {
       accessorKey: 'lastUsedAt',
       header: 'Last Used',
-      cell: ({ row }) => (row.original.lastUsedAt ? new Date(row.original.lastUsedAt).toLocaleDateString() : '-'),
+      cell: ({ row }) => getRelativeTimeString(row.original.lastUsedAt).relativeTimeString,
     },
     {
       id: 'actions',

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -10,7 +10,10 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function getRelativeTimeString(timestamp?: string, fallback = '-'): { date: Date; relativeTimeString: string } {
+export function getRelativeTimeString(
+  timestamp: string | Date | undefined | null,
+  fallback = '-',
+): { date: Date; relativeTimeString: string } {
   if (!timestamp) {
     return { date: new Date(), relativeTimeString: fallback }
   }

--- a/apps/dashboard/src/pages/Images.tsx
+++ b/apps/dashboard/src/pages/Images.tsx
@@ -94,7 +94,14 @@ const Images: React.FC = () => {
           if (prev.items.some((i) => i.id === image.id)) {
             return prev
           }
-          const newImages = [image, ...prev.items]
+
+          // Find the insertion point - used images should remain at the top
+          const insertIndex =
+            prev.items.findIndex((i) => !i.lastUsedAt && i.createdAt <= image.createdAt) || prev.items.length
+
+          const newImages = [...prev.items]
+          newImages.splice(insertIndex, 0, image)
+
           const newTotal = prev.total + 1
           return {
             ...prev,

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -4034,6 +4034,7 @@ components:
     ApiKeyList:
       example:
         createdAt: 2024-03-14T12:00:00Z
+        lastUsedAt: 2000-01-23T04:56:07.000+00:00
         permissions:
           - write:registries
           - write:registries
@@ -4069,8 +4070,13 @@ components:
               - delete:volumes
             type: string
           type: array
+        lastUsedAt:
+          format: date-time
+          nullable: true
+          type: string
       required:
         - createdAt
+        - lastUsedAt
         - name
         - permissions
         - value

--- a/libs/api-client-go/model_api_key_list.go
+++ b/libs/api-client-go/model_api_key_list.go
@@ -30,7 +30,8 @@ type ApiKeyList struct {
 	// When the API key was created
 	CreatedAt time.Time `json:"createdAt"`
 	// The list of organization resource permissions assigned to the API key
-	Permissions []string `json:"permissions"`
+	Permissions []string     `json:"permissions"`
+	LastUsedAt  NullableTime `json:"lastUsedAt"`
 }
 
 type _ApiKeyList ApiKeyList
@@ -39,12 +40,13 @@ type _ApiKeyList ApiKeyList
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewApiKeyList(name string, value string, createdAt time.Time, permissions []string) *ApiKeyList {
+func NewApiKeyList(name string, value string, createdAt time.Time, permissions []string, lastUsedAt NullableTime) *ApiKeyList {
 	this := ApiKeyList{}
 	this.Name = name
 	this.Value = value
 	this.CreatedAt = createdAt
 	this.Permissions = permissions
+	this.LastUsedAt = lastUsedAt
 	return &this
 }
 
@@ -152,6 +154,32 @@ func (o *ApiKeyList) SetPermissions(v []string) {
 	o.Permissions = v
 }
 
+// GetLastUsedAt returns the LastUsedAt field value
+// If the value is explicit nil, the zero value for time.Time will be returned
+func (o *ApiKeyList) GetLastUsedAt() time.Time {
+	if o == nil || o.LastUsedAt.Get() == nil {
+		var ret time.Time
+		return ret
+	}
+
+	return *o.LastUsedAt.Get()
+}
+
+// GetLastUsedAtOk returns a tuple with the LastUsedAt field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ApiKeyList) GetLastUsedAtOk() (*time.Time, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.LastUsedAt.Get(), o.LastUsedAt.IsSet()
+}
+
+// SetLastUsedAt sets field value
+func (o *ApiKeyList) SetLastUsedAt(v time.Time) {
+	o.LastUsedAt.Set(&v)
+}
+
 func (o ApiKeyList) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -166,6 +194,7 @@ func (o ApiKeyList) ToMap() (map[string]interface{}, error) {
 	toSerialize["value"] = o.Value
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["permissions"] = o.Permissions
+	toSerialize["lastUsedAt"] = o.LastUsedAt.Get()
 	return toSerialize, nil
 }
 
@@ -178,6 +207,7 @@ func (o *ApiKeyList) UnmarshalJSON(data []byte) (err error) {
 		"value",
 		"createdAt",
 		"permissions",
+		"lastUsedAt",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-python/daytona_api_client/models/api_key_list.py
+++ b/libs/api-client-python/daytona_api_client/models/api_key_list.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -32,8 +32,9 @@ class ApiKeyList(BaseModel):
     value: StrictStr = Field(description="The masked API key value")
     created_at: datetime = Field(description="When the API key was created", alias="createdAt")
     permissions: List[StrictStr] = Field(description="The list of organization resource permissions assigned to the API key")
+    last_used_at: Optional[datetime] = Field(alias="lastUsedAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions"]
+    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt"]
 
     @field_validator('permissions')
     def permissions_validate_enum(cls, value):
@@ -89,6 +90,11 @@ class ApiKeyList(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if last_used_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.last_used_at is None and "last_used_at" in self.model_fields_set:
+            _dict['lastUsedAt'] = None
+
         return _dict
 
     @classmethod
@@ -104,7 +110,8 @@ class ApiKeyList(BaseModel):
             "name": obj.get("name"),
             "value": obj.get("value"),
             "createdAt": obj.get("createdAt"),
-            "permissions": obj.get("permissions")
+            "permissions": obj.get("permissions"),
+            "lastUsedAt": obj.get("lastUsedAt")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client/src/models/api-key-list.ts
+++ b/libs/api-client/src/models/api-key-list.ts
@@ -42,6 +42,12 @@ export interface ApiKeyList {
    * @memberof ApiKeyList
    */
   permissions: Array<ApiKeyListPermissionsEnum>
+  /**
+   *
+   * @type {Date}
+   * @memberof ApiKeyList
+   */
+  lastUsedAt: Date | null
 }
 
 export const ApiKeyListPermissionsEnum = {


### PR DESCRIPTION
# Last used timestamp for API keys and Images

## Description
When listing API keys and Images, their corresponding tables will now display the timestamp of the last time they were used. For API keys, it's the last time they were used to authenticate with the API, while for Images it's the last time they were used for creating a Sandbox.

Both of these tables are sorted by most recently API key or Image. For those unused, they are sorted by most recently created.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
<img src="https://github.com/user-attachments/assets/0b9be9ee-c885-487c-a9e2-66da438e4a7b" height=256 />