### PR TITLE
feat(docs): custom preview proxy page

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
         github: 'https://github.com/daytonaio',
       },
       editLink: {
-        baseUrl: 'https://github.com/daytonaio/docs/blob/main/',
+        baseUrl: 'https://github.com/daytonaio/daytona/blob/main/apps/docs/',
       },
       tableOfContents: { minHeadingLevel: 2, maxHeadingLevel: 4 },
       customCss: ['./src/fonts/font-face.css', './src/styles/style.scss'],

--- a/apps/docs/src/assets/sidebar/proxy-link.svg
+++ b/apps/docs/src/assets/sidebar/proxy-link.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+  class="lucide lucide-link-icon lucide-link">
+  <path style="fill: none !important"
+    d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+  <path style="fill: none !important"
+    d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+</svg>

--- a/apps/docs/src/content/config.ts
+++ b/apps/docs/src/content/config.ts
@@ -298,6 +298,15 @@ export const getSidebarConfig = (
         },
         {
           type: 'link',
+          href: localizePath('/docs/custom-preview-proxy', locale),
+          label: labels['sidebarconfig.customPreviewProxy'],
+          description: labels['sidebarconfig.customPreviewProxyDescription'],
+          attrs: {
+            icon: 'proxy-link.svg',
+          },
+        },
+        {
+          type: 'link',
           href: '/docs/audit-logs',
           label: labels['sidebarconfig.auditLogs'],
           description: labels['sidebarconfig.auditLogsDescription'],

--- a/apps/docs/src/content/docs/en/custom-preview-proxy.mdx
+++ b/apps/docs/src/content/docs/en/custom-preview-proxy.mdx
@@ -1,0 +1,68 @@
+---
+title: Custom Preview Proxy
+description: Customize the preview proxy with your own domain and logic.
+---
+
+Daytona allows you to deploy your own custom preview proxy to handle preview URLs for sandboxes. This gives you complete control over the preview experience, including custom domains, authentication, error handling, and styling.
+
+**What you can do with a custom preview proxy:**
+
+- **Custom Domain:** Host your proxy under your own domain (e.g., `preview.yourcompany.com`)
+- **User Authentication:** Implement custom authentication logic for private previews
+- **Smart Sandbox Management:** Automatically start stopped sandboxes before forwarding users
+- **Custom Error Pages:** Style error pages to match your brand
+- **Preview Warning Control:** Disable Daytona's preview warning to prevent abuse
+- **CORS Management:** Override Daytona's default CORS settings
+
+---
+
+## How It Works
+
+When a user visits a preview URL, your custom proxy receives the request and can:
+
+1. **Authenticate the user** using custom logic
+2. **Check sandbox status** and start it if needed
+3. **Forward the request** to the actual sandbox
+4. **Handle responses** with custom styling and error pages
+5. **Send custom headers** to control Daytona's behavior
+
+---
+
+## Daytona Headers
+
+Your proxy can send special headers to control Daytona's behavior:
+
+#### Disable Preview Warning
+
+To disable Daytona's preview warning page, send:
+
+```
+X-Daytona-Skip-Preview-Warning: true
+```
+
+#### Disable CORS
+
+To override Daytona's default CORS settings, send:
+
+```
+X-Daytona-Disable-CORS: true
+```
+
+#### Authentication
+
+For private preview links, users should send:
+
+```
+X-Daytona-Preview-Token: {sandboxToken}
+```
+
+The `sandboxToken` can be fetched through the [Daytona SDK or API](/docs/en/preview-and-authentication).
+
+---
+
+## Examples
+
+You can find examples of custom preview proxies on our [Github](https://github.com/daytonaio/daytona-proxy-samples):
+
+- [Typescript Example](https://github.com/daytonaio/daytona-proxy-samples/tree/main/typescript)
+- [Golang Example](https://github.com/daytonaio/daytona-proxy-samples/tree/main/go)

--- a/apps/docs/src/content/docs/en/custom-preview-proxy.mdx
+++ b/apps/docs/src/content/docs/en/custom-preview-proxy.mdx
@@ -11,7 +11,7 @@ Daytona allows you to deploy your own custom preview proxy to handle preview URL
 - **User Authentication:** Implement custom authentication logic for private previews
 - **Smart Sandbox Management:** Automatically start stopped sandboxes before forwarding users
 - **Custom Error Pages:** Style error pages to match your brand
-- **Preview Warning Control:** Disable Daytona's preview warning to prevent abuse
+- **Preview Warning Control:** Disable Daytona's preview warning
 - **CORS Management:** Override Daytona's default CORS settings
 
 ---

--- a/apps/docs/src/content/i18n/en.json
+++ b/apps/docs/src/content/i18n/en.json
@@ -69,6 +69,8 @@
   "sidebarconfig.webTerminalDescription": "Web Terminal access to Daytona Sandboxes.",
   "sidebarconfig.previewAuthentication": "Preview & Authentication",
   "sidebarconfig.previewAuthenticationDescription": "Preview URLs and authentication tokens.",
+  "sidebarconfig.customPreviewProxy": "Custom Preview Proxy",
+  "sidebarconfig.customPreviewProxyDescription": "Customize the preview proxy with your own domain and logic.",
   "sidebarconfig.auditLogs": "Audit Logs",
   "sidebarconfig.auditLogsDescription": "Monitor and track activities across your Daytona organization.",
   "sidebarconfig.regions": "Regions",


### PR DESCRIPTION
# Custom Preview Proxy Page

## Description

Added a custom preview proxy page to the docs that elaborates on what a custom proxy can do and to point to example implementations.
