### PR TITLE
chore(api): db tls env config

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -74,6 +74,11 @@ import { getPinoTransport, swapMessageAndObject } from './common/utils/pino.util
           migrationsRun: configService.get('runMigrations') || !configService.getOrThrow('production'),
           namingStrategy: new CustomNamingStrategy(),
           manualInitialization: configService.get('skipConnections'),
+          ssl: configService.get('database.tls.enabled')
+            ? {
+                rejectUnauthorized: configService.get('database.tls.rejectUnauthorized'),
+              }
+            : undefined,
         }
       },
     }),

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -18,6 +18,10 @@ const configuration = {
     username: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_DATABASE,
+    tls: {
+      enabled: process.env.DB_TLS_ENABLED === 'true',
+      rejectUnauthorized: process.env.DB_TLS_REJECT_UNAUTHORIZED !== 'false',
+    },
   },
   redis: {
     host: process.env.REDIS_HOST,

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -66,7 +66,9 @@ This configures dnsmasq with `address=/proxy.localhost/127.0.0.1`.
 - The registry is configured to allow image deletion for testing
 - Sandbox resource limits are disabled due to inability to partition cgroups in DinD environment where the sock is not mounted
 
-## Configuring outbound HTTP Proxy
+## Additional Network Options
+
+### HTTP Proxy
 
 To configurate an outbound HTTP proxy for the Daytona services, you can set the following environment variables in the `docker-compose.yaml` file for each service that requires proxy access (the API service is the only that requires outbound access to pull images):
 
@@ -83,6 +85,17 @@ environment:
   - NO_PROXY=localhost,runner,dex,registry,minio,jaeger,<your-proxy>
 ```
 
+### Extra CA Certificates
+
+To configure extra CA certificates (for example, paired with `DB_TLS` env vars), set the following environment variable in the API service:
+
+```yaml
+environment:
+  - NODE_EXTRA_CA_CERTS=/path/to/your/cert-bundle.pembundle
+```
+
+The provided file is a cert bundle. Meaning it can contain multiple CA certificates in PEM format.
+
 ## Environment Variables
 
 You can customize the deployment by modifying environment variables in the `docker-compose.yaml` file.
@@ -98,6 +111,8 @@ Below is a full list of environment variables with their default values:
 | `DB_USERNAME`                              | string  | `user`                                               | PostgreSQL database username                |
 | `DB_PASSWORD`                              | string  | `pass`                                               | PostgreSQL database password                |
 | `DB_DATABASE`                              | string  | `daytona`                                            | PostgreSQL database name                    |
+| `DB_TLS_ENABLED`                           | boolean | `false`                                              | Enable TLS for database connection          |
+| `DB_TLS_REJECT_UNAUTHORIZED`               | boolean | `true`                                               | Reject unauthorized TLS certificates        |
 | `REDIS_HOST`                               | string  | `redis`                                              | Redis server hostname                       |
 | `REDIS_PORT`                               | number  | `6379`                                               | Redis server port                           |
 | `OIDC_CLIENT_ID`                           | string  | `daytona`                                            | OIDC client identifier                      |


### PR DESCRIPTION
## Description

Added env vars to configure API db tls options.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation
