### PR TITLE
fix(sdk): websocket, upload/download files for multiple ts/js runtimes

### DIFF
--- a/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
@@ -275,14 +275,14 @@ await daytona.delete(sandbox)  # Clean up when done
 
 ```python
 @intercept_errors(message_prefix="Failed to get sandbox: ")
-async def get(sandbox_id: str) -> AsyncSandbox
+async def get(sandbox_id_or_name: str) -> AsyncSandbox
 ```
 
-Gets a Sandbox by its ID.
+Gets a Sandbox by its ID or name.
 
 **Arguments**:
 
-- `sandbox_id` _str_ - The ID of the Sandbox to retrieve.
+- `sandbox_id_or_name` _str_ - The ID or name of the Sandbox to retrieve.
   
 
 **Returns**:
@@ -292,13 +292,13 @@ Gets a Sandbox by its ID.
 
 **Raises**:
 
-- `DaytonaError` - If sandbox_id is not provided.
+- `DaytonaError` - If sandbox_id_or_name is not provided.
   
 
 **Example**:
 
 ```python
-sandbox = await daytona.get("my-sandbox-id")
+sandbox = await daytona.get("my-sandbox-id-or-name")
 print(sandbox.state)
 ```
 
@@ -306,21 +306,21 @@ print(sandbox.state)
 
 ```python
 @intercept_errors(message_prefix="Failed to find sandbox: ")
-async def find_one(sandbox_id: Optional[str] = None,
+async def find_one(sandbox_id_or_name: Optional[str] = None,
                    labels: Optional[Dict[str, str]] = None) -> AsyncSandbox
 ```
 
-Finds a Sandbox by its ID or labels.
+Finds a Sandbox by its ID or name or labels.
 
 **Arguments**:
 
-- `sandbox_id` _Optional[str]_ - The ID of the Sandbox to retrieve.
+- `sandbox_id_or_name` _Optional[str]_ - The ID or name of the Sandbox to retrieve.
 - `labels` _Optional[Dict[str, str]]_ - Labels to filter Sandboxes.
   
 
 **Returns**:
 
-- `Sandbox` - First Sandbox that matches the ID or labels.
+- `Sandbox` - First Sandbox that matches the ID or name or labels.
   
 
 **Raises**:

--- a/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
@@ -225,14 +225,14 @@ daytona.delete(sandbox)  # Clean up when done
 
 ```python
 @intercept_errors(message_prefix="Failed to get sandbox: ")
-def get(sandbox_id: str) -> Sandbox
+def get(sandbox_id_or_name: str) -> Sandbox
 ```
 
-Gets a Sandbox by its ID.
+Gets a Sandbox by its ID or name.
 
 **Arguments**:
 
-- `sandbox_id` _str_ - The ID of the Sandbox to retrieve.
+- `sandbox_id_or_name` _str_ - The ID or name of the Sandbox to retrieve.
   
 
 **Returns**:
@@ -242,13 +242,13 @@ Gets a Sandbox by its ID.
 
 **Raises**:
 
-- `DaytonaError` - If sandbox_id is not provided.
+- `DaytonaError` - If sandbox_id_or_name is not provided.
   
 
 **Example**:
 
 ```python
-sandbox = daytona.get("my-sandbox-id")
+sandbox = daytona.get("my-sandbox-id-or-name")
 print(sandbox.state)
 ```
 
@@ -256,21 +256,21 @@ print(sandbox.state)
 
 ```python
 @intercept_errors(message_prefix="Failed to find sandbox: ")
-def find_one(sandbox_id: Optional[str] = None,
+def find_one(sandbox_id_or_name: Optional[str] = None,
              labels: Optional[Dict[str, str]] = None) -> Sandbox
 ```
 
-Finds a Sandbox by its ID or labels.
+Finds a Sandbox by its ID or name or labels.
 
 **Arguments**:
 
