### PR TITLE
feat(api,runner,daemon): send org and region id as labels in OTel

### DIFF
--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -221,6 +221,8 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       authToken: sandbox.authToken,
       otelEndpoint,
       skipStart: skipStart,
+      organizationId: sandbox.organizationId,
+      regionId: sandbox.region,
     }
 
     const response = await this.sandboxApiClient.create(createSandboxDto)

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -171,6 +171,8 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       authToken: sandbox.authToken,
       otelEndpoint: otelEndpoint,
       skipStart: skipStart,
+      organizationId: sandbox.organizationId,
+      regionId: sandbox.region,
     }
 
     await this.jobService.createJob(

--- a/apps/daemon/cmd/daemon/config/config.go
+++ b/apps/daemon/cmd/daemon/config/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	TerminationGracePeriodSeconds        int     `envconfig:"DAYTONA_TERMINATION_GRACE_PERIOD_SECONDS"`        // Period in seconds to wait before forcefully terminating processes
 	TerminationCheckIntervalMilliseconds int     `envconfig:"DAYTONA_TERMINATION_CHECK_INTERVAL_MILLISECONDS"` // Interval in milliseconds to check for process termination
 	RecordingsDir                        string  `envconfig:"DAYTONA_RECORDINGS_DIR"`
+	OrganizationId                       *string `envconfig:"DAYTONA_ORGANIZATION_ID"`
+	RegionId                             *string `envconfig:"DAYTONA_REGION_ID"`
 }
 
 var defaultDaemonLogFilePath = "/tmp/daytona-daemon.log"

--- a/apps/daemon/cmd/daemon/main.go
+++ b/apps/daemon/cmd/daemon/main.go
@@ -176,6 +176,8 @@ func run() int {
 		TerminationGracePeriodSeconds:        c.TerminationGracePeriodSeconds,
 		TerminationCheckIntervalMilliseconds: c.TerminationCheckIntervalMilliseconds,
 		RecordingService:                     recordingService,
+		OrganizationId:                       c.OrganizationId,
+		RegionId:                             c.RegionId,
 	})
 
 	// Start the toolbox server in a go routine

--- a/apps/daemon/pkg/toolbox/controller.go
+++ b/apps/daemon/pkg/toolbox/controller.go
@@ -22,7 +22,7 @@ import (
 //	@Router			/init [post]
 //
 //	@id				Initialize
-func (s *server) Initialize(otelServiceName string) gin.HandlerFunc {
+func (s *server) Initialize(otelServiceName string, organizationId, regionId *string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		var req InitializeRequest
 		if err := ctx.ShouldBindJSON(&req); err != nil {
@@ -32,7 +32,7 @@ func (s *server) Initialize(otelServiceName string) gin.HandlerFunc {
 
 		s.authToken = req.Token
 
-		err := s.initTelemetry(ctx.Request.Context(), otelServiceName)
+		err := s.initTelemetry(ctx.Request.Context(), otelServiceName, organizationId, regionId)
 		if err != nil {
 			ctx.AbortWithError(http.StatusBadRequest, err)
 			return

--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -58,6 +58,8 @@ type ServerConfig struct {
 	TerminationGracePeriodSeconds        int
 	TerminationCheckIntervalMilliseconds int
 	RecordingService                     *recording.RecordingService
+	OrganizationId                       *string
+	RegionId                             *string
 }
 
 func NewServer(config ServerConfig) *server {
@@ -71,6 +73,8 @@ func NewServer(config ServerConfig) *server {
 		terminationCheckIntervalMilliseconds: config.TerminationCheckIntervalMilliseconds,
 		configDir:                            config.ConfigDir,
 		recordingService:                     config.RecordingService,
+		organizationId:                       config.OrganizationId,
+		regionId:                             config.RegionId,
 	}
 }
 
@@ -87,6 +91,8 @@ type server struct {
 	configDir                            string
 	recordingService                     *recording.RecordingService
 	httpServer                           *http.Server
+	organizationId                       *string
+	regionId                             *string
 }
 
 type Telemetry struct {
@@ -138,7 +144,7 @@ func (s *server) Start() error {
 		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 	}
 
-	r.POST("/init", s.Initialize(otelServiceName))
+	r.POST("/init", s.Initialize(otelServiceName, s.organizationId, s.regionId))
 
 	r.GET("/version", s.GetVersion)
 

--- a/apps/daemon/pkg/toolbox/telemetry.go
+++ b/apps/daemon/pkg/toolbox/telemetry.go
@@ -11,7 +11,7 @@ import (
 	"github.com/daytonaio/daemon/internal"
 )
 
-func (s *server) initTelemetry(ctx context.Context, serviceName string) error {
+func (s *server) initTelemetry(ctx context.Context, serviceName string, organizationId, regionId *string) error {
 	if s.otelEndpoint == nil {
 		s.logger.InfoContext(ctx, "Otel endpoint not provided, skipping telemetry initialization")
 		return nil
@@ -42,6 +42,19 @@ func (s *server) initTelemetry(ctx context.Context, serviceName string) error {
 		Headers: map[string]string{
 			"sandbox-auth-token": s.authToken,
 		},
+	}
+
+	extraLabels := make(map[string]string)
+	if organizationId != nil && *organizationId != "" {
+		extraLabels["daytona_organization_id"] = *organizationId
+	}
+
+	if regionId != nil && *regionId != "" {
+		extraLabels["daytona_region_id"] = *regionId
+	}
+
+	if len(extraLabels) > 0 {
+		config.ExtraLabels = extraLabels
 	}
 
 	// Use a background context

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1571,10 +1571,17 @@ const docTemplate = `{
                 "networkBlockAll": {
                     "type": "boolean"
                 },
+                "organizationId": {
+                    "description": "Nullable for backward compatibility",
+                    "type": "string"
+                },
                 "osUser": {
                     "type": "string"
                 },
                 "otelEndpoint": {
+                    "type": "string"
+                },
+                "regionId": {
                     "type": "string"
                 },
                 "registry": {

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1466,10 +1466,17 @@
         "networkBlockAll": {
           "type": "boolean"
         },
+        "organizationId": {
+          "description": "Nullable for backward compatibility",
+          "type": "string"
+        },
         "osUser": {
           "type": "string"
         },
         "otelEndpoint": {
+          "type": "string"
+        },
+        "regionId": {
           "type": "string"
         },
         "registry": {

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -67,9 +67,14 @@ definitions:
         type: string
       networkBlockAll:
         type: boolean
+      organizationId:
+        description: Nullable for backward compatibility
+        type: string
       osUser:
         type: string
       otelEndpoint:
+        type: string
+      regionId:
         type: string
       registry:
         $ref: '#/definitions/RegistryDTO'

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -23,6 +23,10 @@ type CreateSandboxDTO struct {
 	AuthToken        *string           `json:"authToken,omitempty"`
 	OtelEndpoint     *string           `json:"otelEndpoint,omitempty"`
 	SkipStart        *bool             `json:"skipStart,omitempty"`
+
+	// Nullable for backward compatibility
+	OrganizationId *string `json:"organizationId,omitempty"`
+	RegionId       *string `json:"regionId,omitempty"`
 } //	@name	CreateSandboxDTO
 
 type ResizeSandboxDTO struct {

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -52,6 +52,14 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 		envVars = append(envVars, "DAYTONA_OTEL_ENDPOINT="+*sandboxDto.OtelEndpoint)
 	}
 
+	if sandboxDto.OrganizationId != nil && *sandboxDto.OrganizationId != "" {
+		envVars = append(envVars, "DAYTONA_ORGANIZATION_ID="+*sandboxDto.OrganizationId)
+	}
+
+	if sandboxDto.RegionId != nil && *sandboxDto.RegionId != "" {
+		envVars = append(envVars, "DAYTONA_REGION_ID="+*sandboxDto.RegionId)
+	}
+
 	labels := make(map[string]string)
 	if len(sandboxDto.Volumes) > 0 {
 		volumeMountPaths := make([]string, len(sandboxDto.Volumes))

--- a/libs/common-go/pkg/telemetry/common.go
+++ b/libs/common-go/pkg/telemetry/common.go
@@ -3,7 +3,13 @@
 
 package telemetry
 
-import "go.opentelemetry.io/otel/sdk/trace"
+import (
+	"os"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+)
 
 type Config struct {
 	Endpoint       string
@@ -11,6 +17,27 @@ type Config struct {
 	ServiceName    string
 	ServiceVersion string
 	Environment    string
+	ExtraLabels    map[string]string
+}
+
+func (c Config) Attributes() []attribute.KeyValue {
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = "unknown"
+	}
+
+	attributes := []attribute.KeyValue{
+		semconv.ServiceName(c.ServiceName),
+		semconv.ServiceVersion(c.ServiceVersion),
+		semconv.ServiceInstanceID(hostname),
+		semconv.DeploymentEnvironmentName(c.Environment),
+	}
+
+	for k, v := range c.ExtraLabels {
+		attributes = append(attributes, attribute.String(k, v))
+	}
+
+	return attributes
 }
 
 type ExporterFilter interface {

--- a/libs/common-go/pkg/telemetry/logging.go
+++ b/libs/common-go/pkg/telemetry/logging.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/daytonaio/common-go/pkg/log"
@@ -17,7 +16,6 @@ import (
 	"go.opentelemetry.io/otel/log/global"
 	otellog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
 
 // InitLogger initializes OpenTelemetry logging with OTLP exporter.
@@ -28,19 +26,9 @@ func InitLogger(ctx context.Context, logger *slog.Logger, config Config) (*slog.
 		return logger, nil, errors.New("logger cannot be nil")
 	}
 
-	hostname, err := os.Hostname()
-	if err != nil || hostname == "" {
-		hostname = "unknown"
-	}
-
 	// Create a new resource with service information
 	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(config.ServiceName),
-			semconv.ServiceVersion(config.ServiceVersion),
-			semconv.ServiceInstanceID(hostname),
-			semconv.DeploymentEnvironmentName(config.Environment),
-		),
+		resource.WithAttributes(config.Attributes()...),
 		resource.WithTelemetrySDK(),
 	)
 	if err != nil {

--- a/libs/common-go/pkg/telemetry/metrics.go
+++ b/libs/common-go/pkg/telemetry/metrics.go
@@ -22,17 +22,13 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdk_metric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
 
 // InitMetrics initializes OpenTelemetry Metrics with an OTLP HTTP exporter.
 func InitMetrics(ctx context.Context, config Config, meterName string) (*sdk_metric.MeterProvider, error) {
 	// Resource describing this service
 	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(config.ServiceName),
-			semconv.ServiceVersion(config.ServiceVersion),
-		),
+		resource.WithAttributes(config.Attributes()...),
 	)
 	if err != nil {
 		return nil, err

--- a/libs/common-go/pkg/telemetry/tracing.go
+++ b/libs/common-go/pkg/telemetry/tracing.go
@@ -6,7 +6,6 @@ package telemetry
 import (
 	"context"
 	"log/slog"
-	"os"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -14,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
 
 // InitTracer initializes OpenTelemetry with Jaeger exporter
@@ -24,19 +22,9 @@ func InitTracer(ctx context.Context, config Config, exporterFilters ...ExporterF
 		slog.Error("OpenTelemetry error", "error", err)
 	}))
 
-	hostname, err := os.Hostname()
-	if err != nil || hostname == "" {
-		hostname = "unknown"
-	}
-
 	// Create a new resource with service information
 	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(config.ServiceName),
-			semconv.ServiceVersion(config.ServiceVersion),
-			semconv.ServiceInstanceID(hostname),
-			semconv.DeploymentEnvironmentName(config.Environment),
-		),
+		resource.WithAttributes(config.Attributes()...),
 		resource.WithTelemetrySDK(),
 	)
 	if err != nil {

--- a/libs/runner-api-client/src/models/create-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/create-sandbox-dto.ts
@@ -93,6 +93,12 @@ export interface CreateSandboxDTO {
      */
     'networkBlockAll'?: boolean;
     /**
+     * Nullable for backward compatibility
+     * @type {string}
+     * @memberof CreateSandboxDTO
+     */
+    'organizationId'?: string;
+    /**
      * 
      * @type {string}
      * @memberof CreateSandboxDTO
@@ -104,6 +110,12 @@ export interface CreateSandboxDTO {
      * @memberof CreateSandboxDTO
      */
     'otelEndpoint'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof CreateSandboxDTO
+     */
+    'regionId'?: string;
     /**
      * 
      * @type {RegistryDTO}


### PR DESCRIPTION
## Description

Added `daytona_organization_id` and `daytona_region_id` to resource attributes of OTel data sent by sandboxes.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
