### PR TITLE
fix(api): sandbox deletion missing calls

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -243,6 +243,13 @@ export class Sandbox {
     }
   }
 
+  public applyDesiredDestroyedState(): void {
+    this.pending = true
+    this.desiredState = SandboxDesiredState.DESTROYED
+    this.backupState = BackupState.NONE
+    this.name = 'DESTROYED_' + this.name + '_' + Date.now()
+  }
+
   @BeforeUpdate()
   updateLastActivityAt() {
     this.lastActivityAt = new Date()

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -111,11 +111,11 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
               }
 
               try {
-                sandbox.pending = true
                 //  if auto-delete interval is 0, delete the sandbox immediately
                 if (sandbox.autoDeleteInterval === 0) {
-                  sandbox.desiredState = SandboxDesiredState.DESTROYED
+                  sandbox.applyDesiredDestroyedState()
                 } else {
+                  sandbox.pending = true
                   sandbox.desiredState = SandboxDesiredState.STOPPED
                 }
                 await this.sandboxRepository.saveWhere(sandbox, { pending: false, state: sandbox.state })
@@ -228,8 +228,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
               }
 
               try {
-                sandbox.pending = true
-                sandbox.desiredState = SandboxDesiredState.DESTROYED
+                sandbox.applyDesiredDestroyedState()
                 await this.sandboxRepository.saveWhere(sandbox, { pending: false, state: sandbox.state })
                 this.syncInstanceState(sandbox.id)
               } catch (error) {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1023,10 +1023,7 @@ export class SandboxService {
     if (sandbox.pending) {
       throw new SandboxError('Sandbox state change in progress')
     }
-    sandbox.pending = true
-    sandbox.desiredState = SandboxDesiredState.DESTROYED
-    sandbox.backupState = BackupState.NONE
-    sandbox.name = 'DESTROYED_' + sandbox.name + '_' + Date.now()
+    sandbox.applyDesiredDestroyedState()
     await this.sandboxRepository.saveWhere(sandbox, { pending: false, state: sandbox.state })
 
     this.eventEmitter.emit(SandboxEvents.DESTROYED, new SandboxDestroyedEvent(sandbox))


### PR DESCRIPTION
## Sandbox deletion missing calls

Adds Sandbox deletion missing calls for backup state and name updates. They should be done on the service, during auto deletion and during autostop of ephemeral sandboxes

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
