### PR TITLE
feat(proxy): separate cookie domain

### DIFF
--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -228,22 +228,23 @@ Below is a full list of environment variables with their default values:
 
 ### Proxy
 
-| Variable                  | Type    | Default Value               | Description                    |
-| ------------------------- | ------- | --------------------------- | ------------------------------ |
-| `DAYTONA_API_URL`         | string  | `http://api:3000/api`       | Daytona API URL                |
-| `PROXY_PORT`              | number  | `4000`                      | Proxy service port             |
-| `PROXY_DOMAIN`            | string  | `proxy.localhost:4000`      | Proxy domain                   |
-| `PROXY_API_KEY`           | string  | `super_secret_key`          | Proxy API authentication key   |
-| `PROXY_PROTOCOL`          | string  | `http`                      | Proxy protocol (http or https) |
-| `OIDC_CLIENT_ID`          | string  | `daytona`                   | OIDC client identifier         |
-| `OIDC_CLIENT_SECRET`      | string  | (empty)                     | OIDC client secret             |
-| `OIDC_DOMAIN`             | string  | `http://dex:5556/dex`       | OIDC domain                    |
-| `OIDC_PUBLIC_DOMAIN`      | string  | `http://localhost:5556/dex` | OIDC public domain             |
-| `OIDC_AUDIENCE`           | string  | `daytona`                   | OIDC audience identifier       |
-| `REDIS_HOST`              | string  | `redis`                     | Redis server hostname          |
-| `REDIS_PORT`              | number  | `6379`                      | Redis server port              |
-| `TOOLBOX_ONLY_MODE`       | boolean | `false`                     | Allow only toolbox requests    |
-| `PREVIEW_WARNING_ENABLED` | boolean | `false`                     | Enable browser preview warning |
+| Variable                  | Type    | Default Value               | Description                     |
+| ------------------------- | ------- | --------------------------- | ------------------------------- |
+| `DAYTONA_API_URL`         | string  | `http://api:3000/api`       | Daytona API URL                 |
+| `PROXY_PORT`              | number  | `4000`                      | Proxy service port              |
+| `PROXY_DOMAIN`            | string  | `proxy.localhost:4000`      | Proxy domain                    |
+| `PROXY_API_KEY`           | string  | `super_secret_key`          | Proxy API authentication key    |
+| `PROXY_PROTOCOL`          | string  | `http`                      | Proxy protocol (http or https)  |
+| `COOKIE_DOMAIN`           | string  | `$PROXY_DOMAIN`             | Cookie domain for proxy cookies |
+| `OIDC_CLIENT_ID`          | string  | `daytona`                   | OIDC client identifier          |
+| `OIDC_CLIENT_SECRET`      | string  | (empty)                     | OIDC client secret              |
+| `OIDC_DOMAIN`             | string  | `http://dex:5556/dex`       | OIDC domain                     |
+| `OIDC_PUBLIC_DOMAIN`      | string  | `http://localhost:5556/dex` | OIDC public domain              |
+| `OIDC_AUDIENCE`           | string  | `daytona`                   | OIDC audience identifier        |
+| `REDIS_HOST`              | string  | `redis`                     | Redis server hostname           |
+| `REDIS_PORT`              | number  | `6379`                      | Redis server port               |
+| `TOOLBOX_ONLY_MODE`       | boolean | `false`                     | Allow only toolbox requests     |
+| `PREVIEW_WARNING_ENABLED` | boolean | `false`                     | Enable browser preview warning  |
 
 ## [OPTIONAL] Configure Auth0 for Authentication
 

--- a/apps/proxy/cmd/proxy/config/config.go
+++ b/apps/proxy/cmd/proxy/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	ProxyDomain           string       `envconfig:"PROXY_DOMAIN" validate:"required"`
 	ProxyProtocol         string       `envconfig:"PROXY_PROTOCOL" validate:"required"`
 	ProxyApiKey           string       `envconfig:"PROXY_API_KEY" validate:"required"`
+	CookieDomain          *string      `envconfig:"COOKIE_DOMAIN"`
 	TLSCertFile           string       `envconfig:"TLS_CERT_FILE"`
 	TLSKeyFile            string       `envconfig:"TLS_KEY_FILE"`
 	EnableTLS             bool         `envconfig:"ENABLE_TLS"`

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -58,6 +58,9 @@ func StartProxy(config *config.Config) error {
 
 	proxy.secureCookie = securecookie.New([]byte(config.ProxyApiKey), nil)
 	cookieDomain := config.ProxyDomain
+	if config.CookieDomain != nil {
+		cookieDomain = *config.CookieDomain
+	}
 	cookieDomain = strings.Split(cookieDomain, ":")[0]
 	cookieDomain = fmt.Sprintf(".%s", cookieDomain)
 	proxy.cookieDomain = cookieDomain


### PR DESCRIPTION
## Description

Separate config value for proxy COOKIE_DOMAIN.

Used in self-hosted single-domain setups where the proxy and API share a domain.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation
