### PR TITLE
feat(api): tweak automatic lifecycle numbers

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -65,7 +65,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-stop-check' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'auto-stop-check' })
   @TrackJobExecution()
   @WithInstrumentation()
   @LogExecution('auto-stop-check')
@@ -98,8 +98,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             order: {
               lastBackupAt: 'ASC',
             },
-            //  todo: increase this number when auto-stop is stable
-            take: 10,
+            take: 100,
           })
 
           await Promise.all(
@@ -134,7 +133,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-archive-check' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'auto-archive-check' })
   @TrackJobExecution()
   @LogExecution('auto-archive-check')
   @WithInstrumentation()
@@ -157,7 +156,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         order: {
           lastBackupAt: 'ASC',
         },
-        take: 200,
+        take: 100,
       })
 
       await Promise.all(
@@ -184,7 +183,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'auto-delete-check' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'auto-delete-check' })
   @TrackJobExecution()
   @LogExecution('auto-delete-check')
   @WithInstrumentation()


### PR DESCRIPTION
## Tweak automatic lifecycle numbers

Minor tweaks to automatic sandbox lifecycle update cron jobs, making the auto stop, auto archive and auto delete actions take place with less delay and use consistent interval/take numbers

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
