### PR TITLE
chore(runner): update dockerfile entrypoint

### DIFF
--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -45,4 +45,4 @@ ENV AWS_DEFAULT_BUCKET=daytona
 
 ENV SERVER_URL=http://api:3000/api
 
-ENTRYPOINT ["sh", "-c", "dockerd & daytona-runner"]
+ENTRYPOINT ["sh", "-c", "/usr/local/bin/dockerd-entrypoint.sh & daytona-runner"]


### PR DESCRIPTION
## Description

Uses `/usr/local/bin/dockerd-entrypoint.sh` instead of just `dockerd` which is the recommended way to start dind images.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
