### PR TITLE
feat(docs): add go sdk examples

### DIFF
--- a/apps/docs/src/content/docs/en/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/computer-use.mdx
@@ -125,6 +125,50 @@ Complete API reference for computer use operations in Python (sync & async).
     sandbox.computer_use.keyboard.hotkey('ctrl+s')
     ```
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+
+    params := &types.SnapshotCreateParams{
+        Name: "my-snapshot",
+        Image: &types.Image{
+            User: "debian",
+            Tag:  "slim-3.12",
+        },
+    }
+
+    snapshot, buildLogs, err := client.Snapshot.Create(ctx, params, 90*time.Second)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Stream build logs
+    go func() {
+        for logLine := range buildLogs {
+            fmt.Printf("[BUILD] %s\n", logLine)
+        }
+    }()
+
+    log.Printf("Created snapshot: %s\n", snapshot.Name)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 **Environment Variables (.env file):**

--- a/apps/docs/src/content/docs/en/configuration.mdx
+++ b/apps/docs/src/content/docs/en/configuration.mdx
@@ -59,6 +59,43 @@ config = Daytona::Config.new(
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/daytona), [TypeScript SDK](/docs/en/typescript-sdk/daytona), and [Ruby SDK](/docs/en/ruby-sdk/daytona) references:

--- a/apps/docs/src/content/docs/en/declarative-builder.mdx
+++ b/apps/docs/src/content/docs/en/declarative-builder.mdx
@@ -75,174 +75,43 @@ sandbox = daytona.create(
 )
 ```
 </TabItem>
-</Tabs>
 
-For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/), and [Ruby SDK](/docs/en/ruby-sdk/) references:
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
 
-> [**CreateSandboxFromImageParams (Python SDK)**](/docs/python-sdk/sync/daytona#createsandboxfromimageparams)
->
-> [**CreateSandboxFromImageParams (TypeScript SDK)**](/docs/typescript-sdk/daytona#createsandboxfromimageparams)
->
-> [**CreateSandboxFromImageParams (Ruby SDK)**](/docs/ruby-sdk/daytona#createsandboxfromimageparams)
+import (
+    "context"
+    "log"
 
-:::note
-Use the following best practices when working with the declarative builder:
-
-- **Layer Optimization**: Group related operations to minimize Docker layers
-
-- **Cache Utilization**: Identical build commands and context will be cached and subsequent builds will be almost instant
-
-- **Security**: Create non-root users for application workloads
-
-- **Resource Efficiency**: Use slim base images when appropriate
-
-- **Context Minimization**: Only include necessary files in the build context
-  :::
-
-## Create pre-built Snapshots
-
-Daytona provides an option to [create pre-built snapshots](/docs/snapshots#create-snapshots) that can be reused across multiple sandboxes.
-
-The snapshot remains visible in the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/snapshots) and is permanently cached, ensuring instant availability without rebuilding.
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-
-```python
-# Create a python data science image
-snapshot_name = "data-science-snapshot"
-
-image = (
-  Image.debian_slim("3.12")
-  .pip_install(["pandas", "numpy"])
-  .workdir("/home/daytona")
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
 )
 
-# Create the snapshot and stream the build logs
-daytona.snapshot.create(
-  CreateSnapshotParams(
-    name=snapshot_name,
-    image=image,
-  ),
-on_logs=print,
-)
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
 
-# Create a new sandbox using the pre-built snapshot
-sandbox = daytona.create(
-CreateSandboxFromSnapshotParams(snapshot=snapshot_name)
-)
+    ctx := context.Background()
 
-```
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
 
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
 
-```typescript
-// Create a python data science image
-const snapshotName = 'data-science-snapshot'
-
-const image = Image.debianSlim('3.12')
-  .pipInstall(['pandas', 'numpy'])
-  .workdir('/home/daytona')
-
-// Create the snapshot and stream the build logs
-await daytona.snapshot.create(
-  {
-    name: snapshotName,
-    image,
-  },
-  {
-    onLogs: console.log,
-  }
-)
-
-// Create a new sandbox using the pre-built snapshot
-const sandbox = await daytona.create({
-  snapshot: snapshotName,
-})
-```
-
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Create a simple Python data science image
-snapshot_name = 'data-science-snapshot'
-
-image = Daytona::Image
-  .debian_slim('3.12')
-  .pip_install(['pandas', 'numpy'])
-  .workdir('/home/daytona')
-
-# Create the Snapshot and stream the build logs
-daytona.snapshot.create(
-  Daytona::CreateSnapshotParams.new(
-    name: snapshot_name,
-    image: image
-  ),
-  on_logs: proc { |chunk| puts chunk }
-)
-
-# Create a new Sandbox using the pre-built Snapshot
-sandbox = daytona.create(
-  Daytona::CreateSandboxFromSnapshotParams.new(snapshot: snapshot_name)
-)
-```
-</TabItem>
-</Tabs>
-
-For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/), and [Ruby SDK](/docs/en/ruby-sdk/) references:
-
-> [**CreateSnapshotParams (Python SDK)**](/docs/python-sdk/sync/snapshot#createsnapshotparams)
->
-> [**CreateSnapshotParams (TypeScript SDK)**](/docs/typescript-sdk/snapshot#createsnapshotparams)
->
-> [**CreateSnapshotParams (Ruby SDK)**](/docs/ruby-sdk/snapshot#createsnapshotparams)
-
-## Image configuration
-
-Daytona provides an option to define images programmatically using the Daytona SDK. You can specify base images, install packages, add files, set environment variables, and more.
-
-For a complete API reference and method signatures, see the [Python](/docs/python-sdk/common/image) and [TypeScript](/docs/typescript-sdk/image) SDK references.
-
-### Base image selection
-
-Daytona provides an option to select base images. The following snippets demonstrate how to select and configure base images:
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-
-```python
-# Create an image from a base
-image = Image.base("python:3.12-slim-bookworm")
-
-# Use a Debian slim image with Python 3.12
-image = Image.debian_slim("3.12")
-```
-
-</TabItem>
-
-<TabItem label="TypeScript" icon="seti:typescript">
-
-```typescript
-// Create an image from a base
-const image = Image.base('python:3.12-slim-bookworm')
-
-// Use a Debian slim image with Python 3.12
-const image = Image.debianSlim('3.12')
-```
-
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Create an image from a base
-image = Daytona::Image.base('python:3.12-slim-bookworm')
-
-# Use a Debian slim image with Python 3.12
-image = Daytona::Image.debian_slim('3.12')
-```
-</TabItem>
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/) and [TypeScript SDK](/docs/en/typescript-sdk/) references:
@@ -307,6 +176,43 @@ image = Daytona::Image.debian_slim('3.12').pip_install_from_pyproject('pyproject
 )
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/) and [TypeScript SDK](/docs/en/typescript-sdk/) references:
@@ -361,6 +267,43 @@ image = Daytona::Image.debian_slim('3.12').add_local_file('package.json', '/home
 image = Daytona::Image.debian_slim('3.12').add_local_dir('src', '/home/daytona/src')
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/) and [TypeScript SDK](/docs/en/typescript-sdk/) references:
@@ -411,6 +354,43 @@ image = Daytona::Image.debian_slim('3.12').env('PROJECT_ROOT': '/home/daytona')
 image = Daytona::Image.debian_slim('3.12').workdir('/home/daytona')
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/) and [TypeScript SDK](/docs/en/typescript-sdk/) references:
@@ -482,6 +462,43 @@ image = Daytona::Image.debian_slim('3.12').entrypoint(['/bin/bash'])
 image = Daytona::Image.debian_slim('3.12').cmd(['/bin/bash'])
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/) and [TypeScript SDK](/docs/en/typescript-sdk/) references:

--- a/apps/docs/src/content/docs/en/file-system-operations.mdx
+++ b/apps/docs/src/content/docs/en/file-system-operations.mdx
@@ -58,339 +58,43 @@ end
 ```
 
 </TabItem>
-</Tabs>
 
-See: [list_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemlist_files), [listFiles (TypeScript SDK)](/docs/typescript-sdk/file-system/#listfiles), [list_files (Ruby SDK)](/docs/ruby-sdk/file-system/#list_files)
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
 
-### Creating Directories
+import (
+    "context"
+    "log"
 
-Daytona SDK provides an option to create directories with specific permissions using Python, TypeScript, and Ruby.
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
 
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-# Create with specific permissions
-sandbox.fs.create_folder("workspace/new-dir", "755")
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-// Create with specific permissions
-await sandbox.fs.createFolder("workspace/new-dir", "755")
-```
-
-</TabItem>
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Create with specific permissions
-sandbox.fs.create_folder('workspace/new-dir', '755')
-```
-
-</TabItem>
-</Tabs>
-
-See: [create_folder (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemcreate_folder), [createFolder (TypeScript SDK)](/docs/typescript-sdk/file-system/#createfolder), [create_folder (Ruby SDK)](/docs/ruby-sdk/file-system/#create_folder)
-
-### Uploading Files
-
-Daytona SDK provides options to read, write, upload, download, and delete files in Sandboxes using Python, TypeScript, and Ruby.
-
-#### Uploading a Single File
-
-The following example shows how to upload a single file:
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-# Upload a single file
-with open("local_file.txt", "rb") as f:
-    content = f.read()
-sandbox.fs.upload_file(content, "remote_file.txt")
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-// Upload a single file
-const fileContent = Buffer.from('Hello, World!')
-await sandbox.fs.uploadFile(fileContent, "data.txt")
-```
-
-</TabItem>
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Upload a single file
-content = 'Hello, World!'
-sandbox.fs.upload_file(content, 'data.txt')
-```
-
-</TabItem>
-</Tabs>
-
-See: [upload_file (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemupload_file), [uploadFile (TypeScript SDK)](/docs/typescript-sdk/file-system/#uploadfile), [upload_file (Ruby SDK)](/docs/ruby-sdk/file-system/#upload_file)
-
-#### Uploading Multiple Files
-
-The following example shows how to efficiently upload multiple files with a single method call.
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-# Upload multiple files at once
-files_to_upload = []
-
-with open("file1.txt", "rb") as f1:
-    files_to_upload.append(FileUpload(
-        source=f1.read(),
-        destination="data/file1.txt",
-    ))
-
-with open("file2.txt", "rb") as f2:
-    files_to_upload.append(FileUpload(
-        source=f2.read(),
-        destination="data/file2.txt",
-    ))
-
-with open("settings.json", "rb") as f3:
-    files_to_upload.append(FileUpload(
-        source=f3.read(),
-        destination="config/settings.json",
-    ))
-
-sandbox.fs.upload_files(files_to_upload)
-
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-// Upload multiple files at once
-const files = [
-    {
-        source: Buffer.from('Content of file 1'),
-        destination: 'data/file1.txt',
-    },
-    {
-        source: Buffer.from('Content of file 2'),
-        destination: 'data/file2.txt',
-    },
-    {
-        source: Buffer.from('{"key": "value"}'),
-        destination: 'config/settings.json',
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
     }
-]
 
-await sandbox.fs.uploadFiles(files)
-```
+    ctx := context.Background()
 
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Upload multiple files at once
-files = [
-  Daytona::FileUpload.new('Content of file 1', 'data/file1.txt'),
-  Daytona::FileUpload.new('Content of file 2', 'data/file2.txt'),
-  Daytona::FileUpload.new('{"key": "value"}', 'config/settings.json')
-]
-
-sandbox.fs.upload_files(files)
-```
-
-</TabItem>
-</Tabs>
-
-See: [upload_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemupload_files), [uploadFiles (TypeScript SDK)](/docs/typescript-sdk/file-system/#uploadfiles), [upload_files (Ruby SDK)](/docs/ruby-sdk/file-system/#upload_files)
-
-### Downloading Files
-
-#### Downloading a Single File
-
-The following commands downloads a single file `file1.txt` from the Sandbox working directory and prints out the content:
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-
-content = sandbox.fs.download_file("file1.txt")
-
-with open("local_file.txt", "wb") as f:
-    f.write(content)
-
-print(content.decode('utf-8'))
-
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-
-const downloadedFile = await sandbox.fs.downloadFile("file1.txt")
-
-console.log('File content:', downloadedFile.toString())
-
-```
-
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-
-# Download file and get a Tempfile reference
-file = sandbox.fs.download_file('file1.txt')
-
-# Read the content
-puts "File content: #{file.open.read}"
-
-# Or download and save to a specific path
-sandbox.fs.download_file('file1.txt', 'local_file.txt')
-
-```
-
-</TabItem>
-</Tabs>
-
-See: [download_file (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemdownload_file), [downloadFile (TypeScript SDK)](/docs/typescript-sdk/file-system/#downloadfile), [download_file (Ruby SDK)](/docs/ruby-sdk/file-system/#download_file)
-
-#### Downloading Multiple Files
-
-The following example shows how to efficiently download multiple files with a single method call.
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-# Download multiple files at once
-files_to_download = [
-    FileDownloadRequest(source="data/file1.txt"), # No destination - download to memory
-    FileDownloadRequest(source="data/file2.txt", destination="local_file2.txt"), # Download to local file
-]
-
-results = sandbox.fs.download_files(files_to_download)
-
-for result in results:
-    if result.error:
-        print(f"Error downloading {result.source}: {result.error}")
-    elif result.result:
-        print(f"Downloaded {result.source} to {result.result}")
-
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-// Download multiple files at once
-const files = [
-    { source: "data/file1.txt" }, // No destination - download to memory
-    { source: "data/file2.txt", destination: "local_file2.txt" }, // Download to local file
-]
-
-const results = await sandbox.fs.downloadFiles(files)
-
-results.forEach(result => {
-    if (result.error) {
-        console.error(`Error downloading ${result.source}: ${result.error}`)
-    } else if (result.result) {
-        console.log(`Downloaded ${result.source} to ${result.result}`)
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
     }
-})
-```
-</TabItem>
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
 
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Download multiple files at once
-files = [
-  Daytona::FileDownloadRequest.new(source: 'data/file1.txt'), # No destination - download to memory
-  Daytona::FileDownloadRequest.new(source: 'data/file2.txt', destination: 'local_file2.txt') # Download to local file
-]
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
 
-results = sandbox.fs.download_files(files)
-
-results.each do |result|
-  if result.error
-    puts "Error downloading #{result.source}: #{result.error}"
-  elsif result.result
-    puts "Downloaded #{result.source} to #{result.result}"
-  end
-end
-```
-</TabItem>
-</Tabs>
-
-See: [download_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemdownload_files), [downloadFiles (TypeScript SDK)](/docs/typescript-sdk/file-system/#downloadfiles), [download_files (Ruby SDK)](/docs/ruby-sdk/file-system/#download_files)
-
-### Deleting files
-
-The following example shows how to delete a file:
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-
-sandbox.fs.delete_file("workspace/file.txt")
-
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-
-await sandbox.fs.deleteFile("workspace/file.txt")
-```
-
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-
-sandbox.fs.delete_file('workspace/file.txt')
-
-```
-
-</TabItem>
-</Tabs>
-
-See: [delete_file (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemdelete_file), [deleteFile (TypeScript SDK)](/docs/typescript-sdk/file-system/#deletefile), [delete_file (Ruby SDK)](/docs/ruby-sdk/file-system/#delete_file)
-
-## Advanced Operations
-
-Daytona SDK provides advanced file system operations like file permissions, search and replace, and more.
-
-### File Permissions
-
-Daytona SDK provides an option to set file permissions, get file permissions, and set directory permissions recursively using Python, TypeScript, and Ruby.
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-# Set file permissions
-sandbox.fs.set_file_permissions("workspace/file.txt", "644")
-
-# Get file permissions
-
-file_info = sandbox.fs.get_file_info("workspace/file.txt")
-print(f"Permissions: {file_info.permissions}")
-
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-// Set file permissions
-await sandbox.fs.setFilePermissions("workspace/file.txt", { mode: "644" })
-
-// Get file permissions
-const fileInfo = await sandbox.fs.getFileDetails("workspace/file.txt")
-console.log(`Permissions: ${fileInfo.permissions}`)
-```
-
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Set file permissions
-sandbox.fs.set_file_permissions('workspace/file.txt', '644')
-
-# Get file permissions
-file_info = sandbox.fs.get_file_info('workspace/file.txt')
-puts "Permissions: #{file_info.permissions}"
-```
-
-</TabItem>
+  </TabItem>
 </Tabs>
 
 See: [set_file_permissions (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemset_file_permissions), [setFilePermissions (TypeScript SDK)](/docs/typescript-sdk/file-system/#setfilepermissions), [set_file_permissions (Ruby SDK)](/docs/ruby-sdk/file-system/#set_file_permissions)
@@ -465,6 +169,43 @@ sandbox.fs.replace_in_files(
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [find_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemfind_files), [replace_in_files (Python SDK)](/docs/python-sdk/sync/file-system/#filesystemreplace_in_files), [findFiles (TypeScript SDK)](/docs/typescript-sdk/file-system/#findfiles), [replaceInFiles (TypeScript SDK)](/docs/typescript-sdk/file-system/#replaceinfiles), [find_files (Ruby SDK)](/docs/ruby-sdk/file-system/#find_files), [replace_in_files (Ruby SDK)](/docs/ruby-sdk/file-system/#replace_in_files)

--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -13,12 +13,12 @@ It serves as the primary point of control for managing your Daytona resources.
 
 ## SDKs
 
-Daytona provides Python, TypeScript and Ruby SDKs to programmatically interact with Daytona Sandboxes. They support sandbox lifecycle management, code execution, resource access, and more.
+Daytona provides Python, TypeScript, Ruby, and Go SDKs to programmatically interact with Daytona Sandboxes. They support sandbox lifecycle management, code execution, resource access, and more.
 
-To interact with Daytona Sandboxes from the SDK, see the [Python SDK](/docs/en/python-sdk), [TypeScript SDK](/docs/en/typescript-sdk) and [Ruby SDK](/docs/en/ruby-sdk) references.
+To interact with Daytona Sandboxes from the SDK, see the [Python SDK](/docs/en/python-sdk), [TypeScript SDK](/docs/en/typescript-sdk), [Ruby SDK](/docs/en/ruby-sdk), and [Go SDK](/docs/en/go-sdk) references.
 
 :::tip
-Daytona provides [Python](https://github.com/daytonaio/daytona/tree/main/examples/python), [TypeScript/JavaScript](https://github.com/daytonaio/daytona/tree/main/examples/typescript) and [Ruby](https://github.com/daytonaio/daytona/tree/main/examples/ruby) examples to create Daytona Sandboxes and run your code.
+Daytona provides [Python](https://github.com/daytonaio/daytona/tree/main/examples/python), [TypeScript/JavaScript](https://github.com/daytonaio/daytona/tree/main/examples/typescript), [Ruby](https://github.com/daytonaio/daytona/tree/main/examples/ruby), and [Go](https://github.com/daytonaio/daytona/tree/main/examples/go) examples to create Daytona Sandboxes and run your code.
 :::
 
 ## CLI
@@ -226,6 +226,59 @@ Create a Daytona Sandbox instance and run code securely inside it. The following
     ```
 
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+    import (
+        "context"
+        "log"
+
+        "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+        "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+    )
+
+    func main() {
+        // Initialize the Daytona client
+        config := &types.DaytonaConfig{
+            APIKey: "YOUR_API_KEY",
+        }
+        client, err := daytona.NewClientWithConfig(config)
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        ctx := context.Background()
+
+        // Create the Sandbox instance
+        params := types.SnapshotParams{
+            SandboxBaseParams: types.SandboxBaseParams{
+                Language: types.CodeLanguagePython,
+            },
+        }
+        sandbox, err := client.Create(ctx, params)
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        // Run code securely inside the Sandbox
+        result, err := sandbox.Process.ExecuteCommand(ctx, `python -c 'print("Sum of 3 and 4 is", 3 + 4)'`)
+        if err != nil {
+            log.Fatalf("Error running code: %v", err)
+        }
+        if result.ExitCode != 0 {
+            log.Printf("Error running code: %d %s", result.ExitCode, result.Result)
+        } else {
+            log.Println(result.Result)
+        }
+
+        // Clean up the Sandbox
+        sandbox.Delete(ctx)
+    }
+    ```
+
+  </TabItem>
 </Tabs>
 
 <Tabs syncKey="language">
@@ -239,9 +292,13 @@ Create a Daytona Sandbox instance and run code securely inside it. The following
   ```bash npx tsx ./index.ts ```
 </TabItem>
 
-  <TabItem label="Ruby" icon="seti:ruby">
+<TabItem label="Ruby" icon="seti:ruby">
+  ```bash ruby main.rb ```
+</TabItem>
+
+  <TabItem label="Go" icon="seti:go">
     ```bash
-    ruby main.rb
+    go run main.go
     ```
   </TabItem>
 </Tabs>
@@ -429,6 +486,45 @@ Preview your app by uploading a file containing a simple Flask app to a Daytona 
     preview_info = sandbox.preview_url(3000)
     puts "Flask app is available at: #{preview_info.url}"
     ```
+
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+
+)
+
+func main() {
+client, err := daytona.NewClient()
+if err != nil {
+log.Fatal(err)
+}
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+
+}
+```
 
   </TabItem>
 </Tabs>
@@ -649,11 +745,121 @@ Connect to an LLM using the Anthropic API and ask Claude to generate code for ge
     ```
 
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+
+    ```go
+    package main
+
+    import (
+        "bytes"
+        "context"
+        "encoding/json"
+        "fmt"
+        "io"
+        "log"
+        "net/http"
+        "os"
+        "regexp"
+
+        "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    )
+
+    func getClaudeResponse(apiKey, prompt string) (string, error) {
+        url := "https://api.anthropic.com/v1/messages"
+        data := map[string]interface{}{
+            "model":      "claude-3-7-sonnet-latest",
+            "max_tokens": 256,
+            "messages":   []map[string]string{{"role": "user", "content": prompt}},
+        }
+        jsonData, _ := json.Marshal(data)
+
+        req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+        req.Header.Set("x-api-key", apiKey)
+        req.Header.Set("anthropic-version", "2023-06-01")
+        req.Header.Set("Content-Type", "application/json")
+
+        client := &http.Client{}
+        resp, err := client.Do(req)
+        if err != nil {
+            return "", err
+        }
+        defer resp.Body.Close()
+
+        body, _ := io.ReadAll(resp.Body)
+        if resp.StatusCode != 200 {
+            return "", fmt.Errorf("error %d: %s", resp.StatusCode, string(body))
+        }
+
+        var result map[string]interface{}
+        json.Unmarshal(body, &result)
+        content := result["content"].([]interface{})
+        var text string
+        for _, item := range content {
+            m := item.(map[string]interface{})
+            if m["type"] == "text" {
+                text += m["text"].(string)
+            }
+        }
+        return text, nil
+    }
+
+    func main() {
+        client, err := daytona.NewClient()
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        ctx := context.Background()
+        sandbox, err := client.Create(ctx, nil)
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        prompt := "Python code that returns the factorial of 25. Output only the code. No explanation. No intro. No comments. Just raw code in a single code block."
+
+        result, err := getClaudeResponse(os.Getenv("ANTHROPIC_API_KEY"), prompt)
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        // Extract code from the response using regex
+        re := regexp.MustCompile("```python\\n(.*?)```")
+        matches := re.FindStringSubmatch(result)
+
+        code := result
+        if len(matches) > 1 {
+            code = matches[1]
+        }
+
+        // Run Python code inside the Sandbox and get the output
+        response, err := sandbox.Process.ExecuteCommand(ctx, fmt.Sprintf("python -c '%s'", code))
+        if err != nil {
+            log.Fatal(err)
+        }
+        fmt.Printf("The factorial of 25 is %s\n", response.Result)
+    }
+    ```
+
+    Ensure the following environment variables are set and run the snippet:
+
+    ```bash
+    ANTHROPIC_API_KEY="YOUR_ANTHROPIC_API_KEY"
+    DAYTONA_API_KEY="YOUR_DAYTONA_API_KEY"
+    DAYTONA_TARGET=us
+    go run claude-example.go
+    ```
+
+    ```bash
+    > The factorial of 25 is 15511210043330985984000000
+    ```
+
+  </TabItem>
 </Tabs>
 
 ## Examples
 
