### PR TITLE
fix: cooldown period for api key lastUsedAt update

### DIFF
--- a/apps/api/src/sandbox/common/redis-lock.provider.ts
+++ b/apps/api/src/sandbox/common/redis-lock.provider.ts
@@ -29,12 +29,4 @@ export class RedisLockProvider {
       await new Promise((resolve) => setTimeout(resolve, 50))
     }
   }
-
-  async get(key: string): Promise<string | null> {
-    return await this.redis.get(key)
-  }
-
-  async set(key: string, value: string, ttl: number): Promise<void> {
-    await this.redis.set(key, value, 'EX', ttl)
-  }
 }


### PR DESCRIPTION
# Cooldown period for api key lastUsedAt update

## Description

Prevents database flooding when multiple requests are made simultaneously.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
