### PR TITLE
feat(guides): add OpenClaw sandbox example

### DIFF
--- a/guides/typescript/openclaw/.env.example
+++ b/guides/typescript/openclaw/.env.example
@@ -1,0 +1,2 @@
+# Get your Daytona API key from: https://app.daytona.io/
+DAYTONA_API_KEY=

--- a/guides/typescript/openclaw/.env.sandbox.example
+++ b/guides/typescript/openclaw/.env.sandbox.example
@@ -1,0 +1,2 @@
+# All vars in .env.sandbox are loaded into the sandbox environment.
+ANTHROPIC_API_KEY=

--- a/guides/typescript/openclaw/.gitignore
+++ b/guides/typescript/openclaw/.gitignore
@@ -1,0 +1,4 @@
+
+/node_modules
+/.env
+/.env.sandbox

--- a/guides/typescript/openclaw/README.md
+++ b/guides/typescript/openclaw/README.md
@@ -1,0 +1,146 @@
+# OpenClaw Daytona Sandbox
+
+## Overview
+
+This example runs [OpenClaw](https://openclaw.ai/), a general purpose AI assistant, inside a Daytona sandbox. You can interact with OpenClaw via its Control UI using a [Daytona preview link](https://www.daytona.io/docs/en/preview-and-authentication/#fetching-a-preview-link).
+
+## Features
+
+- **Secure sandbox execution:** OpenClaw runs in a controlled environment, along with any code or commands run by agents.
+- **Multi-channel gateway:** Can connect to WhatsApp, Telegram, Discord, and more simultaneously.
+- **Preview Control UI:** Use Daytona preview links to access the OpenClaw web dashboard with no local install.
+- **Flexible LLM support:** Connect to Anthropic, OpenAI, and other providers; configure models via `openclaw.json` and `.env.sandbox`.
+
+## Prerequisites
+
+- **Node.js:** Version 18 or higher is required
+
+## Environment Variables
+
+To run this example, you need to set the following environment variables:
+
+**`.env`** (used by the main script only):
+
+- `DAYTONA_API_KEY`: Required for access to Daytona sandboxes. Get it from [Daytona Dashboard](https://app.daytona.io/dashboard/keys)
+
+**`.env.sandbox`** (available inside the OpenClaw sandbox):
+
+- `ANTHROPIC_API_KEY`: Required for Claude. Get it from [Anthropic Console](https://console.anthropic.com/)
+- Any other variables you add here are loaded into the sandbox environment
+
+Create these files in the project directory (copy from `.env.example` and `.env.sandbox.example`).
+
+## Getting Started
+
+### Setup and Run
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Run the example:
+
+   ```bash
+   npm start
+   ```
+
+## How It Works
+
+When this example is run, the agent follows the following workflow:
+
+1. A new Daytona sandbox is created (using the `daytona-medium` snapshot with OpenClaw preinstalled).
+2. OpenClaw is configured with your `openclaw.json` and `.env.sandbox` secrets.
+3. The OpenClaw gateway starts inside the sandbox.
+4. A Daytona preview link is shown pointing to the OpenClaw Control UI.
+5. When the script is terminated (Ctrl+C), the sandbox is deleted—unless `PERSIST_SANDBOX` is set to `true`, in which case the sandbox is left running.
+
+## Example Output
+
+```
+Creating Daytona sandbox...
+Configuring OpenClaw...
+Starting OpenClaw...
+(Ctrl+C to shut down and delete the sandbox)
+
+🔗 Secret link to Control UI: https://18789-898f722f-76fc-4ec6-85ca-a82bb30f3d72.proxy.daytona.works?token=7e38c7347437c5642c57bc769f630e53fe118e001d7b6c6c
+
+OpenClaw logs:
+--------------------------------
+(node:131) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+│
+◇  Doctor changes ────────────────────────╮
+│                                         │
+│  WhatsApp configured, not enabled yet.  │
+│                                         │
+├─────────────────────────────────────────╯
+```
+
+Open the provided URL in your browser to interact with the OpenClaw agent via the Control UI.
+
+## Configuration
+
+### Script configuration
+
+You will find several constants in `src/index.ts` which control the behavior of the script:
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `OPENCLAW_PORT` | 18789 | OpenClaw Gateway and Control UI port |
+| `SHOW_LOGS` | true | Stream OpenClaw stdout/stderr to the terminal. |
+| `MAKE_PUBLIC` | true | Expose the sandbox for public internet access. |
+| `PERSIST_SANDBOX` | true | When true, the sandbox is not deleted when the script exits. |
+| `DAYTONA_SNAPSHOT` | daytona-medium | Sandbox image with OpenClaw preinstalled. |
+
+### OpenClaw Configuration
+
+You can tailor OpenClaw to your setup by editing `openclaw.json`. The script combines this file with built-in defaults and an authorization token, and writes the result to `~/.openclaw/openclaw.json` inside the sandbox.
+
+The default configuration is:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "model": { "primary": "anthropic/claude-sonnet-4-5" }
+    }
+  },
+  "auth": {
+    "profiles": {
+      "anthropic:api": { "provider": "anthropic", "mode": "api_key" }
+    },
+    "order": { "anthropic": ["anthropic:api"] }
+  },
+  "channels": {
+    "whatsapp": { "allowFrom": [] }
+  }
+}
+```
+
+In order to accept WhatsApp messages, the numbers of the allowed senders need to be added to the allowFrom list.
+
+You can extend it with additional sections:
+
+| Section | Purpose |
+|--------|---------|
+| `agents.defaults` | [Model, workspace path, timeouts, sandbox](https://docs.openclaw.ai/gateway/configuration-reference#agent-defaults) |
+| `agents.list` | [Multiple agents with different names and tools](https://docs.openclaw.ai/gateway/configuration-reference#agents-list-per-agent-overrides) |
+| `auth` | [API keys and OAuth for Claude, GPT, etc.](https://docs.openclaw.ai/gateway/configuration-reference#auth-storage) |
+| `channels` | [Connect messaging apps and control who can message](https://docs.openclaw.ai/gateway/configuration-reference#channels) |
+| `gateway` | [Port, authentication, Control UI access](https://docs.openclaw.ai/gateway/configuration-reference#gateway) |
+| `models` | [Add OpenRouter, local models, other providers](https://docs.openclaw.ai/gateway/configuration-reference#custom-providers-and-base-urls) |
+| `session` | [How conversations are grouped and reset](https://docs.openclaw.ai/gateway/configuration-reference#session) |
+| `tools` | [What the agent can do (code, web, browser)](https://docs.openclaw.ai/gateway/configuration-reference#tools) |
+
+For a full reference see [Configuration Reference](https://docs.openclaw.ai/gateway/configuration-reference) and [Configuration Examples](https://docs.openclaw.ai/gateway/configuration-examples).
+
+## License
+
+See the main project LICENSE file for details.
+
+## References
+
+- [OpenClaw Documentation](https://docs.openclaw.ai/)
+- [Daytona Documentation](https://www.daytona.io/docs)

--- a/guides/typescript/openclaw/openclaw.json
+++ b/guides/typescript/openclaw/openclaw.json
@@ -1,0 +1,12 @@
+{
+  "agents": {
+    "defaults": { "model": { "primary": "anthropic/claude-sonnet-4-5" } }
+  },
+  "auth": {
+    "profiles": {
+      "anthropic:api": { "provider": "anthropic", "mode": "api_key" }
+    },
+    "order": { "anthropic": ["anthropic:api"] }
+  },
+  "channels": { "whatsapp": { "allowFrom": [] } }
+}

--- a/guides/typescript/openclaw/package.json
+++ b/guides/typescript/openclaw/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "daytonaclaw",
+  "version": "1.0.0",
+  "description": "OpenClaw AI assistant running in a Daytona sandbox.",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "serve": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@daytonaio/sdk": "^0.139.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/guides/typescript/openclaw/src/index.ts
+++ b/guides/typescript/openclaw/src/index.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "dotenv/config";
+import { Daytona } from "@daytonaio/sdk";
+import type { Sandbox } from "@daytonaio/sdk";
+import { randomBytes } from "crypto";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { deepMerge, readEnvFile } from "./utils.js";
+
+// Constants
+const OPENCLAW_PORT = 18789; // OpenClaw Gateway and Control UI port
+const SHOW_LOGS = true; // Stream OpenClaw stdout/stderr to the terminal
+const MAKE_PUBLIC = true; // Expose the sandbox for public internet access
+const PERSIST_SANDBOX = true; // Keep the sandbox running after the script exits
+const DAYTONA_SNAPSHOT = "daytona-medium"; // This snapshot has openclaw installed
+
+// Paths
+const USER_CONFIG_PATH = join(process.cwd(), "openclaw.json");
+const ENV_SANDBOX_PATH = join(process.cwd(), ".env.sandbox");
+
+// Global variables
+let currentSandbox: Sandbox | null = null;
+let sandboxDeleted = false;
+
+// Shutdown the sandbox
+async function shutdown() {
+  if (sandboxDeleted) return;
+  sandboxDeleted = true;
+  if (!PERSIST_SANDBOX) {
+    console.log("\nShutting down sandbox...");
+    try {
+      await currentSandbox?.delete(30);
+    } catch (e) {
+      console.error(e);
+    }
+  } else {
+    console.log("\nSandbox left running.");
+  }
+  process.exit(0);
+}
+
+// OpenClaw config to run in a Daytona sandbox
+const OPENCLAW_CONFIG = {
+  gateway: {
+    mode: "local" as const,
+    port: OPENCLAW_PORT,
+    bind: "lan" as const,
+    auth: { mode: "token" as const, token: "" },
+    controlUi: { allowInsecureAuth: true }, // This bypasses the pairing step in the Control UI
+  },
+  agents: {
+    defaults: {
+      workspace: "~/.openclaw/workspace",
+    },
+  },
+};
+
+// Main function
+async function main() {
+  // Create a new Daytona instance
+  const daytona = new Daytona();
+
+  // Create a new sandbox
+  console.log("Creating Daytona sandbox...");
+  const sandbox = await daytona.create({
+    snapshot: DAYTONA_SNAPSHOT,
+    autoStopInterval: 0,
+    envVars: readEnvFile(ENV_SANDBOX_PATH),
+    public: MAKE_PUBLIC,
+  });
+  currentSandbox = sandbox;
+
+  // Handle SIGINT
+  process.on("SIGINT", () => shutdown());
+
+  // Get the user home directory
+  const home = await sandbox.getUserHomeDir();
+  const openclawDir = `${home}/.openclaw`;
+
+  // Read the user config and merge it with the base config
+  const userConfig = JSON.parse(readFileSync(USER_CONFIG_PATH, "utf8"));
+  const baseConfig = deepMerge(OPENCLAW_CONFIG, userConfig);
+
+  // Generate a random gateway token and add it to the config
+  const gatewayToken = randomBytes(24).toString("hex");
+  const config = deepMerge(baseConfig, {
+    gateway: {
+      auth: { mode: "token" as const, token: gatewayToken },
+    },
+  });
+
+  // Write the config to the sandbox
+  console.log("Configuring OpenClaw...");
+  await sandbox.fs.createFolder(openclawDir, "755");
+  await sandbox.fs.uploadFile(
+    Buffer.from(JSON.stringify(config, null, 2), "utf8"),
+    `${openclawDir}/openclaw.json`,
+  );
+
+  // Start the gateway
+  const sessionId = "openclaw-gateway";
+  console.log("Starting OpenClaw...");
+  await sandbox.process.createSession(sessionId);
+  const { cmdId } = await sandbox.process.executeSessionCommand(sessionId, {
+    command: "openclaw gateway run",
+    runAsync: true,
+  });
+  console.log("(Ctrl+C to shut down and delete the sandbox)");
+
+  // Stream OpenClaw output to the terminal and delete the sandbox when the process ends
+  sandbox.process
+    .getSessionCommandLogs(
+      sessionId,
+      cmdId,
+      SHOW_LOGS ? (chunk) => process.stdout.write(chunk) : () => {},
+      SHOW_LOGS ? (chunk) => process.stderr.write(chunk) : () => {},
+    )
+    .then(shutdown)
+    .catch(shutdown);
+
+  const signed = await sandbox.getPreviewLink(OPENCLAW_PORT);
+  const dashboardUrl = `${signed.url}?token=${gatewayToken}`;
+  
+  console.log(`\n\x1b[1m🔗 Secret link to Control UI: ${dashboardUrl}\x1b[0m`);
+  console.log(`\nOpenClaw is starting...`);
+  console.log("--------------------------------");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/guides/typescript/openclaw/src/utils.ts
+++ b/guides/typescript/openclaw/src/utils.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync, existsSync } from 'fs'
+import dotenv from 'dotenv'
+
+// Merge two objects recursively
+export function deepMerge<T>(target: T, source: Record<string, unknown>): T {
+  const out = { ...target } as Record<string, unknown>
+  for (const key of Object.keys(source)) {
+    const a = (out as Record<string, unknown>)[key]
+    const b = source[key]
+    if (
+      a != null &&
+      b != null &&
+      typeof a === 'object' &&
+      typeof b === 'object' &&
+      !Array.isArray(a) &&
+      !Array.isArray(b)
+    ) {
+      ;(out as Record<string, unknown>)[key] = deepMerge(a as Record<string, unknown>, b as Record<string, unknown>)
+    } else {
+      ;(out as Record<string, unknown>)[key] = b
+    }
+  }
+  return out as T
+}
+
+// Read env file and return a record of key-value pairs
+export function readEnvFile(path: string): Record<string, string> {
+  if (!existsSync(path)) return {}
+  const parsed = dotenv.parse(readFileSync(path))
+  return Object.fromEntries(
+    Object.entries(parsed).filter(([, v]) => v != null && v !== '') as [string, string][],
+  ) as Record<string, string>
+}

--- a/guides/typescript/openclaw/tsconfig.json
+++ b/guides/typescript/openclaw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Overview

This PR adds an example based on #3554 that creates a new OpenClaw Daytona sandbox with no configuration required.

The example includes:
* A TypeScript program that creates the sandbox, configures OpenClaw, and launches the gateway immediately with a preview link.
* Additional configuration options for OpenCode such as LLM providers, communication channels and assistant behavior.

See the [README](https://github.com/jamesmurdza/daytona/blob/guides/openclaw/guides/typescript/openclaw/README.md) for more details.

## Video

https://github.com/user-attachments/assets/372788a7-81db-473f-9a2f-3e34aa40774d