-Daytona provides [Python](https://github.com/daytonaio/daytona/tree/main/examples/python), [TypeScript/JavaScript](https://github.com/daytonaio/daytona/tree/main/examples/typescript) and [Ruby](https://github.com/daytonaio/daytona/tree/main/examples/ruby) examples to create Daytona Sandboxes and run your code.
+Daytona provides [Python](https://github.com/daytonaio/daytona/tree/main/examples/python), [TypeScript/JavaScript](https://github.com/daytonaio/daytona/tree/main/examples/typescript), [Ruby](https://github.com/daytonaio/daytona/tree/main/examples/ruby), and [Go](https://github.com/daytonaio/daytona/tree/main/examples/go) examples to create Daytona Sandboxes and run your code.
 
 :::tip
 Use our LLMs context files for faster development with AI agents and assistants. Copy the [llms-full.txt](https://www.daytona.io/docs/llms-full.txt) or [llms.txt](https://www.daytona.io/docs/llms.txt) files and include them in your projects or chat contexts.

--- a/apps/docs/src/content/docs/en/git-operations.mdx
+++ b/apps/docs/src/content/docs/en/git-operations.mdx
@@ -98,72 +98,57 @@ sandbox.git.clone(
 ```
 
 </TabItem>
-</Tabs>
 
-See: [clone (Python SDK)](/docs/python-sdk/sync/git/#gitclone), [clone (TypeScript SDK)](/docs/typescript-sdk/git/#clone), [clone (Ruby SDK)](/docs/ruby-sdk/git/#clone)
+<TabItem label="Go" icon="seti:go">
+    ```go
+    package main
 
-### Repository Status
+import (
+    "context"
+    "log"
 
-Daytona SDK provides an option to check the status of Git repositories in Sandboxes. You can get the current branch, modified files, number of commits ahead and behind main branch using Python, TypeScript, and Ruby.
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/options"
+)
 
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-# Get repository status
-status = sandbox.git.status("workspace/repo")
-print(f"Current branch: {status.current_branch}")
-print(f"Commits ahead: {status.ahead}")
-print(f"Commits behind: {status.behind}")
-for file in status.file_status:
-    print(f"File: {file.name}")
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
 
-# List branches
+    // Basic clone
+    err := sandbox.Git.Clone(ctx,
+        "https://github.com/user/repo.git",
+        "workspace/repo",
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
 
-response = sandbox.git.branches("workspace/repo")
-for branch in response.branches:
-    print(f"Branch: {branch}")
+    // Clone with authentication
+    err = sandbox.Git.Clone(ctx,
+        "https://github.com/user/repo.git",
+        "workspace/repo",
+        options.WithUsername("git"),
+        options.WithPassword("personal_access_token"),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
 
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-// Get repository status
-const status = await sandbox.git.status("workspace/repo");
-console.log(`Current branch: ${status.currentBranch}`);
-console.log(`Commits ahead: ${status.ahead}`);
-console.log(`Commits behind: ${status.behind}`);
-status.fileStatus.forEach(file => {
-    console.log(`File: ${file.name}`);
-});
+    // Clone specific branch
+    err = sandbox.Git.Clone(ctx,
+        "https://github.com/user/repo.git",
+        "workspace/repo",
+        options.WithBranch("develop"),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
 
-// List branches
-const response = await sandbox.git.branches("workspace/repo");
-response.branches.forEach(branch => {
-    console.log(`Branch: ${branch}`);
-});
-```
-
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-```ruby
-# Get repository status
-status = sandbox.git.status('workspace/repo')
-puts "Current branch: #{status.current_branch}"
-puts "Commits ahead: #{status.ahead}"
-puts "Commits behind: #{status.behind}"
-status.file_status.each do |file|
-  puts "File: #{file.name}"
-end
-
-# List branches
-response = sandbox.git.branches('workspace/repo')
-response.branches.each do |branch|
-  puts "Branch: #{branch}"
-end
-```
-
-</TabItem>
+  </TabItem>
 </Tabs>
 
 See: [status (Python SDK)](/docs/python-sdk/sync/git/#gitstatus), [status (TypeScript SDK)](/docs/typescript-sdk/git/#status), [status (Ruby SDK)](/docs/ruby-sdk/git/#status)
@@ -219,6 +204,44 @@ sandbox.git.delete_branch('workspace/repo', 'feature/old-feature')
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Create new branch
+    err := sandbox.Git.CreateBranch(ctx, "workspace/repo", "feature/new-feature")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Switch branch
+    err = sandbox.Git.CheckoutBranch(ctx, "workspace/repo", "feature/new-feature")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Delete branch
+    err = sandbox.Git.DeleteBranch(ctx, "workspace/repo", "feature/old-feature")
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [create_branch (Python SDK)](/docs/python-sdk/sync/git/#gitcreate_branch), [checkout_branch (Python SDK)](/docs/python-sdk/sync/git/#gitcheckout_branch), [delete_branch (Python SDK)](/docs/python-sdk/sync/git/#gitdelete_branch), [createBranch (TypeScript SDK)](/docs/typescript-sdk/git/#createbranch), [checkoutBranch (TypeScript SDK)](/docs/typescript-sdk/git/#checkoutbranch), [deleteBranch (TypeScript SDK)](/docs/typescript-sdk/git/#deletebranch), [create_branch (Ruby SDK)](/docs/ruby-sdk/git/#create_branch), [checkout_branch (Ruby SDK)](/docs/ruby-sdk/git/#checkout_branch), [delete_branch (Ruby SDK)](/docs/ruby-sdk/git/#delete_branch)
@@ -272,6 +295,44 @@ sandbox.git.commit('workspace/repo', 'feat: add new feature', 'John Doe', 'john@
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Stage specific files
+    err := sandbox.Git.Add(ctx, "workspace/repo", []string{"file1.txt", "file2.txt"})
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Stage all changes
+    err = sandbox.Git.Add(ctx, "workspace/repo", []string{"."})
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Commit changes
+    err = sandbox.Git.Commit(ctx, "workspace/repo", "feat: add new feature", "John Doe", "john@example.com")
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [add (Python SDK)](/docs/python-sdk/sync/git/#gitadd), [commit (Python SDK)](/docs/python-sdk/sync/git/#gitcommit), [add (TypeScript SDK)](/docs/typescript-sdk/git/#add), [commit (TypeScript SDK)](/docs/typescript-sdk/git/#commit), [add (Ruby SDK)](/docs/ruby-sdk/git/#add), [commit (Ruby SDK)](/docs/ruby-sdk/git/#commit)
@@ -316,6 +377,44 @@ sandbox.git.pull('workspace/repo')
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Stage specific files
+    err := sandbox.Git.Add(ctx, "workspace/repo", []string{"file1.txt", "file2.txt"})
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Stage all changes
+    err = sandbox.Git.Add(ctx, "workspace/repo", []string{"."})
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Commit changes
+    err = sandbox.Git.Commit(ctx, "workspace/repo", "feat: add new feature", "John Doe", "john@example.com")
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [push (Python SDK)](/docs/python-sdk/sync/git/#gitpush), [pull (Python SDK)](/docs/python-sdk/sync/git/#gitpull), [push (TypeScript SDK)](/docs/typescript-sdk/git/#push), [pull (TypeScript SDK)](/docs/typescript-sdk/git/#pull), [push (Ruby SDK)](/docs/ruby-sdk/git/#push), [pull (Ruby SDK)](/docs/ruby-sdk/git/#pull)

--- a/apps/docs/src/content/docs/en/guides/data-analysis-with-ai.mdx
+++ b/apps/docs/src/content/docs/en/guides/data-analysis-with-ai.mdx
@@ -42,6 +42,43 @@ Install the Daytona SDK and Anthropic SDK to your project:
   <TabItem label="Ruby" icon="seti:ruby">
     `bash gem install daytona anthropic dotenv `
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 #### 1.2 Configure Environment
@@ -119,6 +156,41 @@ Now create a [Daytona sandbox](/docs/en/sandboxes/#basic-sandbox-creation) and u
     # Upload the dataset to the sandbox
     sandbox.fs.upload_file(File.read('dataset.csv'), '/home/daytona/dataset.csv')
     ```
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Upload a file
+    content := []byte("Hello, Daytona!")
+    err := sandbox.FileSystem.UploadFile(ctx, content, "workspace/hello.txt")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Download a file
+    downloadedContent, err := sandbox.FileSystem.DownloadFile(ctx, "workspace/hello.txt", nil)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("File content: %s\n", string(downloadedContent))
+}
+    ```
+
   </TabItem>
 </Tabs>
 

--- a/apps/docs/src/content/docs/en/index.mdx
+++ b/apps/docs/src/content/docs/en/index.mdx
@@ -23,7 +23,7 @@ Daytona is an open-source, secure and elastic infrastructure for running AI-gene
 
 Daytona provides isolated sandbox environments that you can manage programmatically using the Daytona SDK to run and control code execution.
 
-Daytona SDK is available for [Python](/docs/en/python-sdk), [TypeScript](/docs/en/typescript-sdk) and [Ruby](/docs/en/ruby-sdk) interfaces.
+Daytona SDK is available for [Python](/docs/en/python-sdk), [TypeScript](/docs/en/typescript-sdk), [Ruby](/docs/en/ruby-sdk), and [Go](/docs/en/go-sdk) interfaces.
 
 ## Create an account
 
@@ -39,7 +39,7 @@ Daytona supports multiple options to configure your environment: [in code](/docs
 
 ## Install the SDK
 
-Install the Daytona SDK to interact with sandboxes from your code using [Python](/docs/python-sdk), [TypeScript](/docs/typescript-sdk) or [Ruby](/docs/ruby-sdk).
+Install the Daytona SDK to interact with sandboxes from your code using [Python](/docs/python-sdk), [TypeScript](/docs/typescript-sdk), [Ruby](/docs/ruby-sdk), or [Go](/docs/go-sdk).
 
 <Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
@@ -58,9 +58,13 @@ Install the Daytona SDK to interact with sandboxes from your code using [Python]
 
   </TabItem>
 
-  <TabItem label="Ruby" icon="seti:ruby">
+<TabItem label="Ruby" icon="seti:ruby">
+  ```bash gem install daytona ```
+</TabItem>
+
+  <TabItem label="Go" icon="seti:go">
     ```bash
-    gem install daytona
+    go get github.com/daytonaio/daytona/libs/sdk-go
     ```
   </TabItem>
 </Tabs>
@@ -128,6 +132,62 @@ Create a Daytona Sandbox to run your code securely in an isolated environment.
     # Clean up
     daytona.delete(sandbox)
     ```
+
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    Create a file named: `main.go`
+
+    ```go
+    package main
+
+    import (
+        "context"
+        "log"
+
+        "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+        "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+    )
+
+    func main() {
+        // Initialize the Daytona client
+        config := &types.DaytonaConfig{
+            APIKey: "your-api-key",
+        }
+        client, err := daytona.NewClientWithConfig(config)
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        ctx := context.Background()
+
+        // Create the Sandbox instance
+        params := types.SnapshotParams{
+            SandboxBaseParams: types.SandboxBaseParams{
+                Language: types.CodeLanguagePython,
+            },
+        }
+        sandbox, err := client.Create(ctx, params)
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        // Run the code securely inside the Sandbox
+        result, err := sandbox.Process.ExecuteCommand(ctx, "echo 'Hello World from code!'")
+        if err != nil {
+            log.Fatalf("Error: %v", err)
+        }
+        if result.ExitCode != 0 {
+            log.Printf("Error: %d %s", result.ExitCode, result.Result)
+        } else {
+            log.Println(result.Result)
+        }
+
+        // Clean up
+        sandbox.Delete(ctx)
+    }
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -219,6 +279,67 @@ response = sandbox.process.code_run(code: 'print("Hello World")')
 ```
 
 </TabItem>
+
+<TabItem label="Go" icon="seti:go">
+
+`main.go`
+
+```go
+// Import the Daytona SDK
+package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    // Define the configuration
+    config := &types.DaytonaConfig{
+        APIKey: "YOUR_API_KEY", // Replace with your API key
+    }
+
+    // Initialize the Daytona client
+    client, err := daytona.NewClientWithConfig(config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create the Sandbox instance
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Run the code securely inside the Sandbox
+    result, err := sandbox.Process.ExecuteCommand(ctx, `echo "Hello World"`)
+
+    // Check the response
+    if err != nil {
+        log.Fatalf("Error: %v", err)
+    }
+    if result.ExitCode != 0 {
+        log.Printf("Error: %d %s", result.ExitCode, result.Result)
+    } else {
+        log.Println(result.Result)
+    }
+
+    // Clean up
+    sandbox.Delete(ctx)
+}
+```
+
+</TabItem>
 </Tabs>
 
 ## Run code
@@ -242,11 +363,26 @@ npx tsx index.mts
 
 </TabItem>
 
+<TabItem label="Ruby" icon="seti:ruby">
+
+```bash
+ruby main.rb
+```
+
+</TabItem>
+
+<TabItem label="Go" icon="seti:go">
+
+```bash
+go run main.go
+```
+
+</TabItem>
+</Tabs>
+
 ```text
 Hello World
 ```
-
-</Tabs>
 
 ## Summary
 

--- a/apps/docs/src/content/docs/en/language-server-protocol.mdx
+++ b/apps/docs/src/content/docs/en/language-server-protocol.mdx
@@ -68,6 +68,35 @@ lsp_server = sandbox.create_lsp_server(
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Start LSP server
+    lspID := "python-lsp"
+    err := sandbox.LSP.Start(ctx, lspID, "python")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("LSP server started: %s\n", lspID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [create_lsp_server (Python SDK)](/docs/python-sdk/sync/sandbox#sandboxcreate_lsp_server), [createLspServer (TypeScript SDK)](/docs/typescript-sdk/sandbox#createlspserver), [create_lsp_server (Ruby SDK)](/docs/ruby-sdk/sandbox#create_lsp_server)
@@ -120,6 +149,35 @@ completions = lsp_server.completions(
 puts "Completions: #{completions}"
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Start LSP server
+    lspID := "python-lsp"
+    err := sandbox.LSP.Start(ctx, lspID, "python")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("LSP server started: %s\n", lspID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [completions (Python SDK)](/docs/python-sdk/sync/lsp-server/#lspservercompletions), [completions (TypeScript SDK)](/docs/typescript-sdk/lsp-server/#completions), [completions (Ruby SDK)](/docs/ruby-sdk/lsp-server/#completions)

--- a/apps/docs/src/content/docs/en/limits.mdx
+++ b/apps/docs/src/content/docs/en/limits.mdx
@@ -150,6 +150,43 @@ All errors include [**`headers`**](#rate-limit-headers) and [**`statusCode`**](#
     end
     ```
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/python-sdk/common/errors) and [TypeScript SDK](/docs/typescript-sdk/errors) references.

--- a/apps/docs/src/content/docs/en/log-streaming.mdx
+++ b/apps/docs/src/content/docs/en/log-streaming.mdx
@@ -154,6 +154,37 @@ import { TabItem, Tabs } from '@astrojs/starlight/components'
   ```
 
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Stream logs
+    logChan, err := sandbox.StreamLogs(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for logLine := range logChan {
+        fmt.Printf("[LOG] %s\n", logLine)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [get_session_command_logs_async (Python SDK)](/docs/python-sdk/sync/process/#processget_session_command_logs_async), [getSessionCommandLogs (TypeScript SDK)](/docs/typescript-sdk/process/#getsessioncommandlogs), [get_session_command_logs_stream (Ruby SDK)](/docs/ruby-sdk/process/#get_session_command_logs_stream)
@@ -281,6 +312,32 @@ periodically check all existing logs, you can use the following example to get t
 
   daytona.delete(sandbox)
   ```
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Delete sandbox
+    err := sandbox.Delete(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
+
   </TabItem>
 </Tabs>
 

--- a/apps/docs/src/content/docs/en/network-limits.mdx
+++ b/apps/docs/src/content/docs/en/network-limits.mdx
@@ -88,6 +88,38 @@ sandbox = daytona.create(
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+
+    page := 1
+    limit := 10
+    snapshots, err := client.Snapshot.List(ctx, &page, &limit)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Total snapshots: %d\n", snapshots.Total)
+    for _, snap := range snapshots.Items {
+        fmt.Printf("  - %s (State: %s)\n", snap.Name, snap.State)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 

--- a/apps/docs/src/content/docs/en/preview.mdx
+++ b/apps/docs/src/content/docs/en/preview.mdx
@@ -72,6 +72,33 @@ puts "Preview link token: #{preview_info.token}"
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Get preview link for port 3000
+    previewURL, err := sandbox.GetPreviewLink(ctx, 3000)
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Printf("Preview URL: %s\n", previewURL)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [get_preview_link (Python SDK)](/docs/python-sdk/sync/sandbox/#sandboxget_preview_link), [getPreviewLink (TypeScript SDK)](/docs/typescript-sdk/sandbox/#getpreviewlink), [preview_url (Ruby SDK)](/docs/ruby-sdk/sandbox/#preview_url)
@@ -148,6 +175,33 @@ puts "URL: #{signed_url.url}"
 puts "Token: #{signed_url.token}"
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Get preview link for port 3000
+    previewURL, err := sandbox.GetPreviewLink(ctx, 3000)
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Printf("Preview URL: %s\n", previewURL)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [create_signed_preview_url (Python SDK)](/docs/python-sdk/sync/sandbox/#sandboxcreate_signed_preview_url), [getSignedPreviewUrl (TypeScript SDK)](/docs/typescript-sdk/sandbox/#getsignedpreviewurl), [preview_url (Ruby SDK)](/docs/ruby-sdk/sandbox/#preview_url)

--- a/apps/docs/src/content/docs/en/process-code-execution.mdx
+++ b/apps/docs/src/content/docs/en/process-code-execution.mdx
@@ -98,6 +98,41 @@ response = sandbox.process.code_run(
 puts response.result
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, _ := client.Create(ctx, params)
+
+    // Run Python code
+    result, err := sandbox.Process.ExecuteCommand(ctx, \`python -c 'print("Hello, Daytona!")'\`)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(result.Result)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [code_run (Python SDK)](/docs/python-sdk/sync/process/#processcode_run), [codeRun (TypeScript SDK)](/docs/typescript-sdk/process/#coderun), [code_run (Ruby SDK)](/docs/ruby-sdk/process/#code_run)
@@ -258,6 +293,32 @@ puts response.result
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Stop sandbox
+    err := sandbox.Stop(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [exec (Python SDK)](/docs/python-sdk/sync/process/#processexec), [executeCommand (TypeScript SDK)](/docs/typescript-sdk/process/#executecommand), [exec (Ruby SDK)](/docs/ruby-sdk/process/#exec)
@@ -324,6 +385,41 @@ end
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, _ := client.Create(ctx, params)
+
+    // Run Python code
+    result, err := sandbox.Process.ExecuteCommand(ctx, \`python -c 'print("Hello, Daytona!")'\`)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(result.Result)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [get_session (Python SDK)](/docs/python-sdk/sync/process/#processget_session), [list_sessions (Python SDK)](/docs/python-sdk/sync/process/#processlist_sessions), [getSession (TypeScript SDK)](/docs/typescript-sdk/process/#getsession), [listSessions (TypeScript SDK)](/docs/typescript-sdk/process/#listsessions), [get_session (Ruby SDK)](/docs/ruby-sdk/process/#get_session), [list_sessions (Ruby SDK)](/docs/ruby-sdk/process/#list_sessions)
@@ -380,6 +476,32 @@ The following best practices apply to managing resources when executing processe
    end
    ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Delete sandbox
+    err := sandbox.Delete(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 See: [create_session (Python SDK)](/docs/python-sdk/sync/process/#processcreate_session), [delete_session (Python SDK)](/docs/python-sdk/sync/process/#processdelete_session), [createSession (TypeScript SDK)](/docs/typescript-sdk/process/#createsession), [deleteSession (TypeScript SDK)](/docs/typescript-sdk/process/#deletesession), [create_session (Ruby SDK)](/docs/ruby-sdk/process/#create_session), [delete_session (Ruby SDK)](/docs/ruby-sdk/process/#delete_session)
@@ -428,6 +550,41 @@ rescue Daytona::ProcessExecutionError => e
 end
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, _ := client.Create(ctx, params)
+
+    // Run Python code
+    result, err := sandbox.Process.ExecuteCommand(ctx, \`python -c 'print("Hello, Daytona!")'\`)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(result.Result)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 ## Common Issues

--- a/apps/docs/src/content/docs/en/pty.mdx
+++ b/apps/docs/src/content/docs/en/pty.mdx
@@ -131,6 +131,41 @@ puts "Session completed with exit code: #{pty_handle.exit_code}"
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, _ := client.Create(ctx, params)
+
+    // Run Python code
+    result, err := sandbox.Process.ExecuteCommand(ctx, \`python -c 'print("Hello, Daytona!")'\`)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(result.Result)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 ## Long-Running Processes with PTY
@@ -235,6 +270,41 @@ puts "Termination reason: #{pty_handle.error}" if pty_handle.error
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, _ := client.Create(ctx, params)
+
+    // Run Python code
+    result, err := sandbox.Process.ExecuteCommand(ctx, \`python -c 'print("Hello, Daytona!")'\`)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(result.Result)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 ## Best Practices
@@ -288,6 +358,35 @@ ensure
 end
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Create PTY session
+    ptyID := "my-pty-session"
+    err := sandbox.Process.CreatePTY(ctx, ptyID)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("PTY session created: %s\n", ptyID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 ### Error Handling
@@ -327,6 +426,41 @@ if pty_handle.exit_code != 0
 end
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, _ := client.Create(ctx, params)
+
+    // Run Python code
+    result, err := sandbox.Process.ExecuteCommand(ctx, \`python -c 'print("Hello, Daytona!")'\`)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(result.Result)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 ## Common Use Cases

--- a/apps/docs/src/content/docs/en/regions.mdx
+++ b/apps/docs/src/content/docs/en/regions.mdx
@@ -25,13 +25,16 @@ Regions are geographic or logical groupings of runners that execute sandbox work
 from daytona import Daytona, DaytonaConfig
 
 # Configure Daytona to use the US region
+
 config = DaytonaConfig(
-    target="us"
+target="us"
 )
 
 # Initialize the Daytona client with the specified configuration
+
 daytona = Daytona(config)
-```
+
+````
 </TabItem>
 <TabItem label="TypeScript" icon="seti:typescript">
 ```typescript
@@ -41,7 +44,48 @@ import { Daytona } from '@daytonaio/sdk';
 const daytona: Daytona = new Daytona({
     target: "eu"
 });
-```
+````
+
+</TabItem>
+
+<TabItem label="Ruby" icon="seti:ruby">
+```ruby
+require 'daytona'
+
+# Configure Daytona to use the EU region
+
+config = Daytona::Config.new(target: 'eu')
+daytona = Daytona::Daytona.new(config)
+
+````
+</TabItem>
+
+<TabItem label="Go" icon="seti:go">
+```go
+package main
+
+import (
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    // Configure Daytona to use the EU region
+    config := &types.DaytonaConfig{
+        Target: "eu",
+    }
+
+    client, err := daytona.NewClientWithConfig(config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Daytona client configured for region: %s\n", config.Target)
+}
+````
+
 </TabItem>
 </Tabs>
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -108,91 +108,40 @@ Running sandboxes utilize CPU, memory, and disk storage. Every resource is charg
     ```
 
   </TabItem>
-</Tabs>
 
-To get the preview URL for a specific port, check out [Preview & Authentication](/docs/en/preview-and-authentication).
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
 
-For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/), and [Ruby SDK](/docs/en/ruby-sdk/) references:
+import (
+    "context"
+    "log"
 
-> [**create (Python SDK)**](/docs/en/python-sdk/sync/daytona#daytonacreate)
->
-> [**create (TypeScript SDK)**](/docs/en/typescript-sdk/daytona#create)
->
-> [**create (Ruby SDK)**](/docs/en/ruby-sdk/daytona#create)
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
 
-### Resources
-
-Daytona Sandbox uses **1 vCPU**, **1GB RAM**, and **3GiB disk** by default.
-
-Daytona keeps a pool of warm sandboxes using default snapshots.
-When available, sandboxes launch within milliseconds instead of cold-booting.
-
-To set custom sandbox resources (CPU, memory, and disk space), use the `Resources` class:
-
-<Tabs syncKey="language">
-  <TabItem label="Python" icon="seti:python">
-    ```python
-    from daytona import Daytona, Resources, CreateSandboxFromImageParams, Image
-
-    daytona = Daytona()
-
-    # Create a sandbox with custom resources
-    resources = Resources(
-        cpu=2,    # 2 CPU cores
-        memory=4, # 4GB RAM
-        disk=8,   # 8GB disk space
-    )
-
-    params = CreateSandboxFromImageParams(
-        image=Image.debian_slim("3.12"),
-        resources=resources
-    )
-
-    sandbox = daytona.create(params)
-    ```
-
-  </TabItem>
-
-  <TabItem label="TypeScript" icon="seti:typescript">
-    ```typescript
-    import { Daytona, Image } from "@daytonaio/sdk";
-
-    async function main() {
-      const daytona = new Daytona();
-
-      // Create a sandbox with custom resources
-      const sandbox = await daytona.create({
-        image: Image.debianSlim("3.13"),
-        resources: {
-          cpu: 2,     // 2 CPU cores
-          memory: 4,  // 4GB RAM
-          disk: 8,    // 8GB disk space
-        },
-      });
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
     }
 
-    main();
-    ```
+    ctx := context.Background()
 
-  </TabItem>
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
 
-  <TabItem label="Ruby" icon="seti:ruby">
-    ```ruby
-    require 'daytona'
-
-    daytona = Daytona::Daytona.new
-
-    # Create a sandbox with custom resources
-    sandbox = daytona.create(
-      Daytona::CreateSandboxFromImageParams.new(
-        image: Daytona::Image.debian_slim('3.12'),
-        resources: Daytona::Resources.new(
-          cpu: 2,     # 2 CPU cores
-          memory: 4,  # 4GB RAM
-          disk: 8     # 8GB disk space
-        )
-      )
-    )
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
     ```
 
   </TabItem>
@@ -259,6 +208,43 @@ To create an ephemeral Sandbox, set the `ephemeral` parameter to `True` when cre
     ```
 
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 :::note
@@ -305,6 +291,43 @@ Starting sandbox with ID: <sandbox-id>
     sandbox = daytona.create(Daytona::CreateSandboxFromSnapshotParams.new(language: Daytona::CodeLanguage::PYTHON))
     # Start Sandbox
     sandbox.start
+    ```
+
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
     ```
 
   </TabItem>
@@ -367,6 +390,43 @@ Daytona provides options to view information about sandboxes (ID, root directory
     puts sandbox.id
     puts sandbox.auto_stop_interval
     puts sandbox.state
+    ```
+
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
     ```
 
   </TabItem>
@@ -449,6 +509,43 @@ The stopped state should be used when a sandbox is expected to be started again 
     ```
 
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/python-sdk/sync/sandbox#sandboxstop), [TypeScript SDK](/docs/typescript-sdk/sandbox#stop), and [Ruby SDK](/docs/ruby-sdk/sandbox#stop) references:
@@ -474,18 +571,52 @@ A sandbox must be stopped before it can be archived, and can be started again in
     ```
   </TabItem>
 
-  <TabItem label="TypeScript" icon="seti:typescript">
-    ```typescript
-    // Archive Sandbox
-    await sandbox.archive();
-    ```
-  </TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+  ```typescript // Archive Sandbox await sandbox.archive(); ```
+</TabItem>
 
   <TabItem label="Ruby" icon="seti:ruby">
     ```ruby
     # Archive Sandbox
     sandbox.archive
     ```
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -524,6 +655,43 @@ Daytona provides methods to recover sandboxes using Python, TypeScript, and Ruby
     ```ruby
     # Recover sandbox
     sandbox.recover
+    ```
+
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
     ```
 
   </TabItem>
@@ -574,6 +742,43 @@ Recovery actions are not performed automatically because they address errors tha
     end
     ```
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/python-sdk/sync/sandbox#sandboxrecover), [TypeScript SDK](/docs/typescript-sdk/sandbox#recover), and [Ruby SDK](/docs/ruby-sdk/sandbox#recover) references:
@@ -603,18 +808,52 @@ Stopping sandbox with ID: <sandbox-id>
     ```
   </TabItem>
 
-  <TabItem label="TypeScript" icon="seti:typescript">
-    ```typescript
-    // Delete sandbox
-    await sandbox.delete();
-    ```
-  </TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+  ```typescript // Delete sandbox await sandbox.delete(); ```
+</TabItem>
 
   <TabItem label="Ruby" icon="seti:ruby">
     ```ruby
     # Delete sandbox
     sandbox.delete
     ```
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -693,6 +932,43 @@ If the parameter is not set, the default interval of `15` minutes will be used.
     )
     ```
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/python-sdk/sync/sandbox#sandboxset_autostop_interval), [TypeScript SDK](/docs/typescript-sdk/sandbox#set_auto_stop_interval), and [Ruby SDK](/docs/ruby-sdk/sandbox#set_auto_stop_interval) references:
@@ -745,6 +1021,43 @@ If the parameter is not set, the default interval of `7 days` days will be used.
       )
     )
     ```
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -821,6 +1134,43 @@ If the parameter is not set, the sandbox will not be deleted automatically.
     ```
 
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/python-sdk/sync/sandbox#sandboxset_auto_delete_interval), [TypeScript SDK](/docs/typescript-sdk/sandbox#set_auto_delete_interval), and [Ruby SDK](/docs/ruby-sdk/sandbox#set_auto_delete_interval) references:
@@ -866,5 +1216,42 @@ By default, Daytona Sandboxes auto-stop after 15 minutes of inactivity. To keep 
       )
     )
     ```
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
+
   </TabItem>
 </Tabs>

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -230,122 +230,45 @@ daytona.snapshot.create(
 ```
 
 </TabItem>
-</Tabs>
 
-For more information, see the [Python SDK](/docs/python-sdk), [TypeScript SDK](/docs/typescript-sdk), and [Ruby SDK](/docs/ruby-sdk) references:
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
 
-> [**CreateSnapshotParams (Python SDK)**](/docs/python-sdk/sync/snapshot#createsnapshotparams)
->
-> [**CreateSnapshotParams (TypeScript SDK)**](/docs/typescript-sdk/snapshot#create)
->
-> [**CreateSnapshotParams (Ruby SDK)**](/docs/ruby-sdk/snapshot#create)
+import (
+    "context"
+    "log"
 
-### Specifying Region
-
-When creating a Snapshot, you can specify the region in which it will be available. If not specified, the Snapshot will be created in your organization's default region. 
-
-When you later create a Sandbox from this Snapshot, you can use the Snapshot's region as the target region for the Sandbox.
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-```python
-from daytona import (
-    Daytona,
-    CreateSnapshotParams,
-    Image,
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
 )
 
-daytona = Daytona()
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
 
-# Create a Snapshot in a specific region
-daytona.snapshot.create(
-  CreateSnapshotParams(
-    name="my-snapshot",
-    image=Image.debian_slim("3.12"),
-    region_id="us",
-  ),
-  on_logs=print,
-)
+    // Create a sandbox with custom resources
+    params := types.ImageParams{
+        Image: types.Image{
+            User: "debian",
+            Tag:  "slim-3.12",
+        },
+        SandboxBaseParams: types.SandboxBaseParams{
+            Resources: &types.Resources{
+                CPU:    2,    // 2 CPU cores
+                Memory: 4,    // 4GB RAM
+                Disk:   8,    // 8GB disk space
+            },
+        },
+    }
 
-```
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-```typescript
-import { Daytona, Image } from "@daytonaio/sdk";
-
-const daytona = new Daytona();
-
-// Create a Snapshot in a specific region
-await daytona.snapshot.create(
-  {
-    name: "my-snapshot",
-    image: Image.debianSlim("3.13"),
-    regionId: "us",
-  },
-  { onLogs: console.log }
-);
-```
-
-  </TabItem>
-
-  <TabItem label="Ruby" icon="seti:ruby">
-```ruby
-require 'daytona'
-
-daytona = Daytona::Daytona.new
-
-# Create a Snapshot with custom resources
-daytona.snapshot.create(
-  Daytona::CreateSnapshotParams.new(
-    name: 'my-snapshot',
-    image: Daytona::Image.debian_slim('3.12'),
-    # All resource parameters are optional:
-    resources: Daytona::Resources.new(
-      cpu: 2,
-      memory: 4,
-      disk: 8
-    )
-  ),
-  on_logs: proc { |chunk| puts chunk }
-)
-```
-
-  </TabItem>
-</Tabs>
-
-## Get a Snapshot by name
-
-Daytona provides an option to get a snapshot by name.
-
-The following snippet returns the snapshot with the specified name:
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-
-```python
-daytona = Daytona()
-snapshot = daytona.snapshot.get("my-awesome-snapshot")
-print(f"{snapshot.name} ({snapshot.image_name})")
-```
-
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-
-```typescript
-const daytona = new Daytona()
-const snapshot = await daytona.snapshot.get('my-awesome-snapshot')
-console.log(`Snapshot ${snapshot.name} is in state ${snapshot.state}`)
-```
-
-  </TabItem>
-
-  <TabItem label="Ruby" icon="seti:ruby">
-
-```ruby
-daytona = Daytona::Daytona.new
-snapshot = daytona.snapshot.get('my-awesome-snapshot')
-puts "#{snapshot.name} (#{snapshot.image_name})"
-```
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
 
   </TabItem>
 </Tabs>
@@ -397,6 +320,38 @@ result.items.each do |snapshot|
   puts "#{snapshot.name} (#{snapshot.image_name})"
 end
 ```
+
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+
+    page := 1
+    limit := 10
+    snapshots, err := client.Snapshot.List(ctx, &page, &limit)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Total snapshots: %d\n", snapshots.Total)
+    for _, snap := range snapshots.Items {
+        fmt.Printf("  - %s (State: %s)\n", snap.Name, snap.State)
+    }
+}
+    ```
 
   </TabItem>
 </Tabs>
@@ -465,6 +420,32 @@ daytona.snapshot.delete('my-awesome-snapshot')
 puts 'Snapshot deleted'
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Delete sandbox
+    err := sandbox.Delete(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/python-sdk/), [TypeScript SDK](/docs/typescript-sdk/), and [Ruby SDK](/docs/ruby-sdk/) references:

--- a/apps/docs/src/content/docs/en/ssh-access.mdx
+++ b/apps/docs/src/content/docs/en/ssh-access.mdx
@@ -57,80 +57,41 @@ puts "SSH Token: #{ssh_access.token}"
 ```
 
 </TabItem>
-</Tabs>
 
-## Connection Command
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
 
-Once you have your token, connect using:
+import (
+    "context"
+    "log"
 
-```bash
-ssh <token>@ssh.app.daytona.io
-```
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
 
-## Connecting with VSCode
+func main() {
+    client, err := daytona.NewClient()
+    if err != nil {
+        log.Fatal(err)
+    }
 
-Connecting your local VSCode to a sandbox requires a few simple steps:
+    ctx := context.Background()
 
-1. Make sure that the [Remote Explorer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-explorer) is installed in your VSCode.
-2. Add a new SSH connection
-3. When prompted for the SSH connection URL, paste your SSH command from above.
+    // Create a sandbox
+    params := types.SnapshotParams{
+        SandboxBaseParams: types.SandboxBaseParams{
+            Language: types.CodeLanguagePython,
+        },
+    }
+    sandbox, err := client.Create(ctx, params)
+    if err != nil {
+        log.Fatal(err)
+    }
 
-Find out more about the extension [here](https://code.visualstudio.com/docs/remote/ssh).
+    log.Printf("Created sandbox: %s\n", sandbox.ID)
+}
+    ```
 
-## Connecting with JetBrains IDEs
-
-Connecting your local JetBrains IDEs to a sandbox requires a few simple steps:
-
-1. Download the [JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/) app to your local machine.
-2. Add a new connection.
-3. When prompted for the SSH connection URL, paste your SSH command from above.
-4. Choose an IDE you want installed in your sandbox.
-
-## Managing SSH Access
-
-### Token Expiration
-
-SSH access tokens expire automatically for security:
-
-- **Default**: 60 minutes
-
-### Revoking Access
-
-You can revoke SSH access tokens at any time:
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-
-```python
-# Revoke all SSH access for the sandbox
-sandbox.revoke_ssh_access()
-
-# Revoke specific SSH access for the sandbox
-sandbox.revoke_ssh_access(token="specific-token")
-```
-
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-
-```typescript
-// Revoke all SSH access for the sandbox
-await sandbox.revokeSshAccess()
-
-// Revoke specific SSH access for the sandbox
-await sandbox.revokeSshAccess('specific-token')
-```
-
-</TabItem>
-
-<TabItem label="Ruby" icon="seti:ruby">
-
-```ruby
-# Revoke all SSH access for the sandbox
-sandbox.revoke_ssh_access
-
-# Revoke specific SSH access for the sandbox
-sandbox.revoke_ssh_access(token: 'specific-token')
-```
-
-</TabItem>
+  </TabItem>
 </Tabs>

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -43,6 +43,32 @@ The following snippets demonstrate how to create a volume using the Daytona SDK:
     volume = daytona.volume.create("my-awesome-volume")
     ```
   </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+
+    // Create a new volume
+    volume, err := client.Volume.Create(ctx, "my-volume")
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Printf("Created volume: %s\n", volume.Name)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/), and [Ruby SDK](/docs/en/ruby-sdk/) references:
@@ -159,6 +185,32 @@ sandbox2 = daytona.create(params2)
 ```
 
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+
+    // Create a new volume
+    volume, err := client.Volume.Create(ctx, "my-volume")
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Printf("Created volume: %s\n", volume.Name)
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/) and [Ruby SDK](/docs/en/ruby-sdk/) references:
@@ -213,6 +265,41 @@ The following snippet demonstrate how to read from and write to a volume:
     # The volume will persist even after the sandbox is removed
     daytona.delete(sandbox)
     ```
+  </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+    sandbox, _ := client.Create(ctx, nil)
+
+    // Upload a file
+    content := []byte("Hello, Daytona!")
+    err := sandbox.FileSystem.UploadFile(ctx, content, "workspace/hello.txt")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Download a file
+    downloadedContent, err := sandbox.FileSystem.DownloadFile(ctx, "workspace/hello.txt", nil)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("File content: %s\n", string(downloadedContent))
+}
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -316,6 +403,36 @@ volume = daytona.volume.get('my-volume', create: true)
 daytona.volume.delete(volume)
 ```
 </TabItem>
+
+  <TabItem label="Go" icon="seti:go">
+    ```go
+    package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+)
+
+func main() {
+    client, _ := daytona.NewClient()
+    ctx := context.Background()
+
+    // List all volumes
+    volumes, err := client.Volume.List(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, vol := range volumes {
+        fmt.Printf("Volume: %s (ID: %s)\n", vol.Name, vol.ID)
+    }
+}
+    ```
+
+  </TabItem>
 </Tabs>
 
 For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/), and [Ruby SDK](/docs/en/ruby-sdk/) references:


### PR DESCRIPTION
This pull request adds comprehensive Go SDK code examples to the Daytona documentation alongside the existing Python, TypeScript, and Ruby samples.