### PR TITLE
fix(api): headers optional in otel-config.dto spec

### DIFF
--- a/apps/api/src/organization/dto/otel-config.dto.ts
+++ b/apps/api/src/organization/dto/otel-config.dto.ts
@@ -18,7 +18,7 @@ export class OtelConfigDto {
       'x-api-key': 'my-api-key',
     },
     nullable: true,
-    type: 'object',
+    required: false,
     additionalProperties: { type: 'string' },
   })
   headers?: Record<string, string>

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9731,7 +9731,6 @@ components:
           type: object
       required:
         - endpoint
-        - headers
       type: object
     OrganizationSandboxDefaultLimitedNetworkEgress:
       example:

--- a/libs/api-client-go/model_otel_config.go
+++ b/libs/api-client-go/model_otel_config.go
@@ -24,7 +24,7 @@ type OtelConfig struct {
 	// Endpoint
 	Endpoint string `json:"endpoint"`
 	// Headers
-	Headers              map[string]string `json:"headers"`
+	Headers              map[string]string `json:"headers,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -34,10 +34,9 @@ type _OtelConfig OtelConfig
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewOtelConfig(endpoint string, headers map[string]string) *OtelConfig {
+func NewOtelConfig(endpoint string) *OtelConfig {
 	this := OtelConfig{}
 	this.Endpoint = endpoint
-	this.Headers = headers
 	return &this
 }
 
@@ -73,18 +72,16 @@ func (o *OtelConfig) SetEndpoint(v string) {
 	o.Endpoint = v
 }
 
-// GetHeaders returns the Headers field value
-// If the value is explicit nil, the zero value for map[string]string will be returned
+// GetHeaders returns the Headers field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *OtelConfig) GetHeaders() map[string]string {
 	if o == nil {
 		var ret map[string]string
 		return ret
 	}
-
 	return o.Headers
 }
 
-// GetHeadersOk returns a tuple with the Headers field value
+// GetHeadersOk returns a tuple with the Headers field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *OtelConfig) GetHeadersOk() (*map[string]string, bool) {
@@ -94,7 +91,16 @@ func (o *OtelConfig) GetHeadersOk() (*map[string]string, bool) {
 	return &o.Headers, true
 }
 
-// SetHeaders sets field value
+// HasHeaders returns a boolean if a field has been set.
+func (o *OtelConfig) HasHeaders() bool {
+	if o != nil && !IsNil(o.Headers) {
+		return true
+	}
+
+	return false
+}
+
+// SetHeaders gets a reference to the given map[string]string and assigns it to the Headers field.
 func (o *OtelConfig) SetHeaders(v map[string]string) {
 	o.Headers = v
 }
@@ -127,7 +133,6 @@ func (o *OtelConfig) UnmarshalJSON(data []byte) (err error) {
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
 		"endpoint",
-		"headers",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-python-async/daytona_api_client_async/models/otel_config.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/otel_config.py
@@ -28,7 +28,7 @@ class OtelConfig(BaseModel):
     OtelConfig
     """ # noqa: E501
     endpoint: StrictStr = Field(description="Endpoint")
-    headers: Optional[Dict[str, StrictStr]] = Field(description="Headers")
+    headers: Optional[Dict[str, StrictStr]] = Field(default=None, description="Headers")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["endpoint", "headers"]
 

--- a/libs/api-client-python/daytona_api_client/models/otel_config.py
+++ b/libs/api-client-python/daytona_api_client/models/otel_config.py
@@ -28,7 +28,7 @@ class OtelConfig(BaseModel):
     OtelConfig
     """ # noqa: E501
     endpoint: StrictStr = Field(description="Endpoint")
-    headers: Optional[Dict[str, StrictStr]] = Field(description="Headers")
+    headers: Optional[Dict[str, StrictStr]] = Field(default=None, description="Headers")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["endpoint", "headers"]
 

--- a/libs/api-client-ruby/lib/daytona_api_client/models/otel_config.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/otel_config.rb
@@ -80,8 +80,6 @@ module DaytonaApiClient
         if (value = attributes[:'headers']).is_a?(Hash)
           self.headers = value
         end
-      else
-        self.headers = nil
       end
     end
 

--- a/libs/api-client/src/models/otel-config.ts
+++ b/libs/api-client/src/models/otel-config.ts
@@ -29,5 +29,5 @@ export interface OtelConfig {
    * @type {{ [key: string]: string; }}
    * @memberof OtelConfig
    */
-  headers: { [key: string]: string } | null
+  headers?: { [key: string]: string } | null
 }


### PR DESCRIPTION
## Description

Sets the appropriate annotation for the headers prop in otel-config.dto.

Without `required: false`, the prop was interpreted as required which would break Golang clients when headers were not set.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
