### PR TITLE
chore: publish daemon in release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,6 +116,10 @@ jobs:
         run: |
           gh release upload ${{ inputs.version }} dist/apps/runner-amd64#daytona-runner-${{ inputs.version }}-amd64 --clobber
 
+      - name: Upload daemon to release assets
+        run: |
+          gh release upload ${{ inputs.version }} dist/apps/daemon-amd64#daytona-daemon-${{ inputs.version }}-amd64 --clobber
+
       - name: Upload computer-use artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
# Publish Daemon in Release Assets

## Description

Publish daemon binary in release assets.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
