### PR TITLE
feat(cli): context relative to current dir

### DIFF
--- a/apps/cli/cmd/common/build.go
+++ b/apps/cli/cmd/common/build.go
@@ -307,8 +307,12 @@ func GetCreateBuildInfoDto(ctx context.Context, dockerfilePath string, contextPa
 			if filepath.IsAbs(contextPath) {
 				absPath = contextPath
 			} else {
-				// Resolve relative paths relative to the Dockerfile directory, not current working directory
-				absPath = filepath.Join(dockerfileDir, contextPath)
+				// When context paths are provided manually (via --context flag),
+				// resolve them relative to the current working directory
+				absPath, err = filepath.Abs(contextPath)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve context path %s: %w", contextPath, err)
+				}
 			}
 			resolvedContextPaths = append(resolvedContextPaths, absPath)
 		}


### PR DESCRIPTION
# Context relative to current dir

## Description

It is more natural/expected for the `daytona snapshot create`'s `--context` flag paths to be relative to the current working directory of the CLI instead of relative to the Dockerfile's path. This also aligns with the way Docker parses it

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2411 