### PR TITLE
fix(api): sandbox sync instance state early exit

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -257,7 +257,7 @@ export class SandboxManager {
       id: sandboxId,
     })
 
-    if (sandbox.state === SandboxState.ERROR || sandbox.state === SandboxState.BUILD_FAILED) {
+    if ([SandboxState.DESTROYED, SandboxState.ERROR, SandboxState.BUILD_FAILED].includes(sandbox.state)) {
       await this.redisLockProvider.unlock(lockKey)
       return
     }


### PR DESCRIPTION
# Sandbox sync instance state early exit

## Description

Adds `SandboxState.DESTROYED` to the list of skipped states when syncing sandbox state with its desired state. This is consistent with the filter applied when fetching the list of sandboxes that require state syncing.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
