### PR TITLE
fix(api): exclude destroyed sandbox from findBySandboxId

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -72,7 +72,7 @@ export class RunnerService {
   }
 
   async findBySandboxId(sandboxId: string): Promise<Runner | null> {
-    const sandbox = await this.sandboxRepository.findOneBy({ id: sandboxId })
+    const sandbox = await this.sandboxRepository.findOneBy({ id: sandboxId, state: Not(SandboxState.DESTROYED) })
     if (!sandbox) {
       throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
     }


### PR DESCRIPTION
# Exclude Destroyed Sandbox from findBySandboxId

## Description

Exclude destroyed sandbox from `findBySandboxId` because destroyed sandboxes should be treated as "not found" by the domain

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
