### PR TITLE
fix: resize image existance and enable backupError driven recovery

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -233,6 +233,7 @@ export class Sandbox {
     backupSnapshot?: string | null,
     backupRegistryId?: string | null,
     backupErrorReason?: string | null,
+    recoverable?: boolean,
   ): Partial<Sandbox> {
     const update: Partial<Sandbox> = {
       backupState,
@@ -263,6 +264,9 @@ export class Sandbox {
     }
     if (backupErrorReason !== undefined) {
       update.backupErrorReason = backupErrorReason
+    }
+    if (recoverable !== undefined) {
+      update.recoverable = recoverable
     }
     return update
   }

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -427,6 +427,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
             undefined,
             undefined,
             sandboxInfo.backupErrorReason,
+            sandboxInfo.recoverable,
           )
           break
         }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -19,6 +19,7 @@ export interface RunnerSandboxInfo {
   daemonVersion?: string
   backupState?: BackupState
   backupErrorReason?: string
+  recoverable?: boolean
 }
 
 export interface RunnerSnapshotInfo {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -107,7 +107,7 @@ export interface RunnerAdapter {
     networkLimitEgress?: boolean,
   ): Promise<void>
 
-  recoverSandbox(sandbox: Sandbox): Promise<void>
+  recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry): Promise<void>
 
   resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void>
 }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -415,7 +415,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     await this.sandboxApiClient.updateNetworkSettings(sandboxId, updateNetworkSettingsDto)
   }
 
-  async recoverSandbox(sandbox: Sandbox): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -434,6 +434,14 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     }
     await this.sandboxApiClient.recover(sandbox.id, recoverSandboxDTO)
   }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -179,6 +179,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       state: this.convertSandboxState(sandboxInfo.data.state),
       backupState: this.convertBackupState(sandboxInfo.data.backupState),
       backupErrorReason: sandboxInfo.data.backupError,
+      recoverable: sandboxInfo.data.recoverable,
       daemonVersion: sandboxInfo.data.daemonVersion,
     }
   }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -216,7 +216,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created DESTROY_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async recoverSandbox(sandbox: Sandbox): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -235,6 +235,14 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     }
     await this.jobService.createJob(
       null,

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -111,7 +111,8 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     return {
       state,
       backupState: sandbox.backupState,
-      backupErrorReason: sandbox.backupErrorReason,
+      backupErrorReason: sandbox.backupErrorReason ?? undefined,
+      recoverable: sandbox.recoverable,
       daemonVersion,
     }
   }

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -405,9 +405,10 @@ export class JobStateHandlerService {
         Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.COMPLETED))
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`CREATE_BACKUP job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
+        const { recoverable, errorReason } = sanitizeSandboxError(job.errorMessage)
         Object.assign(
           updateData,
-          Sandbox.getBackupStateUpdate(sandbox, BackupState.ERROR, undefined, undefined, job.errorMessage),
+          Sandbox.getBackupStateUpdate(sandbox, BackupState.ERROR, undefined, undefined, errorReason, recoverable),
         )
       }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1364,8 +1364,8 @@ export class SandboxService {
   async recover(sandboxIdOrName: string, organization: Organization, skipStart = false): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
-    if (sandbox.state !== SandboxState.ERROR) {
-      throw new BadRequestError('Sandbox must be in error state to recover')
+    if (!sandbox.recoverable) {
+      throw new BadRequestError('Sandbox is not in a recoverable state')
     }
 
     if (sandbox.pending) {
@@ -1408,9 +1408,16 @@ export class SandboxService {
       recoverable: false,
     }
 
+    // If the sandbox was stuck due to a backup error, clear the failed backup state
+    if (sandbox.backupState === BackupState.ERROR) {
+      updateData.backupState = BackupState.NONE
+      updateData.backupErrorReason = null
+      updateData.backupSnapshot = null
+    }
+
     await this.sandboxRepository.updateWhere(sandbox.id, {
       updateData,
-      whereCondition: { state: SandboxState.ERROR },
+      whereCondition: { recoverable: true },
     })
 
     if (skipStart) {
@@ -2143,6 +2150,7 @@ export class SandboxService {
     backupSnapshot?: string | null,
     backupRegistryId?: string | null,
     backupErrorReason?: string | null,
+    recoverable?: boolean,
   ): Promise<void> {
     const sandboxToUpdate = await this.sandboxRepository.findOneByOrFail({
       id: sandboxId,
@@ -2154,6 +2162,7 @@ export class SandboxService {
       backupSnapshot,
       backupRegistryId,
       backupErrorReason,
+      recoverable,
     )
 
     await this.sandboxRepository.update(sandboxId, { updateData, entity: sandboxToUpdate })

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -87,6 +87,7 @@ import {
 } from '../utils/sandbox-lookup-cache.util'
 import { SandboxLookupCacheInvalidationService } from './sandbox-lookup-cache-invalidation.service'
 import { Region } from '../../region/entities/region.entity'
+import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 
 const DEFAULT_CPU = 1
 const DEFAULT_MEMORY = 1
@@ -120,6 +121,7 @@ export class SandboxService {
     private readonly regionService: RegionService,
     private readonly snapshotService: SnapshotService,
     private readonly sandboxLookupCacheInvalidationService: SandboxLookupCacheInvalidationService,
+    private readonly dockerRegistryService: DockerRegistryService,
   ) {}
 
   protected getLockKey(id: string): string {
@@ -1359,7 +1361,7 @@ export class SandboxService {
     return updatedSandbox
   }
 
-  async recover(sandboxIdOrName: string, organization: Organization): Promise<Sandbox> {
+  async recover(sandboxIdOrName: string, organization: Organization, skipStart = false): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
     if (sandbox.state !== SandboxState.ERROR) {
@@ -1385,8 +1387,12 @@ export class SandboxService {
 
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
+    const backupRegistry = sandbox.backupRegistryId
+      ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
+      : undefined
+
     try {
-      await runnerAdapter.recoverSandbox(sandbox)
+      await runnerAdapter.recoverSandbox(sandbox, backupRegistry)
     } catch (error) {
       if (error instanceof Error && error.message.includes('storage cannot be further expanded')) {
         const errorMsg = `Sandbox storage cannot be further expanded. Maximum expansion of ${(sandbox.disk * 0.1).toFixed(2)}GB (10% of original ${sandbox.disk.toFixed(2)}GB) has been reached. Please contact support for further assistance.`
@@ -1406,6 +1412,10 @@ export class SandboxService {
       updateData,
       whereCondition: { state: SandboxState.ERROR },
     })
+
+    if (skipStart) {
+      return await this.findOneByIdOrName(sandbox.id, organization.id)
+    }
 
     // Now that sandbox is in STOPPED state, use the normal start flow
     // This handles quota validation, pending usage, event emission, etc.

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1417,7 +1417,7 @@ export class SandboxService {
 
     await this.sandboxRepository.updateWhere(sandbox.id, {
       updateData,
-      whereCondition: { recoverable: true },
+      whereCondition: { recoverable: true, pending: false, state: sandbox.state },
     })
 
     if (skipStart) {

--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -357,6 +357,7 @@ func Info(ctx *gin.Context) {
 		State:         info.SandboxState,
 		BackupState:   info.BackupState,
 		BackupError:   info.BackupErrorReason,
+		Recoverable:   info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
 		DaemonVersion: daemonVersion,
 	})
 }
@@ -365,6 +366,7 @@ type SandboxInfoResponse struct {
 	State         enums.SandboxState `json:"state"`
 	BackupState   enums.BackupState  `json:"backupState"`
 	BackupError   *string            `json:"backupError,omitempty"`
+	Recoverable   bool               `json:"recoverable"`
 	DaemonVersion *string            `json:"daemonVersion,omitempty"`
 } //	@name	SandboxInfoResponse
 

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1857,6 +1857,9 @@ const docTemplate = `{
                 "daemonVersion": {
                     "type": "string"
                 },
+                "recoverable": {
+                    "type": "boolean"
+                },
                 "state": {
                     "$ref": "#/definitions/enums.SandboxState"
                 }

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1740,6 +1740,9 @@ const docTemplate = `{
                 "osUser": {
                     "type": "string"
                 },
+                "registry": {
+                    "$ref": "#/definitions/RegistryDTO"
+                },
                 "snapshot": {
                     "type": "string"
                 },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1733,6 +1733,9 @@
         "daemonVersion": {
           "type": "string"
         },
+        "recoverable": {
+          "type": "boolean"
+        },
         "state": {
           "$ref": "#/definitions/enums.SandboxState"
         }

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1618,6 +1618,9 @@
         "osUser": {
           "type": "string"
         },
+        "registry": {
+          "$ref": "#/definitions/RegistryDTO"
+        },
         "snapshot": {
           "type": "string"
         },

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -185,6 +185,8 @@ definitions:
         type: boolean
       osUser:
         type: string
+      registry:
+        $ref: '#/definitions/RegistryDTO'
       snapshot:
         type: string
       storageQuota:

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -267,6 +267,8 @@ definitions:
         $ref: '#/definitions/enums.BackupState'
       daemonVersion:
         type: string
+      recoverable:
+        type: boolean
       state:
         $ref: '#/definitions/enums.SandboxState'
     type: object

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -53,6 +53,7 @@ type RecoverSandboxDTO struct {
 	NetworkAllowList  *string           `json:"networkAllowList,omitempty"`
 	ErrorReason       string            `json:"errorReason" validate:"required"`
 	BackupErrorReason string            `json:"backupErrorReason,omitempty"`
+	Registry          *RegistryDTO      `json:"registry,omitempty"`
 } //	@name	RecoverSandboxDTO
 
 type IsRecoverableDTO struct {

--- a/apps/runner/pkg/docker/recover.go
+++ b/apps/runner/pkg/docker/recover.go
@@ -6,17 +6,19 @@ package docker
 import (
 	"context"
 	"fmt"
-
 	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
 	"github.com/daytonaio/runner/pkg/models"
 )
 
 func (d *DockerClient) RecoverSandbox(ctx context.Context, sandboxId string, recoverDto dto.RecoverSandboxDTO) error {
-	// Deduce recovery type from error reason
+	// Deduce recovery type from error reason, falling back to backup error reason
 	recoveryType := common.DeduceRecoveryType(recoverDto.ErrorReason)
 	if recoveryType == models.UnknownRecoveryType {
-		return fmt.Errorf("unable to deduce recovery type from error reason: %s", recoverDto.ErrorReason)
+		recoveryType = common.DeduceRecoveryType(recoverDto.BackupErrorReason)
+	}
+	if recoveryType == models.UnknownRecoveryType {
+		return fmt.Errorf("unable to deduce recovery type from error reason: %s, backup error reason: %s", recoverDto.ErrorReason, recoverDto.BackupErrorReason)
 	}
 
 	switch recoveryType {

--- a/apps/runner/pkg/docker/recover.go
+++ b/apps/runner/pkg/docker/recover.go
@@ -21,7 +21,7 @@ func (d *DockerClient) RecoverSandbox(ctx context.Context, sandboxId string, rec
 
 	switch recoveryType {
 	case models.RecoveryTypeStorageExpansion:
-		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota))
+		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota), recoverDto)
 	default:
 		return fmt.Errorf("unsupported recovery type: %s", recoveryType)
 	}

--- a/apps/runner/pkg/docker/recover_from_storage_limit.go
+++ b/apps/runner/pkg/docker/recover_from_storage_limit.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
 )
 
 // RecoverFromStorageLimit attempts to recover a sandbox from storage limit issues
-// by expanding its storage quota by creating new ones with 100MB increments up to 10% of original.
-func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64) error {
+// by expanding its storage quota by 5% of the original quota per attempt, up to 10% total.
+func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, recoverDto dto.RecoverSandboxDTO) error {
 	originalContainer, err := d.ContainerInspect(ctx, sandboxId)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container: %w", err)
@@ -30,7 +31,7 @@ func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId st
 
 	maxExpansion := originalStorageQuota * 0.1 // 10% of original
 	currentExpansion := currentStorage - originalStorageQuota
-	increment := 0.1 // ~107MB
+	increment := originalStorageQuota * 0.05 // 5% of original per recovery attempt
 	newExpansion := currentExpansion + increment
 	newStorageQuota := originalStorageQuota + newExpansion
 
@@ -59,5 +60,5 @@ func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId st
 		}
 	}
 
-	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery")
+	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", recoverDto.Registry)
 }

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/daytonaio/common-go/pkg/utils"
 	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
@@ -114,22 +115,9 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 	// Ensure the image is available for container recreation.
 	// ImageInspect works for both tags and IDs, unlike ImageExists which only matches tags.
 	// If the image was removed (e.g., after a backup push), pull it from the registry if provided.
-	imageRef := originalContainer.Config.Image
-	_, err = d.apiClient.ImageInspect(ctx, imageRef)
-	if err != nil {
-		if registry == nil {
-			d.logger.WarnContext(ctx, "Image not found by tag, falling back to image ID",
-				"imageRef", imageRef, "imageID", originalContainer.Image)
-			originalContainer.Config.Image = originalContainer.Image
-		} else {
-			d.logger.WarnContext(ctx, "Image not found locally, pulling from registry before resize",
-				"sandboxId", sandboxId, "imageRef", imageRef)
-			_, pullErr := d.PullImage(ctx, imageRef, registry)
-			if pullErr != nil {
-				_ = d.apiClient.ContainerRename(ctx, oldName, sandboxId)
-				return fmt.Errorf("image %s not available locally and pull failed: %w", imageRef, pullErr)
-			}
-		}
+	if err = d.resolveContainerImage(ctx, &originalContainer, registry); err != nil {
+		_ = d.apiClient.ContainerRename(ctx, oldName, sandboxId)
+		return err
 	}
 
 	// Create new container with new storage
@@ -237,4 +225,42 @@ func (d *DockerClient) copyContainerOverlayData(ctx context.Context, oldContaine
 	defer cancel()
 
 	return common.RsyncCopy(copyCtx, d.logger, oldContainerOverlayPath, newUpperDir)
+}
+
+// resolveContainerImage ensures the image referenced by the container config is available locally.
+// It tries the tag first, then falls back to the image ID, and finally pulls from the registry.
+// If the image ID is used as a fallback, originalContainer.Config.Image is updated in place.
+func (d *DockerClient) resolveContainerImage(ctx context.Context, originalContainer *container.InspectResponse, registry *dto.RegistryDTO) error {
+	imageRef := originalContainer.Config.Image
+
+	_, err := d.apiClient.ImageInspect(ctx, imageRef)
+	if err == nil {
+		return nil
+	}
+	if !errdefs.IsNotFound(err) {
+		return fmt.Errorf("failed to inspect image %s: %w", imageRef, err)
+	}
+
+	// Tag not found — try the image ID before touching the network.
+	_, idErr := d.apiClient.ImageInspect(ctx, originalContainer.Image)
+	if idErr == nil {
+		d.logger.WarnContext(ctx, "Image not found by tag, falling back to image ID",
+			"imageRef", imageRef, "imageID", originalContainer.Image)
+		originalContainer.Config.Image = originalContainer.Image
+		return nil
+	}
+	if !errdefs.IsNotFound(idErr) {
+		return fmt.Errorf("failed to inspect image by ID %s: %w", originalContainer.Image, idErr)
+	}
+
+	// Both tag and ID not found — pull from registry as last resort.
+	if registry == nil {
+		return fmt.Errorf("image %s not available locally and no registry provided", imageRef)
+	}
+	d.logger.WarnContext(ctx, "Image not found locally, pulling from registry before resize",
+		"containerName", originalContainer.Name, "imageRef", imageRef)
+	if _, pullErr := d.PullImage(ctx, imageRef, registry); pullErr != nil {
+		return fmt.Errorf("image %s not available locally and pull failed: %w", imageRef, pullErr)
+	}
+	return nil
 }

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -30,7 +30,7 @@ func (d *DockerClient) Resize(ctx context.Context, sandboxId string, sandboxDto 
 			return fmt.Errorf("disk resize requires stopped container")
 		}
 
-		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize")
+		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize", nil)
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func (d *DockerClient) Resize(ctx context.Context, sandboxId string, sandboxDto 
 // Optionally updates CPU/memory at the same time (0 = don't change).
 // Used by both storage recovery and disk resize.
 // Container must be stopped before calling this function.
-func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string, newStorageGB float64, cpu int64, memory int64, operationName string) error {
+func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string, newStorageGB float64, cpu int64, memory int64, operationName string, registry *dto.RegistryDTO) error {
 	if d.filesystem != "xfs" {
 		return fmt.Errorf("%s requires XFS filesystem, current filesystem: %s", operationName, d.filesystem)
 	}
@@ -112,13 +112,24 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 	}
 
 	// Ensure the image is available for container recreation.
-	// If the image tag was pruned (e.g., declarative-build or backup snapshot),
-	// fall back to the image ID — Docker retains layers while the container exists.
+	// ImageInspect works for both tags and IDs, unlike ImageExists which only matches tags.
+	// If the image was removed (e.g., after a backup push), pull it from the registry if provided.
 	imageRef := originalContainer.Config.Image
-	imageExists, _ := d.ImageExists(ctx, imageRef, true)
-	if !imageExists {
-		d.logger.Warn("Image is not found by tag, falling back to image ID", "imageRef", imageRef, "imageID", originalContainer.Image)
-		originalContainer.Config.Image = originalContainer.Image
+	_, err = d.apiClient.ImageInspect(ctx, imageRef)
+	if err != nil {
+		if registry == nil {
+			d.logger.WarnContext(ctx, "Image not found by tag, falling back to image ID",
+				"imageRef", imageRef, "imageID", originalContainer.Image)
+			originalContainer.Config.Image = originalContainer.Image
+		} else {
+			d.logger.WarnContext(ctx, "Image not found locally, pulling from registry before resize",
+				"sandboxId", sandboxId, "imageRef", imageRef)
+			_, pullErr := d.PullImage(ctx, imageRef, registry)
+			if pullErr != nil {
+				_ = d.apiClient.ContainerRename(ctx, oldName, sandboxId)
+				return fmt.Errorf("image %s not available locally and pull failed: %w", imageRef, pullErr)
+			}
+		}
 	}
 
 	// Create new container with new storage

--- a/apps/runner/pkg/runner/v2/executor/backup.go
+++ b/apps/runner/pkg/runner/v2/executor/backup.go
@@ -11,6 +11,7 @@ import (
 
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/daytonaio/runner/pkg/api/dto"
+	"github.com/daytonaio/runner/pkg/common"
 )
 
 func (e *Executor) createBackup(ctx context.Context, job *apiclient.Job) (any, error) {
@@ -21,5 +22,9 @@ func (e *Executor) createBackup(ctx context.Context, job *apiclient.Job) (any, e
 	}
 
 	// TODO: is state cache needed?
-	return nil, e.docker.CreateBackup(ctx, job.ResourceId, createBackupDto)
+	err = e.docker.CreateBackup(ctx, job.ResourceId, createBackupDto)
+	if err != nil {
+		return nil, common.FormatRecoverableError(err)
+	}
+	return nil, nil
 }

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -16,6 +16,9 @@
 // May contain unused imports in some cases
 // @ts-ignore
 import type { DtoVolumeDTO } from './dto-volume-dto';
+// May contain unused imports in some cases
+// @ts-ignore
+import type { RegistryDTO } from './registry-dto';
 
 /**
  * 
@@ -83,6 +86,12 @@ export interface RecoverSandboxDTO {
      * @memberof RecoverSandboxDTO
      */
     'osUser': string;
+    /**
+     * 
+     * @type {RegistryDTO}
+     * @memberof RecoverSandboxDTO
+     */
+    'registry'?: RegistryDTO;
     /**
      * 
      * @type {string}

--- a/libs/runner-api-client/src/models/sandbox-info-response.ts
+++ b/libs/runner-api-client/src/models/sandbox-info-response.ts
@@ -46,6 +46,12 @@ export interface SandboxInfoResponse {
     'daemonVersion'?: string;
     /**
      * 
+     * @type {boolean}
+     * @memberof SandboxInfoResponse
+     */
+    'recoverable'?: boolean;
+    /**
+     * 
      * @type {EnumsSandboxState}
      * @memberof SandboxInfoResponse
      */


### PR DESCRIPTION
Fixes sandbox recovery for cases where backups fail and leave sandboxes in a stuck state. The API now detects backup errors and allows sandboxes to recover gracefully. On the runner side, image pull is now performed before disk resize during recovery, disk storage increments use a 5% step instead of a fixed value, and a skip-start option is added to allow recovery without automatically starting the sandbox.

**Sandbox Recovery Enhancements**

* Added a `recoverable` property to the `Sandbox` entity, API responses, and related DTOs to explicitly track if a sandbox can be recovered after errors. The recovery flow now checks this property instead of relying solely on the sandbox state. [[1]](diffhunk://#diff-ab57a48e2dac4738b29a63ddf6950a2e3ac30dafee47424a43011db7eb36a88dR236) [[2]](diffhunk://#diff-c981ba04812cc991df79671f0bdfa010fe062eb981f49cb2a3d18c69eb0ebaa5R369) [[3]](diffhunk://#diff-01cebc274cb59a89762ceec728c73a82721d2ee19572d57a6ed4b71cf1a549efR22) [[4]](diffhunk://#diff-6cbddaf0eb8270698230f3937bf1cf88b2d10991d85d25e4c87dd7c586a98fa3L114-R115) [[5]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1362-R1368)
* Improved error handling for backup failures: the system now uses both the main error reason and the backup error reason to deduce recovery type, and clears failed backup state when recovering. [[1]](diffhunk://#diff-1fc7f575f8ac5f6585f8421662d15efc46f2240e1e90aa50b6a772a4ac0f701dR408-R411) [[2]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcR1411-R1426) [[3]](diffhunk://#diff-5dfbc1210105bd8d12a29ba34bafdf1fa82915c9b321d55de17d4d02283ccf2dL9-R26)

**Registry Support in Recovery**

* The sandbox recovery flow now optionally passes Docker registry credentials to the runner, allowing recovery from private registries. This is reflected in the DTOs, runner adapters, and API documentation. [[1]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcR1390-R1395) [[2]](diffhunk://#diff-4a3433bf0837596726d79d690ea156809c9f57343852d2923528c81eccefa6a0R438-R445) [[3]](diffhunk://#diff-6cbddaf0eb8270698230f3937bf1cf88b2d10991d85d25e4c87dd7c586a98fa3R239-R246) [[4]](diffhunk://#diff-a107bad648c914497414085267e1d69d70a61ca5ced90487522c10a2509f679bR56) [[5]](diffhunk://#diff-b1f6f0214524d16ea065e907b1063b7fe1dabdd3d04c1f8d372e0b47ddbe6221R1743-R1745) [[6]](diffhunk://#diff-ef7d2ccdbec6ee831c0e23b46c8ad2c6778b21b33364a28dd1c665be9556481eR1621-R1623) [[7]](diffhunk://#diff-c4ed082a8d66601cd42c1660d8ea4453d11c073960b37f8400e49149dedcea6eR188-R189)

**API and Documentation Updates**

* Updated OpenAPI (Swagger) documentation and API responses to include the new `recoverable` and `registry` fields, ensuring clients and users are aware of the enhanced recovery capabilities. [[1]](diffhunk://#diff-b1f6f0214524d16ea065e907b1063b7fe1dabdd3d04c1f8d372e0b47ddbe6221R1860-R1862) [[2]](diffhunk://#diff-ef7d2ccdbec6ee831c0e23b46c8ad2c6778b21b33364a28dd1c665be9556481eR1736-R1738) [[3]](diffhunk://#diff-c4ed082a8d66601cd42c1660d8ea4453d11c073960b37f8400e49149dedcea6eR270-R271)

**Runner and Service Logic Changes**

* Both runner adapter versions (`RunnerAdapterV0` and `RunnerAdapterV2`) and the sandbox service now accept registry information for recovery and use the enhanced error deduction logic. [[1]](diffhunk://#diff-01cebc274cb59a89762ceec728c73a82721d2ee19572d57a6ed4b71cf1a549efL110-R111) [[2]](diffhunk://#diff-4a3433bf0837596726d79d690ea156809c9f57343852d2923528c81eccefa6a0L418-R419) [[3]](diffhunk://#diff-6cbddaf0eb8270698230f3937bf1cf88b2d10991d85d25e4c87dd7c586a98fa3L219-R220) [[4]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcR124) [[5]](diffhunk://#diff-e1ec788868f8f3fabe1bdc9807fd61a2555ce967cfd065a07952477a2b1a4c1bR10-R16)

**Storage Expansion Recovery Improvements**

* The recovery logic for storage limit errors now expands storage by 5% of the original quota per attempt (up to 10% total), making recovery more gradual and controlled.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
