### PR TITLE
fix(api): remove parseuuid pipe on sandbox ids

### DIFF
--- a/apps/api/src/admin/controllers/sandbox.controller.ts
+++ b/apps/api/src/admin/controllers/sandbox.controller.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Controller, HttpCode, NotFoundException, Param, ParseUUIDPipe, Post, UseGuards } from '@nestjs/common'
+import { Controller, HttpCode, NotFoundException, Param, Post, UseGuards } from '@nestjs/common'
 import { ApiBearerAuth, ApiOAuth2, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger'
 import { Audit } from '../../audit/decorators/audit.decorator'
 import { AuditAction } from '../../audit/enums/audit-action.enum'
@@ -50,7 +50,7 @@ export class AdminSandboxController {
     targetIdFromRequest: (req) => req.params.sandboxId,
     targetIdFromResult: (result: SandboxDto) => result?.id,
   })
-  async recoverSandbox(@Param('sandboxId', ParseUUIDPipe) sandboxId: string): Promise<SandboxDto> {
+  async recoverSandbox(@Param('sandboxId') sandboxId: string): Promise<SandboxDto> {
     const organization = await this.organizationService.findBySandboxId(sandboxId)
     if (!organization) {
       throw new NotFoundException('Sandbox not found')

--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -314,7 +314,7 @@ export class RunnerController {
   })
   @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard, SandboxAccessGuard]))
   @RequiredApiRole([SystemRole.ADMIN, 'proxy', 'ssh-gateway', 'region-proxy', 'region-ssh-gateway'])
-  async getRunnerBySandboxId(@Param('sandboxId', ParseUUIDPipe) sandboxId: string): Promise<RunnerFullDto> {
+  async getRunnerBySandboxId(@Param('sandboxId') sandboxId: string): Promise<RunnerFullDto> {
     const runner = await this.runnerService.findBySandboxId(sandboxId)
 
     if (!runner) {


### PR DESCRIPTION
## Description

Removed ParsUUIDPipe from where its used on the sandboxId as its not strictly an UUID.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation