### PR TITLE
fix(dashboard): prevent details sheet opening when clicking delete in runner table

### DIFF
--- a/apps/dashboard/src/components/RunnerTable.tsx
+++ b/apps/dashboard/src/components/RunnerTable.tsx
@@ -390,7 +390,10 @@ const getColumns = ({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
-                onClick={() => onDelete(row.original)}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDelete(row.original)
+                }}
                 className="cursor-pointer text-red-600 dark:text-red-400"
                 disabled={isLoading}
               >


### PR DESCRIPTION
This pull request makes a minor update to the `RunnerTable` component to improve event handling for the delete action in the dropdown menu. The change ensures that clicking the delete option does not trigger any parent click handlers by stopping event propagation.
