### PR TITLE
feat(api): enable all feature flags if posthog is not configured

### DIFF
--- a/apps/api/src/common/providers/openfeature-posthog.provider.ts
+++ b/apps/api/src/common/providers/openfeature-posthog.provider.ts
@@ -34,7 +34,7 @@ export class OpenFeaturePostHogProvider implements Provider {
       try {
         this.client = new PostHog(config.apiKey, config.clientOptions)
       } catch (error) {
-        console.warn('Failed to initialize PostHog client:', error)
+        console.log('Posthog not configured. Feature flags are disabled')
       }
     }
   }

--- a/apps/api/src/common/providers/openfeature-posthog.provider.ts
+++ b/apps/api/src/common/providers/openfeature-posthog.provider.ts
@@ -34,8 +34,10 @@ export class OpenFeaturePostHogProvider implements Provider {
       try {
         this.client = new PostHog(config.apiKey, config.clientOptions)
       } catch (error) {
-        console.log('Posthog not configured. Feature flags are disabled')
+        console.error('Failed to initialize PostHog client. Feature flags will use default values.', error)
       }
+    } else {
+      console.log('PostHog not configured. Feature flags will use default values.')
     }
   }
 

--- a/apps/api/src/organization/controllers/organization-region.controller.ts
+++ b/apps/api/src/organization/controllers/organization-region.controller.ts
@@ -93,7 +93,7 @@ export class OrganizationRegionController {
     },
   })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async createRegion(
     @AuthContext() authContext: OrganizationAuthContext,
     @Body() createRegionDto: CreateRegionDto,
@@ -153,7 +153,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.DELETE_REGIONS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async deleteRegion(@Param('id') id: string): Promise<void> {
     await this.regionService.delete(id)
   }
@@ -182,7 +182,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async regenerateProxyApiKey(@Param('id') id: string): Promise<RegenerateApiKeyResponseDto> {
     const apiKey = await this.regionService.regenerateProxyApiKey(id)
     return new RegenerateApiKeyResponseDto(apiKey)
@@ -212,7 +212,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async updateRegion(@Param('id') id: string, @Body() updateRegionDto: UpdateRegionDto): Promise<void> {
     return await this.regionService.update(id, updateRegionDto)
   }
@@ -241,7 +241,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async regenerateSshGatewayApiKey(@Param('id') id: string): Promise<RegenerateApiKeyResponseDto> {
     const apiKey = await this.regionService.regenerateSshGatewayApiKey(id)
     return new RegenerateApiKeyResponseDto(apiKey)
@@ -271,7 +271,7 @@ export class OrganizationRegionController {
   })
   @UseGuards(RegionAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_REGIONS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async regenerateSnapshotManagerCredentials(@Param('id') id: string): Promise<SnapshotManagerCredentialsDto> {
     return await this.regionService.regenerateSnapshotManagerCredentials(id)
   }

--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -97,7 +97,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_RUNNERS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async create(
     @Body() createRunnerDto: CreateRunnerDto,
     @AuthContext() authContext: OrganizationAuthContext,
@@ -206,7 +206,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_RUNNERS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async findAll(@AuthContext() authContext: OrganizationAuthContext): Promise<RunnerDto[]> {
     return this.runnerService.findAllByOrganization(authContext.organizationId, RegionType.CUSTOM)
   }
@@ -239,7 +239,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard, RunnerAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_RUNNERS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async updateSchedulingStatus(
     @Param('id', ParseUUIDPipe) id: string,
     @Body('unschedulable') unschedulable: boolean,
@@ -270,7 +270,7 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationResourceActionGuard, RunnerAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.DELETE_RUNNERS])
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: true }] })
   async delete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return this.runnerService.remove(id)
   }

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -548,7 +548,7 @@ export class SandboxController {
   })
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_SANDBOXES])
   @UseGuards(SandboxAccessGuard)
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.SANDBOX_RESIZE, defaultValue: false }] })
+  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.SANDBOX_RESIZE, defaultValue: true }] })
   @Audit({
     action: AuditAction.RESIZE,
     targetType: AuditTarget.SANDBOX,

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -13,7 +13,7 @@ import { OrganizationsProvider } from '@/providers/OrganizationsProvider'
 import { SelectedOrganizationProvider } from '@/providers/SelectedOrganizationProvider'
 import { UserOrganizationInvitationsProvider } from '@/providers/UserOrganizationInvitationsProvider'
 import { OrganizationRolePermissionsEnum, OrganizationUserRoleEnum } from '@daytonaio/api-client'
-import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react'
+import { usePostHog } from 'posthog-js/react'
 import React, { Suspense, useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
@@ -53,6 +53,7 @@ import Volumes from './pages/Volumes'
 import Wallet from './pages/Wallet'
 import { ApiProvider } from './providers/ApiProvider'
 import { RegionsProvider } from './providers/RegionsProvider'
+import { useFeatureFlagEnabled } from './hooks/useFeatureFlagEnabled'
 
 // Simple redirection components for external URLs
 const DocsRedirect = () => {

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -55,7 +55,7 @@ import {
   TextSearch,
   Users,
 } from 'lucide-react'
-import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react'
+import { usePostHog } from 'posthog-js/react'
 import React, { useMemo } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
@@ -64,6 +64,7 @@ import { Button } from './ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu'
 import { Kbd } from './ui/kbd'
 import { ScrollArea } from './ui/scroll-area'
+import { useFeatureFlagEnabled } from '@/hooks/useFeatureFlagEnabled'
 
 interface SidebarProps {
   isBannerVisible: boolean

--- a/apps/dashboard/src/hooks/useFeatureFlagEnabled.ts
+++ b/apps/dashboard/src/hooks/useFeatureFlagEnabled.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useFeatureFlagEnabled as phFfEnabled } from 'posthog-js/react'
+import { useConfig } from './useConfig'
+import { FeatureFlags } from '@/enums/FeatureFlags'
+
+export function useFeatureFlagEnabled(flag: FeatureFlags): boolean {
+  const config = useConfig()
+  const isFlagEnabled = phFfEnabled(flag)
+
+  if (!config.posthog) {
+    return true
+  }
+
+  return !!isFlagEnabled
+}


### PR DESCRIPTION
## Description

Enables all feature flags in the API and dashboard if posthog is not configured.
In non-prod environments, where posthog is not configured, there's no reason to block features behind feature flags.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
