### PR TITLE
refactor(sdk-python): wrap 'Session is closed' error

### DIFF
--- a/libs/sdk-python/src/daytona/_utils/errors.py
+++ b/libs/sdk-python/src/daytona/_utils/errors.py
@@ -22,6 +22,8 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import ParamSpec
 
+SESSION_IS_CLOSED_ERROR_MESSAGE = "Session is closed"
+
 P = ParamSpec("P")
 T = TypeVar("T")
 
@@ -57,6 +59,13 @@ def intercept_errors(
                 ):
                     raise DaytonaNotFoundError(f"{message_prefix}{msg}") from None
                 raise DaytonaError(f"{message_prefix}{msg}") from None
+
+            if isinstance(e, RuntimeError) and SESSION_IS_CLOSED_ERROR_MESSAGE in str(e):
+                raise DaytonaError(
+                    f"{message_prefix}{str(e)}: Daytona client is closed"
+                    " — sandbox is used outside its parent's context. "
+                    "Ensure sandboxes are only used within the scope of their parent Daytona object."
+                ) from e
 
             msg = f"{message_prefix}{str(e)}" if message_prefix else str(e)
             raise DaytonaError(msg)  # pylint: disable=raise-missing-from


### PR DESCRIPTION
## Description

Wrap `Session is closed` error with more descriptive error message so that user knows it's their fault when they are using sandbox outside Daytona object scope, e.g.:
```
async def main():
    sandbox = None
    async with AsyncDaytona() as daytona:
        sandbox = await daytona.create()

        # Run the code securely inside the sandbox
        response = await sandbox.process.code_run('print("Hello World!")')
        print(response.result)

    if sandbox:
        await sandbox.delete()


if __name__ == "__main__":
    asyncio.run(main())
```

In the future they will get error like this:
`daytona.common.errors.DaytonaError: Failed to remove sandbox: Session is closed: Daytona client is closed — sandbox is used outside its parent's context. Ensure sandboxes are only used within the scope of their parent Daytona object.`

instead of current error:
`daytona.common.errors.DaytonaError: Failed to remove sandbox: Session is closed`

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
