### PR TITLE
fix(api): align webhook payloads with docs also added event and timestamp

### DIFF
--- a/apps/api/src/generate-openapi.ts
+++ b/apps/api/src/generate-openapi.ts
@@ -5,6 +5,15 @@ import { AppModule } from './app.module'
 import { SwaggerModule } from '@nestjs/swagger'
 import { getOpenApiConfig } from './openapi.config'
 import { addWebhookDocumentation } from './openapi-webhooks'
+import {
+  SandboxCreatedWebhookDto,
+  SandboxStateUpdatedWebhookDto,
+  SnapshotCreatedWebhookDto,
+  SnapshotStateUpdatedWebhookDto,
+  SnapshotRemovedWebhookDto,
+  VolumeCreatedWebhookDto,
+  VolumeStateUpdatedWebhookDto,
+} from './webhook/dto/webhook-event-payloads.dto'
 
 async function generateOpenAPI() {
   const app = await NestFactory.create(AppModule, {
@@ -21,7 +30,17 @@ async function generateOpenAPI() {
   // Generate 3.1.0 version of the OpenAPI specification
   // Needed for the webhook documentation
   const document_3_1_0 = {
-    ...SwaggerModule.createDocument(app, config),
+    ...SwaggerModule.createDocument(app, config, {
+      extraModels: [
+        SandboxCreatedWebhookDto,
+        SandboxStateUpdatedWebhookDto,
+        SnapshotCreatedWebhookDto,
+        SnapshotStateUpdatedWebhookDto,
+        SnapshotRemovedWebhookDto,
+        VolumeCreatedWebhookDto,
+        VolumeStateUpdatedWebhookDto,
+      ],
+    }),
     openapi: '3.1.0',
   }
   const documentWithWebhooks = addWebhookDocumentation(document_3_1_0)

--- a/apps/api/src/openapi-webhooks.ts
+++ b/apps/api/src/openapi-webhooks.ts
@@ -3,8 +3,17 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { OpenAPIObject } from '@nestjs/swagger'
+import { OpenAPIObject, getSchemaPath } from '@nestjs/swagger'
 import { WebhookEvents } from './webhook/constants/webhook-events.constants'
+import {
+  SandboxCreatedWebhookDto,
+  SandboxStateUpdatedWebhookDto,
+  SnapshotCreatedWebhookDto,
+  SnapshotStateUpdatedWebhookDto,
+  SnapshotRemovedWebhookDto,
+  VolumeCreatedWebhookDto,
+  VolumeStateUpdatedWebhookDto,
+} from './webhook/dto/webhook-event-payloads.dto'
 
 export interface OpenAPIObjectWithWebhooks extends OpenAPIObject {
   webhooks?: {
@@ -38,57 +47,7 @@ export function addWebhookDocumentation(document: OpenAPIObject): OpenAPIObjectW
             description: 'Sandbox created event',
             content: {
               'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    event: { type: 'string', example: 'sandbox.created' },
-                    timestamp: { type: 'string', format: 'date-time' },
-                    data: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', example: 'sandbox123' },
-                        organizationId: { type: 'string', example: 'organization123' },
-                        target: { type: 'string', example: 'local' },
-                        snapshot: { type: 'string', example: 'daytonaio/sandbox:latest' },
-                        user: { type: 'string', example: 'daytona' },
-                        env: { type: 'object', additionalProperties: { type: 'string' } },
-                        cpu: { type: 'number', example: 2 },
-                        gpu: { type: 'number', example: 0 },
-                        memory: { type: 'number', example: 4 },
-                        disk: { type: 'number', example: 10 },
-                        public: { type: 'boolean', example: false },
-                        labels: { type: 'object', additionalProperties: { type: 'string' } },
-                        state: {
-                          type: 'string',
-                          enum: [
-                            'creating',
-                            'restoring',
-                            'destroyed',
-                            'destroying',
-                            'started',
-                            'stopped',
-                            'starting',
-                            'stopping',
-                            'error',
-                            'build_failed',
-                            'pending_build',
-                            'building_snapshot',
-                            'unknown',
-                            'pulling_snapshot',
-                            'archived',
-                            'archiving',
-                          ],
-                        },
-                        desiredState: {
-                          type: 'string',
-                          enum: ['destroyed', 'started', 'stopped', 'resized', 'archived'],
-                        },
-                        createdAt: { type: 'string', format: 'date-time' },
-                        updatedAt: { type: 'string', format: 'date-time' },
-                      },
-                    },
-                  },
-                },
+                schema: { $ref: getSchemaPath(SandboxCreatedWebhookDto) },
               },
             },
           },
@@ -105,88 +64,7 @@ export function addWebhookDocumentation(document: OpenAPIObject): OpenAPIObjectW
             description: 'Sandbox state updated event',
             content: {
               'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    event: { type: 'string', example: 'sandbox.state.updated' },
-                    timestamp: { type: 'string', format: 'date-time' },
-                    data: {
-                      type: 'object',
-                      properties: {
-                        sandbox: {
-                          type: 'object',
-                          properties: {
-                            id: { type: 'string', example: 'sandbox123' },
-                            organizationId: { type: 'string', example: 'organization123' },
-                            state: {
-                              type: 'string',
-                              enum: [
-                                'creating',
-                                'restoring',
-                                'destroyed',
-                                'destroying',
-                                'started',
-                                'stopped',
-                                'starting',
-                                'stopping',
-                                'error',
-                                'build_failed',
-                                'pending_build',
-                                'building_snapshot',
-                                'unknown',
-                                'pulling_snapshot',
-                                'archived',
-                                'archiving',
-                              ],
-                            },
-                          },
-                        },
-                        oldState: {
-                          type: 'string',
-                          enum: [
-                            'creating',
-                            'restoring',
-                            'destroyed',
-                            'destroying',
-                            'started',
-                            'stopped',
-                            'starting',
-                            'stopping',
-                            'error',
-                            'build_failed',
-                            'pending_build',
-                            'building_snapshot',
-                            'unknown',
-                            'pulling_snapshot',
-                            'archived',
-                            'archiving',
-                          ],
-                        },
-                        newState: {
-                          type: 'string',
-                          enum: [
-                            'creating',
-                            'restoring',
-                            'destroyed',
-                            'destroying',
-                            'started',
-                            'stopped',
-                            'starting',
-                            'stopping',
-                            'error',
-                            'build_failed',
-                            'pending_build',
-                            'building_snapshot',
-                            'unknown',
-                            'pulling_snapshot',
-                            'archived',
-                            'archiving',
-                          ],
-                        },
-                      },
-                    },
-                  },
-                },
+                schema: { $ref: getSchemaPath(SandboxStateUpdatedWebhookDto) },
               },
             },
           },
@@ -203,43 +81,7 @@ export function addWebhookDocumentation(document: OpenAPIObject): OpenAPIObjectW
             description: 'Snapshot created event',
             content: {
               'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    event: { type: 'string', example: 'snapshot.created' },
-                    timestamp: { type: 'string', format: 'date-time' },
-                    data: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', example: 'snapshot123' },
-                        organizationId: { type: 'string', example: 'organization123' },
-                        general: { type: 'boolean', example: false },
-                        name: { type: 'string', example: 'my-snapshot' },
-                        imageName: { type: 'string', example: 'my-image:latest' },
-                        state: {
-                          type: 'string',
-                          enum: [
-                            'building',
-                            'pending',
-                            'pulling',
-                            'active',
-                            'inactive',
-                            'error',
-                            'build_failed',
-                            'removing',
-                          ],
-                        },
-                        size: { type: 'number', example: 1024 },
-                        cpu: { type: 'number', example: 2 },
-                        gpu: { type: 'number', example: 0 },
-                        mem: { type: 'number', example: 4 },
-                        disk: { type: 'number', example: 10 },
-                        createdAt: { type: 'string', format: 'date-time' },
-                        updatedAt: { type: 'string', format: 'date-time' },
-                      },
-                    },
-                  },
-                },
+                schema: { $ref: getSchemaPath(SnapshotCreatedWebhookDto) },
               },
             },
           },
@@ -256,64 +98,7 @@ export function addWebhookDocumentation(document: OpenAPIObject): OpenAPIObjectW
             description: 'Snapshot state updated event',
             content: {
               'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    event: { type: 'string', example: 'snapshot.state.updated' },
-                    timestamp: { type: 'string', format: 'date-time' },
-                    data: {
-                      type: 'object',
-                      properties: {
-                        snapshot: {
-                          type: 'object',
-                          properties: {
-                            id: { type: 'string', example: 'snapshot123' },
-                            organizationId: { type: 'string', example: 'organization123' },
-                            state: {
-                              type: 'string',
-                              enum: [
-                                'building',
-                                'pending',
-                                'pulling',
-                                'active',
-                                'inactive',
-                                'error',
-                                'build_failed',
-                                'removing',
-                              ],
-                            },
-                          },
-                        },
-                        oldState: {
-                          type: 'string',
-                          enum: [
-                            'building',
-                            'pending',
-                            'pulling',
-                            'active',
-                            'inactive',
-                            'error',
-                            'build_failed',
-                            'removing',
-                          ],
-                        },
-                        newState: {
-                          type: 'string',
-                          enum: [
-                            'building',
-                            'pending',
-                            'pulling',
-                            'active',
-                            'inactive',
-                            'error',
-                            'build_failed',
-                            'removing',
-                          ],
-                        },
-                      },
-                    },
-                  },
-                },
+                schema: { $ref: getSchemaPath(SnapshotStateUpdatedWebhookDto) },
               },
             },
           },
@@ -330,18 +115,7 @@ export function addWebhookDocumentation(document: OpenAPIObject): OpenAPIObjectW
             description: 'Snapshot removed event',
             content: {
               'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    event: { type: 'string', example: 'snapshot.removed' },
-                    timestamp: { type: 'string', format: 'date-time' },
-                    data: {
-                      type: 'string',
-                      description: 'The ID of the removed snapshot',
-                      example: 'snapshot123',
-                    },
-                  },
-                },
+                schema: { $ref: getSchemaPath(SnapshotRemovedWebhookDto) },
               },
             },
           },
@@ -358,37 +132,7 @@ export function addWebhookDocumentation(document: OpenAPIObject): OpenAPIObjectW
             description: 'Volume created event',
             content: {
               'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    event: { type: 'string', example: 'volume.created' },
-                    timestamp: { type: 'string', format: 'date-time' },
-                    data: {
-                      type: 'object',
-                      properties: {
-                        id: { type: 'string', example: 'vol-12345678' },
-                        name: { type: 'string', example: 'my-volume' },
-                        organizationId: { type: 'string', example: '123e4567-e89b-12d3-a456-426614174000' },
-                        state: {
-                          type: 'string',
-                          enum: [
-                            'creating',
-                            'ready',
-                            'pending_create',
-                            'pending_delete',
-                            'deleting',
-                            'deleted',
-                            'error',
-                          ],
-                        },
-                        createdAt: { type: 'string', format: 'date-time' },
-                        updatedAt: { type: 'string', format: 'date-time' },
-                        lastUsedAt: { type: 'string', format: 'date-time' },
-                        errorReason: { type: 'string', example: 'Error processing volume' },
-                      },
-                    },
-                  },
-                },
+                schema: { $ref: getSchemaPath(VolumeCreatedWebhookDto) },
               },
             },
           },
@@ -405,61 +149,7 @@ export function addWebhookDocumentation(document: OpenAPIObject): OpenAPIObjectW
             description: 'Volume state updated event',
             content: {
               'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    event: { type: 'string', example: 'volume.state.updated' },
-                    timestamp: { type: 'string', format: 'date-time' },
-                    data: {
-                      type: 'object',
-                      properties: {
-                        volume: {
-                          type: 'object',
-                          properties: {
-                            id: { type: 'string', example: 'vol-12345678' },
-                            organizationId: { type: 'string', example: '123e4567-e89b-12d3-a456-426614174000' },
-                            state: {
-                              type: 'string',
-                              enum: [
-                                'creating',
-                                'ready',
-                                'pending_create',
-                                'pending_delete',
-                                'deleting',
-                                'deleted',
-                                'error',
-                              ],
-                            },
-                          },
-                        },
-                        oldState: {
-                          type: 'string',
-                          enum: [
-                            'creating',
-                            'ready',
-                            'pending_create',
-                            'pending_delete',
-                            'deleting',
-                            'deleted',
-                            'error',
-                          ],
-                        },
-                        newState: {
-                          type: 'string',
-                          enum: [
-                            'creating',
-                            'ready',
-                            'pending_create',
-                            'pending_delete',
-                            'deleting',
-                            'deleted',
-                            'error',
-                          ],
-                        },
-                      },
-                    },
-                  },
-                },
+                schema: { $ref: getSchemaPath(VolumeStateUpdatedWebhookDto) },
               },
             },
           },

