### PR TITLE
fix(api): validate organization quotas for sandbox start operation

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -565,16 +565,14 @@ export class SandboxService {
 
     await this.organizationService.assertOrganizationIsNotSuspended(organization)
 
+    await this.validateOrganizationQuotas(organization, sandbox.cpu, sandbox.mem, sandbox.disk, sandbox.id)
+
     if (sandbox.runnerId) {
       // Add runner readiness check
       const runner = await this.runnerService.findOne(sandbox.runnerId)
       if (runner.state !== RunnerState.READY) {
         throw new SandboxError('Runner is not ready')
       }
-    } else {
-      //  restore operation
-      //  like a new sandbox creation, we need to validate quotas
-      await this.validateOrganizationQuotas(organization, sandbox.cpu, sandbox.mem, sandbox.disk, sandbox.id)
     }
 
     if (sandbox.pending) {


### PR DESCRIPTION
# Validate organization quotas for sandbox start operation

## Description

Improved validation for organization quotas when starting a sandbox. Previously, it was possible to go over quotas when starting inactive sandboxes which were still assigned to a runner.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation