### PR TITLE
fix: undefined status err on destroy

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
@@ -51,7 +51,7 @@ export class SandboxDestroyAction extends SandboxAction {
           }
         } catch (e) {
           //  if the sandbox is not found on runner, it is already destroyed
-          if (!e.response || e.response.status !== 404) {
+          if (e.response?.status !== 404) {
             throw e
           }
         }
@@ -70,7 +70,7 @@ export class SandboxDestroyAction extends SandboxAction {
           await runnerAdapter.destroySandbox(sandbox.id)
         } catch (e) {
           //  if the sandbox is not found on runner, it is already destroyed
-          if (e.response.status !== 404) {
+          if (e.response?.status !== 404) {
             throw e
           }
         }


### PR DESCRIPTION
# Fix undefined status err on destroy
## Description

Caused some invalid `Cannot read properties of undefined (reading 'status')` errors on delete

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
