### PR TITLE
fix(api): strip protocol from registry URL in RunnerAdapterLegacy

### DIFF
--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.legacy.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.legacy.ts
@@ -184,7 +184,7 @@ export class RunnerAdapterLegacy implements RunnerAdapter {
       registry: registry
         ? {
             project: registry.project,
-            url: registry.url,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
             username: registry.username,
             password: registry.password,
           }
@@ -227,7 +227,7 @@ export class RunnerAdapterLegacy implements RunnerAdapter {
     if (registry) {
       request.registry = {
         project: registry.project,
-        url: registry.url,
+        url: registry.url.replace(/^(https?:\/\/)/, ''),
         username: registry.username,
         password: registry.password,
       }
@@ -253,7 +253,7 @@ export class RunnerAdapterLegacy implements RunnerAdapter {
     if (registry) {
       request.registry = {
         project: registry.project,
-        url: registry.url,
+        url: registry.url.replace(/^(https?:\/\/)/, ''),
         username: registry.username,
         password: registry.password,
       }
@@ -274,7 +274,7 @@ export class RunnerAdapterLegacy implements RunnerAdapter {
     if (registry) {
       request.registry = {
         project: registry.project,
-        url: registry.url,
+        url: registry.url.replace(/^(https?:\/\/)/, ''),
         username: registry.username,
         password: registry.password,
       }


### PR DESCRIPTION
## Description

**Problem:** Registry URLs passed to the runner API included `http://` or `https://` prefixes, causing Docker image reference parsing errors like `"Error parsing reference: \"http://registry:6000/daytona/...\" is not a valid repository/tag"`.

**Solution:** Strip the URL scheme from registry URLs before passing them to the runner API in four methods:
- `createSandbox` (line 187)
- `createBackup` (line 230)  
- `buildSnapshot` (line 256) - critical for snapshot builds
- `pullSnapshot` (line 277)

**Change:** Replace `url: registry.url,` with `url: registry.url.replace(/^(https?:\/\/)/, ''),` in all four locations.

**Result:** Docker receives valid image references (e.g., `registry:6000/daytona/...` instead of `http://registry:6000/daytona/...`), allowing snapshot builds to complete successfully.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
