### PR TITLE
fix(docs): missing docs guides sidebar labels after Astro version bump

### DIFF
--- a/apps/docs/src/content/config.ts
+++ b/apps/docs/src/content/config.ts
@@ -454,7 +454,7 @@ export const getSidebarConfig = (
         {
           type: 'link',
           href: localizePath('/docs/claude', locale),
-          label: labels['sidebarconfig.claude'],
+          label: t('sidebarconfig.claude'),
           disablePagination: true,
           attrs: {
             icon: 'claude.svg',
@@ -466,7 +466,7 @@ export const getSidebarConfig = (
             '/docs/claude-agent-sdk-interactive-terminal-sandbox',
             locale
           ),
-          label: labels['sidebarconfig.claude'],
+          label: t('sidebarconfig.claude'),
           disablePagination: true,
           hideInSidebar: true,
         },
@@ -476,7 +476,7 @@ export const getSidebarConfig = (
             '/docs/claude-agent-sdk-connect-service-sandbox',
             locale
           ),
-          label: labels['sidebarconfig.claude'],
+          label: t('sidebarconfig.claude'),
           disablePagination: true,
           hideInSidebar: true,
         },
@@ -486,7 +486,7 @@ export const getSidebarConfig = (
             '/docs/claude-code-run-tasks-stream-logs-sandbox',
             locale
           ),
-          label: labels['sidebarconfig.claude'],
+          label: t('sidebarconfig.claude'),
           disablePagination: true,
           hideInSidebar: true,
         },


### PR DESCRIPTION
## Description

This PR fixes the issue introduced with merging [PR](https://github.com/daytonaio/daytona/pull/2929). The PR changed the sidebar labels usage logic and it apparently didn't rebase correctly to apply this to Claude guides.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="1496" height="1390" alt="image" src="https://github.com/user-attachments/assets/b729738e-8bb8-4916-a907-3a16c0d700f0" />
