### PR TITLE
feat(api): api key name in audit logs

### DIFF
--- a/apps/api/src/audit/adapters/audit-opensearch.adapter.ts
+++ b/apps/api/src/audit/adapters/audit-opensearch.adapter.ts
@@ -165,6 +165,7 @@ export class AuditOpenSearchStorageAdapter implements AuditLogStorageAdapter, On
             properties: {
               id: { type: 'keyword' },
               actorEmail: { type: 'keyword' },
+              apiKeyName: { type: 'keyword' },
               action: { type: 'keyword' },
               targetType: { type: 'keyword' },
               statusCode: { type: 'integer' },
@@ -181,6 +182,7 @@ export class AuditOpenSearchStorageAdapter implements AuditLogStorageAdapter, On
     auditLog.id = source.id
     auditLog.actorId = source.actorId
     auditLog.actorEmail = source.actorEmail
+    auditLog.apiKeyName = source.apiKeyName
     auditLog.organizationId = source.organizationId
     auditLog.action = source.action
     auditLog.targetType = source.targetType

--- a/apps/api/src/audit/dto/audit-log.dto.ts
+++ b/apps/api/src/audit/dto/audit-log.dto.ts
@@ -18,6 +18,9 @@ export class AuditLogDto {
   actorEmail: string
 
   @ApiPropertyOptional()
+  apiKeyName?: string
+
+  @ApiPropertyOptional()
   organizationId?: string
 
   @ApiProperty()
@@ -58,6 +61,7 @@ export class AuditLogDto {
       id: auditLog.id,
       actorId: auditLog.actorId,
       actorEmail: auditLog.actorEmail,
+      apiKeyName: auditLog.apiKeyName,
       organizationId: auditLog.organizationId,
       action: auditLog.action,
       targetType: auditLog.targetType,

--- a/apps/api/src/audit/dto/create-audit-log-internal.dto.ts
+++ b/apps/api/src/audit/dto/create-audit-log-internal.dto.ts
@@ -10,6 +10,7 @@ import { AuditTarget } from '../enums/audit-target.enum'
 export class CreateAuditLogInternalDto {
   actorId: string
   actorEmail: string
+  apiKeyName?: string
   organizationId?: string
   action: AuditAction
   targetType?: AuditTarget

--- a/apps/api/src/audit/dto/create-audit-log.dto.ts
+++ b/apps/api/src/audit/dto/create-audit-log.dto.ts
@@ -18,6 +18,10 @@ export class CreateAuditLogDto {
 
   @ApiPropertyOptional()
   @IsOptional()
+  apiKeyName?: string
+
+  @ApiPropertyOptional()
+  @IsOptional()
   organizationId?: string
 
   @ApiProperty({

--- a/apps/api/src/audit/entities/audit-log.entity.ts
+++ b/apps/api/src/audit/entities/audit-log.entity.ts
@@ -23,6 +23,9 @@ export class AuditLog {
   actorEmail: string
 
   @Column({ nullable: true })
+  apiKeyName?: string
+
+  @Column({ nullable: true })
   organizationId?: string
 
   @Column()

--- a/apps/api/src/audit/interceptors/audit.interceptor.ts
+++ b/apps/api/src/audit/interceptors/audit.interceptor.ts
@@ -78,6 +78,7 @@ export class AuditInterceptor implements NestInterceptor {
       const auditLog = await this.auditService.createLog({
         actorId: request.user.userId,
         actorEmail: request.user.email,
+        apiKeyName: request.user.apiKey?.name,
         organizationId: request.user.organizationId,
         action: auditContext.action,
         targetType: auditContext.targetType,

--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -63,6 +63,7 @@ export class AuditService implements OnApplicationBootstrap {
     const auditLog = new AuditLog()
     auditLog.actorId = createDto.actorId
     auditLog.actorEmail = createDto.actorEmail
+    auditLog.apiKeyName = createDto.apiKeyName
     auditLog.organizationId = createDto.organizationId
     auditLog.action = createDto.action
     auditLog.targetType = createDto.targetType

--- a/apps/api/src/migrations/1770681600000-migration.ts
+++ b/apps/api/src/migrations/1770681600000-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1770681600000 implements MigrationInterface {
+  name = 'Migration1770681600000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "audit_log" ADD "apiKeyName" character varying`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "audit_log" DROP COLUMN "apiKeyName"`)
+  }
+}

--- a/apps/dashboard/src/components/AuditLogTable.tsx
+++ b/apps/dashboard/src/components/AuditLogTable.tsx
@@ -138,17 +138,21 @@ const getColumns = (): ColumnDef<AuditLog>[] => {
       cell: ({ row }) => {
         const actorEmail = row.original.actorEmail
         const actorId = row.original.actorId
+        const apiKeyName = row.original.apiKeyName
         const label = actorEmail || actorId
 
         return (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="font-medium truncate w-fit max-w-full">{label}</div>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{label}</p>
-            </TooltipContent>
-          </Tooltip>
+          <div className="space-y-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="font-medium truncate w-fit max-w-full">{label}</div>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{label}</p>
+              </TooltipContent>
+            </Tooltip>
+            {apiKeyName && <div className="text-sm text-muted-foreground truncate">API Key: {apiKeyName}</div>}
+          </div>
         )
       },
     },

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -13814,6 +13814,7 @@ components:
         errorMessage: errorMessage
         ipAddress: ipAddress
         actorEmail: actorEmail
+        apiKeyName: apiKeyName
         targetType: targetType
         userAgent: userAgent
         source: source
@@ -13829,6 +13830,8 @@ components:
         actorId:
           type: string
         actorEmail:
+          type: string
+        apiKeyName:
           type: string
         organizationId:
           type: string
@@ -13874,6 +13877,7 @@ components:
             errorMessage: errorMessage
             ipAddress: ipAddress
             actorEmail: actorEmail
+            apiKeyName: apiKeyName
             targetType: targetType
             userAgent: userAgent
             source: source
@@ -13889,6 +13893,7 @@ components:
             errorMessage: errorMessage
             ipAddress: ipAddress
             actorEmail: actorEmail
+            apiKeyName: apiKeyName
             targetType: targetType
             userAgent: userAgent
             source: source

--- a/libs/api-client-go/model_audit_log.go
+++ b/libs/api-client-go/model_audit_log.go
@@ -25,6 +25,7 @@ type AuditLog struct {
 	Id                   string                 `json:"id"`
 	ActorId              string                 `json:"actorId"`
 	ActorEmail           string                 `json:"actorEmail"`
+	ApiKeyName           *string                `json:"apiKeyName,omitempty"`
 	OrganizationId       *string                `json:"organizationId,omitempty"`
 	Action               string                 `json:"action"`
 	TargetType           *string                `json:"targetType,omitempty"`
@@ -133,6 +134,38 @@ func (o *AuditLog) GetActorEmailOk() (*string, bool) {
 // SetActorEmail sets field value
 func (o *AuditLog) SetActorEmail(v string) {
 	o.ActorEmail = v
+}
+
+// GetApiKeyName returns the ApiKeyName field value if set, zero value otherwise.
+func (o *AuditLog) GetApiKeyName() string {
+	if o == nil || IsNil(o.ApiKeyName) {
+		var ret string
+		return ret
+	}
+	return *o.ApiKeyName
+}
+
+// GetApiKeyNameOk returns a tuple with the ApiKeyName field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AuditLog) GetApiKeyNameOk() (*string, bool) {
+	if o == nil || IsNil(o.ApiKeyName) {
+		return nil, false
+	}
+	return o.ApiKeyName, true
+}
+
+// HasApiKeyName returns a boolean if a field has been set.
+func (o *AuditLog) HasApiKeyName() bool {
+	if o != nil && !IsNil(o.ApiKeyName) {
+		return true
+	}
+
+	return false
+}
+
+// SetApiKeyName gets a reference to the given string and assigns it to the ApiKeyName field.
+func (o *AuditLog) SetApiKeyName(v string) {
+	o.ApiKeyName = &v
 }
 
 // GetOrganizationId returns the OrganizationId field value if set, zero value otherwise.
@@ -484,6 +517,9 @@ func (o AuditLog) ToMap() (map[string]interface{}, error) {
 	toSerialize["id"] = o.Id
 	toSerialize["actorId"] = o.ActorId
 	toSerialize["actorEmail"] = o.ActorEmail
+	if !IsNil(o.ApiKeyName) {
+		toSerialize["apiKeyName"] = o.ApiKeyName
+	}
 	if !IsNil(o.OrganizationId) {
 		toSerialize["organizationId"] = o.OrganizationId
 	}
@@ -563,6 +599,7 @@ func (o *AuditLog) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "actorId")
 		delete(additionalProperties, "actorEmail")
+		delete(additionalProperties, "apiKeyName")
 		delete(additionalProperties, "organizationId")
 		delete(additionalProperties, "action")
 		delete(additionalProperties, "targetType")

--- a/libs/api-client-python-async/daytona_api_client_async/models/audit_log.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/audit_log.py
@@ -31,6 +31,7 @@ class AuditLog(BaseModel):
     id: StrictStr
     actor_id: StrictStr = Field(serialization_alias="actorId")
     actor_email: StrictStr = Field(serialization_alias="actorEmail")
+    api_key_name: Optional[StrictStr] = Field(default=None, serialization_alias="apiKeyName")
     organization_id: Optional[StrictStr] = Field(default=None, serialization_alias="organizationId")
     action: StrictStr
     target_type: Optional[StrictStr] = Field(default=None, serialization_alias="targetType")
@@ -43,7 +44,7 @@ class AuditLog(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
     created_at: datetime = Field(serialization_alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "organizationId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
+    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "apiKeyName", "organizationId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -106,6 +107,7 @@ class AuditLog(BaseModel):
             "id": obj.get("id"),
             "actor_id": obj.get("actorId"),
             "actor_email": obj.get("actorEmail"),
+            "api_key_name": obj.get("apiKeyName"),
             "organization_id": obj.get("organizationId"),
             "action": obj.get("action"),
             "target_type": obj.get("targetType"),

--- a/libs/api-client-python/daytona_api_client/models/audit_log.py
+++ b/libs/api-client-python/daytona_api_client/models/audit_log.py
@@ -31,6 +31,7 @@ class AuditLog(BaseModel):
     id: StrictStr
     actor_id: StrictStr = Field(serialization_alias="actorId")
     actor_email: StrictStr = Field(serialization_alias="actorEmail")
+    api_key_name: Optional[StrictStr] = Field(default=None, serialization_alias="apiKeyName")
     organization_id: Optional[StrictStr] = Field(default=None, serialization_alias="organizationId")
     action: StrictStr
     target_type: Optional[StrictStr] = Field(default=None, serialization_alias="targetType")
@@ -43,7 +44,7 @@ class AuditLog(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
     created_at: datetime = Field(serialization_alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "organizationId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
+    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "apiKeyName", "organizationId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -106,6 +107,7 @@ class AuditLog(BaseModel):
             "id": obj.get("id"),
             "actor_id": obj.get("actorId"),
             "actor_email": obj.get("actorEmail"),
+            "api_key_name": obj.get("apiKeyName"),
             "organization_id": obj.get("organizationId"),
             "action": obj.get("action"),
             "target_type": obj.get("targetType"),

--- a/libs/api-client-ruby/lib/daytona_api_client/models/audit_log.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/audit_log.rb
@@ -21,6 +21,8 @@ module DaytonaApiClient
 
     attr_accessor :actor_email
 
+    attr_accessor :api_key_name
+
     attr_accessor :organization_id
 
     attr_accessor :action
@@ -49,6 +51,7 @@ module DaytonaApiClient
         :'id' => :'id',
         :'actor_id' => :'actorId',
         :'actor_email' => :'actorEmail',
+        :'api_key_name' => :'apiKeyName',
         :'organization_id' => :'organizationId',
         :'action' => :'action',
         :'target_type' => :'targetType',
@@ -79,6 +82,7 @@ module DaytonaApiClient
         :'id' => :'String',
         :'actor_id' => :'String',
         :'actor_email' => :'String',
+        :'api_key_name' => :'String',
         :'organization_id' => :'String',
         :'action' => :'String',
         :'target_type' => :'String',
@@ -131,6 +135,10 @@ module DaytonaApiClient
         self.actor_email = attributes[:'actor_email']
       else
         self.actor_email = nil
+      end
+
+      if attributes.key?(:'api_key_name')
+        self.api_key_name = attributes[:'api_key_name']
       end
 
       if attributes.key?(:'organization_id')
@@ -282,6 +290,7 @@ module DaytonaApiClient
           id == o.id &&
           actor_id == o.actor_id &&
           actor_email == o.actor_email &&
+          api_key_name == o.api_key_name &&
           organization_id == o.organization_id &&
           action == o.action &&
           target_type == o.target_type &&
@@ -304,7 +313,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, actor_id, actor_email, organization_id, action, target_type, target_id, status_code, error_message, ip_address, user_agent, source, metadata, created_at].hash
+      [id, actor_id, actor_email, api_key_name, organization_id, action, target_type, target_id, status_code, error_message, ip_address, user_agent, source, metadata, created_at].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/models/audit-log.ts
+++ b/libs/api-client/src/models/audit-log.ts
@@ -41,6 +41,12 @@ export interface AuditLog {
    * @type {string}
    * @memberof AuditLog
    */
+  apiKeyName?: string
+  /**
+   *
+   * @type {string}
+   * @memberof AuditLog
+   */
   organizationId?: string
   /**
    *


### PR DESCRIPTION
## API key name in audit logs

Adds the api key to audit log entries to make tracking usage easier

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="2804" height="784" alt="image" src="https://github.com/user-attachments/assets/db80e704-05ff-4c43-bdf0-6df73a8d01dc" />
