### PR TITLE
feat(docs): add fade-out shadow to sidebar to indicate scrollable content

### DIFF
--- a/apps/docs/src/components/PageFrame.astro
+++ b/apps/docs/src/components/PageFrame.astro
@@ -63,10 +63,16 @@ const { hasSidebar, labels } = Astro.props
     background-color: var(--bg-color);
     overflow-y: auto;
     overscroll-behavior: contain;
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+    -ms-overflow-style: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-extra) var(--bg-color);
     &::-webkit-scrollbar {
-      display: none;
+      width: 8px;
+      background: var(--bg-color);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--border-extra);
+      border-radius: 4px;
     }
     @media (max-width: 1024px) {
       display: none;
@@ -79,6 +85,10 @@ const { hasSidebar, labels } = Astro.props
       border-left: 1px solid var(--border-extra);
       padding-left: 20px;
       padding-right: 20px;
+      scrollbar-width: none;
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR refactors the docs page by adding the scrollbar in the sidebar and a subtle fade indicator at the bottom of the sidebar to hint at more content. The Scrollbar helps a user to see more content exists Like Agent Toolbox etc.

Changes Made:
1. Made the Scrollbar Visible in the Sidebar so that a user can know there is more content.
2. Add a subtle fade-out shadow at the bottom of the sidebar to indicate overflow
   - `:after` pseudo-element to `.sidebar-pane`

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #2214 

## Screenshots


https://github.com/user-attachments/assets/fd70f0c3-826d-4a55-9651-1037206e912c


## Notes

The sidebar will now display a visible, styled scrollbar on desktop, making it clear that it is scrollable. The fade indicator at the bottom remains for extra clarity. This should help users discover hidden sections in the sidebar.