### PR TITLE
feat(proxy): preview warning enable config option

### DIFF
--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -228,21 +228,22 @@ Below is a full list of environment variables with their default values:
 
 ### Proxy
 
-| Variable             | Type    | Default Value               | Description                    |
-| -------------------- | ------- | --------------------------- | ------------------------------ |
-| `DAYTONA_API_URL`    | string  | `http://api:3000/api`       | Daytona API URL                |
-| `PROXY_PORT`         | number  | `4000`                      | Proxy service port             |
-| `PROXY_DOMAIN`       | string  | `proxy.localhost:4000`      | Proxy domain                   |
-| `PROXY_API_KEY`      | string  | `super_secret_key`          | Proxy API authentication key   |
-| `PROXY_PROTOCOL`     | string  | `http`                      | Proxy protocol (http or https) |
-| `OIDC_CLIENT_ID`     | string  | `daytona`                   | OIDC client identifier         |
-| `OIDC_CLIENT_SECRET` | string  | (empty)                     | OIDC client secret             |
-| `OIDC_DOMAIN`        | string  | `http://dex:5556/dex`       | OIDC domain                    |
-| `OIDC_PUBLIC_DOMAIN` | string  | `http://localhost:5556/dex` | OIDC public domain             |
-| `OIDC_AUDIENCE`      | string  | `daytona`                   | OIDC audience identifier       |
-| `REDIS_HOST`         | string  | `redis`                     | Redis server hostname          |
-| `REDIS_PORT`         | number  | `6379`                      | Redis server port              |
-| `TOOLBOX_ONLY_MODE`  | boolean | `false`                     | Allow only toolbox requests    |
+| Variable                  | Type    | Default Value               | Description                    |
+| ------------------------- | ------- | --------------------------- | ------------------------------ |
+| `DAYTONA_API_URL`         | string  | `http://api:3000/api`       | Daytona API URL                |
+| `PROXY_PORT`              | number  | `4000`                      | Proxy service port             |
+| `PROXY_DOMAIN`            | string  | `proxy.localhost:4000`      | Proxy domain                   |
+| `PROXY_API_KEY`           | string  | `super_secret_key`          | Proxy API authentication key   |
+| `PROXY_PROTOCOL`          | string  | `http`                      | Proxy protocol (http or https) |
+| `OIDC_CLIENT_ID`          | string  | `daytona`                   | OIDC client identifier         |
+| `OIDC_CLIENT_SECRET`      | string  | (empty)                     | OIDC client secret             |
+| `OIDC_DOMAIN`             | string  | `http://dex:5556/dex`       | OIDC domain                    |
+| `OIDC_PUBLIC_DOMAIN`      | string  | `http://localhost:5556/dex` | OIDC public domain             |
+| `OIDC_AUDIENCE`           | string  | `daytona`                   | OIDC audience identifier       |
+| `REDIS_HOST`              | string  | `redis`                     | Redis server hostname          |
+| `REDIS_PORT`              | number  | `6379`                      | Redis server port              |
+| `TOOLBOX_ONLY_MODE`       | boolean | `false`                     | Allow only toolbox requests    |
+| `PREVIEW_WARNING_ENABLED` | boolean | `false`                     | Enable browser preview warning |
 
 ## [OPTIONAL] Configure Auth0 for Authentication
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -45,6 +45,8 @@ ENV REDIS_PORT=6379
 
 ENV TOOLBOX_ONLY_MODE=false
 
+ENV PREVIEW_WARNING_ENABLED=false
+
 HEALTHCHECK CMD [ "curl", "-f", "http://localhost:4000/health" ]
 
 ENTRYPOINT ["daytona-proxy"]

--- a/apps/proxy/cmd/proxy/config/config.go
+++ b/apps/proxy/cmd/proxy/config/config.go
@@ -12,17 +12,18 @@ import (
 )
 
 type Config struct {
-	ProxyPort       int          `envconfig:"PROXY_PORT" validate:"required"`
-	ProxyDomain     string       `envconfig:"PROXY_DOMAIN" validate:"required"`
-	ProxyProtocol   string       `envconfig:"PROXY_PROTOCOL" validate:"required"`
-	ProxyApiKey     string       `envconfig:"PROXY_API_KEY" validate:"required"`
-	TLSCertFile     string       `envconfig:"TLS_CERT_FILE"`
-	TLSKeyFile      string       `envconfig:"TLS_KEY_FILE"`
-	EnableTLS       bool         `envconfig:"ENABLE_TLS"`
-	DaytonaApiUrl   string       `envconfig:"DAYTONA_API_URL" validate:"required"`
-	Oidc            OidcConfig   `envconfig:"OIDC"`
-	Redis           *RedisConfig `envconfig:"REDIS"`
-	ToolboxOnlyMode bool         `envconfig:"TOOLBOX_ONLY_MODE"`
+	ProxyPort             int          `envconfig:"PROXY_PORT" validate:"required"`
+	ProxyDomain           string       `envconfig:"PROXY_DOMAIN" validate:"required"`
+	ProxyProtocol         string       `envconfig:"PROXY_PROTOCOL" validate:"required"`
+	ProxyApiKey           string       `envconfig:"PROXY_API_KEY" validate:"required"`
+	TLSCertFile           string       `envconfig:"TLS_CERT_FILE"`
+	TLSKeyFile            string       `envconfig:"TLS_KEY_FILE"`
+	EnableTLS             bool         `envconfig:"ENABLE_TLS"`
+	DaytonaApiUrl         string       `envconfig:"DAYTONA_API_URL" validate:"required"`
+	Oidc                  OidcConfig   `envconfig:"OIDC"`
+	Redis                 *RedisConfig `envconfig:"REDIS"`
+	ToolboxOnlyMode       bool         `envconfig:"TOOLBOX_ONLY_MODE"`
+	PreviewWarningEnabled bool         `envconfig:"PREVIEW_WARNING_ENABLED"`
 }
 
 type OidcConfig struct {

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -129,7 +129,9 @@ func StartProxy(config *config.Config) error {
 		cors.New(corsConfig)(ctx)
 	})
 
-	router.Use(proxy.browserWarningMiddleware())
+	if config.PreviewWarningEnabled {
+		router.Use(proxy.browserWarningMiddleware())
+	}
 
 	router.Any("/*path", func(ctx *gin.Context) {
 		if ctx.Request.Method == "POST" && ctx.Request.URL.Path == ACCEPT_PREVIEW_PAGE_WARNING_PATH {


### PR DESCRIPTION
## Description

Added an environment variable to enable the preview warning in the proxy service.

If `PREVIEW_WARNING_ENABLED` is set to `true`, the proxy will show the preview warning.
By default, the warning is disabled.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

Closes https://github.com/daytonaio/daytona/issues/2934