### PR TITLE
feat(api): allow deletion of pending_build sandboxes

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -348,6 +348,7 @@ export class Sandbox {
             SandboxState.ERROR,
             SandboxState.BUILD_FAILED,
             SandboxState.ARCHIVING,
+            SandboxState.PENDING_BUILD,
           ].includes(this.state)
         ) {
           break

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
@@ -25,7 +25,7 @@ export class SandboxDestroyAction extends SandboxAction {
   }
 
   async run(sandbox: Sandbox, lockCode: LockCode): Promise<SyncState> {
-    if (sandbox.state === SandboxState.ARCHIVED) {
+    if (sandbox.state === SandboxState.ARCHIVED || sandbox.state === SandboxState.PENDING_BUILD) {
       await this.updateSandboxState(sandbox, SandboxState.DESTROYED, lockCode)
       return DONT_SYNC_AGAIN
     }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1230,7 +1230,7 @@ export class SandboxService {
   async destroy(sandboxIdOrName: string, organizationId?: string): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organizationId)
 
-    if (sandbox.pending) {
+    if (sandbox.pending && sandbox.state !== SandboxState.PENDING_BUILD) {
       throw new SandboxError('Sandbox state change in progress')
     }
 
@@ -1238,7 +1238,7 @@ export class SandboxService {
 
     const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
       updateData,
-      whereCondition: { pending: false, state: sandbox.state },
+      whereCondition: { pending: sandbox.pending, state: sandbox.state },
     })
 
     this.eventEmitter.emit(SandboxEvents.DESTROYED, new SandboxDestroyedEvent(updatedSandbox))


### PR DESCRIPTION
## Allow deletion of pending_build sandboxes

Allow deletion of pending_build sandboxes, no underlying instance so it works similarly to the archived into destroyed transition, with the exception of it being `pending = true`

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation