### PR TITLE
fix(mcp): align json namings

### DIFF
--- a/apps/cli/mcp/tools/create_folder.go
+++ b/apps/cli/mcp/tools/create_folder.go
@@ -15,14 +15,14 @@ import (
 
 type CreateFolderArgs struct {
 	Id         *string `json:"id,omitempty"`
-	FolderPath *string `json:"folder_path,omitempty"`
+	FolderPath *string `json:"folderPath,omitempty"`
 	Mode       *string `json:"mode,omitempty"`
 }
 
 func GetCreateFolderTool() mcp.Tool {
 	return mcp.NewTool("create_folder",
 		mcp.WithDescription("Create a new folder in the Daytona sandbox."),
-		mcp.WithString("folder_path", mcp.Required(), mcp.Description("Path to the folder to create.")),
+		mcp.WithString("folderPath", mcp.Required(), mcp.Description("Path to the folder to create.")),
 		mcp.WithString("mode", mcp.Description("Mode of the folder to create (defaults to 0755).")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("ID of the sandbox to create the folder in.")),
 	)
@@ -39,7 +39,7 @@ func CreateFolder(ctx context.Context, request mcp.CallToolRequest, args CreateF
 	}
 
 	if args.FolderPath == nil || *args.FolderPath == "" {
-		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("folder_path parameter is required")
+		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("folderPath parameter is required")
 	}
 
 	mode := "0755" // default mode

--- a/apps/cli/mcp/tools/delete_file.go
+++ b/apps/cli/mcp/tools/delete_file.go
@@ -16,13 +16,13 @@ import (
 
 type DeleteFileArgs struct {
 	Id       *string `json:"id,omitempty"`
-	FilePath *string `json:"file_path,omitempty"`
+	FilePath *string `json:"filePath,omitempty"`
 }
 
 func GetDeleteFileTool() mcp.Tool {
 	return mcp.NewTool("delete_file",
 		mcp.WithDescription("Delete a file or directory in the Daytona sandbox."),
-		mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the file or directory to delete.")),
+		mcp.WithString("filePath", mcp.Required(), mcp.Description("Path to the file or directory to delete.")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("ID of the sandbox to delete the file in.")),
 	)
 }
@@ -38,7 +38,7 @@ func DeleteFile(ctx context.Context, request mcp.CallToolRequest, args DeleteFil
 	}
 
 	if args.FilePath == nil || *args.FilePath == "" {
-		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("file_path parameter is required")
+		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("filePath parameter is required")
 	}
 
 	// Execute delete command

--- a/apps/cli/mcp/tools/download_file.go
+++ b/apps/cli/mcp/tools/download_file.go
@@ -16,7 +16,7 @@ import (
 
 type FileDownloadArgs struct {
 	Id       *string `json:"id,omitempty"`
-	FilePath *string `json:"file_path,omitempty"`
+	FilePath *string `json:"filePath,omitempty"`
 }
 
 type Content struct {
@@ -28,7 +28,7 @@ type Content struct {
 func GetFileDownloadTool() mcp.Tool {
 	return mcp.NewTool("file_download",
 		mcp.WithDescription("Download a file from the Daytona sandbox. Returns the file content either as text or as a base64 encoded image. Handles special cases like matplotlib plots stored as JSON with embedded base64 images."),
-		mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the file to download.")),
+		mcp.WithString("filePath", mcp.Required(), mcp.Description("Path to the file to download.")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("ID of the sandbox to download the file from.")),
 	)
 }
@@ -44,7 +44,7 @@ func FileDownload(ctx context.Context, request mcp.CallToolRequest, args FileDow
 	}
 
 	if args.FilePath == nil || *args.FilePath == "" {
-		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("file_path parameter is required")
+		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("filePath parameter is required")
 	}
 
 	// Download the file

--- a/apps/cli/mcp/tools/execute_command.go
+++ b/apps/cli/mcp/tools/execute_command.go
@@ -24,8 +24,8 @@ type ExecuteCommandArgs struct {
 type CommandResult struct {
 	Stdout    string `json:"stdout"`
 	Stderr    string `json:"stderr"`
-	ExitCode  int    `json:"exit_code"`
-	ErrorType string `json:"error_type,omitempty"`
+	ExitCode  int    `json:"exitCode"`
+	ErrorType string `json:"errorType,omitempty"`
 }
 
 func GetExecuteCommandTool() mcp.Tool {

--- a/apps/cli/mcp/tools/file_info.go
+++ b/apps/cli/mcp/tools/file_info.go
@@ -16,13 +16,13 @@ import (
 
 type FileInfoArgs struct {
 	Id       *string `json:"id,omitempty"`
-	FilePath *string `json:"file_path,omitempty"`
+	FilePath *string `json:"filePath,omitempty"`
 }
 
 func GetFileInfoTool() mcp.Tool {
 	return mcp.NewTool("get_file_info",
 		mcp.WithDescription("Get information about a file in the Daytona sandbox."),
-		mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the file to get information about.")),
+		mcp.WithString("filePath", mcp.Required(), mcp.Description("Path to the file to get information about.")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("ID of the sandbox to get the file information from.")),
 	)
 }
@@ -38,7 +38,7 @@ func FileInfo(ctx context.Context, request mcp.CallToolRequest, args FileInfoArg
 	}
 
 	if args.FilePath == nil || *args.FilePath == "" {
-		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("file_path parameter is required")
+		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("filePath parameter is required")
 	}
 
 	// Get file info

--- a/apps/cli/mcp/tools/git_clone.go
+++ b/apps/cli/mcp/tools/git_clone.go
@@ -19,7 +19,7 @@ type GitCloneArgs struct {
 	Url      *string `json:"url,omitempty"`
 	Path     *string `json:"path,omitempty"`
 	Branch   *string `json:"branch,omitempty"`
-	CommitId *string `json:"commit_id,omitempty"`
+	CommitId *string `json:"commitId,omitempty"`
 	Username *string `json:"username,omitempty"`
 	Password *string `json:"password,omitempty"`
 }
@@ -30,7 +30,7 @@ func GetGitCloneTool() mcp.Tool {
 		mcp.WithString("url", mcp.Required(), mcp.Description("URL of the Git repository to clone.")),
 		mcp.WithString("path", mcp.Description("Directory to clone the repository into (defaults to current directory).")),
 		mcp.WithString("branch", mcp.Description("Branch to clone.")),
-		mcp.WithString("commit_id", mcp.Description("Commit ID to clone.")),
+		mcp.WithString("commitId", mcp.Description("Commit ID to clone.")),
 		mcp.WithString("username", mcp.Description("Username to clone the repository with.")),
 		mcp.WithString("password", mcp.Description("Password to clone the repository with.")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("ID of the sandbox to clone the repository in.")),

--- a/apps/cli/mcp/tools/move_file.go
+++ b/apps/cli/mcp/tools/move_file.go
@@ -15,15 +15,15 @@ import (
 
 type MoveFileArgs struct {
 	Id         *string `json:"id,omitempty"`
-	SourcePath *string `json:"source_path,omitempty"`
-	DestPath   *string `json:"dest_path,omitempty"`
+	SourcePath *string `json:"sourcePath,omitempty"`
+	DestPath   *string `json:"destPath,omitempty"`
 }
 
 func GetMoveFileTool() mcp.Tool {
 	return mcp.NewTool("move_file",
 		mcp.WithDescription("Move or rename a file in the Daytona sandbox."),
-		mcp.WithString("source_path", mcp.Required(), mcp.Description("Source path of the file to move.")),
-		mcp.WithString("dest_path", mcp.Required(), mcp.Description("Destination path where to move the file.")),
+		mcp.WithString("sourcePath", mcp.Required(), mcp.Description("Source path of the file to move.")),
+		mcp.WithString("destPath", mcp.Required(), mcp.Description("Destination path where to move the file.")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("ID of the sandbox to move the file in.")),
 	)
 }
@@ -40,11 +40,11 @@ func MoveFile(ctx context.Context, request mcp.CallToolRequest, args MoveFileArg
 
 	// Get source and destination paths from request arguments
 	if args.SourcePath == nil || *args.SourcePath == "" {
-		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("source_path parameter is required")
+		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("sourcePath parameter is required")
 	}
 
 	if args.DestPath == nil || *args.DestPath == "" {
-		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("dest_path parameter is required")
+		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("destPath parameter is required")
 	}
 
 	_, err = apiClient.ToolboxAPI.MoveFile(ctx, *args.Id).Source(*args.SourcePath).Destination(*args.DestPath).Execute()

--- a/apps/cli/mcp/tools/preview_link.go
+++ b/apps/cli/mcp/tools/preview_link.go
@@ -19,7 +19,7 @@ import (
 type PreviewLinkArgs struct {
 	Id          *string `json:"id,omitempty"`
 	Port        *int32  `json:"port,omitempty"`
-	CheckServer *bool   `json:"check_server,omitempty"`
+	CheckServer *bool   `json:"checkServer,omitempty"`
 	Description *string `json:"description,omitempty"`
 }
 
@@ -28,7 +28,7 @@ func GetPreviewLinkTool() mcp.Tool {
 		mcp.WithDescription("Generate accessible preview URLs for web applications running in the Daytona sandbox. Creates a secure tunnel to expose local ports externally without configuration. Validates if a server is actually running on the specified port and provides diagnostic information for troubleshooting. Supports custom descriptions and metadata for better organization of multiple services."),
 		mcp.WithNumber("port", mcp.Required(), mcp.Description("Port to expose.")),
 		mcp.WithString("description", mcp.Required(), mcp.Description("Description of the service.")),
-		mcp.WithBoolean("check_server", mcp.Required(), mcp.Description("Check if a server is running on the specified port.")),
+		mcp.WithBoolean("checkServer", mcp.Required(), mcp.Description("Check if a server is running on the specified port.")),
 		mcp.WithString("id", mcp.Required(), mcp.Description("ID of the sandbox to generate the preview link for.")),
 	)
 }

--- a/apps/cli/mcp/tools/upload_file.go
+++ b/apps/cli/mcp/tools/upload_file.go
@@ -18,7 +18,7 @@ import (
 
 type FileUploadArgs struct {
 	Id        *string `json:"id,omitempty"`
-	FilePath  *string `json:"file_path,omitempty"`
+	FilePath  *string `json:"filePath,omitempty"`
 	Content   *string `json:"content,omitempty"`
 	Encoding  *string `json:"encoding,omitempty"`
 	Overwrite *bool   `json:"overwrite,omitempty"`
@@ -27,7 +27,7 @@ type FileUploadArgs struct {
 func GetFileUploadTool() mcp.Tool {
 	return mcp.NewTool("file_upload",
 		mcp.WithDescription("Upload files to the Daytona sandbox from text or base64-encoded binary content. Creates necessary parent directories automatically and verifies successful writes. Files persist during the session and have appropriate permissions for further tool operations. Supports overwrite controls and maintains original file formats."),
-		mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the file to upload. Files should always be uploaded to the /tmp directory if user doesn't specify otherwise.")),
+		mcp.WithString("filePath", mcp.Required(), mcp.Description("Path to the file to upload. Files should always be uploaded to the /tmp directory if user doesn't specify otherwise.")),
 		mcp.WithString("content", mcp.Required(), mcp.Description("Content of the file to upload.")),
 		mcp.WithString("encoding", mcp.Required(), mcp.Description("Encoding of the file to upload.")),
 		mcp.WithBoolean("overwrite", mcp.Required(), mcp.Description("Overwrite the file if it already exists.")),
@@ -46,7 +46,7 @@ func FileUpload(ctx context.Context, request mcp.CallToolRequest, args FileUploa
 	}
 
 	if args.FilePath == nil || *args.FilePath == "" {
-		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("file_path parameter is required")
+		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("filePath parameter is required")
 	}
 
 	if args.Content == nil || *args.Content == "" {


### PR DESCRIPTION
# MCP: Align JSON namings

## Description

This PR aligns JSON namings as well as introduces some domain rules for sandbox creation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation