### PR TITLE
chore(api): log sync snapshot state error after 10 retries

### DIFF
--- a/apps/api/src/workspace/managers/snapshot.manager.ts
+++ b/apps/api/src/workspace/managers/snapshot.manager.ts
@@ -148,14 +148,13 @@ export class SnapshotManager {
             }
           }
         } catch (error) {
-          this.logger.error(`Error processing snapshot for workspace ${workspace.id}:`, fromAxiosError(error))
-
           //  if error, retry 10 times
           const errorRetryKey = `${lockKey}-error-retry`
           const errorRetryCount = await this.redis.get(errorRetryKey)
           if (!errorRetryCount) {
             await this.redis.setex(errorRetryKey, 300, '1')
           } else if (parseInt(errorRetryCount) > 10) {
+            this.logger.error(`Error processing snapshot for workspace ${workspace.id}:`, fromAxiosError(error))
             await this.updateWorkspaceSnapshotState(workspace.id, SnapshotState.ERROR)
           } else {
             await this.redis.setex(errorRetryKey, 300, errorRetryCount + 1)


### PR DESCRIPTION
## Log sync snapshot state error after 10 retries

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
