### PR TITLE
fix(api): lock code warning log

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
@@ -48,22 +48,14 @@ export abstract class SandboxAction {
 
     if (currentLockCode === null) {
       this.logger.warn(
-        'no lock code found - state update action expired - skipping',
-        'sandboxId',
-        sandboxId,
-        'state',
-        state,
+        `no lock code found - state update action expired - skipping - sandboxId: ${sandboxId} - state: ${state}`,
       )
       return
     }
 
     if (expectedLockCode.getCode() !== currentLockCode.getCode()) {
       this.logger.warn(
-        'lock code mismatch - state update action expired - skipping',
-        'sandboxId',
-        sandboxId,
-        'state',
-        state,
+        `lock code mismatch - state update action expired - skipping - sandboxId: ${sandboxId} - state: ${state}`,
       )
       return
     }


### PR DESCRIPTION
## Description

Fixed how the warning message in generated for code lock warnings for sandbox state update actions.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
