### PR TITLE
fix(proxy): don't fail early on invalid auth; evaluate all options

### DIFF
--- a/apps/proxy/pkg/proxy/auth.go
+++ b/apps/proxy/pkg/proxy/auth.go
@@ -32,6 +32,7 @@ func (p *Proxy) Authenticate(ctx *gin.Context, sandboxId string) (err error, did
 	// Try auth key from header
 	authKey := ctx.Request.Header.Get(SANDBOX_AUTH_KEY_HEADER)
 	if authKey != "" {
+		ctx.Request.Header.Del(SANDBOX_AUTH_KEY_HEADER)
 		isValid, err := p.getSandboxAuthKeyValid(ctx, sandboxId, authKey)
 		if err != nil {
 			authErrors = append(authErrors, fmt.Sprintf("Auth key header validation error: %v", err))


### PR DESCRIPTION
## Description

This pull request fixes an issue where apps deployed in a sandbox using a Bearer token could not be accessed via the `Authorization` header. The proxy incorrectly attempted to authenticate the Bearer token against the sandbox itself and failed without falling back to other authentication methods, such as cookie or the `X-Daytona-Preview-Token` header.

It refactors the `Authenticate` method in `apps/proxy/pkg/proxy/auth.go` to improve authentication flow and error handling. The new implementation tries multiple authentication methods in order, collects detailed error messages when each method fails, and provides more informative feedback when authentication is unsuccessful.

Authentication flow improvements:

* The method now attempts authentication in the following order: Bearer token (header), Auth key (header), Auth key (query parameter), and cookie. Each method is tried independently, and the process stops as soon as one succeeds.
* If all authentication methods fail, the method redirects the user to the authentication URL and returns a detailed error message that aggregates the reasons for failure from all attempted methods.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
