### PR TITLE
fix(cli): ignore cancelled stream error

### DIFF
--- a/apps/cli/cmd/common/logs.go
+++ b/apps/cli/cmd/common/logs.go
@@ -91,7 +91,10 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 					}
 					return
 				}
-				log.Errorf("Error reading from stream: %v", err)
+				// Don't log context.Canceled as it's an expected case when streaming is stopped
+				if err != context.Canceled {
+					log.Errorf("Error reading from stream: %v", err)
+				}
 				return
 			}
 		}


### PR DESCRIPTION
# Ignore cancelled stream error

## Description

The CLI now ignores the stream read error when the context had been cancelled instead of logging it unnecessarily

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2200 
