### PR TITLE
fix(dashboard): sandbox details sheet last event timestamp

### DIFF
--- a/apps/dashboard/src/components/SandboxDetailsSheet.tsx
+++ b/apps/dashboard/src/components/SandboxDetailsSheet.tsx
@@ -214,9 +214,9 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
             </div>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               <div>
-                <h3 className="text-sm text-muted-foreground">Last used</h3>
+                <h3 className="text-sm text-muted-foreground">Last event</h3>
                 <p className="mt-1 text-sm font-medium">
-                  <TimestampTooltip timestamp={sandbox.createdAt}>
+                  <TimestampTooltip timestamp={sandbox.updatedAt}>
                     {getLastEvent(sandbox).relativeTimeString}
                   </TimestampTooltip>
                 </p>


### PR DESCRIPTION
This pull request updates the labeling and data shown for the last activity in the `SandboxDetailsSheet` component. Instead of displaying when the sandbox was created, it now shows the most recent event timestamp, providing more relevant information to users.

UI/UX Improvements:

* Changed the label from "Last used" to "Last event" and updated the timestamp to use `sandbox.updatedAt` instead of `sandbox.createdAt` in the `SandboxDetailsSheet` component to better reflect recent activity.