### PR TITLE
chore(api): openapi depends on generate:api-client of runner-api-client

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -187,6 +187,7 @@ jobs:
         run: |
           source "$(poetry env info --path)/bin/activate"
           sudo apt-get update && sudo apt-get install -y gcc libx11-dev libxtst-dev
+          go install github.com/swaggo/swag/cmd/swag@v1.16.4
           yarn
           VERSION=0.0.0-dev yarn build --nxBail=true
 

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -37,7 +37,12 @@
     "openapi": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["{projectRoot}/src/**/*.ts", "!{projectRoot}/src/**/*.spec.ts", "{projectRoot}/tsconfig.app.json"],
+      "inputs": [
+        "{projectRoot}/src/**/*.ts",
+        "!{projectRoot}/src/**/*.spec.ts",
+        "{projectRoot}/tsconfig.app.json",
+        { "dependentTasksOutputFiles": "**/*", "transitive": true }
+      ],
       "outputs": ["{workspaceRoot}/dist/apps/api/openapi.json", "{workspaceRoot}/dist/apps/api/openapi.3.1.0.json"],
       "options": {
         "commands": [
@@ -50,7 +55,13 @@
           "NODE_OPTIONS": "--require tsconfig-paths/register",
           "SKIP_CONNECTIONS": "true"
         }
-      }
+      },
+      "dependsOn": [
+        {
+          "target": "generate:api-client",
+          "projects": "runner-api-client"
+        }
+      ]
     },
     "serve": {
       "executor": "@nx/js:node",


### PR DESCRIPTION
## Description

The API imports from runner-api-client, but `api:openapi` had no declared dependency on its generation. This allowed Nx to run them in parallel, causing a race condition -- `generate:api-client` wipes and regenerates `runner-api-client/src,` and if `api:openapi` runs during that window, it fails on missing imports. Even without the race, the dependency is simply correct since the API imports that package.

- Add explicit dependsOn from `api:openapi` to `runner-api-client:generate:api-client
`- Install `swag` in CI `build` job (now needed due to the expanded dependency chain)
