### PR TITLE
fix(api): added retry to runner health check

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -403,6 +403,11 @@ export class SandboxStartAction extends SandboxAction {
     } else {
       // if sandbox has runner, start sandbox
       const runner = await this.runnerService.findOne(sandbox.runnerId)
+
+      if (runner.state !== RunnerState.READY) {
+        return DONT_SYNC_AGAIN
+      }
+
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
       let metadata: { [key: string]: string } | undefined = undefined

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -925,14 +925,6 @@ export class SandboxService {
         throw new SandboxError('Sandbox is not in valid state')
       }
 
-      if (sandbox.runnerId) {
-        // Add runner readiness check
-        const runner = await this.runnerService.findOne(sandbox.runnerId)
-        if (runner.state !== RunnerState.READY) {
-          throw new SandboxError('Runner is not ready')
-        }
-      }
-
       if (sandbox.pending) {
         throw new SandboxError('Sandbox state change in progress')
       }


### PR DESCRIPTION
## Description

Only deems the runner unresponsive after 3 failed health checks, eliminating false negatives.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation