### PR TITLE
feat: increase network allow list limit to 10

### DIFF
--- a/apps/api/src/sandbox/utils/network-validation.util.ts
+++ b/apps/api/src/sandbox/utils/network-validation.util.ts
@@ -32,7 +32,7 @@ export function validateNetworkAllowList(networkAllowList: string): void {
     }
   }
 
-  if (networks.length > 5) {
-    throw new Error(`Network allow list cannot contain more than 5 networks`)
+  if (networks.length > 10) {
+    throw new Error(`Network allow list cannot contain more than 10 networks`)
   }
 }


### PR DESCRIPTION
## Description

Increase limit to a maximum of 10 networks in the sandbox network allow list.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation