### PR TITLE
Bump obstore version for Python 3.14 support

### DIFF
--- a/libs/sdk-python/pyproject.toml
+++ b/libs/sdk-python/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "httpx>=0.28.0,<0.29.0",
     "aiofiles>=24.1.0,<24.2.0",
     "toml>=0.10.0,<0.11.0",
-    "obstore>=0.7.0,<0.8.0",
+    "obstore>=0.7.0,<0.9.0",
     "websockets>=15.0.0,<16.0.0",
     "multipart>=1.0.0,<2.0.0",
     "typing-extensions>=4.0.0; python_version < '3.10'"
@@ -31,6 +31,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 keywords = ["daytona", "sdk"]
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Description

Bump the Daytona SDK obstore version to support Python 3.14.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #2772

## Screenshots

N/A

## Notes

There might need to be more changes. Hoping CI can help see if all the packages resolve fine.
