### PR TITLE
fix: increase archiving timeout

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -467,8 +467,8 @@ export class SandboxManager {
           return DONT_SYNC_AGAIN
         }
 
-        // Check for timeout - if more than 30 minutes since last activity
-        const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000)
+        // Check for timeout - if more than 120 minutes since last activity
+        const thirtyMinutesAgo = new Date(Date.now() - 120 * 60 * 1000)
         if (sandbox.lastActivityAt < thirtyMinutesAgo) {
           await this.updateSandboxState(sandbox.id, SandboxState.ERROR, undefined, 'Archiving operation timed out')
           return DONT_SYNC_AGAIN


### PR DESCRIPTION
# Increase archiving timeout

## Description

Increases the timeout for archiving from 30 to 120 minutes. This isn't the actual duration timeout and instead includes the time while the sandbox is "waiting in line" for other sandboxes to finish archiving in very high load situations.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
