### PR TITLE
feat(dashboard): tweak semantic colors

### DIFF
--- a/apps/dashboard/src/components/ui/alert.tsx
+++ b/apps/dashboard/src/components/ui/alert.tsx
@@ -16,12 +16,11 @@ const alertVariants = cva(
       variant: {
         default: 'bg-card text-card-foreground',
         destructive:
-          'text-destructive bg-destructive/5 [&>svg]:text-current [&_[data-slot=alert-description]]:text-destructive/80 border border-destructive/10 [&_[data-slot=alert-title]]:text-destructive/80',
-        info: 'bg-card text-card-foreground',
-        warning:
-          'bg-warning/5 text-warning border-warning/10 [&_[data-slot=alert-description]]:text-warning/80 border [&_[data-slot=alert-title]]:text-warning/80',
-        success:
-          'bg-success/5 text-success border-success/10 [&_[data-slot=alert-description]]:text-success/80 border [&_[data-slot=alert-title]]:text-success/80',
+          'text-destructive bg-destructive-background text-destructive-foreground border-destructive-separator',
+        info: 'bg-info-background text-info-foreground border-info-separator',
+        warning: 'bg-warning-background text-warning-foreground border-warning-separator',
+        success: 'bg-success-background text-success-foreground border-success-separator',
+        neutral: 'bg-muted/40 border-border',
       },
     },
     defaultVariants: {

--- a/apps/dashboard/src/components/ui/button.tsx
+++ b/apps/dashboard/src/components/ui/button.tsx
@@ -15,7 +15,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        destructive: 'bg-destructive text-white hover:bg-destructive/90',
         outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -25,22 +25,38 @@ body {
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;
     --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
+
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
+
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
+
     --radius: 0.5rem;
     --spacing: 0.25rem;
-    --warning: 32 100% 35%;
-    --warning-foreground: 0 0% 98%;
+
+    --info-background: 217 90% 97%;
+    --info-foreground: 221 83% 53%;
+    --info-separator: 217 90% 92%;
+
     --success: 141 60% 30%;
-    --success-foreground: 0 0% 98%;
+    --success-background: 160 43% 96%;
+    --success-foreground: 161 95% 24%;
+    --success-separator: 151 47% 85%;
+
+    --warning: 32 100% 35%;
+    --warning-background: 43 75% 96%;
+    --warning-foreground: 32 98% 34%;
+    --warning-separator: 43 79% 85%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-background: 3 90% 97%;
+    --destructive-foreground: 0 71% 49%;
+    --destructive-separator: 2 95% 90%;
 
     --sidebar-background: 0 0% 99.5%;
     --sidebar-foreground: 0 0% 26.1%;
@@ -51,6 +67,7 @@ body {
     --sidebar-border: 0 0% 91%;
     --sidebar-ring: 0 0% 59.8%;
   }
+
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
@@ -66,20 +83,35 @@ body {
     --muted-foreground: 0 0% 63.9%;
     --accent: 0 0% 14.9%;
     --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 50.6%;
-    --destructive-foreground: 0 0% 98%;
+
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
+
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --warning: 45 100% 50%;
-    --warning-foreground: 0 0% 98%;
+
+    --info-background: 218 39% 10%;
+    --info-foreground: 220 96% 70%;
+    --info-separator: 217 46% 15%;
+
     --success: 141 71% 48%;
-    --success-foreground: 0 0% 98%;
+    --success-background: 152 30% 8%;
+    --success-foreground: 158 63% 52%;
+    --success-separator: 153 43% 12%;
+
+    --warning: 45 100% 50%;
+    --warning-background: 44 42% 9%;
+    --warning-foreground: 43 96% 56%;
+    --warning-separator: 43 57% 14%;
+
+    --destructive: 0 62.8% 50.6%;
+    --destructive-background: 4 35% 10%;
+    --destructive-foreground: 0 92% 71%;
+    --destructive-separator: 2 44% 15%;
 
     --sidebar-background: 0 0% 10%;
     --sidebar-foreground: 0 0% 95.9%;

--- a/apps/dashboard/src/pages/OrganizationSettings.tsx
+++ b/apps/dashboard/src/pages/OrganizationSettings.tsx
@@ -159,12 +159,12 @@ const OrganizationSettings: React.FC = () => {
         </Card>
 
         {!selectedOrganization.personal && authenticatedUserOrganizationMember !== null && (
-          <Card className="bg-destructive/5 border-destructive/30">
+          <Card className="bg-destructive-background border-destructive-separator">
             <CardContent>
               <div className="flex sm:flex-row flex-col justify-between sm:items-center gap-2">
                 <div className="text-sm">
                   <div className="text-muted-foreground">
-                    <p className="font-semibold text-destructive">Danger Zone</p>
+                    <p className="font-semibold text-destructive-foreground">Danger Zone</p>
                     {isOwner ? (
                       <>Delete the organization and all associated data.</>
                     ) : (

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -50,14 +50,26 @@ module.exports = {
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
+          background: 'hsl(var(--destructive-background))',
+          separator: 'hsl(var(--destructive-separator))',
         },
         warning: {
           DEFAULT: 'hsl(var(--warning))',
           foreground: 'hsl(var(--warning-foreground))',
+          background: 'hsl(var(--warning-background))',
+          separator: 'hsl(var(--warning-separator))',
         },
         success: {
           DEFAULT: 'hsl(var(--success))',
           foreground: 'hsl(var(--success-foreground))',
+          background: 'hsl(var(--success-background))',
+          separator: 'hsl(var(--success-separator))',
+        },
+        info: {
+          DEFAULT: 'hsl(var(--info))',
+          foreground: 'hsl(var(--info-foreground))',
+          background: 'hsl(var(--info-background))',
+          separator: 'hsl(var(--info-separator))',
         },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',


### PR DESCRIPTION
## Description

Improves a11y and semantic colors.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

| Before | After |
| --- | --- |
| <img width="1000" height="425" alt="Screenshot 2025-12-23 at 17 21 29" src="https://github.com/user-attachments/assets/ba8112b3-ed10-4a4c-a714-87faa989120a" /> | <img width="1000" height="425" alt="Screenshot 2025-12-23 at 17 20 56" src="https://github.com/user-attachments/assets/286b2d4d-2045-4de6-9c5e-54f9c8e66c2f" /> |
| <img width="1000" height="425" alt="Screenshot 2025-12-23 at 17 21 25" src="https://github.com/user-attachments/assets/70c1fde7-8b06-4181-b61e-1063f8f22972" /> | <img width="1000" height="425" alt="Screenshot 2025-12-23 at 17 21 01" src="https://github.com/user-attachments/assets/8f5d7e56-55e3-41cf-9b40-07df99f5b377" /> |

