### PR TITLE
chore: update ghcr.io secret value

### DIFF
--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUBBOT_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and release devcontainer Multi-Platform
         uses: devcontainers/ci@v0.3
         env:


### PR DESCRIPTION
# Update ghcr.io secret value

## Description

Use GITHUB_TOKEN instead of GITHUBBOT_TOKEN

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
