### PR TITLE
fix(api): separate job for archiving sandboxes

### DIFF
--- a/apps/api/src/workspace/dto/workspace.dto.ts
+++ b/apps/api/src/workspace/dto/workspace.dto.ts
@@ -269,6 +269,9 @@ export class WorkspaceDto {
         if (workspace.desiredState === WorkspaceDesiredState.DESTROYED) {
           return WorkspaceState.DESTROYING
         }
+        if (workspace.desiredState === WorkspaceDesiredState.ARCHIVED) {
+          return WorkspaceState.ARCHIVING
+        }
         break
       case WorkspaceState.UNKNOWN:
         if (workspace.desiredState === WorkspaceDesiredState.STARTED) {


### PR DESCRIPTION
# Separate Job for Archiving Sandboxes

## Description

Since archiving takes the longest, this can build up a long queue of sandboxes that are not processed. Having a separate job for archiving sandboxes will unblock that.
Additionally, we include the 3-per-node rule in the query itself.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
