### PR TITLE
chore: add per project go work sync PR check

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -26,9 +26,8 @@ jobs:
       - name: go work
         run: |
           go work sync
-          git diff --exit-code go.work || (echo "go.work is not up to date! Please run 'go work sync' and commit" && exit 1)
-          git diff --exit-code go.work.sum || (echo "go.work.sum is not up to date! Please run 'go work sync' and commit" && exit 1)
-
+          git diff --exit-code -- 'go.work*' '*/go.mod' '*/go.sum' || (echo "Go workspace files are not up to date! Please run 'go work sync' and commit the changes." && exit 1)
+          
   golangci:
     name: Go lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This pull request updates the workflow check for Go workspace files in `.github/workflows/pr_checks.yaml` to ensure that all relevant Go workspace and module files are up to date. The check is now broader and provides clearer instructions if files are out of sync.

Workflow improvements:

* The Go workspace validation step now checks all `go.work*`, `*/go.mod`, and `*/go.sum` files for changes, instead of only `go.work` and `go.work.sum`, and gives a clearer error message if updates are needed.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation