### PR TITLE
feat(sdk-rust): add Rust SDK for Daytona

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -93,6 +93,26 @@ jobs:
           working-directory: libs/computer-use
           args: --timeout=5m ./...
 
+  lint-rust:
+    name: Rust lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Check Rust code formatting
+        run: |
+          cd libs/sdk-rust
+          cargo fmt -- --check
+      - name: Run Cargo clippy
+        run: |
+          cd libs/sdk-rust
+          cargo clippy --all-targets -- -D warnings
+      - name: Run Cargo tests
+        run: |
+          cd libs/sdk-rust
+          cargo test
   lint-python:
     name: Python lint
     runs-on: ubuntu-latest
@@ -191,6 +211,10 @@ jobs:
           yarn
           VERSION=0.0.0-dev yarn build --nxBail=true
 
+      - name: Build Rust SDK
+        run: |
+          cd libs/sdk-rust
+          cargo build --release
   license-check:
     runs-on: ubuntu-latest
     steps:
@@ -209,3 +233,10 @@ jobs:
           token: ${{ github.token }}
           config: .licenserc-clients.yaml
           mode: 'check'
+
+      - name: Check Rust License Headers
+        run: |
+          cd libs/sdk-rust
+          grep -q "// Copyright 2019-2025 Daytona Labs Inc." src/lib.rs && \
+          grep -q "// SPDX-License-Identifier: Apache-2.0" src/lib.rs || \
+          (echo "License header check failed" && exit 1)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,6 @@
 # Publishing Daytona SDKs
 
-This document describes how to publish the Daytona SDKs (Python, TypeScript, and Ruby) to their respective package registries.
+This document describes how to publish the Daytona SDKs (Python, TypeScript, Ruby, and Rust) to their respective package registries.
 
 ## Table of Contents
 
@@ -8,6 +8,7 @@ This document describes how to publish the Daytona SDKs (Python, TypeScript, and
 - [Python SDK (PyPI)](#python-sdk-pypi)
 - [TypeScript SDK (npm)](#typescript-sdk-npm)
 - [Ruby SDK (RubyGems)](#ruby-sdk-rubygems)
+- [Rust SDK (crates.io)](#rust-sdk-cratesio)
 - [Automated Publishing (CI/CD)](#automated-publishing-cicd)
 - [Version Management](#version-management)
 
@@ -20,6 +21,7 @@ Before publishing any SDK, ensure you have:
    - PyPI: Token with upload permissions
    - npm: Token with publish permissions
    - RubyGems: API key with push permissions
+   - crates.io: API token for Cargo
 3. **Local Development Setup**:
    - All dependencies installed (`yarn install`)
    - SDKs built successfully
@@ -65,6 +67,31 @@ yarn nx publish sdk-ruby
 
 **Note**: [Guide](https://guides.rubygems.org/patterns/#prerelease-gems) for versioning Ruby gems.
 
+## Rust SDK (crates.io)
+
+### Using Nx
+
+```bash
+# From repository root
+export CARGO_REGISTRIES_CRATES_IO_TOKEN="your-crates-io-token"
+export CARGO_PKG_VERSION="X.Y.Z" # pre-release format: "X.Y.Z-alpha.1"
+yarn nx publish sdk-rust
+```
+
+**Note**: [Cargo publish guide](https://doc.rust-lang.org/cargo/reference/publishing.html) for versioning Rust crates. Pre-release versions use `MAJOR.MINOR.PATCH-PREREL.NUMBER` format.
+
+### Manual Publishing
+
+```bash
+cd libs/sdk-rust
+cargo publish
+```
+
+For dry-run:
+```bash
+cargo publish --dry-run
+```
+
 ## Automated Publishing (CI/CD)
 
 ### GitHub Actions Workflow
@@ -80,6 +107,7 @@ The repository includes a GitHub Actions workflow for automated publishing: `.gi
    - **pypi_pkg_version**: (Optional) Override PyPI version
    - **npm_pkg_version**: (Optional) Override npm version
    - **rubygems_pkg_version**: (Optional) Override RubyGems version
+   - **cargo_pkg_version**: (Optional) Override Cargo version
    - **npm_tag**: npm dist-tag (default: `latest`)
 
 #### Required Secrets
@@ -89,16 +117,16 @@ Ensure these secrets are configured in GitHub repository settings:
 - `PYPI_TOKEN`: PyPI API token
 - `NPM_TOKEN`: npm access token
 - `RUBYGEMS_API_KEY`: RubyGems API key
+- `CARGO_REGISTRIES_CRATES_IO_TOKEN`: crates.io API token
 - `GITHUBBOT_TOKEN`: GitHub token for Homebrew tap updates
 
 ### What the Workflow Does
 
 1. Checks out the code
-2. Sets up all required environments (Go, Java, Python, Node.js, Ruby)
-3. Installs dependencies
-4. Configures credentials for all package registries
-5. Runs `yarn publish` which uses Nx to publish all SDKs in the correct order
-6. Updates the Homebrew tap (for the CLI)
+2. Sets up all required environments (Go, Java, Python, Node.js, Ruby, Rust)
+3. Configures credentials for all package registries
+4. Runs `yarn publish` which uses Nx to publish all SDKs in the correct order
+5. Updates the Homebrew tap (for the CLI)
 
 ## Version Management
 
@@ -136,6 +164,13 @@ Prerelease formats depend on SDK language:
    - `0.126.0.beta.1` - Beta release
    - `0.126.0.rc.1` - Release candidate
 
+4. For **Rust** (crates.io) follow [Cargo semantic versioning](https://doc.rust-lang.org/cargo/reference/publishing.html):
+
+   For pre-releases, use:
+   - `0.126.0-alpha.1` - Alpha release
+   - `0.126.0-beta.1` - Beta release
+   - `0.126.0-rc.1` - Release candidate
+
 ### Checking Published Versions
 
 #### PyPI
@@ -160,6 +195,14 @@ npm info @daytonaio/sdk
 gem search daytona --remote --exact
 # or
 gem info daytona --remote
+```
+
+#### crates.io
+
+```bash
+cargo search daytona
+# or
+curl -s https://crates.io/api/v1/crates/daytona | jq -r .crate.max_version
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ pip install daytona
 npm install @daytonaio/sdk
 ```
 
+### Rust SDK
+
+```toml
+[dependencies]
+daytona = "0.0.0"
+```
+
 ---
 
 ## Features
@@ -184,6 +191,38 @@ func main() {
  if err := sandbox.Delete(ctx); err != nil {
   log.Fatalf("Failed to delete sandbox: %v", err)
  }
+}
+```
+
+### Rust SDK
+
+```rust
+use daytona::{Client, Config, CreateSandboxParams, CodeLanguage};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::builder().api_key("YOUR_API_KEY").build();
+    let client = Client::new(config)?;
+
+    let params = CreateSandboxParams {
+        language: Some(CodeLanguage::Python),
+        ..Default::default()
+    };
+
+    let sandbox = client.create(params).await?;
+    let result = sandbox.process().await?.execute_command(
+        "python3 -c 'print(\"Sum of 3 and 4 is\", 3 + 4)'",
+        None, None, None
+    ).await?;
+
+    if result.exit_code != 0 {
+        eprintln!("Error running code: {} {}", result.exit_code, result.result);
+    } else {
+        println!("{}", result.result);
+    }
+
+    sandbox.delete().await?;
+    Ok(())
 }
 ```
 

--- a/libs/sdk-rust/.gitignore
+++ b/libs/sdk-rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/libs/sdk-rust/Cargo.toml
+++ b/libs/sdk-rust/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "daytona"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/daytonaio/daytona"
+description = "Daytona SDK for Rust"
+keywords = ["daytona", "sdk", "sandbox", "dev-environment"]
+categories = ["api-bindings", "development-tools"]
+
+[dependencies]
+base64 = "0.22"
+regex = "1"
+reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0"
+async-trait = "0.1"
+futures = "0.3"
+urlencoding = "2.1"
+# OpenTelemetry dependencies (optional)
+opentelemetry = { version = "0.28", optional = true }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.28", features = ["http-proto", "reqwest-client"], optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-opentelemetry = { version = "0.28", optional = true }
+
+# Image builder dependencies (optional)
+sha2 = { version = "0.10", optional = true }
+tar = { version = "0.4", optional = true }
+rust-s3 = { version = "0.35", optional = true }
+
+[dev-dependencies]
+tokio-test = "0.4"
+
+[features]
+default = []
+otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "tracing", "tracing-opentelemetry"]
+image-builder = ["sha2", "tar", "rust-s3"]
+full = ["otel", "image-builder"]

--- a/libs/sdk-rust/LICENSE
+++ b/libs/sdk-rust/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Daytona
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. 

--- a/libs/sdk-rust/README.md
+++ b/libs/sdk-rust/README.md
@@ -1,0 +1,49 @@
+# Daytona Rust SDK
+
+Rust SDK for Daytona sandbox lifecycle and toolbox operations.
+
+## Installation
+
+```toml
+[dependencies]
+daytona = "0.0.0"
+```
+
+## Configuration
+
+Supported environment variables:
+
+- `DAYTONA_API_KEY`
+- `DAYTONA_JWT_TOKEN`
+- `DAYTONA_ORGANIZATION_ID`
+- `DAYTONA_API_URL` (default: `https://app.daytona.io/api`)
+- `DAYTONA_TARGET`
+
+## Quick Start
+
+```rust
+use daytona::{Client, Config, CreateSandboxParams};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::builder().api_key("YOUR_API_KEY").build();
+    let client = Client::new(config)?;
+
+    let sandbox = client.create(CreateSandboxParams::default()).await?;
+    let result = sandbox.process().execute_command("echo hello", None, None, None).await?;
+    println!("{}", result.result);
+
+    sandbox.delete().await?;
+    Ok(())
+}
+```
+
+## Implemented Modules
+
+- `Client`: create/get/findOne/list/delete/start/stop
+- `Sandbox`: filesystem, git, process, code interpreter, computer use, lsp server
+- `VolumeService`, `SnapshotService`, `ObjectStorageService`
+
+## License
+
+Apache-2.0

--- a/libs/sdk-rust/examples/basic_usage.rs
+++ b/libs/sdk-rust/examples/basic_usage.rs
@@ -1,0 +1,31 @@
+use daytona::{Client, Config, CreateSandboxParams};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Option 1: Use environment variables (DAYTONA_API_KEY, DAYTONA_API_URL, etc.)
+    // let config = Config::from_env();
+
+    // Option 2: Use builder pattern (recommended for explicit configuration)
+    let config = Config::builder()
+        .api_key(std::env::var("DAYTONA_API_KEY").expect("DAYTONA_API_KEY must be set"))
+        .build();
+
+    let client = Client::new(config)?;
+
+    let sandbox = client.create(CreateSandboxParams::default()).await?;
+    println!(
+        "Created sandbox: {} (state: {:?})",
+        sandbox.id, sandbox.state
+    );
+
+    let process = sandbox.process().await?;
+    let result = process
+        .execute_command("echo 'Hello from Daytona Rust SDK'", None, None, None)
+        .await?;
+    println!("Command output: {}", result.result);
+
+    sandbox.delete().await?;
+    println!("Sandbox deleted");
+
+    Ok(())
+}

--- a/libs/sdk-rust/project.json
+++ b/libs/sdk-rust/project.json
@@ -1,0 +1,42 @@
+{
+  "name": "sdk-rust",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/sdk-rust/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "cargo build --release"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "cargo test"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "cargo clippy --all-targets -- -D warnings"
+      }
+    },
+    "format": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "cargo fmt"
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "cargo publish"
+      }
+  }
+}

--- a/libs/sdk-rust/src/client.rs
+++ b/libs/sdk-rust/src/client.rs
@@ -1,0 +1,857 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::Config;
+use crate::error::DaytonaError;
+use crate::image::DockerImage;
+#[cfg(feature = "otel")]
+use crate::otel::OtelState;
+use crate::sandbox::Sandbox;
+use crate::services::object_storage::ObjectStorageService;
+use crate::services::snapshot::SnapshotService;
+use crate::services::volume::VolumeService;
+use crate::services::ServiceClient;
+use crate::types::{
+    BuildInfo, CreateSandboxParams, PaginatedSandboxes, PreviewLink, ResizeSandboxRequest,
+    SandboxDto, SignedPreviewUrl, SshAccessDto, SshAccessValidationDto,
+};
+use crate::utils::{decode_empty, decode_json, join_url, with_auth};
+use reqwest::Client as HttpClient;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+#[derive(Clone)]
+pub struct Client {
+    pub(crate) inner: Arc<ClientInner>,
+    volume: VolumeService,
+    snapshot: SnapshotService,
+    object_storage: ObjectStorageService,
+    #[cfg(feature = "otel")]
+    otel: Option<Arc<OtelState>>,
+}
+
+pub(crate) struct ClientInner {
+    pub config: Config,
+    pub http: HttpClient,
+    toolbox_proxy_cache: RwLock<HashMap<String, String>>,
+}
+
+impl Client {
+    pub fn new(config: Config) -> Result<Self, DaytonaError> {
+        if config.bearer_token().is_none() {
+            return Err(DaytonaError::Unauthorized(
+                "Authentication required. Please set DAYTONA_API_KEY or DAYTONA_JWT_TOKEN environment variable, or provide api_key or jwt_token in Config".to_string(),
+            ));
+        }
+
+        if config.jwt_token.is_some() && config.organization_id.is_none() {
+            return Err(DaytonaError::Unauthorized(
+                "Organization ID is required when using JWT token".to_string(),
+            ));
+        }
+
+        let http = HttpClient::builder()
+            .timeout(config.timeout.unwrap_or(Duration::from_secs(300)))
+            .build()
+            .map_err(|e| DaytonaError::Network(e.to_string()))?;
+        let inner = Arc::new(ClientInner {
+            config: config.clone(),
+            http: http.clone(),
+            toolbox_proxy_cache: RwLock::new(HashMap::new()),
+        });
+
+        #[cfg(feature = "otel")]
+        let otel = if config.otel_enabled {
+            Some(Arc::new(OtelState::new()?))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            inner,
+            volume: VolumeService::new(ServiceClient::new(
+                config.api_url.clone(),
+                config.clone(),
+                http.clone(),
+            )),
+            snapshot: SnapshotService::new(ServiceClient::new(
+                config.api_url.clone(),
+                config.clone(),
+                http.clone(),
+            )),
+            object_storage: ObjectStorageService::new(ServiceClient::new(
+                config.api_url.clone(),
+                config,
+                http,
+            )),
+            #[cfg(feature = "otel")]
+            otel,
+        })
+    }
+
+    /// Close the client and shutdown OpenTelemetry if enabled
+    pub async fn close(&self) {
+        #[cfg(feature = "otel")]
+        if let Some(ref otel) = self.otel {
+            let _ = otel.shutdown().await;
+        }
+    }
+
+    pub fn volumes(&self) -> &VolumeService {
+        &self.volume
+    }
+
+    pub fn snapshots(&self) -> &SnapshotService {
+        &self.snapshot
+    }
+
+    pub fn object_storage(&self) -> &ObjectStorageService {
+        &self.object_storage
+    }
+
+    pub async fn create(&self, params: CreateSandboxParams) -> Result<Sandbox, DaytonaError> {
+        // Handle ephemeral flag
+        let mut params = params;
+        if params.ephemeral.unwrap_or(false) {
+            if let Some(interval) = params.auto_delete_interval {
+                if interval != 0 {
+                    eprintln!("[Warning] 'ephemeral' and 'autoDeleteInterval' cannot be used together. If ephemeral is true, autoDeleteInterval will be ignored and set to 0.");
+                }
+            }
+            params.auto_delete_interval = Some(0);
+        }
+
+        // Set target from config if not already set
+        if params.target.is_none() {
+            params.target = self.inner.config.target.clone();
+        }
+
+        // Convert image string to build_info
+        if let Some(image) = &params.image {
+            if params.build_info.is_none() {
+                params.build_info = Some(BuildInfo {
+                    dockerfile_content: format!("FROM {}\n", image),
+                    context_hashes: None,
+                });
+            }
+        }
+
+        let req = with_auth(
+            self.inner
+                .http
+                .post(join_url(&self.inner.config.api_url, "/sandbox")),
+            &self.inner.config,
+        )?;
+        let dto: SandboxDto = decode_json(
+            req.json(&params)
+                .send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await?;
+        Ok(Sandbox::from_dto(self.inner.clone(), dto))
+    }
+
+    pub async fn get(&self, sandbox_id_or_name: &str) -> Result<Sandbox, DaytonaError> {
+        let req = with_auth(
+            self.inner.http.get(join_url(
+                &self.inner.config.api_url,
+                &format!("/sandbox/{sandbox_id_or_name}"),
+            )),
+            &self.inner.config,
+        )?;
+        let dto: SandboxDto = decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await?;
+        Ok(Sandbox::from_dto(self.inner.clone(), dto))
+    }
+
+    pub async fn find_one(
+        &self,
+        sandbox_id_or_name: Option<&str>,
+        labels: Option<HashMap<String, String>>,
+    ) -> Result<Sandbox, DaytonaError> {
+        if let Some(id_or_name) = sandbox_id_or_name {
+            if !id_or_name.is_empty() {
+                return self.get(id_or_name).await;
+            }
+        }
+
+        let result = self.list(labels, Some(1), Some(1)).await?;
+        result
+            .items
+            .into_iter()
+            .next()
+            .map(|dto| Sandbox::from_dto(self.inner.clone(), dto))
+            .ok_or_else(|| {
+                DaytonaError::NotFound("No sandbox found for provided filter".to_string())
+            })
+    }
+
+    pub async fn list(
+        &self,
+        labels: Option<HashMap<String, String>>,
+        page: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<PaginatedSandboxes, DaytonaError> {
+        // Validate page and limit parameters
+        if page.is_some_and(|p| p < 1) {
+            return Err(DaytonaError::Api {
+                status: 0,
+                message: "Page must be >= 1".to_string(),
+            });
+        }
+        if limit.is_some_and(|l| l < 1) {
+            return Err(DaytonaError::Api {
+                status: 0,
+                message: "Limit must be >= 1".to_string(),
+            });
+        }
+
+        // Build query string
+        let mut query = Vec::new();
+        if let Some(p) = page {
+            query.push(format!("page={}", p));
+        }
+        if let Some(l) = limit {
+            query.push(format!("limit={}", l));
+        }
+        if let Some(ref lbls) = labels {
+            let labels_json = serde_json::to_string(lbls).unwrap_or_default();
+            query.push(format!("labels={}", urlencoding::encode(&labels_json)));
+        }
+
+        let query_str = if query.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", query.join("&"))
+        };
+
+        let req = with_auth(
+            self.inner.http.get(join_url(
+                &self.inner.config.api_url,
+                &format!("/sandbox{}", query_str),
+            )),
+            &self.inner.config,
+        )?;
+        decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn delete(&self, sandbox_id_or_name: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.inner.http.delete(join_url(
+                &self.inner.config.api_url,
+                &format!("/sandbox/{sandbox_id_or_name}"),
+            )),
+            &self.inner.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn start(&self, sandbox_id_or_name: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.inner.http.post(join_url(
+                &self.inner.config.api_url,
+                &format!("/sandbox/{sandbox_id_or_name}/start"),
+            )),
+            &self.inner.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn stop(&self, sandbox_id_or_name: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.inner.http.post(join_url(
+                &self.inner.config.api_url,
+                &format!("/sandbox/{sandbox_id_or_name}/stop"),
+            )),
+            &self.inner.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn findOne(
+        &self,
+        sandbox_id_or_name: Option<&str>,
+        labels: Option<HashMap<String, String>>,
+    ) -> Result<Sandbox, DaytonaError> {
+        self.find_one(sandbox_id_or_name, labels).await
+    }
+
+    #[cfg(feature = "image-builder")]
+    #[allow(dead_code)]
+    pub(crate) async fn process_image_context(
+        &self,
+        image: &DockerImage,
+    ) -> Result<Vec<String>, DaytonaError> {
+        use s3::creds::Credentials;
+        use s3::region::Region;
+        use s3::Bucket;
+
+        let contexts = image.contexts();
+        if contexts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // 1. Get push access credentials from object storage API
+        let creds: Value = self.object_storage.get_push_access().await?;
+
+        let storage_url = creds["storageUrl"]
+            .as_str()
+            .ok_or_else(|| DaytonaError::Api {
+                status: 0,
+                message: "missing storageUrl in push access response".to_string(),
+            })?;
+        let access_key = creds["accessKey"]
+            .as_str()
+            .ok_or_else(|| DaytonaError::Api {
+                status: 0,
+                message: "missing accessKey in push access response".to_string(),
+            })?;
+        let secret = creds["secret"].as_str().ok_or_else(|| DaytonaError::Api {
+            status: 0,
+            message: "missing secret in push access response".to_string(),
+        })?;
+        let bucket_name = creds["bucket"].as_str().ok_or_else(|| DaytonaError::Api {
+            status: 0,
+            message: "missing bucket in push access response".to_string(),
+        })?;
+        let organization_id =
+            creds["organizationId"]
+                .as_str()
+                .ok_or_else(|| DaytonaError::Api {
+                    status: 0,
+                    message: "missing organizationId in push access response".to_string(),
+                })?;
+
+        // 2. Create S3 bucket instance with credentials
+        let credentials = Credentials::new(
+            Some(access_key),
+            Some(secret),
+            None, // session_token
+            None, // expiration
+            None, // provider_name
+        )
+        .map_err(|e| DaytonaError::Api {
+            status: 0,
+            message: format!("failed to create S3 credentials: {}", e),
+        })?;
+
+        // Parse region from storage URL or default to us-east-1
+        let region = if storage_url.contains("amazonaws.com") {
+            // Extract region from AWS URL (e.g., s3.us-west-2.amazonaws.com)
+            let parts: Vec<&str> = storage_url.split('.').collect();
+            if let Some(pos) = parts.iter().position(|&p| p == "s3") {
+                if pos + 1 < parts.len() {
+                    Region::Custom {
+                        region: parts[pos + 1].to_string(),
+                        endpoint: storage_url.to_string(),
+                    }
+                } else {
+                    Region::Custom {
+                        region: "us-east-1".to_string(),
+                        endpoint: storage_url.to_string(),
+                    }
+                }
+            } else {
+                Region::Custom {
+                    region: "us-east-1".to_string(),
+                    endpoint: storage_url.to_string(),
+                }
+            }
+        } else {
+            Region::Custom {
+                region: "us-east-1".to_string(),
+                endpoint: storage_url.to_string(),
+            }
+        };
+
+        let bucket = Bucket::new(bucket_name, region, credentials)
+            .map_err(|e| DaytonaError::Api {
+                status: 0,
+                message: format!("failed to create S3 bucket: {}", e),
+            })?
+            .with_path_style();
+
+        // 3. Upload each context to object storage and 4. Calculate SHA256 hash
+        let mut context_hashes = Vec::with_capacity(contexts.len());
+
+        for ctx in contexts {
+            // Read the file content
+            let content = tokio::fs::read(&ctx.source_path).await.map_err(|e| {
+                DaytonaError::Network(format!(
+                    "failed to read context file {}: {}",
+                    ctx.source_path, e
+                ))
+            })?;
+
+            // Calculate SHA256 hash
+            let hash = {
+                use sha2::{Digest, Sha256};
+                let mut hasher = Sha256::new();
+                hasher.update(&content);
+                format!("{:x}", hasher.finalize())
+            };
+
+            // Upload to object storage using S3 client
+            let s3_key = format!("{}/{}/context.tar", organization_id, hash);
+
+            // Check if object already exists
+            match bucket.head_object(&s3_key).await {
+                Ok((_, 200)) => {
+                    // Object already exists, skip upload
+                    context_hashes.push(hash);
+                    continue;
+                }
+                _ => {
+                    // Object doesn't exist or error, proceed with upload
+                }
+            }
+
+            let content_type = "application/x-tar";
+            let response = bucket
+                .put_object_with_content_type(&s3_key, &content, content_type)
+                .await
+                .map_err(|e| DaytonaError::Api {
+                    status: 0,
+                    message: format!("failed to upload context to S3: {}", e),
+                })?;
+
+            if response.status_code() != 200 {
+                return Err(DaytonaError::Api {
+                    status: response.status_code(),
+                    message: format!(
+                        "failed to upload context to object storage: {}",
+                        response.status_code()
+                    ),
+                });
+            }
+
+            // 4. Return context hashes
+            context_hashes.push(hash);
+        }
+
+        Ok(context_hashes)
+    }
+
+    #[allow(dead_code)]
+    #[cfg(not(feature = "image-builder"))]
+    pub(crate) async fn process_image_context(
+        &self,
+        _image: &DockerImage,
+    ) -> Result<Vec<String>, DaytonaError> {
+        Err(DaytonaError::Api {
+            status: 0,
+            message: "image-builder feature is required to process image contexts".to_string(),
+        })
+    }
+}
+
+impl ClientInner {
+    pub async fn start_sandbox(&self, sandbox_id_or_name: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{sandbox_id_or_name}/start"),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn stop_sandbox(&self, sandbox_id_or_name: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{sandbox_id_or_name}/stop"),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn delete_sandbox(&self, sandbox_id_or_name: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.delete(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{sandbox_id_or_name}"),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn toolbox_base_url(
+        &self,
+        sandbox_id: &str,
+        region: &str,
+    ) -> Result<String, DaytonaError> {
+        if let Some(found) = self.toolbox_proxy_cache.read().await.get(region).cloned() {
+            return Ok(format!("{}/{}", found.trim_end_matches('/'), sandbox_id));
+        }
+
+        let req = with_auth(
+            self.http.get(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{sandbox_id}/toolbox-proxy-url"),
+            )),
+            &self.config,
+        )?;
+
+        let payload: Value = decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await?;
+        let proxy = payload
+            .get("url")
+            .and_then(Value::as_str)
+            .ok_or_else(|| DaytonaError::Api {
+                status: 0,
+                message: "missing toolbox proxy URL".to_string(),
+            })?
+            .to_string();
+
+        self.toolbox_proxy_cache
+            .write()
+            .await
+            .insert(region.to_string(), proxy.clone());
+
+        Ok(format!("{}/{}", proxy.trim_end_matches('/'), sandbox_id))
+    }
+
+    pub async fn get_sandbox(&self, sandbox_id: &str) -> Result<SandboxDto, DaytonaError> {
+        let req = with_auth(
+            self.http.get(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}", sandbox_id),
+            )),
+            &self.config,
+        )?;
+        decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn archive_sandbox(&self, sandbox_id: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/archive", sandbox_id),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn resize_sandbox(
+        &self,
+        sandbox_id: &str,
+        resources: &ResizeSandboxRequest,
+    ) -> Result<SandboxDto, DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/resize", sandbox_id),
+            )),
+            &self.config,
+        )?;
+        decode_json(
+            req.json(resources)
+                .send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn set_labels(
+        &self,
+        sandbox_id: &str,
+        labels: HashMap<String, String>,
+    ) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.put(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/labels", sandbox_id),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.json(&json!({ "labels": labels }))
+                .send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn set_auto_stop_interval(
+        &self,
+        sandbox_id: &str,
+        interval: i32,
+    ) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/auto-stop-interval/{}", sandbox_id, interval),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn recover(&self, sandbox_id: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/recover", sandbox_id),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn refresh_activity(&self, sandbox_id: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/activity", sandbox_id),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn get_signed_preview_url(
+        &self,
+        sandbox_id: &str,
+        port: i32,
+        expires_in_seconds: Option<i32>,
+    ) -> Result<SignedPreviewUrl, DaytonaError> {
+        let url = match expires_in_seconds {
+            Some(expires) => format!(
+                "/sandbox/{}/preview/{}/signed?expiresIn={}",
+                sandbox_id, port, expires
+            ),
+            None => format!("/sandbox/{}/preview/{}/signed", sandbox_id, port),
+        };
+        let req = with_auth(
+            self.http.get(join_url(&self.config.api_url, &url)),
+            &self.config,
+        )?;
+        decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn expire_signed_preview_url(
+        &self,
+        sandbox_id: &str,
+        port: i32,
+        token: &str,
+    ) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.delete(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/preview/{}/signed/{}", sandbox_id, port, token),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn set_auto_archive_interval(
+        &self,
+        sandbox_id: &str,
+        interval: i32,
+    ) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/auto-archive-interval/{}", sandbox_id, interval),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn set_auto_delete_interval(
+        &self,
+        sandbox_id: &str,
+        interval: i32,
+    ) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/auto-delete-interval/{}", sandbox_id, interval),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn create_ssh_access(
+        &self,
+        sandbox_id: &str,
+        expires_in_minutes: Option<i32>,
+    ) -> Result<SshAccessDto, DaytonaError> {
+        let url = match expires_in_minutes {
+            Some(minutes) => format!("/sandbox/{}/ssh-access?expiresIn={}", sandbox_id, minutes),
+            None => format!("/sandbox/{}/ssh-access", sandbox_id),
+        };
+        let req = with_auth(
+            self.http.post(join_url(&self.config.api_url, &url)),
+            &self.config,
+        )?;
+        decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn revoke_ssh_access(
+        &self,
+        sandbox_id: &str,
+        token: &str,
+    ) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.delete(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/ssh-access/{}", sandbox_id, token),
+            )),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn validate_ssh_access(
+        &self,
+        token: &str,
+    ) -> Result<SshAccessValidationDto, DaytonaError> {
+        let req = with_auth(
+            self.http.get(join_url(
+                &self.config.api_url,
+                &format!("/ssh-access/validate/{}", token),
+            )),
+            &self.config,
+        )?;
+        decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn get_preview_link(
+        &self,
+        sandbox_id: &str,
+        port: i32,
+    ) -> Result<PreviewLink, DaytonaError> {
+        let req = with_auth(
+            self.http.get(join_url(
+                &self.config.api_url,
+                &format!("/sandbox/{}/preview/{}", sandbox_id, port),
+            )),
+            &self.config,
+        )?;
+        decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+}

--- a/libs/sdk-rust/src/code_toolbox.rs
+++ b/libs/sdk-rust/src/code_toolbox.rs
@@ -1,0 +1,726 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Code toolbox implementations for different programming languages.
+//!
+//! These toolboxes provide language-specific command generation for code execution.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+/// Parameters for code execution
+#[derive(Debug, Clone, Default)]
+pub struct CodeRunParams {
+    /// Command-line arguments to pass to the code
+    pub argv: Vec<String>,
+    /// Environment variables to set for the code execution
+    pub env: Option<std::collections::HashMap<String, String>>,
+}
+
+/// Trait for language-specific code toolboxes
+pub trait CodeToolbox: Send + Sync {
+    /// Generate a command to run the provided code
+    fn get_run_command(&self, code: &str, params: Option<&CodeRunParams>) -> String;
+}
+
+/// Python code toolbox implementation
+#[derive(Debug, Clone)]
+pub struct PythonCodeToolbox;
+
+impl PythonCodeToolbox {
+    /// Creates a new Python code toolbox
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Checks if matplotlib is imported in the given Python code
+    fn is_matplotlib_imported(code: &str) -> bool {
+        let patterns = [
+            r"(?m)^[^#]*import\s+matplotlib",
+            r"(?m)^[^#]*from\s+matplotlib",
+        ];
+
+        patterns.iter().any(|pattern| {
+            regex::Regex::new(pattern)
+                .map(|re| re.is_match(code))
+                .unwrap_or(false)
+        })
+    }
+}
+
+impl Default for PythonCodeToolbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodeToolbox for PythonCodeToolbox {
+    fn get_run_command(&self, code: &str, params: Option<&CodeRunParams>) -> String {
+        let mut base64_code = BASE64.encode(code);
+
+        // If matplotlib is imported, wrap the code with special handling
+        if Self::is_matplotlib_imported(code) {
+            let code_wrapper = PYTHON_CODE_WRAPPER.replace("{encoded_code}", &base64_code);
+            base64_code = BASE64.encode(&code_wrapper);
+        }
+
+        let argv = params
+            .and_then(|p| {
+                if p.argv.is_empty() {
+                    None
+                } else {
+                    Some(&p.argv)
+                }
+            })
+            .map(|argv| argv.join(" "))
+            .unwrap_or_default();
+
+        // Execute the bootstrapper code directly with -u flag for unbuffered output
+        format!(
+            r#"sh -c 'python3 -u -c "exec(__import__(\"base64\").b64decode(\"{}\").decode())" {}'"#,
+            base64_code, argv
+        )
+    }
+}
+
+/// TypeScript code toolbox implementation
+#[derive(Debug, Clone)]
+pub struct TypeScriptCodeToolbox;
+
+impl TypeScriptCodeToolbox {
+    /// Creates a new TypeScript code toolbox
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TypeScriptCodeToolbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodeToolbox for TypeScriptCodeToolbox {
+    fn get_run_command(&self, code: &str, params: Option<&CodeRunParams>) -> String {
+        let base64_code = BASE64.encode(code);
+        let argv = params
+            .and_then(|p| {
+                if p.argv.is_empty() {
+                    None
+                } else {
+                    Some(&p.argv)
+                }
+            })
+            .map(|argv| argv.join(" "))
+            .unwrap_or_default();
+
+        format!(
+            r#"sh -c 'echo {} | base64 --decode | npx ts-node -O "{{\"module\":\"CommonJS\"}}" -e "$(cat)" x {} 2>&1 | grep -vE "npm notice"'"#,
+            base64_code, argv
+        )
+    }
+}
+
+/// JavaScript code toolbox implementation
+#[derive(Debug, Clone)]
+pub struct JavaScriptCodeToolbox;
+
+impl JavaScriptCodeToolbox {
+    /// Creates a new JavaScript code toolbox
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for JavaScriptCodeToolbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodeToolbox for JavaScriptCodeToolbox {
+    fn get_run_command(&self, code: &str, params: Option<&CodeRunParams>) -> String {
+        let base64_code = BASE64.encode(code);
+        let argv = params
+            .and_then(|p| {
+                if p.argv.is_empty() {
+                    None
+                } else {
+                    Some(&p.argv)
+                }
+            })
+            .map(|argv| argv.join(" "))
+            .unwrap_or_default();
+
+        format!(
+            r#"sh -c 'echo {} | base64 --decode | node -e "$(cat)" {}'"#,
+            base64_code, argv
+        )
+    }
+}
+
+/// Supported programming languages
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeLanguage {
+    Python,
+    TypeScript,
+    JavaScript,
+}
+
+impl CodeLanguage {
+    /// Get the default toolbox for this language
+    pub fn toolbox(&self) -> Box<dyn CodeToolbox> {
+        match self {
+            CodeLanguage::Python => Box::new(PythonCodeToolbox::new()),
+            CodeLanguage::TypeScript => Box::new(TypeScriptCodeToolbox::new()),
+            CodeLanguage::JavaScript => Box::new(JavaScriptCodeToolbox::new()),
+        }
+    }
+
+    /// Parse a language string into a CodeLanguage
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "python" | "py" => Some(CodeLanguage::Python),
+            "typescript" | "ts" => Some(CodeLanguage::TypeScript),
+            "javascript" | "js" => Some(CodeLanguage::JavaScript),
+            _ => None,
+        }
+    }
+}
+
+// Python code wrapper for matplotlib support
+const PYTHON_CODE_WRAPPER: &str = r#"
+import base64
+import datetime
+import hashlib
+import io
+import json
+import linecache
+import sys
+import traceback
+import types
+from importlib.abc import Loader, MetaPathFinder
+from importlib.util import find_spec, spec_from_loader
+
+# Global variables to hold imported libraries if needed
+np = None
+mpl = None
+pil_img = None
+
+
+plt_patched = False
+processed_figures = set()
+
+
+def _parse_point(point):
+    if isinstance(point, datetime.date):
+        return point.isoformat()
+    if isinstance(point, np.datetime64):
+        return point.astype("datetime64[s]").astype(str)
+    return point
+
+
+def _is_grid_line(line: any) -> bool:
+    x_data = line.get_xdata()
+    if len(x_data) != 2:
+        return False
+
+    y_data = line.get_ydata()
+    if len(y_data) != 2:
+        return False
+
+    if x_data[0] == x_data[1] or y_data[0] == y_data[1]:
+        return True
+
+    return False
+
+
+def _extract_line_chart_elements(ax):
+    elements = []
+
+    for line in ax.get_lines():
+        if _is_grid_line(line):
+            continue
+        label = line.get_label()
+        points = [(_parse_point(x), _parse_point(y)) for x, y in zip(line.get_xdata(), line.get_ydata())]
+
+        element = {"label": label, "points": points}
+        elements.append(element)
+
+    return elements
+
+
+def _extract_scatter_chart_elements(ax):
+    elements = []
+
+    for collection in ax.collections:
+        points = [(_parse_point(x), _parse_point(y)) for x, y in collection.get_offsets()]
+        element = {"label": collection.get_label(), "points": points}
+        elements.append(element)
+
+    return elements
+
+
+def _extract_bar_chart_elements(ax):
+    elements = []
+    change_orientation = False
+
+    for container in ax.containers:
+        heights = [rect.get_height() for rect in container]
+        if all(height == heights[0] for height in heights):
+            # vertical bars
+            change_orientation = True
+            labels = [label.get_text() for label in ax.get_yticklabels()]
+            values = [rect.get_width() for rect in container]
+        else:
+            # horizontal bars
+            labels = [label.get_text() for label in ax.get_xticklabels()]
+            values = heights
+        for label, value in zip(labels, values):
+            element = {"label": label, "group": container.get_label(), "value": value}
+            elements.append(element)
+
+    return elements, change_orientation
+
+
+def _extract_pie_chart_elements(ax):
+    elements = []
+
+    wedges = [patch for patch in ax.patches if isinstance(patch, mpl.patches.Wedge)]
+    if len(wedges) == 0:
+        return elements
+
+    texts = [text_obj.get_text() for text_obj in ax.texts]
+
+    labels = []
+    autopcts = []
+
+    if len(texts) == 2 * len(wedges):
+        labels = [texts[i] for i in range(0, 2 * len(wedges), 2)]
+        autopcts = [texts[i] for i in range(1, 2 * len(wedges), 2)]
+    else:
+        labels = texts[:len(wedges)]
+
+    for idx, wedge in enumerate(wedges):
+        element = {
+            "label": labels[idx],
+            "angle": abs(wedge.theta2 - wedge.theta1),
+            "radius": wedge.r,
+            "autopct": autopcts[idx] if autopcts and len(autopcts) > idx else None,
+        }
+        elements.append(element)
+
+    return elements
+
+
+# pylint: disable=too-many-branches
+def _extract_box_chart_elements(ax):
+    change_orientation = False
+
+    xticklabels = [label.get_text() for label in ax.get_xticklabels()]
+    boxes = []
+    for label, box in zip(xticklabels, ax.patches):
+        vertices = box.get_path().vertices
+        x_vertices = list(vertices[:, 0])
+        y_vertices = list(vertices[:, 1])
+        x = min(x_vertices)
+        y = min(y_vertices)
+
+        boxes.append(
+            {
+                "x": x,
+                "y": y,
+                "label": label,
+                "width": max(x_vertices) - x,
+                "height": max(y_vertices) - y,
+                "outliers": [],
+            }
+        )
+
+    orientation = "horizontal"
+    if all(box["height"] == boxes[0]["height"] for box in boxes):
+        orientation = "vertical"
+
+    if orientation == "vertical":
+        change_orientation = True
+        for box in boxes:
+            box["x"], box["y"] = box["y"], box["x"]
+            box["width"], box["height"] = box["height"], box["width"]
+
+    for line in ax.lines:
+        xdata = line.get_xdata()
+        ydata = line.get_ydata()
+
+        if orientation == "vertical":
+            xdata, ydata = ydata, xdata
+
+        if len(xdata) <= 1 or len(ydata) != 2:
+            continue
+
+        for box in boxes:
+            if box["x"] <= xdata[0] <= xdata[1] <= box["x"] + box["width"]:
+                # Horizontal line (median or cap)
+                if abs(ydata[0] - ydata[1]) < 0.001 and box["y"] <= ydata[0] <= box["y"] + box["height"]:
+                    box["median"] = ydata[0]
+                # Vertical line (whiskers)
+                elif abs(xdata[0] - xdata[1]) < 0.001:
+                    y_min = min(ydata)
+                    y_max = max(ydata)
+
+                    # If attached to bottom of box
+                    if abs(y_max - box["y"]) < 0.001:
+                        box["whisker_lower"] = y_min
+
+                    # If attached to top of box
+                    elif abs(y_min - (box["y"] + box["height"])) < 0.001:
+                        box["whisker_upper"] = y_max
+                break
+
+    outlier_candidates = []
+
+    # Check for any markers in all artists
+    for artist in ax.get_children():
+        if hasattr(artist, "get_xdata") and hasattr(artist, "get_ydata"):
+            try:
+                xdata = artist.get_xdata()
+                ydata = artist.get_ydata()
+
+                if orientation == "vertical":
+                    xdata, ydata = ydata, xdata
+
+                if isinstance(xdata, (list, np.ndarray)) and isinstance(ydata, (list, np.ndarray)):
+                    for i in range(min(len(xdata), len(ydata))):
+                        outlier_candidates.append((float(xdata[i]), float(ydata[i])))
+            except:
+                pass
+
+    # Assign points to boxes and determine if they're outliers
+    for x, y in outlier_candidates:
+        for box in boxes:
+            if box["x"] <= x <= box["x"] + box["width"]:
+                box_center = box["x"] + box["width"] / 2
+                if abs(x - box_center) < 0.001:
+                    y_min = box["y"]
+                    y_max = box["y"] + box["height"]
+
+                    if box.get("whisker_lower", None):
+                        y_min = box["whisker_lower"]
+                    if box.get("whisker_upper", None):
+                        y_max = box["whisker_upper"]
+                    if y < y_min or y > y_max:
+                        box["outliers"].append(y)
+                break
+
+    return [
+        {
+            "label": box["label"],
+            "min": box.get("whisker_lower", None),
+            "first_quartile": box["y"],
+            "median": box.get("median", None),
+            "third_quartile": box["y"] + box["height"],
+            "max": box.get("whisker_upper", None),
+            "outliers": box["outliers"],
+        }
+        for box in boxes
+    ], change_orientation
+
+
+def _save_figure_as_base64(fig, bbox_inches="tight", dpi=100):
+    # First save with matplotlib
+    png_buffer = io.BytesIO()
+    fig.savefig(png_buffer, format="png", bbox_inches=bbox_inches, dpi=dpi)
+    png_buffer.seek(0)
+
+    # Open with PIL and apply maximum compression
+    with pil_img.open(png_buffer) as img:
+        optimized_buffer = io.BytesIO()
+        img.save(optimized_buffer, format="png", optimize=True, quality=100, compress_level=9)
+        optimized_buffer.seek(0)
+        return base64.b64encode(optimized_buffer.getvalue()).decode("utf-8")
+
+
+def _get_figure_hash(fig):
+    png_buffer = io.BytesIO()
+    fig.savefig(png_buffer, format="png", dpi=50)
+    return hashlib.md5(png_buffer.getvalue()).hexdigest()
+
+
+def _get_chart_type(ax):
+    objects = list(
+        filter(
+            lambda obj: not isinstance(obj, mpl.text.Text) and not isinstance(obj, mpl.patches.Shadow),
+            ax._children,  # pylint: disable=protected-access
+        )
+    )
+
+    # Check for Line plots
+    if all(isinstance(line, mpl.lines.Line2D) for line in objects):
+        return "line"
+
+    if all(isinstance(box_or_path, (mpl.patches.PathPatch, mpl.lines.Line2D)) for box_or_path in objects):
+        return "box_and_whisker"
+
+    filtered = []
+    for obj in objects:
+        if isinstance(obj, mpl.lines.Line2D) and _is_grid_line(obj):
+            continue
+        filtered.append(obj)
+
+    objects = filtered
+
+    # Check for Scatter plots
+    if all(isinstance(path, mpl.collections.PathCollection) for path in objects):
+        return "scatter"
+
+    # Check for Bar plots
+    if all(isinstance(rect, mpl.patches.Rectangle) for rect in objects):
+        return "bar"
+
+    # Check for Pie plots
+    if all(isinstance(artist, mpl.patches.Wedge) for artist in objects):
+        return "pie"
+
+    return "unknown"
+
+
+def _is_auto_empty_axis(ax):
+    return ax.get_subplotspec() is not None and not ax.has_data()
+
+
+def _is_colorbar_axis(ax):
+    return any(
+        # pylint: disable=protected-access
+        isinstance(child, mpl.colorbar._ColorbarSpine)
+        for child in ax.get_children()
+    )
+
+
+def _filter_out_unwanted_axes(axes):
+    return [ax for ax in axes if not _is_auto_empty_axis(ax) and not _is_colorbar_axis(ax)]
+
+
+def _extract_ticks_data(converter, ticks) -> list:
+    if isinstance(converter, mpl.dates._SwitchableDateConverter):  # pylint: disable=protected-access
+        return [mpl.dates.num2date(tick).isoformat() for tick in ticks]
+    try:
+        return [float(tick) for tick in ticks]
+    except Exception:
+        return list(ticks)
+
+
+def _extract_scale(converter, scale: str, ticks, labels) -> str:
+    if isinstance(converter, mpl.dates._SwitchableDateConverter):  # pylint: disable=protected-access
+        return "datetime"
+
+    # If the scale is not linear, it can't be categorical
+    if scale != "linear":
+        return scale
+
+    # If all the ticks are integers and are in order from 0 to n-1
+    # and the labels aren't corresponding to the ticks, it's categorical
+    for i, tick_and_label in enumerate(zip(ticks, labels)):
+        tick, label = tick_and_label
+        if isinstance(tick, (int, float)) and tick == i and str(i) != label:
+            continue
+        # Found a tick, which wouldn't be in a categorical scale
+        return "linear"
+
+    return "categorical"
+
+
+def _extract_chart_data(ax):
+    data = {}
+
+    data["title"] = ax.get_title()
+
+    data["x_label"] = ax.get_xlabel()
+    data["y_label"] = ax.get_ylabel()
+
+    x_tick_labels = [label.get_text() for label in ax.get_xticklabels()]
+    data["x_ticks"] = _extract_ticks_data(ax.xaxis.get_converter(), ax.get_xticks())
+    data["x_tick_labels"] = x_tick_labels
+    data["x_scale"] = _extract_scale(ax.xaxis.get_converter(), ax.get_xscale(), ax.get_xticks(), x_tick_labels)
+
+    y_tick_labels = [label.get_text() for label in ax.get_yticklabels()]
+    data["y_ticks"] = _extract_ticks_data(ax.yaxis.get_converter(), ax.get_yticks())
+    data["y_tick_labels"] = y_tick_labels
+    data["y_scale"] = _extract_scale(ax.yaxis.get_converter(), ax.get_yscale(), ax.get_yticks(), y_tick_labels)
+
+    chart_type = _get_chart_type(ax)
+    elements = []
+    change_orientation = False
+
+    if chart_type == "line":
+        elements = _extract_line_chart_elements(ax)
+    elif chart_type == "scatter":
+        elements = _extract_scatter_chart_elements(ax)
+    elif chart_type == "bar":
+        elements, change_orientation = _extract_bar_chart_elements(ax)
+    elif chart_type == "box_and_whisker":
+        elements, change_orientation = _extract_box_chart_elements(ax)
+    elif chart_type == "pie":
+        elements = _extract_pie_chart_elements(ax)
+
+    if change_orientation:
+        data["x_label"], data["y_label"] = data["y_label"], data["x_label"]
+
+    data["type"] = chart_type
+    data["elements"] = elements
+
+    return data
+
+
+def _custom_json_serializer(obj):
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+
+def extract_and_print_figure_metadata(fig):
+    """Extract metadata from a matplotlib figure and print as JSON"""
+    metadata = {}
+    subplots = []
+
+    axes = _filter_out_unwanted_axes(fig.axes)
+
+    for ax in axes:
+        data = _extract_chart_data(ax)
+        subplots.append(data)
+
+    if len(subplots) > 1:
+        metadata = {
+            "title": fig.texts[0].get_text() if fig.texts and len(fig.texts) > 0 else None,
+            "type": "composite_chart",
+            "elements": subplots,
+        }
+    else:
+        metadata = subplots[0] if subplots and len(subplots) > 0 else {"type": "unknown"}
+
+    metadata["png"] = _save_figure_as_base64(fig)
+    json_output = {"type": "chart", "value": metadata}
+
+    print(f"dtn_artifact_k39fd2:{json.dumps(json_output, default=_custom_json_serializer)}")
+
+
+class MatplotlibFinder(MetaPathFinder):
+    """Custom finder to intercept matplotlib.pyplot imports"""
+
+    def find_spec(self, fullname, path, target=None):  # pylint: disable=unused-argument
+        global plt_patched, np, mpl, pil_img  # pylint: disable=global-statement
+        if fullname == "matplotlib.pyplot" and not plt_patched:
+            plt_patched = True
+
+            # Import numpy and matplotlib once we are sure we need them
+            # pylint: disable=import-outside-toplevel
+            import matplotlib
+            import numpy
+            from PIL import Image
+
+            # Store them in global variables for use throughout the module
+            np = numpy
+            mpl = matplotlib
+            pil_img = Image
+
+            original_spec = find_spec(fullname)
+            if original_spec is None:
+                return None
+            return spec_from_loader(
+                fullname,
+                MatplotlibLoader(original_spec.loader),
+                origin=original_spec.origin,
+                is_package=original_spec.submodule_search_locations is not None,
+            )
+        return None
+
+
+class MatplotlibLoader(Loader):
+    """Custom loader to patch the matplotlib.pyplot module"""
+
+    def __init__(self, original_loader):
+        self.original_loader = original_loader
+
+    def create_module(self, spec):
+        return self.original_loader.create_module(spec)
+
+    def exec_module(self, module):
+        self.original_loader.exec_module(module)
+        if hasattr(module, "show"):
+            original_show = module.show
+
+            def custom_show(*args, **kwargs):
+                global processed_figures  # pylint: disable=global-variable-not-assigned
+                fig_nums = module.get_fignums()
+                for fig_num in fig_nums:
+                    fig = module.figure(fig_num)
+                    fig_hash = _get_figure_hash(fig)
+                    if fig_hash not in processed_figures:
+                        extract_and_print_figure_metadata(fig)
+                        processed_figures.add(fig_hash)
+                result = original_show(*args, **kwargs)
+                module.close("all")
+                return result
+
+            module.show = custom_show
+
+
+def setup_user_code_environment(code):
+    """Set up the module to run user code in"""
+    module = types.ModuleType("__main__")
+    module.__file__ = "<target_code>"
+    sys.modules["__main__"] = module
+    code_lines = code.splitlines()
+    linecache.cache["<target_code>"] = (len(code), None, code_lines, "<target_code>")
+    return module
+
+
+def run_user_code(code):
+    """Run the user code with the matplotlib interceptor installed"""
+    # Install matplotlib interceptor
+    sys.meta_path.insert(0, MatplotlibFinder())
+
+    # Set up clean environment for user code
+    module = setup_user_code_environment(code)
+
+    # Compile and run the code
+    compiled = compile(code, "<target_code>", "exec")
+
+    # Execute in the module's namespace
+    exec(compiled, module.__dict__)  # pylint: disable=exec-used
+
+
+if __name__ == "__main__":
+    try:
+        # Get the encoded user code
+        user_code = base64.b64decode("{encoded_code}").decode()
+
+        # Run the code
+        run_user_code(user_code)
+    except Exception:
+        # Print only the relevant parts of the traceback
+        exc_type, exc_value, exc_tb = sys.exc_info()
+
+        # Filter traceback to only show user code frames
+        filtered_tb = []
+        tb = exc_tb
+        while tb is not None:
+            if tb.tb_frame.f_code.co_filename == "<target_code>":
+                filtered_tb.append(tb)
+            tb = tb.tb_next
+
+        if filtered_tb:
+            # Create a new traceback from the filtered frames
+            exc_value.__traceback__ = filtered_tb[-1]
+            traceback.print_exception(exc_type, exc_value, exc_value.__traceback__)
+        else:
+            # Fallback if no user code frames found - raise the original exception type
+            # with the original message but create a fresh traceback
+            raise exc_type(str(exc_value)) from None
+
+        sys.exit(1)
+"#;

--- a/libs/sdk-rust/src/config.rs
+++ b/libs/sdk-rust/src/config.rs
@@ -1,0 +1,123 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+use std::time::Duration;
+
+pub const DEFAULT_API_URL: &str = "https://app.daytona.io/api";
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub api_key: Option<String>,
+    pub jwt_token: Option<String>,
+    pub organization_id: Option<String>,
+    pub api_url: String,
+    pub target: Option<String>,
+    pub timeout: Option<Duration>,
+    pub otel_enabled: bool,
+    /// Experimental features configuration
+    pub experimental: Option<serde_json::Value>,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self {
+            api_key: env::var("DAYTONA_API_KEY").ok(),
+            jwt_token: env::var("DAYTONA_JWT_TOKEN").ok(),
+            organization_id: env::var("DAYTONA_ORGANIZATION_ID").ok(),
+            api_url: env::var("DAYTONA_API_URL")
+                .or_else(|_| {
+                    env::var("DAYTONA_SERVER_URL").inspect(|_url| {
+                        eprintln!("[Deprecation Warning] Environment variable `DAYTONA_SERVER_URL` is deprecated and will be removed in future versions. Use `DAYTONA_API_URL` instead.");
+                    })
+                })
+                .unwrap_or_else(|_| DEFAULT_API_URL.to_string()),
+            target: env::var("DAYTONA_TARGET").ok(),
+            timeout: env::var("DAYTONA_TIMEOUT")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(Duration::from_secs),
+            otel_enabled: env::var("DAYTONA_OTEL_ENABLED")
+                .ok()
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false),
+            experimental: None,
+        }
+    }
+
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::default()
+    }
+
+    pub fn bearer_token(&self) -> Option<&str> {
+        self.api_key.as_deref().or(self.jwt_token.as_deref())
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ConfigBuilder {
+    api_key: Option<String>,
+    jwt_token: Option<String>,
+    organization_id: Option<String>,
+    api_url: Option<String>,
+    target: Option<String>,
+    timeout: Option<Duration>,
+    otel_enabled: Option<bool>,
+    experimental: Option<serde_json::Value>,
+}
+
+impl ConfigBuilder {
+    pub fn api_key(mut self, value: impl Into<String>) -> Self {
+        self.api_key = Some(value.into());
+        self
+    }
+
+    pub fn jwt_token(mut self, value: impl Into<String>) -> Self {
+        self.jwt_token = Some(value.into());
+        self
+    }
+
+    pub fn organization_id(mut self, value: impl Into<String>) -> Self {
+        self.organization_id = Some(value.into());
+        self
+    }
+
+    pub fn api_url(mut self, value: impl Into<String>) -> Self {
+        self.api_url = Some(value.into());
+        self
+    }
+
+    pub fn target(mut self, value: impl Into<String>) -> Self {
+        self.target = Some(value.into());
+        self
+    }
+
+    pub fn timeout(mut self, value: Duration) -> Self {
+        self.timeout = Some(value);
+        self
+    }
+
+    pub fn otel_enabled(mut self, value: bool) -> Self {
+        self.otel_enabled = Some(value);
+        self
+    }
+
+    pub fn experimental(mut self, value: serde_json::Value) -> Self {
+        self.experimental = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Config {
+        let env_cfg = Config::from_env();
+        Config {
+            api_key: self.api_key.or(env_cfg.api_key),
+            jwt_token: self.jwt_token.or(env_cfg.jwt_token),
+            organization_id: self.organization_id.or(env_cfg.organization_id),
+            api_url: self.api_url.unwrap_or(env_cfg.api_url),
+            target: self.target.or(env_cfg.target),
+            timeout: self.timeout.or(env_cfg.timeout),
+            otel_enabled: self.otel_enabled.unwrap_or(env_cfg.otel_enabled),
+            experimental: self.experimental.or(env_cfg.experimental),
+        }
+    }
+}

--- a/libs/sdk-rust/src/error.rs
+++ b/libs/sdk-rust/src/error.rs
@@ -1,0 +1,91 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use reqwest::StatusCode;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DaytonaError {
+    #[error("resource not found: {0}")]
+    NotFound(String),
+    #[error("rate limit exceeded: {0}")]
+    RateLimit(String),
+    #[error("request timed out: {0}")]
+    Timeout(String),
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("internal server error: {0}")]
+    InternalServerError(String),
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("api error ({status}): {message}")]
+    Api { status: u16, message: String },
+}
+
+impl DaytonaError {
+    pub fn from_status(status: StatusCode, message: impl Into<String>) -> Self {
+        let msg = message.into();
+        match status {
+            StatusCode::NOT_FOUND => Self::NotFound(msg),
+            StatusCode::TOO_MANY_REQUESTS => Self::RateLimit(msg),
+            StatusCode::REQUEST_TIMEOUT => Self::Timeout(msg),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Self::Unauthorized(msg),
+            StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT => Self::InternalServerError(msg),
+            _ => Self::Api {
+                status: status.as_u16(),
+                message: msg,
+            },
+        }
+    }
+
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, DaytonaError::NotFound(_))
+    }
+
+    pub fn is_rate_limit(&self) -> bool {
+        matches!(self, DaytonaError::RateLimit(_))
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, DaytonaError::Timeout(_))
+    }
+
+    pub fn status_code(&self) -> Option<u16> {
+        match self {
+            DaytonaError::NotFound(_) => Some(404),
+            DaytonaError::RateLimit(_) => Some(429),
+            DaytonaError::Timeout(_) => Some(408),
+            DaytonaError::Unauthorized(_) => Some(401),
+            DaytonaError::InternalServerError(_) => Some(500),
+            DaytonaError::Api { status, .. } => Some(*status),
+            DaytonaError::Network(_) => None,
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            DaytonaError::NotFound(msg) => msg.clone(),
+            DaytonaError::RateLimit(msg) => msg.clone(),
+            DaytonaError::Timeout(msg) => msg.clone(),
+            DaytonaError::Unauthorized(msg) => msg.clone(),
+            DaytonaError::InternalServerError(msg) => msg.clone(),
+            DaytonaError::Network(msg) => msg.clone(),
+            DaytonaError::Api { message, .. } => message.clone(),
+        }
+    }
+}
+
+impl From<reqwest::Error> for DaytonaError {
+    fn from(e: reqwest::Error) -> Self {
+        DaytonaError::Network(e.to_string())
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for DaytonaError {
+    fn from(e: tokio_tungstenite::tungstenite::Error) -> Self {
+        DaytonaError::Network(e.to_string())
+    }
+}

--- a/libs/sdk-rust/src/image.rs
+++ b/libs/sdk-rust/src/image.rs
@@ -1,0 +1,416 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Represents a Docker image built from a series of Dockerfile instructions.
+#[derive(Debug, Clone)]
+pub struct DockerImage {
+    instructions: Vec<String>,
+    contexts: Vec<DockerImageContext>,
+}
+
+/// Represents a file or directory to include in the Docker build context.
+#[derive(Debug, Clone)]
+pub struct DockerImageContext {
+    pub source_path: String,
+    pub archive_path: String,
+}
+
+impl DockerImage {
+    /// Create from a base image.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04");
+    /// assert_eq!(image.dockerfile(), "FROM ubuntu:22.04");
+    /// ```
+    pub fn base(image: &str) -> Self {
+        DockerImage {
+            instructions: vec![format!("FROM {}", image)],
+            contexts: Vec::new(),
+        }
+    }
+
+    /// Create from debian-slim with optional python version.
+    ///
+    /// If `python_version` is provided, uses `python:{version}-slim` as base.
+    /// Otherwise, uses `debian:12-slim`.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::debian_slim(Some("3.11"));
+    /// assert_eq!(image.dockerfile(), "FROM python:3.11-slim");
+    ///
+    /// let image = DockerImage::debian_slim(None);
+    /// assert_eq!(image.dockerfile(), "FROM debian:12-slim");
+    /// ```
+    pub fn debian_slim(python_version: Option<&str>) -> Self {
+        let base = match python_version {
+            Some(version) => format!("FROM python:{}-slim", version),
+            None => "FROM debian:12-slim".to_string(),
+        };
+        DockerImage {
+            instructions: vec![base],
+            contexts: Vec::new(),
+        }
+    }
+
+    /// Create from existing Dockerfile content.
+    ///
+    /// Parses the content and splits into individual instructions.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::from_dockerfile("FROM ubuntu:22.04\nRUN apt-get update");
+    /// assert_eq!(image.dockerfile(), "FROM ubuntu:22.04\nRUN apt-get update");
+    /// ```
+    pub fn from_dockerfile(dockerfile: &str) -> Self {
+        let instructions: Vec<String> = dockerfile.lines().map(|line| line.to_string()).collect();
+        DockerImage {
+            instructions,
+            contexts: Vec::new(),
+        }
+    }
+
+    /// Add a RUN instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .run("echo hello");
+    /// assert!(image.dockerfile().contains("RUN echo hello"));
+    /// ```
+    pub fn run(mut self, command: &str) -> Self {
+        self.instructions.push(format!("RUN {}", command));
+        self
+    }
+
+    /// Add a pip install instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::debian_slim(Some("3.11"))
+    ///     .pip_install(&["numpy", "pandas"]);
+    /// assert!(image.dockerfile().contains("RUN pip install numpy pandas"));
+    /// ```
+    pub fn pip_install(mut self, packages: &[&str]) -> Self {
+        let pkgs = packages.join(" ");
+        self.instructions.push(format!("RUN pip install {}", pkgs));
+        self
+    }
+
+    /// Add an apt-get install instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("debian:12-slim")
+    ///     .apt_get(&["curl", "wget"]);
+    /// assert!(image.dockerfile().contains("RUN apt-get update && apt-get install -y curl wget"));
+    /// ```
+    pub fn apt_get(mut self, packages: &[&str]) -> Self {
+        let pkgs = packages.join(" ");
+        self.instructions
+            .push(format!("RUN apt-get update && apt-get install -y {}", pkgs));
+        self
+    }
+
+    /// Add an ENV instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .env("MY_VAR", "value");
+    /// assert!(image.dockerfile().contains("ENV MY_VAR=\"value\""));
+    /// ```
+    pub fn env(mut self, key: &str, value: &str) -> Self {
+        self.instructions.push(format!("ENV {}=\"{}\"", key, value));
+        self
+    }
+
+    /// Add a WORKDIR instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .workdir("/app");
+    /// assert!(image.dockerfile().contains("WORKDIR /app"));
+    /// ```
+    pub fn workdir(mut self, path: &str) -> Self {
+        self.instructions.push(format!("WORKDIR {}", path));
+        self
+    }
+
+    /// Add an ENTRYPOINT instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .entrypoint(&["python3", "-m", "http.server"]);
+    /// assert!(image.dockerfile().contains(r#"ENTRYPOINT ["python3", "-m", "http.server"]"#));
+    /// ```
+    pub fn entrypoint(mut self, cmd: &[&str]) -> Self {
+        let args = cmd
+            .iter()
+            .map(|s| format!("\"{}\"", s))
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.instructions.push(format!("ENTRYPOINT [{}]", args));
+        self
+    }
+
+    /// Add a CMD instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .cmd(&["echo", "hello"]);
+    /// assert!(image.dockerfile().contains(r#"CMD ["echo", "hello"]"#));
+    /// ```
+    pub fn cmd(mut self, cmd: &[&str]) -> Self {
+        let args = cmd
+            .iter()
+            .map(|s| format!("\"{}\"", s))
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.instructions.push(format!("CMD [{}]", args));
+        self
+    }
+
+    /// Add a USER instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .user("nonroot");
+    /// assert!(image.dockerfile().contains("USER nonroot"));
+    /// ```
+    pub fn user(mut self, username: &str) -> Self {
+        self.instructions.push(format!("USER {}", username));
+        self
+    }
+
+    /// Add a COPY instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .copy("./src", "/app/src");
+    /// assert!(image.dockerfile().contains("COPY ./src /app/src"));
+    /// ```
+    pub fn copy(mut self, src: &str, dst: &str) -> Self {
+        self.instructions.push(format!("COPY {} {}", src, dst));
+        self
+    }
+
+    /// Add an ADD instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .add("./archive.tar.gz", "/app");
+    /// assert!(image.dockerfile().contains("ADD ./archive.tar.gz /app"));
+    /// ```
+    pub fn add(mut self, src: &str, dst: &str) -> Self {
+        self.instructions.push(format!("ADD {} {}", src, dst));
+        self
+    }
+
+    /// Add EXPOSE instructions for the given ports.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .expose(&[8080, 443]);
+    /// let df = image.dockerfile();
+    /// assert!(df.contains("EXPOSE 8080"));
+    /// assert!(df.contains("EXPOSE 443"));
+    /// ```
+    pub fn expose(mut self, ports: &[i32]) -> Self {
+        for port in ports {
+            self.instructions.push(format!("EXPOSE {}", port));
+        }
+        self
+    }
+
+    /// Add a LABEL instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .label("maintainer", "daytona");
+    /// assert!(image.dockerfile().contains("LABEL maintainer=\"daytona\""));
+    /// ```
+    pub fn label(mut self, key: &str, value: &str) -> Self {
+        self.instructions
+            .push(format!("LABEL {}=\"{}\"", key, value));
+        self
+    }
+
+    /// Add a VOLUME instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .volume(&["/data", "/logs"]);
+    /// assert!(image.dockerfile().contains(r#"VOLUME ["/data", "/logs"]"#));
+    /// ```
+    pub fn volume(mut self, paths: &[&str]) -> Self {
+        let vols = paths
+            .iter()
+            .map(|s| format!("\"{}\"", s))
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.instructions.push(format!("VOLUME [{}]", vols));
+        self
+    }
+
+    /// Add a local file to the build context and generate an ADD instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .add_local_file("./config.toml", "/etc/app/config.toml");
+    /// assert_eq!(image.contexts().len(), 1);
+    /// assert!(image.dockerfile().contains("ADD ./config.toml /etc/app/config.toml"));
+    /// ```
+    pub fn add_local_file(mut self, local: &str, remote: &str) -> Self {
+        self.contexts.push(DockerImageContext {
+            source_path: local.to_string(),
+            archive_path: remote.to_string(),
+        });
+        self.add(local, remote)
+    }
+
+    /// Add a local directory to the build context and generate an ADD instruction.
+    ///
+    /// # Example
+    /// ```
+    /// use daytona::DockerImage;
+    /// let image = DockerImage::base("ubuntu:22.04")
+    ///     .add_local_dir("./src", "/app/src");
+    /// assert_eq!(image.contexts().len(), 1);
+    /// assert!(image.dockerfile().contains("ADD ./src /app/src"));
+    /// ```
+    pub fn add_local_dir(mut self, local: &str, remote: &str) -> Self {
+        self.contexts.push(DockerImageContext {
+            source_path: local.to_string(),
+            archive_path: remote.to_string(),
+        });
+        self.add(local, remote)
+    }
+
+    /// Generate Dockerfile content from all instructions.
+    pub fn dockerfile(&self) -> String {
+        self.instructions.join("\n")
+    }
+
+    /// Get contexts for object storage upload.
+    pub fn contexts(&self) -> &[DockerImageContext] {
+        &self.contexts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_base_image() {
+        let image = DockerImage::base("ubuntu:22.04");
+        assert_eq!(image.dockerfile(), "FROM ubuntu:22.04");
+    }
+
+    #[test]
+    fn test_debian_slim_with_python() {
+        let image = DockerImage::debian_slim(Some("3.11"));
+        assert_eq!(image.dockerfile(), "FROM python:3.11-slim");
+    }
+
+    #[test]
+    fn test_debian_slim_without_python() {
+        let image = DockerImage::debian_slim(None);
+        assert_eq!(image.dockerfile(), "FROM debian:12-slim");
+    }
+
+    #[test]
+    fn test_from_dockerfile() {
+        let content = "FROM ubuntu:22.04\nRUN apt-get update\nRUN apt-get install -y curl";
+        let image = DockerImage::from_dockerfile(content);
+        assert_eq!(image.dockerfile(), content);
+    }
+
+    #[test]
+    fn test_builder_chain() {
+        let image = DockerImage::debian_slim(Some("3.11"))
+            .env("APP_ENV", "production")
+            .workdir("/app")
+            .apt_get(&["curl", "git"])
+            .pip_install(&["flask", "gunicorn"])
+            .copy(".", "/app")
+            .expose(&[8080])
+            .user("appuser")
+            .entrypoint(&["python3"])
+            .cmd(&["-m", "flask", "run"]);
+
+        let df = image.dockerfile();
+        assert!(df.starts_with("FROM python:3.11-slim"));
+        assert!(df.contains("ENV APP_ENV=\"production\""));
+        assert!(df.contains("WORKDIR /app"));
+        assert!(df.contains("RUN apt-get update && apt-get install -y curl git"));
+        assert!(df.contains("RUN pip install flask gunicorn"));
+        assert!(df.contains("COPY . /app"));
+        assert!(df.contains("EXPOSE 8080"));
+        assert!(df.contains("USER appuser"));
+        assert!(df.contains("ENTRYPOINT [\"python3\"]"));
+        assert!(df.contains("CMD [\"-m\", \"flask\", \"run\"]"));
+    }
+
+    #[test]
+    fn test_add_local_file_creates_context() {
+        let image =
+            DockerImage::base("ubuntu:22.04").add_local_file("./config.toml", "/etc/config.toml");
+
+        assert_eq!(image.contexts().len(), 1);
+        assert_eq!(image.contexts()[0].source_path, "./config.toml");
+        assert_eq!(image.contexts()[0].archive_path, "/etc/config.toml");
+        assert!(image
+            .dockerfile()
+            .contains("ADD ./config.toml /etc/config.toml"));
+    }
+
+    #[test]
+    fn test_add_local_dir_creates_context() {
+        let image = DockerImage::base("ubuntu:22.04").add_local_dir("./src", "/app/src");
+
+        assert_eq!(image.contexts().len(), 1);
+        assert_eq!(image.contexts()[0].source_path, "./src");
+        assert_eq!(image.contexts()[0].archive_path, "/app/src");
+    }
+
+    #[test]
+    fn test_labels_and_volumes() {
+        let image = DockerImage::base("ubuntu:22.04")
+            .label("version", "1.0")
+            .volume(&["/data", "/logs"]);
+
+        let df = image.dockerfile();
+        assert!(df.contains("LABEL version=\"1.0\""));
+        assert!(df.contains("VOLUME [\"/data\", \"/logs\"]"));
+    }
+}

--- a/libs/sdk-rust/src/lib.rs
+++ b/libs/sdk-rust/src/lib.rs
@@ -1,0 +1,41 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod client;
+pub mod code_toolbox;
+pub mod config;
+pub mod error;
+pub mod image;
+#[cfg(feature = "otel")]
+pub(crate) mod otel;
+pub mod pty_handle;
+pub mod sandbox;
+pub mod services;
+pub mod types;
+pub mod utils;
+
+pub use client::Client;
+pub use config::Config;
+pub use error::DaytonaError;
+pub use image::DockerImage;
+pub use image::DockerImageContext;
+pub use pty_handle::PtyHandle;
+pub use sandbox::Sandbox;
+pub use services::code_interpreter::CodeInterpreterService;
+pub use services::computer_use::ComputerUseService;
+pub use services::filesystem::FileSystemService;
+pub use services::git::GitService;
+pub use services::lsp_server::LspServerService;
+pub use services::object_storage::ObjectStorageService;
+pub use services::process::ProcessService;
+pub use services::snapshot::SnapshotService;
+pub use services::volume::VolumeService;
+#[allow(unused_imports)]
+pub use types::*;
+
+pub use code_toolbox::CodeLanguage;
+pub use code_toolbox::CodeRunParams;
+pub use code_toolbox::CodeToolbox;
+pub use code_toolbox::JavaScriptCodeToolbox;
+pub use code_toolbox::PythonCodeToolbox;
+pub use code_toolbox::TypeScriptCodeToolbox;

--- a/libs/sdk-rust/src/otel.rs
+++ b/libs/sdk-rust/src/otel.rs
@@ -1,0 +1,115 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use opentelemetry::global;
+use opentelemetry::trace::{Span, Status, Tracer};
+use opentelemetry_otlp::SpanExporter;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::Resource;
+
+const SERVICE_NAME: &str = "daytona-sdk-rust";
+const TRACER_NAME: &str = "daytona-sdk";
+
+pub(crate) struct OtelState {
+    tracer_provider: SdkTracerProvider,
+}
+
+impl OtelState {
+    /// Initialize OTLP HTTP exporter, create tracer provider, and set as global.
+    ///
+    /// The exporter reads configuration from standard OpenTelemetry environment
+    /// variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) and defaults to
+    /// `http://localhost:4318`.
+    pub fn new() -> Result<Self, DaytonaError> {
+        let exporter = SpanExporter::builder()
+            .with_http()
+            .build()
+            .map_err(|e| DaytonaError::Network(format!("Failed to create OTLP exporter: {e}")))?;
+
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_resource(Resource::builder().with_service_name(SERVICE_NAME).build())
+            .build();
+
+        global::set_tracer_provider(tracer_provider.clone());
+
+        Ok(Self { tracer_provider })
+    }
+
+    /// Shutdown the tracer provider, flushing any pending spans.
+    pub async fn shutdown(&self) -> Result<(), DaytonaError> {
+        self.tracer_provider
+            .shutdown()
+            .map_err(|e| DaytonaError::Network(format!("Failed to shutdown tracer provider: {e}")))
+    }
+}
+
+/// Instrument a function call with OpenTelemetry tracing.
+///
+/// If `otel` is `Some`, creates a span named `{component}.{method}` and
+/// executes `f` within it. On error the span status is set accordingly.
+/// If `otel` is `None`, `f` is called directly with no overhead.
+pub(crate) async fn with_instrumentation<T, F, Fut>(
+    otel: Option<&OtelState>,
+    component: &str,
+    method: &str,
+    f: F,
+) -> Result<T, DaytonaError>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T, DaytonaError>>,
+{
+    if otel.is_some() {
+        let tracer = global::tracer(TRACER_NAME);
+        let span_name = format!("{component}.{method}");
+        let mut span = tracer.start(span_name);
+
+        let result = f().await;
+
+        if let Err(ref e) = result {
+            span.set_status(Status::error(e.to_string()));
+        }
+
+        span.end();
+        result
+    } else {
+        f().await
+    }
+}
+
+/// Instrument a void function (no return value).
+///
+/// Convenience wrapper around [`with_instrumentation`] for `()` return type.
+pub(crate) async fn with_instrumentation_void<F, Fut>(
+    otel: Option<&OtelState>,
+    component: &str,
+    method: &str,
+    f: F,
+) -> Result<(), DaytonaError>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<(), DaytonaError>>,
+{
+    with_instrumentation(otel, component, method, f).await
+}
+
+/// HTTP transport wrapper that injects `traceparent` header for
+/// distributed trace context propagation.
+pub(crate) struct OtelTransport<T> {
+    inner: T,
+}
+
+#[allow(dead_code)]
+impl<T> OtelTransport<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}

--- a/libs/sdk-rust/src/pty_handle.rs
+++ b/libs/sdk-rust/src/pty_handle.rs
@@ -1,0 +1,387 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use futures::stream::{SplitSink, SplitStream};
+use futures::{SinkExt, StreamExt};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio::net::TcpStream;
+use tokio::sync::{mpsc, Mutex, Notify, RwLock};
+use tokio_tungstenite::{tungstenite::Message, MaybeTlsStream, WebSocketStream};
+
+/// WebSocket stream type alias.
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// Control message from PTY WebSocket server.
+#[allow(dead_code)]
+#[derive(Debug, serde:: Deserialize)]
+struct ControlMessage {
+    #[serde(rename = "type")]
+    type_: String,
+    status: Option<String>,
+    error: Option<String>,
+}
+
+/// Exit data parsed from WebSocket close reason.
+#[allow(dead_code)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExitData {
+    exit_code: Option<i32>,
+    exit_reason: Option<String>,
+    error: Option<String>,
+}
+
+/// Type alias for the async resize callback.
+pub type ResizeFn = Box<
+    dyn Fn(i32, i32) -> Pin<Box<dyn Future<Output = Result<(), DaytonaError>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Type alias for the async kill callback.
+pub type KillFn =
+    Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<(), DaytonaError>> + Send>> + Send + Sync>;
+
+/// Handle for an interactive PTY session over WebSocket.
+///
+/// Provides methods for sending input, receiving output via channels,
+/// resizing the terminal, and managing the connection lifecycle.
+///
+/// Create a `PtyHandle` via `ProcessService::create_pty` or similar.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example(handle: &mut daytona::PtyHandle) -> Result<(), daytona::DaytonaError> {
+/// handle.wait_for_connection().await?;
+/// handle.send_input(b"ls -la\n").await?;
+///
+/// while let Some(data) = handle.data_chan().recv().await {
+///     print!("{}", String::from_utf8_lossy(&data));
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct PtyHandle {
+    write: Arc<Mutex<SplitSink<WsStream, Message>>>,
+    session_id: String,
+    data_rx: mpsc::Receiver<Vec<u8>>,
+    exit_code: Arc<RwLock<Option<i32>>>,
+    error: Arc<RwLock<Option<String>>>,
+    connected: Arc<RwLock<bool>>,
+    connection_established: Arc<RwLock<bool>>,
+    done: Arc<Notify>,
+    handle_resize: Arc<ResizeFn>,
+    handle_kill: Arc<KillFn>,
+}
+
+#[allow(dead_code)]
+impl PtyHandle {
+    /// Create a new PtyHandle from an established WebSocket connection.
+    ///
+    /// Splits the WebSocket into read/write halves and spawns a background
+    /// task to read messages, parse control messages, and forward terminal
+    /// output to the data channel.
+    pub(crate) fn new(
+        ws: WsStream,
+        session_id: String,
+        handle_resize: ResizeFn,
+        handle_kill: KillFn,
+    ) -> Self {
+        let (write, read) = ws.split();
+        let write = Arc::new(Mutex::new(write));
+        let (data_tx, data_rx) = mpsc::channel(100);
+        let exit_code: Arc<RwLock<Option<i32>>> = Arc::new(RwLock::new(None));
+        let error: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
+        let connected = Arc::new(RwLock::new(false));
+        let connection_established = Arc::new(RwLock::new(false));
+        let done = Arc::new(Notify::new());
+
+        // Spawn background message handler
+        {
+            let exit_code = Arc::clone(&exit_code);
+            let error = Arc::clone(&error);
+            let connected = Arc::clone(&connected);
+            let connection_established = Arc::clone(&connection_established);
+            let done = Arc::clone(&done);
+
+            tokio::spawn(async move {
+                Self::handle_messages(
+                    read,
+                    data_tx,
+                    exit_code,
+                    error,
+                    connected,
+                    connection_established,
+                    done,
+                )
+                .await;
+            });
+        }
+
+        Self {
+            write,
+            session_id,
+            data_rx,
+            exit_code,
+            error,
+            connected,
+            connection_established,
+            done,
+            handle_resize: Arc::new(handle_resize),
+            handle_kill: Arc::new(handle_kill),
+        }
+    }
+
+    /// Get the session ID.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Check if connected to the PTY session.
+    pub async fn is_connected(&self) -> bool {
+        *self.connected.read().await
+    }
+
+    /// Wait for the WebSocket connection to be established.
+    ///
+    /// Blocks until the PTY session confirms it is ready (via a
+    /// `{"type":"control","status":"connected"}` message), or until
+    /// a 10-second timeout expires.
+    pub async fn wait_for_connection(&self) -> Result<(), DaytonaError> {
+        if *self.connection_established.read().await {
+            return Ok(());
+        }
+
+        let start = tokio::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(10);
+
+        loop {
+            if *self.connection_established.read().await {
+                return Ok(());
+            }
+
+            if let Some(err) = self.error.read().await.as_ref() {
+                return Err(DaytonaError::Network(err.clone()));
+            }
+
+            if start.elapsed() >= timeout {
+                return Err(DaytonaError::Timeout("PTY connection timeout".to_string()));
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    /// Get mutable reference to the data channel for reading PTY output.
+    ///
+    /// Use `recv().await` on the returned receiver to get output bytes.
+    /// The channel is closed when the PTY session ends.
+    pub fn data_chan(&mut self) -> &mut mpsc::Receiver<Vec<u8>> {
+        &mut self.data_rx
+    }
+
+    /// Send input data to the PTY session.
+    ///
+    /// Data is sent as a binary WebSocket message and will be processed
+    /// as if typed in the terminal.
+    pub async fn send_input(&self, data: &[u8]) -> Result<(), DaytonaError> {
+        if !*self.connected.read().await {
+            return Err(DaytonaError::Network("PTY is not connected".to_string()));
+        }
+
+        let mut write = self.write.lock().await;
+        write
+            .send(Message::Binary(data.to_vec()))
+            .await
+            .map_err(|e| DaytonaError::Network(format!("Failed to send input to PTY: {}", e)))
+    }
+
+    /// Resize the PTY terminal dimensions.
+    ///
+    /// Notifies terminal applications about the new dimensions via SIGWINCH.
+    pub async fn resize(&self, cols: i32, rows: i32) -> Result<(), DaytonaError> {
+        (self.handle_resize)(cols, rows).await
+    }
+
+    /// Get exit code if the session has ended.
+    pub async fn exit_code(&self) -> Option<i32> {
+        *self.exit_code.read().await
+    }
+
+    /// Get error message if the session failed.
+    pub async fn error(&self) -> Option<String> {
+        self.error.read().await.clone()
+    }
+
+    /// Disconnect from PTY by closing the WebSocket connection.
+    ///
+    /// This does not terminate the underlying process — use [`kill`](Self::kill)
+    /// for that.
+    pub async fn disconnect(self) -> Result<(), DaytonaError> {
+        let mut write = self.write.lock().await;
+        let _ = write.send(Message::Close(None)).await;
+        write
+            .close()
+            .await
+            .map_err(|e| DaytonaError::Network(format!("Failed to close WebSocket: {}", e)))
+    }
+
+    /// Kill the PTY session and terminate the associated process.
+    ///
+    /// Calls the kill handler (typically an HTTP DELETE to the toolbox API).
+    pub async fn kill(&self) -> Result<(), DaytonaError> {
+        (self.handle_kill)().await
+    }
+
+    /// Wait for the PTY process to exit and return the exit code.
+    ///
+    /// Blocks until the PTY session ends (via WebSocket close or error).
+    pub async fn wait(&self) -> Result<i32, DaytonaError> {
+        // Check if already exited
+        if let Some(code) = *self.exit_code.read().await {
+            return Ok(code);
+        }
+
+        loop {
+            tokio::select! {
+                _ = self.done.notified() => {
+                    if let Some(code) = *self.exit_code.read().await {
+                        return Ok(code);
+                    }
+                    if let Some(err) = self.error.read().await.as_ref() {
+                        return Err(DaytonaError::Network(err.clone()));
+                    }
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                    if let Some(code) = *self.exit_code.read().await {
+                        return Ok(code);
+                    }
+                    if let Some(err) = self.error.read().await.as_ref() {
+                        return Err(DaytonaError::Network(err.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Background message handler ──────────────────────────────────────
+
+    /// Background task: read WebSocket messages, dispatch to data channel
+    /// or handle control / close frames.
+    ///
+    /// 1. Text messages that parse as `{"type":"control",...}` update
+    ///    internal state (connected, error).
+    /// 2. Other text and all binary messages are forwarded to `data_tx`.
+    /// 3. Close frames are parsed for exit code / error information.
+    async fn handle_messages(
+        mut read: SplitStream<WsStream>,
+        data_tx: mpsc::Sender<Vec<u8>>,
+        exit_code: Arc<RwLock<Option<i32>>>,
+        error: Arc<RwLock<Option<String>>>,
+        connected: Arc<RwLock<bool>>,
+        connection_established: Arc<RwLock<bool>>,
+        done: Arc<Notify>,
+    ) {
+        loop {
+            match read.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    // Try to parse as control message
+                    if let Ok(ctrl) = serde_json::from_str::<ControlMessage>(&text) {
+                        if ctrl.type_ == "control" {
+                            match ctrl.status.as_deref() {
+                                Some("connected") => {
+                                    *connected.write().await = true;
+                                    *connection_established.write().await = true;
+                                }
+                                Some("error") => {
+                                    let err_msg = ctrl
+                                        .error
+                                        .unwrap_or_else(|| "Unknown connection error".into());
+                                    *error.write().await = Some(err_msg);
+                                    *connected.write().await = false;
+                                }
+                                _ => {}
+                            }
+                            continue;
+                        }
+                    }
+                    // Regular text output — forward to data channel
+                    let _ = data_tx.send(text.as_bytes().to_vec()).await;
+                }
+                Some(Ok(Message::Binary(data))) => {
+                    let _ = data_tx.send(data.to_vec()).await;
+                }
+                Some(Ok(Message::Close(frame))) => {
+                    *connected.write().await = false;
+                    if let Some(frame) = frame {
+                        let reason = frame.reason.to_string();
+                        Self::parse_close_reason(&reason, &exit_code, &error).await;
+                    } else {
+                        *exit_code.write().await = Some(0);
+                    }
+                    done.notify_waiters();
+                    return;
+                }
+                Some(Ok(_)) => {
+                    // Ping / Pong — ignore
+                }
+                Some(Err(e)) => {
+                    use tokio_tungstenite::tungstenite::Error as WsError;
+                    match &e {
+                        WsError::ConnectionClosed | WsError::AlreadyClosed => {
+                            if exit_code.read().await.is_none() {
+                                *exit_code.write().await = Some(0);
+                            }
+                        }
+                        _ => {
+                            *error.write().await = Some(e.to_string());
+                        }
+                    }
+                    *connected.write().await = false;
+                    done.notify_waiters();
+                    return;
+                }
+                None => {
+                    // Stream ended
+                    *connected.write().await = false;
+                    if exit_code.read().await.is_none() {
+                        *exit_code.write().await = Some(0);
+                    }
+                    done.notify_waiters();
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Parse close reason string as JSON exit data.
+    async fn parse_close_reason(
+        reason: &str,
+        exit_code: &Arc<RwLock<Option<i32>>>,
+        error: &Arc<RwLock<Option<String>>>,
+    ) {
+        if reason.is_empty() {
+            *exit_code.write().await = Some(0);
+            return;
+        }
+
+        if let Ok(exit_data) = serde_json::from_str::<ExitData>(reason) {
+            if let Some(code) = exit_data.exit_code {
+                *exit_code.write().await = Some(code);
+            }
+            if let Some(exit_reason) = exit_data.exit_reason {
+                *error.write().await = Some(exit_reason);
+            }
+            if let Some(err) = exit_data.error {
+                *error.write().await = Some(err);
+            }
+        } else {
+            // Not JSON, default to exit code 0
+            *exit_code.write().await = Some(0);
+        }
+    }
+}

--- a/libs/sdk-rust/src/sandbox.rs
+++ b/libs/sdk-rust/src/sandbox.rs
@@ -1,0 +1,494 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::client::ClientInner;
+use crate::error::DaytonaError;
+use crate::services::code_interpreter::CodeInterpreterService;
+use crate::services::computer_use::ComputerUseService;
+use crate::services::filesystem::FileSystemService;
+use crate::services::git::GitService;
+use crate::services::lsp_server::LspServerService;
+use crate::services::process::ProcessService;
+use crate::services::ServiceClient;
+use crate::types::{
+    BuildInfo, DirResponse, ResizeSandboxRequest, SandboxBackupState, SandboxDto, SandboxState,
+    SshAccessDto, SshAccessValidationDto, VolumeMount,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[derive(Clone)]
+pub struct Sandbox {
+    inner: Arc<ClientInner>,
+    pub id: String,
+    pub name: String,
+    /// Organization ID that owns the sandbox
+    pub organization_id: String,
+    /// Daytona snapshot used to create the sandbox
+    pub snapshot: Option<String>,
+    /// OS user running in the sandbox
+    pub user: String,
+    /// Sandbox state
+    pub state: SandboxState,
+    /// Target location where the sandbox runs
+    pub target: String,
+    /// CPU cores allocated
+    pub cpu: i32,
+    /// GPU units allocated
+    pub gpu: i32,
+    /// Memory in GiB
+    pub memory: i32,
+    /// Disk in GiB
+    pub disk: i32,
+    /// Environment variables set in the sandbox
+    pub env: Option<HashMap<String, String>>,
+    /// Custom labels attached to the sandbox
+    pub labels: Option<HashMap<String, String>>,
+    /// Whether the sandbox is publicly accessible
+    pub public: bool,
+    /// Auto-stop interval in minutes
+    pub auto_stop_interval: Option<i32>,
+    /// Auto-archive interval in minutes
+    pub auto_archive_interval: Option<i32>,
+    /// Auto-delete interval in minutes
+    pub auto_delete_interval: Option<i32>,
+    /// Whether to block all network access
+    pub network_block_all: bool,
+    /// Allowed network addresses (CIDR notation)
+    pub network_allow_list: Option<String>,
+    /// Error reason if sandbox is in error state
+    pub error_reason: Option<String>,
+    /// Whether the error is recoverable
+    pub recoverable: Option<bool>,
+    /// Current backup state
+    pub backup_state: SandboxBackupState,
+    /// When the backup was created
+    pub backup_created_at: Option<String>,
+    /// Volumes attached to the sandbox
+    pub volumes: Option<Vec<VolumeMount>>,
+    /// Build information for the sandbox
+    pub build_info: Option<BuildInfo>,
+    /// When the sandbox was created
+    pub created_at: Option<String>,
+    /// When the sandbox was last updated
+    pub updated_at: Option<String>,
+}
+
+impl Sandbox {
+    pub(crate) fn from_dto(inner: Arc<ClientInner>, dto: SandboxDto) -> Self {
+        Self {
+            inner,
+            id: dto.id,
+            name: dto.name,
+            organization_id: dto.organization_id,
+            snapshot: dto.snapshot,
+            user: dto.user.unwrap_or_default(),
+            state: dto.state,
+            target: dto.target,
+            cpu: dto.cpu.unwrap_or(2),
+            gpu: dto.gpu.unwrap_or(0),
+            memory: dto.memory.unwrap_or(4),
+            disk: dto.disk.unwrap_or(10),
+            env: dto.env,
+            labels: dto.labels,
+            public: dto.public.unwrap_or(false),
+            auto_stop_interval: dto.auto_stop_interval,
+            auto_archive_interval: dto.auto_archive_interval,
+            auto_delete_interval: dto.auto_delete_interval,
+            network_block_all: dto.network_block_all,
+            network_allow_list: dto.network_allow_list,
+            error_reason: dto.error_reason,
+            recoverable: dto.recoverable,
+            backup_state: dto.backup_state,
+            backup_created_at: dto.backup_created_at,
+            volumes: dto.volumes,
+            build_info: dto.build_info,
+            created_at: dto.created_at,
+            updated_at: dto.updated_at,
+        }
+    }
+
+    async fn service_client(&self) -> Result<ServiceClient, DaytonaError> {
+        let base = self.inner.toolbox_base_url(&self.id, &self.target).await?;
+        Ok(ServiceClient::new(
+            base,
+            self.inner.config.clone(),
+            self.inner.http.clone(),
+        ))
+    }
+
+    pub async fn filesystem(&self) -> Result<FileSystemService, DaytonaError> {
+        Ok(FileSystemService::new(self.service_client().await?))
+    }
+
+    pub async fn git(&self) -> Result<GitService, DaytonaError> {
+        Ok(GitService::new(self.service_client().await?))
+    }
+
+    pub async fn process(&self) -> Result<ProcessService, DaytonaError> {
+        Ok(ProcessService::new(self.service_client().await?))
+    }
+
+    pub async fn code_interpreter(&self) -> Result<CodeInterpreterService, DaytonaError> {
+        Ok(CodeInterpreterService::new(self.service_client().await?))
+    }
+
+    pub async fn computer_use(&self) -> Result<ComputerUseService, DaytonaError> {
+        Ok(ComputerUseService::new(self.service_client().await?))
+    }
+
+    pub async fn lsp_server(&self) -> Result<LspServerService, DaytonaError> {
+        Ok(LspServerService::new(self.service_client().await?))
+    }
+
+    /// Create a new Language Server Protocol (LSP) server instance.
+    ///
+    /// The LSP server provides language-specific features like code completion,
+    /// diagnostics, and more.
+    ///
+    /// # Arguments
+    /// * `language_id` - The language server type (e.g., "typescript", "python")
+    /// * `path_to_project` - Path to the project root directory. Relative paths are resolved based on the sandbox working directory.
+    ///
+    /// # Returns
+    /// A new `LspServerService` instance configured for the specified language
+    pub async fn create_lsp_server(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+    ) -> Result<LspServerService, DaytonaError> {
+        let service = LspServerService::new(self.service_client().await?);
+        service.start(language_id, path_to_project).await?;
+        Ok(service)
+    }
+
+    /// CamelCase alias for create_lsp_server
+    #[allow(non_snake_case)]
+    pub async fn createLspServer(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+    ) -> Result<LspServerService, DaytonaError> {
+        self.create_lsp_server(language_id, path_to_project).await
+    }
+
+    pub async fn start(&self) -> Result<(), DaytonaError> {
+        self.inner.start_sandbox(&self.id).await
+    }
+
+    pub async fn stop(&self) -> Result<(), DaytonaError> {
+        self.inner.stop_sandbox(&self.id).await
+    }
+
+    pub async fn delete(&self) -> Result<(), DaytonaError> {
+        self.inner.delete_sandbox(&self.id).await
+    }
+
+    pub async fn refresh_data(&mut self) -> Result<(), DaytonaError> {
+        let dto = self.inner.get_sandbox(&self.id).await?;
+        self.state = dto.state;
+        self.name = dto.name;
+        self.organization_id = dto.organization_id;
+        self.snapshot = dto.snapshot;
+        self.user = dto.user.unwrap_or_default();
+        self.cpu = dto.cpu.unwrap_or(2);
+        self.gpu = dto.gpu.unwrap_or(0);
+        self.memory = dto.memory.unwrap_or(4);
+        self.disk = dto.disk.unwrap_or(10);
+        self.labels = dto.labels;
+        self.public = dto.public.unwrap_or(false);
+        self.auto_stop_interval = dto.auto_stop_interval;
+        self.auto_archive_interval = dto.auto_archive_interval;
+        self.auto_delete_interval = dto.auto_delete_interval;
+        self.network_block_all = dto.network_block_all;
+        self.network_allow_list = dto.network_allow_list;
+        self.env = dto.env;
+        self.error_reason = dto.error_reason;
+        self.recoverable = dto.recoverable;
+        self.backup_state = dto.backup_state;
+        self.backup_created_at = dto.backup_created_at;
+        self.volumes = dto.volumes;
+        self.build_info = dto.build_info;
+        self.created_at = dto.created_at;
+        self.updated_at = dto.updated_at;
+        Ok(())
+    }
+
+    pub async fn wait_for_start(&mut self, timeout: Duration) -> Result<(), DaytonaError> {
+        let start = std::time::Instant::now();
+        let check_interval = Duration::from_secs(1);
+
+        loop {
+            self.refresh_data().await?;
+
+            if self.state == SandboxState::Started {
+                return Ok(());
+            }
+
+            if self.state == SandboxState::Error {
+                return Err(DaytonaError::Api {
+                    status: 0,
+                    message: "Sandbox failed to start".to_string(),
+                });
+            }
+
+            if timeout > Duration::ZERO && start.elapsed() > timeout {
+                return Err(DaytonaError::Timeout(
+                    "Sandbox did not start within timeout".to_string(),
+                ));
+            }
+
+            sleep(check_interval).await;
+        }
+    }
+
+    pub async fn wait_for_stop(&mut self, timeout: Duration) -> Result<(), DaytonaError> {
+        let start = std::time::Instant::now();
+        let check_interval = Duration::from_secs(1);
+
+        loop {
+            self.refresh_data().await?;
+
+            if self.state == SandboxState::Stopped {
+                return Ok(());
+            }
+
+            if timeout > Duration::ZERO && start.elapsed() > timeout {
+                return Err(DaytonaError::Timeout(
+                    "Sandbox did not stop within timeout".to_string(),
+                ));
+            }
+
+            sleep(check_interval).await;
+        }
+    }
+
+    pub async fn archive(&mut self) -> Result<(), DaytonaError> {
+        self.inner.archive_sandbox(&self.id).await?;
+        self.refresh_data().await?;
+        Ok(())
+    }
+
+    pub async fn resize(
+        &mut self,
+        resources: &ResizeSandboxRequest,
+        timeout: Duration,
+    ) -> Result<(), DaytonaError> {
+        let start = std::time::Instant::now();
+        self.inner.resize_sandbox(&self.id, resources).await?;
+        let elapsed = start.elapsed();
+        let remaining = if timeout > Duration::ZERO {
+            timeout.saturating_sub(elapsed)
+        } else {
+            Duration::ZERO
+        };
+        self.wait_for_resize(remaining).await?;
+        Ok(())
+    }
+
+    pub async fn wait_for_resize(&mut self, timeout: Duration) -> Result<(), DaytonaError> {
+        let start = std::time::Instant::now();
+        let check_interval = Duration::from_secs(1);
+
+        loop {
+            self.refresh_data().await?;
+
+            if self.state != SandboxState::Resizing {
+                return Ok(());
+            }
+
+            if self.state == SandboxState::Error {
+                return Err(DaytonaError::Api {
+                    status: 0,
+                    message: "Sandbox resize failed".to_string(),
+                });
+            }
+
+            if timeout > Duration::ZERO && start.elapsed() > timeout {
+                return Err(DaytonaError::Timeout(
+                    "Sandbox resize did not complete within timeout".to_string(),
+                ));
+            }
+
+            sleep(check_interval).await;
+        }
+    }
+
+    pub async fn set_labels(
+        &mut self,
+        labels: HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, DaytonaError> {
+        self.inner.set_labels(&self.id, labels).await?;
+        self.refresh_data().await?;
+        Ok(self.labels.clone().unwrap_or_default())
+    }
+
+    pub async fn get_user_home_dir(&self) -> Result<Option<String>, DaytonaError> {
+        let client = self.service_client().await?;
+        let resp: DirResponse = client.get_json("/info/user-home-dir").await?;
+        Ok(resp.dir)
+    }
+
+    pub async fn get_working_dir(&self) -> Result<Option<String>, DaytonaError> {
+        let client = self.service_client().await?;
+        let resp: DirResponse = client.get_json("/info/work-dir").await?;
+        Ok(resp.dir)
+    }
+
+    /// @deprecated Use `get_user_home_dir` instead. This method will be removed in a future version.
+    pub async fn get_user_root_dir(&self) -> Result<Option<String>, DaytonaError> {
+        self.get_user_home_dir().await
+    }
+
+    // CamelCase aliases
+    #[allow(non_snake_case)]
+    pub async fn getUserHomeDir(&self) -> Result<Option<String>, DaytonaError> {
+        self.get_user_home_dir().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn getWorkingDir(&self) -> Result<Option<String>, DaytonaError> {
+        self.get_working_dir().await
+    }
+
+    /// @deprecated Use `getUserHomeDir` instead.
+    #[allow(non_snake_case)]
+    pub async fn getUserRootDir(&self) -> Result<Option<String>, DaytonaError> {
+        self.get_user_home_dir().await
+    }
+
+    pub async fn set_auto_archive_interval(&mut self, interval: i32) -> Result<(), DaytonaError> {
+        self.inner
+            .set_auto_archive_interval(&self.id, interval)
+            .await?;
+        self.auto_archive_interval = Some(interval);
+        Ok(())
+    }
+
+    pub async fn set_auto_delete_interval(&mut self, interval: i32) -> Result<(), DaytonaError> {
+        self.inner
+            .set_auto_delete_interval(&self.id, interval)
+            .await?;
+        self.auto_delete_interval = Some(interval);
+        Ok(())
+    }
+
+    pub async fn set_auto_stop_interval(&mut self, interval: i32) -> Result<(), DaytonaError> {
+        self.inner
+            .set_auto_stop_interval(&self.id, interval)
+            .await?;
+        self.auto_stop_interval = Some(interval);
+        Ok(())
+    }
+
+    pub async fn recover(&mut self, timeout: Option<Duration>) -> Result<(), DaytonaError> {
+        let timeout = timeout.unwrap_or(Duration::from_secs(60));
+
+        self.inner.recover(&self.id).await?;
+
+        // Wait for the sandbox to start
+        self.wait_for_start(timeout).await?;
+
+        // Refresh data to get updated state
+        self.refresh_data().await?;
+
+        Ok(())
+    }
+
+    pub async fn refresh_activity(&self) -> Result<(), DaytonaError> {
+        self.inner.refresh_activity(&self.id).await
+    }
+
+    pub async fn get_signed_preview_url(
+        &self,
+        port: i32,
+        expires_in_seconds: Option<i32>,
+    ) -> Result<crate::types::SignedPreviewUrl, DaytonaError> {
+        self.inner
+            .get_signed_preview_url(&self.id, port, expires_in_seconds)
+            .await
+    }
+
+    pub async fn expire_signed_preview_url(
+        &self,
+        port: i32,
+        token: &str,
+    ) -> Result<(), DaytonaError> {
+        self.inner
+            .expire_signed_preview_url(&self.id, port, token)
+            .await
+    }
+
+    // CamelCase aliases
+    #[allow(non_snake_case)]
+    pub async fn setAutoArchiveInterval(&mut self, interval: i32) -> Result<(), DaytonaError> {
+        self.set_auto_archive_interval(interval).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn setAutoDeleteInterval(&mut self, interval: i32) -> Result<(), DaytonaError> {
+        self.set_auto_delete_interval(interval).await
+    }
+
+    pub async fn create_ssh_access(
+        &self,
+        expires_in_minutes: Option<i32>,
+    ) -> Result<SshAccessDto, DaytonaError> {
+        self.inner
+            .create_ssh_access(&self.id, expires_in_minutes)
+            .await
+    }
+
+    pub async fn revoke_ssh_access(&self, token: &str) -> Result<(), DaytonaError> {
+        self.inner.revoke_ssh_access(&self.id, token).await
+    }
+
+    pub async fn validate_ssh_access(
+        &self,
+        token: &str,
+    ) -> Result<SshAccessValidationDto, DaytonaError> {
+        self.inner.validate_ssh_access(token).await
+    }
+
+    pub async fn get_preview_link(
+        &self,
+        port: i32,
+    ) -> Result<crate::types::PreviewLink, DaytonaError> {
+        self.inner.get_preview_link(&self.id, port).await
+    }
+
+    // CamelCase alias
+    #[allow(non_snake_case)]
+    pub async fn getPreviewLink(
+        &self,
+        port: i32,
+    ) -> Result<crate::types::PreviewLink, DaytonaError> {
+        self.get_preview_link(port).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn setAutoStopInterval(&mut self, interval: i32) -> Result<(), DaytonaError> {
+        self.set_auto_stop_interval(interval).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn refreshActivity(&self) -> Result<(), DaytonaError> {
+        self.refresh_activity().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn getSignedPreviewUrl(
+        &self,
+        port: i32,
+        expires_in_seconds: Option<i32>,
+    ) -> Result<crate::types::SignedPreviewUrl, DaytonaError> {
+        self.get_signed_preview_url(port, expires_in_seconds).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn expireSignedPreviewUrl(&self, port: i32, token: &str) -> Result<(), DaytonaError> {
+        self.expire_signed_preview_url(port, token).await
+    }
+}

--- a/libs/sdk-rust/src/services/code_interpreter.rs
+++ b/libs/sdk-rust/src/services/code_interpreter.rs
@@ -1,0 +1,194 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::{ExecutionError, ExecutionResult, InterpreterContext};
+use futures::{SinkExt, StreamExt};
+use reqwest::Url;
+use serde_json::{json, Value};
+use tokio_tungstenite::{
+    connect_async_with_config,
+    tungstenite::{
+        handshake::client::{generate_key, Request},
+        Message,
+    },
+};
+
+#[derive(Clone)]
+pub struct CodeInterpreterService {
+    client: ServiceClient,
+}
+
+impl CodeInterpreterService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn run_code(
+        &self,
+        code: &str,
+        context_id: Option<&str>,
+        timeout: Option<i32>,
+    ) -> Result<ExecutionResult, DaytonaError> {
+        let ws_url = format!(
+            "{}/process/interpreter/execute",
+            self.client
+                .base_url
+                .replace("https://", "wss://")
+                .replace("http://", "ws://")
+                .trim_end_matches('/')
+        );
+
+        // Build request with auth headers
+        let host = Url::parse(&ws_url)
+            .map_err(|e| DaytonaError::Network(e.to_string()))?
+            .host_str()
+            .unwrap_or("")
+            .to_string();
+
+        let request = Request::builder()
+            .uri(&ws_url)
+            .header("Host", host)
+            .header("Connection", "Upgrade")
+            .header("Upgrade", "websocket")
+            .header("Sec-WebSocket-Version", "13")
+            .header("Sec-WebSocket-Key", generate_key());
+
+        // Add auth headers
+        let request = if let Some(token) = self.client.config.bearer_token() {
+            request.header("Authorization", format!("Bearer {}", token))
+        } else {
+            request
+        };
+
+        let request = request
+            .header("X-Daytona-Source", "rust-sdk")
+            .header("X-Daytona-SDK-Version", env!("CARGO_PKG_VERSION"));
+
+        let request = request
+            .body(())
+            .map_err(|e| DaytonaError::Network(e.to_string()))?;
+
+        let (mut ws, _) = connect_async_with_config(request, None, false)
+            .await
+            .map_err(|e| DaytonaError::Network(e.to_string()))?;
+
+        ws.send(Message::Text(
+            json!({
+                "code": code,
+                "contextId": context_id,
+                "timeout": timeout
+            })
+            .to_string(),
+        ))
+        .await
+        .map_err(|e| DaytonaError::Network(e.to_string()))?;
+
+        let mut result = ExecutionResult::default();
+
+        while let Some(msg) = ws.next().await {
+            let msg = msg.map_err(|e| DaytonaError::Network(e.to_string()))?;
+            match msg {
+                Message::Text(text) => {
+                    if let Ok(v) = serde_json::from_str::<Value>(&text) {
+                        match v.get("type").and_then(Value::as_str).unwrap_or_default() {
+                            "stdout" => result.stdout.push_str(
+                                v.get("text").and_then(Value::as_str).unwrap_or_default(),
+                            ),
+                            "stderr" => result.stderr.push_str(
+                                v.get("text").and_then(Value::as_str).unwrap_or_default(),
+                            ),
+                            "error" => {
+                                result.error = Some(ExecutionError {
+                                    name: v
+                                        .get("name")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                    value: v
+                                        .get("value")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or_default()
+                                        .to_string(),
+                                    traceback: v
+                                        .get("traceback")
+                                        .and_then(Value::as_str)
+                                        .map(ToString::to_string),
+                                })
+                            }
+                            "control" => {
+                                let t = v.get("text").and_then(Value::as_str).unwrap_or_default();
+                                if t == "completed" || t == "interrupted" {
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+
+        Ok(result)
+    }
+    pub async fn create_context(
+        &self,
+        cwd: Option<&str>,
+    ) -> Result<InterpreterContext, DaytonaError> {
+        self.client
+            .post_json("/process/interpreter/contexts", &json!({ "cwd": cwd }))
+            .await
+    }
+
+    pub async fn delete_context(&self, id: &str) -> Result<(), DaytonaError> {
+        self.client
+            .delete_empty(&format!("/process/interpreter/contexts/{id}"))
+            .await
+    }
+
+    pub async fn list_contexts(&self) -> Result<Vec<InterpreterContext>, DaytonaError> {
+        let value: Value = self
+            .client
+            .get_json("/process/interpreter/contexts")
+            .await?;
+        Ok(value
+            .get("contexts")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| serde_json::from_value(v).ok())
+            .collect())
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn runCode(
+        &self,
+        code: &str,
+        context_id: Option<&str>,
+        timeout: Option<i32>,
+    ) -> Result<ExecutionResult, DaytonaError> {
+        self.run_code(code, context_id, timeout).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn createContext(
+        &self,
+        cwd: Option<&str>,
+    ) -> Result<InterpreterContext, DaytonaError> {
+        self.create_context(cwd).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn deleteContext(&self, id: &str) -> Result<(), DaytonaError> {
+        self.delete_context(id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn listContexts(&self) -> Result<Vec<InterpreterContext>, DaytonaError> {
+        self.list_contexts().await
+    }
+}

--- a/libs/sdk-rust/src/services/computer_use.rs
+++ b/libs/sdk-rust/src/services/computer_use.rs
@@ -1,0 +1,307 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::{
+    DisplayInfo, Recording, ScreenshotOptions, ScreenshotRegion, ScreenshotResponse, WindowInfo,
+};
+use serde_json::{json, Value};
+
+#[derive(Clone)]
+pub struct ComputerUseService {
+    client: ServiceClient,
+}
+
+impl ComputerUseService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn start(&self) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json_value("/computer-use/start", &json!({}))
+            .await
+    }
+
+    pub async fn stop(&self) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json_value("/computer-use/stop", &json!({}))
+            .await
+    }
+
+    /// Take a screenshot of the current display.
+    ///
+    /// # Arguments
+    /// * `options` - Optional screenshot settings (show_cursor, format, quality, scale)
+    ///
+    /// # Returns
+    /// A `ScreenshotResponse` containing the base64-encoded image and metadata.
+    pub async fn screenshot(
+        &self,
+        options: Option<&ScreenshotOptions>,
+    ) -> Result<ScreenshotResponse, DaytonaError> {
+        let mut url = "/computer-use/screenshot".to_string();
+
+        if let Some(opts) = options {
+            let mut params = Vec::new();
+            if let Some(show_cursor) = opts.show_cursor {
+                params.push(format!("show_cursor={}", show_cursor));
+            }
+            if let Some(ref format) = opts.format {
+                params.push(format!("format={}", format));
+            }
+            if let Some(quality) = opts.quality {
+                params.push(format!("quality={}", quality));
+            }
+            if let Some(scale) = opts.scale {
+                params.push(format!("scale={}", scale));
+            }
+            if !params.is_empty() {
+                url.push('?');
+                url.push_str(&params.join("&"));
+            }
+        }
+
+        self.client.get_json(&url).await
+    }
+
+    /// Take a screenshot of a specific region of the display.
+    ///
+    /// # Arguments
+    /// * `region` - The region to capture (x, y, width, height)
+    /// * `options` - Optional screenshot settings
+    ///
+    /// # Returns
+    /// A `ScreenshotResponse` containing the base64-encoded image and metadata.
+    pub async fn screenshot_region(
+        &self,
+        region: &ScreenshotRegion,
+        options: Option<&ScreenshotOptions>,
+    ) -> Result<ScreenshotResponse, DaytonaError> {
+        let mut params = vec![
+            format!("x={}", region.x),
+            format!("y={}", region.y),
+            format!("width={}", region.width),
+            format!("height={}", region.height),
+        ];
+
+        if let Some(opts) = options {
+            if let Some(show_cursor) = opts.show_cursor {
+                params.push(format!("show_cursor={}", show_cursor));
+            }
+            if let Some(ref format) = opts.format {
+                params.push(format!("format={}", format));
+            }
+            if let Some(quality) = opts.quality {
+                params.push(format!("quality={}", quality));
+            }
+            if let Some(scale) = opts.scale {
+                params.push(format!("scale={}", scale));
+            }
+        }
+
+        let url = format!("/computer-use/screenshot?{}", params.join("&"));
+        self.client.get_json(&url).await
+    }
+
+    pub async fn mouse_click(
+        &self,
+        x: i32,
+        y: i32,
+        button: Option<&str>,
+        double: Option<bool>,
+    ) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json(
+                "/computer-use/mouse/click",
+                &json!({ "x": x, "y": y, "button": button.unwrap_or("left"), "double": double.unwrap_or(false) }),
+            )
+            .await
+    }
+
+    pub async fn mouse_move(&self, x: i32, y: i32) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json("/computer-use/mouse/move", &json!({ "x": x, "y": y }))
+            .await
+    }
+
+    pub async fn mouse_drag(
+        &self,
+        start_x: i32,
+        start_y: i32,
+        end_x: i32,
+        end_y: i32,
+    ) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json(
+                "/computer-use/mouse/drag",
+                &json!({ "startX": start_x, "startY": start_y, "endX": end_x, "endY": end_y }),
+            )
+            .await
+    }
+
+    pub async fn mouse_scroll(
+        &self,
+        x: i32,
+        y: i32,
+        direction: &str,
+        amount: Option<i32>,
+    ) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json(
+                "/computer-use/mouse/scroll",
+                &json!({ "x": x, "y": y, "direction": direction, "amount": amount.unwrap_or(1) }),
+            )
+            .await
+    }
+
+    pub async fn keyboard_type(&self, text: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty("/computer-use/keyboard/type", &json!({ "text": text }))
+            .await
+    }
+
+    pub async fn keyboard_press(&self, key: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty("/computer-use/keyboard/press", &json!({ "key": key }))
+            .await
+    }
+
+    pub async fn keyboard_hotkey(&self, keys: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty("/computer-use/keyboard/hotkey", &json!({ "keys": keys }))
+            .await
+    }
+
+    pub async fn display_info(&self) -> Result<DisplayInfo, DaytonaError> {
+        self.client.get_json("/computer-use/display/info").await
+    }
+
+    pub async fn display_windows(&self) -> Result<Vec<WindowInfo>, DaytonaError> {
+        let value: Value = self
+            .client
+            .get_json("/computer-use/display/windows")
+            .await?;
+        Ok(value
+            .get("windows")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| serde_json::from_value(v).ok())
+            .collect())
+    }
+
+    pub async fn recording_start(&self, label: Option<&str>) -> Result<Recording, DaytonaError> {
+        self.client
+            .post_json("/computer-use/recording/start", &json!({ "label": label }))
+            .await
+    }
+
+    pub async fn recording_stop(&self, id: &str) -> Result<Recording, DaytonaError> {
+        self.client
+            .post_json("/computer-use/recording/stop", &json!({ "id": id }))
+            .await
+    }
+
+    pub async fn recording_list(&self) -> Result<Vec<Recording>, DaytonaError> {
+        let value: Value = self.client.get_json("/computer-use/recording/list").await?;
+        Ok(value
+            .get("recordings")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| serde_json::from_value(v).ok())
+            .collect())
+    }
+
+    // CamelCase aliases
+    #[allow(non_snake_case)]
+    pub async fn mouseClick(
+        &self,
+        x: i32,
+        y: i32,
+        button: Option<&str>,
+        double: Option<bool>,
+    ) -> Result<Value, DaytonaError> {
+        self.mouse_click(x, y, button, double).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn mouseMove(&self, x: i32, y: i32) -> Result<Value, DaytonaError> {
+        self.mouse_move(x, y).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn mouseDrag(
+        &self,
+        start_x: i32,
+        start_y: i32,
+        end_x: i32,
+        end_y: i32,
+    ) -> Result<Value, DaytonaError> {
+        self.mouse_drag(start_x, start_y, end_x, end_y).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn mouseScroll(
+        &self,
+        x: i32,
+        y: i32,
+        direction: &str,
+        amount: Option<i32>,
+    ) -> Result<Value, DaytonaError> {
+        self.mouse_scroll(x, y, direction, amount).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn keyboardType(&self, text: &str) -> Result<(), DaytonaError> {
+        self.keyboard_type(text).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn keyboardPress(&self, key: &str) -> Result<(), DaytonaError> {
+        self.keyboard_press(key).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn keyboardHotkey(&self, keys: &str) -> Result<(), DaytonaError> {
+        self.keyboard_hotkey(keys).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn displayInfo(&self) -> Result<DisplayInfo, DaytonaError> {
+        self.display_info().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn displayWindows(&self) -> Result<Vec<WindowInfo>, DaytonaError> {
+        self.display_windows().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn recordingStart(&self, label: Option<&str>) -> Result<Recording, DaytonaError> {
+        self.recording_start(label).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn recordingStop(&self, id: &str) -> Result<Recording, DaytonaError> {
+        self.recording_stop(id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn recordingList(&self) -> Result<Vec<Recording>, DaytonaError> {
+        self.recording_list().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn screenshotRegion(
+        &self,
+        region: &ScreenshotRegion,
+        options: Option<&ScreenshotOptions>,
+    ) -> Result<ScreenshotResponse, DaytonaError> {
+        self.screenshot_region(region, options).await
+    }
+}

--- a/libs/sdk-rust/src/services/filesystem.rs
+++ b/libs/sdk-rust/src/services/filesystem.rs
@@ -1,0 +1,221 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::{FileDownloadResponse, FileInfo, FindMatch, ReplaceResult, SearchFilesResponse};
+use serde_json::json;
+
+#[derive(Clone)]
+pub struct FileSystemService {
+    client: ServiceClient,
+}
+
+impl FileSystemService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn create_folder(&self, path: &str, mode: &str) -> Result<(), DaytonaError> {
+        let url = format!(
+            "/files/folder?path={}&mode={}",
+            urlencoding::encode(path),
+            urlencoding::encode(mode)
+        );
+        self.client.post_empty_no_body(&url).await
+    }
+
+    pub async fn delete_file(
+        &self,
+        path: &str,
+        recursive: Option<bool>,
+    ) -> Result<(), DaytonaError> {
+        let url = format!(
+            "/files?path={}&recursive={}",
+            urlencoding::encode(path),
+            recursive.unwrap_or(false)
+        );
+        self.client.delete_empty(&url).await
+    }
+
+    pub async fn list_files(&self, path: &str) -> Result<Vec<FileInfo>, DaytonaError> {
+        self.client
+            .get_json(&format!("/files?path={}", urlencoding::encode(path)))
+            .await
+    }
+
+    pub async fn get_file_info(&self, path: &str) -> Result<FileInfo, DaytonaError> {
+        self.client
+            .get_json(&format!("/files/info?path={}", urlencoding::encode(path)))
+            .await
+    }
+
+    pub async fn upload_file(&self, source: &str, destination: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/files/upload",
+                &json!({ "source": source, "destination": destination }),
+            )
+            .await
+    }
+
+    pub async fn download_file(
+        &self,
+        source: &str,
+        destination: Option<&str>,
+    ) -> Result<FileDownloadResponse, DaytonaError> {
+        let mut url = format!("/files/download?path={}", urlencoding::encode(source));
+        if let Some(dest) = destination {
+            url.push_str(&format!("&destination={}", urlencoding::encode(dest)));
+        }
+        self.client.get_json(&url).await
+    }
+
+    pub async fn search_files(
+        &self,
+        path: &str,
+        pattern: &str,
+    ) -> Result<SearchFilesResponse, DaytonaError> {
+        self.client
+            .post_json(
+                "/files/search",
+                &json!({ "path": path, "pattern": pattern }),
+            )
+            .await
+    }
+
+    pub async fn replace_in_files(
+        &self,
+        files: &[String],
+        pattern: &str,
+        new_value: &str,
+    ) -> Result<Vec<ReplaceResult>, DaytonaError> {
+        self.client
+            .post_json(
+                "/files/replace",
+                &json!({ "files": files, "pattern": pattern, "newValue": new_value }),
+            )
+            .await
+    }
+
+    pub async fn move_files(&self, source: &str, destination: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/files/move",
+                &json!({ "source": source, "destination": destination }),
+            )
+            .await
+    }
+
+    pub async fn set_file_permissions(
+        &self,
+        path: &str,
+        mode: Option<&str>,
+        owner: Option<&str>,
+        group: Option<&str>,
+    ) -> Result<(), DaytonaError> {
+        let mut body = json!({ "path": path });
+        if let Some(m) = mode {
+            body["mode"] = json!(m);
+        }
+        if let Some(o) = owner {
+            body["owner"] = json!(o);
+        }
+        if let Some(g) = group {
+            body["group"] = json!(g);
+        }
+        self.client.post_empty("/files/permissions", &body).await
+    }
+
+    pub async fn find_files(
+        &self,
+        path: &str,
+        pattern: &str,
+    ) -> Result<Vec<FindMatch>, DaytonaError> {
+        self.client
+            .post_json("/files/find", &json!({ "path": path, "pattern": pattern }))
+            .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn createFolder(&self, path: &str, mode: &str) -> Result<(), DaytonaError> {
+        self.create_folder(path, mode).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn deleteFile(
+        &self,
+        path: &str,
+        recursive: Option<bool>,
+    ) -> Result<(), DaytonaError> {
+        self.delete_file(path, recursive).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn listFiles(&self, path: &str) -> Result<Vec<FileInfo>, DaytonaError> {
+        self.list_files(path).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn getFileInfo(&self, path: &str) -> Result<FileInfo, DaytonaError> {
+        self.get_file_info(path).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn uploadFile(&self, source: &str, destination: &str) -> Result<(), DaytonaError> {
+        self.upload_file(source, destination).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn downloadFile(
+        &self,
+        source: &str,
+        destination: Option<&str>,
+    ) -> Result<FileDownloadResponse, DaytonaError> {
+        self.download_file(source, destination).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn searchFiles(
+        &self,
+        path: &str,
+        pattern: &str,
+    ) -> Result<SearchFilesResponse, DaytonaError> {
+        self.search_files(path, pattern).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn replaceInFiles(
+        &self,
+        files: &[String],
+        pattern: &str,
+        new_value: &str,
+    ) -> Result<Vec<ReplaceResult>, DaytonaError> {
+        self.replace_in_files(files, pattern, new_value).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn moveFiles(&self, source: &str, destination: &str) -> Result<(), DaytonaError> {
+        self.move_files(source, destination).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn setFilePermissions(
+        &self,
+        path: &str,
+        mode: Option<&str>,
+        owner: Option<&str>,
+        group: Option<&str>,
+    ) -> Result<(), DaytonaError> {
+        self.set_file_permissions(path, mode, owner, group).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn findFiles(
+        &self,
+        path: &str,
+        pattern: &str,
+    ) -> Result<Vec<FindMatch>, DaytonaError> {
+        self.find_files(path, pattern).await
+    }
+}

--- a/libs/sdk-rust/src/services/git.rs
+++ b/libs/sdk-rust/src/services/git.rs
@@ -1,0 +1,174 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::{BranchesResponse, GitCommitResponse, GitStatus};
+use serde_json::json;
+
+#[derive(Clone)]
+pub struct GitService {
+    client: ServiceClient,
+}
+
+impl GitService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn clone(
+        &self,
+        url: &str,
+        path: &str,
+        branch: Option<&str>,
+    ) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/git/clone",
+                &json!({ "url": url, "path": path, "branch": branch }),
+            )
+            .await
+    }
+
+    pub async fn add(&self, path: &str, files: &[String]) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty("/git/add", &json!({ "path": path, "files": files }))
+            .await
+    }
+
+    pub async fn commit(
+        &self,
+        path: &str,
+        message: &str,
+        author: &str,
+        email: &str,
+        allow_empty: Option<bool>,
+    ) -> Result<GitCommitResponse, DaytonaError> {
+        self.client
+            .post_json(
+                "/git/commit",
+                &json!({
+                    "path": path,
+                    "message": message,
+                    "author": author,
+                    "email": email,
+                    "allowEmpty": allow_empty
+                }),
+            )
+            .await
+    }
+
+    pub async fn push(
+        &self,
+        path: &str,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/git/push",
+                &json!({ "path": path, "username": username, "password": password }),
+            )
+            .await
+    }
+
+    pub async fn pull(
+        &self,
+        path: &str,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/git/pull",
+                &json!({ "path": path, "username": username, "password": password }),
+            )
+            .await
+    }
+
+    pub async fn status(&self, path: &str) -> Result<GitStatus, DaytonaError> {
+        self.client
+            .get_json(&format!("/git/status?path={}", urlencoding::encode(path)))
+            .await
+    }
+
+    pub async fn branches(&self, path: &str) -> Result<BranchesResponse, DaytonaError> {
+        self.client
+            .get_json(&format!("/git/branches?path={}", urlencoding::encode(path)))
+            .await
+    }
+    pub async fn checkout(&self, path: &str, branch: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty("/git/checkout", &json!({ "path": path, "branch": branch }))
+            .await
+    }
+
+    pub async fn delete_branch(&self, path: &str, branch: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/git/delete-branch",
+                &json!({ "path": path, "branch": branch }),
+            )
+            .await
+    }
+
+    // CamelCase aliases
+    // Note: 'Clone' alias is not provided because 'clone' conflicts with the Clone trait
+
+    #[allow(non_snake_case)]
+    pub async fn Add(&self, path: &str, files: &[String]) -> Result<(), DaytonaError> {
+        self.add(path, files).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Commit(
+        &self,
+        path: &str,
+        message: &str,
+        author: &str,
+        email: &str,
+        allow_empty: Option<bool>,
+    ) -> Result<GitCommitResponse, DaytonaError> {
+        self.commit(path, message, author, email, allow_empty).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Push(
+        &self,
+        path: &str,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> Result<(), DaytonaError> {
+        self.push(path, username, password).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Pull(
+        &self,
+        path: &str,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> Result<(), DaytonaError> {
+        self.pull(path, username, password).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Status(&self, path: &str) -> Result<GitStatus, DaytonaError> {
+        self.status(path).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Branches(&self, path: &str) -> Result<BranchesResponse, DaytonaError> {
+        self.branches(path).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Checkout(&self, path: &str, branch: &str) -> Result<(), DaytonaError> {
+        self.checkout(path, branch).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn DeleteBranch(&self, path: &str, branch: &str) -> Result<(), DaytonaError> {
+        self.delete_branch(path, branch).await
+    }
+}

--- a/libs/sdk-rust/src/services/lsp_server.rs
+++ b/libs/sdk-rust/src/services/lsp_server.rs
@@ -1,0 +1,185 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::Position;
+use serde_json::{json, Value};
+
+#[derive(Clone)]
+pub struct LspServerService {
+    client: ServiceClient,
+}
+
+impl LspServerService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn start(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+    ) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/lsp/start",
+                &json!({ "languageId": language_id, "pathToProject": path_to_project }),
+            )
+            .await
+    }
+
+    pub async fn did_open(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+    ) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/lsp/did-open",
+                &json!({ "languageId": language_id, "pathToProject": path_to_project, "uri": uri }),
+            )
+            .await
+    }
+
+    pub async fn did_close(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+    ) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                "/lsp/did-close",
+                &json!({ "languageId": language_id, "pathToProject": path_to_project, "uri": uri }),
+            )
+            .await
+    }
+
+    pub async fn document_symbols(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+    ) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json(
+                "/lsp/document-symbols",
+                &json!({ "languageId": language_id, "pathToProject": path_to_project, "uri": uri }),
+            )
+            .await
+    }
+
+    pub async fn completions(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+        position: Position,
+    ) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json(
+                "/lsp/completions",
+                &json!({ "languageId": language_id, "pathToProject": path_to_project, "uri": uri, "position": position }),
+            )
+            .await
+    }
+
+    pub async fn definition(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+        position: Position,
+    ) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json(
+                "/lsp/definition",
+                &json!({ "languageId": language_id, "pathToProject": path_to_project, "uri": uri, "position": position }),
+            )
+            .await
+    }
+
+    pub async fn references(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+        position: Position,
+    ) -> Result<Value, DaytonaError> {
+        self.client
+            .post_json(
+                "/lsp/references",
+                &json!({ "languageId": language_id, "pathToProject": path_to_project, "uri": uri, "position": position }),
+            )
+            .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn didOpen(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+    ) -> Result<(), DaytonaError> {
+        self.did_open(language_id, path_to_project, uri).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn didClose(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+    ) -> Result<(), DaytonaError> {
+        self.did_close(language_id, path_to_project, uri).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn documentSymbols(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+    ) -> Result<Value, DaytonaError> {
+        self.document_symbols(language_id, path_to_project, uri)
+            .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Completions(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+        position: Position,
+    ) -> Result<Value, DaytonaError> {
+        self.completions(language_id, path_to_project, uri, position)
+            .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Definition(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+        position: Position,
+    ) -> Result<Value, DaytonaError> {
+        self.definition(language_id, path_to_project, uri, position)
+            .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn References(
+        &self,
+        language_id: &str,
+        path_to_project: &str,
+        uri: &str,
+        position: Position,
+    ) -> Result<Value, DaytonaError> {
+        self.references(language_id, path_to_project, uri, position)
+            .await
+    }
+}

--- a/libs/sdk-rust/src/services/mod.rs
+++ b/libs/sdk-rust/src/services/mod.rs
@@ -1,0 +1,150 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod code_interpreter;
+pub mod computer_use;
+pub mod filesystem;
+pub mod git;
+pub mod lsp_server;
+pub mod object_storage;
+pub mod process;
+pub mod snapshot;
+pub mod volume;
+
+use crate::config::Config;
+use crate::error::DaytonaError;
+use crate::utils::{decode_empty, decode_json, with_auth};
+use reqwest::Client as HttpClient;
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct ServiceClient {
+    pub base_url: String,
+    pub config: Config,
+    pub http: HttpClient,
+}
+
+impl ServiceClient {
+    pub fn new(base_url: String, config: Config, http: HttpClient) -> Self {
+        Self {
+            base_url,
+            config,
+            http,
+        }
+    }
+
+    pub async fn get_json<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> Result<T, DaytonaError> {
+        let req = with_auth(
+            self.http.get(format!("{}{}", self.base_url, path)),
+            &self.config,
+        )?;
+        decode_json(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn post_json<B: Serialize, T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T, DaytonaError> {
+        let req = with_auth(
+            self.http.post(format!("{}{}", self.base_url, path)),
+            &self.config,
+        )?;
+        decode_json(
+            req.json(body)
+                .send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn post_json_value<B: Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<Value, DaytonaError> {
+        self.post_json(path, body).await
+    }
+
+    pub async fn post_empty<B: Serialize>(&self, path: &str, body: &B) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(format!("{}{}", self.base_url, path)),
+            &self.config,
+        )?;
+        decode_empty(
+            req.json(body)
+                .send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn post_empty_no_body(&self, path: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.post(format!("{}{}", self.base_url, path)),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn delete_empty(&self, path: &str) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.delete(format!("{}{}", self.base_url, path)),
+            &self.config,
+        )?;
+        decode_empty(
+            req.send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn put_json<B: Serialize, T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T, DaytonaError> {
+        let req = with_auth(
+            self.http.put(format!("{}{}", self.base_url, path)),
+            &self.config,
+        )?;
+        decode_json(
+            req.json(body)
+                .send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+
+    pub async fn put_empty<B: Serialize>(&self, path: &str, body: &B) -> Result<(), DaytonaError> {
+        let req = with_auth(
+            self.http.put(format!("{}{}", self.base_url, path)),
+            &self.config,
+        )?;
+        decode_empty(
+            req.json(body)
+                .send()
+                .await
+                .map_err(|e| DaytonaError::Network(e.to_string()))?,
+        )
+        .await
+    }
+}

--- a/libs/sdk-rust/src/services/object_storage.rs
+++ b/libs/sdk-rust/src/services/object_storage.rs
@@ -1,0 +1,21 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct ObjectStorageService {
+    client: ServiceClient,
+}
+
+impl ObjectStorageService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn get_push_access(&self) -> Result<Value, DaytonaError> {
+        self.client.get_json("/object-storage/push-access").await
+    }
+}

--- a/libs/sdk-rust/src/services/process.rs
+++ b/libs/sdk-rust/src/services/process.rs
@@ -1,0 +1,483 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::{
+    Command, ExecuteResponse, PtyCreateResponse, PtySessionInfo, Session, SessionExecuteResponse,
+};
+use futures::StreamExt;
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
+
+const STDOUT_PREFIX: [u8; 3] = [0x01, 0x01, 0x01];
+const STDERR_PREFIX: [u8; 3] = [0x02, 0x02, 0x02];
+const MAX_PREFIX_LEN: usize = 3;
+
+fn flush_to_channel(
+    data: &[u8],
+    current_type: &str,
+    stdout: &mpsc::Sender<String>,
+    stderr: &mpsc::Sender<String>,
+) {
+    if data.is_empty() {
+        return;
+    }
+    let text = String::from_utf8_lossy(data);
+    match current_type {
+        "stdout" => {
+            let _ = stdout.try_send(text.to_string());
+        }
+        "stderr" => {
+            let _ = stderr.try_send(text.to_string());
+        }
+        _ => {}
+    }
+}
+
+#[derive(Clone)]
+pub struct ProcessService {
+    client: ServiceClient,
+}
+
+impl ProcessService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn execute_command(
+        &self,
+        command: &str,
+        cwd: Option<&str>,
+        env: Option<Value>,
+        timeout: Option<i32>,
+    ) -> Result<ExecuteResponse, DaytonaError> {
+        self.client
+            .post_json(
+                "/process/execute",
+                &json!({ "command": command, "cwd": cwd, "env": env, "timeout": timeout }),
+            )
+            .await
+    }
+
+    /// Execute code using the appropriate language toolbox.
+    ///
+    /// The command is generated using the CodeToolbox for the specified language,
+    /// then executed via `execute_command` with the provided environment variables.
+    pub async fn code_run(
+        &self,
+        code: &str,
+        language: &str,
+        params: Option<&crate::code_toolbox::CodeRunParams>,
+        timeout: Option<i32>,
+    ) -> Result<ExecuteResponse, DaytonaError> {
+        let toolbox = crate::code_toolbox::CodeLanguage::from_str(language)
+            .map(|lang| lang.toolbox())
+            .unwrap_or_else(|| Box::new(crate::code_toolbox::PythonCodeToolbox::new()));
+
+        let command = toolbox.get_run_command(code, params);
+        let env = params.and_then(|p| {
+            p.env.as_ref().and_then(|e| {
+                if e.is_empty() {
+                    None
+                } else {
+                    Some(serde_json::to_value(e).unwrap_or(Value::Null))
+                }
+            })
+        });
+
+        self.execute_command(&command, None, env, timeout).await
+    }
+
+    pub async fn create_pty(
+        &self,
+        id: Option<&str>,
+        cwd: Option<&str>,
+        cols: Option<i32>,
+        rows: Option<i32>,
+    ) -> Result<PtyCreateResponse, DaytonaError> {
+        self.client
+            .post_json(
+                "/process/pty/create",
+                &json!({ "id": id, "cwd": cwd, "cols": cols, "rows": rows }),
+            )
+            .await
+    }
+
+    pub async fn list_pty(&self) -> Result<Vec<PtySessionInfo>, DaytonaError> {
+        self.client.get_json("/process/pty/list").await
+    }
+
+    pub async fn resize_pty(
+        &self,
+        session_id: &str,
+        cols: i32,
+        rows: i32,
+    ) -> Result<PtySessionInfo, DaytonaError> {
+        self.client
+            .post_json(
+                &format!("/process/pty/{session_id}/resize"),
+                &json!({ "cols": cols, "rows": rows }),
+            )
+            .await
+    }
+
+    pub async fn send_input(&self, session_id: &str, data: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                &format!("/process/pty/{session_id}/input"),
+                &json!({ "data": data }),
+            )
+            .await
+    }
+
+    pub async fn read_output(&self, session_id: &str) -> Result<String, DaytonaError> {
+        let value: Value = self
+            .client
+            .get_json(&format!("/process/pty/{session_id}/output"))
+            .await?;
+        Ok(value
+            .get("output")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string())
+    }
+
+    pub async fn create_session(&self, session_id: &str) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty("/process/session", &json!({ "sessionId": session_id }))
+            .await
+    }
+
+    pub async fn get_session(&self, session_id: &str) -> Result<Session, DaytonaError> {
+        self.client
+            .get_json(&format!("/process/session/{}", session_id))
+            .await
+    }
+
+    pub async fn delete_session(&self, session_id: &str) -> Result<(), DaytonaError> {
+        self.client
+            .delete_empty(&format!("/process/session/{}", session_id))
+            .await
+    }
+
+    pub async fn list_sessions(&self) -> Result<Vec<Session>, DaytonaError> {
+        self.client.get_json("/process/session").await
+    }
+
+    pub async fn execute_session_command(
+        &self,
+        session_id: &str,
+        command: &str,
+        run_async: bool,
+        suppress_input_echo: bool,
+    ) -> Result<SessionExecuteResponse, DaytonaError> {
+        self.client
+            .post_json(
+                &format!("/process/session/{}/command", session_id),
+                &json!({
+                    "command": command,
+                    "runAsync": run_async,
+                    "suppressInputEcho": suppress_input_echo
+                }),
+            )
+            .await
+    }
+
+    pub async fn get_session_command(
+        &self,
+        session_id: &str,
+        command_id: &str,
+    ) -> Result<Command, DaytonaError> {
+        self.client
+            .get_json(&format!(
+                "/process/session/{}/command/{}",
+                session_id, command_id
+            ))
+            .await
+    }
+
+    /// Send input data to a running command in a session.
+    ///
+    /// This is useful for interactive commands that require user input.
+    pub async fn send_session_command_input(
+        &self,
+        session_id: &str,
+        command_id: &str,
+        data: &str,
+    ) -> Result<(), DaytonaError> {
+        self.client
+            .post_empty(
+                &format!(
+                    "/process/session/{}/command/{}/input",
+                    session_id, command_id
+                ),
+                &json!({ "data": data }),
+            )
+            .await
+    }
+    pub async fn get_session_command_logs(
+        &self,
+        session_id: &str,
+        command_id: &str,
+    ) -> Result<String, DaytonaError> {
+        let value: serde_json::Value = self
+            .client
+            .get_json(&format!(
+                "/process/session/{}/command/{}/logs",
+                session_id, command_id
+            ))
+            .await?;
+        Ok(value
+            .get("logs")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string())
+    }
+
+    /// Stream command logs via WebSocket with stdout/stderr demux
+    ///
+    /// Uses 3-byte markers: \[0x01,0x01,0x01\] for stdout, \[0x02,0x02,0x02\] for stderr
+    pub async fn get_session_command_logs_stream(
+        &self,
+        session_id: &str,
+        command_id: &str,
+        stdout: mpsc::Sender<String>,
+        stderr: mpsc::Sender<String>,
+    ) -> Result<(), DaytonaError> {
+        let ws_url = format!(
+            "{}/process/session/{}/command/{}/logs?follow=true",
+            self.client
+                .base_url
+                .replace("https://", "wss://")
+                .replace("http://", "ws://")
+                .trim_end_matches('/'),
+            session_id,
+            command_id
+        );
+
+        let token = self.client.config.bearer_token().ok_or_else(|| {
+            DaytonaError::Unauthorized("missing DAYTONA_API_KEY or DAYTONA_JWT_TOKEN".into())
+        })?;
+
+        let mut request = ws_url
+            .into_client_request()
+            .map_err(|e| DaytonaError::Network(e.to_string()))?;
+        request.headers_mut().insert(
+            "Authorization",
+            format!("Bearer {}", token)
+                .parse()
+                .map_err(|_| DaytonaError::Network("invalid auth header value".into()))?,
+        );
+        request.headers_mut().insert(
+            "X-Daytona-Source",
+            "rust-sdk"
+                .parse()
+                .map_err(|_| DaytonaError::Network("invalid header value".into()))?,
+        );
+
+        let (mut ws, _) = connect_async(request)
+            .await
+            .map_err(|e| DaytonaError::Network(e.to_string()))?;
+
+        let mut current_type = "stdout";
+        let mut carry: Vec<u8> = Vec::new();
+
+        while let Some(msg) = ws.next().await {
+            let msg = msg.map_err(|e| DaytonaError::Network(e.to_string()))?;
+            let bytes: Vec<u8> = match msg {
+                Message::Binary(data) => data,
+                Message::Text(text) => text.into_bytes(),
+                Message::Close(_) => break,
+                _ => continue,
+            };
+
+            let mut buffer = Vec::with_capacity(carry.len() + bytes.len());
+            buffer.extend_from_slice(&carry);
+            buffer.extend_from_slice(&bytes);
+
+            let mut start = 0;
+            let mut pos = 0;
+
+            while pos + MAX_PREFIX_LEN <= buffer.len() {
+                if buffer[pos..pos + MAX_PREFIX_LEN] == STDOUT_PREFIX {
+                    if start < pos {
+                        flush_to_channel(&buffer[start..pos], current_type, &stdout, &stderr);
+                    }
+                    current_type = "stdout";
+                    pos += MAX_PREFIX_LEN;
+                    start = pos;
+                } else if buffer[pos..pos + MAX_PREFIX_LEN] == STDERR_PREFIX {
+                    if start < pos {
+                        flush_to_channel(&buffer[start..pos], current_type, &stdout, &stderr);
+                    }
+                    current_type = "stderr";
+                    pos += MAX_PREFIX_LEN;
+                    start = pos;
+                } else {
+                    pos += 1;
+                }
+            }
+
+            // Flush verified data (no markers in [start..pos])
+            if start < pos {
+                flush_to_channel(&buffer[start..pos], current_type, &stdout, &stderr);
+            }
+
+            // Carry remaining bytes that might contain a partial marker
+            carry = buffer[pos..].to_vec();
+        }
+
+        // Flush any remaining carry buffer
+        if !carry.is_empty() {
+            flush_to_channel(&carry, current_type, &stdout, &stderr);
+        }
+
+        Ok(())
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn executeCommand(
+        &self,
+        command: &str,
+        cwd: Option<&str>,
+        env: Option<Value>,
+        timeout: Option<i32>,
+    ) -> Result<ExecuteResponse, DaytonaError> {
+        self.execute_command(command, cwd, env, timeout).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn codeRun(
+        &self,
+        code: &str,
+        language: &str,
+        params: Option<&crate::code_toolbox::CodeRunParams>,
+        timeout: Option<i32>,
+    ) -> Result<ExecuteResponse, DaytonaError> {
+        self.code_run(code, language, params, timeout).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn createPty(
+        &self,
+        id: Option<&str>,
+        cwd: Option<&str>,
+        cols: Option<i32>,
+        rows: Option<i32>,
+    ) -> Result<PtyCreateResponse, DaytonaError> {
+        self.create_pty(id, cwd, cols, rows).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn listPty(&self) -> Result<Vec<PtySessionInfo>, DaytonaError> {
+        self.list_pty().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn resizePty(
+        &self,
+        session_id: &str,
+        cols: i32,
+        rows: i32,
+    ) -> Result<PtySessionInfo, DaytonaError> {
+        self.resize_pty(session_id, cols, rows).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn sendInput(&self, session_id: &str, data: &str) -> Result<(), DaytonaError> {
+        self.send_input(session_id, data).await
+    }
+
+    pub async fn kill_pty_session(&self, session_id: &str) -> Result<(), DaytonaError> {
+        self.client
+            .delete_empty(&format!("/process/pty/{}", session_id))
+            .await
+    }
+    #[allow(non_snake_case)]
+    pub async fn createSession(&self, session_id: &str) -> Result<(), DaytonaError> {
+        self.create_session(session_id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn getSession(&self, session_id: &str) -> Result<Session, DaytonaError> {
+        self.get_session(session_id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn deleteSession(&self, session_id: &str) -> Result<(), DaytonaError> {
+        self.delete_session(session_id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn listSessions(&self) -> Result<Vec<Session>, DaytonaError> {
+        self.list_sessions().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn executeSessionCommand(
+        &self,
+        session_id: &str,
+        command: &str,
+        run_async: bool,
+        suppress_input_echo: bool,
+    ) -> Result<SessionExecuteResponse, DaytonaError> {
+        self.execute_session_command(session_id, command, run_async, suppress_input_echo)
+            .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn getSessionCommand(
+        &self,
+        session_id: &str,
+        command_id: &str,
+    ) -> Result<Command, DaytonaError> {
+        self.get_session_command(session_id, command_id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn sendSessionCommandInput(
+        &self,
+        session_id: &str,
+        command_id: &str,
+        data: &str,
+    ) -> Result<(), DaytonaError> {
+        self.send_session_command_input(session_id, command_id, data)
+            .await
+    }
+    #[allow(non_snake_case)]
+    pub async fn getSessionCommandLogsStream(
+        &self,
+        session_id: &str,
+        command_id: &str,
+        stdout: mpsc::Sender<String>,
+        stderr: mpsc::Sender<String>,
+    ) -> Result<(), DaytonaError> {
+        self.get_session_command_logs_stream(session_id, command_id, stdout, stderr)
+            .await
+    }
+
+    pub async fn get_pty_session_info(
+        &self,
+        session_id: &str,
+    ) -> Result<PtySessionInfo, DaytonaError> {
+        self.client
+            .get_json(&format!("/process/pty/{}", session_id))
+            .await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn killPtySession(&self, session_id: &str) -> Result<(), DaytonaError> {
+        self.kill_pty_session(session_id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn getPtySessionInfo(
+        &self,
+        session_id: &str,
+    ) -> Result<PtySessionInfo, DaytonaError> {
+        self.get_pty_session_info(session_id).await
+    }
+}

--- a/libs/sdk-rust/src/services/snapshot.rs
+++ b/libs/sdk-rust/src/services/snapshot.rs
@@ -1,0 +1,137 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::{CreateSnapshotParams, PaginatedSnapshots, Snapshot};
+use crate::utils::with_auth;
+use futures::StreamExt;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+pub struct SnapshotService {
+    client: ServiceClient,
+}
+
+impl SnapshotService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn list(
+        &self,
+        page: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<PaginatedSnapshots, DaytonaError> {
+        self.client
+            .post_json("/snapshot/list", &json!({ "page": page, "limit": limit }))
+            .await
+    }
+
+    pub async fn get(&self, name_or_id: &str) -> Result<Snapshot, DaytonaError> {
+        self.client
+            .get_json(&format!("/snapshot/{name_or_id}"))
+            .await
+    }
+
+    pub async fn create(
+        &self,
+        params: &CreateSnapshotParams,
+    ) -> Result<(Snapshot, mpsc::Receiver<String>), DaytonaError> {
+        // 1. Create the snapshot
+        let snapshot: Snapshot = self.client.post_json("/snapshot", params).await?;
+
+        // 2. Set up log streaming channel
+        let (log_tx, log_rx) = mpsc::channel::<String>(100);
+
+        // 3. If state is PENDING_BUILD, start streaming logs in background
+        let state = snapshot.state.as_deref().unwrap_or("");
+        if state == "pending_build" || state == "pending" {
+            let svc = self.clone();
+            let snapshot_id = snapshot.id.clone();
+            tokio::spawn(async move {
+                let _ = svc.stream_build_logs(&snapshot_id, log_tx).await;
+            });
+        } else {
+            // Not a build state — close the channel immediately
+            drop(log_tx);
+        }
+
+        Ok((snapshot, log_rx))
+    }
+
+    async fn stream_build_logs(
+        &self,
+        snapshot_id: &str,
+        log_tx: mpsc::Sender<String>,
+    ) -> Result<(), DaytonaError> {
+        // 1. Poll /snapshot/{id} until state is no longer pending/pending_build
+        loop {
+            let current: Snapshot = self
+                .client
+                .get_json(&format!("/snapshot/{snapshot_id}"))
+                .await?;
+
+            let state = current.state.as_deref().unwrap_or("");
+            match state {
+                "pending" | "pending_build" => {
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+                _ => break,
+            }
+        }
+
+        // 2. Stream from GET /snapshots/{id}/build-logs?follow=true
+        let url = format!(
+            "{}/snapshots/{}/build-logs?follow=true",
+            self.client.base_url, snapshot_id
+        );
+
+        let req = with_auth(self.client.http.get(&url), &self.client.config)?;
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| DaytonaError::Network(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(DaytonaError::from_status(status, text));
+        }
+
+        // 3. Use reqwest Response::bytes_stream() for streaming
+        let mut stream = resp.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| DaytonaError::Network(e.to_string()))?;
+            let text = String::from_utf8_lossy(&chunk);
+            buffer.push_str(&text);
+
+            // 4. Parse lines and send to log_tx
+            while let Some(pos) = buffer.find('\n') {
+                let line = buffer[..pos].trim_end_matches('\r').to_string();
+                buffer = buffer[pos + 1..].to_string();
+                if !line.is_empty() && log_tx.send(line).await.is_err() {
+                    // Receiver dropped, stop streaming
+                    return Ok(());
+                }
+            }
+        }
+
+        // Send any remaining content in buffer
+        let remaining = buffer.trim().to_string();
+        if !remaining.is_empty() {
+            let _ = log_tx.send(remaining).await;
+        }
+
+        Ok(())
+    }
+
+    pub async fn delete(&self, name_or_id: &str) -> Result<(), DaytonaError> {
+        self.client
+            .delete_empty(&format!("/snapshot/{name_or_id}"))
+            .await
+    }
+}

--- a/libs/sdk-rust/src/services/volume.rs
+++ b/libs/sdk-rust/src/services/volume.rs
@@ -1,0 +1,59 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::DaytonaError;
+use crate::services::ServiceClient;
+use crate::types::Volume;
+use serde_json::json;
+
+#[derive(Clone)]
+pub struct VolumeService {
+    client: ServiceClient,
+}
+
+impl VolumeService {
+    pub fn new(client: ServiceClient) -> Self {
+        Self { client }
+    }
+
+    pub async fn list(&self) -> Result<Vec<Volume>, DaytonaError> {
+        self.client.get_json("/volume").await
+    }
+
+    pub async fn get(&self, name_or_id: &str) -> Result<Volume, DaytonaError> {
+        self.client.get_json(&format!("/volume/{name_or_id}")).await
+    }
+
+    pub async fn create(&self, name: &str) -> Result<Volume, DaytonaError> {
+        self.client
+            .post_json("/volume", &json!({ "name": name }))
+            .await
+    }
+
+    pub async fn delete(&self, name_or_id: &str) -> Result<(), DaytonaError> {
+        self.client
+            .delete_empty(&format!("/volume/{name_or_id}"))
+            .await
+    }
+
+    // CamelCase aliases
+    #[allow(non_snake_case)]
+    pub async fn List(&self) -> Result<Vec<Volume>, DaytonaError> {
+        self.list().await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Get(&self, name_or_id: &str) -> Result<Volume, DaytonaError> {
+        self.get(name_or_id).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Create(&self, name: &str) -> Result<Volume, DaytonaError> {
+        self.create(name).await
+    }
+
+    #[allow(non_snake_case)]
+    pub async fn Delete(&self, name_or_id: &str) -> Result<(), DaytonaError> {
+        self.delete(name_or_id).await
+    }
+}

--- a/libs/sdk-rust/src/types.rs
+++ b/libs/sdk-rust/src/types.rs
@@ -1,0 +1,551 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::image::DockerImage;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxState {
+    Creating,
+    Starting,
+    Started,
+    Stopping,
+    Stopped,
+    PendingBuild,
+    BuildFailed,
+    Resizing,
+    Error,
+    Destroyed,
+    #[default]
+    Unknown,
+}
+
+/// Backup state of a sandbox
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum SandboxBackupState {
+    #[default]
+    Unknown,
+    BackingUp,
+    Restoring,
+    Archiving,
+    Archived,
+    Error,
+}
+
+/// Build information for a sandbox created from a Docker image or custom Dockerfile
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BuildInfo {
+    /// Dockerfile content for building the sandbox image
+    #[serde(rename = "dockerfileContent")]
+    pub dockerfile_content: String,
+    /// Hashes of context files uploaded to object storage used for building the image
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_hashes: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CodeLanguage {
+    Python,
+    JavaScript,
+    TypeScript,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Resources {
+    pub cpu: Option<i32>,
+    pub gpu: Option<i32>,
+    pub memory: Option<i32>,
+    pub disk: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VolumeMount {
+    #[serde(rename = "volumeId")]
+    pub volume_id: String,
+    #[serde(rename = "mountPath")]
+    pub mount_path: String,
+    pub subpath: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CreateSandboxParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<CodeLanguage>,
+    #[serde(rename = "envVars", skip_serializing_if = "Option::is_none")]
+    pub env_vars: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public: Option<bool>,
+    #[serde(rename = "autoStopInterval", skip_serializing_if = "Option::is_none")]
+    pub auto_stop_interval: Option<i32>,
+    #[serde(
+        rename = "autoArchiveInterval",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub auto_archive_interval: Option<i32>,
+    #[serde(rename = "autoDeleteInterval", skip_serializing_if = "Option::is_none")]
+    pub auto_delete_interval: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volumes: Option<Vec<VolumeMount>>,
+    #[serde(rename = "networkBlockAll", skip_serializing_if = "Option::is_none")]
+    pub network_block_all: Option<bool>,
+    #[serde(rename = "networkAllowList", skip_serializing_if = "Option::is_none")]
+    pub network_allow_list: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ephemeral: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<Resources>,
+    /// The target (region) where the sandbox will be created
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// Build information for the sandbox
+    #[serde(rename = "buildInfo", skip_serializing_if = "Option::is_none")]
+    pub build_info: Option<BuildInfo>,
+    /// Docker image builder for custom Dockerfile definitions.
+    /// When set, the image will be built from the Dockerfile content.
+    /// This field is not serialized directly; it is processed by the client
+    /// to generate build info before sending to the API.
+    #[serde(skip)]
+    pub docker_image: Option<DockerImage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SandboxDto {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub state: SandboxState,
+    #[serde(default)]
+    pub target: String,
+    /// Organization ID that owns the sandbox
+    #[serde(rename = "organizationId")]
+    pub organization_id: String,
+    /// Daytona snapshot used to create the sandbox
+    pub snapshot: Option<String>,
+    /// OS user running in the sandbox
+    pub user: Option<String>,
+    /// Environment variables set in the sandbox
+    pub env: Option<HashMap<String, String>>,
+    pub labels: Option<HashMap<String, String>>,
+    pub public: Option<bool>,
+    #[serde(rename = "autoStopInterval")]
+    pub auto_stop_interval: Option<i32>,
+    #[serde(rename = "autoArchiveInterval")]
+    pub auto_archive_interval: Option<i32>,
+    #[serde(rename = "autoDeleteInterval")]
+    pub auto_delete_interval: Option<i32>,
+    /// Volumes attached to the sandbox
+    pub volumes: Option<Vec<VolumeMount>>,
+    #[serde(rename = "networkBlockAll")]
+    pub network_block_all: bool,
+    #[serde(rename = "networkAllowList")]
+    pub network_allow_list: Option<String>,
+    /// Error reason if sandbox is in error state
+    #[serde(rename = "errorReason")]
+    pub error_reason: Option<String>,
+    /// Whether the error is recoverable
+    pub recoverable: Option<bool>,
+    /// CPU cores allocated
+    pub cpu: Option<i32>,
+    /// GPU units allocated
+    pub gpu: Option<i32>,
+    pub memory: Option<i32>,
+    /// Disk space in GiB
+    pub disk: Option<i32>,
+    /// Current backup state
+    #[serde(default)]
+    pub backup_state: SandboxBackupState,
+    /// When the backup was created
+    #[serde(rename = "backupCreatedAt")]
+    pub backup_created_at: Option<String>,
+    /// Build information for the sandbox
+    pub build_info: Option<BuildInfo>,
+    /// When the sandbox was created
+    #[serde(rename = "createdAt")]
+    pub created_at: Option<String>,
+    /// When the sandbox was last updated
+    #[serde(rename = "updatedAt")]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PaginatedSandboxes {
+    pub items: Vec<SandboxDto>,
+    pub total: i32,
+    pub page: i32,
+    #[serde(rename = "totalPages")]
+    pub total_pages: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExecuteResponse {
+    #[serde(rename = "exitCode")]
+    pub exit_code: i32,
+    pub result: String,
+    pub artifacts: Option<ExecutionArtifacts>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExecutionArtifacts {
+    pub stdout: String,
+    pub charts: Vec<Chart>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExecutionResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub charts: Vec<Chart>,
+    pub error: Option<ExecutionError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExecutionError {
+    pub name: String,
+    pub value: String,
+    pub traceback: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Chart {
+    #[serde(rename = "type")]
+    pub chart_type: ChartType,
+    pub title: Option<String>,
+    pub elements: Option<serde_json::Value>,
+    pub png: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FileInfo {
+    pub name: String,
+    pub size: i64,
+    #[serde(default)]
+    pub mode: String,
+    #[serde(rename = "isDir", default)]
+    pub is_directory: bool,
+    #[serde(rename = "modTime")]
+    pub modified_time: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileUpload {
+    pub source: String,
+    pub destination: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileDownloadRequest {
+    pub source: String,
+    pub destination: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FileDownloadResponse {
+    pub source: String,
+    pub result: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SearchFilesResponse {
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ReplaceResult {
+    pub file: String,
+    pub replaced: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GitFileStatus {
+    pub path: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GitStatus {
+    #[serde(rename = "currentBranch")]
+    pub current_branch: String,
+    pub ahead: i32,
+    pub behind: i32,
+    #[serde(rename = "branchPublished")]
+    pub branch_published: bool,
+    #[serde(rename = "fileStatus")]
+    pub file_status: Vec<GitFileStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GitCommitResponse {
+    pub sha: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BranchesResponse {
+    pub branches: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PtySessionInfo {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    pub active: bool,
+    pub cwd: Option<String>,
+    pub cols: Option<i32>,
+    pub rows: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PtyCreateResponse {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct InterpreterContext {
+    pub id: String,
+    pub language: Option<String>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DisplayInfo {
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WindowInfo {
+    pub id: Option<String>,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Recording {
+    pub id: Option<String>,
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Volume {
+    pub id: String,
+    pub name: String,
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Snapshot {
+    pub id: String,
+    pub name: String,
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PaginatedSnapshots {
+    pub items: Vec<Snapshot>,
+    pub total: i32,
+    pub page: i32,
+    #[serde(rename = "totalPages")]
+    pub total_pages: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CreateSnapshotParams {
+    pub name: String,
+    pub image: Option<String>,
+    pub resources: Option<Resources>,
+    pub entrypoint: Option<Vec<String>>,
+    #[serde(rename = "skipValidation")]
+    pub skip_validation: Option<bool>,
+    /// Docker image builder for custom Dockerfile definitions.
+    /// When set, the snapshot will be built from the Dockerfile content.
+    /// This field is not serialized directly; it is processed by the client
+    /// to generate build info before sending to the API.
+    #[serde(skip)]
+    pub docker_image: Option<DockerImage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PreviewLink {
+    pub url: String,
+    pub token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SignedPreviewUrl {
+    pub url: String,
+    pub token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Position {
+    pub line: i32,
+    pub character: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Session {
+    pub session_id: String,
+    pub commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionExecuteRequest {
+    pub command: String,
+    #[serde(rename = "runAsync")]
+    pub run_async: bool,
+    #[serde(rename = "suppressInputEcho")]
+    pub suppress_input_echo: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionExecuteResponse {
+    pub id: String,
+    #[serde(rename = "exitCode")]
+    pub exit_code: Option<i32>,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Command {
+    pub id: String,
+    pub command: String,
+    #[serde(rename = "exitCode")]
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FindMatch {
+    pub file: String,
+    pub line: i32,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DirResponse {
+    pub dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SshAccessDto {
+    pub token: String,
+    #[serde(rename = "expiresAt")]
+    pub expires_at: String,
+    #[serde(rename = "sshCommand")]
+    pub ssh_command: String,
+    #[serde(rename = "sshHost")]
+    pub ssh_host: String,
+    #[serde(rename = "sshPort")]
+    pub ssh_port: u16,
+    #[serde(rename = "sshUser")]
+    pub ssh_user: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SshAccessValidationDto {
+    pub valid: bool,
+    #[serde(rename = "expiresAt")]
+    pub expires_at: Option<String>,
+    #[serde(rename = "sandboxId")]
+    pub sandbox_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ResizeSandboxRequest {
+    pub cpu: Option<i32>,
+    pub memory: Option<i32>,
+    pub disk: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SandboxLabels {
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PtySize {
+    pub rows: i32,
+    pub cols: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ScreenshotOptions {
+    pub show_cursor: Option<bool>,
+    pub format: Option<String>,
+    pub quality: Option<i32>,
+    pub scale: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ScreenshotRegion {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ScreenshotResponse {
+    pub image: String,
+    pub width: i32,
+    pub height: i32,
+    pub size_bytes: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OutputMessage {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub text: String,
+    pub name: String,
+    pub value: String,
+    pub traceback: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LspLanguageId {
+    Python,
+    JavaScript,
+    TypeScript,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ChartType {
+    Line,
+    Scatter,
+    Bar,
+    Pie,
+    BoxAndWhisker,
+    CompositeChart,
+    #[default]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CodeRunParams {
+    pub argv: Option<Vec<String>>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PtyResult {
+    #[serde(rename = "exitCode")]
+    pub exit_code: Option<i32>,
+    pub error: Option<String>,
+}

--- a/libs/sdk-rust/src/utils.rs
+++ b/libs/sdk-rust/src/utils.rs
@@ -1,0 +1,70 @@
+// Copyright 2019-2025 Daytona Labs Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::Config;
+use crate::error::DaytonaError;
+use reqwest::{RequestBuilder, Response};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+pub fn with_auth(builder: RequestBuilder, config: &Config) -> Result<RequestBuilder, DaytonaError> {
+    let token = config
+        .bearer_token()
+        .ok_or_else(|| DaytonaError::Unauthorized("Authentication required. Please set DAYTONA_API_KEY or DAYTONA_JWT_TOKEN environment variable, or provide api_key or jwt_token in Config".to_string()))?;
+
+    let mut req = builder
+        .bearer_auth(token)
+        .header("X-Daytona-Source", "rust-sdk")
+        .header("X-Daytona-SDK-Version", env!("CARGO_PKG_VERSION"));
+
+    // Add target header if configured
+    if let Some(target) = &config.target {
+        req = req.header("X-Daytona-Target", target);
+    }
+
+    if config.jwt_token.is_some() {
+        if let Some(org) = &config.organization_id {
+            req = req.header("X-Daytona-Organization-ID", org);
+        }
+    }
+
+    Ok(req)
+}
+
+pub async fn decode_json<T: DeserializeOwned>(resp: Response) -> Result<T, DaytonaError> {
+    let status = resp.status();
+    if status.is_success() {
+        return resp.json::<T>().await.map_err(|e| DaytonaError::Api {
+            status: 0,
+            message: format!("failed to parse response body: {e}"),
+        });
+    }
+
+    let text = resp.text().await.unwrap_or_default();
+    Err(DaytonaError::from_status(status, text))
+}
+
+pub async fn decode_empty(resp: Response) -> Result<(), DaytonaError> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(());
+    }
+
+    let text = resp.text().await.unwrap_or_default();
+    Err(DaytonaError::from_status(status, text))
+}
+
+pub fn join_url(base: &str, suffix: &str) -> String {
+    format!(
+        "{}/{}",
+        base.trim_end_matches('/'),
+        suffix.trim_start_matches('/')
+    )
+}
+
+pub fn extract_toolbox_proxy_url(payload: &Value) -> Option<String> {
+    payload
+        .get("url")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}

--- a/libs/sdk-rust/tests/integration_test.rs
+++ b/libs/sdk-rust/tests/integration_test.rs
@@ -1,0 +1,126 @@
+use daytona::{Client, Config, DaytonaError};
+
+#[tokio::test]
+async fn client_constructs_with_api_key() {
+    let config = Config::builder().api_key("test-key").build();
+    let client = Client::new(config);
+    assert!(client.is_ok());
+}
+
+#[tokio::test]
+async fn client_fails_without_auth() {
+    let config = Config::builder().build();
+    let client = Client::new(Config {
+        api_key: None,
+        jwt_token: None,
+        organization_id: None,
+        api_url: config.api_url,
+        target: config.target,
+        timeout: None,
+        otel_enabled: false,
+        experimental: None,
+    });
+    assert!(client.is_err());
+}
+
+#[tokio::test]
+async fn client_constructs_with_jwt_token() {
+    let config = Config::builder()
+        .jwt_token("test-jwt-token")
+        .organization_id("test-org-id")
+        .build();
+    let client = Client::new(config);
+    assert!(client.is_ok());
+}
+
+#[tokio::test]
+async fn client_fails_with_jwt_but_no_organization() {
+    let config = Config::builder().jwt_token("test-jwt-token").build();
+    let client = Client::new(config);
+    assert!(client.is_err());
+}
+
+#[test]
+fn config_builder_sets_api_url() {
+    let config = Config::builder()
+        .api_key("test-key")
+        .api_url("https://custom.api.url/api")
+        .build();
+    assert_eq!(config.api_url, "https://custom.api.url/api");
+}
+
+#[test]
+fn config_builder_sets_target() {
+    let config = Config::builder()
+        .api_key("test-key")
+        .target("us-west-2")
+        .build();
+    assert_eq!(config.target, Some("us-west-2".to_string()));
+}
+
+#[test]
+fn config_builder_sets_timeout() {
+    use std::time::Duration;
+    let config = Config::builder()
+        .api_key("test-key")
+        .timeout(Duration::from_secs(120))
+        .build();
+    assert_eq!(config.timeout, Some(Duration::from_secs(120)));
+}
+
+#[test]
+fn error_is_not_found() {
+    let error = DaytonaError::NotFound("resource not found".to_string());
+    assert!(error.is_not_found());
+    assert!(!error.is_rate_limit());
+    assert!(!error.is_timeout());
+}
+
+#[test]
+fn error_is_rate_limit() {
+    let error = DaytonaError::RateLimit("rate limit exceeded".to_string());
+    assert!(!error.is_not_found());
+    assert!(error.is_rate_limit());
+    assert!(!error.is_timeout());
+}
+
+#[test]
+fn error_is_timeout() {
+    let error = DaytonaError::Timeout("request timed out".to_string());
+    assert!(!error.is_not_found());
+    assert!(!error.is_rate_limit());
+    assert!(error.is_timeout());
+}
+
+#[test]
+fn error_status_code() {
+    let error = DaytonaError::NotFound("not found".to_string());
+    assert_eq!(error.status_code(), Some(404));
+
+    let error = DaytonaError::RateLimit("rate limited".to_string());
+    assert_eq!(error.status_code(), Some(429));
+
+    let error = DaytonaError::Timeout("timed out".to_string());
+    assert_eq!(error.status_code(), Some(408));
+
+    let error = DaytonaError::Unauthorized("unauthorized".to_string());
+    assert_eq!(error.status_code(), Some(401));
+
+    let error = DaytonaError::InternalServerError("internal error".to_string());
+    assert_eq!(error.status_code(), Some(500));
+
+    let error = DaytonaError::Network("network error".to_string());
+    assert_eq!(error.status_code(), None);
+}
+
+#[test]
+fn error_message() {
+    let error = DaytonaError::NotFound("resource not found".to_string());
+    assert_eq!(error.message(), "resource not found");
+
+    let error = DaytonaError::Api {
+        status: 400,
+        message: "bad request".to_string(),
+    };
+    assert_eq!(error.message(), "bad request");
+}


### PR DESCRIPTION
## Summary

Adds a complete Rust SDK providing idiomatic Rust bindings for the Daytona sandbox lifecycle and toolbox operations.

### SDK Features
- **Client**: create/get/list/delete/start/stop sandbox operations
- **Sandbox**: filesystem, git, process, code interpreter, computer use, LSP server
- **Services**: Volume, Snapshot, and ObjectStorage
- **Features**: Optional OpenTelemetry (`otel`) and image-builder support

### Documentation & CI
- CI workflow additions for Rust lint, test, and build
- Documentation updates (README, PUBLISHING.md)
- Fixed duplicate content in PUBLISHING.md

## Test Plan

- [ ] Run `cargo fmt -- --check` in libs/sdk-rust
- [ ] Run `cargo clippy --all-targets -- -D warnings` in libs/sdk-rust
- [ ] Run `cargo test` in libs/sdk-rust
- [ ] Run `cargo build --release` in libs/sdk-rust
- [ ] Verify CI passes on this PR