### PR TITLE
Added sorting states of tables between refreshes to dashboard

### DIFF
--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -29,6 +29,7 @@ import { Pagination } from './Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { TableEmptyState } from './TableEmptyState'
+import { useTableSorting } from '@/hooks/useTableSorting'
 
 interface DataTableProps {
   data: DockerRegistry[]
@@ -50,7 +51,7 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
     [authenticatedUserHasPermission],
   )
 
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useTableSorting('registry')
   const columns = getColumns({ onDelete, onEdit, loading, writePermitted, deletePermitted })
   const table = useReactTable({
     data,

--- a/apps/dashboard/src/components/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable.tsx
@@ -50,6 +50,7 @@ import { DebouncedInput } from './DebouncedInput'
 import { DataTableFacetedFilter, FacetedFilterOption } from './ui/data-table-faceted-filter'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { TableEmptyState } from './TableEmptyState'
+import { useTableSorting } from '@/hooks/useTableSorting'
 
 interface DataTableProps {
   data: Sandbox[]
@@ -84,7 +85,7 @@ export function SandboxTable({
     [authenticatedUserHasPermission],
   )
 
-  const [sorting, setSorting] = useState<SortingState>([
+  const [sorting, setSorting] = useTableSorting('sandbox', [
     {
       id: 'state',
       desc: false,

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -32,6 +32,7 @@ import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { getRelativeTimeString } from '@/lib/utils'
 import { TableEmptyState } from './TableEmptyState'
+import { useTableSorting } from '@/hooks/useTableSorting'
 
 interface VolumeTableProps {
   data: VolumeDto[]
@@ -49,7 +50,7 @@ export function VolumeTable({ data, loading, processingVolumeAction, onDelete, o
     [authenticatedUserHasPermission],
   )
 
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useTableSorting('volume')
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
   const columns = getColumns({

--- a/apps/dashboard/src/hooks/useTableSorting.ts
+++ b/apps/dashboard/src/hooks/useTableSorting.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SortingState } from '@tanstack/react-table'
+import { useState, useEffect } from 'react'
+
+const STORAGE_KEY_PREFIX = 'table_sort_'
+
+export function useTableSorting(tableId: string, defaultSorting: SortingState = []) {
+  const storageKey = `${STORAGE_KEY_PREFIX}${tableId}`
+
+  const [sorting, setSorting] = useState<SortingState>(() => {
+    try {
+      const saved = localStorage.getItem(storageKey)
+      if (saved) {
+        return JSON.parse(saved)
+      }
+    } catch {
+      // Ignore parse error, fallback to default
+    }
+    return defaultSorting
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(sorting))
+    } catch {
+      // Ignore storage error
+    }
+  }, [sorting, storageKey])
+
+  return [sorting, setSorting] as const
+} 


### PR DESCRIPTION
# Fixes #1782 

## Description

Created a new useTableSorting hook that handles persisting and restoring table sorting state in localStorage. The hook:
1. Takes a unique table ID and optional default sorting state
2. Creates a unique storage key for each table
3. Restores the sorting state from localStorage on mount
4. Persists any changes to the sorting state back to localStorage
5. Handles errors gracefully by falling back to defaults

I've updated three main table components to use this hook:

* SandboxTable with default sorting by state and lastEvent
* VolumeTable with no default sorting
* RegistryTable with no default sorting
