### PR TITLE
fix(api): close usage period on STOPPING state

### DIFF
--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -55,7 +55,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           await this.createUsagePeriod(event)
           break
         }
-        case SandboxState.STOPPED:
+        case SandboxState.STOPPING:
           await this.closeUsagePeriod(event.sandbox.id)
           await this.createUsagePeriod(event, true)
           break
@@ -150,7 +150,12 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           usagePeriod.endAt = closeTime
           await transactionalEntityManager.save(usagePeriod)
 
-          if (sandbox && (sandbox.state === SandboxState.STARTED || sandbox.state === SandboxState.STOPPED)) {
+          if (
+            sandbox &&
+            (sandbox.state === SandboxState.STARTED ||
+              sandbox.state === SandboxState.STOPPED ||
+              sandbox.state === SandboxState.STOPPING)
+          ) {
             // Create new usage period
             const newUsagePeriod = SandboxUsagePeriod.fromUsagePeriod(usagePeriod)
             newUsagePeriod.startAt = closeTime


### PR DESCRIPTION
## Description

Close sandbox usage period on STOPPING state. This will close the usage period immediately when the user requests to stop the sandbox.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
