### PR TITLE
fix(sdk-python): handle closed aiohttp session reuse

### DIFF
--- a/libs/sdk-python/src/daytona/_utils/errors.py
+++ b/libs/sdk-python/src/daytona/_utils/errors.py
@@ -75,6 +75,20 @@ def intercept_errors(
                     )
                 ) from e
 
+            # aiohttp raises a bare AssertionError (no message) when a request is made
+            # on a session whose _connector has been set to None by close().
+            # str(AssertionError()) == "" so it falls through to the generic handler and
+            # produces a completely empty DaytonaError message. Catch it here and produce
+            # the same helpful "client is closed" message instead.
+            if isinstance(e, AssertionError) and not str(e):
+                raise DaytonaError(
+                    (
+                        f"{message_prefix}Daytona client is closed"
+                        " — sandbox is used outside its parent's context. "
+                        "Ensure sandboxes are only used within the scope of their parent Daytona object."
+                    )
+                ) from e
+
             msg = f"{message_prefix}{str(e)}" if message_prefix else str(e)
             raise DaytonaError(msg)  # pylint: disable=raise-missing-from
 


### PR DESCRIPTION
This pull request improves the robustness of client shutdown and error handling in the Daytona Python SDK. It ensures that closed REST client sessions are properly nulled out to prevent assertion errors on concurrent requests, and provides a clearer error message when a closed client is used.

**Client shutdown and resource management:**

* After closing the main and toolbox API clients in `daytona/_async/daytona.py`, the underlying REST client session references (`pool_manager` and `retry_client`) are explicitly set to `None` to prevent concurrent requests from triggering assertion errors on dead aiohttp connectors.

**Error handling improvements:**

* In `daytona/_utils/errors.py`, a specific handler for bare `AssertionError` instances (with no message) is added. This produces a helpful "Daytona client is closed" error message when a request is made on a closed client, instead of a generic empty error.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
