### PR TITLE
feat(runner,sdk): support for non s3 volumes via s3proxy and rclone

### DIFF
--- a/apps/api/src/sandbox/managers/volume.manager.ts
+++ b/apps/api/src/sandbox/managers/volume.manager.ts
@@ -223,9 +223,11 @@ export class VolumeManager
             },
           }),
         )
-      } catch (taggingError) {
+      } catch (taggingError: unknown) {
         this.logger.warn(
-          `Volume ${volume.id}: bucket tagging not supported by backend, skipping: ${taggingError.message}`,
+          `Volume ${volume.id}: bucket tagging not supported by backend, skipping: ${
+            taggingError instanceof Error ? taggingError.message : String(taggingError)
+          }`,
         )
       }
 

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -243,6 +243,7 @@ Below is a full list of environment variables with their default values:
 | `AWS_ACCESS_KEY_ID`                     | string  | `minioadmin`                      | AWS access key ID                                     |
 | `AWS_SECRET_ACCESS_KEY`                 | string  | `minioadmin`                      | AWS secret access key                                 |
 | `AWS_DEFAULT_BUCKET`                    | string  | `daytona`                         | AWS default bucket name                               |
+| `VOLUME_MOUNT_DRIVER`                   | string  | `mount-s3`                        | FUSE driver for volume mounts (`rclone` or `mount-s3`) |
 | `DAEMON_START_TIMEOUT_SEC`              | number  | `60`                              | Daemon start timeout in seconds                       |
 | `SANDBOX_START_TIMEOUT_SEC`             | number  | `30`                              | Sandbox start timeout in seconds                      |
 | `USE_SNAPSHOT_ENTRYPOINT`               | boolean | `false`                           | Use snapshot entrypoint for sandbox                   |

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	HealthcheckInterval                time.Duration `envconfig:"HEALTHCHECK_INTERVAL" default:"30s" validate:"min=10s"`
 	HealthcheckTimeout                 time.Duration `envconfig:"HEALTHCHECK_TIMEOUT" default:"10s"`
 	BackupTimeoutMin                   int           `envconfig:"BACKUP_TIMEOUT_MIN" default:"60" validate:"min=1"`
