### PR TITLE
fix(api): recover recoverable sandboxes in-place when runner is draining

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -480,6 +480,17 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
 
     this.logger.debug(`Found ${recoverableSandboxes.length} recoverable sandboxes on draining runner ${runnerId}`)
 
+    const runner = await this.runnerService.findOneOrFail(runnerId)
+
+    if (runner.apiVersion === '2') {
+      this.logger.debug(
+        `Skipping recovery for sandboxes on draining runner ${runnerId} — not supported for runner API v2`,
+      )
+      return
+    }
+
+    const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+
     await Promise.allSettled(
       recoverableSandboxes.map(async (sandbox) => {
         const redisKey = `draining:recover:${sandbox.id}`
@@ -500,9 +511,6 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         }
 
         try {
-          const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
-          const runnerAdapter = await this.runnerAdapterFactory.create(runner)
-
           await runnerAdapter.recoverSandbox(sandbox)
 
           const updateData: Partial<Sandbox> = {
@@ -515,7 +523,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
 
           await this.sandboxRepository.updateWhere(sandbox.id, {
             updateData,
-            whereCondition: { state: In([SandboxState.ERROR, SandboxState.STOPPED]) },
+            whereCondition: { pending: false, state: sandbox.state },
           })
 
           this.logger.log(`Recovered sandbox ${sandbox.id} on draining runner ${runnerId}`)


### PR DESCRIPTION
## Description

Sandboxes stuck with recoverable: true (disk full) on a draining runner would loop indefinitely — the archive path fails to push the image on a full disk, and backup retry also fails, so migration never happens. This fix excludes recoverable sandboxes from the archive and backup-retry paths, then recovers them in-place by calling recoverSandbox (which expands disk by 5%) and resetting state to STOPPED with recoverable: false and backupState: NONE. Resetting the backup state ensures any prior ERROR is cleared so the normal backup pipeline picks the sandbox up, completing the path to migration.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation