### PR TITLE
fix(api): update user email if auth payload email differs

### DIFF
--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -71,6 +71,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         email: payload.email || '',
       })
       this.logger.debug(`Updated name and email address for existing user with ID: ${userId}`)
+    } else if (user.email !== payload.email) {
+      await this.userService.update(user.id, {
+        email: payload.email || '',
+      })
+      this.logger.debug(`Updated email address for existing user with ID: ${userId}`)
     }
 
     const organizationId = request.get(CustomHeaders.ORGANIZATION_ID.name)


### PR DESCRIPTION
## Description

When a user authenticates with an email that differs from their stored user record, the application will update their email to match the authentication provider's current email.
## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2668 
