### PR TITLE
fix(license): add libs/common-go to license check job

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -19,6 +19,7 @@ header:
   paths-ignore:
     - 'libs/**'
     - '!libs/computer-use/**'
+    - '!libs/common-go/**'
     - 'apps/api/src/generate-openapi.ts'
     - 'apps/runner/pkg/api/docs/docs.go'
     - 'examples/**'


### PR DESCRIPTION
## Description

This pull request makes a small update to the `.licenserc.yaml` configuration, adjusting the license scanning rules to better target relevant code.

* License scanning configuration: Added `libs/common-go/**` to the list of paths that should not be ignored, ensuring this directory is included in license checks.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation