### PR TITLE
fix(api): set archived state on backup state completed

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -209,6 +209,11 @@ export class Sandbox {
           },
         ]
         this.backupErrorReason = null
+        if (this.desiredState === SandboxDesiredState.ARCHIVED) {
+          if (this.state === SandboxState.ARCHIVING || this.state === SandboxState.STOPPED) {
+            this.state = SandboxState.ARCHIVED
+          }
+        }
         break
       }
     }


### PR DESCRIPTION
# Set Archived State on Backup State Completed

## Description

Sandbox archived state will be set earlier now. This will prevent unnecessary job iterations for sandboxes that have completed archives.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
