### PR TITLE
fix(api): remove runnerId on archive

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -212,6 +212,7 @@ export class Sandbox {
         if (this.desiredState === SandboxDesiredState.ARCHIVED) {
           if (this.state === SandboxState.ARCHIVING || this.state === SandboxState.STOPPED) {
             this.state = SandboxState.ARCHIVED
+            this.runnerId = null
           }
         }
         break


### PR DESCRIPTION
# Remove RunnerId on Archive

## Description

Fixes a small regression where the runnerId wouldn't be removed from an archived sandbox.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
