### PR TITLE
fix(cli): push snapshot set region

### DIFF
--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -144,6 +144,9 @@ var PushCmd = &cobra.Command{
 		if diskFlag != 0 {
 			createSnapshot.SetDisk(diskFlag)
 		}
+		if regionIdFlag != "" {
+			createSnapshot.SetRegionId(regionIdFlag)
+		}
 
 		_, res, err = apiClient.SnapshotsAPI.CreateSnapshot(ctx).CreateSnapshot(*createSnapshot).Execute()
 		if err != nil {


### PR DESCRIPTION
This pull request introduces a minor enhancement to the snapshot push command in the CLI. It adds support for specifying a region ID when creating a snapshot.

* CLI Enhancement:
  * [`apps/cli/cmd/snapshot/push.go`](diffhunk://#diff-d61855ba5a720215dae307213afdea4bdc0613d824b595e7aaee6a64cb0de469R147-R149): Added logic to set the region ID on the snapshot creation request if the `regionIdFlag` is provided.