### PR TITLE
fix(runner): append recovery notice to recoverable error reason

### DIFF
--- a/apps/runner/pkg/api/middlewares/recoverable_errors.go
+++ b/apps/runner/pkg/api/middlewares/recoverable_errors.go
@@ -20,7 +20,7 @@ func RecoverableErrorsMiddleware() gin.HandlerFunc {
 			err := errs.Last()
 			if common.IsRecoverable(err.Err.Error()) {
 				res := map[string]any{
-					"errorReason": err.Err.Error() + " - you may attempt recovery action",
+					"errorReason": err.Err.Error() + " - you may attempt a recovery action",
 					"recoverable": true,
 				}
 				b, marshalErr := json.Marshal(res)


### PR DESCRIPTION
This pull request makes a small update to the error handling middleware to improve the clarity of recoverable error messages. Now, when a recoverable error occurs, the error reason will include a suggestion that a recovery action may be attempted.