### PR TITLE
feat(sdk,docs): adding resize to the golang and ruby sdks

### DIFF
--- a/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
@@ -789,6 +789,10 @@ the sandbox must be stopped first.
 
 - `void`
 
+**Raises**:
+
+- `Sdk:Error` -
+
 **Examples:**
 
 ```ruby

--- a/examples/go/lifecycle/main.go
+++ b/examples/go/lifecycle/main.go
@@ -104,30 +104,6 @@ func main() {
 		log.Printf("First sandbox -> ID: %s, State: %s\n", sandboxList.Items[0].ID, sandboxList.Items[0].State)
 	}
 
-	// Resize a started sandbox (CPU and memory can be increased)
-	log.Println("\nResizing started sandbox...")
-	resources := &types.Resources{CPU: 2, Memory: 2}
-	if err := sandbox.Resize(ctx, resources); err != nil {
-		log.Fatalf("Failed to resize sandbox: %v", err)
-	}
-	log.Printf("✓ Resize complete: CPU=%d, Memory=%d\n", resources.CPU, resources.Memory)
-
-	// Resize a stopped sandbox (CPU, memory, and disk can be changed)
-	log.Println("\nStopping sandbox for resize...")
-	if err := sandbox.Stop(ctx); err != nil {
-		log.Fatalf("Failed to stop sandbox: %v", err)
-	}
-	log.Println("Resizing stopped sandbox...")
-	resources = &types.Resources{CPU: 4, Memory: 4, Disk: 20}
-	if err := sandbox.Resize(ctx, resources); err != nil {
-		log.Fatalf("Failed to resize sandbox: %v", err)
-	}
-	log.Printf("✓ Resize complete: CPU=%d, Memory=%d, Disk=%d\n", resources.CPU, resources.Memory, resources.Disk)
-	if err := sandbox.Start(ctx); err != nil {
-		log.Fatalf("Failed to start sandbox: %v", err)
-	}
-	log.Println("✓ Sandbox restarted with new resources")
-
 	// Delete the sandbox
 	log.Println("\nDeleting sandbox...")
 	if err := sandbox.Delete(ctx); err != nil {

--- a/examples/ruby/lifecycle/lifecycle.rb
+++ b/examples/ruby/lifecycle/lifecycle.rb
@@ -36,20 +36,6 @@ puts "Total sandboxes count: #{result.total.to_i}"
 
 puts "Printing sandboxes[0] -> id: #{result.items.first.id} state: #{result.items.first.state}"
 
-# Resize a started sandbox (CPU and memory can be increased)
-puts 'Resizing started sandbox...'
-sandbox.resize(Daytona::Resources.new(cpu: 2, memory: 2))
-puts "Resize complete: CPU=#{sandbox.cpu}, Memory=#{sandbox.memory}GB"
-
-# Resize a stopped sandbox (CPU, memory, and disk can be changed)
-puts 'Stopping sandbox for resize...'
-sandbox.stop
-puts 'Resizing stopped sandbox...'
-sandbox.resize(Daytona::Resources.new(cpu: 4, memory: 4, disk: 20))
-puts "Resize complete: CPU=#{sandbox.cpu}, Memory=#{sandbox.memory}GB, Disk=#{sandbox.disk}GB"
-sandbox.start
-puts 'Sandbox restarted with new resources'
-
 puts 'Removing sandbox'
 daytona.delete(sandbox)
 puts 'Sandbox removed'

--- a/libs/sdk-ruby/lib/daytona/sandbox.rb
+++ b/libs/sdk-ruby/lib/daytona/sandbox.rb
@@ -396,6 +396,8 @@ module Daytona
     #   sandbox.stop
     #   sandbox.resize(Daytona::Resources.new(cpu: 2, memory: 4, disk: 30))
     def resize(resources, timeout = DEFAULT_TIMEOUT)
+      raise Sdk::Error, 'Resources must not be nil' if resources.nil?
+
       with_timeout(
         timeout:,
         message: "Sandbox #{id} failed to resize within the #{timeout} seconds timeout period",
@@ -463,7 +465,7 @@ module Daytona
                :preview_url, :create_signed_preview_url, :expire_signed_preview_url,
                :refresh, :refresh_activity, :revoke_ssh_access, :start, :recover, :stop,
                :create_lsp_server, :validate_ssh_access, :wait_for_sandbox_start,
-               :wait_for_sandbox_stop,
+               :wait_for_sandbox_stop, :resize, :wait_for_resize_complete,
                component: 'Sandbox'
 
     private

--- a/libs/toolbox-api-client-go/go.mod
+++ b/libs/toolbox-api-client-go/go.mod
@@ -1,14 +1,3 @@
 module github.com/daytonaio/daytona/libs/toolbox-api-client-go
 
 go 1.23
-
-require github.com/stretchr/testify v1.11.1
-
-require (
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/kr/pretty v0.3.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rogpeppe/go-internal v1.13.1 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)

--- a/libs/toolbox-api-client-go/go.sum
+++ b/libs/toolbox-api-client-go/go.sum
@@ -1,8 +1,0 @@
-github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
-github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Added resize methods to Go and Ruby SDKs, also generated all the API clients. Added a resize paragraph in the Sandboxes documentation.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation