### PR TITLE
feat(api): add error reason to sandbox update endpoint

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -544,7 +544,7 @@ export class SandboxController {
     @Param('sandboxId') sandboxId: string,
     @Body() updateStateDto: UpdateSandboxStateDto,
   ): Promise<void> {
-    await this.sandboxService.updateState(sandboxId, updateStateDto.state)
+    await this.sandboxService.updateState(sandboxId, updateStateDto.state, updateStateDto.errorReason)
   }
 
   @Post(':sandboxIdOrName/backup')

--- a/apps/api/src/sandbox/dto/update-sandbox-state.dto.ts
+++ b/apps/api/src/sandbox/dto/update-sandbox-state.dto.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ApiProperty } from '@nestjs/swagger'
-import { IsEnum } from 'class-validator'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { IsEnum, IsOptional, IsString } from 'class-validator'
 import { SandboxState } from '../enums/sandbox-state.enum'
 
 export class UpdateSandboxStateDto {
@@ -15,4 +15,12 @@ export class UpdateSandboxStateDto {
     example: SandboxState.STARTED,
   })
   state: SandboxState
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: 'Optional error message when reporting an error state',
+    example: 'Failed to pull snapshot image',
+  })
+  errorReason?: string
 }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1248,7 +1248,7 @@ export class SandboxService {
 
   // used by internal services to update the state of a sandbox to resolve domain and runner state mismatch
   // notably, when a sandbox instance stops or errors on the runner, the domain state needs to be updated to reflect the actual state
-  async updateState(sandboxId: string, newState: SandboxState): Promise<void> {
+  async updateState(sandboxId: string, newState: SandboxState, errorReason?: string): Promise<void> {
     const sandbox = await this.sandboxRepository.findOne({
       where: { id: sandboxId },
     })
@@ -1275,6 +1275,9 @@ export class SandboxService {
     const oldState = sandbox.state
     const oldDesiredState = sandbox.desiredState
     sandbox.state = newState
+    if (errorReason !== undefined) {
+      sandbox.errorReason = errorReason
+    }
     //  we need to update the desired state to match the new state
     const desiredState = this.getExpectedDesiredStateForState(newState)
     if (desiredState) {

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -8932,6 +8932,7 @@ components:
       type: object
     UpdateSandboxStateDto:
       example:
+        errorReason: Failed to pull snapshot image
         state: started
       properties:
         state:
@@ -8954,6 +8955,10 @@ components:
             - archived
             - archiving
           example: started
+          type: string
+        errorReason:
+          description: Optional error message when reporting an error state
+          example: Failed to pull snapshot image
           type: string
       required:
         - state

--- a/libs/api-client-go/model_update_sandbox_state_dto.go
+++ b/libs/api-client-go/model_update_sandbox_state_dto.go
@@ -22,7 +22,9 @@ var _ MappedNullable = &UpdateSandboxStateDto{}
 // UpdateSandboxStateDto struct for UpdateSandboxStateDto
 type UpdateSandboxStateDto struct {
 	// The new state for the sandbox
-	State                string `json:"state"`
+	State string `json:"state"`
+	// Optional error message when reporting an error state
+	ErrorReason          *string `json:"errorReason,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -70,6 +72,38 @@ func (o *UpdateSandboxStateDto) SetState(v string) {
 	o.State = v
 }
 
+// GetErrorReason returns the ErrorReason field value if set, zero value otherwise.
+func (o *UpdateSandboxStateDto) GetErrorReason() string {
+	if o == nil || IsNil(o.ErrorReason) {
+		var ret string
+		return ret
+	}
+	return *o.ErrorReason
+}
+
+// GetErrorReasonOk returns a tuple with the ErrorReason field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateSandboxStateDto) GetErrorReasonOk() (*string, bool) {
+	if o == nil || IsNil(o.ErrorReason) {
+		return nil, false
+	}
+	return o.ErrorReason, true
+}
+
+// HasErrorReason returns a boolean if a field has been set.
+func (o *UpdateSandboxStateDto) HasErrorReason() bool {
+	if o != nil && !IsNil(o.ErrorReason) {
+		return true
+	}
+
+	return false
+}
+
+// SetErrorReason gets a reference to the given string and assigns it to the ErrorReason field.
+func (o *UpdateSandboxStateDto) SetErrorReason(v string) {
+	o.ErrorReason = &v
+}
+
 func (o UpdateSandboxStateDto) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -81,6 +115,9 @@ func (o UpdateSandboxStateDto) MarshalJSON() ([]byte, error) {
 func (o UpdateSandboxStateDto) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["state"] = o.State
+	if !IsNil(o.ErrorReason) {
+		toSerialize["errorReason"] = o.ErrorReason
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -125,6 +162,7 @@ func (o *UpdateSandboxStateDto) UnmarshalJSON(data []byte) (err error) {
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "state")
+		delete(additionalProperties, "errorReason")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-python-async/daytona_api_client_async/models/update_sandbox_state_dto.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/update_sandbox_state_dto.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -28,8 +28,9 @@ class UpdateSandboxStateDto(BaseModel):
     UpdateSandboxStateDto
     """ # noqa: E501
     state: StrictStr = Field(description="The new state for the sandbox")
+    error_reason: Optional[StrictStr] = Field(default=None, description="Optional error message when reporting an error state", alias="errorReason")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["state"]
+    __properties: ClassVar[List[str]] = ["state", "errorReason"]
 
     @field_validator('state')
     def state_validate_enum(cls, value):
@@ -96,7 +97,8 @@ class UpdateSandboxStateDto(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "state": obj.get("state")
+            "state": obj.get("state"),
+            "errorReason": obj.get("errorReason")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/update_sandbox_state_dto.py
+++ b/libs/api-client-python/daytona_api_client/models/update_sandbox_state_dto.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -28,8 +28,9 @@ class UpdateSandboxStateDto(BaseModel):
     UpdateSandboxStateDto
     """ # noqa: E501
     state: StrictStr = Field(description="The new state for the sandbox")
+    error_reason: Optional[StrictStr] = Field(default=None, description="Optional error message when reporting an error state", alias="errorReason")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["state"]
+    __properties: ClassVar[List[str]] = ["state", "errorReason"]
 
     @field_validator('state')
     def state_validate_enum(cls, value):
@@ -96,7 +97,8 @@ class UpdateSandboxStateDto(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "state": obj.get("state")
+            "state": obj.get("state"),
+            "errorReason": obj.get("errorReason")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client/src/models/update-sandbox-state-dto.ts
+++ b/libs/api-client/src/models/update-sandbox-state-dto.ts
@@ -24,6 +24,12 @@ export interface UpdateSandboxStateDto {
    * @memberof UpdateSandboxStateDto
    */
   state: UpdateSandboxStateDtoStateEnum
+  /**
+   * Optional error message when reporting an error state
+   * @type {string}
+   * @memberof UpdateSandboxStateDto
+   */
+  errorReason?: string
 }
 
 export const UpdateSandboxStateDtoStateEnum = {


### PR DESCRIPTION
## Add error reason to sandbox update endpoint

Allows the runner to also set the error reason when updating the sandbox state through the API

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
