### PR TITLE
fix: poll unschedulable runner states

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -137,7 +137,7 @@ export class RunnerService {
     this.checkingRunners = true
     const runners = await this.runnerRepository.find({
       where: {
-        unschedulable: Not(true),
+        state: Not(RunnerState.DECOMMISSIONED),
       },
     })
     for (const runner of runners) {


### PR DESCRIPTION
# Poll unschedulable runner states

## Description

Since decommissioning is a rare and sensitive process, handling runner state updates to that value will be done manually

As explained in #2036  there are cases where unschedulable runners' states are still relevant so we should keep polling until the runner is actually decommissioned

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation