### PR TITLE
fix(daemon): swap configDir and ProjectDir params

### DIFF
--- a/apps/daemon/pkg/toolbox/toolbox.go
+++ b/apps/daemon/pkg/toolbox/toolbox.go
@@ -103,7 +103,7 @@ func (s *Server) Start() error {
 	{
 		processController.POST("/execute", process.ExecuteCommand)
 
-		sessionController := session.NewSessionController(s.ProjectDir, configDir)
+		sessionController := session.NewSessionController(configDir, s.ProjectDir)
 		sessionGroup := processController.Group("/session")
 		{
 			sessionGroup.GET("", sessionController.ListSessions)


### PR DESCRIPTION
# Swap `configDir` and `ProjectDir` params

## Description

Because the params were in the incorrect order when calling `NewSessionController`, sessions were spawned in `$HOME/.daytona` rather than in `$HOME`. Additionally, logs were being stored at `$HOME/sessions` instead of `$HOME/.daytona/sessions` amongst other things.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
