### PR TITLE
feat(docs): add guides url redirects

### DIFF
--- a/apps/docs/server/index.mjs
+++ b/apps/docs/server/index.mjs
@@ -2,11 +2,33 @@ import express from 'express'
 
 import { handler as ssrHandler } from '../server/entry.mjs'
 import { env } from './util/environment.mjs'
+import { redirects as slugRedirects } from './util/redirects.mjs'
+
+// Full-path redirect map from the shared URL map (slug redirects)
+const redirects = Object.fromEntries(
+  Object.entries(slugRedirects).map(([from, to]) => [`/docs/${from}`, `/docs/${to}`])
+)
 
 const app = express()
 app.use(express.json())
 app.use((req, res, next) => {
   res.setHeader('X-Frame-Options', 'SAMEORIGIN')
+  next()
+})
+app.use((req, res, next) => {
+  const path = req.path.replace(/\/$/, '') || req.path
+  const target = redirects[path]
+  if (target) {
+    return res.redirect(301, target)
+  }
+  // Handle locale-prefixed paths (/docs/en/slug -> /docs/en/new-slug)
+  const localeMatch = path.match(/^\/docs\/([a-z]{2})\/(.+)$/)
+  if (localeMatch) {
+    const bareTarget = redirects[`/docs/${localeMatch[2]}`]
+    if (bareTarget) {
+      return res.redirect(301, bareTarget.replace('/docs/', `/docs/${localeMatch[1]}/`))
+    }
+  }
   next()
 })
 app.use('/docs', express.static('client/'))

--- a/apps/docs/server/util/redirects.mjs
+++ b/apps/docs/server/util/redirects.mjs
@@ -1,0 +1,27 @@
+/**
+ * Redirect map for pages that changed URLs during the content architecture refactor.
+ *
+ * The single source of truth used by the Express production server (server/index.mjs)
+ * and the Astro middleware (src/middleware.ts).
+ */
+export const redirects = {
+  'inngest-agentkit-coding-agent': 'guides/agentkit/inngest-agentkit-coding-agent',
+  'claude-agent-sdk-connect-service-sandbox': 'guides/claude/claude-agent-sdk-connect-service-sandbox',
+  'claude-agent-sdk-interactive-terminal-sandbox': 'guides/claude/claude-agent-sdk-interactive-terminal-sandbox',
+  'claude-code-run-tasks-stream-logs-sandbox': 'guides/claude/claude-code-run-tasks-stream-logs-sandbox',
+  'codex-sdk-interactive-terminal-sandbox': 'guides/codex/codex-sdk-interactive-terminal-sandbox',
+  'data-analysis-with-ai': 'guides/data-analysis-with-ai',
+  'google-adk-code-generator': 'guides/google-adk-code-generator',
+  'langchain-data-analysis': 'guides/langchain/langchain-data-analysis',
+  'letta-code-agent': 'guides/letta-code/letta-code-agent',
+  'mastra-coding-agent': 'guides/mastra/mastra-coding-agent',
+  'opencode-web-agent': 'guides/opencode/opencode-web-agent',
+  'recursive-language-models': 'guides/recursive-language-models',
+  'trl-grpo-training': 'guides/reinforcement-learning/trl-grpo-training',
+  'preview-and-authentication': 'preview',
+  'regions-and-runners': 'regions',
+  'claude': 'guides/claude',
+  'computer-use-macos': 'computer-use',
+  'computer-use-windows': 'computer-use',
+  'computer-use-linux': 'computer-use',
+}

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -1,0 +1,22 @@
+import { defineMiddleware } from 'astro:middleware'
+
+import { redirects } from './utils/redirects'
+
+export const onRequest = defineMiddleware(({ request, redirect }, next) => {
+  const url = new URL(request.url)
+  const path = url.pathname.replace(/\/$/, '')
+
+  // Match /docs/old-slug or /docs/{locale}/old-slug
+  const match = path.match(/^\/docs(?:\/([a-z]{2}))?\/(.+)$/)
+  if (match) {
+    const locale = match[1]
+    const slug = match[2]
+    const newSlug = redirects[slug]
+    if (newSlug) {
+      const target = locale ? `/docs/${locale}/${newSlug}` : `/docs/${newSlug}`
+      return redirect(target, 301)
+    }
+  }
+
+  return next()
+})

--- a/apps/docs/src/utils/redirects.ts
+++ b/apps/docs/src/utils/redirects.ts
@@ -1,0 +1,3 @@
+import { redirects as _redirects } from '../../server/util/redirects.mjs'
+
+export const redirects: Record<string, string> = _redirects


### PR DESCRIPTION
## Description

After recent documentation content refactor, the guides documentation now resides in its new separate section: `/docs/en/guides`. To preserve the access to URLs, this adds a redirect map to handle URL changes. It implements middleware in both the Express server and Astro middleware to manage redirects from old URL slugs to new URLs.

Example:

Old URL: `/docs/recursive-language-models` or `/docs/en/recursive-language-models`
redirects to
New URL: `/docs/guides/recursive-language-models`