### PR TITLE
fix(api): update snapshot timeout logic to use updatedAt timestamp

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -651,9 +651,12 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
   async handleSnapshotStatePulling(snapshot: Snapshot) {
     const localImageName = snapshot.buildInfo ? snapshot.internalName : snapshot.imageName
     // Check timeout first
+    // Use updatedAt instead of createdAt because updatedAt reflects when the snapshot
+    // entered PULLING state, giving us the full timeout window from that point
     const timeoutMinutes = 15
     const timeoutMs = timeoutMinutes * 60 * 1000
-    if (Date.now() - snapshot.createdAt.getTime() > timeoutMs) {
+    const pullingStartTime = snapshot.updatedAt.getTime()
+    if (Date.now() - pullingStartTime > timeoutMs) {
       await this.updateSnapshotState(snapshot.id, SnapshotState.ERROR, 'Timeout while pulling snapshot')
       return
     }


### PR DESCRIPTION
## Description

### Problem
Snapshots were timing out immediately after entering the `pulling` state with "Timeout while pulling snapshot". The timeout was calculated from the snapshot's creation time (`createdAt`) instead of when it entered the `pulling` state (`updatedAt`).

### Root Cause
In `handleSnapshotStatePulling` in `snapshot.manager.ts`, the timeout used `snapshot.createdAt.getTime()`. If a snapshot spent time in `building` or `build_pending`, the timeout window was already partially consumed when it reached `pulling`, causing premature timeouts.

### The Fix
Changed the timeout calculation to use `snapshot.updatedAt.getTime()` instead of `snapshot.createdAt.getTime()`:

```651:662:daytona/apps/api/src/sandbox/managers/snapshot.manager.ts
async handleSnapshotStatePulling(snapshot: Snapshot) {
  const localImageName = snapshot.buildInfo ? snapshot.internalName : snapshot.imageName
  // Check timeout first
  // Use updatedAt instead of createdAt because updatedAt reflects when the snapshot
  // entered PULLING state, giving us the full timeout window from that point
  const timeoutMinutes = 15
  const timeoutMs = timeoutMinutes * 60 * 1000
  const pullingStartTime = snapshot.updatedAt.getTime()
  if (Date.now() - pullingStartTime > timeoutMs) {
    await this.updateSnapshotState(snapshot.id, SnapshotState.ERROR, 'Timeout while pulling snapshot')
    return
  }
```

### Impact
- Snapshots now get the full 15-minute timeout window when entering `pulling`
- Timeouts occur only if pulling takes longer than 15 minutes from entry into `pulling`
- Prevents false timeouts caused by time spent in earlier states

### Verification
- Tested locally: snapshot completed successfully, transitioning `building` → `pending` → `pulling` → `validating` → `active`
- The timeout logic is in place and will trigger if a snapshot exceeds 15 minutes in the `pulling` state

This ensures snapshots have adequate time to complete the pull operation.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

I haven't widely tested the change so there may be side effects. But it fixes my issue.