### PR TITLE
fix: image name for pending validation state

### DIFF
--- a/apps/api/src/workspace/managers/image.manager.ts
+++ b/apps/api/src/workspace/managers/image.manager.ts
@@ -376,9 +376,15 @@ export class ImageManager {
               break
             case ImageState.PENDING_VALIDATION:
               //  temp workaround to avoid race condition between api instances
-              if (!(await this.dockerProvider.imageExists(image.name))) {
-                await this.redisLockProvider.unlock(lockKey)
-                return
+              {
+                let imageName = image.name
+                if (image.buildInfo) {
+                  imageName = image.internalName
+                }
+                if (!(await this.dockerProvider.imageExists(imageName))) {
+                  await this.redisLockProvider.unlock(lockKey)
+                  return
+                }
               }
 
               await this.handleImageTagStatePendingValidation(image)


### PR DESCRIPTION
# Image name for pending validation state
## Description

The builder should use the internal registry name for image when validating it on the API - otherwise the syncing hangs

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
