### PR TITLE
fix: add `init: true` to runner service to prevent zombie processes

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -124,6 +124,7 @@ services:
 
   runner:
     image: daytonaio/daytona-runner
+    init: true
     environment:
       - ENVIRONMENT=development
       - API_PORT=3003


### PR DESCRIPTION
## Description

Add `init: true` to the runner service in `docker/docker-compose.yaml` to prevent zombie process accumulation.
When the Daytona runner runs as PID 1 inside its container, it does not reap terminated child processes (e.g. containerd-shim), leaving them in a zombie state. The `init: true` directive injects a tiny init process (tini) that properly handles SIGCHLD signals and reaps orphaned children.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

No documentation update is needed — this is a one-line infrastructure configuration change.

## Related Issue(s)

This PR addresses issue #2814 

## Screenshots

N/A

## Notes

This is a minimal, single-line change with no side effects.
The `init: true` option is a Docker Compose built-in that uses tini as PID 1, which is the standard solution for zombie process reaping in containers.