### PR TITLE
fix(sdk): treat 404 errors as a destroyed state during sandbox stop and delete

### DIFF
--- a/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
@@ -64,6 +64,7 @@ Initialize a new Sandbox instance.
 #### AsyncSandbox.refresh\_data
 
 ```python
+@intercept_errors(message_prefix="Failed to refresh sandbox data: ")
 async def refresh_data() -> None
 ```
 

--- a/apps/docs/src/content/docs/en/python-sdk/common/errors.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/common/errors.mdx
@@ -12,3 +12,11 @@ class DaytonaError(Exception)
 Base error for Daytona SDK.
 
 
+## DaytonaNotFoundError
+
+```python
+class DaytonaNotFoundError(DaytonaError)
+```
+
+Error for when a resource is not found.
+

--- a/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
@@ -64,6 +64,7 @@ Initialize a new Sandbox instance.
 #### Sandbox.refresh\_data
 
 ```python
+@intercept_errors(message_prefix="Failed to refresh sandbox data: ")
 def refresh_data() -> None
 ```
 

--- a/libs/sdk-python/src/daytona/common/errors.py
+++ b/libs/sdk-python/src/daytona/common/errors.py
@@ -4,3 +4,7 @@
 
 class DaytonaError(Exception):
     """Base error for Daytona SDK."""
+
+
+class DaytonaNotFoundError(DaytonaError):
+    """Error for when a resource is not found."""


### PR DESCRIPTION
## Description

This PR fixes an issue where the SDK would throw errors when attempting to refresh sandbox data during stop/delete operations if the sandbox had already been destroyed (resulting in a 404 response). This commonly occurred with ephemeral sandboxes that are automatically deleted after stopping.

**Changes:**
- Introduced `DaytonaNotFoundError` exception class to handle 404/not found responses
- Added `refreshDataSafe()` / `__refresh_data_safe()` private methods that catch 404 errors and set sandbox state to `DESTROYED` instead of throwing
- Updated `stop()`, `delete()`, and wait methods to use the safe refresh approach
- Enhanced error interceptor to properly map 404 responses to `DaytonaNotFoundError`

This ensures graceful handling of race conditions and automatic sandbox cleanup scenarios.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation
