### PR TITLE
fix(api): undefined backup snapshot on archive

### DIFF
--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -445,6 +445,6 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
   @OnEvent(SandboxEvents.BACKUP_CREATED)
   @TrackJobExecution()
   private async handleSandboxBackupCreatedEvent(event: SandboxBackupCreatedEvent) {
-    this.handlePendingBackup(event.sandbox)
+    this.setBackupPending(event.sandbox)
   }
 }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -704,10 +704,6 @@ export class SandboxService {
       throw new SandboxError('Sandbox backup is already in progress')
     }
 
-    await this.sandboxRepository.update(sandbox.id, {
-      backupState: BackupState.PENDING,
-    })
-
     this.eventEmitter.emit(SandboxEvents.BACKUP_CREATED, new SandboxBackupCreatedEvent(sandbox))
 
     return sandbox


### PR DESCRIPTION
## Description

Fix for some instances of sandboxes getting stuck in a stopped + desired archived or archiving state due to the `backupSnapshot` value being undefined `invalid body request: Key: 'CreateBackupDTO.Snapshot' Error:Field validation for 'Snapshot' failed on the 'required' tag`

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation