### PR TITLE
fix: dockerfile COPY command path resolutions; stream error handling

### DIFF
--- a/libs/sdk-python/src/daytona/_async/snapshot.py
+++ b/libs/sdk-python/src/daytona/_async/snapshot.py
@@ -136,6 +136,7 @@ class AsyncSnapshotService:
         created_snapshot = await self.__snapshots_api.create_snapshot(create_snapshot_req)
 
         terminal_states = [SnapshotState.ACTIVE, SnapshotState.ERROR, SnapshotState.BUILD_FAILED]
+        log_terminal_states = [*terminal_states, SnapshotState.PENDING_VALIDATION, SnapshotState.VALIDATING]
 
         async def start_log_streaming():
             _, url, *_ = self.__snapshots_api._get_snapshot_build_logs_serialize(  # pylint: disable=protected-access
@@ -150,7 +151,7 @@ class AsyncSnapshotService:
 
             async def should_terminate():
                 latest_snapshot = await self.__snapshots_api.get_snapshot(created_snapshot.id)
-                return latest_snapshot.state in terminal_states
+                return latest_snapshot.state in log_terminal_states
 
             await process_streaming_response(
                 url=url,

--- a/libs/sdk-python/src/daytona/_sync/snapshot.py
+++ b/libs/sdk-python/src/daytona/_sync/snapshot.py
@@ -142,6 +142,7 @@ class SnapshotService:
         created_snapshot = self.__snapshots_api.create_snapshot(create_snapshot_req)
 
         terminal_states = [SnapshotState.ACTIVE, SnapshotState.ERROR, SnapshotState.BUILD_FAILED]
+        log_terminal_states = [*terminal_states, SnapshotState.PENDING_VALIDATION, SnapshotState.VALIDATING]
 
         def start_log_streaming():
             _, url, *_ = self.__snapshots_api._get_snapshot_build_logs_serialize(  # pylint: disable=protected-access
@@ -156,7 +157,7 @@ class SnapshotService:
 
             def should_terminate():
                 latest_snapshot = self.__snapshots_api.get_snapshot(created_snapshot.id)
-                return latest_snapshot.state in terminal_states
+                return latest_snapshot.state in log_terminal_states
 
             asyncio.run(
                 process_streaming_response(

--- a/libs/sdk-python/src/daytona/_utils/stream.py
+++ b/libs/sdk-python/src/daytona/_utils/stream.py
@@ -93,3 +93,6 @@ async def process_streaming_response(
                         await next_chunk
                     except asyncio.CancelledError:
                         pass
+                    except httpx.RemoteProtocolError as e:
+                        if "peer closed connection without sending complete message body" not in str(e):
+                            raise e

--- a/libs/sdk-typescript/src/Image.ts
+++ b/libs/sdk-typescript/src/Image.ts
@@ -25,7 +25,7 @@ const LATEST_PYTHON_MICRO_VERSIONS = ['3.9.22', '3.10.17', '3.11.12', '3.12.10',
  */
 export interface Context {
   sourcePath: string
-  archivePath?: string
+  archivePath: string
 }
 
 /**
@@ -122,9 +122,8 @@ export class Image {
 
     const extraArgs = this.formatPipInstallArgs(options)
 
-    const archivePath = ObjectStorage.computeArchiveBasePath(expandedPath)
-    this._contextList.push({ sourcePath: expandedPath, archivePath })
-    this._dockerfile += `COPY ${archivePath} /.requirements.txt\n`
+    this._contextList.push({ sourcePath: expandedPath, archivePath: expandedPath })
+    this._dockerfile += `COPY ${expandedPath} /.requirements.txt\n`
     this._dockerfile += `RUN python -m pip install -r /.requirements.txt${extraArgs}\n`
 
     return this
@@ -186,9 +185,8 @@ export class Image {
     }
 
     const expandedPath = untildify(localPath)
-    const archivePath = ObjectStorage.computeArchiveBasePath(expandedPath)
-    this._contextList.push({ sourcePath: expandedPath, archivePath })
-    this._dockerfile += `COPY ${archivePath} ${remotePath}\n`
+    this._contextList.push({ sourcePath: expandedPath, archivePath: expandedPath })
+    this._dockerfile += `COPY ${expandedPath} ${remotePath}\n`
 
     return this
   }
@@ -207,10 +205,9 @@ export class Image {
    */
   addLocalDir(localPath: string, remotePath: string): Image {
     const expandedPath = untildify(localPath)
-    const archivePath = ObjectStorage.computeArchiveBasePath(expandedPath)
 
-    this._contextList.push({ sourcePath: expandedPath, archivePath })
-    this._dockerfile += `COPY ${archivePath} ${remotePath}\n`
+    this._contextList.push({ sourcePath: expandedPath, archivePath: expandedPath })
+    this._dockerfile += `COPY ${expandedPath} ${remotePath}\n`
 
     return this
   }

--- a/libs/sdk-typescript/src/Snapshot.ts
+++ b/libs/sdk-typescript/src/Snapshot.ts
@@ -167,6 +167,11 @@ export class SnapshotService {
     }
 
     const terminalStates: SnapshotState[] = [SnapshotState.ACTIVE, SnapshotState.ERROR, SnapshotState.BUILD_FAILED]
+    const logTerminalStates: SnapshotState[] = [
+      ...terminalStates,
+      SnapshotState.PENDING_VALIDATION,
+      SnapshotState.VALIDATING,
+    ]
     const snapshotRef = { createdSnapshot: createdSnapshot }
     let streamPromise: Promise<void> | undefined
     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -175,7 +180,7 @@ export class SnapshotService {
         streamPromise = processStreamingResponse(
           () => this.snapshotsApi.getSnapshotBuildLogs(createdSnapshot.id, undefined, true, { responseType: 'stream' }),
           (chunk) => onChunk(chunk.trimEnd()),
-          async () => terminalStates.includes(snapshotRef.createdSnapshot.state),
+          async () => logTerminalStates.includes(snapshotRef.createdSnapshot.state),
         )
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ disable = [
 ]
 const-rgx = "(([A-Z_][A-Z0-9_]*)|([a-z_][a-z0-9_]*))"
 allowed-redefined-builtins = ["id"]
+
+[tool.basedpyright]
+typeCheckingMode = "off"


### PR DESCRIPTION
# Pull Request Title

## Description

Fixed the TypeScript SDK’s COPY path resolution for declarative builder and improved stream log termination to ensure the stream closes asap.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
