### PR TITLE
fix: add legacy proxy url to preview response

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -462,10 +462,17 @@ export class SandboxController {
         throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
       }
 
+      // Get runner info
+      const runner = await this.runnerService.findOne(sandbox.runnerId)
+      if (!runner) {
+        throw new NotFoundException(`Runner not found for sandbox ${sandboxId}`)
+      }
+
       // Return new preview url only for updated sandboxes
       if (sandbox.daemonVersion) {
         return {
-          url: `${proxyProtocol}://${port}-${sandboxId}.${proxyDomain}`,
+          url: `${proxyProtocol}://${port}-${sandbox.id}.${proxyDomain}`,
+          legacyProxyUrl: `https://${port}-${sandbox.id}.${runner.domain}`,
           token: sandbox.authToken,
         }
       }

--- a/apps/api/src/sandbox/dto/port-preview-url.dto.ts
+++ b/apps/api/src/sandbox/dto/port-preview-url.dto.ts
@@ -21,4 +21,12 @@ export class PortPreviewUrlDto {
   })
   @IsString()
   token: string
+
+  @ApiProperty({
+    description: 'Legacy preview url using runner domain',
+    example: 'https://3000-mysandbox.runner.com',
+    required: false,
+  })
+  @IsString()
+  legacyProxyUrl?: string
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -6080,6 +6080,7 @@ components:
     PortPreviewUrl:
       example:
         url: https://123456-mysandbox.runner.com
+        legacyProxyUrl: https://3000-mysandbox.runner.com
         token: ul67qtv-jl6wb9z5o3eii-ljqt9qed6l
       properties:
         url:
@@ -6089,6 +6090,10 @@ components:
         token:
           description: Access token
           example: ul67qtv-jl6wb9z5o3eii-ljqt9qed6l
+          type: string
+        legacyProxyUrl:
+          description: Legacy preview url using runner domain
+          example: https://3000-mysandbox.runner.com
           type: string
       required:
         - token

--- a/libs/api-client-go/model_port_preview_url.go
+++ b/libs/api-client-go/model_port_preview_url.go
@@ -26,6 +26,8 @@ type PortPreviewUrl struct {
 	Url string `json:"url"`
 	// Access token
 	Token string `json:"token"`
+	// Legacy preview url using runner domain
+	LegacyProxyUrl *string `json:"legacyProxyUrl,omitempty"`
 }
 
 type _PortPreviewUrl PortPreviewUrl
@@ -97,6 +99,38 @@ func (o *PortPreviewUrl) SetToken(v string) {
 	o.Token = v
 }
 
+// GetLegacyProxyUrl returns the LegacyProxyUrl field value if set, zero value otherwise.
+func (o *PortPreviewUrl) GetLegacyProxyUrl() string {
+	if o == nil || IsNil(o.LegacyProxyUrl) {
+		var ret string
+		return ret
+	}
+	return *o.LegacyProxyUrl
+}
+
+// GetLegacyProxyUrlOk returns a tuple with the LegacyProxyUrl field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PortPreviewUrl) GetLegacyProxyUrlOk() (*string, bool) {
+	if o == nil || IsNil(o.LegacyProxyUrl) {
+		return nil, false
+	}
+	return o.LegacyProxyUrl, true
+}
+
+// HasLegacyProxyUrl returns a boolean if a field has been set.
+func (o *PortPreviewUrl) HasLegacyProxyUrl() bool {
+	if o != nil && !IsNil(o.LegacyProxyUrl) {
+		return true
+	}
+
+	return false
+}
+
+// SetLegacyProxyUrl gets a reference to the given string and assigns it to the LegacyProxyUrl field.
+func (o *PortPreviewUrl) SetLegacyProxyUrl(v string) {
+	o.LegacyProxyUrl = &v
+}
+
 func (o PortPreviewUrl) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -109,6 +143,9 @@ func (o PortPreviewUrl) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["url"] = o.Url
 	toSerialize["token"] = o.Token
+	if !IsNil(o.LegacyProxyUrl) {
+		toSerialize["legacyProxyUrl"] = o.LegacyProxyUrl
+	}
 	return toSerialize, nil
 }
 

--- a/libs/api-client-python-async/daytona_api_client_async/models/port_preview_url.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/port_preview_url.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -29,8 +29,9 @@ class PortPreviewUrl(BaseModel):
     """ # noqa: E501
     url: StrictStr = Field(description="Preview url")
     token: StrictStr = Field(description="Access token")
+    legacy_proxy_url: Optional[StrictStr] = Field(default=None, description="Legacy preview url using runner domain", alias="legacyProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["url", "token"]
+    __properties: ClassVar[List[str]] = ["url", "token", "legacyProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -91,7 +92,8 @@ class PortPreviewUrl(BaseModel):
 
         _obj = cls.model_validate({
             "url": obj.get("url"),
-            "token": obj.get("token")
+            "token": obj.get("token"),
+            "legacyProxyUrl": obj.get("legacyProxyUrl")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/port_preview_url.py
+++ b/libs/api-client-python/daytona_api_client/models/port_preview_url.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -29,8 +29,9 @@ class PortPreviewUrl(BaseModel):
     """ # noqa: E501
     url: StrictStr = Field(description="Preview url")
     token: StrictStr = Field(description="Access token")
+    legacy_proxy_url: Optional[StrictStr] = Field(default=None, description="Legacy preview url using runner domain", alias="legacyProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["url", "token"]
+    __properties: ClassVar[List[str]] = ["url", "token", "legacyProxyUrl"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -91,7 +92,8 @@ class PortPreviewUrl(BaseModel):
 
         _obj = cls.model_validate({
             "url": obj.get("url"),
-            "token": obj.get("token")
+            "token": obj.get("token"),
+            "legacyProxyUrl": obj.get("legacyProxyUrl")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client/src/models/port-preview-url.ts
+++ b/libs/api-client/src/models/port-preview-url.ts
@@ -30,4 +30,10 @@ export interface PortPreviewUrl {
    * @memberof PortPreviewUrl
    */
   token: string
+  /**
+   * Legacy preview url using runner domain
+   * @type {string}
+   * @memberof PortPreviewUrl
+   */
+  legacyProxyUrl?: string
 }


### PR DESCRIPTION
# Legacy proxy support
## Description

Adds a `legacyProxyUrl` to getPreviewPort response

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation