### PR TITLE
fix: handle unready runner on delete

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
@@ -34,6 +34,8 @@ export class SandboxDestroyAction extends SandboxAction {
 
     const runner = await this.runnerService.findOne(sandbox.runnerId)
     if (runner.state !== RunnerState.READY) {
+      // Runner is not ready; treat as if deletion on the runner succeeded
+      await this.updateSandboxState(sandbox.id, SandboxState.DESTROYED)
       return DONT_SYNC_AGAIN
     }
 


### PR DESCRIPTION
# Handle unready runner on delete
## Description

Sandboxes used to hang in a deleting state if the runner wasn't ready to delete the sandbox. User intent should have precedence here

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation