### PR TITLE
fix(api): send snapshot as event payload in snapshot remove event

### DIFF
--- a/apps/api/src/notification/gateways/notification.gateway.ts
+++ b/apps/api/src/notification/gateways/notification.gateway.ts
@@ -104,7 +104,7 @@ export class NotificationGateway implements OnGatewayInit, OnModuleInit {
   }
 
   emitSnapshotRemoved(snapshot: SnapshotDto) {
-    this.server.to(snapshot.organizationId).emit(SnapshotEvents.REMOVED, snapshot.id)
+    this.server.to(snapshot.organizationId).emit(SnapshotEvents.REMOVED, snapshot)
   }
 
   emitVolumeCreated(volume: VolumeDto) {


### PR DESCRIPTION
# Send Snapshot as Event Payload in Snapshot Remove Event

## Description

The emitted event only had `snapshot.id` as the payload which caused handlers to fail.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
