### PR TITLE
fix(proxy): check target port numeric

### DIFF
--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -242,7 +242,7 @@ func (p *Proxy) parseHost(host string) (targetPort string, sandboxIdOrSignedToke
 
 	// Check that port is numeric
 	if _, err := strconv.Atoi(targetPort); err != nil {
-		return "", "", errors.New("invalid port: must be numeric")
+		return "", "", fmt.Errorf("invalid port '%s': must be numeric", targetPort)
 	}
 
 	sandboxIdOrSignedToken = after


### PR DESCRIPTION
## Description

Added a check that the target port is numeric when parsing the proxy host.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
