### PR TITLE
fix(runner): don't cancel context for telemetry init

### DIFF
--- a/apps/runner/pkg/docker/daemon.go
+++ b/apps/runner/pkg/docker/daemon.go
@@ -114,9 +114,11 @@ func (d *DockerClient) waitForDaemonRunning(ctx context.Context, containerIP str
 				Transport: otelhttp.NewTransport(http.DefaultTransport),
 			}
 			go func() {
-				err := d.initializeDaemon(ctx, containerIP, *authToken, otelClient)
+				// Don't cancel context
+				initContext := context.WithoutCancel(ctx)
+				err := d.initializeDaemon(initContext, containerIP, *authToken, otelClient)
 				if err != nil {
-					d.logger.ErrorContext(ctx, "Failed to initialize daemon telemetry", "error", err)
+					d.logger.ErrorContext(initContext, "Failed to initialize daemon telemetry", "error", err)
 				}
 			}()
 


### PR DESCRIPTION
## Description

Stops the context from canceling when initializing daemon telemetry.

This fixes a regression introduced with https://github.com/daytonaio/daytona/pull/3901.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
