### PR TITLE
Improve docs search results and experience

### DIFF
--- a/apps/docs/src/components/Search.jsx
+++ b/apps/docs/src/components/Search.jsx
@@ -277,7 +277,7 @@ function Hit({ hit, setIsSearchVisible, indexName }) {
       }}
     >
       <a href={hit.url} tabIndex="-1" onClick={handleClick}>
-        {([DOCS_INDEX_NAME,CLI_INDEX_NAME, SDK_INDEX_NAME].includes(indexName) || indexName === 'website') && (
+        {([DOCS_INDEX_NAME, CLI_INDEX_NAME, SDK_INDEX_NAME].includes(indexName) || indexName === 'website') && (
           <>
             <h5
               style={{

--- a/apps/docs/tools/update-search.js
+++ b/apps/docs/tools/update-search.js
@@ -199,8 +199,9 @@ function searchDocs() {
         const directoryName = path.basename(fullPath)
         switch (tag) {
           case 'Documentation':
-            if(SDK_FOLDER_NAMES.includes(directoryName))
+            if (SDK_FOLDER_NAMES.includes(directoryName))
               return
+            break
           case 'SDK':
             // For SDK we traverse all subfolders inside given initial SDK directory
             break


### PR DESCRIPTION
## Description

### `update-search.js`

#### Added code snippet extraction
Extracts and indexes code snippets from Python, TypeScript, and Bash code blocks for improved searchability.

#### Restructured search for three separate indices
**Major change:** Updated `searchDocs()` function to generate three separate record collections instead of a single unified index.
- Now creates `docsRecords`, `cliRecords`, and `sdkRecords` separately
- Each category (Documentation, CLI, SDK) gets its own search index
- `traverseDirectory()` update for `docs` and `sdk` records
- CLI file handled separately from directory traversals
- Outputs three separate JSON files: `docs.json`, `cli.json`, `sdk.json`

#### Fixed empty descriptions for sentences without punctuation
**Problem:** Sentences/paragraphs that didn't end with punctuation marks were resulting in empty descriptions.  
**Example:** TypeScript SDK - `getProcessErrors`: "Gets error logs for a specific VNC process" (no period at the end)  
**Solution:** Added `isSentenceWithoutPunctuation()` method to handle these cases.

#### Fixed heading extraction regex with code blocks
**Problem:** The heading extraction regex was breaking when code blocks contained comments starting with `#` (interpreted as markdown headings).  
**Solution:** Refactored heading parsing logic:
1. Replace all code blocks with `___CODE_BLOCK_{index}___` placeholders before parsing headings
2. Extract heading positions (start index and length including `#`)
3. Use these positions to extract content between current heading and next heading
4. Restore code blocks in the extracted content
5. Regex now handles escaped underscores in titles (`\\_` → `_`)

#### Fixed incorrect slugs for headings with underscores
**Problem:** Underscores were being removed from heading slugs, causing broken links.  
**Solution:** Added `_` to the allowed characters regex in `headingSlug` generation: `.replace(/[^a-z0-9-_]/g, '')`

#### Added category tags
Added separate tags for each documentation category (Documentation, CLI, SDK) to improve search organization.

#### Enhanced description extraction
Now respects `description` field from frontmatter when available, falling back to auto-extraction from content.

---

### `Search.jsx`

#### Updated index names
Set up three separate search indices: `docs`, `cli`, and `sdk`.

#### Added empty state handling
- Implemented `ConditionalSearchIndex` with `connectStats` HOC to access hit counts
- Hide individual search index sections when they return 0 results (`nbHits === 0`)
- Track `totalHits` across all indices to determine overall empty state
- Display "No results found for '{query}'" message when all indices return zero results
- Improved UX by showing only relevant result sections

#### Added environment variables for index names
Introduced configurable index names via environment variables:
- `PUBLIC_ALGOLIA_DOCS_INDEX_NAME` - Documentation index (default: `'docs_test'`)
- `PUBLIC_ALGOLIA_CLI_INDEX_NAME` - CLI index (default: `'cli_test'`)
- `PUBLIC_ALGOLIA_SDK_INDEX_NAME` - SDK index (default: `'sdk_test'`)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2822 

## Screenshots

### Search results categorization
<img width="2800" height="1508" alt="image" src="https://github.com/user-attachments/assets/05f536c1-f6ef-45e2-a8aa-5032dd722730" />

### No results case
<img width="2786" height="1498" alt="image" src="https://github.com/user-attachments/assets/3e937a77-dcea-437a-ab2f-11f010f1753e" />

