### PR TITLE
fix(api): 500 on invalid json body

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -39,6 +39,7 @@ import { getPinoTransport, swapMessageAndObject } from './common/utils/pino.util
 import { Redis } from 'ioredis'
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis'
 import { RegionModule } from './region/region.module'
+import { BodyParserErrorModule } from './common/modules/body-parser-error.module'
 
 @Module({
   imports: [
@@ -97,9 +98,10 @@ import { RegionModule } from './region/region.module'
         }
       },
     }),
+    BodyParserErrorModule,
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..'),
-      exclude: ['/api/*'],
+      exclude: ['/api/{*path}'],
       renderPath: '/runner-amd64',
       serveStaticOptions: {
         cacheControl: false,
@@ -107,7 +109,7 @@ import { RegionModule } from './region/region.module'
     }),
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'dashboard'),
-      exclude: ['/api/*'],
+      exclude: ['/api/{*path}'],
       renderPath: '/',
       serveStaticOptions: {
         cacheControl: false,
@@ -224,7 +226,7 @@ import { RegionModule } from './region/region.module'
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(VersionHeaderMiddleware).forRoutes({ path: '{*path}', method: RequestMethod.ALL })
-    consumer.apply(FailedAuthRateLimitMiddleware).forRoutes({ path: '*', method: RequestMethod.ALL })
+    consumer.apply(FailedAuthRateLimitMiddleware).forRoutes({ path: '{*path}', method: RequestMethod.ALL })
     consumer.apply(MaintenanceMiddleware).forRoutes({ path: '{*path}', method: RequestMethod.ALL })
   }
 }

--- a/apps/api/src/common/modules/body-parser-error.module.ts
+++ b/apps/api/src/common/modules/body-parser-error.module.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module, OnModuleInit, BadRequestException } from '@nestjs/common'
+import { HttpAdapterHost } from '@nestjs/core'
+import { Request, Response, NextFunction } from 'express'
+@Module({})
+export class BodyParserErrorModule implements OnModuleInit {
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  onModuleInit() {
+    const app = this.httpAdapterHost.httpAdapter.getInstance()
+
+    app.use((err: Error & { body?: unknown }, req: Request, res: Response, next: NextFunction) => {
+      if (err instanceof SyntaxError && 'body' in err) {
+        const response = new BadRequestException('Invalid JSON in request body').getResponse()
+        return res.status(400).json(response)
+      }
+
+      next(err)
+    })
+  }
+}


### PR DESCRIPTION
## 500 on invalid json body

Fixes HTTP 500 on invalid json body for e.g. sandbox create caused by poor error handling in the serve static module

## Logs

`500 - Internal Server Error`
`Missing parameter name at 6: https://git.new/pathToRegexpError`

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
