### PR TITLE
fix: concurrent archiving limits const

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
@@ -16,6 +16,7 @@ import { InjectRedis } from '@nestjs-modules/ioredis'
 import Redis from 'ioredis'
 import { RunnerAdapterFactory } from '../../runner-adapter/runnerAdapter'
 import { ToolboxService } from '../../services/toolbox.service'
+import { MAX_ARCHIVING_CONCURRENT_SANDBOXES } from '../sandbox.manager'
 
 @Injectable()
 export class SandboxArchiveAction extends SandboxAction {
@@ -50,9 +51,9 @@ export class SandboxArchiveAction extends SandboxAction {
 
     //  if the sandbox is already in progress, continue
     if (!inProgressOnRunner.find((s) => s.id === sandbox.id)) {
-      //  max 3 sandboxes can be archived at the same time on the same runner
+      //  MAX_ARCHIVING_CONCURRENT_SANDBOXES sandboxes can be archived at the same time on the same runner
       //  this is to prevent the runner from being overloaded
-      if (inProgressOnRunner.length > 2) {
+      if (inProgressOnRunner.length >= MAX_ARCHIVING_CONCURRENT_SANDBOXES) {
         await this.redisLockProvider.unlock(lockKey)
         return DONT_SYNC_AGAIN
       }

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -35,6 +35,8 @@ import { SYNC_AGAIN, DONT_SYNC_AGAIN } from './sandbox-actions/sandbox.action'
 
 export const SYNC_INSTANCE_STATE_LOCK_KEY = 'sync-instance-state-'
 
+export const MAX_ARCHIVING_CONCURRENT_SANDBOXES = 6
+
 @Injectable()
 export class SandboxManager {
   private readonly logger = new Logger(SandboxManager.name)
@@ -277,7 +279,7 @@ export class SandboxManager {
       .select('"runnerId"')
       .where('"sandbox"."state" = :state', { state: SandboxState.ARCHIVING })
       .groupBy('"runnerId"')
-      .having('COUNT(*) >= 3')
+      .having('COUNT(*) >= :max', { max: MAX_ARCHIVING_CONCURRENT_SANDBOXES })
       .getRawMany()
 
     const sandboxes = await this.sandboxRepository


### PR DESCRIPTION
# Concurrently archiving limits const
## Description

Adds a constant for the amount of concurrently archiving sandboxes a runner may hold at a time

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
