### PR TITLE
feat(api, runner): started sandboxes count metric

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -171,6 +171,7 @@ const configuration = {
     allocatedCpuWeight: parseFloat(process.env.RUNNER_ALLOCATED_CPU_WEIGHT || '0.03'),
     allocatedMemoryWeight: parseFloat(process.env.RUNNER_ALLOCATED_MEMORY_WEIGHT || '0.03'),
     allocatedDiskWeight: parseFloat(process.env.RUNNER_ALLOCATED_DISK_WEIGHT || '0.03'),
+    startedSandboxesWeight: parseFloat(process.env.RUNNER_STARTED_SANDBOXES_WEIGHT || '0.1'),
     cpuPenaltyExponent: parseFloat(process.env.RUNNER_CPU_PENALTY_EXPONENT || '0.15'),
     memoryPenaltyExponent: parseFloat(process.env.RUNNER_MEMORY_PENALTY_EXPONENT || '0.15'),
     diskPenaltyExponent: parseFloat(process.env.RUNNER_DISK_PENALTY_EXPONENT || '0.15'),

--- a/apps/api/src/migrations/1767830400000-migration.ts
+++ b/apps/api/src/migrations/1767830400000-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1767830400000 implements MigrationInterface {
+  name = 'Migration1767830400000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "runner" ADD "currentStartedSandboxes" integer NOT NULL DEFAULT 0`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "runner" DROP COLUMN "currentStartedSandboxes"`)
+  }
+}

--- a/apps/api/src/sandbox/dto/runner.dto.ts
+++ b/apps/api/src/sandbox/dto/runner.dto.ts
@@ -122,6 +122,12 @@ export class RunnerDto {
   currentSnapshotCount: number
 
   @ApiPropertyOptional({
+    description: 'Current number of started sandboxes',
+    example: 5,
+  })
+  currentStartedSandboxes: number
+
+  @ApiPropertyOptional({
     description: 'Runner availability score',
     example: 85,
   })
@@ -194,6 +200,7 @@ export class RunnerDto {
       currentAllocatedMemoryGiB: runner.currentAllocatedMemoryGiB,
       currentAllocatedDiskGiB: runner.currentAllocatedDiskGiB,
       currentSnapshotCount: runner.currentSnapshotCount,
+      currentStartedSandboxes: runner.currentStartedSandboxes,
       availabilityScore: runner.availabilityScore,
       region: runner.region,
       state: runner.state,

--- a/apps/api/src/sandbox/entities/runner.entity.ts
+++ b/apps/api/src/sandbox/entities/runner.entity.ts
@@ -87,6 +87,11 @@ export class Runner {
   @Column({
     default: 0,
   })
+  currentStartedSandboxes: number
+
+  @Column({
+    default: 0,
+  })
   availabilityScore: number
 
   @Column()

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -35,6 +35,7 @@ export interface RunnerMetrics {
   currentDiskUsagePercentage?: number
   currentMemoryUsagePercentage?: number
   currentSnapshotCount?: number
+  currentStartedSandboxes?: number
 }
 
 export interface RunnerInfo {

--- a/apps/runner/pkg/api/controllers/info.go
+++ b/apps/runner/pkg/api/controllers/info.go
@@ -36,6 +36,7 @@ func RunnerInfo(ctx *gin.Context) {
 			CurrentAllocatedMemoryGiB:    metrics.AllocatedMemory,
 			CurrentAllocatedDiskGiB:      metrics.AllocatedDisk,
 			CurrentSnapshotCount:         metrics.SnapshotCount,
+			CurrentStartedSandboxes:      metrics.StartedSandboxes,
 		},
 		Version: internal.Version,
 	}

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1736,6 +1736,9 @@ const docTemplate = `{
                 },
                 "currentSnapshotCount": {
                     "type": "integer"
+                },
+                "currentStartedSandboxes": {
+                    "type": "integer"
                 }
             }
         },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1615,6 +1615,9 @@
         },
         "currentSnapshotCount": {
           "type": "integer"
+        },
+        "currentStartedSandboxes": {
+          "type": "integer"
         }
       }
     },

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -234,6 +234,8 @@ definitions:
         type: number
       currentSnapshotCount:
         type: integer
+      currentStartedSandboxes:
+        type: integer
     type: object
   SandboxInfoResponse:
     properties:

--- a/apps/runner/pkg/api/dto/info.go
+++ b/apps/runner/pkg/api/dto/info.go
@@ -11,6 +11,7 @@ type RunnerMetrics struct {
 	CurrentAllocatedMemoryGiB    int64   `json:"currentAllocatedMemoryGiB"`
 	CurrentAllocatedDiskGiB      int64   `json:"currentAllocatedDiskGiB"`
 	CurrentSnapshotCount         int     `json:"currentSnapshotCount"`
+	CurrentStartedSandboxes      int64   `json:"currentStartedSandboxes"`
 } //	@name	RunnerMetrics
 
 type RunnerInfoResponseDTO struct {

--- a/apps/runner/pkg/models/system_metrics.go
+++ b/apps/runner/pkg/models/system_metrics.go
@@ -6,12 +6,13 @@ package models
 import "time"
 
 type SystemMetrics struct {
-	CPUUsage        float64   `json:"cpu_usage"`
-	RAMUsage        float64   `json:"ram_usage"`
-	DiskUsage       float64   `json:"disk_usage"`
-	AllocatedCPU    int64     `json:"allocated_cpu"`
-	AllocatedMemory int64     `json:"allocated_memory"`
-	AllocatedDisk   int64     `json:"allocated_disk"`
-	SnapshotCount   int       `json:"snapshot_count"`
-	LastUpdated     time.Time `json:"last_updated"`
+	CPUUsage         float64   `json:"cpu_usage"`
+	RAMUsage         float64   `json:"ram_usage"`
+	DiskUsage        float64   `json:"disk_usage"`
+	AllocatedCPU     int64     `json:"allocated_cpu"`
+	AllocatedMemory  int64     `json:"allocated_memory"`
+	AllocatedDisk    int64     `json:"allocated_disk"`
+	SnapshotCount    int       `json:"snapshot_count"`
+	StartedSandboxes int64     `json:"started_sandboxes"`
+	LastUpdated      time.Time `json:"last_updated"`
 }

--- a/apps/runner/pkg/services/metrics.go
+++ b/apps/runner/pkg/services/metrics.go
@@ -118,14 +118,15 @@ func (s *MetricsService) GetSystemMetrics(ctx context.Context) *models.SystemMet
 
 		// Return default values if no metrics are cached
 		return &models.SystemMetrics{
-			CPUUsage:        -1.0,
-			RAMUsage:        -1.0,
-			DiskUsage:       -1.0,
-			AllocatedCPU:    -1,
-			AllocatedMemory: -1,
-			AllocatedDisk:   -1,
-			SnapshotCount:   -1,
-			LastUpdated:     time.Now(),
+			CPUUsage:         -1.0,
+			RAMUsage:         -1.0,
+			DiskUsage:        -1.0,
+			AllocatedCPU:     -1,
+			AllocatedMemory:  -1,
+			AllocatedDisk:    -1,
+			SnapshotCount:    -1,
+			StartedSandboxes: -1,
+			LastUpdated:      time.Now(),
 		}
 	}
 
@@ -142,6 +143,7 @@ func (s *MetricsService) getAllocatedResources(ctx context.Context, metrics *mod
 	var totalAllocatedCpuMicroseconds int64 = 0 // CPU quota in microseconds per period
 	var totalAllocatedMemoryBytes int64 = 0     // Memory in bytes
 	var totalAllocatedDiskGB int64 = 0          // Disk in GB
+	var startedSandboxes int64 = 0              // Count of running containers
 
 	for _, ctr := range containers {
 		cpu, memory, disk, err := s.getContainerAllocatedResources(ctx, ctr.ID)
@@ -152,6 +154,7 @@ func (s *MetricsService) getAllocatedResources(ctx context.Context, metrics *mod
 			if ctr.State == "running" {
 				totalAllocatedCpuMicroseconds += cpu
 				totalAllocatedMemoryBytes += memory
+				startedSandboxes++
 			}
 			// For disk: count all containers (running and stopped)
 			totalAllocatedDiskGB += disk
@@ -162,6 +165,7 @@ func (s *MetricsService) getAllocatedResources(ctx context.Context, metrics *mod
 	metrics.AllocatedCPU = totalAllocatedCpuMicroseconds / 100000              // Convert back to vCPUs
 	metrics.AllocatedMemory = totalAllocatedMemoryBytes / (1024 * 1024 * 1024) // Convert back to GB
 	metrics.AllocatedDisk = totalAllocatedDiskGB
+	metrics.StartedSandboxes = startedSandboxes
 }
 
 func (s *MetricsService) getContainerAllocatedResources(ctx context.Context, containerId string) (int64, int64, int64, error) {

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9404,6 +9404,7 @@ components:
       type: string
     Runner:
       example:
+        currentStartedSandboxes: 5
         memory: 16
         apiKey: api-key-123
         currentMemoryUsagePercentage: 68.2
@@ -9502,6 +9503,10 @@ components:
         currentSnapshotCount:
           description: Current snapshot count
           example: 12
+          type: number
+        currentStartedSandboxes:
+          description: Current number of started sandboxes
+          example: 5
           type: number
         availabilityScore:
           description: Runner availability score

--- a/libs/api-client-go/model_runner.go
+++ b/libs/api-client-go/model_runner.go
@@ -57,6 +57,8 @@ type Runner struct {
 	CurrentAllocatedDiskGiB *float32 `json:"currentAllocatedDiskGiB,omitempty"`
 	// Current snapshot count
 	CurrentSnapshotCount *float32 `json:"currentSnapshotCount,omitempty"`
+	// Current number of started sandboxes
+	CurrentStartedSandboxes *float32 `json:"currentStartedSandboxes,omitempty"`
 	// Runner availability score
 	AvailabilityScore *float32 `json:"availabilityScore,omitempty"`
 	// The region of the runner
@@ -600,6 +602,38 @@ func (o *Runner) SetCurrentSnapshotCount(v float32) {
 	o.CurrentSnapshotCount = &v
 }
 
+// GetCurrentStartedSandboxes returns the CurrentStartedSandboxes field value if set, zero value otherwise.
+func (o *Runner) GetCurrentStartedSandboxes() float32 {
+	if o == nil || IsNil(o.CurrentStartedSandboxes) {
+		var ret float32
+		return ret
+	}
+	return *o.CurrentStartedSandboxes
+}
+
+// GetCurrentStartedSandboxesOk returns a tuple with the CurrentStartedSandboxes field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Runner) GetCurrentStartedSandboxesOk() (*float32, bool) {
+	if o == nil || IsNil(o.CurrentStartedSandboxes) {
+		return nil, false
+	}
+	return o.CurrentStartedSandboxes, true
+}
+
+// HasCurrentStartedSandboxes returns a boolean if a field has been set.
+func (o *Runner) HasCurrentStartedSandboxes() bool {
+	if o != nil && !IsNil(o.CurrentStartedSandboxes) {
+		return true
+	}
+
+	return false
+}
+
+// SetCurrentStartedSandboxes gets a reference to the given float32 and assigns it to the CurrentStartedSandboxes field.
+func (o *Runner) SetCurrentStartedSandboxes(v float32) {
+	o.CurrentStartedSandboxes = &v
+}
+
 // GetAvailabilityScore returns the AvailabilityScore field value if set, zero value otherwise.
 func (o *Runner) GetAvailabilityScore() float32 {
 	if o == nil || IsNil(o.AvailabilityScore) {
@@ -850,6 +884,9 @@ func (o Runner) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CurrentSnapshotCount) {
 		toSerialize["currentSnapshotCount"] = o.CurrentSnapshotCount
 	}
+	if !IsNil(o.CurrentStartedSandboxes) {
+		toSerialize["currentStartedSandboxes"] = o.CurrentStartedSandboxes
+	}
 	if !IsNil(o.AvailabilityScore) {
 		toSerialize["availabilityScore"] = o.AvailabilityScore
 	}
@@ -939,6 +976,7 @@ func (o *Runner) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "currentAllocatedMemoryGiB")
 		delete(additionalProperties, "currentAllocatedDiskGiB")
 		delete(additionalProperties, "currentSnapshotCount")
+		delete(additionalProperties, "currentStartedSandboxes")
 		delete(additionalProperties, "availabilityScore")
 		delete(additionalProperties, "region")
 		delete(additionalProperties, "state")

--- a/libs/api-client-python-async/daytona_api_client_async/models/runner.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/runner.py
@@ -47,6 +47,7 @@ class Runner(BaseModel):
     current_allocated_memory_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current allocated memory in GiB", alias="currentAllocatedMemoryGiB")
     current_allocated_disk_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current allocated disk in GiB", alias="currentAllocatedDiskGiB")
     current_snapshot_count: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current snapshot count", alias="currentSnapshotCount")
+    current_started_sandboxes: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current number of started sandboxes", alias="currentStartedSandboxes")
     availability_score: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Runner availability score", alias="availabilityScore")
     region: StrictStr = Field(description="The region of the runner")
     state: RunnerState = Field(description="The state of the runner")
@@ -56,7 +57,7 @@ class Runner(BaseModel):
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "apiKey", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "availabilityScore", "region", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version"]
+    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "apiKey", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -134,6 +135,7 @@ class Runner(BaseModel):
             "currentAllocatedMemoryGiB": obj.get("currentAllocatedMemoryGiB"),
             "currentAllocatedDiskGiB": obj.get("currentAllocatedDiskGiB"),
             "currentSnapshotCount": obj.get("currentSnapshotCount"),
+            "currentStartedSandboxes": obj.get("currentStartedSandboxes"),
             "availabilityScore": obj.get("availabilityScore"),
             "region": obj.get("region"),
             "state": obj.get("state"),

--- a/libs/api-client-python/daytona_api_client/models/runner.py
+++ b/libs/api-client-python/daytona_api_client/models/runner.py
@@ -47,6 +47,7 @@ class Runner(BaseModel):
     current_allocated_memory_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current allocated memory in GiB", alias="currentAllocatedMemoryGiB")
     current_allocated_disk_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current allocated disk in GiB", alias="currentAllocatedDiskGiB")
     current_snapshot_count: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current snapshot count", alias="currentSnapshotCount")
+    current_started_sandboxes: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Current number of started sandboxes", alias="currentStartedSandboxes")
     availability_score: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Runner availability score", alias="availabilityScore")
     region: StrictStr = Field(description="The region of the runner")
     state: RunnerState = Field(description="The state of the runner")
@@ -56,7 +57,7 @@ class Runner(BaseModel):
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "apiKey", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "availabilityScore", "region", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version"]
+    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "apiKey", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -134,6 +135,7 @@ class Runner(BaseModel):
             "currentAllocatedMemoryGiB": obj.get("currentAllocatedMemoryGiB"),
             "currentAllocatedDiskGiB": obj.get("currentAllocatedDiskGiB"),
             "currentSnapshotCount": obj.get("currentSnapshotCount"),
+            "currentStartedSandboxes": obj.get("currentStartedSandboxes"),
             "availabilityScore": obj.get("availabilityScore"),
             "region": obj.get("region"),
             "state": obj.get("state"),

--- a/libs/api-client/src/models/runner.ts
+++ b/libs/api-client/src/models/runner.ts
@@ -134,6 +134,12 @@ export interface Runner {
    */
   currentSnapshotCount?: number
   /**
+   * Current number of started sandboxes
+   * @type {number}
+   * @memberof Runner
+   */
+  currentStartedSandboxes?: number
+  /**
    * Runner availability score
    * @type {number}
    * @memberof Runner

--- a/libs/runner-api-client/src/models/runner-metrics.ts
+++ b/libs/runner-api-client/src/models/runner-metrics.ts
@@ -60,4 +60,10 @@ export interface RunnerMetrics {
    * @memberof RunnerMetrics
    */
   currentSnapshotCount?: number
+  /**
+   *
+   * @type {number}
+   * @memberof RunnerMetrics
+   */
+  currentStartedSandboxes?: number
 }


### PR DESCRIPTION
## Started sandboxes count metric

Adds a started sandboxes count metric to the runner's data used for availability score calculation

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation