### PR TITLE
feat(dashboard): enable clickable sandboxes with detailed info modal

### DIFF
--- a/apps/dashboard/src/components/SandboxInfoModal.tsx
+++ b/apps/dashboard/src/components/SandboxInfoModal.tsx
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import React, { useState } from 'react'
+import { Copy, Check } from 'lucide-react'
+import { Workspace } from '@daytonaio/api-client'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+
+interface SandboxInfoModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  sandbox: Workspace | null
+}
+
+export const SandboxInfoModal: React.FC<SandboxInfoModalProps> = ({ open, onOpenChange, sandbox }) => {
+  const [copied, setCopied] = useState(false)
+
+  if (!sandbox) return null
+
+  const getProviderMetadata = (metadata: string | undefined) => {
+    if (!metadata) return null
+    try {
+      return JSON.parse(metadata)
+    } catch (e) {
+      console.error('Error parsing provider metadata:', e)
+      return null
+    }
+  }
+
+  const formatSandboxInfo = (sandbox: Workspace) => {
+    const parsed = getProviderMetadata(sandbox.info?.providerMetadata)
+
+    return {
+      id: sandbox.id,
+      name: sandbox.name,
+      organizationId: sandbox.organizationId,
+      state: sandbox.state,
+      target: sandbox.target,
+      image: sandbox.image,
+      user: sandbox.user,
+      cpu: sandbox.cpu,
+      gpu: sandbox.gpu,
+      memory: sandbox.memory,
+      disk: sandbox.disk,
+      public: sandbox.public,
+      env: sandbox.env,
+      labels: sandbox.labels,
+      volumes: sandbox.volumes,
+      errorReason: sandbox.errorReason,
+      snapshotState: sandbox.snapshotState,
+      snapshotCreatedAt: sandbox.snapshotCreatedAt,
+      autoStopInterval: sandbox.autoStopInterval,
+      created: sandbox.info?.created,
+      providerMetadata: {
+        nodeDomain: parsed?.nodeDomain,
+        region: parsed?.region,
+        class: parsed?.class,
+        updatedAt: parsed?.updatedAt,
+      },
+    }
+  }
+
+  const copyToClipboard = async () => {
+    try {
+      const sandboxInfo = formatSandboxInfo(sandbox)
+      const formattedText = JSON.stringify(sandboxInfo, null, 2)
+      await navigator.clipboard.writeText(formattedText)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy to clipboard:', err)
+    }
+  }
+
+  const getStateColor = (state?: string) => {
+    switch (state) {
+      case 'started':
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 border-green-300 dark:border-green-700'
+      case 'error':
+      case 'stopped':
+        return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300 border-red-300 dark:border-red-700'
+      case 'archiving':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300 border-yellow-300 dark:border-yellow-700'
+      case 'archived':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300 border-blue-300 dark:border-blue-700'
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300 border-gray-300 dark:border-gray-700'
+    }
+  }
+
+  const formatLabels = (labels?: { [key: string]: string }) => {
+    if (!labels || Object.keys(labels).length === 0) return 'None'
+    return Object.entries(labels)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ')
+  }
+
+  const formatEnv = (env?: { [key: string]: string }) => {
+    if (!env || Object.keys(env).length === 0) return 'None'
+    return Object.entries(env)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(', ')
+  }
+
+  const formatVolumes = (volumes?: Array<{ volumeId: string; mountPath: string }>) => {
+    if (!volumes || volumes.length === 0) return 'None'
+    return volumes.map((volume) => `${volume.volumeId} → ${volume.mountPath}`).join(', ')
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-6xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Sandbox Information</DialogTitle>
+          <DialogDescription>Detailed information about sandbox {sandbox.id}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Left Column */}
+          <div className="space-y-4">
+            {/* Basic Information */}
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Basic Information</h3>
+              <div className="grid grid-cols-[100px_1fr] gap-2 text-sm">
+                <span className="text-muted-foreground">ID:</span>
+                <span className="font-mono break-all">{sandbox.id}</span>
+
+                <span className="text-muted-foreground">Name:</span>
+                <span>{sandbox.name}</span>
+
+                <span className="text-muted-foreground">Org ID:</span>
+                <span className="font-mono break-all">{sandbox.organizationId}</span>
+
+                <span className="text-muted-foreground">State:</span>
+                <span
+                  className={`inline-flex items-center px-2 py-1 rounded-md text-xs font-medium border w-fit ${getStateColor(sandbox.state)}`}
+                >
+                  {sandbox.state?.charAt(0).toUpperCase() + (sandbox.state?.slice(1) || '')}
+                </span>
+
+                <span className="text-muted-foreground">Target:</span>
+                <span>{sandbox.target}</span>
+
+                <span className="text-muted-foreground">User:</span>
+                <span>{sandbox.user}</span>
+
+                <span className="text-muted-foreground">Image:</span>
+                <span className="font-mono break-all">{sandbox.image || 'Not specified'}</span>
+
+                <span className="text-muted-foreground">Public:</span>
+                <span>{sandbox.public ? 'Yes' : 'No'}</span>
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Resources */}
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Resources</h3>
+              <div className="grid grid-cols-[100px_1fr] gap-2 text-sm">
+                <span className="text-muted-foreground">CPU:</span>
+                <span>{sandbox.cpu ? `${sandbox.cpu} cores` : 'Not specified'}</span>
+
+                <span className="text-muted-foreground">Memory:</span>
+                <span>{sandbox.memory ? `${sandbox.memory} GB` : 'Not specified'}</span>
+
+                <span className="text-muted-foreground">Disk:</span>
+                <span>{sandbox.disk ? `${sandbox.disk} GB` : 'Not specified'}</span>
+
+                <span className="text-muted-foreground">GPU:</span>
+                <span>{sandbox.gpu ? `${sandbox.gpu} units` : 'Not specified'}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Right Column */}
+          <div className="space-y-4">
+            {/* Configuration */}
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Configuration</h3>
+              <div className="grid grid-cols-[100px_1fr] gap-2 text-sm">
+                <span className="text-muted-foreground">Labels:</span>
+                <span className="break-words">{formatLabels(sandbox.labels)}</span>
+
+                <span className="text-muted-foreground">Environment:</span>
+                <span className="break-words font-mono">{formatEnv(sandbox.env)}</span>
+
+                <span className="text-muted-foreground">Volumes:</span>
+                <span className="break-words font-mono">{formatVolumes(sandbox.volumes)}</span>
+
+                <span className="text-muted-foreground">Auto-stop:</span>
+                <span>{sandbox.autoStopInterval ? `${sandbox.autoStopInterval} minutes` : 'Disabled'}</span>
+              </div>
+            </div>
+
+            {/* Error Information */}
+            {sandbox.errorReason && (
+              <>
+                <Separator />
+                <div>
+                  <h3 className="text-sm font-semibold mb-2 text-red-600 dark:text-red-400">Error Information</h3>
+                  <div className="text-sm">
+                    <span className="text-red-600 dark:text-red-400 break-words">{sandbox.errorReason}</span>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter className="flex-col sm:flex-row gap-2">
+          <Button onClick={copyToClipboard} className="flex items-center gap-2">
+            {copied ? (
+              <>
+                <Check className="w-4 h-4" />
+                Copied!
+              </>
+            ) : (
+              <>
+                <Copy className="w-4 h-4" />
+                Copy to Clipboard
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dashboard/src/components/WorkspaceTable.tsx
+++ b/apps/dashboard/src/components/WorkspaceTable.tsx
@@ -60,6 +60,7 @@ interface DataTableProps {
   handleDelete: (id: string) => void
   handleBulkDelete: (ids: string[]) => void
   handleArchive: (id: string) => void
+  onRowClick?: (workspace: Workspace) => void
 }
 
 export function WorkspaceTable({
@@ -71,6 +72,7 @@ export function WorkspaceTable({
   handleDelete,
   handleBulkDelete,
   handleArchive,
+  onRowClick,
 }: DataTableProps) {
   const { authenticatedUserHasPermission } = useSelectedOrganization()
 
@@ -188,7 +190,17 @@ export function WorkspaceTable({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && 'selected'}
-                  className={`${loadingWorkspaces[row.original.id] || row.original.state === WorkspaceState.DESTROYING ? 'opacity-50 pointer-events-none' : ''}`}
+                  className={`${loadingWorkspaces[row.original.id] || row.original.state === WorkspaceState.DESTROYING ? 'opacity-50 pointer-events-none' : ''} ${onRowClick ? 'cursor-pointer hover:bg-muted/50' : ''}`}
+                  onClick={(e) => {
+                    // Don't trigger row click if clicking on interactive elements
+                    const target = e.target as HTMLElement
+                    const isInteractiveElement = target.closest(
+                      'button, a, input, [role="checkbox"], [data-radix-collection-item]',
+                    )
+                    if (!isInteractiveElement && onRowClick) {
+                      onRowClick(row.original)
+                    }
+                  }}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
@@ -645,7 +657,7 @@ const getColumns = ({
         return (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-8 w-8 p-0">
+              <Button variant="ghost" className="h-8 w-8 p-0" onClick={(e) => e.stopPropagation()}>
                 <span className="sr-only">Open menu</span>
                 <MoreHorizontal />
               </Button>

--- a/apps/dashboard/src/pages/Workspaces.tsx
+++ b/apps/dashboard/src/pages/Workspaces.tsx
@@ -8,6 +8,7 @@ import { useApi } from '@/hooks/useApi'
 import { OrganizationSuspendedError } from '@/api/errors'
 import { OrganizationUserRoleEnum, Workspace, WorkspaceState } from '@daytonaio/api-client'
 import { WorkspaceTable } from '@/components/WorkspaceTable'
+import { SandboxInfoModal } from '@/components/SandboxInfoModal'
 import {
   Dialog,
   DialogClose,
@@ -39,6 +40,8 @@ const Workspaces: React.FC = () => {
   const [loadingTable, setLoadingTable] = useState(true)
   const [workspaceToDelete, setWorkspaceToDelete] = useState<string | null>(null)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [selectedWorkspace, setSelectedWorkspace] = useState<Workspace | null>(null)
+  const [showInfoModal, setShowInfoModal] = useState(false)
 
   const navigate = useNavigate()
 
@@ -264,6 +267,11 @@ const Workspaces: React.FC = () => {
     onboardIfNeeded()
   }, [navigate, user, selectedOrganization, apiKeyApi])
 
+  const handleRowClick = (workspace: Workspace) => {
+    setSelectedWorkspace(workspace)
+    setShowInfoModal(true)
+  }
+
   return (
     <div className="p-6">
       <div className="mb-6">
@@ -294,6 +302,7 @@ const Workspaces: React.FC = () => {
         handleArchive={handleArchive}
         data={workspaces}
         loading={loadingTable}
+        onRowClick={handleRowClick}
       />
 
       {workspaceToDelete && (
@@ -329,6 +338,19 @@ const Workspaces: React.FC = () => {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+      )}
+
+      {selectedWorkspace && (
+        <SandboxInfoModal
+          open={showInfoModal}
+          onOpenChange={(isOpen) => {
+            setShowInfoModal(isOpen)
+            if (!isOpen) {
+              setSelectedWorkspace(null)
+            }
+          }}
+          sandbox={selectedWorkspace}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Description:

This PR introduces a new feature to the Sandbox dashboard that allows users to click on individual Sandbox rows to view detailed information in a modal. The implementation improves the user experience, enhances accessibility, and supports the support team's workflow with a copy-to-clipboard feature.

**Changes Made:**

1. `WorkspaceTable.tsx:`
 - Added `onRowClick` to support click handling.
 - Added logic to ignore clicks on interactive elements (buttons, checkboxes, links).

2. Added New File `SandboxInfoModal.tsx:`
- Displays detailed, categorized information such as Basic Info, Resources, Configuration and many more.
- Includes `Copy to Clipboard` for support team use.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1774 

## Screenshots/ScreenRecording:


https://github.com/user-attachments/assets/ec2dbff4-bb58-4dab-8af3-d3c5c462520d

## Notes

Users can click on any Sandbox row in the dashboard to view detailed information in a modal, and easily copy all the information to share with the support team.