### PR TITLE
refactor(api,dashboard): activate snapshot

### DIFF
--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -544,8 +544,7 @@ export class SnapshotService {
         pendingSnapshotCountIncrement = activatedSnapshotCount
       }
 
-      snapshot.state = SnapshotState.ACTIVE
-      snapshot.lastUsedAt = new Date()
+      snapshot.state = SnapshotState.PENDING
       return await this.snapshotRepository.save(snapshot)
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, pendingSnapshotCountIncrement)

--- a/apps/dashboard/src/pages/Snapshots.tsx
+++ b/apps/dashboard/src/pages/Snapshots.tsx
@@ -309,7 +309,7 @@ const Snapshots: React.FC = () => {
     // Optimistically update the snapshot state
     setSnapshotsData((prev) => ({
       ...prev,
-      items: prev.items.map((i) => (i.id === snapshot.id ? { ...i, state: SnapshotState.ACTIVE } : i)),
+      items: prev.items.map((i) => (i.id === snapshot.id ? { ...i, state: SnapshotState.PENDING } : i)),
     }))
 
     try {


### PR DESCRIPTION
## Description

Improved the process of activating an inactive snapshot. Instead of setting the state to "Active" and waiting for the snapshot manager to propagate it to runners, now the state is set to "Pending" which imitates the flow with newly created snapshots.

This will allow users to start using the activated snapshot much sooner, as the snapshot will be immediately propagated to its initial runner.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
