### PR TITLE
fix: add API key name label in onboarding

### DIFF
--- a/apps/dashboard/src/pages/Onboarding.tsx
+++ b/apps/dashboard/src/pages/Onboarding.tsx
@@ -209,16 +209,22 @@ const Onboarding: React.FC = () => {
                         await handleCreateApiKey()
                       }}
                     >
-                      <Input
-                        id="key-name"
-                        type="text"
-                        value={apiKeyName}
-                        onChange={(e) => setApiKeyName(e.target.value)}
-                        required
-                        placeholder="e.g. 'Onboarding'"
-                        className="mb-6 md:text-base px-4 h-10.5"
-                        disabled={!hasSufficientPermissions}
-                      />
+                      <div className="mb-6">
+                        <label htmlFor="key-name" className="block mb-1 text-sm font-medium text-muted-foreground">
+                          API Key Name
+                        </label>
+
+                        <Input
+                          id="key-name"
+                          type="text"
+                          value={apiKeyName}
+                          onChange={(e) => setApiKeyName(e.target.value)}
+                          required
+                          placeholder="e.g. Onboarding"
+                          className="md:text-base px-4 h-10.5"
+                          disabled={!hasSufficientPermissions}
+                        />
+                      </div>
                       <Button
                         type="submit"
                         disabled={isLoadingCreateKey || !hasSufficientPermissions}


### PR DESCRIPTION
## Description

Adds a visible label (“API Key Name”) to the API key creation input field in the onboarding flow. Previously, the field relied only on placeholder text, which could be unclear for users and less accessible. This change improves clarity and accessibility without altering any existing behavior.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Fixes #3283

## Screenshots

N/A

## Notes

This is a UI-only change scoped to the onboarding page. No backend or API behavior is affected.
