### PR TITLE
fix(sdk-python): exclude scripts folder from deptry check

### DIFF
--- a/libs/sdk-python/pyproject.toml
+++ b/libs/sdk-python/pyproject.toml
@@ -38,5 +38,5 @@ keywords = ["daytona", "sdk"]
 license = {text = "Apache-2.0"}
 
 [tool.deptry]
-exclude = ["src/daytona/_utils/chart_data_extractor_wrapper.py", "scripts/sync_generator.py"]
+exclude = ["scripts"]
 extend_exclude = [".venv", "dist", "build", ".pytest_cache", "__pycache__"]


### PR DESCRIPTION
This pull request makes a minor update to the dependency checking configuration by excluding entire script `scripts` directory as the code there is not functional code inside the Python SDK package.

- Dependency configuration:
  * Updated the `[tool.deptry]` section in `pyproject.toml` to exclude the entire `scripts` directory.
