### PR TITLE
fix(api): properly handle toolbox proxy error

### DIFF
--- a/apps/api/src/workspace/controllers/toolbox.controller.ts
+++ b/apps/api/src/workspace/controllers/toolbox.controller.ts
@@ -100,19 +100,24 @@ export class ToolboxController {
       router: async (req: RawBodyRequest<IncomingMessage>) => {
         // eslint-disable-next-line no-useless-escape
         const workspaceId = req.url.match(/^\/api\/toolbox\/([^\/]+)\/toolbox/)?.[1]
-        const node = await this.toolboxService.getNode(workspaceId)
+        try {
+          const node = await this.toolboxService.getNode(workspaceId)
+          // @ts-expect-error - used later to set request headers
+          req._nodeApiKey = node.apiKey
 
-        // @ts-expect-error - used later to set request headers
-        req._nodeApiKey = node.apiKey
+          return node.apiUrl
+        } catch (err) {
+          // @ts-expect-error - used later to throw error
+          req._err = err
+        }
 
-        return node.apiUrl
+        // Must return a valid url
+        return 'http://target-error'
       },
       pathRewrite: (path) => {
         // eslint-disable-next-line no-useless-escape
         const workspaceId = path.match(/^\/api\/toolbox\/([^\/]+)\/toolbox/)?.[1]
-
         const routePath = path.split(`/api/toolbox/${workspaceId}/toolbox`)[1]
-
         const newPath = `/workspaces/${workspaceId}/main/toolbox${routePath}`
 
         return newPath
@@ -122,8 +127,15 @@ export class ToolboxController {
       followRedirects: true,
       proxyTimeout: 5 * 60 * 1000,
       on: {
-        proxyReq: (proxyReq, req) => {
-          // console.log('headers', proxyReq.getHeaders())
+        proxyReq: (proxyReq, req, res) => {
+          // @ts-expect-error - set when routing
+          if (req._err) {
+            res.writeHead(400, { 'Content-Type': 'application/json' })
+            // @ts-expect-error - set when routing
+            res.end(JSON.stringify(req._err))
+            return
+          }
+
           // @ts-expect-error - set when routing
           const nodeApiKey = req._nodeApiKey
 


### PR DESCRIPTION
# Properly Handle Toolbox Proxy Error

## Description

Toolbox proxying errors are not properly handled and returned to the client. Fixes an issue where the proxy would return:
```
Error during cycle: Failed to create sandbox: Failed to get sandbox root directory: Missing parameter name at 6: https://git.new/pathToRegexpError
```

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

![Screenshot 2025-05-20 at 11 57 18](https://github.com/user-attachments/assets/12f97253-1f7c-4075-aef1-cefc35474283)

## Notes

To test:
```
import { CreateWorkspaceTargetEnum } from "@daytonaio/api-client";
import { Daytona } from "@daytonaio/sdk";
import { configDotenv } from "dotenv";
async function daytona() {
  configDotenv();

  const start = Date.now();

  const daytona = new Daytona({
    apiKey: process.env.DAYTONA_API_KEY!,
    serverUrl: process.env.DAYTONA_SERVER_URL!,
    target: process.env.DAYTONA_TARGET as CreateWorkspaceTargetEnum,
  });
  let sandbox = await daytona.create({
    language: "python",
  });

  const end = Date.now();
  console.log(`Time taken: ${end - start} milliseconds`);

  await sandbox.stop();

  console.log(await sandbox.fs.listFiles("/home/daytona"));
}

daytona();

```