### PR TITLE
fix: daytona config argument overrides env vars (fixed edge cases)

### DIFF
--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -76,6 +76,12 @@ class AsyncDaytona:
         ```
     """
 
+    _api_key: Optional[str] = None
+    _jwt_token: Optional[str] = None
+    _organization_id: Optional[str] = None
+    _api_url: Optional[str] = None
+    _target: Optional[str] = None
+
     def __init__(self, config: Optional[DaytonaConfig] = None):
         """Initializes Daytona instance with optional configuration.
 
@@ -110,28 +116,37 @@ class AsyncDaytona:
         default_api_url = "https://app.daytona.io/api"
         self.default_language = CodeLanguage.PYTHON
 
+        if config:
+            self._api_key = None if (not config.api_key and config.jwt_token) else config.api_key
+            self._jwt_token = config.jwt_token
+            self._organization_id = config.organization_id
+            self._api_url = config.api_url or config.server_url
+            self._target = config.target
+
         if config is None or (
-            not all([config.api_key, config.api_url, config.target])
+            not all([self._api_key, self._api_url, self._target])
             and not all(
                 [
-                    config.jwt_token,
-                    config.organization_id,
-                    config.api_url,
-                    config.target,
+                    self._jwt_token,
+                    self._organization_id,
+                    self._api_url,
+                    self._target,
                 ]
             )
         ):
             # Initialize env - it automatically reads from .env and .env.local
             env = Env()
-            env.read_env()  # reads .env
-            # reads .env.local and overrides values
+            env.read_env()
+            env.read_env(".env", override=True)
             env.read_env(".env.local", override=True)
 
-            self._api_key = env.str("DAYTONA_API_KEY", None)
-            self._jwt_token = env.str("DAYTONA_JWT_TOKEN", None)
-            self._organization_id = env.str("DAYTONA_ORGANIZATION_ID", None)
-            self._api_url = env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
-            self._target = env.str("DAYTONA_TARGET", None)
+            self._api_key = self._api_key or (env.str("DAYTONA_API_KEY", None) if not self._jwt_token else None)
+            self._jwt_token = self._jwt_token or env.str("DAYTONA_JWT_TOKEN", None)
+            self._organization_id = self._organization_id or env.str("DAYTONA_ORGANIZATION_ID", None)
+            self._api_url = (
+                self._api_url or env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
+            )
+            self._target = self._target or env.str("DAYTONA_TARGET", None)
 
             if env.str("DAYTONA_SERVER_URL", None) and not env.str("DAYTONA_API_URL", None):
                 warnings.warn(
@@ -140,16 +155,6 @@ class AsyncDaytona:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-
-        if config:
-            if not config.api_key and config.jwt_token:
-                self._api_key = None
-            else:
-                self._api_key = config.api_key or getattr(self, "_api_key", None)
-            self._jwt_token = config.jwt_token or getattr(self, "_jwt_token", None)
-            self._organization_id = config.organization_id or getattr(self, "_organization_id", None)
-            self._api_url = config.api_url or self._api_url
-            self._target = config.target or self._target
 
         if not self._api_key and not self._jwt_token:
             raise DaytonaError("API key or JWT token is required")

--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -79,7 +79,7 @@ class AsyncDaytona:
     _api_key: Optional[str] = None
     _jwt_token: Optional[str] = None
     _organization_id: Optional[str] = None
-    _api_url: Optional[str] = None
+    _api_url: str
     _target: Optional[str] = None
 
     def __init__(self, config: Optional[DaytonaConfig] = None):
@@ -115,21 +115,22 @@ class AsyncDaytona:
 
         default_api_url = "https://app.daytona.io/api"
         self.default_language = CodeLanguage.PYTHON
+        api_url = None
 
         if config:
             self._api_key = None if (not config.api_key and config.jwt_token) else config.api_key
             self._jwt_token = config.jwt_token
             self._organization_id = config.organization_id
-            self._api_url = config.api_url or config.server_url
+            api_url = config.api_url or config.server_url
             self._target = config.target
 
         if config is None or (
-            not all([self._api_key, self._api_url, self._target])
+            not all([self._api_key, api_url, self._target])
             and not all(
                 [
                     self._jwt_token,
                     self._organization_id,
-                    self._api_url,
+                    api_url,
                     self._target,
                 ]
             )
@@ -143,9 +144,7 @@ class AsyncDaytona:
             self._api_key = self._api_key or (env.str("DAYTONA_API_KEY", None) if not self._jwt_token else None)
             self._jwt_token = self._jwt_token or env.str("DAYTONA_JWT_TOKEN", None)
             self._organization_id = self._organization_id or env.str("DAYTONA_ORGANIZATION_ID", None)
-            self._api_url = (
-                self._api_url or env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
-            )
+            api_url = api_url or env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
             self._target = self._target or env.str("DAYTONA_TARGET", None)
 
             if env.str("DAYTONA_SERVER_URL", None) and not env.str("DAYTONA_API_URL", None):
@@ -155,6 +154,8 @@ class AsyncDaytona:
                     DeprecationWarning,
                     stacklevel=2,
                 )
+
+        self._api_url = api_url
 
         if not self._api_key and not self._jwt_token:
             raise DaytonaError("API key or JWT token is required")

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -81,7 +81,7 @@ class Daytona:
     _api_key: Optional[str] = None
     _jwt_token: Optional[str] = None
     _organization_id: Optional[str] = None
-    _api_url: Optional[str] = None
+    _api_url: str
     _target: Optional[str] = None
 
     def __init__(self, config: Optional[DaytonaConfig] = None):
@@ -117,21 +117,22 @@ class Daytona:
 
         default_api_url = "https://app.daytona.io/api"
         self.default_language = CodeLanguage.PYTHON
+        api_url = None
 
         if config:
             self._api_key = None if (not config.api_key and config.jwt_token) else config.api_key
             self._jwt_token = config.jwt_token
             self._organization_id = config.organization_id
-            self._api_url = config.api_url or config.server_url
+            api_url = config.api_url or config.server_url
             self._target = config.target
 
         if config is None or (
-            not all([self._api_key, self._api_url, self._target])
+            not all([self._api_key, api_url, self._target])
             and not all(
                 [
                     self._jwt_token,
                     self._organization_id,
-                    self._api_url,
+                    api_url,
                     self._target,
                 ]
             )
@@ -145,9 +146,7 @@ class Daytona:
             self._api_key = self._api_key or (env.str("DAYTONA_API_KEY", None) if not self._jwt_token else None)
             self._jwt_token = self._jwt_token or env.str("DAYTONA_JWT_TOKEN", None)
             self._organization_id = self._organization_id or env.str("DAYTONA_ORGANIZATION_ID", None)
-            self._api_url = (
-                self._api_url or env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
-            )
+            api_url = api_url or env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
             self._target = self._target or env.str("DAYTONA_TARGET", None)
 
             if env.str("DAYTONA_SERVER_URL", None) and not env.str("DAYTONA_API_URL", None):
@@ -157,6 +156,8 @@ class Daytona:
                     DeprecationWarning,
                     stacklevel=2,
                 )
+
+        self._api_url = api_url
 
         if not self._api_key and not self._jwt_token:
             raise DaytonaError("API key or JWT token is required")

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -78,6 +78,12 @@ class Daytona:
         ```
     """
 
+    _api_key: Optional[str] = None
+    _jwt_token: Optional[str] = None
+    _organization_id: Optional[str] = None
+    _api_url: Optional[str] = None
+    _target: Optional[str] = None
+
     def __init__(self, config: Optional[DaytonaConfig] = None):
         """Initializes Daytona instance with optional configuration.
 
@@ -112,28 +118,37 @@ class Daytona:
         default_api_url = "https://app.daytona.io/api"
         self.default_language = CodeLanguage.PYTHON
 
+        if config:
+            self._api_key = None if (not config.api_key and config.jwt_token) else config.api_key
+            self._jwt_token = config.jwt_token
+            self._organization_id = config.organization_id
+            self._api_url = config.api_url or config.server_url
+            self._target = config.target
+
         if config is None or (
-            not all([config.api_key, config.api_url, config.target])
+            not all([self._api_key, self._api_url, self._target])
             and not all(
                 [
-                    config.jwt_token,
-                    config.organization_id,
-                    config.api_url,
-                    config.target,
+                    self._jwt_token,
+                    self._organization_id,
+                    self._api_url,
+                    self._target,
                 ]
             )
         ):
             # Initialize env - it automatically reads from .env and .env.local
             env = Env()
-            env.read_env()  # reads .env
-            # reads .env.local and overrides values
+            env.read_env()
+            env.read_env(".env", override=True)
             env.read_env(".env.local", override=True)
 
-            self._api_key = env.str("DAYTONA_API_KEY", None)
-            self._jwt_token = env.str("DAYTONA_JWT_TOKEN", None)
-            self._organization_id = env.str("DAYTONA_ORGANIZATION_ID", None)
-            self._api_url = env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
-            self._target = env.str("DAYTONA_TARGET", None)
+            self._api_key = self._api_key or (env.str("DAYTONA_API_KEY", None) if not self._jwt_token else None)
+            self._jwt_token = self._jwt_token or env.str("DAYTONA_JWT_TOKEN", None)
+            self._organization_id = self._organization_id or env.str("DAYTONA_ORGANIZATION_ID", None)
+            self._api_url = (
+                self._api_url or env.str("DAYTONA_API_URL", None) or env.str("DAYTONA_SERVER_URL", default_api_url)
+            )
+            self._target = self._target or env.str("DAYTONA_TARGET", None)
 
             if env.str("DAYTONA_SERVER_URL", None) and not env.str("DAYTONA_API_URL", None):
                 warnings.warn(
@@ -142,16 +157,6 @@ class Daytona:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-
-        if config:
-            if not config.api_key and config.jwt_token:
-                self._api_key = None
-            else:
-                self._api_key = config.api_key or getattr(self, "_api_key", None)
-            self._jwt_token = config.jwt_token or getattr(self, "_jwt_token", None)
-            self._organization_id = config.organization_id or getattr(self, "_organization_id", None)
-            self._api_url = config.api_url or self._api_url
-            self._target = config.target or self._target
 
         if not self._api_key and not self._jwt_token:
             raise DaytonaError("API key or JWT token is required")

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -206,7 +206,7 @@ export class Daytona {
   private readonly apiKey?: string
   private readonly jwtToken?: string
   private readonly organizationId?: string
-  private readonly apiUrl?: string
+  private readonly apiUrl: string
   public readonly volume: VolumeService
   public readonly snapshot: SnapshotService
 
@@ -217,29 +217,26 @@ export class Daytona {
    * @throws {DaytonaError} - `DaytonaError` - When API key is missing
    */
   constructor(config?: DaytonaConfig) {
+    let apiUrl: string | undefined
     if (config) {
       this.apiKey = !config?.apiKey && config?.jwtToken ? undefined : config?.apiKey
       this.jwtToken = config?.jwtToken
       this.organizationId = config?.organizationId
-      this.apiUrl = config?.apiUrl || config?.serverUrl
+      apiUrl = config?.apiUrl || config?.serverUrl
       this.target = config?.target
     }
 
     if (
       !config ||
-      (!(this.apiKey && this.apiUrl && this.target) &&
-        !(this.jwtToken && this.organizationId && this.apiUrl && this.target))
+      (!(this.apiKey && apiUrl && this.target) && !(this.jwtToken && this.organizationId && apiUrl && this.target))
     ) {
       dotenv.config()
       dotenv.config({ path: '.env.local', override: true })
       this.apiKey = this.apiKey || (this.jwtToken ? undefined : process?.env['DAYTONA_API_KEY'])
       this.jwtToken = this.jwtToken || process?.env['DAYTONA_JWT_TOKEN']
       this.organizationId = this.organizationId || process?.env['DAYTONA_ORGANIZATION_ID']
-      this.apiUrl =
-        this.apiUrl ||
-        process?.env['DAYTONA_API_URL'] ||
-        process?.env['DAYTONA_SERVER_URL'] ||
-        'https://app.daytona.io/api'
+      apiUrl =
+        apiUrl || process?.env['DAYTONA_API_URL'] || process?.env['DAYTONA_SERVER_URL'] || 'https://app.daytona.io/api'
       this.target = this.target || process?.env['DAYTONA_TARGET']
 
       if (process?.env['DAYTONA_SERVER_URL'] && !process?.env['DAYTONA_API_URL']) {
@@ -248,6 +245,8 @@ export class Daytona {
         )
       }
     }
+
+    this.apiUrl = apiUrl
 
     const orgHeader: Record<string, string> = {}
     if (!this.apiKey) {


### PR DESCRIPTION
# Pull Request Title

## Description

Ensure environment variables don't override any values passed in via the `config` argument, even if the provided `config` is partial.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

Solve a case where environment variables overwritten values from config argument when it was provided partial config object.

## Related Issue(s)

closes #2078 
