### PR TITLE
fix(api): unlock sync runner snapshots cron

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -101,6 +101,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       .getMany()
 
     if (snapshots.length === 0) {
+      await this.redisLockProvider.unlock(lockKey)
       await this.redis.set('sync-runner-snapshots-skip', 0)
       return
     }


### PR DESCRIPTION
## Description

Added a missing unlock for syncing runner snapshots if no snapshots are left to sync.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
