### PR TITLE
fix(dashboard): use hasVerifiedBusinessEmail from billing info

### DIFF
--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -209,7 +209,7 @@ export default function Limits() {
                     emailVerified: !!user?.profile?.email_verified,
                     creditCardLinked: !!wallet?.creditCardConnected,
                     githubConnected: githubConnected,
-                    businessEmailVerified: !!user?.profile?.business_email_verified,
+                    businessEmailVerified: !!organizationTier?.hasVerifiedBusinessEmail,
                     phoneVerified: !!user?.profile?.phone_verified,
                   }}
                 />


### PR DESCRIPTION
## Description

Use `hasVerifiedBusinessEmail` to populate Tier 3 requirements instead of IDP claims.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
