### PR TITLE
chore(ci): only publish CLI on latest tags

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -81,6 +81,7 @@ jobs:
           yarn publish
 
   update-homebrew-tap:
+    if: ${{ inputs.npm_tag == 'latest' }}
     needs: publish
     runs-on: release-runner
     name: Update Homebrew CLI tap


### PR DESCRIPTION
## Description

Prevent CLI publish for non-latest SDK tags.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
