### PR TITLE
refactor(dashboard): add checkbox command item component & use in filters

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/filters/RegionFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/RegionFilter.tsx
@@ -5,16 +5,15 @@
 
 import {
   Command,
+  CommandCheckboxItem,
   CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandInputButton,
-  CommandItem,
   CommandList,
 } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { cn } from '@/lib/utils'
-import { Check, Loader2, X } from 'lucide-react'
+import { Loader2, X } from 'lucide-react'
 import { FacetedFilterOption } from '../types'
 
 interface RegionFilterProps {
@@ -69,7 +68,8 @@ export function RegionFilter({ value, onFilterChange, options, isLoading }: Regi
             <CommandEmpty>No regions found.</CommandEmpty>
             <CommandGroup>
               {options?.map((region) => (
-                <CommandItem
+                <CommandCheckboxItem
+                  checked={value.includes(region.value)}
                   key={region.value}
                   onSelect={() => {
                     const newValue = value.includes(region.value)
@@ -78,20 +78,8 @@ export function RegionFilter({ value, onFilterChange, options, isLoading }: Regi
                     onFilterChange(newValue.length > 0 ? newValue : undefined)
                   }}
                 >
-                  <div className="flex items-center">
-                    <div
-                      className={cn(
-                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
-                        value.includes(region.value)
-                          ? 'bg-primary text-primary-foreground'
-                          : 'opacity-50 [&_svg]:invisible',
-                      )}
-                    >
-                      <Check className={cn('h-4 w-4')} />
-                    </div>
-                    {region.label}
-                  </div>
-                </CommandItem>
+                  {region.label}
+                </CommandCheckboxItem>
               ))}
             </CommandGroup>
           </>

--- a/apps/dashboard/src/components/SandboxTable/filters/SnapshotFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/SnapshotFilter.tsx
@@ -5,17 +5,16 @@
 
 import {
   Command,
+  CommandCheckboxItem,
   CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandInputButton,
-  CommandItem,
   CommandList,
 } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { cn } from '@/lib/utils'
 import { SnapshotDto } from '@daytonaio/api-client'
-import { Check, Loader2, X } from 'lucide-react'
+import { Loader2, X } from 'lucide-react'
 import { useState } from 'react'
 
 interface SnapshotFilterProps {
@@ -119,24 +118,15 @@ export function SnapshotFilter({
             <CommandEmpty>No Snapshots found.</CommandEmpty>
             <CommandGroup>
               {snapshots.map((snapshot) => (
-                <CommandItem
+                <CommandCheckboxItem
                   key={snapshot.id}
                   onSelect={() => handleSelect(snapshot.name ?? '')}
                   value={snapshot.name}
                   className="cursor-pointer"
+                  checked={value.includes(snapshot.name ?? '')}
                 >
-                  <div
-                    className={cn(
-                      'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
-                      value.includes(snapshot.name ?? '')
-                        ? 'bg-primary text-primary-foreground'
-                        : 'opacity-50 [&_svg]:invisible',
-                    )}
-                  >
-                    <Check className={cn('h-4 w-4')} />
-                  </div>
-                  <span>{snapshot.name}</span>
-                </CommandItem>
+                  {snapshot.name}
+                </CommandCheckboxItem>
               ))}
             </CommandGroup>
           </>

--- a/apps/dashboard/src/components/SandboxTable/filters/StateFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/StateFilter.tsx
@@ -5,16 +5,15 @@
 
 import {
   Command,
+  CommandCheckboxItem,
   CommandGroup,
   CommandInput,
   CommandInputButton,
-  CommandItem,
   CommandList,
 } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { cn } from '@/lib/utils'
 import { SandboxState } from '@daytonaio/api-client'
-import { Check, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import { STATUSES, getStateLabel } from '../constants'
 
 interface StateFilterProps {
@@ -65,7 +64,9 @@ export function StateFilter({ value, onFilterChange }: StateFilterProps) {
       <CommandList>
         <CommandGroup>
           {STATUSES.map((status) => (
-            <CommandItem
+            <CommandCheckboxItem
+              key={status.value}
+              checked={value.includes(status.value)}
               onSelect={() => {
                 const newValue = value.includes(status.value)
                   ? value.filter((v) => v !== status.value)
@@ -73,20 +74,8 @@ export function StateFilter({ value, onFilterChange }: StateFilterProps) {
                 onFilterChange(newValue.length > 0 ? newValue : undefined)
               }}
             >
-              <div className="flex items-center">
-                <div
-                  className={cn(
-                    'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
-                    value.includes(status.value)
-                      ? 'bg-primary text-primary-foreground'
-                      : 'opacity-50 [&_svg]:invisible',
-                  )}
-                >
-                  <Check className={cn('h-4 w-4')} />
-                </div>
-                {status.label}
-              </div>
-            </CommandItem>
+              {status.label}
+            </CommandCheckboxItem>
           ))}
         </CommandGroup>
       </CommandList>

--- a/apps/dashboard/src/components/TableColumnVisibilityToggle.tsx
+++ b/apps/dashboard/src/components/TableColumnVisibilityToggle.tsx
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Check } from 'lucide-react'
-import { Command, CommandList, CommandGroup, CommandItem } from './ui/command'
-import { cn } from '@/lib/utils'
 import type { Column } from '@tanstack/react-table'
+import { Command, CommandCheckboxItem, CommandGroup, CommandList } from './ui/command'
 
 interface TableColumnVisibilityToggleProps {
   columns: Column<any, unknown>[]
@@ -22,19 +20,13 @@ export function TableColumnVisibilityToggle({ columns, getColumnLabel }: TableCo
             .filter((column) => column.getCanHide())
             .map((column) => {
               return (
-                <CommandItem key={column.id} onSelect={() => column.toggleVisibility(!column.getIsVisible())}>
-                  <div className="flex items-center">
-                    <div
-                      className={cn(
-                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
-                        column.getIsVisible() ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible',
-                      )}
-                    >
-                      <Check className={cn('h-4 w-4')} />
-                    </div>
-                    {getColumnLabel(column.id)}
-                  </div>
-                </CommandItem>
+                <CommandCheckboxItem
+                  key={column.id}
+                  checked={column.getIsVisible()}
+                  onSelect={() => column.toggleVisibility()}
+                >
+                  {getColumnLabel(column.id)}
+                </CommandCheckboxItem>
               )
             })}
         </CommandGroup>

--- a/apps/dashboard/src/components/ui/command.tsx
+++ b/apps/dashboard/src/components/ui/command.tsx
@@ -162,9 +162,15 @@ function CommandCheckboxItem({
   return (
     <CommandItem {...props}>
       <div className="flex items-center">
-        <div className="mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary">
-          <Check className="h-4 w-4 " />
+        <div
+          className={cn('mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary', {
+            'bg-primary text-primary-foreground': checked,
+            'opacity-50 [&_svg]:invisible': !checked,
+          })}
+        >
+          <Check className={cn('size-3.5 text-current')} />
         </div>
+        {children}
       </div>
     </CommandItem>
   )

--- a/apps/dashboard/src/components/ui/data-table-faceted-filter.tsx
+++ b/apps/dashboard/src/components/ui/data-table-faceted-filter.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Column } from '@tanstack/react-table'
-import { Check, PlusCircle } from 'lucide-react'
+import { PlusCircle } from 'lucide-react'
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'
@@ -12,6 +12,7 @@ import { Badge } from './badge'
 import { Button } from './button'
 import {
   Command,
+  CommandCheckboxItem,
   CommandEmpty,
   CommandGroup,
   CommandInput,
@@ -84,7 +85,8 @@ export function DataTableFacetedFilter<TData, TValue>({
               {options.map((option) => {
                 const isSelected = selectedValues.has(option.value)
                 return (
-                  <CommandItem
+                  <CommandCheckboxItem
+                    checked={isSelected}
                     key={option.value}
                     onSelect={() => {
                       if (isSelected) {
@@ -96,14 +98,6 @@ export function DataTableFacetedFilter<TData, TValue>({
                       column?.setFilterValue(filterValues.length ? filterValues : undefined)
                     }}
                   >
-                    <div
-                      className={cn(
-                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
-                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible',
-                      )}
-                    >
-                      <Check />
-                    </div>
                     {option.icon && <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />}
                     <span>{option.label}</span>
                     {facets?.get(option.value) && (
@@ -111,7 +105,7 @@ export function DataTableFacetedFilter<TData, TValue>({
                         {facets.get(option.value)}
                       </span>
                     )}
-                  </CommandItem>
+                  </CommandCheckboxItem>
                 )
               })}
             </CommandGroup>

--- a/apps/dashboard/src/components/ui/facet-filter.tsx
+++ b/apps/dashboard/src/components/ui/facet-filter.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import * as React from 'react'
-import { Check, PlusCircle } from 'lucide-react'
+import { PlusCircle } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { Badge } from './badge'
 import { Button } from './button'
 import {
   Command,
+  CommandCheckboxItem,
   CommandEmpty,
   CommandGroup,
   CommandInput,
@@ -18,9 +18,9 @@ import {
   CommandList,
   CommandSeparator,
 } from './command'
+import { FacetedFilterOption } from './data-table-faceted-filter'
 import { Popover, PopoverContent, PopoverTrigger } from './popover'
 import { Separator } from './separator'
-import { FacetedFilterOption } from './data-table-faceted-filter'
 
 interface FacetFilterProps {
   title: string
@@ -71,7 +71,8 @@ export function FacetFilter({ title, options, selectedValues, setSelectedValues,
               {options.map((option) => {
                 const isSelected = selectedValues.has(option.value)
                 return (
-                  <CommandItem
+                  <CommandCheckboxItem
+                    checked={isSelected}
                     key={option.value}
                     onSelect={() => {
                       if (isSelected) {
@@ -82,17 +83,9 @@ export function FacetFilter({ title, options, selectedValues, setSelectedValues,
                       setSelectedValues(new Set(selectedValues))
                     }}
                   >
-                    <div
-                      className={cn(
-                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
-                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50 [&_svg]:invisible',
-                      )}
-                    >
-                      <Check />
-                    </div>
                     {option.icon && <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />}
                     <span>{option.label}</span>
-                  </CommandItem>
+                  </CommandCheckboxItem>
                 )
               })}
             </CommandGroup>


### PR DESCRIPTION
## Description

Extracts out a shared `<CommandCheckboxItem/>` for reuse.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

