### PR TITLE
fix(api): several archival improvements

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -83,6 +83,7 @@ const configuration = {
     consoleLogEnabled: process.env.AUDIT_CONSOLE_LOG_ENABLED === 'true',
   },
   cronTimeZone: process.env.CRON_TIMEZONE,
+  maxConcurrentArchivesPerRunner: parseInt(process.env.MAX_CONCURRENT_ARCHIVES_PER_RUNNER || '6', 10),
 }
 
 export { configuration }

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -321,7 +321,7 @@ export class BackupManager {
         backupState: In([BackupState.NONE]),
       },
       //  todo: increase this number when auto-stop is stable
-      take: 10,
+      take: 100,
     })
 
     await Promise.all(


### PR DESCRIPTION
#Several Archival Improvements

## Description

- increase per-runner concurrency limit and allow for env var override
- fix issue where a backup wasn't being created when a sandbox was archived
- fix issue for sorting archived sandboxes when fetching from db

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
