### PR TITLE
chore(api): use debian slim instead of alpine for docker image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:22-alpine AS daytona
+FROM node:24-slim AS daytona
 
-# Install nodejs
-RUN apk --update add --no-cache bash curl
+# Install dependencies (apt instead of apk)
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl && \
+  rm -rf /var/lib/apt/lists/*
 RUN npm install -g corepack && corepack enable
 
 WORKDIR /daytona


### PR DESCRIPTION
## Description

Use debian slim instead of alpine for docker image for better performance.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes

Ref:
> Alpine's musl vs glibc. This is an underappreciated one. Alpine uses musl libc instead of glibc. Node.js and its native dependencies (including things like DNS resolution and some crypto operations) can behave differently on musl. DNS resolution in particular is a known pain point — musl's resolver doesn't support the same concurrency and caching behavior as glibc's, which can cause noticeably slower lookups under load. If you're making frequent connections to Redis/Postgres by hostname, this alone could create a measurable difference.

