### PR TITLE
fix(api-client-go): allow additional properties in models

### DIFF
--- a/libs/api-client-go/model_account_provider.go
+++ b/libs/api-client-go/model_account_provider.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &AccountProvider{}
 
 // AccountProvider struct for AccountProvider
 type AccountProvider struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
+	Name                 string `json:"name"`
+	DisplayName          string `json:"displayName"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AccountProvider AccountProvider
@@ -107,6 +107,11 @@ func (o AccountProvider) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
 	toSerialize["displayName"] = o.DisplayName
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *AccountProvider) UnmarshalJSON(data []byte) (err error) {
 
 	varAccountProvider := _AccountProvider{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAccountProvider)
+	err = json.Unmarshal(data, &varAccountProvider)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AccountProvider(varAccountProvider)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "displayName")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_announcement.go
+++ b/libs/api-client-go/model_announcement.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type Announcement struct {
 	// The announcement text
 	Text string `json:"text"`
 	// URL to learn more about the announcement
-	LearnMoreUrl *string `json:"learnMoreUrl,omitempty"`
+	LearnMoreUrl         *string `json:"learnMoreUrl,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Announcement Announcement
@@ -118,6 +118,11 @@ func (o Announcement) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LearnMoreUrl) {
 		toSerialize["learnMoreUrl"] = o.LearnMoreUrl
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -145,15 +150,21 @@ func (o *Announcement) UnmarshalJSON(data []byte) (err error) {
 
 	varAnnouncement := _Announcement{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAnnouncement)
+	err = json.Unmarshal(data, &varAnnouncement)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Announcement(varAnnouncement)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "text")
+		delete(additionalProperties, "learnMoreUrl")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_api_key_list.go
+++ b/libs/api-client-go/model_api_key_list.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -36,7 +35,8 @@ type ApiKeyList struct {
 	// When the API key expires
 	ExpiresAt NullableTime `json:"expiresAt"`
 	// The user ID of the user who created the API key
-	UserId string `json:"userId"`
+	UserId               string `json:"userId"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ApiKeyList ApiKeyList
@@ -254,6 +254,11 @@ func (o ApiKeyList) ToMap() (map[string]interface{}, error) {
 	toSerialize["lastUsedAt"] = o.LastUsedAt.Get()
 	toSerialize["expiresAt"] = o.ExpiresAt.Get()
 	toSerialize["userId"] = o.UserId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -287,15 +292,26 @@ func (o *ApiKeyList) UnmarshalJSON(data []byte) (err error) {
 
 	varApiKeyList := _ApiKeyList{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varApiKeyList)
+	err = json.Unmarshal(data, &varApiKeyList)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ApiKeyList(varApiKeyList)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "value")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "permissions")
+		delete(additionalProperties, "lastUsedAt")
+		delete(additionalProperties, "expiresAt")
+		delete(additionalProperties, "userId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_api_key_response.go
+++ b/libs/api-client-go/model_api_key_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -32,7 +31,8 @@ type ApiKeyResponse struct {
 	// The list of organization resource permissions assigned to the API key
 	Permissions []string `json:"permissions"`
 	// When the API key expires
-	ExpiresAt NullableTime `json:"expiresAt"`
+	ExpiresAt            NullableTime `json:"expiresAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ApiKeyResponse ApiKeyResponse
@@ -196,6 +196,11 @@ func (o ApiKeyResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["permissions"] = o.Permissions
 	toSerialize["expiresAt"] = o.ExpiresAt.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -227,15 +232,24 @@ func (o *ApiKeyResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varApiKeyResponse := _ApiKeyResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varApiKeyResponse)
+	err = json.Unmarshal(data, &varApiKeyResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ApiKeyResponse(varApiKeyResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "value")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "permissions")
+		delete(additionalProperties, "expiresAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_audit_log.go
+++ b/libs/api-client-go/model_audit_log.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -23,20 +22,21 @@ var _ MappedNullable = &AuditLog{}
 
 // AuditLog struct for AuditLog
 type AuditLog struct {
-	Id             string                 `json:"id"`
-	ActorId        string                 `json:"actorId"`
-	ActorEmail     string                 `json:"actorEmail"`
-	OrganizationId *string                `json:"organizationId,omitempty"`
-	Action         string                 `json:"action"`
-	TargetType     *string                `json:"targetType,omitempty"`
-	TargetId       *string                `json:"targetId,omitempty"`
-	StatusCode     *float32               `json:"statusCode,omitempty"`
-	ErrorMessage   *string                `json:"errorMessage,omitempty"`
-	IpAddress      *string                `json:"ipAddress,omitempty"`
-	UserAgent      *string                `json:"userAgent,omitempty"`
-	Source         *string                `json:"source,omitempty"`
-	Metadata       map[string]interface{} `json:"metadata,omitempty"`
-	CreatedAt      time.Time              `json:"createdAt"`
+	Id                   string                 `json:"id"`
+	ActorId              string                 `json:"actorId"`
+	ActorEmail           string                 `json:"actorEmail"`
+	OrganizationId       *string                `json:"organizationId,omitempty"`
+	Action               string                 `json:"action"`
+	TargetType           *string                `json:"targetType,omitempty"`
+	TargetId             *string                `json:"targetId,omitempty"`
+	StatusCode           *float32               `json:"statusCode,omitempty"`
+	ErrorMessage         *string                `json:"errorMessage,omitempty"`
+	IpAddress            *string                `json:"ipAddress,omitempty"`
+	UserAgent            *string                `json:"userAgent,omitempty"`
+	Source               *string                `json:"source,omitempty"`
+	Metadata             map[string]interface{} `json:"metadata,omitempty"`
+	CreatedAt            time.Time              `json:"createdAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AuditLog AuditLog
@@ -513,6 +513,11 @@ func (o AuditLog) ToMap() (map[string]interface{}, error) {
 		toSerialize["metadata"] = o.Metadata
 	}
 	toSerialize["createdAt"] = o.CreatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -544,15 +549,33 @@ func (o *AuditLog) UnmarshalJSON(data []byte) (err error) {
 
 	varAuditLog := _AuditLog{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAuditLog)
+	err = json.Unmarshal(data, &varAuditLog)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AuditLog(varAuditLog)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "actorId")
+		delete(additionalProperties, "actorEmail")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "action")
+		delete(additionalProperties, "targetType")
+		delete(additionalProperties, "targetId")
+		delete(additionalProperties, "statusCode")
+		delete(additionalProperties, "errorMessage")
+		delete(additionalProperties, "ipAddress")
+		delete(additionalProperties, "userAgent")
+		delete(additionalProperties, "source")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "createdAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_build_info.go
+++ b/libs/api-client-go/model_build_info.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -30,7 +29,8 @@ type BuildInfo struct {
 	// The creation timestamp
 	CreatedAt time.Time `json:"createdAt"`
 	// The last update timestamp
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _BuildInfo BuildInfo
@@ -184,6 +184,11 @@ func (o BuildInfo) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -212,15 +217,23 @@ func (o *BuildInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varBuildInfo := _BuildInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varBuildInfo)
+	err = json.Unmarshal(data, &varBuildInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = BuildInfo(varBuildInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "dockerfileContent")
+		delete(additionalProperties, "contextHashes")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_command.go
+++ b/libs/api-client-go/model_command.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type Command struct {
 	// The command that was executed
 	Command string `json:"command"`
 	// The exit code of the command
-	ExitCode *float32 `json:"exitCode,omitempty"`
+	ExitCode             *float32 `json:"exitCode,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Command Command
@@ -146,6 +146,11 @@ func (o Command) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ExitCode) {
 		toSerialize["exitCode"] = o.ExitCode
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -174,15 +179,22 @@ func (o *Command) UnmarshalJSON(data []byte) (err error) {
 
 	varCommand := _Command{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCommand)
+	err = json.Unmarshal(data, &varCommand)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Command(varCommand)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "command")
+		delete(additionalProperties, "exitCode")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_completion_context.go
+++ b/libs/api-client-go/model_completion_context.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &CompletionContext{}
 
 // CompletionContext struct for CompletionContext
 type CompletionContext struct {
-	TriggerKind      float32 `json:"triggerKind"`
-	TriggerCharacter *string `json:"triggerCharacter,omitempty"`
+	TriggerKind          float32 `json:"triggerKind"`
+	TriggerCharacter     *string `json:"triggerCharacter,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CompletionContext CompletionContext
@@ -116,6 +116,11 @@ func (o CompletionContext) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.TriggerCharacter) {
 		toSerialize["triggerCharacter"] = o.TriggerCharacter
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -143,15 +148,21 @@ func (o *CompletionContext) UnmarshalJSON(data []byte) (err error) {
 
 	varCompletionContext := _CompletionContext{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCompletionContext)
+	err = json.Unmarshal(data, &varCompletionContext)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CompletionContext(varCompletionContext)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "triggerKind")
+		delete(additionalProperties, "triggerCharacter")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_completion_item.go
+++ b/libs/api-client-go/model_completion_item.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,13 +21,14 @@ var _ MappedNullable = &CompletionItem{}
 
 // CompletionItem struct for CompletionItem
 type CompletionItem struct {
-	Label         string                 `json:"label"`
-	Kind          *float32               `json:"kind,omitempty"`
-	Detail        *string                `json:"detail,omitempty"`
-	Documentation map[string]interface{} `json:"documentation,omitempty"`
-	SortText      *string                `json:"sortText,omitempty"`
-	FilterText    *string                `json:"filterText,omitempty"`
-	InsertText    *string                `json:"insertText,omitempty"`
+	Label                string                 `json:"label"`
+	Kind                 *float32               `json:"kind,omitempty"`
+	Detail               *string                `json:"detail,omitempty"`
+	Documentation        map[string]interface{} `json:"documentation,omitempty"`
+	SortText             *string                `json:"sortText,omitempty"`
+	FilterText           *string                `json:"filterText,omitempty"`
+	InsertText           *string                `json:"insertText,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CompletionItem CompletionItem
@@ -296,6 +296,11 @@ func (o CompletionItem) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.InsertText) {
 		toSerialize["insertText"] = o.InsertText
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -323,15 +328,26 @@ func (o *CompletionItem) UnmarshalJSON(data []byte) (err error) {
 
 	varCompletionItem := _CompletionItem{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCompletionItem)
+	err = json.Unmarshal(data, &varCompletionItem)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CompletionItem(varCompletionItem)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "label")
+		delete(additionalProperties, "kind")
+		delete(additionalProperties, "detail")
+		delete(additionalProperties, "documentation")
+		delete(additionalProperties, "sortText")
+		delete(additionalProperties, "filterText")
+		delete(additionalProperties, "insertText")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_completion_list.go
+++ b/libs/api-client-go/model_completion_list.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &CompletionList{}
 
 // CompletionList struct for CompletionList
 type CompletionList struct {
-	IsIncomplete bool             `json:"isIncomplete"`
-	Items        []CompletionItem `json:"items"`
+	IsIncomplete         bool             `json:"isIncomplete"`
+	Items                []CompletionItem `json:"items"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CompletionList CompletionList
@@ -107,6 +107,11 @@ func (o CompletionList) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["isIncomplete"] = o.IsIncomplete
 	toSerialize["items"] = o.Items
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *CompletionList) UnmarshalJSON(data []byte) (err error) {
 
 	varCompletionList := _CompletionList{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCompletionList)
+	err = json.Unmarshal(data, &varCompletionList)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CompletionList(varCompletionList)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "isIncomplete")
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_compressed_screenshot_response.go
+++ b/libs/api-client-go/model_compressed_screenshot_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type CompressedScreenshotResponse struct {
 	// The current cursor position when the compressed screenshot was taken
 	CursorPosition map[string]interface{} `json:"cursorPosition,omitempty"`
 	// The size of the compressed screenshot data in bytes
-	SizeBytes *float32 `json:"sizeBytes,omitempty"`
+	SizeBytes            *float32 `json:"sizeBytes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CompressedScreenshotResponse CompressedScreenshotResponse
@@ -155,6 +155,11 @@ func (o CompressedScreenshotResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SizeBytes) {
 		toSerialize["sizeBytes"] = o.SizeBytes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -182,15 +187,22 @@ func (o *CompressedScreenshotResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varCompressedScreenshotResponse := _CompressedScreenshotResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCompressedScreenshotResponse)
+	err = json.Unmarshal(data, &varCompressedScreenshotResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CompressedScreenshotResponse(varCompressedScreenshotResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "screenshot")
+		delete(additionalProperties, "cursorPosition")
+		delete(additionalProperties, "sizeBytes")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_computer_use_start_response.go
+++ b/libs/api-client-go/model_computer_use_start_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type ComputerUseStartResponse struct {
 	// A message indicating the result of starting computer use processes
 	Message string `json:"message"`
 	// Status information about all VNC desktop processes after starting
-	Status map[string]interface{} `json:"status"`
+	Status               map[string]interface{} `json:"status"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ComputerUseStartResponse ComputerUseStartResponse
@@ -109,6 +109,11 @@ func (o ComputerUseStartResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["message"] = o.Message
 	toSerialize["status"] = o.Status
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *ComputerUseStartResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varComputerUseStartResponse := _ComputerUseStartResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varComputerUseStartResponse)
+	err = json.Unmarshal(data, &varComputerUseStartResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ComputerUseStartResponse(varComputerUseStartResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_computer_use_status_response.go
+++ b/libs/api-client-go/model_computer_use_status_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &ComputerUseStatusResponse{}
 // ComputerUseStatusResponse struct for ComputerUseStatusResponse
 type ComputerUseStatusResponse struct {
 	// Status of computer use services (active, partial, inactive, error)
-	Status string `json:"status"`
+	Status               string `json:"status"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ComputerUseStatusResponse ComputerUseStatusResponse
@@ -81,6 +81,11 @@ func (o ComputerUseStatusResponse) MarshalJSON() ([]byte, error) {
 func (o ComputerUseStatusResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["status"] = o.Status
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *ComputerUseStatusResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varComputerUseStatusResponse := _ComputerUseStatusResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varComputerUseStatusResponse)
+	err = json.Unmarshal(data, &varComputerUseStatusResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ComputerUseStatusResponse(varComputerUseStatusResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_computer_use_stop_response.go
+++ b/libs/api-client-go/model_computer_use_stop_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type ComputerUseStopResponse struct {
 	// A message indicating the result of stopping computer use processes
 	Message string `json:"message"`
 	// Status information about all VNC desktop processes after stopping
-	Status map[string]interface{} `json:"status"`
+	Status               map[string]interface{} `json:"status"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ComputerUseStopResponse ComputerUseStopResponse
@@ -109,6 +109,11 @@ func (o ComputerUseStopResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["message"] = o.Message
 	toSerialize["status"] = o.Status
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *ComputerUseStopResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varComputerUseStopResponse := _ComputerUseStopResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varComputerUseStopResponse)
+	err = json.Unmarshal(data, &varComputerUseStopResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ComputerUseStopResponse(varComputerUseStopResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "status")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_api_key.go
+++ b/libs/api-client-go/model_create_api_key.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -28,7 +27,8 @@ type CreateApiKey struct {
 	// The list of organization resource permissions assigned to the API key
 	Permissions []string `json:"permissions"`
 	// When the API key expires
-	ExpiresAt NullableTime `json:"expiresAt,omitempty"`
+	ExpiresAt            NullableTime `json:"expiresAt,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateApiKey CreateApiKey
@@ -158,6 +158,11 @@ func (o CreateApiKey) ToMap() (map[string]interface{}, error) {
 	if o.ExpiresAt.IsSet() {
 		toSerialize["expiresAt"] = o.ExpiresAt.Get()
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -186,15 +191,22 @@ func (o *CreateApiKey) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateApiKey := _CreateApiKey{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateApiKey)
+	err = json.Unmarshal(data, &varCreateApiKey)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateApiKey(varCreateApiKey)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "permissions")
+		delete(additionalProperties, "expiresAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_audit_log.go
+++ b/libs/api-client-go/model_create_audit_log.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,12 +21,13 @@ var _ MappedNullable = &CreateAuditLog{}
 
 // CreateAuditLog struct for CreateAuditLog
 type CreateAuditLog struct {
-	ActorId        string  `json:"actorId"`
-	ActorEmail     string  `json:"actorEmail"`
-	OrganizationId *string `json:"organizationId,omitempty"`
-	Action         string  `json:"action"`
-	TargetType     *string `json:"targetType,omitempty"`
-	TargetId       *string `json:"targetId,omitempty"`
+	ActorId              string  `json:"actorId"`
+	ActorEmail           string  `json:"actorEmail"`
+	OrganizationId       *string `json:"organizationId,omitempty"`
+	Action               string  `json:"action"`
+	TargetType           *string `json:"targetType,omitempty"`
+	TargetId             *string `json:"targetId,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateAuditLog CreateAuditLog
@@ -242,6 +242,11 @@ func (o CreateAuditLog) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.TargetId) {
 		toSerialize["targetId"] = o.TargetId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -271,15 +276,25 @@ func (o *CreateAuditLog) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateAuditLog := _CreateAuditLog{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateAuditLog)
+	err = json.Unmarshal(data, &varCreateAuditLog)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateAuditLog(varCreateAuditLog)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "actorId")
+		delete(additionalProperties, "actorEmail")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "action")
+		delete(additionalProperties, "targetType")
+		delete(additionalProperties, "targetId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_build_info.go
+++ b/libs/api-client-go/model_create_build_info.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type CreateBuildInfo struct {
 	// The Dockerfile content used for the build
 	DockerfileContent string `json:"dockerfileContent"`
 	// The context hashes used for the build
-	ContextHashes []string `json:"contextHashes,omitempty"`
+	ContextHashes        []string `json:"contextHashes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateBuildInfo CreateBuildInfo
@@ -118,6 +118,11 @@ func (o CreateBuildInfo) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ContextHashes) {
 		toSerialize["contextHashes"] = o.ContextHashes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -145,15 +150,21 @@ func (o *CreateBuildInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateBuildInfo := _CreateBuildInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateBuildInfo)
+	err = json.Unmarshal(data, &varCreateBuildInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateBuildInfo(varCreateBuildInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "dockerfileContent")
+		delete(additionalProperties, "contextHashes")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_docker_registry.go
+++ b/libs/api-client-go/model_create_docker_registry.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -35,7 +34,8 @@ type CreateDockerRegistry struct {
 	// Registry type
 	RegistryType string `json:"registryType"`
 	// Set as default registry
-	IsDefault *bool `json:"isDefault,omitempty"`
+	IsDefault            *bool `json:"isDefault,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateDockerRegistry CreateDockerRegistry
@@ -269,6 +269,11 @@ func (o CreateDockerRegistry) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.IsDefault) {
 		toSerialize["isDefault"] = o.IsDefault
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -300,15 +305,26 @@ func (o *CreateDockerRegistry) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateDockerRegistry := _CreateDockerRegistry{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateDockerRegistry)
+	err = json.Unmarshal(data, &varCreateDockerRegistry)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateDockerRegistry(varCreateDockerRegistry)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "url")
+		delete(additionalProperties, "username")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "registryType")
+		delete(additionalProperties, "isDefault")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_linked_account.go
+++ b/libs/api-client-go/model_create_linked_account.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type CreateLinkedAccount struct {
 	// The authentication provider of the secondary account
 	Provider string `json:"provider"`
 	// The user ID of the secondary account
-	UserId string `json:"userId"`
+	UserId               string `json:"userId"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateLinkedAccount CreateLinkedAccount
@@ -109,6 +109,11 @@ func (o CreateLinkedAccount) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["provider"] = o.Provider
 	toSerialize["userId"] = o.UserId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *CreateLinkedAccount) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateLinkedAccount := _CreateLinkedAccount{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateLinkedAccount)
+	err = json.Unmarshal(data, &varCreateLinkedAccount)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateLinkedAccount(varCreateLinkedAccount)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "provider")
+		delete(additionalProperties, "userId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_organization.go
+++ b/libs/api-client-go/model_create_organization.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &CreateOrganization{}
 // CreateOrganization struct for CreateOrganization
 type CreateOrganization struct {
 	// The name of organization
-	Name string `json:"name"`
+	Name                 string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateOrganization CreateOrganization
@@ -81,6 +81,11 @@ func (o CreateOrganization) MarshalJSON() ([]byte, error) {
 func (o CreateOrganization) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *CreateOrganization) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateOrganization := _CreateOrganization{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateOrganization)
+	err = json.Unmarshal(data, &varCreateOrganization)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateOrganization(varCreateOrganization)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_organization_invitation.go
+++ b/libs/api-client-go/model_create_organization_invitation.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -30,7 +29,8 @@ type CreateOrganizationInvitation struct {
 	// Array of assigned role IDs for the invitee
 	AssignedRoleIds []string `json:"assignedRoleIds"`
 	// Expiration date of the invitation
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+	ExpiresAt            *time.Time `json:"expiresAt,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateOrganizationInvitation CreateOrganizationInvitation
@@ -177,6 +177,11 @@ func (o CreateOrganizationInvitation) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ExpiresAt) {
 		toSerialize["expiresAt"] = o.ExpiresAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -206,15 +211,23 @@ func (o *CreateOrganizationInvitation) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateOrganizationInvitation := _CreateOrganizationInvitation{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateOrganizationInvitation)
+	err = json.Unmarshal(data, &varCreateOrganizationInvitation)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateOrganizationInvitation(varCreateOrganizationInvitation)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "assignedRoleIds")
+		delete(additionalProperties, "expiresAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_organization_quota.go
+++ b/libs/api-client-go/model_create_organization_quota.go
@@ -20,16 +20,19 @@ var _ MappedNullable = &CreateOrganizationQuota{}
 
 // CreateOrganizationQuota struct for CreateOrganizationQuota
 type CreateOrganizationQuota struct {
-	TotalCpuQuota       *float32 `json:"totalCpuQuota,omitempty"`
-	TotalMemoryQuota    *float32 `json:"totalMemoryQuota,omitempty"`
-	TotalDiskQuota      *float32 `json:"totalDiskQuota,omitempty"`
-	MaxCpuPerSandbox    *float32 `json:"maxCpuPerSandbox,omitempty"`
-	MaxMemoryPerSandbox *float32 `json:"maxMemoryPerSandbox,omitempty"`
-	MaxDiskPerSandbox   *float32 `json:"maxDiskPerSandbox,omitempty"`
-	SnapshotQuota       *float32 `json:"snapshotQuota,omitempty"`
-	MaxSnapshotSize     *float32 `json:"maxSnapshotSize,omitempty"`
-	VolumeQuota         *float32 `json:"volumeQuota,omitempty"`
+	TotalCpuQuota        *float32 `json:"totalCpuQuota,omitempty"`
+	TotalMemoryQuota     *float32 `json:"totalMemoryQuota,omitempty"`
+	TotalDiskQuota       *float32 `json:"totalDiskQuota,omitempty"`
+	MaxCpuPerSandbox     *float32 `json:"maxCpuPerSandbox,omitempty"`
+	MaxMemoryPerSandbox  *float32 `json:"maxMemoryPerSandbox,omitempty"`
+	MaxDiskPerSandbox    *float32 `json:"maxDiskPerSandbox,omitempty"`
+	SnapshotQuota        *float32 `json:"snapshotQuota,omitempty"`
+	MaxSnapshotSize      *float32 `json:"maxSnapshotSize,omitempty"`
+	VolumeQuota          *float32 `json:"volumeQuota,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateOrganizationQuota CreateOrganizationQuota
 
 // NewCreateOrganizationQuota instantiates a new CreateOrganizationQuota object
 // This constructor will assign default values to properties that have it defined,
@@ -373,7 +376,41 @@ func (o CreateOrganizationQuota) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.VolumeQuota) {
 		toSerialize["volumeQuota"] = o.VolumeQuota
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateOrganizationQuota) UnmarshalJSON(data []byte) (err error) {
+	varCreateOrganizationQuota := _CreateOrganizationQuota{}
+
+	err = json.Unmarshal(data, &varCreateOrganizationQuota)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateOrganizationQuota(varCreateOrganizationQuota)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "totalCpuQuota")
+		delete(additionalProperties, "totalMemoryQuota")
+		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "maxCpuPerSandbox")
+		delete(additionalProperties, "maxMemoryPerSandbox")
+		delete(additionalProperties, "maxDiskPerSandbox")
+		delete(additionalProperties, "snapshotQuota")
+		delete(additionalProperties, "maxSnapshotSize")
+		delete(additionalProperties, "volumeQuota")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateOrganizationQuota struct {

--- a/libs/api-client-go/model_create_organization_role.go
+++ b/libs/api-client-go/model_create_organization_role.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type CreateOrganizationRole struct {
 	// The description of the role
 	Description string `json:"description"`
 	// The list of permissions assigned to the role
-	Permissions []string `json:"permissions"`
+	Permissions          []string `json:"permissions"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateOrganizationRole CreateOrganizationRole
@@ -137,6 +137,11 @@ func (o CreateOrganizationRole) ToMap() (map[string]interface{}, error) {
 	toSerialize["name"] = o.Name
 	toSerialize["description"] = o.Description
 	toSerialize["permissions"] = o.Permissions
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -166,15 +171,22 @@ func (o *CreateOrganizationRole) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateOrganizationRole := _CreateOrganizationRole{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateOrganizationRole)
+	err = json.Unmarshal(data, &varCreateOrganizationRole)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateOrganizationRole(varCreateOrganizationRole)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "permissions")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_runner.go
+++ b/libs/api-client-go/model_create_runner.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,18 +21,19 @@ var _ MappedNullable = &CreateRunner{}
 
 // CreateRunner struct for CreateRunner
 type CreateRunner struct {
-	Domain    string  `json:"domain"`
-	ApiUrl    string  `json:"apiUrl"`
-	ProxyUrl  string  `json:"proxyUrl"`
-	ApiKey    string  `json:"apiKey"`
-	Cpu       float32 `json:"cpu"`
-	MemoryGiB float32 `json:"memoryGiB"`
-	DiskGiB   float32 `json:"diskGiB"`
-	Gpu       float32 `json:"gpu"`
-	GpuType   string  `json:"gpuType"`
-	Class     string  `json:"class"`
-	Region    string  `json:"region"`
-	Version   string  `json:"version"`
+	Domain               string  `json:"domain"`
+	ApiUrl               string  `json:"apiUrl"`
+	ProxyUrl             string  `json:"proxyUrl"`
+	ApiKey               string  `json:"apiKey"`
+	Cpu                  float32 `json:"cpu"`
+	MemoryGiB            float32 `json:"memoryGiB"`
+	DiskGiB              float32 `json:"diskGiB"`
+	Gpu                  float32 `json:"gpu"`
+	GpuType              string  `json:"gpuType"`
+	Class                string  `json:"class"`
+	Region               string  `json:"region"`
+	Version              string  `json:"version"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateRunner CreateRunner
@@ -377,6 +377,11 @@ func (o CreateRunner) ToMap() (map[string]interface{}, error) {
 	toSerialize["class"] = o.Class
 	toSerialize["region"] = o.Region
 	toSerialize["version"] = o.Version
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -415,15 +420,31 @@ func (o *CreateRunner) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateRunner := _CreateRunner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateRunner)
+	err = json.Unmarshal(data, &varCreateRunner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateRunner(varCreateRunner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "domain")
+		delete(additionalProperties, "apiUrl")
+		delete(additionalProperties, "proxyUrl")
+		delete(additionalProperties, "apiKey")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "memoryGiB")
+		delete(additionalProperties, "diskGiB")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "gpuType")
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "region")
+		delete(additionalProperties, "version")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_sandbox.go
+++ b/libs/api-client-go/model_create_sandbox.go
@@ -55,8 +55,11 @@ type CreateSandbox struct {
 	// Array of volumes to attach to the sandbox
 	Volumes []SandboxVolume `json:"volumes,omitempty"`
 	// Build information for the sandbox
-	BuildInfo *CreateBuildInfo `json:"buildInfo,omitempty"`
+	BuildInfo            *CreateBuildInfo `json:"buildInfo,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateSandbox CreateSandbox
 
 // NewCreateSandbox instantiates a new CreateSandbox object
 // This constructor will assign default values to properties that have it defined,
@@ -715,7 +718,50 @@ func (o CreateSandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.BuildInfo) {
 		toSerialize["buildInfo"] = o.BuildInfo
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateSandbox) UnmarshalJSON(data []byte) (err error) {
+	varCreateSandbox := _CreateSandbox{}
+
+	err = json.Unmarshal(data, &varCreateSandbox)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateSandbox(varCreateSandbox)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "snapshot")
+		delete(additionalProperties, "user")
+		delete(additionalProperties, "env")
+		delete(additionalProperties, "labels")
+		delete(additionalProperties, "public")
+		delete(additionalProperties, "networkBlockAll")
+		delete(additionalProperties, "networkAllowList")
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "target")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "memory")
+		delete(additionalProperties, "disk")
+		delete(additionalProperties, "autoStopInterval")
+		delete(additionalProperties, "autoArchiveInterval")
+		delete(additionalProperties, "autoDeleteInterval")
+		delete(additionalProperties, "volumes")
+		delete(additionalProperties, "buildInfo")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateSandbox struct {

--- a/libs/api-client-go/model_create_session_request.go
+++ b/libs/api-client-go/model_create_session_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &CreateSessionRequest{}
 // CreateSessionRequest struct for CreateSessionRequest
 type CreateSessionRequest struct {
 	// The ID of the session
-	SessionId string `json:"sessionId"`
+	SessionId            string `json:"sessionId"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateSessionRequest CreateSessionRequest
@@ -81,6 +81,11 @@ func (o CreateSessionRequest) MarshalJSON() ([]byte, error) {
 func (o CreateSessionRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["sessionId"] = o.SessionId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *CreateSessionRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateSessionRequest := _CreateSessionRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateSessionRequest)
+	err = json.Unmarshal(data, &varCreateSessionRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateSessionRequest(varCreateSessionRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sessionId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_snapshot.go
+++ b/libs/api-client-go/model_create_snapshot.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -39,7 +38,8 @@ type CreateSnapshot struct {
 	// Disk space allocated to the sandbox in GB
 	Disk *int32 `json:"disk,omitempty"`
 	// Build information for the snapshot
-	BuildInfo *CreateBuildInfo `json:"buildInfo,omitempty"`
+	BuildInfo            *CreateBuildInfo `json:"buildInfo,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateSnapshot CreateSnapshot
@@ -377,6 +377,11 @@ func (o CreateSnapshot) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.BuildInfo) {
 		toSerialize["buildInfo"] = o.BuildInfo
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -404,15 +409,28 @@ func (o *CreateSnapshot) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateSnapshot := _CreateSnapshot{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateSnapshot)
+	err = json.Unmarshal(data, &varCreateSnapshot)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateSnapshot(varCreateSnapshot)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "imageName")
+		delete(additionalProperties, "entrypoint")
+		delete(additionalProperties, "general")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "memory")
+		delete(additionalProperties, "disk")
+		delete(additionalProperties, "buildInfo")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_user.go
+++ b/libs/api-client-go/model_create_user.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -28,6 +27,7 @@ type CreateUser struct {
 	PersonalOrganizationQuota *CreateOrganizationQuota `json:"personalOrganizationQuota,omitempty"`
 	Role                      *string                  `json:"role,omitempty"`
 	EmailVerified             *bool                    `json:"emailVerified,omitempty"`
+	AdditionalProperties      map[string]interface{}
 }
 
 type _CreateUser CreateUser
@@ -251,6 +251,11 @@ func (o CreateUser) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.EmailVerified) {
 		toSerialize["emailVerified"] = o.EmailVerified
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -279,15 +284,25 @@ func (o *CreateUser) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateUser := _CreateUser{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateUser)
+	err = json.Unmarshal(data, &varCreateUser)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateUser(varCreateUser)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "personalOrganizationQuota")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "emailVerified")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_volume.go
+++ b/libs/api-client-go/model_create_volume.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,7 +21,8 @@ var _ MappedNullable = &CreateVolume{}
 
 // CreateVolume struct for CreateVolume
 type CreateVolume struct {
-	Name string `json:"name"`
+	Name                 string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateVolume CreateVolume
@@ -80,6 +80,11 @@ func (o CreateVolume) MarshalJSON() ([]byte, error) {
 func (o CreateVolume) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *CreateVolume) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateVolume := _CreateVolume{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateVolume)
+	err = json.Unmarshal(data, &varCreateVolume)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateVolume(varCreateVolume)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_create_workspace.go
+++ b/libs/api-client-go/model_create_workspace.go
@@ -49,8 +49,11 @@ type CreateWorkspace struct {
 	// Array of volumes to attach to the workspace
 	Volumes []SandboxVolume `json:"volumes,omitempty"`
 	// Build information for the workspace
-	BuildInfo *CreateBuildInfo `json:"buildInfo,omitempty"`
+	BuildInfo            *CreateBuildInfo `json:"buildInfo,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateWorkspace CreateWorkspace
 
 // NewCreateWorkspace instantiates a new CreateWorkspace object
 // This constructor will assign default values to properties that have it defined,
@@ -604,7 +607,47 @@ func (o CreateWorkspace) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.BuildInfo) {
 		toSerialize["buildInfo"] = o.BuildInfo
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateWorkspace) UnmarshalJSON(data []byte) (err error) {
+	varCreateWorkspace := _CreateWorkspace{}
+
+	err = json.Unmarshal(data, &varCreateWorkspace)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateWorkspace(varCreateWorkspace)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "image")
+		delete(additionalProperties, "user")
+		delete(additionalProperties, "env")
+		delete(additionalProperties, "labels")
+		delete(additionalProperties, "public")
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "target")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "memory")
+		delete(additionalProperties, "disk")
+		delete(additionalProperties, "autoStopInterval")
+		delete(additionalProperties, "autoArchiveInterval")
+		delete(additionalProperties, "volumes")
+		delete(additionalProperties, "buildInfo")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateWorkspace struct {

--- a/libs/api-client-go/model_daytona_configuration.go
+++ b/libs/api-client-go/model_daytona_configuration.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -51,7 +50,8 @@ type DaytonaConfiguration struct {
 	// SSH Gateway command
 	SshGatewayCommand *string `json:"sshGatewayCommand,omitempty"`
 	// Base64 encoded SSH Gateway public key
-	SshGatewayPublicKey *string `json:"sshGatewayPublicKey,omitempty"`
+	SshGatewayPublicKey  *string `json:"sshGatewayPublicKey,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _DaytonaConfiguration DaytonaConfiguration
@@ -518,6 +518,11 @@ func (o DaytonaConfiguration) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SshGatewayPublicKey) {
 		toSerialize["sshGatewayPublicKey"] = o.SshGatewayPublicKey
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -554,15 +559,34 @@ func (o *DaytonaConfiguration) UnmarshalJSON(data []byte) (err error) {
 
 	varDaytonaConfiguration := _DaytonaConfiguration{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varDaytonaConfiguration)
+	err = json.Unmarshal(data, &varDaytonaConfiguration)
 
 	if err != nil {
 		return err
 	}
 
 	*o = DaytonaConfiguration(varDaytonaConfiguration)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "version")
+		delete(additionalProperties, "posthog")
+		delete(additionalProperties, "oidc")
+		delete(additionalProperties, "linkedAccountsEnabled")
+		delete(additionalProperties, "announcements")
+		delete(additionalProperties, "pylonAppId")
+		delete(additionalProperties, "proxyTemplateUrl")
+		delete(additionalProperties, "defaultSnapshot")
+		delete(additionalProperties, "dashboardUrl")
+		delete(additionalProperties, "maxAutoArchiveInterval")
+		delete(additionalProperties, "maintananceMode")
+		delete(additionalProperties, "environment")
+		delete(additionalProperties, "billingApiUrl")
+		delete(additionalProperties, "sshGatewayCommand")
+		delete(additionalProperties, "sshGatewayPublicKey")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_display_info_response.go
+++ b/libs/api-client-go/model_display_info_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &DisplayInfoResponse{}
 // DisplayInfoResponse struct for DisplayInfoResponse
 type DisplayInfoResponse struct {
 	// Array of display information for all connected displays
-	Displays []map[string]interface{} `json:"displays"`
+	Displays             []map[string]interface{} `json:"displays"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _DisplayInfoResponse DisplayInfoResponse
@@ -81,6 +81,11 @@ func (o DisplayInfoResponse) MarshalJSON() ([]byte, error) {
 func (o DisplayInfoResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["displays"] = o.Displays
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *DisplayInfoResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varDisplayInfoResponse := _DisplayInfoResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varDisplayInfoResponse)
+	err = json.Unmarshal(data, &varDisplayInfoResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = DisplayInfoResponse(varDisplayInfoResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "displays")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_docker_registry.go
+++ b/libs/api-client-go/model_docker_registry.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -38,7 +37,8 @@ type DockerRegistry struct {
 	// Creation timestamp
 	CreatedAt time.Time `json:"createdAt"`
 	// Last update timestamp
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _DockerRegistry DockerRegistry
@@ -278,6 +278,11 @@ func (o DockerRegistry) ToMap() (map[string]interface{}, error) {
 	toSerialize["registryType"] = o.RegistryType
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -312,15 +317,27 @@ func (o *DockerRegistry) UnmarshalJSON(data []byte) (err error) {
 
 	varDockerRegistry := _DockerRegistry{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varDockerRegistry)
+	err = json.Unmarshal(data, &varDockerRegistry)
 
 	if err != nil {
 		return err
 	}
 
 	*o = DockerRegistry(varDockerRegistry)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "url")
+		delete(additionalProperties, "username")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "registryType")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_download_files.go
+++ b/libs/api-client-go/model_download_files.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &DownloadFiles{}
 // DownloadFiles struct for DownloadFiles
 type DownloadFiles struct {
 	// List of remote file paths to download
-	Paths []string `json:"paths"`
+	Paths                []string `json:"paths"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _DownloadFiles DownloadFiles
@@ -81,6 +81,11 @@ func (o DownloadFiles) MarshalJSON() ([]byte, error) {
 func (o DownloadFiles) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["paths"] = o.Paths
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *DownloadFiles) UnmarshalJSON(data []byte) (err error) {
 
 	varDownloadFiles := _DownloadFiles{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varDownloadFiles)
+	err = json.Unmarshal(data, &varDownloadFiles)
 
 	if err != nil {
 		return err
 	}
 
 	*o = DownloadFiles(varDownloadFiles)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "paths")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_execute_request.go
+++ b/libs/api-client-go/model_execute_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -26,7 +25,8 @@ type ExecuteRequest struct {
 	// Current working directory
 	Cwd *string `json:"cwd,omitempty"`
 	// Timeout in seconds, defaults to 10 seconds
-	Timeout *float32 `json:"timeout,omitempty"`
+	Timeout              *float32 `json:"timeout,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ExecuteRequest ExecuteRequest
@@ -154,6 +154,11 @@ func (o ExecuteRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Timeout) {
 		toSerialize["timeout"] = o.Timeout
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -181,15 +186,22 @@ func (o *ExecuteRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varExecuteRequest := _ExecuteRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varExecuteRequest)
+	err = json.Unmarshal(data, &varExecuteRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ExecuteRequest(varExecuteRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "command")
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "timeout")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_execute_response.go
+++ b/libs/api-client-go/model_execute_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type ExecuteResponse struct {
 	// Exit code
 	ExitCode float32 `json:"exitCode"`
 	// Command output
-	Result string `json:"result"`
+	Result               string `json:"result"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ExecuteResponse ExecuteResponse
@@ -109,6 +109,11 @@ func (o ExecuteResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["exitCode"] = o.ExitCode
 	toSerialize["result"] = o.Result
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *ExecuteResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varExecuteResponse := _ExecuteResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varExecuteResponse)
+	err = json.Unmarshal(data, &varExecuteResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ExecuteResponse(varExecuteResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "exitCode")
+		delete(additionalProperties, "result")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_file_info.go
+++ b/libs/api-client-go/model_file_info.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,14 +21,15 @@ var _ MappedNullable = &FileInfo{}
 
 // FileInfo struct for FileInfo
 type FileInfo struct {
-	Name        string  `json:"name"`
-	IsDir       bool    `json:"isDir"`
-	Size        float32 `json:"size"`
-	ModTime     string  `json:"modTime"`
-	Mode        string  `json:"mode"`
-	Permissions string  `json:"permissions"`
-	Owner       string  `json:"owner"`
-	Group       string  `json:"group"`
+	Name                 string  `json:"name"`
+	IsDir                bool    `json:"isDir"`
+	Size                 float32 `json:"size"`
+	ModTime              string  `json:"modTime"`
+	Mode                 string  `json:"mode"`
+	Permissions          string  `json:"permissions"`
+	Owner                string  `json:"owner"`
+	Group                string  `json:"group"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FileInfo FileInfo
@@ -269,6 +269,11 @@ func (o FileInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["permissions"] = o.Permissions
 	toSerialize["owner"] = o.Owner
 	toSerialize["group"] = o.Group
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -303,15 +308,27 @@ func (o *FileInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varFileInfo := _FileInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFileInfo)
+	err = json.Unmarshal(data, &varFileInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FileInfo(varFileInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "isDir")
+		delete(additionalProperties, "size")
+		delete(additionalProperties, "modTime")
+		delete(additionalProperties, "mode")
+		delete(additionalProperties, "permissions")
+		delete(additionalProperties, "owner")
+		delete(additionalProperties, "group")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_file_status.go
+++ b/libs/api-client-go/model_file_status.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,10 +21,11 @@ var _ MappedNullable = &FileStatus{}
 
 // FileStatus struct for FileStatus
 type FileStatus struct {
-	Name     string `json:"name"`
-	Staging  string `json:"staging"`
-	Worktree string `json:"worktree"`
-	Extra    string `json:"extra"`
+	Name                 string `json:"name"`
+	Staging              string `json:"staging"`
+	Worktree             string `json:"worktree"`
+	Extra                string `json:"extra"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FileStatus FileStatus
@@ -161,6 +161,11 @@ func (o FileStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize["staging"] = o.Staging
 	toSerialize["worktree"] = o.Worktree
 	toSerialize["extra"] = o.Extra
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -191,15 +196,23 @@ func (o *FileStatus) UnmarshalJSON(data []byte) (err error) {
 
 	varFileStatus := _FileStatus{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFileStatus)
+	err = json.Unmarshal(data, &varFileStatus)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FileStatus(varFileStatus)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "staging")
+		delete(additionalProperties, "worktree")
+		delete(additionalProperties, "extra")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_add_request.go
+++ b/libs/api-client-go/model_git_add_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -24,7 +23,8 @@ var _ MappedNullable = &GitAddRequest{}
 type GitAddRequest struct {
 	Path string `json:"path"`
 	// files to add (use . for all files)
-	Files []string `json:"files"`
+	Files                []string `json:"files"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitAddRequest GitAddRequest
@@ -108,6 +108,11 @@ func (o GitAddRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["path"] = o.Path
 	toSerialize["files"] = o.Files
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -136,15 +141,21 @@ func (o *GitAddRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitAddRequest := _GitAddRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitAddRequest)
+	err = json.Unmarshal(data, &varGitAddRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitAddRequest(varGitAddRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "files")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_branch_request.go
+++ b/libs/api-client-go/model_git_branch_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &GitBranchRequest{}
 
 // GitBranchRequest struct for GitBranchRequest
 type GitBranchRequest struct {
-	Path string `json:"path"`
-	Name string `json:"name"`
+	Path                 string `json:"path"`
+	Name                 string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitBranchRequest GitBranchRequest
@@ -107,6 +107,11 @@ func (o GitBranchRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["path"] = o.Path
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *GitBranchRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitBranchRequest := _GitBranchRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitBranchRequest)
+	err = json.Unmarshal(data, &varGitBranchRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitBranchRequest(varGitBranchRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_checkout_request.go
+++ b/libs/api-client-go/model_git_checkout_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &GitCheckoutRequest{}
 
 // GitCheckoutRequest struct for GitCheckoutRequest
 type GitCheckoutRequest struct {
-	Path   string `json:"path"`
-	Branch string `json:"branch"`
+	Path                 string `json:"path"`
+	Branch               string `json:"branch"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCheckoutRequest GitCheckoutRequest
@@ -107,6 +107,11 @@ func (o GitCheckoutRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["path"] = o.Path
 	toSerialize["branch"] = o.Branch
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *GitCheckoutRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCheckoutRequest := _GitCheckoutRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCheckoutRequest)
+	err = json.Unmarshal(data, &varGitCheckoutRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCheckoutRequest(varGitCheckoutRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "branch")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_clone_request.go
+++ b/libs/api-client-go/model_git_clone_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,12 +21,13 @@ var _ MappedNullable = &GitCloneRequest{}
 
 // GitCloneRequest struct for GitCloneRequest
 type GitCloneRequest struct {
-	Url      string  `json:"url"`
-	Path     string  `json:"path"`
-	Username *string `json:"username,omitempty"`
-	Password *string `json:"password,omitempty"`
-	Branch   *string `json:"branch,omitempty"`
-	CommitId *string `json:"commit_id,omitempty"`
+	Url                  string  `json:"url"`
+	Path                 string  `json:"path"`
+	Username             *string `json:"username,omitempty"`
+	Password             *string `json:"password,omitempty"`
+	Branch               *string `json:"branch,omitempty"`
+	CommitId             *string `json:"commit_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCloneRequest GitCloneRequest
@@ -251,6 +251,11 @@ func (o GitCloneRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CommitId) {
 		toSerialize["commit_id"] = o.CommitId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -279,15 +284,25 @@ func (o *GitCloneRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCloneRequest := _GitCloneRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCloneRequest)
+	err = json.Unmarshal(data, &varGitCloneRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCloneRequest(varGitCloneRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "url")
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "username")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "branch")
+		delete(additionalProperties, "commit_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_commit_info.go
+++ b/libs/api-client-go/model_git_commit_info.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,11 +21,12 @@ var _ MappedNullable = &GitCommitInfo{}
 
 // GitCommitInfo struct for GitCommitInfo
 type GitCommitInfo struct {
-	Hash      string `json:"hash"`
-	Message   string `json:"message"`
-	Author    string `json:"author"`
-	Email     string `json:"email"`
-	Timestamp string `json:"timestamp"`
+	Hash                 string `json:"hash"`
+	Message              string `json:"message"`
+	Author               string `json:"author"`
+	Email                string `json:"email"`
+	Timestamp            string `json:"timestamp"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCommitInfo GitCommitInfo
@@ -188,6 +188,11 @@ func (o GitCommitInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["author"] = o.Author
 	toSerialize["email"] = o.Email
 	toSerialize["timestamp"] = o.Timestamp
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -219,15 +224,24 @@ func (o *GitCommitInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCommitInfo := _GitCommitInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCommitInfo)
+	err = json.Unmarshal(data, &varGitCommitInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCommitInfo(varGitCommitInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "hash")
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "author")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "timestamp")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_commit_request.go
+++ b/libs/api-client-go/model_git_commit_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type GitCommitRequest struct {
 	Author  string `json:"author"`
 	Email   string `json:"email"`
 	// Allow creating an empty commit when no changes are staged
-	AllowEmpty *bool `json:"allow_empty,omitempty"`
+	AllowEmpty           *bool `json:"allow_empty,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCommitRequest GitCommitRequest
@@ -202,6 +202,11 @@ func (o GitCommitRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AllowEmpty) {
 		toSerialize["allow_empty"] = o.AllowEmpty
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -232,15 +237,24 @@ func (o *GitCommitRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCommitRequest := _GitCommitRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCommitRequest)
+	err = json.Unmarshal(data, &varGitCommitRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCommitRequest(varGitCommitRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "author")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "allow_empty")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_commit_response.go
+++ b/libs/api-client-go/model_git_commit_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,7 +21,8 @@ var _ MappedNullable = &GitCommitResponse{}
 
 // GitCommitResponse struct for GitCommitResponse
 type GitCommitResponse struct {
-	Hash string `json:"hash"`
+	Hash                 string `json:"hash"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitCommitResponse GitCommitResponse
@@ -80,6 +80,11 @@ func (o GitCommitResponse) MarshalJSON() ([]byte, error) {
 func (o GitCommitResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["hash"] = o.Hash
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *GitCommitResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varGitCommitResponse := _GitCommitResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitCommitResponse)
+	err = json.Unmarshal(data, &varGitCommitResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitCommitResponse(varGitCommitResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "hash")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_delete_branch_request.go
+++ b/libs/api-client-go/model_git_delete_branch_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &GitDeleteBranchRequest{}
 
 // GitDeleteBranchRequest struct for GitDeleteBranchRequest
 type GitDeleteBranchRequest struct {
-	Path string `json:"path"`
-	Name string `json:"name"`
+	Path                 string `json:"path"`
+	Name                 string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitDeleteBranchRequest GitDeleteBranchRequest
@@ -107,6 +107,11 @@ func (o GitDeleteBranchRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["path"] = o.Path
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *GitDeleteBranchRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitDeleteBranchRequest := _GitDeleteBranchRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitDeleteBranchRequest)
+	err = json.Unmarshal(data, &varGitDeleteBranchRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitDeleteBranchRequest(varGitDeleteBranchRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_repo_request.go
+++ b/libs/api-client-go/model_git_repo_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,9 +21,10 @@ var _ MappedNullable = &GitRepoRequest{}
 
 // GitRepoRequest struct for GitRepoRequest
 type GitRepoRequest struct {
-	Path     string  `json:"path"`
-	Username *string `json:"username,omitempty"`
-	Password *string `json:"password,omitempty"`
+	Path                 string  `json:"path"`
+	Username             *string `json:"username,omitempty"`
+	Password             *string `json:"password,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitRepoRequest GitRepoRequest
@@ -152,6 +152,11 @@ func (o GitRepoRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Password) {
 		toSerialize["password"] = o.Password
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -179,15 +184,22 @@ func (o *GitRepoRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varGitRepoRequest := _GitRepoRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitRepoRequest)
+	err = json.Unmarshal(data, &varGitRepoRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitRepoRequest(varGitRepoRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "path")
+		delete(additionalProperties, "username")
+		delete(additionalProperties, "password")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_git_status.go
+++ b/libs/api-client-go/model_git_status.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,11 +21,12 @@ var _ MappedNullable = &GitStatus{}
 
 // GitStatus struct for GitStatus
 type GitStatus struct {
-	CurrentBranch   string       `json:"currentBranch"`
-	FileStatus      []FileStatus `json:"fileStatus"`
-	Ahead           *float32     `json:"ahead,omitempty"`
-	Behind          *float32     `json:"behind,omitempty"`
-	BranchPublished *bool        `json:"branchPublished,omitempty"`
+	CurrentBranch        string       `json:"currentBranch"`
+	FileStatus           []FileStatus `json:"fileStatus"`
+	Ahead                *float32     `json:"ahead,omitempty"`
+	Behind               *float32     `json:"behind,omitempty"`
+	BranchPublished      *bool        `json:"branchPublished,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _GitStatus GitStatus
@@ -215,6 +215,11 @@ func (o GitStatus) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.BranchPublished) {
 		toSerialize["branchPublished"] = o.BranchPublished
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -243,15 +248,24 @@ func (o *GitStatus) UnmarshalJSON(data []byte) (err error) {
 
 	varGitStatus := _GitStatus{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varGitStatus)
+	err = json.Unmarshal(data, &varGitStatus)
 
 	if err != nil {
 		return err
 	}
 
 	*o = GitStatus(varGitStatus)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "currentBranch")
+		delete(additionalProperties, "fileStatus")
+		delete(additionalProperties, "ahead")
+		delete(additionalProperties, "behind")
+		delete(additionalProperties, "branchPublished")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_health_controller_check_200_response.go
+++ b/libs/api-client-go/model_health_controller_check_200_response.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &HealthControllerCheck200Response{}
 
 // HealthControllerCheck200Response struct for HealthControllerCheck200Response
 type HealthControllerCheck200Response struct {
-	Status  *string                                               `json:"status,omitempty"`
-	Info    map[string]HealthControllerCheck200ResponseInfoValue  `json:"info,omitempty"`
-	Error   map[string]HealthControllerCheck200ResponseInfoValue  `json:"error,omitempty"`
-	Details *map[string]HealthControllerCheck200ResponseInfoValue `json:"details,omitempty"`
+	Status               *string                                               `json:"status,omitempty"`
+	Info                 map[string]HealthControllerCheck200ResponseInfoValue  `json:"info,omitempty"`
+	Error                map[string]HealthControllerCheck200ResponseInfoValue  `json:"error,omitempty"`
+	Details              *map[string]HealthControllerCheck200ResponseInfoValue `json:"details,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _HealthControllerCheck200Response HealthControllerCheck200Response
 
 // NewHealthControllerCheck200Response instantiates a new HealthControllerCheck200Response object
 // This constructor will assign default values to properties that have it defined,
@@ -195,7 +198,36 @@ func (o HealthControllerCheck200Response) ToMap() (map[string]interface{}, error
 	if !IsNil(o.Details) {
 		toSerialize["details"] = o.Details
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *HealthControllerCheck200Response) UnmarshalJSON(data []byte) (err error) {
+	varHealthControllerCheck200Response := _HealthControllerCheck200Response{}
+
+	err = json.Unmarshal(data, &varHealthControllerCheck200Response)
+
+	if err != nil {
+		return err
+	}
+
+	*o = HealthControllerCheck200Response(varHealthControllerCheck200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "info")
+		delete(additionalProperties, "error")
+		delete(additionalProperties, "details")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHealthControllerCheck200Response struct {

--- a/libs/api-client-go/model_health_controller_check_503_response.go
+++ b/libs/api-client-go/model_health_controller_check_503_response.go
@@ -20,11 +20,14 @@ var _ MappedNullable = &HealthControllerCheck503Response{}
 
 // HealthControllerCheck503Response struct for HealthControllerCheck503Response
 type HealthControllerCheck503Response struct {
-	Status  *string                                               `json:"status,omitempty"`
-	Info    map[string]HealthControllerCheck200ResponseInfoValue  `json:"info,omitempty"`
-	Error   map[string]HealthControllerCheck200ResponseInfoValue  `json:"error,omitempty"`
-	Details *map[string]HealthControllerCheck200ResponseInfoValue `json:"details,omitempty"`
+	Status               *string                                               `json:"status,omitempty"`
+	Info                 map[string]HealthControllerCheck200ResponseInfoValue  `json:"info,omitempty"`
+	Error                map[string]HealthControllerCheck200ResponseInfoValue  `json:"error,omitempty"`
+	Details              *map[string]HealthControllerCheck200ResponseInfoValue `json:"details,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _HealthControllerCheck503Response HealthControllerCheck503Response
 
 // NewHealthControllerCheck503Response instantiates a new HealthControllerCheck503Response object
 // This constructor will assign default values to properties that have it defined,
@@ -195,7 +198,36 @@ func (o HealthControllerCheck503Response) ToMap() (map[string]interface{}, error
 	if !IsNil(o.Details) {
 		toSerialize["details"] = o.Details
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *HealthControllerCheck503Response) UnmarshalJSON(data []byte) (err error) {
+	varHealthControllerCheck503Response := _HealthControllerCheck503Response{}
+
+	err = json.Unmarshal(data, &varHealthControllerCheck503Response)
+
+	if err != nil {
+		return err
+	}
+
+	*o = HealthControllerCheck503Response(varHealthControllerCheck503Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "info")
+		delete(additionalProperties, "error")
+		delete(additionalProperties, "details")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHealthControllerCheck503Response struct {

--- a/libs/api-client-go/model_keyboard_hotkey_request.go
+++ b/libs/api-client-go/model_keyboard_hotkey_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &KeyboardHotkeyRequest{}
 // KeyboardHotkeyRequest struct for KeyboardHotkeyRequest
 type KeyboardHotkeyRequest struct {
 	// The hotkey combination to press (e.g., \"ctrl+c\", \"cmd+v\", \"alt+tab\")
-	Keys string `json:"keys"`
+	Keys                 string `json:"keys"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _KeyboardHotkeyRequest KeyboardHotkeyRequest
@@ -81,6 +81,11 @@ func (o KeyboardHotkeyRequest) MarshalJSON() ([]byte, error) {
 func (o KeyboardHotkeyRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["keys"] = o.Keys
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *KeyboardHotkeyRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varKeyboardHotkeyRequest := _KeyboardHotkeyRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varKeyboardHotkeyRequest)
+	err = json.Unmarshal(data, &varKeyboardHotkeyRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = KeyboardHotkeyRequest(varKeyboardHotkeyRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "keys")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_keyboard_press_request.go
+++ b/libs/api-client-go/model_keyboard_press_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type KeyboardPressRequest struct {
 	// The key to press (e.g., a, b, c, enter, space, etc.)
 	Key string `json:"key"`
 	// Array of modifier keys to press along with the main key (ctrl, alt, shift, cmd)
-	Modifiers []string `json:"modifiers,omitempty"`
+	Modifiers            []string `json:"modifiers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _KeyboardPressRequest KeyboardPressRequest
@@ -118,6 +118,11 @@ func (o KeyboardPressRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Modifiers) {
 		toSerialize["modifiers"] = o.Modifiers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -145,15 +150,21 @@ func (o *KeyboardPressRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varKeyboardPressRequest := _KeyboardPressRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varKeyboardPressRequest)
+	err = json.Unmarshal(data, &varKeyboardPressRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = KeyboardPressRequest(varKeyboardPressRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "key")
+		delete(additionalProperties, "modifiers")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_keyboard_type_request.go
+++ b/libs/api-client-go/model_keyboard_type_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type KeyboardTypeRequest struct {
 	// The text to type using the keyboard
 	Text string `json:"text"`
 	// Delay in milliseconds between keystrokes. Defaults to 0
-	Delay *float32 `json:"delay,omitempty"`
+	Delay                *float32 `json:"delay,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _KeyboardTypeRequest KeyboardTypeRequest
@@ -118,6 +118,11 @@ func (o KeyboardTypeRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Delay) {
 		toSerialize["delay"] = o.Delay
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -145,15 +150,21 @@ func (o *KeyboardTypeRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varKeyboardTypeRequest := _KeyboardTypeRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varKeyboardTypeRequest)
+	err = json.Unmarshal(data, &varKeyboardTypeRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = KeyboardTypeRequest(varKeyboardTypeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "text")
+		delete(additionalProperties, "delay")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_list_branch_response.go
+++ b/libs/api-client-go/model_list_branch_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,7 +21,8 @@ var _ MappedNullable = &ListBranchResponse{}
 
 // ListBranchResponse struct for ListBranchResponse
 type ListBranchResponse struct {
-	Branches []string `json:"branches"`
+	Branches             []string `json:"branches"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ListBranchResponse ListBranchResponse
@@ -80,6 +80,11 @@ func (o ListBranchResponse) MarshalJSON() ([]byte, error) {
 func (o ListBranchResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["branches"] = o.Branches
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *ListBranchResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varListBranchResponse := _ListBranchResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varListBranchResponse)
+	err = json.Unmarshal(data, &varListBranchResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ListBranchResponse(varListBranchResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "branches")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_lsp_completion_params.go
+++ b/libs/api-client-go/model_lsp_completion_params.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,9 +26,10 @@ type LspCompletionParams struct {
 	// Path to the project
 	PathToProject string `json:"pathToProject"`
 	// Document URI
-	Uri      string             `json:"uri"`
-	Position Position           `json:"position"`
-	Context  *CompletionContext `json:"context,omitempty"`
+	Uri                  string             `json:"uri"`
+	Position             Position           `json:"position"`
+	Context              *CompletionContext `json:"context,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspCompletionParams LspCompletionParams
@@ -200,6 +200,11 @@ func (o LspCompletionParams) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Context) {
 		toSerialize["context"] = o.Context
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -230,15 +235,24 @@ func (o *LspCompletionParams) UnmarshalJSON(data []byte) (err error) {
 
 	varLspCompletionParams := _LspCompletionParams{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspCompletionParams)
+	err = json.Unmarshal(data, &varLspCompletionParams)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspCompletionParams(varLspCompletionParams)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "languageId")
+		delete(additionalProperties, "pathToProject")
+		delete(additionalProperties, "uri")
+		delete(additionalProperties, "position")
+		delete(additionalProperties, "context")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_lsp_document_request.go
+++ b/libs/api-client-go/model_lsp_document_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type LspDocumentRequest struct {
 	// Path to the project
 	PathToProject string `json:"pathToProject"`
 	// Document URI
-	Uri string `json:"uri"`
+	Uri                  string `json:"uri"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspDocumentRequest LspDocumentRequest
@@ -137,6 +137,11 @@ func (o LspDocumentRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["languageId"] = o.LanguageId
 	toSerialize["pathToProject"] = o.PathToProject
 	toSerialize["uri"] = o.Uri
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -166,15 +171,22 @@ func (o *LspDocumentRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varLspDocumentRequest := _LspDocumentRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspDocumentRequest)
+	err = json.Unmarshal(data, &varLspDocumentRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspDocumentRequest(varLspDocumentRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "languageId")
+		delete(additionalProperties, "pathToProject")
+		delete(additionalProperties, "uri")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_lsp_location.go
+++ b/libs/api-client-go/model_lsp_location.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &LspLocation{}
 
 // LspLocation struct for LspLocation
 type LspLocation struct {
-	Range Range  `json:"range"`
-	Uri   string `json:"uri"`
+	Range                Range  `json:"range"`
+	Uri                  string `json:"uri"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspLocation LspLocation
@@ -107,6 +107,11 @@ func (o LspLocation) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["range"] = o.Range
 	toSerialize["uri"] = o.Uri
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *LspLocation) UnmarshalJSON(data []byte) (err error) {
 
 	varLspLocation := _LspLocation{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspLocation)
+	err = json.Unmarshal(data, &varLspLocation)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspLocation(varLspLocation)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "range")
+		delete(additionalProperties, "uri")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_lsp_server_request.go
+++ b/libs/api-client-go/model_lsp_server_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type LspServerRequest struct {
 	// Language identifier
 	LanguageId string `json:"languageId"`
 	// Path to the project
-	PathToProject string `json:"pathToProject"`
+	PathToProject        string `json:"pathToProject"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspServerRequest LspServerRequest
@@ -109,6 +109,11 @@ func (o LspServerRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["languageId"] = o.LanguageId
 	toSerialize["pathToProject"] = o.PathToProject
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *LspServerRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varLspServerRequest := _LspServerRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspServerRequest)
+	err = json.Unmarshal(data, &varLspServerRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspServerRequest(varLspServerRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "languageId")
+		delete(additionalProperties, "pathToProject")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_lsp_symbol.go
+++ b/libs/api-client-go/model_lsp_symbol.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,9 +21,10 @@ var _ MappedNullable = &LspSymbol{}
 
 // LspSymbol struct for LspSymbol
 type LspSymbol struct {
-	Kind     float32     `json:"kind"`
-	Location LspLocation `json:"location"`
-	Name     string      `json:"name"`
+	Kind                 float32     `json:"kind"`
+	Location             LspLocation `json:"location"`
+	Name                 string      `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _LspSymbol LspSymbol
@@ -134,6 +134,11 @@ func (o LspSymbol) ToMap() (map[string]interface{}, error) {
 	toSerialize["kind"] = o.Kind
 	toSerialize["location"] = o.Location
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -163,15 +168,22 @@ func (o *LspSymbol) UnmarshalJSON(data []byte) (err error) {
 
 	varLspSymbol := _LspSymbol{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varLspSymbol)
+	err = json.Unmarshal(data, &varLspSymbol)
 
 	if err != nil {
 		return err
 	}
 
 	*o = LspSymbol(varLspSymbol)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "kind")
+		delete(additionalProperties, "location")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_match.go
+++ b/libs/api-client-go/model_match.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,9 +21,10 @@ var _ MappedNullable = &Match{}
 
 // Match struct for Match
 type Match struct {
-	File    string  `json:"file"`
-	Line    float32 `json:"line"`
-	Content string  `json:"content"`
+	File                 string  `json:"file"`
+	Line                 float32 `json:"line"`
+	Content              string  `json:"content"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Match Match
@@ -134,6 +134,11 @@ func (o Match) ToMap() (map[string]interface{}, error) {
 	toSerialize["file"] = o.File
 	toSerialize["line"] = o.Line
 	toSerialize["content"] = o.Content
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -163,15 +168,22 @@ func (o *Match) UnmarshalJSON(data []byte) (err error) {
 
 	varMatch := _Match{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMatch)
+	err = json.Unmarshal(data, &varMatch)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Match(varMatch)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "file")
+		delete(additionalProperties, "line")
+		delete(additionalProperties, "content")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_click_request.go
+++ b/libs/api-client-go/model_mouse_click_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -29,7 +28,8 @@ type MouseClickRequest struct {
 	// The mouse button to click (left, right, middle). Defaults to left
 	Button *string `json:"button,omitempty"`
 	// Whether to perform a double-click instead of a single click
-	Double *bool `json:"double,omitempty"`
+	Double               *bool `json:"double,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseClickRequest MouseClickRequest
@@ -183,6 +183,11 @@ func (o MouseClickRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Double) {
 		toSerialize["double"] = o.Double
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -211,15 +216,23 @@ func (o *MouseClickRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseClickRequest := _MouseClickRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseClickRequest)
+	err = json.Unmarshal(data, &varMouseClickRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseClickRequest(varMouseClickRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		delete(additionalProperties, "button")
+		delete(additionalProperties, "double")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_click_response.go
+++ b/libs/api-client-go/model_mouse_click_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type MouseClickResponse struct {
 	// The actual X coordinate where the click occurred
 	X float32 `json:"x"`
 	// The actual Y coordinate where the click occurred
-	Y float32 `json:"y"`
+	Y                    float32 `json:"y"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseClickResponse MouseClickResponse
@@ -109,6 +109,11 @@ func (o MouseClickResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["x"] = o.X
 	toSerialize["y"] = o.Y
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *MouseClickResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseClickResponse := _MouseClickResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseClickResponse)
+	err = json.Unmarshal(data, &varMouseClickResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseClickResponse(varMouseClickResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_drag_request.go
+++ b/libs/api-client-go/model_mouse_drag_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -31,7 +30,8 @@ type MouseDragRequest struct {
 	// The ending Y coordinate for the drag operation
 	EndY float32 `json:"endY"`
 	// The mouse button to use for dragging (left, right, middle). Defaults to left
-	Button *string `json:"button,omitempty"`
+	Button               *string `json:"button,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseDragRequest MouseDragRequest
@@ -202,6 +202,11 @@ func (o MouseDragRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Button) {
 		toSerialize["button"] = o.Button
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -232,15 +237,24 @@ func (o *MouseDragRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseDragRequest := _MouseDragRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseDragRequest)
+	err = json.Unmarshal(data, &varMouseDragRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseDragRequest(varMouseDragRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "startX")
+		delete(additionalProperties, "startY")
+		delete(additionalProperties, "endX")
+		delete(additionalProperties, "endY")
+		delete(additionalProperties, "button")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_drag_response.go
+++ b/libs/api-client-go/model_mouse_drag_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type MouseDragResponse struct {
 	// The actual X coordinate where the drag ended
 	X float32 `json:"x"`
 	// The actual Y coordinate where the drag ended
-	Y float32 `json:"y"`
+	Y                    float32 `json:"y"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseDragResponse MouseDragResponse
@@ -109,6 +109,11 @@ func (o MouseDragResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["x"] = o.X
 	toSerialize["y"] = o.Y
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *MouseDragResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseDragResponse := _MouseDragResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseDragResponse)
+	err = json.Unmarshal(data, &varMouseDragResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseDragResponse(varMouseDragResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_move_request.go
+++ b/libs/api-client-go/model_mouse_move_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type MouseMoveRequest struct {
 	// The target X coordinate to move the mouse cursor to
 	X float32 `json:"x"`
 	// The target Y coordinate to move the mouse cursor to
-	Y float32 `json:"y"`
+	Y                    float32 `json:"y"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseMoveRequest MouseMoveRequest
@@ -109,6 +109,11 @@ func (o MouseMoveRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["x"] = o.X
 	toSerialize["y"] = o.Y
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *MouseMoveRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseMoveRequest := _MouseMoveRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseMoveRequest)
+	err = json.Unmarshal(data, &varMouseMoveRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseMoveRequest(varMouseMoveRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_move_response.go
+++ b/libs/api-client-go/model_mouse_move_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type MouseMoveResponse struct {
 	// The actual X coordinate where the mouse cursor ended up
 	X float32 `json:"x"`
 	// The actual Y coordinate where the mouse cursor ended up
-	Y float32 `json:"y"`
+	Y                    float32 `json:"y"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseMoveResponse MouseMoveResponse
@@ -109,6 +109,11 @@ func (o MouseMoveResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["x"] = o.X
 	toSerialize["y"] = o.Y
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *MouseMoveResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseMoveResponse := _MouseMoveResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseMoveResponse)
+	err = json.Unmarshal(data, &varMouseMoveResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseMoveResponse(varMouseMoveResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_position.go
+++ b/libs/api-client-go/model_mouse_position.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type MousePosition struct {
 	// The X coordinate of the mouse cursor position
 	X float32 `json:"x"`
 	// The Y coordinate of the mouse cursor position
-	Y float32 `json:"y"`
+	Y                    float32 `json:"y"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MousePosition MousePosition
@@ -109,6 +109,11 @@ func (o MousePosition) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["x"] = o.X
 	toSerialize["y"] = o.Y
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *MousePosition) UnmarshalJSON(data []byte) (err error) {
 
 	varMousePosition := _MousePosition{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMousePosition)
+	err = json.Unmarshal(data, &varMousePosition)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MousePosition(varMousePosition)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_scroll_request.go
+++ b/libs/api-client-go/model_mouse_scroll_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -29,7 +28,8 @@ type MouseScrollRequest struct {
 	// The scroll direction (up, down)
 	Direction string `json:"direction"`
 	// The number of scroll units to scroll. Defaults to 1
-	Amount *float32 `json:"amount,omitempty"`
+	Amount               *float32 `json:"amount,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseScrollRequest MouseScrollRequest
@@ -174,6 +174,11 @@ func (o MouseScrollRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Amount) {
 		toSerialize["amount"] = o.Amount
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -203,15 +208,23 @@ func (o *MouseScrollRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseScrollRequest := _MouseScrollRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseScrollRequest)
+	err = json.Unmarshal(data, &varMouseScrollRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseScrollRequest(varMouseScrollRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "x")
+		delete(additionalProperties, "y")
+		delete(additionalProperties, "direction")
+		delete(additionalProperties, "amount")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_mouse_scroll_response.go
+++ b/libs/api-client-go/model_mouse_scroll_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &MouseScrollResponse{}
 // MouseScrollResponse struct for MouseScrollResponse
 type MouseScrollResponse struct {
 	// Whether the mouse scroll operation was successful
-	Success bool `json:"success"`
+	Success              bool `json:"success"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MouseScrollResponse MouseScrollResponse
@@ -81,6 +81,11 @@ func (o MouseScrollResponse) MarshalJSON() ([]byte, error) {
 func (o MouseScrollResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["success"] = o.Success
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *MouseScrollResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varMouseScrollResponse := _MouseScrollResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMouseScrollResponse)
+	err = json.Unmarshal(data, &varMouseScrollResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MouseScrollResponse(varMouseScrollResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "success")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_oidc_config.go
+++ b/libs/api-client-go/model_oidc_config.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type OidcConfig struct {
 	// OIDC client ID
 	ClientId string `json:"clientId"`
 	// OIDC audience
-	Audience string `json:"audience"`
+	Audience             string `json:"audience"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _OidcConfig OidcConfig
@@ -137,6 +137,11 @@ func (o OidcConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize["issuer"] = o.Issuer
 	toSerialize["clientId"] = o.ClientId
 	toSerialize["audience"] = o.Audience
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -166,15 +171,22 @@ func (o *OidcConfig) UnmarshalJSON(data []byte) (err error) {
 
 	varOidcConfig := _OidcConfig{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOidcConfig)
+	err = json.Unmarshal(data, &varOidcConfig)
 
 	if err != nil {
 		return err
 	}
 
 	*o = OidcConfig(varOidcConfig)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "issuer")
+		delete(additionalProperties, "clientId")
+		delete(additionalProperties, "audience")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_organization.go
+++ b/libs/api-client-go/model_organization.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -59,6 +58,7 @@ type Organization struct {
 	MaxDiskPerSandbox float32 `json:"maxDiskPerSandbox"`
 	// Sandbox default network block all
 	SandboxLimitedNetworkEgress bool `json:"sandboxLimitedNetworkEgress"`
+	AdditionalProperties        map[string]interface{}
 }
 
 type _Organization Organization
@@ -558,6 +558,11 @@ func (o Organization) ToMap() (map[string]interface{}, error) {
 	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox
 	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox
 	toSerialize["sandboxLimitedNetworkEgress"] = o.SandboxLimitedNetworkEgress
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -602,15 +607,37 @@ func (o *Organization) UnmarshalJSON(data []byte) (err error) {
 
 	varOrganization := _Organization{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOrganization)
+	err = json.Unmarshal(data, &varOrganization)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Organization(varOrganization)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "createdBy")
+		delete(additionalProperties, "personal")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "suspended")
+		delete(additionalProperties, "suspendedAt")
+		delete(additionalProperties, "suspensionReason")
+		delete(additionalProperties, "suspendedUntil")
+		delete(additionalProperties, "suspensionCleanupGracePeriodHours")
+		delete(additionalProperties, "totalCpuQuota")
+		delete(additionalProperties, "totalMemoryQuota")
+		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "maxCpuPerSandbox")
+		delete(additionalProperties, "maxMemoryPerSandbox")
+		delete(additionalProperties, "maxDiskPerSandbox")
+		delete(additionalProperties, "sandboxLimitedNetworkEgress")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_organization_invitation.go
+++ b/libs/api-client-go/model_organization_invitation.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -44,7 +43,8 @@ type OrganizationInvitation struct {
 	// Creation timestamp
 	CreatedAt time.Time `json:"createdAt"`
 	// Last update timestamp
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _OrganizationInvitation OrganizationInvitation
@@ -362,6 +362,11 @@ func (o OrganizationInvitation) ToMap() (map[string]interface{}, error) {
 	toSerialize["assignedRoles"] = o.AssignedRoles
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -399,15 +404,30 @@ func (o *OrganizationInvitation) UnmarshalJSON(data []byte) (err error) {
 
 	varOrganizationInvitation := _OrganizationInvitation{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOrganizationInvitation)
+	err = json.Unmarshal(data, &varOrganizationInvitation)
 
 	if err != nil {
 		return err
 	}
 
 	*o = OrganizationInvitation(varOrganizationInvitation)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "invitedBy")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "organizationName")
+		delete(additionalProperties, "expiresAt")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "assignedRoles")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_organization_role.go
+++ b/libs/api-client-go/model_organization_role.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -36,7 +35,8 @@ type OrganizationRole struct {
 	// Creation timestamp
 	CreatedAt time.Time `json:"createdAt"`
 	// Last update timestamp
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _OrganizationRole OrganizationRole
@@ -250,6 +250,11 @@ func (o OrganizationRole) ToMap() (map[string]interface{}, error) {
 	toSerialize["isGlobal"] = o.IsGlobal
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -283,15 +288,26 @@ func (o *OrganizationRole) UnmarshalJSON(data []byte) (err error) {
 
 	varOrganizationRole := _OrganizationRole{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOrganizationRole)
+	err = json.Unmarshal(data, &varOrganizationRole)
 
 	if err != nil {
 		return err
 	}
 
 	*o = OrganizationRole(varOrganizationRole)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "permissions")
+		delete(additionalProperties, "isGlobal")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_organization_sandbox_default_limited_network_egress.go
+++ b/libs/api-client-go/model_organization_sandbox_default_limited_network_egress.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -24,6 +23,7 @@ var _ MappedNullable = &OrganizationSandboxDefaultLimitedNetworkEgress{}
 type OrganizationSandboxDefaultLimitedNetworkEgress struct {
 	// Sandbox default limited network egress
 	SandboxDefaultLimitedNetworkEgress bool `json:"sandboxDefaultLimitedNetworkEgress"`
+	AdditionalProperties               map[string]interface{}
 }
 
 type _OrganizationSandboxDefaultLimitedNetworkEgress OrganizationSandboxDefaultLimitedNetworkEgress
@@ -81,6 +81,11 @@ func (o OrganizationSandboxDefaultLimitedNetworkEgress) MarshalJSON() ([]byte, e
 func (o OrganizationSandboxDefaultLimitedNetworkEgress) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["sandboxDefaultLimitedNetworkEgress"] = o.SandboxDefaultLimitedNetworkEgress
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *OrganizationSandboxDefaultLimitedNetworkEgress) UnmarshalJSON(data []by
 
 	varOrganizationSandboxDefaultLimitedNetworkEgress := _OrganizationSandboxDefaultLimitedNetworkEgress{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOrganizationSandboxDefaultLimitedNetworkEgress)
+	err = json.Unmarshal(data, &varOrganizationSandboxDefaultLimitedNetworkEgress)
 
 	if err != nil {
 		return err
 	}
 
 	*o = OrganizationSandboxDefaultLimitedNetworkEgress(varOrganizationSandboxDefaultLimitedNetworkEgress)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sandboxDefaultLimitedNetworkEgress")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_organization_suspension.go
+++ b/libs/api-client-go/model_organization_suspension.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -29,6 +28,7 @@ type OrganizationSuspension struct {
 	Until time.Time `json:"until"`
 	// Suspension cleanup grace period hours
 	SuspensionCleanupGracePeriodHours float32 `json:"suspensionCleanupGracePeriodHours"`
+	AdditionalProperties              map[string]interface{}
 }
 
 type _OrganizationSuspension OrganizationSuspension
@@ -138,6 +138,11 @@ func (o OrganizationSuspension) ToMap() (map[string]interface{}, error) {
 	toSerialize["reason"] = o.Reason
 	toSerialize["until"] = o.Until
 	toSerialize["suspensionCleanupGracePeriodHours"] = o.SuspensionCleanupGracePeriodHours
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -167,15 +172,22 @@ func (o *OrganizationSuspension) UnmarshalJSON(data []byte) (err error) {
 
 	varOrganizationSuspension := _OrganizationSuspension{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOrganizationSuspension)
+	err = json.Unmarshal(data, &varOrganizationSuspension)
 
 	if err != nil {
 		return err
 	}
 
 	*o = OrganizationSuspension(varOrganizationSuspension)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "reason")
+		delete(additionalProperties, "until")
+		delete(additionalProperties, "suspensionCleanupGracePeriodHours")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_organization_usage_overview.go
+++ b/libs/api-client-go/model_organization_usage_overview.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -32,6 +31,7 @@ type OrganizationUsageOverview struct {
 	CurrentSnapshotUsage float32 `json:"currentSnapshotUsage"`
 	TotalVolumeQuota     float32 `json:"totalVolumeQuota"`
 	CurrentVolumeUsage   float32 `json:"currentVolumeUsage"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _OrganizationUsageOverview OrganizationUsageOverview
@@ -323,6 +323,11 @@ func (o OrganizationUsageOverview) ToMap() (map[string]interface{}, error) {
 	toSerialize["currentSnapshotUsage"] = o.CurrentSnapshotUsage
 	toSerialize["totalVolumeQuota"] = o.TotalVolumeQuota
 	toSerialize["currentVolumeUsage"] = o.CurrentVolumeUsage
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -359,15 +364,29 @@ func (o *OrganizationUsageOverview) UnmarshalJSON(data []byte) (err error) {
 
 	varOrganizationUsageOverview := _OrganizationUsageOverview{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOrganizationUsageOverview)
+	err = json.Unmarshal(data, &varOrganizationUsageOverview)
 
 	if err != nil {
 		return err
 	}
 
 	*o = OrganizationUsageOverview(varOrganizationUsageOverview)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "totalCpuQuota")
+		delete(additionalProperties, "totalMemoryQuota")
+		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "currentCpuUsage")
+		delete(additionalProperties, "currentMemoryUsage")
+		delete(additionalProperties, "currentDiskUsage")
+		delete(additionalProperties, "totalSnapshotQuota")
+		delete(additionalProperties, "currentSnapshotUsage")
+		delete(additionalProperties, "totalVolumeQuota")
+		delete(additionalProperties, "currentVolumeUsage")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_organization_user.go
+++ b/libs/api-client-go/model_organization_user.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -38,7 +37,8 @@ type OrganizationUser struct {
 	// Creation timestamp
 	CreatedAt time.Time `json:"createdAt"`
 	// Last update timestamp
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _OrganizationUser OrganizationUser
@@ -278,6 +278,11 @@ func (o OrganizationUser) ToMap() (map[string]interface{}, error) {
 	toSerialize["assignedRoles"] = o.AssignedRoles
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -312,15 +317,27 @@ func (o *OrganizationUser) UnmarshalJSON(data []byte) (err error) {
 
 	varOrganizationUser := _OrganizationUser{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varOrganizationUser)
+	err = json.Unmarshal(data, &varOrganizationUser)
 
 	if err != nil {
 		return err
 	}
 
 	*o = OrganizationUser(varOrganizationUser)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "userId")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "assignedRoles")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_paginated_audit_logs.go
+++ b/libs/api-client-go/model_paginated_audit_logs.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,10 +21,11 @@ var _ MappedNullable = &PaginatedAuditLogs{}
 
 // PaginatedAuditLogs struct for PaginatedAuditLogs
 type PaginatedAuditLogs struct {
-	Items      []AuditLog `json:"items"`
-	Total      float32    `json:"total"`
-	Page       float32    `json:"page"`
-	TotalPages float32    `json:"totalPages"`
+	Items                []AuditLog `json:"items"`
+	Total                float32    `json:"total"`
+	Page                 float32    `json:"page"`
+	TotalPages           float32    `json:"totalPages"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PaginatedAuditLogs PaginatedAuditLogs
@@ -161,6 +161,11 @@ func (o PaginatedAuditLogs) ToMap() (map[string]interface{}, error) {
 	toSerialize["total"] = o.Total
 	toSerialize["page"] = o.Page
 	toSerialize["totalPages"] = o.TotalPages
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -191,15 +196,23 @@ func (o *PaginatedAuditLogs) UnmarshalJSON(data []byte) (err error) {
 
 	varPaginatedAuditLogs := _PaginatedAuditLogs{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPaginatedAuditLogs)
+	err = json.Unmarshal(data, &varPaginatedAuditLogs)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PaginatedAuditLogs(varPaginatedAuditLogs)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "total")
+		delete(additionalProperties, "page")
+		delete(additionalProperties, "totalPages")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_paginated_snapshots_dto.go
+++ b/libs/api-client-go/model_paginated_snapshots_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,10 +21,11 @@ var _ MappedNullable = &PaginatedSnapshotsDto{}
 
 // PaginatedSnapshotsDto struct for PaginatedSnapshotsDto
 type PaginatedSnapshotsDto struct {
-	Items      []SnapshotDto `json:"items"`
-	Total      float32       `json:"total"`
-	Page       float32       `json:"page"`
-	TotalPages float32       `json:"totalPages"`
+	Items                []SnapshotDto `json:"items"`
+	Total                float32       `json:"total"`
+	Page                 float32       `json:"page"`
+	TotalPages           float32       `json:"totalPages"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PaginatedSnapshotsDto PaginatedSnapshotsDto
@@ -161,6 +161,11 @@ func (o PaginatedSnapshotsDto) ToMap() (map[string]interface{}, error) {
 	toSerialize["total"] = o.Total
 	toSerialize["page"] = o.Page
 	toSerialize["totalPages"] = o.TotalPages
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -191,15 +196,23 @@ func (o *PaginatedSnapshotsDto) UnmarshalJSON(data []byte) (err error) {
 
 	varPaginatedSnapshotsDto := _PaginatedSnapshotsDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPaginatedSnapshotsDto)
+	err = json.Unmarshal(data, &varPaginatedSnapshotsDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PaginatedSnapshotsDto(varPaginatedSnapshotsDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "total")
+		delete(additionalProperties, "page")
+		delete(additionalProperties, "totalPages")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_port_preview_url.go
+++ b/libs/api-client-go/model_port_preview_url.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type PortPreviewUrl struct {
 	// Access token
 	Token string `json:"token"`
 	// Legacy preview url using runner domain
-	LegacyProxyUrl *string `json:"legacyProxyUrl,omitempty"`
+	LegacyProxyUrl       *string `json:"legacyProxyUrl,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PortPreviewUrl PortPreviewUrl
@@ -146,6 +146,11 @@ func (o PortPreviewUrl) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LegacyProxyUrl) {
 		toSerialize["legacyProxyUrl"] = o.LegacyProxyUrl
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -174,15 +179,22 @@ func (o *PortPreviewUrl) UnmarshalJSON(data []byte) (err error) {
 
 	varPortPreviewUrl := _PortPreviewUrl{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPortPreviewUrl)
+	err = json.Unmarshal(data, &varPortPreviewUrl)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PortPreviewUrl(varPortPreviewUrl)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "url")
+		delete(additionalProperties, "token")
+		delete(additionalProperties, "legacyProxyUrl")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_position.go
+++ b/libs/api-client-go/model_position.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &Position{}
 
 // Position struct for Position
 type Position struct {
-	Line      float32 `json:"line"`
-	Character float32 `json:"character"`
+	Line                 float32 `json:"line"`
+	Character            float32 `json:"character"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Position Position
@@ -107,6 +107,11 @@ func (o Position) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["line"] = o.Line
 	toSerialize["character"] = o.Character
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *Position) UnmarshalJSON(data []byte) (err error) {
 
 	varPosition := _Position{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPosition)
+	err = json.Unmarshal(data, &varPosition)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Position(varPosition)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "line")
+		delete(additionalProperties, "character")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_posthog_config.go
+++ b/libs/api-client-go/model_posthog_config.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type PosthogConfig struct {
 	// PostHog API key
 	ApiKey string `json:"apiKey"`
 	// PostHog host URL
-	Host string `json:"host"`
+	Host                 string `json:"host"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PosthogConfig PosthogConfig
@@ -109,6 +109,11 @@ func (o PosthogConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["apiKey"] = o.ApiKey
 	toSerialize["host"] = o.Host
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *PosthogConfig) UnmarshalJSON(data []byte) (err error) {
 
 	varPosthogConfig := _PosthogConfig{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPosthogConfig)
+	err = json.Unmarshal(data, &varPosthogConfig)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PosthogConfig(varPosthogConfig)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "apiKey")
+		delete(additionalProperties, "host")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_process_errors_response.go
+++ b/libs/api-client-go/model_process_errors_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type ProcessErrorsResponse struct {
 	// The name of the VNC process whose error logs were retrieved
 	ProcessName string `json:"processName"`
 	// The error log output from the specified VNC process
-	Errors string `json:"errors"`
+	Errors               string `json:"errors"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ProcessErrorsResponse ProcessErrorsResponse
@@ -109,6 +109,11 @@ func (o ProcessErrorsResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["processName"] = o.ProcessName
 	toSerialize["errors"] = o.Errors
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *ProcessErrorsResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varProcessErrorsResponse := _ProcessErrorsResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varProcessErrorsResponse)
+	err = json.Unmarshal(data, &varProcessErrorsResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ProcessErrorsResponse(varProcessErrorsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "processName")
+		delete(additionalProperties, "errors")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_process_logs_response.go
+++ b/libs/api-client-go/model_process_logs_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type ProcessLogsResponse struct {
 	// The name of the VNC process whose logs were retrieved
 	ProcessName string `json:"processName"`
 	// The log output from the specified VNC process
-	Logs string `json:"logs"`
+	Logs                 string `json:"logs"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ProcessLogsResponse ProcessLogsResponse
@@ -109,6 +109,11 @@ func (o ProcessLogsResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["processName"] = o.ProcessName
 	toSerialize["logs"] = o.Logs
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *ProcessLogsResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varProcessLogsResponse := _ProcessLogsResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varProcessLogsResponse)
+	err = json.Unmarshal(data, &varProcessLogsResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ProcessLogsResponse(varProcessLogsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "processName")
+		delete(additionalProperties, "logs")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_process_restart_response.go
+++ b/libs/api-client-go/model_process_restart_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type ProcessRestartResponse struct {
 	// A message indicating the result of restarting the process
 	Message string `json:"message"`
 	// The name of the VNC process that was restarted
-	ProcessName string `json:"processName"`
+	ProcessName          string `json:"processName"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ProcessRestartResponse ProcessRestartResponse
@@ -109,6 +109,11 @@ func (o ProcessRestartResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["message"] = o.Message
 	toSerialize["processName"] = o.ProcessName
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *ProcessRestartResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varProcessRestartResponse := _ProcessRestartResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varProcessRestartResponse)
+	err = json.Unmarshal(data, &varProcessRestartResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ProcessRestartResponse(varProcessRestartResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "message")
+		delete(additionalProperties, "processName")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_process_status_response.go
+++ b/libs/api-client-go/model_process_status_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type ProcessStatusResponse struct {
 	// The name of the VNC process being checked
 	ProcessName string `json:"processName"`
 	// Whether the specified VNC process is currently running
-	Running bool `json:"running"`
+	Running              bool `json:"running"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ProcessStatusResponse ProcessStatusResponse
@@ -109,6 +109,11 @@ func (o ProcessStatusResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["processName"] = o.ProcessName
 	toSerialize["running"] = o.Running
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *ProcessStatusResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varProcessStatusResponse := _ProcessStatusResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varProcessStatusResponse)
+	err = json.Unmarshal(data, &varProcessStatusResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ProcessStatusResponse(varProcessStatusResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "processName")
+		delete(additionalProperties, "running")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_project_dir_response.go
+++ b/libs/api-client-go/model_project_dir_response.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &ProjectDirResponse{}
 
 // ProjectDirResponse struct for ProjectDirResponse
 type ProjectDirResponse struct {
-	Dir *string `json:"dir,omitempty"`
+	Dir                  *string `json:"dir,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ProjectDirResponse ProjectDirResponse
 
 // NewProjectDirResponse instantiates a new ProjectDirResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o ProjectDirResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Dir) {
 		toSerialize["dir"] = o.Dir
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ProjectDirResponse) UnmarshalJSON(data []byte) (err error) {
+	varProjectDirResponse := _ProjectDirResponse{}
+
+	err = json.Unmarshal(data, &varProjectDirResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ProjectDirResponse(varProjectDirResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "dir")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProjectDirResponse struct {

--- a/libs/api-client-go/model_pty_create_request.go
+++ b/libs/api-client-go/model_pty_create_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -33,7 +32,8 @@ type PtyCreateRequest struct {
 	// Number of terminal rows
 	Rows *float32 `json:"rows,omitempty"`
 	// Whether to start the PTY session lazily (only start when first client connects)
-	LazyStart *bool `json:"lazyStart,omitempty"`
+	LazyStart            *bool `json:"lazyStart,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtyCreateRequest PtyCreateRequest
@@ -270,6 +270,11 @@ func (o PtyCreateRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LazyStart) {
 		toSerialize["lazyStart"] = o.LazyStart
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -297,15 +302,25 @@ func (o *PtyCreateRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varPtyCreateRequest := _PtyCreateRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtyCreateRequest)
+	err = json.Unmarshal(data, &varPtyCreateRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtyCreateRequest(varPtyCreateRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "envs")
+		delete(additionalProperties, "cols")
+		delete(additionalProperties, "rows")
+		delete(additionalProperties, "lazyStart")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_pty_create_response.go
+++ b/libs/api-client-go/model_pty_create_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &PtyCreateResponse{}
 // PtyCreateResponse struct for PtyCreateResponse
 type PtyCreateResponse struct {
 	// The unique identifier for the created PTY session
-	SessionId string `json:"sessionId"`
+	SessionId            string `json:"sessionId"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtyCreateResponse PtyCreateResponse
@@ -81,6 +81,11 @@ func (o PtyCreateResponse) MarshalJSON() ([]byte, error) {
 func (o PtyCreateResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["sessionId"] = o.SessionId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *PtyCreateResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varPtyCreateResponse := _PtyCreateResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtyCreateResponse)
+	err = json.Unmarshal(data, &varPtyCreateResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtyCreateResponse(varPtyCreateResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sessionId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_pty_list_response.go
+++ b/libs/api-client-go/model_pty_list_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &PtyListResponse{}
 // PtyListResponse struct for PtyListResponse
 type PtyListResponse struct {
 	// List of active PTY sessions
-	Sessions []PtySessionInfo `json:"sessions"`
+	Sessions             []PtySessionInfo `json:"sessions"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtyListResponse PtyListResponse
@@ -81,6 +81,11 @@ func (o PtyListResponse) MarshalJSON() ([]byte, error) {
 func (o PtyListResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["sessions"] = o.Sessions
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *PtyListResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varPtyListResponse := _PtyListResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtyListResponse)
+	err = json.Unmarshal(data, &varPtyListResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtyListResponse(varPtyListResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sessions")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_pty_resize_request.go
+++ b/libs/api-client-go/model_pty_resize_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type PtyResizeRequest struct {
 	// Number of terminal columns
 	Cols float32 `json:"cols"`
 	// Number of terminal rows
-	Rows float32 `json:"rows"`
+	Rows                 float32 `json:"rows"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtyResizeRequest PtyResizeRequest
@@ -109,6 +109,11 @@ func (o PtyResizeRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["cols"] = o.Cols
 	toSerialize["rows"] = o.Rows
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *PtyResizeRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varPtyResizeRequest := _PtyResizeRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtyResizeRequest)
+	err = json.Unmarshal(data, &varPtyResizeRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtyResizeRequest(varPtyResizeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "cols")
+		delete(additionalProperties, "rows")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_pty_session_info.go
+++ b/libs/api-client-go/model_pty_session_info.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -37,7 +36,8 @@ type PtySessionInfo struct {
 	// Whether the PTY session is currently active
 	Active bool `json:"active"`
 	// Whether the PTY session uses lazy start (only start when first client connects)
-	LazyStart bool `json:"lazyStart"`
+	LazyStart            bool `json:"lazyStart"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _PtySessionInfo PtySessionInfo
@@ -279,6 +279,11 @@ func (o PtySessionInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["active"] = o.Active
 	toSerialize["lazyStart"] = o.LazyStart
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -313,15 +318,27 @@ func (o *PtySessionInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varPtySessionInfo := _PtySessionInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varPtySessionInfo)
+	err = json.Unmarshal(data, &varPtySessionInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = PtySessionInfo(varPtySessionInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "cwd")
+		delete(additionalProperties, "envs")
+		delete(additionalProperties, "cols")
+		delete(additionalProperties, "rows")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "active")
+		delete(additionalProperties, "lazyStart")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_range.go
+++ b/libs/api-client-go/model_range.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,8 +21,9 @@ var _ MappedNullable = &Range{}
 
 // Range struct for Range
 type Range struct {
-	Start Position `json:"start"`
-	End   Position `json:"end"`
+	Start                Position `json:"start"`
+	End                  Position `json:"end"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Range Range
@@ -107,6 +107,11 @@ func (o Range) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["start"] = o.Start
 	toSerialize["end"] = o.End
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *Range) UnmarshalJSON(data []byte) (err error) {
 
 	varRange := _Range{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varRange)
+	err = json.Unmarshal(data, &varRange)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Range(varRange)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "start")
+		delete(additionalProperties, "end")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_region_screenshot_response.go
+++ b/libs/api-client-go/model_region_screenshot_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type RegionScreenshotResponse struct {
 	// The current cursor position when the region screenshot was taken
 	CursorPosition map[string]interface{} `json:"cursorPosition,omitempty"`
 	// The size of the screenshot data in bytes
-	SizeBytes *float32 `json:"sizeBytes,omitempty"`
+	SizeBytes            *float32 `json:"sizeBytes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _RegionScreenshotResponse RegionScreenshotResponse
@@ -155,6 +155,11 @@ func (o RegionScreenshotResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SizeBytes) {
 		toSerialize["sizeBytes"] = o.SizeBytes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -182,15 +187,22 @@ func (o *RegionScreenshotResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varRegionScreenshotResponse := _RegionScreenshotResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varRegionScreenshotResponse)
+	err = json.Unmarshal(data, &varRegionScreenshotResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = RegionScreenshotResponse(varRegionScreenshotResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "screenshot")
+		delete(additionalProperties, "cursorPosition")
+		delete(additionalProperties, "sizeBytes")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_registry_push_access_dto.go
+++ b/libs/api-client-go/model_registry_push_access_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -33,7 +32,8 @@ type RegistryPushAccessDto struct {
 	// Registry project ID
 	Project string `json:"project"`
 	// Token expiration time in ISO format
-	ExpiresAt string `json:"expiresAt"`
+	ExpiresAt            string `json:"expiresAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _RegistryPushAccessDto RegistryPushAccessDto
@@ -221,6 +221,11 @@ func (o RegistryPushAccessDto) ToMap() (map[string]interface{}, error) {
 	toSerialize["registryId"] = o.RegistryId
 	toSerialize["project"] = o.Project
 	toSerialize["expiresAt"] = o.ExpiresAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -253,15 +258,25 @@ func (o *RegistryPushAccessDto) UnmarshalJSON(data []byte) (err error) {
 
 	varRegistryPushAccessDto := _RegistryPushAccessDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varRegistryPushAccessDto)
+	err = json.Unmarshal(data, &varRegistryPushAccessDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = RegistryPushAccessDto(varRegistryPushAccessDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "username")
+		delete(additionalProperties, "secret")
+		delete(additionalProperties, "registryUrl")
+		delete(additionalProperties, "registryId")
+		delete(additionalProperties, "project")
+		delete(additionalProperties, "expiresAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_replace_request.go
+++ b/libs/api-client-go/model_replace_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,9 +21,10 @@ var _ MappedNullable = &ReplaceRequest{}
 
 // ReplaceRequest struct for ReplaceRequest
 type ReplaceRequest struct {
-	Files    []string `json:"files"`
-	Pattern  string   `json:"pattern"`
-	NewValue string   `json:"newValue"`
+	Files                []string `json:"files"`
+	Pattern              string   `json:"pattern"`
+	NewValue             string   `json:"newValue"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ReplaceRequest ReplaceRequest
@@ -134,6 +134,11 @@ func (o ReplaceRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize["files"] = o.Files
 	toSerialize["pattern"] = o.Pattern
 	toSerialize["newValue"] = o.NewValue
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -163,15 +168,22 @@ func (o *ReplaceRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varReplaceRequest := _ReplaceRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varReplaceRequest)
+	err = json.Unmarshal(data, &varReplaceRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ReplaceRequest(varReplaceRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "files")
+		delete(additionalProperties, "pattern")
+		delete(additionalProperties, "newValue")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_replace_result.go
+++ b/libs/api-client-go/model_replace_result.go
@@ -20,10 +20,13 @@ var _ MappedNullable = &ReplaceResult{}
 
 // ReplaceResult struct for ReplaceResult
 type ReplaceResult struct {
-	File    *string `json:"file,omitempty"`
-	Success *bool   `json:"success,omitempty"`
-	Error   *string `json:"error,omitempty"`
+	File                 *string `json:"file,omitempty"`
+	Success              *bool   `json:"success,omitempty"`
+	Error                *string `json:"error,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ReplaceResult ReplaceResult
 
 // NewReplaceResult instantiates a new ReplaceResult object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,35 @@ func (o ReplaceResult) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Error) {
 		toSerialize["error"] = o.Error
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ReplaceResult) UnmarshalJSON(data []byte) (err error) {
+	varReplaceResult := _ReplaceResult{}
+
+	err = json.Unmarshal(data, &varReplaceResult)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ReplaceResult(varReplaceResult)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "file")
+		delete(additionalProperties, "success")
+		delete(additionalProperties, "error")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableReplaceResult struct {

--- a/libs/api-client-go/model_runner.go
+++ b/libs/api-client-go/model_runner.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -73,7 +72,8 @@ type Runner struct {
 	// The last update timestamp of the runner
 	UpdatedAt string `json:"updatedAt"`
 	// The version of the runner
-	Version string `json:"version"`
+	Version              string `json:"version"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Runner Runner
@@ -862,6 +862,11 @@ func (o Runner) ToMap() (map[string]interface{}, error) {
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
 	toSerialize["version"] = o.Version
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -905,15 +910,45 @@ func (o *Runner) UnmarshalJSON(data []byte) (err error) {
 
 	varRunner := _Runner{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varRunner)
+	err = json.Unmarshal(data, &varRunner)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Runner(varRunner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "domain")
+		delete(additionalProperties, "apiUrl")
+		delete(additionalProperties, "proxyUrl")
+		delete(additionalProperties, "apiKey")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "memory")
+		delete(additionalProperties, "disk")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "gpuType")
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "currentCpuUsagePercentage")
+		delete(additionalProperties, "currentMemoryUsagePercentage")
+		delete(additionalProperties, "currentDiskUsagePercentage")
+		delete(additionalProperties, "currentAllocatedCpu")
+		delete(additionalProperties, "currentAllocatedMemoryGiB")
+		delete(additionalProperties, "currentAllocatedDiskGiB")
+		delete(additionalProperties, "currentSnapshotCount")
+		delete(additionalProperties, "availabilityScore")
+		delete(additionalProperties, "region")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "lastChecked")
+		delete(additionalProperties, "unschedulable")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "version")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_runner_snapshot_dto.go
+++ b/libs/api-client-go/model_runner_snapshot_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type RunnerSnapshotDto struct {
 	// Runner ID
 	RunnerId string `json:"runnerId"`
 	// Runner domain
-	RunnerDomain string `json:"runnerDomain"`
+	RunnerDomain         string `json:"runnerDomain"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _RunnerSnapshotDto RunnerSnapshotDto
@@ -137,6 +137,11 @@ func (o RunnerSnapshotDto) ToMap() (map[string]interface{}, error) {
 	toSerialize["runnerSnapshotId"] = o.RunnerSnapshotId
 	toSerialize["runnerId"] = o.RunnerId
 	toSerialize["runnerDomain"] = o.RunnerDomain
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -166,15 +171,22 @@ func (o *RunnerSnapshotDto) UnmarshalJSON(data []byte) (err error) {
 
 	varRunnerSnapshotDto := _RunnerSnapshotDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varRunnerSnapshotDto)
+	err = json.Unmarshal(data, &varRunnerSnapshotDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = RunnerSnapshotDto(varRunnerSnapshotDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "runnerSnapshotId")
+		delete(additionalProperties, "runnerId")
+		delete(additionalProperties, "runnerDomain")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_sandbox.go
+++ b/libs/api-client-go/model_sandbox.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -80,7 +79,8 @@ type Sandbox struct {
 	// Deprecated
 	Class *string `json:"class,omitempty"`
 	// The version of the daemon running in the sandbox
-	DaemonVersion *string `json:"daemonVersion,omitempty"`
+	DaemonVersion        *string `json:"daemonVersion,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Sandbox Sandbox
@@ -1022,6 +1022,11 @@ func (o Sandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.DaemonVersion) {
 		toSerialize["daemonVersion"] = o.DaemonVersion
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -1060,15 +1065,48 @@ func (o *Sandbox) UnmarshalJSON(data []byte) (err error) {
 
 	varSandbox := _Sandbox{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSandbox)
+	err = json.Unmarshal(data, &varSandbox)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Sandbox(varSandbox)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "snapshot")
+		delete(additionalProperties, "user")
+		delete(additionalProperties, "env")
+		delete(additionalProperties, "labels")
+		delete(additionalProperties, "public")
+		delete(additionalProperties, "networkBlockAll")
+		delete(additionalProperties, "networkAllowList")
+		delete(additionalProperties, "target")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "memory")
+		delete(additionalProperties, "disk")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "desiredState")
+		delete(additionalProperties, "errorReason")
+		delete(additionalProperties, "backupState")
+		delete(additionalProperties, "backupCreatedAt")
+		delete(additionalProperties, "autoStopInterval")
+		delete(additionalProperties, "autoArchiveInterval")
+		delete(additionalProperties, "autoDeleteInterval")
+		delete(additionalProperties, "runnerDomain")
+		delete(additionalProperties, "volumes")
+		delete(additionalProperties, "buildInfo")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "daemonVersion")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_sandbox_info.go
+++ b/libs/api-client-go/model_sandbox_info.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -28,7 +27,8 @@ type SandboxInfo struct {
 	// Deprecated
 	Name string `json:"name"`
 	// Additional metadata provided by the provider
-	ProviderMetadata *string `json:"providerMetadata,omitempty"`
+	ProviderMetadata     *string `json:"providerMetadata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SandboxInfo SandboxInfo
@@ -152,6 +152,11 @@ func (o SandboxInfo) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ProviderMetadata) {
 		toSerialize["providerMetadata"] = o.ProviderMetadata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -180,15 +185,22 @@ func (o *SandboxInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varSandboxInfo := _SandboxInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSandboxInfo)
+	err = json.Unmarshal(data, &varSandboxInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SandboxInfo(varSandboxInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "created")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "providerMetadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_sandbox_labels.go
+++ b/libs/api-client-go/model_sandbox_labels.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &SandboxLabels{}
 // SandboxLabels struct for SandboxLabels
 type SandboxLabels struct {
 	// Key-value pairs of labels
-	Labels map[string]string `json:"labels"`
+	Labels               map[string]string `json:"labels"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SandboxLabels SandboxLabels
@@ -81,6 +81,11 @@ func (o SandboxLabels) MarshalJSON() ([]byte, error) {
 func (o SandboxLabels) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["labels"] = o.Labels
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *SandboxLabels) UnmarshalJSON(data []byte) (err error) {
 
 	varSandboxLabels := _SandboxLabels{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSandboxLabels)
+	err = json.Unmarshal(data, &varSandboxLabels)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SandboxLabels(varSandboxLabels)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "labels")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_sandbox_volume.go
+++ b/libs/api-client-go/model_sandbox_volume.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type SandboxVolume struct {
 	// The ID of the volume
 	VolumeId string `json:"volumeId"`
 	// The mount path for the volume
-	MountPath string `json:"mountPath"`
+	MountPath            string `json:"mountPath"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SandboxVolume SandboxVolume
@@ -109,6 +109,11 @@ func (o SandboxVolume) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["volumeId"] = o.VolumeId
 	toSerialize["mountPath"] = o.MountPath
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *SandboxVolume) UnmarshalJSON(data []byte) (err error) {
 
 	varSandboxVolume := _SandboxVolume{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSandboxVolume)
+	err = json.Unmarshal(data, &varSandboxVolume)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SandboxVolume(varSandboxVolume)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "volumeId")
+		delete(additionalProperties, "mountPath")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_screenshot_response.go
+++ b/libs/api-client-go/model_screenshot_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type ScreenshotResponse struct {
 	// The current cursor position when the screenshot was taken
 	CursorPosition map[string]interface{} `json:"cursorPosition,omitempty"`
 	// The size of the screenshot data in bytes
-	SizeBytes *float32 `json:"sizeBytes,omitempty"`
+	SizeBytes            *float32 `json:"sizeBytes,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ScreenshotResponse ScreenshotResponse
@@ -155,6 +155,11 @@ func (o ScreenshotResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SizeBytes) {
 		toSerialize["sizeBytes"] = o.SizeBytes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -182,15 +187,22 @@ func (o *ScreenshotResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varScreenshotResponse := _ScreenshotResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varScreenshotResponse)
+	err = json.Unmarshal(data, &varScreenshotResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ScreenshotResponse(varScreenshotResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "screenshot")
+		delete(additionalProperties, "cursorPosition")
+		delete(additionalProperties, "sizeBytes")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_search_files_response.go
+++ b/libs/api-client-go/model_search_files_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,7 +21,8 @@ var _ MappedNullable = &SearchFilesResponse{}
 
 // SearchFilesResponse struct for SearchFilesResponse
 type SearchFilesResponse struct {
-	Files []string `json:"files"`
+	Files                []string `json:"files"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SearchFilesResponse SearchFilesResponse
@@ -80,6 +80,11 @@ func (o SearchFilesResponse) MarshalJSON() ([]byte, error) {
 func (o SearchFilesResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["files"] = o.Files
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *SearchFilesResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varSearchFilesResponse := _SearchFilesResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSearchFilesResponse)
+	err = json.Unmarshal(data, &varSearchFilesResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SearchFilesResponse(varSearchFilesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "files")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_send_webhook_dto.go
+++ b/libs/api-client-go/model_send_webhook_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type SendWebhookDto struct {
 	// The payload data to send
 	Payload map[string]interface{} `json:"payload"`
 	// Optional event ID for idempotency
-	EventId *string `json:"eventId,omitempty"`
+	EventId              *string `json:"eventId,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SendWebhookDto SendWebhookDto
@@ -146,6 +146,11 @@ func (o SendWebhookDto) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.EventId) {
 		toSerialize["eventId"] = o.EventId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -174,15 +179,22 @@ func (o *SendWebhookDto) UnmarshalJSON(data []byte) (err error) {
 
 	varSendWebhookDto := _SendWebhookDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSendWebhookDto)
+	err = json.Unmarshal(data, &varSendWebhookDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SendWebhookDto(varSendWebhookDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "eventType")
+		delete(additionalProperties, "payload")
+		delete(additionalProperties, "eventId")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_session.go
+++ b/libs/api-client-go/model_session.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type Session struct {
 	// The ID of the session
 	SessionId string `json:"sessionId"`
 	// The list of commands executed in this session
-	Commands []Command `json:"commands"`
+	Commands             []Command `json:"commands"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Session Session
@@ -113,6 +113,11 @@ func (o Session) ToMap() (map[string]interface{}, error) {
 	if o.Commands != nil {
 		toSerialize["commands"] = o.Commands
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -141,15 +146,21 @@ func (o *Session) UnmarshalJSON(data []byte) (err error) {
 
 	varSession := _Session{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSession)
+	err = json.Unmarshal(data, &varSession)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Session(varSession)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sessionId")
+		delete(additionalProperties, "commands")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_session_execute_request.go
+++ b/libs/api-client-go/model_session_execute_request.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -28,7 +27,8 @@ type SessionExecuteRequest struct {
 	RunAsync *bool `json:"runAsync,omitempty"`
 	// Deprecated: Use runAsync instead. Whether to execute the command asynchronously
 	// Deprecated
-	Async *bool `json:"async,omitempty"`
+	Async                *bool `json:"async,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SessionExecuteRequest SessionExecuteRequest
@@ -159,6 +159,11 @@ func (o SessionExecuteRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Async) {
 		toSerialize["async"] = o.Async
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -186,15 +191,22 @@ func (o *SessionExecuteRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varSessionExecuteRequest := _SessionExecuteRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSessionExecuteRequest)
+	err = json.Unmarshal(data, &varSessionExecuteRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SessionExecuteRequest(varSessionExecuteRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "command")
+		delete(additionalProperties, "runAsync")
+		delete(additionalProperties, "async")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_session_execute_response.go
+++ b/libs/api-client-go/model_session_execute_response.go
@@ -25,8 +25,11 @@ type SessionExecuteResponse struct {
 	// The output of the executed command marked with stdout and stderr prefixes
 	Output *string `json:"output,omitempty"`
 	// The exit code of the executed command
-	ExitCode *float32 `json:"exitCode,omitempty"`
+	ExitCode             *float32 `json:"exitCode,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SessionExecuteResponse SessionExecuteResponse
 
 // NewSessionExecuteResponse instantiates a new SessionExecuteResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -160,7 +163,35 @@ func (o SessionExecuteResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ExitCode) {
 		toSerialize["exitCode"] = o.ExitCode
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SessionExecuteResponse) UnmarshalJSON(data []byte) (err error) {
+	varSessionExecuteResponse := _SessionExecuteResponse{}
+
+	err = json.Unmarshal(data, &varSessionExecuteResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = SessionExecuteResponse(varSessionExecuteResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "cmdId")
+		delete(additionalProperties, "output")
+		delete(additionalProperties, "exitCode")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSessionExecuteResponse struct {

--- a/libs/api-client-go/model_set_snapshot_general_status_dto.go
+++ b/libs/api-client-go/model_set_snapshot_general_status_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &SetSnapshotGeneralStatusDto{}
 // SetSnapshotGeneralStatusDto struct for SetSnapshotGeneralStatusDto
 type SetSnapshotGeneralStatusDto struct {
 	// Whether the snapshot is general
-	General bool `json:"general"`
+	General              bool `json:"general"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SetSnapshotGeneralStatusDto SetSnapshotGeneralStatusDto
@@ -81,6 +81,11 @@ func (o SetSnapshotGeneralStatusDto) MarshalJSON() ([]byte, error) {
 func (o SetSnapshotGeneralStatusDto) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["general"] = o.General
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *SetSnapshotGeneralStatusDto) UnmarshalJSON(data []byte) (err error) {
 
 	varSetSnapshotGeneralStatusDto := _SetSnapshotGeneralStatusDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSetSnapshotGeneralStatusDto)
+	err = json.Unmarshal(data, &varSetSnapshotGeneralStatusDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SetSnapshotGeneralStatusDto(varSetSnapshotGeneralStatusDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "general")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_snapshot_dto.go
+++ b/libs/api-client-go/model_snapshot_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -40,7 +39,8 @@ type SnapshotDto struct {
 	UpdatedAt      time.Time       `json:"updatedAt"`
 	LastUsedAt     NullableTime    `json:"lastUsedAt"`
 	// Build information for the snapshot
-	BuildInfo *BuildInfo `json:"buildInfo,omitempty"`
+	BuildInfo            *BuildInfo `json:"buildInfo,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SnapshotDto SnapshotDto
@@ -551,6 +551,11 @@ func (o SnapshotDto) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.BuildInfo) {
 		toSerialize["buildInfo"] = o.BuildInfo
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -591,15 +596,36 @@ func (o *SnapshotDto) UnmarshalJSON(data []byte) (err error) {
 
 	varSnapshotDto := _SnapshotDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSnapshotDto)
+	err = json.Unmarshal(data, &varSnapshotDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SnapshotDto(varSnapshotDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "general")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "imageName")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "size")
+		delete(additionalProperties, "entrypoint")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "mem")
+		delete(additionalProperties, "disk")
+		delete(additionalProperties, "errorReason")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "lastUsedAt")
+		delete(additionalProperties, "buildInfo")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_ssh_access_dto.go
+++ b/libs/api-client-go/model_ssh_access_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -34,7 +33,8 @@ type SshAccessDto struct {
 	// When the SSH access was created
 	CreatedAt time.Time `json:"createdAt"`
 	// When the SSH access was last updated
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt            time.Time `json:"updatedAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SshAccessDto SshAccessDto
@@ -222,6 +222,11 @@ func (o SshAccessDto) ToMap() (map[string]interface{}, error) {
 	toSerialize["expiresAt"] = o.ExpiresAt
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -254,15 +259,25 @@ func (o *SshAccessDto) UnmarshalJSON(data []byte) (err error) {
 
 	varSshAccessDto := _SshAccessDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSshAccessDto)
+	err = json.Unmarshal(data, &varSshAccessDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SshAccessDto(varSshAccessDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "sandboxId")
+		delete(additionalProperties, "token")
+		delete(additionalProperties, "expiresAt")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_ssh_access_validation_dto.go
+++ b/libs/api-client-go/model_ssh_access_validation_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -29,7 +28,8 @@ type SshAccessValidationDto struct {
 	// ID of the runner hosting the sandbox
 	RunnerId *string `json:"runnerId,omitempty"`
 	// Domain of the runner hosting the sandbox
-	RunnerDomain *string `json:"runnerDomain,omitempty"`
+	RunnerDomain         *string `json:"runnerDomain,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SshAccessValidationDto SshAccessValidationDto
@@ -183,6 +183,11 @@ func (o SshAccessValidationDto) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.RunnerDomain) {
 		toSerialize["runnerDomain"] = o.RunnerDomain
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -211,15 +216,23 @@ func (o *SshAccessValidationDto) UnmarshalJSON(data []byte) (err error) {
 
 	varSshAccessValidationDto := _SshAccessValidationDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSshAccessValidationDto)
+	err = json.Unmarshal(data, &varSshAccessValidationDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SshAccessValidationDto(varSshAccessValidationDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "valid")
+		delete(additionalProperties, "sandboxId")
+		delete(additionalProperties, "runnerId")
+		delete(additionalProperties, "runnerDomain")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_storage_access_dto.go
+++ b/libs/api-client-go/model_storage_access_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -33,7 +32,8 @@ type StorageAccessDto struct {
 	// Organization ID
 	OrganizationId string `json:"organizationId"`
 	// S3 bucket name
-	Bucket string `json:"bucket"`
+	Bucket               string `json:"bucket"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _StorageAccessDto StorageAccessDto
@@ -221,6 +221,11 @@ func (o StorageAccessDto) ToMap() (map[string]interface{}, error) {
 	toSerialize["storageUrl"] = o.StorageUrl
 	toSerialize["organizationId"] = o.OrganizationId
 	toSerialize["bucket"] = o.Bucket
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -253,15 +258,25 @@ func (o *StorageAccessDto) UnmarshalJSON(data []byte) (err error) {
 
 	varStorageAccessDto := _StorageAccessDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varStorageAccessDto)
+	err = json.Unmarshal(data, &varStorageAccessDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = StorageAccessDto(varStorageAccessDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "accessKey")
+		delete(additionalProperties, "secret")
+		delete(additionalProperties, "sessionToken")
+		delete(additionalProperties, "storageUrl")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "bucket")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_update_docker_registry.go
+++ b/libs/api-client-go/model_update_docker_registry.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -31,7 +30,8 @@ type UpdateDockerRegistry struct {
 	// Registry password
 	Password *string `json:"password,omitempty"`
 	// Registry project
-	Project *string `json:"project,omitempty"`
+	Project              *string `json:"project,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateDockerRegistry UpdateDockerRegistry
@@ -211,6 +211,11 @@ func (o UpdateDockerRegistry) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Project) {
 		toSerialize["project"] = o.Project
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -240,15 +245,24 @@ func (o *UpdateDockerRegistry) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateDockerRegistry := _UpdateDockerRegistry{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateDockerRegistry)
+	err = json.Unmarshal(data, &varUpdateDockerRegistry)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateDockerRegistry(varUpdateDockerRegistry)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "url")
+		delete(additionalProperties, "username")
+		delete(additionalProperties, "password")
+		delete(additionalProperties, "project")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_update_organization_invitation.go
+++ b/libs/api-client-go/model_update_organization_invitation.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -28,7 +27,8 @@ type UpdateOrganizationInvitation struct {
 	// Array of role IDs
 	AssignedRoleIds []string `json:"assignedRoleIds"`
 	// Expiration date of the invitation
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+	ExpiresAt            *time.Time `json:"expiresAt,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateOrganizationInvitation UpdateOrganizationInvitation
@@ -147,6 +147,11 @@ func (o UpdateOrganizationInvitation) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ExpiresAt) {
 		toSerialize["expiresAt"] = o.ExpiresAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -175,15 +180,22 @@ func (o *UpdateOrganizationInvitation) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateOrganizationInvitation := _UpdateOrganizationInvitation{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateOrganizationInvitation)
+	err = json.Unmarshal(data, &varUpdateOrganizationInvitation)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateOrganizationInvitation(varUpdateOrganizationInvitation)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "assignedRoleIds")
+		delete(additionalProperties, "expiresAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_update_organization_member_access.go
+++ b/libs/api-client-go/model_update_organization_member_access.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type UpdateOrganizationMemberAccess struct {
 	// Organization member role
 	Role string `json:"role"`
 	// Array of assigned role IDs
-	AssignedRoleIds []string `json:"assignedRoleIds"`
+	AssignedRoleIds      []string `json:"assignedRoleIds"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateOrganizationMemberAccess UpdateOrganizationMemberAccess
@@ -111,6 +111,11 @@ func (o UpdateOrganizationMemberAccess) ToMap() (map[string]interface{}, error) 
 	toSerialize := map[string]interface{}{}
 	toSerialize["role"] = o.Role
 	toSerialize["assignedRoleIds"] = o.AssignedRoleIds
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -139,15 +144,21 @@ func (o *UpdateOrganizationMemberAccess) UnmarshalJSON(data []byte) (err error) 
 
 	varUpdateOrganizationMemberAccess := _UpdateOrganizationMemberAccess{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateOrganizationMemberAccess)
+	err = json.Unmarshal(data, &varUpdateOrganizationMemberAccess)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateOrganizationMemberAccess(varUpdateOrganizationMemberAccess)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "role")
+		delete(additionalProperties, "assignedRoleIds")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_update_organization_quota.go
+++ b/libs/api-client-go/model_update_organization_quota.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -22,15 +21,16 @@ var _ MappedNullable = &UpdateOrganizationQuota{}
 
 // UpdateOrganizationQuota struct for UpdateOrganizationQuota
 type UpdateOrganizationQuota struct {
-	TotalCpuQuota       NullableFloat32 `json:"totalCpuQuota"`
-	TotalMemoryQuota    NullableFloat32 `json:"totalMemoryQuota"`
-	TotalDiskQuota      NullableFloat32 `json:"totalDiskQuota"`
-	MaxCpuPerSandbox    NullableFloat32 `json:"maxCpuPerSandbox"`
-	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
-	MaxDiskPerSandbox   NullableFloat32 `json:"maxDiskPerSandbox"`
-	SnapshotQuota       NullableFloat32 `json:"snapshotQuota"`
-	MaxSnapshotSize     NullableFloat32 `json:"maxSnapshotSize"`
-	VolumeQuota         NullableFloat32 `json:"volumeQuota"`
+	TotalCpuQuota        NullableFloat32 `json:"totalCpuQuota"`
+	TotalMemoryQuota     NullableFloat32 `json:"totalMemoryQuota"`
+	TotalDiskQuota       NullableFloat32 `json:"totalDiskQuota"`
+	MaxCpuPerSandbox     NullableFloat32 `json:"maxCpuPerSandbox"`
+	MaxMemoryPerSandbox  NullableFloat32 `json:"maxMemoryPerSandbox"`
+	MaxDiskPerSandbox    NullableFloat32 `json:"maxDiskPerSandbox"`
+	SnapshotQuota        NullableFloat32 `json:"snapshotQuota"`
+	MaxSnapshotSize      NullableFloat32 `json:"maxSnapshotSize"`
+	VolumeQuota          NullableFloat32 `json:"volumeQuota"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateOrganizationQuota UpdateOrganizationQuota
@@ -314,6 +314,11 @@ func (o UpdateOrganizationQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["snapshotQuota"] = o.SnapshotQuota.Get()
 	toSerialize["maxSnapshotSize"] = o.MaxSnapshotSize.Get()
 	toSerialize["volumeQuota"] = o.VolumeQuota.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -349,15 +354,28 @@ func (o *UpdateOrganizationQuota) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateOrganizationQuota := _UpdateOrganizationQuota{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateOrganizationQuota)
+	err = json.Unmarshal(data, &varUpdateOrganizationQuota)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateOrganizationQuota(varUpdateOrganizationQuota)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "totalCpuQuota")
+		delete(additionalProperties, "totalMemoryQuota")
+		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "maxCpuPerSandbox")
+		delete(additionalProperties, "maxMemoryPerSandbox")
+		delete(additionalProperties, "maxDiskPerSandbox")
+		delete(additionalProperties, "snapshotQuota")
+		delete(additionalProperties, "maxSnapshotSize")
+		delete(additionalProperties, "volumeQuota")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_update_organization_role.go
+++ b/libs/api-client-go/model_update_organization_role.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -27,7 +26,8 @@ type UpdateOrganizationRole struct {
 	// The description of the role
 	Description string `json:"description"`
 	// The list of permissions assigned to the role
-	Permissions []string `json:"permissions"`
+	Permissions          []string `json:"permissions"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateOrganizationRole UpdateOrganizationRole
@@ -137,6 +137,11 @@ func (o UpdateOrganizationRole) ToMap() (map[string]interface{}, error) {
 	toSerialize["name"] = o.Name
 	toSerialize["description"] = o.Description
 	toSerialize["permissions"] = o.Permissions
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -166,15 +171,22 @@ func (o *UpdateOrganizationRole) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateOrganizationRole := _UpdateOrganizationRole{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateOrganizationRole)
+	err = json.Unmarshal(data, &varUpdateOrganizationRole)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateOrganizationRole(varUpdateOrganizationRole)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "permissions")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_update_sandbox_state_dto.go
+++ b/libs/api-client-go/model_update_sandbox_state_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &UpdateSandboxStateDto{}
 // UpdateSandboxStateDto struct for UpdateSandboxStateDto
 type UpdateSandboxStateDto struct {
 	// The new state for the sandbox
-	State string `json:"state"`
+	State                string `json:"state"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateSandboxStateDto UpdateSandboxStateDto
@@ -81,6 +81,11 @@ func (o UpdateSandboxStateDto) MarshalJSON() ([]byte, error) {
 func (o UpdateSandboxStateDto) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["state"] = o.State
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *UpdateSandboxStateDto) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateSandboxStateDto := _UpdateSandboxStateDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateSandboxStateDto)
+	err = json.Unmarshal(data, &varUpdateSandboxStateDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateSandboxStateDto(varUpdateSandboxStateDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "state")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_user.go
+++ b/libs/api-client-go/model_user.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -32,7 +31,8 @@ type User struct {
 	// User public keys
 	PublicKeys []UserPublicKey `json:"publicKeys"`
 	// Creation timestamp
-	CreatedAt time.Time `json:"createdAt"`
+	CreatedAt            time.Time `json:"createdAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _User User
@@ -194,6 +194,11 @@ func (o User) ToMap() (map[string]interface{}, error) {
 	toSerialize["email"] = o.Email
 	toSerialize["publicKeys"] = o.PublicKeys
 	toSerialize["createdAt"] = o.CreatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -225,15 +230,24 @@ func (o *User) UnmarshalJSON(data []byte) (err error) {
 
 	varUser := _User{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUser)
+	err = json.Unmarshal(data, &varUser)
 
 	if err != nil {
 		return err
 	}
 
 	*o = User(varUser)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "publicKeys")
+		delete(additionalProperties, "createdAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_user_home_dir_response.go
+++ b/libs/api-client-go/model_user_home_dir_response.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &UserHomeDirResponse{}
 
 // UserHomeDirResponse struct for UserHomeDirResponse
 type UserHomeDirResponse struct {
-	Dir *string `json:"dir,omitempty"`
+	Dir                  *string `json:"dir,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UserHomeDirResponse UserHomeDirResponse
 
 // NewUserHomeDirResponse instantiates a new UserHomeDirResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o UserHomeDirResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Dir) {
 		toSerialize["dir"] = o.Dir
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UserHomeDirResponse) UnmarshalJSON(data []byte) (err error) {
+	varUserHomeDirResponse := _UserHomeDirResponse{}
+
+	err = json.Unmarshal(data, &varUserHomeDirResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = UserHomeDirResponse(varUserHomeDirResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "dir")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUserHomeDirResponse struct {

--- a/libs/api-client-go/model_user_public_key.go
+++ b/libs/api-client-go/model_user_public_key.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type UserPublicKey struct {
 	// Public key
 	Key string `json:"key"`
 	// Key name
-	Name string `json:"name"`
+	Name                 string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UserPublicKey UserPublicKey
@@ -109,6 +109,11 @@ func (o UserPublicKey) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["key"] = o.Key
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *UserPublicKey) UnmarshalJSON(data []byte) (err error) {
 
 	varUserPublicKey := _UserPublicKey{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUserPublicKey)
+	err = json.Unmarshal(data, &varUserPublicKey)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UserPublicKey(varUserPublicKey)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "key")
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_volume_dto.go
+++ b/libs/api-client-go/model_volume_dto.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -37,7 +36,8 @@ type VolumeDto struct {
 	// Last used timestamp
 	LastUsedAt NullableString `json:"lastUsedAt,omitempty"`
 	// The error reason of the volume
-	ErrorReason NullableString `json:"errorReason"`
+	ErrorReason          NullableString `json:"errorReason"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _VolumeDto VolumeDto
@@ -299,6 +299,11 @@ func (o VolumeDto) ToMap() (map[string]interface{}, error) {
 		toSerialize["lastUsedAt"] = o.LastUsedAt.Get()
 	}
 	toSerialize["errorReason"] = o.ErrorReason.Get()
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -332,15 +337,27 @@ func (o *VolumeDto) UnmarshalJSON(data []byte) (err error) {
 
 	varVolumeDto := _VolumeDto{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varVolumeDto)
+	err = json.Unmarshal(data, &varVolumeDto)
 
 	if err != nil {
 		return err
 	}
 
 	*o = VolumeDto(varVolumeDto)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "lastUsedAt")
+		delete(additionalProperties, "errorReason")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_webhook_app_portal_access.go
+++ b/libs/api-client-go/model_webhook_app_portal_access.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -23,7 +22,8 @@ var _ MappedNullable = &WebhookAppPortalAccess{}
 // WebhookAppPortalAccess struct for WebhookAppPortalAccess
 type WebhookAppPortalAccess struct {
 	// The URL to the webhook app portal
-	Url string `json:"url"`
+	Url                  string `json:"url"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _WebhookAppPortalAccess WebhookAppPortalAccess
@@ -81,6 +81,11 @@ func (o WebhookAppPortalAccess) MarshalJSON() ([]byte, error) {
 func (o WebhookAppPortalAccess) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["url"] = o.Url
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -108,15 +113,20 @@ func (o *WebhookAppPortalAccess) UnmarshalJSON(data []byte) (err error) {
 
 	varWebhookAppPortalAccess := _WebhookAppPortalAccess{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varWebhookAppPortalAccess)
+	err = json.Unmarshal(data, &varWebhookAppPortalAccess)
 
 	if err != nil {
 		return err
 	}
 
 	*o = WebhookAppPortalAccess(varWebhookAppPortalAccess)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "url")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_webhook_controller_get_status_200_response.go
+++ b/libs/api-client-go/model_webhook_controller_get_status_200_response.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &WebhookControllerGetStatus200Response{}
 
 // WebhookControllerGetStatus200Response struct for WebhookControllerGetStatus200Response
 type WebhookControllerGetStatus200Response struct {
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled              *bool `json:"enabled,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _WebhookControllerGetStatus200Response WebhookControllerGetStatus200Response
 
 // NewWebhookControllerGetStatus200Response instantiates a new WebhookControllerGetStatus200Response object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o WebhookControllerGetStatus200Response) ToMap() (map[string]interface{}, 
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *WebhookControllerGetStatus200Response) UnmarshalJSON(data []byte) (err error) {
+	varWebhookControllerGetStatus200Response := _WebhookControllerGetStatus200Response{}
+
+	err = json.Unmarshal(data, &varWebhookControllerGetStatus200Response)
+
+	if err != nil {
+		return err
+	}
+
+	*o = WebhookControllerGetStatus200Response(varWebhookControllerGetStatus200Response)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "enabled")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableWebhookControllerGetStatus200Response struct {

--- a/libs/api-client-go/model_webhook_initialization_status.go
+++ b/libs/api-client-go/model_webhook_initialization_status.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -33,7 +32,8 @@ type WebhookInitializationStatus struct {
 	// When the webhook initialization was created
 	CreatedAt string `json:"createdAt"`
 	// When the webhook initialization was last updated
-	UpdatedAt string `json:"updatedAt"`
+	UpdatedAt            string `json:"updatedAt"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _WebhookInitializationStatus WebhookInitializationStatus
@@ -225,6 +225,11 @@ func (o WebhookInitializationStatus) ToMap() (map[string]interface{}, error) {
 	toSerialize["retryCount"] = o.RetryCount
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -257,15 +262,25 @@ func (o *WebhookInitializationStatus) UnmarshalJSON(data []byte) (err error) {
 
 	varWebhookInitializationStatus := _WebhookInitializationStatus{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varWebhookInitializationStatus)
+	err = json.Unmarshal(data, &varWebhookInitializationStatus)
 
 	if err != nil {
 		return err
 	}
 
 	*o = WebhookInitializationStatus(varWebhookInitializationStatus)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "svixApplicationId")
+		delete(additionalProperties, "lastError")
+		delete(additionalProperties, "retryCount")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_windows_response.go
+++ b/libs/api-client-go/model_windows_response.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -25,7 +24,8 @@ type WindowsResponse struct {
 	// Array of window information for all visible windows
 	Windows []map[string]interface{} `json:"windows"`
 	// The total number of windows found
-	Count float32 `json:"count"`
+	Count                float32 `json:"count"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _WindowsResponse WindowsResponse
@@ -109,6 +109,11 @@ func (o WindowsResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["windows"] = o.Windows
 	toSerialize["count"] = o.Count
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -137,15 +142,21 @@ func (o *WindowsResponse) UnmarshalJSON(data []byte) (err error) {
 
 	varWindowsResponse := _WindowsResponse{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varWindowsResponse)
+	err = json.Unmarshal(data, &varWindowsResponse)
 
 	if err != nil {
 		return err
 	}
 
 	*o = WindowsResponse(varWindowsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "windows")
+		delete(additionalProperties, "count")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/model_work_dir_response.go
+++ b/libs/api-client-go/model_work_dir_response.go
@@ -20,8 +20,11 @@ var _ MappedNullable = &WorkDirResponse{}
 
 // WorkDirResponse struct for WorkDirResponse
 type WorkDirResponse struct {
-	Dir *string `json:"dir,omitempty"`
+	Dir                  *string `json:"dir,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _WorkDirResponse WorkDirResponse
 
 // NewWorkDirResponse instantiates a new WorkDirResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o WorkDirResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Dir) {
 		toSerialize["dir"] = o.Dir
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *WorkDirResponse) UnmarshalJSON(data []byte) (err error) {
+	varWorkDirResponse := _WorkDirResponse{}
+
+	err = json.Unmarshal(data, &varWorkDirResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = WorkDirResponse(varWorkDirResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "dir")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableWorkDirResponse struct {

--- a/libs/api-client-go/model_workspace.go
+++ b/libs/api-client-go/model_workspace.go
@@ -12,7 +12,6 @@ Contact: support@daytona.com
 package apiclient
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -90,7 +89,8 @@ type Workspace struct {
 	// The creation timestamp of the last snapshot
 	SnapshotCreatedAt *string `json:"snapshotCreatedAt,omitempty"`
 	// Additional information about the sandbox
-	Info *SandboxInfo `json:"info,omitempty"`
+	Info                 *SandboxInfo `json:"info,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Workspace Workspace
@@ -1200,6 +1200,11 @@ func (o Workspace) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Info) {
 		toSerialize["info"] = o.Info
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -1239,15 +1244,53 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 
 	varWorkspace := _Workspace{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varWorkspace)
+	err = json.Unmarshal(data, &varWorkspace)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Workspace(varWorkspace)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "snapshot")
+		delete(additionalProperties, "user")
+		delete(additionalProperties, "env")
+		delete(additionalProperties, "labels")
+		delete(additionalProperties, "public")
+		delete(additionalProperties, "networkBlockAll")
+		delete(additionalProperties, "networkAllowList")
+		delete(additionalProperties, "target")
+		delete(additionalProperties, "cpu")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "memory")
+		delete(additionalProperties, "disk")
+		delete(additionalProperties, "state")
+		delete(additionalProperties, "desiredState")
+		delete(additionalProperties, "errorReason")
+		delete(additionalProperties, "backupState")
+		delete(additionalProperties, "backupCreatedAt")
+		delete(additionalProperties, "autoStopInterval")
+		delete(additionalProperties, "autoArchiveInterval")
+		delete(additionalProperties, "autoDeleteInterval")
+		delete(additionalProperties, "runnerDomain")
+		delete(additionalProperties, "volumes")
+		delete(additionalProperties, "buildInfo")
+		delete(additionalProperties, "createdAt")
+		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "class")
+		delete(additionalProperties, "daemonVersion")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "image")
+		delete(additionalProperties, "snapshotState")
+		delete(additionalProperties, "snapshotCreatedAt")
+		delete(additionalProperties, "info")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/libs/api-client-go/project.json
+++ b/libs/api-client-go/project.json
@@ -21,7 +21,7 @@
     "generate:api-client": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "yarn run openapi-generator-cli generate --git-repo-id=apiclient --git-user-id=daytonaio -i dist/apps/api/openapi.json -g go --additional-properties=packageName=apiclient,moduleVersion=$DEFAULT_PACKAGE_VERSION,generateInterfaces=true,enumClassPrefix=true,structPrefix=true -o libs/api-client-go"
+        "command": "yarn run openapi-generator-cli generate --git-repo-id=apiclient --git-user-id=daytonaio -i dist/apps/api/openapi.json -g go --additional-properties=disallowAdditionalPropertiesIfNotPresent=false,packageName=apiclient,moduleVersion=$DEFAULT_PACKAGE_VERSION,generateInterfaces=true,enumClassPrefix=true,structPrefix=true -o libs/api-client-go"
       }
     },
     "tidy": {


### PR DESCRIPTION
# Allow Additional Properties in Models

## Description

Allowing additional props in models in the go api client.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
