### PR TITLE
fix(docs): remove clickable anchors from api reference

### DIFF
--- a/apps/docs/src/components/MarkdownContent.astro
+++ b/apps/docs/src/components/MarkdownContent.astro
@@ -18,8 +18,11 @@
     const headings = document.querySelectorAll(
       '.markdown-content h2[id], .markdown-content h3[id], .markdown-content h4[id], .markdown-content h5[id]'
     )
+    const filteredHeadings = Array.from(headings).filter(
+      heading => !heading.closest('#scalar-container')
+    )
 
-    headings.forEach(heading => {
+    filteredHeadings.forEach(heading => {
       const anchor = document.createElement('a')
       anchor.href = `#${heading.id}`
       anchor.className = 'heading-anchor'


### PR DESCRIPTION
## Description

Removes the clickable anchors from the API reference due to its structure not supporting heading URL slugs. For example, clicking the header anchor of the "create a sandbox" API request leads to `/docs/en/tools/api/#scalar-refs-0-5`.

Users can still use the sidebar and its dedicated search for interacting with API references.

