### PR TITLE
fix(api): resolve N+1 query in listSandboxes

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -75,6 +75,16 @@ export class RunnerService {
     return this.runnerRepository.findOneBy({ id })
   }
 
+  async findByIds(runnerIds: string[]): Promise<Runner[]> {
+    if (runnerIds.length === 0) {
+      return []
+    }
+
+    return this.runnerRepository.find({
+      where: { id: In(runnerIds) },
+    })
+  }
+
   async findBySandboxId(sandboxId: string): Promise<Runner | null> {
     const sandbox = await this.sandboxRepository.findOneBy({ id: sandboxId, state: Not(SandboxState.DESTROYED) })
     if (!sandbox) {


### PR DESCRIPTION
# Resolve N+1 query in listSandboxes

## Description

Fetch all runners in a single query via runnerService.findByIds() instead of querying runner per sandbox. 

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
