### PR TITLE
fix(sdk): respect DAYTONA_TARGET env for snapshot creation

### DIFF
--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -199,7 +199,7 @@ class AsyncDaytona:
 
         # Initialize services
         self.volume = AsyncVolumeService(VolumesApi(self._api_client))
-        self.snapshot = AsyncSnapshotService(SnapshotsApi(self._api_client), self._object_storage_api)
+        self.snapshot = AsyncSnapshotService(SnapshotsApi(self._api_client), self._object_storage_api, self._target)
 
     # unasync: delete start
     async def __aenter__(self):

--- a/libs/sdk-python/src/daytona/_async/snapshot.py
+++ b/libs/sdk-python/src/daytona/_async/snapshot.py
@@ -21,9 +21,12 @@ from .object_storage import AsyncObjectStorage
 class AsyncSnapshotService:
     """Service for managing Daytona Snapshots. Can be used to list, get, create and delete Snapshots."""
 
-    def __init__(self, snapshots_api: SnapshotsApi, object_storage_api: ObjectStorageApi):
+    def __init__(
+        self, snapshots_api: SnapshotsApi, object_storage_api: ObjectStorageApi, default_region_id: Optional[str] = None
+    ):
         self.__snapshots_api = snapshots_api
         self.__object_storage_api = object_storage_api
+        self.__default_region_id = default_region_id
 
     @intercept_errors(message_prefix="Failed to list snapshots: ")
     async def list(self, page: Optional[int] = None, limit: Optional[int] = None) -> PaginatedSnapshots:
@@ -144,8 +147,7 @@ class AsyncSnapshotService:
             create_snapshot_req.memory = params.resources.memory
             create_snapshot_req.disk = params.resources.disk
 
-        if params.region_id:
-            create_snapshot_req.region_id = params.region_id
+        create_snapshot_req.region_id = params.region_id or self.__default_region_id
 
         created_snapshot = await self.__snapshots_api.create_snapshot(create_snapshot_req)
 

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -200,7 +200,7 @@ class Daytona:
 
         # Initialize services
         self.volume = VolumeService(VolumesApi(self._api_client))
-        self.snapshot = SnapshotService(SnapshotsApi(self._api_client), self._object_storage_api)
+        self.snapshot = SnapshotService(SnapshotsApi(self._api_client), self._object_storage_api, self._target)
 
     @overload
     def create(

--- a/libs/sdk-python/src/daytona/_sync/snapshot.py
+++ b/libs/sdk-python/src/daytona/_sync/snapshot.py
@@ -27,9 +27,12 @@ from .object_storage import ObjectStorage
 class SnapshotService:
     """Service for managing Daytona Snapshots. Can be used to list, get, create and delete Snapshots."""
 
-    def __init__(self, snapshots_api: SnapshotsApi, object_storage_api: ObjectStorageApi):
+    def __init__(
+        self, snapshots_api: SnapshotsApi, object_storage_api: ObjectStorageApi, default_region_id: Optional[str] = None
+    ):
         self.__snapshots_api = snapshots_api
         self.__object_storage_api = object_storage_api
+        self.__default_region_id = default_region_id
 
     @intercept_errors(message_prefix="Failed to list snapshots: ")
     def list(self, page: Optional[int] = None, limit: Optional[int] = None) -> PaginatedSnapshots:
@@ -150,8 +153,7 @@ class SnapshotService:
             create_snapshot_req.memory = params.resources.memory
             create_snapshot_req.disk = params.resources.disk
 
-        if params.region_id:
-            create_snapshot_req.region_id = params.region_id
+        create_snapshot_req.region_id = params.region_id or self.__default_region_id
 
         created_snapshot = self.__snapshots_api.create_snapshot(create_snapshot_req)
 

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -297,6 +297,7 @@ export class Daytona {
       configuration,
       new SnapshotsApi(configuration, '', axiosInstance),
       this.objectStorageApi,
+      this.target,
     )
     this.clientConfig = configuration
   }

--- a/libs/sdk-typescript/src/Snapshot.ts
+++ b/libs/sdk-typescript/src/Snapshot.ts
@@ -80,6 +80,7 @@ export class SnapshotService {
     private clientConfig: Configuration,
     private snapshotsApi: SnapshotsApi,
     private objectStorageApi: ObjectStorageApi,
+    private defaultRegionId?: string,
   ) {}
 
   /**
@@ -180,9 +181,7 @@ export class SnapshotService {
       createSnapshotReq.disk = params.resources.disk
     }
 
-    if (params.regionId) {
-      createSnapshotReq.regionId = params.regionId
-    }
+    createSnapshotReq.regionId = params.regionId || this.defaultRegionId
 
     let createdSnapshot = (
       await this.snapshotsApi.createSnapshot(createSnapshotReq, undefined, {


### PR DESCRIPTION

This pull request updates the Daytona SDKs (Python and TypeScript) to allow specifying a default region for snapshot creation. Now, if a region is not provided when creating a snapshot, the SDK will use a default region set during service initialization. This improves usability by reducing the need to always specify a region explicitly.

**Default Region Handling for Snapshot Services:**

* The constructors for `AsyncSnapshotService` and `SnapshotService` in both Python (`_async/snapshot.py`, `_sync/snapshot.py`) and TypeScript (`Snapshot.ts`) now accept an optional `default_region_id` (or `defaultRegionId` in TypeScript) parameter. [[1]](diffhunk://#diff-ce2cb5adaa3bd2e8f442f946f2fd376de911e095f975efcf7ece709dfa8b15e7L24-R29) [[2]](diffhunk://#diff-ae3e43557d1d7df155ba8e16006ee2c94414b02940e5cb2c79b6bc08ed015140L30-R35) [[3]](diffhunk://#diff-08c98614f20ece1690903a7ce56b861a9db31ad105deacc6b02b2518177aa1b8R83)
* The snapshot creation methods in these services now assign the snapshot's `region_id` to the provided value or fall back to the default region if none is provided. [[1]](diffhunk://#diff-ce2cb5adaa3bd2e8f442f946f2fd376de911e095f975efcf7ece709dfa8b15e7L147-R150) [[2]](diffhunk://#diff-ae3e43557d1d7df155ba8e16006ee2c94414b02940e5cb2c79b6bc08ed015140L153-R156) [[3]](diffhunk://#diff-08c98614f20ece1690903a7ce56b861a9db31ad105deacc6b02b2518177aa1b8L183-R184)

**Service Initialization Changes:**

* The Daytona SDK client classes (`daytona.py` in both async and sync Python SDKs, and `Daytona.ts` in TypeScript) are updated to pass the target region as the `default_region_id`/`defaultRegionId` to the snapshot service upon initialization. [[1]](diffhunk://#diff-b0de0ea1a0ea8954bf7e41384f777f7604a5aea85672c01ffb31ad270da19781L202-R202) [[2]](diffhunk://#diff-dd9205d356d655d9d25ab25d43d3af9435de97268c12f3deb593a02777e30f7dL203-R203) [[3]](diffhunk://#diff-5c3921a9a025fe26a52dd2a6ea1e4254b1463e240f6a370918ffac0e0cfa7072R300)