### PR TITLE
feat(docs): add interactive anchors to headings

### DIFF
--- a/apps/docs/src/components/MarkdownContent.astro
+++ b/apps/docs/src/components/MarkdownContent.astro
@@ -14,5 +14,39 @@
         }
       })
     }
+
+    const headings = document.querySelectorAll(
+      '.markdown-content h2[id], .markdown-content h3[id], .markdown-content h4[id], .markdown-content h5[id]'
+    )
+
+    headings.forEach(heading => {
+      const anchor = document.createElement('a')
+      anchor.href = `#${heading.id}`
+      anchor.className = 'heading-anchor'
+      anchor.setAttribute('aria-hidden', 'true')
+      anchor.textContent = '#'
+      heading.prepend(anchor)
+
+      heading.addEventListener('click', function (e) {
+        if (e.target === anchor) return
+        document.querySelectorAll('.heading-anchor.visible').forEach(a => {
+          if (a !== anchor) a.classList.remove('visible')
+        })
+        anchor.classList.toggle('visible')
+      })
+
+      anchor.addEventListener('click', function () {
+        anchor.classList.remove('visible')
+      })
+    })
+
+    document.addEventListener('click', function (e) {
+      const target = e.target as HTMLElement
+      if (!target.closest('h2, h3, h4, h5')) {
+        document.querySelectorAll('.heading-anchor.visible').forEach(a => {
+          a.classList.remove('visible')
+        })
+      }
+    })
   })
 </script>

--- a/apps/docs/src/styles/components/markdown.scss
+++ b/apps/docs/src/styles/components/markdown.scss
@@ -16,6 +16,43 @@
   > h5[id] {
     margin-top: 56px;
     margin-bottom: 16px;
+    position: relative;
+
+    .heading-anchor {
+      opacity: 0;
+      position: absolute;
+      right: 100%;
+      top: 52%;
+      transform: translateY(-50%);
+      padding-right: 0.25em;
+      font-size: 0.875em;
+      color: var(--secondary-text-color);
+      text-decoration: none;
+      transition: opacity 150ms ease, color 150ms ease;
+
+      @include for-hover-state {
+        &:hover {
+          color: var(--hover-color);
+        }
+      }
+
+      @include for-mobile-screen-sizes {
+        position: absolute;
+        right: 100%;
+        margin-right: 0.1em;
+        padding-right: 0;
+
+        &.visible {
+          opacity: 1;
+        }
+      }
+    }
+
+    @include for-hover-state {
+      &:hover .heading-anchor {
+        opacity: 1;
+      }
+    }
   }
 
   > p {


### PR DESCRIPTION
## Description

Adds interactive heading anchors: hover on headings to toggle visibility of anchor links and click on the anchor tag (hashtag) to navigate to the heading.

## Related Issue(s)

This PR addresses issue GTM-239.

## Screenshots

On title hover:

<img width="792" height="530" alt="Screenshot 2026-02-09 at 12 23 54" src="https://github.com/user-attachments/assets/4dd21dc3-a432-4367-8fb9-1c410d885701" />

On hashtag hover and/or click:

<img width="798" height="524" alt="Screenshot 2026-02-09 at 12 24 03" src="https://github.com/user-attachments/assets/d7fb23cf-7224-4a12-9175-30d90f437075" />
