### PR TITLE
fix(runner): wait for daemon before version check

### DIFF
--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -5,6 +5,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -38,7 +39,17 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 	}
 
 	if state == enums.SandboxStateStarted || state == enums.SandboxStatePullingSnapshot || state == enums.SandboxStateStarting {
-		daemonVersion, err := d.GetDaemonVersion(ctx, sandboxDto.Id)
+		c, err := d.ContainerInspect(ctx, sandboxDto.Id)
+		if err != nil {
+			return "", "", err
+		}
+
+		containerIP := common.GetContainerIpAddress(ctx, &c)
+		if containerIP == "" {
+			return "", "", errors.New("sandbox IP not found? Is the sandbox started?")
+		}
+
+		daemonVersion, err := d.waitForDaemonRunning(ctx, containerIP, sandboxDto.AuthToken)
 		if err != nil {
 			return "", "", err
 		}


### PR DESCRIPTION
## Description

This should fix the sandboxes erroring out with a failed /version GET during container creation due to concurrent create requests

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation