### PR TITLE
feat: get runners by snapshot

### DIFF
--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -3,16 +3,17 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Body, Controller, Get, Post, Param, Patch, UseGuards } from '@nestjs/common'
+import { Body, Controller, Get, Post, Param, Patch, UseGuards, Query } from '@nestjs/common'
 import { CreateRunnerDto } from '../dto/create-runner.dto'
 import { Runner } from '../entities/runner.entity'
 import { RunnerService } from '../services/runner.service'
-import { ApiOAuth2, ApiTags, ApiOperation, ApiBearerAuth, ApiResponse } from '@nestjs/swagger'
+import { ApiOAuth2, ApiTags, ApiOperation, ApiBearerAuth, ApiResponse, ApiQuery } from '@nestjs/swagger'
 import { SystemActionGuard } from '../../auth/system-action.guard'
 import { RequiredApiRole } from '../../common/decorators/required-role.decorator'
 import { SystemRole } from '../../user/enums/system-role.enum'
 import { ProxyGuard } from '../../auth/proxy.guard'
 import { RunnerDto } from '../dto/runner.dto'
+import { RunnerSnapshotDto } from '../dto/runner-snapshot.dto'
 
 import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
 @ApiTags('runners')
@@ -67,5 +68,25 @@ export class RunnerController {
   async getRunnerBySandboxId(@Param('sandboxId') sandboxId: string): Promise<RunnerDto> {
     const runner = await this.runnerService.findBySandboxId(sandboxId)
     return RunnerDto.fromRunner(runner)
+  }
+
+  @Get('/by-snapshot')
+  @ApiOperation({
+    summary: 'Get runners by snapshot internal name',
+    operationId: 'getRunnersBySnapshotInternalName',
+  })
+  @ApiQuery({
+    name: 'internalName',
+    description: 'Internal name of the snapshot',
+    type: String,
+    required: true,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Runners found for the snapshot',
+    type: [RunnerSnapshotDto],
+  })
+  async getRunnersBySnapshotInternalName(@Query('internalName') internalName: string): Promise<RunnerSnapshotDto[]> {
+    return this.runnerService.getRunnersBySnapshotInternalName(internalName)
   }
 }

--- a/apps/api/src/sandbox/dto/runner-snapshot.dto.ts
+++ b/apps/api/src/sandbox/dto/runner-snapshot.dto.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+
+export class RunnerSnapshotDto {
+  @ApiProperty({
+    description: 'Runner snapshot ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  runnerSnapshotId: string
+
+  @ApiProperty({
+    description: 'Runner ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  runnerId: string
+
+  @ApiProperty({
+    description: 'Runner domain',
+    example: 'runner.example.com',
+  })
+  runnerDomain: string
+
+  constructor(runnerSnapshotId: string, runnerId: string, runnerDomain: string) {
+    this.runnerSnapshotId = runnerSnapshotId
+    this.runnerId = runnerId
+    this.runnerDomain = runnerDomain
+  }
+}


### PR DESCRIPTION
# Add endpoint to get runners by snapshot internal name

## Description

This PR adds a new endpoint to retrieve all runner records where a snapshot-runner record exists for a given snapshot internal name. This feature enables querying which runners have access to a specific snapshot, which is useful for monitoring snapshot distribution across the runner infrastructure.

### Changes Made
* New DTO: Created RunnerSnapshotDto with fields for runnerSnapshotId, runnerId, and runnerDomain
  * Service Method: Added getRunnersBySnapshotInternalName() method to RunnerService that:
  * Finds the snapshot by internal name
  * Queries snapshot runners using the internal name as the snapshotRef
  * Retrieves corresponding runner details
  * Returns formatted DTO objects
* Controller Endpoint: Added `GET /runners/by-snapshot` endpoint with:
  * Query parameter for internalName
  * Proper Swagger documentation
  * Returns array of RunnerSnapshotDto objects

### API Usage
```
GET /runners/by-snapshot?internalName=registry:5000/daytona/57c830c5-ef88-4562-9032-cc7b51c4d711:1.10
```

### Dependencies
No new dependencies are required. The implementation uses existing TypeORM repositories and follows the established patterns in the codebase.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


