### PR TITLE
docs(Readme): Update TypeScript example to use typescript sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ async function main() {
   try {
     // Create the Sandbox instance
     sandbox = await daytona.create({
-      language: 'python',
+      language: 'typescript',
     })
     // Run code securely inside the Sandbox
-    const response = await sandbox.process.codeRun('print("Sum of 3 and 4 is " + str(3 + 4))')
+    const response = await sandbox.process.codeRun('console.log("Sum of 3 and 4 is " + (3 + 4))')
     if (response.exitCode !== 0) {
       console.error('Error running code:', response.exitCode, response.result)
     } else {


### PR DESCRIPTION
## Description

Makes the TypeScript example more consistent by actually using a TypeScript sandbox. Aligns with the official documentation at https://www.daytona.io/docs/en/typescript-sdk/

 ## Changes
  - Changed `language: 'python'` to `language: 'typescript'` in TypeScript example.
  - Updated code sample from `print("Sum of 3 and 4 is " + str(3 + 4))` to `console.log("Sum of 3 and 4 is " + (3 + 4))`
  
 ## Checklist
- [ ] This change requires a documentation update.
- [x] I have made corresponding changes to the documentation.