### PR TITLE
fix: start archived exception

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -300,7 +300,7 @@ export class SandboxController {
       sandbox = await this.waitForSandboxStarted(sandboxId, 30)
     }
 
-    if (!sandbox.runnerDomain) {
+    if (!sandbox.runnerDomain && sandbox.state != SandboxState.ARCHIVED) {
       const runner = await this.runnerService.findBySandboxId(sandboxId)
       if (!runner) {
         throw new NotFoundException(`Runner for sandbox ${sandboxId} not found`)


### PR DESCRIPTION
# Start archived exception

## Description

Fixes a regression caused by changes to waiting for restoring to finish on sandbox start on the API

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
