### PR TITLE
fix: allow sandbox destruction from starting state

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -349,6 +349,7 @@ export class Sandbox {
             SandboxState.BUILD_FAILED,
             SandboxState.ARCHIVING,
             SandboxState.PENDING_BUILD,
+            SandboxState.STARTING,
           ].includes(this.state)
         ) {
           break


### PR DESCRIPTION
## Summary

Fixes #2390

Sandboxes stuck in the `starting` state cannot be deleted because `SandboxState.STARTING` is not included in the list of valid states for the `DESTROYED` desired state transition in `validateDesiredStateTransition()`.

This PR adds `SandboxState.STARTING` to the allowed states array for the `SandboxDesiredState.DESTROYED` case, so users can destroy sandboxes that are stuck in the starting state.

## Changes

- `apps/api/src/sandbox/entities/sandbox.entity.ts`: Added `SandboxState.STARTING` to the valid states for destruction

## Test plan

- Verify that a sandbox in `starting` state can now be deleted/destroyed
- Verify that sandboxes in other already-allowed states can still be destroyed (no regression)
- Verify that the `assertValid()` check passes when `desiredState` is `DESTROYED` and `state` is `starting`

**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)