### PR TITLE
fix(api): api key default value

### DIFF
--- a/apps/api/src/api-key/api-key.service.ts
+++ b/apps/api/src/api-key/api-key.service.ts
@@ -56,7 +56,7 @@ export class ApiKeyService {
       throw new ConflictException('API key with this name already exists')
     }
 
-    const value = apiKeyValue ?? this.generateApiKeyValue()
+    const value = apiKeyValue || this.generateApiKeyValue()
 
     const apiKey = await this.apiKeyRepository.save({
       organizationId,


### PR DESCRIPTION
## Description

Prevented an empty string from being used as a value for an API key.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
