### PR TITLE
fix(runner): set correct entrypoint  on restore

### DIFF
--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -71,7 +71,12 @@ func (d *DockerClient) getContainerCreateConfig(ctx context.Context, sandboxDto 
 		}
 
 		entrypoint = []string{"/usr/local/bin/daytona"}
-		cmd = append(cmd, sandboxDto.Entrypoint...)
+
+		if len(sandboxDto.Entrypoint) != 0 {
+			cmd = append(cmd, sandboxDto.Entrypoint...)
+		} else {
+			cmd = append(cmd, image.Config.Entrypoint...)
+		}
 	}
 
 	return &container.Config{


### PR DESCRIPTION
## Description

This pull request introduces a change to how container entrypoints are set when creating a container in the Docker client logic. The update improves flexibility by allowing a custom entrypoint to be specified via the `sandboxDto` object, and falls back to the image's default entrypoint if none is provided.

Container entrypoint configuration:

* In `container_configs.go`, the logic in `getContainerCreateConfig` now checks if `sandboxDto.Entrypoint` is set. If so, it uses that as the entrypoint; otherwise, it defaults to the image's configured entrypoint.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation