### PR TITLE
fix(dashboard): use correct permission for deleting volumes

### DIFF
--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -45,7 +45,7 @@ export function VolumeTable({ data, loading, processingVolumeAction, onDelete, o
   const { authenticatedUserHasPermission } = useSelectedOrganization()
 
   const deletePermitted = useMemo(
-    () => authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_SANDBOXES),
+    () => authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_VOLUMES),
     [authenticatedUserHasPermission],
   )
 


### PR DESCRIPTION
## Description

Updates the permission check for deleting volumes in the dashbiard to use the correct `delete:volumes` permission.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
