### PR TITLE
fix(api): declarative builder score threshold

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -651,10 +651,14 @@ export class SandboxService {
       let runner: Runner
 
       try {
+        const declarativeBuildScoreThreshold = this.configService.get('runnerUsage.declarativeBuildScoreThreshold')
         runner = await this.runnerService.getRandomAvailableRunner({
           regions: [sandbox.region],
           sandboxClass: sandbox.class,
           snapshotRef: sandbox.buildInfo.snapshotRef,
+          ...(declarativeBuildScoreThreshold !== undefined && {
+            availabilityScoreThreshold: declarativeBuildScoreThreshold,
+          }),
         })
         sandbox.runnerId = runner.id
       } catch (error) {


### PR DESCRIPTION
## Declarative builder score threshold

Fixes the declarative builder score threshold to be used during initial assignment in the service instead of just in the reconciler in the sandbox manager

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
