### PR TITLE
fix(api): add checks for runner sandbox state unknown

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -358,6 +358,8 @@ export class SandboxStartAction extends SandboxAction {
       await this.updateSandboxState(sandbox.id, SandboxState.PULLING_SNAPSHOT)
     } else if (sandboxInfo.state === SandboxState.ERROR) {
       await this.updateSandboxState(sandbox.id, SandboxState.ERROR)
+    } else if (sandboxInfo.state === SandboxState.UNKNOWN) {
+      await this.updateSandboxState(sandbox.id, SandboxState.UNKNOWN)
     } else {
       await this.updateSandboxState(sandbox.id, SandboxState.STARTING)
     }
@@ -459,6 +461,10 @@ export class SandboxStartAction extends SandboxAction {
       case SandboxState.STARTING:
       case SandboxState.RESTORING:
       case SandboxState.CREATING: {
+        break
+      }
+      case SandboxState.UNKNOWN: {
+        await this.updateSandboxState(sandbox.id, SandboxState.UNKNOWN)
         break
       }
       case SandboxState.ERROR: {


### PR DESCRIPTION
## Add checks for runner sandbox state unknown

Add missing runner sandbox state `UNKNOWN` checks when creating sandbox

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation