### PR TITLE
chore: add release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (start with "v")
+        required: true
+        default: 'v0.0.0-dev'
+      pypi_pkg_version:
+        description: 'PyPI package version (default: version)'
+        required: false
+      npm_pkg_version:
+        description: 'NPM package version (default: version)'
+        required: false
+      npm_tag:
+        description: 'NPM tag (default: latest)'
+        required: false
+        default: 'latest'
+
+env:
+  VERSION: ${{ inputs.version }}
+  PYPI_PKG_VERSION: ${{ inputs.pypi_pkg_version || inputs.version}}
+  NPM_PKG_VERSION: ${{ inputs.npm_pkg_version || inputs.version}}
+  NPM_TAG: ${{ inputs.npm_tag }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/daytonaio/daytona-devcontainer:main
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.name "Daytona Release Bot"
+          git config --global user.email "daytona-release@users.noreply.github.com"
+
+      - name: Dependencies
+        run: |
+          corepack enable
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "poetry==2.1.3"
+          go install github.com/swaggo/swag/cmd/swag@v1.16.4
+          yarn install --immutable
+          poetry lock
+          poetry install
+          go work sync
+          go env -w GOFLAGS="-buildvcs=false"
+
+      - name: Build projects
+        run: yarn build:production
+
+      # Write version to required folders so nx release can run
+      - name: Write package.json to required folders
+        run: |
+          echo '{
+            "name": "api",
+            "version": "0.0.0"
+          }' > dist/package.json
+          echo '{
+            "name": "api",
+            "version": "0.0.0"
+          }' > apps/api/package.json
+          echo '{
+            "name": "dashboard",
+            "version": "0.0.0"
+          }' > apps/dashboard/package.json
+          echo '{
+            "name": "docs",
+            "version": "0.0.0"
+          }' > apps/docs/package.json
+          echo '{
+            "name": "runner",
+            "version": "0.0.0"
+          }' > apps/runner/package.json
+
+      - name: Create release
+        run: yarn nx release ${{ inputs.version }} --skip-publish --verbose
+
+      # Don't publish projects with nx for now
+      - name: Publish projects
+        run: yarn publish

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -77,7 +77,7 @@ export default defineConfig({
   }),
   vite: {
     ssr: {
-      noExternal: ['path-to-regexp'],
+      noExternal: ['path-to-regexp', '@astrojs/react'],
     },
   },
 })

--- a/nx.json
+++ b/nx.json
@@ -95,8 +95,26 @@
     }
   },
   "release": {
+    "projects": ["apps/*", "libs/*"],
+    "changelog": {
+      "workspaceChangelog": {
+        "file": false,
+        "createRelease": "github"
+      }
+    },
     "version": {
-      "preVersionCommand": "yarn dlx nx run-many -t build"
+      "manifestRootsToUpdate": ["dist"],
+      "conventionalCommits": true
+    },
+    "conventionalCommits": {
+      "types": {
+        "__INVALID__": {
+          "semverBump": "patch",
+          "changelog": {
+            "title": "Uncategorized changes"
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint \"{apps,libs,test}/**/*.{ts,tsx}\" --fix",
     "lint:jupyter": "nbqa pylint examples/jupyter --recursive=y -sn",
     "build": "nx run-many --target=build --all --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",
-    "build:production": "nx run-many --target=build --all --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=production",
+    "build:production": "nx run-many --target=build --all --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=production --nxBail=true",
     "serve": "nx run-many --target=serve --all --exclude=daemon --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",
     "serve:skip-runner": "nx run-many --target=serve --all --exclude=runner,daemon --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",
     "serve:skip-proxy": "nx run-many --target=serve --all --exclude=proxy,daemon --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",


### PR DESCRIPTION
# Add Release Pipeline

## Description

Added a release pipeline that can be manually triggered from our repo.

The release pipeline will do the following:
- Build all projects to ensure integrity
- Run `nx release` that will create a github release with an appropriate changelog
- Publish all projects (currently that includes publishing our SDKs to NPM and PyPi)

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
