### PR TITLE
fix(api): add default for capacity in migration

### DIFF
--- a/apps/api/src/migrations/1759241690773-migration.ts
+++ b/apps/api/src/migrations/1759241690773-migration.ts
@@ -14,7 +14,7 @@ export class Migration1759241690773 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "runner" ADD "capacity" integer NOT NULL`)
+    await queryRunner.query(`ALTER TABLE "runner" ADD "capacity" integer NOT NULL DEFAULT '1000'`)
     await queryRunner.query(`ALTER TABLE "runner" ADD "used" integer NOT NULL DEFAULT '0'`)
   }
 }


### PR DESCRIPTION
# Add Default for Capacity in Migration

## Description

This PR fixes missing default values for capacity in auto-generated migration

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
