### PR TITLE
fix(runner): improve container exited message

### DIFF
--- a/apps/runner/pkg/docker/start.go
+++ b/apps/runner/pkg/docker/start.go
@@ -5,6 +5,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -110,7 +111,7 @@ func (d *DockerClient) waitForContainerRunning(ctx context.Context, containerId 
 	for {
 		select {
 		case <-timeoutCtx.Done():
-			return fmt.Errorf("timeout waiting for the sandbox to start - please ensure that your entrypoint is long-running", containerId)
+			return errors.New("timeout waiting for the sandbox to start - please ensure that your entrypoint is long-running")
 		case <-ticker.C:
 			c, err := d.ContainerInspect(ctx, containerId)
 			if err != nil {


### PR DESCRIPTION
## Improve container exited message

Improves the error message saying that the container exited during start and suggests to ensure the entrypoint is long-running, e.g. "sleep infinity"

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
