### PR TITLE
fix(runner): exponential backoff for docker info on init

### DIFF
--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -10,8 +10,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/daytonaio/common-go/pkg/utils"
 	"github.com/daytonaio/runner/pkg/cache"
 	"github.com/daytonaio/runner/pkg/netrules"
+	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
 )
 
@@ -58,7 +60,19 @@ func NewDockerClient(config DockerClientConfig) (*DockerClient, error) {
 		config.BackupTimeoutMin = 60
 	}
 
-	info, err := config.ApiClient.Info(context.Background())
+	var info system.Info
+	err := utils.RetryWithExponentialBackoff(
+		context.Background(),
+		"get Docker info",
+		8,
+		1*time.Second,
+		5*time.Second,
+		func() error {
+			var infoErr error
+			info, infoErr = config.ApiClient.Info(context.Background())
+			return infoErr
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Docker info: %w", err)
 	}


### PR DESCRIPTION
## Description

Added an exponential backoff for fetching docker info on runner init.

This caused a race condition in the runner container which would fail to lift the container if dockerd wasn't started in time.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

Closes #3957
