### PR TITLE
fix(dashboard): limit display updates

### DIFF
--- a/apps/dashboard/src/components/TierTable.tsx
+++ b/apps/dashboard/src/components/TierTable.tsx
@@ -36,12 +36,12 @@ export function TierTable({
               label={
                 <div className="flex items-center gap-2 max-w-80">
                   <Info size={16} />
-                  Available Compute (vCPU / RAM / Disk)
+                  Available Compute (vCPU / RAM / Storage)
                 </div>
               }
               content={
                 <div className="max-w-80">
-                  Total vCPU, RAM, and Disk available at any moment across all running sandboxes.
+                  Total vCPU, RAM, and Storage available at any moment across all running sandboxes.
                   <br />
                   The number of concurrent sandboxes depends on how much compute each one uses.
                 </div>

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -18,6 +18,7 @@ import QuotaLine from '@/components/QuotaLine'
 import { Skeleton } from '@/components/ui/skeleton'
 import { OrganizationTier } from '@/billing-api/billingApiClient'
 import { UserProfileIdentity } from './LinkedAccounts'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 
 const Limits: React.FC = () => {
   const { user } = useAuth()
@@ -91,8 +92,7 @@ const Limits: React.FC = () => {
     return (
       <div className="flex items-center gap-1">
         <span className={isHighUsage ? 'text-red-500' : undefined}>
-          {current}/{total}
-          {unit}
+          {current} / {total} {unit}
         </span>
         {isHighUsage && <AlertTriangle className="w-4 h-4 text-red-500" />}
       </div>
@@ -118,7 +118,7 @@ const Limits: React.FC = () => {
             Usage Limits{' '}
             {organizationTier && (
               <Badge variant="outline" className="ml-2 text-sm">
-                Current Tier: {organizationTier.tier}
+                Tier {organizationTier.tier}
               </Badge>
             )}
           </CardTitle>
@@ -134,31 +134,74 @@ const Limits: React.FC = () => {
             </div>
           )}
           {usageOverview && (
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <div className="flex items-center justify-between mb-1 mt-3">
-                  <span>vCPU:</span>
-                  {getUsageDisplay(usageOverview.currentCpuUsage, usageOverview.totalCpuQuota)}
-                </div>
-                <QuotaLine current={usageOverview.currentCpuUsage} total={usageOverview.totalCpuQuota} />
-              </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Resource</TableHead>
+                  <TableHead>Usage</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Compute</TableCell>
+                  <TableCell>
+                    <div className="max-w-80">
+                      <div className="w-full flex justify-end">
+                        {getUsageDisplay(usageOverview.currentCpuUsage, usageOverview.totalCpuQuota, 'vCPU')}
+                      </div>
+                      <QuotaLine current={usageOverview.currentCpuUsage} total={usageOverview.totalCpuQuota} />
+                    </div>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Memory</TableCell>
+                  <TableCell>
+                    <div className="max-w-80">
+                      <div className="w-full flex justify-end">
+                        {getUsageDisplay(usageOverview.currentMemoryUsage, usageOverview.totalMemoryQuota, 'GiB')}
+                      </div>
+                      <QuotaLine current={usageOverview.currentMemoryUsage} total={usageOverview.totalMemoryQuota} />
+                    </div>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Storage</TableCell>
+                  <TableCell>
+                    <div className="max-w-80">
+                      <div className="w-full flex justify-end">
+                        {getUsageDisplay(usageOverview.currentDiskUsage, usageOverview.totalDiskQuota, 'GiB')}
+                      </div>
+                      <QuotaLine current={usageOverview.currentDiskUsage} total={usageOverview.totalDiskQuota} />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+            // <div className="grid grid-cols-2 gap-4">
+            //   <div>
+            //     <div className="flex items-center justify-between mb-1 mt-3">
+            //       <span>Compute</span>
+            //       {getUsageDisplay(usageOverview.currentCpuUsage, usageOverview.totalCpuQuota, ' vCPU')}
+            //     </div>
+            //     <QuotaLine current={usageOverview.currentCpuUsage} total={usageOverview.totalCpuQuota} />
+            //   </div>
 
-              <div>
-                <div className="flex items-center justify-between mb-1 mt-3">
-                  <span>Memory:</span>
-                  {getUsageDisplay(usageOverview.currentMemoryUsage, usageOverview.totalMemoryQuota, 'GB')}
-                </div>
-                <QuotaLine current={usageOverview.currentMemoryUsage} total={usageOverview.totalMemoryQuota} />
-              </div>
+            //   <div>
+            //     <div className="flex items-center justify-between mb-1 mt-3">
+            //       <span>Memory:</span>
+            //       {getUsageDisplay(usageOverview.currentMemoryUsage, usageOverview.totalMemoryQuota, 'GB')}
+            //     </div>
+            //     <QuotaLine current={usageOverview.currentMemoryUsage} total={usageOverview.totalMemoryQuota} />
+            //   </div>
 
-              <div>
-                <div className="flex items-center justify-between mb-1 mt-3">
-                  <span>Disk:</span>
-                  {getUsageDisplay(usageOverview.currentDiskUsage, usageOverview.totalDiskQuota, 'GB')}
-                </div>
-                <QuotaLine current={usageOverview.currentDiskUsage} total={usageOverview.totalDiskQuota} />
-              </div>
-            </div>
+            //   <div>
+            //     <div className="flex items-center justify-between mb-1 mt-3">
+            //       <span>Disk:</span>
+            //       {getUsageDisplay(usageOverview.currentDiskUsage, usageOverview.totalDiskQuota, 'GB')}
+            //     </div>
+            //     <QuotaLine current={usageOverview.currentDiskUsage} total={usageOverview.totalDiskQuota} />
+            //   </div>
+            // </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
# Limit Display Update

## Description

Minor style updates to the limits page.
- updated units to `vCPU`, `GiB` in the usage list
- changed the style of the usage display
- changed `Current Tier:` to `Tier`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1954 
Closes #1953 

## Screenshots

![Screenshot 2025-05-27 at 17 42 31](https://github.com/user-attachments/assets/02ce458d-d54e-496f-b0d8-8a35e2683151)