### PR TITLE
refactor(sdk-typescript): make Image methods synchronous

### DIFF
--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1,5 +1,5 @@
 # Daytona Documentation v0.0.0-dev
-# Generated on: 2025-08-13
+# Generated on: 2025-08-19
 
 
 title: API Keys
@@ -3000,6 +3000,55 @@ main();
 
 :::note
 All resource parameters are optional. If not specified, Daytona will use default values appropriate for the selected language and use case.
+:::
+
+### Network Settings
+
+Daytona Sandboxes provide configurable network access controls to enhance security and manage connectivity. By default, network access follows standard security policies, but you can customize network settings when creating a Sandbox:
+
+- To block all network access, set `networkBlockAll` to `True`
+- To restrict network access to specific addresses, set `networkAllowList` to a comma-separated list of up to 5 CIDR blocks
+
+```python
+from daytona import Daytona, CreateSandboxFromSnapshotParams
+
+daytona = Daytona()
+
+# Block all network access
+
+params = CreateSandboxFromSnapshotParams(
+  network_block_all=True
+)
+sandbox = daytona.create(params)
+
+# Explicitly allow list of network addresses
+
+params = CreateSandboxFromSnapshotParams(
+  network_allow_list="192.168.1.0/16,10.0.0.0/24"
+)
+sandbox = daytona.create(params)
+
+```
+```typescript
+import { Daytona } from '@daytonaio/sdk';
+
+const daytona = new Daytona();
+
+// Block all network access
+const sandbox = await daytona.create({
+  networkBlockAll: true
+});
+
+// Explicitly allow list of network addresses
+const sandbox = await daytona.create({
+  networkAllowList: '192.168.1.0/16,10.0.0.0/24'
+});
+```
+
+
+:::caution
+Enabling unrestricted network access may pose security risks when executing untrusted code.
+It is recommended to whitelist specific network addresses using `networkAllowList` or block all network access using `networkBlockAll` instead.
 :::
 
 ## Sandbox Information

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,5 +1,5 @@
 # Daytona Documentation v0.0.0-dev
-# Generated on: 2025-08-13
+# Generated on: 2025-08-19
 
 # Daytona
 
@@ -134,6 +134,7 @@
 - [Creating Sandboxes](https://daytona.io/docs/en/sandbox-management#creating-sandboxes)
 - [Basic Sandbox Creation](https://daytona.io/docs/en/sandbox-management#basic-sandbox-creation)
 - [Sandbox Resources](https://daytona.io/docs/en/sandbox-management#sandbox-resources)
+- [Network Settings](https://daytona.io/docs/en/sandbox-management#network-settings)
 - [Sandbox Information](https://daytona.io/docs/en/sandbox-management#sandbox-information)
 - [Stop and Start Sandbox](https://daytona.io/docs/en/sandbox-management#stop-and-start-sandbox)
 - [Archive Sandbox](https://daytona.io/docs/en/sandbox-management#archive-sandbox)

--- a/apps/docs/public/search.json
+++ b/apps/docs/public/search.json
@@ -1536,12 +1536,36 @@
     "objectID": 192
   },
   {
+    "title": "Network Settings",
+    "description": "Daytona Sandboxes provide configurable network access controls to enhance security and manage connectivity.",
+    "tag": "Documentation",
+    "url": "/docs/sandbox-management#network-settings",
+    "slug": "/sandbox-management#network-settings",
+    "objectID": 193
+  },
+  {
+    "title": "Block all network access",
+    "description": "",
+    "tag": "Documentation",
+    "url": "/docs/sandbox-management#block-all-network-access",
+    "slug": "/sandbox-management#block-all-network-access",
+    "objectID": 194
+  },
+  {
+    "title": "Explicitly allow list of network addresses",
+    "description": "",
+    "tag": "Documentation",
+    "url": "/docs/sandbox-management#explicitly-allow-list-of-network-addresses",
+    "slug": "/sandbox-management#explicitly-allow-list-of-network-addresses",
+    "objectID": 195
+  },
+  {
     "title": "Sandbox Information",
     "description": "The Daytona SDK provides methods to get information about a Sandbox, such as ID, root directory, and status using Python and TypeScript.",
     "tag": "Documentation",
     "url": "/docs/sandbox-management#sandbox-information",
     "slug": "/sandbox-management#sandbox-information",
-    "objectID": 193
+    "objectID": 196
   },
   {
     "title": "Get Sandbox ID",
@@ -1549,7 +1573,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#get-sandbox-id",
     "slug": "/sandbox-management#get-sandbox-id",
-    "objectID": 194
+    "objectID": 197
   },
   {
     "title": "Get the root directory of the Sandbox user",
@@ -1557,7 +1581,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#get-the-root-directory-of-the-sandbox-user",
     "slug": "/sandbox-management#get-the-root-directory-of-the-sandbox-user",
-    "objectID": 195
+    "objectID": 198
   },
   {
     "title": "Get the Sandbox id, auto-stop interval and state",
@@ -1565,7 +1589,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#get-the-sandbox-id-auto-stop-interval-and-state",
     "slug": "/sandbox-management#get-the-sandbox-id-auto-stop-interval-and-state",
-    "objectID": 196
+    "objectID": 199
   },
   {
     "title": "Stop and Start Sandbox",
@@ -1573,7 +1597,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#stop-and-start-sandbox",
     "slug": "/sandbox-management#stop-and-start-sandbox",
-    "objectID": 197
+    "objectID": 200
   },
   {
     "title": "Stop Sandbox",
@@ -1581,7 +1605,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#stop-sandbox",
     "slug": "/sandbox-management#stop-sandbox",
-    "objectID": 198
+    "objectID": 201
   },
   {
     "title": "The sandbox ID can later be used to find the sandbox and start it",
@@ -1589,7 +1613,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#the-sandbox-id-can-later-be-used-to-find-the-sandbox-and-start-it",
     "slug": "/sandbox-management#the-sandbox-id-can-later-be-used-to-find-the-sandbox-and-start-it",
-    "objectID": 199
+    "objectID": 202
   },
   {
     "title": "Start Sandbox",
@@ -1597,7 +1621,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#start-sandbox",
     "slug": "/sandbox-management#start-sandbox",
-    "objectID": 200
+    "objectID": 203
   },
   {
     "title": "Archive Sandbox",
@@ -1605,7 +1629,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#archive-sandbox",
     "slug": "/sandbox-management#archive-sandbox",
-    "objectID": 201
+    "objectID": 204
   },
   {
     "title": "Archive Sandbox",
@@ -1613,7 +1637,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#archive-sandbox",
     "slug": "/sandbox-management#archive-sandbox",
-    "objectID": 202
+    "objectID": 205
   },
   {
     "title": "Delete Sandbox",
@@ -1621,7 +1645,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#delete-sandbox",
     "slug": "/sandbox-management#delete-sandbox",
-    "objectID": 203
+    "objectID": 206
   },
   {
     "title": "Delete Sandbox",
@@ -1629,7 +1653,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#delete-sandbox",
     "slug": "/sandbox-management#delete-sandbox",
-    "objectID": 204
+    "objectID": 207
   },
   {
     "title": "Automated Lifecycle Management",
@@ -1637,7 +1661,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#automated-lifecycle-management",
     "slug": "/sandbox-management#automated-lifecycle-management",
-    "objectID": 205
+    "objectID": 208
   },
   {
     "title": "Auto-stop Interval",
@@ -1645,7 +1669,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#auto-stop-interval",
     "slug": "/sandbox-management#auto-stop-interval",
-    "objectID": 206
+    "objectID": 209
   },
   {
     "title": "Auto-archive Interval",
@@ -1653,7 +1677,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#auto-archive-interval",
     "slug": "/sandbox-management#auto-archive-interval",
-    "objectID": 207
+    "objectID": 210
   },
   {
     "title": "Auto-delete Interval",
@@ -1661,7 +1685,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#auto-delete-interval",
     "slug": "/sandbox-management#auto-delete-interval",
-    "objectID": 208
+    "objectID": 211
   },
   {
     "title": "Delete the Sandbox immediately after it has been stopped",
@@ -1669,7 +1693,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#delete-the-sandbox-immediately-after-it-has-been-stopped",
     "slug": "/sandbox-management#delete-the-sandbox-immediately-after-it-has-been-stopped",
-    "objectID": 209
+    "objectID": 212
   },
   {
     "title": "Disable auto-deletion",
@@ -1677,7 +1701,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#disable-auto-deletion",
     "slug": "/sandbox-management#disable-auto-deletion",
-    "objectID": 210
+    "objectID": 213
   },
   {
     "title": "Run Indefinitely",
@@ -1685,7 +1709,7 @@
     "tag": "Documentation",
     "url": "/docs/sandbox-management#run-indefinitely",
     "slug": "/sandbox-management#run-indefinitely",
-    "objectID": 211
+    "objectID": 214
   },
   {
     "title": "Snapshots",
@@ -1693,7 +1717,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots",
     "slug": "/snapshots",
-    "objectID": 212
+    "objectID": 215
   },
   {
     "title": "Creating Snapshots",
@@ -1701,7 +1725,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#creating-snapshots",
     "slug": "/snapshots#creating-snapshots",
-    "objectID": 213
+    "objectID": 216
   },
   {
     "title": "Snapshot Resources",
@@ -1709,7 +1733,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#snapshot-resources",
     "slug": "/snapshots#snapshot-resources",
-    "objectID": 214
+    "objectID": 217
   },
   {
     "title": "Create a Snapshot with custom resources",
@@ -1717,7 +1741,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#create-a-snapshot-with-custom-resources",
     "slug": "/snapshots#create-a-snapshot-with-custom-resources",
-    "objectID": 215
+    "objectID": 218
   },
   {
     "title": "Create a Sandbox with custom Snapshot",
@@ -1725,7 +1749,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#create-a-sandbox-with-custom-snapshot",
     "slug": "/snapshots#create-a-sandbox-with-custom-snapshot",
-    "objectID": 216
+    "objectID": 219
   },
   {
     "title": "Images from Private Registries",
@@ -1733,7 +1757,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#images-from-private-registries",
     "slug": "/snapshots#images-from-private-registries",
-    "objectID": 217
+    "objectID": 220
   },
   {
     "title": "Using a Private Docker Hub Image",
@@ -1741,7 +1765,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#using-a-private-docker-hub-image",
     "slug": "/snapshots#using-a-private-docker-hub-image",
-    "objectID": 218
+    "objectID": 221
   },
   {
     "title": "Using a Local Image",
@@ -1749,7 +1773,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#using-a-local-image",
     "slug": "/snapshots#using-a-local-image",
-    "objectID": 219
+    "objectID": 222
   },
   {
     "title": "Deleting Snapshots",
@@ -1757,7 +1781,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#deleting-snapshots",
     "slug": "/snapshots#deleting-snapshots",
-    "objectID": 220
+    "objectID": 223
   },
   {
     "title": "Default Snapshot",
@@ -1765,7 +1789,7 @@
     "tag": "Documentation",
     "url": "/docs/snapshots#default-snapshot",
     "slug": "/snapshots#default-snapshot",
-    "objectID": 221
+    "objectID": 224
   },
   {
     "title": "CLI",
@@ -1773,7 +1797,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli",
     "slug": "/tools/cli",
-    "objectID": 222
+    "objectID": 225
   },
   {
     "title": "daytona",
@@ -1781,7 +1805,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona",
     "slug": "/tools/cli#daytona",
-    "objectID": 223
+    "objectID": 226
   },
   {
     "title": "daytona autocomplete",
@@ -1789,7 +1813,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-autocomplete",
     "slug": "/tools/cli#daytona-autocomplete",
-    "objectID": 224
+    "objectID": 227
   },
   {
     "title": "daytona docs",
@@ -1797,7 +1821,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-docs",
     "slug": "/tools/cli#daytona-docs",
-    "objectID": 225
+    "objectID": 228
   },
   {
     "title": "daytona login",
@@ -1805,7 +1829,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-login",
     "slug": "/tools/cli#daytona-login",
-    "objectID": 226
+    "objectID": 229
   },
   {
     "title": "daytona logout",
@@ -1813,7 +1837,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-logout",
     "slug": "/tools/cli#daytona-logout",
-    "objectID": 227
+    "objectID": 230
   },
   {
     "title": "daytona mcp",
@@ -1821,7 +1845,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-mcp",
     "slug": "/tools/cli#daytona-mcp",
-    "objectID": 228
+    "objectID": 231
   },
   {
     "title": "daytona mcp config",
@@ -1829,7 +1853,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-mcp-config",
     "slug": "/tools/cli#daytona-mcp-config",
-    "objectID": 229
+    "objectID": 232
   },
   {
     "title": "daytona mcp init",
@@ -1837,7 +1861,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-mcp-init",
     "slug": "/tools/cli#daytona-mcp-init",
-    "objectID": 230
+    "objectID": 233
   },
   {
     "title": "daytona mcp start",
@@ -1845,7 +1869,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-mcp-start",
     "slug": "/tools/cli#daytona-mcp-start",
-    "objectID": 231
+    "objectID": 234
   },
   {
     "title": "daytona organization",
@@ -1853,7 +1877,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-organization",
     "slug": "/tools/cli#daytona-organization",
-    "objectID": 232
+    "objectID": 235
   },
   {
     "title": "daytona organization create",
@@ -1861,7 +1885,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-organization-create",
     "slug": "/tools/cli#daytona-organization-create",
-    "objectID": 233
+    "objectID": 236
   },
   {
     "title": "daytona organization delete",
@@ -1869,7 +1893,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-organization-delete",
     "slug": "/tools/cli#daytona-organization-delete",
-    "objectID": 234
+    "objectID": 237
   },
   {
     "title": "daytona organization list",
@@ -1877,7 +1901,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-organization-list",
     "slug": "/tools/cli#daytona-organization-list",
-    "objectID": 235
+    "objectID": 238
   },
   {
     "title": "daytona organization use",
@@ -1885,7 +1909,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-organization-use",
     "slug": "/tools/cli#daytona-organization-use",
-    "objectID": 236
+    "objectID": 239
   },
   {
     "title": "daytona sandbox",
@@ -1893,7 +1917,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-sandbox",
     "slug": "/tools/cli#daytona-sandbox",
-    "objectID": 237
+    "objectID": 240
   },
   {
     "title": "daytona sandbox create",
@@ -1901,7 +1925,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-sandbox-create",
     "slug": "/tools/cli#daytona-sandbox-create",
-    "objectID": 238
+    "objectID": 241
   },
   {
     "title": "daytona sandbox delete",
@@ -1909,7 +1933,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-sandbox-delete",
     "slug": "/tools/cli#daytona-sandbox-delete",
-    "objectID": 239
+    "objectID": 242
   },
   {
     "title": "daytona sandbox info",
@@ -1917,7 +1941,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-sandbox-info",
     "slug": "/tools/cli#daytona-sandbox-info",
-    "objectID": 240
+    "objectID": 243
   },
   {
     "title": "daytona sandbox list",
@@ -1925,7 +1949,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-sandbox-list",
     "slug": "/tools/cli#daytona-sandbox-list",
-    "objectID": 241
+    "objectID": 244
   },
   {
     "title": "daytona sandbox start",
@@ -1933,7 +1957,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-sandbox-start",
     "slug": "/tools/cli#daytona-sandbox-start",
-    "objectID": 242
+    "objectID": 245
   },
   {
     "title": "daytona sandbox stop",
@@ -1941,7 +1965,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-sandbox-stop",
     "slug": "/tools/cli#daytona-sandbox-stop",
-    "objectID": 243
+    "objectID": 246
   },
   {
     "title": "daytona snapshot",
@@ -1949,7 +1973,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-snapshot",
     "slug": "/tools/cli#daytona-snapshot",
-    "objectID": 244
+    "objectID": 247
   },
   {
     "title": "daytona snapshot create",
@@ -1957,7 +1981,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-snapshot-create",
     "slug": "/tools/cli#daytona-snapshot-create",
-    "objectID": 245
+    "objectID": 248
   },
   {
     "title": "daytona snapshot delete",
@@ -1965,7 +1989,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-snapshot-delete",
     "slug": "/tools/cli#daytona-snapshot-delete",
-    "objectID": 246
+    "objectID": 249
   },
   {
     "title": "daytona snapshot list",
@@ -1973,7 +1997,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-snapshot-list",
     "slug": "/tools/cli#daytona-snapshot-list",
-    "objectID": 247
+    "objectID": 250
   },
   {
     "title": "daytona snapshot push",
@@ -1981,7 +2005,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-snapshot-push",
     "slug": "/tools/cli#daytona-snapshot-push",
-    "objectID": 248
+    "objectID": 251
   },
   {
     "title": "daytona version",
@@ -1989,7 +2013,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-version",
     "slug": "/tools/cli#daytona-version",
-    "objectID": 249
+    "objectID": 252
   },
   {
     "title": "daytona volume",
@@ -1997,7 +2021,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-volume",
     "slug": "/tools/cli#daytona-volume",
-    "objectID": 250
+    "objectID": 253
   },
   {
     "title": "daytona volume create",
@@ -2005,7 +2029,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-volume-create",
     "slug": "/tools/cli#daytona-volume-create",
-    "objectID": 251
+    "objectID": 254
   },
   {
     "title": "daytona volume delete",
@@ -2013,7 +2037,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-volume-delete",
     "slug": "/tools/cli#daytona-volume-delete",
-    "objectID": 252
+    "objectID": 255
   },
   {
     "title": "daytona volume get",
@@ -2021,7 +2045,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-volume-get",
     "slug": "/tools/cli#daytona-volume-get",
-    "objectID": 253
+    "objectID": 256
   },
   {
     "title": "daytona volume list",
@@ -2029,7 +2053,7 @@
     "tag": "Documentation",
     "url": "/docs/tools/cli#daytona-volume-list",
     "slug": "/tools/cli#daytona-volume-list",
-    "objectID": 254
+    "objectID": 257
   },
   {
     "title": "Volumes",
@@ -2037,7 +2061,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes",
     "slug": "/volumes",
-    "objectID": 255
+    "objectID": 258
   },
   {
     "title": "Creating Volumes",
@@ -2045,7 +2069,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#creating-volumes",
     "slug": "/volumes#creating-volumes",
-    "objectID": 256
+    "objectID": 259
   },
   {
     "title": "Mounting Volumes",
@@ -2053,7 +2077,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#mounting-volumes",
     "slug": "/volumes#mounting-volumes",
-    "objectID": 257
+    "objectID": 260
   },
   {
     "title": "Create a new volume or get an existing one",
@@ -2061,7 +2085,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#create-a-new-volume-or-get-an-existing-one",
     "slug": "/volumes#create-a-new-volume-or-get-an-existing-one",
-    "objectID": 258
+    "objectID": 261
   },
   {
     "title": "Mount the volume to the sandbox",
@@ -2069,7 +2093,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#mount-the-volume-to-the-sandbox",
     "slug": "/volumes#mount-the-volume-to-the-sandbox",
-    "objectID": 259
+    "objectID": 262
   },
   {
     "title": "When you're done with the sandbox, you can remove it",
@@ -2077,7 +2101,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#when-youre-done-with-the-sandbox-you-can-remove-it",
     "slug": "/volumes#when-youre-done-with-the-sandbox-you-can-remove-it",
-    "objectID": 260
+    "objectID": 263
   },
   {
     "title": "The volume persists after the sandbox is removed",
@@ -2085,7 +2109,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#the-volume-persists-after-the-sandbox-is-removed",
     "slug": "/volumes#the-volume-persists-after-the-sandbox-is-removed",
-    "objectID": 261
+    "objectID": 264
   },
   {
     "title": "Deleting Volumes",
@@ -2093,7 +2117,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#deleting-volumes",
     "slug": "/volumes#deleting-volumes",
-    "objectID": 262
+    "objectID": 265
   },
   {
     "title": "Working with Volumes",
@@ -2101,7 +2125,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#working-with-volumes",
     "slug": "/volumes#working-with-volumes",
-    "objectID": 263
+    "objectID": 266
   },
   {
     "title": "Limitations",
@@ -2109,7 +2133,7 @@
     "tag": "Documentation",
     "url": "/docs/volumes#limitations",
     "slug": "/volumes#limitations",
-    "objectID": 264
+    "objectID": 267
   },
   {
     "title": "Web Terminal",
@@ -2117,6 +2141,6 @@
     "tag": "Documentation",
     "url": "/docs/web-terminal",
     "slug": "/web-terminal",
-    "objectID": 265
+    "objectID": 268
   }
 ]

--- a/apps/docs/src/content/docs/en/typescript-sdk/image.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/image.mdx
@@ -95,7 +95,7 @@ const image = Image.debianSlim('3.12')
 #### fromDockerfile()
 
 ```ts
-static fromDockerfile(path: string): Promise<Image>
+static fromDockerfile(path: string): Image
 ```
 
 Creates an Image from an existing Dockerfile.
@@ -107,7 +107,7 @@ Creates an Image from an existing Dockerfile.
 
 **Returns**:
 
-- `Promise<Image>` - The Image instance.
+- `Image` - The Image instance.
 
 **Example:**
 
@@ -120,7 +120,7 @@ const image = Image.fromDockerfile('Dockerfile')
 #### addLocalDir()
 
 ```ts
-addLocalDir(localPath: string, remotePath: string): Promise<Image>
+addLocalDir(localPath: string, remotePath: string): Image
 ```
 
 Adds a local directory to the image.
@@ -133,7 +133,7 @@ Adds a local directory to the image.
 
 **Returns**:
 
-- `Promise<Image>` - The Image instance.
+- `Image` - The Image instance.
 
 **Example:**
 
@@ -148,7 +148,7 @@ const image = Image
 #### addLocalFile()
 
 ```ts
-addLocalFile(localPath: string, remotePath: string): Promise<Image>
+addLocalFile(localPath: string, remotePath: string): Image
 ```
 
 Adds a local file to the image.
@@ -161,7 +161,7 @@ Adds a local file to the image.
 
 **Returns**:
 
-- `Promise<Image>` - The Image instance.
+- `Image` - The Image instance.
 
 **Example:**
 
@@ -203,7 +203,7 @@ const image = Image
 #### dockerfileCommands()
 
 ```ts
-dockerfileCommands(dockerfileCommands: string[], contextDir?: string): Promise<Image>
+dockerfileCommands(dockerfileCommands: string[], contextDir?: string): Image
 ```
 
 Extends an image with arbitrary Dockerfile-like commands.
@@ -216,7 +216,7 @@ Extends an image with arbitrary Dockerfile-like commands.
 
 **Returns**:
 
-- `Promise<Image>` - The Image instance.
+- `Image` - The Image instance.
 
 **Example:**
 
@@ -311,7 +311,7 @@ const image = Image.debianSlim('3.12').pipInstall('numpy', { findLinks: ['https:
 #### pipInstallFromPyproject()
 
 ```ts
-pipInstallFromPyproject(pyprojectToml: string, options?: PyprojectOptions): Promise<Image>
+pipInstallFromPyproject(pyprojectToml: string, options?: PyprojectOptions): Image
 ```
 
 Installs dependencies from a pyproject.toml file.
@@ -324,7 +324,7 @@ Installs dependencies from a pyproject.toml file.
 
 **Returns**:
 
-- `Promise<Image>` - The Image instance.
+- `Image` - The Image instance.
 
 **Example:**
 
@@ -338,7 +338,7 @@ image.pipInstallFromPyproject('pyproject.toml', { optionalDependencies: ['dev'] 
 #### pipInstallFromRequirements()
 
 ```ts
-pipInstallFromRequirements(requirementsTxt: string, options?: PipInstallOptions): Promise<Image>
+pipInstallFromRequirements(requirementsTxt: string, options?: PipInstallOptions): Image
 ```
 
 Installs dependencies from a requirements.txt file.
@@ -351,7 +351,7 @@ Installs dependencies from a requirements.txt file.
 
 **Returns**:
 
-- `Promise<Image>` - The Image instance.
+- `Image` - The Image instance.
 
 **Example:**
 

--- a/libs/sdk-typescript/src/utils/Import.ts
+++ b/libs/sdk-typescript/src/utils/Import.ts
@@ -17,6 +17,16 @@ const loaderMap = {
   'form-data': () => import('form-data'),
 }
 
+const requireMap = {
+  'fast-glob': () => require('fast-glob'),
+  '@iarna/toml': () => require('@iarna/toml'),
+  stream: () => require('stream'),
+  tar: () => require('tar'),
+  'expand-tilde': () => require('expand-tilde'),
+  fs: () => require('fs'),
+  'form-data': () => require('form-data'),
+}
+
 const validateMap: Record<string, (mod: any) => boolean> = {
   fs: (mod: any) => typeof mod.createReadStream === 'function',
   'form-data': (mod: any) => typeof mod.default === 'function',
@@ -36,6 +46,31 @@ export async function dynamicImport<K extends keyof ModuleMap>(
   let mod: any
   try {
     mod = (await loader()) as any
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new DaytonaError(`${errorPrefix || ''} Module "${name}" is not available in the "${RUNTIME}" runtime: ${msg}`)
+  }
+
+  if (validateMap[name] && !validateMap[name](mod)) {
+    throw new DaytonaError(
+      `${errorPrefix || ''} Module "${name}" didn't pass import validation in the "${RUNTIME}" runtime`,
+    )
+  }
+
+  return mod?.default ?? mod
+}
+
+type RequireMap = typeof requireMap
+
+export function dynamicRequire<K extends keyof RequireMap>(name: K, errorPrefix?: string): ReturnType<RequireMap[K]> {
+  const loader = requireMap[name]
+  if (!loader) {
+    throw new DaytonaError(`${errorPrefix || ''} Unknown module "${name}"`)
+  }
+
+  let mod: any
+  try {
+    mod = loader()
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     throw new DaytonaError(`${errorPrefix || ''} Module "${name}" is not available in the "${RUNTIME}" runtime: ${msg}`)


### PR DESCRIPTION
Use `require` for dynamically importing libraries within the `Image` methods making them synchronous. This allows users to seamlessly chain methods when defining images declaratively.