### PR TITLE
fix(api): sync states db streaming

### DIFF
--- a/apps/api/src/sandbox/common/redis-lock.provider.ts
+++ b/apps/api/src/sandbox/common/redis-lock.provider.ts
@@ -36,7 +36,7 @@ export class RedisLockProvider {
     await this.redis.del(key)
   }
 
-  async locked(key: string): Promise<boolean> {
+  async isLocked(key: string): Promise<boolean> {
     const exists = await this.redis.exists(key)
     return exists === 1
   }


### PR DESCRIPTION
## Description

This pull request introduces significant improvements to the sandbox state synchronization logic, focusing on better concurrency control, increased throughput, and the addition of a targeted cron job for archived/completed sandboxes. The changes optimize how sandboxes are processed in batches, minimize redundant processing, and enhance system reliability.

**Concurrency and Locking Improvements:**

* Added a new `locked` method to `RedisLockProvider` to check if a lock exists for a given key, enabling the system to skip sandboxes that are already being processed.
* Updated the sandbox streaming sync to check for per-sandbox locks before processing, preventing duplicate work and improving reliability.

**Performance and Throughput Enhancements:**

* Increased the batch size for sandbox processing from 100 to 200 in one query, and raised the per-run processing limit from 100 to 1000, allowing for higher throughput.
* Changed concurrent promise handling from `Promise.all` to `Promise.allSettled` to ensure all processing attempts are accounted for, even if some fail, which improves robustness.

**Cron Job and State Sync Updates:**

* Renamed the main cron job to `sync-states-streaming` and increased its lock TTL from 30 seconds to one hour, reducing the risk of overlapping executions.
* Added a new cron job, `sync-archived-completed-states`, to specifically handle sandboxes in the archiving/completed state, ensuring these are processed efficiently and separately from the main sync.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
