### PR TITLE
feat(api): close and reopen usage periods after 24h

### DIFF
--- a/apps/api/src/usage/entities/workspace-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/workspace-usage-period.entity.ts
@@ -37,4 +37,18 @@ export class WorkspaceUsagePeriod {
 
   @Column()
   region: string
+
+  public static fromUsagePeriod(usagePeriod: WorkspaceUsagePeriod) {
+    const usagePeriodEntity = new WorkspaceUsagePeriod()
+    usagePeriodEntity.workspaceId = usagePeriod.workspaceId
+    usagePeriodEntity.organizationId = usagePeriod.organizationId
+    usagePeriodEntity.startAt = usagePeriod.startAt
+    usagePeriodEntity.endAt = usagePeriod.endAt
+    usagePeriodEntity.cpu = usagePeriod.cpu
+    usagePeriodEntity.gpu = usagePeriod.gpu
+    usagePeriodEntity.mem = usagePeriod.mem
+    usagePeriodEntity.disk = usagePeriod.disk
+    usagePeriodEntity.region = usagePeriod.region
+    return usagePeriodEntity
+  }
 }

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -5,7 +5,7 @@
 
 import { Injectable, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { LessThan, Not, Repository } from 'typeorm'
+import { IsNull, LessThan, Not, Repository } from 'typeorm'
 import { WorkspaceUsagePeriod } from '../entities/workspace-usage-period.entity'
 import { OnEvent } from '@nestjs/event-emitter'
 import { WorkspaceStateUpdatedEvent } from '../../workspace/events/workspace-state-updated.event'
@@ -93,7 +93,7 @@ export class UsageService {
 
     const usagePeriods = await this.workspaceUsagePeriodRepository.find({
       where: {
-        endAt: null,
+        endAt: IsNull(),
         // 1 day ago
         startAt: LessThan(new Date(Date.now() - 1000 * 60 * 60 * 24)),
         organizationId: Not(WORKSPACE_WARM_POOL_UNASSIGNED_ORGANIZATION),

--- a/apps/api/src/usage/usage.module.ts
+++ b/apps/api/src/usage/usage.module.ts
@@ -7,10 +7,11 @@ import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { WorkspaceUsagePeriod } from './entities/workspace-usage-period.entity'
 import { UsageService } from './services/usage.service'
+import { RedisLockProvider } from '../workspace/common/redis-lock.provider'
 
 @Module({
   imports: [TypeOrmModule.forFeature([WorkspaceUsagePeriod])],
-  providers: [UsageService],
+  providers: [UsageService, RedisLockProvider],
   exports: [UsageService],
 })
 export class UsageModule {}


### PR DESCRIPTION
# Close and Reopen Usage Periods After 24h

## Description

Closing and reopening usage periods after 24h makes the billing more accurate while not affecting the usage metrics in the API itself.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
