### PR TITLE
fix(api): reduce svix app portal access error log severity

### DIFF
--- a/apps/api/src/webhook/services/webhook.service.ts
+++ b/apps/api/src/webhook/services/webhook.service.ts
@@ -186,7 +186,7 @@ export class WebhookService implements OnModuleInit {
         url: appPortalAccess.url,
       }
     } catch (error) {
-      this.logger.error(`Failed to generate app portal access for organization ${organizationId}:`, error)
+      this.logger.debug(`Failed to generate app portal access for organization ${organizationId}:`, error)
       throw error
     }
   }


### PR DESCRIPTION
## Description

Reduced svix app portal access error log severity to debug because the call will fail for any org that does not have webook access which is intended.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
