### PR TITLE
fix(api): set pending on auto-stop and auto-archive

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -83,7 +83,7 @@ export class SandboxManager {
             organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
             state: SandboxState.STARTED,
             desiredState: SandboxDesiredState.STARTED,
-            pending: false,
+            pending: Not(true),
             autoStopInterval: Not(0),
             lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoStopInterval"`),
           },
@@ -103,6 +103,7 @@ export class SandboxManager {
             }
 
             try {
+              sandbox.pending = true
               sandbox.desiredState = SandboxDesiredState.STOPPED
               await this.sandboxRepository.save(sandbox)
               await this.redisLockProvider.unlock(lockKey)
@@ -139,7 +140,7 @@ export class SandboxManager {
             organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
             state: SandboxState.STOPPED,
             desiredState: SandboxDesiredState.STOPPED,
-            pending: false,
+            pending: Not(true),
             lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoArchiveInterval"`),
           },
           order: {
@@ -159,6 +160,7 @@ export class SandboxManager {
             }
 
             try {
+              sandbox.pending = true
               sandbox.desiredState = SandboxDesiredState.ARCHIVED
               await this.sandboxRepository.save(sandbox)
               await this.redisLockProvider.unlock(lockKey)


### PR DESCRIPTION
# Set pending on auto-stop and auto-archive

## Description

Added missing step that sets sandbox as pending for a state change when setting a new desired state in auto-stop and auto-archive checks. 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
