### PR TITLE
fix(runner): handle pruned image tags and null snapshot in recovery

### DIFF
--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1695,7 +1695,6 @@ const docTemplate = `{
             "required": [
                 "errorReason",
                 "osUser",
-                "snapshot",
                 "userId"
             ],
             "properties": {

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1574,7 +1574,7 @@
     },
     "RecoverSandboxDTO": {
       "type": "object",
-      "required": ["errorReason", "osUser", "snapshot", "userId"],
+      "required": ["errorReason", "osUser", "userId"],
       "properties": {
         "backupErrorReason": {
           "type": "string"

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -199,7 +199,6 @@ definitions:
     required:
       - errorReason
       - osUser
-      - snapshot
       - userId
     type: object
   RegistryDTO:

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -41,7 +41,7 @@ type UpdateNetworkSettingsDTO struct {
 type RecoverSandboxDTO struct {
 	FromVolumeId      string            `json:"fromVolumeId,omitempty"`
 	UserId            string            `json:"userId" validate:"required"`
-	Snapshot          string            `json:"snapshot" validate:"required"`
+	Snapshot          *string           `json:"snapshot,omitempty"`
 	OsUser            string            `json:"osUser" validate:"required"`
 	CpuQuota          int64             `json:"cpuQuota" validate:"min=1"`
 	GpuQuota          int64             `json:"gpuQuota" validate:"min=0"`

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -87,7 +87,7 @@ export interface RecoverSandboxDTO {
    * @type {string}
    * @memberof RecoverSandboxDTO
    */
-  snapshot: string
+  snapshot?: string
   /**
    *
    * @type {number}


### PR DESCRIPTION
This pull request updates the `RecoverSandboxDTO` model to make the `snapshot` field optional rather than required across the backend Go code, OpenAPI documentation, and TypeScript client. Additionally, it improves Docker container recreation logic to handle cases where the image tag is missing by falling back to the image ID. These changes enhance flexibility and robustness when recovering sandboxes and managing Docker images.

**Model changes:**

* Made the `snapshot` field in `RecoverSandboxDTO` optional (removed the `required` constraint) in Go (`sandbox.go`), OpenAPI JSON (`swagger.json`), OpenAPI YAML (`swagger.yaml`), and TypeScript client (`recover-sandbox-dto.ts`). [[1]](diffhunk://#diff-a107bad648c914497414085267e1d69d70a61ca5ced90487522c10a2509f679bL43-R43) [[2]](diffhunk://#diff-ef7d2ccdbec6ee831c0e23b46c8ad2c6778b21b33364a28dd1c665be9556481eL1574-R1574) [[3]](diffhunk://#diff-c4ed082a8d66601cd42c1660d8ea4453d11c073960b37f8400e49149dedcea6eL200) [[4]](diffhunk://#diff-b1f6f0214524d16ea065e907b1063b7fe1dabdd3d04c1f8d372e0b47ddbe6221L1695) [[5]](diffhunk://#diff-5e5aaf3458a3790a718b8f1c5110f50a4db06d5fd1fa9545f21caf85fd687865L90-R90)

**Docker image handling improvements:**

* Updated `ContainerDiskResize` to fall back to using the image ID if the original image tag is missing or pruned, ensuring container recreation does not fail due to missing image tags.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation