### PR TITLE
fix(docs): Add missing `volumes` parameter in SDK docs

### DIFF
--- a/apps/docs/src/content/docs/python-sdk/async/async-daytona.mdx
+++ b/apps/docs/src/content/docs/python-sdk/async/async-daytona.mdx
@@ -473,6 +473,7 @@ Base parameters for creating a new Sandbox.
 - `auto_delete_interval` _Optional[int]_ - Interval in minutes after which a continuously stopped Sandbox will
   automatically be deleted. By default, auto-delete is disabled.
   Negative value means disabled, 0 means delete immediately upon stopping.
+- `volumes` _Optional[List[VolumeMount]]_ - List of volumes mounts to attach to the Sandbox.
 
 ## CreateSandboxFromImageParams
 

--- a/apps/docs/src/content/docs/python-sdk/sync/daytona.mdx
+++ b/apps/docs/src/content/docs/python-sdk/sync/daytona.mdx
@@ -423,6 +423,7 @@ Base parameters for creating a new Sandbox.
 - `auto_delete_interval` _Optional[int]_ - Interval in minutes after which a continuously stopped Sandbox will
   automatically be deleted. By default, auto-delete is disabled.
   Negative value means disabled, 0 means delete immediately upon stopping.
+- `volumes` _Optional[List[VolumeMount]]_ - List of volumes mounts to attach to the Sandbox.
 
 ## CreateSandboxFromImageParams
 

--- a/apps/docs/src/content/docs/typescript-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/typescript-sdk/daytona.mdx
@@ -345,7 +345,7 @@ Base parameters for creating a new Sandbox.
 - `language?` _string_ - Programming language for direct code execution
 - `public?` _boolean_ - Is the Sandbox port preview public
 - `user?` _string_ - Optional os user to use for the Sandbox
-- `volumes?` _VolumeMount\[\]_
+- `volumes?` _VolumeMount\[\]_ - Optional array of volumes to mount to the Sandbox
 ## CreateSandboxFromImageParams
 
 Parameters for creating a new Sandbox.

--- a/libs/sdk-python/src/daytona/common/daytona.py
+++ b/libs/sdk-python/src/daytona/common/daytona.py
@@ -108,6 +108,7 @@ class CreateSandboxBaseParams(BaseModel):
         auto_delete_interval (Optional[int]): Interval in minutes after which a continuously stopped Sandbox will
             automatically be deleted. By default, auto-delete is disabled.
             Negative value means disabled, 0 means delete immediately upon stopping.
+        volumes (Optional[List[VolumeMount]]): List of volumes mounts to attach to the Sandbox.
     """
 
     language: Optional[CodeLanguage] = None

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -126,6 +126,7 @@ export interface Resources {
  * @property {number} [autoStopInterval] - Auto-stop interval in minutes (0 means disabled). Default is 15 minutes.
  * @property {number} [autoArchiveInterval] - Auto-archive interval in minutes (0 means the maximum interval will be used). Default is 7 days.
  * @property {number} [autoDeleteInterval] - Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping). By default, auto-delete is disabled.
+ * @property {VolumeMount[]} [volumes] - Optional array of volumes to mount to the Sandbox
  */
 export type CreateSandboxBaseParams = {
   user?: string


### PR DESCRIPTION
# Add missing `volumes` parameter in SDK docs

## Description

This adds the missing `volumes` parameter to the `CreateSandboxBaseParams` docstring/JSDoc comment, so it now appears in both the Python and TypeScript SDK docs.