### PR TITLE
feat(api): support configuration file loading

### DIFF
--- a/apps/api/config-map.example.yaml
+++ b/apps/api/config-map.example.yaml
@@ -1,0 +1,67 @@
+# Example configuration file for Daytona API
+# Environment variables take precedence over values in this file
+# The config map can be yaml or json
+# To use this file, set the CONFIG_MAP_PATH environment variable to point to it
+
+port: 3000
+appUrl: https://api.example.com
+
+database:
+  host: db
+  port: 5432
+  username: daytona
+  password: password
+  database: daytona
+  tls:
+    enabled: false
+    rejectUnauthorized: true
+
+redis:
+  host: redis
+  port: 6379
+  tls: false
+
+smtp:
+  host: smtp.example.com
+  port: 587
+  user: noreply@example.com
+  password: smtp-password
+  secure: false
+  from: noreply@example.com
+
+s3:
+  endpoint: https://s3.amazonaws.com
+  region: us-east-1
+  accessKey: your-access-key
+  secretKey: your-secret-key
+  defaultBucket: daytona-bucket
+
+defaultRunner:
+  domain: runner.example.com
+  apiKey: runner-api-key
+  proxyUrl: https://proxy.example.com
+  apiUrl: https://api.runner.example.com
+  cpu: 4
+  memory: 8
+  disk: 50
+  gpu: 0
+  region: us
+  version: '0'
+
+log:
+  level: info
+  console:
+    disabled: false
+  requests:
+    enabled: true
+
+defaultOrganizationQuota:
+  totalCpuQuota: 10
+  totalMemoryQuota: 10
+  totalDiskQuota: 30
+  maxCpuPerSandbox: 4
+  maxMemoryPerSandbox: 8
+  maxDiskPerSandbox: 10
+  snapshotQuota: 100
+  maxSnapshotSize: 20
+  volumeQuota: 100

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -44,7 +44,7 @@ export class AppService implements OnApplicationBootstrap, OnApplicationShutdown
   }
 
   async onApplicationBootstrap() {
-    if (this.configService.get('disableCronJobs') || this.configService.get('maintananceMode')) {
+    if (this.configService.get('disableCronJobs') || this.configService.get('maintenanceMode')) {
       await this.stopAllCronJobs()
     }
 

--- a/apps/api/src/common/middleware/maintenance.middleware.ts
+++ b/apps/api/src/common/middleware/maintenance.middleware.ts
@@ -12,7 +12,7 @@ export class MaintenanceMiddleware implements NestMiddleware {
   constructor(private readonly configService: TypedConfigService) {}
 
   use(req: Request, res: Response, next: NextFunction) {
-    const isMaintenanceMode = this.configService.get('maintananceMode')
+    const isMaintenanceMode = this.configService.get('maintenanceMode')
 
     if (isMaintenanceMode) {
       throw new HttpException(

--- a/apps/api/src/config/config-map.loader.ts
+++ b/apps/api/src/config/config-map.loader.ts
@@ -87,5 +87,6 @@ export function getConfigValue(envVar: string, configMapPath: string, configMap:
   }
 
   // Fall back to config map
-  return getNestedValue(configMap, configMapPath)
+  const configValue = getNestedValue(configMap, configMapPath)
+  return configValue === undefined || configValue === null ? undefined : String(configValue)
 }

--- a/apps/api/src/config/config-map.loader.ts
+++ b/apps/api/src/config/config-map.loader.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { parse as parseYaml } from 'yaml'
+import { Logger } from '@nestjs/common'
+
+const logger = new Logger('ConfigMapLoader')
+
+export interface ConfigMap {
+  [key: string]: any
+}
+
+/**
+ * Loads configuration from a JSON or YAML file.
+ * Supports nested configuration objects.
+ *
+ * @param filePath - Path to the config file (JSON or YAML)
+ * @returns Parsed configuration object or empty object if file doesn't exist
+ */
+export function loadConfigMap(filePath?: string): ConfigMap {
+  if (!filePath) {
+    logger.debug('No config map file path provided')
+    return {}
+  }
+
+  if (!existsSync(filePath)) {
+    throw new Error(`Config map file not found: ${filePath}`)
+  }
+
+  try {
+    const fileContent = readFileSync(filePath, 'utf8')
+    const isYaml = filePath.endsWith('.yaml') || filePath.endsWith('.yml')
+
+    const config = isYaml ? parseYaml(fileContent) : JSON.parse(fileContent)
+
+    logger.log(`Successfully loaded config map from: ${filePath}`)
+    return config || {}
+  } catch (error) {
+    logger.error(`Failed to parse config map file: ${filePath}`, error.stack)
+    throw new Error(`Failed to parse config map file: ${filePath}. ${error.message}`)
+  }
+}
+
+/**
+ * Gets a nested value from an object using dot notation.
+ * Example: getNestedValue({ database: { host: 'localhost' } }, 'database.host') => 'localhost'
+ *
+ * @param obj - Source object
+ * @param path - Dot-separated path (e.g., 'database.host')
+ * @returns Value at the path or undefined
+ */
+export function getNestedValue(obj: any, path: string): any {
+  if (!obj || typeof obj !== 'object') {
+    return undefined
+  }
+
+  const keys = path.split('.')
+  let current = obj
+
+  for (const key of keys) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return undefined
+    }
+    current = current[key]
+  }
+
+  return current
+}
+
+/**
+ * Gets a value from environment variable or falls back to config map.
+ * Supports nested config map paths using dot notation.
+ *
+ * @param envVar - Environment variable name
+ * @param configMapPath - Dot-separated path in config map (e.g., 'database.host')
+ * @param configMap - Loaded config map object
+ * @returns Value from env or config map, or undefined
+ */
+export function getConfigValue(envVar: string, configMapPath: string, configMap: ConfigMap): string | undefined {
+  // Environment variables take precedence
+  const envValue = process.env[envVar]
+  if (envValue !== undefined && envValue !== '') {
+    return envValue
+  }
+
+  // Fall back to config map
+  return getNestedValue(configMap, configMapPath)
+}

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -315,7 +315,7 @@ const configuration = {
     ),
     userCacheTtlSeconds: getIntConfig('API_KEY_USER_CACHE_TTL_SECONDS', 'apiKey.userCacheTtlSeconds', '60'),
   },
-  runnerHealthTimeout: parseInt(process.env.RUNNER_HEALTH_TIMEOUT_SECONDS || '3', 10),
+  runnerHealthTimeout: getIntConfig('RUNNER_HEALTH_TIMEOUT_SECONDS', 'runnerHealthTimeout', '3'),
 }
 
 export { configuration }

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -108,7 +108,7 @@ const configuration = {
   },
   skipConnections: getBoolConfig('SKIP_CONNECTIONS', 'skipConnections'),
   maxAutoArchiveInterval: getIntConfig('MAX_AUTO_ARCHIVE_INTERVAL', 'maxAutoArchiveInterval', '43200'),
-  maintananceMode: getBoolConfig('MAINTENANCE_MODE', 'maintananceMode'),
+  maintenanceMode: getBoolConfig('MAINTENANCE_MODE', 'maintenanceMode'),
   disableCronJobs: getBoolConfig('DISABLE_CRON_JOBS', 'disableCronJobs'),
   appRole: getConfig('APP_ROLE', 'appRole', 'all'),
   proxy: {

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -122,9 +122,7 @@ const configuration = {
   },
   audit: {
     toolboxRequestsEnabled: getBoolConfig('AUDIT_TOOLBOX_REQUESTS_ENABLED', 'audit.toolboxRequestsEnabled'),
-    retentionDays: getConfig('AUDIT_LOG_RETENTION_DAYS', 'audit.retentionDays')
-      ? parseInt(getConfig('AUDIT_LOG_RETENTION_DAYS', 'audit.retentionDays'), 10)
-      : undefined,
+    retentionDays: getIntConfig('AUDIT_LOG_RETENTION_DAYS', 'audit.retentionDays'),
     consoleLogEnabled: getBoolConfig('AUDIT_CONSOLE_LOG_ENABLED', 'audit.consoleLogEnabled'),
     publish: {
       enabled: getBoolConfig('AUDIT_PUBLISH_ENABLED', 'audit.publish.enabled'),

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -4,250 +4,318 @@
  */
 
 import { SandboxClass } from '../sandbox/enums/sandbox-class.enum'
+import { getConfigValue, loadConfigMap } from './config-map.loader'
+
+// Load config map from file specified in CONFIG_MAP_PATH environment variable
+const configMap = loadConfigMap(process.env.CONFIG_MAP_PATH)
+
+// Helper function to get config value with env precedence
+const getConfig = (envVar: string, configPath: string, defaultValue?: string): string | undefined => {
+  return getConfigValue(envVar, configPath, configMap) || defaultValue
+}
+
+// Helper function to parse int with config map support
+const getIntConfig = (envVar: string, configPath: string, defaultValue?: string): number | undefined => {
+  const value = getConfig(envVar, configPath, defaultValue)
+  return value !== undefined ? parseInt(value, 10) : undefined
+}
+
+// Helper function to parse float with config map support
+const getFloatConfig = (envVar: string, configPath: string, defaultValue?: string): number => {
+  const value = getConfig(envVar, configPath, defaultValue)
+  return parseFloat(value || '0')
+}
+
+// Helper function to parse boolean with config map support
+const getBoolConfig = (envVar: string, configPath: string): boolean => {
+  const value = getConfig(envVar, configPath)
+  return value === 'true'
+}
 
 const configuration = {
   production: process.env.NODE_ENV === 'production',
-  version: process.env.VERSION || '0.0.0-dev',
-  environment: process.env.ENVIRONMENT,
-  runMigrations: process.env.RUN_MIGRATIONS === 'true',
-  port: parseInt(process.env.PORT, 10),
-  appUrl: process.env.APP_URL,
+  version: getConfig('VERSION', 'version', '0.0.0-dev'),
+  environment: getConfig('ENVIRONMENT', 'environment'),
+  runMigrations: getBoolConfig('RUN_MIGRATIONS', 'runMigrations'),
+  port: getIntConfig('PORT', 'port'),
+  appUrl: getConfig('APP_URL', 'appUrl'),
   database: {
-    host: process.env.DB_HOST,
-    port: parseInt(process.env.DB_PORT || '5432', 10),
-    username: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_DATABASE,
+    host: getConfig('DB_HOST', 'database.host'),
+    port: getIntConfig('DB_PORT', 'database.port', '5432'),
+    username: getConfig('DB_USERNAME', 'database.username'),
+    password: getConfig('DB_PASSWORD', 'database.password'),
+    database: getConfig('DB_DATABASE', 'database.database'),
     tls: {
-      enabled: process.env.DB_TLS_ENABLED === 'true',
-      rejectUnauthorized: process.env.DB_TLS_REJECT_UNAUTHORIZED !== 'false',
+      enabled: getBoolConfig('DB_TLS_ENABLED', 'database.tls.enabled'),
+      rejectUnauthorized: getConfig('DB_TLS_REJECT_UNAUTHORIZED', 'database.tls.rejectUnauthorized') !== 'false',
     },
   },
   redis: {
-    host: process.env.REDIS_HOST,
-    port: parseInt(process.env.REDIS_PORT || '6379', 10),
-    tls: process.env.REDIS_TLS === 'true' ? {} : undefined,
+    host: getConfig('REDIS_HOST', 'redis.host'),
+    port: getIntConfig('REDIS_PORT', 'redis.port', '6379'),
+    tls: getBoolConfig('REDIS_TLS', 'redis.tls') ? {} : undefined,
   },
   posthog: {
-    apiKey: process.env.POSTHOG_API_KEY,
-    host: process.env.POSTHOG_HOST,
-    environment: process.env.POSTHOG_ENVIRONMENT,
+    apiKey: getConfig('POSTHOG_API_KEY', 'posthog.apiKey'),
+    host: getConfig('POSTHOG_HOST', 'posthog.host'),
+    environment: getConfig('POSTHOG_ENVIRONMENT', 'posthog.environment'),
   },
   oidc: {
-    clientId: process.env.OIDC_CLIENT_ID || process.env.OID_CLIENT_ID,
-    issuer: process.env.OIDC_ISSUER_BASE_URL || process.env.OID_ISSUER_BASE_URL,
-    publicIssuer: process.env.PUBLIC_OIDC_DOMAIN,
-    audience: process.env.OIDC_AUDIENCE || process.env.OID_AUDIENCE,
+    clientId: getConfig('OIDC_CLIENT_ID', 'oidc.clientId') || getConfig('OID_CLIENT_ID', 'oidc.clientId'),
+    issuer: getConfig('OIDC_ISSUER_BASE_URL', 'oidc.issuer') || getConfig('OID_ISSUER_BASE_URL', 'oidc.issuer'),
+    publicIssuer: getConfig('PUBLIC_OIDC_DOMAIN', 'oidc.publicIssuer'),
+    audience: getConfig('OIDC_AUDIENCE', 'oidc.audience') || getConfig('OID_AUDIENCE', 'oidc.audience'),
     managementApi: {
-      enabled: process.env.OIDC_MANAGEMENT_API_ENABLED === 'true',
-      clientId: process.env.OIDC_MANAGEMENT_API_CLIENT_ID,
-      clientSecret: process.env.OIDC_MANAGEMENT_API_CLIENT_SECRET,
-      audience: process.env.OIDC_MANAGEMENT_API_AUDIENCE,
+      enabled: getBoolConfig('OIDC_MANAGEMENT_API_ENABLED', 'oidc.managementApi.enabled'),
+      clientId: getConfig('OIDC_MANAGEMENT_API_CLIENT_ID', 'oidc.managementApi.clientId'),
+      clientSecret: getConfig('OIDC_MANAGEMENT_API_CLIENT_SECRET', 'oidc.managementApi.clientSecret'),
+      audience: getConfig('OIDC_MANAGEMENT_API_AUDIENCE', 'oidc.managementApi.audience'),
     },
   },
   smtp: {
-    host: process.env.SMTP_HOST,
-    port: parseInt(process.env.SMTP_PORT || '587', 10),
-    user: process.env.SMTP_USER,
-    password: process.env.SMTP_PASSWORD,
-    secure: process.env.SMTP_SECURE === 'true',
-    from: process.env.SMTP_EMAIL_FROM || 'noreply@mail.daytona.io',
+    host: getConfig('SMTP_HOST', 'smtp.host'),
+    port: getIntConfig('SMTP_PORT', 'smtp.port', '587'),
+    user: getConfig('SMTP_USER', 'smtp.user'),
+    password: getConfig('SMTP_PASSWORD', 'smtp.password'),
+    secure: getBoolConfig('SMTP_SECURE', 'smtp.secure'),
+    from: getConfig('SMTP_EMAIL_FROM', 'smtp.from', 'noreply@mail.daytona.io'),
   },
-  defaultSnapshot: process.env.DEFAULT_SNAPSHOT,
-  dashboardUrl: process.env.DASHBOARD_URL,
+  defaultSnapshot: getConfig('DEFAULT_SNAPSHOT', 'defaultSnapshot'),
+  dashboardUrl: getConfig('DASHBOARD_URL', 'dashboardUrl'),
   // Default to empty string - dashboard will then hit '/api'
-  dashboardBaseApiUrl: process.env.DASHBOARD_BASE_API_URL || '',
+  dashboardBaseApiUrl: getConfig('DASHBOARD_BASE_API_URL', 'dashboardBaseApiUrl', ''),
   transientRegistry: {
-    url: process.env.TRANSIENT_REGISTRY_URL,
-    admin: process.env.TRANSIENT_REGISTRY_ADMIN,
-    password: process.env.TRANSIENT_REGISTRY_PASSWORD,
-    projectId: process.env.TRANSIENT_REGISTRY_PROJECT_ID,
+    url: getConfig('TRANSIENT_REGISTRY_URL', 'transientRegistry.url'),
+    admin: getConfig('TRANSIENT_REGISTRY_ADMIN', 'transientRegistry.admin'),
+    password: getConfig('TRANSIENT_REGISTRY_PASSWORD', 'transientRegistry.password'),
+    projectId: getConfig('TRANSIENT_REGISTRY_PROJECT_ID', 'transientRegistry.projectId'),
   },
   internalRegistry: {
-    url: process.env.INTERNAL_REGISTRY_URL,
-    admin: process.env.INTERNAL_REGISTRY_ADMIN,
-    password: process.env.INTERNAL_REGISTRY_PASSWORD,
-    projectId: process.env.INTERNAL_REGISTRY_PROJECT_ID,
+    url: getConfig('INTERNAL_REGISTRY_URL', 'internalRegistry.url'),
+    admin: getConfig('INTERNAL_REGISTRY_ADMIN', 'internalRegistry.admin'),
+    password: getConfig('INTERNAL_REGISTRY_PASSWORD', 'internalRegistry.password'),
+    projectId: getConfig('INTERNAL_REGISTRY_PROJECT_ID', 'internalRegistry.projectId'),
   },
   s3: {
-    endpoint: process.env.S3_ENDPOINT,
-    stsEndpoint: process.env.S3_STS_ENDPOINT,
-    region: process.env.S3_REGION,
-    accessKey: process.env.S3_ACCESS_KEY,
-    secretKey: process.env.S3_SECRET_KEY,
-    defaultBucket: process.env.S3_DEFAULT_BUCKET,
-    accountId: process.env.S3_ACCOUNT_ID,
-    roleName: process.env.S3_ROLE_NAME,
+    endpoint: getConfig('S3_ENDPOINT', 's3.endpoint'),
+    stsEndpoint: getConfig('S3_STS_ENDPOINT', 's3.stsEndpoint'),
+    region: getConfig('S3_REGION', 's3.region'),
+    accessKey: getConfig('S3_ACCESS_KEY', 's3.accessKey'),
+    secretKey: getConfig('S3_SECRET_KEY', 's3.secretKey'),
+    defaultBucket: getConfig('S3_DEFAULT_BUCKET', 's3.defaultBucket'),
+    accountId: getConfig('S3_ACCOUNT_ID', 's3.accountId'),
+    roleName: getConfig('S3_ROLE_NAME', 's3.roleName'),
   },
-  skipConnections: process.env.SKIP_CONNECTIONS === 'true',
-  maxAutoArchiveInterval: parseInt(process.env.MAX_AUTO_ARCHIVE_INTERVAL || '43200', 10),
-  maintananceMode: process.env.MAINTENANCE_MODE === 'true',
-  disableCronJobs: process.env.DISABLE_CRON_JOBS === 'true',
-  appRole: process.env.APP_ROLE || 'all',
+  skipConnections: getBoolConfig('SKIP_CONNECTIONS', 'skipConnections'),
+  maxAutoArchiveInterval: getIntConfig('MAX_AUTO_ARCHIVE_INTERVAL', 'maxAutoArchiveInterval', '43200'),
+  maintananceMode: getBoolConfig('MAINTENANCE_MODE', 'maintananceMode'),
+  disableCronJobs: getBoolConfig('DISABLE_CRON_JOBS', 'disableCronJobs'),
+  appRole: getConfig('APP_ROLE', 'appRole', 'all'),
   proxy: {
-    domain: process.env.PROXY_DOMAIN,
-    protocol: process.env.PROXY_PROTOCOL,
-    apiKey: process.env.PROXY_API_KEY,
-    templateUrl: process.env.PROXY_TEMPLATE_URL,
+    domain: getConfig('PROXY_DOMAIN', 'proxy.domain'),
+    protocol: getConfig('PROXY_PROTOCOL', 'proxy.protocol'),
+    apiKey: getConfig('PROXY_API_KEY', 'proxy.apiKey'),
+    templateUrl: getConfig('PROXY_TEMPLATE_URL', 'proxy.templateUrl'),
     toolboxUrl:
-      (process.env.PROXY_TOOLBOX_BASE_URL || `${process.env.PROXY_PROTOCOL}://${process.env.PROXY_DOMAIN}`) +
-      '/toolbox',
+      (getConfig('PROXY_TOOLBOX_BASE_URL', 'proxy.toolboxUrl') ||
+        `${getConfig('PROXY_PROTOCOL', 'proxy.protocol')}://${getConfig('PROXY_DOMAIN', 'proxy.domain')}`) + '/toolbox',
   },
   audit: {
-    toolboxRequestsEnabled: process.env.AUDIT_TOOLBOX_REQUESTS_ENABLED === 'true',
-    retentionDays: process.env.AUDIT_LOG_RETENTION_DAYS
-      ? parseInt(process.env.AUDIT_LOG_RETENTION_DAYS, 10)
+    toolboxRequestsEnabled: getBoolConfig('AUDIT_TOOLBOX_REQUESTS_ENABLED', 'audit.toolboxRequestsEnabled'),
+    retentionDays: getConfig('AUDIT_LOG_RETENTION_DAYS', 'audit.retentionDays')
+      ? parseInt(getConfig('AUDIT_LOG_RETENTION_DAYS', 'audit.retentionDays'), 10)
       : undefined,
-    consoleLogEnabled: process.env.AUDIT_CONSOLE_LOG_ENABLED === 'true',
+    consoleLogEnabled: getBoolConfig('AUDIT_CONSOLE_LOG_ENABLED', 'audit.consoleLogEnabled'),
     publish: {
-      enabled: process.env.AUDIT_PUBLISH_ENABLED === 'true',
-      batchSize: process.env.AUDIT_PUBLISH_BATCH_SIZE ? parseInt(process.env.AUDIT_PUBLISH_BATCH_SIZE, 10) : 1000,
-      mode: (process.env.AUDIT_PUBLISH_MODE || 'direct') as 'direct' | 'kafka',
-      storageAdapter: process.env.AUDIT_PUBLISH_STORAGE_ADAPTER || 'opensearch',
-      opensearchIndexName: process.env.AUDIT_PUBLISH_OPENSEARCH_INDEX_NAME || 'audit-logs',
+      enabled: getBoolConfig('AUDIT_PUBLISH_ENABLED', 'audit.publish.enabled'),
+      batchSize: getIntConfig('AUDIT_PUBLISH_BATCH_SIZE', 'audit.publish.batchSize', '1000'),
+      mode: getConfig('AUDIT_PUBLISH_MODE', 'audit.publish.mode', 'direct') as 'direct' | 'kafka',
+      storageAdapter: getConfig('AUDIT_PUBLISH_STORAGE_ADAPTER', 'audit.publish.storageAdapter', 'opensearch'),
+      opensearchIndexName: getConfig(
+        'AUDIT_PUBLISH_OPENSEARCH_INDEX_NAME',
+        'audit.publish.opensearchIndexName',
+        'audit-logs',
+      ),
     },
   },
   kafka: {
-    enabled: process.env.KAFKA_ENABLED === 'true',
-    brokers: process.env.KAFKA_BROKERS || 'localhost:9092',
-    clientId: process.env.KAFKA_CLIENT_ID,
+    enabled: getBoolConfig('KAFKA_ENABLED', 'kafka.enabled'),
+    brokers: getConfig('KAFKA_BROKERS', 'kafka.brokers', 'localhost:9092'),
+    clientId: getConfig('KAFKA_CLIENT_ID', 'kafka.clientId'),
     sasl: {
-      mechanism: process.env.KAFKA_SASL_MECHANISM,
-      username: process.env.KAFKA_SASL_USERNAME,
-      password: process.env.KAFKA_SASL_PASSWORD,
+      mechanism: getConfig('KAFKA_SASL_MECHANISM', 'kafka.sasl.mechanism'),
+      username: getConfig('KAFKA_SASL_USERNAME', 'kafka.sasl.username'),
+      password: getConfig('KAFKA_SASL_PASSWORD', 'kafka.sasl.password'),
     },
     tls: {
-      enabled: process.env.KAFKA_TLS_ENABLED === 'true',
-      rejectUnauthorized: process.env.KAFKA_TLS_REJECT_UNAUTHORIZED !== 'false',
+      enabled: getBoolConfig('KAFKA_TLS_ENABLED', 'kafka.tls.enabled'),
+      rejectUnauthorized: getConfig('KAFKA_TLS_REJECT_UNAUTHORIZED', 'kafka.tls.rejectUnauthorized') !== 'false',
     },
   },
   opensearch: {
-    nodes: process.env.OPENSEARCH_NODES || 'https://localhost:9200',
-    username: process.env.OPENSEARCH_USERNAME,
-    password: process.env.OPENSEARCH_PASSWORD,
+    nodes: getConfig('OPENSEARCH_NODES', 'opensearch.nodes', 'https://localhost:9200'),
+    username: getConfig('OPENSEARCH_USERNAME', 'opensearch.username'),
+    password: getConfig('OPENSEARCH_PASSWORD', 'opensearch.password'),
     aws: {
-      roleArn: process.env.OPENSEARCH_AWS_ROLE_ARN,
-      region: process.env.OPENSEARCH_AWS_REGION,
+      roleArn: getConfig('OPENSEARCH_AWS_ROLE_ARN', 'opensearch.aws.roleArn'),
+      region: getConfig('OPENSEARCH_AWS_REGION', 'opensearch.aws.region'),
     },
     tls: {
-      rejectUnauthorized: process.env.OPENSEARCH_TLS_REJECT_UNAUTHORIZED !== 'false',
+      rejectUnauthorized:
+        getConfig('OPENSEARCH_TLS_REJECT_UNAUTHORIZED', 'opensearch.tls.rejectUnauthorized') !== 'false',
     },
   },
-  cronTimeZone: process.env.CRON_TIMEZONE,
-  maxConcurrentBackupsPerRunner: parseInt(process.env.MAX_CONCURRENT_BACKUPS_PER_RUNNER || '6', 10),
+  cronTimeZone: getConfig('CRON_TIMEZONE', 'cronTimeZone'),
+  maxConcurrentBackupsPerRunner: getIntConfig(
+    'MAX_CONCURRENT_BACKUPS_PER_RUNNER',
+    'maxConcurrentBackupsPerRunner',
+    '6',
+  ),
   webhook: {
-    authToken: process.env.SVIX_AUTH_TOKEN,
-    serverUrl: process.env.SVIX_SERVER_URL,
+    authToken: getConfig('SVIX_AUTH_TOKEN', 'webhook.authToken'),
+    serverUrl: getConfig('SVIX_SERVER_URL', 'webhook.serverUrl'),
   },
   sshGateway: {
-    apiKey: process.env.SSH_GATEWAY_API_KEY,
-    command: process.env.SSH_GATEWAY_COMMAND,
-    publicKey: process.env.SSH_GATEWAY_PUBLIC_KEY,
+    apiKey: getConfig('SSH_GATEWAY_API_KEY', 'sshGateway.apiKey'),
+    command: getConfig('SSH_GATEWAY_COMMAND', 'sshGateway.command'),
+    publicKey: getConfig('SSH_GATEWAY_PUBLIC_KEY', 'sshGateway.publicKey'),
   },
-  organizationSandboxDefaultLimitedNetworkEgress:
-    process.env.ORGANIZATION_SANDBOX_DEFAULT_LIMITED_NETWORK_EGRESS === 'true',
-  pylonAppId: process.env.PYLON_APP_ID,
-  billingApiUrl: process.env.BILLING_API_URL,
+  organizationSandboxDefaultLimitedNetworkEgress: getBoolConfig(
+    'ORGANIZATION_SANDBOX_DEFAULT_LIMITED_NETWORK_EGRESS',
+    'organizationSandboxDefaultLimitedNetworkEgress',
+  ),
+  pylonAppId: getConfig('PYLON_APP_ID', 'pylonAppId'),
+  billingApiUrl: getConfig('BILLING_API_URL', 'billingApiUrl'),
   defaultRunner: {
-    domain: process.env.DEFAULT_RUNNER_DOMAIN,
-    apiKey: process.env.DEFAULT_RUNNER_API_KEY,
-    proxyUrl: process.env.DEFAULT_RUNNER_PROXY_URL,
-    apiUrl: process.env.DEFAULT_RUNNER_API_URL,
-    cpu: parseInt(process.env.DEFAULT_RUNNER_CPU || '4', 10),
-    memory: parseInt(process.env.DEFAULT_RUNNER_MEMORY || '8', 10),
-    disk: parseInt(process.env.DEFAULT_RUNNER_DISK || '50', 10),
-    gpu: parseInt(process.env.DEFAULT_RUNNER_GPU || '0', 10),
-    gpuType: process.env.DEFAULT_RUNNER_GPU_TYPE,
-    class: process.env.DEFAULT_RUNNER_CLASS ? (process.env.DEFAULT_RUNNER_CLASS as SandboxClass) : undefined,
-    version: process.env.DEFAULT_RUNNER_VERSION || '0',
+    domain: getConfig('DEFAULT_RUNNER_DOMAIN', 'defaultRunner.domain'),
+    apiKey: getConfig('DEFAULT_RUNNER_API_KEY', 'defaultRunner.apiKey'),
+    proxyUrl: getConfig('DEFAULT_RUNNER_PROXY_URL', 'defaultRunner.proxyUrl'),
+    apiUrl: getConfig('DEFAULT_RUNNER_API_URL', 'defaultRunner.apiUrl'),
+    cpu: getIntConfig('DEFAULT_RUNNER_CPU', 'defaultRunner.cpu', '4'),
+    memory: getIntConfig('DEFAULT_RUNNER_MEMORY', 'defaultRunner.memory', '8'),
+    disk: getIntConfig('DEFAULT_RUNNER_DISK', 'defaultRunner.disk', '50'),
+    gpu: getIntConfig('DEFAULT_RUNNER_GPU', 'defaultRunner.gpu', '0'),
+    gpuType: getConfig('DEFAULT_RUNNER_GPU_TYPE', 'defaultRunner.gpuType'),
+    class: getConfig('DEFAULT_RUNNER_CLASS', 'defaultRunner.class')
+      ? (getConfig('DEFAULT_RUNNER_CLASS', 'defaultRunner.class') as SandboxClass)
+      : undefined,
+    version: getConfig('DEFAULT_RUNNER_VERSION', 'defaultRunner.version', '0'),
   },
   runnerUsage: {
-    declarativeBuildScoreThreshold: parseInt(process.env.RUNNER_DECLARATIVE_BUILD_SCORE_THRESHOLD || '60', 10),
-    availabilityScoreThreshold: parseInt(process.env.RUNNER_AVAILABILITY_SCORE_THRESHOLD || '60', 10),
-    cpuUsageWeight: parseFloat(process.env.RUNNER_CPU_USAGE_WEIGHT || '0.25'),
-    memoryUsageWeight: parseFloat(process.env.RUNNER_MEMORY_USAGE_WEIGHT || '0.4'),
-    diskUsageWeight: parseFloat(process.env.RUNNER_DISK_USAGE_WEIGHT || '0.4'),
-    allocatedCpuWeight: parseFloat(process.env.RUNNER_ALLOCATED_CPU_WEIGHT || '0.03'),
-    allocatedMemoryWeight: parseFloat(process.env.RUNNER_ALLOCATED_MEMORY_WEIGHT || '0.03'),
-    allocatedDiskWeight: parseFloat(process.env.RUNNER_ALLOCATED_DISK_WEIGHT || '0.03'),
-    cpuPenaltyExponent: parseFloat(process.env.RUNNER_CPU_PENALTY_EXPONENT || '0.15'),
-    memoryPenaltyExponent: parseFloat(process.env.RUNNER_MEMORY_PENALTY_EXPONENT || '0.15'),
-    diskPenaltyExponent: parseFloat(process.env.RUNNER_DISK_PENALTY_EXPONENT || '0.15'),
-    cpuPenaltyThreshold: parseInt(process.env.RUNNER_CPU_PENALTY_THRESHOLD || '90', 10),
-    memoryPenaltyThreshold: parseInt(process.env.RUNNER_MEMORY_PENALTY_THRESHOLD || '75', 10),
-    diskPenaltyThreshold: parseInt(process.env.RUNNER_DISK_PENALTY_THRESHOLD || '75', 10),
+    declarativeBuildScoreThreshold: getIntConfig(
+      'RUNNER_DECLARATIVE_BUILD_SCORE_THRESHOLD',
+      'runnerUsage.declarativeBuildScoreThreshold',
+      '60',
+    ),
+    availabilityScoreThreshold: getIntConfig(
+      'RUNNER_AVAILABILITY_SCORE_THRESHOLD',
+      'runnerUsage.availabilityScoreThreshold',
+      '60',
+    ),
+    cpuUsageWeight: getFloatConfig('RUNNER_CPU_USAGE_WEIGHT', 'runnerUsage.cpuUsageWeight', '0.25'),
+    memoryUsageWeight: getFloatConfig('RUNNER_MEMORY_USAGE_WEIGHT', 'runnerUsage.memoryUsageWeight', '0.4'),
+    diskUsageWeight: getFloatConfig('RUNNER_DISK_USAGE_WEIGHT', 'runnerUsage.diskUsageWeight', '0.4'),
+    allocatedCpuWeight: getFloatConfig('RUNNER_ALLOCATED_CPU_WEIGHT', 'runnerUsage.allocatedCpuWeight', '0.03'),
+    allocatedMemoryWeight: getFloatConfig(
+      'RUNNER_ALLOCATED_MEMORY_WEIGHT',
+      'runnerUsage.allocatedMemoryWeight',
+      '0.03',
+    ),
+    allocatedDiskWeight: getFloatConfig('RUNNER_ALLOCATED_DISK_WEIGHT', 'runnerUsage.allocatedDiskWeight', '0.03'),
+    cpuPenaltyExponent: getFloatConfig('RUNNER_CPU_PENALTY_EXPONENT', 'runnerUsage.cpuPenaltyExponent', '0.15'),
+    memoryPenaltyExponent: getFloatConfig(
+      'RUNNER_MEMORY_PENALTY_EXPONENT',
+      'runnerUsage.memoryPenaltyExponent',
+      '0.15',
+    ),
+    diskPenaltyExponent: getFloatConfig('RUNNER_DISK_PENALTY_EXPONENT', 'runnerUsage.diskPenaltyExponent', '0.15'),
+    cpuPenaltyThreshold: getIntConfig('RUNNER_CPU_PENALTY_THRESHOLD', 'runnerUsage.cpuPenaltyThreshold', '90'),
+    memoryPenaltyThreshold: getIntConfig('RUNNER_MEMORY_PENALTY_THRESHOLD', 'runnerUsage.memoryPenaltyThreshold', '75'),
+    diskPenaltyThreshold: getIntConfig('RUNNER_DISK_PENALTY_THRESHOLD', 'runnerUsage.diskPenaltyThreshold', '75'),
   },
   rateLimit: {
     anonymous: {
-      ttl: process.env.RATE_LIMIT_ANONYMOUS_TTL ? parseInt(process.env.RATE_LIMIT_ANONYMOUS_TTL, 10) : undefined,
-      limit: process.env.RATE_LIMIT_ANONYMOUS_LIMIT ? parseInt(process.env.RATE_LIMIT_ANONYMOUS_LIMIT, 10) : undefined,
+      ttl: getIntConfig('RATE_LIMIT_ANONYMOUS_TTL', 'rateLimit.anonymous.ttl'),
+      limit: getIntConfig('RATE_LIMIT_ANONYMOUS_LIMIT', 'rateLimit.anonymous.limit'),
     },
     authenticated: {
-      ttl: process.env.RATE_LIMIT_AUTHENTICATED_TTL
-        ? parseInt(process.env.RATE_LIMIT_AUTHENTICATED_TTL, 10)
-        : undefined,
-      limit: process.env.RATE_LIMIT_AUTHENTICATED_LIMIT
-        ? parseInt(process.env.RATE_LIMIT_AUTHENTICATED_LIMIT, 10)
-        : undefined,
+      ttl: getIntConfig('RATE_LIMIT_AUTHENTICATED_TTL', 'rateLimit.authenticated.ttl'),
+      limit: getIntConfig('RATE_LIMIT_AUTHENTICATED_LIMIT', 'rateLimit.authenticated.limit'),
     },
     sandboxCreate: {
-      ttl: process.env.RATE_LIMIT_SANDBOX_CREATE_TTL
-        ? parseInt(process.env.RATE_LIMIT_SANDBOX_CREATE_TTL, 10)
-        : undefined,
-      limit: process.env.RATE_LIMIT_SANDBOX_CREATE_LIMIT
-        ? parseInt(process.env.RATE_LIMIT_SANDBOX_CREATE_LIMIT, 10)
-        : undefined,
+      ttl: getIntConfig('RATE_LIMIT_SANDBOX_CREATE_TTL', 'rateLimit.sandboxCreate.ttl'),
+      limit: getIntConfig('RATE_LIMIT_SANDBOX_CREATE_LIMIT', 'rateLimit.sandboxCreate.limit'),
     },
     sandboxLifecycle: {
-      ttl: process.env.RATE_LIMIT_SANDBOX_LIFECYCLE_TTL
-        ? parseInt(process.env.RATE_LIMIT_SANDBOX_LIFECYCLE_TTL, 10)
-        : undefined,
-      limit: process.env.RATE_LIMIT_SANDBOX_LIFECYCLE_LIMIT
-        ? parseInt(process.env.RATE_LIMIT_SANDBOX_LIFECYCLE_LIMIT, 10)
-        : undefined,
+      ttl: getIntConfig('RATE_LIMIT_SANDBOX_LIFECYCLE_TTL', 'rateLimit.sandboxLifecycle.ttl'),
+      limit: getIntConfig('RATE_LIMIT_SANDBOX_LIFECYCLE_LIMIT', 'rateLimit.sandboxLifecycle.limit'),
     },
   },
   log: {
     console: {
-      disabled: process.env.LOG_CONSOLE_DISABLED === 'true',
+      disabled: getBoolConfig('LOG_CONSOLE_DISABLED', 'log.console.disabled'),
     },
-    level: process.env.LOG_LEVEL || 'info',
+    level: getConfig('LOG_LEVEL', 'log.level', 'info'),
     requests: {
-      enabled: process.env.LOG_REQUESTS_ENABLED === 'true',
+      enabled: getBoolConfig('LOG_REQUESTS_ENABLED', 'log.requests.enabled'),
     },
   },
   defaultOrganizationQuota: {
-    totalCpuQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_TOTAL_CPU_QUOTA || '10', 10),
-    totalMemoryQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_TOTAL_MEMORY_QUOTA || '10', 10),
-    totalDiskQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_TOTAL_DISK_QUOTA || '30', 10),
-    maxCpuPerSandbox: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_CPU_PER_SANDBOX || '4', 10),
-    maxMemoryPerSandbox: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_MEMORY_PER_SANDBOX || '8', 10),
-    maxDiskPerSandbox: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_DISK_PER_SANDBOX || '10', 10),
-    snapshotQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_SNAPSHOT_QUOTA || '100', 10),
-    maxSnapshotSize: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_SNAPSHOT_SIZE || '20', 10),
-    volumeQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_VOLUME_QUOTA || '100', 10),
+    totalCpuQuota: getIntConfig('DEFAULT_ORG_QUOTA_TOTAL_CPU_QUOTA', 'defaultOrganizationQuota.totalCpuQuota', '10'),
+    totalMemoryQuota: getIntConfig(
+      'DEFAULT_ORG_QUOTA_TOTAL_MEMORY_QUOTA',
+      'defaultOrganizationQuota.totalMemoryQuota',
+      '10',
+    ),
+    totalDiskQuota: getIntConfig('DEFAULT_ORG_QUOTA_TOTAL_DISK_QUOTA', 'defaultOrganizationQuota.totalDiskQuota', '30'),
+    maxCpuPerSandbox: getIntConfig(
+      'DEFAULT_ORG_QUOTA_MAX_CPU_PER_SANDBOX',
+      'defaultOrganizationQuota.maxCpuPerSandbox',
+      '4',
+    ),
+    maxMemoryPerSandbox: getIntConfig(
+      'DEFAULT_ORG_QUOTA_MAX_MEMORY_PER_SANDBOX',
+      'defaultOrganizationQuota.maxMemoryPerSandbox',
+      '8',
+    ),
+    maxDiskPerSandbox: getIntConfig(
+      'DEFAULT_ORG_QUOTA_MAX_DISK_PER_SANDBOX',
+      'defaultOrganizationQuota.maxDiskPerSandbox',
+      '10',
+    ),
+    snapshotQuota: getIntConfig('DEFAULT_ORG_QUOTA_SNAPSHOT_QUOTA', 'defaultOrganizationQuota.snapshotQuota', '100'),
+    maxSnapshotSize: getIntConfig(
+      'DEFAULT_ORG_QUOTA_MAX_SNAPSHOT_SIZE',
+      'defaultOrganizationQuota.maxSnapshotSize',
+      '20',
+    ),
+    volumeQuota: getIntConfig('DEFAULT_ORG_QUOTA_VOLUME_QUOTA', 'defaultOrganizationQuota.volumeQuota', '100'),
   },
   defaultRegion: {
-    id: process.env.DEFAULT_REGION_ID || 'us',
-    name: process.env.DEFAULT_REGION_NAME || 'us',
-    enforceQuotas: process.env.DEFAULT_REGION_ENFORCE_QUOTAS === 'true',
+    id: getConfig('DEFAULT_REGION_ID', 'defaultRegion.id', 'us'),
+    name: getConfig('DEFAULT_REGION_NAME', 'defaultRegion.name', 'us'),
+    enforceQuotas: getBoolConfig('DEFAULT_REGION_ENFORCE_QUOTAS', 'defaultRegion.enforceQuotas'),
   },
   admin: {
-    apiKey: process.env.ADMIN_API_KEY,
-    totalCpuQuota: parseInt(process.env.ADMIN_TOTAL_CPU_QUOTA || '0', 10),
-    totalMemoryQuota: parseInt(process.env.ADMIN_TOTAL_MEMORY_QUOTA || '0', 10),
-    totalDiskQuota: parseInt(process.env.ADMIN_TOTAL_DISK_QUOTA || '0', 10),
-    maxCpuPerSandbox: parseInt(process.env.ADMIN_MAX_CPU_PER_SANDBOX || '0', 10),
-    maxMemoryPerSandbox: parseInt(process.env.ADMIN_MAX_MEMORY_PER_SANDBOX || '0', 10),
-    maxDiskPerSandbox: parseInt(process.env.ADMIN_MAX_DISK_PER_SANDBOX || '0', 10),
-    snapshotQuota: parseInt(process.env.ADMIN_SNAPSHOT_QUOTA || '100', 10),
-    maxSnapshotSize: parseInt(process.env.ADMIN_MAX_SNAPSHOT_SIZE || '100', 10),
-    volumeQuota: parseInt(process.env.ADMIN_VOLUME_QUOTA || '0', 10),
+    apiKey: getConfig('ADMIN_API_KEY', 'admin.apiKey'),
+    totalCpuQuota: getIntConfig('ADMIN_TOTAL_CPU_QUOTA', 'admin.totalCpuQuota', '0'),
+    totalMemoryQuota: getIntConfig('ADMIN_TOTAL_MEMORY_QUOTA', 'admin.totalMemoryQuota', '0'),
+    totalDiskQuota: getIntConfig('ADMIN_TOTAL_DISK_QUOTA', 'admin.totalDiskQuota', '0'),
+    maxCpuPerSandbox: getIntConfig('ADMIN_MAX_CPU_PER_SANDBOX', 'admin.maxCpuPerSandbox', '0'),
+    maxMemoryPerSandbox: getIntConfig('ADMIN_MAX_MEMORY_PER_SANDBOX', 'admin.maxMemoryPerSandbox', '0'),
+    maxDiskPerSandbox: getIntConfig('ADMIN_MAX_DISK_PER_SANDBOX', 'admin.maxDiskPerSandbox', '0'),
+    snapshotQuota: getIntConfig('ADMIN_SNAPSHOT_QUOTA', 'admin.snapshotQuota', '100'),
+    maxSnapshotSize: getIntConfig('ADMIN_MAX_SNAPSHOT_SIZE', 'admin.maxSnapshotSize', '100'),
+    volumeQuota: getIntConfig('ADMIN_VOLUME_QUOTA', 'admin.volumeQuota', '0'),
   },
