### PR TITLE
bump `daytona_api_client` and `daytona_api_client_async`

### DIFF
--- a/libs/sdk-python/pyproject.toml
+++ b/libs/sdk-python/pyproject.toml
@@ -12,8 +12,8 @@ description = "Python SDK for Daytona"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "daytona_api_client>=0.20.1,<0.21.0",
-    "daytona_api_client_async>=0.20.1,<0.21.0",
+    "daytona_api_client>=0.21.0,<0.22.0",
+    "daytona_api_client_async>=0.21.0,<0.22.0",
     "environs>=9.5.0,<10.0.0",
     "marshmallow>=3.19.0,<4.0.0",
     "pydantic>=2.4.2,<3.0.0",


### PR DESCRIPTION
fixes:

```py
Traceback (most recent call last):
  File "c:\Users\smart\Desktop\GD\Kevin\tempCodeRunnerFile.python", line 1, in <module>
    from daytona import Daytona, DaytonaConfig
  File "C:\Python312\Lib\site-packages\daytona\__init__.py", line 4, in <module>
    from daytona_api_client import SandboxState, SessionExecuteResponse
ImportError: cannot import name 'SandboxState' from 'daytona_api_client' (C:\Python312\Lib\site-packages\daytona_api_client\__init__.py)
```