### PR TITLE
Fix docs readability in light mode

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -57,7 +57,7 @@ export default defineConfig({
         ExploreMore: './src/components/ExploreMore.astro',
       },
       expressiveCode: {
-        minSyntaxHighlightingColorContrast: 0,
+        minSyntaxHighlightingColorContrast: 3.0,
         themes: [myThemeDark, myThemeLight],
       },
     }),

--- a/apps/docs/src/assets/themes/daytona-code-light.json
+++ b/apps/docs/src/assets/themes/daytona-code-light.json
@@ -1,7 +1,7 @@
 {
   "name": "daytona-code-light",
   "colors": {
-    "editor.background": "#0A0A0A",
+    "editor.background": "#ffffff",
     "editor.foreground": "#000",
     "activityBarBadge.background": "#007acc",
     "sideBarTitle.foreground": "#bbbbbb"

--- a/apps/docs/src/styles/_color.scss
+++ b/apps/docs/src/styles/_color.scss
@@ -42,4 +42,5 @@ html[data-theme='light'] body {
   --blue-link: #005fbe;
   --cta-surface-neutral-primary: #dedede;
   --hover-color: #08ae78;
+  --secondary-hover-color: #08ae78;
 }


### PR DESCRIPTION
# Fix docs readability in light mode

## Description

This fixes two issues which made the text in the documentation site hard to read in light mode.

## Screenshots

### Syntax Highlighting
| Before | After |
|--------|-------|
| <img width="750" height="434" alt="Screenshot 2025-07-10 at 6 05 17 PM" src="https://github.com/user-attachments/assets/63e2870b-68bd-443b-8c9a-89eab5f67d20" /> | <img width="739" height="443" alt="Screenshot 2025-07-10 at 6 07 15 PM" src="https://github.com/user-attachments/assets/4203cf05-dad2-487e-879e-d8239211827a" /> |

### Sidebar
| Before | After |
|--------|-------|
| <img width="291" height="224" alt="Screenshot 2025-07-10 at 6 05 37 PM" src="https://github.com/user-attachments/assets/5e4a22c8-2787-4517-b2ed-72572d9ae3e9" /> | <img width="293" height="232" alt="Screenshot 2025-07-10 at 6 05 47 PM" src="https://github.com/user-attachments/assets/d7ba1ea4-da11-4ce5-b4f0-728a3ddc213e" /> |
