### PR TITLE
fix: filter out runners with high usage

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -439,11 +439,14 @@ export class SandboxService {
 
     let runner: Runner
 
+    const excludedRunnerIds = await this.runnerService.getRunnersWithHighStartedSandboxesRatio()
+
     try {
       runner = await this.runnerService.getRandomAvailableRunner({
         region: sandbox.region,
         sandboxClass: sandbox.class,
         snapshotRef: sandbox.buildInfo.snapshotRef,
+        excludedRunnerIds,
       })
       sandbox.runnerId = runner.id
     } catch (error) {


### PR DESCRIPTION
# Filter out runners with high usage
## Description

Filter out runners with high amount of started sandboxes on them relative to their capacity. This is relevant only for the declarative builder where very few runners have the relevant image prebuilt

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation