### PR TITLE
feat(daemon): send entrypoint logs to OTel

### DIFF
--- a/apps/daemon/cmd/daemon/main.go
+++ b/apps/daemon/cmd/daemon/main.go
@@ -113,19 +113,21 @@ func run() int {
 	var entrypointWg sync.WaitGroup
 	if len(args) > 0 {
 		// used for logging in case of errors starting/waiting for the command
-		entrypointLogWriter := os.Stdout
-		entrypointErrLogWriter := os.Stderr
+		var entrypointLogWriter io.Writer = os.Stdout
+		var entrypointErrLogWriter io.Writer = os.Stderr
 
 		if c.EntrypointLogFilePath != "" {
-			entrypointLogFile, err := os.OpenFile(c.EntrypointLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			entrypointLogFile, err := os.OpenFile(c.EntrypointLogFilePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				logger.Error("Failed to open log file, fallback to STDOUT and STDERR",
 					"path", c.EntrypointLogFilePath,
 					"error", err)
 			} else {
 				defer entrypointLogFile.Close()
-				entrypointLogWriter = entrypointLogFile
-				entrypointErrLogWriter = entrypointLogFile
+				stdoutWriter := log.NewPrefixWriter(log.STDOUT_PREFIX, entrypointLogFile)
+				stderrWriter := log.NewPrefixWriter(log.STDERR_PREFIX, entrypointLogFile)
+				entrypointLogWriter = stdoutWriter
+				entrypointErrLogWriter = stderrWriter
 			}
 		}
 
@@ -178,6 +180,7 @@ func run() int {
 		RecordingService:                     recordingService,
 		OrganizationId:                       c.OrganizationId,
 		RegionId:                             c.RegionId,
+		EntrypointLogFilePath:                c.EntrypointLogFilePath,
 	})
 
 	// Start the toolbox server in a go routine

--- a/apps/daemon/internal/util/entrypoint_logs.go
+++ b/apps/daemon/internal/util/entrypoint_logs.go
@@ -4,10 +4,12 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
+
+	"github.com/daytonaio/common-go/pkg/log"
 )
 
 func ReadEntrypointLogs(entrypointLogFilePath string) error {
@@ -21,10 +23,30 @@ func ReadEntrypointLogs(entrypointLogFilePath string) error {
 	}
 	defer logFile.Close()
 
-	_, err = io.Copy(os.Stdout, logFile)
-	if err != nil {
-		return fmt.Errorf("failed to read entrypoint log file: %w", err)
+	errChan := make(chan error, 1)
+	stdoutChan := make(chan []byte)
+	stderrChan := make(chan []byte)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go log.ReadMultiplexedLog(ctx, logFile, true, stdoutChan, stderrChan, errChan)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case line := <-stdoutChan:
+			_, err := os.Stdout.Write(line)
+			if err != nil {
+				return fmt.Errorf("failed to write entrypoint log line to stdout: %w", err)
+			}
+		case line := <-stderrChan:
+			_, err := os.Stderr.Write(line)
+			if err != nil {
+				return fmt.Errorf("failed to write entrypoint log line to stderr: %w", err)
+			}
+		case err := <-errChan:
+			if err != nil {
+				return err
+			}
+		}
 	}
-
-	return nil
 }

--- a/apps/daemon/pkg/session/execute.go
+++ b/apps/daemon/pkg/session/execute.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/daytonaio/common-go/pkg/log"
 )
 
 func (s *SessionService) Execute(sessionId, cmd string, async, isCombinedOutput, suppressInputEcho bool) (*SessionExecute, error) {
@@ -52,8 +53,8 @@ func (s *SessionService) Execute(sessionId, cmd string, async, isCombinedOutput,
 		logFilePath, // %q  -> log
 		logDir,      // %q  -> dir
 		command.InputFilePath(session.Dir(s.configDir)), // %q  -> input
-		toOctalEscapes(STDOUT_PREFIX),                   // %s  -> stdout prefix
-		toOctalEscapes(STDERR_PREFIX),                   // %s  -> stderr prefix
+		toOctalEscapes(log.STDOUT_PREFIX),               // %s  -> stdout prefix
+		toOctalEscapes(log.STDERR_PREFIX),               // %s  -> stderr prefix
 		cmd,                                             // %s  -> verbatim script body
 		exitCodeFilePath,                                // %q
 	)
@@ -110,7 +111,7 @@ func (s *SessionService) Execute(sessionId, cmd string, async, isCombinedOutput,
 
 			if isCombinedOutput {
 				// remove prefixes from log bytes
-				logBytes = bytes.ReplaceAll(bytes.ReplaceAll(logBytes, STDOUT_PREFIX, []byte{}), STDERR_PREFIX, []byte{})
+				logBytes = bytes.ReplaceAll(bytes.ReplaceAll(logBytes, log.STDOUT_PREFIX, []byte{}), log.STDERR_PREFIX, []byte{})
 				logContent = string(logBytes)
 			}
 

--- a/apps/daemon/pkg/session/input.go
+++ b/apps/daemon/pkg/session/input.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/daytonaio/common-go/pkg/log"
 )
 
 // SendInput sends data to the session's stdin for a specific running command
@@ -62,7 +63,7 @@ func (s *SessionService) SendInput(sessionId, commandId string, data string) err
 		} else {
 			defer logFile.Close()
 			// Write with STDOUT prefix to maintain log format consistency
-			dataWithPrefix := append(STDOUT_PREFIX, []byte(data)...)
+			dataWithPrefix := append(log.STDOUT_PREFIX, []byte(data)...)
 			_, err = logFile.Write(dataWithPrefix)
 			if err != nil {
 				s.logger.Error("failed to echo input to log file", "error", err)

--- a/apps/daemon/pkg/session/log.go
+++ b/apps/daemon/pkg/session/log.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/daytonaio/common-go/pkg/log"
 )
 
 type FetchLogsOptions struct {
@@ -130,7 +131,7 @@ func (s *SessionService) GetSessionCommandLogs(sessionId, commandId string, requ
 
 	if opts.IsCombinedOutput {
 		// remove prefixes from log bytes
-		logBytes = bytes.ReplaceAll(bytes.ReplaceAll(logBytes, STDOUT_PREFIX, []byte{}), STDERR_PREFIX, []byte{})
+		logBytes = bytes.ReplaceAll(bytes.ReplaceAll(logBytes, log.STDOUT_PREFIX, []byte{}), log.STDERR_PREFIX, []byte{})
 	}
 
 	return logBytes, nil
@@ -219,7 +220,7 @@ func processLogChunkWithPrefixFiltering(chunk []byte, buffer *[]byte) []byte {
 			// If remaining bytes could be start of STDOUT_PREFIX (0x01, 0x01, 0x01)
 			couldBeStdoutPrefix := true
 			for i, b := range remainingBytes {
-				if b != STDOUT_PREFIX[i] {
+				if b != log.STDOUT_PREFIX[i] {
 					couldBeStdoutPrefix = false
 					break
 				}
@@ -228,7 +229,7 @@ func processLogChunkWithPrefixFiltering(chunk []byte, buffer *[]byte) []byte {
 			// If remaining bytes could be start of STDERR_PREFIX (0x02, 0x02, 0x02)
 			couldBeStderrPrefix := true
 			for i, b := range remainingBytes {
-				if b != STDERR_PREFIX[i] {
+				if b != log.STDERR_PREFIX[i] {
 					couldBeStderrPrefix = false
 					break
 				}
@@ -246,18 +247,18 @@ func processLogChunkWithPrefixFiltering(chunk []byte, buffer *[]byte) []byte {
 		}
 
 		// Check for STDOUT_PREFIX (0x01, 0x01, 0x01)
-		if (*buffer)[processed] == STDOUT_PREFIX[0] &&
-			(*buffer)[processed+1] == STDOUT_PREFIX[1] &&
-			(*buffer)[processed+2] == STDOUT_PREFIX[2] {
+		if (*buffer)[processed] == log.STDOUT_PREFIX[0] &&
+			(*buffer)[processed+1] == log.STDOUT_PREFIX[1] &&
+			(*buffer)[processed+2] == log.STDOUT_PREFIX[2] {
 			// Found STDOUT_PREFIX, skip it
 			processed += 3
 			continue
 		}
 
 		// Check for STDERR_PREFIX (0x02, 0x02, 0x02)
-		if (*buffer)[processed] == STDERR_PREFIX[0] &&
-			(*buffer)[processed+1] == STDERR_PREFIX[1] &&
-			(*buffer)[processed+2] == STDERR_PREFIX[2] {
+		if (*buffer)[processed] == log.STDERR_PREFIX[0] &&
+			(*buffer)[processed+1] == log.STDERR_PREFIX[1] &&
+			(*buffer)[processed+2] == log.STDERR_PREFIX[2] {
 			// Found STDERR_PREFIX, skip it
 			processed += 3
 			continue

--- a/apps/daemon/pkg/session/types.go
+++ b/apps/daemon/pkg/session/types.go
@@ -12,12 +12,6 @@ import (
 	cmap "github.com/orcaman/concurrent-map/v2"
 )
 
-// Stream prefixes for multiplexing stdout/stderr in logs
-var (
-	STDOUT_PREFIX = []byte{0x01, 0x01, 0x01}
-	STDERR_PREFIX = []byte{0x02, 0x02, 0x02}
-)
-
 type session struct {
 	id          string
 	cmd         *exec.Cmd

--- a/apps/daemon/pkg/toolbox/controller.go
+++ b/apps/daemon/pkg/toolbox/controller.go
@@ -22,7 +22,7 @@ import (
 //	@Router			/init [post]
 //
 //	@id				Initialize
-func (s *server) Initialize(otelServiceName string, organizationId, regionId *string) gin.HandlerFunc {
+func (s *server) Initialize(otelServiceName string, entrypointLogFilePath string, organizationId, regionId *string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		var req InitializeRequest
 		if err := ctx.ShouldBindJSON(&req); err != nil {
@@ -32,7 +32,7 @@ func (s *server) Initialize(otelServiceName string, organizationId, regionId *st
 
 		s.authToken = req.Token
 
-		err := s.initTelemetry(ctx.Request.Context(), otelServiceName, organizationId, regionId)
+		err := s.initTelemetry(ctx.Request.Context(), otelServiceName, entrypointLogFilePath, organizationId, regionId)
 		if err != nil {
 			ctx.AbortWithError(http.StatusBadRequest, err)
 			return

--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -60,6 +60,7 @@ type ServerConfig struct {
 	RecordingService                     *recording.RecordingService
 	OrganizationId                       *string
 	RegionId                             *string
+	EntrypointLogFilePath                string
 }
 
 func NewServer(config ServerConfig) *server {
@@ -75,6 +76,7 @@ func NewServer(config ServerConfig) *server {
 		recordingService:                     config.RecordingService,
 		organizationId:                       config.OrganizationId,
 		regionId:                             config.RegionId,
+		entrypointLogFilePath:                config.EntrypointLogFilePath,
 	}
 }
 
@@ -90,9 +92,13 @@ type server struct {
 	terminationCheckIntervalMilliseconds int
 	configDir                            string
 	recordingService                     *recording.RecordingService
+	entrypointLogFilePath                string
+	entrypointLogCancel                  context.CancelFunc
 	httpServer                           *http.Server
 	organizationId                       *string
 	regionId                             *string
+	ctx                                  context.Context
+	cancel                               context.CancelFunc
 }
 
 type Telemetry struct {
@@ -102,6 +108,9 @@ type Telemetry struct {
 }
 
 func (s *server) Start() error {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	defer s.cancel()
+
 	docs.SwaggerInfo.Description = "Daytona Toolbox API"
 	docs.SwaggerInfo.Title = "Daytona Toolbox API"
 	docs.SwaggerInfo.BasePath = "/"
@@ -144,7 +153,7 @@ func (s *server) Start() error {
 		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 	}
 
-	r.POST("/init", s.Initialize(otelServiceName, s.organizationId, s.regionId))
+	r.POST("/init", s.Initialize(otelServiceName, s.entrypointLogFilePath, s.organizationId, s.regionId))
 
 	r.GET("/version", s.GetVersion)
 

--- a/apps/daemon/pkg/toolbox/telemetry.go
+++ b/apps/daemon/pkg/toolbox/telemetry.go
@@ -6,12 +6,14 @@ package toolbox
 import (
 	"context"
 	"fmt"
+	"os"
 
+	"github.com/daytonaio/common-go/pkg/log"
 	"github.com/daytonaio/common-go/pkg/telemetry"
 	"github.com/daytonaio/daemon/internal"
 )
 
-func (s *server) initTelemetry(ctx context.Context, serviceName string, organizationId, regionId *string) error {
+func (s *server) initTelemetry(ctx context.Context, serviceName, entrypointLogFilePath string, organizationId, regionId *string) error {
 	if s.otelEndpoint == nil {
 		s.logger.InfoContext(ctx, "Otel endpoint not provided, skipping telemetry initialization")
 		return nil
@@ -66,6 +68,46 @@ func (s *server) initTelemetry(ctx context.Context, serviceName string, organiza
 		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
 	s.logger = newLogger
+
+	if s.entrypointLogCancel != nil {
+		s.entrypointLogCancel()
+	}
+
+	entrypointCtx, entrypointCancel := context.WithCancel(s.ctx)
+	s.entrypointLogCancel = entrypointCancel
+
+	go func() {
+		if entrypointLogFilePath == "" {
+			return
+		}
+
+		entrypointLogFile, err := os.Open(entrypointLogFilePath)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to open entrypoint log file", "error", err, "daytona-entrypoint", true)
+			return
+		}
+		defer entrypointLogFile.Close()
+
+		errChan := make(chan error, 1)
+		stdoutChan := make(chan []byte)
+		stderrChan := make(chan []byte)
+		go log.ReadMultiplexedLog(entrypointCtx, entrypointLogFile, true, stdoutChan, stderrChan, errChan)
+		for {
+			select {
+			case <-entrypointCtx.Done():
+				return
+			case line := <-stdoutChan:
+				s.logger.InfoContext(telemetryContext, string(line), "daytona-entrypoint", true)
+			case line := <-stderrChan:
+				s.logger.ErrorContext(telemetryContext, string(line), "daytona-entrypoint", true)
+			case err := <-errChan:
+				if err != nil {
+					s.logger.ErrorContext(telemetryContext, "Error reading entrypoint log file", "error", err, "daytona-entrypoint", true)
+				}
+				return
+			}
+		}
+	}()
 
 	// Initialize OpenTelemetry metrics
 	mp, err := telemetry.InitMetrics(ctx, config, "daytona.sandbox")

--- a/libs/common-go/pkg/log/prefix_writer.go
+++ b/libs/common-go/pkg/log/prefix_writer.go
@@ -1,0 +1,51 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"io"
+)
+
+type PrefixWriter struct {
+	prefix []byte
+	writer io.Writer
+}
+
+func NewPrefixWriter(prefix []byte, writer io.Writer) *PrefixWriter {
+	return &PrefixWriter{prefix: prefix, writer: writer}
+}
+
+func (w *PrefixWriter) Write(p []byte) (n int, err error) {
+	// Build a fresh buffer so we don't mutate w.prefix.
+	logLine := make([]byte, len(w.prefix)+len(p))
+	copy(logLine, w.prefix)
+	copy(logLine[len(w.prefix):], p)
+
+	written, writeErr := w.writer.Write(logLine)
+
+	// If fewer than the prefix bytes were written, no payload bytes were written.
+	if written < len(w.prefix) {
+		if writeErr == nil {
+			writeErr = io.ErrShortWrite
+		}
+		return 0, writeErr
+	}
+
+	// Compute how many payload bytes were written.
+	payloadWritten := written - len(w.prefix)
+	if payloadWritten > len(p) {
+		payloadWritten = len(p)
+	}
+
+	// If not all payload bytes were written, treat as short write.
+	if payloadWritten < len(p) {
+		if writeErr == nil {
+			writeErr = io.ErrShortWrite
+		}
+		return payloadWritten, writeErr
+	}
+
+	// All payload bytes written.
+	return len(p), writeErr
+}

--- a/libs/common-go/pkg/log/read_multiplex_log.go
+++ b/libs/common-go/pkg/log/read_multiplex_log.go
@@ -1,0 +1,185 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"time"
+)
+
+// Stream prefixes for multiplexing stdout/stderr in logs
+var (
+	STDOUT_PREFIX = []byte{0x01, 0x01, 0x01}
+	STDERR_PREFIX = []byte{0x02, 0x02, 0x02}
+)
+
+func ReadMultiplexedLog(ctx context.Context, logReader io.Reader, follow bool, stdoutChan chan []byte, stderrChan chan []byte, errChan chan error) {
+	reader := bufio.NewReader(logReader)
+
+	// Accumulated buffer across reads so we can safely detect prefixes
+	var buf []byte
+
+	const (
+		streamNone = iota
+		streamStdout
+		streamStderr
+	)
+
+	currentStream := streamNone
+	maxPrefixLen := len(STDOUT_PREFIX)
+	if l := len(STDERR_PREFIX); l > maxPrefixLen {
+		maxPrefixLen = l
+	}
+
+	// Helper to determine which prefix occurs next in buf and at what index.
+	findNextPrefix := func(b []byte) (idx int, stream int, prefixLen int) {
+		idxOut := bytes.Index(b, STDOUT_PREFIX)
+		idxErr := bytes.Index(b, STDERR_PREFIX)
+
+		// No prefix found at all.
+		if idxOut == -1 && idxErr == -1 {
+			return -1, streamNone, 0
+		}
+
+		// Only one of them found.
+		if idxOut != -1 && (idxErr == -1 || idxOut <= idxErr) {
+			return idxOut, streamStdout, len(STDOUT_PREFIX)
+		}
+		return idxErr, streamStderr, len(STDERR_PREFIX)
+	}
+
+	sleepTimer := time.NewTimer(0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			chunk := make([]byte, 1024)
+			n, err := reader.Read(chunk)
+
+			// Append any bytes that were actually read.
+			if n > 0 {
+				buf = append(buf, chunk[:n]...)
+			}
+
+			atEOF := false
+			if err != nil {
+				if err == io.EOF {
+					atEOF = true
+				} else {
+					// Report non-EOF errors but still try to process any accumulated data.
+					select {
+					case errChan <- err:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+
+			// Process the buffer: route bytes between prefixes to the appropriate stream.
+			for {
+				if currentStream == streamNone {
+					// We are not currently in any stream: look for the first prefix.
+					idx, stream, prefixLen := findNextPrefix(buf)
+					if idx == -1 {
+						// No prefix yet. To avoid losing a prefix that may be split across reads,
+						// keep at most (maxPrefixLen-1) trailing bytes; discard any earlier noise.
+						if !atEOF && len(buf) > maxPrefixLen-1 {
+							buf = buf[len(buf)-(maxPrefixLen-1):]
+						}
+						break
+					}
+
+					// Discard anything before the first recognized prefix.
+					if idx > 0 {
+						buf = buf[idx:]
+						idx = 0
+					}
+
+					// Consume the prefix and set the current stream.
+					buf = buf[prefixLen:]
+					currentStream = stream
+					continue
+				}
+
+				// We are currently in a stream: look for the next prefix.
+				idx, nextStream, prefixLen := findNextPrefix(buf)
+				if idx == -1 {
+					// No next prefix in the buffer.
+					if atEOF {
+						// At EOF, flush whatever remains in the buffer to the current stream.
+						if len(buf) > 0 {
+							out := make([]byte, len(buf))
+							copy(out, buf)
+							if currentStream == streamStdout {
+								select {
+								case <-ctx.Done():
+									return
+								case stdoutChan <- out:
+								}
+							} else if currentStream == streamStderr {
+								select {
+								case <-ctx.Done():
+									return
+								case stderrChan <- out:
+								}
+							}
+						}
+						buf = nil
+					}
+					// In the non-EOF case, keep buf as-is so that a prefix split across reads
+					// is not broken; we'll continue once more data arrives.
+					break
+				}
+
+				// Data up to the next prefix belongs to the current stream.
+				if idx > 0 {
+					chunkData := make([]byte, idx)
+					copy(chunkData, buf[:idx])
+					if currentStream == streamStdout {
+						select {
+						case <-ctx.Done():
+							return
+						case stdoutChan <- chunkData:
+						}
+					} else if currentStream == streamStderr {
+						select {
+						case <-ctx.Done():
+							return
+						case stderrChan <- chunkData:
+						}
+					}
+				}
+
+				// Consume the data and the next prefix, then switch streams.
+				buf = buf[idx+prefixLen:]
+				currentStream = nextStream
+			}
+
+			if err != nil {
+				if err == io.EOF {
+					if !follow {
+						// Signal EOF and stop if we are not following.
+						errChan <- io.EOF
+						return
+					}
+					// If following, just continue waiting for more data.
+					sleepTimer.Reset(50 * time.Millisecond)
+					select {
+					case <-ctx.Done():
+						return
+					case <-sleepTimer.C:
+					}
+				} else {
+					// Err already sent to channel above
+					return
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**Entrypoint Log Streaming and Telemetry**
* Enhanced telemetry initialization in `toolbox/telemetry.go` to stream entrypoint logs to telemetry by reading the log file and sending stdout/stderr lines to the logger asynchronously.
* Updated the server and initialization flow to accept and pass the entrypoint log file path, enabling the new log streaming feature. [[1]](diffhunk://#diff-ac7f85f99e2243cbca74ed582ebdf01c1081d3b6fbcebf74e27c6e059390a9f4L25-R25) [[2]](diffhunk://#diff-ac7f85f99e2243cbca74ed582ebdf01c1081d3b6fbcebf74e27c6e059390a9f4L35-R35) [[3]](diffhunk://#diff-71b445829f3efd79537cd3e4a098d77c1b54690bb3bce078259d4ba114265782R61) [[4]](diffhunk://#diff-71b445829f3efd79537cd3e4a098d77c1b54690bb3bce078259d4ba114265782R75) [[5]](diffhunk://#diff-71b445829f3efd79537cd3e4a098d77c1b54690bb3bce078259d4ba114265782R91) [[6]](diffhunk://#diff-71b445829f3efd79537cd3e4a098d77c1b54690bb3bce078259d4ba114265782L141-R144) [[7]](diffhunk://#diff-0cd24443090a1ea107d3b90a9846a830fced35682f8a22345b60f326f342c9d8R9-R16)

**Log Prefix Handling and Utilities**
* Moved `STDOUT_PREFIX` and `STDERR_PREFIX` definitions from `apps/daemon/pkg/session/types.go` to the new shared `libs/common-go/pkg/log/read_multiplex_log.go` file, making them accessible via the `log` package for consistent usage across the codebase. [[1]](diffhunk://#diff-303e435ac4957359426a2d009857e578044a804a690fcf72adf88641114fe8e4L15-L20) [[2]](diffhunk://#diff-8e2ac504dd6d293d42d1001cf480596af0102188b873346747dd731493c8204dR1-R45)
* Updated all references to log prefixes in session and input handling files (`execute.go`, `input.go`, `log.go`) to use the centralized `log.STDOUT_PREFIX` and `log.STDERR_PREFIX` instead of local definitions. [[1]](diffhunk://#diff-6dd0be4d472e878d1b9ac465f0caeaa2745de0d1b8f2339ccaf6c58f619384bcL55-R57) [[2]](diffhunk://#diff-6dd0be4d472e878d1b9ac465f0caeaa2745de0d1b8f2339ccaf6c58f619384bcL113-R114) [[3]](diffhunk://#diff-8466107b46254914d2343f31160ece9190f51ffb1c75ab70df5ee68ea447c172L65-R66) [[4]](diffhunk://#diff-dfbce3576e614469976ffea41a9d07b956bdd1cebcea3cd3ef1b54a3a8c350e5L133-R134) [[5]](diffhunk://#diff-dfbce3576e614469976ffea41a9d07b956bdd1cebcea3cd3ef1b54a3a8c350e5L253-R254) [[6]](diffhunk://#diff-dfbce3576e614469976ffea41a9d07b956bdd1cebcea3cd3ef1b54a3a8c350e5L262-R263) [[7]](diffhunk://#diff-dfbce3576e614469976ffea41a9d07b956bdd1cebcea3cd3ef1b54a3a8c350e5L280-R292)

**New Log Utilities**
* Added `PrefixWriter` in `libs/common-go/pkg/log/prefix_writer.go` to help write log lines with the correct prefix for stdout or stderr, and updated entrypoint log writing in `main.go` to use this utility for improved log format consistency. [[1]](diffhunk://#diff-988a5fe25585aab4244afd64a0bb6327777a0a8deb9ab687ca853931a7a670f5R1-R27) [[2]](diffhunk://#diff-b3dfea52e0d353ade9c2dde2ca1da28188b6799030d8de73983f22e892e277d5L127-R130)
* Introduced `ReadMultiplexedLog` in `libs/common-go/pkg/log/read_multiplex_log.go` for reading multiplexed log files and demultiplexing stdout/stderr streams, now used in log reading and telemetry streaming. [[1]](diffhunk://#diff-8e2ac504dd6d293d42d1001cf480596af0102188b873346747dd731493c8204dR1-R45) [[2]](diffhunk://#diff-9157844b234c774c40e8204801898d11c0ba187ecb9bf1da36417e56db3131d3L24-R53)

**Code Cleanup and Imports**
* Removed unused imports and updated import statements to use the new shared log utilities. [[1]](diffhunk://#diff-9157844b234c774c40e8204801898d11c0ba187ecb9bf1da36417e56db3131d3R7-R12) [[2]](diffhunk://#diff-6dd0be4d472e878d1b9ac465f0caeaa2745de0d1b8f2339ccaf6c58f619384bcR20) [[3]](diffhunk://#diff-8466107b46254914d2343f31160ece9190f51ffb1c75ab70df5ee68ea447c172R13) [[4]](diffhunk://#diff-dfbce3576e614469976ffea41a9d07b956bdd1cebcea3cd3ef1b54a3a8c350e5R20)

**Entrypoint Log Reading**
* Refactored `ReadEntrypointLogs` to use the new multiplexed log reader, allowing for proper demultiplexing and output to the correct streams.