### PR TITLE
fix: optimize backup ordering

### DIFF
--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -150,16 +150,26 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
           backupStates: [BackupState.PENDING, BackupState.IN_PROGRESS],
         })
         .andWhere('r.state = :ready', { ready: RunnerState.READY })
-        .orderBy(
-          'CASE sandbox.state ' +
-            `WHEN '${SandboxState.ARCHIVING}' THEN 1 ` + // Manual archival action
-            `WHEN '${SandboxState.STOPPED}' THEN 2 ` + // Auto-archive poller
-            `WHEN '${SandboxState.STARTED}' THEN 3 ` + // Ad-hoc backup poller
-            'END',
-          'ASC',
+        // Prioritize manual archival action, then auto-archive poller, then ad-hoc backup poller
+        .addSelect(
+          `
+          CASE sandbox.state
+            WHEN :archiving THEN 1
+            WHEN :stopped   THEN 2
+            WHEN :started   THEN 3
+            ELSE 999
+          END
+          `,
+          'state_priority',
         )
-        .addOrderBy('sandbox.lastBackupAt', 'ASC', 'NULLS FIRST') // Process sandboxes with no backups first, then oldest to newest
-        .addOrderBy('sandbox.createdAt', 'ASC') // If there hasn't been a backup yet, process older sandboxes first
+        .setParameters({
+          archiving: SandboxState.ARCHIVING,
+          stopped: SandboxState.STOPPED,
+          started: SandboxState.STARTED,
+        })
+        .orderBy('state_priority', 'ASC')
+        .addOrderBy('sandbox.lastBackupAt', 'ASC', 'NULLS FIRST') // Process sandboxes with no backups first
+        .addOrderBy('sandbox.createdAt', 'ASC') // For equal lastBackupAt, process older sandboxes first
         .take(100)
         .getMany()
 

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -158,7 +158,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
             'END',
           'ASC',
         )
-        .addOrderBy('sandbox.lastBackupAt', 'ASC') // Process the one with the oldest lastBackupAt
+        .addOrderBy('sandbox.lastBackupAt', 'ASC', 'NULLS FIRST') // Process sandboxes with no backups first, then oldest to newest
         .addOrderBy('sandbox.createdAt', 'ASC') // If there hasn't been a backup yet, process older sandboxes first
         .take(100)
         .getMany()


### PR DESCRIPTION
# Optimize backup ordering

## Description

Updates to the backup action ordering:
1. Manual archive call
2. Auto-archive poller
3. Ad-hoc backup poller
4. Non-existent/old last backup timestamp
5. Oldest sandbox creation timestamp

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
