### PR TITLE
fix(daemon): use concurrent-map for sessions and commands

### DIFF
--- a/apps/daemon/pkg/toolbox/process/session/log.go
+++ b/apps/daemon/pkg/toolbox/process/session/log.go
@@ -36,13 +36,13 @@ func (s *SessionController) GetSessionCommandLogs(c *gin.Context) {
 	sessionId := c.Param("sessionId")
 	cmdId := c.Param("commandId")
 
-	session, ok := sessions[sessionId]
+	session, ok := sessions.Get(sessionId)
 	if !ok {
 		c.AbortWithError(http.StatusNotFound, errors.New("session not found"))
 		return
 	}
 
-	command, ok := sessions[sessionId].commands[cmdId]
+	command, ok := session.commands.Get(cmdId)
 	if !ok {
 		c.AbortWithError(http.StatusNotFound, errors.New("command not found"))
 		return

--- a/apps/daemon/pkg/toolbox/process/session/types.go
+++ b/apps/daemon/pkg/toolbox/process/session/types.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+
+	cmap "github.com/orcaman/concurrent-map/v2"
 )
 
 type CreateSessionRequest struct {
@@ -37,7 +39,7 @@ type session struct {
 	id          string
 	cmd         *exec.Cmd
 	stdinWriter io.Writer
-	commands    map[string]*Command
+	commands    cmap.ConcurrentMap[string, *Command]
 	ctx         context.Context
 	cancel      context.CancelFunc
 }


### PR DESCRIPTION
## Description

Use `cmap` to handle concurrent map access in sessions and commands.
This prevents daemon panics in case of concurrent read and writes which can happen in some scenarios.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
