### PR TITLE
fix(dashboard): exclude members page when force redirecting to wallet page

### DIFF
--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -41,7 +41,7 @@ const Dashboard: React.FC = () => {
       return
     }
 
-    const excludedRoutes = [RoutePath.BILLING_WALLET, RoutePath.USER_INVITATIONS]
+    const excludedRoutes = [RoutePath.BILLING_WALLET, RoutePath.USER_INVITATIONS, RoutePath.MEMBERS]
     const shouldSkipRedirect = excludedRoutes.some((route) => location.pathname.startsWith(route))
 
     if (wallet && wallet.ongoingBalanceCents <= 0 && !shouldSkipRedirect) {


### PR DESCRIPTION
## Description

Added the org members page to list of excluded routes when force redirecting to the wallet page in case of missing payment info or negative balance.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
