### PR TITLE
fix(api): archiving sbx state is non-blocking

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -326,7 +326,11 @@ export class Sandbox {
     if (this.pending && String(this.state) === String(this.desiredState)) {
       this.pending = false
     }
-    if (this.state === SandboxState.ERROR || this.state === SandboxState.BUILD_FAILED) {
+    if (
+      this.state === SandboxState.ERROR ||
+      this.state === SandboxState.BUILD_FAILED ||
+      (this.state === SandboxState.ARCHIVING && this.desiredState === SandboxDesiredState.ARCHIVED)
+    ) {
       this.pending = false
     }
   }


### PR DESCRIPTION
## Description

Fixes a regression caused by https://github.com/daytonaio/daytona/pull/2756 that prevented 'archiving' sandboxes to be started.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation