### PR TITLE
fix(runner): add explicit error log when daemon start timeouts

### DIFF
--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -301,7 +301,7 @@ func Start(ctx *gin.Context) {
 		return
 	}
 
-	err = runner.Docker.Start(ctx.Request.Context(), sandboxId, metadata)
+	err = runner.Docker.Start(ctx.Request.Context(), sandboxId, metadata, false)
 
 	if err != nil {
 		runner.StatesCache.SetSandboxState(ctx, sandboxId, enums.SandboxStateError)

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -43,7 +43,7 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 	}
 
 	if state == enums.SandboxStateStopped || state == enums.SandboxStateCreating {
-		err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata)
+		err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata, true)
 		if err != nil {
 			return "", err
 		}
@@ -92,7 +92,7 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		return "", err
 	}
 
-	err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata)
+	err = d.Start(ctx, sandboxDto.Id, sandboxDto.Metadata, true)
 	if err != nil {
 		return "", err
 	}

--- a/apps/runner/pkg/docker/daemon.go
+++ b/apps/runner/pkg/docker/daemon.go
@@ -8,12 +8,15 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"time"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/common-go/pkg/timer"
 	"github.com/daytonaio/runner/pkg/common"
 	"github.com/docker/docker/api/types/container"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func (d *DockerClient) startDaytonaDaemon(ctx context.Context, containerId string, workDir string) error {
@@ -49,7 +52,7 @@ func (d *DockerClient) startDaytonaDaemon(ctx context.Context, containerId strin
 	return nil
 }
 
-func (d *DockerClient) waitForDaemonRunning(ctx context.Context, containerIP string) error {
+func (d *DockerClient) waitForDaemonRunning(ctx context.Context, containerId, containerIP string, onCreateStart bool) error {
 	defer timer.Timer()()
 
 	// Build the target URL
@@ -66,6 +69,28 @@ func (d *DockerClient) waitForDaemonRunning(ctx context.Context, containerIP str
 	for {
 		select {
 		case <-timeoutCtx.Done():
+			ct, err := d.ContainerInspect(ctx, containerId)
+			if err != nil {
+				log.Errorf("Failed to inspect container on waiting for daemon to start error %s: %v", containerId, err)
+				return fmt.Errorf("timeout waiting for daemon to start")
+			}
+
+			if ct.State != nil && !ct.State.Running {
+				logs, err := d.readLastErrorLog(ctx, containerId)
+				if err != nil {
+					log.Errorf("Failed to read error log for container %s: %v", containerId, err)
+					return fmt.Errorf("timeout waiting for daemon to start")
+				}
+
+				if logs != "" {
+					logErr := fmt.Errorf("sandbox exited with error: %s", logs)
+					if onCreateStart {
+						return common_errors.NewBadRequestError(logErr)
+					}
+					return logErr
+				}
+			}
+
 			return fmt.Errorf("timeout waiting for daemon to start")
 		default:
 			conn, err := net.DialTimeout("tcp", target.Host, 1*time.Second)
@@ -77,4 +102,65 @@ func (d *DockerClient) waitForDaemonRunning(ctx context.Context, containerIP str
 			return nil
 		}
 	}
+}
+
+func (d *DockerClient) readLastErrorLog(ctx context.Context, containerId string) (string, error) {
+	logs, err := d.apiClient.ContainerLogs(ctx, containerId, container.LogsOptions{
+		ShowStdout: false,
+		ShowStderr: true,
+		Follow:     false,
+		Tail:       "50", // Get more lines to ensure we find the last error
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get container logs: %w", err)
+	}
+	defer logs.Close()
+
+	var logOutput []byte
+	buf := make([]byte, 8192)
+	for {
+		n, err := logs.Read(buf)
+		if n > 0 {
+			logOutput = append(logOutput, buf[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	// Sanitize logs and extract only the last error
+	sanitizedLogs := sanitizeLogPrefixes(string(logOutput))
+
+	return sanitizedLogs, nil
+}
+
+func sanitizeLogPrefixes(logs string) string {
+	// Remove Docker's 8-byte log stream header
+	// Format: [stream_type(1 byte)][padding(3 bytes)][size(4 bytes)]
+	// Example: \u0002\u0000\u0000\u0000\u0000\u0000\u0000k or \u0002\u0000\u0000\u0000\u0000\u0000\u0000\
+	dockerHeaderPattern := regexp.MustCompile(`[\x00-\x02][\x00]{3}[\x00-\xff]{4}`)
+	sanitized := dockerHeaderPattern.ReplaceAllString(logs, "")
+
+	// Remove ANSI color codes (e.g., \x1b[31m for red, \x1b[33m for yellow, etc.)
+	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	sanitized = ansiPattern.ReplaceAllString(sanitized, "")
+
+	// Extract only lines starting with ERRO[0...] (e.g., ERRO[0000], ERRO[0010])
+	errorPattern := regexp.MustCompile(`(?m)^ERRO\[\d+\].*$`)
+	errorLines := errorPattern.FindAllString(sanitized, -1)
+
+	// If no error lines found, return original sanitized content
+	if len(errorLines) == 0 {
+		// return empty string if no error found, to avoid leaking non-error logs
+		return ""
+	}
+
+	// Take only the last error line
+	lastErrorLine := errorLines[len(errorLines)-1]
+
+	// Remove the ERRO[0...] prefix from the line
+	erroPrefixPattern := regexp.MustCompile(`^ERRO\[\d+\]\s*`)
+	sanitized = erroPrefixPattern.ReplaceAllString(lastErrorLine, "")
+
+	return sanitized
 }


### PR DESCRIPTION
## Description

This pull request enhances error handling and logging when starting Docker sandboxes, making it easier to diagnose failures by surfacing relevant error logs. The main changes add logic to extract and return the last error message from the sandbox logs if the daemon fails to start, and update function signatures and calls to support this improved error reporting.

**Error handling and logging improvements:**

* Added a new `readLastErrorLog` function in `docker/daemon.go` to extract the last error line from the sandbox stderr logs, sanitizing Docker log headers and removing ANSI color codes. Only error lines prefixed with `ERRO[...]` are considered, and only the last such line is returned. (`[apps/runner/pkg/docker/daemon.go]`)
* Enhanced the `waitForDaemonRunning` function to inspect the sandbox state on timeout. If the sandbox is not running, it retrieves and returns the last error log (as a `BadRequestError` if starting during creation), providing more actionable feedback on failure.

**API and function signature updates:**

* Updated the `Start` method in `docker/start.go` and its callers to accept an `onCreateStart` boolean argument, allowing differentiated error handling depending on whether the sandbox is being started as part of creation. 
* Modified all calls to `waitForDaemonRunning` to pass the new `containerId` and `onCreateStart` arguments, ensuring the enhanced error handling logic is used throughout sandbox startup. 

**Minor code quality improvements:**

* Improved variable naming for container inspection results for clarity in `waitForContainerRunning`. (`[apps/runner/pkg/docker/start.go]`)
* Added missing imports for `regexp` and `logrus` to support log sanitization and error logging. (`[apps/runner/pkg/docker/daemon.go]`)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="968" height="106" alt="Screenshot 2025-12-18 at 14 20 12" src="https://github.com/user-attachments/assets/ea324c74-067b-4c6b-b477-e73a7cf79a89" />
<img width="981" height="596" alt="Screenshot 2025-12-18 at 14 20 21" src="https://github.com/user-attachments/assets/661bc723-d9a2-42c5-b333-3d3ffd1bdb3c" />
