### PR TITLE
fix(deployment): wrong port number in registry-ui

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -99,7 +99,7 @@ services:
       - REGISTRY_TITLE=Docker Registry UI
       - DELETE_IMAGES=true
       - SHOW_CONTENT_DIGEST=true
-      - NGINX_PROXY_PASS_URL=http://localhost:6000
+      - NGINX_PROXY_PASS_URL=http://registry:6000
       - SHOW_CATALOG_NB_TAGS=true
       - CATALOG_MIN_BRANCHES=1
       - CATALOG_MAX_BRANCHES=1
@@ -109,7 +109,7 @@ services:
     networks:
       - daytona-network
     ports:
-      - 5100:5100
+      - 5100:80
 
   registry:
     image: registry:2.8.2


### PR DESCRIPTION
## Description

Following the doc https://www.daytona.io/docs/en/oss-deployment/, we cannot access Registry UI by http://localhost:5100/. This pr fixes the issue.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #2830