### PR TITLE
fix(dashboard,api): allow underscore in image name

### DIFF
--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -30,7 +30,7 @@ import { OrganizationEvents } from '../../organization/constants/organization-ev
 import { OrganizationSuspendedSnapshotDeactivatedEvent } from '../../organization/events/organization-suspended-snapshot-deactivated.event'
 import { SnapshotRunnerState } from '../enums/snapshot-runner-state.enum'
 
-const IMAGE_NAME_REGEX = /^[a-zA-Z0-9.\-:]+(\/[a-zA-Z0-9.\-:]+)*$/
+const IMAGE_NAME_REGEX = /^[a-zA-Z0-9_.\-:]+(\/[a-zA-Z0-9_.\-:]+)*$/
 @Injectable()
 export class SnapshotService {
   private readonly logger = new Logger(SnapshotService.name)

--- a/apps/dashboard/src/pages/Snapshots.tsx
+++ b/apps/dashboard/src/pages/Snapshots.tsx
@@ -32,7 +32,7 @@ import { Label } from '@/components/ui/label'
 import { handleApiError } from '@/lib/error-handling'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 
-const IMAGE_NAME_REGEX = /^[a-zA-Z0-9.\-:]+(\/[a-zA-Z0-9.\-:]+)*$/
+const IMAGE_NAME_REGEX = /^[a-zA-Z0-9_.\-:]+(\/[a-zA-Z0-9_.\-:]+)*$/
 
 const Snapshots: React.FC = () => {
   const { notificationSocket } = useNotificationSocket()


### PR DESCRIPTION
# Allow Underscore in Image Name

## Description

Images can have underscores in the name and project. This PR adds _ to the allowed list of characters

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
