### PR TITLE
fix(api): sync start states fix

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -539,7 +539,6 @@ export class SandboxStartAction extends SandboxAction {
         break
       }
       case SandboxState.STARTING:
-        this.logger.warn(`Timeout while starting sandbox ${sandbox.id} last activity at ${sandbox.lastActivityAt}`)
         if (await this.checkTimeoutError(sandbox, 5, 'Timeout while starting sandbox')) {
           return DONT_SYNC_AGAIN
         }


### PR DESCRIPTION
## Description

This pull request improves error handling and runner selection logic in the `SandboxStartAction` class. The main changes focus on handling sandbox timeouts more robustly, improving logging for unexpected states, and fixing runner exclusion logic during sandbox assignment.

**Error handling and timeout management:**

* Added timeout checks for various sandbox states (`STARTING`, `RESTORING`, `CREATING`, and `DESTROYED`) using a new `checkTimeoutError` method, which transitions sandboxes to an error state if they exceed the allowed inactivity period. 
* Improved logging for sandboxes in destroyed or unexpected states, and replaced direct `console.error` usage with structured logger calls.

**Code cleanup and refactoring:**

* Removed the unused and outdated `getEntrypointFromDockerfile` method, replacing it with the new `checkTimeoutError` utility for timeout handling.

**Runner selection improvements:**

* Fixed the logic for excluding runner IDs by properly handling the case when `excludedRunnerId` is not set, ensuring that runner exclusion works as intended during assignment. 
* Improved runner availability logging to handle cases where the runner object may be null.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
