### PR TITLE
fix(api): labels query fallback

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -122,7 +122,7 @@ export class SandboxController {
     @Query('labels') labelsQuery?: string,
     @Query('includeErroredDeleted') includeErroredDeleted?: boolean,
   ): Promise<SandboxDto[]> {
-    const labels = labelsQuery ? JSON.parse(labelsQuery) : {}
+    const labels = labelsQuery ? JSON.parse(labelsQuery) : undefined
     const sandboxes = await this.sandboxService.findAllDeprecated(
       authContext.organizationId,
       labels,
@@ -182,7 +182,7 @@ export class SandboxController {
       {
         id,
         name,
-        labels: labels ? JSON.parse(labels) : {},
+        labels: labels ? JSON.parse(labels) : undefined,
         includeErroredDestroyed,
         states,
         snapshots,


### PR DESCRIPTION
## Description

Changed the fallback value for the `labels` query parameter from an empty object `{}` to `undefined` in two locations within the sandbox controller.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
