### PR TITLE
fix(common-go): don't write http errors if headers were already written

### DIFF
--- a/libs/common-go/pkg/errors/middleware.go
+++ b/libs/common-go/pkg/errors/middleware.go
@@ -19,6 +19,11 @@ func NewErrorMiddleware(defaultErrorHandler func(ctx *gin.Context, err error) Er
 	return func(ctx *gin.Context) {
 		ctx.Next()
 
+		// Do not override the response if it has already been written
+		if ctx.Writer.Written() {
+			return
+		}
+
 		errs := ctx.Errors
 		if len(errs) > 0 {
 			var errorResponse ErrorResponse


### PR DESCRIPTION
## Description

Don't write http errors if headers were already written in the context.

This prevents issues when extra errors were appended to the request body even though the request already succeeded.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
