### PR TITLE
fix(proxy): websocket connections and simplify implementation

### DIFF
--- a/apps/daemon/pkg/toolbox/proxy/proxy.go
+++ b/apps/daemon/pkg/toolbox/proxy/proxy.go
@@ -13,20 +13,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]string, error) {
+func GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	targetPort := ctx.Param("port")
 	if targetPort == "" {
 		ctx.Error(common_errors.NewBadRequestError(errors.New("target port is required")))
-		return nil, "", nil, errors.New("target port is required")
+		return nil, nil, errors.New("target port is required")
 	}
 
 	// Build the target URL
 	targetURL := fmt.Sprintf("http://localhost:%s", targetPort)
-	target, err := url.Parse(targetURL)
-	if err != nil {
-		ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to parse target URL: %w", err)))
-		return nil, "", nil, fmt.Errorf("failed to parse target URL: %w", err)
-	}
 
 	// Get the wildcard path and normalize it
 	path := ctx.Param("path")
@@ -39,10 +34,11 @@ func GetProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]string, erro
 	}
 
 	// Create the complete target URL with path
-	fullTargetURL := fmt.Sprintf("%s%s", targetURL, path)
-	if ctx.Request.URL.RawQuery != "" {
-		fullTargetURL = fmt.Sprintf("%s?%s", fullTargetURL, ctx.Request.URL.RawQuery)
+	target, err := url.Parse(fmt.Sprintf("%s%s", targetURL, path))
+	if err != nil {
+		ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to parse target URL: %w", err)))
+		return nil, nil, fmt.Errorf("failed to parse target URL: %w", err)
 	}
 
-	return target, fullTargetURL, nil, nil
+	return target, nil, nil
 }

--- a/apps/proxy/pkg/proxy/get_target.go
+++ b/apps/proxy/pkg/proxy/get_target.go
@@ -43,7 +43,7 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 		return nil, nil, fmt.Errorf("failed to get sandbox public status: %w", err)
 	}
 
-	if !*isPublic || targetPort == "22222" || targetPort == "6080" {
+	if !*isPublic || targetPort == "22222" {
 		err, didRedirect := p.Authenticate(ctx, sandboxID)
 		if err != nil {
 			if !didRedirect {

--- a/apps/proxy/pkg/proxy/get_target.go
+++ b/apps/proxy/pkg/proxy/get_target.go
@@ -18,29 +18,29 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]string, error) {
+func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	// Extract port and sandbox ID from the host header
 	// Expected format: 1234-some-id-uuid.proxy.domain
 	targetPort, sandboxID, err := p.parseHost(ctx.Request.Host)
 	if err != nil {
 		ctx.Error(common_errors.NewBadRequestError(err))
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	if targetPort == "" {
 		ctx.Error(common_errors.NewBadRequestError(errors.New("target port is required")))
-		return nil, "", nil, errors.New("target port is required")
+		return nil, nil, errors.New("target port is required")
 	}
 
 	if sandboxID == "" {
 		ctx.Error(common_errors.NewBadRequestError(errors.New("sandbox ID is required")))
-		return nil, "", nil, errors.New("sandbox ID is required")
+		return nil, nil, errors.New("sandbox ID is required")
 	}
 
 	isPublic, err := p.getSandboxPublic(ctx, sandboxID)
 	if err != nil {
 		ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to get sandbox public status: %w", err)))
-		return nil, "", nil, fmt.Errorf("failed to get sandbox public status: %w", err)
+		return nil, nil, fmt.Errorf("failed to get sandbox public status: %w", err)
 	}
 
 	if !*isPublic || targetPort == "22222" || targetPort == "6080" {
@@ -49,23 +49,18 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]s
 			if !didRedirect {
 				ctx.Error(common_errors.NewUnauthorizedError(err))
 			}
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 	}
 
 	runnerInfo, err := p.getRunnerInfo(ctx, sandboxID)
 	if err != nil {
 		ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to get runner info: %w", err)))
-		return nil, "", nil, fmt.Errorf("failed to get runner info: %w", err)
+		return nil, nil, fmt.Errorf("failed to get runner info: %w", err)
 	}
 
 	// Build the target URL
 	targetURL := fmt.Sprintf("%s/sandboxes/%s/toolbox/proxy/%s", runnerInfo.ApiUrl, sandboxID, targetPort)
-	target, err := url.Parse(targetURL)
-	if err != nil {
-		ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to parse target URL: %w", err)))
-		return nil, "", nil, fmt.Errorf("failed to parse target URL: %w", err)
-	}
 
 	// Get the wildcard path and normalize it
 	path := ctx.Param("path")
@@ -78,13 +73,15 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]s
 	}
 
 	// Create the complete target URL with path
-	fullTargetURL := fmt.Sprintf("%s%s", targetURL, path)
-	if ctx.Request.URL.RawQuery != "" {
-		fullTargetURL = fmt.Sprintf("%s?%s", fullTargetURL, ctx.Request.URL.RawQuery)
+	target, err := url.Parse(fmt.Sprintf("%s%s", targetURL, path))
+	if err != nil {
+		ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to parse target URL: %w", err)))
+		return nil, nil, fmt.Errorf("failed to parse target URL: %w", err)
 	}
 
-	return target, fullTargetURL, map[string]string{
+	return target, map[string]string{
 		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
+		"X-Forwarded-Host":        ctx.Request.Host,
 	}, nil
 }
 

--- a/apps/runner/pkg/api/controllers/command_logs.go
+++ b/apps/runner/pkg/api/controllers/command_logs.go
@@ -17,20 +17,20 @@ import (
 )
 
 func ProxyCommandLogsStream(ctx *gin.Context) {
-	targetURL, fullTargetURL, extraHeaders, err := getProxyTarget(ctx)
+	targetURL, extraHeaders, err := getProxyTarget(ctx)
 	if err != nil {
 		// Error already sent to the context
 		return
 	}
 
 	if ctx.Query("follow") != "true" {
-		proxy.NewProxyRequestHandler(func(ctx *gin.Context) (*url.URL, string, map[string]string, error) {
-			return targetURL, fullTargetURL, extraHeaders, nil
+		proxy.NewProxyRequestHandler(func(ctx *gin.Context) (*url.URL, map[string]string, error) {
+			return targetURL, extraHeaders, nil
 		})(ctx)
 		return
 	}
 
-	fullTargetURL = strings.Replace(fullTargetURL, "http://", "ws://", 1)
+	fullTargetURL := strings.Replace(targetURL.String(), "http://", "ws://", 1)
 
 	ws, _, err := websocket.DefaultDialer.DialContext(ctx, fullTargetURL, nil)
 	if err != nil {

--- a/apps/runner/pkg/api/controllers/command_logs.go
+++ b/apps/runner/pkg/api/controllers/command_logs.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -32,7 +33,7 @@ func ProxyCommandLogsStream(ctx *gin.Context) {
 
 	fullTargetURL := strings.Replace(targetURL.String(), "http://", "ws://", 1)
 
-	ws, _, err := websocket.DefaultDialer.DialContext(ctx, fullTargetURL, nil)
+	ws, _, err := websocket.DefaultDialer.DialContext(context.Background(), fullTargetURL+"?follow=true", nil)
 	if err != nil {
 		ctx.Error(errors.NewBadRequestError(fmt.Errorf("failed to create outgoing request: %w", err)))
 		return
@@ -41,16 +42,25 @@ func ProxyCommandLogsStream(ctx *gin.Context) {
 	ctx.Header("Content-Type", "application/octet-stream")
 
 	ws.SetCloseHandler(func(code int, text string) error {
+		if code == websocket.CloseNormalClosure {
+			return nil
+		}
 		ctx.AbortWithStatus(code)
 		return nil
 	})
 
 	defer ws.Close()
 
-	go func() {
-		for {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
 			_, msg, err := ws.ReadMessage()
 			if err != nil {
+				if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+					return
+				}
 				log.Errorf("Error reading message: %v", err)
 				ws.Close()
 				return
@@ -64,7 +74,5 @@ func ProxyCommandLogsStream(ctx *gin.Context) {
 			}
 			ctx.Writer.Flush()
 		}
-	}()
-
-	<-ctx.Done()
+	}
 }

--- a/apps/runner/pkg/api/controllers/proxy.go
+++ b/apps/runner/pkg/api/controllers/proxy.go
@@ -43,20 +43,20 @@ func ProxyRequest(ctx *gin.Context) {
 	proxy.NewProxyRequestHandler(getProxyTarget)(ctx)
 }
 
-func getProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]string, error) {
+func getProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	runner := runner.GetInstance(nil)
 
 	sandboxId := ctx.Param("sandboxId")
 	if sandboxId == "" {
 		ctx.Error(common.NewBadRequestError(errors.New("sandbox ID is required")))
-		return nil, "", nil, errors.New("sandbox ID is required")
+		return nil, nil, errors.New("sandbox ID is required")
 	}
 
 	// Get container details
 	container, err := runner.Docker.ContainerInspect(ctx.Request.Context(), sandboxId)
 	if err != nil {
 		ctx.Error(common.NewNotFoundError(fmt.Errorf("sandbox container not found: %w", err)))
-		return nil, "", nil, fmt.Errorf("sandbox container not found: %w", err)
+		return nil, nil, fmt.Errorf("sandbox container not found: %w", err)
 	}
 
 	var containerIP string
@@ -67,16 +67,11 @@ func getProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]string, erro
 
 	if containerIP == "" {
 		ctx.Error(common.NewBadRequestError(errors.New("container has no IP address, it might not be running")))
-		return nil, "", nil, errors.New("container has no IP address, it might not be running")
+		return nil, nil, errors.New("container has no IP address, it might not be running")
 	}
 
 	// Build the target URL
 	targetURL := fmt.Sprintf("http://%s:2280", containerIP)
-	target, err := url.Parse(targetURL)
-	if err != nil {
-		ctx.Error(common.NewBadRequestError(fmt.Errorf("failed to parse target URL: %w", err)))
-		return nil, "", nil, fmt.Errorf("failed to parse target URL: %w", err)
-	}
 
 	// Get the wildcard path and normalize it
 	path := ctx.Param("path")
@@ -89,10 +84,11 @@ func getProxyTarget(ctx *gin.Context) (*url.URL, string, map[string]string, erro
 	}
 
 	// Create the complete target URL with path
-	fullTargetURL := fmt.Sprintf("%s%s", targetURL, path)
-	if ctx.Request.URL.RawQuery != "" {
-		fullTargetURL = fmt.Sprintf("%s?%s", fullTargetURL, ctx.Request.URL.RawQuery)
+	target, err := url.Parse(fmt.Sprintf("%s%s", targetURL, path))
+	if err != nil {
+		ctx.Error(common.NewBadRequestError(fmt.Errorf("failed to parse target URL: %w", err)))
+		return nil, nil, fmt.Errorf("failed to parse target URL: %w", err)
 	}
 
-	return target, fullTargetURL, nil, nil
+	return target, nil, nil
 }

--- a/apps/runner/pkg/api/middlewares/auth.go
+++ b/apps/runner/pkg/api/middlewares/auth.go
@@ -20,6 +20,8 @@ func AuthMiddleware() gin.HandlerFunc {
 			authHeader = ctx.GetHeader(constants.AUTHORIZATION_HEADER)
 		}
 
+		ctx.Request.Header.Del(constants.DAYTONA_AUTHORIZATION_HEADER)
+
 		if authHeader == "" {
 			ctx.Error(common.NewUnauthorizedError(errors.New("authorization header required")))
 			ctx.Abort()

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -4,20 +4,13 @@
 package proxy
 
 import (
-	"errors"
-	"fmt"
-	"io"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
-	"strings"
 	"time"
 
-	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var proxyTransport = &http.Transport{
@@ -26,38 +19,6 @@ var proxyTransport = &http.Transport{
 	DialContext: (&net.Dialer{
 		KeepAlive: 30 * time.Second,
 	}).DialContext,
-}
-
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
-}
-
-// Custom HTTP client that follows redirects while maintaining original headers
-var proxyClient = &http.Client{
-	Transport: proxyTransport,
-	// Create a custom redirect policy
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		// Copy headers from original request
-		if len(via) > 0 {
-			// Copy the headers from the original request
-			for key, values := range via[0].Header {
-				// Skip certain headers that shouldn't be copied
-				if key != "Cookie" {
-					for _, value := range values {
-						req.Header.Add(key, value)
-					}
-				}
-			}
-		}
-
-		// Limit the number of redirects to prevent infinite loops
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	},
 }
 
 // ProxyRequest handles proxying requests to a sandbox's container
@@ -75,95 +36,32 @@ var proxyClient = &http.Client{
 //	@Failure		409			{object}	string	"Sandbox container conflict"
 //	@Failure		500			{object}	string	"Internal server error"
 //	@Router			/workspaces/{workspaceId}/{projectId}/toolbox/{path} [get]
-func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (*url.URL, string, map[string]string, error)) gin.HandlerFunc {
+func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.URL, extraHeaders map[string]string, err error)) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		target, fullTargetURL, extraHeaders, err := getProxyTarget(ctx)
+		target, extraHeaders, err := getProxyTarget(ctx)
 		if err != nil {
 			// Error already sent to the context
 			return
 		}
 
-		// Create a new outgoing request
-		outReq, err := http.NewRequestWithContext(
-			ctx.Request.Context(),
-			ctx.Request.Method,
-			fullTargetURL,
-			ctx.Request.Body,
-		)
-		if err != nil {
-			ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to create outgoing request: %w", err)))
-			return
-		}
-
-		// Copy headers from original request
-		for key, values := range ctx.Request.Header {
-			// Skip the Connection header
-			if key != "Connection" {
-				for _, value := range values {
-					outReq.Header.Add(key, value)
+		reverseProxy := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				req.Host = target.Host
+				req.URL.Scheme = target.Scheme
+				req.URL.Host = target.Host
+				req.URL.Path = target.Path
+				if target.RawQuery == "" || req.URL.RawQuery == "" {
+					req.URL.RawQuery = target.RawQuery + req.URL.RawQuery
+				} else {
+					req.URL.RawQuery = target.RawQuery + "&" + req.URL.RawQuery
 				}
-			}
+				for key, value := range extraHeaders {
+					req.Header.Add(key, value)
+				}
+			},
+			Transport: proxyTransport,
 		}
 
-		// Set the Host header to the target
-		outReq.Host = target.Host
-		outReq.Header.Set("Connection", "keep-alive")
-
-		for key, value := range extraHeaders {
-			outReq.Header.Add(key, value)
-		}
-
-		if ctx.Request.Header.Get("Upgrade") == "websocket" {
-			ws, err := upgrader.Upgrade(ctx.Writer, ctx.Request, nil)
-			if err != nil {
-				ctx.AbortWithError(http.StatusInternalServerError, err)
-				return
-			}
-			defer ws.Close()
-
-			reqExtraHeaders := http.Header{}
-			for key, value := range extraHeaders {
-				reqExtraHeaders.Add(key, value)
-			}
-
-			conn, _, err := websocket.DefaultDialer.DialContext(ctx.Request.Context(), strings.Replace(fullTargetURL, "http", "ws", 1), reqExtraHeaders)
-			if err != nil {
-				ctx.AbortWithError(http.StatusInternalServerError, err)
-				return
-			}
-			defer conn.Close()
-
-			go func() {
-				io.Copy(ws.NetConn(), conn.NetConn())
-			}()
-
-			io.Copy(conn.NetConn(), ws.NetConn())
-
-			return
-		}
-
-		// Execute the request with our custom client that handles redirects
-		resp, err := proxyClient.Do(outReq)
-		if err != nil {
-			ctx.AbortWithError(http.StatusBadGateway, fmt.Errorf("proxy request failed: %w", err))
-			return
-		}
-		defer resp.Body.Close()
-
-		// Copy response headers
-		for key, values := range resp.Header {
-			for _, value := range values {
-				ctx.Writer.Header().Add(key, value)
-			}
-		}
-
-		// Set the status code
-		ctx.Writer.WriteHeader(resp.StatusCode)
-
-		// Copy the response body
-		if _, err := io.Copy(ctx.Writer, resp.Body); err != nil {
-			log.Errorf("Error copying response body: %v", err)
-			// Error already sent to client, just log here
-		}
+		reverseProxy.ServeHTTP(ctx.Writer, ctx.Request)
 	}
 }


### PR DESCRIPTION
# Proxy Websocket fixes

## Description

Fix proxy websocket handling and simplify implementation.
Additionally, rolled back proxy auth protection for port 6080

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
