### PR TITLE
fix(dashboard): fetch billing info only when owner

### DIFF
--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -12,7 +12,6 @@ import {
   CreditCard,
   HardDrive,
   KeyRound,
-  Link2,
   ListChecks,
   LockKeyhole,
   LogOut,
@@ -180,7 +179,7 @@ export function Sidebar({ isBannerVisible }: SidebarProps) {
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup>
-          <SidebarGroupLabel>Billing</SidebarGroupLabel>
+          {billingItems.length > 0 && <SidebarGroupLabel>Billing</SidebarGroupLabel>}
           <SidebarGroupContent>
             <SidebarMenu>
               {billingItems.map((item) => (


### PR DESCRIPTION
# Fetch Billing Info Only When User is Owner

## Description

Currently, billing info is fetched for all organization users but only the owner can access it in the billing API.
Now the info will only be fetched if the current user is an owner of the organization.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
