### PR TITLE
fix(sdk-python): include response body in upload_files error

### DIFF
--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -739,4 +739,13 @@ class AsyncFileSystem:
                 response = await client.post(
                     url, data=data_fields, files=file_fields, headers=headers  # any non-file form fields
                 )
-                _ = response.raise_for_status()
+                if response.is_error:
+                    try:
+                        detail = ", ".join(response.json()["errors"])
+                    except Exception:
+                        detail = response.text
+                    raise DaytonaError(
+                        f"Failed to upload files: {response.status_code}: {detail}",
+                        status_code=response.status_code,
+                    )
+

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -713,4 +713,13 @@ class FileSystem:
                 response = client.post(
                     url, data=data_fields, files=file_fields, headers=headers  # any non-file form fields
                 )
-                _ = response.raise_for_status()
+                if response.is_error:
+                    try:
+                        detail = ", ".join(response.json()["errors"])
+                    except Exception:
+                        detail = response.text
+                    raise DaytonaError(
+                        f"Failed to upload files: {response.status_code}: {detail}",
+                        status_code=response.status_code,
+                    )
+


### PR DESCRIPTION
## Summary

Fixes #4048

`upload_files()` uses `response.raise_for_status()` which only shows the HTTP status line (e.g. `"Client error '400 Bad Request'"`) but drops the response body containing useful error details like `{"errors": ["/tests/file.txt: mkdir /tests: permission denied"]}`.

This PR replaces `raise_for_status()` with custom error handling that:
1. Checks `response.is_error`
2. Attempts to parse the JSON `errors` array from the response body
3. Falls back to `response.text` for non-JSON responses
4. Raises a `DaytonaError` with the full error detail and status code

### Changes
- `libs/sdk-python/src/daytona/_sync/filesystem.py` — sync `upload_files()`
- `libs/sdk-python/src/daytona/_async/filesystem.py` — async `upload_files()`

### Before
```
DaytonaError("Failed to upload files: Client error '400 Bad Request' for url '...'")
```

### After
```
DaytonaError("Failed to upload files: 400: /tests/file.txt: mkdir /tests: permission denied")
```

**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**