### PR TITLE
fix(api): efficient audit log query

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "dotenv": "^17.0.1",
     "ejs": "^3.1.10",
     "envalid": "^8.0.0",
+    "es-toolkit": "^1.41.0",
     "expand-tilde": "^2.0.2",
     "express": "^5.1.0",
     "express-openid-connect": "^2.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18271,6 +18271,7 @@ __metadata:
     dotenv: "npm:^17.0.1"
     ejs: "npm:^3.1.10"
     envalid: "npm:^8.0.0"
+    es-toolkit: "npm:^1.41.0"
     eslint: "npm:^9.8.0"
     eslint-config-prettier: "npm:10.1.8"
     eslint-plugin-import: "npm:2.31.0"
@@ -19479,6 +19480,18 @@ __metadata:
     is-date-object: "npm:^1.0.5"
     is-symbol: "npm:^1.0.4"
   checksum: 10c0/c7e87467abb0b438639baa8139f701a06537d2b9bc758f23e8622c3b42fd0fdb5bde0f535686119e446dd9d5e4c0f238af4e14960f4771877cf818d023f6730b
+  languageName: node
+  linkType: hard
+
+"es-toolkit@npm:^1.41.0":
+  version: 1.41.0
+  resolution: "es-toolkit@npm:1.41.0"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+  checksum: 10c0/4edcc19984df0e521d222082d055f131233cada9277de3f427311ecd43dc99442dc66a39f86b1b10c298c5a72133231928eb91668c0bff4f11e12af8b6d758a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Added regular id field to index mappings to enable memory-efficient sorting and filtering. OpenSearch's _id metadata field forces field data to be loaded into heap memory for sort operations. A keyword field with doc values uses disk-based storage, avoiding heap pressure on large indices.

Changed OpenSearch module init. Resolves the issue where first data stream index does not have ISM policy attached.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

