### PR TITLE
refactor: configure poetry to use global environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,4 +19,11 @@ RUN curl -fL https://app.getambassador.io/download/tel2oss/releases/download/v2.
 
 RUN echo "address=/proxy.localhost/127.0.0.1" >> /etc/dnsmasq.conf
 
+# Create non-root user and grant full Python access
+RUN useradd -m -s /bin/bash daytona && \
+    PYTHON_VERSION_DIR=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") && \
+    mkdir -p "/usr/local/lib/python${PYTHON_VERSION_DIR}/dist-packages" && \
+    chown -R daytona:daytona /usr/local /usr/lib/python3 "/usr/local/lib/python${PYTHON_VERSION_DIR}" && \
+    chmod -R u+w /usr/local /usr/lib/python3 "/usr/local/lib/python${PYTHON_VERSION_DIR}"
+
 CMD ["sh", "-c", "service dnsmasq start && echo 'nameserver 127.0.0.1' > /etc/resolv.conf && tail -f /dev/null"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,7 @@
   },
   "remoteEnv": {
     "NX_DAEMON": "true",
-    "NODE_ENV": "development",
-    "POETRY_VIRTUALENVS_IN_PROJECT": "true"
+    "NODE_ENV": "development"
   },
   "customizations": {
     // Configure properties specific to VS Code.
@@ -30,10 +29,7 @@
         "bradlc.vscode-tailwindcss"
       ],
       "settings": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
-        "python.terminal.activateEnvironment": true,
-        "python.terminal.activateEnvInCurrentTerminal": true
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
       }
     }
   },

--- a/poetry.lock
+++ b/poetry.lock
@@ -1616,28 +1616,24 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "importlib-metadata"
-version = "8.7.0"
+version = "8.4.0"
 description = "Read metadata from Python packages"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 groups = ["dev"]
 markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and python_version <= \"3.11\" or python_full_version < \"3.10.2\""
 files = [
-    {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
-    {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
+    {file = "importlib_metadata-8.4.0-py3-none-any.whl", hash = "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1"},
+    {file = "importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5"},
 ]
 
 [package.dependencies]
-zipp = ">=3.20"
+zipp = ">=0.5"
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
 perf = ["ipython"]
-test = ["flufl.flake8", "importlib_resources (>=1.3) ; python_version < \"3.9\"", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
+test = ["flufl.flake8", "importlib-resources (>=1.3) ; python_version < \"3.9\"", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
 
 [[package]]
 name = "importlib-resources"

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+create = false


### PR DESCRIPTION
# Use Global Env for Poetry

Configure Poetry to use the system Python environment instead of creating a virtual environment.
Since the devcontainer already isolates the monorepo environment and we already use a single shared virtual environment across the entire monorepo, there’s no need for virtual environments at all. This approach simplifies the development setup and reduces potential issues related to activating or switching between environments.

## Related Issue(s)
Closes #2623 
