### PR TITLE
fix: allow multiple states in get runner sandboxes

### DIFF
--- a/apps/runner/pkg/services/sandbox_sync.go
+++ b/apps/runner/pkg/services/sandbox_sync.go
@@ -55,7 +55,7 @@ func (s *SandboxSyncService) GetLocalContainerStates(ctx context.Context) (map[s
 		// Get the current state of this container
 		state, err := s.docker.DeduceSandboxState(ctx, sandboxId)
 		if err != nil {
-			log.Warnf("Failed to deduce state for sandbox %s: %v", sandboxId, err)
+			log.Debugf("Failed to deduce state for sandbox %s: %v", sandboxId, err)
 			continue
 		}
 
@@ -73,8 +73,9 @@ func (s *SandboxSyncService) GetRemoteSandboxStates(ctx context.Context) (map[st
 		}
 		s.client = client
 	}
-
-	sandboxes, _, err := s.client.SandboxAPI.GetSandboxesForRunner(ctx).State(string(apiclient.SANDBOXSTATE_STARTED)).Execute()
+	sandboxes, _, err := s.client.SandboxAPI.GetSandboxesForRunner(ctx).
+		States(string(apiclient.SANDBOXSTATE_STARTED)).SkipReconcilingSandboxes(true).
+		Execute()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sandboxes from API: %w", err)
 	}

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -1284,12 +1284,21 @@ paths:
           schema:
             type: string
           style: simple
-        - explode: true
+        - description: Comma-separated list of sandbox states to filter by
+          explode: true
           in: query
-          name: state
-          required: true
+          name: states
+          required: false
           schema:
             type: string
+          style: form
+        - description: Skip sandboxes where state differs from desired state
+          explode: true
+          in: query
+          name: skipReconcilingSandboxes
+          required: false
+          schema:
+            type: boolean
           style: form
       responses:
         '200':
@@ -1359,14 +1368,6 @@ paths:
           schema:
             type: string
           style: simple
-        - description: Include verbose output
-          explode: true
-          in: query
-          name: verbose
-          required: false
-          schema:
-            type: boolean
-          style: form
         - description: ID of the sandbox
           explode: false
           in: path
@@ -1375,6 +1376,14 @@ paths:
           schema:
             type: string
           style: simple
+        - description: Include verbose output
+          explode: true
+          in: query
+          name: verbose
+          required: false
+          schema:
+            type: boolean
+          style: form
       responses:
         '200':
           content:
@@ -5283,14 +5292,6 @@ paths:
           schema:
             type: string
           style: simple
-        - description: Include verbose output
-          explode: true
-          in: query
-          name: verbose
-          required: false
-          schema:
-            type: boolean
-          style: form
         - description: ID of the workspace
           explode: false
           in: path
@@ -5299,6 +5300,14 @@ paths:
           schema:
             type: string
           style: simple
+        - description: Include verbose output
+          explode: true
+          in: query
+          name: verbose
+          required: false
+          schema:
+            type: boolean
+          style: form
       responses:
         '200':
           content:
@@ -10333,8 +10342,8 @@ components:
           enum:
             - internal
             - organization
-            - public
             - transient
+            - backup
           type: string
         isDefault:
           description: Set as default registry
@@ -10382,8 +10391,8 @@ components:
           enum:
             - internal
             - organization
-            - public
             - transient
+            - backup
           example: internal
           type: string
         createdAt:

--- a/libs/api-client-go/api_sandbox.go
+++ b/libs/api-client-go/api_sandbox.go
@@ -1189,20 +1189,28 @@ func (a *SandboxAPIService) GetSandboxExecute(r SandboxAPIGetSandboxRequest) (*S
 }
 
 type SandboxAPIGetSandboxesForRunnerRequest struct {
-	ctx                    context.Context
-	ApiService             SandboxAPI
-	state                  *string
-	xDaytonaOrganizationID *string
-}
-
-func (r SandboxAPIGetSandboxesForRunnerRequest) State(state string) SandboxAPIGetSandboxesForRunnerRequest {
-	r.state = &state
-	return r
+	ctx                      context.Context
+	ApiService               SandboxAPI
+	xDaytonaOrganizationID   *string
+	states                   *string
+	skipReconcilingSandboxes *bool
 }
 
 // Use with JWT to specify the organization ID
 func (r SandboxAPIGetSandboxesForRunnerRequest) XDaytonaOrganizationID(xDaytonaOrganizationID string) SandboxAPIGetSandboxesForRunnerRequest {
 	r.xDaytonaOrganizationID = &xDaytonaOrganizationID
+	return r
+}
+
+// Comma-separated list of sandbox states to filter by
+func (r SandboxAPIGetSandboxesForRunnerRequest) States(states string) SandboxAPIGetSandboxesForRunnerRequest {
+	r.states = &states
+	return r
+}
+
+// Skip sandboxes where state differs from desired state
+func (r SandboxAPIGetSandboxesForRunnerRequest) SkipReconcilingSandboxes(skipReconcilingSandboxes bool) SandboxAPIGetSandboxesForRunnerRequest {
+	r.skipReconcilingSandboxes = &skipReconcilingSandboxes
 	return r
 }
 
@@ -1244,11 +1252,13 @@ func (a *SandboxAPIService) GetSandboxesForRunnerExecute(r SandboxAPIGetSandboxe
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
-	if r.state == nil {
-		return localVarReturnValue, nil, reportError("state is required and must be specified")
-	}
 
-	parameterAddToHeaderOrQuery(localVarQueryParams, "state", r.state, "form", "")
+	if r.states != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "states", r.states, "form", "")
+	}
+	if r.skipReconcilingSandboxes != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "skipReconcilingSandboxes", r.skipReconcilingSandboxes, "form", "")
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -2316,8 +2316,9 @@ class SandboxApi:
     @validate_call
     async def get_sandboxes_for_runner(
         self,
-        state: StrictStr,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        states: Annotated[Optional[StrictStr], Field(description="Comma-separated list of sandbox states to filter by")] = None,
+        skip_reconciling_sandboxes: Annotated[Optional[StrictBool], Field(description="Skip sandboxes where state differs from desired state")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2334,10 +2335,12 @@ class SandboxApi:
         """Get sandboxes for the authenticated runner
 
 
-        :param state: (required)
-        :type state: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param states: Comma-separated list of sandbox states to filter by
+        :type states: str
+        :param skip_reconciling_sandboxes: Skip sandboxes where state differs from desired state
+        :type skip_reconciling_sandboxes: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2361,8 +2364,9 @@ class SandboxApi:
         """ # noqa: E501
 
         _param = self._get_sandboxes_for_runner_serialize(
-            state=state,
             x_daytona_organization_id=x_daytona_organization_id,
+            states=states,
+            skip_reconciling_sandboxes=skip_reconciling_sandboxes,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2386,8 +2390,9 @@ class SandboxApi:
     @validate_call
     async def get_sandboxes_for_runner_with_http_info(
         self,
-        state: StrictStr,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        states: Annotated[Optional[StrictStr], Field(description="Comma-separated list of sandbox states to filter by")] = None,
+        skip_reconciling_sandboxes: Annotated[Optional[StrictBool], Field(description="Skip sandboxes where state differs from desired state")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2404,10 +2409,12 @@ class SandboxApi:
         """Get sandboxes for the authenticated runner
 
 
-        :param state: (required)
-        :type state: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param states: Comma-separated list of sandbox states to filter by
+        :type states: str
+        :param skip_reconciling_sandboxes: Skip sandboxes where state differs from desired state
+        :type skip_reconciling_sandboxes: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2431,8 +2438,9 @@ class SandboxApi:
         """ # noqa: E501
 
         _param = self._get_sandboxes_for_runner_serialize(
-            state=state,
             x_daytona_organization_id=x_daytona_organization_id,
+            states=states,
+            skip_reconciling_sandboxes=skip_reconciling_sandboxes,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2456,8 +2464,9 @@ class SandboxApi:
     @validate_call
     async def get_sandboxes_for_runner_without_preload_content(
         self,
-        state: StrictStr,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        states: Annotated[Optional[StrictStr], Field(description="Comma-separated list of sandbox states to filter by")] = None,
+        skip_reconciling_sandboxes: Annotated[Optional[StrictBool], Field(description="Skip sandboxes where state differs from desired state")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2474,10 +2483,12 @@ class SandboxApi:
         """Get sandboxes for the authenticated runner
 
 
-        :param state: (required)
-        :type state: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param states: Comma-separated list of sandbox states to filter by
+        :type states: str
+        :param skip_reconciling_sandboxes: Skip sandboxes where state differs from desired state
+        :type skip_reconciling_sandboxes: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2501,8 +2512,9 @@ class SandboxApi:
         """ # noqa: E501
 
         _param = self._get_sandboxes_for_runner_serialize(
-            state=state,
             x_daytona_organization_id=x_daytona_organization_id,
+            states=states,
+            skip_reconciling_sandboxes=skip_reconciling_sandboxes,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2521,8 +2533,9 @@ class SandboxApi:
 
     def _get_sandboxes_for_runner_serialize(
         self,
-        state,
         x_daytona_organization_id,
+        states,
+        skip_reconciling_sandboxes,
         _request_auth,
         _content_type,
         _headers,
@@ -2545,9 +2558,13 @@ class SandboxApi:
 
         # process the path parameters
         # process the query parameters
-        if state is not None:
+        if states is not None:
             
-            _query_params.append(('state', state))
+            _query_params.append(('states', states))
+            
+        if skip_reconciling_sandboxes is not None:
+            
+            _query_params.append(('skipReconcilingSandboxes', skip_reconciling_sandboxes))
             
         # process the header parameters
         if x_daytona_organization_id is not None:

--- a/libs/api-client-python-async/daytona_api_client_async/models/create_docker_registry.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/create_docker_registry.py
@@ -40,8 +40,8 @@ class CreateDockerRegistry(BaseModel):
     @field_validator('registry_type')
     def registry_type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['internal', 'organization', 'public', 'transient']):
-            raise ValueError("must be one of enum values ('internal', 'organization', 'public', 'transient')")
+        if value not in set(['internal', 'organization', 'transient', 'backup']):
+            raise ValueError("must be one of enum values ('internal', 'organization', 'transient', 'backup')")
         return value
 
     model_config = ConfigDict(

--- a/libs/api-client-python-async/daytona_api_client_async/models/docker_registry.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/docker_registry.py
@@ -42,8 +42,8 @@ class DockerRegistry(BaseModel):
     @field_validator('registry_type')
     def registry_type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['internal', 'organization', 'public', 'transient']):
-            raise ValueError("must be one of enum values ('internal', 'organization', 'public', 'transient')")
+        if value not in set(['internal', 'organization', 'transient', 'backup']):
+            raise ValueError("must be one of enum values ('internal', 'organization', 'transient', 'backup')")
         return value
 
     model_config = ConfigDict(

--- a/libs/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/libs/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -2316,8 +2316,9 @@ class SandboxApi:
     @validate_call
     def get_sandboxes_for_runner(
         self,
-        state: StrictStr,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        states: Annotated[Optional[StrictStr], Field(description="Comma-separated list of sandbox states to filter by")] = None,
+        skip_reconciling_sandboxes: Annotated[Optional[StrictBool], Field(description="Skip sandboxes where state differs from desired state")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2334,10 +2335,12 @@ class SandboxApi:
         """Get sandboxes for the authenticated runner
 
 
-        :param state: (required)
-        :type state: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param states: Comma-separated list of sandbox states to filter by
+        :type states: str
+        :param skip_reconciling_sandboxes: Skip sandboxes where state differs from desired state
+        :type skip_reconciling_sandboxes: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2361,8 +2364,9 @@ class SandboxApi:
         """ # noqa: E501
 
         _param = self._get_sandboxes_for_runner_serialize(
-            state=state,
             x_daytona_organization_id=x_daytona_organization_id,
+            states=states,
+            skip_reconciling_sandboxes=skip_reconciling_sandboxes,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2386,8 +2390,9 @@ class SandboxApi:
     @validate_call
     def get_sandboxes_for_runner_with_http_info(
         self,
-        state: StrictStr,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        states: Annotated[Optional[StrictStr], Field(description="Comma-separated list of sandbox states to filter by")] = None,
+        skip_reconciling_sandboxes: Annotated[Optional[StrictBool], Field(description="Skip sandboxes where state differs from desired state")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2404,10 +2409,12 @@ class SandboxApi:
         """Get sandboxes for the authenticated runner
 
 
-        :param state: (required)
-        :type state: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param states: Comma-separated list of sandbox states to filter by
+        :type states: str
+        :param skip_reconciling_sandboxes: Skip sandboxes where state differs from desired state
+        :type skip_reconciling_sandboxes: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2431,8 +2438,9 @@ class SandboxApi:
         """ # noqa: E501
 
         _param = self._get_sandboxes_for_runner_serialize(
-            state=state,
             x_daytona_organization_id=x_daytona_organization_id,
+            states=states,
+            skip_reconciling_sandboxes=skip_reconciling_sandboxes,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2456,8 +2464,9 @@ class SandboxApi:
     @validate_call
     def get_sandboxes_for_runner_without_preload_content(
         self,
-        state: StrictStr,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        states: Annotated[Optional[StrictStr], Field(description="Comma-separated list of sandbox states to filter by")] = None,
+        skip_reconciling_sandboxes: Annotated[Optional[StrictBool], Field(description="Skip sandboxes where state differs from desired state")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2474,10 +2483,12 @@ class SandboxApi:
         """Get sandboxes for the authenticated runner
 
 
-        :param state: (required)
-        :type state: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param states: Comma-separated list of sandbox states to filter by
+        :type states: str
+        :param skip_reconciling_sandboxes: Skip sandboxes where state differs from desired state
+        :type skip_reconciling_sandboxes: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2501,8 +2512,9 @@ class SandboxApi:
         """ # noqa: E501
 
         _param = self._get_sandboxes_for_runner_serialize(
-            state=state,
             x_daytona_organization_id=x_daytona_organization_id,
+            states=states,
+            skip_reconciling_sandboxes=skip_reconciling_sandboxes,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2521,8 +2533,9 @@ class SandboxApi:
 
     def _get_sandboxes_for_runner_serialize(
         self,
-        state,
         x_daytona_organization_id,
+        states,
+        skip_reconciling_sandboxes,
         _request_auth,
         _content_type,
         _headers,
@@ -2545,9 +2558,13 @@ class SandboxApi:
 
         # process the path parameters
         # process the query parameters
-        if state is not None:
+        if states is not None:
             
-            _query_params.append(('state', state))
+            _query_params.append(('states', states))
+            
+        if skip_reconciling_sandboxes is not None:
+            
+            _query_params.append(('skipReconcilingSandboxes', skip_reconciling_sandboxes))
             
         # process the header parameters
         if x_daytona_organization_id is not None:

--- a/libs/api-client-python/daytona_api_client/models/create_docker_registry.py
+++ b/libs/api-client-python/daytona_api_client/models/create_docker_registry.py
@@ -40,8 +40,8 @@ class CreateDockerRegistry(BaseModel):
     @field_validator('registry_type')
     def registry_type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['internal', 'organization', 'public', 'transient']):
-            raise ValueError("must be one of enum values ('internal', 'organization', 'public', 'transient')")
+        if value not in set(['internal', 'organization', 'transient', 'backup']):
+            raise ValueError("must be one of enum values ('internal', 'organization', 'transient', 'backup')")
         return value
 
     model_config = ConfigDict(

--- a/libs/api-client-python/daytona_api_client/models/docker_registry.py
+++ b/libs/api-client-python/daytona_api_client/models/docker_registry.py
@@ -42,8 +42,8 @@ class DockerRegistry(BaseModel):
     @field_validator('registry_type')
     def registry_type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['internal', 'organization', 'public', 'transient']):
-            raise ValueError("must be one of enum values ('internal', 'organization', 'public', 'transient')")
+        if value not in set(['internal', 'organization', 'transient', 'backup']):
+            raise ValueError("must be one of enum values ('internal', 'organization', 'transient', 'backup')")
         return value
 
     model_config = ConfigDict(

--- a/libs/api-client/src/.openapi-generator/FILES
+++ b/libs/api-client/src/.openapi-generator/FILES
@@ -142,8 +142,8 @@ models/update-organization-invitation.ts
 models/update-organization-member-access.ts
 models/update-organization-quota.ts
 models/update-organization-role.ts
-models/user-home-dir-response.ts
 models/update-sandbox-state-dto.ts
+models/user-home-dir-response.ts
 models/user-public-key.ts
 models/user.ts
 models/volume-dto.ts

--- a/libs/api-client/src/api/sandbox-api.ts
+++ b/libs/api-client/src/api/sandbox-api.ts
@@ -461,18 +461,18 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
     /**
      *
      * @summary Get sandboxes for the authenticated runner
-     * @param {string} state
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {string} [states] Comma-separated list of sandbox states to filter by
+     * @param {boolean} [skipReconcilingSandboxes] Skip sandboxes where state differs from desired state
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getSandboxesForRunner: async (
-      state: string,
       xDaytonaOrganizationID?: string,
+      states?: string,
+      skipReconcilingSandboxes?: boolean,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'state' is not null or undefined
-      assertParamExists('getSandboxesForRunner', 'state', state)
       const localVarPath = `/sandbox/for-runner`
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
@@ -491,8 +491,12 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
 
       // authentication oauth2 required
 
-      if (state !== undefined) {
-        localVarQueryParameter['state'] = state
+      if (states !== undefined) {
+        localVarQueryParameter['states'] = states
+      }
+
+      if (skipReconcilingSandboxes !== undefined) {
+        localVarQueryParameter['skipReconcilingSandboxes'] = skipReconcilingSandboxes
       }
 
       if (xDaytonaOrganizationID != null) {
@@ -1335,19 +1339,22 @@ export const SandboxApiFp = function (configuration?: Configuration) {
     /**
      *
      * @summary Get sandboxes for the authenticated runner
-     * @param {string} state
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {string} [states] Comma-separated list of sandbox states to filter by
+     * @param {boolean} [skipReconcilingSandboxes] Skip sandboxes where state differs from desired state
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getSandboxesForRunner(
-      state: string,
       xDaytonaOrganizationID?: string,
+      states?: string,
+      skipReconcilingSandboxes?: boolean,
       options?: RawAxiosRequestConfig,
     ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Sandbox>>> {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getSandboxesForRunner(
-        state,
         xDaytonaOrganizationID,
+        states,
+        skipReconcilingSandboxes,
         options,
       )
       const localVarOperationServerIndex = configuration?.serverIndex ?? 0
@@ -1858,18 +1865,20 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
     /**
      *
      * @summary Get sandboxes for the authenticated runner
-     * @param {string} state
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {string} [states] Comma-separated list of sandbox states to filter by
+     * @param {boolean} [skipReconcilingSandboxes] Skip sandboxes where state differs from desired state
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getSandboxesForRunner(
-      state: string,
       xDaytonaOrganizationID?: string,
+      states?: string,
+      skipReconcilingSandboxes?: boolean,
       options?: RawAxiosRequestConfig,
     ): AxiosPromise<Array<Sandbox>> {
       return localVarFp
-        .getSandboxesForRunner(state, xDaytonaOrganizationID, options)
+        .getSandboxesForRunner(xDaytonaOrganizationID, states, skipReconcilingSandboxes, options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -2240,15 +2249,21 @@ export class SandboxApi extends BaseAPI {
   /**
    *
    * @summary Get sandboxes for the authenticated runner
-   * @param {string} state
    * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+   * @param {string} [states] Comma-separated list of sandbox states to filter by
+   * @param {boolean} [skipReconcilingSandboxes] Skip sandboxes where state differs from desired state
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof SandboxApi
    */
-  public getSandboxesForRunner(state: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
+  public getSandboxesForRunner(
+    xDaytonaOrganizationID?: string,
+    states?: string,
+    skipReconcilingSandboxes?: boolean,
+    options?: RawAxiosRequestConfig,
+  ) {
     return SandboxApiFp(this.configuration)
-      .getSandboxesForRunner(state, xDaytonaOrganizationID, options)
+      .getSandboxesForRunner(xDaytonaOrganizationID, states, skipReconcilingSandboxes, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/libs/api-client/src/models/create-docker-registry.ts
+++ b/libs/api-client/src/models/create-docker-registry.ts
@@ -65,8 +65,8 @@ export interface CreateDockerRegistry {
 export const CreateDockerRegistryRegistryTypeEnum = {
   INTERNAL: 'internal',
   ORGANIZATION: 'organization',
-  PUBLIC: 'public',
   TRANSIENT: 'transient',
+  BACKUP: 'backup',
 } as const
 
 export type CreateDockerRegistryRegistryTypeEnum =

--- a/libs/api-client/src/models/docker-registry.ts
+++ b/libs/api-client/src/models/docker-registry.ts
@@ -71,8 +71,8 @@ export interface DockerRegistry {
 export const DockerRegistryRegistryTypeEnum = {
   INTERNAL: 'internal',
   ORGANIZATION: 'organization',
-  PUBLIC: 'public',
   TRANSIENT: 'transient',
+  BACKUP: 'backup',
 } as const
 
 export type DockerRegistryRegistryTypeEnum =


### PR DESCRIPTION
# Allow multiple states in get runner sandboxes
## Description

Allow multiple states in get runner sandboxes as well as a "skip reconciling sandboxes" flag
Relaxes some logging from warn to debug
Regenerates the api clients

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
