### PR TITLE
fix(dashboard): increase size of top-level spinner

### DIFF
--- a/apps/dashboard/src/components/LoadingFallback.tsx
+++ b/apps/dashboard/src/components/LoadingFallback.tsx
@@ -50,7 +50,7 @@ const LoadingFallback = () => (
     <SidebarInset className="overflow-hidden">
       <div className="fixed top-0 left-0 w-full h-full p-6 bg-background z-[3]">
         <div className="flex items-center justify-center h-full">
-          <Loader2 className="w-4 h-4 animate-spin" />
+          <Loader2 className="w-8 h-8 animate-spin" />
         </div>
       </div>
     </SidebarInset>


### PR DESCRIPTION
## Description

Increased size of top-level spinner.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

### Before
<img width="3022" height="1630" alt="image" src="https://github.com/user-attachments/assets/236232e5-36b9-4482-ae74-a3e6bdb01516" />

### After
<img width="3022" height="1636" alt="image" src="https://github.com/user-attachments/assets/29373611-c280-4d2b-94c7-51d56d67ce86" />
