### PR TITLE
fix(runner): backup timeout

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	CollectorWindowSize      int           `envconfig:"COLLECTOR_WINDOW_SIZE" default:"60" validate:"min=1"`
 	HealthcheckInterval      time.Duration `envconfig:"HEALTHCHECK_INTERVAL" default:"30s" validate:"min=10s"`
 	HealthcheckTimeout       time.Duration `envconfig:"HEALTHCHECK_TIMEOUT" default:"10s"`
+	BackupTimeoutMin         int           `envconfig:"BACKUP_TIMEOUT_MIN" default:"60" validate:"min=1"`
 	ApiVersion               int           `envconfig:"API_VERSION" default:"2"`
 }
 

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -99,6 +99,7 @@ func main() {
 		ResourceLimitsDisabled:   cfg.ResourceLimitsDisabled,
 		UseSnapshotEntrypoint:    cfg.UseSnapshotEntrypoint,
 		VolumeCleanupIntervalSec: cfg.VolumeCleanupIntervalSec,
+		BackupTimeoutMin:         cfg.BackupTimeoutMin,
 	})
 
 	// Start Docker events monitor

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -30,6 +30,7 @@ type DockerClientConfig struct {
 	SandboxStartTimeoutSec   int
 	UseSnapshotEntrypoint    bool
 	VolumeCleanupIntervalSec int
+	BackupTimeoutMin         int
 }
 
 func NewDockerClient(config DockerClientConfig) *DockerClient {
@@ -41,6 +42,11 @@ func NewDockerClient(config DockerClientConfig) *DockerClient {
 	if config.SandboxStartTimeoutSec <= 0 {
 		log.Warnf("Invalid SandboxStartTimeoutSec value: %d. Using default value: 30 seconds", config.SandboxStartTimeoutSec)
 		config.SandboxStartTimeoutSec = 30
+	}
+
+	if config.BackupTimeoutMin <= 0 {
+		log.Warnf("Invalid BackupTimeoutMin value: %d. Using default value: 60 minutes", config.BackupTimeoutMin)
+		config.BackupTimeoutMin = 60
 	}
 
 	return &DockerClient{
@@ -60,6 +66,7 @@ func NewDockerClient(config DockerClientConfig) *DockerClient {
 		sandboxStartTimeoutSec:   config.SandboxStartTimeoutSec,
 		useSnapshotEntrypoint:    config.UseSnapshotEntrypoint,
 		volumeCleanupIntervalSec: config.VolumeCleanupIntervalSec,
+		backupTimeoutMin:         config.BackupTimeoutMin,
 	}
 }
 
@@ -85,6 +92,7 @@ type DockerClient struct {
 	sandboxStartTimeoutSec   int
 	useSnapshotEntrypoint    bool
 	volumeCleanupIntervalSec int
+	backupTimeoutMin         int
 	volumeCleanupMutex       sync.Mutex
 	lastVolumeCleanup        time.Time
 }


### PR DESCRIPTION
## Backup timeout

Adds a backup timeout to the runner, defaults to 60 minutes

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
