### PR TITLE
feat: redis auth

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -88,13 +88,7 @@ import { AdminModule } from './admin/admin.module'
           cache: {
             type: 'ioredis',
             ignoreErrors: true,
-            options: {
-              keyPrefix: 'typeorm:',
-              host: configService.get('redis.host'),
-              port: configService.get('redis.port'),
-              tls: configService.get('redis.tls'),
-              lazyConnect: configService.get('skipConnections'),
-            },
+            options: configService.getRedisConfig({ keyPrefix: 'typeorm:' }),
           },
           entitySkipConstructor: true,
         }
@@ -119,33 +113,18 @@ import { AdminModule } from './admin/admin.module'
     }),
     RedisModule.forRootAsync({
       inject: [TypedConfigService],
-      useFactory: (configService: TypedConfigService) => {
-        return {
-          type: 'single',
-          options: {
-            host: configService.getOrThrow('redis.host'),
-            port: configService.getOrThrow('redis.port'),
-            tls: configService.get('redis.tls'),
-            lazyConnect: configService.get('skipConnections'),
-          },
-        }
-      },
+      useFactory: (configService: TypedConfigService) => ({
+        type: 'single',
+        options: configService.getRedisConfig(),
+      }),
     }),
     RedisModule.forRootAsync(
       {
         inject: [TypedConfigService],
-        useFactory: (configService: TypedConfigService) => {
-          return {
-            type: 'single',
-            options: {
-              host: configService.getOrThrow('redis.host'),
-              port: configService.getOrThrow('redis.port'),
-              tls: configService.get('redis.tls'),
-              lazyConnect: configService.get('skipConnections'),
-              db: 1,
-            },
-          }
-        },
+        useFactory: (configService: TypedConfigService) => ({
+          type: 'single',
+          options: configService.getRedisConfig({ db: 1 }),
+        }),
       },
       'throttler',
     ),

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -24,6 +24,8 @@ const configuration = {
   redis: {
     host: process.env.REDIS_HOST,
     port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    username: process.env.REDIS_USERNAME,
+    password: process.env.REDIS_PASSWORD,
     tls: process.env.REDIS_TLS === 'true' ? {} : undefined,
   },
   posthog: {

--- a/apps/api/src/config/typed-config.service.ts
+++ b/apps/api/src/config/typed-config.service.ts
@@ -11,6 +11,7 @@ import { AwsSigv4Signer, AwsSigv4SignerResponse } from '@opensearch-project/open
 import { defaultProvider } from '@aws-sdk/credential-provider-node'
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers'
 import { ClientOptions } from '@opensearch-project/opensearch'
+import { RedisOptions } from 'ioredis'
 
 type Configuration = typeof configuration
 
@@ -157,6 +158,23 @@ export class TypedConfigService {
           rejectUnauthorized: this.get('opensearch.tls.rejectUnauthorized'),
         },
       }
+    }
+  }
+
+  /**
+   * Get the Redis configuration
+   * @param overrides Optional overrides for the Redis configuration
+   * @returns The Redis configuration
+   */
+  getRedisConfig(overrides?: Partial<RedisOptions>): RedisOptions {
+    return {
+      host: this.getOrThrow('redis.host'),
+      port: this.getOrThrow('redis.port'),
+      username: this.get('redis.username'),
+      password: this.get('redis.password'),
+      tls: this.get('redis.tls'),
+      lazyConnect: this.get('skipConnections'),
+      ...overrides,
     }
   }
 }


### PR DESCRIPTION
## Description

- Added getRedisConfig() helper to TypedConfigService following existing patterns for Kafka and OpenSearch
- Consolidated Redis connection config across TypeORM cache, RedisModule, and throttler RedisModule