### PR TITLE
fix(proxy): dont log context canceled errors on last activity update

### DIFF
--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -287,7 +287,7 @@ func (p *Proxy) updateLastActivity(ctx context.Context, sandboxId string, should
 	if !cached {
 		_, err := p.apiclient.SandboxAPI.UpdateLastActivity(ctx, sandboxId).Execute()
 		if err != nil {
-			if ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return
 			}
 			log.Errorf("failed to update last activity for sandbox %s: %v", sandboxId, err)


### PR DESCRIPTION
## Description

Don't log context canceled errors in last activity update.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
