### PR TITLE
fix(dashboard): allow dashboard use if billing api fails

### DIFF
--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -44,7 +44,7 @@ const Dashboard: React.FC = () => {
     const excludedRoutes = [RoutePath.BILLING_WALLET, RoutePath.USER_INVITATIONS]
     const shouldSkipRedirect = excludedRoutes.some((route) => location.pathname.startsWith(route))
 
-    if ((!wallet || wallet?.ongoingBalanceCents <= 0) && !shouldSkipRedirect) {
+    if (wallet && wallet.ongoingBalanceCents <= 0 && !shouldSkipRedirect) {
       navigate(RoutePath.BILLING_WALLET)
     }
   }, [wallet, config.billingApiUrl]) // Only depend on wallet to avoid infinite loops from navigation

--- a/apps/dashboard/src/providers/BillingProvider.tsx
+++ b/apps/dashboard/src/providers/BillingProvider.tsx
@@ -39,7 +39,7 @@ export const BillingProvider: React.FC<BillingProviderProps> = ({ children }) =>
         return await billingApi.getOrganizationWallet(selectedOrganizationId)
       } catch (error) {
         handleApiError(error, 'Failed to fetch wallet data')
-        throw error
+        return null
       }
     },
     [billingApi, isOwner, config.billingApiUrl],
@@ -50,7 +50,12 @@ export const BillingProvider: React.FC<BillingProviderProps> = ({ children }) =>
       if (!config.billingApiUrl || !selectedOrganizationId || !isOwner()) {
         return null
       }
-      return await billingApi.getOrganizationTier(selectedOrganizationId)
+      try {
+        return await billingApi.getOrganizationTier(selectedOrganizationId)
+      } catch (error) {
+        handleApiError(error, 'Failed to fetch organization tier')
+        return null
+      }
     },
     [billingApi, isOwner, config.billingApiUrl],
   )
@@ -63,7 +68,7 @@ export const BillingProvider: React.FC<BillingProviderProps> = ({ children }) =>
       return await billingApi.listTiers()
     } catch (error) {
       handleApiError(error, 'Failed to fetch tiers')
-      throw error
+      return []
     }
   }, [billingApi, config.billingApiUrl])
 
@@ -72,7 +77,12 @@ export const BillingProvider: React.FC<BillingProviderProps> = ({ children }) =>
       if (!config.billingApiUrl || !selectedOrganizationId || !isOwner()) {
         return []
       }
-      return await billingApi.listOrganizationEmails(selectedOrganizationId)
+      try {
+        return await billingApi.listOrganizationEmails(selectedOrganizationId)
+      } catch (error) {
+        handleApiError(error, 'Failed to fetch organization emails')
+        return []
+      }
     },
     [billingApi, isOwner, config.billingApiUrl],
   )
@@ -82,7 +92,12 @@ export const BillingProvider: React.FC<BillingProviderProps> = ({ children }) =>
       if (!config.billingApiUrl || !selectedOrganizationId || !isOwner()) {
         return null
       }
-      return await billingApi.getOrganizationBillingPortalUrl(selectedOrganizationId)
+      try {
+        return await billingApi.getOrganizationBillingPortalUrl(selectedOrganizationId)
+      } catch (error) {
+        handleApiError(error, 'Failed to fetch billing portal url')
+        return null
+      }
     },
     [billingApi, isOwner, config.billingApiUrl],
   )


### PR DESCRIPTION
# Allow Dashboard Use if Billing API Fails

## Description

This fix allows for the dashboard to load even if the billing api calls fail. Before this, the dashboard would throw a suspense error that would display a full-page error page.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
