### PR TITLE
Limit concurrent builds

### DIFF
--- a/apps/api/src/workspace/managers/image.manager.ts
+++ b/apps/api/src/workspace/managers/image.manager.ts
@@ -516,14 +516,7 @@ export class ImageManager {
     }
 
     try {
-      const excludedNodeIds = (
-        await this.imageNodeRepository
-          .createQueryBuilder('imageNode')
-          .select('imageNode.nodeId')
-          .groupBy('imageNode.nodeId')
-          .having('COUNT(DISTINCT imageNode.imageRef) > :minImageCount', { minImageCount: 2 })
-          .getRawMany()
-      ).map((item) => item.nodeId)
+      const excludedNodeIds = await this.nodeService.getNodesWithMultipleImagesBuilding()
 
       // Find a node to build the image on
       const nodeId = await this.nodeService.getRandomAvailableNode({

--- a/apps/api/src/workspace/managers/workspace.manager.ts
+++ b/apps/api/src/workspace/managers/workspace.manager.ts
@@ -33,6 +33,7 @@ import { WorkspaceStartedEvent } from '../events/workspace-started.event'
 import { WorkspaceArchivedEvent } from '../events/workspace-archived.event'
 import { WorkspaceDestroyedEvent } from '../events/workspace-destroyed.event'
 import { WorkspaceCreatedEvent } from '../events/workspace-create.event'
+import { ImageNode } from '../entities/image-node.entity'
 
 type BreakFromSwitch = boolean
 const SYNC_INSTANCE_STATE_LOCK_KEY = 'sync-instance-state-'
@@ -44,6 +45,8 @@ export class WorkspaceManager {
   constructor(
     @InjectRepository(Workspace)
     private readonly workspaceRepository: Repository<Workspace>,
+    @InjectRepository(ImageNode)
+    private readonly imageNodeRepository: Repository<ImageNode>,
     private readonly nodeService: NodeService,
     private readonly nodeApiFactory: NodeApiFactory,
     private readonly dockerRegistryService: DockerRegistryService,
@@ -237,11 +240,11 @@ export class WorkspaceManager {
     // Try to assign an available node with the image build
     let nodeId: string
     try {
-      nodeId = await this.nodeService.getRandomAvailableNode(
-        workspace.region,
-        workspace.class,
-        workspace.buildInfo.imageRef,
-      )
+      nodeId = await this.nodeService.getRandomAvailableNode({
+        region: workspace.region,
+        workspaceClass: workspace.class,
+        imageRef: workspace.buildInfo.imageRef,
+      })
     } catch (error) {
       // Continue to next assignment method
     }
@@ -273,8 +276,21 @@ export class WorkspaceManager {
       }
     }
 
+    const excludedNodeIds = (
+      await this.imageNodeRepository
+        .createQueryBuilder('imageNode')
+        .select('imageNode.nodeId')
+        .groupBy('imageNode.nodeId')
+        .having('COUNT(DISTINCT imageNode.imageRef) > :minImageCount', { minImageCount: 2 })
+        .getRawMany()
+    ).map((item) => item.nodeId)
+
     // Try to assign a new available node
-    nodeId = await this.nodeService.getRandomAvailableNode(workspace.region, workspace.class)
+    nodeId = await this.nodeService.getRandomAvailableNode({
+      region: workspace.region,
+      workspaceClass: workspace.class,
+      excludedNodeIds: excludedNodeIds,
+    })
 
     this.buildOnNode(workspace.buildInfo, nodeId, workspace.organizationId)
 
@@ -314,7 +330,13 @@ export class WorkspaceManager {
       return
     }
 
-    await this.nodeService.createImageNode(nodeId, buildInfo.imageRef, ImageNodeState.BUILDING_IMAGE)
+    const response = (await nodeImageApi.imageExists(buildInfo.imageRef)).data
+    let state = ImageNodeState.BUILDING_IMAGE
+    if (response && response.exists) {
+      state = ImageNodeState.READY
+    }
+
+    await this.nodeService.createImageNode(nodeId, buildInfo.imageRef, state)
   }
 
   private async handleWorkspaceDesiredStateArchived(workspaceId: string): Promise<void> {
@@ -789,11 +811,11 @@ export class WorkspaceManager {
           //  TODO: usage should be based on compute usage
 
           const image = await this.imageService.getImageByName(workspace.image, workspace.organizationId)
-          const availableNodes = await this.nodeService.findAvailableNodes(
-            workspace.region,
-            workspace.class,
-            image.internalName,
-          )
+          const availableNodes = await this.nodeService.findAvailableNodes({
+            region: workspace.region,
+            workspaceClass: workspace.class,
+            imageRef: image.internalName,
+          })
           const lessUsedNodes = availableNodes.filter((node) => node.id !== workspace.nodeId)
 
           //  temp workaround to move workspaces to less used node
@@ -869,7 +891,11 @@ export class WorkspaceManager {
 
       //  exclude the node that the last node workspace was on
       const availableNodes = (
-        await this.nodeService.findAvailableNodes(workspace.region, workspace.class, image.internalName)
+        await this.nodeService.findAvailableNodes({
+          region: workspace.region,
+          workspaceClass: workspace.class,
+          imageRef: image.internalName,
+        })
       ).filter((node) => node.id != workspace.prevNodeId)
 
       //  get random node from available nodes

--- a/apps/api/src/workspace/managers/workspace.manager.ts
+++ b/apps/api/src/workspace/managers/workspace.manager.ts
@@ -276,14 +276,7 @@ export class WorkspaceManager {
       }
     }
 
-    const excludedNodeIds = (
-      await this.imageNodeRepository
-        .createQueryBuilder('imageNode')
-        .select('imageNode.nodeId')
-        .groupBy('imageNode.nodeId')
-        .having('COUNT(DISTINCT imageNode.imageRef) > :minImageCount', { minImageCount: 2 })
-        .getRawMany()
-    ).map((item) => item.nodeId)
+    const excludedNodeIds = await this.nodeService.getNodesWithMultipleImagesBuilding()
 
     // Try to assign a new available node
     nodeId = await this.nodeService.getRandomAvailableNode({

--- a/apps/api/src/workspace/services/node.service.ts
+++ b/apps/api/src/workspace/services/node.service.ts
@@ -74,7 +74,10 @@ export class NodeService {
   async findAvailableNodes(params: GetNodeParams): Promise<Node[]> {
     const imageNodeFilter: FindOptionsWhere<ImageNode> = {
       state: ImageNodeState.READY,
-      nodeId: Not(In(params.excludedNodeIds || [])),
+    }
+
+    if (params.excludedNodeIds && params.excludedNodeIds.length > 0) {
+      imageNodeFilter.nodeId = Not(In(params.excludedNodeIds))
     }
 
     if (params.imageRef !== undefined) {

--- a/apps/api/src/workspace/services/node.service.ts
+++ b/apps/api/src/workspace/services/node.service.ts
@@ -242,13 +242,14 @@ export class NodeService {
     await this.imageNodeRepository.save(imageNode)
   }
 
-  async getNodesWithMultipleImagesBuilding(minImageCount = 2): Promise<Set<string>> {
-    const nodes = await this.imageNodeRepository
-      .createQueryBuilder('imageNode')
-      .select('imageNode.nodeId')
-      .where('imageNode.state = :state', { state: ImageNodeState.BUILDING_IMAGE })
-      .groupBy('imageNode.nodeId')
-      .having('COUNT(DISTINCT imageNode.imageRef) > :minImageCount', { minImageCount })
+  async getNodesWithMultipleImagesBuilding(maxImageCount = 2): Promise<Set<string>> {
+    const nodes = await this.workspaceRepository
+      .createQueryBuilder('workspace')
+      .select('workspace.nodeId')
+      .where('workspace.state = :state', { state: WorkspaceState.BUILDING_IMAGE })
+      .andWhere('workspace.buildInfoImageRef IS NOT NULL')
+      .groupBy('workspace.nodeId')
+      .having('COUNT(DISTINCT workspace.buildInfoImageRef) > :maxImageCount', { maxImageCount })
       .getRawMany()
 
     return new Set(nodes.map((item) => item.nodeId))

--- a/apps/api/src/workspace/services/workspace.service.ts
+++ b/apps/api/src/workspace/services/workspace.service.ts
@@ -329,7 +329,11 @@ export class WorkspaceService {
     const imageRef = workspace.buildInfo ? workspace.buildInfo.imageRef : image.internalName
 
     try {
-      workspace.nodeId = await this.nodeService.getRandomAvailableNode(workspace.region, workspace.class, imageRef)
+      workspace.nodeId = await this.nodeService.getRandomAvailableNode({
+        region: workspace.region,
+        workspaceClass: workspace.class,
+        imageRef,
+      })
     } catch (error) {
       if (error instanceof BadRequestError == false || error.message !== 'No available nodes' || !workspace.buildInfo) {
         throw error

--- a/apps/cli/cmd/common/logs.go
+++ b/apps/cli/cmd/common/logs.go
@@ -18,11 +18,12 @@ import (
 )
 
 type ReadLogParams struct {
-	Id           string
-	ServerUrl    string
-	ServerApi    config.ServerApi
-	Follow       *bool
-	ResourceType ResourceType
+	Id                   string
+	ServerUrl            string
+	ServerApi            config.ServerApi
+	ActiveOrganizationId *string
+	Follow               *bool
+	ResourceType         ResourceType
 }
 
 type ResourceType string
@@ -48,6 +49,10 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *params.ServerApi.Key))
 	} else if params.ServerApi.Token != nil {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", params.ServerApi.Token.AccessToken))
+
+		if params.ActiveOrganizationId != nil {
+			req.Header.Add("X-Daytona-Organization-ID", *params.ActiveOrganizationId)
+		}
 	}
 
 	req.Header.Add("Accept", "application/octet-stream")
@@ -61,7 +66,7 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Server returned non-OK status: %d", resp.StatusCode)
+		log.Errorf("Server returned a non-OK status while retrieving logs: %d", resp.StatusCode)
 		return
 	}
 

--- a/apps/cli/cmd/image/build.go
+++ b/apps/cli/cmd/image/build.go
@@ -68,11 +68,12 @@ var BuildCmd = &cobra.Command{
 		defer stopLogs()
 
 		go common.ReadBuildLogs(logsContext, common.ReadLogParams{
-			Id:           image.Id,
-			ServerUrl:    activeProfile.Api.Url,
-			ServerApi:    activeProfile.Api,
-			Follow:       util.Pointer(true),
-			ResourceType: common.ResourceTypeImage,
+			Id:                   image.Id,
+			ServerUrl:            activeProfile.Api.Url,
+			ServerApi:            activeProfile.Api,
+			ActiveOrganizationId: activeProfile.ActiveOrganizationId,
+			Follow:               util.Pointer(true),
+			ResourceType:         common.ResourceTypeImage,
 		})
 
 		err = common.AwaitImageState(ctx, apiClient, imageName, daytonaapiclient.IMAGESTATE_PENDING)

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -132,15 +132,21 @@ var CreateCmd = &cobra.Command{
 				return err
 			}
 
+			err = common.AwaitSandboxState(ctx, apiClient, workspace.Id, daytonaapiclient.WORKSPACESTATE_BUILDING_IMAGE)
+			if err != nil {
+				return err
+			}
+
 			logsContext, stopLogs := context.WithCancel(context.Background())
 			defer stopLogs()
 
 			go common.ReadBuildLogs(logsContext, common.ReadLogParams{
-				Id:           workspace.Id,
-				ServerUrl:    activeProfile.Api.Url,
-				ServerApi:    activeProfile.Api,
-				Follow:       util.Pointer(true),
-				ResourceType: common.ResourceTypeWorkspace,
+				Id:                   workspace.Id,
+				ServerUrl:            activeProfile.Api.Url,
+				ServerApi:            activeProfile.Api,
+				ActiveOrganizationId: activeProfile.ActiveOrganizationId,
+				Follow:               util.Pointer(true),
+				ResourceType:         common.ResourceTypeWorkspace,
 			})
 
 			err = common.AwaitSandboxState(ctx, apiClient, workspace.Id, daytonaapiclient.WORKSPACESTATE_STARTED)


### PR DESCRIPTION
# Limit concurrent builds
## Description

Improves choosing the runner for building by limiting the concurrent builds on a runner to less than three.
Small refactor to the node retrieval function to accommodate this change

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
