### PR TITLE
fix(api): handle destroyed sandbox on runner

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -561,7 +561,8 @@ export class SandboxManager {
           const sandboxInfoResponse = await runnerSandboxApi.info(sandbox.id)
           const sandboxInfo = sandboxInfoResponse.data
           if (sandboxInfo?.state === RunnerSandboxState.SandboxStateDestroyed) {
-            return DONT_SYNC_AGAIN
+            await this.updateSandboxState(sandbox.id, SandboxState.DESTROYING)
+            return SYNC_AGAIN
           }
           await runnerSandboxApi.destroy(sandbox.id)
         } catch (e) {


### PR DESCRIPTION
# Fix Handle Destroyed Sandbox on Runner

## Description

If the sandbox is destroyed on the runner, put the sandbox in `destroying` state instead of keeping it in it's original state.
If the original state is kept, sandboxes will never get destroyed.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