+	VolumeMountDriver                  string        `envconfig:"VOLUME_MOUNT_DRIVER" default:"mount-s3"`
 	ApiVersion                         int           `envconfig:"API_VERSION" default:"2"`
 	InitializeDaemonTelemetry          bool          `envconfig:"INITIALIZE_DAEMON_TELEMETRY" default:"true"`
 	SnapshotErrorCacheRetention        time.Duration `envconfig:"SNAPSHOT_ERROR_CACHE_RETENTION" default:"10m" validate:"min=5m"`

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -159,6 +159,7 @@ func run() int {
 		VolumeCleanupExclusionPeriod: cfg.VolumeCleanupExclusionPeriod,
 		BackupTimeoutMin:             cfg.BackupTimeoutMin,
 		InitializeDaemonTelemetry:    cfg.InitializeDaemonTelemetry,
+		VolumeMountDriver:            cfg.VolumeMountDriver,
 	})
 	if err != nil {
 		logger.Error("Error creating Docker client wrapper", "error", err)

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -35,6 +35,7 @@ type DockerClientConfig struct {
 	VolumeCleanupExclusionPeriod time.Duration
 	BackupTimeoutMin             int
 	InitializeDaemonTelemetry    bool
+	VolumeMountDriver            string
 }
 
 func NewDockerClient(config DockerClientConfig) (*DockerClient, error) {
@@ -94,6 +95,7 @@ func NewDockerClient(config DockerClientConfig) (*DockerClient, error) {
 		backupTimeoutMin:             config.BackupTimeoutMin,
 		initializeDaemonTelemetry:    config.InitializeDaemonTelemetry,
 		filesystem:                   filesystem,
+		volumeMountDriver:            config.VolumeMountDriver,
 	}, nil
 }
 
@@ -126,4 +128,5 @@ type DockerClient struct {
 	lastVolumeCleanup            time.Time
 	initializeDaemonTelemetry    bool
 	filesystem                   string
+	volumeMountDriver            string
 }

--- a/apps/runner/pkg/docker/volumes_mountpaths.go
+++ b/apps/runner/pkg/docker/volumes_mountpaths.go
@@ -201,18 +201,22 @@ func (d *DockerClient) getRcloneMountCmd(ctx context.Context, volume string, sub
 		"--daemon",
 	}
 
+	cmd := exec.CommandContext(ctx, "rclone", args...)
+
+	cmd.Env = append(cmd.Env, "RCLONE_S3_PATH_STYLE=true") // s3proxy does not support virtual-hosted style
+
 	if d.awsEndpointUrl != "" {
-		args = append(args, "--s3-endpoint="+d.awsEndpointUrl)
-	}
-	if d.awsAccessKeyId != "" {
-		args = append(args, "--s3-access-key-id="+d.awsAccessKeyId)
-	}
-	if d.awsSecretAccessKey != "" {
-		args = append(args, "--s3-secret-access-key="+d.awsSecretAccessKey)
+		cmd.Env = append(cmd.Env, "RCLONE_S3_ENDPOINT="+d.awsEndpointUrl)
 	}
 
-	cmd := exec.CommandContext(ctx, "rclone", args...)
-	cmd.Env = append(os.Environ(), "RCLONE_S3_PATH_STYLE=true") // s3proxy does not support virtual-hosted style
+	if d.awsAccessKeyId != "" {
+		cmd.Env = append(cmd.Env, "RCLONE_S3_ACCESS_KEY_ID="+d.awsAccessKeyId)
+	}
+
+	if d.awsSecretAccessKey != "" {
+		cmd.Env = append(cmd.Env, "RCLONE_S3_SECRET_ACCESS_KEY="+d.awsSecretAccessKey)
+	}
+
 	cmd.Stderr = io.Writer(&log.ErrorLogWriter{})
 	cmd.Stdout = io.Writer(&log.InfoLogWriter{})
 

--- a/libs/sdk-go/pkg/daytona/object_storage.go
+++ b/libs/sdk-go/pkg/daytona/object_storage.go
@@ -70,12 +70,14 @@ func NewObjectStorage(config objectStorageConfig) *objectStorage {
 		aws.ToString(sessionToken),
 	)
 
-	// Create S3 client
+	// s3proxy does not implement AWS SDK v2 checksum headers — suppress unless required by protocol.
 	client := s3.New(s3.Options{
-		Region:       region,
-		Credentials:  creds,
-		BaseEndpoint: aws.String(config.EndpointURL),
-		UsePathStyle: true,
+		Region:                     region,
+		Credentials:                creds,
+		BaseEndpoint:               aws.String(config.EndpointURL),
+		UsePathStyle:               true,
+		RequestChecksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+		ResponseChecksumValidation: aws.ResponseChecksumValidationWhenRequired,
 	})
 
 	return &objectStorage{

--- a/libs/sdk-python/src/daytona/_async/object_storage.py
+++ b/libs/sdk-python/src/daytona/_async/object_storage.py
@@ -37,6 +37,7 @@ class AsyncObjectStorage:
         bucket_name: str = "daytona-volume-builds",
     ):
         self.bucket_name: str = bucket_name
+        # obstore (Rust object_store crate) does not send AWS-specific checksum headers — s3proxy compatible as-is.
         with isolated_env():
             self.store: S3Store = S3Store(
                 bucket=bucket_name,

--- a/libs/sdk-python/src/daytona/_sync/object_storage.py
+++ b/libs/sdk-python/src/daytona/_sync/object_storage.py
@@ -35,6 +35,7 @@ class ObjectStorage:
         bucket_name: str = "daytona-volume-builds",
     ):
         self.bucket_name: str = bucket_name
+        # obstore (Rust object_store crate) does not send AWS-specific checksum headers — s3proxy compatible as-is.
         with isolated_env():
             self.store: S3Store = S3Store(
                 bucket=bucket_name,

--- a/libs/sdk-ruby/lib/daytona/object_storage.rb
+++ b/libs/sdk-ruby/lib/daytona/object_storage.rb
@@ -26,12 +26,16 @@ module Daytona
     def initialize(endpoint_url:, aws_access_key_id:, aws_secret_access_key:, aws_session_token:, # rubocop:disable Metrics/ParameterLists
                    bucket_name: DEFAULT_BUCKET_NAME, region: DEFAULT_REGION)
       @bucket_name = bucket_name
+      # s3proxy requires path-style addressing and does not implement AWS SDK checksum headers.
       @s3_client = Aws::S3::Client.new(
         region:,
         endpoint: endpoint_url,
         access_key_id: aws_access_key_id,
         secret_access_key: aws_secret_access_key,
-        session_token: aws_session_token
+        session_token: aws_session_token,
+        force_path_style: true,
+        request_checksum_calculation: 'when_required',
+        response_checksum_validation: 'when_required'
       )
     end
 

--- a/libs/sdk-typescript/src/ObjectStorage.ts
+++ b/libs/sdk-typescript/src/ObjectStorage.ts
@@ -50,6 +50,9 @@ export class ObjectStorage {
         sessionToken: config.sessionToken,
       },
       forcePathStyle: true,
+      // s3proxy does not implement AWS SDK v3 checksum headers — suppress unless required by protocol.
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
     })
   }
 


### PR DESCRIPTION
## Description

This PR adds support for non-S3 volumes using s3proxy and rclone by introducing a VOLUME_MOUNT_DRIVER configuration option, allowing users to select between mount-s3 and rclone drivers. The runner and SDKs have been updated to work with S3-compatible storage backends that do not require AWS-specific checksum headers. The runner now includes logic for rclone-based volume mounting, and error handling has been improved for cases where bucket tagging is not supported by the backend. Documentation and the devcontainer setup have also been updated to reflect these new storage options.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation
