### PR TITLE
fix(api): remove eager load for build info

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -189,7 +189,6 @@ export class Sandbox {
 
   @ManyToOne(() => BuildInfo, (buildInfo) => buildInfo.sandboxes, {
     nullable: true,
-    eager: true,
   })
   @JoinColumn()
   buildInfo?: BuildInfo

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -399,8 +399,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       return
     }
 
-    const sandbox = await this.sandboxRepository.findOneByOrFail({
-      id: sandboxId,
+    const sandbox = await this.sandboxRepository.findOneOrFail({
+      where: { id: sandboxId },
+      relations: ['buildInfo'],
     })
 
     if ([SandboxState.DESTROYED, SandboxState.ERROR, SandboxState.BUILD_FAILED].includes(sandbox.state)) {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -893,6 +893,7 @@ export class SandboxService {
         ...(organizationId ? { organizationId: organizationId } : {}),
         ...(returnDestroyed ? {} : { state: Not(SandboxState.DESTROYED) }),
       },
+      relations: ['buildInfo'],
     })
 
     if (!sandbox && organizationId) {
@@ -902,6 +903,7 @@ export class SandboxService {
           organizationId: organizationId,
           ...(returnDestroyed ? {} : { state: Not(SandboxState.DESTROYED) }),
         },
+        relations: ['buildInfo'],
       })
     }
 


### PR DESCRIPTION
## Remove eager load for build info

This PR removes eager loading by default for build info and keeps it only in the manager for the build process is called properly and when API GET-ing a single sandbox

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation