### PR TITLE
fix(runner): make metrics endpoint private

### DIFF
--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -96,7 +96,7 @@ func (a *ApiServer) Start() error {
 	protected := a.router.Group("/")
 	protected.Use(middlewares.AuthMiddleware())
 
-	metricsController := public.Group("/metrics")
+	metricsController := protected.Group("/metrics")
 	{
 		metricsController.GET("", gin.WrapH(promhttp.Handler()))
 	}


### PR DESCRIPTION
## Description

This pull request updates the routing for the `/metrics` endpoint to require authentication, increasing the security of the metrics endpoint.

- Security improvement:
  * Changed the `/metrics` endpoint to be under the `protected` route group, so it now requires authentication via `AuthMiddleware`, instead of being publicly accessible. (`apps/runner/pkg/api/server.go`)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation