### PR TITLE
chore(runner): add server url to dockerfile

### DIFF
--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -43,4 +43,6 @@ ENV AWS_ACCESS_KEY_ID=minioadmin
 ENV AWS_SECRET_ACCESS_KEY=minioadmin
 ENV AWS_DEFAULT_BUCKET=daytona
 
+ENV SERVER_URL=http://api:3000/api
+
 ENTRYPOINT ["sh", "-c", "dockerd & daytona-runner"]


### PR DESCRIPTION
# Add Server Url to Runner Dockerfile

## Description

Adds the SERVER_URL env var to the runner dockerfile.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2568 