### PR TITLE
refactor(api): asynchronous registry cleanup

### DIFF
--- a/apps/api/src/migrations/1763318758683-migration.ts
+++ b/apps/api/src/migrations/1763318758683-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1763318758683 implements MigrationInterface {
+  name = 'Migration1763318758683'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sandbox" ADD "cleanupCompleted" boolean NOT NULL DEFAULT false`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sandbox" DROP COLUMN "cleanupCompleted"`)
+  }
+}

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -184,6 +184,9 @@ export class Sandbox {
   @Column({ default: () => 'MD5(random()::text)' })
   authToken: string
 
+  @Column({ default: false })
+  cleanupCompleted: boolean
+
   @ManyToOne(() => BuildInfo, (buildInfo) => buildInfo.sandboxes, {
     nullable: true,
     eager: true,

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -22,7 +22,6 @@ import { fromAxiosError } from '../../common/utils/from-axios-error'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { OnEvent } from '@nestjs/event-emitter'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
-import { SandboxDestroyedEvent } from '../events/sandbox-destroyed.event'
 import { SandboxBackupCreatedEvent } from '../events/sandbox-backup-created.event'
 import { SandboxArchivedEvent } from '../events/sandbox-archived.event'
 import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
@@ -430,10 +429,53 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     this.setBackupPending(event.sandbox)
   }
 
-  @OnEvent(SandboxEvents.DESTROYED)
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'cleanup-sandbox-artifacts', waitForCompletion: true })
   @TrackJobExecution()
-  private async handleSandboxDestroyedEvent(event: SandboxDestroyedEvent) {
-    this.deleteSandboxBackupRepositoryFromRegistry(event.sandbox)
+  @LogExecution('cleanup-sandbox-artifacts')
+  @WithInstrumentation()
+  async cleanupDestroyedSandboxes(): Promise<void> {
+    const lockKey = 'cleanup-sandbox-artifacts'
+    const hasLock = await this.redisLockProvider.lock(lockKey, 60)
+    if (!hasLock) {
+      return
+    }
+
+    try {
+      const sandboxes = await this.sandboxRepository
+        .createQueryBuilder('sandbox')
+        .where('sandbox.state = :state', { state: SandboxState.DESTROYED })
+        .andWhere('sandbox.cleanupCompleted != :cleanupCompleted', { cleanupCompleted: true })
+        .orderBy('CASE WHEN sandbox."backupRegistryId" IS NOT NULL THEN 0 ELSE 1 END', 'ASC')
+        .take(100)
+        .getMany()
+
+      await Promise.allSettled(
+        sandboxes.map(async (sandbox) => {
+          const lockKey = `sandbox-artifacts-cleanup-${sandbox.id}`
+          const hasLock = await this.redisLockProvider.lock(lockKey, 60)
+          if (!hasLock) {
+            return
+          }
+
+          try {
+            // Only attempt repository cleanup if backupRegistryId exists
+            if (sandbox.backupRegistryId) {
+              await this.deleteSandboxBackupRepositoryFromRegistry(sandbox)
+            }
+            sandbox.cleanupCompleted = true
+            await this.sandboxRepository.save(sandbox)
+          } catch (error) {
+            this.logger.error(`Error cleaning up sandbox ${sandbox.id}:`, fromAxiosError(error))
+          } finally {
+            await this.redisLockProvider.unlock(lockKey)
+          }
+        }),
+      )
+    } catch (error) {
+      this.logger.error(`Error processing destroyed sandbox cleanup: `, error)
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @OnEvent(SandboxEvents.BACKUP_CREATED)

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1122,6 +1122,7 @@ export class SandboxService {
 
     const destroyedSandboxs = await this.sandboxRepository.delete({
       state: SandboxState.DESTROYED,
+      cleanupCompleted: true,
       updatedAt: LessThan(twentyFourHoursAgo),
     })
 


### PR DESCRIPTION
## Asynchronous registry cleanup

Instead of the API instances processing registry (backup image) cleanups whenever a user deletes a sandbox, this is now done asynchronously to distribute the connection load over time

TODO: consider the behavior of marking the "cleanupCompleted" as true even if the registry cleanup was unsuccessful - this was the behavior until now - or implement a N retries mechanism

Currently, only backups are "cleaned up" but sandboxes without a backupRegistryId are kept in the query for other future artifacts 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
