### PR TITLE
feat(api): organization suspension cleanup grace period

### DIFF
--- a/apps/api/src/migrations/1754042247109-migration.ts
+++ b/apps/api/src/migrations/1754042247109-migration.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1754042247109 implements MigrationInterface {
+  name = 'Migration1754042247109'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "organization" ADD "suspensionCleanupGracePeriodHours" integer NOT NULL DEFAULT '24'`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN "suspensionCleanupGracePeriodHours"`)
+  }
+}

--- a/apps/api/src/organization/controllers/organization.controller.ts
+++ b/apps/api/src/organization/controllers/organization.controller.ts
@@ -412,4 +412,30 @@ export class OrganizationController {
   async unsuspend(@Param('organizationId') organizationId: string): Promise<void> {
     return this.organizationService.unsuspend(organizationId)
   }
+
+  @Get('/by-sandbox-id/:sandboxId')
+  @ApiOperation({
+    summary: 'Get organization by sandbox ID',
+    operationId: 'getOrganizationBySandboxId',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Organization',
+    type: OrganizationDto,
+  })
+  @ApiParam({
+    name: 'sandboxId',
+    description: 'Sandbox ID',
+    type: 'string',
+  })
+  @RequiredSystemRole(SystemRole.ADMIN)
+  @UseGuards(CombinedAuthGuard, SystemActionGuard)
+  async getBySandboxId(@Param('sandboxId') sandboxId: string): Promise<OrganizationDto> {
+    const organization = await this.organizationService.findBySandboxId(sandboxId)
+    if (!organization) {
+      throw new NotFoundException(`Organization with sandbox ID ${sandboxId} not found`)
+    }
+
+    return OrganizationDto.fromOrganization(organization)
+  }
 }

--- a/apps/api/src/organization/dto/organization-suspension.dto.ts
+++ b/apps/api/src/organization/dto/organization-suspension.dto.ts
@@ -18,4 +18,10 @@ export class OrganizationSuspensionDto {
   })
   @IsOptional()
   until?: Date
+
+  @ApiProperty({
+    description: 'Suspension cleanup grace period hours',
+  })
+  @IsOptional()
+  suspensionCleanupGracePeriodHours?: number
 }

--- a/apps/api/src/organization/dto/organization.dto.ts
+++ b/apps/api/src/organization/dto/organization.dto.ts
@@ -58,6 +58,41 @@ export class OrganizationDto {
   })
   suspendedUntil?: Date
 
+  @ApiProperty({
+    description: 'Suspension cleanup grace period hours',
+  })
+  suspensionCleanupGracePeriodHours?: number
+
+  @ApiProperty({
+    description: 'Total CPU quota',
+  })
+  totalCpuQuota: number
+
+  @ApiProperty({
+    description: 'Total memory quota',
+  })
+  totalMemoryQuota: number
+
+  @ApiProperty({
+    description: 'Total disk quota',
+  })
+  totalDiskQuota: number
+
+  @ApiProperty({
+    description: 'Max CPU per sandbox',
+  })
+  maxCpuPerSandbox: number
+
+  @ApiProperty({
+    description: 'Max memory per sandbox',
+  })
+  maxMemoryPerSandbox: number
+
+  @ApiProperty({
+    description: 'Max disk per sandbox',
+  })
+  maxDiskPerSandbox: number
+
   static fromOrganization(organization: Organization): OrganizationDto {
     const dto: OrganizationDto = {
       id: organization.id,
@@ -70,6 +105,13 @@ export class OrganizationDto {
       suspensionReason: organization.suspensionReason,
       suspendedAt: organization.suspendedAt,
       suspendedUntil: organization.suspendedUntil,
+      suspensionCleanupGracePeriodHours: organization.suspensionCleanupGracePeriodHours,
+      totalCpuQuota: organization.totalCpuQuota,
+      totalMemoryQuota: organization.totalMemoryQuota,
+      totalDiskQuota: organization.totalDiskQuota,
+      maxCpuPerSandbox: organization.maxCpuPerSandbox,
+      maxMemoryPerSandbox: organization.maxMemoryPerSandbox,
+      maxDiskPerSandbox: organization.maxDiskPerSandbox,
     }
 
     return dto

--- a/apps/api/src/organization/entities/organization.entity.ts
+++ b/apps/api/src/organization/entities/organization.entity.ts
@@ -127,6 +127,12 @@ export class Organization {
   suspensionReason?: string
 
   @Column({
+    type: 'int',
+    default: 24,
+  })
+  suspensionCleanupGracePeriodHours: number
+
+  @Column({
     nullable: true,
     type: 'timestamp with time zone',
   })

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -247,7 +247,10 @@ export function Sidebar({ isBannerVisible }: SidebarProps) {
                         <br />
                         Started sandboxes will be stopped{' '}
                         {formatRelative(
-                          addHours(new Date(selectedOrganization.suspendedAt), 24),
+                          addHours(
+                            new Date(selectedOrganization.suspendedAt),
+                            selectedOrganization.suspensionCleanupGracePeriodHours,
+                          ),
                           new Date(selectedOrganization.suspendedAt),
                         )}
                       </p>

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -496,6 +496,34 @@ paths:
       summary: Unsuspend organization
       tags:
         - organizations
+  /organizations/by-sandbox-id/{sandboxId}:
+    get:
+      operationId: getOrganizationBySandboxId
+      parameters:
+        - description: Sandbox ID
+          explode: false
+          in: path
+          name: sandboxId
+          required: true
+          schema:
+            type: string
+          style: simple
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+          description: Organization
+      security:
+        - bearer: []
+        - oauth2:
+            - openid
+            - profile
+            - email
+      summary: Get organization by sandbox ID
+      tags:
+        - organizations
   /organizations/{organizationId}/roles:
     get:
       operationId: listOrganizationRoles
@@ -1312,7 +1340,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Sandbox'
-          description: Sandbox has been started
+          description: Sandbox has been started or is being restored from archived
+            state
       security:
         - bearer: []
         - oauth2:
@@ -6292,15 +6321,22 @@ components:
       type: object
     Organization:
       example:
-        createdAt: 2000-01-23T04:56:07.000+00:00
-        suspendedUntil: 2000-01-23T04:56:07.000+00:00
-        createdBy: createdBy
+        totalCpuQuota: 6.027456183070403
         suspensionReason: suspensionReason
         suspendedAt: 2000-01-23T04:56:07.000+00:00
-        name: name
         personal: true
-        id: id
+        suspensionCleanupGracePeriodHours: 0.8008281904610115
         suspended: true
+        createdAt: 2000-01-23T04:56:07.000+00:00
+        maxCpuPerSandbox: 5.637376656633329
+        suspendedUntil: 2000-01-23T04:56:07.000+00:00
+        maxDiskPerSandbox: 7.061401241503109
+        createdBy: createdBy
+        name: name
+        maxMemoryPerSandbox: 2.3021358869347655
+        id: id
+        totalMemoryQuota: 1.4658129805029452
+        totalDiskQuota: 5.962133916683182
         updatedAt: 2000-01-23T04:56:07.000+00:00
       properties:
         id:
@@ -6337,16 +6373,44 @@ components:
           description: Suspended until
           format: date-time
           type: string
+        suspensionCleanupGracePeriodHours:
+          description: Suspension cleanup grace period hours
+          type: number
+        totalCpuQuota:
+          description: Total CPU quota
+          type: number
+        totalMemoryQuota:
+          description: Total memory quota
+          type: number
+        totalDiskQuota:
+          description: Total disk quota
+          type: number
+        maxCpuPerSandbox:
+          description: Max CPU per sandbox
+          type: number
+        maxMemoryPerSandbox:
+          description: Max memory per sandbox
+          type: number
+        maxDiskPerSandbox:
+          description: Max disk per sandbox
+          type: number
       required:
         - createdAt
         - createdBy
         - id
+        - maxCpuPerSandbox
+        - maxDiskPerSandbox
+        - maxMemoryPerSandbox
         - name
         - personal
         - suspended
         - suspendedAt
         - suspendedUntil
+        - suspensionCleanupGracePeriodHours
         - suspensionReason
+        - totalCpuQuota
+        - totalDiskQuota
+        - totalMemoryQuota
         - updatedAt
       type: object
     UsageOverview:
@@ -6436,6 +6500,7 @@ components:
       example:
         reason: reason
         until: 2000-01-23T04:56:07.000+00:00
+        suspensionCleanupGracePeriodHours: 0.8008281904610115
       properties:
         reason:
           description: Suspension reason
@@ -6444,8 +6509,12 @@ components:
           description: Suspension until
           format: date-time
           type: string
+        suspensionCleanupGracePeriodHours:
+          description: Suspension cleanup grace period hours
+          type: number
       required:
         - reason
+        - suspensionCleanupGracePeriodHours
         - until
       type: object
     CreateOrganizationRole:

--- a/libs/api-client-go/api_organizations.go
+++ b/libs/api-client-go/api_organizations.go
@@ -149,6 +149,19 @@ type OrganizationsAPI interface {
 	GetOrganizationExecute(r OrganizationsAPIGetOrganizationRequest) (*Organization, *http.Response, error)
 
 	/*
+		GetOrganizationBySandboxId Get organization by sandbox ID
+
+		@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		@param sandboxId Sandbox ID
+		@return OrganizationsAPIGetOrganizationBySandboxIdRequest
+	*/
+	GetOrganizationBySandboxId(ctx context.Context, sandboxId string) OrganizationsAPIGetOrganizationBySandboxIdRequest
+
+	// GetOrganizationBySandboxIdExecute executes the request
+	//  @return Organization
+	GetOrganizationBySandboxIdExecute(r OrganizationsAPIGetOrganizationBySandboxIdRequest) (*Organization, *http.Response, error)
+
+	/*
 		GetOrganizationInvitationsCountForAuthenticatedUser Get count of organization invitations for authenticated user
 
 		@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1275,6 +1288,108 @@ func (a *OrganizationsAPIService) GetOrganizationExecute(r OrganizationsAPIGetOr
 
 	localVarPath := localBasePath + "/organizations/{organizationId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"organizationId"+"}", url.PathEscape(parameterValueToString(r.organizationId, "organizationId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type OrganizationsAPIGetOrganizationBySandboxIdRequest struct {
+	ctx        context.Context
+	ApiService OrganizationsAPI
+	sandboxId  string
+}
+
+func (r OrganizationsAPIGetOrganizationBySandboxIdRequest) Execute() (*Organization, *http.Response, error) {
+	return r.ApiService.GetOrganizationBySandboxIdExecute(r)
+}
+
+/*
+GetOrganizationBySandboxId Get organization by sandbox ID
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param sandboxId Sandbox ID
+	@return OrganizationsAPIGetOrganizationBySandboxIdRequest
+*/
+func (a *OrganizationsAPIService) GetOrganizationBySandboxId(ctx context.Context, sandboxId string) OrganizationsAPIGetOrganizationBySandboxIdRequest {
+	return OrganizationsAPIGetOrganizationBySandboxIdRequest{
+		ApiService: a,
+		ctx:        ctx,
+		sandboxId:  sandboxId,
+	}
+}
+
+// Execute executes the request
+//
+//	@return Organization
+func (a *OrganizationsAPIService) GetOrganizationBySandboxIdExecute(r OrganizationsAPIGetOrganizationBySandboxIdRequest) (*Organization, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *Organization
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsAPIService.GetOrganizationBySandboxId")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/organizations/by-sandbox-id/{sandboxId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"sandboxId"+"}", url.PathEscape(parameterValueToString(r.sandboxId, "sandboxId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/libs/api-client-go/model_organization.go
+++ b/libs/api-client-go/model_organization.go
@@ -43,6 +43,20 @@ type Organization struct {
 	SuspensionReason string `json:"suspensionReason"`
 	// Suspended until
 	SuspendedUntil time.Time `json:"suspendedUntil"`
+	// Suspension cleanup grace period hours
+	SuspensionCleanupGracePeriodHours float32 `json:"suspensionCleanupGracePeriodHours"`
+	// Total CPU quota
+	TotalCpuQuota float32 `json:"totalCpuQuota"`
+	// Total memory quota
+	TotalMemoryQuota float32 `json:"totalMemoryQuota"`
+	// Total disk quota
+	TotalDiskQuota float32 `json:"totalDiskQuota"`
+	// Max CPU per sandbox
+	MaxCpuPerSandbox float32 `json:"maxCpuPerSandbox"`
+	// Max memory per sandbox
+	MaxMemoryPerSandbox float32 `json:"maxMemoryPerSandbox"`
+	// Max disk per sandbox
+	MaxDiskPerSandbox float32 `json:"maxDiskPerSandbox"`
 }
 
 type _Organization Organization
@@ -51,7 +65,7 @@ type _Organization Organization
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewOrganization(id string, name string, createdBy string, personal bool, createdAt time.Time, updatedAt time.Time, suspended bool, suspendedAt time.Time, suspensionReason string, suspendedUntil time.Time) *Organization {
+func NewOrganization(id string, name string, createdBy string, personal bool, createdAt time.Time, updatedAt time.Time, suspended bool, suspendedAt time.Time, suspensionReason string, suspendedUntil time.Time, suspensionCleanupGracePeriodHours float32, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, maxCpuPerSandbox float32, maxMemoryPerSandbox float32, maxDiskPerSandbox float32) *Organization {
 	this := Organization{}
 	this.Id = id
 	this.Name = name
@@ -63,6 +77,13 @@ func NewOrganization(id string, name string, createdBy string, personal bool, cr
 	this.SuspendedAt = suspendedAt
 	this.SuspensionReason = suspensionReason
 	this.SuspendedUntil = suspendedUntil
+	this.SuspensionCleanupGracePeriodHours = suspensionCleanupGracePeriodHours
+	this.TotalCpuQuota = totalCpuQuota
+	this.TotalMemoryQuota = totalMemoryQuota
+	this.TotalDiskQuota = totalDiskQuota
+	this.MaxCpuPerSandbox = maxCpuPerSandbox
+	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
+	this.MaxDiskPerSandbox = maxDiskPerSandbox
 	return &this
 }
 
@@ -314,6 +335,174 @@ func (o *Organization) SetSuspendedUntil(v time.Time) {
 	o.SuspendedUntil = v
 }
 
+// GetSuspensionCleanupGracePeriodHours returns the SuspensionCleanupGracePeriodHours field value
+func (o *Organization) GetSuspensionCleanupGracePeriodHours() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.SuspensionCleanupGracePeriodHours
+}
+
+// GetSuspensionCleanupGracePeriodHoursOk returns a tuple with the SuspensionCleanupGracePeriodHours field value
+// and a boolean to check if the value has been set.
+func (o *Organization) GetSuspensionCleanupGracePeriodHoursOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.SuspensionCleanupGracePeriodHours, true
+}
+
+// SetSuspensionCleanupGracePeriodHours sets field value
+func (o *Organization) SetSuspensionCleanupGracePeriodHours(v float32) {
+	o.SuspensionCleanupGracePeriodHours = v
+}
+
+// GetTotalCpuQuota returns the TotalCpuQuota field value
+func (o *Organization) GetTotalCpuQuota() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.TotalCpuQuota
+}
+
+// GetTotalCpuQuotaOk returns a tuple with the TotalCpuQuota field value
+// and a boolean to check if the value has been set.
+func (o *Organization) GetTotalCpuQuotaOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.TotalCpuQuota, true
+}
+
+// SetTotalCpuQuota sets field value
+func (o *Organization) SetTotalCpuQuota(v float32) {
+	o.TotalCpuQuota = v
+}
+
+// GetTotalMemoryQuota returns the TotalMemoryQuota field value
+func (o *Organization) GetTotalMemoryQuota() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.TotalMemoryQuota
+}
+
+// GetTotalMemoryQuotaOk returns a tuple with the TotalMemoryQuota field value
+// and a boolean to check if the value has been set.
+func (o *Organization) GetTotalMemoryQuotaOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.TotalMemoryQuota, true
+}
+
+// SetTotalMemoryQuota sets field value
+func (o *Organization) SetTotalMemoryQuota(v float32) {
+	o.TotalMemoryQuota = v
+}
+
+// GetTotalDiskQuota returns the TotalDiskQuota field value
+func (o *Organization) GetTotalDiskQuota() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.TotalDiskQuota
+}
+
+// GetTotalDiskQuotaOk returns a tuple with the TotalDiskQuota field value
+// and a boolean to check if the value has been set.
+func (o *Organization) GetTotalDiskQuotaOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.TotalDiskQuota, true
+}
+
+// SetTotalDiskQuota sets field value
+func (o *Organization) SetTotalDiskQuota(v float32) {
+	o.TotalDiskQuota = v
+}
+
+// GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value
+func (o *Organization) GetMaxCpuPerSandbox() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.MaxCpuPerSandbox
+}
+
+// GetMaxCpuPerSandboxOk returns a tuple with the MaxCpuPerSandbox field value
+// and a boolean to check if the value has been set.
+func (o *Organization) GetMaxCpuPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.MaxCpuPerSandbox, true
+}
+
+// SetMaxCpuPerSandbox sets field value
+func (o *Organization) SetMaxCpuPerSandbox(v float32) {
+	o.MaxCpuPerSandbox = v
+}
+
+// GetMaxMemoryPerSandbox returns the MaxMemoryPerSandbox field value
+func (o *Organization) GetMaxMemoryPerSandbox() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.MaxMemoryPerSandbox
+}
+
+// GetMaxMemoryPerSandboxOk returns a tuple with the MaxMemoryPerSandbox field value
+// and a boolean to check if the value has been set.
+func (o *Organization) GetMaxMemoryPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.MaxMemoryPerSandbox, true
+}
+
+// SetMaxMemoryPerSandbox sets field value
+func (o *Organization) SetMaxMemoryPerSandbox(v float32) {
+	o.MaxMemoryPerSandbox = v
+}
+
+// GetMaxDiskPerSandbox returns the MaxDiskPerSandbox field value
+func (o *Organization) GetMaxDiskPerSandbox() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.MaxDiskPerSandbox
+}
+
+// GetMaxDiskPerSandboxOk returns a tuple with the MaxDiskPerSandbox field value
+// and a boolean to check if the value has been set.
+func (o *Organization) GetMaxDiskPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.MaxDiskPerSandbox, true
+}
+
+// SetMaxDiskPerSandbox sets field value
+func (o *Organization) SetMaxDiskPerSandbox(v float32) {
+	o.MaxDiskPerSandbox = v
+}
+
 func (o Organization) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -334,6 +523,13 @@ func (o Organization) ToMap() (map[string]interface{}, error) {
 	toSerialize["suspendedAt"] = o.SuspendedAt
 	toSerialize["suspensionReason"] = o.SuspensionReason
 	toSerialize["suspendedUntil"] = o.SuspendedUntil
+	toSerialize["suspensionCleanupGracePeriodHours"] = o.SuspensionCleanupGracePeriodHours
+	toSerialize["totalCpuQuota"] = o.TotalCpuQuota
+	toSerialize["totalMemoryQuota"] = o.TotalMemoryQuota
+	toSerialize["totalDiskQuota"] = o.TotalDiskQuota
+	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox
+	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox
+	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox
 	return toSerialize, nil
 }
 
@@ -352,6 +548,13 @@ func (o *Organization) UnmarshalJSON(data []byte) (err error) {
 		"suspendedAt",
 		"suspensionReason",
 		"suspendedUntil",
+		"suspensionCleanupGracePeriodHours",
+		"totalCpuQuota",
+		"totalMemoryQuota",
+		"totalDiskQuota",
+		"maxCpuPerSandbox",
+		"maxMemoryPerSandbox",
+		"maxDiskPerSandbox",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-go/model_organization_suspension.go
+++ b/libs/api-client-go/model_organization_suspension.go
@@ -27,6 +27,8 @@ type OrganizationSuspension struct {
 	Reason string `json:"reason"`
 	// Suspension until
 	Until time.Time `json:"until"`
+	// Suspension cleanup grace period hours
+	SuspensionCleanupGracePeriodHours float32 `json:"suspensionCleanupGracePeriodHours"`
 }
 
 type _OrganizationSuspension OrganizationSuspension
@@ -35,10 +37,11 @@ type _OrganizationSuspension OrganizationSuspension
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewOrganizationSuspension(reason string, until time.Time) *OrganizationSuspension {
+func NewOrganizationSuspension(reason string, until time.Time, suspensionCleanupGracePeriodHours float32) *OrganizationSuspension {
 	this := OrganizationSuspension{}
 	this.Reason = reason
 	this.Until = until
+	this.SuspensionCleanupGracePeriodHours = suspensionCleanupGracePeriodHours
 	return &this
 }
 
@@ -98,6 +101,30 @@ func (o *OrganizationSuspension) SetUntil(v time.Time) {
 	o.Until = v
 }
 
+// GetSuspensionCleanupGracePeriodHours returns the SuspensionCleanupGracePeriodHours field value
+func (o *OrganizationSuspension) GetSuspensionCleanupGracePeriodHours() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.SuspensionCleanupGracePeriodHours
+}
+
+// GetSuspensionCleanupGracePeriodHoursOk returns a tuple with the SuspensionCleanupGracePeriodHours field value
+// and a boolean to check if the value has been set.
+func (o *OrganizationSuspension) GetSuspensionCleanupGracePeriodHoursOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.SuspensionCleanupGracePeriodHours, true
+}
+
+// SetSuspensionCleanupGracePeriodHours sets field value
+func (o *OrganizationSuspension) SetSuspensionCleanupGracePeriodHours(v float32) {
+	o.SuspensionCleanupGracePeriodHours = v
+}
+
 func (o OrganizationSuspension) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -110,6 +137,7 @@ func (o OrganizationSuspension) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["reason"] = o.Reason
 	toSerialize["until"] = o.Until
+	toSerialize["suspensionCleanupGracePeriodHours"] = o.SuspensionCleanupGracePeriodHours
 	return toSerialize, nil
 }
 
@@ -120,6 +148,7 @@ func (o *OrganizationSuspension) UnmarshalJSON(data []byte) (err error) {
 	requiredProperties := []string{
 		"reason",
 		"until",
+		"suspensionCleanupGracePeriodHours",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-python-async/daytona_api_client_async/api/organizations_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/organizations_api.py
@@ -2716,6 +2716,265 @@ class OrganizationsApi:
 
 
     @validate_call
+    async def get_organization_by_sandbox_id(
+        self,
+        sandbox_id: Annotated[StrictStr, Field(description="Sandbox ID")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Organization:
+        """Get organization by sandbox ID
+
+
+        :param sandbox_id: Sandbox ID (required)
+        :type sandbox_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_organization_by_sandbox_id_serialize(
+            sandbox_id=sandbox_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Organization",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    async def get_organization_by_sandbox_id_with_http_info(
+        self,
+        sandbox_id: Annotated[StrictStr, Field(description="Sandbox ID")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Organization]:
+        """Get organization by sandbox ID
+
+
+        :param sandbox_id: Sandbox ID (required)
+        :type sandbox_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_organization_by_sandbox_id_serialize(
+            sandbox_id=sandbox_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Organization",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    async def get_organization_by_sandbox_id_without_preload_content(
+        self,
+        sandbox_id: Annotated[StrictStr, Field(description="Sandbox ID")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get organization by sandbox ID
+
+
+        :param sandbox_id: Sandbox ID (required)
+        :type sandbox_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_organization_by_sandbox_id_serialize(
+            sandbox_id=sandbox_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Organization",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _get_organization_by_sandbox_id_serialize(
+        self,
+        sandbox_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if sandbox_id is not None:
+            _path_params['sandboxId'] = sandbox_id
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/organizations/by-sandbox-id/{sandboxId}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     async def get_organization_invitations_count_for_authenticated_user(
         self,
         _request_timeout: Union[

--- a/libs/api-client-python-async/daytona_api_client_async/models/organization.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/organization.py
@@ -19,8 +19,8 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from typing import Any, ClassVar, Dict, List, Union
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -38,8 +38,15 @@ class Organization(BaseModel):
     suspended_at: datetime = Field(description="Suspended at", alias="suspendedAt")
     suspension_reason: StrictStr = Field(description="Suspended reason", alias="suspensionReason")
     suspended_until: datetime = Field(description="Suspended until", alias="suspendedUntil")
+    suspension_cleanup_grace_period_hours: Union[StrictFloat, StrictInt] = Field(description="Suspension cleanup grace period hours", alias="suspensionCleanupGracePeriodHours")
+    total_cpu_quota: Union[StrictFloat, StrictInt] = Field(description="Total CPU quota", alias="totalCpuQuota")
+    total_memory_quota: Union[StrictFloat, StrictInt] = Field(description="Total memory quota", alias="totalMemoryQuota")
+    total_disk_quota: Union[StrictFloat, StrictInt] = Field(description="Total disk quota", alias="totalDiskQuota")
+    max_cpu_per_sandbox: Union[StrictFloat, StrictInt] = Field(description="Max CPU per sandbox", alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Union[StrictFloat, StrictInt] = Field(description="Max memory per sandbox", alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Union[StrictFloat, StrictInt] = Field(description="Max disk per sandbox", alias="maxDiskPerSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "createdBy", "personal", "createdAt", "updatedAt", "suspended", "suspendedAt", "suspensionReason", "suspendedUntil"]
+    __properties: ClassVar[List[str]] = ["id", "name", "createdBy", "personal", "createdAt", "updatedAt", "suspended", "suspendedAt", "suspensionReason", "suspendedUntil", "suspensionCleanupGracePeriodHours", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,7 +115,14 @@ class Organization(BaseModel):
             "suspended": obj.get("suspended"),
             "suspendedAt": obj.get("suspendedAt"),
             "suspensionReason": obj.get("suspensionReason"),
-            "suspendedUntil": obj.get("suspendedUntil")
+            "suspendedUntil": obj.get("suspendedUntil"),
+            "suspensionCleanupGracePeriodHours": obj.get("suspensionCleanupGracePeriodHours"),
+            "totalCpuQuota": obj.get("totalCpuQuota"),
+            "totalMemoryQuota": obj.get("totalMemoryQuota"),
+            "totalDiskQuota": obj.get("totalDiskQuota"),
+            "maxCpuPerSandbox": obj.get("maxCpuPerSandbox"),
+            "maxMemoryPerSandbox": obj.get("maxMemoryPerSandbox"),
+            "maxDiskPerSandbox": obj.get("maxDiskPerSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/organization_suspension.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/organization_suspension.py
@@ -19,8 +19,8 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
+from typing import Any, ClassVar, Dict, List, Union
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -30,8 +30,9 @@ class OrganizationSuspension(BaseModel):
     """ # noqa: E501
     reason: StrictStr = Field(description="Suspension reason")
     until: datetime = Field(description="Suspension until")
+    suspension_cleanup_grace_period_hours: Union[StrictFloat, StrictInt] = Field(description="Suspension cleanup grace period hours", alias="suspensionCleanupGracePeriodHours")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["reason", "until"]
+    __properties: ClassVar[List[str]] = ["reason", "until", "suspensionCleanupGracePeriodHours"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -92,7 +93,8 @@ class OrganizationSuspension(BaseModel):
 
         _obj = cls.model_validate({
             "reason": obj.get("reason"),
-            "until": obj.get("until")
+            "until": obj.get("until"),
+            "suspensionCleanupGracePeriodHours": obj.get("suspensionCleanupGracePeriodHours")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/api/organizations_api.py
+++ b/libs/api-client-python/daytona_api_client/api/organizations_api.py
@@ -2716,6 +2716,265 @@ class OrganizationsApi:
 
 
     @validate_call
+    def get_organization_by_sandbox_id(
+        self,
+        sandbox_id: Annotated[StrictStr, Field(description="Sandbox ID")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Organization:
+        """Get organization by sandbox ID
+
+
+        :param sandbox_id: Sandbox ID (required)
+        :type sandbox_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_organization_by_sandbox_id_serialize(
+            sandbox_id=sandbox_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Organization",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def get_organization_by_sandbox_id_with_http_info(
+        self,
+        sandbox_id: Annotated[StrictStr, Field(description="Sandbox ID")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Organization]:
+        """Get organization by sandbox ID
+
+
+        :param sandbox_id: Sandbox ID (required)
+        :type sandbox_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_organization_by_sandbox_id_serialize(
+            sandbox_id=sandbox_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Organization",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def get_organization_by_sandbox_id_without_preload_content(
+        self,
+        sandbox_id: Annotated[StrictStr, Field(description="Sandbox ID")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get organization by sandbox ID
+
+
+        :param sandbox_id: Sandbox ID (required)
+        :type sandbox_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_organization_by_sandbox_id_serialize(
+            sandbox_id=sandbox_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Organization",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _get_organization_by_sandbox_id_serialize(
+        self,
+        sandbox_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if sandbox_id is not None:
+            _path_params['sandboxId'] = sandbox_id
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/organizations/by-sandbox-id/{sandboxId}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def get_organization_invitations_count_for_authenticated_user(
         self,
         _request_timeout: Union[

--- a/libs/api-client-python/daytona_api_client/models/organization.py
+++ b/libs/api-client-python/daytona_api_client/models/organization.py
@@ -19,8 +19,8 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from typing import Any, ClassVar, Dict, List, Union
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -38,8 +38,15 @@ class Organization(BaseModel):
     suspended_at: datetime = Field(description="Suspended at", alias="suspendedAt")
     suspension_reason: StrictStr = Field(description="Suspended reason", alias="suspensionReason")
     suspended_until: datetime = Field(description="Suspended until", alias="suspendedUntil")
+    suspension_cleanup_grace_period_hours: Union[StrictFloat, StrictInt] = Field(description="Suspension cleanup grace period hours", alias="suspensionCleanupGracePeriodHours")
+    total_cpu_quota: Union[StrictFloat, StrictInt] = Field(description="Total CPU quota", alias="totalCpuQuota")
+    total_memory_quota: Union[StrictFloat, StrictInt] = Field(description="Total memory quota", alias="totalMemoryQuota")
+    total_disk_quota: Union[StrictFloat, StrictInt] = Field(description="Total disk quota", alias="totalDiskQuota")
+    max_cpu_per_sandbox: Union[StrictFloat, StrictInt] = Field(description="Max CPU per sandbox", alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Union[StrictFloat, StrictInt] = Field(description="Max memory per sandbox", alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Union[StrictFloat, StrictInt] = Field(description="Max disk per sandbox", alias="maxDiskPerSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "name", "createdBy", "personal", "createdAt", "updatedAt", "suspended", "suspendedAt", "suspensionReason", "suspendedUntil"]
+    __properties: ClassVar[List[str]] = ["id", "name", "createdBy", "personal", "createdAt", "updatedAt", "suspended", "suspendedAt", "suspensionReason", "suspendedUntil", "suspensionCleanupGracePeriodHours", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,7 +115,14 @@ class Organization(BaseModel):
             "suspended": obj.get("suspended"),
             "suspendedAt": obj.get("suspendedAt"),
             "suspensionReason": obj.get("suspensionReason"),
-            "suspendedUntil": obj.get("suspendedUntil")
+            "suspendedUntil": obj.get("suspendedUntil"),
+            "suspensionCleanupGracePeriodHours": obj.get("suspensionCleanupGracePeriodHours"),
+            "totalCpuQuota": obj.get("totalCpuQuota"),
+            "totalMemoryQuota": obj.get("totalMemoryQuota"),
+            "totalDiskQuota": obj.get("totalDiskQuota"),
+            "maxCpuPerSandbox": obj.get("maxCpuPerSandbox"),
+            "maxMemoryPerSandbox": obj.get("maxMemoryPerSandbox"),
+            "maxDiskPerSandbox": obj.get("maxDiskPerSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/organization_suspension.py
+++ b/libs/api-client-python/daytona_api_client/models/organization_suspension.py
@@ -19,8 +19,8 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
+from typing import Any, ClassVar, Dict, List, Union
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -30,8 +30,9 @@ class OrganizationSuspension(BaseModel):
     """ # noqa: E501
     reason: StrictStr = Field(description="Suspension reason")
     until: datetime = Field(description="Suspension until")
+    suspension_cleanup_grace_period_hours: Union[StrictFloat, StrictInt] = Field(description="Suspension cleanup grace period hours", alias="suspensionCleanupGracePeriodHours")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["reason", "until"]
+    __properties: ClassVar[List[str]] = ["reason", "until", "suspensionCleanupGracePeriodHours"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -92,7 +93,8 @@ class OrganizationSuspension(BaseModel):
 
         _obj = cls.model_validate({
             "reason": obj.get("reason"),
-            "until": obj.get("until")
+            "until": obj.get("until"),
+            "suspensionCleanupGracePeriodHours": obj.get("suspensionCleanupGracePeriodHours")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client/src/api/organizations-api.ts
+++ b/libs/api-client/src/api/organizations-api.ts
@@ -518,6 +518,49 @@ export const OrganizationsApiAxiosParamCreator = function (configuration?: Confi
     },
     /**
      *
+     * @summary Get organization by sandbox ID
+     * @param {string} sandboxId Sandbox ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getOrganizationBySandboxId: async (
+      sandboxId: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'sandboxId' is not null or undefined
+      assertParamExists('getOrganizationBySandboxId', 'sandboxId', sandboxId)
+      const localVarPath = `/organizations/by-sandbox-id/{sandboxId}`.replace(
+        `{${'sandboxId'}}`,
+        encodeURIComponent(String(sandboxId)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication bearer required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+      // authentication oauth2 required
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     *
      * @summary Get count of organization invitations for authenticated user
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -1475,6 +1518,29 @@ export const OrganizationsApiFp = function (configuration?: Configuration) {
     },
     /**
      *
+     * @summary Get organization by sandbox ID
+     * @param {string} sandboxId Sandbox ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getOrganizationBySandboxId(
+      sandboxId: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Organization>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getOrganizationBySandboxId(sandboxId, options)
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap['OrganizationsApi.getOrganizationBySandboxId']?.[localVarOperationServerIndex]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+    /**
+     *
      * @summary Get count of organization invitations for authenticated user
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -2019,6 +2085,16 @@ export const OrganizationsApiFactory = function (
     },
     /**
      *
+     * @summary Get organization by sandbox ID
+     * @param {string} sandboxId Sandbox ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getOrganizationBySandboxId(sandboxId: string, options?: RawAxiosRequestConfig): AxiosPromise<Organization> {
+      return localVarFp.getOrganizationBySandboxId(sandboxId, options).then((request) => request(axios, basePath))
+    },
+    /**
+     *
      * @summary Get count of organization invitations for authenticated user
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -2391,6 +2467,20 @@ export class OrganizationsApi extends BaseAPI {
   public getOrganization(organizationId: string, options?: RawAxiosRequestConfig) {
     return OrganizationsApiFp(this.configuration)
       .getOrganization(organizationId, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   *
+   * @summary Get organization by sandbox ID
+   * @param {string} sandboxId Sandbox ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof OrganizationsApi
+   */
+  public getOrganizationBySandboxId(sandboxId: string, options?: RawAxiosRequestConfig) {
+    return OrganizationsApiFp(this.configuration)
+      .getOrganizationBySandboxId(sandboxId, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/libs/api-client/src/models/organization-suspension.ts
+++ b/libs/api-client/src/models/organization-suspension.ts
@@ -30,4 +30,10 @@ export interface OrganizationSuspension {
    * @memberof OrganizationSuspension
    */
   until: Date
+  /**
+   * Suspension cleanup grace period hours
+   * @type {number}
+   * @memberof OrganizationSuspension
+   */
+  suspensionCleanupGracePeriodHours: number
 }

--- a/libs/api-client/src/models/organization.ts
+++ b/libs/api-client/src/models/organization.ts
@@ -78,4 +78,46 @@ export interface Organization {
    * @memberof Organization
    */
   suspendedUntil: Date
+  /**
+   * Suspension cleanup grace period hours
+   * @type {number}
+   * @memberof Organization
+   */
+  suspensionCleanupGracePeriodHours: number
+  /**
+   * Total CPU quota
+   * @type {number}
+   * @memberof Organization
+   */
+  totalCpuQuota: number
+  /**
+   * Total memory quota
+   * @type {number}
+   * @memberof Organization
+   */
+  totalMemoryQuota: number
+  /**
+   * Total disk quota
+   * @type {number}
+   * @memberof Organization
+   */
+  totalDiskQuota: number
+  /**
+   * Max CPU per sandbox
+   * @type {number}
+   * @memberof Organization
+   */
+  maxCpuPerSandbox: number
+  /**
+   * Max memory per sandbox
+   * @type {number}
+   * @memberof Organization
+   */
+  maxMemoryPerSandbox: number
+  /**
+   * Max disk per sandbox
+   * @type {number}
+   * @memberof Organization
+   */
+  maxDiskPerSandbox: number
 }


### PR DESCRIPTION
# Organization Suspension Cleanup Grace Period

## Description

Added a cleanup grace period property to organizations that controls the amount of hours that should pass before resources are cleaned up after a suspension.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
