### PR TITLE
fix(api): allow start from stopped archiving sandboxes

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -631,8 +631,14 @@ export class SandboxService {
       throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
     }
 
-    if (String(sandbox.state) !== String(sandbox.desiredState) && sandbox.state !== SandboxState.ARCHIVING) {
-      throw new SandboxError('State change in progress')
+    if (String(sandbox.state) !== String(sandbox.desiredState)) {
+      // Allow start of stopped | archived and archiving | archived sandboxes
+      if (
+        sandbox.desiredState !== SandboxDesiredState.ARCHIVED ||
+        (sandbox.state !== SandboxState.STOPPED && sandbox.state !== SandboxState.ARCHIVING)
+      ) {
+        throw new SandboxError('State change in progress')
+      }
     }
 
     if (![SandboxState.STOPPED, SandboxState.ARCHIVED, SandboxState.ARCHIVING].includes(sandbox.state)) {


### PR DESCRIPTION
# Allow Start from Stopped Archiving Sandboxes

## Description

`stopped | archived` sandboxes should be able to start as well. Previously, only `archiving | archived` sandboxes could be started.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
