### PR TITLE
refactor(api,dashboard): only shared regions can be set as org default region

### DIFF
--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -271,7 +271,7 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
       throw new ConflictException('Organization already has a default region set')
     }
 
-    const defaultRegion = await this.validateOrganizationDefaultRegion(defaultRegionId, organizationId)
+    const defaultRegion = await this.validateOrganizationDefaultRegion(defaultRegionId)
     organization.defaultRegionId = defaultRegionId
 
     if (defaultRegion.enforceQuotas) {
@@ -408,15 +408,11 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
   }
 
   /**
-   * @param organizationId - Optional when validating during organization creation.
-   * @throws NotFoundException - If the region is not found or not available to the organization
+   * @throws NotFoundException - If the region is not found, hidden, or not a shared region
    */
-  async validateOrganizationDefaultRegion(defaultRegionId: string, organizationId?: string): Promise<Region> {
+  async validateOrganizationDefaultRegion(defaultRegionId: string): Promise<Region> {
     const region = await this.regionService.findOne(defaultRegionId)
-    if (!region || region.hidden) {
-      throw new NotFoundException('Region not found')
-    }
-    if (organizationId && region.organizationId && region.organizationId !== organizationId) {
+    if (!region || region.hidden || region.organizationId !== null) {
       throw new NotFoundException('Region not found')
     }
 

--- a/apps/dashboard/src/components/Organizations/OrganizationPicker.tsx
+++ b/apps/dashboard/src/components/Organizations/OrganizationPicker.tsx
@@ -27,7 +27,7 @@ export const OrganizationPicker: React.FC = () => {
 
   const { organizations, refreshOrganizations } = useOrganizations()
   const { selectedOrganization, onSelectOrganization } = useSelectedOrganization()
-  const { regions, loadingRegions, getRegionName } = useRegions()
+  const { sharedRegions, loadingRegions, getRegionName } = useRegions()
 
   const [optimisticSelectedOrganization, setOptimisticSelectedOrganization] = useState(selectedOrganization)
   const [loadingSelectOrganization, setLoadingSelectOrganization] = useState(false)
@@ -140,7 +140,7 @@ export const OrganizationPicker: React.FC = () => {
       <CreateOrganizationDialog
         open={showCreateOrganizationDialog}
         onOpenChange={setShowCreateOrganizationDialog}
-        regions={regions}
+        regions={sharedRegions}
         loadingRegions={loadingRegions}
         getRegionName={getRegionName}
         onCreateOrganization={handleCreateOrganization}

--- a/apps/dashboard/src/contexts/RegionsContext.tsx
+++ b/apps/dashboard/src/contexts/RegionsContext.tsx
@@ -9,6 +9,8 @@ import { createContext } from 'react'
 export interface IRegionsContext {
   regions: Region[]
   loadingRegions: boolean
+  sharedRegions: Region[]
+  organizationRegions: Region[]
   refreshRegions: () => Promise<Region[]>
   getRegionName: (regionId: string) => string | undefined
 }

--- a/apps/dashboard/src/pages/OrganizationSettings.tsx
+++ b/apps/dashboard/src/pages/OrganizationSettings.tsx
@@ -24,7 +24,7 @@ const OrganizationSettings: React.FC = () => {
 
   const { refreshOrganizations } = useOrganizations()
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
-  const { getRegionName, regions, loadingRegions } = useRegions()
+  const { getRegionName, sharedRegions, loadingRegions } = useRegions()
 
   const [loadingDeleteOrganization, setLoadingDeleteOrganization] = useState(false)
   const [loadingLeaveOrganization, setLoadingLeaveOrganization] = useState(false)
@@ -165,7 +165,7 @@ const OrganizationSettings: React.FC = () => {
       <SetDefaultRegionDialog
         open={showSetDefaultRegionDialog}
         onOpenChange={setSetDefaultRegionDialog}
-        regions={regions}
+        regions={sharedRegions}
         loadingRegions={loadingRegions}
         onSetDefaultRegion={handleSetDefaultRegion}
       />

--- a/apps/dashboard/src/providers/RegionsProvider.tsx
+++ b/apps/dashboard/src/providers/RegionsProvider.tsx
@@ -53,14 +53,24 @@ export function RegionsProvider(props: Props) {
     [regions],
   )
 
+  const sharedRegions = useMemo(() => {
+    return regions.filter((region) => region.organizationId === null)
+  }, [regions])
+
+  const organizationRegions = useMemo(() => {
+    return regions.filter((region) => region.organizationId !== null)
+  }, [regions])
+
   const contextValue: IRegionsContext = useMemo(() => {
     return {
       regions,
       loadingRegions,
+      sharedRegions,
+      organizationRegions,
       refreshRegions: getRegions,
       getRegionName,
     }
-  }, [regions, loadingRegions, getRegions, getRegionName])
+  }, [regions, loadingRegions, sharedRegions, organizationRegions, getRegions, getRegionName])
 
   return <RegionsContext.Provider value={contextValue}>{props.children}</RegionsContext.Provider>
 }


### PR DESCRIPTION
## Description

Modified the validation flow for setting a default region for an organization. Only shared regions are supported. 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
