### PR TITLE
fix(api): correctly parse Docker image names with registry and no project path

### DIFF
--- a/apps/api/src/common/utils/docker-image.util.ts
+++ b/apps/api/src/common/utils/docker-image.util.ts
@@ -101,7 +101,7 @@ export function parseDockerImage(imageName: string): DockerImage {
   }
 
   // Check if first part looks like a registry (contains '.' or ':')
-  if (parts.length >= 3) {
+  if (parts.length >= 2 && (parts[0].includes('.') || parts[0].includes(':'))) {
     result.registry = parts[0]
     parts.shift() // Remove registry part
   }


### PR DESCRIPTION
## Summary
- Fix Docker image name parsing for registry/repo format (no project path)
- Images like `tlktestregistry.azurecr.io/agents-tolo:pod.release.9` were
  incorrectly parsed with the registry hostname as the `project` field
- The registry is now detected by checking if the first path segment
  contains `.` or `:`, rather than requiring 3+ path segments