### PR TITLE
This PR adds a beginner-friendly setup section to the Python SDK documentation.  It includes: * Python version requirements (3.9+) * How to create and activate a virtual environment * How to install the SDK * A simple verification Python snippet  This helps new users get started with the Daytona Python SDK more easily.  Happy to update this further if needed!

### DIFF
--- a/apps/docs/src/content/docs/en/python-sdk/index.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/index.mdx
@@ -10,8 +10,6 @@ The Daytona Python SDK provides a robust interface for programmatically interact
 
 ## Beginner Setup (Python)
 
-Before installing the SDK, make sure your local Python environment is properly set up.
-
 ### Requirements
 - Python 3.9 or higher
 - pip installed


### PR DESCRIPTION
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
