### PR TITLE
refactor(dashboard): improve sandbox table ux

### DIFF
--- a/apps/dashboard/src/components/SandboxDetailsSheet.tsx
+++ b/apps/dashboard/src/components/SandboxDetailsSheet.tsx
@@ -10,7 +10,8 @@ import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { getRelativeTimeString } from '@/lib/utils'
-import { Archive, Camera, X, GitFork, Trash, Play, Tag } from 'lucide-react'
+import { Archive, Camera, X, GitFork, Trash, Play, Tag, Copy } from 'lucide-react'
+import { toast } from 'sonner'
 
 interface SandboxDetailsSheetProps {
   sandbox: Sandbox | null
@@ -60,6 +61,16 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
 
   const getLastEvent = (sandbox: Sandbox): { date: Date; relativeTimeString: string } => {
     return getRelativeTimeString(sandbox.updatedAt)
+  }
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success('Copied to clipboard')
+    } catch (err) {
+      console.error('Failed to copy text:', err)
+      toast.error('Failed to copy to clipboard')
+    }
   }
 
   return (
@@ -149,11 +160,36 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
             <TabsTrigger value="terminal">Terminal</TabsTrigger>
           </TabsList> */}
           <TabsContent value="overview" className="flex-1 p-6 space-y-10 overflow-y-auto min-h-0">
-            <div className="grid grid-cols-1 md:grid-cols-[320px_1fr_1fr_1fr] gap-6">
+            <div className="grid grid-cols-2 gap-6">
               <div>
-                <h3 className="text-sm text-muted-foreground">ID</h3>
-                <p className="mt-1 text-sm font-medium">{sandbox.id}</p>
+                <h3 className="text-sm text-muted-foreground">Name</h3>
+                <div className="mt-1 flex items-center gap-2">
+                  <p className="text-sm font-medium truncate">{sandbox.name}</p>
+                  <button
+                    onClick={() => copyToClipboard(sandbox.name)}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Copy name"
+                  >
+                    <Copy className="w-3 h-3" />
+                  </button>
+                </div>
               </div>
+              <div>
+                <h3 className="text-sm text-muted-foreground">UUID</h3>
+                <div className="mt-1 flex items-center gap-2">
+                  <p className="text-sm font-medium truncate">{sandbox.id}</p>
+                  <button
+                    onClick={() => copyToClipboard(sandbox.id)}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Copy UUID"
+                  >
+                    <Copy className="w-3 h-3" />
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               <div>
                 <h3 className="text-sm text-muted-foreground">State</h3>
                 <div className="mt-1 text-sm">
@@ -162,12 +198,39 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
               </div>
               <div>
                 <h3 className="text-sm text-muted-foreground">Snapshot</h3>
-                <p className="mt-1 text-sm font-medium">{sandbox.snapshot}</p>
+                <div className="mt-1 flex items-center gap-2">
+                  <p className="text-sm font-medium truncate">{sandbox.snapshot || '-'}</p>
+                  {sandbox.snapshot && (
+                    <button
+                      onClick={() => copyToClipboard(sandbox.snapshot || '')}
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Copy snapshot"
+                    >
+                      <Copy className="w-3 h-3" />
+                    </button>
+                  )}
+                </div>
               </div>
               <div>
                 <h3 className="text-sm text-muted-foreground">Region</h3>
-                <p className="mt-1 text-sm font-medium">{sandbox.target}</p>
+                <div className="mt-1 flex items-center gap-2">
+                  <p className="text-sm font-medium truncate">{sandbox.target}</p>
+                  <button
+                    onClick={() => copyToClipboard(sandbox.target)}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Copy region"
+                  >
+                    <Copy className="w-3 h-3" />
+                  </button>
+                </div>
               </div>
+              <div>
+                <h3 className="text-sm text-muted-foreground">Last used</h3>
+                <p className="mt-1 text-sm font-medium">{getLastEvent(sandbox).relativeTimeString}</p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               <div>
                 <h3 className="text-sm text-muted-foreground">Resources</h3>
                 <div className="mt-1 text-sm font-medium flex items-center gap-1">
