### PR TITLE
fix: disable S3 flexible checksums for s3proxy compatibility

### DIFF
--- a/apps/api/src/sandbox/managers/volume.manager.ts
+++ b/apps/api/src/sandbox/managers/volume.manager.ts
@@ -61,6 +61,8 @@ export class VolumeManager
         secretAccessKey,
       },
       forcePathStyle: true,
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
     })
   }
 

--- a/libs/sdk-typescript/src/ObjectStorage.ts
+++ b/libs/sdk-typescript/src/ObjectStorage.ts
@@ -50,6 +50,8 @@ export class ObjectStorage {
         sessionToken: config.sessionToken,
       },
       forcePathStyle: true,
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
     })
   }
 


### PR DESCRIPTION
## Description

Disable AWS SDK v3 flexible checksums to fix compatibility with s3proxy (S3 compatibility layer for Azure Blob Storage).

AWS SDK v3's `@aws-sdk/middleware-flexible-checksums` sends `x-amz-checksum-algorithm` and related headers by default on every request. s3proxy does not implement these headers, causing requests to fail when using Azure Blob Storage as the backend.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes

This is safe because Azure Blob Storage has its own built-in integrity checks, making the S3 flexible checksums redundant. `WHEN_REQUIRED` ensures checksums are only sent when S3 explicitly mandates them (which s3proxy never will).

No documentation changes needed — this is an internal configuration fix with no user-facing API changes.

- The `mount-s3` binary supports `--upload-checksums off` (alternatives: `crc32c` which is the default)
- The AWS SDK v3 `requestChecksumCalculation` / `responseChecksumValidation` options accept `'WHEN_REQUIRED'` or `'WHEN_SUPPORTED'` — we use `'WHEN_REQUIRED'` to minimize unnecessary headers
- If s3proxy is eventually replaced with a full S3 implementation, these settings can be safely removed