### PR TITLE
feat(ux): apply context-specific labels to table pagination

### DIFF
--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -107,7 +107,7 @@ export function ApiKeyTable({ data, loading, loadingKeys, onRevoke }: DataTableP
           </TableBody>
         </Table>
       </div>
-      <Pagination table={table} className="mt-4" />
+      <Pagination table={table} className="mt-4" entityName="API Keys" />
     </div>
   )
 }

--- a/apps/dashboard/src/components/ImageTable.tsx
+++ b/apps/dashboard/src/components/ImageTable.tsx
@@ -141,7 +141,7 @@ export function ImageTable({
           </TableBody>
         </Table>
       </div>
-      <Pagination table={table} className="mt-4" />
+      <Pagination table={table} className="mt-4" entityName="Images" />
     </div>
   )
 }

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
@@ -152,7 +152,7 @@ export function OrganizationInvitationTable({
             </TableBody>
           </Table>
         </div>
-        <Pagination table={table} className="mt-4" />
+        <Pagination table={table} className="mt-4" entityName="Invitations" />
       </div>
 
       {invitationToUpdate && (

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
@@ -171,7 +171,7 @@ export function OrganizationMemberTable({
             </TableBody>
           </Table>
         </div>
-        <Pagination table={table} className="mt-4" />
+        <Pagination table={table} className="mt-4" entityName="Members" />
       </div>
 
       {memberToUpdate && (

--- a/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
+++ b/apps/dashboard/src/components/OrganizationRoles/OrganizationRoleTable.tsx
@@ -153,7 +153,7 @@ export function OrganizationRoleTable({
             </TableBody>
           </Table>
         </div>
-        <Pagination table={table} className="mt-4" />
+        <Pagination table={table} className="mt-4" entityName="Roles" />
       </div>
 
       {roleToUpdate && (

--- a/apps/dashboard/src/components/Pagination.tsx
+++ b/apps/dashboard/src/components/Pagination.tsx
@@ -13,9 +13,10 @@ interface PaginationProps<TData> {
   table: Table<TData>
   selectionEnabled?: boolean
   className?: string
+  entityName?: string
 }
 
-export function Pagination<TData>({ table, selectionEnabled, className }: PaginationProps<TData>) {
+export function Pagination<TData>({ table, selectionEnabled, className, entityName }: PaginationProps<TData>) {
   return (
     <div className={`flex items-center justify-between px-2 w-full ${className}`}>
       {selectionEnabled ? (
@@ -28,7 +29,7 @@ export function Pagination<TData>({ table, selectionEnabled, className }: Pagina
       )}
       <div className="flex items-center space-x-6 lg:space-x-8">
         <div className="flex items-center space-x-2">
-          <p className="text-sm font-medium">Rows per page</p>
+          <p className="text-sm font-medium">{entityName ? `${entityName} per page` : 'Rows per page'}</p>
           <Select
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {

--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -113,7 +113,7 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
           </TableBody>
         </Table>
       </div>
-      <Pagination table={table} className="mt-4" />
+      <Pagination table={table} className="mt-4" entityName="Registries" />
     </div>
   )
 }

--- a/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/UserOrganizationInvitations/UserOrganizationInvitationTable.tsx
@@ -123,7 +123,7 @@ export function UserOrganizationInvitationTable({
             </TableBody>
           </Table>
         </div>
-        <Pagination table={table} className="mt-4" />
+        <Pagination table={table} className="mt-4" entityName="Invitations" />
       </div>
 
       {invitationToDecline && (

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -178,7 +178,7 @@ export function VolumeTable({ data, loading, processingVolumeAction, onDelete, o
             </div>
           )}
         </div>
-        <Pagination table={table} selectionEnabled />
+        <Pagination table={table} selectionEnabled entityName="Volumes" />
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/WorkspaceTable.tsx
+++ b/apps/dashboard/src/components/WorkspaceTable.tsx
@@ -244,7 +244,7 @@ export function WorkspaceTable({
             </div>
           )}
         </div>
-        <Pagination table={table} selectionEnabled />
+        <Pagination table={table} selectionEnabled entityName="Sandboxes" />
       </div>
     </div>
   )


### PR DESCRIPTION
## Description:

This PR enhances the user experience of table pagination by introducing context-specific labels. Instead of using generic terms like "Rows per page" or "Items," the labels now reflect the specific content of each table, making the interface more intuitive and informative.

Changes Made: 

1. Added optional `entityName` prop to the interface in `Pagination.tsx`:
- Implemented dynamic label generation: `{entityName} per page` or fallback to `Rows per page`.

2. Updated All Table Components with context-specific entity names:
- `WorkspaceTable` → "Sandboxes per page"
- `VolumeTable` → "Volumes per page"
- `ImageTable` → "Images per page"
- `ApiKeyTable` → "API Keys per page"
- `RegistryTable` → "Registries per page"
- `OrganizationRoleTable` → "Organization Roles per page"
- `OrganizationMemberTable` → "Members per page"
- `OrganizationInvitationTable` → "Invitations per page"
- `UserOrganizationInvitationTable` → "Organization Invitations per page"

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1871 

## Screenshots

![Untitled](https://github.com/user-attachments/assets/f136adc8-5c02-4106-bb66-ccbd1337ab1d)
![Untitled2](https://github.com/user-attachments/assets/dd7182a1-a1e2-4082-8521-258f25a1c287)
![Untitled3](https://github.com/user-attachments/assets/8c6b7b36-8e3b-4977-ac67-0a0871bf5655)
![Untitled4](https://github.com/user-attachments/assets/c7414b40-e7e1-4bc2-9e78-2f79c6e2633d)
![Untitled5](https://github.com/user-attachments/assets/55603d9d-9238-4492-b570-b7738262d137)
![Untitled6](https://github.com/user-attachments/assets/6e5c9c95-4845-4fd6-8225-9bd7780e22e8)
![Untitled7](https://github.com/user-attachments/assets/9927ea5d-29c2-4d30-a919-4531db0d884a)


## Notes

Please add any relevant notes if necessary.
