### PR TITLE
fix(api-client): error when running with urllib3 < 2.1.0

### DIFF
--- a/hack/python-client/postprocess.sh
+++ b/hack/python-client/postprocess.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script normalizes generated Python client metadata after OpenAPI generation.
+# Usage: postprocess.sh <projectRoot>
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <projectRoot>" >&2
+  exit 1
+fi
+
+PROJECT_ROOT="$1"
+
+# Set license in pyproject.toml to Apache-2.0
+sed -i 's/^license = ".*"/license = "Apache-2.0"/' "$PROJECT_ROOT/pyproject.toml"
+
+# Ensure urllib3 lower bound is pinned to version 2.1.0 in pyproject.toml, setup.py, and requirements.txt.
+# This prevents compatibility issues such as:
+# `TypeError: PoolKey.__new__() got an unexpected keyword argument 'key_ca_cert_data'`
+# which occur with urllib3 versions earlier than 2.1.0.
+sed -i -E 's/(urllib3[^0-9\n]*)([0-9]+\.[0-9]+\.[0-9]+)/\12.1.0/g' \
+  "$PROJECT_ROOT/pyproject.toml" \
+  "$PROJECT_ROOT/setup.py" \
+  "$PROJECT_ROOT/requirements.txt"
+
+echo "Postprocessed Python client at $PROJECT_ROOT"
+
+
+

--- a/libs/api-client-python-async/project.json
+++ b/libs/api-client-python-async/project.json
@@ -9,7 +9,7 @@
       "options": {
         "commands": [
           "yarn run openapi-generator-cli generate --git-repo-id=daytona --git-user-id=daytonaio -i dist/apps/api/openapi.json -g python --additional-properties=packageName=daytona_api_client_async,projectName=daytona_api_client_async,packageVersion=$DEFAULT_PACKAGE_VERSION,pythonPackageName=daytona_api_client_async,disallowAdditionalPropertiesIfNotPresent=false,library=asyncio -o {projectRoot}",
-          "sed -i 's/^license = \".*\"/license = \"Apache-2.0\"/' {projectRoot}/pyproject.toml"
+          "bash hack/python-client/postprocess.sh {projectRoot}"
         ],
         "parallel": false
       },

--- a/libs/api-client-python-async/pyproject.toml
+++ b/libs/api-client-python-async/pyproject.toml
@@ -12,7 +12,7 @@ include = ["daytona_api_client_async/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 aiohttp = ">= 3.8.4"
 aiohttp-retry = ">= 2.8.3"

--- a/libs/api-client-python-async/requirements.txt
+++ b/libs/api-client-python-async/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 aiohttp >= 3.8.4
 aiohttp-retry >= 2.8.3

--- a/libs/api-client-python-async/setup.py
+++ b/libs/api-client-python-async/setup.py
@@ -25,7 +25,7 @@ NAME = "daytona_api_client_async"
 VERSION = "0.0.0-dev"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.1.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "aiohttp >= 3.8.4",
     "aiohttp-retry >= 2.8.3",

--- a/libs/api-client-python/project.json
+++ b/libs/api-client-python/project.json
@@ -9,7 +9,7 @@
       "options": {
         "commands": [
           "yarn run openapi-generator-cli generate --git-repo-id=daytona --git-user-id=daytonaio -i dist/apps/api/openapi.json -g python --additional-properties=packageName=daytona_api_client,projectName=daytona_api_client,packageVersion=$DEFAULT_PACKAGE_VERSION,pythonPackageName=daytona_api_client,disallowAdditionalPropertiesIfNotPresent=false -o {projectRoot}",
-          "sed -i 's/^license = \".*\"/license = \"Apache-2.0\"/' {projectRoot}/pyproject.toml"
+          "bash hack/python-client/postprocess.sh {projectRoot}"
         ],
         "parallel": false
       },

--- a/libs/api-client-python/pyproject.toml
+++ b/libs/api-client-python/pyproject.toml
@@ -12,7 +12,7 @@ include = ["daytona_api_client/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"

--- a/libs/api-client-python/requirements.txt
+++ b/libs/api-client-python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/libs/api-client-python/setup.py
+++ b/libs/api-client-python/setup.py
@@ -25,7 +25,7 @@ NAME = "daytona_api_client"
 VERSION = "0.0.0-dev"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.1.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/poetry.lock
+++ b/poetry.lock
@@ -1081,7 +1081,7 @@ develop = true
 pydantic = ">= 2"
 python-dateutil = ">= 2.8.2"
 typing-extensions = ">= 4.7.1"
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 
 [package.source]
 type = "directory"
@@ -1103,7 +1103,7 @@ aiohttp-retry = ">= 2.8.3"
 pydantic = ">= 2"
 python-dateutil = ">= 2.8.2"
 typing-extensions = ">= 4.7.1"
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 
 [package.source]
 type = "directory"


### PR DESCRIPTION
## Description

There’s a bug in the Python SDK when using versions of urllib3 older than 2.1.0, even though they fall within the supported version range.

Minimal reproducible example:

1. Make sure an older version of urllib3 is installed:
```bash
pip install 'urllib3==2.0.7' --force-reinstall --break-system-packages
```

2. Run some code:
```python
from daytona import Daytona
daytona = Daytona(config)
sandbox = daytona.find_one("*****")
```

3. You'll get this error:
```
TypeError: PoolKey.__new__() got an unexpected keyword argument 'key_ca_cert_data'
```

This issue is resolved by upgrading to urllib3>=2.1.0, even though version 2.0.7 was originally within the allowed range.
