### PR TITLE
fix(sdk-typescript): ignore reader.cancel() errors; use native FormData for specific runtimes

### DIFF
--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -12,7 +12,6 @@ import {
   ReplaceResult,
   SearchFilesResponse,
 } from '@daytonaio/toolbox-api-client'
-import FormData from 'form-data'
 import { FileSystemApi } from '@daytonaio/toolbox-api-client'
 import { dynamicImport } from './utils/Import'
 import { RUNTIME, Runtime } from './utils/Runtime'
@@ -477,7 +476,6 @@ export class FileSystem {
   public async uploadFiles(files: FileUpload[], timeout: number = 30 * 60): Promise<void> {
     const isNonStreamingRuntime =
       RUNTIME === Runtime.DENO || RUNTIME === Runtime.BROWSER || RUNTIME === Runtime.SERVERLESS
-    // Use native FormData in Deno
     const FormDataClass = isNonStreamingRuntime
       ? FormData
       : ((await dynamicImport('form-data', 'Uploading files is not supported: ')) as any)

--- a/libs/sdk-typescript/src/utils/Stream.ts
+++ b/libs/sdk-typescript/src/utils/Stream.ts
@@ -47,7 +47,15 @@ export async function processStreamingResponse(
         const stop = await shouldTerminate()
         if (stop) {
           exitCheckStreak++
-          if (!requireConsecutiveTermination || exitCheckStreak > 1) break
+          if (!requireConsecutiveTermination || exitCheckStreak > 1) {
+            try {
+              await reader.cancel()
+            } catch {
+              /* ignore */
+            }
+            readPromise = null
+            break
+          }
         } else {
           exitCheckStreak = 0
         }
@@ -70,7 +78,11 @@ export async function processStreamingResponse(
     if (remaining) {
       onChunk(remaining)
     }
-    await reader.cancel()
+    try {
+      await reader.cancel()
+    } catch {
+      /* ignore */
+    }
   }
 }
 


### PR DESCRIPTION
## Description

This PR includes two fixes:
1. Cancel any in-flight `reader.read()` before breaking from the streaming loop to avoid Undici’s `TypeError: terminated` when the socket closes mid-read. Errors from `reader.cancel()` are ignored since cancellation is only best-effort cleanup and doesn’t affect already-read data; the runtime/GC will clean up remaining resources automatically.
2. Use native `FormData` in supported runtimes (Deno, Browser, Serverless). Removed leftover `import FormData from 'form-data'`, so that native `FormData` implementation can be used when available. This solves errors like `info: 'a.on is not a function',` in runtimes that have builtin `FormData`.


Closes #2918
