### PR TITLE
feat(api,dashboard): organization infra feature flag

### DIFF
--- a/apps/api/src/common/constants/feature-flags.ts
+++ b/apps/api/src/common/constants/feature-flags.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export const FeatureFlags = {
+  ORGANIZATION_INFRASTRUCTURE: 'organization_infrastructure',
+} as const

--- a/apps/api/src/organization/controllers/region.controller.ts
+++ b/apps/api/src/organization/controllers/region.controller.ts
@@ -35,6 +35,8 @@ import { RegionService } from '../../region/services/region.service'
 import { RegionAccessGuard } from '../../region/guards/region-access.guard'
 import { RegenerateApiKeyResponseDto } from '../../region/dto/regenerate-api-key.dto'
 import { RegionType } from '../../region/enums/region-type.enum'
+import { RequireFlagsEnabled } from '@openfeature/nestjs-sdk'
+import { FeatureFlags } from '../../common/constants/feature-flags'
 
 @ApiTags('regions')
 @Controller('regions')
@@ -88,6 +90,7 @@ export class OrganizationRegionController {
     },
   })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async createRegion(
     @AuthContext() authContext: OrganizationAuthContext,
     @Body() createRegionDto: CreateRegionDto,
@@ -147,6 +150,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.DELETE_REGIONS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async deleteRegion(@Param('id') id: string): Promise<void> {
     await this.regionService.delete(id)
   }
@@ -175,6 +179,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async regenerateProxyApiKey(@Param('id') id: string): Promise<RegenerateApiKeyResponseDto> {
     const apiKey = await this.regionService.regenerateProxyApiKey(id)
     return new RegenerateApiKeyResponseDto(apiKey)
@@ -204,6 +209,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async regenerateSshGatewayApiKey(@Param('id') id: string): Promise<RegenerateApiKeyResponseDto> {
     const apiKey = await this.regionService.regenerateSshGatewayApiKey(id)
     return new RegenerateApiKeyResponseDto(apiKey)

--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -58,6 +58,8 @@ import { SandboxAccessGuard } from '../guards/sandbox-access.guard'
 import { RunnerFullDto } from '../dto/runner-full.dto'
 import { RegionType } from '../../region/enums/region-type.enum'
 import { RegionService } from '../../region/services/region.service'
+import { RequireFlagsEnabled } from '@openfeature/nestjs-sdk'
+import { FeatureFlags } from '../../common/constants/feature-flags'
 
 @ApiTags('runners')
 @Controller('runners')
@@ -97,6 +99,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_RUNNERS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async create(
     @Body() createRunnerDto: CreateRunnerDto,
     @AuthContext() authContext: OrganizationAuthContext,
@@ -160,6 +163,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_RUNNERS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async findAll(@AuthContext() authContext: OrganizationAuthContext): Promise<RunnerDto[]> {
     return this.runnerService.findAllByOrganization(authContext.organizationId, RegionType.CUSTOM)
   }
@@ -215,6 +219,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard, RunnerAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_RUNNERS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async updateSchedulingStatus(
     @Param('id') id: string,
     @Body('unschedulable') unschedulable: boolean,
@@ -245,6 +250,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard, RunnerAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.DELETE_RUNNERS])
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async delete(@Param('id') id: string): Promise<void> {
     return this.runnerService.remove(id)
   }

--- a/apps/dashboard/src/components/PostHogProviderWrapper.tsx
+++ b/apps/dashboard/src/components/PostHogProviderWrapper.tsx
@@ -14,7 +14,7 @@ interface PostHogProviderWrapperProps {
 export const PostHogProviderWrapper: FC<PostHogProviderWrapperProps> = ({ children }) => {
   const config = useConfig()
 
-  if (!import.meta.env.PROD || !config.posthog) {
+  if (!config.posthog) {
     return children
   }
 

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -57,6 +57,8 @@ import { Button } from './ui/button'
 import { Card, CardHeader, CardTitle } from './ui/card'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip'
+import { useFeatureFlagEnabled } from 'posthog-js/react'
+import { FeatureFlags } from '@/enums/FeatureFlags'
 interface SidebarProps {
   isBannerVisible: boolean
   billingEnabled: boolean
@@ -71,6 +73,8 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
     useSelectedOrganization()
   const { count: organizationInvitationsCount } = useUserOrganizationInvitations()
   const { isInitialized: webhooksInitialized, openAppPortal } = useWebhooks()
+  const orgInfraEnabled = useFeatureFlagEnabled(FeatureFlags.ORGANIZATION_INFRASTRUCTURE)
+
   const sidebarItems = useMemo(() => {
     const arr: Array<{
       icon: React.ReactElement
@@ -171,6 +175,10 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
   }, [billingEnabled, authenticatedUserOrganizationMember?.role])
 
   const infrastructureItems = useMemo(() => {
+    if (!orgInfraEnabled) {
+      return []
+    }
+
     const arr = [
       {
         icon: <MapPinned size={16} strokeWidth={1.5} />,
@@ -188,7 +196,7 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
     }
 
     return arr
-  }, [authenticatedUserHasPermission])
+  }, [authenticatedUserHasPermission, orgInfraEnabled])
 
   const handleSignOut = () => {
     signoutRedirect()

--- a/apps/dashboard/src/enums/FeatureFlags.ts
+++ b/apps/dashboard/src/enums/FeatureFlags.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export enum FeatureFlags {
+  ORGANIZATION_INFRASTRUCTURE = 'organization_infrastructure',
+}


### PR DESCRIPTION
This pull request introduces a new feature flag, `ORGANIZATION_INFRASTRUCTURE`, and integrates it throughout both the backend API and frontend dashboard applications. The flag is used to conditionally enable or disable organization infrastructure-related features, such as regions and runners, based on its status. The implementation ensures that both API endpoints and UI routes/components are protected by the feature flag, providing a consistent experience across the stack.

**Feature flag definition and usage**

* Added `FeatureFlags` constant and enum to both API (`apps/api/src/common/constants/feature-flags.ts`) and dashboard (`apps/dashboard/src/enums/FeatureFlags.ts`) codebases to define the `ORGANIZATION_INFRASTRUCTURE` flag. [[1]](diffhunk://#diff-4eac5c6928164b492908f8bf8f7d0de1e26636ef389177168799206a369b3207R1-R8) [[2]](diffhunk://#diff-b55c8009272d4e0ca5f81beef5bdc5259c15f07e557bd44035f523e770658a3aR1-R8)

**Backend API feature flag enforcement**

* Applied the `@RequireFlagsEnabled` decorator to key region and runner controller methods, restricting create, delete, update, and key regeneration endpoints to only be available when the feature flag is enabled. [[1]](diffhunk://#diff-30840ca0d858c9d69ef50a3d92a8138435d7423b497f97f28c9bcfaaaa11c878R93) [[2]](diffhunk://#diff-30840ca0d858c9d69ef50a3d92a8138435d7423b497f97f28c9bcfaaaa11c878R153) [[3]](diffhunk://#diff-30840ca0d858c9d69ef50a3d92a8138435d7423b497f97f28c9bcfaaaa11c878R182) [[4]](diffhunk://#diff-30840ca0d858c9d69ef50a3d92a8138435d7423b497f97f28c9bcfaaaa11c878R212) [[5]](diffhunk://#diff-64212dd108cf34b5a04683e77a1160b19e07a09129ca7cbaa9c54f323f53dd39R102) [[6]](diffhunk://#diff-64212dd108cf34b5a04683e77a1160b19e07a09129ca7cbaa9c54f323f53dd39R166) [[7]](diffhunk://#diff-64212dd108cf34b5a04683e77a1160b19e07a09129ca7cbaa9c54f323f53dd39R222) [[8]](diffhunk://#diff-64212dd108cf34b5a04683e77a1160b19e07a09129ca7cbaa9c54f323f53dd39R253)

**Frontend dashboard feature flag enforcement**

* Wrapped the Regions and Runners routes in a new `RequiredFeatureFlagWrapper` component, which redirects users away from these pages if the feature flag is not enabled. Sidebar navigation items for infrastructure are also conditionally rendered based on the flag. [[1]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7L225-R243) [[2]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R294-R303) [[3]](diffhunk://#diff-ee93bab0914ad4d66d91b0a43d39f3bc6030b4b87acb301e4d2ee7c916fd3436R60-R61) [[4]](diffhunk://#diff-ee93bab0914ad4d66d91b0a43d39f3bc6030b4b87acb301e4d2ee7c916fd3436R76-R77) [[5]](diffhunk://#diff-ee93bab0914ad4d66d91b0a43d39f3bc6030b4b87acb301e4d2ee7c916fd3436R178-R181) [[6]](diffhunk://#diff-ee93bab0914ad4d66d91b0a43d39f3bc6030b4b87acb301e4d2ee7c916fd3436L191-R199)

**Minor refactoring for analytics**

* Removed unnecessary production environment check from PostHog analytics initialization, simplifying the logic for enabling analytics. [[1]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7L78-R79) [[2]](diffhunk://#diff-4d4d02792bf5611f23a80a7a6e961e8fc00cce863bfea7544c43ff0ec567da9aL17-R17)

**Codebase consistency**

* Ensured consistent imports and usage of the feature flag utilities (`useFeatureFlagEnabled`) across React components and controller files. [[1]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7L16-R16) [[2]](diffhunk://#diff-1f2d307449b13a083ae29e6755022141a01f879b12018c84b75256fb1ca62da7R53) [[3]](diffhunk://#diff-ee93bab0914ad4d66d91b0a43d39f3bc6030b4b87acb301e4d2ee7c916fd3436R60-R61)

These changes centralize feature flag management and ensure that organization infrastructure features are only accessible when explicitly enabled, improving control and rollout flexibility.