### PR TITLE
fix(api): update sandbox only upon belonging events

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -824,10 +824,10 @@ export class SandboxController {
       // eslint-disable-next-line
       let timeout: NodeJS.Timeout
       const handleStateUpdated = (event: SandboxStateUpdatedEvent) => {
-        latestSandbox = event.sandbox
         if (event.sandbox.id !== sandbox.id) {
           return
         }
+        latestSandbox = event.sandbox
         if (event.sandbox.state === SandboxState.STARTED) {
           this.eventEmitter.off(SandboxEvents.STATE_UPDATED, handleStateUpdated)
           clearTimeout(timeout)


### PR DESCRIPTION
# Update Sandbox After Event Filter

## Description

Make sure the update event belongs to the target sandbox before applying the sandbox update.
