### PR TITLE
feat: add ripgrep to default snapshot

### DIFF
--- a/images/sandbox/Dockerfile
+++ b/images/sandbox/Dockerfile
@@ -1,7 +1,9 @@
 FROM mcr.microsoft.com/devcontainers/python
 
 # Update package list and install required dependencies
-RUN apt-get update && apt-get install -y curl sudo python3-pip python3-venv && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    curl sudo python3-pip python3-venv ripgrep && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install pipx and uv
 RUN python3 -m pip install pipx && pipx ensurepath && pipx install uv


### PR DESCRIPTION
# Add ripgrep to default snapshot

## Description

Adds `ripgrep` to the default snapshot - this will then be used for the `sandbox.search()` SDK method that will look something like this:

```
sandbox.search(
    query: str,
    path: str = ".",                      # default current dir
    file_types: list[str] = None,         # e.g., ["py", "js"]
    include_globs: list[str] = None,      # e.g., ["*.ts", "src/**/*.js"]
    exclude_globs: list[str] = None,      # e.g., ["*.test.*", "node_modules/*"]
    case_sensitive: bool = True,
    multiline: bool = False,
    context: int = 0,                     # lines of context around matches
    count_only: bool = False,             # return match counts
    filenames_only: bool = False,         # return list of files with matches
    json: bool = False,                   # structured output (like rg --json)
    max_results: int = None,              # optional result cap
    rg_args: list[str] = None             # passthrough for advanced users
) -> SearchResults
```

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation