### PR TITLE
fix(proxy): exponential backoff for api requests

### DIFF
--- a/apps/proxy/pkg/proxy/auth.go
+++ b/apps/proxy/pkg/proxy/auth.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/daytonaio/common-go/pkg/utils"
 	"github.com/gin-gonic/gin"
 )
 
@@ -101,7 +102,12 @@ func (p *Proxy) Authenticate(ctx *gin.Context, sandboxIdOrSignedToken string, po
 }
 
 func (p *Proxy) getSandboxIdFromSignedPreviewUrlToken(ctx *gin.Context, sandboxIdOrSignedToken string, port float32, cookieDomain string) (string, error) {
-	sandboxId, _, err := p.apiclient.PreviewAPI.GetSandboxIdFromSignedPreviewUrlToken(ctx.Request.Context(), sandboxIdOrSignedToken, port).Execute()
+	var sandboxId string
+	err := utils.RetryWithExponentialBackoff(ctx.Request.Context(), fmt.Sprintf("getSandboxIdFromSignedPreviewUrlToken(%s)", sandboxIdOrSignedToken), proxyMaxRetries, proxyBaseDelay, proxyMaxDelay, func() error {
+		s, _, e := p.apiclient.PreviewAPI.GetSandboxIdFromSignedPreviewUrlToken(ctx.Request.Context(), sandboxIdOrSignedToken, port).Execute()
+		sandboxId = s
+		return e
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to get sandbox ID: %w. Is the token expired?", err)
 	}

--- a/apps/proxy/pkg/proxy/get_sandbox_build_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_build_target.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/daytonaio/common-go/pkg/utils"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/gin-gonic/gin"
 )
@@ -63,10 +64,11 @@ func (p *Proxy) getSandboxBuildTarget(ctx *gin.Context) (*url.URL, map[string]st
 }
 
 func (p *Proxy) getSandbox(ctx context.Context, sandboxId string) (*apiclient.Sandbox, error) {
-	sandbox, _, err := p.apiclient.SandboxAPI.GetSandbox(ctx, sandboxId).Execute()
-	if err != nil {
-		return nil, err
-	}
-
-	return sandbox, nil
+	var sandbox *apiclient.Sandbox
+	err := utils.RetryWithExponentialBackoff(ctx, fmt.Sprintf("getSandbox(%s)", sandboxId), proxyMaxRetries, proxyBaseDelay, proxyMaxDelay, func() error {
+		s, _, e := p.apiclient.SandboxAPI.GetSandbox(ctx, sandboxId).Execute()
+		sandbox = s
+		return e
+	})
+	return sandbox, err
 }

--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/daytonaio/common-go/pkg/utils"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/gin-gonic/gin"
 
 	log "github.com/sirupsen/logrus"
@@ -125,7 +127,12 @@ func (p *Proxy) getSandboxRunnerInfo(ctx context.Context, sandboxId string) (*Ru
 		return runnerInfo, nil
 	}
 
-	runner, _, err := p.apiclient.RunnersAPI.GetRunnerBySandboxId(context.Background(), sandboxId).Execute()
+	var runner *apiclient.RunnerFull
+	err = utils.RetryWithExponentialBackoff(ctx, fmt.Sprintf("getSandboxRunnerInfo(%s)", sandboxId), proxyMaxRetries, proxyBaseDelay, proxyMaxDelay, func() error {
+		r, _, e := p.apiclient.RunnersAPI.GetRunnerBySandboxId(context.Background(), sandboxId).Execute()
+		runner = r
+		return e
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -153,15 +160,30 @@ func (p *Proxy) getSandboxPublic(ctx context.Context, sandboxId string) (*bool, 
 		return isPublicCache, nil
 	}
 
-	isPublic := false
-	_, resp, _ := p.apiclient.PreviewAPI.IsSandboxPublic(context.Background(), sandboxId).Execute()
-	if resp != nil && resp.StatusCode == http.StatusOK {
-		isPublic = true
+	var isPublic bool
+	err = utils.RetryWithExponentialBackoff(ctx, fmt.Sprintf("getSandboxPublic(%s)", sandboxId), proxyMaxRetries, proxyBaseDelay, proxyMaxDelay, func() error {
+		_, resp, apiErr := p.apiclient.PreviewAPI.IsSandboxPublic(context.Background(), sandboxId).Execute()
+		if resp != nil && resp.StatusCode == http.StatusOK {
+			isPublic = true
+			return nil
+		}
+		if apiErr != nil {
+			if resp != nil && resp.StatusCode >= 400 && resp.StatusCode < 500 &&
+				resp.StatusCode != http.StatusRequestTimeout && resp.StatusCode != http.StatusTooManyRequests {
+				isPublic = false
+				return nil
+			}
+			return apiErr
+		}
+		isPublic = false
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	err = p.sandboxPublicCache.Set(ctx, sandboxId, isPublic, 1*time.Hour)
-	if err != nil {
-		log.Errorf("Failed to set sandbox public in cache: %v", err)
+	if cacheErr := p.sandboxPublicCache.Set(ctx, sandboxId, isPublic, 1*time.Hour); cacheErr != nil {
+		log.Errorf("Failed to set sandbox public in cache: %v", cacheErr)
 	}
 
 	return &isPublic, nil
@@ -194,9 +216,6 @@ func (p *Proxy) getSandboxBearerTokenValid(ctx context.Context, sandboxId string
 	return p.validateAndCache(ctx, sandboxId, bearerToken, apiValidation)
 }
 
-const authValidationRetries = 2
-const authValidationRetryDelay = 250 * time.Millisecond
-
 func (p *Proxy) validateAndCache(
 	ctx context.Context,
 	sandboxId string,
@@ -210,17 +229,14 @@ func (p *Proxy) validateAndCache(
 	}
 
 	var isValid bool
-	var validationErr error
-	for attempt := range authValidationRetries {
-		isValid, validationErr = apiValidation()
-		if validationErr == nil {
-			break
+	validationErr := utils.RetryWithExponentialBackoff(ctx, fmt.Sprintf("validateAndCache(%s)", sandboxId), proxyMaxRetries, proxyBaseDelay, proxyMaxDelay, func() error {
+		result, err := apiValidation()
+		if err != nil {
+			return err
 		}
-		if attempt < authValidationRetries-1 {
-			log.Warnf("Auth validation attempt %d/%d failed for sandbox %s: %v, retrying...", attempt+1, authValidationRetries, sandboxId, validationErr)
-			time.Sleep(authValidationRetryDelay)
-		}
-	}
+		isValid = result
+		return nil
+	})
 	if validationErr != nil {
 		return nil, validationErr
 	}

--- a/apps/proxy/pkg/proxy/get_snapshot_target.go
+++ b/apps/proxy/pkg/proxy/get_snapshot_target.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/daytonaio/common-go/pkg/utils"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/gin-gonic/gin"
 
@@ -71,12 +72,13 @@ func (p *Proxy) getSnapshotTarget(ctx *gin.Context) (*url.URL, map[string]string
 }
 
 func (p *Proxy) getSnapshot(ctx context.Context, snapshotId string) (*apiclient.SnapshotDto, error) {
-	snapshot, _, err := p.apiclient.SnapshotsAPI.GetSnapshot(ctx, snapshotId).Execute()
-	if err != nil {
-		return nil, err
-	}
-
-	return snapshot, nil
+	var snapshot *apiclient.SnapshotDto
+	err := utils.RetryWithExponentialBackoff(ctx, fmt.Sprintf("getSnapshot(%s)", snapshotId), proxyMaxRetries, proxyBaseDelay, proxyMaxDelay, func() error {
+		s, _, e := p.apiclient.SnapshotsAPI.GetSnapshot(ctx, snapshotId).Execute()
+		snapshot = s
+		return e
+	})
+	return snapshot, err
 }
 
 func (p *Proxy) getRunnerInfo(ctx context.Context, runnerId string) (*RunnerInfo, error) {
@@ -85,7 +87,12 @@ func (p *Proxy) getRunnerInfo(ctx context.Context, runnerId string) (*RunnerInfo
 		return runnerInfo, nil
 	}
 
-	runner, _, err := p.apiclient.RunnersAPI.GetRunnerFullById(ctx, runnerId).Execute()
+	var runner *apiclient.RunnerFull
+	err = utils.RetryWithExponentialBackoff(ctx, fmt.Sprintf("getRunnerInfo(%s)", runnerId), proxyMaxRetries, proxyBaseDelay, proxyMaxDelay, func() error {
+		r, _, e := p.apiclient.RunnersAPI.GetRunnerFullById(context.Background(), runnerId).Execute()
+		runner = r
+		return e
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/apps/proxy/pkg/proxy/retry.go
+++ b/apps/proxy/pkg/proxy/retry.go
@@ -1,0 +1,12 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import "time"
+
+const (
+	proxyMaxRetries = 3
+	proxyBaseDelay  = 150 * time.Millisecond
+	proxyMaxDelay   = 1 * time.Second
+)


### PR DESCRIPTION
## Description

Cleanup proxy retries and expand them to include runner/snapshot retrieval

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation