### PR TITLE
feat(api): improve propagation for activated snapshots

### DIFF
--- a/apps/api/src/sandbox/constants/snapshot-events.ts
+++ b/apps/api/src/sandbox/constants/snapshot-events.ts
@@ -5,6 +5,7 @@
 
 export const SnapshotEvents = {
   CREATED: 'snapshot.created',
+  ACTIVATED: 'snapshot.activated',
   STATE_UPDATED: 'snapshot.state.updated',
   REMOVED: 'snapshot.removed',
 } as const

--- a/apps/api/src/sandbox/events/snapshot-activated.event.ts
+++ b/apps/api/src/sandbox/events/snapshot-activated.event.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Snapshot } from '../entities/snapshot.entity'
+
+export class SnapshotActivatedEvent {
+  constructor(public readonly snapshot: Snapshot) {}
+}

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -42,6 +42,7 @@ import { BackupState } from '../enums/backup-state.enum'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { SnapshotInfoResponse } from '@daytonaio/runner-api-client'
+import { SnapshotActivatedEvent } from '../events/snapshot-activated.event'
 
 const SYNC_AGAIN = 'sync-again'
 const DONT_SYNC_AGAIN = 'dont-sync-again'
@@ -1219,6 +1220,13 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     event: SnapshotEvents.CREATED,
   })
   private async handleSnapshotCreatedEvent(event: SnapshotCreatedEvent) {
+    await this.syncSnapshotState(event.snapshot.id)
+  }
+
+  @OnAsyncEvent({
+    event: SnapshotEvents.ACTIVATED,
+  })
+  private async handleSnapshotActivatedEvent(event: SnapshotActivatedEvent) {
     await this.syncSnapshotState(event.snapshot.id)
   }
 }

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -49,6 +49,7 @@ import { RunnerService } from './runner.service'
 import { RegionService } from '../../region/services/region.service'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { SandboxRepository } from '../repositories/sandbox.repository'
+import { SnapshotActivatedEvent } from '../events/snapshot-activated.event'
 
 const IMAGE_NAME_REGEX = /^[a-zA-Z0-9_.\-:]+(\/[a-zA-Z0-9_.\-:]+)*(@sha256:[a-f0-9]{64})?$/
 @Injectable()
@@ -573,7 +574,11 @@ export class SnapshotService {
       }
 
       snapshot.state = SnapshotState.PENDING
-      return await this.snapshotRepository.save(snapshot)
+      const savedSnapshot = await this.snapshotRepository.save(snapshot)
+
+      this.eventEmitter.emit(SnapshotEvents.ACTIVATED, new SnapshotActivatedEvent(savedSnapshot))
+
+      return savedSnapshot
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, pendingSnapshotCountIncrement)
       throw error


### PR DESCRIPTION
This pull request introduces support for a new "activated" event in the snapshot lifecycle. The main changes add a new event type, define the corresponding event class, emit this event when a snapshot is activated, and handle the event to synchronize snapshot state. These changes improve the system's ability to react to snapshot activations in a more modular and event-driven way.

**Event system enhancements:**

* Added a new `ACTIVATED` event type to the `SnapshotEvents` constant in `snapshot-events.ts` to represent when a snapshot is activated.
* Created a new `SnapshotActivatedEvent` class to encapsulate data for the activated event in `snapshot-activated.event.ts`.

**Snapshot activation workflow:**

* Updated the `SnapshotService` to emit the `SnapshotActivatedEvent` after a snapshot is marked as activated and saved, ensuring other parts of the system can react to this event.
* Updated imports in both `snapshot.manager.ts` and `snapshot.service.ts` to include the new `SnapshotActivatedEvent`. [[1]](diffhunk://#diff-d5b6fb1e12aaeb476b8d74812d2f6aaad18a61c34484299dcf89ebb65151e866R45) [[2]](diffhunk://#diff-468bcdc11c5c4818688b6707fbaebe106f83682aa7bba458d5e0535903821965R52)

**Event handling:**

* Added a new event handler in `SnapshotManager` to listen for the `ACTIVATED` event and trigger synchronization of the snapshot state when a snapshot is activated.