### PR TITLE
fix(api): allow get by id for general snapshots

### DIFF
--- a/apps/api/src/sandbox/controllers/snapshot.controller.ts
+++ b/apps/api/src/sandbox/controllers/snapshot.controller.ts
@@ -41,6 +41,7 @@ import { CreateSnapshotDto } from '../dto/create-snapshot.dto'
 import { SnapshotDto } from '../dto/snapshot.dto'
 import { PaginatedSnapshotsDto } from '../dto/paginated-snapshots.dto'
 import { SnapshotAccessGuard } from '../guards/snapshot-access.guard'
+import { SnapshotReadAccessGuard } from '../guards/snapshot-read-access.guard'
 import { CustomHeaders } from '../../common/constants/header.constants'
 import { AuthContext } from '../../common/decorators/auth-context.decorator'
 import { OrganizationAuthContext } from '../../common/interfaces/auth-context.interface'
@@ -178,7 +179,7 @@ export class SnapshotController {
     status: 404,
     description: 'Snapshot not found',
   })
-  @UseGuards(SnapshotAccessGuard)
+  @UseGuards(SnapshotReadAccessGuard)
   async getSnapshot(
     @Param('id') snapshotIdOrName: string,
     @AuthContext() authContext: OrganizationAuthContext,

--- a/apps/api/src/sandbox/guards/snapshot-read-access.guard.ts
+++ b/apps/api/src/sandbox/guards/snapshot-read-access.guard.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common'
+import { SnapshotService } from '../services/snapshot.service'
+import {
+  BaseAuthContext,
+  isOrganizationAuthContext,
+  OrganizationAuthContext,
+} from '../../common/interfaces/auth-context.interface'
+import { SystemRole } from '../../user/enums/system-role.enum'
+import { Snapshot } from '../entities/snapshot.entity'
+import { isSshGatewayContext } from '../../common/interfaces/ssh-gateway-context.interface'
+import { isProxyContext } from '../../common/interfaces/proxy-context.interface'
+import { isRegionProxyContext, RegionProxyContext } from '../../common/interfaces/region-proxy.interface'
+import {
+  isRegionSSHGatewayContext,
+  RegionSSHGatewayContext,
+} from '../../common/interfaces/region-ssh-gateway.interface'
+
+@Injectable()
+export class SnapshotReadAccessGuard implements CanActivate {
+  constructor(private readonly snapshotService: SnapshotService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest()
+    const snapshotId: string = request.params.snapshotId || request.params.id
+
+    let snapshot: Snapshot
+
+    const authContext: BaseAuthContext = request.user
+
+    try {
+      snapshot = await this.snapshotService.getSnapshot(snapshotId)
+    } catch {
+      if (!isOrganizationAuthContext(authContext)) {
+        throw new NotFoundException(`Snapshot with ID ${snapshotId} not found`)
+      }
+
+      snapshot = await this.snapshotService.getSnapshotByName(snapshotId, authContext.organizationId)
+    }
+
+    try {
+      switch (true) {
+        case isRegionProxyContext(authContext):
+        case isRegionSSHGatewayContext(authContext): {
+          const regionContext = authContext as RegionProxyContext | RegionSSHGatewayContext
+          const isAvailable = await this.snapshotService.isAvailableInRegion(snapshot.id, regionContext.regionId)
+          if (!isAvailable) {
+            throw new NotFoundException(`Snapshot is not available in region ${regionContext.regionId}`)
+          }
+          break
+        }
+        case isProxyContext(authContext):
+        case isSshGatewayContext(authContext):
+          break
+        default: {
+          const orgAuthContext = authContext as OrganizationAuthContext
+          if (
+            orgAuthContext.role !== SystemRole.ADMIN &&
+            snapshot.organizationId !== orgAuthContext.organizationId &&
+            !snapshot.general
+          ) {
+            throw new ForbiddenException('Request organization ID does not match resource organization ID')
+          }
+        }
+      }
+
+      request.snapshot = snapshot
+
+      return true
+    } catch (error) {
+      if (!(error instanceof NotFoundException)) {
+        console.error(error)
+      }
+      throw new NotFoundException(`Snapshot with ID or name ${snapshotId} not found`)
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new guard to improve access control for reading snapshots in the API.

**Access control improvements:**

* Added a new `SnapshotReadAccessGuard` in `snapshot-read-access.guard.ts`, implementing detailed logic to verify snapshot read permissions based on the user's authentication context, organization, and region. This includes checks for region and proxy contexts, organization roles, and snapshot availability.
* Updated the `SnapshotController` to use the new `SnapshotReadAccessGuard` instead of the previous `SnapshotAccessGuard` for the `getSnapshot` endpoint, ensuring that the improved access logic is enforced when retrieving snapshots.
* Imported the new guard in `snapshot.controller.ts` to support its usage in the controller.