### PR TITLE
fix(dashboard): invalidate limits queries after redeeming coupon

### DIFF
--- a/apps/dashboard/src/hooks/mutations/useRedeemCouponMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useRedeemCouponMutation.ts
@@ -20,6 +20,10 @@ export const useRedeemCouponMutation = () => {
     mutationFn: ({ organizationId, couponCode }) => billingApi.redeemCoupon(organizationId, couponCode),
     onSuccess: (_data, { organizationId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.organization.wallet(organizationId) })
+
+      // a coupon can upgrade the tier
+      queryClient.invalidateQueries({ queryKey: queryKeys.organization.tier(organizationId) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.organization.usage.overview(organizationId) })
     },
   })
 }


### PR DESCRIPTION
## Description

Redeeming a coupon can upgrade the tier so we need to invalidate the related queries.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation