### PR TITLE
fix(api): set recoverable false on start sync and recover audit

### DIFF
--- a/apps/api/src/audit/enums/audit-action.enum.ts
+++ b/apps/api/src/audit/enums/audit-action.enum.ts
@@ -42,6 +42,7 @@ export enum AuditAction {
   UPDATE_SANDBOX_DEFAULT_LIMITED_NETWORK_EGRESS = 'update_sandbox_default_limited_network_egress',
   CREATE_SSH_ACCESS = 'create_ssh_access',
   REVOKE_SSH_ACCESS = 'revoke_ssh_access',
+  RECOVER = 'recover',
 
   // toolbox actions (must be prefixed with 'toolbox_')
   TOOLBOX_DELETE_FILE = 'toolbox_delete_file',

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -412,6 +412,12 @@ export class SandboxController {
   })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_SANDBOXES])
   @UseGuards(SandboxAccessGuard)
+  @Audit({
+    action: AuditAction.RECOVER,
+    targetType: AuditTarget.SANDBOX,
+    targetIdFromRequest: (req) => req.params.sandboxIdOrName,
+    targetIdFromResult: (result: SandboxDto) => result?.id,
+  })
   async recoverSandbox(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('sandboxIdOrName') sandboxIdOrName: string,

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -96,6 +96,7 @@ export class SandboxStartAction extends SandboxAction {
             undefined,
             daemonVersion,
             BackupState.NONE,
+            false,
           )
           return DONT_SYNC_AGAIN
         }

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox.action.ts
@@ -41,6 +41,7 @@ export abstract class SandboxAction {
     errorReason?: string,
     daemonVersion?: string,
     backupState?: BackupState,
+    recoverable?: boolean,
   ) {
     //  check if the lock code is still valid
     const lockKey = getStateChangeLockKey(sandboxId)
@@ -115,6 +116,10 @@ export abstract class SandboxAction {
 
     if (backupState !== undefined) {
       sandbox.setBackupState(backupState)
+    }
+
+    if (recoverable !== undefined) {
+      sandbox.recoverable = recoverable
     }
 
     await this.sandboxRepository.save(sandbox)


### PR DESCRIPTION
## Description

Fixes when runners syncs an error sandbox that got started, also audit logs the recover action.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation