### PR TITLE
fix(docs): use correct method for sandbox preview link

### DIFF
--- a/apps/docs/src/content/docs/en/preview-and-authentication.mdx
+++ b/apps/docs/src/content/docs/en/preview-and-authentication.mdx
@@ -28,7 +28,7 @@ print(f"Preview link token: {preview_info.token}")
 <TabItem label="TypeScript" icon="seti:typescript">
 ```typescript
 
-const previewInfo = await sandbox.getPreviewUrl(3000);
+const previewInfo = await sandbox.getPreviewLink(3000);
 
 console.log(`Preview link url: ${previewInfo.url}`);
 console.log(`Preview link token: ${previewInfo.token}`);

--- a/apps/docs/src/content/docs/ja/preview-and-authentication.mdx
+++ b/apps/docs/src/content/docs/ja/preview-and-authentication.mdx
@@ -35,7 +35,7 @@ print(f"Preview link token: {preview_info.token}")
 <TabItem label="TypeScript" icon="seti:typescript">
 ```typescript
 
-const previewInfo = await sandbox.getPreviewUrl(3000);
+const previewInfo = await sandbox.getPreviewLink(3000);
 
 console.log(`Preview link url: ${previewInfo.url}`);
 console.log(`Preview link token: ${previewInfo.token}`);


### PR DESCRIPTION
## Description

Addressed the incorrect method that was being used for getting sandbox preview link in the documentation.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation
