### PR TITLE
fix(api): cache build info updates

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -660,7 +660,9 @@ export class SandboxService {
 
       if (existingBuildInfo) {
         sandbox.buildInfo = existingBuildInfo
-        await this.buildInfoRepository.update(sandbox.buildInfo.snapshotRef, { lastUsedAt: new Date() })
+        if (await this.redisLockProvider.lock(`build-info:${existingBuildInfo.snapshotRef}:update`, 60)) {
+          await this.buildInfoRepository.update(sandbox.buildInfo.snapshotRef, { lastUsedAt: new Date() })
+        }
       } else {
         const buildInfoEntity = this.buildInfoRepository.create({
           ...createSandboxDto.buildInfo,


### PR DESCRIPTION
## Cache build info updates

Adds a cache for build info updates in sandbox creations

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
