### PR TITLE
fix(proxy): reduce runner info cache

### DIFF
--- a/apps/proxy/pkg/proxy/get_target.go
+++ b/apps/proxy/pkg/proxy/get_target.go
@@ -105,7 +105,7 @@ func (p *Proxy) getRunnerInfo(ctx context.Context, sandboxId string) (*RunnerInf
 		ApiKey: runner.ApiKey,
 	}
 
-	err = p.runnerCache.Set(ctx, sandboxId, info, 1*time.Hour)
+	err = p.runnerCache.Set(ctx, sandboxId, info, 2*time.Minute)
 	if err != nil {
 		log.Errorf("Failed to set runner info in cache: %v", err)
 	}
@@ -129,7 +129,7 @@ func (p *Proxy) getSandboxPublic(ctx context.Context, sandboxId string) (*bool, 
 		isPublic = true
 	}
 
-	err = p.sandboxPublicCache.Set(ctx, sandboxId, isPublic, 2*time.Minute)
+	err = p.sandboxPublicCache.Set(ctx, sandboxId, isPublic, 1*time.Hour)
 	if err != nil {
 		log.Errorf("Failed to set sandbox public in cache: %v", err)
 	}


### PR DESCRIPTION
# Reduce Runner Info Cache

## Description

Reduce runner info cache in proxy to 2 minutes. Before, the cache might have stale info if the sandbox was archived, causing the proxy to route to the wrong runner.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
