### PR TITLE
refactor(api): ignore case for organization invitation email address

### DIFF
--- a/apps/api/src/common/utils/email.util.ts
+++ b/apps/api/src/common/utils/email.util.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export class EmailUtils {
+  static normalize(email: string): string {
+    return email.toLowerCase().trim()
+  }
+
+  static areEqual(email1: string, email2: string): boolean {
+    return this.normalize(email1) === this.normalize(email2)
+  }
+}

--- a/apps/api/src/organization/controllers/organization.controller.ts
+++ b/apps/api/src/organization/controllers/organization.controller.ts
@@ -39,6 +39,7 @@ import { UserService } from '../../user/user.service'
 import { Audit, TypedRequest } from '../../audit/decorators/audit.decorator'
 import { AuditAction } from '../../audit/enums/audit-action.enum'
 import { AuditTarget } from '../../audit/enums/audit-target.enum'
+import { EmailUtils } from '../../common/utils/email.util'
 
 @ApiTags('organizations')
 @Controller('organizations')
@@ -111,7 +112,7 @@ export class OrganizationController {
   ): Promise<void> {
     try {
       const invitation = await this.organizationInvitationService.findOneOrFail(invitationId)
-      if (invitation.email !== authContext.email) {
+      if (!EmailUtils.areEqual(invitation.email, authContext.email)) {
         throw new ForbiddenException('User email does not match invitation email')
       }
     } catch (error) {
@@ -147,7 +148,7 @@ export class OrganizationController {
   ): Promise<void> {
     try {
       const invitation = await this.organizationInvitationService.findOneOrFail(invitationId)
-      if (invitation.email !== authContext.email) {
+      if (!EmailUtils.areEqual(invitation.email, authContext.email)) {
         throw new ForbiddenException('User email does not match invitation email')
       }
     } catch (error) {

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -6,7 +6,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { User, UserSSHKeyPair } from './user.entity'
-import { DataSource, In, Repository } from 'typeorm'
+import { DataSource, ILike, In, Repository } from 'typeorm'
 import { CreateUserDto } from './dto/create-user.dto'
 import * as crypto from 'crypto'
 import * as forge from 'node-forge'
@@ -78,8 +78,12 @@ export class UserService {
     return this.userRepository.findOneOrFail({ where: { id } })
   }
 
-  async findOneByEmail(email: string): Promise<User | null> {
-    return this.userRepository.findOne({ where: { email } })
+  async findOneByEmail(email: string, ignoreCase = false): Promise<User | null> {
+    return this.userRepository.findOne({
+      where: {
+        email: ignoreCase ? ILike(email) : email,
+      },
+    })
   }
 
   async remove(id: string): Promise<void> {


### PR DESCRIPTION
## Description

Introduced case-insensitive email handling for organization invitations. 

For example, user with email address `john.doe@acme.org` would be able to accept organization invitations sent to following emails:
- `John.Doe@acme.org`
- `JOHN.doe@acme.org`
- ...

This will resolve issues where users would not be able to accept invitations even though they receive it in their email inbox.


- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
