### PR TITLE
feat(cli): support DAYTONA_API env vars

### DIFF
--- a/apps/cli/config/config.go
+++ b/apps/cli/config/config.go
@@ -83,7 +83,7 @@ func (c *Config) GetActiveProfile() (Profile, error) {
 
 	if apiUrl != "" && apiKey != "" {
 		return Profile{
-			Id: "default",
+			Id: "env",
 			Api: ServerApi{
 				Url: apiUrl,
 				Key: &apiKey,


### PR DESCRIPTION
## Description

Added support for `DAYTONA_API_URL` and `DAYTONA_API_KEY` env vars in the CLI to match SDK behavior.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
