### PR TITLE
fix(api): remove runner proxy fallback for old sandboxes

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -637,31 +637,25 @@ export class SandboxController {
       throw new BadRequestError('Invalid port')
     }
 
-    const proxyDomain = this.configService.get('proxy.domain')
-    const proxyProtocol = this.configService.get('proxy.protocol')
-    if (proxyDomain && proxyProtocol) {
-      const sandbox = await this.sandboxService.findOne(sandboxId)
-      if (!sandbox) {
-        throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
-      }
+    const proxyDomain = this.configService.getOrThrow('proxy.domain')
+    const proxyProtocol = this.configService.getOrThrow('proxy.protocol')
 
-      // Get runner info
-      const runner = await this.runnerService.findOne(sandbox.runnerId)
-      if (!runner) {
-        throw new NotFoundException(`Runner not found for sandbox ${sandboxId}`)
-      }
-
-      // Return new preview url only for updated sandboxes
-      if (sandbox.daemonVersion) {
-        return {
-          url: `${proxyProtocol}://${port}-${sandbox.id}.${proxyDomain}`,
-          legacyProxyUrl: `https://${port}-${sandbox.id}.${runner.domain}`,
-          token: sandbox.authToken,
-        }
-      }
+    const sandbox = await this.sandboxService.findOne(sandboxId)
+    if (!sandbox) {
+      throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
     }
 
-    return this.sandboxService.getPortPreviewUrl(sandboxId, port)
+    // Get runner info
+    const runner = await this.runnerService.findOne(sandbox.runnerId)
+    if (!runner) {
+      throw new NotFoundException(`Runner not found for sandbox ${sandboxId}`)
+    }
+
+    return {
+      url: `${proxyProtocol}://${port}-${sandbox.id}.${proxyDomain}`,
+      legacyProxyUrl: `https://${port}-${sandbox.id}.${runner.domain}`,
+      token: sandbox.authToken,
+    }
   }
 
   @Get(':sandboxId/build-logs')

--- a/apps/api/src/sandbox/controllers/workspace.deprecated.controller.ts
+++ b/apps/api/src/sandbox/controllers/workspace.deprecated.controller.ts
@@ -543,24 +543,17 @@ export class WorkspaceController {
       throw new BadRequestError('Invalid port')
     }
 
-    const proxyDomain = this.configService.get('proxy.domain')
-    const proxyProtocol = this.configService.get('proxy.protocol')
-    if (proxyDomain && proxyProtocol) {
-      const workspace = await this.workspaceService.findOne(workspaceId)
-      if (!workspace) {
-        throw new NotFoundException(`Workspace with ID ${workspaceId} not found`)
-      }
-
-      // Return new preview url only for updated workspaces/sandboxes
-      if (workspace.daemonVersion) {
-        return {
-          url: `${proxyProtocol}://${port}-${workspaceId}.${proxyDomain}`,
-          token: workspace.authToken,
-        }
-      }
+    const proxyDomain = this.configService.getOrThrow('proxy.domain')
+    const proxyProtocol = this.configService.getOrThrow('proxy.protocol')
+    const workspace = await this.workspaceService.findOne(workspaceId)
+    if (!workspace) {
+      throw new NotFoundException(`Workspace with ID ${workspaceId} not found`)
     }
 
-    return this.workspaceService.getPortPreviewUrl(workspaceId, port)
+    return {
+      url: `${proxyProtocol}://${port}-${workspaceId}.${proxyDomain}`,
+      token: workspace.authToken,
+    }
   }
 
   @Get(':workspaceId/build-logs')

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -587,36 +587,6 @@ export class SandboxService {
     return sandbox
   }
 
-  async getPortPreviewUrl(sandboxId: string, port: number): Promise<PortPreviewUrlDto> {
-    if (port < 1 || port > 65535) {
-      throw new BadRequestError('Invalid port')
-    }
-
-    const sandbox = await this.sandboxRepository.findOne({
-      where: { id: sandboxId },
-    })
-
-    if (!sandbox) {
-      throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
-    }
-
-    // Validate sandbox is in valid state
-    if (sandbox.state !== SandboxState.STARTED) {
-      throw new SandboxError('Sandbox must be started to get port preview URL')
-    }
-
-    // Get runner info
-    const runner = await this.runnerService.findOne(sandbox.runnerId)
-    if (!runner) {
-      throw new NotFoundException(`Runner not found for sandbox ${sandboxId}`)
-    }
-
-    return {
-      url: `https://${port}-${sandbox.id}.${runner.domain}`,
-      token: sandbox.authToken,
-    }
-  }
-
   async destroy(sandboxId: string): Promise<void> {
     const sandbox = await this.sandboxRepository.findOne({
       where: {


### PR DESCRIPTION
# Remove Runner Proxy Fallback for Old Sandboxes

## Description

Removed the old runner proxy fallback that is getting deprecated.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation