### PR TITLE
chore: ignore docs when linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ export default [
   ...nx.configs['flat/typescript'],
   ...nx.configs['flat/javascript'],
   {
-    ignores: ['**/dist', '**/vite.config.*.timestamp*', '**/vitest.config.*.timestamp*'],
+    ignores: ['**/dist', '**/vite.config.*.timestamp*', '**/vitest.config.*.timestamp*', 'apps/docs/**'],
   },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],


### PR DESCRIPTION
# Ignore Docs When Linting

## Description

Ignore docs when linting because we're refactoring them soon so no time should be wasted on configuring their pipeline at this time. Linting doesn't affect functionality.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
