### PR TITLE
fix(docker-compose): add NGINX_LISTEN_PORT to registry-ui to fix port mapping issue

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -100,6 +100,7 @@ services:
       - DELETE_IMAGES=true
       - SHOW_CONTENT_DIGEST=true
       - NGINX_PROXY_PASS_URL=http://localhost:6000
+      - NGINX_LISTEN_PORT=5100
       - SHOW_CATALOG_NB_TAGS=true
       - CATALOG_MIN_BRANCHES=1
       - CATALOG_MAX_BRANCHES=1


### PR DESCRIPTION
## Related Issue

Fixes [daytonaio/daytona#2830](https://github.com/daytonaio/daytona/issues/2830)

## Problem
The registry-ui container in the default docker-compose.yaml was not accessible
at http://localhost:5100 because the internal Nginx listened on port 80 by default.

This PR adds `NGINX_LISTEN_PORT=5100` 

✅ Verified locally that the UI becomes reachable and fully functional.