### PR TITLE
fix(api): trim registry url when building snapshots

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -604,7 +604,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
 
       // save snapshotRunner
 
-      const internalSnapshotName = `${registry.url}/${registry.project}/${snapshot.buildInfo.snapshotRef}`
+      const internalSnapshotName = `${registry.url.replace(/^(https?:\/\/)/, '')}/${registry.project}/${snapshot.buildInfo.snapshotRef}`
 
       snapshot.internalName = internalSnapshotName
       await this.snapshotRepository.save(snapshot)


### PR DESCRIPTION
## Description

Trims registry scheme when building a snapshot. The trim is included when a snapshot image is added directly. It was only missing for building snapshots declaratively.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
