### PR TITLE
refactor(api): check user has access to sandbox

### DIFF
--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -62,6 +62,12 @@ export class OrganizationUserService {
     })
   }
 
+  async exists(organizationId: string, userId: string): Promise<boolean> {
+    return this.organizationUserRepository.exists({
+      where: { organizationId, userId },
+    })
+  }
+
   async updateAccess(
     organizationId: string,
     userId: string,


### PR DESCRIPTION
This pull request refactors how user access to organization sandboxes is checked in the preview API controller to improve efficiency and clarity. The main change is switching from fetching all organizations for a user and searching for a match, to directly checking if the user exists in the organization using a new method.

**Refactoring access checks in `PreviewController`:**

* Replaced the use of `OrganizationService.findByUser` and manual organization matching with a direct existence check using `OrganizationUserService.exists`, simplifying and optimizing access verification logic.
* Updated dependency injection in `PreviewController` to use `OrganizationUserService` instead of `OrganizationService`. [[1]](diffhunk://#diff-0bba752e304b41d2337d72430cf4610454974a9fced6547ab1479e64bc989c2dL12-R12) [[2]](diffhunk://#diff-0bba752e304b41d2337d72430cf4610454974a9fced6547ab1479e64bc989c2dL23-R23)

**New method added for existence check:**

* Added an `exists` method to `OrganizationUserService` that checks if a user is a member of a specific organization.