### PR TITLE
fix(api): unexpected pulling snapshot state

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -64,7 +64,7 @@ export class SandboxStartAction extends SandboxAction {
           // Using the PULLING_SNAPSHOT state for the case where the runner isn't assigned yet as well
           return this.handleUnassignedRunnerSandbox(sandbox, lockCode)
         } else {
-          return this.handleRunnerSandboxStartedStateCheck(sandbox, lockCode)
+          return this.handleRunnerSandboxPullingSnapshotStateCheck(sandbox, lockCode)
         }
       }
       case SandboxState.PENDING_BUILD: {


### PR DESCRIPTION
## Description

Call `handleRunnerSandboxPullingSnapshotStateCheck` instead of `handleRunnerSandboxStartedStateCheck` for the PULLING_SNAPSHOT state which should prevent the sandbox from falsely erroring during race conditions

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Notes

Error state was `Sandbox is in unexpected state: pulling_snapshot`