### PR TITLE
fix(runner): destroy exited containers

### DIFF
--- a/apps/runner/pkg/docker/destroy.go
+++ b/apps/runner/pkg/docker/destroy.go
@@ -25,18 +25,15 @@ func (d *DockerClient) Destroy(ctx context.Context, containerId string) error {
 		}
 	}()
 
-	state, err := d.DeduceSandboxState(ctx, containerId)
-	if err != nil && state == enums.SandboxStateError {
-		return err
-	}
-
+	// Ignore err because we want to destroy the container even if it exited
+	state, _ := d.DeduceSandboxState(ctx, containerId)
 	if state == enums.SandboxStateDestroyed || state == enums.SandboxStateDestroying {
 		return nil
 	}
 
 	d.cache.SetSandboxState(ctx, containerId, enums.SandboxStateDestroying)
 
-	_, err = d.ContainerInspect(ctx, containerId)
+	_, err := d.ContainerInspect(ctx, containerId)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			d.cache.SetSandboxState(ctx, containerId, enums.SandboxStateDestroyed)


### PR DESCRIPTION
# Fix Destroying Exited Containers

## Description

Removed the err check when destroying a sandbox on a runner.
The err check prevented exited containers from being deleted.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
