### PR TITLE
fix(api): update state conflict

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1230,13 +1230,14 @@ export class SandboxService {
     }
 
     const oldState = sandbox.state
+    const oldDesiredState = sandbox.desiredState
     sandbox.state = newState
     //  we need to update the desired state to match the new state
     const desiredState = this.getExpectedDesiredStateForState(newState)
     if (desiredState) {
       sandbox.desiredState = desiredState
     }
-    await this.sandboxRepository.saveWhere(sandbox, { pending: false, state: oldState })
+    await this.sandboxRepository.saveWhere(sandbox, { pending: false, state: oldState, desiredState: oldDesiredState })
   }
 
   @OnEvent(WarmPoolEvents.TOPUP_REQUESTED)


### PR DESCRIPTION
## Update state conflict

Fixes regression with `saveWhere` which made the runner updating the sandbox always return a conflict

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
