### PR TITLE
docs: fix typos across multiple documentation files

### DIFF
--- a/apps/docs/src/content/docs/en/audit-logs.mdx
+++ b/apps/docs/src/content/docs/en/audit-logs.mdx
@@ -26,7 +26,7 @@ Each log entry includes the following columns:
 | Field     | Description                            |
 |---------- |----------------------------------------|
 | **Time**  | Timestamp of when the action occurred (UTC)  |
-| **User**  | Email of the user who performed action  |
+| **User**  | Email of the user who performed the action  |
 | **Action**| Operation executed                      |
 | **Target**| Resource type affected                  |
 | **Outcome**| Result status code and message         |

--- a/apps/docs/src/content/docs/en/declarative-builder.mdx
+++ b/apps/docs/src/content/docs/en/declarative-builder.mdx
@@ -123,7 +123,7 @@ See: [CreateSnapshotParams (Python SDK)](/docs/python-sdk/sync/snapshot#createsn
 
 ## Image Configuration
 
-The Daytona SDK provides methods to define images programmatically using the Daytona SDK. You can specify base images, install packages, add files, set environment variables, and more.
+The Daytona SDK provides methods to define images programmatically. You can specify base images, install packages, add files, set environment variables, and more.
 
 For a complete API reference and method signatures, check the [Python](/docs/python-sdk/common/image) and [TypeScript](/docs/typescript-sdk/image) SDK references.
 

--- a/apps/docs/src/content/docs/en/file-system-operations.mdx
+++ b/apps/docs/src/content/docs/en/file-system-operations.mdx
@@ -161,7 +161,7 @@ See: [upload_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemup
 
 #### Downloading a Single File
 
-The following commands downloads a single file `file1.txt` from the Sandbox working directory and prints out the content:
+The following command downloads a single file `file1.txt` from the Sandbox working directory and prints out the content:
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/langchain-data-analysis.mdx
+++ b/apps/docs/src/content/docs/en/langchain-data-analysis.mdx
@@ -40,7 +40,7 @@ Install the required packages for this example:
     - `langchain`: LangChain framework for building AI agents
     - `langchain-anthropic`: Integration package connecting Claude (Anthropic) APIs and LangChain
     - `langchain-daytona-data-analysis`: Provides the `DaytonaDataAnalysisTool` for LangChain agents
-    - `python-dotenv`: Used for loading environment variables from `.env` file
+    - `python-dotenv`: Used for loading environment variables from a `.env` file
   </TabItem>
 </Tabs>
 
@@ -60,7 +60,7 @@ ANTHROPIC_API_KEY=sk-ant-***
 
 ### 3. Download Dataset
 
-We'll be using a publicly available dataset of vehicle valuation. You can download it directly from:
+We'll be using a publicly available dataset of vehicle valuations. You can download it directly from:
 
 [https://download.daytona.io/dataset.csv](https://download.daytona.io/dataset.csv)
 

--- a/apps/docs/src/content/docs/en/network-limits.mdx
+++ b/apps/docs/src/content/docs/en/network-limits.mdx
@@ -202,6 +202,6 @@ This list is continuously updated. If you require access to additional essential
 If you encounter network access issues or need unrestricted network access
 
 1. Check your **organization tier** in the [Dashboard](https://app.daytona.io/dashboard/limits)
-2. Upgrade your **organization tier** by completing the required verification steps to unlock higher limits tiers automatically
+2. Upgrade your **organization tier** by completing the required verification steps to unlock higher-limit tiers automatically
 3. Verify your **network allow list** configuration
 4. Contact support at [support@daytona.io](mailto:support@daytona.io) for assistance

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -70,7 +70,7 @@ This configures dnsmasq with `address=/proxy.localhost/127.0.0.1`.
 
 ### HTTP Proxy
 
-To configurate an outbound HTTP proxy for the Daytona services, you can set the following environment variables in the `docker-compose.yaml` file for each service that requires proxy access (the API service is the only that requires outbound access to pull images):
+To configure an outbound HTTP proxy for the Daytona services, you can set the following environment variables in the `docker-compose.yaml` file for each service that requires proxy access (the API service is the only that requires outbound access to pull images):
 
 - `HTTP_PROXY`: URL of the HTTP proxy server
 - `HTTPS_PROXY`: URL of the HTTPS proxy server
@@ -352,8 +352,8 @@ OIDC_AUDIENCE=your_custom_api_identifier
 OIDC_MANAGEMENT_API_ENABLED=true
 OIDC_MANAGEMENT_API_CLIENT_ID=your_m2m_app_client_id
 OIDC_MANAGEMENT_API_CLIENT_SECRET=your_m2m_app_client_secret
-OIDC_MANAGEMENT_API_AUDIENCE=your_auth0_managment_api_identifier
-```
+OIDC_MANAGEMENT_API_AUDIENCE=your_auth0_management_api_identifier
+``` 
 
 #### Proxy Service Configuration
 

--- a/apps/docs/src/content/docs/en/preview-and-authentication.mdx
+++ b/apps/docs/src/content/docs/en/preview-and-authentication.mdx
@@ -52,7 +52,7 @@ For programmatic access, use the authorization token to access the preview URL:
 
 ```bash
 curl -H "x-daytona-preview-token: vg5c0ylmcimr8b_v1ne0u6mdnvit6gc0" \
-https://3000-sandbox-123456.proxy.daytona.work
+https://3000-sandbox-123456.proxy.daytona.works
 ```
 
 ## Warning Page

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
@@ -192,7 +192,7 @@ async def create(
 
 Creates Sandboxes from specified image available on some registry or declarative Daytona Image.
 You can specify various parameters, including resources, language, image, environment variables,
-and volumes. Daytona creates snapshot from provided image and uses it to create Sandbox.
+and volumes. Daytona creates a snapshot from the provided image and uses it to create the Sandbox.
 
 **Arguments**:
 
@@ -478,7 +478,7 @@ Base parameters for creating a new Sandbox.
 - `auto_delete_interval` _Optional[int]_ - Interval in minutes after which a continuously stopped Sandbox will
   automatically be deleted. By default, auto-delete is disabled.
   Negative value means disabled, 0 means delete immediately upon stopping.
-- `volumes` _Optional[List[VolumeMount]]_ - List of volumes mounts to attach to the Sandbox.
+- `volumes` _Optional[List[VolumeMount]]_ - List of volume mounts to attach to the Sandbox.
 - `network_block_all` _Optional[bool]_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _Optional[str]_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
 - `ephemeral` _Optional[bool]_ - Whether the Sandbox should be ephemeral.

--- a/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
@@ -428,7 +428,7 @@ Base parameters for creating a new Sandbox.
 - `auto_delete_interval` _Optional[int]_ - Interval in minutes after which a continuously stopped Sandbox will
   automatically be deleted. By default, auto-delete is disabled.
   Negative value means disabled, 0 means delete immediately upon stopping.
-- `volumes` _Optional[List[VolumeMount]]_ - List of volumes mounts to attach to the Sandbox.
+- `volumes` _Optional[List[VolumeMount]]_ - List of volume mounts to attach to the Sandbox.
 - `network_block_all` _Optional[bool]_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _Optional[str]_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
 - `ephemeral` _Optional[bool]_ - Whether the Sandbox should be ephemeral.

--- a/apps/docs/src/content/docs/en/regions.mdx
+++ b/apps/docs/src/content/docs/en/regions.mdx
@@ -11,7 +11,7 @@ The Daytona SDK can be configured to run in multiple geographic regions. The fol
 | United States | `us` |
 | Europe        | `eu` |
 
-The region is specificed by setting the `target` parameter on initialization:
+The region is specified by setting the `target` parameter on initialization:
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/sandbox-management.mdx
+++ b/apps/docs/src/content/docs/en/sandbox-management.mdx
@@ -436,7 +436,7 @@ The parameter can either be set to:
 - a time interval in minutes
 - `0`, which means the maximum interval of `30 days` will be used
 
-If the parameter is not set, the default interval of `7 days` days will be used.
+If the parameter is not set, the default interval of `7 days` will be used.
 
 <Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -64,7 +64,7 @@ In order to avoid having to manually set up a private container registry and pus
 
 To create a Snapshot from a local image:
 
-1. Run `docker images` to ensure the image and tag you want to use is available
+1. Run `docker images` to ensure the image and tag you want to use are available
 2. Run `daytona snapshot push <your_local_docker_image>` to create a Snapshot and push it to Daytona, e.g.:
 
 ```bash

--- a/apps/docs/src/content/docs/en/tools/api.mdx
+++ b/apps/docs/src/content/docs/en/tools/api.mdx
@@ -2247,7 +2247,7 @@ Get list of open windows
 
 | Status Code | Description             |
 | :---------- | :---------------------- |
-| **`200`**   | List of all workspacees |
+| **`200`**   | List of all workspaces |
 
 ## POST /workspace
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/computer-use.mdx
@@ -663,7 +663,7 @@ Takes a compressed screenshot of the entire screen
 
 **Parameters**:
 
-- `options?` _ScreenshotOptions = {}_ - Compression and display options
+- `options?` _ScreenshotOptions {}_ - Compression and display options
 
 
 **Returns**:

--- a/apps/docs/src/content/docs/en/typescript-sdk/errors.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/errors.mdx
@@ -56,7 +56,7 @@ Error.constructor
 ```
 ## DaytonaNotFoundError
 
-Base error for Daytona SDK.
+Base error for the Daytona SDK.
 
 **Properties**:
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/git.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/git.mdx
@@ -92,7 +92,7 @@ console.log(`Branches: ${response.branches}`);
 checkoutBranch(path: string, branch: string): Promise<void>
 ```
 
-Checkout branche in the repository.
+Checks out a branch in the repository.
 
 **Parameters**:
 
@@ -248,7 +248,7 @@ await git.createBranch('workspace/repo', 'new-feature');
 deleteBranch(path: string, name: string): Promise<void>
 ```
 
-Delete branche in the repository.
+Deletes a branch in the repository.
 
 **Parameters**:
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/index.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/index.mdx
@@ -73,7 +73,7 @@ When using the SDK in browser-based environments or frameworks like Vite and Nex
 
 ### Daytona in Vite Projects
 
-When using Daytona SDK in a Vite-based project, you need to configure node polyfills to ensure compatibility. Add the following configuration to your `vite.config.ts` file in the plugins array:
+When using the Daytona SDK in a Vite-based project, you need to configure node polyfills to ensure compatibility. Add the following configuration to your `vite.config.ts` file in the plugins array:
 
 ```typescript
 import { nodePolyfills } from 'vite-plugin-node-polyfills'


### PR DESCRIPTION
This PR fixes various typos found across the documentation.

## Files Updated (17 total)
- audit-logs.mdx
- declarative-builder.mdx
- file-system-operations.mdx
- langchain-data-analysis.mdx
- network-limits.mdx
- oss-deployment.mdx
- preview-and-authentication.mdx
- python-sdk/async/async-daytona.mdx
- python-sdk/sync/daytona.mdx
- regions.mdx
- sandbox-management.mdx
- snapshots.mdx
- tools/api.mdx
- typescript-sdk/computer-use.mdx
- typescript-sdk/errors.mdx
- typescript-sdk/git.mdx
- typescript-sdk/index.mdx

## Changes
- Fixed spelling errors
- Corrected grammar issues
- Improved consistency

## Checklist
- [x] Documentation built successfully
- [x] Commit signed off
- [x] Followed contribution guidelines