### PR TITLE
fix(dashboard): api key warning on member remove

### DIFF
--- a/apps/dashboard/src/components/OrganizationMembers/RemoveOrganizationMemberDialog.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/RemoveOrganizationMemberDialog.tsx
@@ -40,7 +40,10 @@ export const RemoveOrganizationMemberDialog: React.FC<RemoveOrganizationMemberDi
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Remove Member</DialogTitle>
-          <DialogDescription>Are you sure you want to remove this member from the organization?</DialogDescription>
+          <DialogDescription>
+            Are you sure you want to remove this member from the organization? Any API keys they have created will
+            become ineffective.
+          </DialogDescription>
         </DialogHeader>
         <DialogFooter>
           <DialogClose asChild>


### PR DESCRIPTION
## Description

Simple warning message when removing an organization member, as we've been getting complaints of API keys not working "all of a sudden".

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation