### PR TITLE
fix: skip errored entries when getting runners for snapshot

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -316,7 +316,10 @@ export class RunnerService {
     // Find all snapshot runners for this snapshot
     // Note: snapshotRef contains the internalName, not the snapshot ID
     const snapshotRunners = await this.snapshotRunnerRepository.find({
-      where: { snapshotRef: internalName },
+      where: {
+        snapshotRef: internalName,
+        state: Not(SnapshotRunnerState.ERROR),
+      },
     })
 
     this.logger.debug(`Found ${snapshotRunners.length} snapshot runners for snapshot ${snapshot.id}`)


### PR DESCRIPTION
# Skip errored entries when getting runners for snapshot
## Description

Errored entries should be disregarded when listing runners for snapshot

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
