### PR TITLE
fix(sdk-python): volume subpath regression

### DIFF
--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -401,7 +401,8 @@ class AsyncDaytona:
         volumes = []
         if params.volumes:
             volumes = [
-                SandboxVolume(volume_id=volume.volume_id, mount_path=volume.mount_path) for volume in params.volumes
+                SandboxVolume(volume_id=volume.volume_id, mount_path=volume.mount_path, subpath=volume.subpath)
+                for volume in params.volumes
             ]
 
         # Create sandbox using dictionary

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -353,7 +353,8 @@ class Daytona:
         volumes = []
         if params.volumes:
             volumes = [
-                SandboxVolume(volume_id=volume.volume_id, mount_path=volume.mount_path) for volume in params.volumes
+                SandboxVolume(volume_id=volume.volume_id, mount_path=volume.mount_path, subpath=volume.subpath)
+                for volume in params.volumes
             ]
 
         # Create sandbox using dictionary


### PR DESCRIPTION
## Description

Volume subpath param is not passed in Python SDK.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

closes #3606 
