### PR TITLE
feat(api): usage period sandbox id endAt index

### DIFF
--- a/apps/api/src/migrations/1770880371265-migration.ts
+++ b/apps/api/src/migrations/1770880371265-migration.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1770880371265 implements MigrationInterface {
+  name = 'Migration1770880371265'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Note: not using CONCURRENTLY + skipping transactions because of reverting issue: https://github.com/typeorm/typeorm/issues/9981
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_usage_periods_sandbox_end" ON "sandbox_usage_periods" ("sandboxId", "endAt") `,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_sandbox_usage_periods_sandbox_end"`)
+  }
+}

--- a/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
 
 @Entity('sandbox_usage_periods')
+@Index('idx_sandbox_usage_periods_sandbox_end', ['sandboxId', 'endAt'])
 export class SandboxUsagePeriod {
   @PrimaryGeneratedColumn('uuid')
   id: string


### PR DESCRIPTION
## Description

Adds an index to the usage periods table on `sandboxId` + `endAt` fields

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X