### PR TITLE
chore(api): don't rely on auth during openapi generation

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -35,6 +35,10 @@ import { catchError, map } from 'rxjs/operators'
     {
       provide: JwtStrategy,
       useFactory: async (userService: UserService, httpService: HttpService, configService: TypedConfigService) => {
+        if (configService.get('skipConnections')) {
+          return
+        }
+
         // Get the OpenID configuration from the issuer
         const discoveryUrl = `${configService.get('oidc.issuer')}/.well-known/openid-configuration`
         const metadata = await firstValueFrom(


### PR DESCRIPTION
# Don't Rely on Auth During Openapi Generation

## Description

If the auth endpoint failed (in CI for example) the openapi spec would fail to generate

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