-- `sandbox_id` _Optional[str]_ - The ID of the Sandbox to retrieve.
+- `sandbox_id_or_name` _Optional[str]_ - The ID or name of the Sandbox to retrieve.
 - `labels` _Optional[Dict[str, str]]_ - Labels to filter Sandboxes.
   
 
 **Returns**:
 
-- `Sandbox` - First Sandbox that matches the ID or labels.
+- `Sandbox` - First Sandbox that matches the ID or name or labels.
   
 
 **Raises**:

--- a/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
@@ -196,7 +196,7 @@ await daytona.delete(sandbox);
 findOne(filter: SandboxFilter): Promise<Sandbox>
 ```
 
-Finds a Sandbox by its ID or labels.
+Finds a Sandbox by its ID or name or labels.
 
 **Parameters**:
 
@@ -205,7 +205,7 @@ Finds a Sandbox by its ID or labels.
 
 **Returns**:
 
-- `Promise<Sandbox>` - First Sandbox that matches the ID or labels.
+- `Promise<Sandbox>` - First Sandbox that matches the ID or name or labels.
 
 **Example:**
 
@@ -219,14 +219,14 @@ console.log(`Sandbox ID: ${sandbox.id}, State: ${sandbox.state}`);
 #### get()
 
 ```ts
-get(sandboxId: string): Promise<Sandbox>
+get(sandboxIdOrName: string): Promise<Sandbox>
 ```
 
-Gets a Sandbox by its ID.
+Gets a Sandbox by its ID or name.
 
 **Parameters**:
 
-- `sandboxId` _string_ - The ID of the Sandbox to retrieve
+- `sandboxIdOrName` _string_ - The ID or name of the Sandbox to retrieve
 
 
 **Returns**:
@@ -236,7 +236,7 @@ Gets a Sandbox by its ID.
 **Example:**
 
 ```ts
-const sandbox = await daytona.get('my-sandbox-id');
+const sandbox = await daytona.get('my-sandbox-id-or-name');
 console.log(`Sandbox state: ${sandbox.state}`);
 ```
 
@@ -458,7 +458,7 @@ Filter for Sandboxes.
 
 **Properties**:
 
-- `id?` _string_ - The ID of the Sandbox to retrieve
+- `idOrName?` _string_ - The ID or name of the Sandbox to retrieve
 - `labels?` _Record\<string, string\>_ - Labels to filter Sandboxes
 ## VolumeMount
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
@@ -505,6 +505,36 @@ await fs.uploadFiles(files);
 ***
 
 
+## DownloadMetadata
+
+Represents metadata for a file download operation.
+
+**Properties**:
+
+- `destination?` _string_ - Destination path in the local filesystem where the file content will be streamed to.
+- `error?` _string_ - Error message if the download failed, undefined if successful.
+- `result?` _string \| Uint8Array\<ArrayBufferLike\> \| Buffer\<ArrayBufferLike\>_ - The download result - file path (if destination provided in the request)
+    or bytes content (if no destination in the request), undefined if failed or no data received.
+## FileDownloadRequest
+
+Represents a request to download a single file from the Sandbox.
+
+**Properties**:
+
+- `destination?` _string_ - Destination path in the local filesystem where the file content will be
+    streamed to. If not provided, the file will be downloaded in the bytes buffer (might cause memory issues if the file is large).
+- `source` _string_ - Source path in the Sandbox. Relative paths are resolved based on the user's
+    root directory.
+## FileDownloadResponse
+
+Represents the response to a single file download request.
+
+**Properties**:
+
+- `error?` _string_ - Error message if the download failed, undefined if successful.
+- `result?` _string \| Buffer\<ArrayBufferLike\>_ - The download result - file path (if destination provided in the request)
+    or bytes content (if no destination in the request), undefined if failed or no data received.
+- `source` _string_ - The original source path requested for download.
 ## FilePermissionsParams
 
 Parameters for setting file permissions in the Sandbox.

--- a/apps/docs/src/content/docs/en/typescript-sdk/snapshot.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/snapshot.mdx
@@ -197,7 +197,6 @@ Represents a paginated list of Daytona Snapshots.
 **Extends:**
 
 - `Omit`\<`PaginatedSnapshotsDto`, `"items"`\>
-
 ## CreateSnapshotParams
 
 ```ts

--- a/libs/sdk-typescript/src/Process.ts
+++ b/libs/sdk-typescript/src/Process.ts
@@ -747,7 +747,7 @@ function findSubarray(haystack: Uint8Array, needle: Uint8Array): number {
 }
 
 function createWebSocket(url: string, token: string, headers: Record<string, string>): WebSocket {
-  if (RUNTIME === Runtime.BROWSER || RUNTIME === Runtime.SERVERLESS) {
+  if (RUNTIME === Runtime.BROWSER || RUNTIME === Runtime.DENO || RUNTIME === Runtime.SERVERLESS) {
     return new WebSocket(
       url + '&DAYTONA_SANDBOX_AUTH_KEY=' + token,
       `X-Daytona-SDK-Version~${headers['X-Daytona-SDK-Version']}`,

--- a/libs/sdk-typescript/src/utils/Binary.ts
+++ b/libs/sdk-typescript/src/utils/Binary.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'buffer'
+import { DaytonaError } from '../errors/DaytonaError'
+
+/**
+ * Converts various data types to Uint8Array
+ */
+export function toUint8Array(data: string | ArrayBuffer | ArrayBufferView): Uint8Array {
+  if (typeof data === 'string') {
+    return new TextEncoder().encode(data)
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data)
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+  }
+  throw new DaytonaError('Unsupported data type for byte conversion.')
+}
+
+/**
+ * Concatenates multiple Uint8Array chunks into a single Uint8Array
+ */
+export function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
+  const size = parts.reduce((sum, part) => sum + part.byteLength, 0)
+  const result = new Uint8Array(size)
+  let offset = 0
+  for (const part of parts) {
+    result.set(part, offset)
+    offset += part.byteLength
+  }
+  return result
+}
+
+/**
+ * Converts Uint8Array to Buffer (uses polyfill in non-Node environments)
+ */
+export function toBuffer(data: Uint8Array): Buffer {
+  return Buffer.from(data)
+}
+
+/**
+ * Decodes Uint8Array to UTF-8 string
+ */
+export function utf8Decode(data: Uint8Array): string {
+  return new TextDecoder('utf-8').decode(data)
+}
+
+/**
+ * Finds all occurrences of a pattern in a byte buffer
+ */
+export function findAllBytes(buffer: Uint8Array, pattern: Uint8Array): number[] {
+  const results: number[] = []
+  let i = 0
+  while (i <= buffer.length - pattern.length) {
+    let match = true
+    for (let j = 0; j < pattern.length; j++) {
+      if (buffer[i + j] !== pattern[j]) {
+        match = false
+        break
+      }
+    }
+    if (match) {
+      results.push(i)
+      i += pattern.length
+    } else {
+      i++
+    }
+  }
+  return results
+}
+
+/**
+ * Finds the first occurrence of a pattern in a byte buffer within a range
+ */
+export function findBytesInRange(buffer: Uint8Array, start: number, end: number, pattern: Uint8Array): number {
+  let i = start
+  while (i <= end - pattern.length) {
+    let match = true
+    for (let j = 0; j < pattern.length; j++) {
+      if (buffer[i + j] !== pattern[j]) {
+        match = false
+        break
+      }
+    }
+    if (match) return i
+    i++
+  }
+  return -1
+}
+
+/**
+ * Checks if a sequence starts at a given position in a byte buffer
+ * Returns the position after the sequence if found, -1 otherwise
+ */
+export function indexAfterSequence(buffer: Uint8Array, start: number, sequence: Uint8Array): number {
+  for (let j = 0; j < sequence.length; j++) {
+    if (buffer[start + j] !== sequence[j]) return -1
+  }
+  return start + sequence.length
+}
+
+/**
+ * Collects all bytes from various stream types into a single Uint8Array
+ */
+export async function collectStreamBytes(stream: any): Promise<Uint8Array> {
+  if (!stream) return new Uint8Array(0)
+
+  // ReadableStream (WHATWG)
+  if (typeof stream.getReader === 'function') {
+    const reader = stream.getReader()
+    const chunks: Uint8Array[] = []
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        if (value?.byteLength) {
+          chunks.push(value)
+        }
+      }
+    } finally {
+      await reader.cancel()
+    }
+    return concatUint8Arrays(chunks)
+  }
+
+  // AsyncIterable
+  if (stream?.[Symbol.asyncIterator]) {
+    const chunks: Uint8Array[] = []
+    for await (const chunk of stream) {
+      chunks.push(toUint8Array(chunk))
+    }
+    return concatUint8Arrays(chunks)
+  }
+
+  // Direct data types
+  if (typeof stream === 'string' || stream instanceof ArrayBuffer || ArrayBuffer.isView(stream)) {
+    return toUint8Array(stream)
+  }
+
+  // Blob
+  if (typeof Blob !== 'undefined' && stream instanceof Blob) {
+    const arrayBuffer = await stream.arrayBuffer()
+    return new Uint8Array(arrayBuffer)
+  }
+
+  // Response
+  if (typeof Response !== 'undefined' && stream instanceof Response) {
+    const arrayBuffer = await stream.arrayBuffer()
+    return new Uint8Array(arrayBuffer)
+  }
+
+  throw new DaytonaError('Unsupported stream type for byte collection.')
+}
+
+/**
+ * Checks if value is a File object (browser environment)
+ */
+export function isFile(value: any): boolean {
+  const FileConstructor = (globalThis as any).File
+  return typeof FileConstructor !== 'undefined' && value instanceof FileConstructor
+}

