### PR TITLE
feat(api): user creation timestamp

### DIFF
--- a/apps/api/src/migrations/1753430929609-migration.ts
+++ b/apps/api/src/migrations/1753430929609-migration.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1753430929609 implements MigrationInterface {
+  name = 'Migration1753430929609'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`)
+
+    // For existing users, set createdAt to match their personal organization's createdAt
+    await queryRunner.query(`
+        UPDATE "user" u
+        SET "createdAt" = (
+            SELECT o."createdAt"
+            FROM "organization" o
+            WHERE o."createdBy" = u.id
+            AND o.personal = true
+            LIMIT 1
+        )
+        WHERE EXISTS (
+            SELECT 1 
+            FROM "organization" o 
+            WHERE o."createdBy" = u.id 
+            AND o.personal = true
+        )
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "createdAt"`)
+  }
+}

--- a/apps/api/src/migrations/1753430929609-migration.ts
+++ b/apps/api/src/migrations/1753430929609-migration.ts
@@ -13,20 +13,11 @@ export class Migration1753430929609 implements MigrationInterface {
 
     // For existing users, set createdAt to match their personal organization's createdAt
     await queryRunner.query(`
-        UPDATE "user" u
-        SET "createdAt" = (
-            SELECT o."createdAt"
-            FROM "organization" o
-            WHERE o."createdBy" = u.id
-            AND o.personal = true
-            LIMIT 1
-        )
-        WHERE EXISTS (
-            SELECT 1 
-            FROM "organization" o 
-            WHERE o."createdBy" = u.id 
-            AND o.personal = true
-        )
+        UPDATE "user" u 
+        SET "createdAt" = o."createdAt" 
+        FROM "organization" o 
+        WHERE o."createdBy" = u.id 
+          AND o.personal = true;
     `)
   }
 

--- a/apps/api/src/user/dto/user.dto.ts
+++ b/apps/api/src/user/dto/user.dto.ts
@@ -30,12 +30,18 @@ export class UserDto {
   })
   publicKeys: UserPublicKeyDto[]
 
+  @ApiProperty({
+    description: 'Creation timestamp',
+  })
+  createdAt: Date
+
   static fromUser(user: User): UserDto {
     const dto: UserDto = {
       id: user.id,
       name: user.name,
       email: user.email,
       publicKeys: user.publicKeys.map(UserPublicKeyDto.fromUserPublicKey),
+      createdAt: user.createdAt,
     }
 
     return dto

--- a/apps/api/src/user/user.entity.ts
+++ b/apps/api/src/user/user.entity.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Column, Entity, PrimaryColumn } from 'typeorm'
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm'
 import { SystemRole } from './enums/system-role.enum'
 
 export interface UserSSHKeyPair {
@@ -49,4 +49,9 @@ export class User {
     default: SystemRole.USER,
   })
   role: SystemRole
+
+  @CreateDateColumn({
+    type: 'timestamp with time zone',
+  })
+  createdAt: Date
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -6711,6 +6711,7 @@ components:
       type: object
     User:
       example:
+        createdAt: 2000-01-23T04:56:07.000+00:00
         publicKeys:
           - name: name
             key: key
@@ -6734,7 +6735,12 @@ components:
           items:
             $ref: '#/components/schemas/UserPublicKey'
           type: array
+        createdAt:
+          description: Creation timestamp
+          format: date-time
+          type: string
       required:
+        - createdAt
         - email
         - id
         - name

--- a/libs/api-client-go/model_user.go
+++ b/libs/api-client-go/model_user.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // checks if the User type satisfies the MappedNullable interface at compile time
@@ -30,6 +31,8 @@ type User struct {
 	Email string `json:"email"`
 	// User public keys
 	PublicKeys []UserPublicKey `json:"publicKeys"`
+	// Creation timestamp
+	CreatedAt time.Time `json:"createdAt"`
 }
 
 type _User User
@@ -38,12 +41,13 @@ type _User User
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUser(id string, name string, email string, publicKeys []UserPublicKey) *User {
+func NewUser(id string, name string, email string, publicKeys []UserPublicKey, createdAt time.Time) *User {
 	this := User{}
 	this.Id = id
 	this.Name = name
 	this.Email = email
 	this.PublicKeys = publicKeys
+	this.CreatedAt = createdAt
 	return &this
 }
 
@@ -151,6 +155,30 @@ func (o *User) SetPublicKeys(v []UserPublicKey) {
 	o.PublicKeys = v
 }
 
+// GetCreatedAt returns the CreatedAt field value
+func (o *User) GetCreatedAt() time.Time {
+	if o == nil {
+		var ret time.Time
+		return ret
+	}
+
+	return o.CreatedAt
+}
+
+// GetCreatedAtOk returns a tuple with the CreatedAt field value
+// and a boolean to check if the value has been set.
+func (o *User) GetCreatedAtOk() (*time.Time, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.CreatedAt, true
+}
+
+// SetCreatedAt sets field value
+func (o *User) SetCreatedAt(v time.Time) {
+	o.CreatedAt = v
+}
+
 func (o User) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -165,6 +193,7 @@ func (o User) ToMap() (map[string]interface{}, error) {
 	toSerialize["name"] = o.Name
 	toSerialize["email"] = o.Email
 	toSerialize["publicKeys"] = o.PublicKeys
+	toSerialize["createdAt"] = o.CreatedAt
 	return toSerialize, nil
 }
 
@@ -177,6 +206,7 @@ func (o *User) UnmarshalJSON(data []byte) (err error) {
 		"name",
 		"email",
 		"publicKeys",
+		"createdAt",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-python-async/daytona_api_client_async/models/user.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/user.py
@@ -18,6 +18,7 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List
 from daytona_api_client_async.models.user_public_key import UserPublicKey
@@ -32,8 +33,9 @@ class User(BaseModel):
     name: StrictStr = Field(description="User name")
     email: StrictStr = Field(description="User email")
     public_keys: List[UserPublicKey] = Field(description="User public keys", alias="publicKeys")
+    created_at: datetime = Field(description="Creation timestamp", alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "email", "publicKeys"]
+    __properties: ClassVar[List[str]] = ["id", "name", "email", "publicKeys", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -103,7 +105,8 @@ class User(BaseModel):
             "id": obj.get("id"),
             "name": obj.get("name"),
             "email": obj.get("email"),
-            "publicKeys": [UserPublicKey.from_dict(_item) for _item in obj["publicKeys"]] if obj.get("publicKeys") is not None else None
+            "publicKeys": [UserPublicKey.from_dict(_item) for _item in obj["publicKeys"]] if obj.get("publicKeys") is not None else None,
+            "createdAt": obj.get("createdAt")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/user.py
+++ b/libs/api-client-python/daytona_api_client/models/user.py
@@ -18,6 +18,7 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List
 from daytona_api_client.models.user_public_key import UserPublicKey
@@ -32,8 +33,9 @@ class User(BaseModel):
     name: StrictStr = Field(description="User name")
     email: StrictStr = Field(description="User email")
     public_keys: List[UserPublicKey] = Field(description="User public keys", alias="publicKeys")
+    created_at: datetime = Field(description="Creation timestamp", alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "email", "publicKeys"]
+    __properties: ClassVar[List[str]] = ["id", "name", "email", "publicKeys", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -103,7 +105,8 @@ class User(BaseModel):
             "id": obj.get("id"),
             "name": obj.get("name"),
             "email": obj.get("email"),
-            "publicKeys": [UserPublicKey.from_dict(_item) for _item in obj["publicKeys"]] if obj.get("publicKeys") is not None else None
+            "publicKeys": [UserPublicKey.from_dict(_item) for _item in obj["publicKeys"]] if obj.get("publicKeys") is not None else None,
+            "createdAt": obj.get("createdAt")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client/src/models/user.ts
+++ b/libs/api-client/src/models/user.ts
@@ -46,4 +46,10 @@ export interface User {
    * @memberof User
    */
   publicKeys: Array<UserPublicKey>
+  /**
+   * Creation timestamp
+   * @type {Date}
+   * @memberof User
+   */
+  createdAt: Date
 }


### PR DESCRIPTION
## Description

Added `createdAt` property to the User entity. For existing users, this value will be set to match their personal organization's creation timestamp.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation