### PR TITLE
fix(docs): removed click to view parts from guides

### DIFF
--- a/apps/docs/src/content/docs/en/claude-agent-sdk-connect-service-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/claude-agent-sdk-connect-service-sandbox.mdx
@@ -82,10 +82,7 @@ The system will start and wait for your prompt.
 
 Example chat session:
 
-<details>
-  <summary>Click to view example chat session</summary>
-  <div>
-    ```
+```
 $ npm run start
 Creating Developer Agent sandbox...
 Installing Developer Agent SDK...
@@ -138,11 +135,7 @@ Your Lunar Lander game is live at:
 TASK_COMPLETE
 
 [Project Manager] All tasks completed!
-
 ```
-
-  </div>
-</details>
 
 ---
 

--- a/apps/docs/src/content/docs/en/claude-agent-sdk-interactive-terminal-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/claude-agent-sdk-interactive-terminal-sandbox.mdx
@@ -19,10 +19,7 @@ When you launch the main module, a Daytona sandbox is created and a Python agent
 
 You interact with the main program via a command line chat interface. The program sends your prompts to the agent inside the sandbox, which executes them and returns the results:
 
-<details>
-  <summary>Click to view example workflow</summary>
-  <div>
-    ```
+```
 $ npm run start                                   174s
 Creating sandbox...
 Installing Agent SDK...
@@ -71,8 +68,6 @@ The game features smooth movement, collision detection with trees and rocks, and
 Enjoy your adventure! 🗡️✨
 User:
 ```
-  </div>
-</details>
 
 The agent can also host web apps and provide you with a preview link using the [Daytona Preview Links](https://www.daytona.io/docs/en/preview-and-authentication/) feature. When your task involves running or previewing a web application, the agent automatically reasons about this need, hosts the app, and generates a preview link for you to inspect the live result:
 
@@ -138,10 +133,7 @@ The agent will start and wait for your prompt.
 
 Example chat session:
 
-<details>
-  <summary>Click to view example chat session</summary>
-  <div>
-    ```
+```
 $ npm run start
 Creating sandbox...
 Installing Agent SDK...
@@ -220,10 +212,7 @@ The page includes:
 Click the link to see your fun pet store landing page in action! 🐾
 User:
 
-````
-
-</div>
-</details>
+```
 
 ### 4. Understanding the Agent's Architecture
 
@@ -235,6 +224,7 @@ This example consists of two main components:
 #### Initialization
 
 On initialization, the main program:
+
 1. Creates a new [Daytona sandbox](/docs/en/sandboxes) with your Anthropic API key included in the environment variables.
 2. Installs the Claude Agent SDK by running `pip install` in the sandbox with [process execution](/docs/en/process-code-execution#process-execution).
 3. Creates a new [code interpreter context](/docs/en/process-code-execution#stateful-code-interpreter).
@@ -248,7 +238,7 @@ Once the agent is running, the program creates a readline interface to read user
 Each user request is passed to the agent by running a Python command in the code interpreter context:
 
 ```typescript
- const result = await sandbox.codeInterpreter.runCode(
+const result = await sandbox.codeInterpreter.runCode(
   `coding_agent.run_query_sync(os.environ.get('PROMPT', ''))`,
   {
     context: ctx,
@@ -256,8 +246,8 @@ Each user request is passed to the agent by running a Python command in the code
     onStdout,
     onStderr,
   }
-);
-````
+)
+```
 
 The `onStdout` and `onStderr` callbacks are used to pass the agent's output back to the main program. After the agent finishes responding to the prompt, the main program waits for the next user input.
 


### PR DESCRIPTION
## Description

Removed "click to view" collapsible sections from guides and replaced them with direct content display for better readability and user experience. Users can now see example workflows and code sessions immediately without additional clicks.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots
<img width="3085" height="1050" alt="image" src="https://github.com/user-attachments/assets/f26306f8-c805-435d-a6e5-94d49a57152c" />


