### PR TITLE
fix(sdk): coroutine subscripting error in download_file

### DIFF
--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -148,8 +148,10 @@ class AsyncFileSystem:
         local_path = args[1]
         timeout = args[2] if len(args) == 3 else 30 * 60
         # pylint: disable=protected-access
-        response = await self.download_files(
-            [FileDownloadRequest(source=remote_path, destination=local_path)], timeout=timeout
+        response = (
+            await self.download_files(
+                [FileDownloadRequest(source=remote_path, destination=local_path)], timeout=timeout
+            )
         )[0]
         if response.error:
             raise DaytonaError(response.error)

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -150,8 +150,8 @@ class FileSystem:
         local_path = args[1]
         timeout = args[2] if len(args) == 3 else 30 * 60
         # pylint: disable=protected-access
-        response = self.download_files(
-            [FileDownloadRequest(source=remote_path, destination=local_path)], timeout=timeout
+        response = (
+            self.download_files([FileDownloadRequest(source=remote_path, destination=local_path)], timeout=timeout)
         )[0]
         if response.error:
             raise DaytonaError(response.error)


### PR DESCRIPTION
## Description

Added missing parentheses around await expression before indexing. The [0] subscript was being applied to the coroutine object instead of the awaited result, causing a TypeError when downloading files with a destination path specified.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes download_file to index the first result only after awaiting/calling download_files, preventing subscripting of a coroutine and TypeError.
> 
> - **Bug Fix**
>   - `libs/sdk-python/src/daytona/_async/filesystem.py`
>     - `AsyncFileSystem.download_file`: add parentheses to `await self.download_files(...)` so `[0]` indexes the awaited result.
>   - `libs/sdk-python/src/daytona/_sync/filesystem.py`
>     - `FileSystem.download_file`: parenthesize `self.download_files(...)` before `[0]` for consistent indexing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0016bcef69b88f6ff254ced3ec84808ca292080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->