### PR TITLE
fix(daemon): Return error instead of calling log.Fatal

### DIFF
--- a/apps/daemon/pkg/toolbox/toolbox.go
+++ b/apps/daemon/pkg/toolbox/toolbox.go
@@ -70,13 +70,13 @@ func (s *Server) Start() error {
 
 	dirname, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to get user home directory: %w", err)
 	}
 
 	configDir := path.Join(dirname, ".daytona")
 	err = os.MkdirAll(configDir, 0755)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
 	log.Println("configDir", configDir)


### PR DESCRIPTION
# Return error instead of exiting with log.Fatal

## Description

Since everything is prepared for a graceful shutdown in [`daemon/main.go`](https://github.com/daytonaio/daytona/blob/main/apps/daemon/cmd/daemon/main.go#L61), the `toolbox.Server` should return an error instead of exiting by calling `log.Fatal` when an error occurs while starting the server.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses no issue.