### PR TITLE
fix(daemon): reduce port detection CPU overhead

### DIFF
--- a/apps/daemon/go.mod
+++ b/apps/daemon/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/bytedance/sonic v1.12.6 // indirect
 	github.com/bytedance/sonic/loader v0.2.1 // indirect
+	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect

--- a/apps/daemon/go.sum
+++ b/apps/daemon/go.sum
@@ -15,6 +15,8 @@ github.com/bytedance/sonic v1.12.6/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKz
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.1 h1:1GgorWTqf12TA8mma4DDSbaQigE2wOgQo7iCjjJv3+E=
 github.com/bytedance/sonic/loader v0.2.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 h1:BjkPE3785EwPhhyuFkbINB+2a1xATwk8SNDWnJiD41g=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5/go.mod h1:jtAfVaU/2cu1+wdSRPWE2c1N2qeAA3K4RH9pYgqwets=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=


### PR DESCRIPTION
# Reduce Port Detection CPU Overhead

## Description

The daemon open port detector had a very high CPU overhead because of opening a lot of tcp connections per second.
With the use of https://github.com/cakturk/go-netstat, the overhead was practically completely removed and the daemon process now consumes almost no CPU resources.

Before:
<img width="1347" alt="Screenshot 2025-06-25 at 16 20 38" src="https://github.com/user-attachments/assets/cf5703d4-6780-4b7a-a10a-9e975b0c21ae" />

After:
<img width="1337" alt="Screenshot 2025-06-25 at 16 19 26" src="https://github.com/user-attachments/assets/d385e5c6-04bd-45ac-9687-6b548791f2cb" />


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
