### PR TITLE
chore: license check update

### DIFF
--- a/.licenserc-clients.yaml
+++ b/.licenserc-clients.yaml
@@ -6,7 +6,7 @@ header:
       Copyright Daytona Platforms Inc.
       SPDX-License-Identifier: Apache-2.0
     pattern: |
-      Copyright (\d{4}(-\d{4})? )?Daytona Platforms Inc\.
+      Copyright (\d{4} )?Daytona Platforms Inc\.
       SPDX-License-Identifier: Apache-2\.0
   paths:
     - 'libs/**/*.go'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -6,7 +6,7 @@ header:
       Copyright Daytona Platforms Inc.
       SPDX-License-Identifier: AGPL-3.0
     pattern: |
-      Copyright (\d{4}(-\d{4})? )?Daytona Platforms Inc\.
+      Copyright (\d{4} )?Daytona Platforms Inc\.
       SPDX-License-Identifier: AGPL-3\.0
   paths:
     - '**/*.go'


### PR DESCRIPTION
## Description

Updated license header validation for both AGPL and Apache licenses to accept flexible copyright year formats:
- Single years (e.g., "Copyright 2026 Daytona Platforms Inc.")
- No year specified (e.g., "Copyright Daytona Platforms Inc.")

This regex-based approach ensures compatibility with existing 2025 license headers while allowing new files to either include the current year when created or omit the year entirely, eliminating the need for annual license configuration updates.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
