### PR TITLE
fix(api): check snapshot state when creating sandbox

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -862,16 +862,16 @@ export class SnapshotManager {
     }
 
     try {
-      const sevenDaysAgo = new Date(Date.now() - 7 * 1000 * 60 * 60 * 24)
+      const twoWeeksAgo = new Date(Date.now() - 14 * 1000 * 60 * 60 * 24)
 
-      // Find all active snapshots that haven't been used in over 7 days or have null lastUsedAt
+      // Find all active snapshots that haven't been used in over 14 days or have null lastUsedAt
       const oldSnapshots = await this.snapshotRepository.find({
         where: [
           {
             general: false,
             state: SnapshotState.ACTIVE,
-            lastUsedAt: Or(IsNull(), LessThan(sevenDaysAgo)),
-            createdAt: LessThan(sevenDaysAgo),
+            lastUsedAt: Or(IsNull(), LessThan(twoWeeksAgo)),
+            createdAt: LessThan(twoWeeksAgo),
           },
         ],
         take: 100,


### PR DESCRIPTION
# Check Snapshot State When Creating Sandbox

## Description

Added a snapshot state check when creating a sandbox so that the user is aware if the snapshot is not active.
Also upped the snapshot inactive threshold to 14 days instead of 7.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