--- a/libs/sdk-typescript/src/utils/FileTransfer.ts
+++ b/libs/sdk-typescript/src/utils/FileTransfer.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'buffer'
+import busboy from 'busboy'
+import { DaytonaError } from '../errors/DaytonaError'
+import { dynamicImport } from './Import'
+import { collectStreamBytes, toBuffer, toUint8Array } from './Binary'
+import { extractBoundary, getHeader, parseMultipartWithFormData } from './Multipart'
+import { parseMultipart } from './Multipart'
+import { DownloadMetadata } from '../FileSystem'
+
+/**
+ * Safely aborts a stream
+ */
+export function abortStream(stream: any): void {
+  if (stream && typeof stream.destroy === 'function') {
+    stream.destroy()
+  } else if (stream && typeof stream.cancel === 'function') {
+    stream.cancel()
+  }
+}
+
+/**
+ * Normalizes response data to extract the actual stream
+ */
+export function normalizeResponseStream(responseData: any): any {
+  if (!responseData || typeof responseData !== 'object') {
+    return responseData
+  }
+
+  // WHATWG ReadableStream
+  if (responseData.body && typeof responseData.body.getReader === 'function') {
+    return responseData.body
+  }
+
+  // Some adapters use .stream
+  if (responseData.stream) {
+    return responseData.stream
+  }
+
+  return responseData
+}
+
+/**
+ * Processes multipart response using busboy (Node.js path)
+ */
+export async function processDownloadFilesResponseWithBusboy(
+  stream: any,
+  headers: Record<string, string>,
+  metadataMap: Map<string, DownloadMetadata>,
+): Promise<void> {
+  const fileTasks: Promise<void>[] = []
+
+  await new Promise<void>((resolve, reject) => {
+    const bb = busboy({
+      headers,
+      preservePath: true,
+    })
+
+    bb.on('file', (fieldName: string, fileStream: any, fileInfo: { filename?: string }) => {
+      const source = fileInfo?.filename
+      if (!source) {
+        abortStream(stream)
+        reject(new DaytonaError(`Received unexpected file "${fileInfo?.filename}".`))
+        return
+      }
+
+      const metadata = metadataMap.get(source)
+      if (!metadata) {
+        abortStream(stream)
+        reject(new DaytonaError(`Target metadata missing for valid source: ${source}`))
+        return
+      }
+
+      if (fieldName === 'error') {
+        // Collect error message
+        const chunks: Buffer[] = []
+        fileStream.on('data', (chunk: Buffer) => chunks.push(chunk))
+        fileStream.on('end', () => {
+          metadata.error = Buffer.concat(chunks).toString('utf-8').trim()
+        })
+        fileStream.on('error', (err: any) => {
+          metadata.error = `Stream error: ${err.message}`
+        })
+      } else if (fieldName === 'file') {
+        if (metadata.destination) {
+          // Stream to file
+          fileTasks.push(
+            new Promise((resolveTask) => {
+              dynamicImport('fs', 'Downloading files to local files is not supported: ').then((fs) => {
+                const writeStream = fs.createWriteStream(metadata.destination!, { autoClose: true })
+                fileStream.pipe(writeStream)
+                writeStream.on('finish', () => {
+                  metadata.result = metadata.destination!
+                  resolveTask()
+                })
+                writeStream.on('error', (err: any) => {
+                  metadata.error = `Write stream failed: ${err.message}`
+                  resolveTask()
+                })
+                fileStream.on('error', (err: any) => {
+                  metadata.error = `Read stream failed: ${err.message}`
+                })
+              })
+            }),
+          )
+        } else {
+          // Collect to buffer
+          const chunks: Buffer[] = []
+          fileStream.on('data', (chunk: Buffer) => {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+          })
+          fileStream.on('end', () => {
+            metadata.result = Buffer.concat(chunks)
+          })
+          fileStream.on('error', (err: any) => {
+            metadata.error = `Read failed: ${err.message}`
+          })
+        }
+      } else {
+        // Unknown field, drain it
+        fileStream.resume()
+      }
+    })
+
+    bb.on('error', (err: any) => {
+      abortStream(stream)
+      reject(err)
+    })
+
+    bb.on('finish', resolve)
+
+    // Feed stream into busboy
+    feedStreamToBusboy(stream, bb).catch((err) => bb.destroy(err as Error))
+  })
+
+  await Promise.all(fileTasks)
+}
+
+/**
+ * Feeds various stream types into busboy
+ */
+async function feedStreamToBusboy(stream: any, bb: any): Promise<void> {
+  // Node.js stream (piping)
+  if (typeof stream?.pipe === 'function') {
+    stream.pipe(bb)
+    return
+  }
+
+  // Direct buffer-like data
+  if (typeof stream === 'string' || stream instanceof ArrayBuffer || ArrayBuffer.isView(stream)) {
+    const data = toUint8Array(stream)
+    bb.write(Buffer.from(data))
+    bb.end()
+    return
+  }
+
+  // WHATWG ReadableStream
+  if (typeof stream?.getReader === 'function') {
+    const reader = stream.getReader()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      bb.write(Buffer.from(value))
+    }
+    bb.end()
+    return
+  }
+
+  // AsyncIterable
+  if (stream?.[Symbol.asyncIterator]) {
+    for await (const chunk of stream) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(toUint8Array(chunk))
+      bb.write(buffer)
+    }
+    bb.end()
+    return
+  }
+
+  // Unsupported stream type
+  throw new DaytonaError(`Unsupported stream type: ${stream?.constructor?.name || typeof stream}`)
+}
+
+export async function processDownloadFilesResponseWithBuffered(
+  stream: any,
+  headers: Record<string, string>,
+  metadataMap: Map<string, DownloadMetadata>,
+): Promise<void> {
+  const contentType = getHeader(headers, 'content-type') || ''
+  const bodyBytes = await collectStreamBytes(stream)
+
+  // Try native FormData parsing for multipart/form-data
+  if (/^multipart\/form-data/i.test(contentType) && typeof Response !== 'undefined') {
+    try {
+      const formDataMap = await parseMultipartWithFormData(bodyBytes, contentType)
+
+      formDataMap.forEach((value, fieldName) => {
+        const metadata = metadataMap.get(value.filename)
+        if (!metadata) return
+
+        if (fieldName.includes('error')) {
+          metadata.error = new TextDecoder('utf-8').decode(value.data).trim()
+        } else {
+          metadata.result = toBuffer(value.data)
+        }
+      })
+
+      return
+    } catch {
+      // Fall through to manual parsing
+    }
+  }
+
+  // Manual multipart parsing (handles multipart/mixed, etc.)
+  const boundary = extractBoundary(contentType)
+  if (!boundary) {
+    throw new DaytonaError(`Missing multipart boundary in Content-Type: "${contentType}"`)
+  }
+
+  const parts = parseMultipart(bodyBytes, boundary)
+  for (const part of parts) {
+    if (!part.filename) continue
+    const metadata = metadataMap.get(part.filename)
+    if (!metadata) continue
+
+    if (part.name === 'error') {
+      metadata.error = new TextDecoder('utf-8').decode(part.data).trim()
+    } else if (part.name === 'file') {
+      metadata.result = toBuffer(part.data)
+    }
+  }
+
+  return
+}

