### PR TITLE
Loosen Ruby SDK dotenv dependency version constraint

### DIFF
--- a/libs/sdk-ruby/daytona.gemspec
+++ b/libs/sdk-ruby/daytona.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-s3', '~> 1.0'
   spec.add_dependency 'daytona_api_client', Daytona::Sdk::VERSION
   spec.add_dependency 'daytona_toolbox_api_client', Daytona::Sdk::VERSION
-  spec.add_dependency 'dotenv', '~> 2.0'
+  spec.add_dependency 'dotenv', '> 2.0'
   spec.add_dependency 'toml', '~> 0.3'
   spec.add_dependency 'websocket-client-simple', '~> 0.6'
 end


### PR DESCRIPTION
## Description

The current dotenv constrain prevents using a modern version of Ruby dotenv, this loosens those constraints