### PR TITLE
chore(go-sdk): remove replace and fetch real version of tools-api-cli…

### DIFF
--- a/libs/sdk-go/go.mod
+++ b/libs/sdk-go/go.mod
@@ -7,8 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.93.2
 	github.com/daytonaio/daytona/libs/api-client-go v0.0.0-20260120123750-b98371563343
-	github.com/daytonaio/daytona/libs/toolbox-api-client-go v0.0.0
-	github.com/google/uuid v1.6.0
+	github.com/daytonaio/daytona/libs/toolbox-api-client-go v0.0.0-20260128154817-2e2bf16516bc
 	github.com/gorilla/websocket v1.5.3
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/stretchr/testify v1.11.1
@@ -26,12 +25,6 @@ require (
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rogpeppe/go-internal v1.13.1 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// Remove this once the toolbox lib is commited
-replace github.com/daytonaio/daytona/libs/toolbox-api-client-go => ../toolbox-api-client-go

--- a/libs/sdk-go/go.sum
+++ b/libs/sdk-go/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daytonaio/daytona/libs/api-client-go v0.0.0-20260120123750-b98371563343 h1:1Kf2urqPt1rUoC8Vu4wGO/56th6TRHYiCB2041RsceM=
 github.com/daytonaio/daytona/libs/api-client-go v0.0.0-20260120123750-b98371563343/go.mod h1:1wKpdKRwUzXN7KqR+8MMpq2iEGrprBCgFgFbli89DMo=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/daytonaio/daytona/libs/toolbox-api-client-go v0.0.0-20260128154817-2e2bf16516bc h1:vEKJvcufC2AbdBEk7Bdq3AAyC1ZjjVawjNclu4ISwXs=
+github.com/daytonaio/daytona/libs/toolbox-api-client-go v0.0.0-20260128154817-2e2bf16516bc/go.mod h1:YJD2yevQHDl0jIrlrzTerZJxJZS6wBOVMfl1A2efkVY=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
## Description

In order to make go-sdk publicly fetchable, we also need to make it depend on the external tools-client-api-go. This PR includes fixes for go.mod and go.sum to make this happen.

This will allow to include go-sdk in your projects after the change.

## Documentation

- [NO ] This change requires a documentation update
- [NO ] I have made corresponding changes to the documentation


## Notes

Please add any relevant notes if necessary.