--- a/libs/sdk-typescript/src/utils/Import.ts
+++ b/libs/sdk-typescript/src/utils/Import.ts
@@ -28,7 +28,12 @@ const requireMap = {
 }
 
 const validateMap: Record<string, (mod: any) => boolean> = {
-  fs: (mod: any) => typeof mod.createReadStream === 'function',
+  'fast-glob': (mod: any) => typeof mod.default === 'function' && typeof mod.default.sync === 'function',
+  '@iarna/toml': (mod: any) => typeof mod.parse === 'function' && typeof mod.stringify === 'function',
+  stream: (mod: any) => typeof mod.Readable === 'function' && typeof mod.Writable === 'function',
+  tar: (mod: any) => typeof mod.extract === 'function' && typeof mod.create === 'function',
+  'expand-tilde': (mod: any) => typeof mod.default === 'function',
+  fs: (mod: any) => typeof mod.createReadStream === 'function' && typeof mod.readFile === 'function',
   'form-data': (mod: any) => typeof mod.default === 'function',
 }
 

--- a/libs/sdk-typescript/src/utils/Multipart.ts
+++ b/libs/sdk-typescript/src/utils/Multipart.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { concatUint8Arrays, findAllBytes, findBytesInRange, indexAfterSequence, utf8Decode, isFile } from './Binary'
+
+export interface MultipartPart {
+  name: string | undefined
+  filename: string | undefined
+  headers: Record<string, string>
+  data: Uint8Array
+}
+
+/**
+ * Extracts the boundary from a Content-Type header
+ */
+export function extractBoundary(contentType: string): string | null {
+  const match = /boundary="?([^";]+)"?/i.exec(contentType || '')
+  return match ? match[1] : null
+}
+
+/**
+ * Extracts a parameter value from Content-Disposition header
+ */
+function getDispositionParam(disposition: string, paramName: 'name' | 'filename'): string | undefined {
+  const match = disposition.match(new RegExp(`${paramName}\\*?=([^;]+)`, 'i'))
+  if (!match) return undefined
+  return match[1].replace(/^"|"$/g, '').trim()
+}
+
+/**
+ * Parses multipart/form-data or multipart/mixed response body
+ */
+export function parseMultipart(body: Uint8Array, boundary: string): MultipartPart[] {
+  const encoder = new TextEncoder()
+  const dashBoundary = encoder.encode(`--${boundary}`)
+  const crlf = encoder.encode('\r\n')
+  const boundaryLine = concatUint8Arrays([dashBoundary, crlf])
+
+  const boundaryPositions = findAllBytes(body, dashBoundary)
+  if (boundaryPositions.length === 0) return []
+
+  const parts: MultipartPart[] = []
+
+  for (let i = 0; i < boundaryPositions.length; i++) {
+    const start = boundaryPositions[i]
+
+    // Headers start after "--boundary\r\n"
+    const headerStart = indexAfterSequence(body, start, boundaryLine)
+    if (headerStart < 0) continue
+
+    // Part ends before next boundary
+    const nextBoundary = boundaryPositions[i + 1] ?? body.length
+    let partEnd = nextBoundary - 2 // Remove trailing CRLF
+    if (partEnd < headerStart) partEnd = headerStart
+
+    // Find headers/body separator (\r\n\r\n)
+    const separator = findBytesInRange(body, headerStart, partEnd, encoder.encode('\r\n\r\n'))
+    if (separator < 0) continue
+
+    // Parse headers
+    const headersText = utf8Decode(body.subarray(headerStart, separator))
+    const headers: Record<string, string> = {}
+
+    headersText.split(/\r\n/).forEach((line) => {
+      const [key, ...valueParts] = line.split(':')
+      if (valueParts.length > 0) {
+        headers[key.trim().toLowerCase()] = valueParts.join(':').trim()
+      }
+    })
+
+    // Extract body
+    const dataStart = separator + 4
+    const data = body.subarray(dataStart, partEnd)
+
+    // Extract name and filename from Content-Disposition
+    const disposition = headers['content-disposition'] || ''
+    const name = getDispositionParam(disposition, 'name')
+    const filename = getDispositionParam(disposition, 'filename')
+
+    parts.push({ name, filename, headers, data })
+  }
+
+  return parts
+}
+
+/**
+ * Parses multipart response using browser's native FormData API
+ * This is more reliable than manual parsing when available
+ */
+export async function parseMultipartWithFormData(
+  bodyBytes: Uint8Array,
+  contentType: string,
+): Promise<Map<string, { filename: string; data: Uint8Array }>> {
+  const result = new Map<string, { filename: string; data: Uint8Array }>()
+
+  // Create a Blob and parse with FormData API
+  const blob = new Blob([bodyBytes.slice()], { type: contentType })
+  const formData = await new Response(blob).formData()
+
+  // Process FormData entries (forEach is more universally supported than entries())
+  const filePromises: Promise<void>[] = []
+  formData.forEach((value, fieldName) => {
+    if (isFile(value)) {
+      filePromises.push(
+        (async () => {
+          const file = value as File
+          const arrayBuffer = await file.arrayBuffer()
+          result.set(fieldName, {
+            filename: file.name,
+            data: new Uint8Array(arrayBuffer),
+          })
+        })(),
+      )
+    }
+  })
+
+  await Promise.all(filePromises)
+  return result
+}
+
+/**
+ * Extracts a header value from response headers (case-insensitive)
+ */
+export function getHeader(headers: any, key: string): string | undefined {
+  if (!headers) return undefined
+  const headerKey = Object.keys(headers).find((h) => h.toLowerCase() === key.toLowerCase())
+  if (!headerKey) return undefined
+  const value = headers[headerKey]
+  return Array.isArray(value) ? value[0] : value
+}


### PR DESCRIPTION
## Description

Fixed file upload/download and WebSocket functionality to work correctly across multiple TypeScript/JavaScript runtimes (Node.js, Browser, Deno. Bun, Serverless environments).

### Key Changes

**File Operations**
- Refactored `downloadFiles()` to handle streaming (Node.js) vs buffered (Browser/Serverless) responses
- Fixed `uploadFiles()` to use appropriate FormData implementations per runtime
- Extracted file transfer logic to dedicated utility functions for better maintainability
- Fixed Blob creation in browser/Deno environments using `.slice()` for proper ArrayBuffer handling

**WebSocket**
- Added Deno runtime support for WebSocket connections

### Testing
Tested across Node.js, Browser, Deno, Bun and Serverless runtimes (Cloudflare worker).

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR closes #2650
