### PR TITLE
fix(api): suspended org workspace stopped event emit

### DIFF
--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -31,6 +31,7 @@ import { Cron, CronExpression } from '@nestjs/schedule'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { RedisLockProvider } from '../../workspace/common/redis-lock.provider'
+import { OrganizationSuspendedWorkspaceStoppedEvent } from '../events/organization-suspended-workspace-stopped.event'
 
 @Injectable()
 export class OrganizationService implements OnModuleInit {
@@ -354,7 +355,10 @@ export class OrganizationService implements OnModuleInit {
     })
 
     workspaces.map((workspace) =>
-      this.eventEmitter.emitAsync(OrganizationEvents.SUSPENDED_WORKSPACE_STOPPED, workspace.id),
+      this.eventEmitter.emitAsync(
+        OrganizationEvents.SUSPENDED_WORKSPACE_STOPPED,
+        new OrganizationSuspendedWorkspaceStoppedEvent(workspace.id),
+      ),
     )
 
     await this.redis.del(lockKey)


### PR DESCRIPTION
# Suspended Org Workspace Stopped Event Emit Fix

## Description

Fix event emit when stopping suspended org sandboxes.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
