### PR TITLE
fix(daemon): get session command exit code

### DIFF
--- a/apps/daemon/pkg/toolbox/process/session/session.go
+++ b/apps/daemon/pkg/toolbox/process/session/session.go
@@ -186,6 +186,9 @@ func (s *SessionController) getSessionCommand(sessionId, cmdId string) (*Command
 	_, exitCodeFilePath := command.LogFilePath(session.Dir(s.configDir))
 	exitCode, err := os.ReadFile(exitCodeFilePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return command, nil
+		}
 		return nil, errors.New("failed to read exit code file")
 	}
 


### PR DESCRIPTION
# Get Session Command Exit Code fix

## Description

If the exit code file is missing, it means that the command is still running so we can return it without an exit code.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
