### PR TITLE
fix: sync instance state loop condition

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
@@ -57,7 +57,7 @@ export class SandboxDestroyAction extends SandboxAction {
         }
 
         await this.updateSandboxState(sandbox.id, SandboxState.DESTROYED)
-        return SYNC_AGAIN
+        return DONT_SYNC_AGAIN
       }
       default: {
         // destroy sandbox

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-stop.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-stop.action.ts
@@ -54,7 +54,7 @@ export class SandboxStopAction extends SandboxAction {
             sandboxToUpdate.state = SandboxState.STOPPED
             sandboxToUpdate.setBackupState(BackupState.NONE)
             await this.sandboxRepository.save(sandboxToUpdate)
-            return SYNC_AGAIN
+            return DONT_SYNC_AGAIN
           }
           case SandboxState.ERROR: {
             await this.updateSandboxState(

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -373,6 +373,14 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       return
     }
 
+    //  prevent potential race condition, or SYNC_AGAIN loop bug
+    //  this should never happen
+    if (String(sandbox.state) === String(sandbox.desiredState)) {
+      this.logger.warn(`Sandbox ${sandboxId} is already in the desired state ${sandbox.desiredState}, skipping sync`)
+      await this.redisLockProvider.unlock(lockKey)
+      return
+    }
+
     let syncState = DONT_SYNC_AGAIN
 
     try {


### PR DESCRIPTION
## Description

Fixes the invalid sync instance state loop condition that would cause one extra cycle on already reconciled instance.
Added extra validation logic for detecting extra cycles, that produces the warning logs and stops the cycle.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

