### PR TITLE
feat(dashboard): add bulk actions for sandboxes (start, stop, archive, delete)

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/BulkActionsDropdown.tsx
+++ b/apps/dashboard/src/components/SandboxTable/BulkActionsDropdown.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useState } from 'react'
+import { Button } from '../ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from '../ui/dropdown-menu'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog'
+import { ChevronDown, Play, Square, Archive } from 'lucide-react'
+import { Sandbox, SandboxState } from '@daytonaio/api-client'
+
+interface BulkActionsDropdownProps {
+  selectedSandboxes: Sandbox[]
+  selectedCount: number
+  onBulkStart: (ids: string[]) => void
+  onBulkStop: (ids: string[]) => void
+  onBulkArchive: (ids: string[]) => void
+  onBulkDelete: (ids: string[]) => void
+  onClearSelection: () => void
+}
+
+interface BulkAction {
+  label: string
+  icon: React.ReactNode
+  action: 'start' | 'stop' | 'archive' | 'delete'
+  color?: string
+  destructive?: boolean
+}
+
+export function BulkActionsDropdown({
+  selectedSandboxes,
+  selectedCount,
+  onBulkStart,
+  onBulkStop,
+  onBulkArchive,
+  onBulkDelete,
+  onClearSelection,
+}: BulkActionsDropdownProps) {
+  const [confirmAction, setConfirmAction] = useState<BulkAction | null>(null)
+  const [isOpen, setIsOpen] = useState(false)
+
+  // Check which actions are available based on selected sandboxes states
+  const getAvailableActions = (): BulkAction[] => {
+    const actions: BulkAction[] = []
+
+    // Count sandboxes by state
+    const stoppedCount = selectedSandboxes.filter((s) => s.state === SandboxState.STOPPED).length
+    const startedCount = selectedSandboxes.filter((s) => s.state === SandboxState.STARTED).length
+    const archivedCount = selectedSandboxes.filter((s) => s.state === SandboxState.ARCHIVED).length
+
+    // Start action - available if any sandbox is stopped or archived
+    if (stoppedCount > 0 || archivedCount > 0) {
+      actions.push({
+        label: `Start ${stoppedCount + archivedCount > 1 ? 'All' : ''}`,
+        icon: <Play className="w-4 h-4" />,
+        action: 'start',
+      })
+    }
+
+    // Stop action - available if any sandbox is started
+    if (startedCount > 0) {
+      actions.push({
+        label: `Stop ${startedCount > 1 ? 'All' : ''}`,
+        icon: <Square className="w-4 h-4" />,
+        action: 'stop',
+      })
+    }
+
+    // Archive action - available if any sandbox is stopped
+    if (stoppedCount > 0) {
+      actions.push({
+        label: `Archive ${stoppedCount > 1 ? 'All' : ''}`,
+        icon: <Archive className="w-4 h-4" />,
+        action: 'archive',
+      })
+    }
+
+    return actions
+  }
+
+  const handleActionClick = (action: BulkAction) => {
+    setConfirmAction(action)
+    setIsOpen(false)
+  }
+
+  const handleConfirmAction = () => {
+    if (!confirmAction) return
+
+    const selectedIds = selectedSandboxes.map((s) => s.id)
+
+    switch (confirmAction.action) {
+      case 'start':
+        onBulkStart(
+          selectedIds.filter((id) => {
+            const sandbox = selectedSandboxes.find((s) => s.id === id)
+            return sandbox?.state === SandboxState.STOPPED || sandbox?.state === SandboxState.ARCHIVED
+          }),
+        )
+        break
+      case 'stop':
+        onBulkStop(
+          selectedIds.filter((id) => {
+            const sandbox = selectedSandboxes.find((s) => s.id === id)
+            return sandbox?.state === SandboxState.STARTED
+          }),
+        )
+        break
+      case 'archive':
+        onBulkArchive(
+          selectedIds.filter((id) => {
+            const sandbox = selectedSandboxes.find((s) => s.id === id)
+            return sandbox?.state === SandboxState.STOPPED
+          }),
+        )
+        break
+      case 'delete':
+        onBulkDelete(selectedIds)
+        break
+    }
+
+    setConfirmAction(null)
+    onClearSelection()
+  }
+
+  const getActionDescription = (action: BulkAction): string => {
+    const count = selectedCount
+    const actionWord = action.action
+
+    switch (action.action) {
+      case 'start':
+        return `This will start ${count === 1 ? 'this sandbox' : `these ${count} sandboxes`}. Only stopped and archived sandboxes will be affected.`
+      case 'stop':
+        return `This will stop ${count === 1 ? 'this sandbox' : `these ${count} sandboxes`}. Only started sandboxes will be affected.`
+      case 'archive':
+        return `This will archive ${count === 1 ? 'this sandbox' : `these ${count} sandboxes`}. Only stopped sandboxes will be affected. Archived sandboxes are moved to cost-effective storage.`
+      case 'delete':
+        return `This will permanently delete ${count === 1 ? 'this sandbox' : `these ${count} sandboxes`}. This action cannot be undone.`
+      default:
+        return `This will ${actionWord} ${count === 1 ? 'this sandbox' : `these ${count} sandboxes`}.`
+    }
+  }
+
+  const availableActions = getAvailableActions()
+
+  return (
+    <>
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="sm" className="h-8">
+            Actions
+            <ChevronDown className="w-4 h-4 ml-1" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          {availableActions.map((action, index) => (
+            <div key={action.action}>
+              <DropdownMenuItem onClick={() => handleActionClick(action)} className={action.color}>
+                {action.icon}
+                {action.label}
+              </DropdownMenuItem>
+              {index === availableActions.length - 2 && availableActions[availableActions.length - 1].destructive && (
+                <DropdownMenuSeparator />
+              )}
+            </div>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {confirmAction && (
+        <AlertDialog open={true} onOpenChange={() => setConfirmAction(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{confirmAction.label} Sandboxes</AlertDialogTitle>
+              <AlertDialogDescription>{getActionDescription(confirmAction)}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleConfirmAction}
+                className={
+                  confirmAction.destructive ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90' : ''
+                }
+              >
+                {confirmAction.label}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
+  )
+}

--- a/apps/dashboard/src/components/SandboxTable/index.tsx
+++ b/apps/dashboard/src/components/SandboxTable/index.tsx
@@ -23,6 +23,7 @@ import { TableEmptyState } from '../TableEmptyState'
 import { SandboxTableProps } from './types'
 import { useSandboxTable } from './useSandboxTable'
 import { SandboxTableHeader } from './SandboxTableHeader'
+import { BulkActionsDropdown } from './BulkActionsDropdown'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { OrganizationRolePermissionsEnum } from '@daytonaio/api-client'
 import { cn } from '@/lib/utils'
@@ -43,6 +44,9 @@ export function SandboxTable({
   handleStop,
   handleDelete,
   handleBulkDelete,
+  handleBulkStart,
+  handleBulkStop,
+  handleBulkArchive,
   handleArchive,
   handleVnc,
   getWebTerminalUrl,
@@ -210,33 +214,47 @@ export function SandboxTable({
               <div className="text-sm text-muted-foreground">
                 {selectedCount} {selectedCount === 1 ? 'sandbox' : 'sandboxes'} selected
               </div>
-              <AlertDialog open={bulkDeleteDialogOpen} onOpenChange={setBulkDeleteDialogOpen}>
-                <AlertDialogTrigger asChild>
-                  <Button variant="ghost" size="sm" className="h-8">
-                    <Trash2 className="w-4 h-4" />
-                    Delete {selectedCount > 1 ? 'All' : ''}
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Delete Sandboxes</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      Are you sure you want to delete{' '}
-                      {selectedCount === 1 ? 'this sandbox' : `these ${selectedCount} sandboxes`}? This action cannot be
-                      undone.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={handleBulkDeleteConfirm}
-                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                    >
-                      Delete
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+              <div className="flex items-center gap-2">
+                <BulkActionsDropdown
+                  selectedSandboxes={table
+                    .getRowModel()
+                    .rows.filter((row) => row.getIsSelected())
+                    .map((row) => row.original)}
+                  selectedCount={selectedCount}
+                  onBulkStart={handleBulkStart}
+                  onBulkStop={handleBulkStop}
+                  onBulkArchive={handleBulkArchive}
+                  onBulkDelete={handleBulkDelete}
+                  onClearSelection={() => table.toggleAllRowsSelected(false)}
+                />
+                <AlertDialog open={bulkDeleteDialogOpen} onOpenChange={setBulkDeleteDialogOpen}>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-8 text-destructive hover:text-destructive">
+                      <Trash2 className="w-4 h-4" />
+                      Delete {selectedCount > 1 ? 'All' : ''}
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete Sandboxes</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Are you sure you want to delete{' '}
+                        {selectedCount === 1 ? 'this sandbox' : `these ${selectedCount} sandboxes`}? This action cannot
+                        be undone.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={handleBulkDeleteConfirm}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      >
+                        Delete
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
             </div>
           </motion.div>
         )}

--- a/apps/dashboard/src/components/SandboxTable/types.ts
+++ b/apps/dashboard/src/components/SandboxTable/types.ts
@@ -17,6 +17,9 @@ export interface SandboxTableProps {
   handleStop: (id: string) => void
   handleDelete: (id: string) => void
   handleBulkDelete: (ids: string[]) => void
+  handleBulkStart: (ids: string[]) => void
+  handleBulkStop: (ids: string[]) => void
+  handleBulkArchive: (ids: string[]) => void
   handleArchive: (id: string) => void
   handleVnc: (id: string) => void
   getWebTerminalUrl: (id: string) => Promise<string | null>


### PR DESCRIPTION
## Description

This PR enhances the Dashboard by introducing bulk actions system for sandboxes. Users can now perform bulk start, stop, archive, and delete operations with improved UX. A new `BulkActionsDropdown` component dynamically displays relevant actions based on selected sandbox states.

Features Implemented:

1. Bulk Start Action
- dropdown that shows only relevant actions based on selected sandbox states.
- Dynamic action availability (e.g., Start only shows if there are stopped/archived sandboxes).

2. Bulk Stop Action
-  Only appears if there are started sandboxes selected.

3. Bulk Archive Action
- Only available for sandboxes in the stopped state.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #2145 

## Screenshots


https://github.com/user-attachments/assets/b9cec3c7-6778-4445-a525-cf57f388d8b6

<img width="1624" height="975" alt="Screenshot 2025-08-01 at 5 12 16 PM" src="https://github.com/user-attachments/assets/09a615d4-309d-4340-9981-74c70bfe417a" />


## Notes

Please add any relevant notes if necessary.
