### PR TITLE
chore(api): skip sandbox access 404 logs

### DIFF
--- a/apps/api/src/sandbox/guards/sandbox-access.guard.ts
+++ b/apps/api/src/sandbox/guards/sandbox-access.guard.ts
@@ -45,7 +45,9 @@ export class SandboxAccessGuard implements CanActivate {
 
       return true
     } catch (error) {
-      console.error(error)
+      if (!(error instanceof NotFoundException)) {
+        console.error(error)
+      }
       throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
     }
   }


### PR DESCRIPTION
# Skip sandbox access 404 logs
## Description

If the Sandbox access guard returns 404, we don't need to show that in API logs

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
