### PR TITLE
feat(docs): recovery examples and sdk ref

### DIFF
--- a/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
@@ -34,6 +34,7 @@ Represents a Daytona Sandbox.
 - `disk` _int_ - Amount of disk space allocated to the Sandbox in GiB.
 - `state` _SandboxState_ - Current state of the Sandbox (e.g., "started", "stopped").
 - `error_reason` _str_ - Error message if Sandbox is in error state.
+- `recoverable` _bool_ - Whether the Sandbox error is recoverable.
 - `backup_state` _SandboxBackupStateEnum_ - Current state of Sandbox backup.
 - `backup_created_at` _str_ - When the backup was created.
 - `auto_stop_interval` _int_ - Auto-stop interval in minutes.
@@ -212,9 +213,39 @@ Starts the Sandbox and waits for it to be ready.
 **Example**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.start(timeout=40)  # Wait up to 40 seconds
 print("Sandbox started successfully")
+```
+
+#### AsyncSandbox.recover
+
+```python
+@intercept_errors(message_prefix="Failed to recover sandbox: ")
+@with_timeout(error_message=lambda self, timeout: (
+    f"Sandbox {self.id} failed to recover within the {timeout} seconds timeout period"
+))
+async def recover(timeout: Optional[float] = 60)
+```
+
+Recovers the Sandbox from a recoverable error and waits for it to be ready.
+
+**Arguments**:
+
+- `timeout` _Optional[float]_ - Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+  
+
+**Raises**:
+
+- `DaytonaError` - If timeout is negative. If sandbox fails to recover or times out.
+  
+
+**Example**:
+
+```python
+sandbox = daytona.get("my-sandbox-id")
+await sandbox.recover(timeout=40)  # Wait up to 40 seconds
+print("Sandbox recovered successfully")
 ```
 
 #### AsyncSandbox.stop
@@ -242,7 +273,7 @@ Stops the Sandbox and waits for it to be fully stopped.
 **Example**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.stop()
 print("Sandbox stopped successfully")
 ```

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-snapshot.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-snapshot.mdx
@@ -214,5 +214,4 @@ Parameters for creating a new snapshot.
   it will be used to create a new image in Daytona.
 - `resources` _Optional[Resources]_ - Resources of the snapshot.
 - `entrypoint` _Optional[List[str]]_ - Entrypoint of the snapshot.
-- `skip_validation` _Optional[bool]_ - Whether to skip validation for the snapshot.
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
@@ -34,6 +34,7 @@ Represents a Daytona Sandbox.
 - `disk` _int_ - Amount of disk space allocated to the Sandbox in GiB.
 - `state` _SandboxState_ - Current state of the Sandbox (e.g., "started", "stopped").
 - `error_reason` _str_ - Error message if Sandbox is in error state.
+- `recoverable` _bool_ - Whether the Sandbox error is recoverable.
 - `backup_state` _SandboxBackupStateEnum_ - Current state of Sandbox backup.
 - `backup_created_at` _str_ - When the backup was created.
 - `auto_stop_interval` _int_ - Auto-stop interval in minutes.
@@ -212,9 +213,39 @@ Starts the Sandbox and waits for it to be ready.
 **Example**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.start(timeout=40)  # Wait up to 40 seconds
 print("Sandbox started successfully")
+```
+
+#### Sandbox.recover
+
+```python
+@intercept_errors(message_prefix="Failed to recover sandbox: ")
+@with_timeout(error_message=lambda self, timeout: (
+    f"Sandbox {self.id} failed to recover within the {timeout} seconds timeout period"
+))
+def recover(timeout: Optional[float] = 60)
+```
+
+Recovers the Sandbox from a recoverable error and waits for it to be ready.
+
+**Arguments**:
+
+- `timeout` _Optional[float]_ - Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+  
+
+**Raises**:
+
+- `DaytonaError` - If timeout is negative. If sandbox fails to recover or times out.
+  
+
+**Example**:
+
+```python
+sandbox = daytona.get("my-sandbox-id")
+sandbox.recover(timeout=40)  # Wait up to 40 seconds
+print("Sandbox recovered successfully")
 ```
 
 #### Sandbox.stop
@@ -242,7 +273,7 @@ Stops the Sandbox and waits for it to be fully stopped.
 **Example**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.stop()
 print("Sandbox stopped successfully")
 ```

--- a/apps/docs/src/content/docs/en/python-sdk/sync/snapshot.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/snapshot.mdx
@@ -214,5 +214,4 @@ Parameters for creating a new snapshot.
   it will be used to create a new image in Daytona.
 - `resources` _Optional[Resources]_ - Resources of the snapshot.
 - `entrypoint` _Optional[List[str]]_ - Entrypoint of the snapshot.
-- `skip_validation` _Optional[bool]_ - Whether to skip validation for the snapshot.
 

--- a/apps/docs/src/content/docs/en/sandbox-management.mdx
+++ b/apps/docs/src/content/docs/en/sandbox-management.mdx
@@ -530,3 +530,33 @@ By default, Sandboxes auto-stop after 15 minutes of inactivity. To keep a Sandbo
     ```
   </TabItem>
 </Tabs>
+
+## Recover from Error State
+
+When a Sandbox enters an error state, it can sometimes be recovered using the `recover` method, depending on the underlying error reason. The `recoverable` flag indicates whether the error state can be resolved through an automated recovery procedure.
+
+:::note
+Recovery actions are not performed automatically because they address errors that require **further user intervention**, such as freeing up storage space.
+:::
+
+<Tabs syncKey="language">
+  <TabItem label="Python" icon="seti:python">
+    ```python
+    # Check if the Sandbox is recoverable
+    if sandbox.recoverable:
+        sandbox.recover()
+        print("Sandbox recovered successfully")
+    ```
+  </TabItem>
+
+  <TabItem label="TypeScript" icon="seti:typescript">
+    ```typescript
+    // Check if the Sandbox is recoverable
+    if (sandbox.recoverable) {
+        await sandbox.recover();
+        console.log('Sandbox recovered successfully');
+    }
+    ```
+  </TabItem>
+</Tabs>
+

--- a/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
@@ -156,6 +156,13 @@ Represents a Daytona Sandbox.
     ```ts
     SandboxDto.public
     ```
+- `recoverable?` _boolean_ - Whether the Sandbox error is recoverable.
+    
+    ##### Implementation of
+    
+    ```ts
+    SandboxDto.recoverable
+    ```
 - `snapshot?` _string_ - Daytona snapshot used to create the Sandbox
     
     ##### Implementation of
@@ -408,6 +415,38 @@ Gets the working directory path inside the Sandbox.
 ```ts
 const workDir = await sandbox.getWorkDir();
 console.log(`Sandbox working directory: ${workDir}`);
+```
+
+***
+
+#### recover()
+
+```ts
+recover(timeout?: number): Promise<void>
+```
+
+Recover the Sandbox from a recoverable error and wait for it to be ready.
+
+**Parameters**:
+
+- `timeout?` _number = 60_ - Maximum time to wait in seconds. 0 means no timeout.
+    Defaults to 60-second timeout.
+
+
+**Returns**:
+
+- `Promise<void>`
+
+**Throws**:
+
+- `DaytonaError` - If Sandbox fails to recover or times out
+
+**Example:**
+
+```ts
+const sandbox = await daytona.get('my-sandbox-id');
+await sandbox.recover();
+console.log('Sandbox recovered successfully');
 ```
 
 ***
@@ -673,7 +712,7 @@ This method stops the Sandbox and waits for it to be fully stopped.
 **Example:**
 
 ```ts
-const sandbox = await daytona.getCurrentSandbox('my-sandbox');
+const sandbox = await daytona.get('my-sandbox-id');
 await sandbox.stop();
 console.log('Sandbox stopped successfully');
 ```

--- a/apps/docs/src/content/docs/en/typescript-sdk/snapshot.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/snapshot.mdx
@@ -205,7 +205,6 @@ type CreateSnapshotParams = {
   image: string | Image;
   name: string;
   resources: Resources;
-  skipValidation: boolean;
 };
 ```
 
@@ -217,7 +216,6 @@ Parameters for creating a new snapshot.
 - `image` _string \| Image_
 - `name` _string_
 - `resources?` _Resources_
-- `skipValidation?` _boolean_
 
 
 ## Snapshot

--- a/apps/docs/src/content/docs/ja/python-sdk/async/async-sandbox.mdx
+++ b/apps/docs/src/content/docs/ja/python-sdk/async/async-sandbox.mdx
@@ -185,7 +185,7 @@ async def start(timeout: Optional[float] = 60)
 **例**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.start(timeout=40)  # 最大 40 秒待機
 print("Sandbox started successfully")
 ```
@@ -215,7 +215,7 @@ async def stop(timeout: Optional[float] = 60)
 **例**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.stop()
 print("Sandbox stopped successfully")
 ```

--- a/apps/docs/src/content/docs/ja/python-sdk/sync/sandbox.mdx
+++ b/apps/docs/src/content/docs/ja/python-sdk/sync/sandbox.mdx
@@ -185,7 +185,7 @@ def start(timeout: Optional[float] = 60)
 **例**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.start(timeout=40)  # 最大 40 秒待機
 print("Sandbox started successfully")
 ```
@@ -215,7 +215,7 @@ def stop(timeout: Optional[float] = 60)
 **例**:
 
 ```python
-sandbox = daytona.get_current_sandbox("my-sandbox")
+sandbox = daytona.get("my-sandbox-id")
 sandbox.stop()
 print("Sandbox stopped successfully")
 ```

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -277,7 +277,7 @@ class AsyncSandbox(SandboxDto):
 
         Example:
             ```python
-            sandbox = daytona.get_current_sandbox("my-sandbox")
+            sandbox = daytona.get("my-sandbox-id")
             sandbox.start(timeout=40)  # Wait up to 40 seconds
             print("Sandbox started successfully")
             ```
@@ -305,7 +305,7 @@ class AsyncSandbox(SandboxDto):
 
         Example:
             ```python
-            sandbox = daytona.get_current_sandbox("my-sandbox")
+            sandbox = daytona.get("my-sandbox-id")
             await sandbox.recover(timeout=40)  # Wait up to 40 seconds
             print("Sandbox recovered successfully")
             ```
@@ -333,7 +333,7 @@ class AsyncSandbox(SandboxDto):
 
         Example:
             ```python
-            sandbox = daytona.get_current_sandbox("my-sandbox")
+            sandbox = daytona.get("my-sandbox-id")
             sandbox.stop()
             print("Sandbox stopped successfully")
             ```

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -280,7 +280,7 @@ class Sandbox(SandboxDto):
 
         Example:
             ```python
-            sandbox = daytona.get_current_sandbox("my-sandbox")
+            sandbox = daytona.get("my-sandbox-id")
             sandbox.start(timeout=40)  # Wait up to 40 seconds
             print("Sandbox started successfully")
             ```
@@ -308,7 +308,7 @@ class Sandbox(SandboxDto):
 
         Example:
             ```python
-            sandbox = daytona.get_current_sandbox("my-sandbox")
+            sandbox = daytona.get("my-sandbox-id")
             sandbox.recover(timeout=40)  # Wait up to 40 seconds
             print("Sandbox recovered successfully")
             ```
@@ -336,7 +336,7 @@ class Sandbox(SandboxDto):
 
         Example:
             ```python
-            sandbox = daytona.get_current_sandbox("my-sandbox")
+            sandbox = daytona.get("my-sandbox-id")
             sandbox.stop()
             print("Sandbox stopped successfully")
             ```

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -289,8 +289,8 @@ export class Sandbox implements SandboxDto {
    * @throws {DaytonaError} - `DaytonaError` - If Sandbox fails to recover or times out
    *
    * @example
-   * const sandbox = await daytona.getCurrentSandbox('my-sandbox');
-   * await sandbox.recover(40);  // Wait up to 40 seconds
+   * const sandbox = await daytona.get('my-sandbox-id');
+   * await sandbox.recover();
    * console.log('Sandbox recovered successfully');
    */
   public async recover(timeout = 60): Promise<void> {
@@ -315,7 +315,7 @@ export class Sandbox implements SandboxDto {
    * @returns {Promise<void>}
    *
    * @example
-   * const sandbox = await daytona.getCurrentSandbox('my-sandbox');
+   * const sandbox = await daytona.get('my-sandbox-id');
    * await sandbox.stop();
    * console.log('Sandbox stopped successfully');
    */


### PR DESCRIPTION
## Description

Docs for recovery action as well as SDK refference for the recoverable flags and recover methods.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Screenshots

<img width="753" height="596" alt="Screenshot 2025-12-15 at 14 20 00" src="https://github.com/user-attachments/assets/49e34eb7-bc61-4041-bb00-2babd65366ea" />

