### PR TITLE
fix(daemon): remove default force push

### DIFF
--- a/apps/daemon/pkg/git/push.go
+++ b/apps/daemon/pkg/git/push.go
@@ -26,7 +26,7 @@ func (s *Service) Push(auth *http.BasicAuth) error {
 	options := &git.PushOptions{
 		Auth: auth,
 		RefSpecs: []config.RefSpec{
-			config.RefSpec(fmt.Sprintf("+%s:%s", ref.Name(), ref.Name())),
+			config.RefSpec(fmt.Sprintf("%s:%s", ref.Name(), ref.Name())),
 		},
 	}
 


### PR DESCRIPTION
# Remove Default Force Push

## Description

Removed the `+` from the push refspec that caused force push to be by default. We should add force as an option in the push api call.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
