### PR TITLE
chore(docs): add syncKey to tabs for persistence

### DIFF
--- a/apps/docs/src/content/docs/en/computer-use-linux.mdx
+++ b/apps/docs/src/content/docs/en/computer-use-linux.mdx
@@ -32,7 +32,7 @@ Complete API reference for computer use operations in Python (sync & async).
 
 ## Quick Example
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona

--- a/apps/docs/src/content/docs/en/configuration.mdx
+++ b/apps/docs/src/content/docs/en/configuration.mdx
@@ -21,7 +21,7 @@ Daytona SDK provides an option to configure settings using the `DaytonaConfig` c
 - `api_url`: URL of your Daytona API
 - `target`: Daytona Target to create the Sandboxes on.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 from daytona import DaytonaConfig
@@ -60,7 +60,7 @@ Daytona SDK supports environment variables for configuration. The SDK automatica
 
 Set environment variables in your shell:
 
-<Tabs>
+<Tabs syncKey="shell">
   <TabItem label="Bash/Zsh" icon="seti:shell">
     ```bash
     export DAYTONA_API_KEY=your-api-key

--- a/apps/docs/src/content/docs/en/data-analysis-with-ai.mdx
+++ b/apps/docs/src/content/docs/en/data-analysis-with-ai.mdx
@@ -29,7 +29,7 @@ This example shows how to build an AI-powered data analyst that automatically ge
 
 Install the Daytona SDK and Anthropic SDK to your project:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     `bash pip install daytona anthropic python-dotenv `
   </TabItem>
@@ -67,7 +67,7 @@ Download the file and save it as `dataset.csv` in your project directory.
 
 Now create a Daytona sandbox and upload your dataset:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from dotenv import load_dotenv
@@ -111,7 +111,7 @@ Now we'll create the core functionality that connects Claude with Daytona to ana
 
 First, let's create a function to handle code execution and chart extraction:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     import base64
@@ -181,7 +181,7 @@ Next, we'll create the prompt that tells Claude about our dataset and what analy
 - The specific analysis request (vote average trends over time)
 - Instructions for code generation
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from anthropic import Anthropic
@@ -232,7 +232,7 @@ Next, we'll create the prompt that tells Claude about our dataset and what analy
 
 Now we'll connect Claude to our Daytona sandbox using tool calling. This allows Claude to automatically execute the Python code it generates:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     msg = anthropic.messages.create(
@@ -290,7 +290,7 @@ Now we'll connect Claude to our Daytona sandbox using tool calling. This allows 
 
 Finally, we'll parse Claude's response and execute any generated code in our Daytona sandbox:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     for content_block in msg.content:
@@ -337,7 +337,7 @@ That's it! The `run_ai_generated_code` function we created automatically handles
 
 Now you can run the complete code to see the results.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```bash
     python data-analysis.py
@@ -359,7 +359,7 @@ You should see the chart in your project directory that will look similar to thi
 
 Here are the complete, ready-to-run examples:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     import base64

--- a/apps/docs/src/content/docs/en/declarative-builder.mdx
+++ b/apps/docs/src/content/docs/en/declarative-builder.mdx
@@ -19,7 +19,7 @@ You can create declarative images on-the-fly when creating Sandboxes. This is id
 
 Declarative images are cached for 24 hours, and will be automatically reused when running the same script. Thus, subsequent runs on the same Runner will be almost instantaneous.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Define a simple declarative image with Python packages
