### PR TITLE
fix(api): include cmd with entrypoint for sandbox

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -632,6 +632,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       snapshotInfoResponse.hash,
       snapshotInfoResponse.sizeGB,
       snapshotInfoResponse.entrypoint,
+      snapshotInfoResponse.cmd,
     )
 
     try {
@@ -1076,6 +1077,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     hash: string,
     sizeGB: number,
     entrypoint?: string[] | string,
+    cmd?: string[],
   ) {
     let shouldSave = false
     if (!snapshot.ref) {
@@ -1116,6 +1118,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
           snapshot.entrypoint = [entrypoint]
         }
       }
+    }
+
+    if (cmd && cmd.length > 0) {
+      shouldSave = true
+      snapshot.entrypoint = snapshot.entrypoint.concat(cmd)
     }
 
     if (shouldSave) {


### PR DESCRIPTION
## Description

This pull request updates the `SnapshotManager` to better handle command information when managing snapshots. The main enhancement is the addition of a new `cmd` parameter, which allows for more flexible and accurate construction of the snapshot's entrypoint.

**Enhancements to snapshot creation and update:**

* The `createOrUpdateSnapshot` method now accepts an optional `cmd` parameter, which is an array of strings representing additional command arguments.
* When a `cmd` is provided and is non-empty, its contents are appended to the `entrypoint` array for the snapshot, ensuring the full command is captured.
* The `cmd` value from the `snapshotInfoResponse` is now passed through to the `createOrUpdateSnapshot` method, allowing upstream sources to specify command arguments.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
