### PR TITLE
chore(runner): build-amd64 always build for linux

### DIFF
--- a/apps/runner/project.json
+++ b/apps/runner/project.json
@@ -48,7 +48,8 @@
         "main": "{projectRoot}/cmd/runner/main.go",
         "outputPath": "dist/apps/runner-amd64",
         "env": {
-          "GOARCH": "amd64"
+          "GOARCH": "amd64",
+          "GOOS": "linux"
         }
       },
       "configurations": {


### PR DESCRIPTION
## Description

Always build for linux when building amd64.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
