### PR TITLE
feat(api,cli,dashboard): device auth flow

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -39,6 +39,7 @@ import { getPinoTransport, swapMessageAndObject } from './common/utils/pino.util
 import { Redis } from 'ioredis'
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis'
 import { RegionModule } from './region/region.module'
+import { DeviceAuthModule } from './device-auth/device-auth.module'
 
 @Module({
   imports: [
@@ -201,6 +202,7 @@ import { RegionModule } from './region/region.module'
     ObjectStorageModule,
     AuditModule,
     HealthModule,
+    DeviceAuthModule,
     OpenFeatureModule.forRoot({
       contextFactory: (request: ExecutionContext) => {
         const req = request.switchToHttp().getRequest()

--- a/apps/api/src/device-auth/device-auth.controller.ts
+++ b/apps/api/src/device-auth/device-auth.controller.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Query,
+  UseGuards,
+  BadRequestException,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common'
+import { ApiTags, ApiOperation, ApiResponse, ApiOAuth2, ApiBearerAuth, ApiHeader, ApiQuery } from '@nestjs/swagger'
+import { DeviceAuthService } from './device-auth.service'
+import { DeviceCodeRequestDto } from './dto/device-code-request.dto'
+import { DeviceCodeResponseDto } from './dto/device-code-response.dto'
+import { DeviceTokenRequestDto } from './dto/device-token-request.dto'
+import { DeviceTokenResponseDto, DeviceTokenErrorDto } from './dto/device-token-response.dto'
+import { DeviceApproveRequestDto } from './dto/device-approve-request.dto'
+import { DeviceStatusResponseDto } from './dto/device-status-response.dto'
+import { CombinedAuthGuard } from '../auth/combined-auth.guard'
+import { AuthContext } from '../common/decorators/auth-context.decorator'
+import { OrganizationAuthContext } from '../common/interfaces/auth-context.interface'
+import { CustomHeaders } from '../common/constants/header.constants'
+import { TypedConfigService } from '../config/typed-config.service'
+
+@ApiTags('device-auth')
+@Controller('auth/device')
+export class DeviceAuthController {
+  constructor(
+    private readonly deviceAuthService: DeviceAuthService,
+    private readonly configService: TypedConfigService,
+  ) {}
+
+  @Post('code')
+  @ApiOperation({
+    summary: 'Request device authorization code',
+    description: 'Initiates a device authorization flow by generating a device code and user code',
+    operationId: 'requestDeviceCode',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Device authorization codes generated successfully',
+    type: DeviceCodeResponseDto,
+  })
+  @HttpCode(HttpStatus.OK)
+  async requestDeviceCode(@Body() request: DeviceCodeRequestDto): Promise<DeviceCodeResponseDto> {
+    const result = await this.deviceAuthService.createDeviceAuthorizationRequest(request.client_id, request.scope)
+
+    const dashboardUrl = this.configService.get('dashboardUrl') || 'https://app.daytona.io'
+    // Strip /dashboard suffix if present since /device is a top-level route
+    const baseUrl = dashboardUrl.replace(/\/dashboard\/?$/, '')
+
+    return {
+      device_code: result.deviceCode,
+      user_code: result.userCode,
+      verification_uri: `${baseUrl}/device`,
+      verification_uri_complete: `${baseUrl}/device?user_code=${result.userCode}`,
+      expires_in: result.expiresIn,
+      interval: result.interval,
+    }
+  }
+
+  @Post('token')
+  @ApiOperation({
+    summary: 'Poll for device token',
+    description: 'Polls for the token after user has authenticated via browser',
+    operationId: 'pollDeviceToken',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Token response (success or pending/error status)',
+    type: DeviceTokenResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Error response',
+    type: DeviceTokenErrorDto,
+  })
+  @HttpCode(HttpStatus.OK)
+  async pollDeviceToken(@Body() request: DeviceTokenRequestDto): Promise<DeviceTokenResponseDto | DeviceTokenErrorDto> {
+    if (request.grant_type !== 'urn:ietf:params:oauth:grant-type:device_code') {
+      throw new BadRequestException('Invalid grant type')
+    }
+
+    const result = await this.deviceAuthService.pollForToken(request.device_code, request.client_id)
+
+    switch (result.status) {
+      case 'approved':
+        return {
+          access_token: result.accessToken!,
+          token_type: 'Bearer',
+          expires_in: 31536000, // 1 year
+          scope: result.scope || '',
+          organization_id: result.organizationId!,
+          organization_name: result.organizationName!,
+        }
+      case 'pending':
+        return { error: 'authorization_pending' }
+      case 'denied':
+        return { error: 'access_denied', error_description: 'The user denied the authorization request' }
+      case 'expired':
+        return { error: 'expired_token', error_description: 'The device code has expired' }
+      case 'slow_down':
+        return { error: 'slow_down', error_description: 'Please slow down the polling rate' }
+      default:
+        return { error: 'authorization_pending' }
+    }
+  }
+
+  @Get('status')
+  @ApiOperation({
+    summary: 'Get device authorization status',
+    description: 'Gets the current status of a device authorization request by user code',
+    operationId: 'getDeviceStatus',
+  })
+  @ApiQuery({ name: 'user_code', required: true, description: 'The user code to check status for' })
+  @ApiResponse({
+    status: 200,
+    description: 'Device authorization status',
+    type: DeviceStatusResponseDto,
+  })
+  async getDeviceStatus(@Query('user_code') userCode: string): Promise<DeviceStatusResponseDto> {
+    const request = await this.deviceAuthService.getDeviceAuthorizationByUserCode(userCode)
+
+    if (!request) {
+      throw new BadRequestException('Invalid or expired user code')
+    }
+
+    const now = new Date()
+    const expiresIn = Math.max(0, Math.floor((request.expiresAt.getTime() - now.getTime()) / 1000))
+
+    return {
+      user_code: request.userCode,
+      client_id: request.clientId,
+      scope: request.scope || '',
+      status: request.status,
+      expires_in: expiresIn,
+    }
+  }
+
+  @Post('approve')
+  @UseGuards(CombinedAuthGuard)
+  @ApiHeader(CustomHeaders.ORGANIZATION_ID)
+  @ApiOAuth2(['openid', 'profile', 'email'])
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Approve or deny device authorization',
+    description: 'Approves or denies a device authorization request. Requires authentication.',
+    operationId: 'approveDeviceAuthorization',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Device authorization processed successfully',
+  })
+  @HttpCode(HttpStatus.OK)
+  async approveDeviceAuthorization(
+    @AuthContext() authContext: OrganizationAuthContext,
+    @Body() request: DeviceApproveRequestDto,
+  ): Promise<{ success: boolean; message: string }> {
+    const organizationId = request.organization_id || authContext.organizationId
+
+    if (request.action === 'approve') {
+      return this.deviceAuthService.approveDeviceAuthorization(request.user_code, authContext.userId, organizationId)
+    } else {
+      return this.deviceAuthService.denyDeviceAuthorization(request.user_code)
+    }
+  }
+}

--- a/apps/api/src/device-auth/device-auth.entity.ts
+++ b/apps/api/src/device-auth/device-auth.entity.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Column, Entity, PrimaryGeneratedColumn, CreateDateColumn, Index } from 'typeorm'
+
+export enum DeviceAuthStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  DENIED = 'denied',
+  EXPIRED = 'expired',
+}
+
+@Entity('device_authorization_request')
+export class DeviceAuthorizationRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ unique: true })
+  @Index()
+  deviceCode: string
+
+  @Column({ unique: true })
+  @Index()
+  userCode: string
+
+  @Column()
+  clientId: string
+
+  @Column({ nullable: true })
+  scope: string
+
+  @Column({
+    type: 'enum',
+    enum: DeviceAuthStatus,
+    default: DeviceAuthStatus.PENDING,
+  })
+  status: DeviceAuthStatus
+
+  @Column({ nullable: true })
+  userId: string
+
+  @Column({ nullable: true })
+  organizationId: string
+
+  @Column({ nullable: true })
+  accessToken: string
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @Column()
+  expiresAt: Date
+
+  @Column({ nullable: true })
+  approvedAt: Date
+
+  @Column({ nullable: true })
+  lastPolledAt: Date
+}

--- a/apps/api/src/device-auth/device-auth.module.ts
+++ b/apps/api/src/device-auth/device-auth.module.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { DeviceAuthController } from './device-auth.controller'
+import { DeviceAuthService } from './device-auth.service'
+import { DeviceAuthorizationRequest } from './device-auth.entity'
+import { ApiKeyModule } from '../api-key/api-key.module'
+import { OrganizationModule } from '../organization/organization.module'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DeviceAuthorizationRequest]), ApiKeyModule, OrganizationModule],
+  controllers: [DeviceAuthController],
+  providers: [DeviceAuthService],
+  exports: [DeviceAuthService],
+})
+export class DeviceAuthModule {}

--- a/apps/api/src/device-auth/device-auth.service.ts
+++ b/apps/api/src/device-auth/device-auth.service.ts
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository, LessThan } from 'typeorm'
+import * as crypto from 'crypto'
+import { DeviceAuthorizationRequest, DeviceAuthStatus } from './device-auth.entity'
+import { ApiKeyService } from '../api-key/api-key.service'
+import { OrganizationService } from '../organization/services/organization.service'
+import { OrganizationResourcePermission } from '../organization/enums/organization-resource-permission.enum'
+import { Cron, CronExpression } from '@nestjs/schedule'
+
+@Injectable()
+export class DeviceAuthService {
+  private readonly logger = new Logger(DeviceAuthService.name)
+  private readonly DEVICE_CODE_EXPIRY_SECONDS = 900 // 15 minutes
+  private readonly POLLING_INTERVAL_SECONDS = 5
+  private readonly MIN_POLL_INTERVAL_MS = 4000 // 4 seconds (slightly less than 5 for timing tolerance)
+
+  constructor(
+    @InjectRepository(DeviceAuthorizationRequest)
+    private readonly deviceAuthRepository: Repository<DeviceAuthorizationRequest>,
+    private readonly apiKeyService: ApiKeyService,
+    private readonly organizationService: OrganizationService,
+  ) {}
+
+  private generateDeviceCode(): string {
+    return crypto.randomBytes(32).toString('base64url')
+  }
+
+  private generateUserCode(): string {
+    // Generate a 8-character code like "WDJB-MJHT"
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ' // Excluding I, O to avoid confusion
+    let code = ''
+    for (let i = 0; i < 8; i++) {
+      if (i === 4) code += '-'
+      code += chars.charAt(Math.floor(Math.random() * chars.length))
+    }
+    return code
+  }
+
+  async createDeviceAuthorizationRequest(
+    clientId: string,
+    scope?: string,
+  ): Promise<{
+    deviceCode: string
+    userCode: string
+    expiresIn: number
+    interval: number
+  }> {
+    const deviceCode = this.generateDeviceCode()
+    let userCode = this.generateUserCode()
+
+    // Ensure userCode is unique
+    let attempts = 0
+    while (await this.deviceAuthRepository.findOne({ where: { userCode } })) {
+      userCode = this.generateUserCode()
+      attempts++
+      if (attempts > 10) {
+        throw new BadRequestException('Failed to generate unique user code')
+      }
+    }
+
+    const expiresAt = new Date(Date.now() + this.DEVICE_CODE_EXPIRY_SECONDS * 1000)
+
+    const request = this.deviceAuthRepository.create({
+      deviceCode,
+      userCode,
+      clientId,
+      scope,
+      status: DeviceAuthStatus.PENDING,
+      expiresAt,
+    })
+
+    await this.deviceAuthRepository.save(request)
+
+    return {
+      deviceCode,
+      userCode,
+      expiresIn: this.DEVICE_CODE_EXPIRY_SECONDS,
+      interval: this.POLLING_INTERVAL_SECONDS,
+    }
+  }
+
+  async getDeviceAuthorizationByUserCode(userCode: string): Promise<DeviceAuthorizationRequest | null> {
+    const normalizedCode = userCode.toUpperCase().trim()
+    return this.deviceAuthRepository.findOne({
+      where: { userCode: normalizedCode },
+    })
+  }
+
+  async pollForToken(
+    deviceCode: string,
+    clientId: string,
+  ): Promise<{
+    status: 'pending' | 'approved' | 'denied' | 'expired' | 'slow_down'
+    accessToken?: string
+    organizationId?: string
+    organizationName?: string
+    scope?: string
+  }> {
+    const request = await this.deviceAuthRepository.findOne({
+      where: { deviceCode, clientId },
+    })
+
+    if (!request) {
+      throw new NotFoundException('Device authorization request not found')
+    }
+
+    // Check if expired
+    if (new Date() > request.expiresAt) {
+      if (request.status !== DeviceAuthStatus.EXPIRED) {
+        request.status = DeviceAuthStatus.EXPIRED
+        await this.deviceAuthRepository.save(request)
+      }
+      return { status: 'expired' }
+    }
+
+    // Check polling rate
+    if (request.lastPolledAt) {
+      const timeSinceLastPoll = Date.now() - request.lastPolledAt.getTime()
+      if (timeSinceLastPoll < this.MIN_POLL_INTERVAL_MS) {
+        return { status: 'slow_down' }
+      }
+    }
+
+    // Update last polled time
+    request.lastPolledAt = new Date()
+    await this.deviceAuthRepository.save(request)
+
+    if (request.status === DeviceAuthStatus.PENDING) {
+      return { status: 'pending' }
+    }
+
+    if (request.status === DeviceAuthStatus.DENIED) {
+      return { status: 'denied' }
+    }
+
+    if (request.status === DeviceAuthStatus.APPROVED && request.accessToken && request.organizationId) {
+      // Get organization name
+      let organizationName = 'Unknown'
+      try {
+        const org = await this.organizationService.findOne(request.organizationId)
+        organizationName = org.name
+      } catch {
+        // Ignore error, use default name
+      }
+
+      return {
+        status: 'approved',
+        accessToken: request.accessToken,
+        organizationId: request.organizationId,
+        organizationName,
+        scope: request.scope || undefined,
+      }
+    }
+
+    return { status: 'pending' }
+  }
+
+  async approveDeviceAuthorization(
+    userCode: string,
+    userId: string,
+    organizationId: string,
+  ): Promise<{ success: boolean; message: string }> {
+    const normalizedCode = userCode.toUpperCase().trim()
+    const request = await this.deviceAuthRepository.findOne({
+      where: { userCode: normalizedCode },
+    })
+
+    if (!request) {
+      throw new NotFoundException('Device authorization request not found')
+    }
+
+    if (new Date() > request.expiresAt) {
+      request.status = DeviceAuthStatus.EXPIRED
+      await this.deviceAuthRepository.save(request)
+      throw new BadRequestException('Device authorization request has expired')
+    }
+
+    if (request.status !== DeviceAuthStatus.PENDING) {
+      throw new BadRequestException('Device authorization request is no longer pending')
+    }
+
+    // Get all available permissions for a full-access API key
+    const permissions = Object.values(OrganizationResourcePermission)
+
+    // Generate API key using the existing API key service
+    const { value: accessToken } = await this.apiKeyService.createApiKey(
+      organizationId,
+      userId,
+      `cli-device-${Date.now()}`,
+      permissions,
+    )
+
+    request.status = DeviceAuthStatus.APPROVED
+    request.userId = userId
+    request.organizationId = organizationId
+    request.accessToken = accessToken
+    request.approvedAt = new Date()
+
+    await this.deviceAuthRepository.save(request)
+
+    return { success: true, message: 'Device authorization approved' }
+  }
+
+  async denyDeviceAuthorization(userCode: string): Promise<{ success: boolean; message: string }> {
+    const normalizedCode = userCode.toUpperCase().trim()
+    const request = await this.deviceAuthRepository.findOne({
+      where: { userCode: normalizedCode },
+    })
+
+    if (!request) {
+      throw new NotFoundException('Device authorization request not found')
+    }
+
+    if (new Date() > request.expiresAt) {
+      request.status = DeviceAuthStatus.EXPIRED
+      await this.deviceAuthRepository.save(request)
+      throw new BadRequestException('Device authorization request has expired')
+    }
+
+    if (request.status !== DeviceAuthStatus.PENDING) {
+      throw new BadRequestException('Device authorization request is no longer pending')
+    }
+
+    request.status = DeviceAuthStatus.DENIED
+    await this.deviceAuthRepository.save(request)
+
+    return { success: true, message: 'Device authorization denied' }
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanupExpiredRequests(): Promise<void> {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+
+    const result = await this.deviceAuthRepository.delete({
+      expiresAt: LessThan(oneHourAgo),
+    })
+
+    if (result.affected && result.affected > 0) {
+      this.logger.log(`Cleaned up ${result.affected} expired device authorization requests`)
+    }
+  }
+}

--- a/apps/api/src/device-auth/dto/device-approve-request.dto.ts
+++ b/apps/api/src/device-auth/dto/device-approve-request.dto.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+import { IsString, IsIn, IsOptional } from 'class-validator'
+
+export class DeviceApproveRequestDto {
+  @ApiProperty({ example: 'WDJB-MJHT' })
+  @IsString()
+  user_code: string
+
+  @ApiProperty({ example: 'approve', enum: ['approve', 'deny'] })
+  @IsString()
+  @IsIn(['approve', 'deny'])
+  action: 'approve' | 'deny'
+
+  @ApiProperty({ example: 'org-abc123', required: false })
+  @IsString()
+  @IsOptional()
+  organization_id?: string
+}

--- a/apps/api/src/device-auth/dto/device-code-request.dto.ts
+++ b/apps/api/src/device-auth/dto/device-code-request.dto.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+import { IsString, IsOptional } from 'class-validator'
+
+export class DeviceCodeRequestDto {
+  @ApiProperty({ example: 'daytona-cli', description: 'Client identifier' })
+  @IsString()
+  client_id: string
+
+  @ApiProperty({ example: 'workspaces:read workspaces:write', required: false })
+  @IsString()
+  @IsOptional()
+  scope?: string
+}

--- a/apps/api/src/device-auth/dto/device-code-response.dto.ts
+++ b/apps/api/src/device-auth/dto/device-code-response.dto.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+
+export class DeviceCodeResponseDto {
+  @ApiProperty({ example: 'GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS' })
+  device_code: string
+
+  @ApiProperty({ example: 'WDJB-MJHT' })
+  user_code: string
+
+  @ApiProperty({ example: 'https://app.daytona.io/device' })
+  verification_uri: string
+
+  @ApiProperty({ example: 'https://app.daytona.io/device?user_code=WDJB-MJHT' })
+  verification_uri_complete: string
+
+  @ApiProperty({ example: 900 })
+  expires_in: number
+
+  @ApiProperty({ example: 5 })
+  interval: number
+}

--- a/apps/api/src/device-auth/dto/device-status-response.dto.ts
+++ b/apps/api/src/device-auth/dto/device-status-response.dto.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+
+export class DeviceStatusResponseDto {
+  @ApiProperty({ example: 'WDJB-MJHT' })
+  user_code: string
+
+  @ApiProperty({ example: 'daytona-cli' })
+  client_id: string
+
+  @ApiProperty({ example: 'workspaces:read workspaces:write' })
+  scope: string
+
+  @ApiProperty({ example: 'pending' })
+  status: string
+
+  @ApiProperty({ example: 300 })
+  expires_in: number
+}

--- a/apps/api/src/device-auth/dto/device-token-request.dto.ts
+++ b/apps/api/src/device-auth/dto/device-token-request.dto.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+import { IsString } from 'class-validator'
+
+export class DeviceTokenRequestDto {
+  @ApiProperty({ example: 'urn:ietf:params:oauth:grant-type:device_code' })
+  @IsString()
+  grant_type: string
+
+  @ApiProperty({ example: 'GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS' })
+  @IsString()
+  device_code: string
+
+  @ApiProperty({ example: 'daytona-cli' })
+  @IsString()
+  client_id: string
+}

--- a/apps/api/src/device-auth/dto/device-token-response.dto.ts
+++ b/apps/api/src/device-auth/dto/device-token-response.dto.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiProperty } from '@nestjs/swagger'
+
+export class DeviceTokenResponseDto {
+  @ApiProperty({ example: 'dtn_xxxxxxxxxxxxxxxxxxxxx' })
+  access_token: string
+
+  @ApiProperty({ example: 'Bearer' })
+  token_type: string
+
+  @ApiProperty({ example: 31536000 })
+  expires_in: number
+
+  @ApiProperty({ example: 'workspaces:read workspaces:write' })
+  scope: string
+
+  @ApiProperty({ example: 'org-abc123' })
+  organization_id: string
+
+  @ApiProperty({ example: 'my-organization' })
+  organization_name: string
+}
+
+export class DeviceTokenErrorDto {
+  @ApiProperty({ example: 'authorization_pending' })
+  error: string
+
+  @ApiProperty({ example: 'The authorization request is still pending', required: false })
+  error_description?: string
+}

--- a/apps/api/src/migrations/1765500000000-migration.ts
+++ b/apps/api/src/migrations/1765500000000-migration.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1765500000000 implements MigrationInterface {
+  name = 'Migration1765500000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create the device_auth_status enum type
+    await queryRunner.query(`
+      CREATE TYPE "device_auth_status_enum" AS ENUM ('pending', 'approved', 'denied', 'expired')
+    `)
+
+    // Create the device_authorization_request table
+    await queryRunner.query(`
+      CREATE TABLE "device_authorization_request" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "deviceCode" character varying NOT NULL,
+        "userCode" character varying NOT NULL,
+        "clientId" character varying NOT NULL,
+        "scope" character varying,
+        "status" "device_auth_status_enum" NOT NULL DEFAULT 'pending',
+        "userId" character varying,
+        "organizationId" character varying,
+        "accessToken" character varying,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "expiresAt" TIMESTAMP NOT NULL,
+        "approvedAt" TIMESTAMP,
+        "lastPolledAt" TIMESTAMP,
+        CONSTRAINT "UQ_device_authorization_request_deviceCode" UNIQUE ("deviceCode"),
+        CONSTRAINT "UQ_device_authorization_request_userCode" UNIQUE ("userCode"),
+        CONSTRAINT "PK_device_authorization_request" PRIMARY KEY ("id")
+      )
+    `)
+
+    // Create indexes for better query performance
+    await queryRunner.query(`
+      CREATE INDEX "IDX_device_authorization_request_deviceCode" ON "device_authorization_request" ("deviceCode")
+    `)
+    await queryRunner.query(`
+      CREATE INDEX "IDX_device_authorization_request_userCode" ON "device_authorization_request" ("userCode")
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_device_authorization_request_userCode"`)
+    await queryRunner.query(`DROP INDEX "IDX_device_authorization_request_deviceCode"`)
+    await queryRunner.query(`DROP TABLE "device_authorization_request"`)
+    await queryRunner.query(`DROP TYPE "device_auth_status_enum"`)
+  }
+}