@@ -181,10 +244,6 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
                     {sandbox.disk} GiB
                   </div>
                 </div>
-              </div>
-              <div>
-                <h3 className="text-sm text-muted-foreground">Last used</h3>
-                <p className="mt-1 text-sm font-medium">{getLastEvent(sandbox).relativeTimeString}</p>
               </div>
             </div>
             <div>

--- a/apps/dashboard/src/components/SandboxTable/SandboxState.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxState.tsx
@@ -21,8 +21,8 @@ export function SandboxState({ state, errorReason }: SandboxStateProps) {
   if (state === SandboxStateType.ERROR || state === SandboxStateType.BUILD_FAILED) {
     const errorContent = (
       <div className={`flex items-center gap-1 text-red-600 dark:text-red-400`}>
-        {stateIcon}
-        {label}
+        <div className="w-4 h-4 flex items-center justify-center flex-shrink-0">{stateIcon}</div>
+        <span className="truncate">{label}</span>
       </div>
     )
 
@@ -44,8 +44,8 @@ export function SandboxState({ state, errorReason }: SandboxStateProps) {
 
   return (
     <div className={`flex items-center gap-1 ${state === SandboxStateType.ARCHIVED ? 'text-muted-foreground' : ''}`}>
-      <div className="w-4 h-4 flex items-center justify-center">{stateIcon}</div>
-      <span>{label}</span>
+      <div className="w-4 h-4 flex items-center justify-center flex-shrink-0">{stateIcon}</div>
+      <span className="truncate">{label}</span>
     </div>
   )
 }

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
@@ -17,6 +17,7 @@ import {
   HardDrive,
   MemoryStick,
   RefreshCw,
+  Columns,
 } from 'lucide-react'
 import { Button } from '../ui/button'
 import {
@@ -39,6 +40,7 @@ import { LastEventFilter, LastEventFilterIndicator } from './filters/LastEventFi
 import { SnapshotFilter, SnapshotFilterIndicator } from './filters/SnapshotFilter'
 import { ResourceFilter, ResourceFilterIndicator, ResourceFilterValue } from './filters/ResourceFilter'
 import { LabelFilter, LabelFilterIndicator } from './filters/LabelFilter'
+import { TableColumnVisibilityToggle } from '../TableColumnVisibilityToggle'
 
 const RESOURCE_FILTERS = [
   { type: 'cpu' as const, label: 'CPU', icon: Cpu },
@@ -70,24 +72,44 @@ export function SandboxTableHeader({
 
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-center mb-4">
-      <div className="flex gap-2 items-center">
+      <div className="flex flex-wrap gap-2 items-center">
         <DebouncedInput
           value={(table.getColumn('name')?.getFilterValue() as string) ?? ''}
           onChange={(value) => table.getColumn('name')?.setFilterValue(value)}
-          placeholder="Search by Name"
-          className="max-w-[200px]"
+          placeholder="Search by Name or UUID"
+          className="w-[240px]"
         />
 
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onRefresh}
-          disabled={isRefreshing}
-          className="flex items-center gap-2"
-        >
+        <Button variant="outline" onClick={onRefresh} disabled={isRefreshing} className="flex items-center gap-2">
           <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
           Refresh
         </Button>
+
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline">
+              <Columns className="w-4 h-4" />
+              View
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-[200px] p-0">
+            <TableColumnVisibilityToggle
+              columns={table.getAllColumns().filter((column) => ['name', 'id', 'labels'].includes(column.id))}
+              getColumnLabel={(id: string) => {
+                switch (id) {
+                  case 'name':
+                    return 'Name'
+                  case 'id':
+                    return 'UUID'
+                  case 'labels':
+                    return 'Labels'
+                  default:
+                    return id
+                }
+              }}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -9,9 +9,9 @@ import { ColumnDef } from '@tanstack/react-table'
 import { ArrowUp, ArrowDown } from 'lucide-react'
 import { Checkbox } from '../ui/checkbox'
 import { getRelativeTimeString } from '@/lib/utils'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { SandboxState as SandboxStateComponent } from './SandboxState'
 import { SandboxTableActions } from './SandboxTableActions'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 
 interface SortableHeaderProps {
   column: any
@@ -76,6 +76,7 @@ export function getColumns({
   const columns: ColumnDef<Sandbox>[] = [
     {
       id: 'select',
+      size: 30,
       header: ({ table }) => (
         <Checkbox
           checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
@@ -111,6 +112,9 @@ export function getColumns({
     },
     {
       id: 'name',
+      size: 320,
+      enableSorting: true,
+      enableHiding: true,
       header: ({ column }) => {
         return <SortableHeader column={column} label="Name" />
       },
@@ -118,8 +122,25 @@ export function getColumns({
       cell: ({ row }) => {
         const displayName = getDisplayName(row.original)
         return (
-          <div className=" w-full truncate">
-            <span>{displayName}</span>
+          <div className="w-full truncate">
+            <span className="truncate block">{displayName}</span>
+          </div>
+        )
+      },
+    },
+    {
+      id: 'id',
+      size: 320,
+      enableSorting: false,
+      enableHiding: true,
+      header: () => {
+        return <span>UUID</span>
+      },
+      accessorKey: 'id',
+      cell: ({ row }) => {
+        return (
+          <div className="w-full truncate">
+            <span className="truncate block">{row.original.id}</span>
           </div>
         )
       },
@@ -127,11 +148,13 @@ export function getColumns({
     {
       id: 'state',
       size: 140,
+      enableSorting: true,
+      enableHiding: false,
       header: ({ column }) => {
         return <SortableHeader column={column} label="State" />
       },
       cell: ({ row }) => (
-        <div className=" w-full truncate">
+        <div className="w-full truncate">
           <SandboxStateComponent state={row.original.state} errorReason={row.original.errorReason} />
         </div>
       ),
@@ -139,16 +162,19 @@ export function getColumns({
     },
     {
       id: 'snapshot',
+      size: 150,
+      enableSorting: true,
+      enableHiding: false,
       header: ({ column }) => {
         return <SortableHeader column={column} label="Snapshot" />
       },
       cell: ({ row }) => {
         return (
-          <div className=" w-full truncate">
+          <div className="w-full truncate">
             {row.original.snapshot ? (
-              <div className="truncate max-w-md">{row.original.snapshot}</div>
+              <div className="truncate">{row.original.snapshot}</div>
             ) : (
-              <div className="truncate max-w-md text-muted-foreground/50">-</div>
+              <div className="truncate text-muted-foreground/50">-</div>
             )}
           </div>
         )
@@ -157,35 +183,42 @@ export function getColumns({
     },
     {
       id: 'region',
-      size: 80,
+      size: 100,
+      enableSorting: true,
+      enableHiding: false,
       header: ({ column }) => {
         return <SortableHeader column={column} label="Region" dataState="sortable" />
       },
       cell: ({ row }) => {
-        return <span>{row.original.target}</span>
+        return (
+          <div className="w-full truncate">
+            <span className="truncate block">{row.original.target}</span>
+          </div>
+        )
       },
       accessorKey: 'target',
     },
     {
       id: 'resources',
-      size: 10,
-      minSize: 200,
+      size: 190,
+      enableSorting: false,
+      enableHiding: false,
       header: () => {
         return <span>Resources</span>
       },
       cell: ({ row }) => {
         return (
-          <div className="flex items-center gap-2">
-            <div>
+          <div className="flex items-center gap-2 w-full truncate">
+            <div className="whitespace-nowrap">
               {row.original.cpu} <span className="text-muted-foreground">vCPU</span>
             </div>
             <div className="w-[1px] h-6 bg-muted-foreground/20 rounded-full inline-block"></div>
-            <div>
-              {row.original.memory} <span className=" text-muted-foreground">GiB</span>
+            <div className="whitespace-nowrap">
+              {row.original.memory} <span className="text-muted-foreground">GiB</span>
             </div>
             <div className="w-[1px] h-6 bg-muted-foreground/20 rounded-full inline-block"></div>
-            <div>
-              {row.original.disk} <span className=" text-muted-foreground">GiB</span>
+            <div className="whitespace-nowrap">
+              {row.original.disk} <span className="text-muted-foreground">GiB</span>
             </div>
           </div>
         )
@@ -195,6 +228,7 @@ export function getColumns({
       id: 'labels',
       size: 110,
       enableSorting: false,
+      enableHiding: true,
       header: () => {
         return <span>Labels</span>
       },
@@ -229,13 +263,20 @@ export function getColumns({
     },
     {
       id: 'lastEvent',
-      size: 140,
+      size: 120,
+      enableSorting: true,
+      enableHiding: false,
       header: ({ column }) => {
         return <SortableHeader column={column} label="Last Event" />
       },
       accessorFn: (row) => getLastEvent(row).date,
       cell: ({ row }) => {
-        return <span>{getLastEvent(row.original).relativeTimeString}</span>
+        const lastEvent = getLastEvent(row.original)
+        return (
+          <div className="w-full truncate">
+            <span className="truncate block">{lastEvent.relativeTimeString}</span>
+          </div>
+        )
       },
     },
     {
@@ -243,7 +284,7 @@ export function getColumns({
       size: 100,
       enableHiding: false,
       cell: ({ row }) => (
-        <div>
+        <div className="w-full flex justify-end">
           <SandboxTableActions
             sandbox={row.original}
             writePermitted={writePermitted}

--- a/apps/dashboard/src/components/SandboxTable/filters/SnapshotFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/SnapshotFilter.tsx
@@ -7,8 +7,7 @@ import { SnapshotDto } from '@daytonaio/api-client'
 import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
-import { Check, Loader2 } from 'lucide-react'
-import { X } from 'lucide-react'
+import { Check, Loader2, Search, X } from 'lucide-react'
 import { useState } from 'react'
 import { DebouncedInput } from '@/components/DebouncedInput'
 
@@ -83,12 +82,15 @@ export function SnapshotFilter({
   return (
     <Command>
       <div className="flex items-center gap-2 justify-between p-2">
-        <DebouncedInput
-          placeholder="Filter by snapshot..."
-          className="border border-border rounded-md h-8 flex-1"
-          value={searchValue}
-          onChange={handleSearchChange}
-        />
+        <div className="flex items-center border border-border rounded-md h-8 flex-1 px-3">
+          <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          <DebouncedInput
+            placeholder="Search..."
+            className="border-0 h-auto p-0 flex-1 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+            value={searchValue}
+            onChange={handleSearchChange}
+          />
+        </div>
         <button
           className="text-sm text-muted-foreground hover:text-primary px-2"
           onClick={() => {

--- a/apps/dashboard/src/components/SandboxTable/index.tsx
+++ b/apps/dashboard/src/components/SandboxTable/index.tsx
@@ -124,7 +124,7 @@ export function SandboxTable({
         isRefreshing={isRefreshing}
       />
 
-      <Table className="border-separate border-spacing-0">
+      <Table className="border-separate border-spacing-0" style={{ tableLayout: 'fixed', width: '100%' }}>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
@@ -140,6 +140,9 @@ export function SandboxTable({
                       'sticky top-0 z-[3] border-b border-border',
                       header.column.getCanSort() ? 'hover:bg-muted cursor-pointer' : '',
                     )}
+                    style={{
+                      width: `${header.column.getSize()}px`,
+                    }}
                   >
                     {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                   </TableHead>
@@ -181,9 +184,7 @@ export function SandboxTable({
                     }}
                     className="border-b border-border"
                     style={{
-                      width: cell.column.id === 'name' ? '35%' : cell.column.id === 'select' ? '30px' : 'auto',
-                      maxWidth: cell.column.id === 'select' ? '30px' : cell.column.getSize() + 80,
-                      minWidth: cell.column.id === 'select' ? '30px' : cell.column.getSize(),
+                      width: `${cell.column.getSize()}px`,
                     }}
                     sticky={cell.column.id === 'actions' ? 'right' : undefined}
                   >

--- a/apps/dashboard/src/components/SandboxTable/types.ts
+++ b/apps/dashboard/src/components/SandboxTable/types.ts
@@ -129,7 +129,7 @@ export const convertTableFiltersToApiFilters = (columnFilters: ColumnFiltersStat
     switch (filter.id) {
       case 'name':
         if (filter.value && typeof filter.value === 'string') {
-          filters.name = filter.value
+          filters.idOrName = filter.value
         }
         break
       case 'state':
@@ -241,8 +241,8 @@ export const convertApiSortingToTableSorting = (sorting: SandboxSorting): Sortin
 export const convertApiFiltersToTableFilters = (filters: SandboxFilters): ColumnFiltersState => {
   const columnFilters: ColumnFiltersState = []
 
-  if (filters.name) {
-    columnFilters.push({ id: 'name', value: filters.name })
+  if (filters.idOrName) {
+    columnFilters.push({ id: 'name', value: filters.idOrName })
   }
 
   if (filters.states && filters.states.length > 0) {

--- a/apps/dashboard/src/components/TableColumnVisibilityToggle.tsx
+++ b/apps/dashboard/src/components/TableColumnVisibilityToggle.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Check } from 'lucide-react'
+import { Command, CommandList, CommandGroup, CommandItem } from './ui/command'
+import { cn } from '@/lib/utils'
+import type { Column } from '@tanstack/react-table'
+
+interface TableColumnVisibilityToggleProps {
+  columns: Column<any, unknown>[]
+  getColumnLabel: (id: string) => string
+}
+
+export function TableColumnVisibilityToggle({ columns, getColumnLabel }: TableColumnVisibilityToggleProps) {
+  return (
+    <Command>
+      <CommandList>
+        <CommandGroup>
+          {columns
+            .filter((column) => column.getCanHide())
+            .map((column) => {
+              return (
+                <CommandItem key={column.id} onSelect={() => column.toggleVisibility(!column.getIsVisible())}>
+                  <div className="flex items-center">
+                    <div
+                      className={cn(
+                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                        column.getIsVisible() ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible',
+                      )}
+                    >
+                      <Check className={cn('h-4 w-4')} />
+                    </div>
+                    {getColumnLabel(column.id)}
+                  </div>
+                </CommandItem>
+              )
+            })}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}

--- a/apps/dashboard/src/enums/LocalStorageKey.ts
+++ b/apps/dashboard/src/enums/LocalStorageKey.ts
@@ -7,4 +7,5 @@ export enum LocalStorageKey {
   SelectedOrganizationId = 'SelectedOrganizationId',
   SkipOnboardingPrefix = 'SkipOnboarding_',
   AnnouncementBannerDismissed = 'AnnouncementBannerDismissed',
+  SandboxTableColumnVisibility = 'SandboxTableColumnVisibility',
 }

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -92,3 +92,8 @@ export function formatDuration(minutes: number): string {
   const years = days / 365
   return `${Math.floor(years)}y`
 }
+
+export function isValidUUID(str: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  return uuidRegex.test(str)
+}


### PR DESCRIPTION
## Description

This PR introduces several changes with the intent to improve UX when browsing the sandboxes table:
- truncated overflowing cells
- introduced fixed layout
- added support for configuring displayed columns with persisted preference
- added copy buttons for details drawer values

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="2424" height="1142" alt="image" src="https://github.com/user-attachments/assets/96626a66-0ba0-40ea-b1cb-868eeb91557c" />

<img width="1586" height="1170" alt="image" src="https://github.com/user-attachments/assets/7b8289e0-70c8-4de2-8a90-75808e71cfe5" />

