### PR TITLE
refactor(docs): running locally -> OSS Deployment

### DIFF
--- a/apps/docs/src/content/config.ts
+++ b/apps/docs/src/content/config.ts
@@ -404,10 +404,18 @@ export const getSidebarConfig = (
             icon: 'chart.svg',
           },
         },
+      ],
+    },
+    {
+      type: 'group',
+      label: labels['sidebarconfig.deployments'],
+      homePageHref: localizePath('/docs', locale),
+      category: NavigationCategory.GENERAL,
+      entries: [
         {
           type: 'link',
-          href: localizePath('/docs/running-locally', locale),
-          label: labels['sidebarconfig.runningLocally'],
+          href: localizePath('/docs/oss-deployment', locale),
+          label: labels['sidebarconfig.ossDeployment'],
           disablePagination: true,
           attrs: {
             icon: 'computer.svg',

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -1,8 +1,8 @@
 ---
-title: Running Daytona Locally
+title: Open Source Deployment
 ---
 
-This guide will walk you through running Daytona locally using Docker Compose.
+This guide will walk you through running Daytona Open Source locally using Docker Compose.
 
 The compose file can be found in the [docker](https://github.com/daytonaio/daytona/tree/main/docker) folder of the Daytona repository.
 
@@ -31,7 +31,7 @@ The Docker Compose configuration includes all the necessary services to run Dayt
 
 ## Quick Start
 
-1. Clone the Daytona repository
+1. Clone the [Daytona repository](https://github.com/daytonaio/daytona)
 2. [Install Docker and Docker Compose](https://docs.docker.com/get-docker/)
 3. Run the following command (from the root of the Daytona repo) to start all services:
 

--- a/apps/docs/src/content/i18n/en.json
+++ b/apps/docs/src/content/i18n/en.json
@@ -97,5 +97,6 @@
   "sidebarconfig.asyncDaytona": "AsyncDaytona",
   "sidebarconfig.asyncSandbox": "AsyncSandbox",
   "sidebarconfig.dataAnalysis": "Data Analysis with AI",
-  "sidebarconfig.runningLocally": "Running Locally"
+  "sidebarconfig.ossDeployment": "Open Source",
+  "sidebarconfig.deployments": "Deployments"
 }


### PR DESCRIPTION
# Running Locally -> OSS Deployment

## Description

Refactored Running Locally to OSS Deployment in the docs. Added a Deployment Section that will contain all deployment methods.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
<img width="2216" height="1826" alt="Screenshot 2025-09-23 at 10 58 25" src="https://github.com/user-attachments/assets/7ac94cea-0e84-49b7-bf99-eab22df0505a" />


