### PR TITLE
fix(dashboard): coupon redemption message from api

### DIFF
--- a/apps/dashboard/src/billing-api/billingApiClient.ts
+++ b/apps/dashboard/src/billing-api/billingApiClient.ts
@@ -66,8 +66,9 @@ export class BillingApiClient {
     return response.data
   }
 
-  public async redeemCoupon(organizationId: string, couponCode: string): Promise<void> {
-    await this.axiosInstance.post(`/organization/${organizationId}/redeem-coupon/${couponCode}`)
+  public async redeemCoupon(organizationId: string, couponCode: string): Promise<string> {
+    const response = await this.axiosInstance.post(`/organization/${organizationId}/redeem-coupon/${couponCode}`)
+    return response.data?.message || 'Coupon redeemed successfully'
   }
 
   public async getOrganizationTier(organizationId: string): Promise<OrganizationTier> {

--- a/apps/dashboard/src/pages/Wallet.tsx
+++ b/apps/dashboard/src/pages/Wallet.tsx
@@ -90,8 +90,7 @@ const Wallet = () => {
     setRedeemCouponError(null)
     setRedeemCouponSuccess(null)
     try {
-      await billingApi.redeemCoupon(selectedOrganization.id, couponCode)
-      setRedeemCouponSuccess('Coupon redeemed successfully')
+      setRedeemCouponSuccess(await billingApi.redeemCoupon(selectedOrganization.id, couponCode))
       setTimeout(() => {
         setRedeemCouponSuccess(null)
       }, 3000)


### PR DESCRIPTION
## Description

Usage coupon redemption message from API instead of hardcoded.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
