### PR TITLE
docs: add Google Artifact Registry configuration and update network limits

### DIFF
--- a/apps/docs/src/content/docs/en/limits.mdx
+++ b/apps/docs/src/content/docs/en/limits.mdx
@@ -26,7 +26,7 @@ You can unlock higher limits by completing the following steps:
 | ------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Tier 1 | 10 / 10GiB / 30GiB               | Email verified                                                                                                          |
 | Tier 2 | 100 / 200GiB / 300GiB            | Credit card linked, $25 top-up, [GitHub connected](/docs/en/linked-accounts#how-to-link-an-account). |
-| Tier 3 | 250 / 500GiB / 2000GiB           | Business email verified, Phone verified, $500 top-up.                                                                   |
+| Tier 3 | 250 / 500GiB / 2000GiB           | Business email verified, $500 top-up.                                                                   |
 | Tier 4 | 500 / 1000GiB / 5000GiB          | $2000 top-up every 30 days.                                                                                             |
 | Custom | Custom limits                    | Contact [support@daytona.io](mailto:support@daytona.io)                                                                 |
 

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -48,6 +48,16 @@ To use a private Docker Hub image, you'll need to [add a Container Registry](/do
 - **Password**: Use a [Docker Hub Personal Access Token](https://docs.docker.com/docker-hub/access-tokens/) (not your account password)
 - **Create the Snapshot**: Once the registry is added, you can create a Snapshot using the full image path as the image name: `docker.io/<username>/<image>:<tag>`
 
+#### Using Google Artifact Registry
+
+To use an image from Google Artifact Registry, you need to configure the registry using a [Service Account key](https://cloud.google.com/iam/docs/keys-create-delete) in JSON format:
+
+- **Registry URL**: The base URL for your region (e.g., `https://us-central1-docker.pkg.dev` or `https://us-central1-docker.pkg.dev/your-org`).
+- **Username**: Set this specifically to `_json_key`.
+- **Password**: Paste the full contents of your Service Account JSON key file.
+- **Project**: Your Google Cloud Project ID.
+- **Create the Snapshot**: Once added, create a Snapshot using the full image path: `us-central1-docker.pkg.dev/<project>/<repo>/<image>:<tag>`.
+
 ### Using a Local Image
 
 In order to avoid having to manually set up a private container registry and push your image there, the [Daytona CLI](/docs/en/getting-started#setting-up-the-daytona-cli) allows you to create a Snapshot from your local image or from a local Dockerfile and use it in your Sandboxes.


### PR DESCRIPTION
This PR adds documentation for configuring Google Artifact Registry (GAR) for private snapshots and updates network limits documentation.

## Changes
- Added Google Artifact Registry configuration section to snapshots.mdx
- Updated network limits documentation in limits.mdx

## Checklist
- [x] Documentation built successfully
- [x] Commit signed off
- [x] Followed contribution guidelines