--- a/apps/api/src/webhook/dto/webhook-event-payloads.dto.ts
+++ b/apps/api/src/webhook/dto/webhook-event-payloads.dto.ts
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { SandboxState } from '../../sandbox/enums/sandbox-state.enum'
+import { SandboxClass } from '../../sandbox/enums/sandbox-class.enum'
+import { SnapshotState } from '../../sandbox/enums/snapshot-state.enum'
+import { VolumeState } from '../../sandbox/enums/volume-state.enum'
+import { SandboxCreatedEvent } from '../../sandbox/events/sandbox-create.event'
+import { SandboxStateUpdatedEvent } from '../../sandbox/events/sandbox-state-updated.event'
+import { SnapshotCreatedEvent } from '../../sandbox/events/snapshot-created.event'
+import { SnapshotStateUpdatedEvent } from '../../sandbox/events/snapshot-state-updated.event'
+import { SnapshotRemovedEvent } from '../../sandbox/events/snapshot-removed.event'
+import { VolumeCreatedEvent } from '../../sandbox/events/volume-created.event'
+import { VolumeStateUpdatedEvent } from '../../sandbox/events/volume-state-updated.event'
+
+export abstract class BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Event type identifier',
+    example: 'sandbox.created',
+  })
+  event: string
+
+  @ApiProperty({
+    description: 'Timestamp when the event occurred',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  timestamp: string
+}
+
+@ApiSchema({ name: 'SandboxCreatedWebhook' })
+export class SandboxCreatedWebhookDto extends BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Sandbox ID',
+    example: 'sandbox123',
+  })
+  id: string
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 'org123',
+  })
+  organizationId: string
+
+  @ApiProperty({
+    description: 'Sandbox state',
+    enum: SandboxState,
+    enumName: 'SandboxState',
+  })
+  state: SandboxState
+
+  @ApiProperty({
+    description: 'Sandbox class',
+    enum: SandboxClass,
+    enumName: 'SandboxClass',
+  })
+  class: SandboxClass
+
+  @ApiProperty({
+    description: 'When the sandbox was created',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  createdAt: string
+
+  static fromEvent(event: SandboxCreatedEvent, eventType: string): SandboxCreatedWebhookDto {
+    return {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      id: event.sandbox.id,
+      organizationId: event.sandbox.organizationId,
+      state: event.sandbox.state,
+      class: event.sandbox.class,
+      createdAt: event.sandbox.createdAt.toISOString(),
+    }
+  }
+}
+
+@ApiSchema({ name: 'SandboxStateUpdatedWebhook' })
+export class SandboxStateUpdatedWebhookDto extends BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Sandbox ID',
+    example: 'sandbox123',
+  })
+  id: string
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 'org123',
+  })
+  organizationId: string
+
+  @ApiProperty({
+    description: 'Previous state',
+    enum: SandboxState,
+    enumName: 'SandboxState',
+  })
+  oldState: SandboxState
+
+  @ApiProperty({
+    description: 'New state',
+    enum: SandboxState,
+    enumName: 'SandboxState',
+  })
+  newState: SandboxState
+
+  @ApiProperty({
+    description: 'When the sandbox was last updated',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  updatedAt: string
+
+  static fromEvent(event: SandboxStateUpdatedEvent, eventType: string): SandboxStateUpdatedWebhookDto {
+    return {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      id: event.sandbox.id,
+      organizationId: event.sandbox.organizationId,
+      oldState: event.oldState,
+      newState: event.newState,
+      updatedAt: event.sandbox.updatedAt.toISOString(),
+    }
+  }
+}
+
+@ApiSchema({ name: 'SnapshotCreatedWebhook' })
+export class SnapshotCreatedWebhookDto extends BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Snapshot ID',
+    example: 'snapshot123',
+  })
+  id: string
+
+  @ApiProperty({
+    description: 'Snapshot name',
+    example: 'my-snapshot',
+  })
+  name: string
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 'org123',
+  })
+  organizationId: string
+
+  @ApiProperty({
+    description: 'Snapshot state',
+    enum: SnapshotState,
+    enumName: 'SnapshotState',
+  })
+  state: SnapshotState
+
+  @ApiProperty({
+    description: 'When the snapshot was created',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  createdAt: string
+
+  static fromEvent(event: SnapshotCreatedEvent, eventType: string): SnapshotCreatedWebhookDto {
+    return {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      id: event.snapshot.id,
+      name: event.snapshot.name,
+      organizationId: event.snapshot.organizationId,
+      state: event.snapshot.state,
+      createdAt: event.snapshot.createdAt.toISOString(),
+    }
+  }
+}
+
+@ApiSchema({ name: 'SnapshotStateUpdatedWebhook' })
+export class SnapshotStateUpdatedWebhookDto extends BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Snapshot ID',
+    example: 'snapshot123',
+  })
+  id: string
+
+  @ApiProperty({
+    description: 'Snapshot name',
+    example: 'my-snapshot',
+  })
+  name: string
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 'org123',
+  })
+  organizationId: string
+
+  @ApiProperty({
+    description: 'Previous state',
+    enum: SnapshotState,
+    enumName: 'SnapshotState',
+  })
+  oldState: SnapshotState
+
+  @ApiProperty({
+    description: 'New state',
+    enum: SnapshotState,
+    enumName: 'SnapshotState',
+  })
+  newState: SnapshotState
+
+  @ApiProperty({
+    description: 'When the snapshot was last updated',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  updatedAt: string
+
+  static fromEvent(event: SnapshotStateUpdatedEvent, eventType: string): SnapshotStateUpdatedWebhookDto {
+    return {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      id: event.snapshot.id,
+      name: event.snapshot.name,
+      organizationId: event.snapshot.organizationId,
+      oldState: event.oldState,
+      newState: event.newState,
+      updatedAt: event.snapshot.updatedAt.toISOString(),
+    }
+  }
+}
+
+@ApiSchema({ name: 'SnapshotRemovedWebhook' })
+export class SnapshotRemovedWebhookDto extends BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Snapshot ID',
+    example: 'snapshot123',
+  })
+  id: string
+
+  @ApiProperty({
+    description: 'Snapshot name',
+    example: 'my-snapshot',
+  })
+  name: string
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 'org123',
+  })
+  organizationId: string
+
+  @ApiProperty({
+    description: 'When the snapshot was removed',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  removedAt: string
+
+  static fromEvent(event: SnapshotRemovedEvent, eventType: string): SnapshotRemovedWebhookDto {
+    return {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      id: event.snapshot.id,
+      name: event.snapshot.name,
+      organizationId: event.snapshot.organizationId,
+      removedAt: new Date().toISOString(),
+    }
+  }
+}
+
+@ApiSchema({ name: 'VolumeCreatedWebhook' })
+export class VolumeCreatedWebhookDto extends BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Volume ID',
+    example: 'vol-12345678',
+  })
+  id: string
+
+  @ApiProperty({
+    description: 'Volume name',
+    example: 'my-volume',
+  })
+  name: string
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 'org123',
+  })
+  organizationId: string
+
+  @ApiProperty({
+    description: 'Volume state',
+    enum: VolumeState,
+    enumName: 'VolumeState',
+  })
+  state: VolumeState
+
+  @ApiProperty({
+    description: 'When the volume was created',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  createdAt: string
+
+  static fromEvent(event: VolumeCreatedEvent, eventType: string): VolumeCreatedWebhookDto {
+    return {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      id: event.volume.id,
+      name: event.volume.name,
+      organizationId: event.volume.organizationId,
+      state: event.volume.state,
+      createdAt: event.volume.createdAt.toISOString(),
+    }
+  }
+}
+
+@ApiSchema({ name: 'VolumeStateUpdatedWebhook' })
+export class VolumeStateUpdatedWebhookDto extends BaseWebhookEventDto {
+  @ApiProperty({
+    description: 'Volume ID',
+    example: 'vol-12345678',
+  })
+  id: string
+
+  @ApiProperty({
+    description: 'Volume name',
+    example: 'my-volume',
+  })
+  name: string
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 'org123',
+  })
+  organizationId: string
+
+  @ApiProperty({
+    description: 'Previous state',
+    enum: VolumeState,
+    enumName: 'VolumeState',
+  })
+  oldState: VolumeState
+
+  @ApiProperty({
+    description: 'New state',
+    enum: VolumeState,
+    enumName: 'VolumeState',
+  })
+  newState: VolumeState
+
+  @ApiProperty({
+    description: 'When the volume was last updated',
+    example: '2025-12-19T10:30:00.000Z',
+    format: 'date-time',
+  })
+  updatedAt: string
+
+  static fromEvent(event: VolumeStateUpdatedEvent, eventType: string): VolumeStateUpdatedWebhookDto {
+    return {
+      event: eventType,
+      timestamp: new Date().toISOString(),
+      id: event.volume.id,
+      name: event.volume.name,
+      organizationId: event.volume.organizationId,
+      oldState: event.oldState,
+      newState: event.newState,
+      updatedAt: event.volume.updatedAt.toISOString(),
+    }
+  }
+}

--- a/apps/api/src/webhook/services/webhook-event-handler.service.ts
+++ b/apps/api/src/webhook/services/webhook-event-handler.service.ts
@@ -17,6 +17,15 @@ import { SnapshotRemovedEvent } from '../../sandbox/events/snapshot-removed.even
 import { VolumeCreatedEvent } from '../../sandbox/events/volume-created.event'
 import { VolumeStateUpdatedEvent } from '../../sandbox/events/volume-state-updated.event'
 import { WebhookEvents } from '../constants/webhook-events.constants'
+import {
+  SandboxCreatedWebhookDto,
+  SandboxStateUpdatedWebhookDto,
+  SnapshotCreatedWebhookDto,
+  SnapshotStateUpdatedWebhookDto,
+  SnapshotRemovedWebhookDto,
+  VolumeCreatedWebhookDto,
+  VolumeStateUpdatedWebhookDto,
+} from '../dto/webhook-event-payloads.dto'
 
 @Injectable()
 export class WebhookEventHandlerService {
@@ -31,13 +40,8 @@ export class WebhookEventHandlerService {
     }
 
     try {
-      await this.webhookService.sendWebhook(event.sandbox.organizationId, WebhookEvents.SANDBOX_CREATED, {
-        id: event.sandbox.id,
-        organizationId: event.sandbox.organizationId,
-        state: event.sandbox.state,
-        class: event.sandbox.class,
-        createdAt: event.sandbox.createdAt,
-      })
+      const payload = SandboxCreatedWebhookDto.fromEvent(event, WebhookEvents.SANDBOX_CREATED)
+      await this.webhookService.sendWebhook(event.sandbox.organizationId, WebhookEvents.SANDBOX_CREATED, payload)
     } catch (error) {
       this.logger.error(`Failed to send webhook for sandbox created: ${error.message}`)
     }
@@ -50,13 +54,8 @@ export class WebhookEventHandlerService {
     }
 
     try {
-      await this.webhookService.sendWebhook(event.sandbox.organizationId, WebhookEvents.SANDBOX_STATE_UPDATED, {
-        id: event.sandbox.id,
-        organizationId: event.sandbox.organizationId,
-        oldState: event.oldState,
-        newState: event.newState,
-        updatedAt: event.sandbox.updatedAt,
-      })
+      const payload = SandboxStateUpdatedWebhookDto.fromEvent(event, WebhookEvents.SANDBOX_STATE_UPDATED)
+      await this.webhookService.sendWebhook(event.sandbox.organizationId, WebhookEvents.SANDBOX_STATE_UPDATED, payload)
     } catch (error) {
       this.logger.error(`Failed to send webhook for sandbox state updated: ${error.message}`)
     }
@@ -69,13 +68,8 @@ export class WebhookEventHandlerService {
     }
 
     try {
-      await this.webhookService.sendWebhook(event.snapshot.organizationId, WebhookEvents.SNAPSHOT_CREATED, {
-        id: event.snapshot.id,
-        name: event.snapshot.name,
-        organizationId: event.snapshot.organizationId,
-        state: event.snapshot.state,
-        createdAt: event.snapshot.createdAt,
-      })
+      const payload = SnapshotCreatedWebhookDto.fromEvent(event, WebhookEvents.SNAPSHOT_CREATED)
+      await this.webhookService.sendWebhook(event.snapshot.organizationId, WebhookEvents.SNAPSHOT_CREATED, payload)
     } catch (error) {
       this.logger.error(`Failed to send webhook for snapshot created: ${error.message}`)
     }
@@ -88,14 +82,12 @@ export class WebhookEventHandlerService {
     }
 
     try {
-      await this.webhookService.sendWebhook(event.snapshot.organizationId, WebhookEvents.SNAPSHOT_STATE_UPDATED, {
-        id: event.snapshot.id,
-        name: event.snapshot.name,
-        organizationId: event.snapshot.organizationId,
-        oldState: event.oldState,
-        newState: event.newState,
-        updatedAt: event.snapshot.updatedAt,
-      })
+      const payload = SnapshotStateUpdatedWebhookDto.fromEvent(event, WebhookEvents.SNAPSHOT_STATE_UPDATED)
+      await this.webhookService.sendWebhook(
+        event.snapshot.organizationId,
+        WebhookEvents.SNAPSHOT_STATE_UPDATED,
+        payload,
+      )
     } catch (error) {
       this.logger.error(`Failed to send webhook for snapshot state updated: ${error.message}`)
     }
@@ -108,12 +100,8 @@ export class WebhookEventHandlerService {
     }
 
     try {
-      await this.webhookService.sendWebhook(event.snapshot.organizationId, WebhookEvents.SNAPSHOT_REMOVED, {
-        id: event.snapshot.id,
-        name: event.snapshot.name,
-        organizationId: event.snapshot.organizationId,
-        removedAt: new Date().toISOString(),
-      })
+      const payload = SnapshotRemovedWebhookDto.fromEvent(event, WebhookEvents.SNAPSHOT_REMOVED)
+      await this.webhookService.sendWebhook(event.snapshot.organizationId, WebhookEvents.SNAPSHOT_REMOVED, payload)
     } catch (error) {
       this.logger.error(`Failed to send webhook for snapshot removed: ${error.message}`)
     }
@@ -126,13 +114,8 @@ export class WebhookEventHandlerService {
     }
 
     try {
-      await this.webhookService.sendWebhook(event.volume.organizationId, WebhookEvents.VOLUME_CREATED, {
-        id: event.volume.id,
-        name: event.volume.name,
-        organizationId: event.volume.organizationId,
-        state: event.volume.state,
-        createdAt: event.volume.createdAt,
-      })
+      const payload = VolumeCreatedWebhookDto.fromEvent(event, WebhookEvents.VOLUME_CREATED)
+      await this.webhookService.sendWebhook(event.volume.organizationId, WebhookEvents.VOLUME_CREATED, payload)
     } catch (error) {
       this.logger.error(`Failed to send webhook for volume created: ${error.message}`)
     }
@@ -145,14 +128,8 @@ export class WebhookEventHandlerService {
     }
 
     try {
-      await this.webhookService.sendWebhook(event.volume.organizationId, WebhookEvents.VOLUME_STATE_UPDATED, {
-        id: event.volume.id,
-        name: event.volume.name,
-        organizationId: event.volume.organizationId,
-        oldState: event.oldState,
-        newState: event.newState,
-        updatedAt: event.volume.updatedAt,
-      })
+      const payload = VolumeStateUpdatedWebhookDto.fromEvent(event, WebhookEvents.VOLUME_STATE_UPDATED)
+      await this.webhookService.sendWebhook(event.volume.organizationId, WebhookEvents.VOLUME_STATE_UPDATED, payload)
     } catch (error) {
       this.logger.error(`Failed to send webhook for volume state updated: ${error.message}`)
     }


### PR DESCRIPTION
## Description

Fixes webhook payload mismatch between OpenAPI spec and actual sent data. Previously docs showed nested format but code sent flat. Now both match. Also adds `event` and `timestamp` fields to all webhooks for self-describing events. Creates typed DTOs for single source of truth.

**OpenAPI documentation improvements:**

* Updated the OpenAPI generation in `generate-openapi.ts` to include all webhook event payload DTOs via the `extraModels` option, ensuring their schemas are available for documentation. [[1]](diffhunk://#diff-c2193e3ec4be2ed157447f07101d6ca8943f6f90d3783e86be1b05193228fe85R8-R16) [[2]](diffhunk://#diff-c2193e3ec4be2ed157447f07101d6ca8943f6f90d3783e86be1b05193228fe85L24-R43)
* Refactored the webhook documentation in `openapi-webhooks.ts` to use `$ref` references to the DTO schemas for all webhook events, replacing the previous manual schema definitions for each event. This affects events for sandbox, snapshot, and volume creation and state updates, as well as snapshot removal. [[1]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L6-R16) [[2]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L41-R50) [[3]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L108-R67) [[4]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L206-R84) [[5]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L259-R101) [[6]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L333-R118) [[7]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L361-R135) [[8]](diffhunk://#diff-240d6f31b162115bccf3ec2da7e3f246de41847340a6f1b0c12ecddc80acccd0L408-R152)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation