### PR TITLE
feat: sandbox entrypoint logs viewing

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -931,6 +931,36 @@ export class SandboxController {
     return logProxy.create()
   }
 
+  @Get(':sandboxIdOrName/logs')
+  @ApiOperation({
+    summary: 'Get sandbox logs',
+    operationId: 'getSandboxLogs',
+  })
+  @ApiParam({
+    name: 'sandboxIdOrName',
+    description: 'ID or name of the sandbox',
+    type: 'string',
+  })
+  @ApiQuery({
+    name: 'timestamps',
+    required: false,
+    type: Boolean,
+    description: 'Whether to include timestamps in the logs',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Sandbox logs',
+    type: String,
+  })
+  @UseGuards(SandboxAccessGuard)
+  async getSandboxLogs(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Param('sandboxIdOrName') sandboxIdOrName: string,
+    @Query('timestamps', new ParseBoolPipe({ optional: true })) timestamps?: boolean,
+  ): Promise<string> {
+    return await this.sandboxService.getSandboxLogs(sandboxIdOrName, authContext.organizationId, timestamps)
+  }
+
   @Post(':sandboxIdOrName/ssh-access')
   @HttpCode(200)
   @ApiOperation({

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.legacy.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.legacy.ts
@@ -337,6 +337,11 @@ export class RunnerAdapterLegacy implements RunnerAdapter {
     return response.data
   }
 
+  async getSandboxLogs(sandboxId: string, timestamps?: boolean): Promise<string> {
+    const response = await this.sandboxApiClient.logs(sandboxId, timestamps)
+    return response.data
+  }
+
   async getSandboxDaemonVersion(sandboxId: string): Promise<string> {
     const getVersionResponse = await this.toolboxApiClient.sandboxesSandboxIdToolboxPathGet(sandboxId, 'version')
     if (!getVersionResponse.data || !(getVersionResponse.data as any).version) {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -80,6 +80,8 @@ export interface RunnerAdapter {
   getSnapshotInfo(snapshotName: string): Promise<RunnerSnapshotInfo>
   getSnapshotLogs(snapshotRef: string, follow: boolean): Promise<string>
 
+  getSandboxLogs(sandboxId: string, timestamps?: boolean): Promise<string>
+
   getSandboxDaemonVersion(sandboxId: string): Promise<string>
 
   updateNetworkSettings(

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ForbiddenException, Injectable, Logger, NotFoundException, ConflictException } from '@nestjs/common'
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  HttpException,
+} from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Not, Repository, LessThan, In, JsonContains, FindOptionsWhere, ILike } from 'typeorm'
 import { Sandbox } from '../entities/sandbox.entity'
@@ -1501,6 +1508,27 @@ export class SandboxService {
     const updateResult = await this.sandboxRepository.update(sandboxId, updateData)
     if (!updateResult.affected) {
       throw new NotFoundException(`Sandbox with id ${sandboxId} no longer exists`)
+    }
+  }
+
+  async getSandboxLogs(sandboxIdOrName: string, organizationId: string, timestamps?: boolean): Promise<string> {
+    const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organizationId)
+
+    if (!sandbox.runnerId) {
+      throw new NotFoundException(`Sandbox with ID or name ${sandboxIdOrName} has no runner assigned`)
+    }
+
+    const runner = await this.runnerService.findOne(sandbox.runnerId)
+    if (!runner) {
+      throw new NotFoundException(`Runner for sandbox ${sandboxIdOrName} not found`)
+    }
+
+    try {
+      const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+      return await runnerAdapter.getSandboxLogs(sandbox.id, timestamps)
+    } catch (error) {
+      this.logger.error(`Failed to fetch logs for sandbox ${sandboxIdOrName}:`, error)
+      throw new HttpException(`Error fetching sandbox logs: ${error.message}`, 500)
     }
   }
 }

--- a/apps/cli/cmd/sandbox/logs.go
+++ b/apps/cli/cmd/sandbox/logs.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/config"
+	"github.com/spf13/cobra"
+)
+
+var LogsCmd = &cobra.Command{
+	Use:     "logs [SANDBOX_ID] | [SANDBOX_NAME]",
+	Short:   "Get sandbox logs",
+	Args:    cobra.ExactArgs(1),
+	Aliases: common.GetAliases("logs"),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		sandboxIdOrNameArg := args[0]
+		showTimestamps, _ := cmd.Flags().GetBool("timestamps")
+
+		// Get config to access server URL and auth
+		c, err := config.GetConfig()
+		if err != nil {
+			return err
+		}
+
+		activeProfile, err := c.GetActiveProfile()
+		if err != nil {
+			return err
+		}
+
+		// Build URL with timestamps parameter
+		url := fmt.Sprintf("%s/sandbox/%s/logs", activeProfile.Api.Url, sandboxIdOrNameArg)
+		if showTimestamps {
+			url += "?timestamps=true"
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %v", err)
+		}
+
+		// Add authorization header
+		if activeProfile.Api.Key != nil {
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *activeProfile.Api.Key))
+		} else if activeProfile.Api.Token != nil {
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", activeProfile.Api.Token.AccessToken))
+			if activeProfile.ActiveOrganizationId != nil {
+				req.Header.Add("X-Daytona-Organization-ID", *activeProfile.ActiveOrganizationId)
+			}
+		}
+
+		req.Header.Add("Accept", "text/plain")
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to connect to server: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("server returned a non-OK status while retrieving logs: %d", resp.StatusCode)
+		}
+
+		// Read and print the response body
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				fmt.Print(string(buf[:n]))
+			}
+			if err != nil {
+				break
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	LogsCmd.Flags().Bool("timestamps", false, "Show timestamps in logs (default: false)")
+	SandboxCmd.AddCommand(LogsCmd)
+}

--- a/apps/cli/cmd/sandbox/sandbox.go
+++ b/apps/cli/cmd/sandbox/sandbox.go
@@ -24,4 +24,5 @@ func init() {
 	SandboxCmd.AddCommand(StartCmd)
 	SandboxCmd.AddCommand(StopCmd)
 	SandboxCmd.AddCommand(ArchiveCmd)
+	SandboxCmd.AddCommand(LogsCmd)
 }

--- a/apps/dashboard/src/components/SandboxLogs.tsx
+++ b/apps/dashboard/src/components/SandboxLogs.tsx
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import React, { useState, useRef, useEffect, useMemo } from 'react'
+import { useSandboxLogs } from '@/hooks/useSandboxLogs'
+import { Loader2, RefreshCw, Archive, Trash2, Clock } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { SandboxState } from '@daytonaio/api-client'
+
+interface SandboxLogsProps {
+  sandboxId: string
+  sandboxState?: SandboxState
+}
+
+const stateUnavailableMessages: Partial<
+  Record<
+    SandboxState,
+    {
+      icon: LucideIcon
+      title: string
+      message: string
+    }
+  >
+> = {
+  [SandboxState.ARCHIVED]: {
+    icon: Archive,
+    title: 'Sandbox Archived',
+    message: 'Logs are not available for archived sandboxes',
+  },
+  [SandboxState.ARCHIVING]: {
+    icon: Archive,
+    title: 'Sandbox Archiving',
+    message: 'Logs are not available while the sandbox is archiving',
+  },
+  [SandboxState.DESTROYED]: {
+    icon: Trash2,
+    title: 'Sandbox Destroyed',
+    message: 'Logs are not available for destroyed sandboxes',
+  },
+  [SandboxState.DESTROYING]: {
+    icon: Trash2,
+    title: 'Sandbox Destroying',
+    message: 'Logs are not available while the sandbox is destroying',
+  },
+}
+
+// Function to parse logs with timestamps and format them for display
+const parseLogsWithTimestamps = (logs: string, showTimestamps: boolean): React.ReactElement[] => {
+  if (!logs) return []
+
+  const lines = logs.split('\n')
+  const parsedLines: React.ReactElement[] = []
+
+  lines.forEach((line, index) => {
+    if (line.trim() === '') {
+      parsedLines.push(<br key={index} />)
+      return
+    }
+
+    // Check if line starts with a timestamp (Docker format: YYYY-MM-DDTHH:MM:SS.sssssssssZ)
+    const timestampRegex = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+(.*)$/
+    const match = line.match(timestampRegex)
+
+    if (match) {
+      const [, timestamp, content] = match
+      if (showTimestamps) {
+        // Parse UTC timestamp and format it in browser's timezone
+        const date = new Date(timestamp)
+        const formattedTimestamp = date
+          .toLocaleString('en-US', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+          })
+          .replace(',', '')
+        parsedLines.push(
+          <div key={index} className="flex items-baseline gap-4">
+            <span className="text-gray-500 text-xs font-mono flex-shrink-0">{formattedTimestamp}</span>
+            <span className="text-white font-mono text-sm leading-relaxed whitespace-pre-wrap">{content}</span>
+          </div>,
+        )
+      } else {
+        // Show only content without timestamp
+        parsedLines.push(
+          <div key={index} className="text-white font-mono text-sm leading-relaxed whitespace-pre-wrap">
+            {content}
+          </div>,
+        )
+      }
+    } else {
+      // Line without timestamp
+      parsedLines.push(
+        <div key={index} className="text-white font-mono text-sm leading-relaxed whitespace-pre-wrap">
+          {line}
+        </div>,
+      )
+    }
+  })
+
+  return parsedLines
+}
+
+const SandboxLogs: React.FC<SandboxLogsProps> = ({ sandboxId, sandboxState }) => {
+  const { data: logs, isLoading, error, refetch, isRefetching } = useSandboxLogs(sandboxId)
+  const [showTimestamps, setShowTimestamps] = useState(true)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+  const handleTimestampToggle = (checked: boolean) => {
+    setShowTimestamps(checked)
+  }
+
+  // Auto-scroll to bottom when logs change
+  useEffect(() => {
+    if (scrollContainerRef.current && logs) {
+      scrollContainerRef.current.scrollTop = scrollContainerRef.current.scrollHeight
+    }
+  }, [logs, showTimestamps])
+
+  const parsedLogs = useMemo(() => parseLogsWithTimestamps(logs ?? '', showTimestamps), [logs, showTimestamps])
+
+  const unavailableMessage = sandboxState ? stateUnavailableMessages[sandboxState] : undefined
+  if (unavailableMessage) {
+    const Icon = unavailableMessage.icon
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center min-h-0 bg-black font-mono text-sm rounded-md border border-gray-700 h-full">
+        <div className="text-center">
+          <Icon className="w-12 h-12 mb-4 mx-auto" />
+          <p className="mb-2 text-lg font-semibold">{unavailableMessage.title}</p>
+          <p className="text-sm text-gray-400">{unavailableMessage.message}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center min-h-0 bg-black text-green-400 font-mono text-sm rounded-md border border-gray-700 h-full">
+        <div className="flex items-center gap-2">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span>Loading logs...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center min-h-0 bg-black text-red-400 font-mono text-sm rounded-md border border-gray-700 h-full">
+        <div className="text-center">
+          <p className="mb-4">Failed to load entrypoint logs</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isRefetching}
+            className="bg-gray-800 border-gray-600 text-green-400 hover:bg-gray-700"
+          >
+            {isRefetching ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+            Retry
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 h-full bg-black border border-gray-700 rounded-md overflow-hidden">
+      <div className="flex items-center justify-between p-2 bg-gray-800 border-b border-gray-700">
+        <div className="flex items-center gap-2 text-green-400 font-mono text-xs">
+          <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+          <span>Sandbox Entrypoint Logs</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1">
+            <Clock className="w-3 h-3 text-gray-400" />
+            <Switch
+              checked={showTimestamps}
+              onCheckedChange={handleTimestampToggle}
+              className="data-[state=checked]:bg-green-400 scale-75"
+            />
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isRefetching}
+            className="h-6 w-6 p-0 text-green-400 hover:bg-gray-700"
+          >
+            {isRefetching ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
+          </Button>
+        </div>
+      </div>
+      <div ref={scrollContainerRef} className="flex-1 overflow-auto p-3">
+        <div className="space-y-1">
+          {logs ? parsedLogs : <span className="text-white font-mono text-sm">No logs available</span>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SandboxLogs

--- a/apps/dashboard/src/hooks/useSandboxLogs.ts
+++ b/apps/dashboard/src/hooks/useSandboxLogs.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useQuery, QueryKey } from '@tanstack/react-query'
+import { useApi } from '@/hooks/useApi'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+
+export const getSandboxLogsQueryKey = (organizationId: string | undefined, sandboxId: string): QueryKey => {
+  return ['sandbox-logs' as const, organizationId, sandboxId]
+}
+
+export function useSandboxLogs(sandboxId: string) {
+  const { sandboxApi } = useApi()
+  const { selectedOrganization } = useSelectedOrganization()
+
+  return useQuery<string>({
+    queryKey: getSandboxLogsQueryKey(selectedOrganization?.id, sandboxId),
+    queryFn: async () => {
+      if (!selectedOrganization || !sandboxId) {
+        throw new Error('No organization selected or sandbox ID missing')
+      }
+
+      const response = await sandboxApi.getSandboxLogs(sandboxId, selectedOrganization.id, true)
+      return response.data
+    },
+    enabled: !!selectedOrganization && !!sandboxId,
+    staleTime: 1000 * 5, // 5 seconds
+    gcTime: 1000 * 30, // 30 seconds
+    refetchInterval: 1000 * 10, // Refetch every 10 seconds for live logs
+  })
+}

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -363,6 +363,66 @@ const docTemplate = `{
                 }
             }
         },
+        "/sandboxes/{sandboxId}/logs": {
+            "get": {
+                "description": "Get the entire log output of a sandbox container",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "sandbox"
+                ],
+                "summary": "Get sandbox logs",
+                "operationId": "Logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Sandbox ID",
+                        "name": "sandboxId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Whether to include timestamps in the logs",
+                        "name": "timestamps",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Container logs",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/sandboxes/{sandboxId}/network-settings": {
             "get": {
                 "description": "Get sandbox network settings",

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -331,6 +331,62 @@
         }
       }
     },
+    "/sandboxes/{sandboxId}/logs": {
+      "get": {
+        "description": "Get the entire log output of a sandbox container",
+        "produces": ["text/plain"],
+        "tags": ["sandbox"],
+        "summary": "Get sandbox logs",
+        "operationId": "Logs",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Sandbox ID",
+            "name": "sandboxId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "Whether to include timestamps in the logs",
+            "name": "timestamps",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Container logs",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/sandboxes/{sandboxId}/network-settings": {
       "get": {
         "description": "Get sandbox network settings",

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -530,6 +530,46 @@ paths:
       summary: Destroy sandbox
       tags:
         - sandbox
+  /sandboxes/{sandboxId}/logs:
+    get:
+      description: Get the entire log output of a sandbox container
+      operationId: Logs
+      parameters:
+        - description: Sandbox ID
+          in: path
+          name: sandboxId
+          required: true
+          type: string
+        - description: Whether to include timestamps in the logs
+          in: query
+          name: timestamps
+          type: boolean
+      produces:
+        - text/plain
+      responses:
+        '200':
+          description: Container logs
+          schema:
+            type: string
+        '400':
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        '401':
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        '500':
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Get sandbox logs
+      tags:
+        - sandbox
   /sandboxes/{sandboxId}/network-settings:
     get:
       description: Get sandbox network settings

--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -110,6 +110,7 @@ func (a *ApiServer) Start() error {
 	{
 		sandboxController.POST("", controllers.Create)
 		sandboxController.GET("/:sandboxId", controllers.Info)
+		sandboxController.GET("/:sandboxId/logs", controllers.Logs)
 		sandboxController.POST("/:sandboxId/destroy", controllers.Destroy)
 		sandboxController.POST("/:sandboxId/start", controllers.Start)
 		sandboxController.POST("/:sandboxId/stop", controllers.Stop)

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -2183,6 +2183,50 @@ paths:
       summary: Get build logs
       tags:
         - sandbox
+  /sandbox/{sandboxIdOrName}/logs:
+    get:
+      operationId: getSandboxLogs
+      parameters:
+        - description: Use with JWT to specify the organization ID
+          explode: false
+          in: header
+          name: X-Daytona-Organization-ID
+          required: false
+          schema:
+            type: string
+          style: simple
+        - description: ID or name of the sandbox
+          explode: false
+          in: path
+          name: sandboxIdOrName
+          required: true
+          schema:
+            type: string
+          style: simple
+        - description: Whether to include timestamps in the logs
+          explode: true
+          in: query
+          name: timestamps
+          required: false
+          schema:
+            type: boolean
+          style: form
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Sandbox logs
+      security:
+        - bearer: []
+        - oauth2:
+            - openid
+            - profile
+            - email
+      summary: Get sandbox logs
+      tags:
+        - sandbox
   /sandbox/{sandboxIdOrName}/ssh-access:
     delete:
       operationId: revokeSshAccess

--- a/libs/api-client-go/api_sandbox.go
+++ b/libs/api-client-go/api_sandbox.go
@@ -128,6 +128,19 @@ type SandboxAPI interface {
 	GetSandboxExecute(r SandboxAPIGetSandboxRequest) (*Sandbox, *http.Response, error)
 
 	/*
+		GetSandboxLogs Get sandbox logs
+
+		@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+		@param sandboxIdOrName ID or name of the sandbox
+		@return SandboxAPIGetSandboxLogsRequest
+	*/
+	GetSandboxLogs(ctx context.Context, sandboxIdOrName string) SandboxAPIGetSandboxLogsRequest
+
+	// GetSandboxLogsExecute executes the request
+	//  @return string
+	GetSandboxLogsExecute(r SandboxAPIGetSandboxLogsRequest) (string, *http.Response, error)
+
+	/*
 		GetSandboxRegions List all regions where sandboxes have been created
 
 		@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1190,6 +1203,128 @@ func (a *SandboxAPIService) GetSandboxExecute(r SandboxAPIGetSandboxRequest) (*S
 
 	if r.verbose != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "verbose", r.verbose, "form", "")
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.xDaytonaOrganizationID != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "X-Daytona-Organization-ID", r.xDaytonaOrganizationID, "simple", "")
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type SandboxAPIGetSandboxLogsRequest struct {
+	ctx                    context.Context
+	ApiService             SandboxAPI
+	sandboxIdOrName        string
+	xDaytonaOrganizationID *string
+	timestamps             *bool
+}
+
+// Use with JWT to specify the organization ID
+func (r SandboxAPIGetSandboxLogsRequest) XDaytonaOrganizationID(xDaytonaOrganizationID string) SandboxAPIGetSandboxLogsRequest {
+	r.xDaytonaOrganizationID = &xDaytonaOrganizationID
+	return r
+}
+
+// Whether to include timestamps in the logs
+func (r SandboxAPIGetSandboxLogsRequest) Timestamps(timestamps bool) SandboxAPIGetSandboxLogsRequest {
+	r.timestamps = &timestamps
+	return r
+}
+
+func (r SandboxAPIGetSandboxLogsRequest) Execute() (string, *http.Response, error) {
+	return r.ApiService.GetSandboxLogsExecute(r)
+}
+
+/*
+GetSandboxLogs Get sandbox logs
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param sandboxIdOrName ID or name of the sandbox
+	@return SandboxAPIGetSandboxLogsRequest
+*/
+func (a *SandboxAPIService) GetSandboxLogs(ctx context.Context, sandboxIdOrName string) SandboxAPIGetSandboxLogsRequest {
+	return SandboxAPIGetSandboxLogsRequest{
+		ApiService:      a,
+		ctx:             ctx,
+		sandboxIdOrName: sandboxIdOrName,
+	}
+}
+
+// Execute executes the request
+//
+//	@return string
+func (a *SandboxAPIService) GetSandboxLogsExecute(r SandboxAPIGetSandboxLogsRequest) (string, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue string
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SandboxAPIService.GetSandboxLogs")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/sandbox/{sandboxIdOrName}/logs"
+	localVarPath = strings.Replace(localVarPath, "{"+"sandboxIdOrName"+"}", url.PathEscape(parameterValueToString(r.sandboxIdOrName, "sandboxIdOrName")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if r.timestamps != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "timestamps", r.timestamps, "form", "")
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}

--- a/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -2314,6 +2314,297 @@ class SandboxApi:
 
 
     @validate_call
+    async def get_sandbox_logs(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        timestamps: Annotated[Optional[StrictBool], Field(description="Whether to include timestamps in the logs")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> str:
+        """Get sandbox logs
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param timestamps: Whether to include timestamps in the logs
+        :type timestamps: bool
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_sandbox_logs_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            timestamps=timestamps,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    async def get_sandbox_logs_with_http_info(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        timestamps: Annotated[Optional[StrictBool], Field(description="Whether to include timestamps in the logs")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[str]:
+        """Get sandbox logs
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param timestamps: Whether to include timestamps in the logs
+        :type timestamps: bool
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_sandbox_logs_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            timestamps=timestamps,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    async def get_sandbox_logs_without_preload_content(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        timestamps: Annotated[Optional[StrictBool], Field(description="Whether to include timestamps in the logs")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get sandbox logs
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param timestamps: Whether to include timestamps in the logs
+        :type timestamps: bool
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_sandbox_logs_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            timestamps=timestamps,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _get_sandbox_logs_serialize(
+        self,
+        sandbox_id_or_name,
+        x_daytona_organization_id,
+        timestamps,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if sandbox_id_or_name is not None:
+            _path_params['sandboxIdOrName'] = sandbox_id_or_name
+        # process the query parameters
+        if timestamps is not None:
+            
+            _query_params.append(('timestamps', timestamps))
+            
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/sandbox/{sandboxIdOrName}/logs',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     async def get_sandbox_regions(
         self,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,

--- a/libs/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/libs/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -2314,6 +2314,297 @@ class SandboxApi:
 
 
     @validate_call
+    def get_sandbox_logs(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        timestamps: Annotated[Optional[StrictBool], Field(description="Whether to include timestamps in the logs")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> str:
+        """Get sandbox logs
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param timestamps: Whether to include timestamps in the logs
+        :type timestamps: bool
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_sandbox_logs_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            timestamps=timestamps,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def get_sandbox_logs_with_http_info(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        timestamps: Annotated[Optional[StrictBool], Field(description="Whether to include timestamps in the logs")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[str]:
+        """Get sandbox logs
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param timestamps: Whether to include timestamps in the logs
+        :type timestamps: bool
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_sandbox_logs_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            timestamps=timestamps,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def get_sandbox_logs_without_preload_content(
+        self,
+        sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        timestamps: Annotated[Optional[StrictBool], Field(description="Whether to include timestamps in the logs")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get sandbox logs
+
+
+        :param sandbox_id_or_name: ID or name of the sandbox (required)
+        :type sandbox_id_or_name: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param timestamps: Whether to include timestamps in the logs
+        :type timestamps: bool
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._get_sandbox_logs_serialize(
+            sandbox_id_or_name=sandbox_id_or_name,
+            x_daytona_organization_id=x_daytona_organization_id,
+            timestamps=timestamps,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _get_sandbox_logs_serialize(
+        self,
+        sandbox_id_or_name,
+        x_daytona_organization_id,
+        timestamps,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if sandbox_id_or_name is not None:
+            _path_params['sandboxIdOrName'] = sandbox_id_or_name
+        # process the query parameters
+        if timestamps is not None:
+            
+            _query_params.append(('timestamps', timestamps))
+            
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/sandbox/{sandboxIdOrName}/logs',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def get_sandbox_regions(
         self,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,

--- a/libs/api-client/src/api/sandbox-api.ts
+++ b/libs/api-client/src/api/sandbox-api.ts
@@ -462,6 +462,60 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
     },
     /**
      *
+     * @summary Get sandbox logs
+     * @param {string} sandboxIdOrName ID or name of the sandbox
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {boolean} [timestamps] Whether to include timestamps in the logs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getSandboxLogs: async (
+      sandboxIdOrName: string,
+      xDaytonaOrganizationID?: string,
+      timestamps?: boolean,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'sandboxIdOrName' is not null or undefined
+      assertParamExists('getSandboxLogs', 'sandboxIdOrName', sandboxIdOrName)
+      const localVarPath = `/sandbox/{sandboxIdOrName}/logs`.replace(
+        `{${'sandboxIdOrName'}}`,
+        encodeURIComponent(String(sandboxIdOrName)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication bearer required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+      // authentication oauth2 required
+
+      if (timestamps !== undefined) {
+        localVarQueryParameter['timestamps'] = timestamps
+      }
+
+      if (xDaytonaOrganizationID != null) {
+        localVarHeaderParameter['X-Daytona-Organization-ID'] = String(xDaytonaOrganizationID)
+      }
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     *
      * @summary List all regions where sandboxes have been created
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
      * @param {*} [options] Override http request option.
@@ -1587,6 +1641,38 @@ export const SandboxApiFp = function (configuration?: Configuration) {
     },
     /**
      *
+     * @summary Get sandbox logs
+     * @param {string} sandboxIdOrName ID or name of the sandbox
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {boolean} [timestamps] Whether to include timestamps in the logs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getSandboxLogs(
+      sandboxIdOrName: string,
+      xDaytonaOrganizationID?: string,
+      timestamps?: boolean,
+      options?: RawAxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getSandboxLogs(
+        sandboxIdOrName,
+        xDaytonaOrganizationID,
+        timestamps,
+        options,
+      )
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath =
+        operationServerMap['SandboxApi.getSandboxLogs']?.[localVarOperationServerIndex]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+    /**
+     *
      * @summary List all regions where sandboxes have been created
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
      * @param {*} [options] Override http request option.
@@ -2254,6 +2340,25 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
     },
     /**
      *
+     * @summary Get sandbox logs
+     * @param {string} sandboxIdOrName ID or name of the sandbox
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {boolean} [timestamps] Whether to include timestamps in the logs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getSandboxLogs(
+      sandboxIdOrName: string,
+      xDaytonaOrganizationID?: string,
+      timestamps?: boolean,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<string> {
+      return localVarFp
+        .getSandboxLogs(sandboxIdOrName, xDaytonaOrganizationID, timestamps, options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     *
      * @summary List all regions where sandboxes have been created
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
      * @param {*} [options] Override http request option.
@@ -2729,6 +2834,27 @@ export class SandboxApi extends BaseAPI {
   ) {
     return SandboxApiFp(this.configuration)
       .getSandbox(sandboxIdOrName, xDaytonaOrganizationID, verbose, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   *
+   * @summary Get sandbox logs
+   * @param {string} sandboxIdOrName ID or name of the sandbox
+   * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+   * @param {boolean} [timestamps] Whether to include timestamps in the logs
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof SandboxApi
+   */
+  public getSandboxLogs(
+    sandboxIdOrName: string,
+    xDaytonaOrganizationID?: string,
+    timestamps?: boolean,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return SandboxApiFp(this.configuration)
+      .getSandboxLogs(sandboxIdOrName, xDaytonaOrganizationID, timestamps, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/libs/runner-api-client/src/api/sandbox-api.ts
+++ b/libs/runner-api-client/src/api/sandbox-api.ts
@@ -242,6 +242,52 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
       }
     },
     /**
+     * Get the entire log output of a sandbox container
+     * @summary Get sandbox logs
+     * @param {string} sandboxId Sandbox ID
+     * @param {boolean} [timestamps] Whether to include timestamps in the logs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    logs: async (
+      sandboxId: string,
+      timestamps?: boolean,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'sandboxId' is not null or undefined
+      assertParamExists('logs', 'sandboxId', sandboxId)
+      const localVarPath = `/sandboxes/{sandboxId}/logs`.replace(
+        `{${'sandboxId'}}`,
+        encodeURIComponent(String(sandboxId)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication Bearer required
+      await setApiKeyToObject(localVarHeaderParameter, 'Authorization', configuration)
+
+      if (timestamps !== undefined) {
+        localVarQueryParameter['timestamps'] = timestamps
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
      * Remove a sandbox that has been previously destroyed
      * @summary Remove a destroyed sandbox
      * @param {string} sandboxId Sandbox ID
@@ -574,6 +620,30 @@ export const SandboxApiFp = function (configuration?: Configuration) {
         )(axios, localVarOperationServerBasePath || basePath)
     },
     /**
+     * Get the entire log output of a sandbox container
+     * @summary Get sandbox logs
+     * @param {string} sandboxId Sandbox ID
+     * @param {boolean} [timestamps] Whether to include timestamps in the logs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async logs(
+      sandboxId: string,
+      timestamps?: boolean,
+      options?: RawAxiosRequestConfig,
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.logs(sandboxId, timestamps, options)
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0
+      const localVarOperationServerBasePath = operationServerMap['SandboxApi.logs']?.[localVarOperationServerIndex]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, localVarOperationServerBasePath || basePath)
+    },
+    /**
      * Remove a sandbox that has been previously destroyed
      * @summary Remove a destroyed sandbox
      * @param {string} sandboxId Sandbox ID
@@ -755,6 +825,17 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
       return localVarFp.info(sandboxId, options).then((request) => request(axios, basePath))
     },
     /**
+     * Get the entire log output of a sandbox container
+     * @summary Get sandbox logs
+     * @param {string} sandboxId Sandbox ID
+     * @param {boolean} [timestamps] Whether to include timestamps in the logs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    logs(sandboxId: string, timestamps?: boolean, options?: RawAxiosRequestConfig): AxiosPromise<string> {
+      return localVarFp.logs(sandboxId, timestamps, options).then((request) => request(axios, basePath))
+    },
+    /**
      * Remove a sandbox that has been previously destroyed
      * @summary Remove a destroyed sandbox
      * @param {string} sandboxId Sandbox ID
@@ -889,6 +970,21 @@ export class SandboxApi extends BaseAPI {
   public info(sandboxId: string, options?: RawAxiosRequestConfig) {
     return SandboxApiFp(this.configuration)
       .info(sandboxId, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Get the entire log output of a sandbox container
+   * @summary Get sandbox logs
+   * @param {string} sandboxId Sandbox ID
+   * @param {boolean} [timestamps] Whether to include timestamps in the logs
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof SandboxApi
+   */
+  public logs(sandboxId: string, timestamps?: boolean, options?: RawAxiosRequestConfig) {
+    return SandboxApiFp(this.configuration)
+      .logs(sandboxId, timestamps, options)
       .then((request) => request(this.axios, this.basePath))
   }
 


### PR DESCRIPTION
## Sandbox entrypoint logs viewing

Allows the users to view their Sandbox entrypoint logs through the dashboard or the CLI.
The initial version is meant for users to check what went wrong in the entrypoint and act accordingly. There is no streaming and only the last 1000 lines are fetched at a time.

The logs in the dashboard are put into the Sandbox drawer which is now resizable. Timestamps for each log line can optionally be turned on

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="3831" height="1939" alt="image" src="https://github.com/user-attachments/assets/84a8def2-ba51-4c13-a4c4-d4712ad4cc6f" />

