### PR TITLE
feat(runner): allow setting the network of the sandbox container

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	CacheRetentionDays int    `envconfig:"CACHE_RETENTION_DAYS"`
 	Environment        string `envconfig:"ENVIRONMENT"`
 	ContainerRuntime   string `envconfig:"CONTAINER_RUNTIME"`
+	ContainerNetwork   string `envconfig:"CONTAINER_NETWORK"`
 	LogFilePath        string `envconfig:"LOG_FILE_PATH"`
 	AWSRegion          string `envconfig:"AWS_REGION"`
 	AWSEndpointUrl     string `envconfig:"AWS_ENDPOINT_URL"`
@@ -70,6 +71,10 @@ func GetConfig() (*Config, error) {
 
 func GetContainerRuntime() string {
 	return config.ContainerRuntime
+}
+
+func GetContainerNetwork() string {
+	return config.ContainerNetwork
 }
 
 func GetEnvironment() string {

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -70,12 +70,12 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		}
 	}
 
-	containerConfig, hostConfig, err := d.getContainerConfigs(ctx, sandboxDto, volumeMountPathBinds)
+	containerConfig, hostConfig, networkingConfig, err := d.getContainerConfigs(ctx, sandboxDto, volumeMountPathBinds)
 	if err != nil {
 		return "", err
 	}
 
-	c, err := d.apiClient.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, sandboxDto.Id)
+	c, err := d.apiClient.ContainerCreate(ctx, containerConfig, hostConfig, networkingConfig, nil, sandboxDto.Id)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Pull Request Title

## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

In a self-hosted deployment, when the `runner`, `proxy`, and `api` are placed in a custom network, if the sandbox container uses the default network, all API calls from the `runner` to the `sandbox daemon 2280` will time out.


## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

1. First, set the environment variable `CONTAINER_NETWORK=sandbox` when starting the runner.

2. After creating the sandbox through the sdk, you can see that the container network is sandbox.
<img width="853" alt="image" src="https://github.com/user-attachments/assets/ebcff124-3268-45f6-a185-f33406a7def1" />


## Notes

Please add any relevant notes if necessary.