@@ -64,7 +64,7 @@ See: [CreateSandboxFromImageParams (Python SDK)](/docs/python-sdk/sync/daytona#c
 
 For images that will be reused across multiple Sandboxes, create a pre-built Snapshot. This Snapshot will remain visible in the Daytona dashboard and be permanently cached, ensuring instant availability without rebuilding.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Create a simple Python data science image
@@ -131,7 +131,7 @@ For a complete API reference and method signatures, check the [Python](/docs/pyt
 
 These examples demonstrate how to select and configure base images:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Create an image from a base
@@ -158,7 +158,7 @@ See: [base (Python SDK)](/docs/python-sdk/common/image#imagebase), [debian_slim 
 
 Use these methods to install Python packages and dependencies:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Add pip packages
@@ -193,7 +193,7 @@ See: [pip_install (Python SDK)](/docs/python-sdk/common/image#imagepip_install),
 
 These examples show how to add files and directories to your image:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Add a local file
@@ -220,7 +220,7 @@ See: [add_local_file (Python SDK)](/docs/python-sdk/common/image#imageadd_local_
 
 Configure environment variables and working directories with these methods:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Set environment variables
@@ -247,7 +247,7 @@ See: [env (Python SDK)](/docs/python-sdk/common/image#imageenv), [workdir (Pytho
 
 Execute commands during build and configure container startup behavior:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Run shell commands during build
@@ -288,7 +288,7 @@ See: [run_commands (Python SDK)](/docs/python-sdk/common/image#imagerun_commands
 
 Integrate existing Dockerfiles or add custom Dockerfile commands:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Add custom Dockerfile commands

--- a/apps/docs/src/content/docs/en/file-system-operations.mdx
+++ b/apps/docs/src/content/docs/en/file-system-operations.mdx
@@ -16,7 +16,7 @@ File operations assume you are operating in the Sandbox user's home directory (e
 
 Daytona SDK provides an option to list files and directories in a Sandbox using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # List files in a directory
@@ -52,7 +52,7 @@ See: [list_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemlist
 
 Daytona SDK provides an option to create directories with specific permissions using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Create with specific permissions
@@ -78,7 +78,7 @@ Daytona SDK provides options to read, write, upload, download, and delete files 
 
 The following example shows how to upload a single file:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Upload a single file
@@ -103,7 +103,7 @@ See: [upload_file (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemupl
 
 The following example shows how to efficiently upload multiple files with a single method call.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Upload multiple files at once
@@ -163,7 +163,7 @@ See: [upload_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemup
 
 The following commands downloads a single file `file1.txt` from the Sandbox working directory and prints out the content:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 
@@ -194,7 +194,7 @@ See: [download_file (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemd
 
 The following example shows how to efficiently download multiple files with a single method call.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Download multiple files at once
@@ -240,7 +240,7 @@ See: [download_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystem
 
 The following example shows how to delete a file:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 
@@ -267,7 +267,7 @@ Daytona SDK provides advanced file system operations like file permissions, sear
 
 Daytona SDK provides an option to set file permissions, get file permissions, and set directory permissions recursively using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Set file permissions
@@ -299,7 +299,7 @@ See: [set_file_permissions (Python SDK)](/docs/python-sdk/sync/file-system/#file
 
 Daytona SDK provides an option to search for text in files and replace text in files using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Search for text in files; if a folder is specified, the search is recursive

--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -14,7 +14,7 @@ For steps on additional configuration, including setting environment variables a
 
 Daytona provides official Python and TypeScript SDKs for interacting with the Daytona platform. Install the SDK using your preferred method:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```bash
     pip install daytona
@@ -42,7 +42,7 @@ Daytona provides official Python and TypeScript SDKs for interacting with the Da
 
 Run the following code to create a Daytona Sandbox and execute commands:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, DaytonaConfig
@@ -106,7 +106,7 @@ Run the following code to create a Daytona Sandbox and execute commands:
   </TabItem>
 </Tabs>
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```bash
     python main.py
@@ -124,7 +124,7 @@ Run the following code to create a Daytona Sandbox and execute commands:
 
 The following snippet uploads a file containing a simple Flask app to a Daytona Sandbox. The web server runs on port `3000` and is accessible through the provided preview URL:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, DaytonaConfig, SessionExecuteRequest
@@ -253,7 +253,7 @@ You can access the Sandbox [Web Terminal](/docs/en/web-terminal) by printing out
 
 The following snippet connects to an LLM using the Anthropic API and asks Claude to generate code for getting the factorial of 25 and then executes it inside of a Daytona Sandbox:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ````python
     import os
@@ -466,7 +466,7 @@ export default nextConfig
 
 If you want to use [images from your local device](/docs/en/snapshots#using-a-local-image) or simply prefer managing your Sandboxes using the command line interface, install the Daytona CLI by running:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Mac/Linux">
     ```bash
     brew install daytonaio/cli/daytona

--- a/apps/docs/src/content/docs/en/git-operations.mdx
+++ b/apps/docs/src/content/docs/en/git-operations.mdx
@@ -17,7 +17,7 @@ the Dockerfile if present, or falling back to the user's home directory if not -
 
 Daytona SDK provides an option to clone Git repositories into Sandboxes using Python and TypeScript. You can clone public or private repositories, specific branches, and authenticate using personal access tokens.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Basic clone
@@ -80,7 +80,7 @@ See: [clone (Python SDK)](/docs/python-sdk/sync/git/#gitclone), [clone (TypeScri
 
 Daytona SDK provides an option to check the status of Git repositories in Sandboxes. You can get the current branch, modified files, number of commits ahead and behind main branch using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Get repository status
@@ -130,7 +130,7 @@ Daytona SDK provides an option to manage branches in Git repositories. You can c
 
 Daytona SDK provides an option to create, switch, and delete branches in Git repositories using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Create new branch
@@ -169,7 +169,7 @@ Daytona SDK provides an option to stage and commit changes in Git repositories. 
 
 ### Working with Changes
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Stage specific files
@@ -210,7 +210,7 @@ Daytona SDK provides an option to work with remote repositories in Git.
 
 Daytona SDK provides an option to push and pull changes using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Push changes

--- a/apps/docs/src/content/docs/en/language-server-protocol.mdx
+++ b/apps/docs/src/content/docs/en/language-server-protocol.mdx
@@ -10,7 +10,7 @@ The Daytona SDK provides Language Server Protocol (LSP) support through Sandbox 
 
 Daytona SDK provides an option to create LSP servers in Python and TypeScript. The `path_to_project` argument is relative to the current Sandbox working directory when no leading `/` is used. The working directory is specified by WORKDIR when it is present in the Dockerfile, and otherwise falls back to the user's home directory.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 from daytona import Daytona, LspLanguageId
@@ -68,7 +68,7 @@ Daytona SDK provides LSP features for code analysis and editing.
 
 Daytona SDK provides an option to get code completions for a specific position in a file using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 completions = lsp_server.completions(

--- a/apps/docs/src/content/docs/en/mcp.mdx
+++ b/apps/docs/src/content/docs/en/mcp.mdx
@@ -18,7 +18,7 @@ Before getting started, ensure you have:
 
 ### 1. Install Daytona CLI
 
-<Tabs>
+<Tabs syncKey="os">
 <TabItem label="Mac/Linux">
 ```bash
 brew install daytonaio/cli/daytona

--- a/apps/docs/src/content/docs/en/network-limits.mdx
+++ b/apps/docs/src/content/docs/en/network-limits.mdx
@@ -25,7 +25,7 @@ To learn more about organization tiers and limits, see the [Limits documentation
 
 You can control network access when creating sandboxes using the `networkAllowList` and `networkBlockAll` parameters:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
 ```python

--- a/apps/docs/src/content/docs/en/preview-and-authentication.mdx
+++ b/apps/docs/src/content/docs/en/preview-and-authentication.mdx
@@ -13,7 +13,7 @@ Any process listening for HTTP traffic on ports 3000–9999 can be previewed.
 
 To fetch the preview link and the authorization token for a specific port, you can simply use the SDK method:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 

--- a/apps/docs/src/content/docs/en/process-code-execution.mdx
+++ b/apps/docs/src/content/docs/en/process-code-execution.mdx
@@ -14,7 +14,7 @@ Daytona SDK provides an option to execute code in Python and TypeScript.
 
 Daytona SDK provides an option to run code snippets in Python and TypeScript. You can execute code with input, timeout, and environment variables.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Run Python code
@@ -77,7 +77,7 @@ the Dockerfile if present, or falling back to the user's home directory if not -
 
 Daytona SDK provides an option to execute shell commands in Python and TypeScript. You can run commands with input, timeout, and environment variables.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Execute any shell command
@@ -132,7 +132,7 @@ Daytona SDK provides an option to start, stop, and manage background process ses
 
 Daytona SDK provides an option to start and stop background processes. You can run long-running commands and monitor process status.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Check session's executed commands
@@ -183,7 +183,7 @@ The following best practices apply to managing resources when executing processe
 2. Clean up sessions after execution
 3. Handle session exceptions properly
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
    ```python
    # Python - Clean up session
@@ -221,7 +221,7 @@ The following best practices apply to error handling when executing processes:
 - Log error details for debugging
 - Use try-catch blocks for error handling
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 try:

--- a/apps/docs/src/content/docs/en/pty.mdx
+++ b/apps/docs/src/content/docs/en/pty.mdx
@@ -19,7 +19,7 @@ A PTY (Pseudo Terminal) is a virtual terminal interface that allows programs to 
 
 PTY sessions excel at handling interactive commands that require user input and can be resized during execution.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 import time
@@ -102,7 +102,7 @@ console.log(`Session completed with exit code: ${result.exitCode}`)
 
 PTY sessions are perfect for managing long-running processes that need to be monitored or terminated.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 import time
@@ -183,7 +183,7 @@ if (result.error) {
 
 Always clean up PTY sessions to prevent resource leaks:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Python: Use try/finally
@@ -218,7 +218,7 @@ try {
 
 Monitor exit codes and handle errors appropriately:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Python: Check exit codes

--- a/apps/docs/src/content/docs/en/regions.mdx
+++ b/apps/docs/src/content/docs/en/regions.mdx
@@ -13,7 +13,7 @@ The Daytona SDK can be configured to run in multiple geographic regions. The fol
 
 The region is specificed by setting the `target` parameter on initialization:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 from daytona import Daytona, DaytonaConfig

--- a/apps/docs/src/content/docs/en/sandbox-management.mdx
+++ b/apps/docs/src/content/docs/en/sandbox-management.mdx
@@ -30,7 +30,7 @@ If you want to prolong the auto-stop interval, you can [set the auto-stop interv
 
 The Daytona SDK provides methods to create Sandboxes with default configurations, specific languages, custom names, or custom labels using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, CreateSandboxFromSnapshotParams
@@ -105,7 +105,7 @@ Organizations get a maximum Sandbox resource limit of 4 vCPUs, 8GB RAM, and 10GB
 
 Check your available resources and limits in the [dashboard](https://app.daytona.io/dashboard/limits).
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, Resources, CreateSandboxFromImageParams, Image
@@ -165,7 +165,7 @@ Ephemeral Sandboxes are Sandboxes that are automatically deleted once they are s
 
 To create an ephemeral Sandbox, set `ephemeral` to `True` when creating a Sandbox:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, CreateSandboxFromSnapshotParams
@@ -212,7 +212,7 @@ Learn more about network limits in the [Network Limits](/docs/en/network-limits)
 
 The Daytona SDK provides methods to get information about a Sandbox, such as ID, root directory, and status using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # Get Sandbox ID
@@ -257,7 +257,7 @@ The Daytona SDK provides methods to stop and start Sandboxes using Python and Ty
 
 Stopped Sandboxes maintain filesystem persistence while their memory state is cleared. They incur only disk usage costs and can be started again when needed.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxParams(language="python"))
@@ -313,7 +313,7 @@ Starting an archived Sandbox takes more time than starting a stopped Sandbox, de
 
 A Sandbox must be stopped before it can be archived, and can be started again in the same way as a stopped Sandbox.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # Archive Sandbox
@@ -335,7 +335,7 @@ See: [archive (Python SDK)](/docs/python-sdk/sync/sandbox#sandboxarchive), [arch
 
 The Daytona SDK provides methods to delete Sandboxes using Python and TypeScript.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # Delete Sandbox
@@ -397,7 +397,7 @@ The parameter can either be set to:
 
 If the parameter is not set, the default interval of `15` minutes will be used.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(
@@ -428,7 +428,7 @@ The parameter can either be set to:
 
 If the parameter is not set, the default interval of `7 days` days will be used.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(
@@ -460,7 +460,7 @@ The parameter can either be set to:
 
 If the parameter is not set, the Sandbox will not be deleted automatically.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(
@@ -501,7 +501,7 @@ If the parameter is not set, the Sandbox will not be deleted automatically.
 
 By default, Sandboxes auto-stop after 15 minutes of inactivity. To keep a Sandbox running without interruption, set the auto-stop interval to `0` when creating a new Sandbox:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -103,7 +103,7 @@ Snapshots can be customized with specific resource requirements. By default, Day
 
 To customize these resources, use the `Resources` class to define exactly what you need:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 from daytona import (
@@ -163,7 +163,7 @@ Check your available resources and limits in the [dashboard](https://app.daytona
 
 To use a Snapshot in your Sandbox, specify the `snapshot` field in the `CreateSandboxFromSnapshotParams` object:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 sandbox = daytona.create(CreateSandboxFromSnapshotParams(

--- a/apps/docs/src/content/docs/en/ssh-access.mdx
+++ b/apps/docs/src/content/docs/en/ssh-access.mdx
@@ -13,7 +13,7 @@ To connect to a sandbox, you'll need to create an SSH access token first. This t
 SSH access can be initialized from the dashboard by opening the sandbox’s options menu and selecting `Create SSH Access`.
 It can also be initialized programmatically using one of the SDKs listed below.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
 ```python
@@ -83,7 +83,7 @@ SSH access tokens expire automatically for security:
 
 You can revoke SSH access tokens at any time:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
 ```python

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -14,7 +14,7 @@ Volumes are FUSE-based mounts that provide shared file access across Sandboxes. 
 
 Before mounting a volume to a Sandbox, it must be created.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```bash
 volume = daytona.volume.get("my-volume", create=True)
@@ -40,7 +40,7 @@ Once a volume is created, it can be mounted to a Sandbox by specifying it in the
 - **Cannot mount to system directories**: The following system directories are prohibited:
   - `/proc`, `/sys`, `/dev`, `/boot`, `/etc`, `/bin`, `/sbin`, `/lib`, `/lib64`
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 import os
@@ -90,7 +90,7 @@ See: [CreateSandboxFromSnapshotParams (Python SDK)](/docs/python-sdk/sync/dayton
 
 Once mounted, you can read from and write to the volume just like any other directory in the Sandbox file system. Files written to the volume persist beyond the lifecycle of any individual Sandbox.
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # Write to a file in the mounted volume
@@ -120,7 +120,7 @@ Once mounted, you can read from and write to the volume just like any other dire
 
 When a volume is no longer needed, it can be deleted.
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 volume = daytona.volume.get("my-volume", create=True)

--- a/apps/docs/src/content/docs/ja/configuration.mdx
+++ b/apps/docs/src/content/docs/ja/configuration.mdx
@@ -22,7 +22,7 @@ Daytona SDK では、Python と TypeScript で `DaytonaConfig` クラスを使�
 - `api_url`: Daytona の API の URL
 - `target`: サンドボックスを作成する Daytona のターゲット（リージョン）
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 from daytona import DaytonaConfig
@@ -84,7 +84,7 @@ DAYTONA_TARGET=us
 
 シェルで環境変数を設定します：
 
-<Tabs>
+<Tabs syncKey="shell">
 <TabItem label="Bash/Zsh" icon="seti:shell">
 ```bash
 export DAYTONA_API_KEY=your-api-key

--- a/apps/docs/src/content/docs/ja/data-analysis-with-ai.mdx
+++ b/apps/docs/src/content/docs/ja/data-analysis-with-ai.mdx
@@ -27,7 +27,7 @@ Daytona のサンドボックス（Daytonaが管理する隔離された一時�
 
 Daytona SDK と Anthropic SDK をプロジェクトにインストールします:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     `bash pip install daytona anthropic python-dotenv `
   </TabItem>
@@ -65,7 +65,7 @@ ANTHROPIC_API_KEY=sk-ant-***
 
 Daytona のサンドボックスを作成し、データセットをアップロードします:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from dotenv import load_dotenv
@@ -109,7 +109,7 @@ Daytona のサンドボックスを作成し、データセットをアップロ
 
 まず、コード実行とチャート抽出を処理する関数を作成します:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     import base64
@@ -179,7 +179,7 @@ Daytona のサンドボックスを作成し、データセットをアップロ
 - 具体的な分析リクエスト（製造年別の平均価格の推移）
 - コード生成に関する指示
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from anthropic import Anthropic
@@ -230,7 +230,7 @@ Daytona のサンドボックスを作成し、データセットをアップロ
 
 ここでは、ツール呼び出しを使用してClaudeをDaytonaのサンドボックスに接続します。これにより、Claudeは生成したPythonコードを自動的に実行できます。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     msg = anthropic.messages.create(
@@ -288,7 +288,7 @@ Daytona のサンドボックスを作成し、データセットをアップロ
 
 最後に、Claude のレスポンスを解析し、生成されたコードを Daytona のサンドボックスで実行します:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     for content_block in msg.content:
@@ -335,7 +335,7 @@ Daytona のサンドボックスを作成し、データセットをアップロ
 
 完全なコードを実行して結果を確認します。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```bash
     python data-analysis.py
@@ -357,7 +357,7 @@ Daytona のサンドボックスを作成し、データセットをアップロ
 
 以下に、すぐに実行できるサンプル一式を示します:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     import base64

--- a/apps/docs/src/content/docs/ja/declarative-builder.mdx
+++ b/apps/docs/src/content/docs/ja/declarative-builder.mdx
@@ -48,7 +48,7 @@ Daytona（サンドボックスの作成・管理プラットフォーム）の�
 これにより、ビルド処理のために自前のコンピュートリソースを使う必要がなくなり、Daytonaのインフラストラクチャにオフロードできます。\
 各バージョンごとに個別のスナップショットを登録・検証する必要もありません。依存関係リストを素早く反復しやすくなり、また、数十〜数百の類似ユースケース/セットアップ向けにわずかに異なるバージョンを用意することもできます。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # Define the dynamic image
@@ -112,7 +112,7 @@ Daytona（サンドボックスの作成・管理プラットフォーム）の�
 
 このスナップショットはDaytonaダッシュボード上に表示され続け、永続的にキャッシュされるため、再ビルドは不要です。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # スナップショット用の一意の名前を生成
@@ -221,7 +221,7 @@ Daytona（サンドボックスの作成・管理プラットフォーム）の�
 
 既存の Dockerfile をイメージのベースとして使いたい場合は、次のようにインポートできます。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     image = Image.from_dockerfile("app/Dockerfile").pip_install(["numpy"])

--- a/apps/docs/src/content/docs/ja/file-system-operations.mdx
+++ b/apps/docs/src/content/docs/ja/file-system-operations.mdx
@@ -16,7 +16,7 @@ Daytona SDK は、サンドボックス（Daytonaが管理する隔離された�
 
 Daytona SDK は、Python と TypeScript を用いてサンドボックス内のファイルやディレクトリを一覧表示できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # List files in a directory
@@ -50,7 +50,7 @@ files.forEach(file => {
 
 Daytona SDK は、Python と TypeScript で特定のパーミッションを指定してディレクトリを作成できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Create with specific permissions
@@ -74,7 +74,7 @@ Daytona SDK は、Python と TypeScript を用いて、サンドボックス内�
 
 単一ファイルをアップロードする場合は、次のように実行します。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Upload a single file
@@ -97,7 +97,7 @@ await sandbox.fs.uploadFile(fileContent, "data.txt")
 
 以下は、1回のメソッド呼び出しで複数ファイルを効率的にアップロードする例です。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Upload multiple files at once
@@ -153,7 +153,7 @@ await sandbox.fs.uploadFiles(files)
 
 次のコマンドは、サンドボックスユーザーのホームディレクトリから `file1.txt` をダウンロードし、その内容を出力します。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 
@@ -182,7 +182,7 @@ console.log('File content:', downloadedFile.toString())
 
 不要になったファイルは、`delete_file` 関数で削除できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 
@@ -207,7 +207,7 @@ Daytona SDK は、ファイル権限の設定・取得、検索と置換など�
 
 Daytona SDK では、Python と TypeScript から、ファイル権限の設定・取得や、ディレクトリ権限の再帰的な設定が行えます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Set file permissions
@@ -237,7 +237,7 @@ console.log(`Permissions: ${fileInfo.permissions}`)
 
 Daytona SDK では、Python と TypeScript から、ファイル内のテキストの検索および置換を行えます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Search for text in files; if a folder is specified, the search is recursive

--- a/apps/docs/src/content/docs/ja/getting-started.mdx
+++ b/apps/docs/src/content/docs/ja/getting-started.mdx
@@ -14,7 +14,7 @@ Daytona SDKはDaytonaと連携するための公式[Python](/docs/ja/python-sdk)
 
 Daytona は、Daytona プラットフォームと連携するための公式 Python および TypeScript の SDK を提供しています。お好みの方法で SDK をインストールしてください。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```bash
     pip install daytona
@@ -39,7 +39,7 @@ Daytona は、Daytona プラットフォームと連携するための公式 Pyt
 
 次のコードを実行して、Daytona のサンドボックスを作成し、コマンドを実行します。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, DaytonaConfig
@@ -103,7 +103,7 @@ Daytona は、Daytona プラットフォームと連携するための公式 Pyt
   </TabItem>
 </Tabs>
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```bash
     python main.py
@@ -121,7 +121,7 @@ Daytona は、Daytona プラットフォームと連携するための公式 Pyt
 
 次のスニペットは、シンプルな Flask アプリを含むファイルを Daytona のサンドボックスにアップロードします。Web サーバーはポート `3000` で起動し、提供されたプレビューURLからアクセスできます。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, DaytonaConfig, SessionExecuteRequest
@@ -250,7 +250,7 @@ Daytona は、Daytona プラットフォームと連携するための公式 Pyt
 
 次のスニペットは、Anthropic API を用いて LLM に接続し、Claude に 25 の階乗を求めるコードの生成を依頼し、そのコードを Daytona のサンドボックス（Daytonaが管理する隔離された一時的な実行環境）内で実行します。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ````python
     import os
@@ -455,7 +455,7 @@ export default nextConfig
 
 [ローカルデバイス上のイメージ](/docs/ja/snapshots#using-a-local-image)を使用する場合、またはコマンドラインインターフェースでサンドボックスを管理したい場合は、次のコマンドで Daytona CLI をインストールしてください:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Mac/Linux">
     ```bash
     brew install daytonaio/cli/daytona

--- a/apps/docs/src/content/docs/ja/git-operations.mdx
+++ b/apps/docs/src/content/docs/ja/git-operations.mdx
@@ -16,7 +16,7 @@ Daytona SDKは、Sandbox（Daytonaが管理する隔離された一時的な実�
 
 Daytona SDKは、PythonおよびTypeScriptからSandboxにGitリポジトリをクローンできます。パブリック/プライベートリポジトリ、特定ブランチのクローンに対応し、Personal Access Tokenを用いた認証も可能です。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Basic clone
@@ -77,7 +77,7 @@ await sandbox.git.clone(
 
 Daytona SDKは、Sandbox内のGitリポジトリのステータス確認にも対応しています。PythonおよびTypeScriptで、現在のブランチ、変更ファイル、メインブランチに対する先行/遅行コミット数を取得できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Get repository status
@@ -125,7 +125,7 @@ Daytona SDK は、Git リポジトリのブランチ管理機能を提供しま�
 
 Daytona SDK では、Python と TypeScript から Git リポジトリのブランチを作成・切り替え・削除できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # 新しいブランチを作成
@@ -160,7 +160,7 @@ Daytona SDK では、Git リポジトリの変更をステージしてコミッ�
 
 ### 変更の扱い
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # 特定のファイルをステージ
@@ -196,7 +196,7 @@ Daytona SDK は Git のリモートリポジトリを扱う機能を提供しま
 
 Daytona SDK は、Python と TypeScript から Git リポジトリに対してプッシュ、プル、リモートの一覧表示を行う機能を提供します。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # 変更をプッシュ

--- a/apps/docs/src/content/docs/ja/language-server-protocol.mdx
+++ b/apps/docs/src/content/docs/ja/language-server-protocol.mdx
@@ -10,7 +10,7 @@ Daytona（デイトナ）SDKは、サンドボックスインスタンス経由�
 
 Daytona（デイトナ）SDKは、PythonおよびTypeScriptでLSPサーバーを作成する機能を提供します。`path_to_project` の基準パスはデフォルトで現在のサンドボックスユーザーのホーム直下です。たとえば `workspace/project` は `/home/[username]/workspace/project` を指します。先頭を `/` にすることで絶対パスも指定できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 from daytona import Daytona, LspLanguageId
@@ -53,7 +53,7 @@ const lspServer = await sandbox.createLspServer(
 
 Daytona SDK では、Python および TypeScript の `LspLanguageId` 列挙体を使用して、各種言語向けの LSP サーバーを作成できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 from daytona import LspLanguageId
@@ -88,7 +88,7 @@ Daytona SDK は、コード解析や編集のための各種 LSP 機能を提供
 
 Daytona SDK では、Python と TypeScript を用いて、ファイル内の特定位置のコード補完候補を取得できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 completions = lsp_server.completions(

--- a/apps/docs/src/content/docs/ja/mcp.mdx
+++ b/apps/docs/src/content/docs/ja/mcp.mdx
@@ -18,7 +18,7 @@ Daytona Model Context Protocol (MCP) サーバーは、AIエージェントがDa
 
 ### 1. Daytona CLI のインストール
 
-<Tabs>
+<Tabs syncKey="os">
 <TabItem label="Mac/Linux">
 ```bash
 brew install daytonaio/cli/daytona

--- a/apps/docs/src/content/docs/ja/preview-and-authentication.mdx
+++ b/apps/docs/src/content/docs/ja/preview-and-authentication.mdx
@@ -20,7 +20,7 @@ https://3000-sandbox-123456.proxy.daytona.work
 
 特定のポートに対応するプレビューリンクとトークンを取得するには、SDKのメソッドを使用します:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 

--- a/apps/docs/src/content/docs/ja/process-code-execution.mdx
+++ b/apps/docs/src/content/docs/ja/process-code-execution.mdx
@@ -14,7 +14,7 @@ Daytona SDK は、Python と TypeScript でコードを実行できます。
 
 Daytona SDK は、Python と TypeScript のコードスニペット実行に対応しています。入力、タイムアウト、環境変数を指定して実行できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # Python コードを実行
@@ -74,7 +74,7 @@ Daytona SDK は、サンドボックス（Daytonaが管理する隔離された�
 
 Daytona SDK は、Python と TypeScript からシェルコマンドを実行できます。標準入力、タイムアウト、環境変数を指定してコマンドを実行可能です。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # 任意のシェルコマンドを実行
@@ -125,7 +125,7 @@ Daytona SDK は、サンドボックス（Daytonaが管理する隔離された�
 
 Daytona SDK は、バックグラウンドプロセスの開始および停止機能を提供します。長時間実行のコマンドを実行し、プロセスの状態を監視できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 # セッションで実行されたコマンドを確認
@@ -168,7 +168,7 @@ Daytona SDK は、サンドボックス（Daytonaが管理する隔離された�
 - 実行後はセッションを確実にクリーンアップする
 - セッションで発生する例外を適切に処理する
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
    ```python
    # Python - セッションのクリーンアップ
@@ -202,7 +202,7 @@ Daytona SDK は、サンドボックス（Daytonaが管理する隔離された�
 - デバッグのためにエラーの詳細を記録する
 - エラーハンドリングには try-catch ブロックを使用する
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 try:

--- a/apps/docs/src/content/docs/ja/python-sdk/index.mdx
+++ b/apps/docs/src/content/docs/ja/python-sdk/index.mdx
@@ -26,7 +26,7 @@ poetry add daytona
 
 Daytona の Python SDK を使い始めるためのシンプルな例を示します。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Sync" icon="seti:python">
     ```python
     from daytona import Daytona
@@ -72,7 +72,7 @@ Daytona の Python SDK を使い始めるためのシンプルな例を示しま
 
 SDK は環境変数を使うか、コンストラクタにオプションを渡して設定できます:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Sync" icon="seti:python">
     ```python
     from daytona import Daytona, DaytonaConfig

--- a/apps/docs/src/content/docs/ja/sandbox-management.mdx
+++ b/apps/docs/src/content/docs/ja/sandbox-management.mdx
@@ -30,7 +30,7 @@ Daytona SDK は、デフォルトまたはカスタム構成でサンドボッ�
 
 Daytona SDK には、Python と TypeScript により、デフォルト構成、特定の言語、またはカスタムラベルでサンドボックスを作成するメソッドが用意されています。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, CreateSandboxFromSnapshotParams
@@ -87,7 +87,7 @@ Daytona のサンドボックスは、デフォルトで **1 vCPU**、**1GB RAM*
 
 [ダッシュボード](https://app.daytona.io/dashboard/limits)で利用可能なリソースと上限を確認してください。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, Resources, CreateSandboxFromImageParams, Image
@@ -146,7 +146,7 @@ Daytona のサンドボックスは、セキュリティ強化と接続性管理
 - すべてのネットワークアクセスをブロックするには、`networkBlockAll` を `True` に設定します
 - 特定のアドレスにアクセスを制限するには、`networkAllowList` に最大 5 つの CIDR ブロックをカンマ区切りで設定します
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, CreateSandboxFromSnapshotParams
@@ -198,7 +198,7 @@ Daytona のサンドボックスは、セキュリティ強化と接続性管理
 
 Daytona SDK は、Python と TypeScript で、ID、ルートディレクトリ、状態などサンドボックスに関する情報を取得するためのメソッドを提供します。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # サンドボックス ID を取得
@@ -239,7 +239,7 @@ Daytona SDK は、Python と TypeScript でサンドボックスを停止・起�
 
 停止したサンドボックスは、メモリ状態がクリアされますが、ファイルシステムは保持されます。ディスク使用量のコストのみが発生し、必要に応じて再度起動できます。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxParams(language="python"))
@@ -291,7 +291,7 @@ Daytona SDK は、Python と TypeScript からサンドボックスをアーカ�
 
 サンドボックスはアーカイブ前に停止している必要があり、停止中のサンドボックスと同様の手順で再度起動できます。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # Archive Sandbox
@@ -311,7 +311,7 @@ Daytona SDK は、Python と TypeScript からサンドボックスをアーカ�
 
 Daytona SDK には、Python と TypeScript でサンドボックスを削除するためのメソッドが用意されています。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     # サンドボックスを削除
@@ -373,7 +373,7 @@ Daytona のサンドボックスは、ユーザーが指定した間隔に基づ
 
 :::
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(
@@ -404,7 +404,7 @@ Daytona のサンドボックスは、ユーザーが指定した間隔に基づ
 
 パラメータが未設定の場合、デフォルトの `7 days` が使用されます。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(
@@ -436,7 +436,7 @@ Daytona のサンドボックスは、ユーザーが指定した間隔に基づ
 
 パラメータが未設定の場合、サンドボックスは自動削除されません。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(
@@ -473,7 +473,7 @@ Daytona のサンドボックスは、ユーザーが指定した間隔に基づ
 
 デフォルトでは、サンドボックスは15分間操作がないと自動停止します。中断なくサンドボックスを稼働させ続けるには、新しいサンドボックスを作成する際に自動停止間隔を`0`に設定してください。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(

--- a/apps/docs/src/content/docs/ja/snapshots.mdx
+++ b/apps/docs/src/content/docs/ja/snapshots.mdx
@@ -23,7 +23,7 @@ entrypoint フィールドは任意です。イメージに長時間稼働する
 
 スナップショットがプルおよび検証され、`Active` 状態になれば使用可能です。使用するカスタムスナップショットを指定するために、`CreateSandboxFromSnapshotParams` オブジェクトを定義します:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     sandbox = daytona.create(CreateSandboxFromSnapshotParams(
@@ -43,7 +43,7 @@ entrypoint フィールドは任意です。イメージに長時間稼働する
 
 完全な例:
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import Daytona, CreateSandboxFromSnapshotParams
@@ -108,7 +108,7 @@ entrypoint フィールドは任意です。イメージに長時間稼働する
 
 利用可能なリソースと上限は[ダッシュボード](https://app.daytona.io/dashboard/limits)で確認してください。
 
-<Tabs>
+<Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
     ```python
     from daytona import (

--- a/apps/docs/src/content/docs/ja/volumes.mdx
+++ b/apps/docs/src/content/docs/ja/volumes.mdx
@@ -14,7 +14,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 サンドボックスにボリュームをマウントする前に、先に作成しておく必要があります。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```bash
 volume = daytona.volume.get("my-volume", create=True)
@@ -31,7 +31,7 @@ const volume = await daytona.volume.get('my-volume', true)
 
 ボリュームを作成したら、`CreateSandboxFromSnapshotParams` オブジェクトで指定してサンドボックスにマウントできます:
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 import os
@@ -93,7 +93,7 @@ main()
 
 ボリュームが不要になった場合は削除できます。
 
-<Tabs>
+<Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 ```python
 volume = daytona.volume.get("my-volume", create=True)


### PR DESCRIPTION
## Description

Adds `SyncKey` attributes to `<Tabs/>` for persistence.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2643

