### PR TITLE
fix(runner): do not force websocket logs to octet-stream

### DIFF
--- a/apps/runner/pkg/api/controllers/proxy.go
+++ b/apps/runner/pkg/api/controllers/proxy.go
@@ -34,7 +34,7 @@ import (
 //	@Router			/sandboxes/{sandboxId}/toolbox/{path} [post]
 //	@Router			/sandboxes/{sandboxId}/toolbox/{path} [delete]
 func ProxyRequest(ctx *gin.Context) {
-	if regexp.MustCompile(`^/process/session/.+/command/.+/logs$`).MatchString(ctx.Param("path")) {
+	if ctx.Request.Header.Get("Upgrade") != "websocket" && regexp.MustCompile(`^/process/session/.+/command/.+/logs$`).MatchString(ctx.Param("path")) {
 		if ctx.Query("follow") == "true" {
 			ProxyCommandLogsStream(ctx)
 			return


### PR DESCRIPTION
## Description

Fixes a regression that caused session command logs to fail when requested through webscocket.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
