### PR TITLE
fix: use get preview port endpoint

### DIFF
--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -178,9 +178,12 @@ var CreateCmd = &cobra.Command{
 			return fmt.Errorf("failed to get runner domain")
 		}
 
-		sandboxUrl := fmt.Sprintf("https://%d-%s.%s", SANDBOX_TERMINAL_PORT, sandbox.Id, *runnerDomain)
+		previewUrl, res, err := apiClient.SandboxAPI.GetPortPreviewUrl(ctx, sandbox.Id, SANDBOX_TERMINAL_PORT).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
 
-		views_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox is accessible at %s", views_common.LinkStyle.Render(sandboxUrl)))
+		views_common.RenderInfoMessageBold(fmt.Sprintf("Sandbox is accessible at %s", views_common.LinkStyle.Render(previewUrl.Url)))
 		return nil
 	},
 }

--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -147,7 +147,7 @@ var PushCmd = &cobra.Command{
 			return err
 		}
 
-		views_common.RenderInfoMessage(fmt.Sprintf("%s  Use '%s' to create a new sandbox using this snapshot", views_common.Checkmark, targetImage))
+		views_common.RenderInfoMessage(fmt.Sprintf("%s  Use '%s' to create a new sandbox using this snapshot", views_common.Checkmark, nameFlag))
 		return nil
 	},
 }


### PR DESCRIPTION
# Use the API endpoint for getting preview port in the CLI

## Description

Use the API endpoint for getting preview port in the CLI - a switch from the legacy proxy

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
