### PR TITLE
refactor(api): unassigned sandboxes

### DIFF
--- a/apps/api/src/migrations/1770000000000-migration.ts
+++ b/apps/api/src/migrations/1770000000000-migration.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1770000000000 implements MigrationInterface {
+  name = 'Migration1770000000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add unassigned column to sandbox table
+    await queryRunner.query(`ALTER TABLE "sandbox" ADD "unassigned" boolean NOT NULL DEFAULT false`)
+
+    // Set unassigned = true for all existing warm pool sandboxes (organizationId = '00000000-0000-0000-0000-000000000000')
+    await queryRunner.query(
+      `UPDATE "sandbox" SET "unassigned" = true WHERE "organizationId" = '00000000-0000-0000-0000-000000000000'`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sandbox" DROP COLUMN "unassigned"`)
+  }
+}

--- a/apps/api/src/migrations/1770000000001-migration.ts
+++ b/apps/api/src/migrations/1770000000001-migration.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1770000000001 implements MigrationInterface {
+  name = 'Migration1770000000001'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create index for efficient querying of unassigned sandboxes
+    await queryRunner.query(`CREATE INDEX "sandbox_unassigned_idx" ON "sandbox" ("unassigned")`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."sandbox_unassigned_idx"`)
+  }
+}

--- a/apps/api/src/migrations/1770000000002-migration.ts
+++ b/apps/api/src/migrations/1770000000002-migration.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1770000000002 implements MigrationInterface {
+  name = 'Migration1770000000002'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add organizationId column to warm_pool table with default value
+    await queryRunner.query(
+      `ALTER TABLE "warm_pool" ADD "organizationId" uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000'`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "warm_pool" DROP COLUMN "organizationId"`)
+  }
+}

--- a/apps/api/src/migrations/1770000000003-migration.ts
+++ b/apps/api/src/migrations/1770000000003-migration.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1770000000003 implements MigrationInterface {
+  name = 'Migration1770000000003'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Drop the old index
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."warm_pool_find_idx"`)
+
+    // Create the new index with organizationId included
+    await queryRunner.query(
+      `CREATE INDEX "warm_pool_find_idx" ON "warm_pool" ("organizationId", "snapshot", "target", "class", "cpu", "mem", "disk", "gpu", "osUser", "env")`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the new index
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."warm_pool_find_idx"`)
+
+    // Recreate the old index without organizationId
+    await queryRunner.query(
+      `CREATE INDEX "warm_pool_find_idx" ON "warm_pool" ("snapshot", "target", "class", "cpu", "mem", "disk", "gpu", "osUser", "env")`,
+    )
+  }
+}

--- a/apps/api/src/migrations/1770000000004-migration.ts
+++ b/apps/api/src/migrations/1770000000004-migration.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1770000000004 implements MigrationInterface {
+  name = 'Migration1770000000004'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add unassigned column to sandbox_usage_periods table
+    await queryRunner.query(`ALTER TABLE "sandbox_usage_periods" ADD "unassigned" boolean NOT NULL DEFAULT false`)
+
+    // Add unassigned column to sandbox_usage_periods_archive table
+    await queryRunner.query(
+      `ALTER TABLE "sandbox_usage_periods_archive" ADD "unassigned" boolean NOT NULL DEFAULT false`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sandbox_usage_periods_archive" DROP COLUMN "unassigned"`)
+    await queryRunner.query(`ALTER TABLE "sandbox_usage_periods" DROP COLUMN "unassigned"`)
+  }
+}

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -43,6 +43,7 @@ import { BuildInfo } from './build-info.entity'
 @Index('sandbox_pending_idx', ['id'], {
   where: `"pending" = true`,
 })
+@Index('sandbox_unassigned_idx', ['unassigned'])
 @Index('sandbox_labels_gin_full_idx', { synchronize: false })
 export class Sandbox {
   @PrimaryGeneratedColumn('uuid')
@@ -203,6 +204,11 @@ export class Sandbox {
 
   @Column({ default: false })
   pending?: boolean
+
+  //  internal flag to indicate if the sandbox is unassigned (e.g. warm pool)
+  //  unassigned sandboxes are not visible to users and cannot be interacted with
+  @Column({ default: false })
+  unassigned: boolean
 
   @Column({ default: () => 'MD5(random()::text)' })
   authToken: string

--- a/apps/api/src/sandbox/entities/warm-pool.entity.ts
+++ b/apps/api/src/sandbox/entities/warm-pool.entity.ts
@@ -5,12 +5,33 @@
 
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
 import { SandboxClass } from '../enums/sandbox-class.enum'
+import { SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/sandbox.constants'
 
 @Entity()
-@Index('warm_pool_find_idx', ['snapshot', 'target', 'class', 'cpu', 'mem', 'disk', 'gpu', 'osUser', 'env'])
+@Index('warm_pool_find_idx', [
+  'organizationId',
+  'snapshot',
+  'target',
+  'class',
+  'cpu',
+  'mem',
+  'disk',
+  'gpu',
+  'osUser',
+  'env',
+])
 export class WarmPool {
   @PrimaryGeneratedColumn('uuid')
   id: string
+
+  //  The organization this warm pool belongs to.
+  //  If set to SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION, any organization can use this pool.
+  //  If set to a specific organization ID, only that organization can use this pool.
+  @Column({
+    type: 'uuid',
+    default: SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+  })
+  organizationId: string
 
   @Column()
   pool: number

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -89,6 +89,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
             where: {
               runnerId: runner.id,
               organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+              unassigned: false,
               state: SandboxState.STARTED,
               backupState: In([BackupState.NONE, BackupState.COMPLETED]),
               lastBackupAt: Or(IsNull(), LessThan(new Date(Date.now() - 1 * 60 * 60 * 1000))),

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -87,6 +87,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             where: {
               runnerId: runner.id,
               organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+              unassigned: false,
               state: SandboxState.STARTED,
               desiredState: SandboxDesiredState.STARTED,
               pending: Not(true),
@@ -147,6 +148,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       const sandboxes = await this.sandboxRepository.find({
         where: {
           organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+          unassigned: false,
           state: SandboxState.STOPPED,
           desiredState: SandboxDesiredState.STOPPED,
           pending: Not(true),
@@ -203,6 +205,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             where: {
               runnerId: runner.id,
               organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
+              unassigned: false,
               state: SandboxState.STOPPED,
               desiredState: SandboxDesiredState.STOPPED,
               pending: Not(true),

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -327,6 +327,7 @@ export class SandboxService {
     const sandbox = new Sandbox(warmPoolItem.target)
 
     sandbox.organizationId = SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION
+    sandbox.unassigned = true
 
     sandbox.class = warmPoolItem.class
     sandbox.snapshot = warmPoolItem.snapshot
@@ -567,6 +568,7 @@ export class SandboxService {
     warmPoolSandbox.public = createSandboxDto.public || false
     warmPoolSandbox.labels = createSandboxDto.labels || {}
     warmPoolSandbox.organizationId = organization.id
+    warmPoolSandbox.unassigned = false
     warmPoolSandbox.createdAt = new Date()
 
     if (createSandboxDto.autoStopInterval !== undefined) {
@@ -789,6 +791,7 @@ export class SandboxService {
   ): Promise<Sandbox[]> {
     const baseFindOptions: FindOptionsWhere<Sandbox> = {
       organizationId,
+      unassigned: false,
       ...(labels ? { labels: JsonContains(labels) } : {}),
     }
 
@@ -859,6 +862,7 @@ export class SandboxService {
 
     const baseFindOptions: FindOptionsWhere<Sandbox> = {
       organizationId,
+      unassigned: false,
       ...(id ? { id: ILike(`${id}%`) } : {}),
       ...(name ? { name: ILike(`${name}%`) } : {}),
       ...(labels ? { labels: JsonContains(labels) } : {}),
@@ -975,6 +979,7 @@ export class SandboxService {
       where: {
         id: sandboxIdOrName,
         organizationId,
+        unassigned: false,
         ...stateFilter,
       },
       relations,
@@ -990,6 +995,7 @@ export class SandboxService {
         where: {
           name: sandboxIdOrName,
           organizationId,
+          unassigned: false,
           ...stateFilter,
         },
         relations,
@@ -1016,6 +1022,7 @@ export class SandboxService {
     const sandbox = await this.sandboxRepository.findOne({
       where: {
         id: sandboxId,
+        unassigned: false,
         ...(returnDestroyed ? {} : { state: Not(SandboxState.DESTROYED) }),
       },
     })
@@ -1036,6 +1043,7 @@ export class SandboxService {
     let sandbox = await this.sandboxRepository.findOne({
       where: {
         id: sandboxIdOrName,
+        unassigned: false,
         ...(organizationId ? { organizationId: organizationId } : {}),
       },
       select: ['organizationId'],
@@ -1047,6 +1055,7 @@ export class SandboxService {
         where: {
           name: sandboxIdOrName,
           organizationId: organizationId,
+          unassigned: false,
         },
         select: ['organizationId'],
         loadEagerRelations: false,
@@ -1102,6 +1111,7 @@ export class SandboxService {
 
     const where: FindOptionsWhere<Sandbox> = {
       organizationId: organizationId,
+      unassigned: false,
       state: Not(SandboxState.DESTROYED),
     }
 
@@ -1160,6 +1170,7 @@ export class SandboxService {
 
     const where: FindOptionsWhere<Sandbox> = {
       organizationId: organizationId,
+      unassigned: false,
       state: Not(SandboxState.DESTROYED),
     }
 
@@ -1863,7 +1874,7 @@ export class SandboxService {
 
   async isSandboxPublic(sandboxId: string): Promise<boolean> {
     const sandbox = await this.sandboxRepository.findOne({
-      where: { id: sandboxId },
+      where: { id: sandboxId, unassigned: false },
     })
 
     if (!sandbox) {

--- a/apps/api/src/usage/entities/sandbox-usage-period-archive.entity.ts
+++ b/apps/api/src/usage/entities/sandbox-usage-period-archive.entity.ts
@@ -42,6 +42,10 @@ export class SandboxUsagePeriodArchive {
   @Column()
   region: string
 
+  // Indicates if the usage period is for an unassigned sandbox (e.g. warm pool)
+  @Column({ default: false })
+  unassigned: boolean
+
   public static fromUsagePeriod(usagePeriod: SandboxUsagePeriod) {
     const usagePeriodEntity = new SandboxUsagePeriodArchive()
     usagePeriodEntity.sandboxId = usagePeriod.sandboxId
@@ -53,6 +57,7 @@ export class SandboxUsagePeriodArchive {
     usagePeriodEntity.mem = usagePeriod.mem
     usagePeriodEntity.disk = usagePeriod.disk
     usagePeriodEntity.region = usagePeriod.region
+    usagePeriodEntity.unassigned = usagePeriod.unassigned
     return usagePeriodEntity
   }
 }

--- a/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
@@ -38,6 +38,10 @@ export class SandboxUsagePeriod {
   @Column()
   region: string
 
+  // Indicates if the usage period is for an unassigned sandbox (e.g. warm pool)
+  @Column({ default: false })
+  unassigned: boolean
+
   public static fromUsagePeriod(usagePeriod: SandboxUsagePeriod) {
     const usagePeriodEntity = new SandboxUsagePeriod()
     usagePeriodEntity.sandboxId = usagePeriod.sandboxId
@@ -49,6 +53,7 @@ export class SandboxUsagePeriod {
     usagePeriodEntity.mem = usagePeriod.mem
     usagePeriodEntity.disk = usagePeriod.disk
     usagePeriodEntity.region = usagePeriod.region
+    usagePeriodEntity.unassigned = usagePeriod.unassigned
     return usagePeriodEntity
   }
 }

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -91,6 +91,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     usagePeriod.disk = event.sandbox.disk
     usagePeriod.organizationId = event.sandbox.organizationId
     usagePeriod.region = event.sandbox.region
+    usagePeriod.unassigned = event.sandbox.unassigned
 
     await this.sandboxUsagePeriodRepository.save(usagePeriod)
   }


### PR DESCRIPTION
## Unassigned sandboxes in the warm pool 

Minor refactor to the warm pool creation and assignment which helps in tracking sandboxes that are unassigned as well as their usage periods

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation