### PR TITLE
fix(api): wait for warm pool events

### DIFF
--- a/apps/api/src/workspace/services/workspace-warm-pool.service.ts
+++ b/apps/api/src/workspace/services/workspace-warm-pool.service.ts
@@ -167,11 +167,17 @@ export class WorkspaceWarmPoolService {
 
         const missingCount = warmPoolItem.pool - workspaceCount
         if (missingCount > 0) {
+          const promises = []
           this.logger.debug(`Creating ${missingCount} workspaces for warm pool id ${warmPoolItem.id}`)
 
           for (let i = 0; i < missingCount; i++) {
-            this.eventEmitter.emit(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem))
+            promises.push(
+              this.eventEmitter.emitAsync(WarmPoolEvents.TOPUP_REQUESTED, new WarmPoolTopUpRequested(warmPoolItem)),
+            )
           }
+
+          // Wait for all promises to settle before releasing the lock. Otherwise, another worker could start creating workspaces
+          await Promise.allSettled(promises)
         }
 
         await this.redisLockProvider.unlock(lockKey)


### PR DESCRIPTION
# Wait for Warm Pool Top Ups to Resolve

## Description

Fixes a scenario where more than one api instance would create warm pool sandboxes. This would cause more of them to be created than specified in the warm pool.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
