### PR TITLE
refactor(runner): rename daemon binary on init

### DIFF
--- a/apps/runner/pkg/daemon/util.go
+++ b/apps/runner/pkg/daemon/util.go
@@ -25,7 +25,7 @@ func WriteDaemonBinary() (string, error) {
 		return "", err
 	}
 
-	daemonPath := filepath.Join(tmpBinariesDir, "daemon-amd64")
+	daemonPath := filepath.Join(tmpBinariesDir, "daytona")
 	_, err = os.Stat(daemonPath)
 	if err != nil && !os.IsNotExist(err) {
 		return "", err


### PR DESCRIPTION
# Rename daemon binary on init

## Description

This PR introduces refactor where daemon binary is renamed to daytona for backward compatibility

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
