### PR TITLE
fix(api): snapshot missing image in registry

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -700,7 +700,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     if (!imageExistsInRegistry) {
       this.logger.warn(`Snapshot ${snapshot.id} image ${snapshot.ref} not found in registry, waiting for propagation`)
       // Don't mark as ready yet, wait for the image to be available in the registry
-      // Save the snapshot ref for retries, this method will time out if the image is not found time
+      // Save the snapshot ref for retries, this method will time out if the image is not found in time
       await this.snapshotRepository.save(snapshot)
       return DONT_SYNC_AGAIN
     }


### PR DESCRIPTION
## Snapshot missing image in registry

Fixes cases where a snapshot will end up in an active state even though the ref isn't readily available in the registry - also fixes the race condition that causes that

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
