### PR TITLE
fix(api): sync newer sandboxes first

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -261,7 +261,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         })
         .andWhere('sandbox."desiredState"::text != sandbox.state::text')
         .andWhere('sandbox."desiredState"::text != :archived', { archived: SandboxDesiredState.ARCHIVED })
-        .orderBy('sandbox."lastActivityAt"', 'ASC')
+        .orderBy('sandbox."lastActivityAt"', 'DESC')
 
       const stream = await queryBuilder.stream()
       let processedCount = 0


### PR DESCRIPTION
# Sync Newer Sandboxes First

## Description

Take newer sandboxes first when syncing.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
