### PR TITLE
fix(sdk-typescript): optimize session command logs demuxing

### DIFF
--- a/libs/sdk-typescript/src/Process.ts
+++ b/libs/sdk-typescript/src/Process.ts
@@ -759,7 +759,7 @@ function concatenateUint8Arrays(chunks: Uint8Array[]): Uint8Array {
  */
 function findSubarray(haystack: Uint8Array, needle: Uint8Array, fromIndex = 0): number {
   if (needle.length === 0) return 0
-  if (haystack.length < needle.length || fromIndex < 0 || fromIndex >= haystack.length) return -1
+  if (haystack.length < needle.length || fromIndex < 0 || fromIndex > haystack.length - needle.length) return -1
 
   const limit = haystack.length - needle.length
   for (let i = fromIndex; i <= limit; i++) {


### PR DESCRIPTION
## Description

Optimize session command log processing to prevent errors such as `RangeError: Maximum call stack size exceeded`.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes

The fix is available for testing in the alpha version of the SDK using: `npm i @daytonaio/sdk@0.113.1-alpha.1`
