### PR TITLE
fix(dashboard): row animation duration tweak

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/index.tsx
+++ b/apps/dashboard/src/components/SandboxTable/index.tsx
@@ -163,15 +163,12 @@ export function SandboxTable({
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
-                className={`${
-                  sandboxIsLoading[row.original.id] || row.original.state === SandboxState.DESTROYED
-                    ? 'opacity-80 pointer-events-none'
-                    : '[&:hover>*:nth-child(2)]:underline'
-                } ${
-                  sandboxStateIsTransitioning[row.original.id]
-                    ? 'bg-muted transition-colors duration-300 animate-pulse'
-                    : 'transition-colors duration-300'
-                } ${onRowClick ? 'cursor-pointer' : ''}`}
+                className={cn('group/table-row transition-all', {
+                  'opacity-80 pointer-events-none':
+                    sandboxIsLoading[row.original.id] || row.original.state === SandboxState.DESTROYED,
+                  'bg-muted animate-pulse': sandboxStateIsTransitioning[row.original.id],
+                  'cursor-pointer': onRowClick,
+                })}
                 onClick={() => onRowClick?.(row.original)}
               >
                 {row.getVisibleCells().map((cell) => (
@@ -182,7 +179,9 @@ export function SandboxTable({
                         e.stopPropagation()
                       }
                     }}
-                    className="border-b border-border"
+                    className={cn('border-b border-border', {
+                      'group-hover/table-row:underline': cell.column.id === 'name',
+                    })}
                     style={{
                       width: `${cell.column.getSize()}px`,
                     }}


### PR DESCRIPTION
## Description

Fixes row flashing in sandboxes table during state transitions.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

