### PR TITLE
fix(runner): register update network settings route

### DIFF
--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -113,6 +113,7 @@ func (a *ApiServer) Start() error {
 		sandboxController.POST("/:sandboxId/backup", controllers.CreateBackup)
 		sandboxController.POST("/:sandboxId/resize", controllers.Resize)
 		sandboxController.DELETE("/:sandboxId", controllers.RemoveDestroyed)
+		sandboxController.POST("/:sandboxId/network-settings", controllers.UpdateNetworkSettings)
 
 		// Add proxy endpoint within the sandbox controller for toolbox
 		// Using Any() to handle all HTTP methods for the toolbox proxy


### PR DESCRIPTION
# Register Update Network Settings Route

## Description

The update network settings route was missing from the runner api server.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
