### PR TITLE
fix(api): limit auto-archive operations per runner

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -72,6 +72,14 @@ export class RunnerService {
     return this.runnerRepository.find()
   }
 
+  async findAllReady(): Promise<Runner[]> {
+    return this.runnerRepository.find({
+      where: {
+        state: RunnerState.READY,
+      },
+    })
+  }
+
   async findOne(id: string): Promise<Runner | null> {
     return this.runnerRepository.findOneBy({ id })
   }


### PR DESCRIPTION
# Limit Auto-archive Operations per Runner

## Description

Added a check to only start archiving sandboxes on runners that are below the threshold.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation