### PR TITLE
fix(daemon): terminal connection issues

### DIFF
--- a/apps/daemon/pkg/terminal/decoder.go
+++ b/apps/daemon/pkg/terminal/decoder.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package terminal
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+type UTF8Decoder struct {
+	buffer []byte
+}
+
+func NewUTF8Decoder() *UTF8Decoder {
+	return &UTF8Decoder{
+		buffer: make([]byte, 0, 1024),
+	}
+}
+
+// Write appends new data to the internal buffer and decodes valid UTF-8 runes.
+// It returns the decoded string. Any incomplete bytes are kept for the next call.
+func (d *UTF8Decoder) Write(data []byte) string {
+	// Combine buffer + new data
+	data = append(d.buffer, data...)
+	var output bytes.Buffer
+
+	i := 0
+	for i < len(data) {
+		r, size := utf8.DecodeRune(data[i:])
+		if r == utf8.RuneError {
+			if size == 1 {
+				// Likely an incomplete rune, break and buffer remaining
+				break
+			}
+		}
+		output.WriteRune(r)
+		i += size
+	}
+
+	// Save leftover bytes (possibly an incomplete rune)
+	d.buffer = d.buffer[:0]
+	if i < len(data) {
+		d.buffer = append(d.buffer, data[i:]...)
+	}
+
+	return output.String()
+}

--- a/apps/daemon/pkg/terminal/decoder.go
+++ b/apps/daemon/pkg/terminal/decoder.go
@@ -30,8 +30,16 @@ func (d *UTF8Decoder) Write(data []byte) string {
 		r, size := utf8.DecodeRune(data[i:])
 		if r == utf8.RuneError {
 			if size == 1 {
-				// Likely an incomplete rune, break and buffer remaining
-				break
+				// Could be incomplete rune at the end
+				remaining := len(data) - i
+				if remaining < utf8.UTFMax {
+					// Buffer the remaining bytes for next call
+					break
+				}
+				// Otherwise, it's an invalid byte, emit replacement and advance by 1
+				output.WriteRune(r)
+				i++
+				continue
 			}
 		}
 		output.WriteRune(r)

--- a/apps/daemon/pkg/terminal/server.go
+++ b/apps/daemon/pkg/terminal/server.go
@@ -15,8 +15,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-var decoder = NewUTF8Decoder()
-
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		return true // Be careful with this in production
@@ -51,6 +49,9 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close()
+
+	// Create a new UTF8Decoder instance for this connection
+	decoder := NewUTF8Decoder()
 
 	sizeCh := make(chan common.TTYSize)
 	stdInReader, stdInWriter := io.Pipe()


### PR DESCRIPTION
# Fix web terminal connection issues

## Description

Sandbox web terminal would close the websocket connection when multi-byte UTF-8 characters were split across buffer reads, causing the browser websocket to close with the following error:

`Could not decode a text frame as UTF-8`

Added a UTF8Decoder that buffers incomplete UTF-8 byte sequences across reads, ensuring only valid UTF-8 strings are sent over the websocket.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fb84d7f1-b83a-4b0b-aa58-78ff3a538c0f" />
