### PR TITLE
fix(api): retry not found sandbox state

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -27,6 +27,8 @@ import { TypedConfigService } from '../../../config/typed-config.service'
 import { Runner } from '../../entities/runner.entity'
 import { Organization } from '../../../organization/entities/organization.entity'
 import { RedisLockProvider } from '../../common/redis-lock.provider'
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import Redis from 'ioredis'
 
 @Injectable()
 export class SandboxStartAction extends SandboxAction {
@@ -43,6 +45,7 @@ export class SandboxStartAction extends SandboxAction {
     protected readonly organizationService: OrganizationService,
     protected readonly configService: TypedConfigService,
     private readonly redisLockProvider: RedisLockProvider,
+    @InjectRedis() private readonly redis: Redis,
   ) {
     super(runnerService, runnerAdapterFactory, sandboxRepository, toolboxService)
   }
@@ -375,6 +378,10 @@ export class SandboxStartAction extends SandboxAction {
 
     switch (sandboxInfo.state) {
       case SandboxState.STARTED: {
+        // Clear any DESTROYED retry key since sandbox is now started
+        const destroyedRetryKey = `destroyed-retry-${sandbox.id}`
+        await this.redis.del(destroyedRetryKey)
+
         let daemonVersion: string | undefined
         try {
           daemonVersion = await runnerAdapter.getSandboxDaemonVersion(sandbox.id)
@@ -420,6 +427,31 @@ export class SandboxStartAction extends SandboxAction {
       case SandboxState.ERROR: {
         await this.updateSandboxState(sandbox.id, SandboxState.ERROR)
         break
+      }
+      case SandboxState.DESTROYED: {
+        // Retry up to 3 times since the sandbox might not have started spinning up on the runner yet
+        const destroyedRetryKey = `destroyed-retry-${sandbox.id}`
+        const retryCountRaw = await this.redis.get(destroyedRetryKey)
+        const retryCount = retryCountRaw ? parseInt(retryCountRaw) : 0
+
+        if (retryCount < 3) {
+          // Increment retry count and set expiration (5 minutes should be enough for retries)
+          await this.redis.setex(destroyedRetryKey, 300, String(retryCount + 1))
+          this.logger.warn(
+            `Sandbox ${sandbox.id} is in DESTROYED state on runner, retrying (attempt ${retryCount + 1}/3)`,
+          )
+          break // Continue to return SYNC_AGAIN
+        } else {
+          // Max retries reached, clear the retry key and handle as error
+          await this.redis.del(destroyedRetryKey)
+          await this.updateSandboxState(
+            sandbox.id,
+            SandboxState.ERROR,
+            undefined,
+            'Sandbox is in DESTROYED state on runner after 3 retries',
+          )
+          return DONT_SYNC_AGAIN
+        }
       }
       // also any other state that is not STARTED
       default: {


### PR DESCRIPTION
## Retry not found sandbox state

Retry not found sandbox state since runner returns "destroyed"

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
