### PR TITLE
fix(dashboard): add warm pool condition when handling sandbox websocket events

### DIFF
--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -343,6 +343,12 @@ const Sandboxes: React.FC = () => {
       oldState: SandboxState
       newState: SandboxState
     }) => {
+      // warm pool sandboxes
+      if (data.oldState === data.newState && data.newState === SandboxState.STARTED) {
+        handleSandboxCreatedEvent(data.sandbox)
+        return
+      }
+
       let updatedState = data.newState
 
       // error,build_failed | destroyed should be displayed as destroyed in the UI


### PR DESCRIPTION
## Description

Added a missing condition for warm pool sandboxes when updating the sandbox list in the dashboard when a sandbox state updated event is received.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

