### PR TITLE
fix(runner): decode base64 ssh public key

### DIFF
--- a/apps/runner/pkg/sshgateway/config.go
+++ b/apps/runner/pkg/sshgateway/config.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"os"
@@ -37,12 +38,19 @@ func GetSSHGatewayPort() int {
 
 // GetSSHPublicKey returns the SSH public key from configuration
 // Get ssh public key of ssh gateway - external ssh gateway, not runner ssh gateway
+// Should be base64 encoded
 func GetSSHPublicKey() (string, error) {
 	publicKey := os.Getenv("SSH_PUBLIC_KEY")
 	if publicKey == "" {
 		return "", fmt.Errorf("SSH_PUBLIC_KEY environment variable not set")
 	}
-	return publicKey, nil
+
+	decodedKey, err := base64.StdEncoding.DecodeString(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to base64 decode SSH_PUBLIC_KEY: %w", err)
+	}
+
+	return string(decodedKey), nil
 }
 
 // GetSSHHostKeyPath returns the SSH host key path from configuration


### PR DESCRIPTION
# Decode Base64 SSH Public Key

## Description

SSH_PUBLIC_KEY should be base64 encoded for easier management.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation