### PR TITLE
feat(ui): add always-visible theme toggle

### DIFF
--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -198,6 +198,16 @@ export function Sidebar() {
               </TooltipProvider>
             </SidebarMenuItem>
           )}
+          <SidebarMenuItem key="theme-toggle">
+            <SidebarMenuButton
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              className="text-xs h-8 py-0"
+              title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {theme === 'dark' ? <Sun className="!w-4 !h-4" /> : <Moon className="!w-4 !h-4" />}
+              <span>{theme === 'dark' ? 'Light mode' : 'Dark mode'}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
           <SidebarMenuItem key="slack">
             <SidebarMenuButton asChild>
               <a href={DAYTONA_SLACK_URL} className="text-xs h-8 py-0" target="_blank" rel="noopener noreferrer">
@@ -260,16 +270,6 @@ export function Sidebar() {
                         {organizationInvitationsCount}
                       </span>
                     )}
-                  </Button>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Button
-                    variant="ghost"
-                    className="w-full cursor-pointer justify-start"
-                    onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-                  >
-                    {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
-                    {theme === 'dark' ? 'Light mode' : 'Dark mode'}
                   </Button>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>


### PR DESCRIPTION
## Description:

This PR enhances theme toggle accessibility and streamlines the UI by:

- Adding the theme toggle to the `SidebarMenu` for easier access.
- Making the toggle always visible, so users no longer need to search for it or click through the user dropdown.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #1870 

## Screenshots

![Screenshot 2025-06-02 at 10 35 39 AM](https://github.com/user-attachments/assets/5b244cb0-9147-46da-8c2b-dafc02af5497)
![Screenshot 2025-06-02 at 10 35 57 AM](https://github.com/user-attachments/assets/0371b04c-1742-4e65-be52-0b452d5ac594)


## Notes

**This implementation gives much better visibility to the theme toggle feature. Users can see and access it easily without having to open any dropdown menus, making it just a single click to change themes.**