### PR TITLE
fix: wait for mount

### DIFF
--- a/apps/runner/pkg/docker/volumes_mountpaths.go
+++ b/apps/runner/pkg/docker/volumes_mountpaths.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/daytonaio/runner/cmd/runner/config"
 	"github.com/daytonaio/runner/internal/util"
@@ -68,6 +69,12 @@ func (d *DockerClient) getVolumesMountPathBinds(ctx context.Context, volumes []d
 			return nil, fmt.Errorf("failed to mount S3 volume %s (subpath: %s) to %s: %s", volumeIdPrefixed, subpathStr, runnerVolumeMountPath, err)
 		}
 
+		// Wait for FUSE mount to be fully ready before proceeding
+		err = d.waitForMountReady(ctx, runnerVolumeMountPath)
+		if err != nil {
+			return nil, fmt.Errorf("mount %s not ready after mounting: %s", runnerVolumeMountPath, err)
+		}
+
 		log.Infof("mounted S3 volume %s (subpath: %s) to %s", volumeIdPrefixed, subpathStr, runnerVolumeMountPath)
 
 		volumeMountPathBinds = append(volumeMountPathBinds, fmt.Sprintf("%s/:%s/", runnerVolumeMountPath, vol.MountPath))
@@ -106,6 +113,43 @@ func (d *DockerClient) isDirectoryMounted(path string) bool {
 	_, err := cmd.Output()
 
 	return err == nil
+}
+
+// waitForMountReady waits for a FUSE mount to be fully accessible
+// FUSE mounts can be asynchronous - the mount command may return before the filesystem is ready
+// This prevents a race condition where the container writes to the directory before the mount is ready
+func (d *DockerClient) waitForMountReady(ctx context.Context, path string) error {
+	maxAttempts := 50 // 5 seconds total (50 * 100ms)
+	sleepDuration := 100 * time.Millisecond
+
+	for i := 0; i < maxAttempts; i++ {
+		// First verify the mountpoint is still registered
+		if !d.isDirectoryMounted(path) {
+			return fmt.Errorf("mount disappeared during readiness check")
+		}
+
+		// Try to stat the mount point to ensure filesystem is responsive
+		// This will fail if FUSE is not ready yet
+		_, err := os.Stat(path)
+		if err == nil {
+			// Try to read directory to ensure it's fully operational
+			_, err = os.ReadDir(path)
+			if err == nil {
+				log.Infof("mount %s is ready after %d attempts", path, i+1)
+				return nil
+			}
+		}
+
+		// Wait a bit before retrying
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for mount ready: %w", ctx.Err())
+		case <-time.After(sleepDuration):
+			// Continue to next iteration
+		}
+	}
+
+	return fmt.Errorf("mount did not become ready within timeout")
 }
 
 func (d *DockerClient) getMountCmd(ctx context.Context, volume string, subpath *string, path string) *exec.Cmd {


### PR DESCRIPTION
## Description

Fixed a race condition in FUSE mount initialization where containers could start before the mount was fully ready. The mount-s3 command returns before the FUSE filesystem is fully initialized, causing files to be written to the underlying directory instead of the mounted filesystem, which prevents the mount from completing successfully.
Added waitForMountReady() function that verifies the FUSE mount is fully operational by:
Checking the mountpoint is registered
Testing filesystem responsiveness with os.Stat()
Validating directory operations with os.ReadDir()
Waiting up to 5 seconds with 100ms intervals
This ensures containers only start after FUSE mounts are fully ready and operational.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

