### PR TITLE
fix(api): add missing system admin condition in org access guard

### DIFF
--- a/apps/api/src/organization/guards/organization-access.guard.ts
+++ b/apps/api/src/organization/guards/organization-access.guard.ts
@@ -36,7 +36,15 @@ export class OrganizationAccessGuard implements CanActivate {
       return false
     }
 
-    if (organizationIdParam && authContext.apiKey && authContext.apiKey.organizationId !== organizationIdParam) {
+    if (
+      organizationIdParam &&
+      authContext.apiKey &&
+      authContext.apiKey.organizationId !== organizationIdParam &&
+      authContext.role !== SystemRole.ADMIN
+    ) {
+      this.logger.warn(
+        `Organization ID mismatch in the request context. Expected: ${organizationIdParam}, Actual: ${authContext.apiKey.organizationId}`,
+      )
       this.logger.warn('Organization ID mismatch in the request context.')
       return false
     }


### PR DESCRIPTION
## Description

Resolves an issue where a user with system admin permissions was unable to perform org-level actions guarded by `OrganizationAccessGuard`.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
