### PR TITLE
fix: image push uninteractive and entrypoint flag

### DIFF
--- a/apps/cli/cmd/image/push.go
+++ b/apps/cli/cmd/image/push.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/daytonaio/daytona/cli/apiclient"
@@ -107,6 +108,10 @@ var PushCmd = &cobra.Command{
 			Name: targetImage,
 		}
 
+		if entrypointFlag != "" {
+			createImage.Entrypoint = strings.Split(entrypointFlag, " ")
+		}
+
 		// Poll until the image is really available on the registry
 		// This is a workaround for harbor's delay in making newly created images available
 		for {
@@ -135,4 +140,8 @@ var PushCmd = &cobra.Command{
 		views_common.RenderInfoMessage(fmt.Sprintf("%s  Use '%s' to create a new sandbox using this image", views_common.Checkmark, targetImage))
 		return nil
 	},
+}
+
+func init() {
+	PushCmd.Flags().StringVarP(&entrypointFlag, "entrypoint", "e", "", "The entrypoint command for the image")
 }

--- a/apps/cli/views/util/spinner.go
+++ b/apps/cli/views/util/spinner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/cli/views/common"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/term"
 )
 
 var isAborted bool
@@ -57,14 +58,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func WithSpinner(message string, fn func() error) error {
-	p := start(message, false)
-	defer stop(p)
+	if isTTY() {
+		p := start(message, false)
+		defer stop(p)
+	}
 	return fn()
 }
 
 func WithInlineSpinner(message string, fn func() error) error {
-	p := start(message, true)
-	defer stop(p)
+	if isTTY() {
+		p := start(message, true)
+		defer stop(p)
+	}
 	return fn()
 }
 
@@ -110,4 +115,8 @@ func (m model) View() string {
 	}
 
 	return str
+}
+
+func isTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }


### PR DESCRIPTION
# Image push uninteractive and entrypoint flag
## Description

Fixes a spinner bug when using calling `image push` uninteractively
Also adds an `entrypoint` flag

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #1997 
Closes #2004 