### PR TITLE
fix(daemon): cu plugin crash

### DIFF
--- a/apps/daemon/pkg/toolbox/computeruse/manager/manager.go
+++ b/apps/daemon/pkg/toolbox/computeruse/manager/manager.go
@@ -275,13 +275,16 @@ func GetComputerUse(logger *slog.Logger, path string) (computeruse.IComputerUse,
 		Managed:         true,
 	})
 
+	success := false
+	defer func() {
+		if !success {
+			client.Kill()
+		}
+	}()
+
 	logger.Info("Computer use registered", "pluginName", pluginName)
 	rpcClient, err := client.Client()
 	if err != nil {
-		// Clean up the client before returning to avoid goroutine leaks and WaitGroup panics
-		client.Kill()
-
-		// Try to get detailed error information
 		pluginErr := detectPluginError(logger, path)
 		if pluginErr != nil {
 			return nil, fmt.Errorf("failed to get RPC client for computer-use plugin - detailed error\n[type]: %s - [error]: %s - [details]: %s", pluginErr.Type, pluginErr.Message, pluginErr.Details)
@@ -291,25 +294,20 @@ func GetComputerUse(logger *slog.Logger, path string) (computeruse.IComputerUse,
 
 	raw, err := rpcClient.Dispense(pluginName)
 	if err != nil {
-		// Clean up the client before returning
-		client.Kill()
 		return nil, fmt.Errorf("failed to dispense computer-use plugin: %w", err)
 	}
 
 	impl, ok := raw.(computeruse.IComputerUse)
 	if !ok {
-		// Clean up the client before returning
-		client.Kill()
 		return nil, fmt.Errorf("unexpected type from computer-use plugin")
 	}
 
 	_, err = impl.Initialize()
 	if err != nil {
-		// Clean up the client before returning
-		client.Kill()
 		return nil, fmt.Errorf("failed to initialize computer-use plugin: %w", err)
 	}
 
+	success = true
 	logger.Info("Computer-use plugin initialized successfully")
 	computerUse.client = client
 	computerUse.impl = impl


### PR DESCRIPTION
## Daemon crashing due to computer use plugin mismanagement

Daemon crashing due to computer use plugin mismanagement - adds a client kill call to avoid WaitGroup panics

## Additional info



```
2025-12-19T04:43:47.212Z [DEBUG] daytona-computer-use: starting plugin: path=/usr/local/lib/daytona-computer-use args=["/usr/local/lib/daytona-computer-use"]
2025-12-19T04:43:47.215Z [DEBUG] daytona-computer-use: plugin started: path=/usr/local/lib/daytona-computer-use pid=78
2025-12-19T04:43:47.215Z [DEBUG] daytona-computer-use.daytona-computer-use: /usr/local/lib/daytona-computer-use: error while loading shared libraries: libXtst.so.6: cannot open shared object file: No such file or directory
2025-12-19T04:43:47.215Z [DEBUG] daytona-computer-use: waiting for RPC address: plugin=/usr/local/lib/daytona-computer-use
panic: sync: WaitGroup is reused before previous Wait has returned

goroutine 115 [running]:
sync.(*WaitGroup).Wait(0xc000304298)
	/usr/local/go/src/sync/waitgroup.go:208 +0xf4
github.com/hashicorp/go-plugin.(*Client).Start.func2()
	/go/pkg/mod/github.com/hashicorp/go-plugin@v1.6.3/client.go:772 +0x9b
created by github.com/hashicorp/go-plugin.(*Client).Start in goroutine 93
	/go/pkg/mod/github.com/hashicorp/go-plugin@v1.6.3/client.go:764 +0x1b5f

```
## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
