### PR TITLE
fix: unschedulable backupless sandbox domain check

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -560,10 +560,6 @@ export class SandboxService {
       if (runner.state !== RunnerState.READY) {
         throw new SandboxError('Runner is not ready')
       }
-
-      if (runner.unschedulable && sandbox.backupState !== BackupState.COMPLETED) {
-        throw new SandboxError('Runner is unschedulable - can not start sandbox until the backup is completed')
-      }
     } else {
       //  restore operation
       //  like a new sandbox creation, we need to validate quotas


### PR DESCRIPTION
# Unschedulable runner with backupless sandbox domain check
## Description

Removes the unnecessary domain-level check when starting a sandbox without a backup that is assigned to an unschedulable runner

This case is already handled in the sandbox manager - the sandbox should keep the existing runner until it is stopped long enough for a backup to be created in the future

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2036 

Drafted for more detailed testing