### PR TITLE
feat(cli): add "Did you mean?" suggestions for command typos

### DIFF
--- a/apps/cli/cmd/mcp/mcp.go
+++ b/apps/cli/cmd/mcp/mcp.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -11,6 +12,7 @@ var MCPCmd = &cobra.Command{
 	Use:   "mcp",
 	Short: "Manage Daytona MCP Server",
 	Long:  "Commands for managing Daytona MCP Server",
+	RunE:  internal.GetParentCmdRunE(),
 }
 
 func init() {

--- a/apps/cli/cmd/organization/organization.go
+++ b/apps/cli/cmd/organization/organization.go
@@ -24,6 +24,7 @@ var OrganizationCmd = &cobra.Command{
 
 		return nil
 	},
+	RunE: internal.GetParentCmdRunE(),
 }
 
 func init() {

--- a/apps/cli/cmd/sandbox/sandbox.go
+++ b/apps/cli/cmd/sandbox/sandbox.go
@@ -14,6 +14,7 @@ var SandboxCmd = &cobra.Command{
 	Long:    "Commands for managing Daytona sandboxes",
 	Aliases: []string{"sandboxes"},
 	GroupID: internal.SANDBOX_GROUP,
+	RunE:    internal.GetParentCmdRunE(),
 }
 
 func init() {

--- a/apps/cli/cmd/snapshot/snapshot.go
+++ b/apps/cli/cmd/snapshot/snapshot.go
@@ -14,6 +14,7 @@ var SnapshotsCmd = &cobra.Command{
 	Long:    "Commands for managing Daytona snapshots",
 	Aliases: []string{"snapshots"},
 	GroupID: internal.SANDBOX_GROUP,
+	RunE:    internal.GetParentCmdRunE(),
 }
 
 func init() {

--- a/apps/cli/cmd/volume/volume.go
+++ b/apps/cli/cmd/volume/volume.go
@@ -14,6 +14,7 @@ var VolumeCmd = &cobra.Command{
 	Long:    "Commands for managing Daytona volumes",
 	Aliases: []string{"volumes"},
 	GroupID: internal.SANDBOX_GROUP,
+	RunE:    internal.GetParentCmdRunE(),
 }
 
 func init() {

--- a/apps/cli/internal/cmd.go
+++ b/apps/cli/internal/cmd.go
@@ -3,7 +3,47 @@
 
 package internal
 
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 const (
 	USER_GROUP    = "user"
 	SANDBOX_GROUP = "sandbox"
 )
+
+// DefaultSuggestionsMinDistance is the Levenshtein distance threshold for suggestions.
+// Typos within this distance will trigger "Did you mean?" suggestions.
+const DefaultSuggestionsMinDistance = 2
+
+// GetParentCmdRunE returns a RunE function for parent commands that shows suggestions
+// when an unknown subcommand is provided. This enables "Did you mean?" functionality
+// for typos in subcommands (e.g., "daytona sandbox lst" -> "Did you mean list?").
+func GetParentCmdRunE() func(*cobra.Command, []string) error {
+	return func(c *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			// Set suggestion distance threshold for Cobra's SuggestionsFor
+			if c.SuggestionsMinimumDistance <= 0 {
+				c.SuggestionsMinimumDistance = DefaultSuggestionsMinDistance
+			}
+
+			// Build error message with suggestions using Cobra's SuggestionsFor
+			unknownCmd := args[0]
+			errMsg := fmt.Sprintf("unknown command %q for %q", unknownCmd, c.CommandPath())
+
+			// Get suggestions from Cobra (uses Levenshtein distance)
+			suggestions := c.SuggestionsFor(unknownCmd)
+			if len(suggestions) > 0 {
+				errMsg += "\n\nDid you mean this?\n"
+				for _, s := range suggestions {
+					errMsg += fmt.Sprintf("\t%s\n", s)
+				}
+			}
+
+			return fmt.Errorf("%s", errMsg)
+		}
+		return c.Help()
+	}
+}

--- a/apps/cli/main.go
+++ b/apps/cli/main.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -69,6 +71,15 @@ func main() {
 
 	err := rootCmd.Execute()
 	if err != nil {
+		errStr := err.Error()
+		// Check if it's an unknown command error (Cobra includes suggestions)
+		if strings.Contains(errStr, "unknown command") {
+			// Print the error message cleanly to stderr
+			fmt.Fprintln(os.Stderr, errStr)
+			fmt.Fprintln(os.Stderr, "\nRun 'daytona --help' for usage.")
+			os.Exit(1)
+		}
+		// For other errors, use the standard logging
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary
Implements command auto-suggestions when users enter typos, mimicking the behavior found in tools like `git`.

- Clean error output for unknown commands (replaces logrus formatting with stderr)
- Uses Cobra's built-in Levenshtein distance algorithm for suggestions
- Works for both top-level commands (`daytona napshot`) and subcommands (`daytona sandbox lst`)
- Unrecognizable typos show no suggestion to avoid confusion

Fixes #3001

## Examples

**Top-level command typo:**
```bash
$ daytona napshot
Error: unknown command "napshot" for "daytona"

Did you mean this?
	snapshot

Run 'daytona --help' for usage.
```

**Subcommand typo:**
```bash
$ daytona sandbox lst
Error: unknown command "lst" for "daytona sandbox"

Did you mean this?
	list

Run 'daytona --help' for usage.
```

**Unrecognizable typo (no suggestion):**
```bash
$ daytona sandbox xyz
Error: unknown command "xyz" for "daytona sandbox"

Run 'daytona --help' for usage.
```

## Test plan
- [x] `daytona napshot` suggests `snapshot`
- [x] `daytona sanbox` suggests `sandbox`
- [x] `daytona sandbox lst` suggests `list`
- [x] `daytona sandbox creat` suggests `create`
- [x] `daytona volume delet` suggests `delete`
- [x] `daytona snapshot psh` suggests `push`
- [x] `daytona sandbox xyz` shows no suggestion (unrecognizable)
- [x] Normal commands (`daytona sandbox`, `daytona --help`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)