### PR TITLE
docs(Readme): Fix TypeScript SDK example using non-existent remove method

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ async function main() {
   } catch (error) {
     console.error('Sandbox flow error:', error)
   } finally {
-    if (sandbox) await daytona.remove(sandbox)
+    if (sandbox) await daytona.delete(sandbox)
   }
 }
 


### PR DESCRIPTION
## Description

In the README’s TypeScript SDK example, daytona.remove(sandbox) is used, a non-existent method that throws errors.
This PR replaces it with daytona.delete(sandbox) so the example runs correctly.
Docs-only change.

- [ ] This change requires a documentation update
- [ x ] I have made corresponding changes to the documentation

Code reference
https://github.com/daytonaio/daytona/blob/main/README.md#L127