### PR TITLE
feat(api): delete build failed sandboxes after 7 days

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -970,12 +970,13 @@ export class SandboxService {
 
   @Cron(CronExpression.EVERY_10_MINUTES)
   async cleanupBuildFailedSandboxes() {
-    const sevenDaysAgo = new Date()
-    sevenDaysAgo.setHours(sevenDaysAgo.getHours() - 24 * 7)
+    const twentyFourHoursAgo = new Date()
+    twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24)
 
     const destroyedSandboxs = await this.sandboxRepository.delete({
       state: SandboxState.BUILD_FAILED,
-      updatedAt: LessThan(sevenDaysAgo),
+      desiredState: SandboxDesiredState.DESTROYED,
+      updatedAt: LessThan(twentyFourHoursAgo),
     })
 
     if (destroyedSandboxs.affected > 0) {


### PR DESCRIPTION
# Delete Build Failed Sandboxes After 7 Days

## Description

Delete build failed sandboxes after 7 days.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
