### PR TITLE
fix(api): db streaming for backup processing

### DIFF
--- a/apps/api/src/sandbox/common/redis-lock.provider.ts
+++ b/apps/api/src/sandbox/common/redis-lock.provider.ts
@@ -22,6 +22,11 @@ export class RedisLockProvider {
     await this.redis.del(key)
   }
 
+  async locked(key: string): Promise<boolean> {
+    const exists = await this.redis.exists(key)
+    return exists === 1
+  }
+
   async waitForLock(key: string, ttl: number): Promise<void> {
     while (true) {
       const acquired = await this.lock(key, ttl)


### PR DESCRIPTION
# DB Streaming for Backup Processing

## Description

Added db query streaming when processing backups.
This makes the processing more efficient.

Additionally, raised the processing limit in the sandbox sync state processing.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
