### PR TITLE
feat(api): improve warm pool selection

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -290,6 +290,9 @@ const configuration = {
     userCacheTtlSeconds: parseInt(process.env.API_KEY_USER_CACHE_TTL_SECONDS || '60', 10),
   },
   runnerHealthTimeout: parseInt(process.env.RUNNER_HEALTH_TIMEOUT_SECONDS || '3', 10),
+  warmPool: {
+    candidateLimit: parseInt(process.env.WARM_POOL_CANDIDATE_LIMIT || '300', 10),
+  },
 }
 
 export { configuration }


### PR DESCRIPTION
## Improve warm pool selection

Improves warm pool sandbox retrieval to take a random one from the pool to avoid multiple create calls competing for the same redis lock. Also combines two query (for runners and sandbox) into one and adds a guard that checks that the runner's availability score is over the threshold

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation