### PR TITLE
fix(api): strip scheme from registry on backup create

### DIFF
--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -201,7 +201,7 @@ export class BackupManager {
 
     // Generate backup snapshot name
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-    const backupSnapshot = `${registry.url}/${registry.project}/backup-${sandbox.id}:${timestamp}`
+    const backupSnapshot = `${registry.url.replace('https://', '').replace('http://', '')}/${registry.project}/backup-${sandbox.id}:${timestamp}`
 
     //  if sandbox has a backup snapshot, add it to the existingBackupSnapshots array
     if (


### PR DESCRIPTION
# Strip Scheme from Registry on Backup Create

## Description

If registry url has a scheme (http/https), backups fail to create because of an invalid reference format

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
