### PR TITLE
fix(sdk-python): one toolbox api client for all sandboxes

### DIFF
--- a/libs/sdk-python/src/daytona/internal/__init__.py
+++ b/libs/sdk-python/src/daytona/internal/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/libs/sdk-python/src/daytona/internal/toolbox_api_client_proxy.py
+++ b/libs/sdk-python/src/daytona/internal/toolbox_api_client_proxy.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable, Generic, TypeVar
+
+from daytona_toolbox_api_client import ApiClient
+from daytona_toolbox_api_client_async import ApiClient as AsyncApiClient
+from typing_extensions import Awaitable
+
+# TypeVar constrained to either sync or async ApiClient
+ApiClientT = TypeVar("ApiClientT", ApiClient, AsyncApiClient)
+
+
+class _ToolboxApiClientProxy(Generic[ApiClientT]):
+    """Wrapper around an API client that adjusts `param_serialize` method.
+
+    It intercepts `param_serialize` to prepend the sandbox ID to the `resource_path` and
+    set `_host` to the toolbox base URL, while delegating all other attributes
+    and methods to the underlying API client.
+    """
+
+    def __init__(self, api_client: ApiClientT, sandbox_id: str):
+        self._api_client: ApiClientT = api_client
+        self._sandbox_id = sandbox_id
+        self._toolbox_base_url = None
+
+    def param_serialize(self, *args, **kwargs):
+        """Intercepts param_serialize to prepend sandbox ID to resource_path."""
+        resource_path = kwargs.get("resource_path")
+
+        if resource_path:
+            resource_path = f"/{self._sandbox_id}{resource_path}"
+
+        kwargs["resource_path"] = resource_path
+        kwargs["_host"] = self._toolbox_base_url
+
+        return self._api_client.param_serialize(*args, **kwargs)
+
+    def __getattr__(self, name):
+        """Delegate all other attributes to the wrapped client."""
+        return getattr(self._api_client, name)
+
+
+class AsyncToolboxApiClientProxyLazyBaseUrl(_ToolboxApiClientProxy[AsyncApiClient]):
+    """Wrapper around an async API client that adjusts `call_api` method.
+
+    It intercepts `call_api` to prepend the toolbox base URL to the `url` if it is not already set.
+    While delegating all other attributes and methods to the underlying async API client.
+    """
+
+    def __init__(self, api_client: AsyncApiClient, sandbox_id: str, get_toolbox_base_url: Callable[[], Awaitable[str]]):
+        super().__init__(api_client, sandbox_id)
+        self._get_toolbox_base_url = get_toolbox_base_url
+
+    async def call_api(self, *args, **kwargs):
+        url = str(args[1])
+
+        if url.startswith("/"):
+            await self.load_toolbox_base_url()
+            url = self._toolbox_base_url + url
+            args = (args[0], url, *args[2:])
+
+        return await self._api_client.call_api(*args, **kwargs)
+
+    async def load_toolbox_base_url(self):
+        if self._toolbox_base_url is None:
+            self._toolbox_base_url = await self._get_toolbox_base_url()
+
+
+class ToolboxApiClientProxyLazyBaseUrl(_ToolboxApiClientProxy[ApiClient]):
+    """Wrapper around a sync API client that adjusts `call_api` method.
+
+    It intercepts `call_api` to prepend the toolbox base URL to the `url` if it is not already set.
+    While delegating all other attributes and methods to the underlying sync API client.
+    """
+
+    def __init__(self, api_client: ApiClient, sandbox_id: str, get_toolbox_base_url: Callable[[], str]):
+        super().__init__(api_client, sandbox_id)
+        self._get_toolbox_base_url = get_toolbox_base_url
+
+    def call_api(self, *args, **kwargs):
+        url = str(args[1])
+
+        if url.startswith("/"):
+            self.load_toolbox_base_url()
+            url = self._toolbox_base_url + url
+            args = (args[0], url, *args[2:])
+
+        return self._api_client.call_api(*args, **kwargs)
+
+    def load_toolbox_base_url(self):
+        if self._toolbox_base_url is None:
+            self._toolbox_base_url = self._get_toolbox_base_url()


### PR DESCRIPTION
## Description

This PR reduces memory consumption and improves connection pooling by implementing a **shared toolbox API client** architecture.

**Before**: Each sandbox created its own `ToolboxApiClient` instance with separate connection pools  
**After**: All sandboxes share a single `ToolboxApiClient` with lightweight per-sandbox proxy wrappers

**Changes:**
- Added `internal/toolbox_api_client_proxy.py` with proxy wrapper classes that intercept `param_serialize` to prepend sandbox ID to resource paths (e.g., `/sandbox-123/api/process/execute`) and retrieve toolbox base URL on first request.
- Modified `_async/daytona.py` and `_sync/daytona.py` to create a single shared client
- Updated `_async/sandbox.py` and `_sync/sandbox.py` to use proxy wrappers instead of separate clients

**Benefits:**
- **Efficient connection pooling**: All sandboxes share the same HTTP connection pool
- **Concurrency safe**: No race conditions between sandboxes. Each sandbox has its own proxy around API client that appends toolbox base URL and sandbox ID to each request.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

