### PR TITLE
fix(api): validate container existence before proxying

### DIFF
--- a/apps/api/src/sandbox/services/toolbox.service.ts
+++ b/apps/api/src/sandbox/services/toolbox.service.ts
@@ -11,6 +11,8 @@ import { Runner } from '../entities/runner.entity'
 import axios from 'axios'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { RedisLockProvider } from '../common/redis-lock.provider'
+import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
+import { RunnerService } from './runner.service'
 
 @Injectable()
 export class ToolboxService {
@@ -22,6 +24,8 @@ export class ToolboxService {
     @InjectRepository(Runner)
     private readonly runnerRepository: Repository<Runner>,
     private readonly redisLockProvider: RedisLockProvider,
+    private readonly runnerService: RunnerService,
+    private readonly runnerAdapterFactory: RunnerAdapterFactory,
   ) {}
 
   async forwardRequestToRunner(sandboxId: string, method: string, path: string, data?: any): Promise<any> {
@@ -98,6 +102,41 @@ export class ToolboxService {
 
       if (sandbox.state !== SandboxState.STARTED) {
         throw new BadRequestException('Sandbox is not running')
+      }
+
+      try {
+        const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+        const sandboxInfo = await runnerAdapter.sandboxInfo(sandboxId)
+
+        if (sandboxInfo.state === SandboxState.STARTED) {
+          return runner
+        }
+
+        this.logger.warn(
+          `Sandbox ${sandboxId} is marked as STARTED in DB but actual state is ${sandboxInfo.state}. Updating to ERROR.`,
+        )
+        await this.sandboxRepository.update(sandboxId, {
+          state: SandboxState.ERROR,
+          errorReason: `Container state mismatch: expected STARTED, actual ${sandboxInfo.state}`,
+        })
+        throw new BadRequestException(
+          `Sandbox is not running (actual state: ${sandboxInfo.state}). Please restart the sandbox.`,
+        )
+      } catch (error) {
+        if (error instanceof BadRequestException) throw error
+
+        if (error.response?.status === 404 || error.message?.includes('not found')) {
+          this.logger.warn(
+            `Sandbox ${sandboxId} is marked as STARTED but container not found on runner. Updating to ERROR.`,
+          )
+          await this.sandboxRepository.update(sandboxId, {
+            state: SandboxState.ERROR,
+            errorReason: 'Container not found on runner',
+          })
+          throw new BadRequestException('Sandbox container not found. Please restart the sandbox.')
+        }
+
+        this.logger.error(`Failed to verify sandbox ${sandboxId} state on runner:`, error)
       }
 
       return runner


### PR DESCRIPTION
Sandboxes seem to be marked as `STARTED` in the database, while their containers no longer exist on the runner. This seems to happen in these cases:
- OOM kills removing containers
- Runner crashes or restarts
- Manual container deletion
- Docker daemon issues

When this occurs, attempting to connect via web console results in:
```json
{"statusCode":404,"message":"not found: sandbox container not found: Error response from daemon: No such container"}
```

The root cause seems to be that `ToolboxService.getRunner()` only checks the database state without verifying the container actually exists on the runner.