### PR TITLE
fix(api): unlock auto-stop/archive/delete workers after they're done

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -63,174 +63,192 @@ export class SandboxManager {
   @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-stop-check' })
   @OtelSpan()
   async autostopCheck(): Promise<void> {
+    const lockKey = 'auto-stop-check-worker-selected'
     //  lock the sync to only run one instance at a time
-    //  keep the worker selected for 1 minute
-    if (!(await this.redisLockProvider.lock('auto-stop-check-worker-selected', 60))) {
+    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
       return
     }
 
-    // Get all ready runners
-    const allRunners = await this.runnerService.findAll()
-    const readyRunners = allRunners.filter((runner) => runner.state === RunnerState.READY)
+    try {
+      // Get all ready runners
+      const allRunners = await this.runnerService.findAll()
+      const readyRunners = allRunners.filter((runner) => runner.state === RunnerState.READY)
 
-    // Process all runners in parallel
-    await Promise.all(
-      readyRunners.map(async (runner) => {
-        const sandboxes = await this.sandboxRepository.find({
-          where: {
-            runnerId: runner.id,
-            organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
-            state: SandboxState.STARTED,
-            desiredState: SandboxDesiredState.STARTED,
-            pending: Not(true),
-            autoStopInterval: Not(0),
-            lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoStopInterval"`),
-          },
-          order: {
-            lastBackupAt: 'ASC',
-          },
-          //  todo: increase this number when auto-stop is stable
-          take: 10,
-        })
+      // Process all runners in parallel
+      await Promise.all(
+        readyRunners.map(async (runner) => {
+          const sandboxes = await this.sandboxRepository.find({
+            where: {
+              runnerId: runner.id,
+              organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+              state: SandboxState.STARTED,
+              desiredState: SandboxDesiredState.STARTED,
+              pending: Not(true),
+              autoStopInterval: Not(0),
+              lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoStopInterval"`),
+            },
+            order: {
+              lastBackupAt: 'ASC',
+            },
+            //  todo: increase this number when auto-stop is stable
+            take: 10,
+          })
 
-        await Promise.all(
-          sandboxes.map(async (sandbox) => {
-            const lockKey = SYNC_INSTANCE_STATE_LOCK_KEY + sandbox.id
-            const acquired = await this.redisLockProvider.lock(lockKey, 30)
-            if (!acquired) {
-              return
-            }
-
-            try {
-              sandbox.pending = true
-              //  if auto-delete interval is 0, delete the sandbox immediately
-              if (sandbox.autoDeleteInterval === 0) {
-                sandbox.desiredState = SandboxDesiredState.DESTROYED
-              } else {
-                sandbox.desiredState = SandboxDesiredState.STOPPED
+          await Promise.all(
+            sandboxes.map(async (sandbox) => {
+              const lockKey = SYNC_INSTANCE_STATE_LOCK_KEY + sandbox.id
+              const acquired = await this.redisLockProvider.lock(lockKey, 30)
+              if (!acquired) {
+                return
               }
-              await this.sandboxRepository.save(sandbox)
-              this.syncInstanceState(sandbox.id)
-            } catch (error) {
-              this.logger.error(`Error processing auto-stop state for sandbox ${sandbox.id}:`, fromAxiosError(error))
-            } finally {
-              await this.redisLockProvider.unlock(lockKey)
-            }
-          }),
-        )
-      }),
-    )
+
+              try {
+                sandbox.pending = true
+                //  if auto-delete interval is 0, delete the sandbox immediately
+                if (sandbox.autoDeleteInterval === 0) {
+                  sandbox.desiredState = SandboxDesiredState.DESTROYED
+                } else {
+                  sandbox.desiredState = SandboxDesiredState.STOPPED
+                }
+                await this.sandboxRepository.save(sandbox)
+                this.syncInstanceState(sandbox.id)
+              } catch (error) {
+                this.logger.error(`Error processing auto-stop state for sandbox ${sandbox.id}:`, fromAxiosError(error))
+              } finally {
+                await this.redisLockProvider.unlock(lockKey)
+              }
+            }),
+          )
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-archive-check' })
   async autoArchiveCheck(): Promise<void> {
+    const lockKey = 'auto-archive-check-worker-selected'
     //  lock the sync to only run one instance at a time
-    //  keep the worker selected for 1 minute
-    if (!(await this.redisLockProvider.lock('auto-archive-check-worker-selected', 60))) {
+    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
       return
     }
 
-    // Get all ready runners
-    const allRunners = await this.runnerService.findAll()
-    const readyRunners = allRunners.filter((runner) => runner.state === RunnerState.READY)
+    try {
+      // Get all ready runners
+      const allRunners = await this.runnerService.findAll()
+      const readyRunners = allRunners.filter((runner) => runner.state === RunnerState.READY)
 
-    // Process all runners in parallel
-    await Promise.all(
-      readyRunners.map(async (runner) => {
-        const sandboxes = await this.sandboxRepository.find({
-          where: {
-            runnerId: runner.id,
-            organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
-            state: SandboxState.STOPPED,
-            desiredState: SandboxDesiredState.STOPPED,
-            pending: Not(true),
-            lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoArchiveInterval"`),
-          },
-          order: {
-            lastBackupAt: 'ASC',
-          },
-          //  max 3 sandboxes can be archived at the same time on the same runner
-          //  this is to prevent the runner from being overloaded
-          take: 3,
-        })
+      // Process all runners in parallel
+      await Promise.all(
+        readyRunners.map(async (runner) => {
+          const sandboxes = await this.sandboxRepository.find({
+            where: {
+              runnerId: runner.id,
+              organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+              state: SandboxState.STOPPED,
+              desiredState: SandboxDesiredState.STOPPED,
+              pending: Not(true),
+              lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoArchiveInterval"`),
+            },
+            order: {
+              lastBackupAt: 'ASC',
+            },
+            //  max 3 sandboxes can be archived at the same time on the same runner
+            //  this is to prevent the runner from being overloaded
+            take: 3,
+          })
 
-        await Promise.all(
-          sandboxes.map(async (sandbox) => {
-            const lockKey = SYNC_INSTANCE_STATE_LOCK_KEY + sandbox.id
-            const acquired = await this.redisLockProvider.lock(lockKey, 30)
-            if (!acquired) {
-              return
-            }
+          await Promise.all(
+            sandboxes.map(async (sandbox) => {
+              const lockKey = SYNC_INSTANCE_STATE_LOCK_KEY + sandbox.id
+              const acquired = await this.redisLockProvider.lock(lockKey, 30)
+              if (!acquired) {
+                return
+              }
 
-            try {
-              sandbox.pending = true
-              sandbox.desiredState = SandboxDesiredState.ARCHIVED
-              await this.sandboxRepository.save(sandbox)
-              this.syncInstanceState(sandbox.id)
-            } catch (error) {
-              this.logger.error(`Error processing auto-archive state for sandbox ${sandbox.id}:`, fromAxiosError(error))
-            } finally {
-              await this.redisLockProvider.unlock(lockKey)
-            }
-          }),
-        )
-      }),
-    )
+              try {
+                sandbox.pending = true
+                sandbox.desiredState = SandboxDesiredState.ARCHIVED
+                await this.sandboxRepository.save(sandbox)
+                this.syncInstanceState(sandbox.id)
+              } catch (error) {
+                this.logger.error(
+                  `Error processing auto-archive state for sandbox ${sandbox.id}:`,
+                  fromAxiosError(error),
+                )
+              } finally {
+                await this.redisLockProvider.unlock(lockKey)
+              }
+            }),
+          )
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-delete-check' })
   async autoDeleteCheck(): Promise<void> {
+    const lockKey = 'auto-delete-check-worker-selected'
     //  lock the sync to only run one instance at a time
-    //  keep the worker selected for 1 minute
-    if (!(await this.redisLockProvider.lock('auto-delete-check-worker-selected', 60))) {
+    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
       return
     }
 
-    // Get all ready runners
-    const allRunners = await this.runnerService.findAll()
-    const readyRunners = allRunners.filter((runner) => runner.state === RunnerState.READY)
+    try {
+      // Get all ready runners
+      const allRunners = await this.runnerService.findAll()
+      const readyRunners = allRunners.filter((runner) => runner.state === RunnerState.READY)
 
-    // Process all runners in parallel
-    await Promise.all(
-      readyRunners.map(async (runner) => {
-        const sandboxes = await this.sandboxRepository.find({
-          where: {
-            runnerId: runner.id,
-            organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
-            state: SandboxState.STOPPED,
-            desiredState: SandboxDesiredState.STOPPED,
-            pending: Not(true),
-            autoDeleteInterval: MoreThanOrEqual(0),
-            lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoDeleteInterval"`),
-          },
-          order: {
-            lastActivityAt: 'ASC',
-          },
-          take: 100,
-        })
+      // Process all runners in parallel
+      await Promise.all(
+        readyRunners.map(async (runner) => {
+          const sandboxes = await this.sandboxRepository.find({
+            where: {
+              runnerId: runner.id,
+              organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+              state: SandboxState.STOPPED,
+              desiredState: SandboxDesiredState.STOPPED,
+              pending: Not(true),
+              autoDeleteInterval: MoreThanOrEqual(0),
+              lastActivityAt: Raw((alias) => `${alias} < NOW() - INTERVAL '1 minute' * "autoDeleteInterval"`),
+            },
+            order: {
+              lastActivityAt: 'ASC',
+            },
+            take: 100,
+          })
 
-        await Promise.all(
-          sandboxes.map(async (sandbox) => {
-            const lockKey = SYNC_INSTANCE_STATE_LOCK_KEY + sandbox.id
-            const acquired = await this.redisLockProvider.lock(lockKey, 30)
-            if (!acquired) {
-              return
-            }
+          await Promise.all(
+            sandboxes.map(async (sandbox) => {
+              const lockKey = SYNC_INSTANCE_STATE_LOCK_KEY + sandbox.id
+              const acquired = await this.redisLockProvider.lock(lockKey, 30)
+              if (!acquired) {
+                return
+              }
 
-            try {
-              sandbox.pending = true
-              sandbox.desiredState = SandboxDesiredState.DESTROYED
-              await this.sandboxRepository.save(sandbox)
-              this.syncInstanceState(sandbox.id)
-            } catch (error) {
-              this.logger.error(`Error processing auto-delete state for sandbox ${sandbox.id}:`, fromAxiosError(error))
-            } finally {
-              await this.redisLockProvider.unlock(lockKey)
-            }
-          }),
-        )
-      }),
-    )
+              try {
+                sandbox.pending = true
+                sandbox.desiredState = SandboxDesiredState.DESTROYED
+                await this.sandboxRepository.save(sandbox)
+                this.syncInstanceState(sandbox.id)
+              } catch (error) {
+                this.logger.error(
+                  `Error processing auto-delete state for sandbox ${sandbox.id}:`,
+                  fromAxiosError(error),
+                )
+              } finally {
+                await this.redisLockProvider.unlock(lockKey)
+              }
+            }),
+          )
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-states' })


### PR DESCRIPTION
# Unlock Auto-stop/archive/delete Workers After They're Done

## Description

Without the unlock, the respective jobs were running every 2 minutes instead of every minute because the lock would persist for an additional cron interval after the locking one.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
