### PR TITLE
Improve computational complexity of _parse_output in python clients

### DIFF
--- a/libs/sdk-python/src/daytona/_async/process.py
+++ b/libs/sdk-python/src/daytona/_async/process.py
@@ -152,9 +152,9 @@ class AsyncProcess:
         # Create new response with processed output and charts
         # TODO: Remove model_construct once everything is migrated to pydantic # pylint: disable=fixme
         return ExecuteResponse.model_construct(
-            exit_code=response.exit_code
-            if response.exit_code is not None
-            else response.additional_properties.get("code"),
+            exit_code=(
+                response.exit_code if response.exit_code is not None else response.additional_properties.get("code")
+            ),
             result=artifacts.stdout,
             artifacts=artifacts,
             additional_properties=response.additional_properties,

--- a/libs/sdk-python/src/daytona/_sync/process.py
+++ b/libs/sdk-python/src/daytona/_sync/process.py
@@ -73,7 +73,6 @@ class Process:
         Returns:
             ExecutionArtifacts: The artifacts from the command execution
         """
-        
         stdout_lines = []
         charts = []
 
@@ -157,9 +156,9 @@ class Process:
         # Create new response with processed output and charts
         # TODO: Remove model_construct once everything is migrated to pydantic # pylint: disable=fixme
         return ExecuteResponse.model_construct(
-            exit_code=response.exit_code
-            if response.exit_code is not None
-            else response.additional_properties.get("code"),
+            exit_code=(
+                response.exit_code if response.exit_code is not None else response.additional_properties.get("code")
+            ),
             result=artifacts.stdout,
             artifacts=artifacts,
             additional_properties=response.additional_properties,


### PR DESCRIPTION
## Description

This PR reduces the computational complexity of string concatenation in _parse_output. The old method (`stdout += line`) has computational complexity O(n^2), while the new method (`stdout = "\n".join(lines)`) is O(n).

I ran into issues running agents backed by Daytona with the python async client, where my code would suddenly lock up and hang when running multiple sandboxes concurrently. The source was that one of the commands exec'd in Daytona was emitting a large number of lines, and this code was taking forever to run. It's particularly nasty for the async client, since this is non-async code which blocks up the loop. When I make this change locally in my environment, the difference is very noticeable.

First time contributing here, so let me know if there is anything else needed to get this in. Thank you!

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

N/A

## Screenshots

N/A

## Notes

N/A
