### PR TITLE
Sync items stream

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -244,31 +244,63 @@ export class SandboxManager {
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-states' })
   @OtelSpan()
   async syncStates(): Promise<void> {
-    const lockKey = 'sync-states'
-    if (!(await this.redisLockProvider.lock(lockKey, 30))) {
+    const globalLockKey = 'sync-states'
+    if (!(await this.redisLockProvider.lock(globalLockKey, 30))) {
       return
     }
 
-    const sandboxes = await this.sandboxRepository.find({
-      where: {
-        state: Not(In([SandboxState.DESTROYED, SandboxState.ERROR, SandboxState.BUILD_FAILED])),
-        desiredState: Raw(
-          () =>
-            `"Sandbox"."desiredState"::text != "Sandbox"."state"::text AND "Sandbox"."desiredState"::text != 'archived'`,
-        ),
-      },
-      take: 100,
-      order: {
-        lastActivityAt: 'DESC',
-      },
-    })
+    try {
+      const queryBuilder = this.sandboxRepository
+        .createQueryBuilder('sandbox')
+        .select(['sandbox.id'])
+        .where('sandbox.state NOT IN (:...excludedStates)', {
+          excludedStates: [SandboxState.DESTROYED, SandboxState.ERROR, SandboxState.BUILD_FAILED],
+        })
+        .andWhere('sandbox.desiredState::text != sandbox.state::text')
+        .andWhere('sandbox.desiredState::text != :archived', { archived: 'archived' })
+        .orderBy('sandbox.lastActivityAt', 'ASC')
 
-    await Promise.all(
-      sandboxes.map(async (sandbox) => {
-        this.syncInstanceState(sandbox.id)
-      }),
-    )
-    await this.redisLockProvider.unlock(lockKey)
+      const stream = await queryBuilder.stream()
+      let processedCount = 0
+      const maxProcessPerRun = 200
+      const pendingProcesses: Promise<void>[] = []
+
+      await new Promise<void>((resolve, reject) => {
+        stream.on('data', (row: any) => {
+          if (processedCount >= maxProcessPerRun) {
+            stream.destroy()
+            return
+          }
+
+          // Process sandbox asynchronously but track the promise
+          const processPromise = this.syncInstanceState(row.sandbox_id)
+          pendingProcesses.push(processPromise)
+          processedCount++
+
+          // Limit concurrent processing to avoid overwhelming the system
+          if (pendingProcesses.length >= 10) {
+            stream.pause()
+            Promise.all(pendingProcesses.splice(0, pendingProcesses.length))
+              .then(() => stream.resume())
+              .catch(reject)
+          }
+        })
+
+        stream.on('end', async () => {
+          try {
+            // Wait for any remaining processes to complete
+            await Promise.all(pendingProcesses)
+            resolve()
+          } catch (error) {
+            reject(error)
+          }
+        })
+
+        stream.on('error', reject)
+      })
+    } finally {
+      await this.redisLockProvider.unlock(globalLockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-archived-desired-states' })

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -256,9 +256,9 @@ export class SandboxManager {
         .where('sandbox.state NOT IN (:...excludedStates)', {
           excludedStates: [SandboxState.DESTROYED, SandboxState.ERROR, SandboxState.BUILD_FAILED],
         })
-        .andWhere('sandbox.desiredState::text != sandbox.state::text')
-        .andWhere('sandbox.desiredState::text != :archived', { archived: 'archived' })
-        .orderBy('sandbox.lastActivityAt', 'ASC')
+        .andWhere('sandbox."desiredState"::text != sandbox.state::text')
+        .andWhere('sandbox."desiredState"::text != :archived', { archived: 'archived' })
+        .orderBy('sandbox."lastActivityAt"', 'ASC')
 
       const stream = await queryBuilder.stream()
       let processedCount = 0

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -279,7 +279,7 @@ export class SandboxManager {
             processedCount++
 
             // Limit concurrent processing to avoid overwhelming the system
-            if (pendingProcesses.length >= 10) {
+            if (pendingProcesses.length >= 100) {
               stream.pause()
               Promise.all(pendingProcesses.splice(0, pendingProcesses.length))
                 .then(() => stream.resume())

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "passport-jwt": "^4.0.1",
     "pathe": "^2.0.3",
     "pg": "^8.13.3",
+    "pg-query-stream": "^4.10.3",
     "posthog-js": "^1.217.6",
     "posthog-node": "^4.10.1",
     "prism-react-renderer": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14541,6 +14541,7 @@ __metadata:
     passport-jwt: "npm:^4.0.1"
     pathe: "npm:^2.0.3"
     pg: "npm:^8.13.3"
+    pg-query-stream: "npm:^4.10.3"
     postcss: "npm:8.4.38"
     posthog-js: "npm:^1.217.6"
     posthog-node: "npm:^4.10.1"
@@ -24383,6 +24384,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-cursor@npm:^2.15.3":
+  version: 2.15.3
+  resolution: "pg-cursor@npm:2.15.3"
+  peerDependencies:
+    pg: ^8
+  checksum: 10c0/60ea02689af0b6bd89946a7abb123260506e6fe9be1ea3c547e7d6fbbde5a6c8ca066f4114d6bd6699a87c47c93c9c5d7bfa6ff39bb62290221f5a3c0e1516b2
+  languageName: node
+  linkType: hard
+
 "pg-int8@npm:1.0.1":
   version: 1.0.1
   resolution: "pg-int8@npm:1.0.1"
@@ -24403,6 +24413,17 @@ __metadata:
   version: 1.10.3
   resolution: "pg-protocol@npm:1.10.3"
   checksum: 10c0/f7ef54708c93ee6d271e37678296fc5097e4337fca91a88a3d99359b78633dbdbf6e983f0adb34b7cdd261b7ec7266deb20c3233bf3dfdb498b3e1098e8750b9
+  languageName: node
+  linkType: hard
+
+"pg-query-stream@npm:^4.10.3":
+  version: 4.10.3
+  resolution: "pg-query-stream@npm:4.10.3"
+  dependencies:
+    pg-cursor: "npm:^2.15.3"
+  peerDependencies:
+    pg: ^8
+  checksum: 10c0/b39231104ed9c511036ac0abb402cc9a3d145503c93a69cbc7cef7ebfed1b323a9b8b98a7685620675da68fd48d5404e20e95a2804edd32fad09df18b5192c69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Sync items stream

## Description

Replaces the existing polling mechanism with query streaming. The current polling mechanism is inefficient and can cause some sandboxes to wait for the state change for a long time (possibly indefinitely).
Query streaming ensures that all pending state changes will be processed.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

