### PR TITLE
fix(api): stop returning destroyed sandboxes in getSandbox endpoint

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -273,7 +273,7 @@ export class SandboxController {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     @Query('verbose') verbose?: boolean,
   ): Promise<SandboxDto> {
-    const sandbox = await this.sandboxService.findOne(sandboxId, true)
+    const sandbox = await this.sandboxService.findOne(sandboxId)
 
     let runner: Runner
     if (sandbox.runnerId) {

--- a/apps/api/src/sandbox/controllers/workspace.deprecated.controller.ts
+++ b/apps/api/src/sandbox/controllers/workspace.deprecated.controller.ts
@@ -217,7 +217,7 @@ export class WorkspaceController {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     @Query('verbose') verbose?: boolean,
   ): Promise<WorkspaceDto> {
-    const workspace = await this.workspaceService.findOne(workspaceId, true)
+    const workspace = await this.workspaceService.findOne(workspaceId)
 
     let runner: Runner
     if (workspace.runnerId) {


### PR DESCRIPTION
## Description

Removed the explicit `true` parameter from sandboxService.findOne() and workspaceService.findOne() calls in controllers, allowing them to use the default behavior of not returning destroyed sandboxes.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation