### PR TITLE
fix(runner): added default dry run on volumes cleanup and exit on failed docker list

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	UseSnapshotEntrypoint              bool          `envconfig:"USE_SNAPSHOT_ENTRYPOINT"`
 	Domain                             string        `envconfig:"RUNNER_DOMAIN" validate:"omitempty,hostname|ip"`
 	VolumeCleanupIntervalSec           int           `envconfig:"VOLUME_CLEANUP_INTERVAL_SEC" default:"30" validate:"min=10"`
+	VolumeCleanupDryRun                bool          `envconfig:"VOLUME_CLEANUP_DRY_RUN" default:"true"`
 	PollTimeout                        time.Duration `envconfig:"POLL_TIMEOUT" default:"30s"`
 	PollLimit                          int           `envconfig:"POLL_LIMIT" default:"10" validate:"min=1,max=100"`
 	CollectorWindowSize                int           `envconfig:"COLLECTOR_WINDOW_SIZE" default:"60" validate:"min=1"`

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -99,6 +99,7 @@ func main() {
 		ResourceLimitsDisabled:   cfg.ResourceLimitsDisabled,
 		UseSnapshotEntrypoint:    cfg.UseSnapshotEntrypoint,
 		VolumeCleanupIntervalSec: cfg.VolumeCleanupIntervalSec,
+		VolumeCleanupDryRun:      cfg.VolumeCleanupDryRun,
 		BackupTimeoutMin:         cfg.BackupTimeoutMin,
 	})
 

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -30,6 +30,7 @@ type DockerClientConfig struct {
 	SandboxStartTimeoutSec   int
 	UseSnapshotEntrypoint    bool
 	VolumeCleanupIntervalSec int
+	VolumeCleanupDryRun      bool
 	BackupTimeoutMin         int
 }
 
@@ -66,6 +67,7 @@ func NewDockerClient(config DockerClientConfig) *DockerClient {
 		sandboxStartTimeoutSec:   config.SandboxStartTimeoutSec,
 		useSnapshotEntrypoint:    config.UseSnapshotEntrypoint,
 		volumeCleanupIntervalSec: config.VolumeCleanupIntervalSec,
+		volumeCleanupDryRun:      config.VolumeCleanupDryRun,
 		backupTimeoutMin:         config.BackupTimeoutMin,
 	}
 }
@@ -92,6 +94,7 @@ type DockerClient struct {
 	sandboxStartTimeoutSec   int
 	useSnapshotEntrypoint    bool
 	volumeCleanupIntervalSec int
+	volumeCleanupDryRun      bool
 	backupTimeoutMin         int
 	volumeCleanupMutex       sync.Mutex
 	lastVolumeCleanup        time.Time


### PR DESCRIPTION
This pull request adds support for a dry-run mode to the orphaned volume mount cleanup logic in the runner application. The dry-run mode allows the cleanup process to log which volumes would be cleaned up without actually performing any deletions. This is controlled by a new configuration option and is enabled by default. The changes also improve error handling in the volume mount tracking logic.

**Volume Cleanup Dry-Run Feature:**

* Added a new `VolumeCleanupDryRun` configuration option to the `Config` struct in `config.go`, with a default value of `true`. This allows enabling or disabling dry-run mode via environment variables.
* Propagated the new `VolumeCleanupDryRun` option through the runner's main initialization and the Docker client configuration, ensuring the setting is available where needed. [[1]](diffhunk://#diff-f9a99bbfde515954f8ab0b5fafc1024d1b0ad48129b6de04a6997a7d057be678R102) [[2]](diffhunk://#diff-4465978f21c6dd3dced203f2229b76621e249d9811744eced0f6437bd8d70159R33) [[3]](diffhunk://#diff-4465978f21c6dd3dced203f2229b76621e249d9811744eced0f6437bd8d70159R64) [[4]](diffhunk://#diff-4465978f21c6dd3dced203f2229b76621e249d9811744eced0f6437bd8d70159R90)

**Volume Cleanup Logic Improvements:**

* Updated the `CleanupOrphanedVolumeMounts` method to respect the dry-run mode: when enabled, it logs the directories that would be cleaned up instead of actually removing them.
* Improved error handling in `getInUseVolumeMounts` by returning an error if container listing fails, and updated its signature accordingly. This prevents accidental cleanup if the in-use volume list cannot be determined. [[1]](diffhunk://#diff-3aeda819353a0910dfb111a024ecf93838044b0fd5916d4eefb523f64bf473a9R35-R67) [[2]](diffhunk://#diff-3aeda819353a0910dfb111a024ecf93838044b0fd5916d4eefb523f64bf473a9L69-R80)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
