### PR TITLE
docs: add WarpGrep AI code search to file system operations

### DIFF
--- a/apps/docs/src/content/docs/en/file-system-operations.mdx
+++ b/apps/docs/src/content/docs/en/file-system-operations.mdx
@@ -1086,15 +1086,15 @@ For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SD
 >
 > [**move or rename file or directory (API)**](/docs/en/tools/api/#daytona-toolbox/tag/file-system/POST/files/move)
 
-### AI-powered code search with WarpGrep
+### Fast agentic filesystem search by Morph (WarpGrep)
 
-[WarpGrep](https://docs.morphllm.com/sdk/components/warp-grep/tool) is an AI code search tool by [Morph](https://www.morphllm.com), an external company. It runs as an isolated subagent that searches your codebase and returns only the relevant file spans, keeping your primary agent's context clean.
-
-WarpGrep works with Daytona sandboxes through the `remoteCommands` pattern, which wires its search primitives (grep, read, list directory) to commands executed inside your sandbox.
+[WarpGrep](https://docs.morphllm.com/sdk/components/warp-grep/tool) by [Morph](https://www.morphllm.com) is an RL-trained search subagent for codebases. Instead of your primary agent searching files directly, WarpGrep searches in an isolated context and returns only the relevant file spans.
 
 :::note
-WarpGrep requires a Morph API key. Get one at [morphllm.com/dashboard](https://www.morphllm.com/dashboard).
+WarpGrep is a third-party service. Get an API key at [morphllm.com/dashboard](https://www.morphllm.com/dashboard).
 :::
+
+Connect WarpGrep to a Daytona sandbox using `remoteCommands`:
 
 <Tabs syncKey="language">
 <TabItem label="TypeScript" icon="seti:typescript">
@@ -1110,18 +1110,21 @@ const warpGrep = createWarpGrepTool({
   apiKey: process.env.MORPH_API_KEY,
   remoteCommands: {
     grep: async (pattern, path, flags) => {
-      const cmd = `rg --line-number --no-heading --color never ${flags ?? ''} '${pattern}' '${path}'`
-      const res = await sandbox.process.executeCommand(cmd)
+      const res = await sandbox.process.executeCommand(
+        `rg --line-number --no-heading --color never ${flags ?? ''} '${pattern}' '${path}'`
+      )
       return res.result
     },
     read: async (filePath, startLine, endLine) => {
-      const cmd = `sed -n '${startLine},${endLine}p' '${filePath}'`
-      const res = await sandbox.process.executeCommand(cmd)
+      const res = await sandbox.process.executeCommand(
+        `sed -n '${startLine},${endLine}p' '${filePath}'`
+      )
       return res.result
     },
     listDir: async (dirPath, maxDepth) => {
-      const cmd = `find '${dirPath}' -maxdepth ${maxDepth} -not -path '*/.git/*' -not -path '*/node_modules/*'`
-      const res = await sandbox.process.executeCommand(cmd)
+      const res = await sandbox.process.executeCommand(
+        `find '${dirPath}' -maxdepth ${maxDepth} -not -path '*/.git/*' -not -path '*/node_modules/*'`
+      )
       return res.result
     },
   },
@@ -1133,50 +1136,36 @@ const warpGrep = createWarpGrepTool({
 </TabItem>
 <TabItem label="Python" icon="seti:python">
 
-WarpGrep can be used from Python via the [direct API protocol](https://docs.morphllm.com/sdk/components/warp-grep/direct). Execute tool calls inside the Daytona sandbox and send results back to the Morph API.
-
 ```python
 import os
-import requests
-
 from daytona import Daytona
+from morphllm import MorphClient
 
 daytona = Daytona()
 sandbox = daytona.create()
 
-MORPH_API_KEY = os.environ["MORPH_API_KEY"]
+morph = MorphClient(api_key=os.environ["MORPH_API_KEY"])
 
-# Generate repo structure from sandbox
-tree_result = sandbox.process.exec(
-    "find . -maxdepth 2 -not -path '*/.git/*' -not -path '*/node_modules/*'"
-)
-
-# Send initial query to WarpGrep
-response = requests.post(
-    "https://api.morphllm.com/v1/chat/completions",
-    headers={"Authorization": f"Bearer {MORPH_API_KEY}"},
-    json={
-        "model": "morph-warp-grep-v2",
-        "messages": [
-            {
-                "role": "user",
-                "content": (
-                    f"<repo_structure>{tree_result.result}</repo_structure>\n"
-                    f"<search_string>Find the authentication middleware</search_string>"
-                ),
-            }
-        ],
-        "temperature": 0.0,
-        "max_tokens": 2048,
+result = morph.warp_grep.search(
+    query="Find the authentication middleware",
+    remote_commands={
+        "grep": lambda pattern, path, flags="": sandbox.process.exec(
+            f"rg --line-number --no-heading --color never {flags} '{pattern}' '{path}'"
+        ).result,
+        "read": lambda path, start, end: sandbox.process.exec(
+            f"sed -n '{start},{end}p' '{path}'"
+        ).result,
+        "list_dir": lambda path, max_depth: sandbox.process.exec(
+            f"find '{path}' -maxdepth {max_depth} -not -path '*/.git/*' -not -path '*/node_modules/*'"
+        ).result,
     },
 )
 
-# Parse tool calls from response, execute them in the sandbox,
-# and continue the multi-turn loop (max 4 turns) until finish is called.
-# See: https://docs.morphllm.com/sdk/components/warp-grep/direct
+for file in result.files:
+    print(f"{file.path}:{file.lines}")
 ```
 
 </TabItem>
 </Tabs>
 
-For more information, see the [WarpGrep Tool SDK](https://docs.morphllm.com/sdk/components/warp-grep/tool) and [Direct API](https://docs.morphllm.com/sdk/components/warp-grep/direct) references.
+For more details, see the [WarpGrep SDK docs](https://docs.morphllm.com/sdk/components/warp-grep/tool) and [Direct API reference](https://docs.morphllm.com/sdk/components/warp-grep/direct).


### PR DESCRIPTION
## Summary
- Adds a new AI-powered code search with WarpGrep section under Advanced operations in the file system operations docs
- Shows how to wire WarpGrep remoteCommands to Daytona sandbox command execution
- Includes TypeScript SDK example and Python direct API example
- Notes that Morph (https://www.morphllm.com) is an external company with a link to get an API key at https://www.morphllm.com/dashboard

## References
- WarpGrep Tool SDK docs: https://docs.morphllm.com/sdk/components/warp-grep/tool
- WarpGrep Direct API docs: https://docs.morphllm.com/sdk/components/warp-grep/direct