### PR TITLE
fix: validate volumes on sandbox create

### DIFF
--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -151,6 +151,35 @@ export class VolumeService {
     return volume
   }
 
+  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<void> {
+    if (!volumeIdOrNames.length) {
+      return
+    }
+
+    const volumes = await this.volumeRepository.find({
+      where: [
+        { id: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
+        { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
+      ],
+    })
+
+    // Check if all requested volumes were found and are in a READY state
+    const foundIds = new Set(volumes.map((v) => v.id))
+    const foundNames = new Set(volumes.map((v) => v.name))
+
+    for (const idOrName of volumeIdOrNames) {
+      if (!foundIds.has(idOrName) && !foundNames.has(idOrName)) {
+        throw new NotFoundException(`Volume '${idOrName}' not found`)
+      }
+    }
+
+    for (const volume of volumes) {
+      if (volume.state !== VolumeState.READY) {
+        throw new BadRequestError(`Volume '${volume.name}' is not in a ready state. Current state: ${volume.state}`)
+      }
+    }
+  }
+
   @OnEvent(SandboxEvents.CREATED)
   private async handleSandboxCreatedEvent(event: SandboxCreatedEvent) {
     if (!event.sandbox.volumes.length) {


### PR DESCRIPTION
# Validate volumes on sandbox create
## Description

Adds a validation to the volume ids/names passed to the sandbox creation endpoint as well as their states. This makes it so sandbox creations fails early, on API level, instead of after the sandbox entry had already been created

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
