### PR TITLE
fix(api): add destroyed state check to update sandbox state

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -15,7 +15,6 @@ import { RunnerService } from './runner.service'
 import { SandboxError } from '../../exceptions/sandbox-error.exception'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { RunnerState } from '../enums/runner-state.enum'
 import { BackupState } from '../enums/backup-state.enum'
 import { Snapshot } from '../entities/snapshot.entity'
 import { SnapshotState } from '../enums/snapshot-state.enum'
@@ -1266,6 +1265,11 @@ export class SandboxService {
     //  only allow updating the state of started | stopped sandboxes
     if (![SandboxState.STARTED, SandboxState.STOPPED].includes(sandbox.state)) {
       throw new BadRequestError('Sandbox is not in a valid state to be updated')
+    }
+
+    if (sandbox.desiredState == SandboxDesiredState.DESTROYED) {
+      this.logger.debug(`Sandbox ${sandboxId} is already DESTROYED, skipping state update`)
+      return
     }
 
     const oldState = sandbox.state


### PR DESCRIPTION
## Description

This pull request introduces a safeguard to the `SandboxService` logic, ensuring that no state updates are performed if the sandbox's desired state is set to `DESTROYED`. This helps prevent unintended changes to sandboxes that are marked for destruction.

State update logic improvement:

* Added a conditional check in the `SandboxService` to immediately return from the state update method if `sandbox.desiredState` is `SandboxDesiredState.DESTROYED`, preventing further state changes for sandboxes pending destruction.

Code cleanup:

* Removed the unused import of `RunnerState` from `apps/api/src/sandbox/services/sandbox.service.ts` to tidy up dependencies.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
