### PR TITLE
chore: add docs .env to git

### DIFF
--- a/apps/docs/.env
+++ b/apps/docs/.env
@@ -1,0 +1,2 @@
+PUBLIC_WEB_URL=https://www.daytona.io
+FUNCTIONS_PORT=8000

--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -1,2 +1,0 @@
-PUBLIC_WEB_URL=https://docs.daytona.io
-FUNCTIONS_PORT=8000

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -15,7 +15,6 @@ yarn-error.log*
 pnpm-debug.log*
 
 # environment variables
-.env
 .env.production
 
 # macOS-specific files


### PR DESCRIPTION
# Add Docs .env to Git

## Description

- fixes default docs builds that require PUBLIC_WEB_URL to be set

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
