### PR TITLE
fix(dashboard): snapshot table pagination row layout 

### DIFF
--- a/apps/dashboard/src/components/SnapshotTable.tsx
+++ b/apps/dashboard/src/components/SnapshotTable.tsx
@@ -239,44 +239,36 @@ export function SnapshotTable({
           </TableBody>
         </Table>
       </div>
-      <div className="flex items-center justify-between gap-2 mt-4">
-        <div className="flex items-center gap-4">
-          {deletePermitted && selectedRows.length > 0 && (
-            <Popover open={bulkDeleteConfirmationOpen} onOpenChange={setBulkDeleteConfirmationOpen}>
-              <PopoverTrigger>
-                <Button variant="destructive" size="sm">
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Bulk Delete
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent side="top">
-                <div className="flex flex-col gap-4">
-                  <p>Are you sure you want to delete these Snapshots?</p>
-                  <div className="flex items-center space-x-2">
-                    <Button
-                      variant="destructive"
-                      onClick={() => {
-                        handleBulkDelete()
-                        setBulkDeleteConfirmationOpen(false)
-                      }}
-                    >
-                      Delete
-                    </Button>
-                    <Button variant="outline" onClick={() => setBulkDeleteConfirmationOpen(false)}>
-                      Cancel
-                    </Button>
-                  </div>
+      <div className="flex items-center justify-between space-x-2 py-4">
+        {deletePermitted && selectedRows.length > 0 && (
+          <Popover open={bulkDeleteConfirmationOpen} onOpenChange={setBulkDeleteConfirmationOpen}>
+            <PopoverTrigger>
+              <Button variant="destructive" size="sm" className="h-8">
+                Bulk Delete
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent side="top">
+              <div className="flex flex-col gap-4">
+                <p>Are you sure you want to delete these Snapshots?</p>
+                <div className="flex items-center space-x-2">
+                  <Button
+                    variant="destructive"
+                    onClick={() => {
+                      handleBulkDelete()
+                      setBulkDeleteConfirmationOpen(false)
+                    }}
+                  >
+                    Delete
+                  </Button>
+                  <Button variant="outline" onClick={() => setBulkDeleteConfirmationOpen(false)}>
+                    Cancel
+                  </Button>
                 </div>
-              </PopoverContent>
-            </Popover>
-          )}
-          {deletePermitted && (
-            <span className="text-sm text-muted-foreground whitespace-nowrap">
-              {selectedRows.length} of {data.length} row(s) selected
-            </span>
-          )}
-        </div>
-        <Pagination table={table} className="mt-4" entityName="Snapshots" />
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
+        {deletePermitted && <Pagination table={table} selectionEnabled entityName="Snapshots" />}
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -162,43 +162,39 @@ export function VolumeTable({ data, loading, processingVolumeAction, onDelete, o
         </Table>
       </div>
       <div className="flex items-center justify-between space-x-2 py-4">
-        <div className="flex items-center space-x-2">
-          {table.getRowModel().rows.some((row) => row.getIsSelected()) && (
-            <div className="flex items-center space-x-2">
-              <Popover open={bulkDeleteConfirmationOpen} onOpenChange={setBulkDeleteConfirmationOpen}>
-                <PopoverTrigger>
-                  <Button variant="destructive" size="sm" className="h-8">
-                    Bulk Delete
+        {table.getRowModel().rows.some((row) => row.getIsSelected()) && (
+          <Popover open={bulkDeleteConfirmationOpen} onOpenChange={setBulkDeleteConfirmationOpen}>
+            <PopoverTrigger>
+              <Button variant="destructive" size="sm" className="h-8">
+                Bulk Delete
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent side="top">
+              <div className="flex flex-col gap-4">
+                <p>Are you sure you want to delete these Volumes?</p>
+                <div className="flex items-center space-x-2">
+                  <Button
+                    variant="destructive"
+                    onClick={() => {
+                      onBulkDelete(
+                        table
+                          .getRowModel()
+                          .rows.filter((row) => row.getIsSelected())
+                          .map((row) => row.original),
+                      )
+                      setBulkDeleteConfirmationOpen(false)
+                    }}
+                  >
+                    Delete
                   </Button>
-                </PopoverTrigger>
-                <PopoverContent side="top">
-                  <div className="flex flex-col gap-4">
-                    <p>Are you sure you want to delete these Volumes?</p>
-                    <div className="flex items-center space-x-2">
-                      <Button
-                        variant="destructive"
-                        onClick={() => {
-                          onBulkDelete(
-                            table
-                              .getRowModel()
-                              .rows.filter((row) => row.getIsSelected())
-                              .map((row) => row.original),
-                          )
-                          setBulkDeleteConfirmationOpen(false)
-                        }}
-                      >
-                        Delete
-                      </Button>
-                      <Button variant="outline" onClick={() => setBulkDeleteConfirmationOpen(false)}>
-                        Cancel
-                      </Button>
-                    </div>
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
-          )}
-        </div>
+                  <Button variant="outline" onClick={() => setBulkDeleteConfirmationOpen(false)}>
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
         <Pagination table={table} selectionEnabled entityName="Volumes" />
       </div>
     </div>


### PR DESCRIPTION
## Description

Fixed layout for pagination row on "Snapshots" page. Also, removed redundant wrapper elements from pagination row on "Volumes" page.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

### Before
<img width="2462" height="144" alt="image" src="https://github.com/user-attachments/assets/f941002d-88d0-4c41-b0bc-0fc643671c81" />

### After
<img width="2438" height="120" alt="image" src="https://github.com/user-attachments/assets/dd95f2da-b9ad-4d9c-931f-8a449af6581a" />
