### PR TITLE
chore: remove go.work.sync from release update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -349,10 +349,10 @@ jobs:
         run: |
           git checkout -b sync-gosum-${{ inputs.version }}
           GONOSUMDB=github.com/daytonaio/daytona go work sync
-          if git diff --quiet -- go.work.sum **/go.sum; then
+          if git diff --quiet -- **/go.sum; then
             echo "No go.sum changes detected; skipping commit and PR creation."
           else
-            git add go.work.sum **/go.sum
+            git add **/go.sum
             git commit -s -m "chore: sync go.sum for ${{ inputs.version }}"
             git push origin sync-gosum-${{ inputs.version }}
             gh pr create \


### PR DESCRIPTION
## Description

Remove `go.work.sync` from release update because it was recently removed from git.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
