### PR TITLE
fix(typescript-sdk): remove console error from interceptor

### DIFF
--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -692,7 +692,6 @@ export class Daytona {
         return response
       },
       (error) => {
-        console.log('error', error)
         let errorMessage: string
 
         if (error instanceof AxiosError && error.message.includes('timeout of')) {


### PR DESCRIPTION
## Description

Removed unnecessary console.log from error interceptor in TS SDK.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
