### PR TITLE
refactor(api,dashboard): org owners can manage all api keys within organization

### DIFF
--- a/apps/api/src/api-key/api-key.service.ts
+++ b/apps/api/src/api-key/api-key.service.ts
@@ -70,7 +70,7 @@ export class ApiKeyService {
     return { apiKey, value }
   }
 
-  async getApiKeys(organizationId: string, userId: string): Promise<ApiKey[]> {
+  async getApiKeys(organizationId: string, userId?: string): Promise<ApiKey[]> {
     const apiKeys = await this.apiKeyRepository.find({
       where: { organizationId, userId },
       order: {
@@ -82,17 +82,50 @@ export class ApiKeyService {
       },
     })
 
-    const organizationUser = await this.organizationUserService.findOne(organizationId, userId)
-    if (!organizationUser) {
-      throw new NotFoundException('Organization user (API key owner) not found')
+    if (apiKeys.length === 0) {
+      return []
     }
 
-    return apiKeys.map((apiKey) => {
-      return {
-        ...apiKey,
-        permissions: this.getEffectivePermissions(apiKey, organizationUser),
+    if (userId) {
+      // We need to fetch who created the API keys to calculate their effective permissions (e.g. a permission was unassigned from user after they already created an API key with that permission)
+      const organizationUser = await this.organizationUserService.findOne(organizationId, userId)
+      if (!organizationUser) {
+        throw new NotFoundException('Organization user (API key owner) not found')
       }
-    })
+
+      return apiKeys.map((apiKey) => {
+        return {
+          ...apiKey,
+          permissions: this.getEffectivePermissions(apiKey, organizationUser),
+        }
+      })
+    }
+
+    // We are fetching all API keys for the organization, use a map to avoid repeated database calls for the same user
+    const organizationUserCache = new Map<string, OrganizationUser | null>()
+
+    return await Promise.all(
+      apiKeys.map(async (apiKey) => {
+        let organizationUser = organizationUserCache.get(apiKey.userId)
+
+        if (organizationUser === undefined) {
+          // User not in cache, fetch from database
+          organizationUser = await this.organizationUserService.findOne(apiKey.organizationId, apiKey.userId)
+          organizationUserCache.set(apiKey.userId, organizationUser)
+        }
+
+        if (!organizationUser) {
+          // If organization user is not found, return the API key with original permissions
+          // This could happen if the user was removed from the organization but API key remains
+          return apiKey
+        }
+
+        return {
+          ...apiKey,
+          permissions: this.getEffectivePermissions(apiKey, organizationUser),
+        }
+      }),
+    )
   }
 
   async getApiKeyByName(organizationId: string, userId: string, name: string): Promise<ApiKey> {

--- a/apps/api/src/api-key/dto/api-key-list.dto.ts
+++ b/apps/api/src/api-key/dto/api-key-list.dto.ts
@@ -48,6 +48,12 @@ export class ApiKeyListDto {
   })
   expiresAt?: Date
 
+  @ApiProperty({
+    description: 'The user ID of the user who created the API key',
+    example: '123',
+  })
+  userId: string
+
   constructor(partial: Partial<ApiKeyListDto>) {
     Object.assign(this, partial)
   }
@@ -62,6 +68,7 @@ export class ApiKeyListDto {
       permissions: apiKey.permissions,
       lastUsedAt: apiKey.lastUsedAt,
       expiresAt: apiKey.expiresAt,
+      userId: apiKey.userId,
     })
   }
 }

--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -36,13 +36,13 @@ import { TableEmptyState } from './TableEmptyState'
 interface DataTableProps {
   data: ApiKeyList[]
   loading: boolean
-  loadingKeys: Record<string, boolean>
-  onRevoke: (keyName: string) => void
+  isLoadingKey: (key: ApiKeyList) => boolean
+  onRevoke: (key: ApiKeyList) => void
 }
 
-export function ApiKeyTable({ data, loading, loadingKeys, onRevoke }: DataTableProps) {
+export function ApiKeyTable({ data, loading, isLoadingKey, onRevoke }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
-  const columns = getColumns({ onRevoke, loadingKeys })
+  const columns = getColumns({ onRevoke, isLoadingKey })
   const table = useReactTable({
     data,
     columns,
@@ -89,7 +89,7 @@ export function ApiKeyTable({ data, loading, loadingKeys, onRevoke }: DataTableP
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && 'selected'}
-                  className={`${loadingKeys[row.original.name] ? 'opacity-50 pointer-events-none' : ''}`}
+                  className={`${isLoadingKey(row.original) ? 'opacity-50 pointer-events-none' : ''}`}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell className="px-2" key={cell.id}>
@@ -156,10 +156,10 @@ const getExpiresAtColor = (expiresAt: Date | null) => {
 
 const getColumns = ({
   onRevoke,
-  loadingKeys,
+  isLoadingKey,
 }: {
-  onRevoke: (keyName: string) => void
-  loadingKeys: Record<string, boolean>
+  onRevoke: (key: ApiKeyList) => void
+  isLoadingKey: (key: ApiKeyList) => boolean
 }): ColumnDef<ApiKeyList>[] => {
   const columns: ColumnDef<ApiKeyList>[] = [
     {
@@ -276,7 +276,7 @@ const getColumns = ({
         return <div className="px-4">Actions</div>
       },
       cell: ({ row }) => {
-        const isLoading = loadingKeys[row.original.name]
+        const isLoading = isLoadingKey(row.original)
 
         return (
           <Dialog>
@@ -299,7 +299,7 @@ const getColumns = ({
                   </Button>
                 </DialogClose>
                 <DialogClose asChild>
-                  <Button variant="destructive" onClick={() => onRevoke(row.original.name)}>
+                  <Button variant="destructive" onClick={() => onRevoke(row.original)}>
                     Revoke
                   </Button>
                 </DialogClose>

--- a/apps/dashboard/src/pages/Keys.tsx
+++ b/apps/dashboard/src/pages/Keys.tsx
@@ -59,16 +59,17 @@ const Keys: React.FC = () => {
     fetchKeys()
   }, [fetchKeys])
 
-  const handleRevoke = async (keyName: string) => {
-    setLoadingKeys((prev) => ({ ...prev, [keyName]: true }))
+  const handleRevoke = async (key: ApiKeyList) => {
+    const loadingId = getLoadingKeyId(key)
+    setLoadingKeys((prev) => ({ ...prev, [loadingId]: true }))
     try {
-      await apiKeyApi.deleteApiKey(keyName, selectedOrganization?.id)
+      await apiKeyApi.deleteApiKeyForUser(key.userId, key.name, selectedOrganization?.id)
       toast.success('API key revoked successfully')
       await fetchKeys(false)
     } catch (error) {
       handleApiError(error, 'Failed to revoke API key')
     } finally {
-      setLoadingKeys((prev) => ({ ...prev, [keyName]: false }))
+      setLoadingKeys((prev) => ({ ...prev, [loadingId]: false }))
     }
   }
 
@@ -88,6 +89,18 @@ const Keys: React.FC = () => {
     }
   }
 
+  const getLoadingKeyId = useCallback((key: ApiKeyList) => {
+    return `${key.userId}-${key.name}`
+  }, [])
+
+  const isLoadingKey = useCallback(
+    (key: ApiKeyList) => {
+      const loadingId = getLoadingKeyId(key)
+      return loadingKeys[loadingId]
+    },
+    [getLoadingKeyId, loadingKeys],
+  )
+
   return (
     <div className="px-6 py-2">
       <div className="mb-2 h-12 flex items-center justify-between">
@@ -95,7 +108,7 @@ const Keys: React.FC = () => {
         <CreateApiKeyDialog availablePermissions={availablePermissions} onCreateApiKey={handleCreateKey} />
       </div>
 
-      <ApiKeyTable data={keys} loading={loading} loadingKeys={loadingKeys} onRevoke={handleRevoke} />
+      <ApiKeyTable data={keys} loading={loading} isLoadingKey={isLoadingKey} onRevoke={handleRevoke} />
     </div>
   )
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -168,6 +168,44 @@ paths:
       summary: Get API key
       tags:
         - api-keys
+  /api-keys/{userId}/{name}:
+    delete:
+      operationId: deleteApiKeyForUser
+      parameters:
+        - description: Use with JWT to specify the organization ID
+          explode: false
+          in: header
+          name: X-Daytona-Organization-ID
+          required: false
+          schema:
+            type: string
+          style: simple
+        - explode: false
+          in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+          style: simple
+        - explode: false
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+          style: simple
+      responses:
+        '204':
+          description: API key deleted successfully.
+      security:
+        - bearer: []
+        - oauth2:
+            - openid
+            - profile
+            - email
+      summary: Delete API key for user
+      tags:
+        - api-keys
   /organizations/invitations:
     get:
       operationId: listOrganizationInvitationsForAuthenticatedUser
@@ -6439,6 +6477,7 @@ components:
           - write:registries
         name: My API Key
         value: bb_********************def
+        userId: '123'
         expiresAt: 2024-03-14T12:00:00Z
       properties:
         name:
@@ -6483,12 +6522,17 @@ components:
           format: date-time
           nullable: true
           type: string
+        userId:
+          description: The user ID of the user who created the API key
+          example: '123'
+          type: string
       required:
         - createdAt
         - expiresAt
         - lastUsedAt
         - name
         - permissions
+        - userId
         - value
       type: object
     OrganizationRole:

--- a/libs/api-client-go/api_api_keys.go
+++ b/libs/api-client-go/api_api_keys.go
@@ -47,6 +47,19 @@ type ApiKeysAPI interface {
 	DeleteApiKeyExecute(r ApiKeysAPIDeleteApiKeyRequest) (*http.Response, error)
 
 	/*
+		DeleteApiKeyForUser Delete API key for user
+
+		@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		@param userId
+		@param name
+		@return ApiKeysAPIDeleteApiKeyForUserRequest
+	*/
+	DeleteApiKeyForUser(ctx context.Context, userId string, name string) ApiKeysAPIDeleteApiKeyForUserRequest
+
+	// DeleteApiKeyForUserExecute executes the request
+	DeleteApiKeyForUserExecute(r ApiKeysAPIDeleteApiKeyForUserRequest) (*http.Response, error)
+
+	/*
 		GetApiKey Get API key
 
 		@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -252,6 +265,110 @@ func (a *ApiKeysAPIService) DeleteApiKeyExecute(r ApiKeysAPIDeleteApiKeyRequest)
 	}
 
 	localVarPath := localBasePath + "/api-keys/{name}"
+	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", url.PathEscape(parameterValueToString(r.name, "name")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.xDaytonaOrganizationID != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "X-Daytona-Organization-ID", r.xDaytonaOrganizationID, "simple", "")
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+type ApiKeysAPIDeleteApiKeyForUserRequest struct {
+	ctx                    context.Context
+	ApiService             ApiKeysAPI
+	userId                 string
+	name                   string
+	xDaytonaOrganizationID *string
+}
+
+// Use with JWT to specify the organization ID
+func (r ApiKeysAPIDeleteApiKeyForUserRequest) XDaytonaOrganizationID(xDaytonaOrganizationID string) ApiKeysAPIDeleteApiKeyForUserRequest {
+	r.xDaytonaOrganizationID = &xDaytonaOrganizationID
+	return r
+}
+
+func (r ApiKeysAPIDeleteApiKeyForUserRequest) Execute() (*http.Response, error) {
+	return r.ApiService.DeleteApiKeyForUserExecute(r)
+}
+
+/*
+DeleteApiKeyForUser Delete API key for user
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param userId
+	@param name
+	@return ApiKeysAPIDeleteApiKeyForUserRequest
+*/
+func (a *ApiKeysAPIService) DeleteApiKeyForUser(ctx context.Context, userId string, name string) ApiKeysAPIDeleteApiKeyForUserRequest {
+	return ApiKeysAPIDeleteApiKeyForUserRequest{
+		ApiService: a,
+		ctx:        ctx,
+		userId:     userId,
+		name:       name,
+	}
+}
+
+// Execute executes the request
+func (a *ApiKeysAPIService) DeleteApiKeyForUserExecute(r ApiKeysAPIDeleteApiKeyForUserRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod = http.MethodDelete
+		localVarPostBody   interface{}
+		formFiles          []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ApiKeysAPIService.DeleteApiKeyForUser")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api-keys/{userId}/{name}"
+	localVarPath = strings.Replace(localVarPath, "{"+"userId"+"}", url.PathEscape(parameterValueToString(r.userId, "userId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"name"+"}", url.PathEscape(parameterValueToString(r.name, "name")), -1)
 
 	localVarHeaderParams := make(map[string]string)

--- a/libs/api-client-go/model_api_key_list.go
+++ b/libs/api-client-go/model_api_key_list.go
@@ -35,6 +35,8 @@ type ApiKeyList struct {
 	LastUsedAt NullableTime `json:"lastUsedAt"`
 	// When the API key expires
 	ExpiresAt NullableTime `json:"expiresAt"`
+	// The user ID of the user who created the API key
+	UserId string `json:"userId"`
 }
 
 type _ApiKeyList ApiKeyList
@@ -43,7 +45,7 @@ type _ApiKeyList ApiKeyList
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewApiKeyList(name string, value string, createdAt time.Time, permissions []string, lastUsedAt NullableTime, expiresAt NullableTime) *ApiKeyList {
+func NewApiKeyList(name string, value string, createdAt time.Time, permissions []string, lastUsedAt NullableTime, expiresAt NullableTime, userId string) *ApiKeyList {
 	this := ApiKeyList{}
 	this.Name = name
 	this.Value = value
@@ -51,6 +53,7 @@ func NewApiKeyList(name string, value string, createdAt time.Time, permissions [
 	this.Permissions = permissions
 	this.LastUsedAt = lastUsedAt
 	this.ExpiresAt = expiresAt
+	this.UserId = userId
 	return &this
 }
 
@@ -210,6 +213,30 @@ func (o *ApiKeyList) SetExpiresAt(v time.Time) {
 	o.ExpiresAt.Set(&v)
 }
 
+// GetUserId returns the UserId field value
+func (o *ApiKeyList) GetUserId() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.UserId
+}
+
+// GetUserIdOk returns a tuple with the UserId field value
+// and a boolean to check if the value has been set.
+func (o *ApiKeyList) GetUserIdOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.UserId, true
+}
+
+// SetUserId sets field value
+func (o *ApiKeyList) SetUserId(v string) {
+	o.UserId = v
+}
+
 func (o ApiKeyList) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -226,6 +253,7 @@ func (o ApiKeyList) ToMap() (map[string]interface{}, error) {
 	toSerialize["permissions"] = o.Permissions
 	toSerialize["lastUsedAt"] = o.LastUsedAt.Get()
 	toSerialize["expiresAt"] = o.ExpiresAt.Get()
+	toSerialize["userId"] = o.UserId
 	return toSerialize, nil
 }
 
@@ -240,6 +268,7 @@ func (o *ApiKeyList) UnmarshalJSON(data []byte) (err error) {
 		"permissions",
 		"lastUsedAt",
 		"expiresAt",
+		"userId",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-python-async/daytona_api_client_async/api/api_keys_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/api_keys_api.py
@@ -597,6 +597,288 @@ class ApiKeysApi:
 
 
     @validate_call
+    async def delete_api_key_for_user(
+        self,
+        user_id: StrictStr,
+        name: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> None:
+        """Delete API key for user
+
+
+        :param user_id: (required)
+        :type user_id: str
+        :param name: (required)
+        :type name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._delete_api_key_for_user_serialize(
+            user_id=user_id,
+            name=name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    async def delete_api_key_for_user_with_http_info(
+        self,
+        user_id: StrictStr,
+        name: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[None]:
+        """Delete API key for user
+
+
+        :param user_id: (required)
+        :type user_id: str
+        :param name: (required)
+        :type name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._delete_api_key_for_user_serialize(
+            user_id=user_id,
+            name=name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    async def delete_api_key_for_user_without_preload_content(
+        self,
+        user_id: StrictStr,
+        name: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Delete API key for user
+
+
+        :param user_id: (required)
+        :type user_id: str
+        :param name: (required)
+        :type name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._delete_api_key_for_user_serialize(
+            user_id=user_id,
+            name=name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _delete_api_key_for_user_serialize(
+        self,
+        user_id,
+        name,
+        x_daytona_organization_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if user_id is not None:
+            _path_params['userId'] = user_id
+        if name is not None:
+            _path_params['name'] = name
+        # process the query parameters
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='DELETE',
+            resource_path='/api-keys/{userId}/{name}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     async def get_api_key(
         self,
         name: StrictStr,

--- a/libs/api-client-python-async/daytona_api_client_async/models/api_key_list.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/api_key_list.py
@@ -34,8 +34,9 @@ class ApiKeyList(BaseModel):
     permissions: List[StrictStr] = Field(description="The list of organization resource permissions assigned to the API key")
     last_used_at: Optional[datetime] = Field(description="When the API key was last used", alias="lastUsedAt")
     expires_at: Optional[datetime] = Field(description="When the API key expires", alias="expiresAt")
+    user_id: StrictStr = Field(description="The user ID of the user who created the API key", alias="userId")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt", "expiresAt"]
+    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt", "expiresAt", "userId"]
 
     @field_validator('permissions')
     def permissions_validate_enum(cls, value):
@@ -118,7 +119,8 @@ class ApiKeyList(BaseModel):
             "createdAt": obj.get("createdAt"),
             "permissions": obj.get("permissions"),
             "lastUsedAt": obj.get("lastUsedAt"),
-            "expiresAt": obj.get("expiresAt")
+            "expiresAt": obj.get("expiresAt"),
+            "userId": obj.get("userId")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/api/api_keys_api.py
+++ b/libs/api-client-python/daytona_api_client/api/api_keys_api.py
@@ -597,6 +597,288 @@ class ApiKeysApi:
 
 
     @validate_call
+    def delete_api_key_for_user(
+        self,
+        user_id: StrictStr,
+        name: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> None:
+        """Delete API key for user
+
+
+        :param user_id: (required)
+        :type user_id: str
+        :param name: (required)
+        :type name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._delete_api_key_for_user_serialize(
+            user_id=user_id,
+            name=name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def delete_api_key_for_user_with_http_info(
+        self,
+        user_id: StrictStr,
+        name: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[None]:
+        """Delete API key for user
+
+
+        :param user_id: (required)
+        :type user_id: str
+        :param name: (required)
+        :type name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._delete_api_key_for_user_serialize(
+            user_id=user_id,
+            name=name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def delete_api_key_for_user_without_preload_content(
+        self,
+        user_id: StrictStr,
+        name: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Delete API key for user
+
+
+        :param user_id: (required)
+        :type user_id: str
+        :param name: (required)
+        :type name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._delete_api_key_for_user_serialize(
+            user_id=user_id,
+            name=name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _delete_api_key_for_user_serialize(
+        self,
+        user_id,
+        name,
+        x_daytona_organization_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if user_id is not None:
+            _path_params['userId'] = user_id
+        if name is not None:
+            _path_params['name'] = name
+        # process the query parameters
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='DELETE',
+            resource_path='/api-keys/{userId}/{name}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def get_api_key(
         self,
         name: StrictStr,

--- a/libs/api-client-python/daytona_api_client/models/api_key_list.py
+++ b/libs/api-client-python/daytona_api_client/models/api_key_list.py
@@ -34,8 +34,9 @@ class ApiKeyList(BaseModel):
     permissions: List[StrictStr] = Field(description="The list of organization resource permissions assigned to the API key")
     last_used_at: Optional[datetime] = Field(description="When the API key was last used", alias="lastUsedAt")
     expires_at: Optional[datetime] = Field(description="When the API key expires", alias="expiresAt")
+    user_id: StrictStr = Field(description="The user ID of the user who created the API key", alias="userId")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt", "expiresAt"]
+    __properties: ClassVar[List[str]] = ["name", "value", "createdAt", "permissions", "lastUsedAt", "expiresAt", "userId"]
 
     @field_validator('permissions')
     def permissions_validate_enum(cls, value):
@@ -118,7 +119,8 @@ class ApiKeyList(BaseModel):
             "createdAt": obj.get("createdAt"),
             "permissions": obj.get("permissions"),
             "lastUsedAt": obj.get("lastUsedAt"),
-            "expiresAt": obj.get("expiresAt")
+            "expiresAt": obj.get("expiresAt"),
+            "userId": obj.get("userId")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client/src/api/api-keys-api.ts
+++ b/libs/api-client/src/api/api-keys-api.ts
@@ -138,6 +138,57 @@ export const ApiKeysApiAxiosParamCreator = function (configuration?: Configurati
     },
     /**
      *
+     * @summary Delete API key for user
+     * @param {string} userId
+     * @param {string} name
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteApiKeyForUser: async (
+      userId: string,
+      name: string,
+      xDaytonaOrganizationID?: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'userId' is not null or undefined
+      assertParamExists('deleteApiKeyForUser', 'userId', userId)
+      // verify required parameter 'name' is not null or undefined
+      assertParamExists('deleteApiKeyForUser', 'name', name)
+      const localVarPath = `/api-keys/{userId}/{name}`
+        .replace(`{${'userId'}}`, encodeURIComponent(String(userId)))
+        .replace(`{${'name'}}`, encodeURIComponent(String(name)))
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication bearer required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+      // authentication oauth2 required
+
+      if (xDaytonaOrganizationID != null) {
+        localVarHeaderParameter['X-Daytona-Organization-ID'] = String(xDaytonaOrganizationID)
+      }
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     *
      * @summary Get API key
      * @param {string} name
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
@@ -326,6 +377,38 @@ export const ApiKeysApiFp = function (configuration?: Configuration) {
     },
     /**
      *
+     * @summary Delete API key for user
+     * @param {string} userId
+     * @param {string} name
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteApiKeyForUser(
+      userId: string,
+      name: string,
+      xDaytonaOrganizationID?: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteApiKeyForUser(
+        userId,
+        name,
+        xDaytonaOrganizationID,
+        options,
+      )
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap['ApiKeysApi.deleteApiKeyForUser']?.[localVarOperationServerIndex]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+    /**
+     *
      * @summary Get API key
      * @param {string} name
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
@@ -435,6 +518,25 @@ export const ApiKeysApiFactory = function (configuration?: Configuration, basePa
     },
     /**
      *
+     * @summary Delete API key for user
+     * @param {string} userId
+     * @param {string} name
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteApiKeyForUser(
+      userId: string,
+      name: string,
+      xDaytonaOrganizationID?: string,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<void> {
+      return localVarFp
+        .deleteApiKeyForUser(userId, name, xDaytonaOrganizationID, options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     *
      * @summary Get API key
      * @param {string} name
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
@@ -505,6 +607,27 @@ export class ApiKeysApi extends BaseAPI {
   public deleteApiKey(name: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
     return ApiKeysApiFp(this.configuration)
       .deleteApiKey(name, xDaytonaOrganizationID, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   *
+   * @summary Delete API key for user
+   * @param {string} userId
+   * @param {string} name
+   * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof ApiKeysApi
+   */
+  public deleteApiKeyForUser(
+    userId: string,
+    name: string,
+    xDaytonaOrganizationID?: string,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return ApiKeysApiFp(this.configuration)
+      .deleteApiKeyForUser(userId, name, xDaytonaOrganizationID, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/libs/api-client/src/models/api-key-list.ts
+++ b/libs/api-client/src/models/api-key-list.ts
@@ -54,6 +54,12 @@ export interface ApiKeyList {
    * @memberof ApiKeyList
    */
   expiresAt: Date | null
+  /**
+   * The user ID of the user who created the API key
+   * @type {string}
+   * @memberof ApiKeyList
+   */
+  userId: string
 }
 
 export const ApiKeyListPermissionsEnum = {


### PR DESCRIPTION
## Description

This PR introduces support for system admins and organization owners to manage (list, revoke) all keys  within an organization.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
