### PR TITLE
fix: runner id alias

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -401,7 +401,7 @@ export class RunnerService {
   async getRunnersWithMultipleSnapshotsBuilding(maxSnapshotCount = 2): Promise<string[]> {
     const runners = await this.sandboxRepository
       .createQueryBuilder('sandbox')
-      .select('sandbox.runnerId')
+      .select('sandbox.runnerId', 'runnerId')
       .where('sandbox.state = :state', { state: SandboxState.BUILDING_SNAPSHOT })
       .andWhere('sandbox.buildInfoSnapshotRef IS NOT NULL')
       .groupBy('sandbox.runnerId')


### PR DESCRIPTION
## Runner ID alias

Fixes the "No available runners" message appearing more often than needed when using declarative builds by fixing the sql query alias when getting excluded runner IDs due to concurrency numbers

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation