### PR TITLE
feat(cli): Improved exec parsing & added --tty

### DIFF
--- a/apps/cli/cmd/sandbox/exec.go
+++ b/apps/cli/cmd/sandbox/exec.go
@@ -5,21 +5,24 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/toolbox"
+	apiclient_go "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
 
 var ExecCmd = &cobra.Command{
-	Use:   "exec [SANDBOX_ID | SANDBOX_NAME] -- [COMMAND] [ARGS...]",
+	Use:   "exec [SANDBOX_ID | SANDBOX_NAME] [flags] -- COMMAND [ARGS...]",
 	Short: "Execute a command in a sandbox",
-	Long:  "Execute a command in a running sandbox",
-	Args:  cobra.MinimumNArgs(2),
+	Long:  "Execute a command in a running sandbox.\n\nFlags must be specified before -- which separates the sandbox identifier from the command to run.",
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
@@ -28,10 +31,23 @@ var ExecCmd = &cobra.Command{
 			return err
 		}
 
-		sandboxIdOrName := args[0]
+		// cmd.ArgsLenAtDash() returns the number of args before "--", or -1 if "--" was not used.
+		// Cobra consumes "--" itself, so we cannot search for it in args directly.
+		dashIndex := cmd.ArgsLenAtDash()
 
-		// Find the command args after "--"
-		commandArgs := args[1:]
+		if dashIndex == -1 {
+			return fmt.Errorf("use -- to separate the sandbox from the command: exec SANDBOX -- COMMAND [ARGS...]")
+		}
+		if dashIndex == 0 {
+			return fmt.Errorf("sandbox ID or name is required: exec SANDBOX -- COMMAND [ARGS...]")
+		}
+		if dashIndex > 1 {
+			return fmt.Errorf("unexpected arguments before --: only one sandbox ID or name is allowed")
+		}
+
+		sandboxIdOrName := args[0]
+		commandArgs := args[dashIndex:]
+
 		if len(commandArgs) == 0 {
 			return fmt.Errorf("no command specified")
 		}
@@ -48,49 +64,153 @@ var ExecCmd = &cobra.Command{
 
 		toolboxClient := toolbox.NewClient(apiClient)
 
-		command := strings.Join(commandArgs, " ")
-
-		executeRequest := toolbox.ExecuteRequest{
-			Command: command,
-		}
-		if execCwd != "" {
-			executeRequest.Cwd = &execCwd
-		}
-		if execTimeout > 0 {
-			timeout := float32(execTimeout)
-			executeRequest.Timeout = &timeout
+		// If TTY mode is enabled, use interactive TTY execution
+		if execTTY {
+			return executeTTY(ctx, toolboxClient, sandbox, commandArgs)
 		}
 
-		// Execute the command via toolbox
-		response, err := toolboxClient.ExecuteCommand(ctx, sandbox, executeRequest)
-		if err != nil {
-			return err
-		}
-
-		// Print the output (stdout + stderr combined)
-		if response.Result != "" {
-			fmt.Print(response.Result)
-		}
-
-		// Exit with the command's exit code
-		exitCode := int(response.ExitCode)
-		if exitCode != 0 {
-			if response.Result == "" {
-				fmt.Fprintf(os.Stderr, "Command failed with exit code %d\n", exitCode)
-			}
-			os.Exit(exitCode)
-		}
-
-		return nil
+		// Otherwise use regular command execution
+		return executeRegular(ctx, toolboxClient, sandbox, commandArgs)
 	},
+}
+
+func executeRegular(ctx context.Context, toolboxClient *toolbox.Client, sandbox *apiclient_go.Sandbox, commandArgs []string) error {
+	// Build command from args
+	command := buildCommand(commandArgs)
+
+	executeRequest := toolbox.ExecuteRequest{
+		Command: command,
+	}
+	if execCwd != "" {
+		executeRequest.Cwd = &execCwd
+	}
+	if execTimeout > 0 {
+		timeout := float32(execTimeout)
+		executeRequest.Timeout = &timeout
+	}
+
+	// Execute the command via toolbox
+	response, err := toolboxClient.ExecuteCommand(ctx, sandbox, executeRequest)
+	if err != nil {
+		return err
+	}
+
+	// Print the output (stdout + stderr combined)
+	if response.Result != "" {
+		fmt.Print(response.Result)
+	}
+
+	// Exit with the command's exit code
+	exitCode := int(response.ExitCode)
+	if exitCode != 0 {
+		if response.Result == "" {
+			fmt.Fprintf(os.Stderr, "Command failed with exit code %d\n", exitCode)
+		}
+		os.Exit(exitCode)
+	}
+
+	return nil
+}
+
+func executeTTY(ctx context.Context, toolboxClient *toolbox.Client, sandbox *apiclient_go.Sandbox, commandArgs []string) error {
+	sessionID := fmt.Sprintf("exec-%d", time.Now().UnixNano())
+
+	executeRequest := toolbox.PTYCreateRequest{
+		ID: sessionID,
+	}
+
+	if len(commandArgs) > 0 {
+		cmd := commandArgs[0]
+		executeRequest.Command = &cmd
+		if len(commandArgs) > 1 {
+			executeRequest.Args = commandArgs[1:]
+		}
+	}
+
+	if execCwd != "" {
+		executeRequest.Cwd = execCwd
+	}
+	if execTimeout > 0 {
+		timeout := uint32(execTimeout)
+		executeRequest.Timeout = &timeout
+	}
+
+	// Execute the command via PTY
+	err := toolboxClient.ExecuteCommandTTY(ctx, sandbox, executeRequest)
+	// If the remote process exited with a non-zero code, propagate it cleanly.
+	// By the time we reach here, connectAndStreamTTY has already returned, so
+	// defer term.Restore has run and the terminal is in its original state.
+	var exitErr *toolbox.ExitCodeError
+	if errors.As(err, &exitErr) {
+		os.Exit(exitErr.Code)
+	}
+	return err
 }
 
 var (
 	execCwd     string
+	execTTY     bool
 	execTimeout int
 )
+
+// quoteArg applies quoting rules so that parseCommand on the daemon side can
+// re-split the command string back into the original argument slice.
+func quoteArg(arg string) string {
+	if strings.ContainsAny(arg, " \t'\"") {
+		if !strings.Contains(arg, "'") {
+			return "'" + arg + "'"
+		}
+		// Fall back to double-quote wrapping, escaping any internal double quotes.
+		escaped := strings.ReplaceAll(arg, `"`, `\"`)
+		return `"` + escaped + `"`
+	}
+	return arg
+}
+
+// buildCommand reconstructs the command string from args with proper quoting.
+// For shell -c commands, only args[2] is treated as the script; any remaining
+// args (which become $0, $1, … inside the script) are preserved as separate
+// argv entries.
+// For regular commands, arguments that contain whitespace or quotes are quoted
+// so that parseCommand on the daemon side re-splits them correctly.
+func buildCommand(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	// For shell -c commands, wrap only the script argument (args[2]) in single
+	// quotes so that parseCommand on the daemon reconstructs the correct argv:
+	//   [shell, "-c", script, arg0, arg1, ...]
+	// Single quotes inside the script are escaped using the POSIX idiom: ' → '\''
+	if len(args) >= 3 && args[1] == "-c" {
+		cmdParts := make([]string, 0, len(args))
+		cmdParts = append(cmdParts, args[0], args[1])
+
+		// Script argument gets special single-quote wrapping.
+		escapedScript := strings.ReplaceAll(args[2], "'", `'\''`)
+		cmdParts = append(cmdParts, "'"+escapedScript+"'")
+
+		// Additional arguments after the script are preserved as separate
+		// argv entries, using the normal quoting rules.
+		for _, arg := range args[3:] {
+			cmdParts = append(cmdParts, quoteArg(arg))
+		}
+
+		return strings.Join(cmdParts, " ")
+	}
+
+	// For regular commands, quote arguments that contain whitespace or quote
+	// characters so that parseCommand re-splits them correctly and does not
+	// misinterpret unquoted quote characters as starting a quoted segment.
+	quotedArgs := make([]string, len(args))
+	for i, arg := range args {
+		quotedArgs[i] = quoteArg(arg)
+	}
+	return strings.Join(quotedArgs, " ")
+}
 
 func init() {
 	ExecCmd.Flags().StringVar(&execCwd, "cwd", "", "Working directory for command execution")
 	ExecCmd.Flags().IntVar(&execTimeout, "timeout", 0, "Command timeout in seconds (0 for no timeout)")
+	ExecCmd.Flags().BoolVar(&execTTY, "tty", false, "Enable TTY mode for interactive commands")
 }

--- a/apps/cli/cmd/sandbox/exec_test.go
+++ b/apps/cli/cmd/sandbox/exec_test.go
@@ -1,0 +1,247 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandConstruction(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		contains string
+	}{
+		{
+			name:     "simple command",
+			args:     []string{"echo", "hello"},
+			contains: "echo hello",
+		},
+		{
+			name:     "shell command with -c",
+			args:     []string{"sh", "-c", "echo hello && echo world"},
+			contains: "sh -c echo hello && echo world",
+		},
+		{
+			name:     "command with multiple args",
+			args:     []string{"ls", "-la", "/tmp"},
+			contains: "ls -la /tmp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test that command construction logic would work
+			if len(tt.args) >= 3 && tt.args[1] == "-c" {
+				// Shell -c case
+				parts := []string{tt.args[0], tt.args[1]}
+				cmdPart := strings.Join(tt.args[2:], " ")
+				result := strings.Join(append(parts, cmdPart), " ")
+				assert.Contains(t, result, tt.contains)
+			} else {
+				// Regular case
+				result := strings.Join(tt.args, " ")
+				assert.Contains(t, result, tt.contains)
+			}
+		})
+	}
+}
+
+func TestBuildCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "simple command no quoting needed",
+			args:     []string{"echo", "hello"},
+			expected: "echo hello",
+		},
+		{
+			name:     "arg with spaces uses single quotes",
+			args:     []string{"echo", "hello world"},
+			expected: "echo 'hello world'",
+		},
+		{
+			name:     "arg with single quote but no spaces uses double quotes",
+			args:     []string{"echo", "O'Brien"},
+			expected: `echo "O'Brien"`,
+		},
+		{
+			name:     "arg with double quote but no spaces uses single quotes",
+			args:     []string{"echo", `say"hello"`},
+			expected: `echo 'say"hello"'`,
+		},
+		{
+			name:     "shell -c script without quotes",
+			args:     []string{"sh", "-c", "echo hello && echo world"},
+			expected: "sh -c 'echo hello && echo world'",
+		},
+		{
+			name:     "shell -c script with single quote uses POSIX escape idiom",
+			args:     []string{"sh", "-c", "echo O'Brien"},
+			expected: `sh -c 'echo O'\''Brien'`,
+		},
+		{
+			name:     "shell -c script with multiple single quotes",
+			args:     []string{"sh", "-c", "echo 'hello' 'world'"},
+			expected: `sh -c 'echo '\''hello'\'' '\''world'\'''`,
+		},
+		{
+			name:     "shell -c with extra positional args preserves argv",
+			args:     []string{"sh", "-c", "echo $0 $1", "hello", "world"},
+			expected: "sh -c 'echo $0 $1' hello world",
+		},
+		{
+			name:     "shell -c with extra args needing quoting",
+			args:     []string{"sh", "-c", "echo $0", "hello world"},
+			expected: "sh -c 'echo $0' 'hello world'",
+		},
+		{
+			name:     "empty args returns empty string",
+			args:     []string{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildCommand(tt.args)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExecFlagBehavior(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		expectTTY bool
+		expectCwd bool
+	}{
+		{
+			name:      "basic exec without flags",
+			args:      []string{"--tty=false", "sandbox-id", "echo", "hello"},
+			expectTTY: false,
+			expectCwd: false,
+		},
+		{
+			name:      "exec with --tty flag",
+			args:      []string{"--tty", "sandbox-id", "bash"},
+			expectTTY: true,
+			expectCwd: false,
+		},
+		{
+			name:      "exec with --cwd flag",
+			args:      []string{"--cwd", "/tmp", "sandbox-id", "ls"},
+			expectTTY: false,
+			expectCwd: true,
+		},
+		{
+			name:      "exec with multiple flags",
+			args:      []string{"--cwd", "/tmp", "--tty", "--timeout", "30", "sandbox-id", "bash"},
+			expectTTY: true,
+			expectCwd: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Cobra strips -- before RunE; verify flags are present in the raw CLI args
+			hasTTY := contains(tt.args, "--tty")
+			hasCwd := contains(tt.args, "--cwd")
+
+			assert.Equal(t, tt.expectTTY, hasTTY)
+			assert.Equal(t, tt.expectCwd, hasCwd)
+		})
+	}
+}
+
+// TestArgsLenAtDash simulates how Cobra passes args to RunE after consuming "--".
+// Cobra strips "--" and sets ArgsLenAtDash to the count of args before it.
+func TestArgsLenAtDash(t *testing.T) {
+	tests := []struct {
+		name              string
+		argsAfterCobra    []string // what Cobra passes to RunE (-- is stripped)
+		argsLenAtDash     int      // what cmd.ArgsLenAtDash() returns (-1 = no --)
+		expectSandbox     string
+		expectCmds        []string
+		expectErr         bool
+	}{
+		{
+			name:           "sandbox and command separated by --",
+			argsAfterCobra: []string{"sandbox-id", "echo", "hello", "world"},
+			argsLenAtDash:  1,
+			expectSandbox:  "sandbox-id",
+			expectCmds:     []string{"echo", "hello", "world"},
+		},
+		{
+			name:           "sandbox and multi-arg command",
+			argsAfterCobra: []string{"sandbox-id", "bash", "-i"},
+			argsLenAtDash:  1,
+			expectSandbox:  "sandbox-id",
+			expectCmds:     []string{"bash", "-i"},
+		},
+		{
+			name:           "no -- separator used",
+			argsAfterCobra: []string{"sandbox-id", "vim"},
+			argsLenAtDash:  -1,
+			expectErr:      true,
+		},
+		{
+			name:           "-- used but no sandbox ID before it",
+			argsAfterCobra: []string{"vim"},
+			argsLenAtDash:  0,
+			expectErr:      true,
+		},
+		{
+			name:           "-- used but no command after it",
+			argsAfterCobra: []string{"sandbox-id"},
+			argsLenAtDash:  1,
+			expectSandbox:  "sandbox-id",
+			expectCmds:     []string{},
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dashIndex := tt.argsLenAtDash
+
+			if dashIndex == -1 {
+				assert.True(t, tt.expectErr, "should error when no -- used")
+				return
+			}
+			if dashIndex == 0 {
+				assert.True(t, tt.expectErr, "should error when no sandbox ID before --")
+				return
+			}
+
+			sandboxId := tt.argsAfterCobra[0]
+			commandArgs := tt.argsAfterCobra[dashIndex:]
+
+			assert.Equal(t, tt.expectSandbox, sandboxId)
+
+			if tt.expectErr {
+				assert.Empty(t, commandArgs)
+			} else {
+				assert.Equal(t, tt.expectCmds, commandArgs)
+			}
+		})
+	}
+}
+
+// Helper function
+func contains(slice []string, item string) bool {
+	for _, v := range slice {
+		if v == item {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/charmbracelet/bubbletea v1.1.0
 	github.com/daytonaio/daytona/libs/api-client-go v0.150.0
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/gorilla/websocket v1.5.3
 	github.com/mark3labs/mcp-go v0.32.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.34.0
 )
 

--- a/apps/cli/toolbox/toolbox.go
+++ b/apps/cli/toolbox/toolbox.go
@@ -7,24 +7,60 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/daytonaio/daytona/cli/config"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/gorilla/websocket"
+	"golang.org/x/term"
 )
+
+// ExitCodeError is returned when the remote TTY process exits with a non-zero exit code.
+// It carries the exit code so callers can propagate it without printing an error message.
+type ExitCodeError struct {
+	Code int
+}
+
+func (e *ExitCodeError) Error() string {
+	return fmt.Sprintf("exit code %d", e.Code)
+}
 
 type ExecuteRequest struct {
 	Command string   `json:"command"`
 	Cwd     *string  `json:"cwd,omitempty"`
 	Timeout *float32 `json:"timeout,omitempty"`
+	TTY     *bool    `json:"tty,omitempty"`
 }
 
 type ExecuteResponse struct {
 	ExitCode float32 `json:"exitCode"`
 	Result   string  `json:"result"`
+}
+
+// PTYCreateRequest mirrors the daemon's PTYCreateRequest for the /process/pty endpoint.
+type PTYCreateRequest struct {
+	ID      string            `json:"id"`
+	Command *string           `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Cwd     string            `json:"cwd,omitempty"`
+	Timeout *uint32           `json:"timeout,omitempty"`
+	Cols    *uint16           `json:"cols,omitempty"`
+	Rows    *uint16           `json:"rows,omitempty"`
+	Envs    map[string]string `json:"envs,omitempty"`
+}
+
+// PTYCreateResponse is the response from creating a PTY session.
+type PTYCreateResponse struct {
+	SessionID string `json:"sessionId"`
 }
 
 type Client struct {
@@ -57,6 +93,35 @@ func (c *Client) getProxyURL(ctx context.Context, sandboxId, region string) (str
 	return toolboxProxyUrl.Url, nil
 }
 
+// defaultHTTPTimeout is used for all outbound HTTP requests to the daemon.
+const defaultHTTPTimeout = 30 * time.Second
+
+// getAuthHeaders reads the active profile from config once and returns the
+// corresponding HTTP headers (Authorization + optional Org ID). Callers should
+// call this once per user-facing operation and pass the resulting headers down
+// to avoid redundant config file reads.
+func getAuthHeaders() (http.Header, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config: %w", err)
+	}
+	activeProfile, err := cfg.GetActiveProfile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active profile: %w", err)
+	}
+
+	h := http.Header{}
+	if activeProfile.Api.Key != nil {
+		h.Set("Authorization", "Bearer "+*activeProfile.Api.Key)
+	} else if activeProfile.Api.Token != nil {
+		h.Set("Authorization", "Bearer "+activeProfile.Api.Token.AccessToken)
+	}
+	if activeProfile.ActiveOrganizationId != nil {
+		h.Set("X-Daytona-Organization-ID", *activeProfile.ActiveOrganizationId)
+	}
+	return h, nil
+}
+
 func (c *Client) ExecuteCommand(ctx context.Context, sandbox *apiclient.Sandbox, request ExecuteRequest) (*ExecuteResponse, error) {
 	proxyURL, err := c.getProxyURL(ctx, sandbox.Id, sandbox.Target)
 	if err != nil {
@@ -83,27 +148,15 @@ func (c *Client) executeCommandViaProxy(ctx context.Context, proxyURL, sandboxId
 
 	req.Header.Set("Content-Type", "application/json")
 
-	cfg, err := config.GetConfig()
+	auth, err := getAuthHeaders()
 	if err != nil {
 		return nil, err
 	}
-
-	activeProfile, err := cfg.GetActiveProfile()
-	if err != nil {
-		return nil, err
+	for k, v := range auth {
+		req.Header[k] = v
 	}
 
-	if activeProfile.Api.Key != nil {
-		req.Header.Set("Authorization", "Bearer "+*activeProfile.Api.Key)
-	} else if activeProfile.Api.Token != nil {
-		req.Header.Set("Authorization", "Bearer "+activeProfile.Api.Token.AccessToken)
-	}
-
-	if activeProfile.ActiveOrganizationId != nil {
-		req.Header.Set("X-Daytona-Organization-ID", *activeProfile.ActiveOrganizationId)
-	}
-
-	client := &http.Client{}
+	client := &http.Client{Timeout: defaultHTTPTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
@@ -125,4 +178,282 @@ func (c *Client) executeCommandViaProxy(ctx context.Context, proxyURL, sandboxId
 	}
 
 	return &response, nil
+}
+
+// ExecuteCommandTTY creates a PTY session for the given command and streams it interactively.
+func (c *Client) ExecuteCommandTTY(ctx context.Context, sandbox *apiclient.Sandbox, request PTYCreateRequest) error {
+	proxyURL, err := c.getProxyURL(ctx, sandbox.Id, sandbox.Target)
+	if err != nil {
+		return err
+	}
+
+	// Load auth headers once and reuse across all sub-calls.
+	auth, err := getAuthHeaders()
+	if err != nil {
+		return err
+	}
+
+	// Create PTY session
+	sessionID, err := c.createPTYSession(ctx, proxyURL, sandbox.Id, request, auth)
+	if err != nil {
+		return err
+	}
+
+	// Best-effort cleanup when the session ends.
+	defer c.deletePTYSession(proxyURL, sandbox.Id, sessionID, auth)
+
+	// Connect to the session as an interactive terminal
+	return c.connectAndStreamPTY(ctx, proxyURL, sandbox.Id, sessionID, auth)
+}
+
+// createPTYSession creates a new PTY session via the daemon's /process/pty endpoint.
+func (c *Client) createPTYSession(ctx context.Context, proxyURL, sandboxId string, request PTYCreateRequest, auth http.Header) (string, error) {
+	url := fmt.Sprintf("%s/%s/process/pty", strings.TrimSuffix(proxyURL, "/"), sandboxId)
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range auth {
+		req.Header[k] = v
+	}
+
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to create PTY session: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("failed to create PTY session: status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var response PTYCreateResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return "", fmt.Errorf("failed to parse PTY session response: %w", err)
+	}
+
+	return response.SessionID, nil
+}
+
+// connectAndStreamPTY connects to a PTY session via WebSocket and streams stdin/stdout.
+func (c *Client) connectAndStreamPTY(ctx context.Context, proxyURL, sandboxId, sessionID string, auth http.Header) error {
+	base := strings.TrimSuffix(proxyURL, "/")
+	wsBase := strings.Replace(base, "https://", "wss://", 1)
+	wsBase = strings.Replace(wsBase, "http://", "ws://", 1)
+
+	wsURL := fmt.Sprintf("%s/%s/process/pty/%s/connect", wsBase, sandboxId, sessionID)
+
+	// Dial WebSocket
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 30 * time.Second,
+	}
+	ws, _, err := dialer.DialContext(ctx, wsURL, auth)
+	if err != nil {
+		return fmt.Errorf("failed to connect to PTY session: %w", err)
+	}
+	defer ws.Close()
+
+	// Ensure stdin and stdout are attached to a TTY before enabling raw mode.
+	stdinFd := int(os.Stdin.Fd())
+	stdoutFd := int(os.Stdout.Fd())
+	if !term.IsTerminal(stdinFd) || !term.IsTerminal(stdoutFd) {
+		return fmt.Errorf("--tty requires an interactive terminal on both stdin and stdout (are you piping input or running in CI?)")
+	}
+
+	// Set up raw terminal mode
+	oldState, err := term.MakeRaw(stdinFd)
+	if err != nil {
+		return fmt.Errorf("failed to setup terminal: %w", err)
+	}
+	defer term.Restore(stdinFd, oldState)
+
+	// Get initial terminal size and send to server
+	cols, rows, err := term.GetSize(stdoutFd)
+	if err != nil {
+		cols = 80
+		rows = 24
+	}
+	if err := c.resizePTYSession(ctx, proxyURL, sandboxId, sessionID, uint16(cols), uint16(rows), auth); err != nil {
+		slog.Debug("initial PTY resize failed", "error", err)
+	}
+
+	// Handle terminal resizing (platform-specific: SIGWINCH on Unix, no-op on Windows)
+	stopResizeHandler := setupResizeHandler(ctx, proxyURL, sandboxId, sessionID, c, auth)
+	defer stopResizeHandler()
+
+	done := make(chan error, 2)
+
+	// Handle termination signals.
+	intChan := make(chan os.Signal, 1)
+	signal.Notify(intChan, syscall.SIGINT, syscall.SIGTERM)
+	defer func() {
+		signal.Stop(intChan)
+		close(intChan)
+	}()
+	go func() {
+		if sig, ok := <-intChan; ok {
+			switch sig {
+			case syscall.SIGINT:
+				ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
+				_ = ws.WriteMessage(websocket.BinaryMessage, []byte{3})
+			case syscall.SIGTERM:
+				_ = ws.Close()
+			}
+		}
+	}()
+
+	// Read from stdin and write to WebSocket.
+	quit := make(chan struct{})
+	go func() {
+		buffer := make([]byte, 4096)
+		for {
+			n, err := os.Stdin.Read(buffer)
+			if err != nil {
+				if err != io.EOF {
+					select {
+					case done <- err:
+					default:
+					}
+				}
+				return
+			}
+			if n > 0 {
+				select {
+				case <-quit:
+					return
+				default:
+				}
+				data := make([]byte, n)
+				copy(data, buffer[:n])
+				ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
+				if err := ws.WriteMessage(websocket.BinaryMessage, data); err != nil {
+					select {
+					case done <- err:
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	// Read from WebSocket and write to stdout.
+	// The existing PTY sends exit codes via WebSocket close frames (not text control messages).
+	go func() {
+		for {
+			msgType, data, err := ws.ReadMessage()
+			if err != nil {
+				// Check for WebSocket close frame carrying exit code info.
+				var closeErr *websocket.CloseError
+				if errors.As(err, &closeErr) {
+					var closeData struct {
+						ExitCode int `json:"exitCode"`
+					}
+					if jsonErr := json.Unmarshal([]byte(closeErr.Text), &closeData); jsonErr == nil && closeData.ExitCode != 0 {
+						done <- &ExitCodeError{Code: closeData.ExitCode}
+						return
+					}
+					done <- nil
+					return
+				}
+				// Any other error (network drop, etc.) — propagate so callers can fail appropriately.
+				done <- err
+				return
+			}
+
+			// Filter control messages (e.g. "connected") sent as TextMessage.
+			if msgType == websocket.TextMessage {
+				var ctrl struct {
+					Type   string `json:"type"`
+					Status string `json:"status"`
+					Error  string `json:"error"`
+				}
+				if json.Unmarshal(data, &ctrl) == nil && ctrl.Type == "control" {
+					if ctrl.Status == "error" {
+						done <- fmt.Errorf("PTY session error: %s", ctrl.Error)
+						return
+					}
+					// "connected" or other informational — skip
+					continue
+				}
+			}
+
+			os.Stdout.Write(data)
+		}
+	}()
+
+	err = <-done
+	close(quit)
+	return err
+}
+
+// resizePTYSession sends a resize request to the PTY session.
+func (c *Client) resizePTYSession(ctx context.Context, proxyURL, sandboxId, sessionID string, cols, rows uint16, auth http.Header) error {
+	url := fmt.Sprintf("%s/%s/process/pty/%s/resize", strings.TrimSuffix(proxyURL, "/"), sandboxId, sessionID)
+
+	req := map[string]uint16{
+		"cols": cols,
+		"rows": rows,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range auth {
+		httpReq.Header[k] = v
+	}
+
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resize request failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return nil
+}
+
+// deletePTYSession attempts to delete the PTY session (best-effort cleanup).
+func (c *Client) deletePTYSession(proxyURL, sandboxId, sessionId string, auth http.Header) {
+	url := fmt.Sprintf("%s/%s/process/pty/%s", strings.TrimSuffix(proxyURL, "/"), sandboxId, sessionId)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return
+	}
+	for k, v := range auth {
+		req.Header[k] = v
+	}
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
 }

--- a/apps/cli/toolbox/toolbox_test.go
+++ b/apps/cli/toolbox/toolbox_test.go
@@ -1,0 +1,126 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPTYCreateRequestMarshaling(t *testing.T) {
+	cols := uint16(100)
+	rows := uint16(40)
+	timeout := uint32(300)
+	command := "bash"
+	envs := map[string]string{
+		"TERM": "xterm-256color",
+		"USER": "testuser",
+	}
+
+	request := PTYCreateRequest{
+		ID:      "test-session-1",
+		Command: &command,
+		Args:    []string{"-i", "-l"},
+		Cols:    &cols,
+		Rows:    &rows,
+		Timeout: &timeout,
+		Cwd:     "/tmp",
+		Envs:    envs,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	// Unmarshal back
+	var unmarshaled PTYCreateRequest
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+
+	// Verify all fields are preserved
+	assert.Equal(t, request.ID, unmarshaled.ID)
+	assert.Equal(t, request.Command, unmarshaled.Command)
+	assert.Equal(t, request.Args, unmarshaled.Args)
+	assert.Equal(t, request.Cols, unmarshaled.Cols)
+	assert.Equal(t, request.Rows, unmarshaled.Rows)
+	assert.Equal(t, request.Timeout, unmarshaled.Timeout)
+	assert.Equal(t, request.Cwd, unmarshaled.Cwd)
+	assert.Equal(t, request.Envs, unmarshaled.Envs)
+}
+
+func TestPTYCreateResponseMarshaling(t *testing.T) {
+	response := PTYCreateResponse{
+		SessionID: "pty-1234567890",
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(response)
+	assert.NoError(t, err)
+
+	// Unmarshal back
+	var unmarshaled PTYCreateResponse
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+
+	assert.Equal(t, response.SessionID, unmarshaled.SessionID)
+}
+
+func TestExecuteRequestWithTTYFlag(t *testing.T) {
+	ttyFlag := true
+
+	request := ExecuteRequest{
+		Command: "echo hello",
+		TTY:     &ttyFlag,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	// Unmarshal back
+	var unmarshaled ExecuteRequest
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+
+	assert.Equal(t, request.Command, unmarshaled.Command)
+	assert.NotNil(t, unmarshaled.TTY)
+	assert.True(t, *unmarshaled.TTY)
+}
+
+func TestExecuteRequestWithoutTTYFlag(t *testing.T) {
+	request := ExecuteRequest{
+		Command: "echo hello",
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	// Unmarshal back
+	var unmarshaled ExecuteRequest
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+
+	assert.Equal(t, request.Command, unmarshaled.Command)
+	assert.Nil(t, unmarshaled.TTY)
+}
+
+func TestPTYCreateRequestDefaults(t *testing.T) {
+	command := "bash"
+	request := PTYCreateRequest{
+		ID:      "test-1",
+		Command: &command,
+	}
+
+	assert.Equal(t, "test-1", request.ID)
+	assert.Equal(t, "bash", *request.Command)
+	assert.Nil(t, request.Args)
+	assert.Nil(t, request.Cols)
+	assert.Nil(t, request.Rows)
+	assert.Nil(t, request.Timeout)
+	assert.Equal(t, "", request.Cwd)
+	assert.Nil(t, request.Envs)
+}

--- a/apps/cli/toolbox/toolbox_unix.go
+++ b/apps/cli/toolbox/toolbox_unix.go
@@ -1,0 +1,38 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build unix
+
+package toolbox
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+// setupResizeHandler installs a SIGWINCH handler that forwards terminal resize
+// events to the remote TTY session. Returns a cleanup function that stops
+// signal handling.
+func setupResizeHandler(ctx context.Context, proxyURL, sandboxId, sessionID string, c *Client, auth http.Header) func() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGWINCH)
+
+	go func() {
+		for range sigChan {
+			cols, rows, err := term.GetSize(int(os.Stdout.Fd()))
+			if err == nil {
+				c.resizePTYSession(ctx, proxyURL, sandboxId, sessionID, uint16(cols), uint16(rows), auth)
+			}
+		}
+	}()
+
+	return func() {
+		signal.Stop(sigChan)
+		close(sigChan)
+	}
+}

--- a/apps/cli/toolbox/toolbox_windows.go
+++ b/apps/cli/toolbox/toolbox_windows.go
@@ -1,0 +1,17 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build windows
+
+package toolbox
+
+import (
+	"context"
+	"net/http"
+)
+
+// setupResizeHandler is a no-op on Windows because SIGWINCH is not available.
+// Terminal resize events are not forwarded on this platform.
+func setupResizeHandler(_ context.Context, _, _, _ string, _ *Client, _ http.Header) func() {
+	return func() {}
+}

--- a/apps/daemon/pkg/toolbox/process/execute.go
+++ b/apps/daemon/pkg/toolbox/process/execute.go
@@ -34,6 +34,13 @@ func ExecuteCommand(logger *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
+		// TTY mode is not supported on this endpoint; clients must use /process/pty.
+		// Reject early before doing any work.
+		if request.TTY != nil && *request.TTY {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "TTY=true is not supported on this endpoint; use /process/pty instead"})
+			return
+		}
+
 		cmdParts := parseCommand(request.Command)
 		if len(cmdParts) == 0 {
 			c.AbortWithError(http.StatusBadRequest, errors.New("empty command"))
@@ -102,15 +109,35 @@ func ExecuteCommand(logger *slog.Logger) gin.HandlerFunc {
 	}
 }
 
-// parseCommand splits a command string properly handling quotes
+// parseCommand splits a command string properly handling quotes and backslashes.
+// Outside of quotes, only \' is treated as an escape (to support the POSIX '\''
+// idiom produced by buildCommand). All other backslashes are literal.
+// Within double-quoted strings, `\"` is treated as a literal double-quote character.
+// Other backslashes are written through as-is. This allows arguments produced by
+// buildCommand (which escapes internal `"` as `\"`) to round-trip correctly.
 func parseCommand(command string) []string {
 	var args []string
 	var current bytes.Buffer
 	var inQuotes bool
 	var quoteChar rune
 
-	for _, r := range command {
+	runes := []rune(command)
+	i := 0
+	for i < len(runes) {
+		r := runes[i]
 		switch {
+		case r == '\\' && !inQuotes && i+1 < len(runes) && runes[i+1] == '\'':
+			// Outside quotes, \' produces a literal single-quote. This is required
+			// to decode the '\'' idiom produced by buildCommand, where a single-quote
+			// inside a -c script is encoded as '\'' (close-quote, \', open-quote).
+			// All other backslashes outside quotes pass through literally so that
+			// paths (C:\tmp), regexes, etc. round-trip unchanged.
+			i++
+			current.WriteRune(runes[i])
+		case r == '\\' && inQuotes && quoteChar == '"' && i+1 < len(runes) && runes[i+1] == '"':
+			// \" inside a double-quoted string: emit a literal double-quote and skip the next char.
+			i++
+			current.WriteRune('"')
 		case r == '"' || r == '\'':
 			if !inQuotes {
 				inQuotes = true
@@ -129,6 +156,7 @@ func parseCommand(command string) []string {
 		default:
 			current.WriteRune(r)
 		}
+		i++
 	}
 
 	if current.Len() > 0 {

--- a/apps/daemon/pkg/toolbox/process/execute_test.go
+++ b/apps/daemon/pkg/toolbox/process/execute_test.go
@@ -1,0 +1,228 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple command",
+			input:    "echo hello",
+			expected: []string{"echo", "hello"},
+		},
+		{
+			name:     "command with quoted string",
+			input:    `echo "hello world"`,
+			expected: []string{"echo", "hello world"},
+		},
+		{
+			name:     "command with single quoted string",
+			input:    `echo 'hello world'`,
+			expected: []string{"echo", "hello world"},
+		},
+		{
+			name:     "multiple arguments",
+			input:    "ls -la /tmp",
+			expected: []string{"ls", "-la", "/tmp"},
+		},
+		{
+			name:     "nested quotes",
+			input:    `sh -c "echo 'hello'"`,
+			expected: []string{"sh", "-c", "echo 'hello'"},
+		},
+		{
+			name:     "backslash-escaped double-quote inside double-quoted string",
+			input:    `echo "He said \"hello\""`,
+			expected: []string{"echo", `He said "hello"`},
+		},
+		{
+			name:     "unquoted backslash-quote escapes single-quote (POSIX)",
+			input:    `echo O\'Brien`,
+			expected: []string{"echo", "O'Brien"},
+		},
+		{
+			name:     "unquoted backslash before non-quote char is literal",
+			input:    `echo C:\tmp`,
+			expected: []string{"echo", `C:\tmp`},
+		},
+		{
+			name:     "POSIX single-quote escape idiom: '\\'' inside single-quoted string",
+			input:    `sh -c 'echo O'\''Brien'`,
+			expected: []string{"sh", "-c", "echo O'Brien"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil, // parseCommand returns nil for empty input
+		},
+		{
+			name:     "spaces only",
+			input:    "   ",
+			expected: nil, // parseCommand returns nil for whitespace-only input
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseCommand(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExecuteRequest_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request ExecuteRequest
+		valid   bool
+	}{
+		{
+			name: "valid request",
+			request: ExecuteRequest{
+				Command: "echo hello",
+			},
+			valid: true,
+		},
+		{
+			name: "empty command",
+			request: ExecuteRequest{
+				Command: "",
+			},
+			valid: false,
+		},
+		{
+			name: "request with timeout",
+			request: ExecuteRequest{
+				Command: "sleep 10",
+				Timeout: toUint32Ptr(5),
+			},
+			valid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Basic validation: command is required
+			if tt.valid {
+				assert.NotEmpty(t, tt.request.Command, "valid request should have non-empty command")
+			} else {
+				assert.Empty(t, tt.request.Command, "invalid request should have empty command")
+			}
+		})
+	}
+}
+
+// TestBuildCommandRoundTrip is an end-to-end contract test between buildCommand
+// (apps/cli/cmd/sandbox/exec.go) and parseCommand (this package).
+//
+// buildCommand encodes a []string into a single command string; parseCommand must
+// decode it back to an identical slice. Because the two functions live in separate
+// Go modules they cannot share a test binary, so this test hard-codes the exact
+// strings that buildCommand produces and verifies parseCommand recovers the
+// original arguments.  If buildCommand's encoding ever changes, both this test
+// and TestBuildCommand in apps/cli/cmd/sandbox/exec_test.go must be updated
+// together.
+//
+// Encoding rules implemented by buildCommand:
+//
+//	sh/bash -c <script> [arg0 ...]  → sh -c '<script>' [quoteArg(arg0) ...]
+//	arg with spaces, no ' → 'arg'
+//	arg with spaces and ' → "arg" (internal " escaped as \")
+//	arg with ' or " but no spaces → "arg" or 'arg' respectively
+//	arg without special chars → arg  (no quoting)
+func TestBuildCommandRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		encoded     string // exact output of buildCommand(original)
+		original    []string
+	}{
+		{
+			name:     "simple command — no quoting needed",
+			encoded:  "echo hello",
+			original: []string{"echo", "hello"},
+		},
+		{
+			name:     "arg with spaces uses single quotes",
+			encoded:  "echo 'hello world'",
+			original: []string{"echo", "hello world"},
+		},
+		{
+			name:     "arg with spaces and single-quote falls back to double-quote wrapping",
+			encoded:  `echo "it's alive"`,
+			original: []string{"echo", "it's alive"},
+		},
+		{
+			name:     "arg with spaces, single-quote, and double-quote: double-quote wrapping with \\\"",
+			encoded:  `echo "say \"hi\" it's fine"`,
+			original: []string{"echo", `say "hi" it's fine`},
+		},
+		{
+			name:     "shell -c script without single quotes",
+			encoded:  "sh -c 'echo hello && echo world'",
+			original: []string{"sh", "-c", "echo hello && echo world"},
+		},
+		{
+			name:     "shell -c script with one single-quote — POSIX '\\'' idiom",
+			encoded:  `sh -c 'echo O'\''Brien'`,
+			original: []string{"sh", "-c", "echo O'Brien"},
+		},
+		{
+			name:     "shell -c script with multiple single-quotes",
+			encoded:  `sh -c 'echo '\''hello'\'' '\''world'\'''`,
+			original: []string{"sh", "-c", "echo 'hello' 'world'"},
+		},
+		{
+			name:     "bash -c with single-quote in variable assignment",
+			encoded:  `bash -c 'NAME=O'\''Brien; echo $NAME'`,
+			original: []string{"bash", "-c", "NAME=O'Brien; echo $NAME"},
+		},
+		{
+			name:     "sh -c with extra positional args preserves argv",
+			encoded:  "sh -c 'echo $0 $1' hello world",
+			original: []string{"sh", "-c", "echo $0 $1", "hello", "world"},
+		},
+		{
+			name:     "sh -c with extra args needing quoting",
+			encoded:  "sh -c 'echo $0' 'hello world'",
+			original: []string{"sh", "-c", "echo $0", "hello world"},
+		},
+		{
+			name:     "arg with single-quote but no spaces — double-quote wrapping",
+			encoded:  `echo "O'Brien"`,
+			original: []string{"echo", "O'Brien"},
+		},
+		{
+			name:     "literal backslash in path preserved",
+			encoded:  `echo C:\tmp`,
+			original: []string{"echo", `C:\tmp`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCommand(tt.encoded)
+			assert.Equal(t, tt.original, got,
+				"parseCommand(%q) should round-trip to the original args", tt.encoded)
+		})
+	}
+}
+
+// Helper functions
+
+func toUint32Ptr(val uint32) *uint32 {
+	return &val
+}
+
+func toUint16Ptr(val uint16) *uint16 {
+	return &val
+}

--- a/apps/daemon/pkg/toolbox/process/pty/controller.go
+++ b/apps/daemon/pkg/toolbox/process/pty/controller.go
@@ -69,12 +69,18 @@ func (p *PTYController) CreatePTYSession(c *gin.Context) {
 		req.Rows = util.Pointer(uint16(24))
 	}
 	// Set upper limits to avoid ioctl errors
-	if *req.Cols > 1000 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid value for cols - must be less than 1000"})
+	if *req.Cols < 1 || *req.Cols > 1000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid value for cols - must be between 1 and 1000"})
 		return
 	}
-	if *req.Rows > 1000 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid value for rows - must be less than 1000"})
+	if *req.Rows < 1 || *req.Rows > 1000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid value for rows - must be between 1 and 1000"})
+		return
+	}
+
+	// Validate: LazyStart with Command makes no sense
+	if req.LazyStart && req.Command != nil && *req.Command != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lazyStart cannot be used with a command"})
 		return
 	}
 
@@ -88,6 +94,9 @@ func (p *PTYController) CreatePTYSession(c *gin.Context) {
 			CreatedAt: time.Now(),
 			Active:    false,
 			LazyStart: req.LazyStart,
+			Command:   stringOrEmpty(req.Command),
+			Args:      req.Args,
+			Timeout:   uint32OrZero(req.Timeout),
 		},
 		clients: cmap.New[*wsClient](),
 		logger:  p.logger.With(slog.String("sessionId", req.ID)),
@@ -246,12 +255,12 @@ func (p *PTYController) ResizePTYSession(c *gin.Context) {
 		return
 	}
 
-	if req.Cols > 1000 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "cols must be less than 1000"})
+	if req.Cols < 1 || req.Cols > 1000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cols must be between 1 and 1000"})
 		return
 	}
-	if req.Rows > 1000 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "rows must be less than 1000"})
+	if req.Rows < 1 || req.Rows > 1000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "rows must be between 1 and 1000"})
 		return
 	}
 
@@ -270,4 +279,18 @@ func (p *PTYController) ResizePTYSession(c *gin.Context) {
 	// Return updated session info
 	updatedInfo := session.Info()
 	c.JSON(http.StatusOK, updatedInfo)
+}
+
+func stringOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func uint32OrZero(v *uint32) uint32 {
+	if v == nil {
+		return 0
+	}
+	return *v
 }

--- a/apps/daemon/pkg/toolbox/process/pty/session.go
+++ b/apps/daemon/pkg/toolbox/process/pty/session.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/creack/pty"
 	"github.com/daytonaio/daemon/pkg/common"
@@ -40,16 +41,32 @@ func (s *PTYSession) start() error {
 		s.inCh = make(chan []byte, 1024)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if s.info.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(s.info.Timeout)*time.Second)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
 	s.ctx = ctx
 	s.cancel = cancel
 
-	shell := common.GetShell()
-	if shell == "" {
-		return errors.New("no shell resolved")
+	var cmdBin string
+	var cmdArgs []string
+	if s.info.Command != "" {
+		cmdBin = s.info.Command
+		cmdArgs = s.info.Args
+	} else {
+		shell := common.GetShell()
+		if shell == "" {
+			cancel()
+			return errors.New("no shell resolved")
+		}
+		cmdBin = shell
+		cmdArgs = []string{"-i", "-l"}
 	}
 
-	cmd := exec.CommandContext(ctx, shell, "-i", "-l")
+	cmd := exec.CommandContext(ctx, cmdBin, cmdArgs...)
 	cmd.Dir = s.info.Cwd
 
 	// Env

--- a/apps/daemon/pkg/toolbox/process/pty/types.go
+++ b/apps/daemon/pkg/toolbox/process/pty/types.go
@@ -72,6 +72,9 @@ type PTYSessionInfo struct {
 	CreatedAt time.Time         `json:"createdAt" validate:"required"`
 	Active    bool              `json:"active" validate:"required"`
 	LazyStart bool              `json:"lazyStart" validate:"required"` // Whether this session uses lazy start
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Timeout   uint32            `json:"timeout,omitempty"` // seconds; 0 = no timeout
 } // @name PtySessionInfo
 
 // API Request/Response types
@@ -84,6 +87,10 @@ type PTYCreateRequest struct {
 	Cols      *uint16           `json:"cols" validate:"optional"`
 	Rows      *uint16           `json:"rows" validate:"optional"`
 	LazyStart bool              `json:"lazyStart,omitempty"` // Don't start PTY until first client connects
+	// If Command is set, run it instead of the default interactive shell.
+	Command *string  `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	Timeout *uint32  `json:"timeout,omitempty"` // seconds; 0 = no timeout
 } // @name PtyCreateRequest
 
 // PTYCreateResponse represents the response when creating a PTY session

--- a/apps/daemon/pkg/toolbox/process/types.go
+++ b/apps/daemon/pkg/toolbox/process/types.go
@@ -9,6 +9,8 @@ type ExecuteRequest struct {
 	Timeout *uint32 `json:"timeout,omitempty" validate:"optional"`
 	// Current working directory
 	Cwd *string `json:"cwd,omitempty" validate:"optional"`
+	// Enable TTY mode for interactive commands
+	TTY *bool `json:"tty,omitempty" validate:"optional"`
 } // @name ExecuteRequest
 
 // TODO: Set ExitCode as required once all sandboxes migrated to the new daemon

--- a/apps/runner/project.json
+++ b/apps/runner/project.json
@@ -24,7 +24,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{workspaceRoot}",
-        "command": "cp dist/libs/computer-use-amd64 {projectRoot}/pkg/daemon/static/daytona-computer-use"
+        "command": "if [ -n \"$SKIP_COMPUTER_USE_BUILD\" ]; then echo 'Skipping computer-use copy'; touch {projectRoot}/pkg/daemon/static/daytona-computer-use; else cp dist/libs/computer-use-amd64 {projectRoot}/pkg/daemon/static/daytona-computer-use; fi"
       },
       "cache": true,
       "inputs": [


### PR DESCRIPTION
## Description

The daytona cli couldn't parse any complex shell commands properly, e.g. sh -c 'echo "test"'. The cli also was lacking the ability to open a TTY. Both of these features have been added and the flags have been moved in a more appropriate place (before the --)

## Documentation

- [X] This change requires a documentation update
- [X] I have made corresponding changes to the documentation

## Related Issue(s)

Fixes #4042 

This is also required for GasTown to support Daytona agents and generally useful.
Relates to steveyegge/gastown#2229

## Additional Notes
```
Execute a command in a running sandbox.

Flags must be specified before -- which separates the sandbox identifier from the command to run.

Usage:
  daytona exec [SANDBOX_ID | SANDBOX_NAME] [flags] -- COMMAND [ARGS...]

Flags:
      --cwd string    Working directory for command execution
      --timeout int   Command timeout in seconds (0 for no timeout)
      --tty           Enable TTY mode for interactive commands

Global Flags:
      --help   help for daytona
```
