### PR TITLE
feat(sdk,docs): ephemeral sandboxes

### DIFF
--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -6,7 +6,7 @@
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { In, IsNull, LessThan, Not, Or, Repository } from 'typeorm'
+import { In, IsNull, LessThan, MoreThan, Not, Or, Repository } from 'typeorm'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { RunnerService } from '../services/runner.service'
@@ -88,6 +88,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
               state: SandboxState.STARTED,
               backupState: In([BackupState.NONE, BackupState.COMPLETED]),
               lastBackupAt: Or(IsNull(), LessThan(new Date(Date.now() - 1 * 60 * 60 * 1000))),
+              autoDeleteInterval: MoreThan(0),
             },
             order: {
               lastBackupAt: 'ASC',

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -6,7 +6,7 @@
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { In, IsNull, LessThan, MoreThan, Not, Or, Repository } from 'typeorm'
+import { In, IsNull, LessThan, Not, Or, Repository } from 'typeorm'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { RunnerService } from '../services/runner.service'
@@ -88,7 +88,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
               state: SandboxState.STARTED,
               backupState: In([BackupState.NONE, BackupState.COMPLETED]),
               lastBackupAt: Or(IsNull(), LessThan(new Date(Date.now() - 1 * 60 * 60 * 1000))),
-              autoDeleteInterval: MoreThan(0),
+              autoDeleteInterval: Not(0),
             },
             order: {
               lastBackupAt: 'ASC',

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -522,6 +522,10 @@ export class SandboxService {
       throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
     }
 
+    if (sandbox.autoDeleteInterval === 0) {
+      throw new SandboxError('Ephemeral sandboxes cannot be backed up')
+    }
+
     if (![BackupState.COMPLETED, BackupState.NONE].includes(sandbox.backupState)) {
       throw new SandboxError('Sandbox backup is already in progress')
     }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -172,6 +172,11 @@ export class SandboxService {
     if (sandbox.pending) {
       throw new SandboxError('Sandbox state change in progress')
     }
+
+    if (sandbox.autoDeleteInterval === 0) {
+      throw new SandboxError('Ephemeral sandboxes cannot be archived')
+    }
+
     sandbox.state = SandboxState.ARCHIVING
     sandbox.desiredState = SandboxDesiredState.ARCHIVED
     await this.sandboxRepository.save(sandbox)

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
@@ -476,6 +476,7 @@ Base parameters for creating a new Sandbox.
 - `volumes` _Optional[List[VolumeMount]]_ - List of volumes mounts to attach to the Sandbox.
 - `network_block_all` _Optional[bool]_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _Optional[str]_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
+- `ephemeral` _Optional[bool]_ - Whether the Sandbox should be ephemeral. If True, auto_delete_interval will be set to 0.
 
 ## CreateSandboxFromImageParams
 

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
@@ -272,6 +272,7 @@ async def wait_for_sandbox_stop(timeout: Optional[float] = 60) -> None
 Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
 reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
 for the Sandbox to stop.
+Treats destroyed as stopped to cover ephemeral sandboxes that are automatically deleted after stopping.
 
 **Arguments**:
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
@@ -426,6 +426,7 @@ Base parameters for creating a new Sandbox.
 - `volumes` _Optional[List[VolumeMount]]_ - List of volumes mounts to attach to the Sandbox.
 - `network_block_all` _Optional[bool]_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _Optional[str]_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
+- `ephemeral` _Optional[bool]_ - Whether the Sandbox should be ephemeral. If True, auto_delete_interval will be set to 0.
 
 ## CreateSandboxFromImageParams
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
@@ -272,6 +272,7 @@ def wait_for_sandbox_stop(timeout: Optional[float] = 60) -> None
 Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
 reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
 for the Sandbox to stop.
+Treats destroyed as stopped to cover ephemeral sandboxes that are automatically deleted after stopping.
 
 **Arguments**:
 

--- a/apps/docs/src/content/docs/en/sandbox-management.mdx
+++ b/apps/docs/src/content/docs/en/sandbox-management.mdx
@@ -159,7 +159,8 @@ To create an ephemeral Sandbox, set `ephemeral` to `True` when creating a Sandbo
     # Create an ephemeral Sandbox
 
     params = CreateSandboxFromSnapshotParams(
-      ephemeral=True
+      ephemeral=True,
+      auto_stop_interval=5 # the ephemeral sandbox will be deleted after 5 minutes of inactivity
     )
     sandbox = daytona.create(params)
     ```
@@ -174,7 +175,8 @@ To create an ephemeral Sandbox, set `ephemeral` to `True` when creating a Sandbo
 
     // Create an ephemeral Sandbox
     const sandbox = await daytona.create({
-      ephemeral: true
+      ephemeral: true,
+      autoStopInterval: 5 // the ephemeral sandbox will be deleted after 5 minutes of inactivity
     });
     ```
 

--- a/apps/docs/src/content/docs/en/sandbox-management.mdx
+++ b/apps/docs/src/content/docs/en/sandbox-management.mdx
@@ -145,7 +145,7 @@ All resource parameters are optional. If not specified, Daytona will use default
 
 ### Ephemeral Sandboxes
 
-Ephemeral Sandboxes are Sandboxes that are automatically deleted after a period of inactivity. They are useful for short-lived tasks or for testing purposes.
+Ephemeral Sandboxes are Sandboxes that are automatically deleted once they are stopped. They are useful for short-lived tasks or for testing purposes.
 
 To create an ephemeral Sandbox, set `ephemeral` to `True` when creating a Sandbox:
 

--- a/apps/docs/src/content/docs/en/sandbox-management.mdx
+++ b/apps/docs/src/content/docs/en/sandbox-management.mdx
@@ -52,6 +52,7 @@ The Daytona SDK provides methods to create Sandboxes with default configurations
     sandbox = daytona.create(params)
 
     ```
+
   </TabItem>
 
   <TabItem label="TypeScript" icon="seti:typescript">
@@ -69,6 +70,7 @@ The Daytona SDK provides methods to create Sandboxes with default configurations
     // Create a Sandbox with custom labels
     const sandbox = await daytona.create({ labels: { SOME_LABEL: 'my-label' } });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -110,6 +112,7 @@ Check your available resources and limits in the [dashboard](https://app.daytona
     sandbox = daytona.create(params)
 
     ```
+
   </TabItem>
 
   <TabItem label="TypeScript" icon="seti:typescript">
@@ -132,11 +135,54 @@ Check your available resources and limits in the [dashboard](https://app.daytona
 
     main();
     ```
+
   </TabItem>
 </Tabs>
 
 :::note
 All resource parameters are optional. If not specified, Daytona will use default values appropriate for the selected language and use case.
+:::
+
+### Ephemeral Sandboxes
+
+Ephemeral Sandboxes are Sandboxes that are automatically deleted after a period of inactivity. They are useful for short-lived tasks or for testing purposes.
+
+To create an ephemeral Sandbox, set `ephemeral` to `True` when creating a Sandbox:
+
+<Tabs>
+  <TabItem label="Python" icon="seti:python">
+    ```python
+    from daytona import Daytona, CreateSandboxFromSnapshotParams
+
+    daytona = Daytona()
+
+    # Create an ephemeral Sandbox
+
+    params = CreateSandboxFromSnapshotParams(
+      ephemeral=True
+    )
+    sandbox = daytona.create(params)
+    ```
+
+  </TabItem>
+
+  <TabItem label="TypeScript" icon="seti:typescript">
+    ```typescript
+    import { Daytona } from '@daytonaio/sdk';
+
+    const daytona = new Daytona();
+
+    // Create an ephemeral Sandbox
+    const sandbox = await daytona.create({
+      ephemeral: true
+    });
+    ```
+
+  </TabItem>
+</Tabs>
+
+:::note
+Setting ["autoDeleteInterval: 0"](#auto-delete-interval) has the same effect as setting "ephemeral" to `true`.
 :::
 
 ### Network Settings (Firewall)
@@ -168,6 +214,7 @@ Daytona Sandboxes provide configurable network firewall controls to enhance secu
     sandbox = daytona.create(params)
 
     ```
+
   </TabItem>
 
   <TabItem label="TypeScript" icon="seti:typescript">
@@ -186,6 +233,7 @@ Daytona Sandboxes provide configurable network firewall controls to enhance secu
       networkAllowList: '192.168.1.0/16,10.0.0.0/24'
     });
     ```
+
   </TabItem>
 </Tabs>
 
@@ -215,6 +263,7 @@ The Daytona SDK provides methods to get information about a Sandbox, such as ID,
     print(sandbox.state)
 
     ```
+
   </TabItem>
 
   <TabItem label="TypeScript" icon="seti:typescript">
@@ -230,6 +279,7 @@ The Daytona SDK provides methods to get information about a Sandbox, such as ID,
     console.log(sandbox.autoStopInterval)
     console.log(sandbox.state)
     ```
+
   </TabItem>
 </Tabs>
 
@@ -261,6 +311,7 @@ Stopped Sandboxes maintain filesystem persistence while their memory state is cl
     sandbox.start()
 
     ```
+
   </TabItem>
 
   <TabItem label="TypeScript" icon="seti:typescript">
@@ -279,6 +330,7 @@ Stopped Sandboxes maintain filesystem persistence while their memory state is cl
     // Start Sandbox
     await sandbox.start();
     ```
+
   </TabItem>
 </Tabs>
 
@@ -455,6 +507,7 @@ If the parameter is not set, the Sandbox will not be deleted automatically.
     sandbox.set_auto_delete_interval(-1)
 
     ```
+
   </TabItem>
 
   <TabItem label="TypeScript" icon="seti:typescript">
@@ -470,6 +523,7 @@ If the parameter is not set, the Sandbox will not be deleted automatically.
     // Disable auto-deletion
     await sandbox.setAutoDeleteInterval(-1)
     ```
+
   </TabItem>
 </Tabs>
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
@@ -341,6 +341,7 @@ Base parameters for creating a new Sandbox.
 - `autoDeleteInterval?` _number_ - Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping). By default, auto-delete is disabled.
 - `autoStopInterval?` _number_ - Auto-stop interval in minutes (0 means disabled). Default is 15 minutes.
 - `envVars?` _Record\<string, string\>_ - Optional environment variables to set in the Sandbox
+- `ephemeral?` _boolean_ - Whether the Sandbox should be ephemeral. If true, autoDeleteInterval will be set to 0.
 - `labels?` _Record\<string, string\>_ - Sandbox labels
 - `language?` _string_ - Programming language for direct code execution
 - `networkAllowList?` _string_ - Comma-separated list of allowed CIDR network addresses for the Sandbox
@@ -358,6 +359,7 @@ Parameters for creating a new Sandbox.
 - `autoDeleteInterval?` _number_
 - `autoStopInterval?` _number_
 - `envVars?` _Record\<string, string\>_
+- `ephemeral?` _boolean_
 - `image` _string \| Image_ - Custom Docker image to use for the Sandbox. If an Image object is provided,
     the image will be dynamically built.
 - `labels?` _Record\<string, string\>_
@@ -379,6 +381,7 @@ Parameters for creating a new Sandbox from a snapshot.
 - `autoDeleteInterval?` _number_
 - `autoStopInterval?` _number_
 - `envVars?` _Record\<string, string\>_
+- `ephemeral?` _boolean_
 - `labels?` _Record\<string, string\>_
 - `language?` _string_
 - `networkAllowList?` _string_

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -307,6 +307,7 @@ class AsyncSandbox(SandboxDto):
         """Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
         reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
         for the Sandbox to stop.
+        Treats destroyed as stopped to cover ephemeral sandboxes that are automatically deleted after stopping.
 
         Args:
             timeout (Optional[float]): Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
@@ -314,7 +315,7 @@ class AsyncSandbox(SandboxDto):
         Raises:
             DaytonaError: If timeout is negative. If Sandbox fails to stop or times out.
         """
-        while self.state != "stopped":
+        while self.state not in ["stopped", "destroyed"]:
             try:
                 await self.refresh_data()
 

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -310,6 +310,7 @@ class Sandbox(SandboxDto):
         """Waits for the Sandbox to reach the 'stopped' state. Polls the Sandbox status until it
         reaches the 'stopped' state, encounters an error or times out. It will wait up to 60 seconds
         for the Sandbox to stop.
+        Treats destroyed as stopped to cover ephemeral sandboxes that are automatically deleted after stopping.
 
         Args:
             timeout (Optional[float]): Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
@@ -317,7 +318,7 @@ class Sandbox(SandboxDto):
         Raises:
             DaytonaError: If timeout is negative. If Sandbox fails to stop or times out.
         """
-        while self.state != "stopped":
+        while self.state not in ["stopped", "destroyed"]:
             try:
                 self.refresh_data()
 

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -128,6 +128,7 @@ export interface Resources {
  * @property {VolumeMount[]} [volumes] - Optional array of volumes to mount to the Sandbox
  * @property {boolean} [networkBlockAll] - Whether to block all network access for the Sandbox
  * @property {string} [networkAllowList] - Comma-separated list of allowed CIDR network addresses for the Sandbox
+ * @property {boolean} [ephemeral] - Whether the Sandbox should be ephemeral. If true, autoDeleteInterval will be set to 0.
  */
 export type CreateSandboxBaseParams = {
   user?: string
@@ -141,6 +142,7 @@ export type CreateSandboxBaseParams = {
   volumes?: VolumeMount[]
   networkBlockAll?: boolean
   networkAllowList?: string
+  ephemeral?: boolean
 }
 
 /**
@@ -417,6 +419,15 @@ export class Daytona {
       (!Number.isInteger(params.autoStopInterval) || params.autoStopInterval < 0)
     ) {
       throw new DaytonaError('autoStopInterval must be a non-negative integer')
+    }
+
+    if (params.ephemeral) {
+      if (params.autoDeleteInterval !== undefined && params.autoDeleteInterval !== 0) {
+        console.warn(
+          "'ephemeral' and 'autoDeleteInterval' cannot be used together. If ephemeral is true, autoDeleteInterval will be ignored and set to 0.",
+        )
+      }
+      params.autoDeleteInterval = 0
     }
 
     if (

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -311,11 +311,12 @@ export class Sandbox implements SandboxDto {
     const checkInterval = 100 // Wait 100 ms between checks
     const startTime = Date.now()
 
-    while (this.state !== 'stopped') {
+    // Treat destroyed as stopped to cover ephemeral sandboxes that are automatically deleted after stopping
+    while (this.state !== 'stopped' && this.state !== 'destroyed') {
       await this.refreshData()
 
       // @ts-expect-error this.refreshData() can modify this.state so this check is fine
-      if (this.state === 'stopped') {
+      if (this.state === 'stopped' || this.state === 'destroyed') {
         return
       }
 


### PR DESCRIPTION
# Ephemeral Sandbox SDK Support

## Description

Added an `ephemeral` param when creating a sandbox.
The parameter sets the `autoDeleteInterval` to 0 on the API.

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Screenshots
<img width="689" height="604" alt="Screenshot 2025-09-02 at 14 26 13" src="https://github.com/user-attachments/assets/cf9fd8e0-3e7c-43e8-86f8-3c99d024bade" />

