### PR TITLE
fix(api): move runner find into if

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -546,16 +546,16 @@ export class SandboxService {
       throw new SandboxError('Runner not found for warm pool sandbox')
     }
 
-    const runner = await this.runnerService.findOne(warmPoolSandbox.runnerId)
-    if (!runner) {
-      throw new NotFoundException(`Runner with ID ${warmPoolSandbox.runnerId} not found`)
-    }
-
     if (
       createSandboxDto.networkBlockAll !== undefined ||
       createSandboxDto.networkAllowList !== undefined ||
       organization.sandboxLimitedNetworkEgress
     ) {
+      const runner = await this.runnerService.findOne(warmPoolSandbox.runnerId)
+      if (!runner) {
+        throw new NotFoundException(`Runner with ID ${warmPoolSandbox.runnerId} not found`)
+      }
+
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
       await runnerAdapter.updateNetworkSettings(
         warmPoolSandbox.id,


### PR DESCRIPTION
## Move runner find into inner scope in warm pool assignments

Minor optimization to avoid warm pool assignments from having to query the runner's existence in the DB for sandboxes with an unlimited network

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
