### PR TITLE
fix(api): excess snapshot propagation

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -214,6 +214,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       ]
 
       const propagateLimit = Math.ceil(runners.length / 3) - snapshotRunnersDistinctRunnersIds.length
+
+      if (propagateLimit <= 0) {
+        return
+      }
+
       const unallocatedRunners = runners.filter(
         (runner) => !snapshotRunnersDistinctRunnersIds.some((snapshotRunnerId) => snapshotRunnerId === runner.id),
       )


### PR DESCRIPTION
# Fix excess snapshot propagation
## Description

Javascript `slice` function would "overflow" with negative limit causing the propagation to go to e.g. all but one or all but two runners

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation