### PR TITLE
Improve docs navigation

### DIFF
--- a/apps/docs/src/content/config.ts
+++ b/apps/docs/src/content/config.ts
@@ -70,7 +70,6 @@ export const sidebarConfig: NavigationGroup[] = [
         attrs: {
           icon: 'server.svg',
         },
-        relatedGroupCategory: NavigationCategory.GENERAL,
       },
       {
         type: 'link',
@@ -80,7 +79,6 @@ export const sidebarConfig: NavigationGroup[] = [
         attrs: {
           icon: 'terminal.svg',
         },
-        relatedGroupCategory: NavigationCategory.GENERAL,
       },
     ],
   },

--- a/apps/docs/src/content/config.ts
+++ b/apps/docs/src/content/config.ts
@@ -90,6 +90,14 @@ export const sidebarConfig: NavigationGroup[] = [
     entries: [
       {
         type: 'link',
+        href: '/docs',
+        label: 'Home',
+        attrs: {
+          icon: 'home.svg',
+        },
+      },
+      {
+        type: 'link',
         href: '/docs/getting-started',
         label: 'Getting Started',
         description:
@@ -314,6 +322,11 @@ export const sidebarConfig: NavigationGroup[] = [
     entries: [
       {
         type: 'link',
+        href: '/docs/typescript-sdk',
+        label: 'Home',
+      },
+      {
+        type: 'link',
         href: '/docs/typescript-sdk/daytona',
         label: 'Daytona',
       },
@@ -329,6 +342,13 @@ export const sidebarConfig: NavigationGroup[] = [
     label: 'Python SDK Reference',
     homePageHref: '/docs/python-sdk',
     category: NavigationCategory.PYTHON_SDK,
+    entries: [
+      {
+        type: 'link',
+        href: '/docs/python-sdk',
+        label: 'Home',
+      },
+    ],
   },
   {
     type: 'group',


### PR DESCRIPTION
# Improve docs navigation

## Description

This fixes confusing behavior of the docs sidebar:

Previously the subpages looked like top-level pages, due to having no Home link. Additionally, the API Reference and CLI Reference pages showed subpages when they have none.

Screenshots of the fixed sidebar:

<p float="left">
  <img src="https://github.com/user-attachments/assets/bd6ef178-9a18-4101-a37e-96713432b86e" width="45%" />
  <img src="https://github.com/user-attachments/assets/77764faf-741f-4df6-b9f1-20674809b509" width="45%" />
</p>
