### PR TITLE
fix: rename pip package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 ### Python SDK
 
 ```bash
-pip install daytona-sdk
+pip install daytona
 ```
 
 ### TypeScript SDK
@@ -78,7 +78,7 @@ npm install @daytonaio/sdk
 ### Python SDK
 
 ```py
-from daytona_sdk import Daytona, DaytonaConfig, CreateSandboxParams
+from daytona import Daytona, DaytonaConfig, CreateSandboxParams
 
 # Initialize the Daytona client
 daytona = Daytona(DaytonaConfig(api_key="YOUR_API_KEY"))

--- a/apps/dashboard/src/pages/Onboarding.tsx
+++ b/apps/dashboard/src/pages/Onboarding.tsx
@@ -307,9 +307,9 @@ console.log(response.result);
   `,
   },
   python: {
-    install: `pip install daytona-sdk`,
+    install: `pip install daytona`,
     run: `python main.py`,
-    example: `from daytona_sdk import Daytona, DaytonaConfig
+    example: `from daytona import Daytona, DaytonaConfig
   
 # Define the configuration
 config = DaytonaConfig(api_key="your-api-key")


### PR DESCRIPTION
# Rename pip package

## Description

Changes the usage of our pip package from `daytona_sdk` to `daytona`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation