### PR TITLE
fix(dashboard): don't show sandbox cleanup date if passed

### DIFF
--- a/apps/dashboard/src/hooks/useSuspensionBanner.tsx
+++ b/apps/dashboard/src/hooks/useSuspensionBanner.tsx
@@ -92,8 +92,12 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
         ? addHours(suspendedAtDate, suspension.suspensionCleanupGracePeriodHours ?? 0)
         : null
 
+      const cleanupDatePassed = cleanupDate !== null && cleanupDate <= new Date()
+
       const cleanupText = cleanupDate
-        ? `Sandboxes will be stopped ${formatDistanceToNow(cleanupDate, { addSuffix: true })}`
+        ? cleanupDatePassed
+          ? 'Sandboxes will be stopped'
+          : `Sandboxes will be stopped ${formatDistanceToNow(cleanupDate, { addSuffix: true })}`
         : 'Sandboxes will be stopped soon'
 
       addBanner({
@@ -118,8 +122,11 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
       ? addHours(suspendedAtDate, suspension.suspensionCleanupGracePeriodHours ?? 0)
       : null
 
+    const cleanupDatePassed = cleanupDate !== null && cleanupDate <= new Date()
     const cleanupText = cleanupDate
-      ? `Sandboxes will be stopped ${formatDistanceToNow(cleanupDate, { addSuffix: true })}`
+      ? cleanupDatePassed
+        ? 'Sandboxes will be stopped'
+        : `Sandboxes will be stopped ${formatDistanceToNow(cleanupDate, { addSuffix: true })}`
       : 'Sandboxes will be stopped soon'
 
     addBanner({


### PR DESCRIPTION
## Description

Don't show sandbox cleanup date in the past.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

