### PR TITLE
fix(api): validate snapshot ref set

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -354,6 +354,10 @@ export class SandboxService {
         throw new BadRequestError(`Snapshot ${snapshotIdOrName} is ${snapshot.state}`)
       }
 
+      if (!snapshot.ref) {
+        throw new BadRequestError('Snapshot ref is not defined')
+      }
+
       let cpu = snapshot.cpu
       let mem = snapshot.mem
       let disk = snapshot.disk


### PR DESCRIPTION
## Description

Validates the snapshot has a properly set "ref" when creating a sandbox

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
