### PR TITLE
fix(dashboard): render Limits page to organization owners only

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -142,7 +142,14 @@ function App() {
               </RequiredPermissionsOrganizationPageWrapper>
             }
           />
-          <Route path={getRouteSubPath(RoutePath.LIMITS)} element={<Limits />} />
+          <Route
+            path={getRouteSubPath(RoutePath.LIMITS)}
+            element={
+              <OwnerAccessOrganizationPageWrapper>
+                <Limits />
+              </OwnerAccessOrganizationPageWrapper>
+            }
+          />
           {import.meta.env.VITE_BILLING_API_URL && (
             <Route
               path={getRouteSubPath(RoutePath.BILLING)}

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -81,14 +81,15 @@ export function Sidebar() {
       arr.push({ icon: <HardDrive className="w-5 h-5" />, label: 'Volumes', path: RoutePath.VOLUMES })
     }
 
+    if (authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER) {
+      arr.push({ icon: <LockKeyhole className="w-5 h-5" />, label: 'Limits', path: RoutePath.LIMITS })
+    }
+
     if (
       import.meta.env.VITE_BILLING_API_URL &&
       authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
     ) {
-      arr.push(
-        { icon: <LockKeyhole className="w-5 h-5" />, label: 'Limits', path: RoutePath.LIMITS },
-        { icon: <CreditCard className="w-5 h-5" />, label: 'Billing', path: RoutePath.BILLING },
-      )
+      arr.push({ icon: <CreditCard className="w-5 h-5" />, label: 'Billing', path: RoutePath.BILLING })
     }
 
     if (!selectedOrganization?.personal) {


### PR DESCRIPTION
# Render Limits Page to Organization Owners Only

## Description

Modifies the conditional logic for rendering the "Limits" page. Only organization owners have access to it.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
