### PR TITLE
chore(docs): add allowed domains build route

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -63,6 +63,13 @@ export default defineConfig({
       ...generateI18nConfig(config),
     }),
   ],
+  security: {
+    allowedDomains: [
+      { hostname: 'daytona.io' },
+      { hostname: 'www.daytona.io' },
+      { hostname: 'localhost' },
+    ],
+  },
   output: 'server',
   adapter: node({
     mode: 'middleware',


### PR DESCRIPTION
## Description

Adds `security.allowedDomains` to the Astro config so the `Host` header is trusted for production domains, restoring correct URL construction in SSR routes.

Astro 5.14.2+ no longer trusts the `Host` header in `NodeApp.createRequest` when `security.allowedDomains` is not configured, causing the request URL to fall back. This breaks the SSR catch-all route's self-proxy in `proxyLocalizedContent`, which uses `Astro.request.url` origin to fetch the localized static page.

https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains