### PR TITLE
feat(dashboard): display auto-delete information when stopping sandbox

### DIFF
--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -71,3 +71,24 @@ export function capitalize(value: string) {
 export function getMaskedApiKey(key: string) {
   return `${key.substring(0, 3)}********************${key.slice(-3)}`
 }
+
+export function formatDuration(minutes: number): string {
+  minutes = Math.abs(minutes)
+
+  if (minutes < 60) {
+    return `${Math.floor(minutes)}m`
+  }
+
+  const hours = minutes / 60
+  if (hours < 24) {
+    return `${Math.floor(hours)}h`
+  }
+
+  const days = hours / 24
+  if (days < 365) {
+    return `${Math.floor(days)}d`
+  }
+
+  const years = days / 365
+  return `${Math.floor(years)}y`
+}

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -36,6 +36,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import SandboxDetailsSheet from '@/components/SandboxDetailsSheet'
+import { formatDuration } from '@/lib/utils'
 
 const Sandboxes: React.FC = () => {
   const { sandboxApi, apiKeyApi, toolboxApi, snapshotApi } = useApi()
@@ -216,7 +217,14 @@ const Sandboxes: React.FC = () => {
 
     try {
       await sandboxApi.stopSandbox(id, selectedOrganization?.id)
-      toast.success(`Stopping sandbox with ID: ${id}`)
+      toast.success(
+        `Stopping sandbox with ID: ${id}`,
+        sandboxToStop?.autoDeleteInterval !== undefined && sandboxToStop.autoDeleteInterval >= 0
+          ? {
+              description: `This sandbox will be deleted automatically ${sandboxToStop.autoDeleteInterval === 0 ? 'upon stopping' : `in ${formatDuration(sandboxToStop.autoDeleteInterval)}`}.`,
+            }
+          : undefined,
+      )
     } catch (error) {
       handleApiError(error, 'Failed to stop sandbox')
       setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: previousState } : s)))


### PR DESCRIPTION
## Description

Added an appropriate description to the toast message when stopping a sandbox if the auto-delete interval is set for the sandbox.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

### No auto-delete
<img width="806" height="232" alt="image" src="https://github.com/user-attachments/assets/ff11ad25-284b-423a-9032-87139117f0da" />

### Delete immediately upon stopping
<img width="848" height="358" alt="image" src="https://github.com/user-attachments/assets/5b4b79a0-7269-4775-b48f-3275004d97a7" />

### Misc auto-delete intervals
<img width="788" height="268" alt="image" src="https://github.com/user-attachments/assets/936fa077-015d-42a4-b298-c6515fa14729" />

<img width="798" height="264" alt="image" src="https://github.com/user-attachments/assets/835499d2-6fc4-4273-8172-f31cfc00861e" />
