### PR TITLE
fix(docs): modify guides card styling

### DIFF
--- a/apps/docs/src/components/GuidesList.astro
+++ b/apps/docs/src/components/GuidesList.astro
@@ -132,13 +132,13 @@ const guides: GuideItem[] = navLinks.map(link => {
     flex-direction: column;
     padding: 1em;
     width: 100%;
-    height: 160px;
+    min-height: 160px;
     box-sizing: border-box;
-    overflow: hidden;
   }
 
   .guide-title {
     font-weight: bold;
+    line-height: 1.4;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;


### PR DESCRIPTION
## Description

Modifies the guides list component styling by adding minimum height to list and line height to title.

<img width="776" height="236" alt="Screenshot 2026-03-03 at 15 34 30" src="https://github.com/user-attachments/assets/46ee8f1b-05e2-4b7f-ae07-7d283c849feb" />

<img width="771" height="248" alt="Screenshot 2026-03-03 at 15 36 51" src="https://github.com/user-attachments/assets/62bd44fb-6ca3-4703-9fec-9c853b2f3a0a" />
