### PR TITLE
feat(api,dashboard): expiring api keys 

### DIFF
--- a/apps/api/src/api-key/api-key.controller.ts
+++ b/apps/api/src/api-key/api-key.controller.ts
@@ -49,6 +49,7 @@ export class ApiKeyController {
       authContext.userId,
       createApiKeyDto.name,
       createApiKeyDto.permissions,
+      createApiKeyDto.expiresAt,
     )
 
     return ApiKeyResponseDto.fromApiKey(apiKey, value)

--- a/apps/api/src/api-key/api-key.entity.ts
+++ b/apps/api/src/api-key/api-key.entity.ts
@@ -44,4 +44,7 @@ export class ApiKey {
 
   @Column({ nullable: true })
   lastUsedAt?: Date
+
+  @Column({ nullable: true })
+  expiresAt?: Date
 }

--- a/apps/api/src/api-key/api-key.service.ts
+++ b/apps/api/src/api-key/api-key.service.ts
@@ -44,6 +44,7 @@ export class ApiKeyService {
     userId: string,
     name: string,
     permissions: OrganizationResourcePermission[],
+    expiresAt?: Date,
   ): Promise<{ apiKey: ApiKey; value: string }> {
     const existingKey = await this.apiKeyRepository.findOne({ where: { organizationId, userId, name } })
     if (existingKey) {
@@ -61,6 +62,7 @@ export class ApiKeyService {
       keySuffix: this.getApiKeySuffix(value),
       permissions,
       createdAt: new Date(),
+      expiresAt,
     })
 
     return { apiKey, value }

--- a/apps/api/src/api-key/dto/api-key-list.dto.ts
+++ b/apps/api/src/api-key/dto/api-key-list.dto.ts
@@ -34,8 +34,19 @@ export class ApiKeyListDto {
   })
   permissions: OrganizationResourcePermission[]
 
-  @ApiProperty({ nullable: true })
+  @ApiProperty({
+    description: 'When the API key was last used',
+    example: '2024-03-14T12:00:00.000Z',
+    nullable: true,
+  })
   lastUsedAt?: Date
+
+  @ApiProperty({
+    description: 'When the API key expires',
+    example: '2024-03-14T12:00:00.000Z',
+    nullable: true,
+  })
+  expiresAt?: Date
 
   constructor(partial: Partial<ApiKeyListDto>) {
     Object.assign(this, partial)
@@ -50,6 +61,7 @@ export class ApiKeyListDto {
       createdAt: apiKey.createdAt,
       permissions: apiKey.permissions,
       lastUsedAt: apiKey.lastUsedAt,
+      expiresAt: apiKey.expiresAt,
     })
   }
 }

--- a/apps/api/src/api-key/dto/api-key-response.dto.ts
+++ b/apps/api/src/api-key/dto/api-key-response.dto.ts
@@ -34,12 +34,20 @@ export class ApiKeyResponseDto {
   })
   permissions: OrganizationResourcePermission[]
 
+  @ApiProperty({
+    description: 'When the API key expires',
+    example: '2025-06-09T12:00:00.000Z',
+    nullable: true,
+  })
+  expiresAt?: Date
+
   static fromApiKey(apiKey: ApiKey, value: string): ApiKeyResponseDto {
     return {
       name: apiKey.name,
       value,
       createdAt: apiKey.createdAt,
       permissions: apiKey.permissions,
+      expiresAt: apiKey.expiresAt,
     }
   }
 }

--- a/apps/api/src/api-key/dto/create-api-key.dto.ts
+++ b/apps/api/src/api-key/dto/create-api-key.dto.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ArrayNotEmpty, IsArray, IsEnum, IsNotEmpty, IsString } from 'class-validator'
-import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { ArrayNotEmpty, IsArray, IsDate, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator'
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
+import { Type } from 'class-transformer'
 
 @ApiSchema({ name: 'CreateApiKey' })
 export class CreateApiKeyDto {
@@ -28,4 +29,14 @@ export class CreateApiKeyDto {
   @ArrayNotEmpty()
   @IsEnum(OrganizationResourcePermission, { each: true })
   permissions: OrganizationResourcePermission[]
+
+  @ApiPropertyOptional({
+    description: 'When the API key expires',
+    example: '2025-06-09T12:00:00.000Z',
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  expiresAt?: Date
 }

--- a/apps/api/src/migrations/1749474791343-migration.ts
+++ b/apps/api/src/migrations/1749474791343-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1749474791343 implements MigrationInterface {
+  name = 'Migration1749474791343'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "api_key" ADD "expiresAt" TIMESTAMP`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "api_key" DROP COLUMN "expiresAt"`)
+  }
+}

--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -107,6 +107,30 @@ export function ApiKeyTable({ data, loading, loadingKeys, onRevoke }: DataTableP
   )
 }
 
+const getExpiresAtColor = (expiresAt: Date | null) => {
+  if (!expiresAt) {
+    return 'text-foreground'
+  }
+
+  const MILLISECONDS_IN_MINUTE = 1000 * 60
+  const MINUTES_IN_DAY = 24 * 60
+
+  const diffInMinutes = Math.floor((new Date(expiresAt).getTime() - new Date().getTime()) / MILLISECONDS_IN_MINUTE)
+
+  // Already expired
+  if (diffInMinutes < 0) {
+    return 'text-red-500'
+  }
+
+  // Expires within a day
+  if (diffInMinutes < MINUTES_IN_DAY) {
+    return 'text-yellow-600 dark:text-yellow-400'
+  }
+
+  // Expires in more than a day
+  return 'text-foreground'
+}
+
 const getColumns = ({
   onRevoke,
   loadingKeys,
@@ -150,14 +174,77 @@ const getColumns = ({
       accessorKey: 'createdAt',
       header: 'Created',
       cell: ({ row }) => {
-        return getRelativeTimeString(row.original.createdAt).relativeTimeString
+        const createdAt = row.original.createdAt
+        const relativeTime = getRelativeTimeString(createdAt).relativeTimeString
+        const fullDate = new Date(createdAt).toLocaleString()
+
+        return (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <span className="cursor-default">{relativeTime}</span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{fullDate}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )
       },
     },
     {
       accessorKey: 'lastUsedAt',
       header: 'Last Used',
       cell: ({ row }) => {
-        return getRelativeTimeString(row.original.lastUsedAt).relativeTimeString
+        const lastUsedAt = row.original.lastUsedAt
+        const relativeTime = getRelativeTimeString(lastUsedAt).relativeTimeString
+
+        if (!lastUsedAt) {
+          return relativeTime
+        }
+
+        const fullDate = new Date(lastUsedAt).toLocaleString()
+
+        return (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <span className="cursor-default">{relativeTime}</span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{fullDate}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )
+      },
+    },
+    {
+      accessorKey: 'expiresAt',
+      header: 'Expires',
+      cell: ({ row }) => {
+        const expiresAt = row.original.expiresAt
+        const relativeTime = getRelativeTimeString(expiresAt).relativeTimeString
+
+        if (!expiresAt) {
+          return relativeTime
+        }
+
+        const fullDate = new Date(expiresAt).toLocaleString()
+        const color = getExpiresAtColor(expiresAt)
+
+        return (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <span className={`cursor-default ${color}`}>{relativeTime}</span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{fullDate}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )
       },
     },
     {

--- a/apps/dashboard/src/components/CreateApiKeyDialog.tsx
+++ b/apps/dashboard/src/components/CreateApiKeyDialog.tsx
@@ -23,15 +23,21 @@ import { CREATE_API_KEY_PERMISSIONS_GROUPS } from '@/constants/CreateApiKeyPermi
 import { CreateApiKeyPermissionGroup } from '@/types/CreateApiKeyPermissionGroup'
 import { Label } from '@/components/ui/label'
 import { getMaskedApiKey } from '@/lib/utils'
+import { DatePicker } from '@/components/ui/date-picker'
 
 interface CreateApiKeyDialogProps {
   availablePermissions: CreateApiKeyPermissionsEnum[]
-  onCreateApiKey: (name: string, permissions: CreateApiKeyPermissionsEnum[]) => Promise<ApiKeyResponse | null>
+  onCreateApiKey: (
+    name: string,
+    permissions: CreateApiKeyPermissionsEnum[],
+    expiresAt: Date | null,
+  ) => Promise<ApiKeyResponse | null>
 }
 
 export const CreateApiKeyDialog: React.FC<CreateApiKeyDialogProps> = ({ availablePermissions, onCreateApiKey }) => {
   const [open, setOpen] = useState(false)
   const [name, setName] = useState('')
+  const [expiresAt, setExpiresAt] = useState<Date | undefined>(undefined)
   const [checkedPermissions, setCheckedPermissions] = useState<CreateApiKeyPermissionsEnum[]>([])
   const [loading, setLoading] = useState(false)
 
@@ -55,10 +61,11 @@ export const CreateApiKeyDialog: React.FC<CreateApiKeyDialogProps> = ({ availabl
   const handleCreateApiKey = async () => {
     setLoading(true)
     try {
-      const key = await onCreateApiKey(name, checkedPermissions)
+      const key = await onCreateApiKey(name, checkedPermissions, expiresAt ?? null)
       if (key) {
         setCreatedKey(key)
         setName('')
+        setExpiresAt(undefined)
         setCheckedPermissions(availablePermissions)
       }
     } finally {
@@ -118,6 +125,7 @@ export const CreateApiKeyDialog: React.FC<CreateApiKeyDialogProps> = ({ availabl
         setOpen(isOpen)
         if (!isOpen) {
           setName('')
+          setExpiresAt(undefined)
           setCheckedPermissions(availablePermissions)
           setCreatedKey(null)
           setCopied(null)
@@ -188,6 +196,10 @@ export const CreateApiKeyDialog: React.FC<CreateApiKeyDialogProps> = ({ availabl
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Name"
               />
+            </div>
+            <div className="space-y-3">
+              <Label htmlFor="expires-at">Expires</Label>
+              <DatePicker value={expiresAt} onChange={setExpiresAt} disabledBefore={new Date()} id="expires-at" />
             </div>
             {availableGroups.length > 0 && (
               <div className="space-y-3">

--- a/apps/dashboard/src/components/ui/calendar.tsx
+++ b/apps/dashboard/src/components/ui/calendar.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import * as React from 'react'
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker'
+
+import { cn } from '@/lib/utils'
+import { Button, buttonVariants } from '@/components/ui/button'
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = 'label',
+  buttonVariant = 'ghost',
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>['variant']
+}) {
+  const defaultClassNames = getDefaultClassNames()
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        'bg-background group/calendar p-3 [--cell-size:2rem] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className,
+      )}
+      captionLayout={captionLayout}
+      formatters={{
+        formatMonthDropdown: (date) => date.toLocaleString('default', { month: 'short' }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn('w-fit', defaultClassNames.root),
+        months: cn('relative flex flex-col gap-4 md:flex-row', defaultClassNames.months),
+        month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
+        nav: cn('absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1', defaultClassNames.nav),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          'h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50',
+          defaultClassNames.button_previous,
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          'h-[--cell-size] w-[--cell-size] select-none p-0 aria-disabled:opacity-50',
+          defaultClassNames.button_next,
+        ),
+        month_caption: cn(
+          'flex h-[--cell-size] w-full items-center justify-center px-[--cell-size]',
+          defaultClassNames.month_caption,
+        ),
+        dropdowns: cn(
+          'flex h-[--cell-size] w-full items-center justify-center gap-1.5 text-sm font-medium',
+          defaultClassNames.dropdowns,
+        ),
+        dropdown_root: cn(
+          'has-focus:border-ring border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] relative rounded-md border',
+          defaultClassNames.dropdown_root,
+        ),
+        dropdown: cn('absolute inset-0 opacity-0', defaultClassNames.dropdown),
+        caption_label: cn(
+          'select-none font-medium',
+          captionLayout === 'label'
+            ? 'text-sm'
+            : '[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-sm [&>svg]:size-3.5',
+          defaultClassNames.caption_label,
+        ),
+        table: 'w-full border-collapse',
+        weekdays: cn('flex', defaultClassNames.weekdays),
+        weekday: cn(
+          'text-muted-foreground flex-1 select-none rounded-md text-[0.8rem] font-normal',
+          defaultClassNames.weekday,
+        ),
+        week: cn('mt-2 flex w-full', defaultClassNames.week),
+        week_number_header: cn('w-[--cell-size] select-none', defaultClassNames.week_number_header),
+        week_number: cn('text-muted-foreground select-none text-[0.8rem]', defaultClassNames.week_number),
+        day: cn(
+          'group/day relative aspect-square h-full w-full select-none p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md',
+          defaultClassNames.day,
+        ),
+        range_start: cn('bg-accent rounded-l-md', defaultClassNames.range_start),
+        range_middle: cn('rounded-none', defaultClassNames.range_middle),
+        range_end: cn('bg-accent rounded-r-md', defaultClassNames.range_end),
+        today: cn(
+          'bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none',
+          defaultClassNames.today,
+        ),
+        outside: cn('text-muted-foreground aria-selected:text-muted-foreground', defaultClassNames.outside),
+        disabled: cn('text-muted-foreground opacity-50', defaultClassNames.disabled),
+        hidden: cn('invisible', defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return <div data-slot="calendar" ref={rootRef} className={cn('rounded-md', className)} {...props} />
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === 'left') {
+            return <ChevronLeftIcon className={cn('size-4', className)} {...props} />
+          }
+
+          if (orientation === 'right') {
+            return <ChevronRightIcon className={cn('size-4', className)} {...props} />
+          }
+
+          return <ChevronDownIcon className={cn('size-4', className)} {...props} />
+        },
+        DayButton: CalendarDayButton,
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-[--cell-size] items-center justify-center text-center">{children}</div>
+            </td>
+          )
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  )
+}
+
+function CalendarDayButton({ className, day, modifiers, ...props }: React.ComponentProps<typeof DayButton>) {
+  const defaultClassNames = getDefaultClassNames()
+
+  const ref = React.useRef<HTMLButtonElement>(null)
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus()
+  }, [modifiers.focused])
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString()}
+      data-selected-single={
+        modifiers.selected && !modifiers.range_start && !modifiers.range_end && !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 flex aspect-square h-auto w-full min-w-[--cell-size] flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] [&>span]:text-xs [&>span]:opacity-70',
+        defaultClassNames.day,
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Calendar, CalendarDayButton }

--- a/apps/dashboard/src/components/ui/date-picker.tsx
+++ b/apps/dashboard/src/components/ui/date-picker.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { format } from 'date-fns'
+import { Calendar as CalendarIcon, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+
+interface DatePickerProps {
+  value?: Date
+  onChange: (date?: Date) => void
+  required?: boolean
+  disabledBefore?: Date
+  id?: string
+}
+
+export function DatePicker({ value, onChange, required, disabledBefore, id }: DatePickerProps) {
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onChange(undefined)
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          data-empty={!value}
+          className="flex w-full data-[empty=true]:text-muted-foreground justify-between text-left font-normal hover:bg-background"
+        >
+          <div className="flex items-center gap-2">
+            <CalendarIcon className="h-4 w-4" />
+            {value ? format(value, 'PPP') : <span>Select date</span>}
+          </div>
+          {value && (
+            <Button type="button" variant="ghost" size="sm" className="h-auto p-1 hover:bg-muted" onClick={handleClear}>
+              <X className="h-3 w-3" />
+            </Button>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={value}
+          onSelect={onChange}
+          required={required}
+          disabled={(() => {
+            const conditions = []
+            if (disabledBefore) {
+              conditions.push({ before: disabledBefore })
+            }
+            return conditions
+          })()}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -22,28 +22,43 @@ export function getRelativeTimeString(
     const date = new Date(timestamp)
     const now = new Date()
     const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60))
+    const isFuture = diffInMinutes < 0
+    const absDiffInMinutes = Math.abs(diffInMinutes)
 
-    if (diffInMinutes < 1) return { date, relativeTimeString: 'just now' }
-    if (diffInMinutes === 1) return { date, relativeTimeString: '1 minute ago' }
-    if (diffInMinutes < 60) return { date, relativeTimeString: `${diffInMinutes} minutes ago` }
+    if (absDiffInMinutes < 1)
+      return {
+        date,
+        relativeTimeString: isFuture ? 'shortly' : 'just now',
+      }
 
-    const hours = Math.floor(diffInMinutes / 60)
-    const minutes = diffInMinutes % 60
-
-    if (hours === 1) {
-      return minutes > 0
-        ? { date, relativeTimeString: `1 hour ${minutes} minutes ago` }
-        : { date, relativeTimeString: '1 hour ago' }
+    if (absDiffInMinutes < 60) {
+      return {
+        date,
+        relativeTimeString: isFuture ? `in ${absDiffInMinutes}m` : `${absDiffInMinutes}m ago`,
+      }
     }
 
+    const hours = Math.floor(absDiffInMinutes / 60)
     if (hours < 24) {
-      return minutes > 0
-        ? { date, relativeTimeString: `${hours} hours ${minutes} minutes ago` }
-        : { date, relativeTimeString: `${hours} hours ago` }
+      return {
+        date,
+        relativeTimeString: isFuture ? `in ${hours}h` : `${hours}h ago`,
+      }
     }
 
     const days = Math.floor(hours / 24)
-    return { date, relativeTimeString: days === 1 ? 'yesterday' : `${days} days ago` }
+    if (days < 365) {
+      return {
+        date,
+        relativeTimeString: isFuture ? `in ${days}d` : `${days}d ago`,
+      }
+    }
+
+    const years = Math.floor(days / 365)
+    return {
+      date,
+      relativeTimeString: isFuture ? `in ${years}y` : `${years}y ago`,
+    }
   } catch (e) {
     return { date: new Date(), relativeTimeString: fallback }
   }

--- a/apps/dashboard/src/pages/Keys.tsx
+++ b/apps/dashboard/src/pages/Keys.tsx
@@ -75,9 +75,10 @@ const Keys: React.FC = () => {
   const handleCreateKey = async (
     name: string,
     permissions: CreateApiKeyPermissionsEnum[],
+    expiresAt: Date | null,
   ): Promise<ApiKeyResponse | null> => {
     try {
-      const key = (await apiKeyApi.createApiKey({ name, permissions }, selectedOrganization?.id)).data
+      const key = (await apiKeyApi.createApiKey({ name, permissions, expiresAt }, selectedOrganization?.id)).data
       toast.success('API key created successfully')
       await fetchKeys(false)
       return key

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -972,33 +972,6 @@ paths:
       summary: Create user
       tags:
         - users
-  /users/{id}:
-    get:
-      operationId: getUser
-      parameters:
-        - explode: false
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-          style: simple
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-          description: User details
-      security:
-        - bearer: []
-        - oauth2:
-            - openid
-            - profile
-            - email
-      summary: Get user by ID
-      tags:
-        - users
   /users/{id}/regenerate-key-pair:
     post:
       operationId: regenerateKeyPair
@@ -1094,6 +1067,33 @@ paths:
             - profile
             - email
       summary: Unlink account
+      tags:
+        - users
+  /users/{id}:
+    get:
+      operationId: getUser
+      parameters:
+        - explode: false
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          style: simple
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: User details
+      security:
+        - bearer: []
+        - oauth2:
+            - openid
+            - profile
+            - email
+      summary: Get user by ID
       tags:
         - users
   /workspace:
@@ -4224,6 +4224,7 @@ components:
           - write:registries
           - write:registries
         name: My API Key
+        expiresAt: 2025-06-09T12:00:00Z
       properties:
         name:
           description: The name of the API key
@@ -4245,6 +4246,12 @@ components:
               - delete:volumes
             type: string
           type: array
+        expiresAt:
+          description: When the API key expires
+          example: 2025-06-09T12:00:00Z
+          format: date-time
+          nullable: true
+          type: string
       required:
         - name
         - permissions
@@ -4257,6 +4264,7 @@ components:
           - write:registries
         name: My API Key
         value: bb_sk_1234567890abcdef
+        expiresAt: 2025-06-09T12:00:00Z
       properties:
         name:
           description: The name of the API key
@@ -4287,8 +4295,15 @@ components:
               - delete:volumes
             type: string
           type: array
+        expiresAt:
+          description: When the API key expires
+          example: 2025-06-09T12:00:00Z
+          format: date-time
+          nullable: true
+          type: string
       required:
         - createdAt
+        - expiresAt
         - name
         - permissions
         - value
@@ -4296,12 +4311,13 @@ components:
     ApiKeyList:
       example:
         createdAt: 2024-03-14T12:00:00Z
-        lastUsedAt: 2000-01-23T04:56:07.000+00:00
+        lastUsedAt: 2024-03-14T12:00:00Z
         permissions:
           - write:registries
           - write:registries
         name: My API Key
         value: bb_********************def
+        expiresAt: 2024-03-14T12:00:00Z
       properties:
         name:
           description: The name of the API key
@@ -4333,11 +4349,20 @@ components:
             type: string
           type: array
         lastUsedAt:
+          description: When the API key was last used
+          example: 2024-03-14T12:00:00Z
+          format: date-time
+          nullable: true
+          type: string
+        expiresAt:
+          description: When the API key expires
+          example: 2024-03-14T12:00:00Z
           format: date-time
           nullable: true
           type: string
       required:
         - createdAt
+        - expiresAt
         - lastUsedAt
         - name
         - permissions

--- a/libs/api-client-go/model_api_key_list.go
+++ b/libs/api-client-go/model_api_key_list.go
@@ -30,8 +30,11 @@ type ApiKeyList struct {
 	// When the API key was created
 	CreatedAt time.Time `json:"createdAt"`
 	// The list of organization resource permissions assigned to the API key
-	Permissions []string     `json:"permissions"`
-	LastUsedAt  NullableTime `json:"lastUsedAt"`
+	Permissions []string `json:"permissions"`
+	// When the API key was last used
+	LastUsedAt NullableTime `json:"lastUsedAt"`
+	// When the API key expires
+	ExpiresAt NullableTime `json:"expiresAt"`
 }
 
 type _ApiKeyList ApiKeyList
@@ -40,13 +43,14 @@ type _ApiKeyList ApiKeyList
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewApiKeyList(name string, value string, createdAt time.Time, permissions []string, lastUsedAt NullableTime) *ApiKeyList {
+func NewApiKeyList(name string, value string, createdAt time.Time, permissions []string, lastUsedAt NullableTime, expiresAt NullableTime) *ApiKeyList {
 	this := ApiKeyList{}
 	this.Name = name
 	this.Value = value
 	this.CreatedAt = createdAt
 	this.Permissions = permissions
 	this.LastUsedAt = lastUsedAt
+	this.ExpiresAt = expiresAt
 	return &this
 }
 
@@ -180,6 +184,32 @@ func (o *ApiKeyList) SetLastUsedAt(v time.Time) {
 	o.LastUsedAt.Set(&v)
 }
 
+// GetExpiresAt returns the ExpiresAt field value
+// If the value is explicit nil, the zero value for time.Time will be returned
+func (o *ApiKeyList) GetExpiresAt() time.Time {
+	if o == nil || o.ExpiresAt.Get() == nil {
+		var ret time.Time
+		return ret
+	}
+
+	return *o.ExpiresAt.Get()
+}
+
+// GetExpiresAtOk returns a tuple with the ExpiresAt field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ApiKeyList) GetExpiresAtOk() (*time.Time, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ExpiresAt.Get(), o.ExpiresAt.IsSet()
+}
+
+// SetExpiresAt sets field value
+func (o *ApiKeyList) SetExpiresAt(v time.Time) {
+	o.ExpiresAt.Set(&v)
+}
+
 func (o ApiKeyList) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -195,6 +225,7 @@ func (o ApiKeyList) ToMap() (map[string]interface{}, error) {
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["permissions"] = o.Permissions
 	toSerialize["lastUsedAt"] = o.LastUsedAt.Get()
+	toSerialize["expiresAt"] = o.ExpiresAt.Get()
 	return toSerialize, nil
 }
 
@@ -208,6 +239,7 @@ func (o *ApiKeyList) UnmarshalJSON(data []byte) (err error) {
 		"createdAt",
 		"permissions",
 		"lastUsedAt",
+		"expiresAt",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-go/model_api_key_response.go
+++ b/libs/api-client-go/model_api_key_response.go
@@ -31,6 +31,8 @@ type ApiKeyResponse struct {
 	CreatedAt time.Time `json:"createdAt"`
 	// The list of organization resource permissions assigned to the API key
 	Permissions []string `json:"permissions"`
+	// When the API key expires
+	ExpiresAt NullableTime `json:"expiresAt"`
 }
 
 type _ApiKeyResponse ApiKeyResponse
@@ -39,12 +41,13 @@ type _ApiKeyResponse ApiKeyResponse
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewApiKeyResponse(name string, value string, createdAt time.Time, permissions []string) *ApiKeyResponse {
+func NewApiKeyResponse(name string, value string, createdAt time.Time, permissions []string, expiresAt NullableTime) *ApiKeyResponse {
 	this := ApiKeyResponse{}
 	this.Name = name
 	this.Value = value
 	this.CreatedAt = createdAt
 	this.Permissions = permissions
+	this.ExpiresAt = expiresAt
 	return &this
 }
 
@@ -152,6 +155,32 @@ func (o *ApiKeyResponse) SetPermissions(v []string) {
 	o.Permissions = v
 }
 
+// GetExpiresAt returns the ExpiresAt field value
+// If the value is explicit nil, the zero value for time.Time will be returned
+func (o *ApiKeyResponse) GetExpiresAt() time.Time {
+	if o == nil || o.ExpiresAt.Get() == nil {
+		var ret time.Time
+		return ret
+	}
+
+	return *o.ExpiresAt.Get()
+}
+
+// GetExpiresAtOk returns a tuple with the ExpiresAt field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ApiKeyResponse) GetExpiresAtOk() (*time.Time, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ExpiresAt.Get(), o.ExpiresAt.IsSet()
+}
+
+// SetExpiresAt sets field value
+func (o *ApiKeyResponse) SetExpiresAt(v time.Time) {
+	o.ExpiresAt.Set(&v)
+}
+
 func (o ApiKeyResponse) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -166,6 +195,7 @@ func (o ApiKeyResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize["value"] = o.Value
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["permissions"] = o.Permissions
+	toSerialize["expiresAt"] = o.ExpiresAt.Get()
 	return toSerialize, nil
 }
 
@@ -178,6 +208,7 @@ func (o *ApiKeyResponse) UnmarshalJSON(data []byte) (err error) {
 		"value",
 		"createdAt",
 		"permissions",
+		"expiresAt",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-go/model_create_api_key.go
+++ b/libs/api-client-go/model_create_api_key.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // checks if the CreateApiKey type satisfies the MappedNullable interface at compile time
@@ -26,6 +27,8 @@ type CreateApiKey struct {
 	Name string `json:"name"`
 	// The list of organization resource permissions assigned to the API key
 	Permissions []string `json:"permissions"`
+	// When the API key expires
+	ExpiresAt NullableTime `json:"expiresAt,omitempty"`
 }
 
 type _CreateApiKey CreateApiKey
@@ -97,6 +100,49 @@ func (o *CreateApiKey) SetPermissions(v []string) {
 	o.Permissions = v
 }
 
+// GetExpiresAt returns the ExpiresAt field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *CreateApiKey) GetExpiresAt() time.Time {
+	if o == nil || IsNil(o.ExpiresAt.Get()) {
+		var ret time.Time
+		return ret
+	}
+	return *o.ExpiresAt.Get()
+}
+
+// GetExpiresAtOk returns a tuple with the ExpiresAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *CreateApiKey) GetExpiresAtOk() (*time.Time, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.ExpiresAt.Get(), o.ExpiresAt.IsSet()
+}
+
+// HasExpiresAt returns a boolean if a field has been set.
+func (o *CreateApiKey) HasExpiresAt() bool {
+	if o != nil && o.ExpiresAt.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetExpiresAt gets a reference to the given NullableTime and assigns it to the ExpiresAt field.
+func (o *CreateApiKey) SetExpiresAt(v time.Time) {
+	o.ExpiresAt.Set(&v)
+}
+
+// SetExpiresAtNil sets the value for ExpiresAt to be an explicit nil
+func (o *CreateApiKey) SetExpiresAtNil() {
+	o.ExpiresAt.Set(nil)
+}
+
+// UnsetExpiresAt ensures that no value is present for ExpiresAt, not even an explicit nil
+func (o *CreateApiKey) UnsetExpiresAt() {
+	o.ExpiresAt.Unset()
+}
+
 func (o CreateApiKey) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -109,6 +155,9 @@ func (o CreateApiKey) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	toSerialize["permissions"] = o.Permissions
+	if o.ExpiresAt.IsSet() {
+		toSerialize["expiresAt"] = o.ExpiresAt.Get()
+	}
 	return toSerialize, nil
 }
 

--- a/libs/api-client-python-async/daytona_api_client_async/models/api_key_list.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/api_key_list.py
@@ -32,9 +32,10 @@ class ApiKeyList(BaseModel):
     value: StrictStr = Field(description="The masked API key value")
     created_at: datetime = Field(description="When the API key was created", alias="createdAt")
     permissions: List[StrictStr] = Field(description="The list of organization resource permissions assigned to the API key")
-    last_used_at: Optional[datetime] = Field(alias="lastUsedAt")
+    last_used_at: Optional[datetime] = Field(description="When the API key was last used", alias="lastUsedAt")
+    expires_at: Optional[datetime] = Field(description="When the API key expires", alias="expiresAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt"]
+    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt", "expiresAt"]
 
     @field_validator('permissions')
     def permissions_validate_enum(cls, value):
@@ -95,6 +96,11 @@ class ApiKeyList(BaseModel):
         if self.last_used_at is None and "last_used_at" in self.model_fields_set:
             _dict['lastUsedAt'] = None
 
+        # set to None if expires_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.expires_at is None and "expires_at" in self.model_fields_set:
+            _dict['expiresAt'] = None
+
         return _dict
 
     @classmethod
@@ -111,7 +117,8 @@ class ApiKeyList(BaseModel):
             "value": obj.get("value"),
             "createdAt": obj.get("createdAt"),
             "permissions": obj.get("permissions"),
-            "lastUsedAt": obj.get("lastUsedAt")
+            "lastUsedAt": obj.get("lastUsedAt"),
+            "expiresAt": obj.get("expiresAt")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/api_key_response.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/api_key_response.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -32,8 +32,9 @@ class ApiKeyResponse(BaseModel):
     value: StrictStr = Field(description="The API key value")
     created_at: datetime = Field(description="When the API key was created", alias="createdAt")
     permissions: List[StrictStr] = Field(description="The list of organization resource permissions assigned to the API key")
+    expires_at: Optional[datetime] = Field(description="When the API key expires", alias="expiresAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions"]
+    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "expiresAt"]
 
     @field_validator('permissions')
     def permissions_validate_enum(cls, value):
@@ -89,6 +90,11 @@ class ApiKeyResponse(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if expires_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.expires_at is None and "expires_at" in self.model_fields_set:
+            _dict['expiresAt'] = None
+
         return _dict
 
     @classmethod
@@ -104,7 +110,8 @@ class ApiKeyResponse(BaseModel):
             "name": obj.get("name"),
             "value": obj.get("value"),
             "createdAt": obj.get("createdAt"),
-            "permissions": obj.get("permissions")
+            "permissions": obj.get("permissions"),
+            "expiresAt": obj.get("expiresAt")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/create_api_key.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/create_api_key.py
@@ -18,8 +18,9 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -29,8 +30,9 @@ class CreateApiKey(BaseModel):
     """ # noqa: E501
     name: StrictStr = Field(description="The name of the API key")
     permissions: List[StrictStr] = Field(description="The list of organization resource permissions assigned to the API key")
+    expires_at: Optional[datetime] = Field(default=None, description="When the API key expires", alias="expiresAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "permissions"]
+    __properties: ClassVar[List[str]] = ["name", "permissions", "expiresAt"]
 
     @field_validator('permissions')
     def permissions_validate_enum(cls, value):
@@ -86,6 +88,11 @@ class CreateApiKey(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if expires_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.expires_at is None and "expires_at" in self.model_fields_set:
+            _dict['expiresAt'] = None
+
         return _dict
 
     @classmethod
@@ -99,7 +106,8 @@ class CreateApiKey(BaseModel):
 
         _obj = cls.model_validate({
             "name": obj.get("name"),
-            "permissions": obj.get("permissions")
+            "permissions": obj.get("permissions"),
+            "expiresAt": obj.get("expiresAt")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/api_key_list.py
+++ b/libs/api-client-python/daytona_api_client/models/api_key_list.py
@@ -36,9 +36,10 @@ class ApiKeyList(BaseModel):
     permissions: List[StrictStr] = Field(
         description="The list of organization resource permissions assigned to the API key"
     )
-    last_used_at: Optional[datetime] = Field(alias="lastUsedAt")
+    last_used_at: Optional[datetime] = Field(description="When the API key was last used", alias="lastUsedAt")
+    expires_at: Optional[datetime] = Field(description="When the API key expires", alias="expiresAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt"]
+    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt", "expiresAt"]
 
     @field_validator("permissions")
     def permissions_validate_enum(cls, value):
@@ -114,6 +115,11 @@ class ApiKeyList(BaseModel):
         if self.last_used_at is None and "last_used_at" in self.model_fields_set:
             _dict["lastUsedAt"] = None
 
+        # set to None if expires_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.expires_at is None and "expires_at" in self.model_fields_set:
+            _dict["expiresAt"] = None
+
         return _dict
 
     @classmethod
@@ -132,6 +138,7 @@ class ApiKeyList(BaseModel):
                 "createdAt": obj.get("createdAt"),
                 "permissions": obj.get("permissions"),
                 "lastUsedAt": obj.get("lastUsedAt"),
+                "expiresAt": obj.get("expiresAt"),
             }
         )
         # store additional fields in additional_properties

--- a/libs/api-client-python/daytona_api_client/models/api_key_response.py
+++ b/libs/api-client-python/daytona_api_client/models/api_key_response.py
@@ -20,7 +20,7 @@ import json
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -36,8 +36,9 @@ class ApiKeyResponse(BaseModel):
     permissions: List[StrictStr] = Field(
         description="The list of organization resource permissions assigned to the API key"
     )
+    expires_at: Optional[datetime] = Field(description="When the API key expires", alias="expiresAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions"]
+    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "expiresAt"]
 
     @field_validator("permissions")
     def permissions_validate_enum(cls, value):
@@ -108,6 +109,11 @@ class ApiKeyResponse(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if expires_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.expires_at is None and "expires_at" in self.model_fields_set:
+            _dict["expiresAt"] = None
+
         return _dict
 
     @classmethod
@@ -125,6 +131,7 @@ class ApiKeyResponse(BaseModel):
                 "value": obj.get("value"),
                 "createdAt": obj.get("createdAt"),
                 "permissions": obj.get("permissions"),
+                "expiresAt": obj.get("expiresAt"),
             }
         )
         # store additional fields in additional_properties

--- a/libs/api-client-python/daytona_api_client/models/create_api_key.py
+++ b/libs/api-client-python/daytona_api_client/models/create_api_key.py
@@ -18,8 +18,9 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -33,8 +34,9 @@ class CreateApiKey(BaseModel):
     permissions: List[StrictStr] = Field(
         description="The list of organization resource permissions assigned to the API key"
     )
+    expires_at: Optional[datetime] = Field(default=None, description="When the API key expires", alias="expiresAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "permissions"]
+    __properties: ClassVar[List[str]] = ["name", "permissions", "expiresAt"]
 
     @field_validator("permissions")
     def permissions_validate_enum(cls, value):
@@ -105,6 +107,11 @@ class CreateApiKey(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if expires_at (nullable) is None
+        # and model_fields_set contains the field
+        if self.expires_at is None and "expires_at" in self.model_fields_set:
+            _dict["expiresAt"] = None
+
         return _dict
 
     @classmethod
@@ -116,7 +123,9 @@ class CreateApiKey(BaseModel):
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
-        _obj = cls.model_validate({"name": obj.get("name"), "permissions": obj.get("permissions")})
+        _obj = cls.model_validate(
+            {"name": obj.get("name"), "permissions": obj.get("permissions"), "expiresAt": obj.get("expiresAt")}
+        )
         # store additional fields in additional_properties
         for _key in obj.keys():
             if _key not in cls.__properties:

--- a/libs/api-client/src/models/api-key-list.ts
+++ b/libs/api-client/src/models/api-key-list.ts
@@ -43,11 +43,17 @@ export interface ApiKeyList {
    */
   permissions: Array<ApiKeyListPermissionsEnum>
   /**
-   *
+   * When the API key was last used
    * @type {Date}
    * @memberof ApiKeyList
    */
   lastUsedAt: Date | null
+  /**
+   * When the API key expires
+   * @type {Date}
+   * @memberof ApiKeyList
+   */
+  expiresAt: Date | null
 }
 
 export const ApiKeyListPermissionsEnum = {

--- a/libs/api-client/src/models/api-key-response.ts
+++ b/libs/api-client/src/models/api-key-response.ts
@@ -42,6 +42,12 @@ export interface ApiKeyResponse {
    * @memberof ApiKeyResponse
    */
   permissions: Array<ApiKeyResponsePermissionsEnum>
+  /**
+   * When the API key expires
+   * @type {Date}
+   * @memberof ApiKeyResponse
+   */
+  expiresAt: Date | null
 }
 
 export const ApiKeyResponsePermissionsEnum = {

--- a/libs/api-client/src/models/create-api-key.ts
+++ b/libs/api-client/src/models/create-api-key.ts
@@ -30,6 +30,12 @@ export interface CreateApiKey {
    * @memberof CreateApiKey
    */
   permissions: Array<CreateApiKeyPermissionsEnum>
+  /**
+   * When the API key expires
+   * @type {Date}
+   * @memberof CreateApiKey
+   */
+  expiresAt?: Date | null
 }
 
 export const CreateApiKeyPermissionsEnum = {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "prism-react-renderer": "^2.4.1",
     "raw-body": "^3.0.0",
     "react": "19.0.0",
+    "react-day-picker": "^9.7.0",
     "react-dom": "19.0.0",
     "react-error-boundary": "^6.0.0",
     "react-oidc-context": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4504,6 +4504,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@date-fns/tz@npm:1.2.0"
+  checksum: 10c0/411e9d4303b10951f6fd0189d18fb845f0d934a575df2176bc10daf664282c765fb6b057a977e446bbb1229151d89e7788978600a019f1fc24b5c75276d496bd
+  languageName: node
+  linkType: hard
+
 "@daytonaio/api-client@workspace:libs/api-client":
   version: 0.0.0-use.local
   resolution: "@daytonaio/api-client@workspace:libs/api-client"
@@ -15486,19 +15493,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns-jalali@npm:4.1.0-0":
+  version: 4.1.0-0
+  resolution: "date-fns-jalali@npm:4.1.0-0"
+  checksum: 10c0/f9ad98d9f7e8e5abe0d070dc806b0c8baded2b1208626c42e92cbd2605b5171f5714d6b79b20cc2666267d821699244c9d0b5e93274106cf57d6232da77596ed
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:4.1.0, date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
+  languageName: node
+  linkType: hard
+
 "date-fns@npm:^2.16.1":
   version: 2.30.0
   resolution: "date-fns@npm:2.30.0"
   dependencies:
     "@babel/runtime": "npm:^7.21.0"
   checksum: 10c0/e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "date-fns@npm:4.1.0"
-  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
@@ -15643,6 +15657,7 @@ __metadata:
     prism-react-renderer: "npm:^2.4.1"
     raw-body: "npm:^3.0.0"
     react: "npm:19.0.0"
+    react-day-picker: "npm:^9.7.0"
     react-dom: "npm:19.0.0"
     react-error-boundary: "npm:^6.0.0"
     react-oidc-context: "npm:^3.3.0"
@@ -25138,6 +25153,19 @@ __metadata:
   bin:
     rc: ./cli.js
   checksum: 10c0/24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
+  languageName: node
+  linkType: hard
+
+"react-day-picker@npm:^9.7.0":
+  version: 9.7.0
+  resolution: "react-day-picker@npm:9.7.0"
+  dependencies:
+    "@date-fns/tz": "npm:1.2.0"
+    date-fns: "npm:4.1.0"
+    date-fns-jalali: "npm:4.1.0-0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10c0/c08c45a53aebceda1c938d2e4c95eb1702dcf149715e3457739f8930dce19a3be5780e5bad12dcc9d244d50b7e0efb226c336d81c1c062f616cf422e6a3804a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Expiring API Keys

## Description

Introduces support for expiring API keys. When creating a new API keys, users can optionally set an expiration date for the key. If not set, the key will be valid until revoked.

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Screenshots

![image](https://github.com/user-attachments/assets/b6487e98-f55a-41f6-b7f1-cee26904cf07)

![image](https://github.com/user-attachments/assets/0e3c275d-38dc-42ee-99f8-2dd09ae7c38d)

![image](https://github.com/user-attachments/assets/4670b40a-c7a8-4dd1-91c4-87ee6bdb18a6)
