### PR TITLE
fix(proxy): add forwarded for ip

### DIFF
--- a/apps/proxy/pkg/proxy/auth_callback.go
+++ b/apps/proxy/pkg/proxy/auth_callback.go
@@ -193,6 +193,9 @@ func (p *Proxy) hasSandboxAccess(ctx context.Context, sandboxId string, authToke
 		},
 	}
 	clientConfig.AddDefaultHeader("Authorization", "Bearer "+authToken)
+	if ginCtx, ok := ctx.(*gin.Context); ok {
+		clientConfig.AddDefaultHeader("X-Forwarded-For", ginCtx.ClientIP())
+	}
 
 	apiClient := apiclient.NewAPIClient(clientConfig)
 


### PR DESCRIPTION
## Description

Adds an X-Forwarded-For header to the proxy's auth calls to give the API correct information about the caller's source IP

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation