### PR TITLE
fix(api): prioritize new runners when checking runners status

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -203,7 +203,10 @@ export class RunnerService {
           state: Not(RunnerState.DECOMMISSIONED),
         },
         order: {
-          lastChecked: 'ASC',
+          lastChecked: {
+            direction: 'ASC',
+            nulls: 'FIRST',
+          },
         },
         take: 100,
       })


### PR DESCRIPTION
## Description

Fixes an issue where newly added runners were not being picked up by the cron job for updating runners status.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
