### PR TITLE
refactor: cache user on api key token validate

### DIFF
--- a/apps/api/src/auth/api-key.strategy.ts
+++ b/apps/api/src/auth/api-key.strategy.ts
@@ -11,12 +11,22 @@ import { UserService } from '../user/user.service'
 import { AuthContext } from '../common/interfaces/auth-context.interface'
 import { TypedConfigService } from '../config/typed-config.service'
 import { ProxyContext } from '../common/interfaces/proxy-context.interface'
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import Redis from 'ioredis'
+import { SystemRole } from '../user/enums/system-role.enum'
+
+type UserCache = {
+  userId: string
+  role: SystemRole
+  email: string
+}
 
 @Injectable()
 export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') implements OnModuleInit {
   private readonly logger = new Logger(ApiKeyStrategy.name)
 
   constructor(
+    @InjectRedis() private readonly redis: Redis,
     private readonly apiKeyService: ApiKeyService,
     private readonly userService: UserService,
     private readonly configService: TypedConfigService,
@@ -51,19 +61,25 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') implem
       this.logger.debug(`Updating last used timestamp for API key: ${token.substring(0, 8)}...`)
       await this.apiKeyService.updateLastUsedAt(apiKey.organizationId, apiKey.userId, apiKey.name, new Date())
 
-      let user = await this.userService.findOne(apiKey.userId)
-      if (!user) {
-        this.logger.debug(`Creating new user for userId: ${apiKey.userId}`)
-        user = await this.userService.create({
-          id: apiKey.userId,
-          name: 'API Key User',
-        })
+      let userCache = await this.getUserCache(apiKey.userId)
+      if (!userCache) {
+        const user = await this.userService.findOne(apiKey.userId)
+        if (!user) {
+          this.logger.error(`Api key has invalid user: ${apiKey.keySuffix} - ${apiKey.userId}`)
+          throw new UnauthorizedException('User not found')
+        }
+        userCache = {
+          userId: user.id,
+          role: user.role,
+          email: user.email,
+        }
+        await this.redis.set(`api-key:user:${apiKey.userId}`, JSON.stringify(userCache), 'EX', 60)
       }
 
       const result = {
-        userId: user.id,
-        role: user.role,
-        email: user.email,
+        userId: userCache.userId,
+        role: userCache.role,
+        email: userCache.email,
         apiKey,
         organizationId: apiKey.organizationId,
       }
@@ -78,6 +94,19 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') implem
       }
 
       throw new UnauthorizedException('Invalid API key')
+    }
+  }
+
+  private async getUserCache(userId: string): Promise<UserCache | null> {
+    try {
+      const userCacheRaw = await this.redis.get(`api-key:user:${userId}`)
+      if (userCacheRaw) {
+        return JSON.parse(userCacheRaw)
+      }
+      return null
+    } catch (error) {
+      this.logger.error('Error getting user cache:', error)
+      return null
     }
   }
 }


### PR DESCRIPTION
# Cache user on api key token validate

## Description

Implemented user cache on api key token validation to improve performance and reduce the DB pressure.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
