### PR TITLE
fix(api): always remove snapshot after cleanup

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -346,18 +346,17 @@ export class SnapshotManager {
           },
         })
 
-        if (countActiveSnapshots > 0) {
-          return
+        // Only remove snapshot runners if no other snapshots depend on them
+        if (countActiveSnapshots === 0) {
+          await this.snapshotRunnerRepository.update(
+            {
+              snapshotRef: snapshot.internalName,
+            },
+            {
+              state: SnapshotRunnerState.REMOVING,
+            },
+          )
         }
-
-        await this.snapshotRunnerRepository.update(
-          {
-            snapshotRef: snapshot.internalName,
-          },
-          {
-            state: SnapshotRunnerState.REMOVING,
-          },
-        )
 
         await this.snapshotRepository.remove(snapshot)
       }),


### PR DESCRIPTION
# Always Remove Snapshot After Cleanup

## Description

Remove snapshot from DB after cleanup job. If other snapshot runners depend on the internal image, their cleanup is skipped and the snapshot is still removed from the db.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
