### PR TITLE
chore(api): remove openapi build dependency

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -31,8 +31,7 @@
           "extractLicenses": true,
           "inspect": false
         }
-      },
-      "dependsOn": ["openapi"]
+      }
     },
     "openapi": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
## Description

Removed "openapi" from the "build" target deps of the API.

This caused docker builds to fail and adds an unnecessary chain of dependencies when building the API.
Since we have API clients committed, we don't need to build them on every api build. 
This removes Golang as a direct build dep of the API (API -> runner api client -> runner).

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
