### PR TITLE
fix(api): allow snapshots creation from images from registries with ports

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -807,8 +807,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       throw new Error('No default internal registry configured')
     }
 
-    //  get tag from snapshot name
-    const tag = snapshot.imageName.split(':')[1]
+    // take only image:tag part without optional registry:port/project
+    const image = snapshot.imageName.split('/').at(-1)
+
+    //  get tag from snapshot image
+    const tag = image.split(':')[1]
     const internalSnapshotName = `${registry.url.replace(/^(https?:\/\/)/, '')}/${registry.project}/${snapshot.id}:${tag}`
 
     snapshot.internalName = internalSnapshotName


### PR DESCRIPTION
# Allows snapshots creation from images from registries with ports

## Description

Fixes API server error when images for snapshots are pulled from the registry via a custom port. This is useful for development using a local Docker setup where registry is deployed on 6000 port

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2564
