### PR TITLE
fix: gracefully handle ECONNRESET in WebSocket log streaming

### DIFF
--- a/libs/sdk-typescript/src/utils/Stream.ts
+++ b/libs/sdk-typescript/src/utils/Stream.ts
@@ -15,6 +15,18 @@ function isStreamTerminationError(err: unknown): boolean {
   if (typeof e.message === 'string' && /terminated/i.test(e.message)) return true
   if (e.code === 'UND_ERR_SOCKET') return true
 
+  // Connection reset/closed errors (e.g. sandbox auto-deleted while streaming)
+  if (e.code === 'ECONNRESET') return true
+  if (e.code === 'ECONNREFUSED') return true
+  if (e.code === 'EPIPE') return true
+  if (e.code === 'ERR_STREAM_DESTROYED') return true
+  if (typeof e.message === 'string' && /ECONNRESET/i.test(e.message)) return true
+  if (typeof e.message === 'string' && /socket hang up/i.test(e.message)) return true
+  if (typeof e.message === 'string' && /aborted/i.test(e.message)) return true
+
+  // WebSocket close events that are not clean closures
+  if (typeof e.message === 'string' && /WebSocket was closed/i.test(e.message)) return true
+
   // Look into nested causes, Undici often nests errors
   if (e.cause) return isStreamTerminationError(e.cause)
 
@@ -24,11 +36,11 @@ function isStreamTerminationError(err: unknown): boolean {
 /**
  * Process a streaming response from fetch(), where getStream() returns a Fetch Response.
  *
- * @param getStream – zero-arg function that does `await fetch(...)` and returns the Response
- * @param onChunk – called with each decoded UTF-8 chunk
- * @param shouldTerminate – pollable; if true for two consecutive timeouts (or once if requireConsecutiveTermination=false), the loop breaks
- * @param chunkTimeout – milliseconds to wait for a new chunk before calling shouldTerminate()
- * @param requireConsecutiveTermination – whether you need two time-outs in a row to break
+ * @param getStream - zero-arg function that does `await fetch(...)` and returns the Response
+ * @param onChunk - called with each decoded UTF-8 chunk
+ * @param shouldTerminate - pollable; if true for two consecutive timeouts (or once if requireConsecutiveTermination=false), the loop breaks
+ * @param chunkTimeout - milliseconds to wait for a new chunk before calling shouldTerminate()
+ * @param requireConsecutiveTermination - whether you need two time-outs in a row to break
  */
 export async function processStreamingResponse(
   getStream: () => Promise<Response>,
@@ -75,7 +87,7 @@ export async function processStreamingResponse(
         } else {
           exitCheckStreak = 0
         }
-        // loop again—but do NOT overwrite readPromise!
+        // loop again--but do NOT overwrite readPromise!
       } else {
         // readPromise has resolved
         readPromise = null
@@ -294,25 +306,10 @@ export function stdDemuxStream(
       }
     }
 
-    // Event handler for errors
-    const handleError = (error: any) => {
-      // Convert Event or plain error to Error instance for consistency
-      const err = error && error instanceof Event ? new Error('WebSocket error') : error
-      cleanup()
-      try {
-        ws.close()
-      } catch {
-        /* ignore if already closed */
-      }
-      reject(err)
-    }
-
-    // Event handler for socket closure
-    const handleClose = () => {
-      // Flush any remaining buffered payload on clean close
+    // Helper to flush remaining buffered data from decoders
+    const flushBuffered = () => {
       if (buf.length > 0 && currentDataType) {
         const remainingBytes = new Uint8Array(buf)
-        // Use {stream: false} or omit to flush any buffered incomplete UTF-8 sequences
         if (currentDataType === 'stdout') {
           const text = stdoutDecoder.decode(remainingBytes, { stream: false })
           onStdout(text)
@@ -327,6 +324,41 @@ export function stdDemuxStream(
         if (stdoutFlushed) onStdout(stdoutFlushed)
         if (stderrFlushed) onStderr(stderrFlushed)
       }
+    }
+
+    // Event handler for errors
+    const handleError = (error: any) => {
+      // Check if the error is a connection-level termination (e.g. sandbox auto-deleted
+      // while streaming). In that case, treat it like a clean close instead of propagating
+      // the error — this prevents ECONNRESET crashes when sandboxes with autoDeleteInterval
+      // are deleted while log streams are still open.
+      if (isStreamTerminationError(error)) {
+        flushBuffered()
+        cleanup()
+        try {
+          ws.close()
+        } catch {
+          /* ignore if already closed */
+        }
+        resolve()
+        return
+      }
+
+      // Convert Event or plain error to Error instance for consistency
+      const err = error && error instanceof Event ? new Error('WebSocket error') : error
+      cleanup()
+      try {
+        ws.close()
+      } catch {
+        /* ignore if already closed */
+      }
+      reject(err)
+    }
+
+    // Event handler for socket closure
+    const handleClose = () => {
+      // Flush any remaining buffered payload on clean close
+      flushBuffered()
       cleanup()
       resolve()
     }


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

Fixes #2510

## Summary

When using `getSessionCommandLogs()` with sandboxes that have `autoDeleteInterval`, the streaming WebSocket connection is not automatically closed when the sandbox is auto-deleted. This causes an unhandled `ECONNRESET` error to propagate to the caller several minutes later, crashing the application.

This PR fixes the issue by teaching the `stdDemuxStream` WebSocket error handler to recognize connection-level termination errors and resolve gracefully instead of rejecting with an unhandled error.

## Changes

**`libs/sdk-typescript/src/utils/Stream.ts`**:

1. **Extended `isStreamTerminationError()`** to recognize additional connection-level error codes that occur when the remote end disappears:
   - `ECONNRESET` — the specific error from the issue
   - `ECONNREFUSED`, `EPIPE`, `ERR_STREAM_DESTROYED` — related connection teardown errors
   - `socket hang up`, `aborted`, `WebSocket was closed` — message-based detection

2. **Updated `stdDemuxStream`'s `handleError`** to check `isStreamTerminationError()` before deciding whether to reject. When a connection-level termination error is detected (e.g., sandbox auto-deleted), the handler now:
   - Flushes any remaining buffered data to the stdout/stderr callbacks
   - Cleans up event listeners
   - Closes the WebSocket
   - **Resolves** the promise gracefully instead of rejecting

3. **Extracted `flushBuffered()` helper** to reduce code duplication between `handleError` and `handleClose`, which both need to flush remaining decoder state.

## Before

```
Error: aborted
    at TLSSocket.socketCloseListener (node:_http_client:460:19)
    ...
{
  code: 'ECONNRESET'
}
```

## After

The stream resolves cleanly when the sandbox is deleted. Any data buffered up to the point of disconnection is still delivered to the callbacks before the promise resolves.

## Test plan

- [ ] Create a sandbox with `autoDeleteInterval: 3` (minutes)
- [ ] Start streaming logs with `getSessionCommandLogs()` using callbacks
- [ ] Wait for sandbox auto-deletion
- [ ] Verify the streaming promise resolves without throwing `ECONNRESET`
- [ ] Verify all log data received before deletion is still delivered to callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)