### PR TITLE
chore(sdk-go): publish procedure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,10 @@ jobs:
             "version": "0.0.0"
           }' > apps/runner/package.json
 
+      - name: Publish Go SDK
+        run: |
+          VERSION=${{ inputs.version }} yarn nx publish sdk-go
+
       - name: Create release
         run: yarn nx release ${{ inputs.version }} --skip-publish --verbose
 

--- a/libs/api-client-go/project.json
+++ b/libs/api-client-go/project.json
@@ -50,6 +50,19 @@
       "options": {
         "command": "cd {projectRoot} && go fmt ./... && prettier --write \"**/*.yaml\""
       }
+    },
+    "check-version-env": {},
+    "set-version": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "commands": [
+          "cd apps/cli && go mod edit -require=github.com/daytonaio/daytona/libs/api-client-go@$VERSION",
+          "cd libs/sdk-go && go mod edit -require=github.com/daytonaio/daytona/libs/api-client-go@$VERSION"
+        ],
+        "parallel": false
+      },
+      "dependsOn": ["check-version-env"]
     }
   }
 }

--- a/libs/sdk-go/project.json
+++ b/libs/sdk-go/project.json
@@ -92,26 +92,31 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "commands": [
-          "echo \"${VERSION:-v0.0.0-dev}\" > pkg/daytona/VERSION",
-          "git add pkg/daytona/VERSION",
-          "git commit -s -m \"chore(sdk-go): set version to ${VERSION:-v0.0.0-dev}\" || true"
-        ],
+        "commands": ["echo \"${VERSION:-v0.0.0-dev}\" > pkg/daytona/VERSION"],
         "parallel": false
       }
     },
+    "check-version-env": {},
     "publish": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
         "commands": [
-          "echo 'Go SDK version set to:'",
-          "cat pkg/daytona/VERSION",
+          "git add pkg/daytona/VERSION",
+          "git add go.mod ../../apps/cli/go.mod",
+          "git commit -s -m \"chore(sdk-go): bump to ${VERSION:-v0.0.0-dev}\" || true",
           "git push origin HEAD"
         ],
         "parallel": false
       },
-      "dependsOn": ["set-version"]
+      "dependsOn": [
+        "check-version-env",
+        "set-version",
+        {
+          "target": "set-version",
+          "projects": ["api-client-go", "toolbox-api-client-go"]
+        }
+      ]
     }
   }
 }

--- a/libs/toolbox-api-client-go/project.json
+++ b/libs/toolbox-api-client-go/project.json
@@ -48,6 +48,15 @@
           "projects": "daemon"
         }
       ]
+    },
+    "check-version-env": {},
+    "set-version": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "command": "cd libs/sdk-go && go mod edit -require=github.com/daytonaio/daytona/libs/toolbox-api-client-go@$VERSION"
+      },
+      "dependsOn": ["check-version-env"]
     }
   },
   "tags": []

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "migration:revert": "cd apps/api && npx ts-node -P ./tsconfig.json -r tsconfig-paths/register ../../node_modules/typeorm/cli.js migration:revert -d ./src/data-source.ts",
     "shadcn:add": "TS_NODE_PROJECT=apps/dashboard/tsconfig.app.json npx shadcn@latest add",
     "docs": "nx run-many --target=docs --all",
-    "publish": "nx run-many --target=publish --all",
+    "publish": "nx run-many --target=publish --exclude=sdk-go --all",
     "translate:docs": "npx gtx-cli translate --config apps/docs/gt.config.json",
     "push-manifest": "nx run-many --target=push-manifest --all --parallel=$(getconf _NPROCESSORS_ONLN)"
   },


### PR DESCRIPTION
## Description

Added publishing automation for sdk-go.

When publishing, the api-client-go and toolbox-api-client-go relevant go.mod files are updated and commited. Also, the VERSION file in the go sdk is updated.

This publish needs to be done before the github tag is created, so it's ran before `yarn nx release` in the release workflow.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
