### PR TITLE
fix: check runner state on sb start and archive

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -39,6 +39,13 @@ export class SandboxStartAction extends SandboxAction {
   }
 
   async run(sandbox: Sandbox): Promise<SyncState> {
+    if (sandbox.runnerId !== null) {
+      const runner = await this.runnerService.findOne(sandbox.runnerId)
+      if (runner.state !== RunnerState.READY) {
+        return DONT_SYNC_AGAIN
+      }
+    }
+
     switch (sandbox.state) {
       case SandboxState.PENDING_BUILD: {
         return this.handleUnassignedBuildSandbox(sandbox)


### PR DESCRIPTION
# Check the runner state on sb start and archive

## Description

Added runner ready state check on start and archive sandbox actions.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