-  skipUserEmailVerification: process.env.SKIP_USER_EMAIL_VERIFICATION === 'true',
+  skipUserEmailVerification: getBoolConfig('SKIP_USER_EMAIL_VERIFICATION', 'skipUserEmailVerification'),
   apiKey: {
-    validationCacheTtlSeconds: parseInt(process.env.API_KEY_VALIDATION_CACHE_TTL_SECONDS || '10', 10),
-    userCacheTtlSeconds: parseInt(process.env.API_KEY_USER_CACHE_TTL_SECONDS || '60', 10),
+    validationCacheTtlSeconds: getIntConfig(
+      'API_KEY_VALIDATION_CACHE_TTL_SECONDS',
+      'apiKey.validationCacheTtlSeconds',
+      '10',
+    ),
+    userCacheTtlSeconds: getIntConfig('API_KEY_USER_CACHE_TTL_SECONDS', 'apiKey.userCacheTtlSeconds', '60'),
   },
   runnerHealthTimeout: parseInt(process.env.RUNNER_HEALTH_TIMEOUT_SECONDS || '3', 10),
 }

--- a/apps/api/src/config/dto/configuration.dto.ts
+++ b/apps/api/src/config/dto/configuration.dto.ts
@@ -194,7 +194,7 @@ export class ConfigurationDto {
     example: false,
   })
   @IsBoolean()
