### PR TITLE
fix(api): unassign runner and backup on sandbox destroy

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -333,4 +333,12 @@ export class Sandbox {
       this.pending = false
     }
   }
+
+  @BeforeUpdate()
+  handleDestroyedState() {
+    if (this.state === SandboxState.DESTROYED) {
+      this.runnerId = null
+      this.backupState = BackupState.NONE
+    }
+  }
 }


### PR DESCRIPTION
## Unassign runner and backup on sandbox destroy

Fixes some cases where these two properties are left on their previous values which causes inconsistencies 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
