### PR TITLE
fix(runner): get WorkingDir from container config to avoid inspecting unpulled images

### DIFF
--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -295,13 +295,7 @@ func Start(ctx *gin.Context) {
 		return
 	}
 
-	containerInfo, err := runner.Docker.ContainerInspect(ctx.Request.Context(), sandboxId)
-	if err != nil {
-		ctx.Error(err)
-		return
-	}
-
-	err = runner.Docker.Start(ctx.Request.Context(), sandboxId, metadata, containerInfo.Config.WorkingDir)
+	err = runner.Docker.Start(ctx.Request.Context(), sandboxId, metadata)
 
 	if err != nil {
 		runner.Cache.SetSandboxState(ctx, sandboxId, enums.SandboxStateError)

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -39,21 +39,8 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		return sandboxDto.Id, nil
 	}
 
-	volumeMountPathBinds := make([]string, 0)
-	if sandboxDto.Volumes != nil {
-		volumeMountPathBinds, err = d.getVolumesMountPathBinds(ctx, sandboxDto.Volumes)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	containerConfig, hostConfig, networkingConfig, err := d.getContainerConfigs(ctx, sandboxDto, volumeMountPathBinds)
-	if err != nil {
-		return "", err
-	}
-
 	if state == enums.SandboxStateStopped || state == enums.SandboxStateCreating {
-		err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata, containerConfig.WorkingDir)
+		err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata)
 		if err != nil {
 			return "", err
 		}
@@ -77,12 +64,25 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		return "", err
 	}
 
+	volumeMountPathBinds := make([]string, 0)
+	if sandboxDto.Volumes != nil {
+		volumeMountPathBinds, err = d.getVolumesMountPathBinds(ctx, sandboxDto.Volumes)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	containerConfig, hostConfig, networkingConfig, err := d.getContainerConfigs(ctx, sandboxDto, volumeMountPathBinds)
+	if err != nil {
+		return "", err
+	}
+
 	c, err := d.apiClient.ContainerCreate(ctx, containerConfig, hostConfig, networkingConfig, nil, sandboxDto.Id)
 	if err != nil {
 		return "", err
 	}
 
-	err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata, containerConfig.WorkingDir)
+	err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata)
 	if err != nil {
 		return "", err
 	}

--- a/apps/runner/pkg/docker/start.go
+++ b/apps/runner/pkg/docker/start.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (d *DockerClient) Start(ctx context.Context, containerId string, metadata map[string]string, workDir string) error {
+func (d *DockerClient) Start(ctx context.Context, containerId string, metadata map[string]string) error {
 	defer timer.Timer()()
 	d.cache.SetSandboxState(ctx, containerId, enums.SandboxStateStarting)
 
@@ -72,7 +72,7 @@ func (d *DockerClient) Start(ctx context.Context, containerId string, metadata m
 
 	processesCtx := context.Background()
 	go func() {
-		if err := d.startDaytonaDaemon(processesCtx, containerId, workDir); err != nil {
+		if err := d.startDaytonaDaemon(processesCtx, containerId, c.Config.WorkingDir); err != nil {
 			log.Errorf("Failed to start Daytona daemon: %s\n", err.Error())
 		}
 	}()


### PR DESCRIPTION
# WorkingDir retrieval fix

## Description

Previously, we inspected the image to determine the `WorkingDir`, which could fail when the image hadn’t been pulled yet. This change reads the `WorkingDir` from the container config instead, providing the same `WorkingDir` value while avoiding pre-pull inspect failures and improving safety.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
