### PR TITLE
fix: return runners by snapshot ref

### DIFF
--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -103,14 +103,14 @@ export class RunnerController {
     return RunnerDto.fromRunner(runner)
   }
 
-  @Get('/by-snapshot')
+  @Get('/by-snapshot-ref')
   @ApiOperation({
-    summary: 'Get runners by snapshot internal name',
-    operationId: 'getRunnersBySnapshotInternalName',
+    summary: 'Get runners by snapshot ref',
+    operationId: 'getRunnersBySnapshotRef',
   })
   @ApiQuery({
-    name: 'internalName',
-    description: 'Internal name of the snapshot',
+    name: 'ref',
+    description: 'Snapshot ref',
     type: String,
     required: true,
   })
@@ -119,7 +119,7 @@ export class RunnerController {
     description: 'Runners found for the snapshot',
     type: [RunnerSnapshotDto],
   })
-  async getRunnersBySnapshotInternalName(@Query('internalName') internalName: string): Promise<RunnerSnapshotDto[]> {
-    return this.runnerService.getRunnersBySnapshotInternalName(internalName)
+  async getRunnersBySnapshotRef(@Query('ref') ref: string): Promise<RunnerSnapshotDto[]> {
+    return this.runnerService.getRunnersBySnapshotRef(ref)
   }
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -1776,14 +1776,14 @@ paths:
       summary: Get runner by sandbox ID
       tags:
         - runners
-  /runners/by-snapshot:
+  /runners/by-snapshot-ref:
     get:
-      operationId: getRunnersBySnapshotInternalName
+      operationId: getRunnersBySnapshotRef
       parameters:
-        - description: Internal name of the snapshot
+        - description: Snapshot ref
           explode: true
           in: query
-          name: internalName
+          name: ref
           required: true
           schema:
             type: string
@@ -1803,7 +1803,7 @@ paths:
             - openid
             - profile
             - email
-      summary: Get runners by snapshot internal name
+      summary: Get runners by snapshot ref
       tags:
         - runners
   /toolbox/{sandboxId}/toolbox/project-dir:

--- a/libs/api-client-go/api_runners.go
+++ b/libs/api-client-go/api_runners.go
@@ -47,16 +47,16 @@ type RunnersAPI interface {
 	GetRunnerBySandboxIdExecute(r RunnersAPIGetRunnerBySandboxIdRequest) (*Runner, *http.Response, error)
 
 	/*
-		GetRunnersBySnapshotInternalName Get runners by snapshot internal name
+		GetRunnersBySnapshotRef Get runners by snapshot ref
 
 		@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-		@return RunnersAPIGetRunnersBySnapshotInternalNameRequest
+		@return RunnersAPIGetRunnersBySnapshotRefRequest
 	*/
-	GetRunnersBySnapshotInternalName(ctx context.Context) RunnersAPIGetRunnersBySnapshotInternalNameRequest
+	GetRunnersBySnapshotRef(ctx context.Context) RunnersAPIGetRunnersBySnapshotRefRequest
 
-	// GetRunnersBySnapshotInternalNameExecute executes the request
+	// GetRunnersBySnapshotRefExecute executes the request
 	//  @return []RunnerSnapshotDto
-	GetRunnersBySnapshotInternalNameExecute(r RunnersAPIGetRunnersBySnapshotInternalNameRequest) ([]RunnerSnapshotDto, *http.Response, error)
+	GetRunnersBySnapshotRefExecute(r RunnersAPIGetRunnersBySnapshotRefRequest) ([]RunnerSnapshotDto, *http.Response, error)
 
 	/*
 		ListRunners List all runners
@@ -284,30 +284,30 @@ func (a *RunnersAPIService) GetRunnerBySandboxIdExecute(r RunnersAPIGetRunnerByS
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
-type RunnersAPIGetRunnersBySnapshotInternalNameRequest struct {
-	ctx          context.Context
-	ApiService   RunnersAPI
-	internalName *string
+type RunnersAPIGetRunnersBySnapshotRefRequest struct {
+	ctx        context.Context
+	ApiService RunnersAPI
+	ref        *string
 }
 
-// Internal name of the snapshot
-func (r RunnersAPIGetRunnersBySnapshotInternalNameRequest) InternalName(internalName string) RunnersAPIGetRunnersBySnapshotInternalNameRequest {
-	r.internalName = &internalName
+// Snapshot ref
+func (r RunnersAPIGetRunnersBySnapshotRefRequest) Ref(ref string) RunnersAPIGetRunnersBySnapshotRefRequest {
+	r.ref = &ref
 	return r
 }
 
-func (r RunnersAPIGetRunnersBySnapshotInternalNameRequest) Execute() ([]RunnerSnapshotDto, *http.Response, error) {
-	return r.ApiService.GetRunnersBySnapshotInternalNameExecute(r)
+func (r RunnersAPIGetRunnersBySnapshotRefRequest) Execute() ([]RunnerSnapshotDto, *http.Response, error) {
+	return r.ApiService.GetRunnersBySnapshotRefExecute(r)
 }
 
 /*
-GetRunnersBySnapshotInternalName Get runners by snapshot internal name
+GetRunnersBySnapshotRef Get runners by snapshot ref
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	@return RunnersAPIGetRunnersBySnapshotInternalNameRequest
+	@return RunnersAPIGetRunnersBySnapshotRefRequest
 */
-func (a *RunnersAPIService) GetRunnersBySnapshotInternalName(ctx context.Context) RunnersAPIGetRunnersBySnapshotInternalNameRequest {
-	return RunnersAPIGetRunnersBySnapshotInternalNameRequest{
+func (a *RunnersAPIService) GetRunnersBySnapshotRef(ctx context.Context) RunnersAPIGetRunnersBySnapshotRefRequest {
+	return RunnersAPIGetRunnersBySnapshotRefRequest{
 		ApiService: a,
 		ctx:        ctx,
 	}
@@ -316,7 +316,7 @@ func (a *RunnersAPIService) GetRunnersBySnapshotInternalName(ctx context.Context
 // Execute executes the request
 //
 //	@return []RunnerSnapshotDto
-func (a *RunnersAPIService) GetRunnersBySnapshotInternalNameExecute(r RunnersAPIGetRunnersBySnapshotInternalNameRequest) ([]RunnerSnapshotDto, *http.Response, error) {
+func (a *RunnersAPIService) GetRunnersBySnapshotRefExecute(r RunnersAPIGetRunnersBySnapshotRefRequest) ([]RunnerSnapshotDto, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
 		localVarPostBody    interface{}
@@ -324,21 +324,21 @@ func (a *RunnersAPIService) GetRunnersBySnapshotInternalNameExecute(r RunnersAPI
 		localVarReturnValue []RunnerSnapshotDto
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RunnersAPIService.GetRunnersBySnapshotInternalName")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RunnersAPIService.GetRunnersBySnapshotRef")
 	if err != nil {
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/runners/by-snapshot"
+	localVarPath := localBasePath + "/runners/by-snapshot-ref"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.internalName == nil {
-		return localVarReturnValue, nil, reportError("internalName is required and must be specified")
+	if r.ref == nil {
+		return localVarReturnValue, nil, reportError("ref is required and must be specified")
 	}
 
-	parameterAddToHeaderOrQuery(localVarQueryParams, "internalName", r.internalName, "form", "")
+	parameterAddToHeaderOrQuery(localVarQueryParams, "ref", r.ref, "form", "")
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/libs/api-client-python-async/daytona_api_client_async/api/runners_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/runners_api.py
@@ -567,9 +567,9 @@ class RunnersApi:
 
 
     @validate_call
-    async def get_runners_by_snapshot_internal_name(
+    async def get_runners_by_snapshot_ref(
         self,
-        internal_name: Annotated[StrictStr, Field(description="Internal name of the snapshot")],
+        ref: Annotated[StrictStr, Field(description="Snapshot ref")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -583,11 +583,11 @@ class RunnersApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[RunnerSnapshotDto]:
-        """Get runners by snapshot internal name
+        """Get runners by snapshot ref
 
 
-        :param internal_name: Internal name of the snapshot (required)
-        :type internal_name: str
+        :param ref: Snapshot ref (required)
+        :type ref: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -610,8 +610,8 @@ class RunnersApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_runners_by_snapshot_internal_name_serialize(
-            internal_name=internal_name,
+        _param = self._get_runners_by_snapshot_ref_serialize(
+            ref=ref,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -633,9 +633,9 @@ class RunnersApi:
 
 
     @validate_call
-    async def get_runners_by_snapshot_internal_name_with_http_info(
+    async def get_runners_by_snapshot_ref_with_http_info(
         self,
-        internal_name: Annotated[StrictStr, Field(description="Internal name of the snapshot")],
+        ref: Annotated[StrictStr, Field(description="Snapshot ref")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -649,11 +649,11 @@ class RunnersApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[RunnerSnapshotDto]]:
-        """Get runners by snapshot internal name
+        """Get runners by snapshot ref
 
 
-        :param internal_name: Internal name of the snapshot (required)
-        :type internal_name: str
+        :param ref: Snapshot ref (required)
+        :type ref: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -676,8 +676,8 @@ class RunnersApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_runners_by_snapshot_internal_name_serialize(
-            internal_name=internal_name,
+        _param = self._get_runners_by_snapshot_ref_serialize(
+            ref=ref,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -699,9 +699,9 @@ class RunnersApi:
 
 
     @validate_call
-    async def get_runners_by_snapshot_internal_name_without_preload_content(
+    async def get_runners_by_snapshot_ref_without_preload_content(
         self,
-        internal_name: Annotated[StrictStr, Field(description="Internal name of the snapshot")],
+        ref: Annotated[StrictStr, Field(description="Snapshot ref")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -715,11 +715,11 @@ class RunnersApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get runners by snapshot internal name
+        """Get runners by snapshot ref
 
 
-        :param internal_name: Internal name of the snapshot (required)
-        :type internal_name: str
+        :param ref: Snapshot ref (required)
+        :type ref: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -742,8 +742,8 @@ class RunnersApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_runners_by_snapshot_internal_name_serialize(
-            internal_name=internal_name,
+        _param = self._get_runners_by_snapshot_ref_serialize(
+            ref=ref,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -760,9 +760,9 @@ class RunnersApi:
         return response_data.response
 
 
-    def _get_runners_by_snapshot_internal_name_serialize(
+    def _get_runners_by_snapshot_ref_serialize(
         self,
-        internal_name,
+        ref,
         _request_auth,
         _content_type,
         _headers,
@@ -785,9 +785,9 @@ class RunnersApi:
 
         # process the path parameters
         # process the query parameters
-        if internal_name is not None:
+        if ref is not None:
             
-            _query_params.append(('internalName', internal_name))
+            _query_params.append(('ref', ref))
             
         # process the header parameters
         # process the form parameters
@@ -811,7 +811,7 @@ class RunnersApi:
 
         return self.api_client.param_serialize(
             method='GET',
-            resource_path='/runners/by-snapshot',
+            resource_path='/runners/by-snapshot-ref',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/libs/api-client-python/daytona_api_client/api/runners_api.py
+++ b/libs/api-client-python/daytona_api_client/api/runners_api.py
@@ -567,9 +567,9 @@ class RunnersApi:
 
 
     @validate_call
-    def get_runners_by_snapshot_internal_name(
+    def get_runners_by_snapshot_ref(
         self,
-        internal_name: Annotated[StrictStr, Field(description="Internal name of the snapshot")],
+        ref: Annotated[StrictStr, Field(description="Snapshot ref")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -583,11 +583,11 @@ class RunnersApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> List[RunnerSnapshotDto]:
-        """Get runners by snapshot internal name
+        """Get runners by snapshot ref
 
 
-        :param internal_name: Internal name of the snapshot (required)
-        :type internal_name: str
+        :param ref: Snapshot ref (required)
+        :type ref: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -610,8 +610,8 @@ class RunnersApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_runners_by_snapshot_internal_name_serialize(
-            internal_name=internal_name,
+        _param = self._get_runners_by_snapshot_ref_serialize(
+            ref=ref,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -633,9 +633,9 @@ class RunnersApi:
 
 
     @validate_call
-    def get_runners_by_snapshot_internal_name_with_http_info(
+    def get_runners_by_snapshot_ref_with_http_info(
         self,
-        internal_name: Annotated[StrictStr, Field(description="Internal name of the snapshot")],
+        ref: Annotated[StrictStr, Field(description="Snapshot ref")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -649,11 +649,11 @@ class RunnersApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> ApiResponse[List[RunnerSnapshotDto]]:
-        """Get runners by snapshot internal name
+        """Get runners by snapshot ref
 
 
-        :param internal_name: Internal name of the snapshot (required)
-        :type internal_name: str
+        :param ref: Snapshot ref (required)
+        :type ref: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -676,8 +676,8 @@ class RunnersApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_runners_by_snapshot_internal_name_serialize(
-            internal_name=internal_name,
+        _param = self._get_runners_by_snapshot_ref_serialize(
+            ref=ref,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -699,9 +699,9 @@ class RunnersApi:
 
 
     @validate_call
-    def get_runners_by_snapshot_internal_name_without_preload_content(
+    def get_runners_by_snapshot_ref_without_preload_content(
         self,
-        internal_name: Annotated[StrictStr, Field(description="Internal name of the snapshot")],
+        ref: Annotated[StrictStr, Field(description="Snapshot ref")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -715,11 +715,11 @@ class RunnersApi:
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
     ) -> RESTResponseType:
-        """Get runners by snapshot internal name
+        """Get runners by snapshot ref
 
 
-        :param internal_name: Internal name of the snapshot (required)
-        :type internal_name: str
+        :param ref: Snapshot ref (required)
+        :type ref: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -742,8 +742,8 @@ class RunnersApi:
         :return: Returns the result object.
         """ # noqa: E501
 
-        _param = self._get_runners_by_snapshot_internal_name_serialize(
-            internal_name=internal_name,
+        _param = self._get_runners_by_snapshot_ref_serialize(
+            ref=ref,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -760,9 +760,9 @@ class RunnersApi:
         return response_data.response
 
 
-    def _get_runners_by_snapshot_internal_name_serialize(
+    def _get_runners_by_snapshot_ref_serialize(
         self,
-        internal_name,
+        ref,
         _request_auth,
         _content_type,
         _headers,
@@ -785,9 +785,9 @@ class RunnersApi:
 
         # process the path parameters
         # process the query parameters
-        if internal_name is not None:
+        if ref is not None:
             
-            _query_params.append(('internalName', internal_name))
+            _query_params.append(('ref', ref))
             
         # process the header parameters
         # process the form parameters
@@ -811,7 +811,7 @@ class RunnersApi:
 
         return self.api_client.param_serialize(
             method='GET',
-            resource_path='/runners/by-snapshot',
+            resource_path='/runners/by-snapshot-ref',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/libs/api-client/src/api/runners-api.ts
+++ b/libs/api-client/src/api/runners-api.ts
@@ -125,18 +125,15 @@ export const RunnersApiAxiosParamCreator = function (configuration?: Configurati
     },
     /**
      *
-     * @summary Get runners by snapshot internal name
-     * @param {string} internalName Internal name of the snapshot
+     * @summary Get runners by snapshot ref
+     * @param {string} ref Snapshot ref
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getRunnersBySnapshotInternalName: async (
-      internalName: string,
-      options: RawAxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'internalName' is not null or undefined
-      assertParamExists('getRunnersBySnapshotInternalName', 'internalName', internalName)
-      const localVarPath = `/runners/by-snapshot`
+    getRunnersBySnapshotRef: async (ref: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'ref' is not null or undefined
+      assertParamExists('getRunnersBySnapshotRef', 'ref', ref)
+      const localVarPath = `/runners/by-snapshot-ref`
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
       let baseOptions
@@ -154,8 +151,8 @@ export const RunnersApiAxiosParamCreator = function (configuration?: Configurati
 
       // authentication oauth2 required
 
-      if (internalName !== undefined) {
-        localVarQueryParameter['internalName'] = internalName
+      if (ref !== undefined) {
+        localVarQueryParameter['ref'] = ref
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -296,19 +293,19 @@ export const RunnersApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @summary Get runners by snapshot internal name
-     * @param {string} internalName Internal name of the snapshot
+     * @summary Get runners by snapshot ref
+     * @param {string} ref Snapshot ref
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async getRunnersBySnapshotInternalName(
-      internalName: string,
+    async getRunnersBySnapshotRef(
+      ref: string,
       options?: RawAxiosRequestConfig,
     ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<RunnerSnapshotDto>>> {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getRunnersBySnapshotInternalName(internalName, options)
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getRunnersBySnapshotRef(ref, options)
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0
       const localVarOperationServerBasePath =
-        operationServerMap['RunnersApi.getRunnersBySnapshotInternalName']?.[localVarOperationServerIndex]?.url
+        operationServerMap['RunnersApi.getRunnersBySnapshotRef']?.[localVarOperationServerIndex]?.url
       return (axios, basePath) =>
         createRequestFunction(
           localVarAxiosArgs,
@@ -393,18 +390,13 @@ export const RunnersApiFactory = function (configuration?: Configuration, basePa
     },
     /**
      *
-     * @summary Get runners by snapshot internal name
-     * @param {string} internalName Internal name of the snapshot
+     * @summary Get runners by snapshot ref
+     * @param {string} ref Snapshot ref
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getRunnersBySnapshotInternalName(
-      internalName: string,
-      options?: RawAxiosRequestConfig,
-    ): AxiosPromise<Array<RunnerSnapshotDto>> {
-      return localVarFp
-        .getRunnersBySnapshotInternalName(internalName, options)
-        .then((request) => request(axios, basePath))
+    getRunnersBySnapshotRef(ref: string, options?: RawAxiosRequestConfig): AxiosPromise<Array<RunnerSnapshotDto>> {
+      return localVarFp.getRunnersBySnapshotRef(ref, options).then((request) => request(axios, basePath))
     },
     /**
      *
@@ -465,15 +457,15 @@ export class RunnersApi extends BaseAPI {
 
   /**
    *
-   * @summary Get runners by snapshot internal name
-   * @param {string} internalName Internal name of the snapshot
+   * @summary Get runners by snapshot ref
+   * @param {string} ref Snapshot ref
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof RunnersApi
    */
-  public getRunnersBySnapshotInternalName(internalName: string, options?: RawAxiosRequestConfig) {
+  public getRunnersBySnapshotRef(ref: string, options?: RawAxiosRequestConfig) {
     return RunnersApiFp(this.configuration)
-      .getRunnersBySnapshotInternalName(internalName, options)
+      .getRunnersBySnapshotRef(ref, options)
       .then((request) => request(this.axios, this.basePath))
   }
 


### PR DESCRIPTION
# Fix return runners by snapshot ref
## Description

Changes the logic to focus only on the `snapshot_runners` table as the source of truth - it is maintained to communicate which snapshots the API expects each runner to have. Fixes declarative ad-hoc builds missing in the response

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
