### PR TITLE
feat(api): get sandbox org id cache

### DIFF
--- a/apps/api/src/sandbox/services/sandbox-lookup-cache-invalidation.service.ts
+++ b/apps/api/src/sandbox/services/sandbox-lookup-cache-invalidation.service.ts
@@ -9,6 +9,8 @@ import {
   sandboxLookupCacheKeyByAuthToken,
   sandboxLookupCacheKeyById,
   sandboxLookupCacheKeyByName,
+  sandboxOrgIdCacheKeyById,
+  sandboxOrgIdCacheKeyByName,
 } from '../utils/sandbox-lookup-cache.util'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { OnEvent } from '@nestjs/event-emitter'
@@ -93,6 +95,63 @@ export class SandboxLookupCacheInvalidationService {
       .catch((error) =>
         this.logger.warn(
           `Failed to invalidate sandbox lookup cache for ${args.sandboxId}: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      )
+  }
+
+  invalidateOrgId(args: {
+    sandboxId: string
+    organizationId: string
+    name: string
+    previousOrganizationId?: string | null
+    previousName?: string | null
+  }): void {
+    const cache = this.dataSource.queryResultCache
+    if (!cache) {
+      return
+    }
+
+    const organizationIds = Array.from(
+      new Set(
+        [args.organizationId, args.previousOrganizationId].filter((id): id is string =>
+          Boolean(id && id.trim().length > 0),
+        ),
+      ),
+    )
+    const names = Array.from(
+      new Set([args.name, args.previousName].filter((n): n is string => Boolean(n && n.trim().length > 0))),
+    )
+
+    const cacheIds: string[] = []
+    for (const organizationId of organizationIds) {
+      cacheIds.push(
+        sandboxOrgIdCacheKeyById({
+          organizationId,
+          sandboxId: args.sandboxId,
+        }),
+      )
+      for (const sandboxName of names) {
+        cacheIds.push(
+          sandboxOrgIdCacheKeyByName({
+            organizationId,
+            sandboxName,
+          }),
+        )
+      }
+    }
+
+    // Also invalidate the "no org" variants (when organizationId was not provided to getOrganizationId)
+    cacheIds.push(sandboxOrgIdCacheKeyById({ sandboxId: args.sandboxId }))
+    for (const sandboxName of names) {
+      cacheIds.push(sandboxOrgIdCacheKeyByName({ sandboxName }))
+    }
+
+    cache
+      .remove(cacheIds)
+      .then(() => this.logger.debug(`Invalidated sandbox orgId cache for ${args.sandboxId}`))
+      .catch((error) =>
+        this.logger.warn(
+          `Failed to invalidate sandbox orgId cache for ${args.sandboxId}: ${error instanceof Error ? error.message : String(error)}`,
         ),
       )
   }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -77,8 +77,11 @@ import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import {
   SANDBOX_LOOKUP_CACHE_TTL_MS,
+  SANDBOX_ORG_ID_CACHE_TTL_MS,
   sandboxLookupCacheKeyById,
   sandboxLookupCacheKeyByName,
+  sandboxOrgIdCacheKeyById,
+  sandboxOrgIdCacheKeyByName,
 } from '../utils/sandbox-lookup-cache.util'
 import { SandboxLookupCacheInvalidationService } from './sandbox-lookup-cache-invalidation.service'
 
@@ -613,6 +616,14 @@ export class SandboxService {
 
     const result = await this.sandboxRepository.save(warmPoolSandbox)
 
+    // Defensive invalidation of orgId cache since the sandbox moved from unassigned to a real organization
+    this.sandboxLookupCacheInvalidationService.invalidateOrgId({
+      sandboxId: warmPoolSandbox.id,
+      organizationId: organization.id,
+      name: warmPoolSandbox.name,
+      previousOrganizationId: SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION,
+    })
+
     // Treat this as a newly started sandbox
     this.eventEmitter.emit(
       SandboxEvents.STATE_UPDATED,
@@ -1039,7 +1050,10 @@ export class SandboxService {
         ...(organizationId ? { organizationId: organizationId } : {}),
       },
       select: ['organizationId'],
-      loadEagerRelations: false,
+      cache: {
+        id: sandboxOrgIdCacheKeyById({ organizationId, sandboxId: sandboxIdOrName }),
+        milliseconds: SANDBOX_ORG_ID_CACHE_TTL_MS,
+      },
     })
 
     if (!sandbox && organizationId) {
@@ -1049,7 +1063,10 @@ export class SandboxService {
           organizationId: organizationId,
         },
         select: ['organizationId'],
-        loadEagerRelations: false,
+        cache: {
+          id: sandboxOrgIdCacheKeyByName({ organizationId, sandboxName: sandboxIdOrName }),
+          milliseconds: SANDBOX_ORG_ID_CACHE_TTL_MS,
+        },
       })
     }
 

--- a/apps/api/src/sandbox/utils/sandbox-lookup-cache.util.ts
+++ b/apps/api/src/sandbox/utils/sandbox-lookup-cache.util.ts
@@ -5,6 +5,7 @@
 
 export const SANDBOX_LOOKUP_CACHE_TTL_MS = 10_000
 export const SANDBOX_BUILD_INFO_CACHE_TTL_MS = 60_000
+export const SANDBOX_ORG_ID_CACHE_TTL_MS = 60_000
 
 type SandboxLookupCacheKeyArgs = {
   organizationId?: string | null
@@ -25,4 +26,18 @@ export function sandboxLookupCacheKeyByName(args: SandboxLookupCacheKeyArgs & { 
 
 export function sandboxLookupCacheKeyByAuthToken(args: { authToken: string }): string {
   return `sandbox:lookup:by-authToken:${args.authToken}`
+}
+
+type SandboxOrgIdCacheKeyArgs = {
+  organizationId?: string
+}
+
+export function sandboxOrgIdCacheKeyById(args: SandboxOrgIdCacheKeyArgs & { sandboxId: string }): string {
+  const organizationId = args.organizationId ?? 'none'
+  return `sandbox:orgId:by-id:org:${organizationId}:value:${args.sandboxId}`
+}
+
+export function sandboxOrgIdCacheKeyByName(args: SandboxOrgIdCacheKeyArgs & { sandboxName: string }): string {
+  const organizationId = args.organizationId ?? 'none'
+  return `sandbox:orgId:by-name:org:${organizationId}:value:${args.sandboxName}`
 }


### PR DESCRIPTION
## Description

Caches the organization ID retrieval based on sandbox ID which is used in the access guard and called very frequently

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation