### PR TITLE
docs: add security vulnerability disclosure policy and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS — Daytona
+# These owners are automatically requested for review on PRs that modify the listed files.
+
+# Security and compliance policies
+SECURITY.md          @aprojic
+CODE_OF_CONDUCT.md   @aprojic

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,27 @@
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, please contact us at [support@daytona.io](mailto:support@daytona.io).
+At Daytona, we take security seriously. If you believe you have found a security vulnerability in any Daytona-owned repository or service, please report it responsibly.
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please email us at: **security@daytona.io**
+
+You can also report vulnerabilities privately through [GitHub's security advisory feature](https://github.com/daytonaio/daytona/security/advisories/new).
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment
+- Any relevant screenshots or proof-of-concept
+
+We will acknowledge receipt within 2 business days and provide an initial assessment within 5 business days.
+
+## Supported Versions
+
+We accept vulnerability reports for the latest stable release of Daytona.
+
+## Safe Harbor
+
+Daytona supports safe harbor for security researchers who act in good faith and in accordance with this policy.


### PR DESCRIPTION
## Summary

- Update `SECURITY.md` with a comprehensive vulnerability disclosure policy (reporting channels, expected information, response timelines, supported versions, safe harbor)
- Add `.github/CODEOWNERS` to require review by @aprojic for changes to `SECURITY.md` and `CODE_OF_CONDUCT.md`

## Test plan

- [x] Verify SECURITY.md renders correctly on GitHub
- [ ] Verify CODEOWNERS triggers review requests on matching file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)