### PR TITLE
feat(docs): add vulnerability disclosure program to security exhibit

### DIFF
--- a/apps/docs/src/content/docs/en/security-exhibit.mdx
+++ b/apps/docs/src/content/docs/en/security-exhibit.mdx
@@ -105,6 +105,10 @@ Container images are built from minimal base images and scanned for vulnerabilit
 
 Daytona completes penetration testing at least annually, conducted by a recognized independent third party. Testing scope includes the Daytona platform, APIs, sandbox isolation mechanisms, and control plane. A summary of test results and remediation status is available to Customers upon request.
 
+### Vulnerability disclosure program
+
+Daytona welcomes contributions from the security community to identify and responsibly disclose vulnerabilities in its platform. Daytona maintains a public Vulnerability Disclosure Policy with defined scope, exclusions, safe harbor protections, and coordinated disclosure timelines. Rewards ranging from $100 to $1,000 are offered for valid, original findings based on severity, exploitability, and report quality. Reports should be submitted to [security@daytona.io](mailto:security@daytona.io). Full program details are published in Daytona's [Security Policy](https://github.com/daytonaio/daytona/blob/main/SECURITY.md).
+
 ## Compliance and certifications
 
 Daytona pursues and maintains industry-recognized compliance certifications to demonstrate its commitment to security and data protection.


### PR DESCRIPTION
## Summary

- Adds a **Vulnerability disclosure program** subsection to the security exhibit, placed after "Penetration testing" and before "Compliance and certifications"
- References the public [SECURITY.md](https://github.com/daytonaio/daytona/blob/main/SECURITY.md) for full program details (scope, exclusions, safe harbor, disclosure timelines)
- Documents the reward range ($100–$1,000) and reporting channel (security@daytona.io)

## Context

PR #4003 established the detailed VDP in `SECURITY.md`. The security exhibit — which supplements the ToS and DPA — should reference this program to provide a complete picture of Daytona's external security validation practices.

## Verification

- [x] Section placement is correct (after penetration testing, before compliance)
- [x] Tone matches the exhibit's formal, audit-defensible voice
- [x] All claims verifiable against SECURITY.md
- [x] No scope/exclusion/safe harbor details duplicated — defers to SECURITY.md