### PR TITLE
fix(api): runner assign on failed sandbox build

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -181,7 +181,7 @@ export class SandboxStartAction extends SandboxAction {
           await this.updateSandboxState(sandbox.id, targetSandboxState, lockCode, runner.id)
           return SYNC_AGAIN
         } else if (snapshotRunner.state === SnapshotRunnerState.ERROR) {
-          await this.updateSandboxState(sandbox.id, errorSandboxState, lockCode, snapshotRunner.errorReason)
+          await this.updateSandboxState(sandbox.id, errorSandboxState, lockCode, runner.id, snapshotRunner.errorReason)
           return DONT_SYNC_AGAIN
         }
       }


### PR DESCRIPTION
## Runner assign on failed sandbox build

Makes the sandbox get a runner assigned on failed declarative image build

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
