### PR TITLE
feat(ui): add guidance and purpose to container registries empty state

### DIFF
--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -16,8 +16,7 @@ import {
 import { TableHeader, TableRow, TableHead, TableBody, TableCell, Table } from './ui/table'
 import { Button } from './ui/button'
 import { useMemo, useState } from 'react'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
-import { Pencil, MoreHorizontal, Loader2 } from 'lucide-react'
+import { MoreHorizontal } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -105,7 +104,13 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
               !loading && (
                 <TableRow>
                   <TableCell colSpan={columns.length} className="h-24 text-center">
-                    No results.
+                    <div className="flex flex-col items-center justify-center space-y-2">
+                      <p className="text-muted-foreground">No container registries found.</p>
+                      <p className="text-sm text-muted-foreground">
+                        Connect to external container registries (e.g., Docker Hub, GCR, ECR) to pull images for your
+                        Sandboxes.
+                      </p>
+                    </div>
                   </TableCell>
                 </TableRow>
               )


### PR DESCRIPTION
## Description:

This PR improves the user experience of the Container Registries section by enhancing the empty state with purpose-driven messaging and actionable guidance.

**Changes Made:** 

1. Updated the empty state in `RegistryTable.tsx` to replace the generic "No results." message with a more informative and helpful message.

2. The new empty state includes:
- A clear message: "No container registries found."
- Helpful guidance: "Connect to external container registries (e.g., Docker Hub, GCR, ECR) to pull images for your Sandboxes."

3. Cleaned up unused imports to avoid linting issues.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1875 

## Screenshots

![Untitled2](https://github.com/user-attachments/assets/00032197-7a12-4ce9-88e1-b3b868bc57b0)


## Notes

Users now understand what container registries are for and why they might want to add them.