### PR TITLE
fix(api): rate limit tracker names uniformed across routes

### DIFF
--- a/apps/api/src/common/guards/anonymous-rate-limit.guard.ts
+++ b/apps/api/src/common/guards/anonymous-rate-limit.guard.ts
@@ -7,7 +7,6 @@ import { Injectable, ExecutionContext } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { ThrottlerGuard, ThrottlerModuleOptions, ThrottlerRequest, ThrottlerStorage } from '@nestjs/throttler'
 import { Request } from 'express'
-import { createHash } from 'crypto'
 
 @Injectable()
 export class AnonymousRateLimitGuard extends ThrottlerGuard {
@@ -24,7 +23,7 @@ export class AnonymousRateLimitGuard extends ThrottlerGuard {
   protected generateKey(context: ExecutionContext, suffix: string, name: string): string {
     // Override to make rate limiting per-rate-limit-type, not per-route
     // This ensures all routes share the same counter for anonymous rate limiting
-    return createHash('sha256').update(`${name}-${suffix}`).digest('hex')
+    return `${name}-${suffix}`
   }
 
   async handleRequest(requestProps: ThrottlerRequest): Promise<boolean> {

--- a/apps/api/src/common/guards/authenticated-rate-limit.guard.ts
+++ b/apps/api/src/common/guards/authenticated-rate-limit.guard.ts
@@ -11,7 +11,6 @@ import { getRedisConnectionToken } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { THROTTLER_SCOPE_KEY } from '../decorators/throttler-scope.decorator'
-import { createHash } from 'crypto'
 
 @Injectable()
 export class AuthenticatedRateLimitGuard extends ThrottlerGuard {
@@ -48,7 +47,7 @@ export class AuthenticatedRateLimitGuard extends ThrottlerGuard {
   protected generateKey(context: ExecutionContext, suffix: string, name: string): string {
     // Override to make rate limiting per-rate-limit-type, not per-route
     // This ensures all routes share the same counter per rate limit type (authenticated, sandbox-create, sandbox-lifecycle)
-    return createHash('sha256').update(`${name}-${suffix}`).digest('hex')
+    return `${name}-${suffix}`
   }
 
   async handleRequest(requestProps: ThrottlerRequest): Promise<boolean> {


### PR DESCRIPTION
## Description

Override generateKey() in guards so all routes share the same counter for each limit type (anonymous, authenticated, sandbox-lifecycle).

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation