### PR TITLE
fix(daemon): sdk version subprotocol in websockets

### DIFF
--- a/apps/daemon/internal/util/websocket.go
+++ b/apps/daemon/internal/util/websocket.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package util
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+// UpgradeToWebSocket is a toolbox utility function that upgrades an HTTP connection to a WebSocket connection.
+// It automatically extracts and accepts SDK version subprotocols (if present) from the request headers and accepts them during handshake.
+// It uses a permissive CORS (CheckOrigin always returns true) to allow connections from any origin.
+func UpgradeToWebSocket(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {
+	// Extract SDK version subprotocol from request headers
+	subprotocol := ExtractSdkVersionSubprotocol(r.Header)
+	var protocols []string
+	if subprotocol != "" {
+		protocols = []string{subprotocol}
+	}
+
+	// Create a new upgrader for this request to prevent concurrency issues
+	upgrader := websocket.Upgrader{
+		CheckOrigin:  func(r *http.Request) bool { return true },
+		Subprotocols: protocols,
+	}
+
+	// Upgrade the connection to a WebSocket protocol
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return ws, nil
+}

--- a/apps/daemon/pkg/toolbox/process/interpreter/controller.go
+++ b/apps/daemon/pkg/toolbox/process/interpreter/controller.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/daytonaio/daemon/internal/util"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
@@ -94,7 +95,8 @@ func (c *Controller) CreateContext(ctx *gin.Context) {
 //
 //	@id				ExecuteInterpreterCode
 func (c *Controller) Execute(ctx *gin.Context) {
-	ws, err := upgrader.Upgrade(ctx.Writer, ctx.Request, nil)
+	// Upgrade to WebSocket
+	ws, err := util.UpgradeToWebSocket(ctx.Writer, ctx.Request)
 	if err != nil {
 		ctx.AbortWithStatus(http.StatusBadRequest)
 		return

--- a/apps/daemon/pkg/toolbox/process/interpreter/websocket.go
+++ b/apps/daemon/pkg/toolbox/process/interpreter/websocket.go
@@ -5,18 +5,12 @@ package interpreter
 
 import (
 	"encoding/json"
-	"net/http"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 )
-
-// WebSocket upgrader with permissive origin policy
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
 
 // attachWebSocket connects a WebSocket client to the interpreter context
 func (c *Context) attachWebSocket(ws *websocket.Conn) {

--- a/apps/daemon/pkg/toolbox/process/pty/controller.go
+++ b/apps/daemon/pkg/toolbox/process/pty/controller.go
@@ -192,8 +192,8 @@ func (p *PTYController) ConnectPTYSession(c *gin.Context) {
 		return
 	}
 
-	// Always upgrade to WebSocket first
-	ws, err := ptyUpgrader.Upgrade(c.Writer, c.Request, nil)
+	// Upgrade to WebSocket
+	ws, err := util.UpgradeToWebSocket(c.Writer, c.Request)
 	if err != nil {
 		log.WithError(err).Error("ws upgrade failed")
 		return

--- a/apps/daemon/pkg/toolbox/process/pty/websocket.go
+++ b/apps/daemon/pkg/toolbox/process/pty/websocket.go
@@ -6,18 +6,12 @@ package pty
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 )
-
-// WebSocket upgrader with permissive origin policy
-var ptyUpgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
 
 // attachWebSocket connects a new WebSocket client to the PTY session
 func (s *PTYSession) attachWebSocket(ws *websocket.Conn) {

--- a/apps/daemon/pkg/toolbox/process/session/execute.go
+++ b/apps/daemon/pkg/toolbox/process/session/execute.go
@@ -187,12 +187,6 @@ func (s *SessionController) SessionExecuteCommand(c *gin.Context) {
 			logContent := string(logBytes)
 
 			sdkVersion := util.ExtractSdkVersionFromHeader(c.Request.Header)
-			if sdkVersion != "" {
-				upgrader.Subprotocols = []string{"X-Daytona-SDK-Version~" + sdkVersion}
-			} else {
-				upgrader.Subprotocols = []string{}
-			}
-
 			versionComparison, err := util.CompareVersions(sdkVersion, "0.27.0-0")
 			if err != nil {
 				log.Error(err)


### PR DESCRIPTION
This pull request refactors WebSocket upgrade logic across several toolbox modules to centralize and standardize how HTTP connections are upgraded to WebSocket connections, including handling of SDK version subprotocols. The main change is the introduction of a shared utility function for WebSocket upgrades, which simplifies code and ensures consistent behavior.

### WebSocket Upgrade Refactoring

* Added a new utility function `UpgradeToWebSocket` in `apps/daemon/internal/util/websocket.go` that upgrades HTTP connections to WebSocket connections, automatically handling SDK version subprotocols and using a permissive CORS policy.
* Replaced direct usage of `websocket.Upgrader` and custom upgrader instances in `pty`, `interpreter`, and `session` modules with calls to the new `UpgradeToWebSocket` utility function for consistent and simplified WebSocket upgrades. [[1]](diffhunk://#diff-242e4fcc00524c81be574324e68e27a21c65caf8574778befc46169781a85ab2L195-R196) [[2]](diffhunk://#diff-be15384e442fb34ef2592f453e16c97c472f45868586b73fc6393e6952f83a7aL97-R99) [[3]](diffhunk://#diff-fdbedab85abd808e127d84198431f09e697e28dec81ef8cb68ca08553679bc28L162-R163)

### SDK Version Subprotocol Extraction

* Refactored SDK version extraction logic by moving protocol parsing into a new helper function `ExtractSdkVersionSubprotocol` in `version.go`, which is now used by `ExtractSdkVersionFromHeader` and the new WebSocket upgrade utility.
* Removed manual assignment of `Subprotocols` in session controller methods, since the new upgrade utility automatically handles this. [[1]](diffhunk://#diff-3a9077c8aace96b45aae077d8be4c92c13eb8ab60448a17b0fea446dd6a07856L180-L185) [[2]](diffhunk://#diff-fdbedab85abd808e127d84198431f09e697e28dec81ef8cb68ca08553679bc28L54-L59)

### Code Cleanup

* Removed redundant upgrader instances and related imports from modules now using the shared utility function, reducing duplication and improving maintainability. [[1]](diffhunk://#diff-1cc1937c4f4282240d3984522b1a2393782a54bb63ff78284bf8ccaae6bfa502L8-L20) [[2]](diffhunk://#diff-f5dbda261346e560aa7d6154e048d376b29f22d2385278b720d63f129637ca00L9-L21) [[3]](diffhunk://#diff-fdbedab85abd808e127d84198431f09e697e28dec81ef8cb68ca08553679bc28L162-R163)
* Updated imports in controllers to use the new utility package.
