### PR TITLE
fix(api): clear anonymous rate limit for system role users

### DIFF
--- a/apps/api/src/common/guards/authenticated-rate-limit.guard.ts
+++ b/apps/api/src/common/guards/authenticated-rate-limit.guard.ts
@@ -51,6 +51,7 @@ export class AuthenticatedRateLimitGuard extends ThrottlerGuard {
 
     // Skip rate limiting for M2M system roles (checked AFTER auth runs)
     if (this.isSystemRole(request.user)) {
+      await this.clearAnonymousRateLimit(request, context)
       return true
     }
 


### PR DESCRIPTION
## Description

Invalidating Redis records made for anonymous rate limiting in case of system role users.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
