### PR TITLE
fix(api): proxy cache invalidation service

### DIFF
--- a/apps/api/src/sandbox/sandbox.module.ts
+++ b/apps/api/src/sandbox/sandbox.module.ts
@@ -45,6 +45,7 @@ import { SandboxDestroyAction } from './managers/sandbox-actions/sandbox-destroy
 import { SandboxArchiveAction } from './managers/sandbox-actions/sandbox-archive.action'
 import { SshAccess } from './entities/ssh-access.entity'
 import { SandboxRepository } from './repositories/sandbox.repository'
+import { ProxyCacheInvalidationService } from './services/proxy-cache-invalidation.service'
 
 @Module({
   imports: [
@@ -80,6 +81,7 @@ import { SandboxRepository } from './repositories/sandbox.repository'
     RunnerService,
     ToolboxService,
     SnapshotService,
+    ProxyCacheInvalidationService,
     SnapshotManager,
     SandboxSubscriber,
     RedisLockProvider,

--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import { Injectable, Logger } from '@nestjs/common'
+import { OnEvent } from '@nestjs/event-emitter'
+import Redis from 'ioredis'
+
+import { SandboxEvents } from '../constants/sandbox-events.constants'
+import { SandboxArchivedEvent } from '../events/sandbox-archived.event'
+
+@Injectable()
+export class ProxyCacheInvalidationService {
+  private readonly logger = new Logger(ProxyCacheInvalidationService.name)
+  private static readonly RUNNER_INFO_CACHE_PREFIX = 'proxy:sandbox-runner-info:'
+
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  @OnEvent(SandboxEvents.ARCHIVED)
+  async handleSandboxArchived(event: SandboxArchivedEvent): Promise<void> {
+    await this.invalidateRunnerCache(event.sandbox.id)
+  }
+
+  private async invalidateRunnerCache(sandboxId: string): Promise<void> {
+    try {
+      await this.redis.del(`${ProxyCacheInvalidationService.RUNNER_INFO_CACHE_PREFIX}${sandboxId}`)
+      this.logger.debug(`Invalidated sandbox runner cache for ${sandboxId}`)
+    } catch (error) {
+      this.logger.warn(`Failed to invalidate runner cache for sandbox ${sandboxId}: ${error.message}`)
+    }
+  }
+}


### PR DESCRIPTION
## Proxy cache invalidation service

Adds a proxy cache invalidation service to the API which makes sure that once a Sandbox starts being archived and is eventually restored, the proxy will have the latest information on which runner it is assigned to instead of potentially fetching the wrong one from cache

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
