### PR TITLE
feat(dashboard): add click-to-copy SandboxID with toast confirmation

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -8,6 +8,8 @@ import { Sandbox, SandboxDesiredState, SandboxState } from '@daytonaio/api-clien
 import { ColumnDef } from '@tanstack/react-table'
 import { ArrowDown, ArrowUp } from 'lucide-react'
 import React from 'react'
+import { toast } from 'sonner'
+import { CopyButton } from '../CopyButton'
 import { EllipsisWithTooltip } from '../EllipsisWithTooltip'
 import { Checkbox } from '../ui/checkbox'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
@@ -129,8 +131,18 @@ export function getColumns({
       cell: ({ row }) => {
         const displayName = getDisplayName(row.original)
         return (
-          <div className="w-full truncate">
+          <div className="w-full truncate flex items-center gap-2 group/copy-button">
             <span className="truncate block">{displayName}</span>
+            <CopyButton
+              value={row.original.id}
+              tooltipText="Copy UUID"
+              size="icon-xs"
+              autoHide
+              onClick={(e) => {
+                e.stopPropagation()
+                toast.success('Copied to clipboard')
+              }}
+            />
           </div>
         )
       },

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -134,8 +134,8 @@ export function getColumns({
           <div className="w-full truncate flex items-center gap-2 group/copy-button">
             <span className="truncate block">{displayName}</span>
             <CopyButton
-              value={row.original.id}
-              tooltipText="Copy UUID"
+              value={displayName}
+              tooltipText="Copy name"
               size="icon-xs"
               autoHide
               onClick={(e) => {
@@ -158,8 +158,18 @@ export function getColumns({
       accessorKey: 'id',
       cell: ({ row }) => {
         return (
-          <div className="w-full truncate">
+          <div className="w-full truncate flex items-center gap-2 group/copy-button">
             <span className="truncate block">{row.original.id}</span>
+            <CopyButton
+              value={row.original.id}
+              tooltipText="Copy UUID"
+              size="icon-xs"
+              autoHide
+              onClick={(e) => {
+                e.stopPropagation()
+                toast.success('Copied to clipboard')
+              }}
+            />
           </div>
         )
       },


### PR DESCRIPTION
## Description

This PR Adds click-to-copy functionality for SandboxIDs directly within the dashboard table. The implementation mirrors the existing copy behavior from the details sheet, including toast confirmation and hover-based visibility.

### The Problem
- Users could not quickly copy SandboxIDs from the dashboard table.
- Copy functionality existed in the details sheet but was missing in the table view.
- No consistent UX pattern for copying IDs across different views.

### The Fix
- Updated `columns.tsx` to enhance the ID column.
- Added a `CopyButton` component next to the SandboxID.
- Integrated `toast` from `sonner` to display a success message: **"Copied to clipboard"**.
- Implemented `autoHide` behavior so the copy button only appears on row hover (matching the details sheet pattern).
- Added `e.stopPropagation()` to prevent row click events when the copy button is clicked.
- Used a `flex` layout to align the SandboxID text and copy button cleanly.
- Included tooltip text: **"Copy UUID"** for better accessibility and clarity.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #3363

## Screenshots


https://github.com/user-attachments/assets/61d52fbd-911e-478b-9615-f7adf3e6ffb2


## Notes

Please add any relevant notes if necessary.
