### PR TITLE
fix(sdk): add timeout for pending_build state to prevent indefinite waits

### DIFF
--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -437,11 +437,9 @@ class AsyncDaytona:
                     SandboxState.BUILD_FAILED,
                 ]
 
-            pending_build_start = time.time()
-
             while response_ref["response"].state == SandboxState.PENDING_BUILD:
                 if timeout:
-                    elapsed = time.time() - pending_build_start
+                    elapsed = time.time() - start_time
                     if elapsed > timeout:
                         raise DaytonaError(
                             f"Sandbox build has been pending for more than {timeout} seconds."

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -398,11 +398,9 @@ class Daytona:
                     SandboxState.BUILD_FAILED,
                 ]
 
-            pending_build_start = time.time()
-
             while response_ref["response"].state == SandboxState.PENDING_BUILD:
                 if timeout:
-                    elapsed = time.time() - pending_build_start
+                    elapsed = time.time() - start_time
                     if elapsed > timeout:
                         raise DaytonaError(
                             f"Sandbox build has been pending for more than {timeout} seconds."

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -505,11 +505,9 @@ export class Daytona {
           SandboxState.BUILD_FAILED,
         ]
 
-        const pendingBuildStart = Date.now()
-
         while (sandboxInstance.state === SandboxState.PENDING_BUILD) {
           if (options.timeout) {
-            const elapsed = (Date.now() - pendingBuildStart) / 1000
+            const elapsed = (Date.now() - startTime) / 1000
             if (elapsed > options.timeout) {
               throw new DaytonaError(
                 `Sandbox build has been pending for more than ${options.timeout} seconds. Please check the sandbox state again later.`,


### PR DESCRIPTION
## Description

Adds timeout handling for sandboxes in PENDING_BUILD state to prevent indefinite waits when no runners are available (as the API will queue declarative builds instead of throwing errors).

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
