### PR TITLE
fix(api): extract error message from object-constructed exceptions

### DIFF
--- a/apps/api/src/filters/all-exceptions.filter.ts
+++ b/apps/api/src/filters/all-exceptions.filter.ts
@@ -52,7 +52,15 @@ export class AllExceptionsFilter implements ExceptionFilter {
     if (exception instanceof HttpException) {
       statusCode = exception.getStatus()
       error = STATUS_CODES[statusCode]
-      message = exception.message
+      const exceptionResponse = exception.getResponse()
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse
+      } else {
+        const responseMessage = (exceptionResponse as Record<string, unknown>).message
+        message = Array.isArray(responseMessage)
+          ? responseMessage.join(', ')
+          : (responseMessage as string) || exception.message
+      }
     } else {
       this.logger.error(exception)
       error = STATUS_CODES[HttpStatus.INTERNAL_SERVER_ERROR]


### PR DESCRIPTION
This pull request improves how error messages are extracted and returned from HTTP exceptions in the `AllExceptionsFilter`. 

### Summary

The `AllExceptionsFilter` was using `exception.message` to populate the error response `message` field. This works for exceptions constructed with a string (e.g. `throw new BadRequestException('Something went wrong')`), but returns a generic `"Bad Request Exception"` for exceptions constructed with an object — most notably `ValidationPipe` errors.

The fix extracts the message from `exception.getResponse()` instead. When `ValidationPipe` (or any other code) constructs an `HttpException` with an object response, the detailed error messages are stored in the response body, not in the top-level `message` property.

#### Before

A request like `/sandbox/paginated?states=someinvalidstate` returns:

```
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Bad Request Exception"
}
```

#### After

A request like `/sandbox/paginated?states=someinvalidstate` returns the correct validation message:

```
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "each value must be one of the following values: started, starting, ..."
}
```
