### PR TITLE
fix(api): exclude dangling logs during post-retention cleanup

### DIFF
--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -140,6 +140,7 @@ export class AuditService implements OnApplicationBootstrap {
       this.logger.log(`Starting cleanup of audit logs older than ${retentionDays} days`)
 
       const deletedLogs = await this.auditLogRepository.delete({
+        statusCode: Not(IsNull()),
         createdAt: LessThan(cutoffDate),
       })
 


### PR DESCRIPTION
## Description

Added a precautionary condition for excluding dangling logs (no status code value) when performing a cleanup of audit logs that are older than the retention period.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
