### PR TITLE
feat(api): multiple regions param

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -155,7 +155,7 @@ export class SandboxStartAction extends SandboxAction {
     // Try to assign an available runner with the snapshot already available
     try {
       const runner = await this.runnerService.getRandomAvailableRunner({
-        region: [sandbox.region],
+        regions: [sandbox.region],
         sandboxClass: sandbox.class,
         snapshotRef: snapshotRef,
       })
@@ -197,7 +197,7 @@ export class SandboxStartAction extends SandboxAction {
 
     try {
       runner = await this.runnerService.getRandomAvailableRunner({
-        region: [sandbox.region],
+        regions: [sandbox.region],
         sandboxClass: sandbox.class,
         excludedRunnerIds: excludedRunnerIds,
       })
@@ -379,7 +379,7 @@ export class SandboxStartAction extends SandboxAction {
       if (sandbox.backupState === BackupState.COMPLETED) {
         if (runner.availabilityScore < this.configService.getOrThrow('runnerUsage.availabilityScoreThreshold')) {
           const availableRunners = await this.runnerService.findAvailableRunners({
-            region: [sandbox.region],
+            regions: [sandbox.region],
             sandboxClass: sandbox.class,
           })
           const lessUsedRunners = availableRunners.filter((runner) => runner.id !== originalRunnerId)
@@ -708,7 +708,7 @@ export class SandboxStartAction extends SandboxAction {
 
     const runnersWithBaseSnapshot: Runner[] = snapshotRef
       ? await this.runnerService.findAvailableRunners({
-          region: [sandbox.region],
+          regions: [sandbox.region],
           sandboxClass: sandbox.class,
           snapshotRef,
           excludedRunnerIds,
@@ -719,8 +719,8 @@ export class SandboxStartAction extends SandboxAction {
     } else {
       //  if no runner has the base snapshot, get all available runners
       availableRunners = await this.runnerService.findAvailableRunners({
-        region: [sandbox.region],
-        excludedRunnerIds: [excludedRunnerId],
+        regions: [sandbox.region],
+        excludedRunnerIds,
       })
     }
 

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -809,7 +809,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       }
 
       initialRunner = await this.runnerService.getRandomAvailableRunner({
-        region: [defaultRegion],
+        regions: [defaultRegion],
         excludedRunnerIds: excludedRunnerIds,
       })
     } catch (error) {

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -149,8 +149,8 @@ export class RunnerService {
       runnerFilter.id = Not(In(excludedRunnerIds))
     }
 
-    if (params.region?.length) {
-      runnerFilter.region = In(params.region)
+    if (params.regions?.length) {
+      runnerFilter.region = In(params.regions)
     }
 
     if (params.sandboxClass !== undefined) {
@@ -594,7 +594,7 @@ export class RunnerService {
 }
 
 export class GetRunnerParams {
-  region?: string[]
+  regions?: string[]
   sandboxClass?: SandboxClass
   snapshotRef?: string
   excludedRunnerIds?: string[]

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -258,7 +258,7 @@ export class SandboxService {
     }
 
     const runner = await this.runnerService.getRandomAvailableRunner({
-      region: [sandbox.region],
+      regions: [sandbox.region],
       sandboxClass: sandbox.class,
       snapshotRef: snapshot.ref,
     })
@@ -380,7 +380,7 @@ export class SandboxService {
       }
 
       const runner = await this.runnerService.getRandomAvailableRunner({
-        region: [region],
+        regions: [region],
         sandboxClass,
         snapshotRef: snapshot.ref,
       })
@@ -613,7 +613,7 @@ export class SandboxService {
 
       try {
         runner = await this.runnerService.getRandomAvailableRunner({
-          region: [sandbox.region],
+          regions: [sandbox.region],
           sandboxClass: sandbox.class,
           snapshotRef: sandbox.buildInfo.snapshotRef,
         })


### PR DESCRIPTION
## Multiple regions param

Makes the region param when retrieving runners be an array of strings instead of a single string

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