--- a/apps/cli/cmd/auth/token.go
+++ b/apps/cli/cmd/auth/token.go
@@ -1,0 +1,320 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
+	view_common "github.com/daytonaio/daytona/cli/views/common"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+type DeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+type TokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	TokenType        string `json:"token_type"`
+	ExpiresIn        int    `json:"expires_in"`
+	Scope            string `json:"scope"`
+	OrganizationID   string `json:"organization_id"`
+	OrganizationName string `json:"organization_name"`
+}
+
+type TokenError struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+var TokenNewCmd = &cobra.Command{
+	Use:     "token",
+	Short:   "Create a new API token via browser authentication",
+	Long:    "Opens a browser window for authentication and automatically saves the API token to your config",
+	Args:    cobra.NoArgs,
+	GroupID: internal.USER_GROUP,
+	RunE:    runTokenNew,
+}
+
+var (
+	profileFlag string
+)
+
+func init() {
+	TokenNewCmd.Flags().StringVar(&profileFlag, "profile", "", "Profile name to save token under")
+}
+
+func runTokenNew(cmd *cobra.Command, args []string) error {
+	apiURL := config.GetDaytonaApiUrl()
+
+	if internal.Version == "v0.0.0-dev" {
+		apiURL = "http://localhost:3001/api"
+	}
+
+	// Step 1: Request device code
+	view_common.RenderInfoMessage("Requesting device authorization...")
+
+	deviceResp, err := requestDeviceCode(apiURL)
+	if err != nil {
+		return fmt.Errorf("failed to request device code: %w", err)
+	}
+
+	// Step 2: Display code and open browser
+	fmt.Println()
+	view_common.RenderInfoMessageBold("Please visit this URL in your browser:")
+	fmt.Println()
+	fmt.Printf("    %s\n", deviceResp.VerificationURIComplete)
+	fmt.Println()
+	view_common.RenderInfoMessage("Or go to " + deviceResp.VerificationURI + " and enter code:")
+	fmt.Println()
+	fmt.Printf("    %s\n", deviceResp.UserCode)
+	fmt.Println()
+
+	// Try to open browser automatically
+	if err := browser.OpenURL(deviceResp.VerificationURIComplete); err != nil {
+		view_common.RenderInfoMessage("Could not open browser automatically.")
+		view_common.RenderInfoMessage("Please visit the URL above manually.")
+	} else {
+		view_common.RenderInfoMessage("Browser opened. Complete authentication there.")
+	}
+
+	fmt.Println()
+	view_common.RenderInfoMessage("Waiting for authorization...")
+
+	// Step 3: Poll for token
+	token, err := pollForToken(apiURL, deviceResp)
+	if err != nil {
+		return fmt.Errorf("authentication failed: %w", err)
+	}
+
+	// Step 4: Save token to config
+	fmt.Println()
+	view_common.RenderInfoMessageBold("Authentication successful!")
+	view_common.RenderInfoMessage(fmt.Sprintf("Token is connected to organization: %s", token.OrganizationName))
+
+	// Determine profile name
+	profileName := profileFlag
+	if profileName == "" {
+		profileName = "device-auth"
+	}
+
+	if err := saveTokenToConfig(apiURL, profileName, token); err != nil {
+		return fmt.Errorf("failed to save token: %w", err)
+	}
+
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		configDir = "~/.config/daytona"
+	}
+
+	view_common.RenderInfoMessageBold(fmt.Sprintf("Token saved to %s/config.json in profile '%s'", configDir, profileName))
+
+	return nil
+}
+
+func requestDeviceCode(apiURL string) (*DeviceCodeResponse, error) {
+	url := fmt.Sprintf("%s/auth/device/code", apiURL)
+
+	payload := map[string]string{
+		"client_id": "daytona-cli",
+		"scope":     "workspaces:read workspaces:write",
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to request device code: %s", string(body))
+	}
+
+	var deviceResp DeviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
+		return nil, err
+	}
+
+	return &deviceResp, nil
+}
+
+func pollForToken(apiURL string, deviceResp *DeviceCodeResponse) (*TokenResponse, error) {
+	url := fmt.Sprintf("%s/auth/device/token", apiURL)
+	interval := time.Duration(deviceResp.Interval) * time.Second
+	expiresAt := time.Now().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
+
+	for {
+		// Wait for the polling interval
+		time.Sleep(interval)
+
+		if time.Now().After(expiresAt) {
+			return nil, fmt.Errorf("device code expired, please try again")
+		}
+
+		payload := map[string]string{
+			"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+			"device_code": deviceResp.DeviceCode,
+			"client_id":   "daytona-cli",
+		}
+
+		jsonPayload, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonPayload))
+		if err != nil {
+			return nil, err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if we got a successful token response
+		if resp.StatusCode == http.StatusOK {
+			// Try to parse as success response
+			var tokenResp TokenResponse
+			if err := json.Unmarshal(body, &tokenResp); err != nil {
+				return nil, err
+			}
+
+			// Check if it's actually a success (has access_token)
+			if tokenResp.AccessToken != "" {
+				return &tokenResp, nil
+			}
+
+			// Otherwise it might be an error response
+			var errResp TokenError
+			if err := json.Unmarshal(body, &errResp); err != nil {
+				return nil, err
+			}
+
+			switch errResp.Error {
+			case "authorization_pending":
+				// Keep waiting
+				continue
+			case "slow_down":
+				// Increase polling interval
+				interval += 5 * time.Second
+				continue
+			case "access_denied":
+				return nil, fmt.Errorf("authorization denied by user")
+			case "expired_token":
+				return nil, fmt.Errorf("device code expired, please try again")
+			case "":
+				// No error, continue polling
+				continue
+			default:
+				return nil, fmt.Errorf("unexpected error: %s", errResp.Error)
+			}
+		}
+
+		// Parse error response
+		var errResp TokenError
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			return nil, fmt.Errorf("unexpected response: %s", string(body))
+		}
+
+		switch errResp.Error {
+		case "authorization_pending":
+			// Keep waiting
+			continue
+		case "slow_down":
+			// Increase polling interval
+			interval += 5 * time.Second
+			continue
+		case "access_denied":
+			return nil, fmt.Errorf("authorization denied by user")
+		case "expired_token":
+			return nil, fmt.Errorf("device code expired, please try again")
+		default:
+			return nil, fmt.Errorf("unexpected error: %s - %s", errResp.Error, errResp.ErrorDescription)
+		}
+	}
+}
+
+func saveTokenToConfig(apiURL string, profileName string, token *TokenResponse) error {
+	c, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	// Check if profile already exists
+	existingProfile, _ := c.GetProfile(profileName)
+	if existingProfile.Id != "" {
+		// Update existing profile
+		existingProfile.Api.Key = &token.AccessToken
+		existingProfile.Api.Token = nil
+		existingProfile.Api.Url = apiURL
+		existingProfile.ActiveOrganizationId = &token.OrganizationID
+
+		if err := c.EditProfile(existingProfile); err != nil {
+			return err
+		}
+	} else {
+		// Create new profile
+		profile := config.Profile{
+			Id:   profileName,
+			Name: profileName,
+			Api: config.ServerApi{
+				Url: apiURL,
+				Key: &token.AccessToken,
+			},
+			ActiveOrganizationId: &token.OrganizationID,
+		}
+
+		if err := c.AddProfile(profile); err != nil {
+			return err
+		}
+	}
+
+	// Get personal organization ID if needed (for browser-based OAuth this is different)
+	// For API key auth, we already have the organization from the token response
+	activeProfile, err := c.GetActiveProfile()
+	if err != nil {
+		return nil // Config saved successfully, this is just a follow-up action
+	}
+
+	// If we just set the profile as active, make sure we have the organization set
+	if activeProfile.Id == profileName && activeProfile.ActiveOrganizationId == nil {
+		activeProfile.ActiveOrganizationId = &token.OrganizationID
+		if err := c.EditProfile(activeProfile); err != nil {
+			return err
+		}
+	}
+
+	// Try to get personal org if this is a new profile
+	if activeProfile.Id == profileName {
+		personalOrgId, err := common.GetPersonalOrganizationId(activeProfile)
+		if err == nil && personalOrgId != "" {
+			activeProfile.ActiveOrganizationId = &personalOrgId
+			_ = c.EditProfile(activeProfile)
+		}
+	}
+
+	return nil
+}

--- a/apps/cli/main.go
+++ b/apps/cli/main.go
@@ -38,6 +38,7 @@ func init() {
 
 	rootCmd.AddCommand(auth.LoginCmd)
 	rootCmd.AddCommand(auth.LogoutCmd)
+	rootCmd.AddCommand(auth.TokenNewCmd)
 	rootCmd.AddCommand(sandbox.SandboxCmd)
 	rootCmd.AddCommand(snapshot.SnapshotsCmd)
 	rootCmd.AddCommand(volume.VolumeCmd)

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -40,6 +40,7 @@ import LandingPage from './pages/LandingPage'
 import Limits from './pages/Limits'
 import Logout from './pages/Logout'
 import NotFound from './pages/NotFound'
+import DeviceAuthorization from './pages/DeviceAuthorization'
 import Registries from './pages/Registries'
 import Sandboxes from './pages/Sandboxes'
 import Snapshots from './pages/Snapshots'
@@ -124,6 +125,7 @@ function App() {
       <Route path={RoutePath.LOGOUT} element={<Logout />} />
       <Route path={RoutePath.DOCS} element={<DocsRedirect />} />
       <Route path={RoutePath.SLACK} element={<SlackRedirect />} />
+      <Route path={RoutePath.DEVICE} element={<DeviceAuthorization />} />
       <Route
         path={RoutePath.DASHBOARD}
         element={

--- a/apps/dashboard/src/enums/RoutePath.ts
+++ b/apps/dashboard/src/enums/RoutePath.ts
@@ -14,6 +14,7 @@ export enum RoutePath {
   DASHBOARD = '/dashboard',
   DOCS = '/docs',
   SLACK = '/slack',
+  DEVICE = '/device',
 
   // Dashboard sub-routes
   KEYS = '/dashboard/keys',

--- a/apps/dashboard/src/pages/DeviceAuthorization.tsx
+++ b/apps/dashboard/src/pages/DeviceAuthorization.tsx
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import React, { useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useAuth } from 'react-oidc-context'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Loader2, CheckCircle2, XCircle, Terminal, Shield } from 'lucide-react'
+import { useConfig } from '@/hooks/useConfig'
+import { toast } from 'sonner'
+import LoadingFallback from '@/components/LoadingFallback'
+
+interface DeviceStatus {
+  user_code: string
+  client_id: string
+  scope: string
+  status: string
+  expires_in: number
+}
+
+interface Organization {
+  id: string
+  name: string
+  personal: boolean
+}
+
+const DeviceAuthorization: React.FC = () => {
+  const [searchParams] = useSearchParams()
+  const { apiUrl } = useConfig()
+  const { isAuthenticated, isLoading: authLoading, user, signinRedirect } = useAuth()
+
+  const [userCode, setUserCode] = useState(searchParams.get('user_code') || '')
+  const [deviceStatus, setDeviceStatus] = useState<DeviceStatus | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<'approved' | 'denied' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [organizations, setOrganizations] = useState<Organization[]>([])
+  const [selectedOrgId, setSelectedOrgId] = useState<string>('')
+
+  const fetchDeviceStatus = useCallback(
+    async (code: string) => {
+      if (!code.trim()) return
+
+      setLoading(true)
+      setError(null)
+      setDeviceStatus(null)
+
+      try {
+        const response = await fetch(`${apiUrl}/auth/device/status?user_code=${encodeURIComponent(code.trim())}`)
+        if (!response.ok) {
+          const data = await response.json()
+          throw new Error(data.message || 'Invalid or expired code')
+        }
+        const data: DeviceStatus = await response.json()
+        setDeviceStatus(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to verify code')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [apiUrl],
+  )
+
+  const fetchOrganizations = useCallback(async () => {
+    if (!user?.access_token) return
+
+    try {
+      const response = await fetch(`${apiUrl}/organizations`, {
+        headers: {
+          Authorization: `Bearer ${user.access_token}`,
+        },
+      })
+      if (response.ok) {
+        const data: Organization[] = await response.json()
+        setOrganizations(data)
+        // Default to personal organization or first one
+        const personalOrg = data.find((org) => org.personal)
+        setSelectedOrgId(personalOrg?.id || data[0]?.id || '')
+      }
+    } catch {
+      // Silently fail, user can still proceed
+    }
+  }, [apiUrl, user?.access_token])
+
+  useEffect(() => {
+    // Auto-fetch status if user_code is in URL
+    if (searchParams.get('user_code')) {
+      fetchDeviceStatus(searchParams.get('user_code')!)
+    }
+  }, [searchParams, fetchDeviceStatus])
+
+  useEffect(() => {
+    if (isAuthenticated && user) {
+      fetchOrganizations()
+    }
+  }, [isAuthenticated, user, fetchOrganizations])
+
+  const handleSubmitCode = (e: React.FormEvent) => {
+    e.preventDefault()
+    fetchDeviceStatus(userCode)
+  }
+
+  const handleApprove = async () => {
+    if (!deviceStatus || !user?.access_token || !selectedOrgId) return
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`${apiUrl}/auth/device/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user.access_token}`,
+          'X-Daytona-Organization-ID': selectedOrgId,
+        },
+        body: JSON.stringify({
+          user_code: deviceStatus.user_code,
+          action: 'approve',
+          organization_id: selectedOrgId,
+        }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.message || 'Failed to approve authorization')
+      }
+
+      setResult('approved')
+      toast.success('Device authorization approved!')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to approve authorization')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDeny = async () => {
+    if (!deviceStatus || !user?.access_token) return
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`${apiUrl}/auth/device/approve`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user.access_token}`,
+          'X-Daytona-Organization-ID': selectedOrgId,
+        },
+        body: JSON.stringify({
+          user_code: deviceStatus.user_code,
+          action: 'deny',
+        }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.message || 'Failed to deny authorization')
+      }
+
+      setResult('denied')
+      toast.info('Device authorization denied')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to deny authorization')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleLogin = () => {
+    signinRedirect({
+      state: {
+        returnTo: `/device${userCode ? `?user_code=${userCode}` : ''}`,
+      },
+    })
+  }
+
+  if (authLoading) {
+    return <LoadingFallback />
+  }
+
+  // Show success/denied result
+  if (result) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            {result === 'approved' ? (
+              <>
+                <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center">
+                  <CheckCircle2 className="h-6 w-6 text-green-600 dark:text-green-400" />
+                </div>
+                <CardTitle>Authorization Approved</CardTitle>
+                <CardDescription>You can now close this window and return to your terminal.</CardDescription>
+              </>
+            ) : (
+              <>
+                <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-red-100 dark:bg-red-900 flex items-center justify-center">
+                  <XCircle className="h-6 w-6 text-red-600 dark:text-red-400" />
+                </div>
+                <CardTitle>Authorization Denied</CardTitle>
+                <CardDescription>The CLI authentication request has been denied.</CardDescription>
+              </>
+            )}
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
+            <Terminal className="h-6 w-6 text-primary" />
+          </div>
+          <CardTitle>CLI Device Authorization</CardTitle>
+          <CardDescription>Authorize Daytona CLI to access your account</CardDescription>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <XCircle className="h-4 w-4" />
+              <AlertTitle>Error</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {!deviceStatus ? (
+            <form onSubmit={handleSubmitCode} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="userCode">Enter the code from your terminal</Label>
+                <Input
+                  id="userCode"
+                  placeholder="XXXX-XXXX"
+                  value={userCode}
+                  onChange={(e) => setUserCode(e.target.value.toUpperCase())}
+                  className="text-center text-lg font-mono tracking-widest"
+                  maxLength={9}
+                  autoComplete="off"
+                  autoFocus
+                />
+              </div>
+              <Button type="submit" className="w-full" disabled={loading || !userCode.trim()}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Verify Code
+              </Button>
+            </form>
+          ) : (
+            <div className="space-y-4">
+              <Alert>
+                <Shield className="h-4 w-4" />
+                <AlertTitle>Authorization Request</AlertTitle>
+                <AlertDescription>
+                  <strong>{deviceStatus.client_id}</strong> is requesting access to your Daytona account.
+                </AlertDescription>
+              </Alert>
+
+              <div className="rounded-lg bg-muted p-4 space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Code:</span>
+                  <span className="font-mono font-medium">{deviceStatus.user_code}</span>
+                </div>
+                {deviceStatus.scope && (
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Permissions:</span>
+                    <span className="font-medium">Full access</span>
+                  </div>
+                )}
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Expires in:</span>
+                  <span className="font-medium">{Math.floor(deviceStatus.expires_in / 60)} minutes</span>
+                </div>
+              </div>
+
+              {!isAuthenticated ? (
+                <div className="space-y-3">
+                  <p className="text-sm text-muted-foreground text-center">
+                    Please sign in to approve or deny this request.
+                  </p>
+                  <Button onClick={handleLogin} className="w-full">
+                    Sign In to Continue
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  {organizations.length > 1 && (
+                    <div className="space-y-2">
+                      <Label htmlFor="organization">Organization</Label>
+                      <Select value={selectedOrgId} onValueChange={setSelectedOrgId}>
+                        <SelectTrigger id="organization">
+                          <SelectValue placeholder="Select organization" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {organizations.map((org) => (
+                            <SelectItem key={org.id} value={org.id}>
+                              {org.name} {org.personal && '(Personal)'}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </CardContent>
+
+        {deviceStatus && isAuthenticated && (
+          <CardFooter className="flex gap-3">
+            <Button variant="outline" className="flex-1" onClick={handleDeny} disabled={submitting}>
+              {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Deny
+            </Button>
+            <Button className="flex-1" onClick={handleApprove} disabled={submitting || !selectedOrgId}>
+              {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Approve
+            </Button>
+          </CardFooter>
+        )}
+      </Card>
+    </div>
+  )
+}
+
+export default DeviceAuthorization


### PR DESCRIPTION
## Device auth flow

Adds `daytona api-key create` to the CLI allowing users or agents like Claude Code to call it, have the user auth in browser and then have the api key ready to use

## Documentation

- [X] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="3759" height="1823" alt="image" src="https://github.com/user-attachments/assets/6933c322-8043-40b1-9c83-274bb0099659" />

<img width="924" height="880" alt="image" src="https://github.com/user-attachments/assets/e08ba86a-5066-413b-bf85-006939ddc974" />
