### PR TITLE
fix(api): 500 on sandbox delete

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -20,6 +20,7 @@ import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { SandboxClass } from '../enums/sandbox-class.enum'
 import { BackupState } from '../enums/backup-state.enum'
 import { v4 as uuidv4 } from 'uuid'
+import { SandboxError } from '../../exceptions/sandbox-error.exception'
 import { SandboxVolume } from '../dto/sandbox.dto'
 import { BuildInfo } from './build-info.entity'
 
@@ -295,7 +296,7 @@ export class Sandbox {
         ) {
           break
         }
-        throw new Error(`Sandbox ${this.id} is not in a valid state to be started. State: ${this.state}`)
+        throw new SandboxError(`Sandbox ${this.id} is not in a valid state to be started. State: ${this.state}`)
       case SandboxDesiredState.STOPPED:
         if (
           [
@@ -309,7 +310,7 @@ export class Sandbox {
         ) {
           break
         }
-        throw new Error(`Sandbox ${this.id} is not in a valid state to be stopped. State: ${this.state}`)
+        throw new SandboxError(`Sandbox ${this.id} is not in a valid state to be stopped. State: ${this.state}`)
       case SandboxDesiredState.ARCHIVED:
         if (
           [
@@ -322,7 +323,7 @@ export class Sandbox {
         ) {
           break
         }
-        throw new Error(`Sandbox ${this.id} is not in a valid state to be archived. State: ${this.state}`)
+        throw new SandboxError(`Sandbox ${this.id} is not in a valid state to be archived. State: ${this.state}`)
       case SandboxDesiredState.DESTROYED:
         if (
           [
@@ -338,7 +339,7 @@ export class Sandbox {
         ) {
           break
         }
-        throw new Error(`Sandbox ${this.id} is not in a valid state to be destroyed. State: ${this.state}`)
+        throw new SandboxError(`Sandbox ${this.id} is not in a valid state to be destroyed. State: ${this.state}`)
     }
   }
 


### PR DESCRIPTION
## Description

API would 500 if calling delete on `starting` sandbox. Not really an user error, we might change this, but also not a 500 as it's intentionally handled

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation