### PR TITLE
feat(dashboard): expose per sandbox limits

### DIFF
--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -280,7 +280,7 @@ function RateLimits({
         <div className="text-foreground text-sm font-medium">{title}</div>
         <div className="text-muted-foreground text-sm">{description}</div>
       </div>
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-2 sm:gap-4 sm:grid-cols-3">
         {rateLimits.map(
           ({ label, value, unit }) => value && <RateLimitItem key={label} label={label} value={value} unit={unit} />,
         )}


### PR DESCRIPTION
## Description

Exposes limits per sandbox in `/limits`.

## Related issues(s)

closes DAS-3

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
<img width="1079" height="567" alt="Screenshot 2026-01-07 at 18 20 13" src="https://github.com/user-attachments/assets/cba6d626-f4ca-4a0d-847b-4743975d25f8" />

