### PR TITLE
fix(proxy): add missing redis tls support

### DIFF
--- a/apps/proxy/cmd/proxy/config/config.go
+++ b/apps/proxy/cmd/proxy/config/config.go
@@ -47,6 +47,7 @@ type RedisConfig struct {
 	Host     *string `envconfig:"HOST"`
 	Port     *int    `envconfig:"PORT"`
 	Password *string `envconfig:"PASSWORD"`
+	TLS      *bool   `envconfig:"TLS"`
 }
 
 var DEFAULT_PROXY_PORT int = 4000

--- a/libs/common-go/pkg/cache/redis_cache.go
+++ b/libs/common-go/pkg/cache/redis_cache.go
@@ -5,6 +5,7 @@ package cache
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -74,10 +75,14 @@ func NewRedisCache[T any](config *config.RedisConfig, keyPrefix string) (*RedisC
 	}
 
 	if client == nil {
-		client = redis.NewClient(&redis.Options{
+		options := &redis.Options{
 			Addr:     fmt.Sprintf("%s:%d", *config.Host, *config.Port),
 			Password: password,
-		})
+		}
+		if config.TLS != nil && *config.TLS {
+			options.TLSConfig = &tls.Config{}
+		}
+		client = redis.NewClient(options)
 	}
 
 	return &RedisCache[T]{


### PR DESCRIPTION
## Description

Proxy was missing redis TLS config (which the API has).

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
