### PR TITLE
chore: add GONOSUMDB to release workflow env

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ env:
   DAYTONA_AUTH0_CLIENT_SECRET: ${{ secrets.DAYTONA_AUTH0_CLIENT_SECRET }}
   DAYTONA_AUTH0_AUDIENCE: ${{ secrets.DAYTONA_AUTH0_AUDIENCE }}
   POETRY_VIRTUALENVS_IN_PROJECT: true
+  GONOSUMDB: github.com/daytonaio/daytona
 
 jobs:
   publish:


### PR DESCRIPTION
## Description

Added GONOSUMDB to global release workflow env since it fails sometimes due to go cache.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
