### PR TITLE
fix(fs): wrong httpx stream param invoked

### DIFF
--- a/libs/sdk-python/scripts/sync_generator.py
+++ b/libs/sdk-python/scripts/sync_generator.py
@@ -79,6 +79,7 @@ POST_REPLACEMENTS = [
     (re.compile(r"\bSync([A-Z]\w*)\b"), r"\1"),
     # httpx client fix
     (re.compile(r"httpx\.SyncClient\b"), "httpx.Client"),
+    (re.compile(r"\.aiter_bytes\b"), ".iter_bytes"),
     # Update module imports
     (re.compile(r"from daytona\._async"), "from daytona._sync"),
     # Documentation cleanup

--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -157,7 +157,7 @@ class AsyncFileSystem:
         )
 
         async with httpx.AsyncClient(timeout=timeout or None) as client:
-            async with client.stream(method, url, headers) as response:
+            async with client.stream(method, url, headers=headers) as response:
                 response.raise_for_status()
                 parent = os.path.dirname(local_path)
                 if parent:

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -157,14 +157,14 @@ class FileSystem:
         )
 
         with httpx.Client(timeout=timeout or None) as client:
-            with client.stream(method, url, headers) as response:
+            with client.stream(method, url, headers=headers) as response:
                 response.raise_for_status()
                 parent = os.path.dirname(local_path)
                 if parent:
                     os.makedirs(parent, exist_ok=True)
 
                 with open(local_path, "wb") as f:
-                    for chunk in response.aiter_bytes(chunk_size=10 * 1024):
+                    for chunk in response.iter_bytes(chunk_size=10 * 1024):
                         if chunk:
                             f.write(chunk)
             return None


### PR DESCRIPTION
# Pull Request Title

## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

I haven't seen any issues yet, but the issue exists and is 100% reproducible. It happens when you try to use [this api](https://www.daytona.io/docs/python-sdk/sync/file-system/#filesystemdownload_file-1)

Basically it is wrongly using `httpx`, headers is used as a keyword parameter in `httpx.client`, but it is passed in as a positional parameter.

reference from httpx: 

https://github.com/encode/httpx/blob/26d48e0634e6ee9cdc0533996db289ce4b430177/httpx/_client.py#L827-L844

And below `_sync.filesystem.py` is using aiter_bytes(an async func) in a sync function, it should be iter_bytes instead.
