### PR TITLE
fix: improve error message in sandbox

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -286,7 +286,8 @@ export class SandboxManager {
       if (error.code === 'ECONNRESET') {
         syncState = SYNC_AGAIN
       } else {
-        this.logger.error(`Error processing desired state for sandbox ${sandboxId}:`, fromAxiosError(error))
+        const sandboxError = fromAxiosError(error)
+        this.logger.error(`Error processing desired state for sandbox ${sandboxId}:`, sandboxError)
 
         const sandbox = await this.sandboxRepository.findOneBy({
           id: sandboxId,
@@ -295,7 +296,7 @@ export class SandboxManager {
           //  edge case where sandbox is deleted while desired state is being processed
           return
         }
-        await this.updateSandboxState(sandbox.id, SandboxState.ERROR, undefined, error.message || String(error))
+        await this.updateSandboxState(sandbox.id, SandboxState.ERROR, undefined, sandboxError.message || String(error))
       }
     }
 


### PR DESCRIPTION
# Improve error message in sandbox
## Description

Use a more specific error message for sandbox state instead of just a 500 error or a 40x error which would lead users to believe they made a mistake

Before:
`Request failed with status code 500` 

After:
`timeout waiting for container 4b5ac9ac-9c4b-4933-aee5-55a3f68582b8 to start` 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation