### PR TITLE
fix(api): assertOrganizationIsNotSuspended return type is not a promise

### DIFF
--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -412,7 +412,7 @@ export class OrganizationService implements OnModuleInit {
     await this.removeWithEntityManager(payload.entityManager, organization, true)
   }
 
-  async assertOrganizationIsNotSuspended(organization: Organization): Promise<void> {
+  assertOrganizationIsNotSuspended(organization: Organization): void {
     if (!organization.suspended) {
       return
     }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -77,7 +77,7 @@ export class SandboxService {
     disk: number,
     excludeSandboxId?: string,
   ): Promise<void> {
-    await this.organizationService.assertOrganizationIsNotSuspended(organization)
+    this.organizationService.assertOrganizationIsNotSuspended(organization)
 
     // Check per-sandbox resource limits
     if (cpu > organization.maxCpuPerSandbox) {
@@ -563,7 +563,7 @@ export class SandboxService {
       throw new SandboxError('Sandbox is not in valid state')
     }
 
-    await this.organizationService.assertOrganizationIsNotSuspended(organization)
+    this.organizationService.assertOrganizationIsNotSuspended(organization)
 
     if (sandbox.runnerId) {
       // Add runner readiness check

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -74,7 +74,7 @@ export class SnapshotService {
       }
     }
 
-    await this.organizationService.assertOrganizationIsNotSuspended(organization)
+    this.organizationService.assertOrganizationIsNotSuspended(organization)
 
     // check if the organization has reached the snapshot quota
     const snapshots = await this.snapshotRepository.find({


### PR DESCRIPTION
# Fix return type of helper method for asserting organization is not suspended

## Description

Fixed return type for `OrganizationService.assertOrganizationIsNotSuspended` since it's not an asynchronous method.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
