### PR TITLE
Fix findOneBySnapshotImageName to ignore transient registry

### DIFF
--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -5,7 +5,7 @@
 
 import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { IsNull, Repository } from 'typeorm'
+import { In, IsNull, Repository } from 'typeorm'
 import { DockerRegistry } from '../entities/docker-registry.entity'
 import { CreateDockerRegistryDto } from '../dto/create-docker-registry.dto'
 import { UpdateDockerRegistryDto } from '../dto/update-docker-registry.dto'
@@ -129,8 +129,11 @@ export class DockerRegistryService {
 
   async findOneBySnapshotImageName(imageName: string, organizationId?: string): Promise<DockerRegistry | null> {
     const whereCondition = organizationId
-      ? [{ organizationId }, { organizationId: IsNull() }]
-      : [{ organizationId: IsNull() }]
+      ? [
+          { organizationId, registryType: In([RegistryType.INTERNAL, RegistryType.ORGANIZATION]) },
+          { organizationId: IsNull(), registryType: In([RegistryType.INTERNAL, RegistryType.ORGANIZATION]) },
+        ]
+      : [{ organizationId: IsNull(), registryType: In([RegistryType.INTERNAL, RegistryType.ORGANIZATION]) }]
 
     const registries = await this.dockerRegistryRepository.find({
       where: whereCondition,


### PR DESCRIPTION
# Fix findOneBySnapshotImageName to ignore transient registry

## Description

This PR fixes an error that occurs when propagating snapshots to runner nodes in environments where both the transient and internal registries share the same domain.
Previously, findOneBySnapshotImageName could incorrectly match the transient registry, causing snapshot propagation to fail.
With this fix, the method now ignores the transient registry when searching by image name, ensuring the correct registry is used even if both registries are on the same domain.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
