### PR TITLE
feat(api): cron job scopes

### DIFF
--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -50,6 +50,7 @@ export class AppService implements OnApplicationBootstrap, OnApplicationShutdown
 
   private stopUnusedCronJobs(): void {
     if (this.configService.get('cron.disableAll') || this.configService.get('maintananceMode')) {
+      this.logger.log('Stopping all cron jobs')
       this.stopAllCronJobs()
       return
     }
@@ -86,7 +87,7 @@ export class AppService implements OnApplicationBootstrap, OnApplicationShutdown
       const jobs = scopedJobs.get(scope)
       if (jobs) {
         Array.from(jobs.keys()).forEach((job) => {
-          this.logger.error(`Stopping cron job: ${job} due to not being in enabled scopes`)
+          this.logger.log(`Stopping cron job: ${job} due to not being in enabled scopes`)
           this.schedulerRegistry.deleteCronJob(job)
         })
       }

--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -19,6 +19,7 @@ import { AuditLogPublisher } from '../interfaces/audit-publisher.interface'
 import { AuditLogFilter } from '../interfaces/audit-filter.interface'
 import { DistributedLock } from '../../common/decorators/distributed-lock.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 @Injectable()
 export class AuditService implements OnApplicationBootstrap {
@@ -125,7 +126,7 @@ export class AuditService implements OnApplicationBootstrap {
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_2AM, {
-    name: 'cleanup-old-audit-logs',
+    name: `${CRON_SCOPES.AUDIT}:cleanup-old-audit-logs`,
     waitForCompletion: true,
     disabled: true,
   })
@@ -154,7 +155,7 @@ export class AuditService implements OnApplicationBootstrap {
 
   // Resolve dangling audit logs where status code is not set and created at is more than half an hour ago
   @Cron(CronExpression.EVERY_MINUTE, {
-    name: 'resolve-dangling-audit-logs',
+    name: `${CRON_SCOPES.AUDIT}:resolve-dangling-audit-logs`,
     waitForCompletion: true,
   })
   @DistributedLock()
@@ -179,7 +180,7 @@ export class AuditService implements OnApplicationBootstrap {
   }
 
   @Cron(CronExpression.EVERY_SECOND, {
-    name: 'publish-audit-logs',
+    name: `${CRON_SCOPES.AUDIT}:publish-audit-logs`,
     waitForCompletion: true,
     disabled: true,
   })

--- a/apps/api/src/common/constants/cron-scopes.ts
+++ b/apps/api/src/common/constants/cron-scopes.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export const CRON_SCOPES = {
+  AUDIT: 'audit',
+  SANDBOXES: 'sandboxes',
+  ORGANIZATIONS: 'organizations',
+  SNAPSHOTS: 'snapshots',
+  RUNNERS: 'runners',
+  BACKUPS: 'backups',
+  VOLUMES: 'volumes',
+  WARM_POOLS: 'warm-pools',
+  USAGE_PERIODS: 'usage-periods',
+} as const

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -82,8 +82,12 @@ const configuration = {
   skipConnections: process.env.SKIP_CONNECTIONS === 'true',
   maxAutoArchiveInterval: parseInt(process.env.MAX_AUTO_ARCHIVE_INTERVAL || '43200', 10),
   maintananceMode: process.env.MAINTENANCE_MODE === 'true',
-  disableCronJobs: process.env.DISABLE_CRON_JOBS === 'true',
   appRole: process.env.APP_ROLE || 'all',
+  cron: {
+    disableAll: process.env.DISABLE_CRON_JOBS === 'true',
+    disabledCronScopes: process.env.DISABLED_CRON_SCOPES ? process.env.DISABLED_CRON_SCOPES.split(',') : [],
+    onlyEnabledCronScopes: process.env.ONLY_ENABLED_CRON_SCOPES ? process.env.ONLY_ENABLED_CRON_SCOPES.split(',') : [],
+  },
   proxy: {
     domain: process.env.PROXY_DOMAIN,
     protocol: process.env.PROXY_PROTOCOL,

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -42,6 +42,7 @@ import { setTimeout } from 'timers/promises'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 @Injectable()
 export class OrganizationService implements OnModuleInit, TrackableJobExecutions, OnApplicationShutdown {
@@ -312,7 +313,7 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     return organization
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'stop-suspended-organization-sandboxes' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: `${CRON_SCOPES.ORGANIZATIONS}:stop-suspended-organization-sandboxes` })
   @TrackJobExecution()
   @LogExecution('stop-suspended-organization-sandboxes')
   @WithInstrumentation()
@@ -366,7 +367,9 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     await this.redisLockProvider.unlock(lockKey)
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'deactivate-suspended-organization-snapshots' })
+  @Cron(CronExpression.EVERY_MINUTE, {
+    name: `${CRON_SCOPES.ORGANIZATIONS}:deactivate-suspended-organization-snapshots`,
+  })
   @TrackJobExecution()
   @LogExecution('deactivate-suspended-organization-snapshots')
   @WithInstrumentation()

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -34,6 +34,7 @@ import { setTimeout } from 'timers/promises'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 @Injectable()
 export class BackupManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -67,7 +68,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
   }
 
   //  todo: make frequency configurable or more efficient
-  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'ad-hoc-backup-check' })
+  @Cron(CronExpression.EVERY_5_MINUTES, { name: `${CRON_SCOPES.BACKUPS}:ad-hoc-backup-check` })
   @TrackJobExecution()
   @LogExecution('ad-hoc-backup-check')
   @WithInstrumentation()
@@ -133,7 +134,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-backup-states' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: `${CRON_SCOPES.BACKUPS}:check-backup-states` })
   @TrackJobExecution()
   @LogExecution('check-backup-states')
   @WithInstrumentation()
@@ -231,7 +232,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-stop-state-create-backups' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: `${CRON_SCOPES.BACKUPS}:sync-stop-state-create-backups` })
   @TrackJobExecution()
   @LogExecution('sync-stop-state-create-backups')
   @WithInstrumentation()

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -39,6 +39,7 @@ import { setTimeout } from 'timers/promises'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { getStateChangeLockKey } from '../utils/lock-key.util'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 @Injectable()
 export class SandboxManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -64,7 +65,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-stop-check' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: `${CRON_SCOPES.SANDBOXES}:auto-stop-check` })
   @TrackJobExecution()
   @WithInstrumentation()
   @LogExecution('auto-stop-check')
@@ -133,7 +134,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-archive-check' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: `${CRON_SCOPES.SANDBOXES}:auto-archive-check` })
   @TrackJobExecution()
   @LogExecution('auto-archive-check')
   @WithInstrumentation()
@@ -183,7 +184,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-delete-check' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: `${CRON_SCOPES.SANDBOXES}:auto-delete-check` })
   @TrackJobExecution()
   @LogExecution('auto-delete-check')
   @WithInstrumentation()
@@ -245,7 +246,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-states' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: `${CRON_SCOPES.SANDBOXES}:sync-states` })
   @TrackJobExecution()
   @WithInstrumentation()
   @LogExecution('sync-states')
@@ -313,7 +314,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-archived-desired-states' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: `${CRON_SCOPES.SANDBOXES}:sync-archived-desired-states` })
   @TrackJobExecution()
   @LogExecution('sync-archived-desired-states')
   @WithInstrumentation()

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -35,6 +35,7 @@ import { TypedConfigService } from '../../config/typed-config.service'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { PER_SANDBOX_LIMIT_MESSAGE } from '../../common/constants/error-messages'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 @Injectable()
 export class SnapshotManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -72,7 +73,10 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
-  @Cron(CronExpression.EVERY_5_SECONDS, { name: 'sync-runner-snapshots', waitForCompletion: true })
+  @Cron(CronExpression.EVERY_5_SECONDS, {
+    name: `${CRON_SCOPES.SNAPSHOTS}:sync-runner-snapshots`,
+    waitForCompletion: true,
+  })
   @TrackJobExecution()
   @LogExecution('sync-runner-snapshots')
   @WithInstrumentation()
@@ -112,7 +116,10 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     await this.redisLockProvider.unlock(lockKey)
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-runner-snapshot-states', waitForCompletion: true })
+  @Cron(CronExpression.EVERY_10_SECONDS, {
+    name: `${CRON_SCOPES.SNAPSHOTS}:sync-runner-snapshot-states`,
+    waitForCompletion: true,
+  })
   @TrackJobExecution()
   @LogExecution('sync-runner-snapshot-states')
   @WithInstrumentation()
@@ -354,7 +361,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-snapshot-cleanup' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: `${CRON_SCOPES.SNAPSHOTS}:check-snapshot-cleanup` })
   @TrackJobExecution()
   @LogExecution('check-snapshot-cleanup')
   @WithInstrumentation()
@@ -399,7 +406,10 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     await this.redisLockProvider.unlock(lockKey)
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-snapshot-state', waitForCompletion: true })
+  @Cron(CronExpression.EVERY_10_SECONDS, {
+    name: `${CRON_SCOPES.SNAPSHOTS}:check-snapshot-state`,
+    waitForCompletion: true,
+  })
   @TrackJobExecution()
   @LogExecution('check-snapshot-state')
   @WithInstrumentation()
@@ -475,7 +485,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
   }
 
   @Cron(CronExpression.EVERY_30_MINUTES, {
-    name: 'cleanup-local-snapshots',
+    name: `${CRON_SCOPES.SNAPSHOTS}:cleanup-local-snapshots`,
   })
   @TrackJobExecution()
   @LogExecution('cleanup-local-snapshots')
@@ -866,7 +876,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     await this.snapshotRepository.save(snapshot)
   }
 
-  @Cron(CronExpression.EVERY_HOUR, { name: 'cleanup-old-buildinfo-snapshot-runners' })
+  @Cron(CronExpression.EVERY_HOUR, { name: `${CRON_SCOPES.SNAPSHOTS}:cleanup-old-buildinfo-snapshot-runners` })
   @TrackJobExecution()
   @LogExecution('cleanup-old-buildinfo-snapshot-runners')
   @WithInstrumentation()
@@ -908,7 +918,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
-  @Cron(CronExpression.EVERY_10_MINUTES, { name: 'deactivate-old-snapshots' })
+  @Cron(CronExpression.EVERY_10_MINUTES, { name: `${CRON_SCOPES.SNAPSHOTS}:deactivate-old-snapshots` })
   @TrackJobExecution()
   @LogExecution('deactivate-old-snapshots')
   @WithInstrumentation()
@@ -975,7 +985,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
-  @Cron(CronExpression.EVERY_10_MINUTES, { name: 'cleanup-inactive-snapshots-from-runners' })
+  @Cron(CronExpression.EVERY_10_MINUTES, { name: `${CRON_SCOPES.SNAPSHOTS}:cleanup-inactive-snapshots-from-runners` })
   @TrackJobExecution()
   @LogExecution('cleanup-inactive-snapshots-from-runners')
   @WithInstrumentation()

--- a/apps/api/src/sandbox/managers/volume.manager.ts
+++ b/apps/api/src/sandbox/managers/volume.manager.ts
@@ -21,6 +21,7 @@ import { TrackJobExecution } from '../../common/decorators/track-job-execution.d
 import { setTimeout } from 'timers/promises'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 const VOLUME_STATE_LOCK_KEY = 'volume-state-'
 
@@ -82,7 +83,7 @@ export class VolumeManager
       return
     }
 
-    this.schedulerRegistry.getCronJob('process-pending-volumes').start()
+    this.schedulerRegistry.getCronJob(`${CRON_SCOPES.VOLUMES}:process-pending-volumes`).start()
   }
 
   async onApplicationShutdown() {
@@ -105,7 +106,11 @@ export class VolumeManager
     }
   }
 
-  @Cron(CronExpression.EVERY_5_SECONDS, { name: 'process-pending-volumes', waitForCompletion: true, disabled: true })
+  @Cron(CronExpression.EVERY_5_SECONDS, {
+    name: `${CRON_SCOPES.VOLUMES}:process-pending-volumes`,
+    waitForCompletion: true,
+    disabled: true,
+  })
   @TrackJobExecution()
   @LogExecution('process-pending-volumes')
   @WithInstrumentation()

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -26,6 +26,7 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 @Injectable()
 export class RunnerService {
@@ -194,7 +195,7 @@ export class RunnerService {
     })
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-runners', waitForCompletion: true })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: `${CRON_SCOPES.RUNNERS}:check-runners`, waitForCompletion: true })
   @LogExecution('check-runners')
   @WithInstrumentation()
   private async handleCheckRunners() {

--- a/apps/api/src/sandbox/services/sandbox-warm-pool.service.ts
+++ b/apps/api/src/sandbox/services/sandbox-warm-pool.service.ts
@@ -29,6 +29,7 @@ import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { isValidUuid } from '../../common/utils/uuid'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 export type FetchWarmPoolSandboxParams = {
   snapshot: string
@@ -149,7 +150,7 @@ export class SandboxWarmPoolService {
   }
 
   //  todo: make frequency configurable or more efficient
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'warm-pool-check' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: `${CRON_SCOPES.WARM_POOLS}:warm-pool-check` })
   @LogExecution('warm-pool-check')
   @WithInstrumentation()
   async warmPoolCheck(): Promise<void> {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -67,6 +67,7 @@ import { customAlphabet as customNanoid, nanoid, urlAlphabet } from 'nanoid'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { validateMountPaths } from '../utils/volume-mount-path-validation.util'
 import { SandboxRepository } from '../repositories/sandbox.repository'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 const DEFAULT_CPU = 1
 const DEFAULT_MEMORY = 1
@@ -1113,7 +1114,7 @@ export class SandboxService {
     return sandbox
   }
 
-  @Cron(CronExpression.EVERY_10_MINUTES, { name: 'cleanup-destroyed-sandboxes' })
+  @Cron(CronExpression.EVERY_10_MINUTES, { name: `${CRON_SCOPES.SANDBOXES}:cleanup-destroyed-sandboxes` })
   @LogExecution('cleanup-destroyed-sandboxes')
   @WithInstrumentation()
   async cleanupDestroyedSandboxes() {
@@ -1130,7 +1131,7 @@ export class SandboxService {
     }
   }
 
-  @Cron(CronExpression.EVERY_10_MINUTES, { name: 'cleanup-build-failed-sandboxes' })
+  @Cron(CronExpression.EVERY_10_MINUTES, { name: `${CRON_SCOPES.SANDBOXES}:cleanup-build-failed-sandboxes` })
   @LogExecution('cleanup-build-failed-sandboxes')
   @WithInstrumentation()
   async cleanupBuildFailedSandboxes() {
@@ -1242,7 +1243,7 @@ export class SandboxService {
     await this.createForWarmPool(event.warmPool)
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'handle-unschedulable-runners' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: `${CRON_SCOPES.SANDBOXES}:handle-unschedulable-runners` })
   @LogExecution('handle-unschedulable-runners')
   @WithInstrumentation()
   private async handleUnschedulableRunners() {

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -21,6 +21,7 @@ import { TrackJobExecution } from '../../common/decorators/track-job-execution.d
 import { setTimeout as sleep } from 'timers/promises'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
+import { CRON_SCOPES } from '../../common/constants/cron-scopes'
 
 @Injectable()
 export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
@@ -112,7 +113,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'close-and-reopen-usage-periods' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: `${CRON_SCOPES.USAGE_PERIODS}:close-and-reopen-usage-periods` })
   @TrackJobExecution()
   @LogExecution('close-and-reopen-usage-periods')
   @WithInstrumentation()
@@ -171,7 +172,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     await this.redisLockProvider.unlock('close-and-reopen-usage-periods')
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'archive-usage-periods' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: `${CRON_SCOPES.USAGE_PERIODS}:archive-usage-periods` })
   @TrackJobExecution()
   @LogExecution('archive-usage-periods')
   @WithInstrumentation()


### PR DESCRIPTION
## Description

Added scopes to all cron jobs and the ability to disable/enable scoped jobs from running based on env vars.
By default, all jobs are turned on.

Available scopes are:

```typescript
export const CRON_SCOPES = {
  SANDBOXES: 'sandboxes',
  ORGANIZATIONS: 'organizations',
  SNAPSHOTS: 'snapshots',
  RUNNERS: 'runners',
  BACKUPS: 'backups',
  VOLUMES: 'volumes',
  WARM_POOLS: 'warm-pools',
  USAGE_PERIODS: 'usage-periods',
} as const
```

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
