### PR TITLE
chore(api): remove node install from dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-alpine AS daytona
 
 # Install nodejs
-RUN apk --update add --no-cache nodejs=22.16.0-r2 npm bash curl
+RUN apk --update add --no-cache bash curl
 RUN npm install -g corepack && corepack enable
 
 WORKDIR /daytona


### PR DESCRIPTION
## Description

Removed faulty node install from api Dockerfile. The node install was not needed anyway since it's part of the image itself.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
