### PR TITLE
feat(api): sandbox usage period archive

### DIFF
--- a/apps/api/src/migrations/1755521645207-migration.ts
+++ b/apps/api/src/migrations/1755521645207-migration.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1755521645207 implements MigrationInterface {
+  name = 'Migration1755521645207'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "sandbox_usage_periods_archive" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "sandboxId" character varying NOT NULL, "organizationId" character varying NOT NULL, "startAt" TIMESTAMP WITH TIME ZONE NOT NULL, "endAt" TIMESTAMP WITH TIME ZONE NOT NULL, "cpu" double precision NOT NULL, "gpu" double precision NOT NULL, "mem" double precision NOT NULL, "disk" double precision NOT NULL, "region" character varying NOT NULL, CONSTRAINT "sandbox_usage_periods_archive_id_pk" PRIMARY KEY ("id"))`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "sandbox_usage_periods_archive"`)
+  }
+}

--- a/apps/api/src/usage/entities/sandbox-usage-period-archive.entity.ts
+++ b/apps/api/src/usage/entities/sandbox-usage-period-archive.entity.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import { SandboxUsagePeriod } from './sandbox-usage-period.entity'
+
+// Duplicate of SandboxUsagePeriod
+// Used to archive usage periods and keep the original table lightweight
+// Will only contain closed usage periods
+@Entity('sandbox_usage_periods_archive')
+export class SandboxUsagePeriodArchive {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column()
+  sandboxId: string
+
+  @Column()
+  // Redundant property to optimize billing queries
+  organizationId: string
+
+  @Column({ type: 'timestamp with time zone' })
+  startAt: Date
+
+  @Column({ type: 'timestamp with time zone' })
+  endAt: Date
+
+  @Column({ type: 'float' })
+  cpu: number
+
+  @Column({ type: 'float' })
+  gpu: number
+
+  @Column({ type: 'float' })
+  mem: number
+
+  @Column({ type: 'float' })
+  disk: number
+
+  @Column()
+  region: string
+
+  public static fromUsagePeriod(usagePeriod: SandboxUsagePeriod) {
+    const usagePeriodEntity = new SandboxUsagePeriodArchive()
+    usagePeriodEntity.sandboxId = usagePeriod.sandboxId
+    usagePeriodEntity.organizationId = usagePeriod.organizationId
+    usagePeriodEntity.startAt = usagePeriod.startAt
+    usagePeriodEntity.endAt = usagePeriod.endAt
+    usagePeriodEntity.cpu = usagePeriod.cpu
+    usagePeriodEntity.gpu = usagePeriod.gpu
+    usagePeriodEntity.mem = usagePeriod.mem
+    usagePeriodEntity.disk = usagePeriod.disk
+    usagePeriodEntity.region = usagePeriod.region
+    return usagePeriodEntity
+  }
+}

--- a/apps/api/src/usage/usage.module.ts
+++ b/apps/api/src/usage/usage.module.ts
@@ -9,9 +9,10 @@ import { SandboxUsagePeriod } from './entities/sandbox-usage-period.entity'
 import { UsageService } from './services/usage.service'
 import { RedisLockProvider } from '../sandbox/common/redis-lock.provider'
 import { Sandbox } from '../sandbox/entities/sandbox.entity'
+import { SandboxUsagePeriodArchive } from './entities/sandbox-usage-period-archive.entity'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SandboxUsagePeriod, Sandbox])],
+  imports: [TypeOrmModule.forFeature([SandboxUsagePeriod, Sandbox, SandboxUsagePeriodArchive])],
   providers: [UsageService, RedisLockProvider],
   exports: [UsageService],
 })


### PR DESCRIPTION
# Sandbox Usage Period Archive

## Description

Every minute, a background job archives 100 sandbox usage period records to a different table.
This is supposed to make the sandbox usage period table more light in order to reduce select and update loads.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
