### PR TITLE
fix(sdk): isolate Daytona object storage initialization from OS environment

### DIFF
--- a/libs/sdk-python/src/daytona/_async/object_storage.py
+++ b/libs/sdk-python/src/daytona/_async/object_storage.py
@@ -12,6 +12,7 @@ import aiofiles.os
 from obstore.store import S3Store
 
 from .._utils.docs_ignore import docs_ignore
+from .._utils.environment import isolated_env
 
 
 class AsyncObjectStorage:
@@ -34,13 +35,14 @@ class AsyncObjectStorage:
         bucket_name: str = "daytona-volume-builds",
     ):
         self.bucket_name = bucket_name
-        self.store = S3Store(
-            bucket=bucket_name,
-            endpoint=endpoint_url,
-            access_key_id=aws_access_key_id,
-            secret_access_key=aws_secret_access_key,
-            token=aws_session_token,
-        )
+        with isolated_env():
+            self.store = S3Store(
+                bucket=bucket_name,
+                endpoint=endpoint_url,
+                access_key_id=aws_access_key_id,
+                secret_access_key=aws_secret_access_key,
+                token=aws_session_token,
+            )
 
     async def upload(self, path: str, organization_id: str, archive_base_path: str | None = None) -> str:
         """Uploads a file to the object storage service.

--- a/libs/sdk-python/src/daytona/_sync/object_storage.py
+++ b/libs/sdk-python/src/daytona/_sync/object_storage.py
@@ -13,6 +13,7 @@ import threading
 from obstore.store import S3Store
 
 from .._utils.docs_ignore import docs_ignore
+from .._utils.environment import isolated_env
 
 
 class ObjectStorage:
@@ -35,13 +36,14 @@ class ObjectStorage:
         bucket_name: str = "daytona-volume-builds",
     ):
         self.bucket_name = bucket_name
-        self.store = S3Store(
-            bucket=bucket_name,
-            endpoint=endpoint_url,
-            access_key_id=aws_access_key_id,
-            secret_access_key=aws_secret_access_key,
-            token=aws_session_token,
-        )
+        with isolated_env():
+            self.store = S3Store(
+                bucket=bucket_name,
+                endpoint=endpoint_url,
+                access_key_id=aws_access_key_id,
+                secret_access_key=aws_secret_access_key,
+                token=aws_session_token,
+            )
 
     def upload(self, path: str, organization_id: str, archive_base_path: str | None = None) -> str:
         """Uploads a file to the object storage service.

--- a/libs/sdk-python/src/daytona/_utils/environment.py
+++ b/libs/sdk-python/src/daytona/_utils/environment.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from contextlib import contextmanager
+from copy import deepcopy
+
+
+@contextmanager
+def isolated_env(temp_env=None):
+    """Temporarily replaces os.environ with a controlled copy."""
+    old_env = deepcopy(os.environ)
+    os.environ.clear()
+    if temp_env:
+        os.environ.update(temp_env)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_env)


### PR DESCRIPTION
## fix(sdk): isolate Daytona object storage initialization from OS environment

### Summary
This PR ensures that S3Store initialization in the Daytona SDK is isolated from the host OS environment variables, preventing potential conflicts and environment pollution.

#### Changes
- Added new `isolated_env()` context manager utility that temporarily clears and restores `os.environ`
- Wrapped S3Store initialization in both `AsyncObjectStorage` and `ObjectStorage` classes with the `isolated_env()` context manager
- This prevents S3Store from inadvertently reading AWS credentials or configuration from the OS environment

### Impact
- More predictable and isolated object storage behavior
- Prevents unintended credential leakage from host environment
- Ensures only explicitly provided credentials are used for Daytona S3Store initialization

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
