### PR TITLE
refactor(api): swap strategy order in combined auth guard

### DIFF
--- a/apps/api/src/auth/api-key.strategy.ts
+++ b/apps/api/src/auth/api-key.strategy.ts
@@ -17,6 +17,7 @@ import { SystemRole } from '../user/enums/system-role.enum'
 import { RunnerService } from '../sandbox/services/runner.service'
 import { generateApiKeyHash } from '../common/utils/api-key'
 import { RegionService } from '../region/services/region.service'
+import { JWT_REGEX } from './constants/jwt-regex.constant'
 
 type UserCache = {
   userId: string
@@ -44,7 +45,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') implem
     this.logger.log('ApiKeyStrategy initialized')
   }
 
-  async validate(token: string): Promise<AuthContextType> {
+  async validate(token: string): Promise<AuthContextType | null> {
     this.logger.debug('Validate method called')
     this.logger.debug(`Validating API key: ${token.substring(0, 8)}...`)
 
@@ -74,6 +75,11 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') implem
       return {
         role: 'health-check',
       }
+    }
+
+    // Tokens matching JWT structure are not API keys — skip DB lookups and delegate to the JWT strategy.
+    if (JWT_REGEX.test(token)) {
+      return null
     }
 
     try {
@@ -170,7 +176,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') implem
       this.logger.debug('Error checking region SSH gateway API key:', error)
     }
 
-    throw new UnauthorizedException('Invalid API key')
+    return null
   }
 
   private async getUserCache(userId: string): Promise<UserCache | null> {

--- a/apps/api/src/auth/combined-auth.guard.ts
+++ b/apps/api/src/auth/combined-auth.guard.ts
@@ -3,42 +3,28 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, ExecutionContext, Logger } from '@nestjs/common'
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 
+/**
+ * Main authentication guard for the application.
+ *
+ * Strategies are tried in array order.
+ * On first success, the rest are skipped.
+ *
+ * `handleRequest` is invoked once — either when a strategy succeeds or when all strategies fail.
+ * It returns the authenticated user object or throws a generic `UnauthorizedException`.
+ */
 @Injectable()
-export class CombinedAuthGuard extends AuthGuard(['jwt', 'api-key']) {
+export class CombinedAuthGuard extends AuthGuard(['api-key', 'jwt']) {
   private readonly logger = new Logger(CombinedAuthGuard.name)
 
-  constructor() {
-    super()
-    this.logger.debug('CombinedAuthGuard constructor called')
-  }
-
-  async canActivate(context: ExecutionContext): Promise<boolean> {
-    this.logger.debug('CombinedAuthGuard.canActivate called')
-    try {
-      const result = await super.canActivate(context)
-      this.logger.debug('Authentication result:', result)
-      return result as boolean
-    } catch (error) {
-      this.logger.debug('Authentication error:', error)
-      throw error
-    }
-  }
-
-  handleRequest(err: any, user: any, info: any, context: ExecutionContext) {
-    this.logger.debug('CombinedAuthGuard.handleRequest called')
-    this.logger.debug('Error:', err)
-    this.logger.debug('User:', user)
-    this.logger.debug('Info:', info)
-
+  handleRequest(err: any, user: any) {
     if (err || !user) {
-      this.logger.debug('Authentication failed')
-      return super.handleRequest(err, user, info, context)
+      this.logger.debug('Authentication failed', { err, user })
+      throw new UnauthorizedException('Invalid credentials')
     }
 
-    this.logger.debug('Authentication successful')
     return user
   }
 }

--- a/apps/api/src/auth/constants/jwt-regex.constant.ts
+++ b/apps/api/src/auth/constants/jwt-regex.constant.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * Matches the structure of a JWT token: three base64url-encoded segments
+ * separated by dots (header.payload.signature).
+ *
+ * Both header and payload must start with `eyJ` — the base64url encoding of `{"`,
+ * which is guaranteed since both are JSON objects.
+ *
+ * The signature segment has no prefix constraint since it is raw bytes.
+ */
+export const JWT_REGEX = /^eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/


### PR DESCRIPTION
This pull request improves authentication handling by refining the distinction between API keys and JWT tokens, optimizing the authentication guard order, and simplifying error handling. The main changes ensure that JWT tokens are not mistakenly processed as API keys, streamline the authentication flow, and make error responses more consistent and secure.

**Authentication strategy improvements:**

* Added a `JWT_REGEX` constant in `jwt-regex.constant.ts` to accurately detect JWT tokens based on their structure. (`apps/api/src/auth/constants/jwt-regex.constant.ts`)
* Updated `ApiKeyStrategy` to return `null` (instead of throwing an exception which terminates the chain of trying strategies) when a token matches the JWT structure, ensuring JWTs are delegated to the JWT strategy and not processed as API keys. (`apps/api/src/auth/api-key.strategy.ts`) [[1]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4R20) [[2]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L47-R48) [[3]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4R80-R84) [[4]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L173-R179)

**Authentication guard changes:**

* Changed the order of authentication strategies in `CombinedAuthGuard` to try `api-key` before `jwt`, giving preference to API key authentication check given its higher frequency
* Simplified and clarified error handling in `CombinedAuthGuard`, throwing a generic `UnauthorizedException` with a consistent message when authentication fails. (`apps/api/src/auth/combined-auth.guard.ts`)
* Removed unnecessary logging and method overrides from `CombinedAuthGuard` for cleaner and more maintainable code. (`apps/api/src/auth/combined-auth.guard.ts`)