### PR TITLE
fix(proxy): browser detection

### DIFF
--- a/apps/proxy/pkg/proxy/warning_page.go
+++ b/apps/proxy/pkg/proxy/warning_page.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -296,7 +297,11 @@ func isBrowser(userAgent string) bool {
 	ua := useragent.New(userAgent)
 
 	browser, _ := ua.Browser()
-	return browser != ""
+	browser = strings.ToLower(browser)
+
+	browsers := []string{"chrome", "firefox", "safari", "edge", "opera", "brave", "vivaldi", "samsung", "opera"}
+
+	return slices.Contains(browsers, browser)
 }
 
 // hasAcceptedWarning checks if the user has already accepted the warning

--- a/apps/proxy/pkg/proxy/warning_page.go
+++ b/apps/proxy/pkg/proxy/warning_page.go
@@ -299,7 +299,7 @@ func isBrowser(userAgent string) bool {
 	browser, _ := ua.Browser()
 	browser = strings.ToLower(browser)
 
-	browsers := []string{"chrome", "firefox", "safari", "edge", "opera", "brave", "vivaldi", "samsung", "opera"}
+	browsers := []string{"chrome", "firefox", "safari", "edge", "brave", "vivaldi", "samsung", "opera"}
 
 	return slices.Contains(browsers, browser)
 }


### PR DESCRIPTION
# Fix Browser Detection

## Description

Added a list of browsers that should be detected.

Fixes an issue where client libraries (e.g. `axios` or `requests`) were detected as browsers.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
