### PR TITLE
feat(api): get runners breakdown by region

### DIFF
--- a/apps/api/src/admin/controllers/runner.controller.ts
+++ b/apps/api/src/admin/controllers/runner.controller.ts
@@ -29,6 +29,7 @@ import { RegionService } from '../../region/services/region.service'
 import { CreateRunnerResponseDto } from '../../sandbox/dto/create-runner-response.dto'
 import { RunnerFullDto } from '../../sandbox/dto/runner-full.dto'
 import { RunnerDto } from '../../sandbox/dto/runner.dto'
+import { RunnersByRegionDto } from '../../sandbox/dto/runners-by-region.dto'
 import { RunnerService } from '../../sandbox/services/runner.service'
 import { SystemRole } from '../../user/enums/system-role.enum'
 
@@ -91,6 +92,27 @@ export class AdminRunnerController {
     })
 
     return CreateRunnerResponseDto.fromRunner(runner, apiKey)
+  }
+
+  @Get('by-region')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get runners breakdown by region',
+    operationId: 'adminGetRunnersBreakdownByRegion',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns runner domains grouped by region',
+    schema: {
+      type: 'object',
+      additionalProperties: {
+        type: 'array',
+        items: { type: 'string' },
+      },
+    },
+  })
+  async getRunnersBreakdownByRegion(): Promise<RunnersByRegionDto> {
+    return this.runnerService.getRunnersBreakdownByRegion()
   }
 
   @Get(':id')

--- a/apps/api/src/region/controllers/region.controller.ts
+++ b/apps/api/src/region/controllers/region.controller.ts
@@ -30,6 +30,6 @@ export class RegionController {
     type: [RegionDto],
   })
   async listRegions(): Promise<RegionDto[]> {
-    return this.regionService.findAllByRegionType(RegionType.SHARED)
+    return this.regionService.findAllByRegionTypes([RegionType.SHARED])
   }
 }

--- a/apps/api/src/region/services/region.service.ts
+++ b/apps/api/src/region/services/region.service.ts
@@ -206,13 +206,17 @@ export class RegionService {
   }
 
   /**
-   * @param type - The type of the regions to find.
+   * @param regionTypes - Types of regions to find.
    * @returns The regions found ordered by name ascending.
    */
-  async findAllByRegionType(regionType: RegionType): Promise<RegionDto[]> {
+  async findAllByRegionTypes(regionTypes: RegionType[]): Promise<RegionDto[]> {
+    if (regionTypes.length === 0) {
+      return []
+    }
+
     const regions = await this.regionRepository.find({
       where: {
-        regionType,
+        regionType: In(regionTypes),
       },
       order: {
         name: 'ASC',

--- a/apps/api/src/sandbox/dto/runners-by-region.dto.ts
+++ b/apps/api/src/sandbox/dto/runners-by-region.dto.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ApiSchema } from '@nestjs/swagger'
+
+@ApiSchema({ name: 'RunnersByRegion' })
+export class RunnersByRegionDto {
+  [region: string]: string[]
+}

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -15,7 +15,7 @@ import {
 } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { DataSource, FindOptionsWhere, In, MoreThanOrEqual, Not, Repository, UpdateResult } from 'typeorm'
+import { DataSource, FindOptionsWhere, In, IsNull, MoreThanOrEqual, Not, Repository, UpdateResult } from 'typeorm'
 import { Runner } from '../entities/runner.entity'
 import { CreateRunnerInternalDto } from '../dto/create-runner-internal.dto'
 import { SandboxClass } from '../enums/sandbox-class.enum'
@@ -202,18 +202,20 @@ export class RunnerService {
     const runners = await this.runnerRepository.find({
       where: {
         region: In(regionIds),
+        domain: Not(IsNull()),
       },
       select: ['domain', 'region'],
     })
 
     const result: RunnersByRegionDto = {}
     for (const runner of runners) {
+      if (!runner.domain) {
+        continue
+      }
       if (!result[runner.region]) {
         result[runner.region] = []
       }
-      if (runner.domain) {
-        result[runner.region].push(runner.domain)
-      }
+      result[runner.region].push(runner.domain)
     }
 
     return result

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -8066,6 +8066,30 @@ paths:
       summary: Create runner
       tags:
       - admin
+  /admin/runners/by-region:
+    get:
+      operationId: adminGetRunnersBreakdownByRegion
+      parameters: []
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+          description: Returns runner domains grouped by region
+      security:
+      - bearer: []
+      - oauth2:
+        - openid
+        - profile
+        - email
+      summary: Get runners breakdown by region
+      tags:
+      - admin
   /admin/runners/{id}:
     delete:
       operationId: adminDeleteRunner

--- a/libs/api-client-go/api_admin.go
+++ b/libs/api-client-go/api_admin.go
@@ -61,6 +61,18 @@ type AdminAPI interface {
 	AdminGetRunnerByIdExecute(r AdminAPIAdminGetRunnerByIdRequest) (*RunnerFull, *http.Response, error)
 
 	/*
+	AdminGetRunnersBreakdownByRegion Get runners breakdown by region
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return AdminAPIAdminGetRunnersBreakdownByRegionRequest
+	*/
+	AdminGetRunnersBreakdownByRegion(ctx context.Context) AdminAPIAdminGetRunnersBreakdownByRegionRequest
+
+	// AdminGetRunnersBreakdownByRegionExecute executes the request
+	//  @return map[string][]string
+	AdminGetRunnersBreakdownByRegionExecute(r AdminAPIAdminGetRunnersBreakdownByRegionRequest) (*map[string][]string, *http.Response, error)
+
+	/*
 	AdminListRunners List all runners
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -341,6 +353,103 @@ func (a *AdminAPIService) AdminGetRunnerByIdExecute(r AdminAPIAdminGetRunnerById
 
 	localVarPath := localBasePath + "/admin/runners/{id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type AdminAPIAdminGetRunnersBreakdownByRegionRequest struct {
+	ctx context.Context
+	ApiService AdminAPI
+}
+
+func (r AdminAPIAdminGetRunnersBreakdownByRegionRequest) Execute() (*map[string][]string, *http.Response, error) {
+	return r.ApiService.AdminGetRunnersBreakdownByRegionExecute(r)
+}
+
+/*
+AdminGetRunnersBreakdownByRegion Get runners breakdown by region
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return AdminAPIAdminGetRunnersBreakdownByRegionRequest
+*/
+func (a *AdminAPIService) AdminGetRunnersBreakdownByRegion(ctx context.Context) AdminAPIAdminGetRunnersBreakdownByRegionRequest {
+	return AdminAPIAdminGetRunnersBreakdownByRegionRequest{
+		ApiService: a,
+		ctx: ctx,
+	}
+}
+
+// Execute executes the request
+//  @return map[string][]string
+func (a *AdminAPIService) AdminGetRunnersBreakdownByRegionExecute(r AdminAPIAdminGetRunnersBreakdownByRegionRequest) (*map[string][]string, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *map[string][]string
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AdminAPIService.AdminGetRunnersBreakdownByRegion")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/admin/runners/by-region"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/libs/api-client-python-async/daytona_api_client_async/api/admin_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/admin_api.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr
-from typing import List, Optional
+from typing import Dict, List, Optional
 from typing_extensions import Annotated
 from daytona_api_client_async.models.admin_create_runner import AdminCreateRunner
 from daytona_api_client_async.models.create_runner_response import CreateRunnerResponse
@@ -811,6 +811,250 @@ class AdminApi:
         return self.api_client.param_serialize(
             method='GET',
             resource_path='/admin/runners/{id}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    async def admin_get_runners_breakdown_by_region(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Dict[str, List[str]]:
+        """Get runners breakdown by region
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._admin_get_runners_breakdown_by_region_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, List[str]]",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    async def admin_get_runners_breakdown_by_region_with_http_info(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Dict[str, List[str]]]:
+        """Get runners breakdown by region
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._admin_get_runners_breakdown_by_region_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, List[str]]",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    async def admin_get_runners_breakdown_by_region_without_preload_content(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get runners breakdown by region
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._admin_get_runners_breakdown_by_region_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, List[str]]",
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _admin_get_runners_breakdown_by_region_serialize(
+        self,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/admin/runners/by-region',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/libs/api-client-python/daytona_api_client/api/admin_api.py
+++ b/libs/api-client-python/daytona_api_client/api/admin_api.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr
-from typing import List, Optional
+from typing import Dict, List, Optional
 from typing_extensions import Annotated
 from daytona_api_client.models.admin_create_runner import AdminCreateRunner
 from daytona_api_client.models.create_runner_response import CreateRunnerResponse
@@ -811,6 +811,250 @@ class AdminApi:
         return self.api_client.param_serialize(
             method='GET',
             resource_path='/admin/runners/{id}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    def admin_get_runners_breakdown_by_region(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Dict[str, List[str]]:
+        """Get runners breakdown by region
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._admin_get_runners_breakdown_by_region_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, List[str]]",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def admin_get_runners_breakdown_by_region_with_http_info(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Dict[str, List[str]]]:
+        """Get runners breakdown by region
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._admin_get_runners_breakdown_by_region_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, List[str]]",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def admin_get_runners_breakdown_by_region_without_preload_content(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get runners breakdown by region
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._admin_get_runners_breakdown_by_region_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, List[str]]",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _admin_get_runners_breakdown_by_region_serialize(
+        self,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/admin/runners/by-region',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/libs/api-client-ruby/lib/daytona_api_client/api/admin_api.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/api/admin_api.rb
@@ -205,6 +205,61 @@ module DaytonaApiClient
       return data, status_code, headers
     end
 
+    # Get runners breakdown by region
+    # @param [Hash] opts the optional parameters
+    # @return [Hash<String, Array<String>>]
+    def admin_get_runners_breakdown_by_region(opts = {})
+      data, _status_code, _headers = admin_get_runners_breakdown_by_region_with_http_info(opts)
+      data
+    end
+
+    # Get runners breakdown by region
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(Hash<String, Array<String>>, Integer, Hash)>] Hash<String, Array<String>> data, response status code and response headers
+    def admin_get_runners_breakdown_by_region_with_http_info(opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: AdminApi.admin_get_runners_breakdown_by_region ...'
+      end
+      # resource path
+      local_var_path = '/admin/runners/by-region'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'Hash<String, Array<String>>'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || ['bearer', 'oauth2']
+
+      new_options = opts.merge(
+        :operation => :"AdminApi.admin_get_runners_breakdown_by_region",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: AdminApi#admin_get_runners_breakdown_by_region\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # List all runners
     # @param [Hash] opts the optional parameters
     # @option opts [String] :region_id Filter runners by region ID

--- a/libs/api-client/src/api/admin-api.ts
+++ b/libs/api-client/src/api/admin-api.ts
@@ -159,6 +159,42 @@ export const AdminApiAxiosParamCreator = function (configuration?: Configuration
         },
         /**
          * 
+         * @summary Get runners breakdown by region
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        adminGetRunnersBreakdownByRegion: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/admin/runners/by-region`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication oauth2 required
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary List all runners
          * @param {string} [regionId] Filter runners by region ID
          * @param {*} [options] Override http request option.
@@ -329,6 +365,18 @@ export const AdminApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Get runners breakdown by region
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async adminGetRunnersBreakdownByRegion(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: Array<string>; }>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.adminGetRunnersBreakdownByRegion(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AdminApi.adminGetRunnersBreakdownByRegion']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @summary List all runners
          * @param {string} [regionId] Filter runners by region ID
          * @param {*} [options] Override http request option.
@@ -408,6 +456,15 @@ export const AdminApiFactory = function (configuration?: Configuration, basePath
         },
         /**
          * 
+         * @summary Get runners breakdown by region
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        adminGetRunnersBreakdownByRegion(options?: RawAxiosRequestConfig): AxiosPromise<{ [key: string]: Array<string>; }> {
+            return localVarFp.adminGetRunnersBreakdownByRegion(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @summary List all runners
          * @param {string} [regionId] Filter runners by region ID
          * @param {*} [options] Override http request option.
@@ -480,6 +537,17 @@ export class AdminApi extends BaseAPI {
      */
     public adminGetRunnerById(id: string, options?: RawAxiosRequestConfig) {
         return AdminApiFp(this.configuration).adminGetRunnerById(id, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get runners breakdown by region
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AdminApi
+     */
+    public adminGetRunnersBreakdownByRegion(options?: RawAxiosRequestConfig) {
+        return AdminApiFp(this.configuration).adminGetRunnersBreakdownByRegion(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
This pull request introduces a new API endpoint that allows administrators to retrieve a breakdown of runner domains grouped by region.

**New API endpoint for runners breakdown by region:**

* Added a new admin endpoint `/admin/runners/by-region` that returns a mapping of region IDs to arrays of runner domains. [[1]](diffhunk://#diff-49dd0b23471af9907f99c8f392cf64c6fa07a0fa5cc76cb95e12de19519aebb5R97-R117) [[2]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR8069-R8092)
* Implemented the `getRunnersBreakdownByRegion` method in `RunnerService` to aggregate runner domains by their associated region.
* Introduced the `RunnersByRegionDto` DTO to represent the response structure for the new endpoint.

**Example response from new endpoint:**

```
{
  "x1": [
    "n9f2.example.mock",
    "q7k4.example.mock",
    "..."
  ],
  "y2": [
    "m3a8.example.mock",
    "..."
  ],
  "z9": [
    "r5c1.example.mock",
    "..."
  ]
}
```