### PR TITLE
refactor(api): remove org permission requirement for transient registry push access

### DIFF
--- a/apps/api/src/docker-registry/controllers/docker-registry.controller.ts
+++ b/apps/api/src/docker-registry/controllers/docker-registry.controller.ts
@@ -120,7 +120,6 @@ export class DockerRegistryController {
     description: 'Temporary registry access has been generated',
     type: RegistryPushAccessDto,
   })
-  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGISTRIES])
   async getTransientPushAccess(@AuthContext() authContext: OrganizationAuthContext): Promise<RegistryPushAccessDto> {
     return this.dockerRegistryService.getRegistryPushAccess(authContext.organizationId, authContext.userId)
   }


### PR DESCRIPTION
## Description

Removed an unnecessary requirement for `write:registries` organization permission when getting transient registry push access. This permission is intended for controlling write access for registries controlled by the organization.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
