### PR TITLE
fix(api): usage period query for close

### DIFF
--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -99,10 +99,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     const lastUsagePeriod = await this.sandboxUsagePeriodRepository.findOne({
       where: {
         sandboxId,
-        endAt: null,
-      },
-      order: {
-        startAt: 'DESC',
+        endAt: IsNull(),
       },
     })
 


### PR DESCRIPTION
## Description

Fixes wrong usage period query when closing a period in the usage service.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
