### PR TITLE
fix(api): remove rate limit from hasSandboxAccess

### DIFF
--- a/apps/api/src/sandbox/controllers/preview.controller.ts
+++ b/apps/api/src/sandbox/controllers/preview.controller.ts
@@ -10,7 +10,6 @@ import { ApiResponse, ApiOperation, ApiParam, ApiTags, ApiOAuth2, ApiBearerAuth 
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { CombinedAuthGuard } from '../../auth/combined-auth.guard'
 import { OrganizationUserService } from '../../organization/services/organization-user.service'
-import { AuthenticatedRateLimitGuard } from '../../common/guards/authenticated-rate-limit.guard'
 
 @ApiTags('preview')
 @Controller('preview')
@@ -125,7 +124,7 @@ export class PreviewController {
     description: 'User access status to the sandbox',
     type: Boolean,
   })
-  @UseGuards(CombinedAuthGuard, AuthenticatedRateLimitGuard)
+  @UseGuards(CombinedAuthGuard)
   @ApiOAuth2(['openid', 'profile', 'email'])
   @ApiBearerAuth()
   async hasSandboxAccess(@Req() req: Request, @Param('sandboxId') sandboxId: string): Promise<boolean> {


### PR DESCRIPTION
## Description

Removed unnecessary rate limit from `hasSandboxAccess` preview controller method.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
