### PR TITLE
fix(dashboard): table rounded border overflow

### DIFF
--- a/apps/dashboard/src/components/ui/table.tsx
+++ b/apps/dashboard/src/components/ui/table.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils'
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
-    <div className="flex-1 w-full overflow-auto">
+    <div className="flex-1 w-full overflow-auto rounded-md">
       <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
     </div>
   ),


### PR DESCRIPTION
## Description

Fixed overflow that's occurring in table corners due to rounded borders.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

### Before
<img width="1332" height="648" alt="image" src="https://github.com/user-attachments/assets/48eb5076-a4fe-43c6-a57d-e6cb690874f0" />

### After
<img width="1242" height="652" alt="image" src="https://github.com/user-attachments/assets/d5504379-445a-49d0-927b-c54abb723b69" />
