### PR TITLE
fix(docs): homepage next button

### DIFF
--- a/apps/docs/src/utils/navigation.ts
+++ b/apps/docs/src/utils/navigation.ts
@@ -210,8 +210,8 @@ export function getPagination(
       sidebarConfig,
       (link as MainNavigationLink).relatedGroupCategory
     )
-    if (links && links.length > 0) {
-      result.next = { href: links[0].href, label: links[0].label }
+    if (links && links.length > 1) {
+      result.next = { href: links[1].href, label: links[1].label }
     }
   } else {
     const links = getNavLinksByCategory(sidebarConfig, group.category)


### PR DESCRIPTION
## Description

currently if Iam on the Home page, the Next pagination button also points to Home. this fixes the issue so that it directs to the correct next page within the related group

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #2730


## Screenshots

<img width="1167" height="319" alt="image" src="https://github.com/user-attachments/assets/74d7e64c-9d1a-49a9-99c5-01ae771df73e" />

