### PR TITLE
feat(api): sandbox actions retries

### DIFF
--- a/apps/api/src/sandbox/constants/errors-for-archive-retry.ts
+++ b/apps/api/src/sandbox/constants/errors-for-archive-retry.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+// Substrings in an error message that should trigger retry for archive operations
+export const ARCHIVE_RETRY_ERROR_SUBSTRINGS: string[] = ['Request failed with status code 502']

--- a/apps/api/src/sandbox/constants/errors-for-destroy-retry.ts
+++ b/apps/api/src/sandbox/constants/errors-for-destroy-retry.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+// Substrings in an error message that should trigger retry for destroy operations
+export const DESTROY_RETRY_ERROR_SUBSTRINGS: string[] = ['Request failed with status code 502']

--- a/apps/api/src/sandbox/constants/errors-for-start-retry.ts
+++ b/apps/api/src/sandbox/constants/errors-for-start-retry.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+// Substrings in an error message that should trigger retry for start operations
+export const START_RETRY_ERROR_SUBSTRINGS: string[] = ['Request failed with status code 502']

--- a/apps/api/src/sandbox/constants/errors-for-stop-retry.ts
+++ b/apps/api/src/sandbox/constants/errors-for-stop-retry.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+// Substrings in an error message that should trigger retry for stop operations
+export const STOP_RETRY_ERROR_SUBSTRINGS: string[] = ['Request failed with status code 502']

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
@@ -12,6 +12,8 @@ import { Repository } from 'typeorm'
 import { SandboxState } from '../../enums/sandbox-state.enum'
 import { ToolboxService } from '../../services/toolbox.service'
 import { BackupState } from '../../enums/backup-state.enum'
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import Redis from 'ioredis'
 
 export const SYNC_AGAIN = 'sync-again'
 export const DONT_SYNC_AGAIN = 'dont-sync-again'
@@ -27,6 +29,7 @@ export abstract class SandboxAction {
     @InjectRepository(Sandbox)
     protected readonly sandboxRepository: Repository<Sandbox>,
     protected readonly toolboxService: ToolboxService,
+    @InjectRedis() protected readonly redis: Redis,
   ) {}
 
   abstract run(sandbox: Sandbox): Promise<SyncState>
@@ -76,5 +79,71 @@ export abstract class SandboxAction {
     }
 
     await this.sandboxRepository.save(sandbox)
+  }
+
+  /**
+   * Retry wrapper for sandbox operations that should retry on specific error patterns
+   * Uses Redis to count retries, allowing the cron job to recall the operations
+   * @param sandboxId - The sandbox ID for generating a unique retry key
+   * @param operationType - Type of operation (e.g., 'start', 'stop', 'destroy', 'archive') for key uniqueness
+   * @param operation - The async operation to retry
+   * @param retryErrorSubstrings - Array of error message substrings that should trigger retry
+   * @param maxRetries - Maximum number of retry attempts (default: 3)
+   * @param onError - Optional callback to handle specific error cases before retry check (returns SyncState if handled, null otherwise)
+   * @returns SYNC_AGAIN on success, DONT_SYNC_AGAIN if retries exhausted or to let cron job retry, or throws error
+   */
+  protected async retryOperation<T>(
+    sandboxId: string,
+    operationType: string,
+    operation: () => Promise<T>,
+    retryErrorSubstrings: string[],
+    maxRetries = 3,
+    onError?: (error: any) => Promise<SyncState | null>,
+  ): Promise<SyncState> {
+    const retryKey = `retry:${operationType}:${sandboxId}`
+    const retryCount = await this.redis.incr(retryKey)
+
+    // Set TTL on first increment (720 seconds = 12 minutes)
+    if (retryCount === 1) {
+      await this.redis.expire(retryKey, 720)
+    }
+
+    try {
+      await operation()
+      // Success - clear retry counter
+      await this.redis.del(retryKey)
+      return SYNC_AGAIN
+    } catch (error) {
+      // Check for custom error handling first
+      if (onError) {
+        const handled = await onError(error)
+        if (handled !== null) {
+          // If handled, clear retry counter if it was successful
+          if (handled === SYNC_AGAIN) {
+            await this.redis.del(retryKey)
+          }
+          return handled
+        }
+      }
+
+      // Check if error message contains a retryable error substring
+      const isRetryableError =
+        error?.message &&
+        retryErrorSubstrings.some((substring) => error.message.toLowerCase().includes(substring.toLowerCase()))
+
+      if (isRetryableError) {
+        if (retryCount >= maxRetries) {
+          // All retries exhausted - clear counter and let cron job pick it up
+          await this.redis.del(retryKey)
+          return DONT_SYNC_AGAIN
+        }
+        // Retryable error with retries remaining - let cron job retry
+        return DONT_SYNC_AGAIN
+      }
+
+      // Not a retryable error - clear counter and rethrow
+      await this.redis.del(retryKey)
+      throw error
+    }
   }
 }


### PR DESCRIPTION
## Sandbox actions retries

Adds retries to sandbox actions for start, stop, destroy and archive. This is meant to automatically handle specific transient issue with up to 3 retries

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
