### PR TITLE
feat(dashboard): minimum $10 automatic top up and billing label updates

### DIFF
--- a/apps/dashboard/src/components/UsageChart.tsx
+++ b/apps/dashboard/src/components/UsageChart.tsx
@@ -81,7 +81,7 @@ export function UsageChart({ usageData, showTotal, title }: UsageChartProps) {
   const chartConfig = useMemo(() => {
     const mapped: Record<string, { label: string; color: string }> = {
       diskGB: {
-        label: 'Disk',
+        label: 'Storage',
         color: 'hsl(var(--chart-1))',
       },
       ramGB: {
@@ -119,7 +119,7 @@ export function UsageChart({ usageData, showTotal, title }: UsageChartProps) {
               value: 'cpu',
             },
             {
-              label: 'Disk',
+              label: 'Storage',
               value: 'diskGB',
             },
             // {

--- a/apps/dashboard/src/pages/Billing.tsx
+++ b/apps/dashboard/src/pages/Billing.tsx
@@ -260,7 +260,14 @@ const Billing = () => {
                       <strong>Target</strong> is the amount of credit you want to have in your account after they are
                       automatically topped up. The target must always be greater than the threshold.
                     </div>
-                    <div>Setting both values to 0 will disable automatic top ups.</div>
+                    <div>
+                      Setting both values to 0 will disable automatic top ups.
+                      <br />
+                      The threshold must always be less than the target.
+                    </div>
+                    <div>
+                      <strong>Note:</strong> Target must be at least $10 more than the threshold.
+                    </div>
                   </div>
                 }
               />
@@ -272,15 +279,15 @@ const Billing = () => {
                 <CardDescription>
                   <div className="flex flex-col gap-6">
                     <div className="flex justify-between items-end">
-                      <Label>Threshold</Label>
+                      <Label>Threshold ($)</Label>
                       <Input
                         type="number"
                         className="w-24"
                         value={automaticTopUp?.thresholdAmount ?? 0}
                         onChange={(e) => {
                           let targetAmount = automaticTopUp?.targetAmount ?? 0
-                          if (Number(e.target.value) > targetAmount) {
-                            targetAmount = Number(e.target.value)
+                          if (Number(e.target.value) > targetAmount - 10) {
+                            targetAmount = Number(e.target.value) + 10
                           }
 
                           setAutomaticTopUp({
@@ -299,8 +306,8 @@ const Billing = () => {
                       value={automaticTopUp?.thresholdAmount ? [automaticTopUp.thresholdAmount] : undefined}
                       onValueChange={(value) => {
                         let targetAmount = automaticTopUp?.targetAmount ?? 0
-                        if (value[0] > targetAmount) {
-                          targetAmount = value[0]
+                        if (value[0] > targetAmount - 10) {
+                          targetAmount = value[0] + 10
                         }
 
                         setAutomaticTopUp({
@@ -310,7 +317,7 @@ const Billing = () => {
                       }}
                     />
                     <div className="flex justify-between items-end">
-                      <Label>Target</Label>
+                      <Label>Target ($)</Label>
                       <Input
                         type="number"
                         className="w-24"
@@ -341,7 +348,11 @@ const Billing = () => {
                       value={automaticTopUp?.targetAmount ? [automaticTopUp.targetAmount] : undefined}
                       onValueChange={(value) => {
                         const thresholdAmount = automaticTopUp?.thresholdAmount ?? 0
-                        if (value[0] < thresholdAmount) {
+                        if (value[0] <= 10 && value[0] < thresholdAmount) {
+                          return
+                        }
+
+                        if (value[0] > 10 && value[0] < thresholdAmount + 10) {
                           return
                         }
 

--- a/apps/dashboard/src/pages/Billing.tsx
+++ b/apps/dashboard/src/pages/Billing.tsx
@@ -177,9 +177,9 @@ const Billing = () => {
             ) : (
               <CardDescription className="flex flex-col justify-between h-full">
                 <div>
-                  <div className="text-2xl font-bold">Balance: ${(wallet.balanceCents / 100).toFixed(2)}</div>
+                  <div className="text-2xl font-bold">Balance: ${(wallet.ongoingBalanceCents / 100).toFixed(2)}</div>
                   <div className="text-xl font-bold my-2">
-                    Spent: ${((wallet.balanceCents - wallet.ongoingBalanceCents) / 100).toFixed(2)}
+                    Spent this month: ${((wallet.balanceCents - wallet.ongoingBalanceCents) / 100).toFixed(2)}
                   </div>
                 </div>
                 {!user?.profile.email_verified && (
@@ -258,16 +258,10 @@ const Billing = () => {
                     </div>
                     <div>
                       <strong>Target</strong> is the amount of credit you want to have in your account after they are
-                      automatically topped up. The target must always be greater than the threshold.
+                      automatically topped up. The target must always be greater than the threshold by{' '}
+                      <strong>at least $10</strong>.
                     </div>
-                    <div>
-                      Setting both values to 0 will disable automatic top ups.
-                      <br />
-                      The threshold must always be less than the target.
-                    </div>
-                    <div>
-                      <strong>Note:</strong> Target must be at least $10 more than the threshold.
-                    </div>
+                    <div>Setting both values to 0 will disable automatic top ups.</div>
                   </div>
                 }
               />


### PR DESCRIPTION
# Minimum $10 Automatic Top Up and Billing Label Updates

## Description

Added a minimum $10 automatic top up and updated billing labels:
- Disk to Storage in the Breakdown Chart
- Balance now shows the ongoing balance
- `Spent this month` added below

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
![Screenshot 2025-05-28 at 11 46 57](https://github.com/user-attachments/assets/e91b75e1-6860-4a59-ba81-88e3cb5e9ab3)
