### PR TITLE
Increase default TTL for create_signed_preview_url

### DIFF
--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -533,6 +533,8 @@ class AsyncSandbox(SandboxDto):
         Returns:
             SignedPortPreviewUrl: The response object for the signed preview url.
         """
+        if expires_in_seconds is None:
+            expires_in_seconds = 300
         return await self._sandbox_api.get_signed_port_preview_url(self.id, port, expires_in_seconds=expires_in_seconds)
 
     @intercept_errors(message_prefix="Failed to expire signed preview url: ")


### PR DESCRIPTION
## Description

This PR increases the default expiration time for create_signed_preview_url from 60 seconds to 300 seconds when expires_in_seconds is not explicitly provided.

Previously, preview URLs expired too quickly (after 60 seconds), which could interrupt development workflows. Increasing the default TTL improves usability while still allowing developers to override the expiration time if needed.

No additional dependencies are required for this change
## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR does not address a specific issue 

## Screenshots

Not applicable

## Notes

The change maintains backward compatibility and allows overriding the TTL if needed.
