### PR TITLE
Fix: bug when running with urllib3 < 2.2.0

### DIFF
--- a/libs/api-client-python-async/pyproject.toml
+++ b/libs/api-client-python-async/pyproject.toml
@@ -12,7 +12,7 @@ include = ["daytona_api_client_async/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.2.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 aiohttp = ">= 3.8.4"
 aiohttp-retry = ">= 2.8.3"

--- a/libs/api-client-python-async/requirements.txt
+++ b/libs/api-client-python-async/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.2.0, < 3.0.0
 python_dateutil >= 2.8.2
 aiohttp >= 3.8.4
 aiohttp-retry >= 2.8.3

--- a/libs/api-client-python-async/setup.py
+++ b/libs/api-client-python-async/setup.py
@@ -25,7 +25,7 @@ NAME = "daytona_api_client_async"
 VERSION = "0.0.0-dev"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.2.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "aiohttp >= 3.8.4",
     "aiohttp-retry >= 2.8.3",

--- a/libs/api-client-python/pyproject.toml
+++ b/libs/api-client-python/pyproject.toml
@@ -12,7 +12,7 @@ include = ["daytona_api_client/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.2.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"

--- a/libs/api-client-python/requirements.txt
+++ b/libs/api-client-python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.2.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/libs/api-client-python/setup.py
+++ b/libs/api-client-python/setup.py
@@ -25,7 +25,7 @@ NAME = "daytona_api_client"
 VERSION = "0.0.0-dev"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.2.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/poetry.lock
+++ b/poetry.lock
@@ -1081,7 +1081,7 @@ develop = true
 pydantic = ">= 2"
 python-dateutil = ">= 2.8.2"
 typing-extensions = ">= 4.7.1"
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.2.0, < 3.0.0"
 
 [package.source]
 type = "directory"
@@ -1103,7 +1103,7 @@ aiohttp-retry = ">= 2.8.3"
 pydantic = ">= 2"
 python-dateutil = ">= 2.8.2"
 typing-extensions = ">= 4.7.1"
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.2.0, < 3.0.0"
 
 [package.source]
 type = "directory"


### PR DESCRIPTION
## Description

There's currently a bug in the python SDK when running with lower versions of `urllib3` even though they are supported by the range.

Minimum reproducible example:

1. Ensure you have an older version of urllib3 installed:
```bash
pip install 'urllib3==2.0.7' --force-reinstall --break-system-packages
```

2. Run this basic code:
```python
from daytona import Daytona, DaytonaConfig, Image, CreateSnapshotParams, CreateSandboxFromSnapshotParams
DAYTONA_API_KEY='dtn_******'
config = DaytonaConfig(api_key=DAYTONA_API_KEY)
daytona = Daytona(config)
sandbox = daytona.find_one("*****")
```

3. You'll see this error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/daytona/_utils/errors.py", line 53, in sync_wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/daytona/_sync/daytona.py", line 506, in get
    sandbox_instance = self._sandbox_api.get_sandbox(sandbox_id_or_name)
  File "/usr/local/lib/python3.10/dist-packages/pydantic/_internal/_validate_call.py", line 39, in wrapper_function
    return wrapper(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/pydantic/_internal/_validate_call.py", line 136, in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
  File "/usr/local/lib/python3.10/dist-packages/daytona_api_client/api/sandbox_api.py", line 2088, in get_sandbox
    response_data = self.api_client.call_api(
  File "/usr/local/lib/python3.10/dist-packages/daytona_api_client/api_client.py", line 274, in call_api
    response_data = self.rest_client.request(
  File "/usr/local/lib/python3.10/dist-packages/daytona_api_client/rest.py", line 247, in request
    r = self.pool_manager.request(
  File "/usr/local/lib/python3.10/dist-packages/urllib3/_request_methods.py", line 110, in request
    return self.request_encode_url(
  File "/usr/local/lib/python3.10/dist-packages/urllib3/_request_methods.py", line 143, in request_encode_url
    return self.urlopen(method, url, **extra_kw)
  File "/usr/local/lib/python3.10/dist-packages/urllib3/poolmanager.py", line 432, in urlopen
    conn = self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
  File "/usr/local/lib/python3.10/dist-packages/urllib3/poolmanager.py", line 303, in connection_from_host
    return self.connection_from_context(request_context)
  File "/usr/local/lib/python3.10/dist-packages/urllib3/poolmanager.py", line 326, in connection_from_context
    pool_key = pool_key_constructor(request_context)
  File "/usr/local/lib/python3.10/dist-packages/urllib3/poolmanager.py", line 147, in _default_key_normalizer
    return key_class(**context)
TypeError: PoolKey.__new__() got an unexpected keyword argument 'key_ca_cert_data'
```

This issue gets fixed when upgrading to urllib3==2.2.0, even though 2.0.7 was within the original range. 
Fix = update range...

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
