### PR TITLE
fix(api): add missing nullable api property option for volume lastUsedAt 

### DIFF
--- a/apps/api/src/workspace/dto/image.dto.ts
+++ b/apps/api/src/workspace/dto/image.dto.ts
@@ -45,7 +45,7 @@ export class ImageDto {
   updatedAt: Date
 
   @ApiProperty({ nullable: true })
-  lastUsedAt: Date
+  lastUsedAt?: Date
 
   static fromImage(image: Image): ImageDto {
     return {

--- a/apps/api/src/workspace/dto/volume.dto.ts
+++ b/apps/api/src/workspace/dto/volume.dto.ts
@@ -51,6 +51,7 @@ export class VolumeDto {
   @ApiProperty({
     description: 'Last used timestamp',
     example: '2023-01-01T00:00:00.000Z',
+    nullable: true,
   })
   lastUsedAt: string
 

--- a/apps/api/src/workspace/dto/volume.dto.ts
+++ b/apps/api/src/workspace/dto/volume.dto.ts
@@ -53,7 +53,7 @@ export class VolumeDto {
     example: '2023-01-01T00:00:00.000Z',
     nullable: true,
   })
-  lastUsedAt: string
+  lastUsedAt?: string
 
   @ApiProperty({
     description: 'The error reason of the volume',

--- a/apps/api/src/workspace/entities/image.entity.ts
+++ b/apps/api/src/workspace/entities/image.entity.ts
@@ -70,7 +70,7 @@ export class Image {
   updatedAt: Date
 
   @Column({ nullable: true })
-  lastUsedAt: Date
+  lastUsedAt?: Date
 
   @ManyToOne(() => BuildInfo, (buildInfo) => buildInfo.images, {
     nullable: true,

--- a/apps/api/src/workspace/entities/volume.entity.ts
+++ b/apps/api/src/workspace/entities/volume.entity.ts
@@ -38,7 +38,7 @@ export class Volume {
   updatedAt: Date
 
   @Column({ nullable: true })
-  lastUsedAt: Date
+  lastUsedAt?: Date
 
   public getBucketName(): string {
     return `daytona-volume-${this.id}`

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -6304,6 +6304,7 @@ components:
         lastUsedAt:
           description: Last used timestamp
           example: 2023-01-01T00:00:00.000Z
+          nullable: true
           type: string
         errorReason:
           description: The error reason of the volume

--- a/libs/api-client-go/model_volume_dto.go
+++ b/libs/api-client-go/model_volume_dto.go
@@ -35,7 +35,7 @@ type VolumeDto struct {
 	// Last update timestamp
 	UpdatedAt string `json:"updatedAt"`
 	// Last used timestamp
-	LastUsedAt string `json:"lastUsedAt"`
+	LastUsedAt NullableString `json:"lastUsedAt"`
 	// The error reason of the volume
 	ErrorReason NullableString `json:"errorReason"`
 }
@@ -46,7 +46,7 @@ type _VolumeDto VolumeDto
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewVolumeDto(id string, name string, organizationId string, state VolumeState, createdAt string, updatedAt string, lastUsedAt string, errorReason NullableString) *VolumeDto {
+func NewVolumeDto(id string, name string, organizationId string, state VolumeState, createdAt string, updatedAt string, lastUsedAt NullableString, errorReason NullableString) *VolumeDto {
 	this := VolumeDto{}
 	this.Id = id
 	this.Name = name
@@ -212,27 +212,29 @@ func (o *VolumeDto) SetUpdatedAt(v string) {
 }
 
 // GetLastUsedAt returns the LastUsedAt field value
+// If the value is explicit nil, the zero value for string will be returned
 func (o *VolumeDto) GetLastUsedAt() string {
-	if o == nil {
+	if o == nil || o.LastUsedAt.Get() == nil {
 		var ret string
 		return ret
 	}
 
-	return o.LastUsedAt
+	return *o.LastUsedAt.Get()
 }
 
 // GetLastUsedAtOk returns a tuple with the LastUsedAt field value
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *VolumeDto) GetLastUsedAtOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.LastUsedAt, true
+	return o.LastUsedAt.Get(), o.LastUsedAt.IsSet()
 }
 
 // SetLastUsedAt sets field value
 func (o *VolumeDto) SetLastUsedAt(v string) {
-	o.LastUsedAt = v
+	o.LastUsedAt.Set(&v)
 }
 
 // GetErrorReason returns the ErrorReason field value
@@ -277,7 +279,7 @@ func (o VolumeDto) ToMap() (map[string]interface{}, error) {
 	toSerialize["state"] = o.State
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
-	toSerialize["lastUsedAt"] = o.LastUsedAt
+	toSerialize["lastUsedAt"] = o.LastUsedAt.Get()
 	toSerialize["errorReason"] = o.ErrorReason.Get()
 	return toSerialize, nil
 }

--- a/libs/api-client-python-async/daytona_api_client_async/models/volume_dto.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/volume_dto.py
@@ -34,7 +34,7 @@ class VolumeDto(BaseModel):
     state: VolumeState = Field(description="Volume state")
     created_at: StrictStr = Field(description="Creation timestamp", alias="createdAt")
     updated_at: StrictStr = Field(description="Last update timestamp", alias="updatedAt")
-    last_used_at: StrictStr = Field(description="Last used timestamp", alias="lastUsedAt")
+    last_used_at: Optional[StrictStr] = Field(description="Last used timestamp", alias="lastUsedAt")
     error_reason: Optional[StrictStr] = Field(description="The error reason of the volume", alias="errorReason")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id", "name", "organizationId", "state", "createdAt", "updatedAt", "lastUsedAt", "errorReason"]
@@ -84,6 +84,11 @@ class VolumeDto(BaseModel):
         if self.additional_properties is not None:
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
+
+        # set to None if last_used_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.last_used_at is None and "last_used_at" in self.model_fields_set:
+            _dict['lastUsedAt'] = None
 
         # set to None if error_reason (nullable) is None
         # and model_fields_set contains the field

--- a/libs/api-client-python/daytona_api_client/models/volume_dto.py
+++ b/libs/api-client-python/daytona_api_client/models/volume_dto.py
@@ -36,7 +36,7 @@ class VolumeDto(BaseModel):
     state: VolumeState = Field(description="Volume state")
     created_at: StrictStr = Field(description="Creation timestamp", alias="createdAt")
     updated_at: StrictStr = Field(description="Last update timestamp", alias="updatedAt")
-    last_used_at: StrictStr = Field(description="Last used timestamp", alias="lastUsedAt")
+    last_used_at: Optional[StrictStr] = Field(description="Last used timestamp", alias="lastUsedAt")
     error_reason: Optional[StrictStr] = Field(description="The error reason of the volume", alias="errorReason")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = [
@@ -96,6 +96,11 @@ class VolumeDto(BaseModel):
         if self.additional_properties is not None:
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
+
+        # set to None if last_used_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.last_used_at is None and "last_used_at" in self.model_fields_set:
+            _dict["lastUsedAt"] = None
 
         # set to None if error_reason (nullable) is None
         # and model_fields_set contains the field

--- a/libs/api-client/src/models/volume-dto.ts
+++ b/libs/api-client/src/models/volume-dto.ts
@@ -63,7 +63,7 @@ export interface VolumeDto {
    * @type {string}
    * @memberof VolumeDto
    */
-  lastUsedAt: string
+  lastUsedAt: string | null
   /**
    * The error reason of the volume
    * @type {string}


### PR DESCRIPTION
## Description

Adds missing nullable API property option for `VolumeDto.lastUsedAt`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
