### PR TITLE
fix: runner systemd permissions

### DIFF
--- a/apps/runner/packaging/systemd/daytona-runner.service
+++ b/apps/runner/packaging/systemd/daytona-runner.service
@@ -25,7 +25,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/var/lib/daytona/runner /var/log/daytona /tmp
+ReadWritePaths=/var/lib/daytona/runner /var/log/daytona /etc/iptables /tmp
 
 # Resource limits
 LimitNOFILE=65536


### PR DESCRIPTION
## Description

Add /etc/iptables to ReadWritePaths so runner can work with iptables-persistent. 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation