### PR TITLE
fix(daemon): git push non-fast-forward

### DIFF
--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -37,7 +37,7 @@ func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.Ba
 	}
 
 	if repo.Branch != "" {
-		cloneOptions.ReferenceName = plumbing.ReferenceName("refs/heads/" + repo.Branch)
+		cloneOptions.ReferenceName = plumbing.NewBranchReferenceName(repo.Branch)
 	}
 
 	_, err := git.PlainClone(s.ProjectDir, false, cloneOptions)

--- a/apps/daemon/pkg/git/push.go
+++ b/apps/daemon/pkg/git/push.go
@@ -4,6 +4,9 @@
 package git
 
 import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/go-git/go-git/v5"
@@ -15,8 +18,16 @@ func (s *Service) Push(auth *http.BasicAuth) error {
 		return err
 	}
 
+	ref, err := repo.Head()
+	if err != nil {
+		return err
+	}
+
 	options := &git.PushOptions{
 		Auth: auth,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec(fmt.Sprintf("+%s:%s", ref.Name(), ref.Name())),
+		},
 	}
 
 	return repo.Push(options)


### PR DESCRIPTION
# Fix Git Push non-fast-forward Error

## Description

Currently, git push would fail if any remote branch was updated before it was last fetched. This fix ensures that users can push changes only to the specified branch.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
