### PR TITLE
refactor(api): sync archived desired states ordering

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -640,7 +640,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       },
       take: 100,
       order: {
-        lastActivityAt: 'ASC',
+        updatedAt: 'ASC',
       },
     })
 


### PR DESCRIPTION
## Sync archived desired states ordering

Changes the `syncArchivedDesiredStates` method to use order by `updatedAt` instead of `lastActivityAt`, cca 14x performance optimization due to better index utilization - no change in behavior

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation