### PR TITLE
fix: return immediately from api if the sandbox is starting from an archived state

### DIFF
--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import time
 import warnings
 from importlib.metadata import version
 from typing import Callable, Dict, List, Optional, Union, overload
@@ -362,6 +363,8 @@ class AsyncDaytona:
         if timeout < 0:
             raise DaytonaError("Timeout must be a non-negative number")
 
+        start_time = time.time()
+
         if params.auto_stop_interval is not None and params.auto_stop_interval < 0:
             raise DaytonaError("auto_stop_interval must be a non-negative integer")
 
@@ -452,7 +455,8 @@ class AsyncDaytona:
         if sandbox.state != SandboxState.STARTED:
             # Wait for sandbox to start
             try:
-                await sandbox.wait_for_sandbox_start()
+                time_elapsed = time.time() - start_time
+                await sandbox.wait_for_sandbox_start(timeout=max(0.001, timeout - time_elapsed) if timeout else timeout)
             finally:
                 # If not Daytona SaaS, we don't need to handle pulling image state
                 pass

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -226,7 +226,7 @@ class AsyncSandbox(SandboxDto):
                 raise e
 
         time_elapsed = time.time() - start_time
-        await self.wait_for_sandbox_start(timeout=max(0.1, timeout - time_elapsed) if timeout else None)
+        await self.wait_for_sandbox_start(timeout=max(0.1, timeout - time_elapsed) if timeout else timeout)
 
     @intercept_errors(message_prefix="Failed to stop sandbox: ")
     @with_timeout(

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -326,6 +326,8 @@ class Daytona:
         if timeout < 0:
             raise DaytonaError("Timeout must be a non-negative number")
 
+        start_time = time.time()
+
         if params.auto_stop_interval is not None and params.auto_stop_interval < 0:
             raise DaytonaError("auto_stop_interval must be a non-negative integer")
 
@@ -416,7 +418,8 @@ class Daytona:
         if sandbox.state != SandboxState.STARTED:
             # Wait for sandbox to start
             try:
-                sandbox.wait_for_sandbox_start()
+                time_elapsed = time.time() - start_time
+                sandbox.wait_for_sandbox_start(timeout=max(0.001, timeout - time_elapsed) if timeout else timeout)
             finally:
                 # If not Daytona SaaS, we don't need to handle pulling image state
                 pass

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -229,7 +229,7 @@ class Sandbox(SandboxDto):
                 raise e
 
         time_elapsed = time.time() - start_time
-        self.wait_for_sandbox_start(timeout=max(0.1, timeout - time_elapsed) if timeout else None)
+        self.wait_for_sandbox_start(timeout=max(0.1, timeout - time_elapsed) if timeout else timeout)
 
     @intercept_errors(message_prefix="Failed to stop sandbox: ")
     @with_timeout(

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional
 from daytona_api_client import PortPreviewUrl
 from daytona_api_client import Sandbox as SandboxDto
 from daytona_api_client import SandboxApi, ToolboxApi
+from daytona_api_client.exceptions import BadRequestException
 from pydantic import ConfigDict, PrivateAttr
 
 from .._utils.errors import intercept_errors
@@ -217,9 +218,18 @@ class Sandbox(SandboxDto):
             print("Sandbox started successfully")
             ```
         """
-        sandbox = self._sandbox_api.start_sandbox(self.id, _request_timeout=timeout or None)
-        self.__process_sandbox_dto(sandbox)
-        self.wait_for_sandbox_start()
+        start_time = time.time()
+        try:
+            sandbox = self._sandbox_api.start_sandbox(self.id, _request_timeout=timeout or None)
+            self.__process_sandbox_dto(sandbox)
+        except BadRequestException as e:
+            if "Sandbox failed to start: Timeout after" in str(e.body):
+                self.refresh_data()
+            else:
+                raise e
+
+        time_elapsed = time.time() - start_time
+        self.wait_for_sandbox_start(timeout=max(0.1, timeout - time_elapsed) if timeout else None)
 
     @intercept_errors(message_prefix="Failed to stop sandbox: ")
     @with_timeout(

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -494,7 +494,9 @@ export class Daytona {
 
       if (sandbox.state !== 'started') {
         const timeElapsed = Date.now() - startTime
-        await sandbox.waitUntilStarted(options.timeout ? options.timeout - timeElapsed / 1000 : 0)
+        await sandbox.waitUntilStarted(
+          options.timeout ? Math.max(0.001, options.timeout - timeElapsed / 1000) : options.timeout,
+        )
       }
 
       return sandbox

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -210,7 +210,7 @@ export class Sandbox implements SandboxDto {
     }
 
     const timeElapsed = Date.now() - startTime
-    await this.waitUntilStarted(timeout ? Math.max(0.1, timeout - timeElapsed / 1000) : undefined)
+    await this.waitUntilStarted(timeout ? Math.max(0.1, timeout - timeElapsed / 1000) : timeout)
   }
 
   /**

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -196,21 +196,12 @@ export class Sandbox implements SandboxDto {
     if (timeout < 0) {
       throw new DaytonaError('Timeout must be a non-negative number')
     }
+
     const startTime = Date.now()
-
-    try {
-      const response = await this.sandboxApi.startSandbox(this.id, undefined, { timeout: timeout * 1000 })
-      this.processSandboxDto(response.data)
-    } catch (error) {
-      if (error instanceof DaytonaError && error.message.includes('Sandbox failed to start: Timeout after')) {
-        await this.refreshData()
-      } else {
-        throw error
-      }
-    }
-
+    const response = await this.sandboxApi.startSandbox(this.id, undefined, { timeout: timeout * 1000 })
+    this.processSandboxDto(response.data)
     const timeElapsed = Date.now() - startTime
-    await this.waitUntilStarted(timeout ? Math.max(0.1, timeout - timeElapsed / 1000) : timeout)
+    await this.waitUntilStarted(timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout)
   }
 
   /**
@@ -235,7 +226,7 @@ export class Sandbox implements SandboxDto {
     await this.sandboxApi.stopSandbox(this.id, undefined, { timeout: timeout * 1000 })
     await this.refreshData()
     const timeElapsed = Date.now() - startTime
-    await this.waitUntilStopped(timeout ? timeout - timeElapsed / 1000 : 0)
+    await this.waitUntilStopped(timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout)
   }
 
   /**


### PR DESCRIPTION
# Sandbox Start Timeout Fix

## Description

Currently, on the server side, the sandbox start operation waits up to 30 seconds for the sandbox to reach the `STARTED` state before throwing a `BadRequestException` on timeout. This design eliminates the need for client-side polling and improves perceived responsiveness in typical scenarios.

However, when starting a sandbox from the `ARCHIVED` state, the operation can take significantly longer, depending on factors like archive size. In such cases, the 30-second limit is often exceeded, resulting in a timeout exception that the client does not handle properly.

This PR addresses that by returning the API response immediately (without throwing an exception) if the sandbox is being started from the `ARCHIVED` state. The SDK then takes over, polling the sandbox state until it transitions to `STARTED` or the user-defined timeout is reached.
