### PR TITLE
fix(runner): resolve errored sandbox state mismatch

### DIFF
--- a/apps/runner/pkg/docker/state.go
+++ b/apps/runner/pkg/docker/state.go
@@ -23,7 +23,7 @@ func (d *DockerClient) DeduceSandboxState(ctx context.Context, sandboxId string)
 		if errdefs.IsNotFound(err) {
 			return enums.SandboxStateDestroyed, nil
 		}
-		return enums.SandboxStateError, fmt.Errorf("failed to inspect container: %w", err)
+		return enums.SandboxStateError, fmt.Errorf("failed to inspect sandbox: %w", err)
 	}
 
 	switch container.State.Status {
@@ -50,7 +50,7 @@ func (d *DockerClient) DeduceSandboxState(ctx context.Context, sandboxId string)
 			return enums.SandboxStateStopped, nil
 		}
 
-		return enums.SandboxStateError, fmt.Errorf("container exited with code %d, reason: %s", container.State.ExitCode, container.State.Error)
+		return enums.SandboxStateError, fmt.Errorf("sandbox exited with code %d, reason: %s", container.State.ExitCode, container.State.Error)
 
 	case "dead":
 		return enums.SandboxStateDestroyed, nil

--- a/apps/runner/pkg/services/sandbox.go
+++ b/apps/runner/pkg/services/sandbox.go
@@ -10,6 +10,8 @@ import (
 	"github.com/daytonaio/runner/pkg/docker"
 	"github.com/daytonaio/runner/pkg/models"
 	"github.com/daytonaio/runner/pkg/models/enums"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type SandboxService struct {
@@ -26,9 +28,11 @@ func NewSandboxService(statesCache *cache.StatesCache, docker *docker.DockerClie
 
 func (s *SandboxService) GetSandboxStatesInfo(ctx context.Context, sandboxId string) *models.CachedStates {
 	sandboxState, err := s.docker.DeduceSandboxState(ctx, sandboxId)
-	if err == nil {
-		s.statesCache.SetSandboxState(ctx, sandboxId, sandboxState)
+	if err != nil {
+		log.Warnf("Failed to deduce sandbox %s state: %v", sandboxId, err)
 	}
+
+	s.statesCache.SetSandboxState(ctx, sandboxId, sandboxState)
 
 	data, err := s.statesCache.Get(ctx, sandboxId)
 	if err != nil {


### PR DESCRIPTION
## Description

This pull request makes improvements to error handling and logging in the sandbox state detection logic, as well as clarifies terminology in error messages. The main focus is on making error reporting more descriptive and ensuring that issues are logged for better observability.

**Error handling and logging improvements:**

* Added logging with `logrus` to warn when sandbox state deduction fails in `GetSandboxStatesInfo`, ensuring that errors are visible in logs. (`apps/runner/pkg/services/sandbox.go`) [[1]](diffhunk://#diff-a32769e93f6f8465c6b71c8ed8bfb0388751db767c2073226d27c8d66662cfecR13-R14) [[2]](diffhunk://#diff-a32769e93f6f8465c6b71c8ed8bfb0388751db767c2073226d27c8d66662cfecL29-R36)

**Terminology and error message consistency:**

* Updated error messages in `DeduceSandboxState` to use "sandbox" instead of "container" for clarity and consistency. (`apps/runner/pkg/docker/state.go`) [[1]](diffhunk://#diff-e23dceba0c365aa9d322e65c43eb50f6d726a343366ae96d87c26e67a035dcffL26-R26) [[2]](diffhunk://#diff-e23dceba0c365aa9d322e65c43eb50f6d726a343366ae96d87c26e67a035dcffL53-R53)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Note
This patch will be resolved and completely fixed by #2870 
