### PR TITLE
gt: updating gt.config.json API routing

### DIFF
--- a/apps/docs/gt.config.json
+++ b/apps/docs/gt.config.json
@@ -17,7 +17,6 @@
     }
   },
   "locales": ["en", "ja"],
-  "baseUrl": "https://api.gtx.dev",
   "ssr": true,
   "options": {
     "experimentalFlattenJsonFiles": true,


### PR DESCRIPTION
Remove outdated gt.config.json "baseUrl" pointing to old version of GT API

# GT update for gt.config.json

## Description

GT was alerted of translation upload issues by the Daytona team. These were caused by the gt.config.json pointing to an outdated API via the "baseUrl" field. The config no longer requires a "baseUrl" field and will pick up the current API automatically. Translations are already completed and stored, so re-running the translate command will now fetch an update them immediately.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
