### PR TITLE
feat(api): skip anonymous rate limit for config

### DIFF
--- a/apps/api/src/config/config.controller.ts
+++ b/apps/api/src/config/config.controller.ts
@@ -3,15 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Controller, Get, UseGuards } from '@nestjs/common'
+import { Controller, Get } from '@nestjs/common'
 import { TypedConfigService } from './typed-config.service'
 import { ApiOperation, ApiTags, ApiResponse } from '@nestjs/swagger'
 import { ConfigurationDto } from './dto/configuration.dto'
-import { AnonymousRateLimitGuard } from '../common/guards/anonymous-rate-limit.guard'
 
 @ApiTags('config')
 @Controller('config')
-@UseGuards(AnonymousRateLimitGuard)
 export class ConfigController {
   constructor(private readonly configService: TypedConfigService) {}
 


### PR DESCRIPTION
## Skip anonymous rate limit for config

Removes the anonymous rate limit for get /config which clients use

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