-  maintananceMode: boolean
+  maintenanceMode: boolean
 
   @ApiProperty({
     description: 'Current environment',
@@ -248,7 +248,7 @@ export class ConfigurationDto {
     this.defaultSnapshot = configService.getOrThrow('defaultSnapshot')
     this.dashboardUrl = configService.getOrThrow('dashboardUrl')
     this.maxAutoArchiveInterval = configService.getOrThrow('maxAutoArchiveInterval')
-    this.maintananceMode = configService.getOrThrow('maintananceMode')
+    this.maintenanceMode = configService.getOrThrow('maintenanceMode')
     this.environment = configService.getOrThrow('environment')
 
     this.sshGatewayCommand = configService.get('sshGateway.command')

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -185,7 +185,7 @@ Below is a full list of environment variables with their default values:
 | `SSH_GATEWAY_COMMAND`                      | string  | `ssh -p 2222 {{TOKEN}}@localhost`                    | SSH gateway command template                                                                         |
 | `RUNNER_DECLARATIVE_BUILD_SCORE_THRESHOLD` | number  | `10`                                                 | Runner declarative build score threshold                                                             |
 | `RUNNER_AVAILABILITY_SCORE_THRESHOLD`      | number  | `10`                                                 | Runner availability score threshold                                                                  |
-| `RUNNER_HEALTH_TIMEOUT_SECONDS`            | number  | `3`                                                  | Runner health-check timeout in seconds                                                                         |
+| `RUNNER_HEALTH_TIMEOUT_SECONDS`            | number  | `3`                                                  | Runner health-check timeout in seconds                                                               |
 | `RUN_MIGRATIONS`                           | boolean | `true`                                               | Enable database migrations on startup                                                                |
 | `ADMIN_API_KEY`                            | string  | (empty)                                              | Admin API key, auto-generated if empty, used only upon initial setup, not recommended for production |
 | `ADMIN_TOTAL_CPU_QUOTA`                    | number  | `0`                                                  | Admin total CPU quota, used only upon initial setup                                                  |
@@ -198,37 +198,46 @@ Below is a full list of environment variables with their default values:
 | `ADMIN_MAX_SNAPSHOT_SIZE`                  | number  | `100`                                                | Admin max snapshot size, used only upon initial setup                                                |
 | `ADMIN_VOLUME_QUOTA`                       | number  | `0`                                                  | Admin volume quota, used only upon initial setup                                                     |
 | `SKIP_USER_EMAIL_VERIFICATION`             | boolean | `true`                                               | Skip user email verification process                                                                 |
-| `RATE_LIMIT_ANONYMOUS_TTL`                 | number  | (empty)                                              | Anonymous rate limit time-to-live (seconds, empty - rate limit is disabled)                                             |
-| `RATE_LIMIT_ANONYMOUS_LIMIT`               | number  | (empty)                                              | Anonymous rate limit (requests per TTL, empty - rate limit is disabled)                                                |
-| `RATE_LIMIT_AUTHENTICATED_TTL`             | number  | (empty)                                              | Authenticated rate limit time-to-live (seconds, empty - rate limit is disabled)                                         |
-| `RATE_LIMIT_AUTHENTICATED_LIMIT`           | number  | (empty)                                              | Authenticated rate limit (requests per TTL, empty - rate limit is disabled)                                          |
-| `RATE_LIMIT_SANDBOX_CREATE_TTL`            | number  | (empty)                                              | Sandbox create rate limit time-to-live (seconds, empty - rate limit is disabled)                                        |
-| `RATE_LIMIT_SANDBOX_CREATE_LIMIT`          | number  | (empty)                                              | Sandbox create rate limit (requests per TTL, empty - rate limit is disabled)                                           |
-| `RATE_LIMIT_SANDBOX_LIFECYCLE_TTL`         | number  | (empty)                                              | Sandbox lifecycle rate limit time-to-live (seconds, empty - rate limit is disabled)                                     |
-| `RATE_LIMIT_SANDBOX_LIFECYCLE_LIMIT`       | number  | (empty)                                              | Sandbox lifecycle rate limit (requests per TTL, empty - rate limit is disabled)                                      |
+| `RATE_LIMIT_ANONYMOUS_TTL`                 | number  | (empty)                                              | Anonymous rate limit time-to-live (seconds, empty - rate limit is disabled)                          |
+| `RATE_LIMIT_ANONYMOUS_LIMIT`               | number  | (empty)                                              | Anonymous rate limit (requests per TTL, empty - rate limit is disabled)                              |
+| `RATE_LIMIT_AUTHENTICATED_TTL`             | number  | (empty)                                              | Authenticated rate limit time-to-live (seconds, empty - rate limit is disabled)                      |
+| `RATE_LIMIT_AUTHENTICATED_LIMIT`           | number  | (empty)                                              | Authenticated rate limit (requests per TTL, empty - rate limit is disabled)                          |
+| `RATE_LIMIT_SANDBOX_CREATE_TTL`            | number  | (empty)                                              | Sandbox create rate limit time-to-live (seconds, empty - rate limit is disabled)                     |
+| `RATE_LIMIT_SANDBOX_CREATE_LIMIT`          | number  | (empty)                                              | Sandbox create rate limit (requests per TTL, empty - rate limit is disabled)                         |
+| `RATE_LIMIT_SANDBOX_LIFECYCLE_TTL`         | number  | (empty)                                              | Sandbox lifecycle rate limit time-to-live (seconds, empty - rate limit is disabled)                  |
+| `RATE_LIMIT_SANDBOX_LIFECYCLE_LIMIT`       | number  | (empty)                                              | Sandbox lifecycle rate limit (requests per TTL, empty - rate limit is disabled)                      |
 | `DEFAULT_REGION_ID`                        | string  | `us`                                                 | Default region ID                                                                                    |
 | `DEFAULT_REGION_NAME`                      | string  | `us`                                                 | Default region name                                                                                  |
 | `DEFAULT_REGION_ENFORCE_QUOTAS`            | boolean | `false`                                              | Enable region-based resource limits for default region                                               |
 
+:::tip
+The API Service can also be configured using a yaml or json config map.
+
+Set the CONFIG_MAP_PATH environment variable to the path of the config file.
+Environment variables have precedence over config file values.
+
+The schema for the config file can be found [here](https://github.com/daytonaio/daytona/blob/main/apps/api/src/config/configuration.ts).
+:::
+
 ### Runner
 
-| Variable                   | Type    | Default Value                     | Description                           |
-| -------------------------- | ------- | --------------------------------- | ------------------------------------- |
-| `VERSION`                  | string  | `0.0.1`                           | Runner service version                |
-| `ENVIRONMENT`              | string  | `development`                     | Application environment               |
-| `API_PORT`                 | number  | `3003`                            | Runner API service port               |
-| `API_TOKEN`                | string  | `secret_api_token`                | Runner API authentication token       |
-| `LOG_FILE_PATH`            | string  | `/home/daytona/runner/runner.log` | Path to runner log file               |
-| `RESOURCE_LIMITS_DISABLED` | boolean | `true`                            | Disable resource limits for sandboxes |
-| `AWS_ENDPOINT_URL`         | string  | `http://minio:9000`               | AWS S3-compatible storage endpoint    |
-| `AWS_REGION`               | string  | `us-east-1`                       | AWS region                            |
-| `AWS_ACCESS_KEY_ID`        | string  | `minioadmin`                      | AWS access key ID                     |
-| `AWS_SECRET_ACCESS_KEY`    | string  | `minioadmin`                      | AWS secret access key                 |
-| `AWS_DEFAULT_BUCKET`       | string  | `daytona`                         | AWS default bucket name               |
-| `SERVER_URL`               | string  | `http://api:3000/api`             | Daytona API server URL                |
-| `DAEMON_START_TIMEOUT_SEC` | number  | `60`                              | Daemon start timeout in seconds       |
-| `SANDBOX_START_TIMEOUT_SEC`| number  | `30`                              | Sandbox start timeout in seconds      |
-  
+| Variable                    | Type    | Default Value                     | Description                           |
+| --------------------------- | ------- | --------------------------------- | ------------------------------------- |
+| `VERSION`                   | string  | `0.0.1`                           | Runner service version                |
+| `ENVIRONMENT`               | string  | `development`                     | Application environment               |
+| `API_PORT`                  | number  | `3003`                            | Runner API service port               |
+| `API_TOKEN`                 | string  | `secret_api_token`                | Runner API authentication token       |
+| `LOG_FILE_PATH`             | string  | `/home/daytona/runner/runner.log` | Path to runner log file               |
+| `RESOURCE_LIMITS_DISABLED`  | boolean | `true`                            | Disable resource limits for sandboxes |
+| `AWS_ENDPOINT_URL`          | string  | `http://minio:9000`               | AWS S3-compatible storage endpoint    |
+| `AWS_REGION`                | string  | `us-east-1`                       | AWS region                            |
+| `AWS_ACCESS_KEY_ID`         | string  | `minioadmin`                      | AWS access key ID                     |
+| `AWS_SECRET_ACCESS_KEY`     | string  | `minioadmin`                      | AWS secret access key                 |
+| `AWS_DEFAULT_BUCKET`        | string  | `daytona`                         | AWS default bucket name               |
+| `SERVER_URL`                | string  | `http://api:3000/api`             | Daytona API server URL                |
+| `DAEMON_START_TIMEOUT_SEC`  | number  | `60`                              | Daemon start timeout in seconds       |
+| `SANDBOX_START_TIMEOUT_SEC` | number  | `30`                              | Sandbox start timeout in seconds      |
+
 ### SSH Gateway
 
 | Variable           | Type   | Default Value                        | Description                |

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -7472,10 +7472,10 @@ components:
         maxAutoArchiveInterval: 43200
         pylonAppId: pylon-app-123
         proxyTemplateUrl: 'https://{{PORT}}-{{sandboxId}}.proxy.example.com'
-        maintananceMode: false
         environment: production
         defaultSnapshot: ubuntu:22.04
         sshGatewayCommand: 'ssh -p 2222 {{TOKEN}}@localhost'
+        maintenanceMode: false
         announcements:
           feature-update:
             text: New feature available!
@@ -7530,7 +7530,7 @@ components:
           description: Maximum auto-archive interval in minutes
           example: 43200
           type: number
-        maintananceMode:
+        maintenanceMode:
           description: Whether maintenance mode is enabled
           example: false
           type: boolean
@@ -7560,7 +7560,7 @@ components:
         - defaultSnapshot
         - environment
         - linkedAccountsEnabled
-        - maintananceMode
+        - maintenanceMode
         - maxAutoArchiveInterval
         - oidc
         - proxyTemplateUrl

--- a/libs/api-client-go/model_daytona_configuration.go
+++ b/libs/api-client-go/model_daytona_configuration.go
@@ -44,7 +44,7 @@ type DaytonaConfiguration struct {
 	// Maximum auto-archive interval in minutes
 	MaxAutoArchiveInterval float32 `json:"maxAutoArchiveInterval"`
 	// Whether maintenance mode is enabled
-	MaintananceMode bool `json:"maintananceMode"`
+	MaintenanceMode bool `json:"maintenanceMode"`
 	// Current environment
 	Environment string `json:"environment"`
 	// Billing API URL
@@ -64,7 +64,7 @@ type _DaytonaConfiguration DaytonaConfiguration
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDaytonaConfiguration(version string, oidc OidcConfig, linkedAccountsEnabled bool, announcements map[string]Announcement, proxyTemplateUrl string, proxyToolboxUrl string, defaultSnapshot string, dashboardUrl string, maxAutoArchiveInterval float32, maintananceMode bool, environment string) *DaytonaConfiguration {
+func NewDaytonaConfiguration(version string, oidc OidcConfig, linkedAccountsEnabled bool, announcements map[string]Announcement, proxyTemplateUrl string, proxyToolboxUrl string, defaultSnapshot string, dashboardUrl string, maxAutoArchiveInterval float32, maintenanceMode bool, environment string) *DaytonaConfiguration {
 	this := DaytonaConfiguration{}
 	this.Version = version
 	this.Oidc = oidc
@@ -75,7 +75,7 @@ func NewDaytonaConfiguration(version string, oidc OidcConfig, linkedAccountsEnab
 	this.DefaultSnapshot = defaultSnapshot
 	this.DashboardUrl = dashboardUrl
 	this.MaxAutoArchiveInterval = maxAutoArchiveInterval
-	this.MaintananceMode = maintananceMode
+	this.MaintenanceMode = maintenanceMode
 	this.Environment = environment
 	return &this
 }
@@ -368,28 +368,28 @@ func (o *DaytonaConfiguration) SetMaxAutoArchiveInterval(v float32) {
 	o.MaxAutoArchiveInterval = v
 }
 
-// GetMaintananceMode returns the MaintananceMode field value
-func (o *DaytonaConfiguration) GetMaintananceMode() bool {
+// GetMaintenanceMode returns the MaintenanceMode field value
+func (o *DaytonaConfiguration) GetMaintenanceMode() bool {
 	if o == nil {
 		var ret bool
 		return ret
 	}
 
-	return o.MaintananceMode
+	return o.MaintenanceMode
 }
 
-// GetMaintananceModeOk returns a tuple with the MaintananceMode field value
+// GetMaintenanceModeOk returns a tuple with the MaintenanceMode field value
 // and a boolean to check if the value has been set.
-func (o *DaytonaConfiguration) GetMaintananceModeOk() (*bool, bool) {
+func (o *DaytonaConfiguration) GetMaintenanceModeOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.MaintananceMode, true
+	return &o.MaintenanceMode, true
 }
 
-// SetMaintananceMode sets field value
-func (o *DaytonaConfiguration) SetMaintananceMode(v bool) {
-	o.MaintananceMode = v
+// SetMaintenanceMode sets field value
+func (o *DaytonaConfiguration) SetMaintenanceMode(v bool) {
+	o.MaintenanceMode = v
 }
 
 // GetEnvironment returns the Environment field value
@@ -569,7 +569,7 @@ func (o DaytonaConfiguration) ToMap() (map[string]interface{}, error) {
 	toSerialize["defaultSnapshot"] = o.DefaultSnapshot
 	toSerialize["dashboardUrl"] = o.DashboardUrl
 	toSerialize["maxAutoArchiveInterval"] = o.MaxAutoArchiveInterval
-	toSerialize["maintananceMode"] = o.MaintananceMode
+	toSerialize["maintenanceMode"] = o.MaintenanceMode
 	toSerialize["environment"] = o.Environment
 	if !IsNil(o.BillingApiUrl) {
 		toSerialize["billingApiUrl"] = o.BillingApiUrl
@@ -605,7 +605,7 @@ func (o *DaytonaConfiguration) UnmarshalJSON(data []byte) (err error) {
 		"defaultSnapshot",
 		"dashboardUrl",
 		"maxAutoArchiveInterval",
-		"maintananceMode",
+		"maintenanceMode",
 		"environment",
 	}
 
@@ -647,7 +647,7 @@ func (o *DaytonaConfiguration) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "defaultSnapshot")
 		delete(additionalProperties, "dashboardUrl")
 		delete(additionalProperties, "maxAutoArchiveInterval")
-		delete(additionalProperties, "maintananceMode")
+		delete(additionalProperties, "maintenanceMode")
 		delete(additionalProperties, "environment")
 		delete(additionalProperties, "billingApiUrl")
 		delete(additionalProperties, "sshGatewayCommand")

--- a/libs/api-client-python-async/daytona_api_client_async/models/daytona_configuration.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/daytona_configuration.py
@@ -42,7 +42,7 @@ class DaytonaConfiguration(BaseModel):
     default_snapshot: StrictStr = Field(description="Default snapshot for sandboxes", alias="defaultSnapshot")
     dashboard_url: StrictStr = Field(description="Dashboard URL", alias="dashboardUrl")
     max_auto_archive_interval: Union[StrictFloat, StrictInt] = Field(description="Maximum auto-archive interval in minutes", alias="maxAutoArchiveInterval")
-    maintanance_mode: StrictBool = Field(description="Whether maintenance mode is enabled", alias="maintananceMode")
+    maintenance_mode: StrictBool = Field(description="Whether maintenance mode is enabled", alias="maintenanceMode")
     environment: StrictStr = Field(description="Current environment")
     billing_api_url: Optional[StrictStr] = Field(default=None, description="Billing API URL", alias="billingApiUrl")
     ssh_gateway_command: Optional[StrictStr] = Field(default=None, description="SSH Gateway command", alias="sshGatewayCommand")
@@ -141,7 +141,7 @@ class DaytonaConfiguration(BaseModel):
             "defaultSnapshot": obj.get("defaultSnapshot"),
             "dashboardUrl": obj.get("dashboardUrl"),
             "maxAutoArchiveInterval": obj.get("maxAutoArchiveInterval"),
-            "maintananceMode": obj.get("maintananceMode"),
+            "maintenanceMode": obj.get("maintenanceMode"),
             "environment": obj.get("environment"),
             "billingApiUrl": obj.get("billingApiUrl"),
             "sshGatewayCommand": obj.get("sshGatewayCommand"),

--- a/libs/api-client-python/daytona_api_client/models/daytona_configuration.py
+++ b/libs/api-client-python/daytona_api_client/models/daytona_configuration.py
@@ -42,7 +42,7 @@ class DaytonaConfiguration(BaseModel):
     default_snapshot: StrictStr = Field(description="Default snapshot for sandboxes", alias="defaultSnapshot")
     dashboard_url: StrictStr = Field(description="Dashboard URL", alias="dashboardUrl")
     max_auto_archive_interval: Union[StrictFloat, StrictInt] = Field(description="Maximum auto-archive interval in minutes", alias="maxAutoArchiveInterval")
-    maintanance_mode: StrictBool = Field(description="Whether maintenance mode is enabled", alias="maintananceMode")
+    maintenance_mode: StrictBool = Field(description="Whether maintenance mode is enabled", alias="maintenanceMode")
     environment: StrictStr = Field(description="Current environment")
     billing_api_url: Optional[StrictStr] = Field(default=None, description="Billing API URL", alias="billingApiUrl")
     ssh_gateway_command: Optional[StrictStr] = Field(default=None, description="SSH Gateway command", alias="sshGatewayCommand")
@@ -141,7 +141,7 @@ class DaytonaConfiguration(BaseModel):
             "defaultSnapshot": obj.get("defaultSnapshot"),
             "dashboardUrl": obj.get("dashboardUrl"),
             "maxAutoArchiveInterval": obj.get("maxAutoArchiveInterval"),
-            "maintananceMode": obj.get("maintananceMode"),
+            "maintenanceMode": obj.get("maintenanceMode"),
             "environment": obj.get("environment"),
             "billingApiUrl": obj.get("billingApiUrl"),
             "sshGatewayCommand": obj.get("sshGatewayCommand"),

--- a/libs/api-client/src/models/daytona-configuration.ts
+++ b/libs/api-client/src/models/daytona-configuration.ts
@@ -102,7 +102,7 @@ export interface DaytonaConfiguration {
    * @type {boolean}
    * @memberof DaytonaConfiguration
    */
-  maintananceMode: boolean
+  maintenanceMode: boolean
   /**
    * Current environment
    * @type {string}


### PR DESCRIPTION
This pull request introduces support for configuring the API service using an external YAML or JSON config map file, in addition to environment variables. It adds an example configuration file, implements a loader utility for reading and merging config values, and updates documentation to describe the new configuration method.

**Config map support for API service:**

* Added an example config map file (`config-map.example.yaml`) that demonstrates all supported configuration options, including database, Redis, SMTP, S3, runner, logging, and quota settings.
* Implemented a new utility (`config-map.loader.ts`) to load configuration from a YAML or JSON file, retrieve nested values using dot notation, and resolve config values with environment variable precedence.

**Documentation updates:**

* Updated the OSS deployment documentation to describe the new config map feature, how to enable it with `CONFIG_MAP_PATH`, and clarified that environment variables override config file values.