### PR TITLE
fix(api): don't query errored workspaces for org suspension

### DIFF
--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -319,6 +319,7 @@ export class OrganizationService implements OnModuleInit {
       where: {
         organizationId: In(suspendedOrganizationIds),
         desiredState: WorkspaceDesiredState.STARTED,
+        state: Not(WorkspaceState.ERROR),
       },
     })
 


### PR DESCRIPTION
# Don't query errored workspaces for org suspension

## Description

Query only non-errored workspaces.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
