### PR TITLE
fix(api): decorate object storage controller with bearer auth

### DIFF
--- a/apps/api/src/object-storage/controllers/object-storage.controller.ts
+++ b/apps/api/src/object-storage/controllers/object-storage.controller.ts
@@ -4,7 +4,7 @@
  */
 
 import { Controller, Get, UseGuards, HttpCode } from '@nestjs/common'
-import { ApiOAuth2, ApiTags, ApiOperation, ApiResponse, ApiHeader } from '@nestjs/swagger'
+import { ApiOAuth2, ApiTags, ApiOperation, ApiResponse, ApiHeader, ApiBearerAuth } from '@nestjs/swagger'
 import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
 import { OrganizationAuthContext } from '../../common/interfaces/auth-context.interface'
 import { ObjectStorageService } from '../services/object-storage.service'
@@ -18,6 +18,7 @@ import { AuthContext } from '../../common/decorators/auth-context.decorator'
 @ApiHeader(CustomHeaders.ORGANIZATION_ID)
 @UseGuards(CombinedAuthGuard, OrganizationResourceActionGuard)
 @ApiOAuth2(['openid', 'profile', 'email'])
+@ApiBearerAuth()
 export class ObjectStorageController {
   constructor(private readonly objectStorageService: ObjectStorageService) {}
 

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -6946,6 +6946,7 @@ paths:
                 $ref: '#/components/schemas/StorageAccessDto'
           description: Temporary storage access has been generated
       security:
+        - bearer: []
         - oauth2:
             - openid
             - profile

--- a/libs/api-client-python-async/daytona_api_client_async/api/object_storage_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/object_storage_api.py
@@ -277,6 +277,7 @@ class ObjectStorageApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'bearer', 
             'oauth2'
         ]
 

--- a/libs/api-client-python/daytona_api_client/api/object_storage_api.py
+++ b/libs/api-client-python/daytona_api_client/api/object_storage_api.py
@@ -277,6 +277,7 @@ class ObjectStorageApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'bearer', 
             'oauth2'
         ]
 

--- a/libs/api-client/src/api/object-storage-api.ts
+++ b/libs/api-client/src/api/object-storage-api.ts
@@ -62,6 +62,10 @@ export const ObjectStorageApiAxiosParamCreator = function (configuration?: Confi
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
+      // authentication bearer required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
       // authentication oauth2 required
 
       if (xDaytonaOrganizationID != null) {


### PR DESCRIPTION
# Decorate Object Storage Controller with Bearer Auth

## Description

Decorates the controller so that api clients are correctly generated.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
