### PR TITLE
fix(proxy): cache proxy url instead of api url in runner info

### DIFF
--- a/apps/proxy/pkg/proxy/get_target.go
+++ b/apps/proxy/pkg/proxy/get_target.go
@@ -101,7 +101,7 @@ func (p *Proxy) getRunnerInfo(ctx context.Context, sandboxId string) (*RunnerInf
 	}
 
 	info := RunnerInfo{
-		ApiUrl: runner.ApiUrl,
+		ApiUrl: runner.ProxyUrl,
 		ApiKey: runner.ApiKey,
 	}
 


### PR DESCRIPTION
# Cache Proxy URL Instead of API URL in Runner Info

## Description

Caching the proxy url is consistent with behavior in the toolbox controller on the API.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
