### PR TITLE
Fix potential panic in CLI commands (start, stop, archive) due to missing args check

### DIFF
--- a/apps/cli/cmd/sandbox/archive.go
+++ b/apps/cli/cmd/sandbox/archive.go
@@ -15,7 +15,7 @@ import (
 var ArchiveCmd = &cobra.Command{
 	Use:   "archive [SANDBOX_ID] | [SANDBOX_NAME]",
 	Short: "Archive a sandbox",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/start.go
+++ b/apps/cli/cmd/sandbox/start.go
@@ -15,7 +15,7 @@ import (
 var StartCmd = &cobra.Command{
 	Use:   "start [SANDBOX_ID] | [SANDBOX_NAME]",
 	Short: "Start a sandbox",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/stop.go
+++ b/apps/cli/cmd/sandbox/stop.go
@@ -15,7 +15,7 @@ import (
 var StopCmd = &cobra.Command{
 	Use:   "stop [SANDBOX_ID] | [SANDBOX_NAME]",
 	Short: "Stop a sandbox",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 


### PR DESCRIPTION
Changed `cobra.MaximumNArgs(1)` to `cobra.ExactArgs(1)` in `start.go`, `stop.go`, and `archive.go` to prevent `index out of range` panic when no arguments are provided.

---
*Automated PR created by OpenClaw daily-pr routine (Backlog queue).*