### PR TITLE
feat(api): snapshot runner last used at

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1772734390158-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1772734390158-migration.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1772734390158 implements MigrationInterface {
+  name = 'Migration1772734390158'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "snapshot_runner" ADD "lastUsedAt" TIMESTAMP WITH TIME ZONE`)
+    await queryRunner.query(
+      // Note: not using CONCURRENTLY + skipping transactions because of reverting issue: https://github.com/typeorm/typeorm/issues/9981
+      `CREATE INDEX "snapshot_runner_lastusedat_idx" ON "snapshot_runner" ("lastUsedAt")`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."snapshot_runner_lastusedat_idx"`)
+    await queryRunner.query(`ALTER TABLE "snapshot_runner" DROP COLUMN "lastUsedAt"`)
+  }
+}

--- a/apps/api/src/sandbox/entities/snapshot-runner.entity.ts
+++ b/apps/api/src/sandbox/entities/snapshot-runner.entity.ts
@@ -11,6 +11,7 @@ import { SnapshotRunnerState } from '../enums/snapshot-runner-state.enum'
 @Index('snapshot_runner_runnerid_snapshotref_idx', ['runnerId', 'snapshotRef'])
 @Index('snapshot_runner_runnerid_idx', ['runnerId'])
 @Index('snapshot_runner_state_idx', ['state'])
+@Index('snapshot_runner_lastusedat_idx', ['lastUsedAt'])
 export class SnapshotRunner {
   @PrimaryGeneratedColumn('uuid')
   id: string
@@ -43,4 +44,7 @@ export class SnapshotRunner {
     type: 'timestamp with time zone',
   })
   updatedAt: Date
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  lastUsedAt: Date | null
 }

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -191,6 +191,7 @@ export class SandboxStartAction extends SandboxAction {
       })
       if (runner) {
         await this.updateSandboxState(sandbox, SandboxState.UNKNOWN, lockCode, runner.id)
+        await this.runnerService.updateSnapshotRunnerLastUsedAt(runner.id, snapshotRef)
         return SYNC_AGAIN
       }
     } catch {
@@ -498,6 +499,18 @@ export class SandboxStartAction extends SandboxAction {
 
       const metadata: { [key: string]: string } | undefined = organization?.sandboxMetadata
 
+      let restartSnapshotRef: string | null = null
+      if (sandbox.buildInfo) {
+        restartSnapshotRef = sandbox.buildInfo.snapshotRef
+      } else if (sandbox.snapshot) {
+        try {
+          const snap = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
+          restartSnapshotRef = snap.ref
+        } catch {
+          // non-critical
+        }
+      }
+
       try {
         await runnerAdapter.startSandbox(sandbox.id, sandbox.authToken, metadata)
       } catch (error) {
@@ -520,6 +533,9 @@ export class SandboxStartAction extends SandboxAction {
       }
 
       await this.updateSandboxState(sandbox, SandboxState.STARTING, lockCode)
+      if (restartSnapshotRef) {
+        await this.runnerService.updateSnapshotRunnerLastUsedAt(sandbox.runnerId, restartSnapshotRef)
+      }
       return SYNC_AGAIN
     }
 

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -191,7 +191,9 @@ export class SandboxStartAction extends SandboxAction {
       })
       if (runner) {
         await this.updateSandboxState(sandbox, SandboxState.UNKNOWN, lockCode, runner.id)
-        await this.runnerService.updateSnapshotRunnerLastUsedAt(runner.id, snapshotRef)
+        this.runnerService
+          .updateSnapshotRunnerLastUsedAt(runner.id, snapshotRef)
+          .catch(() => this.logger.warn(`Failed to update snapshot runner lastUsedAt: ${runner.id}/${snapshotRef}`))
         return SYNC_AGAIN
       }
     } catch {

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -499,18 +499,6 @@ export class SandboxStartAction extends SandboxAction {
 
       const metadata: { [key: string]: string } | undefined = organization?.sandboxMetadata
 
-      let restartSnapshotRef: string | null = null
-      if (sandbox.buildInfo) {
-        restartSnapshotRef = sandbox.buildInfo.snapshotRef
-      } else if (sandbox.snapshot) {
-        try {
-          const snap = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
-          restartSnapshotRef = snap.ref
-        } catch {
-          // non-critical
-        }
-      }
-
       try {
         await runnerAdapter.startSandbox(sandbox.id, sandbox.authToken, metadata)
       } catch (error) {
@@ -533,9 +521,6 @@ export class SandboxStartAction extends SandboxAction {
       }
 
       await this.updateSandboxState(sandbox, SandboxState.STARTING, lockCode)
-      if (restartSnapshotRef) {
-        await this.runnerService.updateSnapshotRunnerLastUsedAt(sandbox.runnerId, restartSnapshotRef)
-      }
       return SYNC_AGAIN
     }
 

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -1060,7 +1060,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         .select('sr.id')
         .where('sr.state = :state', { state: SnapshotRunnerState.READY })
         .andWhere('EXISTS (SELECT 1 FROM build_info bi WHERE bi."snapshotRef" = sr."snapshotRef")')
-        .andWhere('(sr."lastUsedAt" IS NULL OR sr."lastUsedAt" < :threshold)', { threshold: oneDayAgo })
+        .andWhere('COALESCE(sr."lastUsedAt", sr."updatedAt") < :threshold', { threshold: oneDayAgo })
         .take(10000)
         .getMany()
 
@@ -1075,7 +1075,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
 
       if (result.affected > 0) {
         this.logger.debug(
-          `Marked ${result.affected} stale declarative build SnapshotRunners for removal (lastUsedAt > 1 day)`,
+          `Marked ${result.affected} stale declarative build SnapshotRunners for removal (lastUsedAt or updatedAt older than 1 day)`,
         )
       }
     } catch (error) {

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -1041,6 +1041,50 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
+  @Cron(CronExpression.EVERY_HOUR, { name: 'cleanup-stale-declarative-build-snapshot-runners' })
+  @TrackJobExecution()
+  @LogExecution('cleanup-stale-declarative-build-snapshot-runners')
+  @WithInstrumentation()
+  async cleanupStaleDeclarativeBuildSnapshotRunners() {
+    const lockKey = 'cleanup-stale-declarative-build-snapshot-runners-lock'
+    if (!(await this.redisLockProvider.lock(lockKey, 300))) {
+      return
+    }
+
+    try {
+      const oneDayAgo = new Date()
+      oneDayAgo.setDate(oneDayAgo.getDate() - 1)
+
+      const staleEntries = await this.snapshotRunnerRepository
+        .createQueryBuilder('sr')
+        .select('sr.id')
+        .where('sr.state = :state', { state: SnapshotRunnerState.READY })
+        .andWhere('EXISTS (SELECT 1 FROM build_info bi WHERE bi."snapshotRef" = sr."snapshotRef")')
+        .andWhere('(sr."lastUsedAt" IS NULL OR sr."lastUsedAt" < :threshold)', { threshold: oneDayAgo })
+        .take(10000)
+        .getMany()
+
+      if (staleEntries.length === 0) {
+        return
+      }
+
+      const result = await this.snapshotRunnerRepository.update(
+        { id: In(staleEntries.map((e) => e.id)) },
+        { state: SnapshotRunnerState.REMOVING },
+      )
+
+      if (result.affected > 0) {
+        this.logger.debug(
+          `Marked ${result.affected} stale declarative build SnapshotRunners for removal (lastUsedAt > 1 day)`,
+        )
+      }
+    } catch (error) {
+      this.logger.error(`Failed to cleanup stale declarative build snapshot runners: ${fromAxiosError(error)}`)
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
+  }
+
   @Cron(CronExpression.EVERY_10_MINUTES, { name: 'deactivate-old-snapshots' })
   @TrackJobExecution()
   @LogExecution('deactivate-old-snapshots')

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -789,6 +789,13 @@ export class RunnerService {
     }
   }
 
+  async updateSnapshotRunnerLastUsedAt(runnerId: string, snapshotRef: string): Promise<void> {
+    if (!(await this.redisLockProvider.lock(`snapshot-runner:${runnerId}:${snapshotRef}:update-last-used`, 60))) {
+      return
+    }
+    await this.snapshotRunnerRepository.update({ runnerId, snapshotRef }, { lastUsedAt: new Date() })
+  }
+
   // TODO: combine getRunnersWithMultipleSnapshotsBuilding and getRunnersWithMultipleSnapshotsPulling?
 
   async getRunnersWithMultipleSnapshotsBuilding(maxSnapshotCount = 6): Promise<string[]> {


### PR DESCRIPTION
## Description

Adds a `lastUsedAt` column to `snapshot_runner` to track when each runner last served a sandbox for a given snapshot. This enables future cleanup to remove cached images from runners that have not been used recently, even if other runners still use the same snapshot. The field is updated when a runner is selected because it has a ready snapshot.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation