### PR TITLE
fix(runner): use single fuse mount per volume with bind subdirs for subpaths

### DIFF
--- a/apps/runner/pkg/docker/volumes_cleanup.go
+++ b/apps/runner/pkg/docker/volumes_cleanup.go
@@ -82,6 +82,11 @@ func (d *DockerClient) getInUseVolumeMounts(ctx context.Context) (map[string]boo
 			src := normalizePath(m.Source)
 			if strings.HasPrefix(src, prefix) {
 				inUse[src] = true
+				// Also mark the volume root as in-use when a subpath is mounted.
+				// e.g. src="/mnt/daytona-volume-abc/sub" → root="/mnt/daytona-volume-abc"
+				if idx := strings.Index(src[len(prefix):], "/"); idx != -1 {
+					inUse[src[:len(prefix)+idx]] = true
+				}
 			}
 		}
 	}

--- a/apps/runner/pkg/docker/volumes_mountpaths.go
+++ b/apps/runner/pkg/docker/volumes_mountpaths.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,6 +56,10 @@ func (d *DockerClient) getVolumesMountPathBinds(ctx context.Context, volumes []d
 		bindSource := baseMountPath
 		if vol.Subpath != nil && *vol.Subpath != "" {
 			bindSource = filepath.Join(baseMountPath, *vol.Subpath)
+			// Ensure the resolved path stays within baseMountPath to prevent path traversal
+			if !strings.HasPrefix(filepath.Clean(bindSource), filepath.Clean(baseMountPath)) {
+				return nil, fmt.Errorf("invalid subpath %q: resolves outside volume mount", *vol.Subpath)
+			}
 			err := os.MkdirAll(bindSource, 0755)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create subpath directory %s: %s", bindSource, err)


### PR DESCRIPTION
## Description

Replaces per-subpath FUSE mounts with a single FUSE mount per volume at the volume root. Subpath isolation is achieved by creating subdirectories on the mounted filesystem and using them as bind sources for containers. This reduces the number of mount-s3 FUSE processes proportionally to the number of unique volumes instead of volume+subpath combinations - which lowers runner CPU wasted on FUSE mounts idle. The mutex granularity is simplified to per-volume, and the md5 subpath hashing logic is removed as it is no longer needed.                                              

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation