### PR TITLE
fix(api): unlock auto-stop and auto-archive in case of error

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -106,10 +106,11 @@ export class SandboxManager {
               sandbox.pending = true
               sandbox.desiredState = SandboxDesiredState.STOPPED
               await this.sandboxRepository.save(sandbox)
-              await this.redisLockProvider.unlock(lockKey)
               this.syncInstanceState(sandbox.id)
             } catch (error) {
               this.logger.error(`Error processing auto-stop state for sandbox ${sandbox.id}:`, fromAxiosError(error))
+            } finally {
+              await this.redisLockProvider.unlock(lockKey)
             }
           }),
         )
@@ -163,10 +164,11 @@ export class SandboxManager {
               sandbox.pending = true
               sandbox.desiredState = SandboxDesiredState.ARCHIVED
               await this.sandboxRepository.save(sandbox)
-              await this.redisLockProvider.unlock(lockKey)
               this.syncInstanceState(sandbox.id)
             } catch (error) {
               this.logger.error(`Error processing auto-archive state for sandbox ${sandbox.id}:`, fromAxiosError(error))
+            } finally {
+              await this.redisLockProvider.unlock(lockKey)
             }
           }),
         )


### PR DESCRIPTION
## Description

Single instance lock is now released in case of error when processing auto-stop or auto-archive action for sandbox.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
