### PR TITLE
fix(computer-use): replace non-existent novnc_proxy with websockify command

### DIFF
--- a/libs/computer-use/pkg/computeruse/computeruse.go
+++ b/libs/computer-use/pkg/computeruse/computeruse.go
@@ -126,6 +126,11 @@ func (c *ComputerUse) initializeProcesses(homeDir string) {
 		vncPort = "5901"
 	}
 
+	noVncPort := os.Getenv("NO_VNC_PORT")
+	if noVncPort == "" {
+		noVncPort = "6901"
+	}
+
 	display := os.Getenv("DISPLAY")
 	if display == "" {
 		display = ":0"
@@ -194,8 +199,8 @@ func (c *ComputerUse) initializeProcesses(homeDir string) {
 	// Process 4: novnc (Web-based VNC client)
 	c.processes["novnc"] = &Process{
 		Name:        "novnc",
-		Command:     "/usr/share/novnc/utils/novnc_proxy",
-		Args:        []string{"--vnc", "localhost:" + vncPort},
+		Command:     "websockify",
+		Args:        []string{"--web=/usr/share/novnc/", noVncPort, "localhost:" + vncPort},
 		User:        user,
 		Priority:    400,
 		AutoRestart: true,


### PR DESCRIPTION
# Fix NoVNC Process Startup in Computer-Use Plugin

## Problem
The computer-use plugin was failing to start the NoVNC process due to referencing a non-existent command `/usr/share/novnc/utils/novnc_proxy`. This command doesn't exist in modern Ubuntu 22.04 NoVNC packages, causing the plugin initialization to fail.

## Root Cause
- The original code assumed an older NoVNC package structure that included `novnc_proxy` utility
- Modern NoVNC packages (Ubuntu 22.04) only provide the standard `websockify` command

## Solution
Updated the NoVNC process configuration in `computeruse.go` to:

1. **Replace Command**: Changed from `/usr/share/novnc/utils/novnc_proxy` to `websockify`
2. **Fix Parameters**: Updated to use websockify parameter format:
   - Old: `["--vnc", "localhost:" + vncPort]`
   - New: `["--web=/usr/share/novnc/", noVncPort, "localhost:" + vncPort]`
3. **Add Environment Variable Support**: Added `NO_VNC_PORT` environment variable with fallback to "6901"

## Verification
- ✅ Container verification shows `/usr/share/novnc/utils/novnc_proxy` does not exist
- ✅ Container verification shows `websockify` command is available

## Files Changed
- `libs/computer-use/pkg/computeruse/computeruse.go`
  - Updated NoVNC process configuration in `initializeProcesses()` method
  - Added NO_VNC_PORT environment variable support

This ensures the computer-use plugin can successfully manage the NoVNC web interface alongside other desktop environment processes.