### PR TITLE
feat(dashboard): sandboxes list provider with client & server impleme…

### DIFF
--- a/apps/dashboard/.env
+++ b/apps/dashboard/.env
@@ -1,5 +1,8 @@
 VITE_API_URL=http://localhost:3000/api
 VITE_ENABLE_MOCKING=
 
+# Set to 'true' to use client-side sandbox pagination (deprecated, for prod compatibility)
+VITE_CLIENT_SIDE_SANDBOX_PAGINATION=
+
 VITE_ALGOLIA_API_KEY=
 VITE_ALGOLIA_APP_ID=

--- a/apps/dashboard/src/components/SandboxTable/index.tsx
+++ b/apps/dashboard/src/components/SandboxTable/index.tsx
@@ -36,6 +36,7 @@ export function SandboxTable({
   sandboxIsLoading,
   sandboxStateIsTransitioning,
   loading,
+  isRefetching = false,
   snapshots,
   snapshotsDataIsLoading,
   snapshotsDataHasMore,
@@ -177,10 +178,13 @@ export function SandboxTable({
         snapshotsDataHasMore={snapshotsDataHasMore}
         onChangeSnapshotSearchValue={onChangeSnapshotSearchValue}
         onRefresh={handleRefresh}
-        isRefreshing={isRefreshing}
+        isRefreshing={isRefreshing || isRefetching}
       />
 
-      <Table className="border-separate border-spacing-0" style={{ tableLayout: 'fixed', width: '100%' }}>
+      <Table
+        className={cn('border-separate border-spacing-0 transition-opacity duration-200', isRefetching && 'opacity-60')}
+        style={{ tableLayout: 'fixed', width: '100%' }}
+      >
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
@@ -208,7 +212,7 @@ export function SandboxTable({
           ))}
         </TableHeader>
         <TableBody>
-          {loading ? (
+          {loading && data.length === 0 ? (
             <TableRow>
               <TableCell colSpan={table.getAllColumns().length} className="h-10 text-center">
                 Loading...

--- a/apps/dashboard/src/components/SandboxTable/types.ts
+++ b/apps/dashboard/src/components/SandboxTable/types.ts
@@ -20,6 +20,7 @@ export interface SandboxTableProps {
   sandboxIsLoading: Record<string, boolean>
   sandboxStateIsTransitioning: Record<string, boolean>
   loading: boolean
+  isRefetching?: boolean
   snapshots: SnapshotDto[]
   snapshotsDataIsLoading: boolean
   snapshotsDataHasMore?: boolean

--- a/apps/dashboard/src/hooks/mutations/mutationKeys.ts
+++ b/apps/dashboard/src/hooks/mutations/mutationKeys.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export interface SandboxMutationVariables {
+  sandboxId: string
+}
+
+const sandboxMutationKeyAll = ['sandboxes'] as const
+
+export const mutationKeys = {
+  sandboxes: {
+    all: sandboxMutationKeyAll,
+    start: [...sandboxMutationKeyAll, 'start'] as const,
+    recover: [...sandboxMutationKeyAll, 'recover'] as const,
+    stop: [...sandboxMutationKeyAll, 'stop'] as const,
+    archive: [...sandboxMutationKeyAll, 'archive'] as const,
+    delete: [...sandboxMutationKeyAll, 'delete'] as const,
+  },
+} as const

--- a/apps/dashboard/src/hooks/mutations/useArchiveSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useArchiveSandboxMutation.ts
@@ -6,11 +6,8 @@
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { queryKeys } from '@/hooks/queries/queryKeys'
+import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
-interface ArchiveSandboxVariables {
-  sandboxId: string
-}
 
 export const useArchiveSandboxMutation = () => {
   const { sandboxApi } = useApi()
@@ -18,11 +15,12 @@ export const useArchiveSandboxMutation = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ sandboxId }: ArchiveSandboxVariables) => {
+    mutationKey: mutationKeys.sandboxes.archive,
+    mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.archiveSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: (_, { sandboxId }) => {
-      queryClient.invalidateQueries({
+    onSuccess: async (_, { sandboxId }) => {
+      await queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })
     },

--- a/apps/dashboard/src/hooks/mutations/useArchiveSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useArchiveSandboxMutation.ts
@@ -9,19 +9,30 @@ import { queryKeys } from '@/hooks/queries/queryKeys'
 import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+interface SandboxMutationContext {
+  organizationId?: string
+}
+
 export const useArchiveSandboxMutation = () => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useMutation<void, unknown, SandboxMutationVariables, SandboxMutationContext>({
     mutationKey: mutationKeys.sandboxes.archive,
     mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.archiveSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: async (_, { sandboxId }) => {
+    onMutate: () => ({
+      organizationId: selectedOrganization?.id,
+    }),
+    onSuccess: async (_, { sandboxId }, context) => {
+      if (!context?.organizationId) {
+        return
+      }
+
       await queryClient.invalidateQueries({
-        queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
+        queryKey: queryKeys.sandboxes.detail(context.organizationId, sandboxId),
       })
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useCreateSandboxMutation.tsx
+++ b/apps/dashboard/src/hooks/mutations/useCreateSandboxMutation.tsx
@@ -6,8 +6,8 @@
 import { CreateSandboxFromImageParams, CreateSandboxFromSnapshotParams, Daytona, Sandbox } from '@daytonaio/sdk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from 'react-oidc-context'
+import { queryKeys } from '../queries/queryKeys'
 import { useSelectedOrganization } from '../useSelectedOrganization'
-import { getSandboxesQueryKey } from '../useSandboxes'
 
 export type CreateSandboxParams = (CreateSandboxFromSnapshotParams | CreateSandboxFromImageParams) & {
   target?: string
@@ -39,7 +39,7 @@ export const useCreateSandboxMutation = () => {
     },
     onSuccess: async () => {
       if (selectedOrganization?.id) {
-        await queryClient.invalidateQueries({ queryKey: getSandboxesQueryKey(selectedOrganization.id) })
+        await queryClient.invalidateQueries({ queryKey: queryKeys.sandboxes.list(selectedOrganization.id) })
       }
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useDeleteSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useDeleteSandboxMutation.ts
@@ -6,11 +6,8 @@
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { queryKeys } from '@/hooks/queries/queryKeys'
+import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
-interface DeleteSandboxVariables {
-  sandboxId: string
-}
 
 export const useDeleteSandboxMutation = () => {
   const { sandboxApi } = useApi()
@@ -18,11 +15,12 @@ export const useDeleteSandboxMutation = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ sandboxId }: DeleteSandboxVariables) => {
+    mutationKey: mutationKeys.sandboxes.delete,
+    mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.deleteSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: (_, { sandboxId }) => {
-      queryClient.invalidateQueries({
+    onSuccess: async (_, { sandboxId }) => {
+      await queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })
     },

--- a/apps/dashboard/src/hooks/mutations/useDeleteSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useDeleteSandboxMutation.ts
@@ -9,19 +9,30 @@ import { queryKeys } from '@/hooks/queries/queryKeys'
 import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+interface SandboxMutationContext {
+  organizationId?: string
+}
+
 export const useDeleteSandboxMutation = () => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useMutation<void, unknown, SandboxMutationVariables, SandboxMutationContext>({
     mutationKey: mutationKeys.sandboxes.delete,
     mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.deleteSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: async (_, { sandboxId }) => {
+    onMutate: () => ({
+      organizationId: selectedOrganization?.id,
+    }),
+    onSuccess: async (_, { sandboxId }, context) => {
+      if (!context?.organizationId) {
+        return
+      }
+
       await queryClient.invalidateQueries({
-        queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
+        queryKey: queryKeys.sandboxes.detail(context.organizationId, sandboxId),
       })
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useRecoverSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useRecoverSandboxMutation.ts
@@ -9,19 +9,30 @@ import { queryKeys } from '@/hooks/queries/queryKeys'
 import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+interface SandboxMutationContext {
+  organizationId?: string
+}
+
 export const useRecoverSandboxMutation = () => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useMutation<void, unknown, SandboxMutationVariables, SandboxMutationContext>({
     mutationKey: mutationKeys.sandboxes.recover,
     mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.recoverSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: async (_, { sandboxId }) => {
+    onMutate: () => ({
+      organizationId: selectedOrganization?.id,
+    }),
+    onSuccess: async (_, { sandboxId }, context) => {
+      if (!context?.organizationId) {
+        return
+      }
+
       await queryClient.invalidateQueries({
-        queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
+        queryKey: queryKeys.sandboxes.detail(context.organizationId, sandboxId),
       })
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useRecoverSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useRecoverSandboxMutation.ts
@@ -6,11 +6,8 @@
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { queryKeys } from '@/hooks/queries/queryKeys'
+import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
-interface RecoverSandboxVariables {
-  sandboxId: string
-}
 
 export const useRecoverSandboxMutation = () => {
   const { sandboxApi } = useApi()
@@ -18,11 +15,12 @@ export const useRecoverSandboxMutation = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ sandboxId }: RecoverSandboxVariables) => {
+    mutationKey: mutationKeys.sandboxes.recover,
+    mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.recoverSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: (_, { sandboxId }) => {
-      queryClient.invalidateQueries({
+    onSuccess: async (_, { sandboxId }) => {
+      await queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })
     },

--- a/apps/dashboard/src/hooks/mutations/useStartSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useStartSandboxMutation.ts
@@ -9,19 +9,30 @@ import { queryKeys } from '@/hooks/queries/queryKeys'
 import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+interface SandboxMutationContext {
+  organizationId?: string
+}
+
 export const useStartSandboxMutation = () => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useMutation<void, unknown, SandboxMutationVariables, SandboxMutationContext>({
     mutationKey: mutationKeys.sandboxes.start,
     mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.startSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: async (_, { sandboxId }) => {
+    onMutate: () => ({
+      organizationId: selectedOrganization?.id,
+    }),
+    onSuccess: async (_, { sandboxId }, context) => {
+      if (!context?.organizationId) {
+        return
+      }
+
       await queryClient.invalidateQueries({
-        queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
+        queryKey: queryKeys.sandboxes.detail(context.organizationId, sandboxId),
       })
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useStartSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useStartSandboxMutation.ts
@@ -6,11 +6,8 @@
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { queryKeys } from '@/hooks/queries/queryKeys'
+import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
-interface StartSandboxVariables {
-  sandboxId: string
-}
 
 export const useStartSandboxMutation = () => {
   const { sandboxApi } = useApi()
@@ -18,11 +15,12 @@ export const useStartSandboxMutation = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ sandboxId }: StartSandboxVariables) => {
+    mutationKey: mutationKeys.sandboxes.start,
+    mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.startSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: (_, { sandboxId }) => {
-      queryClient.invalidateQueries({
+    onSuccess: async (_, { sandboxId }) => {
+      await queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })
     },

--- a/apps/dashboard/src/hooks/mutations/useStopSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useStopSandboxMutation.ts
@@ -9,19 +9,30 @@ import { queryKeys } from '@/hooks/queries/queryKeys'
 import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+interface SandboxMutationContext {
+  organizationId?: string
+}
+
 export const useStopSandboxMutation = () => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useMutation<void, unknown, SandboxMutationVariables, SandboxMutationContext>({
     mutationKey: mutationKeys.sandboxes.stop,
     mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.stopSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: async (_, { sandboxId }) => {
+    onMutate: () => ({
+      organizationId: selectedOrganization?.id,
+    }),
+    onSuccess: async (_, { sandboxId }, context) => {
+      if (!context?.organizationId) {
+        return
+      }
+
       await queryClient.invalidateQueries({
-        queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
+        queryKey: queryKeys.sandboxes.detail(context.organizationId, sandboxId),
       })
     },
   })

--- a/apps/dashboard/src/hooks/mutations/useStopSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useStopSandboxMutation.ts
@@ -6,11 +6,8 @@
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { queryKeys } from '@/hooks/queries/queryKeys'
+import { mutationKeys, SandboxMutationVariables } from './mutationKeys'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-
-interface StopSandboxVariables {
-  sandboxId: string
-}
 
 export const useStopSandboxMutation = () => {
   const { sandboxApi } = useApi()
@@ -18,11 +15,12 @@ export const useStopSandboxMutation = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ sandboxId }: StopSandboxVariables) => {
+    mutationKey: mutationKeys.sandboxes.stop,
+    mutationFn: async ({ sandboxId }: SandboxMutationVariables) => {
       await sandboxApi.stopSandbox(sandboxId, selectedOrganization?.id)
     },
-    onSuccess: (_, { sandboxId }) => {
-      queryClient.invalidateQueries({
+    onSuccess: async (_, { sandboxId }) => {
+      await queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })
     },

--- a/apps/dashboard/src/hooks/queries/queryKeys.ts
+++ b/apps/dashboard/src/hooks/queries/queryKeys.ts
@@ -113,6 +113,8 @@ export const queryKeys = {
         },
       ] as const
     },
+    organization: (organizationId: string | undefined) =>
+      [...queryKeys.sandboxes.list(organizationId), 'organization'] as const,
     detail: (organizationId: string, sandboxId: string) =>
       [...queryKeys.sandboxes.all, organizationId, sandboxId, 'detail'] as const,
     terminalSession: (sandboxId: string) => [...queryKeys.sandboxes.all, sandboxId, 'terminal-session'] as const,

--- a/apps/dashboard/src/hooks/queries/queryKeys.ts
+++ b/apps/dashboard/src/hooks/queries/queryKeys.ts
@@ -5,6 +5,7 @@
 
 import { SnapshotQueryParams } from './useSnapshotsQuery'
 import type { AuditLogsQueryParams } from './useAuditLogsQuery'
+import type { SandboxQueryParams } from '../useSandboxes'
 
 export const queryKeys = {
   config: {
@@ -99,6 +100,19 @@ export const queryKeys = {
   },
   sandboxes: {
     all: ['sandboxes'] as const,
+    list: (organizationId: string | undefined, params?: SandboxQueryParams) => {
+      const base = [...queryKeys.sandboxes.all, organizationId, 'list'] as const
+      if (!params) return base
+      return [
+        ...base,
+        {
+          page: params.page,
+          pageSize: params.pageSize,
+          ...(params.filters && { filters: params.filters }),
+          ...(params.sorting && { sorting: params.sorting }),
+        },
+      ] as const
+    },
     detail: (organizationId: string, sandboxId: string) =>
       [...queryKeys.sandboxes.all, organizationId, sandboxId, 'detail'] as const,
     terminalSession: (sandboxId: string) => [...queryKeys.sandboxes.all, sandboxId, 'terminal-session'] as const,

--- a/apps/dashboard/src/hooks/usePendingMutationKeys.ts
+++ b/apps/dashboard/src/hooks/usePendingMutationKeys.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MutationKey, useMutationState } from '@tanstack/react-query'
+import { useMemo } from 'react'
+
+interface PendingMutationSelector<T extends string, TVariables = unknown> {
+  mutationKey: MutationKey
+  getKey: (variables: TVariables | undefined) => T | undefined
+}
+
+const isMutationKeyPrefixMatch = (actual: MutationKey | undefined, expected: MutationKey) => {
+  if (!actual || actual.length < expected.length) {
+    return false
+  }
+
+  return expected.every((value, index) => actual[index] === value)
+}
+
+export function usePendingMutationKeys<T extends string, TVariables = unknown>(
+  selectors: readonly PendingMutationSelector<T, TVariables>[],
+) {
+  const pendingRawKeys = useMutationState<T | undefined>({
+    filters: {
+      status: 'pending',
+      predicate: (mutation) =>
+        selectors.some((selector) => isMutationKeyPrefixMatch(mutation.options.mutationKey, selector.mutationKey)),
+    },
+    select: (mutation) => {
+      for (const selector of selectors) {
+        if (!isMutationKeyPrefixMatch(mutation.options.mutationKey, selector.mutationKey)) {
+          continue
+        }
+
+        return selector.getKey(mutation.state.variables as TVariables | undefined)
+      }
+
+      return undefined
+    },
+  })
+
+  return useMemo(() => new Set(pendingRawKeys.filter((key): key is T => Boolean(key))), [pendingRawKeys])
+}

--- a/apps/dashboard/src/hooks/useSandboxWsSync.ts
+++ b/apps/dashboard/src/hooks/useSandboxWsSync.ts
@@ -15,6 +15,12 @@ interface UseSandboxWsSyncOptions {
   refetchOnCreate?: boolean
 }
 
+function isPaginatedSandboxes(data: unknown): data is PaginatedSandboxes {
+  return Boolean(
+    data && typeof data === 'object' && 'items' in data && Array.isArray((data as PaginatedSandboxes).items),
+  )
+}
+
 export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSandboxWsSyncOptions = {}) {
   const { notificationSocket } = useNotificationSocket()
   const { selectedOrganization } = useSelectedOrganization()
@@ -26,13 +32,25 @@ export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSand
     const orgId = selectedOrganization.id
 
     const updateStateInListCache = (targetId: string, state: SandboxState) => {
-      queryClient.setQueriesData<PaginatedSandboxes>({ queryKey: queryKeys.sandboxes.list(orgId) }, (oldData) => {
-        if (!oldData) return oldData
-        return {
-          ...oldData,
-          items: oldData.items.map((s) => (s.id === targetId ? { ...s, state } : s)),
-        }
-      })
+      queryClient.setQueriesData(
+        { queryKey: queryKeys.sandboxes.list(orgId) },
+        (oldData: PaginatedSandboxes | Sandbox[] | undefined) => {
+          if (!oldData) return oldData
+
+          if (Array.isArray(oldData)) {
+            return oldData.map((sandbox) => (sandbox.id === targetId ? { ...sandbox, state } : sandbox))
+          }
+
+          if (!isPaginatedSandboxes(oldData)) {
+            return oldData
+          }
+
+          return {
+            ...oldData,
+            items: oldData.items.map((s) => (s.id === targetId ? { ...s, state } : s)),
+          }
+        },
+      )
     }
 
     const updateStateInDetailCache = (targetId: string, state: SandboxState) => {

--- a/apps/dashboard/src/hooks/useSandboxWsSync.ts
+++ b/apps/dashboard/src/hooks/useSandboxWsSync.ts
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { queryKeys } from '@/hooks/queries/queryKeys'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { getSandboxesQueryKey } from '@/hooks/useSandboxes'
-import { queryKeys } from '@/hooks/queries/queryKeys'
 import { PaginatedSandboxes, Sandbox, SandboxDesiredState, SandboxState } from '@daytonaio/api-client'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
@@ -27,7 +26,7 @@ export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSand
     const orgId = selectedOrganization.id
 
     const updateStateInListCache = (targetId: string, state: SandboxState) => {
-      queryClient.setQueriesData<PaginatedSandboxes>({ queryKey: getSandboxesQueryKey(orgId) }, (oldData) => {
+      queryClient.setQueriesData<PaginatedSandboxes>({ queryKey: queryKeys.sandboxes.list(orgId) }, (oldData) => {
         if (!oldData) return oldData
         return {
           ...oldData,
@@ -52,7 +51,7 @@ export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSand
 
     const invalidate = () => {
       queryClient.invalidateQueries({
-        queryKey: getSandboxesQueryKey(orgId),
+        queryKey: queryKeys.sandboxes.list(orgId),
         refetchType: 'none',
       })
 
@@ -63,11 +62,11 @@ export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSand
       }
     }
 
-    const handleCreated = (_sandbox: Sandbox) => {
+    const handleCreated = () => {
       if (sandboxId) return
 
       queryClient.invalidateQueries({
-        queryKey: getSandboxesQueryKey(orgId),
+        queryKey: queryKeys.sandboxes.list(orgId),
         refetchType: refetchOnCreate ? 'active' : 'none',
       })
     }
@@ -77,7 +76,7 @@ export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSand
 
       // warm pool sandboxes — treat as created
       if (data.oldState === data.newState && data.newState === SandboxState.STARTED) {
-        handleCreated(data.sandbox)
+        handleCreated()
         return
       }
 

--- a/apps/dashboard/src/hooks/useSandboxes.ts
+++ b/apps/dashboard/src/hooks/useSandboxes.ts
@@ -48,23 +48,6 @@ export interface SandboxQueryParams {
   sorting?: SandboxSorting
 }
 
-export const getSandboxesQueryKey = (organizationId: string | undefined, params?: SandboxQueryParams): QueryKey => {
-  const baseKey = ['sandboxes' as const, organizationId]
-
-  if (!params) {
-    return baseKey
-  }
-
-  const normalizedParams = {
-    page: params.page,
-    pageSize: params.pageSize,
-    ...(params.filters && { filters: params.filters }),
-    ...(params.sorting && { sorting: params.sorting }),
-  }
-
-  return [...baseKey, normalizedParams]
-}
-
 export function useSandboxes(queryKey: QueryKey, params: SandboxQueryParams) {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
@@ -118,7 +101,7 @@ export function useSandboxes(queryKey: QueryKey, params: SandboxQueryParams) {
               total: paginatedData.total + 1,
             }
           }
-        } catch (error) {
+        } catch {
           // TODO: rethrow if not 4xx
         }
       }

--- a/apps/dashboard/src/hooks/useSandboxes.ts
+++ b/apps/dashboard/src/hooks/useSandboxes.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { QueryKey, useQuery } from '@tanstack/react-query'
+import { keepPreviousData, QueryKey, useQuery } from '@tanstack/react-query'
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import {
@@ -54,6 +54,7 @@ export function useSandboxes(queryKey: QueryKey, params: SandboxQueryParams) {
 
   return useQuery<PaginatedSandboxes>({
     queryKey,
+    placeholderData: keepPreviousData,
     queryFn: async () => {
       if (!selectedOrganization) {
         throw new Error('No organization selected')

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -82,6 +82,7 @@ const Sandboxes: React.FC = () => {
     totalItems,
     pageCount,
     isLoading: sandboxesDataIsLoading,
+    isRefetching: sandboxesDataIsRefetching,
     error: sandboxesDataError,
     pagination,
     onPaginationChange: handlePaginationChange,
@@ -674,6 +675,7 @@ const Sandboxes: React.FC = () => {
             isRefreshing={sandboxDataIsRefreshing}
             data={sandboxItems || []}
             loading={sandboxesDataIsLoading}
+            isRefetching={sandboxesDataIsRefetching}
             snapshots={snapshotsData?.items || []}
             snapshotsDataIsLoading={snapshotsDataIsLoading}
             snapshotsDataHasMore={snapshotsDataHasMore}

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -23,203 +23,108 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { DAYTONA_DOCS_URL } from '@/constants/ExternalLinks'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { RoutePath } from '@/enums/RoutePath'
+import { mutationKeys, type SandboxMutationVariables } from '@/hooks/mutations/mutationKeys'
 import { SnapshotFilters, SnapshotQueryParams, useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
-import { useNotificationSocket } from '@/hooks/useNotificationSocket'
+import { usePendingMutationKeys } from '@/hooks/usePendingMutationKeys'
 import { useRegions } from '@/hooks/useRegions'
-import {
-  DEFAULT_SANDBOX_SORTING,
-  getSandboxesQueryKey,
-  SandboxFilters,
-  SandboxQueryParams,
-  SandboxSorting,
-  useSandboxes,
-} from '@/hooks/useSandboxes'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { createBulkActionToast } from '@/lib/bulk-action-toast'
 import { handleApiError } from '@/lib/error-handling'
 import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { formatDuration, pluralize } from '@/lib/utils'
-import { OrganizationUserRoleEnum, Sandbox, SandboxDesiredState, SandboxState } from '@daytonaio/api-client'
-import { QueryKey, useQueryClient } from '@tanstack/react-query'
-import { PlusIcon } from 'lucide-react'
+import { SandboxListProvider, useSandboxListContext } from '@/providers/SandboxListProvider'
+import { OrganizationUserRoleEnum, Sandbox, SandboxState } from '@daytonaio/api-client'
+import { AlertCircle, PlusIcon, RefreshCw } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
+const sandboxPendingMutationSelectors = [
+  {
+    mutationKey: mutationKeys.sandboxes.start,
+    getKey: (variables: SandboxMutationVariables | undefined) => variables?.sandboxId,
+  },
+  {
+    mutationKey: mutationKeys.sandboxes.recover,
+    getKey: (variables: SandboxMutationVariables | undefined) => variables?.sandboxId,
+  },
+  {
+    mutationKey: mutationKeys.sandboxes.stop,
+    getKey: (variables: SandboxMutationVariables | undefined) => variables?.sandboxId,
+  },
+  {
+    mutationKey: mutationKeys.sandboxes.archive,
+    getKey: (variables: SandboxMutationVariables | undefined) => variables?.sandboxId,
+  },
+  {
+    mutationKey: mutationKeys.sandboxes.delete,
+    getKey: (variables: SandboxMutationVariables | undefined) => variables?.sandboxId,
+  },
+] as const
+
 const Sandboxes: React.FC = () => {
   const { sandboxApi, apiKeyApi, toolboxApi } = useApi()
   const { user } = useAuth()
   const navigate = useNavigate()
-  const { notificationSocket } = useNotificationSocket()
   const config = useConfig()
-  const queryClient = useQueryClient()
   const { selectedOrganization, authenticatedUserOrganizationMember, authenticatedUserHasPermission } =
     useSelectedOrganization()
 
-  // Pagination
-
-  const [paginationParams, setPaginationParams] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_PAGE_SIZE,
-  })
-
-  const handlePaginationChange = useCallback(({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
-    setPaginationParams({ pageIndex, pageSize })
-  }, [])
-
-  // Filters
-
-  const [filters, setFilters] = useState<SandboxFilters>({})
-
-  const handleFiltersChange = useCallback((filters: SandboxFilters) => {
-    setFilters(filters)
-    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [])
-
-  // Sorting
-
-  const [sorting, setSorting] = useState<SandboxSorting>(DEFAULT_SANDBOX_SORTING)
-
-  const handleSortingChange = useCallback((sorting: SandboxSorting) => {
-    setSorting(sorting)
-    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [])
-
-  // Sandboxes Data
-
-  const queryParams = useMemo<SandboxQueryParams>(
-    () => ({
-      page: paginationParams.pageIndex + 1, // 1-indexed
-      pageSize: paginationParams.pageSize,
-      filters: filters,
-      sorting: sorting,
-    }),
-    [paginationParams, filters, sorting],
-  )
-
-  const baseQueryKey = useMemo<QueryKey>(
-    () => getSandboxesQueryKey(selectedOrganization?.id),
-    [selectedOrganization?.id],
-  )
-
-  const queryKey = useMemo<QueryKey>(
-    () => getSandboxesQueryKey(selectedOrganization?.id, queryParams),
-    [selectedOrganization?.id, queryParams],
-  )
-
   const {
-    data: sandboxesData,
+    sandboxes: sandboxItems,
+    totalItems,
+    pageCount,
     isLoading: sandboxesDataIsLoading,
     error: sandboxesDataError,
-    refetch: refetchSandboxesData,
-  } = useSandboxes(queryKey, queryParams)
+    pagination,
+    onPaginationChange: handlePaginationChange,
+    sorting,
+    onSortingChange: handleSortingChange,
+    filters,
+    onFiltersChange: handleFiltersChange,
+    handleRefresh,
+    isRefreshing: sandboxDataIsRefreshing,
+    startSandbox,
+    recoverSandbox,
+    stopSandbox,
+    archiveSandbox,
+    deleteSandbox,
+  } = useSandboxListContext()
 
-  useEffect(() => {
-    if (sandboxesDataError) {
-      handleApiError(sandboxesDataError, 'Failed to fetch sandboxes')
+  const pendingSandboxMutationIds = usePendingMutationKeys(sandboxPendingMutationSelectors)
+  const [sandboxAsyncOperationIsLoading, setSandboxAsyncOperationIsLoading] = useState<Record<string, boolean>>({})
+  const [sandboxStateIsTransitioning, setSandboxStateIsTransitioning] = useState<Record<string, boolean>>({})
+  const sandboxTransitionTimeoutsRef = useRef<Record<string, number>>({})
+
+  const sandboxIsLoading = useMemo(() => {
+    const combined = { ...sandboxAsyncOperationIsLoading }
+
+    for (const sandboxId of pendingSandboxMutationIds) {
+      combined[sandboxId] = true
     }
-  }, [sandboxesDataError])
 
-  const updateSandboxInCache = useCallback(
-    (sandboxId: string, updates: Partial<Sandbox>) => {
-      queryClient.setQueryData(queryKey, (oldData: any) => {
-        if (!oldData) return oldData
-        return {
-          ...oldData,
-          items: oldData.items.map((sandbox: Sandbox) =>
-            sandbox.id === sandboxId ? { ...sandbox, ...updates } : sandbox,
-          ),
-        }
-      })
-    },
-    [queryClient, queryKey],
-  )
-
-  /**
-   * Marks all sandbox queries for this organization as stale.
-   *
-   * Useful when sandbox event occurs and we don't have a good way of knowing for which combination of query parameters the sandbox would be shown.
-   *
-   * @param shouldRefetchActiveQueries If true, only active queries will be refetched. Otherwise, no queries will be refetched.
-   */
-  const markAllSandboxQueriesAsStale = useCallback(
-    async (shouldRefetchActiveQueries = false) => {
-      queryClient.invalidateQueries({
-        queryKey: baseQueryKey,
-        refetchType: shouldRefetchActiveQueries ? 'active' : 'none',
-      })
-    },
-    [queryClient, baseQueryKey],
-  )
-
-  /**
-   * Aborts all outgoing refetches for the provided key.
-   *
-   * Useful for preventing refetches from overwriting optimistic updates.
-   *
-   * @param queryKey
-   */
-  const cancelQueryRefetches = useCallback(
-    async (queryKey: QueryKey) => {
-      queryClient.cancelQueries({ queryKey })
-    },
-    [queryClient],
-  )
-
-  // Go to previous page if there are no items on the current page
-
-  useEffect(() => {
-    if (sandboxesData?.items.length === 0 && paginationParams.pageIndex > 0) {
-      setPaginationParams((prev) => ({
-        ...prev,
-        pageIndex: prev.pageIndex - 1,
-      }))
-    }
-  }, [sandboxesData?.items.length, paginationParams.pageIndex])
-
-  // Ephemeral Sandbox States
-
-  const [sandboxIsLoading, setSandboxIsLoading] = useState<Record<string, boolean>>({})
-  const [sandboxStateIsTransitioning, setSandboxStateIsTransitioning] = useState<Record<string, boolean>>({}) // display transition animation
-
-  // Manual Refreshing
-
-  const [sandboxDataIsRefreshing, setSandboxDataIsRefreshing] = useState(false)
-
-  const handleRefresh = useCallback(async () => {
-    setSandboxDataIsRefreshing(true)
-    try {
-      await refetchSandboxesData()
-    } catch (error) {
-      handleApiError(error, 'Failed to refresh sandboxes')
-    } finally {
-      setSandboxDataIsRefreshing(false)
-    }
-  }, [refetchSandboxesData])
-
-  // Delete Sandbox Dialog
+    return combined
+  }, [sandboxAsyncOperationIsLoading, pendingSandboxMutationIds])
 
   const [sandboxToDelete, setSandboxToDelete] = useState<string | null>(null)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
-
-  // Sandbox Details Drawer
 
   const [selectedSandbox, setSelectedSandbox] = useState<Sandbox | null>(null)
   const [showSandboxDetails, setShowSandboxDetails] = useState(false)
 
   useEffect(() => {
-    if (!selectedSandbox || !sandboxesData?.items) {
+    if (!selectedSandbox || !sandboxItems) {
       return
     }
 
-    const selectedSandboxInData = sandboxesData.items.find((s) => s.id === selectedSandbox.id)
+    const selectedSandboxInData = sandboxItems.find((s) => s.id === selectedSandbox.id)
 
     if (!selectedSandboxInData) {
       setSelectedSandbox(null)
@@ -230,42 +135,66 @@ const Sandboxes: React.FC = () => {
     if (selectedSandboxInData !== selectedSandbox) {
       setSelectedSandbox(selectedSandboxInData)
     }
-  }, [sandboxesData?.items, selectedSandbox])
+  }, [sandboxItems, selectedSandbox])
 
-  const performSandboxStateOptimisticUpdate = useCallback(
-    (sandboxId: string, newState: SandboxState) => {
-      updateSandboxInCache(sandboxId, { state: newState })
+  const clearSandboxTransitionTimeout = useCallback((sandboxId: string) => {
+    const timeoutId = sandboxTransitionTimeoutsRef.current[sandboxId]
+    if (timeoutId === undefined) {
+      return
+    }
 
-      if (selectedSandbox?.id === sandboxId) {
-        setSelectedSandbox((prev) => (prev ? { ...prev, state: newState } : null))
-      }
+    window.clearTimeout(timeoutId)
+    delete sandboxTransitionTimeoutsRef.current[sandboxId]
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      Object.values(sandboxTransitionTimeoutsRef.current).forEach((timeoutId) => {
+        window.clearTimeout(timeoutId)
+      })
+    }
+  }, [])
+
+  const startSandboxTransition = useCallback(
+    (sandboxId: string) => {
+      clearSandboxTransitionTimeout(sandboxId)
+      setSandboxStateIsTransitioning((prev) => ({ ...prev, [sandboxId]: true }))
     },
-    [updateSandboxInCache, selectedSandbox?.id],
+    [clearSandboxTransitionTimeout],
   )
 
-  const revertSandboxStateOptimisticUpdate = useCallback(
-    (sandboxId: string, previousState?: SandboxState) => {
-      if (!previousState) {
-        return
-      }
+  const stopSandboxTransition = useCallback(
+    (sandboxId: string) => {
+      clearSandboxTransitionTimeout(sandboxId)
 
-      updateSandboxInCache(sandboxId, { state: previousState })
-
-      if (selectedSandbox?.id === sandboxId) {
-        setSelectedSandbox((prev) => (prev ? { ...prev, state: previousState } : null))
-      }
+      sandboxTransitionTimeoutsRef.current[sandboxId] = window.setTimeout(() => {
+        delete sandboxTransitionTimeoutsRef.current[sandboxId]
+        setSandboxStateIsTransitioning((prev) => ({ ...prev, [sandboxId]: false }))
+      }, 2000)
     },
-    [updateSandboxInCache, selectedSandbox?.id],
+    [clearSandboxTransitionTimeout],
   )
 
-  // SSH Access Dialogs
+  const runSandboxTransition = useCallback(
+    async (sandboxId: string, action: () => Promise<void>) => {
+      startSandboxTransition(sandboxId)
+      try {
+        await action()
+      } finally {
+        stopSandboxTransition(sandboxId)
+      }
+    },
+    [startSandboxTransition, stopSandboxTransition],
+  )
+
+  const setSandboxAsyncLoading = useCallback((sandboxId: string, isLoading: boolean) => {
+    setSandboxAsyncOperationIsLoading((prev) => ({ ...prev, [sandboxId]: isLoading }))
+  }, [])
 
   const [showCreateSshDialog, setShowCreateSshDialog] = useState(false)
   const [showRevokeSshDialog, setShowRevokeSshDialog] = useState(false)
   const [sshSandboxId, setSshSandboxId] = useState<string>('')
   const createSandboxSheetRef = useRef<{ open: () => void }>(null)
-
-  // Snapshot Filter
 
   const [snapshotFilters, setSnapshotFilters] = useState<SnapshotFilters>({})
 
@@ -298,257 +227,98 @@ const Sandboxes: React.FC = () => {
     }
   }, [snapshotsDataError])
 
-  // Region Filter
-
   const { availableRegions: regionsData, loadingAvailableRegions: regionsDataIsLoading, getRegionName } = useRegions()
 
-  // Subscribe to Sandbox Events
-
-  useEffect(() => {
-    const handleSandboxCreatedEvent = (sandbox: Sandbox) => {
-      const isFirstPage = paginationParams.pageIndex === 0
-      const isDefaultFilters = Object.keys(filters).length === 0
-      const isDefaultSorting =
-        sorting.field === DEFAULT_SANDBOX_SORTING.field && sorting.direction === DEFAULT_SANDBOX_SORTING.direction
-
-      const shouldRefetchActiveQueries = isFirstPage && isDefaultFilters && isDefaultSorting
-
-      markAllSandboxQueriesAsStale(shouldRefetchActiveQueries)
-    }
-
-    const handleSandboxStateUpdatedEvent = (data: {
-      sandbox: Sandbox
-      oldState: SandboxState
-      newState: SandboxState
-    }) => {
-      // warm pool sandboxes
-      if (data.oldState === data.newState && data.newState === SandboxState.STARTED) {
-        handleSandboxCreatedEvent(data.sandbox)
-        return
-      }
-
-      let updatedState = data.newState
-
-      // error,build_failed | destroyed should be displayed as destroyed in the UI
-      if (
-        data.sandbox.desiredState === SandboxDesiredState.DESTROYED &&
-        (data.newState === SandboxState.ERROR || data.newState === SandboxState.BUILD_FAILED)
-      ) {
-        updatedState = SandboxState.DESTROYED
-      }
-
-      performSandboxStateOptimisticUpdate(data.sandbox.id, updatedState)
-
-      markAllSandboxQueriesAsStale()
-    }
-
-    const handleSandboxDesiredStateUpdatedEvent = (data: {
-      sandbox: Sandbox
-      oldDesiredState: SandboxDesiredState
-      newDesiredState: SandboxDesiredState
-    }) => {
-      // error,build_failed | destroyed should be displayed as destroyed in the UI
-
-      if (data.newDesiredState !== SandboxDesiredState.DESTROYED) {
-        return
-      }
-
-      if (data.sandbox.state !== SandboxState.ERROR && data.sandbox.state !== SandboxState.BUILD_FAILED) {
-        return
-      }
-
-      performSandboxStateOptimisticUpdate(data.sandbox.id, SandboxState.DESTROYED)
-
-      markAllSandboxQueriesAsStale()
-    }
-
-    if (!notificationSocket) {
-      return
-    }
-
-    notificationSocket.on('sandbox.created', handleSandboxCreatedEvent)
-    notificationSocket.on('sandbox.state.updated', handleSandboxStateUpdatedEvent)
-    notificationSocket.on('sandbox.desired-state.updated', handleSandboxDesiredStateUpdatedEvent)
-
-    return () => {
-      notificationSocket.off('sandbox.created', handleSandboxCreatedEvent)
-      notificationSocket.off('sandbox.state.updated', handleSandboxStateUpdatedEvent)
-      notificationSocket.off('sandbox.desired-state.updated', handleSandboxDesiredStateUpdatedEvent)
-    }
-  }, [
-    filters,
-    markAllSandboxQueriesAsStale,
-    notificationSocket,
-    paginationParams.pageIndex,
-    performSandboxStateOptimisticUpdate,
-    sorting.direction,
-    sorting.field,
-  ])
-
-  // Sandbox Action Handlers
-
   const handleStart = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
-
-    const sandboxToStart = sandboxesData?.items.find((s) => s.id === id)
-    const previousState = sandboxToStart?.state
-
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.STARTING)
-
-    try {
-      await sandboxApi.startSandbox(id, selectedOrganization?.id)
-      toast.success(`Starting sandbox with ID: ${id}`)
-      await markAllSandboxQueriesAsStale()
-    } catch (error) {
-      handleApiError(error, 'Failed to start sandbox', {
-        action:
-          error instanceof OrganizationSuspendedError &&
-          config.billingApiUrl &&
-          authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER ? (
-            <Button variant="secondary" onClick={() => navigate(RoutePath.BILLING_WALLET)}>
-              Go to billing
-            </Button>
-          ) : undefined,
-      })
-      revertSandboxStateOptimisticUpdate(id, previousState)
-    } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-      setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-      }, 2000)
-    }
+    await runSandboxTransition(id, async () => {
+      try {
+        await startSandbox(id)
+        toast.success(`Starting sandbox with ID: ${id}`)
+      } catch (error) {
+        handleApiError(error, 'Failed to start sandbox', {
+          action:
+            error instanceof OrganizationSuspendedError &&
+            config.billingApiUrl &&
+            authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER ? (
+              <Button variant="secondary" onClick={() => navigate(RoutePath.BILLING_WALLET)}>
+                Go to billing
+              </Button>
+            ) : undefined,
+        })
+      }
+    })
   }
 
   const handleRecover = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
-
-    const sandboxToRecover = sandboxesData?.items.find((s) => s.id === id)
-    const previousState = sandboxToRecover?.state
-
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.STARTING)
-
-    try {
-      await sandboxApi.recoverSandbox(id, selectedOrganization?.id)
-      toast.success('Sandbox recovered. Restarting...')
-      await markAllSandboxQueriesAsStale()
-    } catch (error) {
-      handleApiError(error, 'Failed to recover sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
-    } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-      setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-      }, 2000)
-    }
+    await runSandboxTransition(id, async () => {
+      try {
+        await recoverSandbox(id)
+        toast.success('Sandbox recovered. Restarting...')
+      } catch (error) {
+        handleApiError(error, 'Failed to recover sandbox')
+      }
+    })
   }
 
   const handleStop = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+    const sandboxToStop = sandboxItems.find((s) => s.id === id)
 
-    const sandboxToStop = sandboxesData?.items.find((s) => s.id === id)
-    const previousState = sandboxToStop?.state
-
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.STOPPING)
-
-    try {
-      await sandboxApi.stopSandbox(id, selectedOrganization?.id)
-      toast.success(
-        `Stopping sandbox with ID: ${id}`,
-        sandboxToStop?.autoDeleteInterval !== undefined && sandboxToStop.autoDeleteInterval >= 0
-          ? {
-              description: `This sandbox will be deleted automatically ${sandboxToStop.autoDeleteInterval === 0 ? 'upon stopping' : `in ${formatDuration(sandboxToStop.autoDeleteInterval)} unless it is started again`}.`,
-            }
-          : undefined,
-      )
-      await markAllSandboxQueriesAsStale()
-    } catch (error) {
-      handleApiError(error, 'Failed to stop sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
-    } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-      setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-      }, 2000)
-    }
+    await runSandboxTransition(id, async () => {
+      try {
+        await stopSandbox(id)
+        toast.success(
+          `Stopping sandbox with ID: ${id}`,
+          sandboxToStop?.autoDeleteInterval !== undefined && sandboxToStop.autoDeleteInterval >= 0
+            ? {
+                description: `This sandbox will be deleted automatically ${sandboxToStop.autoDeleteInterval === 0 ? 'upon stopping' : `in ${formatDuration(sandboxToStop.autoDeleteInterval)} unless it is started again`}.`,
+              }
+            : undefined,
+        )
+      } catch (error) {
+        handleApiError(error, 'Failed to stop sandbox')
+      }
+    })
   }
 
   const handleDelete = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+    await runSandboxTransition(id, async () => {
+      try {
+        await deleteSandbox(id)
+        setSandboxToDelete(null)
+        setShowDeleteDialog(false)
 
-    const sandboxToDelete = sandboxesData?.items.find((s) => s.id === id)
-    const previousState = sandboxToDelete?.state
+        if (selectedSandbox?.id === id) {
+          setShowSandboxDetails(false)
+          setSelectedSandbox(null)
+        }
 
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.DESTROYING)
-
-    try {
-      await sandboxApi.deleteSandbox(id, selectedOrganization?.id)
-      setSandboxToDelete(null)
-      setShowDeleteDialog(false)
-
-      if (selectedSandbox?.id === id) {
-        setShowSandboxDetails(false)
-        setSelectedSandbox(null)
+        toast.success(`Deleting sandbox with ID:  ${id}`)
+      } catch (error) {
+        handleApiError(error, 'Failed to delete sandbox')
       }
-
-      toast.success(`Deleting sandbox with ID:  ${id}`)
-
-      await markAllSandboxQueriesAsStale()
-    } catch (error) {
-      handleApiError(error, 'Failed to delete sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
-    } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-      setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-      }, 2000)
-    }
+    })
   }
 
   const handleArchive = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
-
-    const sandboxToArchive = sandboxesData?.items.find((s) => s.id === id)
-    const previousState = sandboxToArchive?.state
-
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.ARCHIVING)
-
-    try {
-      await sandboxApi.archiveSandbox(id, selectedOrganization?.id)
-      toast.success(`Archiving sandbox with ID: ${id}`)
-      await markAllSandboxQueriesAsStale()
-    } catch (error) {
-      handleApiError(error, 'Failed to archive sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
-    } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-      setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-      }, 2000)
-    }
+    await runSandboxTransition(id, async () => {
+      try {
+        await archiveSandbox(id)
+        toast.success(`Archiving sandbox with ID: ${id}`)
+      } catch (error) {
+        handleApiError(error, 'Failed to archive sandbox')
+      }
+    })
   }
 
-  // todo(rpavlini): we should refactor this and move to react-query mutations
   const executeBulkAction = useCallback(
     async ({
       ids,
       actionName,
-      optimisticState,
       apiCall,
       toastMessages,
     }: {
       ids: string[]
       actionName: string
-      optimisticState: SandboxState
       apiCall: (id: string) => Promise<unknown>
       toastMessages: {
         successTitle: string
@@ -557,10 +327,6 @@ const Sandboxes: React.FC = () => {
         canceledTitle: string
       }
     }) => {
-      await cancelQueryRefetches(queryKey)
-
-      const previousStatesById = new Map((sandboxesData?.items ?? []).map((sandbox) => [sandbox.id, sandbox.state]))
-
       let isCancelled = false
       let processedCount = 0
       let successCount = 0
@@ -584,26 +350,19 @@ const Sandboxes: React.FC = () => {
             action: { label: 'Cancel', onClick: onCancel },
           })
 
-          setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-          setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
-          performSandboxStateOptimisticUpdate(id, optimisticState)
+          startSandboxTransition(id)
 
           try {
             await apiCall(id)
             successCount += 1
           } catch (error) {
             failureCount += 1
-            revertSandboxStateOptimisticUpdate(id, previousStatesById.get(id))
             console.error(`${actionName} sandbox failed`, id, error)
           } finally {
-            setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-            setTimeout(() => {
-              setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-            }, 2000)
+            stopSandboxTransition(id)
           }
         }
 
-        await markAllSandboxQueriesAsStale()
         bulkToast.result({ successCount, failureCount }, toastMessages)
       } catch (error) {
         console.error(`${actionName} sandboxes failed`, error)
@@ -612,22 +371,14 @@ const Sandboxes: React.FC = () => {
 
       return { successCount, failureCount }
     },
-    [
-      cancelQueryRefetches,
-      queryKey,
-      sandboxesData?.items,
-      performSandboxStateOptimisticUpdate,
-      revertSandboxStateOptimisticUpdate,
-      markAllSandboxQueriesAsStale,
-    ],
+    [startSandboxTransition, stopSandboxTransition],
   )
 
   const handleBulkStart = (ids: string[]) =>
     executeBulkAction({
       ids,
       actionName: 'Starting',
-      optimisticState: SandboxState.STARTING,
-      apiCall: (id) => sandboxApi.startSandbox(id, selectedOrganization?.id),
+      apiCall: (id) => startSandbox(id),
       toastMessages: {
         successTitle: `${pluralize(ids.length, 'sandbox', 'sandboxes')} started.`,
         errorTitle: `Failed to start ${pluralize(ids.length, 'sandbox', 'sandboxes')}.`,
@@ -640,8 +391,7 @@ const Sandboxes: React.FC = () => {
     executeBulkAction({
       ids,
       actionName: 'Stopping',
-      optimisticState: SandboxState.STOPPING,
-      apiCall: (id) => sandboxApi.stopSandbox(id, selectedOrganization?.id),
+      apiCall: (id) => stopSandbox(id),
       toastMessages: {
         successTitle: `${pluralize(ids.length, 'sandbox', 'sandboxes')} stopped.`,
         errorTitle: `Failed to stop ${pluralize(ids.length, 'sandbox', 'sandboxes')}.`,
@@ -654,8 +404,7 @@ const Sandboxes: React.FC = () => {
     executeBulkAction({
       ids,
       actionName: 'Archiving',
-      optimisticState: SandboxState.ARCHIVING,
-      apiCall: (id) => sandboxApi.archiveSandbox(id, selectedOrganization?.id),
+      apiCall: (id) => archiveSandbox(id),
       toastMessages: {
         successTitle: `${pluralize(ids.length, 'sandbox', 'sandboxes')} archived.`,
         errorTitle: `Failed to archive ${pluralize(ids.length, 'sandbox', 'sandboxes')}.`,
@@ -670,8 +419,7 @@ const Sandboxes: React.FC = () => {
     await executeBulkAction({
       ids,
       actionName: 'Deleting',
-      optimisticState: SandboxState.DESTROYING,
-      apiCall: (id) => sandboxApi.deleteSandbox(id, selectedOrganization?.id),
+      apiCall: (id) => deleteSandbox(id),
       toastMessages: {
         successTitle: `${pluralize(ids.length, 'sandbox', 'sandboxes')} deleted.`,
         errorTitle: `Failed to delete ${pluralize(ids.length, 'sandbox', 'sandboxes')}.`,
@@ -688,14 +436,14 @@ const Sandboxes: React.FC = () => {
 
   const getPortPreviewUrl = useCallback(
     async (sandboxId: string, port: number): Promise<string> => {
-      setSandboxIsLoading((prev) => ({ ...prev, [sandboxId]: true }))
+      setSandboxAsyncLoading(sandboxId, true)
       try {
         return (await sandboxApi.getSignedPortPreviewUrl(sandboxId, port, selectedOrganization?.id)).data.url
       } finally {
-        setSandboxIsLoading((prev) => ({ ...prev, [sandboxId]: false }))
+        setSandboxAsyncLoading(sandboxId, false)
       }
     },
-    [sandboxApi, selectedOrganization],
+    [sandboxApi, selectedOrganization, setSandboxAsyncLoading],
   )
 
   const getVncUrl = async (sandboxId: string): Promise<string | null> => {
@@ -709,17 +457,13 @@ const Sandboxes: React.FC = () => {
   }
 
   const handleVnc = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-
-    // Notify user immediately that we're checking VNC status
+    setSandboxAsyncLoading(id, true)
     toast.info('Checking VNC desktop status...')
 
     try {
-      // First, check if computer use is already started
       const statusResponse = await toolboxApi.getComputerUseStatusDeprecated(id, selectedOrganization?.id)
       const status = statusResponse.data.status
 
-      // Check if computer use is active (all processes running)
       if (status === 'active') {
         const vncUrl = await getVncUrl(id)
         if (vncUrl) {
@@ -727,12 +471,10 @@ const Sandboxes: React.FC = () => {
           toast.success('Opening VNC desktop...')
         }
       } else {
-        // Computer use is not active, try to start it
         try {
           await toolboxApi.startComputerUseDeprecated(id, selectedOrganization?.id)
           toast.success('Starting VNC desktop...')
 
-          // Wait a moment for processes to start, then open VNC
           await new Promise((resolve) => setTimeout(resolve, 5000))
 
           try {
@@ -759,7 +501,6 @@ const Sandboxes: React.FC = () => {
             handleApiError(error, 'Failed to check VNC status after start')
           }
         } catch (startError: any) {
-          // Check if this is a computer-use availability error
           const errorMessage = startError?.response?.data?.message || startError?.message || String(startError)
 
           if (errorMessage === 'Computer-use functionality is not available') {
@@ -788,7 +529,7 @@ const Sandboxes: React.FC = () => {
     } catch (error) {
       handleApiError(error, 'Failed to check VNC status')
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+      setSandboxAsyncLoading(id, false)
     }
   }
 
@@ -805,14 +546,13 @@ const Sandboxes: React.FC = () => {
   )
 
   const handleScreenRecordings = async (id: string) => {
-    // Check if sandbox is started
-    const sandbox = sandboxesData?.items?.find((s) => s.id === id)
+    const sandbox = sandboxItems?.find((s) => s.id === id)
     if (!sandbox || sandbox.state !== SandboxState.STARTED) {
       toast.error('Sandbox must be started to access Screen Recordings')
       return
     }
 
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
+    setSandboxAsyncLoading(id, true)
     try {
       const portPreviewUrl = await getPortPreviewUrl(id, 33333)
       window.open(portPreviewUrl, '_blank')
@@ -820,7 +560,7 @@ const Sandboxes: React.FC = () => {
     } catch (error) {
       handleApiError(error, 'Failed to open Screen Recordings')
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+      setSandboxAsyncLoading(id, false)
     }
   }
 
@@ -856,9 +596,6 @@ const Sandboxes: React.FC = () => {
   }, [canCreateSandbox])
 
   useRegisterCommands(rootCommands, { groupId: 'sandbox-actions', groupLabel: 'Sandbox actions', groupOrder: 0 })
-
-  // Redirect user to the onboarding page if they haven't created an api key yet
-  // Perform only once per user
 
   useEffect(() => {
     const onboardIfNeeded = async () => {
@@ -898,53 +635,68 @@ const Sandboxes: React.FC = () => {
         </div>
       </PageHeader>
       <PageContent size="full" className="flex-1 max-h-[calc(100vh-65px)]">
-        <SandboxTable
-          sandboxIsLoading={sandboxIsLoading}
-          sandboxStateIsTransitioning={sandboxStateIsTransitioning}
-          handleStart={handleStart}
-          handleStop={handleStop}
-          handleDelete={(id: string) => {
-            setSandboxToDelete(id)
-            setShowDeleteDialog(true)
-          }}
-          handleBulkDelete={handleBulkDelete}
-          handleBulkStart={handleBulkStart}
-          handleBulkStop={handleBulkStop}
-          handleBulkArchive={handleBulkArchive}
-          handleArchive={handleArchive}
-          handleVnc={handleVnc}
-          getWebTerminalUrl={getWebTerminalUrl}
-          handleCreateSshAccess={openCreateSshDialog}
-          handleRevokeSshAccess={openRevokeSshDialog}
-          handleRefresh={handleRefresh}
-          isRefreshing={sandboxDataIsRefreshing}
-          data={sandboxesData?.items || []}
-          loading={sandboxesDataIsLoading}
-          snapshots={snapshotsData?.items || []}
-          snapshotsDataIsLoading={snapshotsDataIsLoading}
-          snapshotsDataHasMore={snapshotsDataHasMore}
-          onChangeSnapshotSearchValue={(name?: string) => handleSnapshotFiltersChange({ name })}
-          regionsData={regionsData || []}
-          regionsDataIsLoading={regionsDataIsLoading}
-          onRowClick={(sandbox: Sandbox) => {
-            setSelectedSandbox(sandbox)
-            setShowSandboxDetails(true)
-          }}
-          pageCount={sandboxesData?.totalPages || 0}
-          totalItems={sandboxesData?.total || 0}
-          onPaginationChange={handlePaginationChange}
-          pagination={{
-            pageIndex: paginationParams.pageIndex,
-            pageSize: paginationParams.pageSize,
-          }}
-          sorting={sorting}
-          onSortingChange={handleSortingChange}
-          filters={filters}
-          onFiltersChange={handleFiltersChange}
-          handleRecover={handleRecover}
-          getRegionName={getRegionName}
-          handleScreenRecordings={handleScreenRecordings}
-        />
+        {sandboxesDataError ? (
+          <Empty className="py-12">
+            <EmptyHeader>
+              <EmptyMedia variant="icon" className="bg-destructive-background text-destructive">
+                <AlertCircle />
+              </EmptyMedia>
+              <EmptyTitle className="text-destructive">Failed to load sandboxes</EmptyTitle>
+              <EmptyDescription>Something went wrong while fetching sandboxes. Please try again.</EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button variant="secondary" size="sm" onClick={() => handleRefresh()} disabled={sandboxDataIsRefreshing}>
+                <RefreshCw />
+                Retry
+              </Button>
+            </EmptyContent>
+          </Empty>
+        ) : (
+          <SandboxTable
+            sandboxIsLoading={sandboxIsLoading}
+            sandboxStateIsTransitioning={sandboxStateIsTransitioning}
+            handleStart={handleStart}
+            handleStop={handleStop}
+            handleDelete={(id: string) => {
+              setSandboxToDelete(id)
+              setShowDeleteDialog(true)
+            }}
+            handleBulkDelete={handleBulkDelete}
+            handleBulkStart={handleBulkStart}
+            handleBulkStop={handleBulkStop}
+            handleBulkArchive={handleBulkArchive}
+            handleArchive={handleArchive}
+            handleVnc={handleVnc}
+            getWebTerminalUrl={getWebTerminalUrl}
+            handleCreateSshAccess={openCreateSshDialog}
+            handleRevokeSshAccess={openRevokeSshDialog}
+            handleRefresh={handleRefresh}
+            isRefreshing={sandboxDataIsRefreshing}
+            data={sandboxItems || []}
+            loading={sandboxesDataIsLoading}
+            snapshots={snapshotsData?.items || []}
+            snapshotsDataIsLoading={snapshotsDataIsLoading}
+            snapshotsDataHasMore={snapshotsDataHasMore}
+            onChangeSnapshotSearchValue={(name?: string) => handleSnapshotFiltersChange({ name })}
+            regionsData={regionsData || []}
+            regionsDataIsLoading={regionsDataIsLoading}
+            onRowClick={(sandbox: Sandbox) => {
+              setSelectedSandbox(sandbox)
+              setShowSandboxDetails(true)
+            }}
+            pageCount={pageCount}
+            totalItems={totalItems}
+            onPaginationChange={handlePaginationChange}
+            pagination={pagination}
+            sorting={sorting}
+            onSortingChange={handleSortingChange}
+            filters={filters}
+            onFiltersChange={handleFiltersChange}
+            handleRecover={handleRecover}
+            getRegionName={getRegionName}
+            handleScreenRecordings={handleScreenRecordings}
+          />
+        )}
 
         {sandboxToDelete && (
           <AlertDialog
@@ -1023,4 +775,10 @@ const Sandboxes: React.FC = () => {
   )
 }
 
-export default Sandboxes
+const SandboxesPage: React.FC = () => (
+  <SandboxListProvider>
+    <Sandboxes />
+  </SandboxListProvider>
+)
+
+export default SandboxesPage

--- a/apps/dashboard/src/providers/SandboxListProvider/SandboxListClientPaginatedProvider.tsx
+++ b/apps/dashboard/src/providers/SandboxListProvider/SandboxListClientPaginatedProvider.tsx
@@ -1,0 +1,263 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SandboxListContext, SandboxListContextValue } from './SandboxListContext'
+import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { DEFAULT_SANDBOX_SORTING, SandboxFilters, SandboxSorting } from '@/hooks/useSandboxes'
+import { useApi } from '@/hooks/useApi'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { handleApiError } from '@/lib/error-handling'
+import { compareSandboxesBySorting, matchesSandboxFilters } from './SandboxListClientUtils'
+import { useSandboxListMutations } from './useSandboxListMutations'
+import { useSandboxListWsSync } from './useSandboxListWsSync'
+import { Sandbox, SandboxDesiredState, SandboxState } from '@daytonaio/api-client'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+const QUERY_KEY_PREFIX = 'sandboxes-client'
+
+/**
+ * @deprecated Temporary provider using client-side pagination and filtering while the
+ * server-side paginated endpoint is not yet deployed to production.
+ * Use SandboxListServerPaginatedProvider once the backend supports it.
+ */
+export const SandboxListClientPaginatedProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { sandboxApi } = useApi()
+  const { selectedOrganization } = useSelectedOrganization()
+  const queryClient = useQueryClient()
+
+  const queryKey = useMemo(() => [QUERY_KEY_PREFIX, selectedOrganization?.id] as const, [selectedOrganization?.id])
+
+  const {
+    data: allSandboxes = [],
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<Sandbox[]>({
+    queryKey,
+    queryFn: async () => {
+      if (!selectedOrganization) return []
+      const response = await sandboxApi.listSandboxes(selectedOrganization.id)
+      return response.data
+    },
+    enabled: !!selectedOrganization,
+  })
+
+  const [paginationParams, setPaginationParams] = useState({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  })
+
+  const handlePaginationChange = useCallback(({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
+    setPaginationParams({ pageIndex, pageSize })
+  }, [])
+
+  const [filters, setFilters] = useState<SandboxFilters>({})
+
+  const handleFiltersChange = useCallback((filters: SandboxFilters) => {
+    setFilters(filters)
+    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+  }, [])
+
+  const [sorting, setSorting] = useState<SandboxSorting>(DEFAULT_SANDBOX_SORTING)
+
+  const handleSortingChange = useCallback((sorting: SandboxSorting) => {
+    setSorting(sorting)
+    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+  }, [])
+
+  const processedData = useMemo(() => {
+    const filtered = allSandboxes.filter((sandbox) => matchesSandboxFilters(sandbox, filters))
+    filtered.sort((a, b) => compareSandboxesBySorting(a, b, sorting))
+
+    const totalItems = filtered.length
+    const pageCount = Math.max(1, Math.ceil(totalItems / paginationParams.pageSize))
+    const start = paginationParams.pageIndex * paginationParams.pageSize
+    const items = filtered.slice(start, start + paginationParams.pageSize)
+
+    return { items, totalItems, pageCount }
+  }, [allSandboxes, filters, sorting, paginationParams])
+
+  useEffect(() => {
+    if (processedData.items.length === 0 && paginationParams.pageIndex > 0) {
+      setPaginationParams((prev) => ({
+        ...prev,
+        pageIndex: prev.pageIndex - 1,
+      }))
+    }
+  }, [processedData.items.length, paginationParams.pageIndex])
+
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true)
+    try {
+      const result = await refetch()
+      if (result.error) {
+        throw result.error
+      }
+    } catch (refreshError) {
+      handleApiError(refreshError, 'Failed to refresh sandboxes')
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [refetch])
+
+  const performSandboxStateOptimisticUpdate = useCallback(
+    (sandboxId: string, newState: SandboxState) => {
+      queryClient.setQueryData<Sandbox[]>(queryKey, (prev) =>
+        prev?.map((s) => (s.id === sandboxId ? { ...s, state: newState } : s)),
+      )
+    },
+    [queryClient, queryKey],
+  )
+
+  const revertSandboxStateOptimisticUpdate = useCallback(
+    (sandboxId: string, previousState?: SandboxState) => {
+      if (!previousState) return
+      queryClient.setQueryData<Sandbox[]>(queryKey, (prev) =>
+        prev?.map((s) => (s.id === sandboxId ? { ...s, state: previousState } : s)),
+      )
+    },
+    [queryClient, queryKey],
+  )
+
+  const getSandboxState = useCallback(
+    (sandboxId: string) => allSandboxes.find((sandbox) => sandbox.id === sandboxId)?.state,
+    [allSandboxes],
+  )
+
+  const upsertSandboxInCache = useCallback(
+    (sandbox: Sandbox) => {
+      queryClient.setQueryData<Sandbox[]>(queryKey, (prev = []) => {
+        const sandboxExists = prev.some((item) => item.id === sandbox.id)
+        if (!sandboxExists) {
+          return [sandbox, ...prev]
+        }
+
+        return prev.map((item) => (item.id === sandbox.id ? sandbox : item))
+      })
+    },
+    [queryClient, queryKey],
+  )
+
+  const onSandboxCreated = useCallback(
+    (sandbox: Sandbox) => {
+      upsertSandboxInCache(sandbox)
+    },
+    [upsertSandboxInCache],
+  )
+
+  const onSandboxStateUpdated = useCallback(
+    (data: { sandbox: Sandbox; oldState: SandboxState; newState: SandboxState }) => {
+      if (data.oldState === data.newState && data.newState === SandboxState.STARTED) {
+        onSandboxCreated(data.sandbox)
+        return
+      }
+
+      if (data.newState === SandboxState.DESTROYED) {
+        upsertSandboxInCache({ ...data.sandbox, state: SandboxState.DESTROYED })
+        return
+      }
+
+      if (
+        data.sandbox.desiredState === SandboxDesiredState.DESTROYED &&
+        (data.newState === SandboxState.ERROR || data.newState === SandboxState.BUILD_FAILED)
+      ) {
+        upsertSandboxInCache({ ...data.sandbox, state: SandboxState.DESTROYED })
+        return
+      }
+
+      upsertSandboxInCache(data.sandbox)
+    },
+    [onSandboxCreated, upsertSandboxInCache],
+  )
+
+  const onSandboxDesiredStateUpdated = useCallback(
+    (data: { sandbox: Sandbox; oldDesiredState: SandboxDesiredState; newDesiredState: SandboxDesiredState }) => {
+      if (data.newDesiredState !== SandboxDesiredState.DESTROYED) {
+        return
+      }
+
+      if (data.sandbox.state !== SandboxState.ERROR && data.sandbox.state !== SandboxState.BUILD_FAILED) {
+        return
+      }
+
+      upsertSandboxInCache({ ...data.sandbox, state: SandboxState.DESTROYED })
+    },
+    [upsertSandboxInCache],
+  )
+
+  useSandboxListWsSync({
+    onSandboxCreated,
+    onSandboxStateUpdated,
+    onSandboxDesiredStateUpdated,
+  })
+
+  const markAllQueriesAsStale = useCallback(
+    async (shouldRefetchActive = false) => {
+      await queryClient.invalidateQueries({
+        queryKey,
+        refetchType: shouldRefetchActive ? 'active' : 'none',
+      })
+    },
+    [queryClient, queryKey],
+  )
+
+  const cancelOutgoingRefetches = useCallback(async () => {
+    await queryClient.cancelQueries({ queryKey })
+  }, [queryClient, queryKey])
+
+  const { startSandbox, recoverSandbox, stopSandbox, archiveSandbox, deleteSandbox } = useSandboxListMutations({
+    getSandboxState,
+    performSandboxStateOptimisticUpdate,
+    revertSandboxStateOptimisticUpdate,
+    cancelOutgoingRefetches,
+    markAllQueriesAsStale,
+  })
+
+  const value = useMemo<SandboxListContextValue>(
+    () => ({
+      sandboxes: processedData.items,
+      totalItems: processedData.totalItems,
+      pageCount: processedData.pageCount,
+      isLoading,
+      error: error ?? null,
+      pagination: paginationParams,
+      onPaginationChange: handlePaginationChange,
+      sorting,
+      onSortingChange: handleSortingChange,
+      filters,
+      onFiltersChange: handleFiltersChange,
+      handleRefresh,
+      isRefreshing,
+      startSandbox,
+      recoverSandbox,
+      stopSandbox,
+      archiveSandbox,
+      deleteSandbox,
+    }),
+    [
+      processedData,
+      isLoading,
+      error,
+      paginationParams,
+      handlePaginationChange,
+      sorting,
+      handleSortingChange,
+      filters,
+      handleFiltersChange,
+      handleRefresh,
+      isRefreshing,
+      startSandbox,
+      recoverSandbox,
+      stopSandbox,
+      archiveSandbox,
+      deleteSandbox,
+    ],
+  )
+
+  return <SandboxListContext.Provider value={value}>{children}</SandboxListContext.Provider>
+}

--- a/apps/dashboard/src/providers/SandboxListProvider/SandboxListClientPaginatedProvider.tsx
+++ b/apps/dashboard/src/providers/SandboxListProvider/SandboxListClientPaginatedProvider.tsx
@@ -5,6 +5,7 @@
 
 import { SandboxListContext, SandboxListContextValue } from './SandboxListContext'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { queryKeys } from '@/hooks/queries/queryKeys'
 import { DEFAULT_SANDBOX_SORTING, SandboxFilters, SandboxSorting } from '@/hooks/useSandboxes'
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
@@ -16,8 +17,6 @@ import { Sandbox, SandboxDesiredState, SandboxState } from '@daytonaio/api-clien
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
-const QUERY_KEY_PREFIX = 'sandboxes-client'
-
 /**
  * @deprecated Temporary provider using client-side pagination and filtering while the
  * server-side paginated endpoint is not yet deployed to production.
@@ -28,11 +27,12 @@ export const SandboxListClientPaginatedProvider: React.FC<{ children: React.Reac
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
 
-  const queryKey = useMemo(() => [QUERY_KEY_PREFIX, selectedOrganization?.id] as const, [selectedOrganization?.id])
+  const queryKey = useMemo(() => queryKeys.sandboxes.organization(selectedOrganization?.id), [selectedOrganization?.id])
 
   const {
     data: allSandboxes = [],
     isLoading,
+    isFetching,
     error,
     refetch,
   } = useQuery<Sandbox[]>({
@@ -191,6 +191,7 @@ export const SandboxListClientPaginatedProvider: React.FC<{ children: React.Reac
   )
 
   useSandboxListWsSync({
+    enabled: !!selectedOrganization?.id,
     onSandboxCreated,
     onSandboxStateUpdated,
     onSandboxDesiredStateUpdated,
@@ -224,6 +225,7 @@ export const SandboxListClientPaginatedProvider: React.FC<{ children: React.Reac
       totalItems: processedData.totalItems,
       pageCount: processedData.pageCount,
       isLoading,
+      isRefetching: isFetching && allSandboxes.length > 0,
       error: error ?? null,
       pagination: paginationParams,
       onPaginationChange: handlePaginationChange,
@@ -241,7 +243,9 @@ export const SandboxListClientPaginatedProvider: React.FC<{ children: React.Reac
     }),
     [
       processedData,
+      allSandboxes.length,
       isLoading,
+      isFetching,
       error,
       paginationParams,
       handlePaginationChange,

--- a/apps/dashboard/src/providers/SandboxListProvider/SandboxListClientUtils.ts
+++ b/apps/dashboard/src/providers/SandboxListProvider/SandboxListClientUtils.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SandboxFilters, SandboxSorting } from '@/hooks/useSandboxes'
+import {
+  ListSandboxesPaginatedOrderEnum,
+  ListSandboxesPaginatedSortEnum,
+  ListSandboxesPaginatedStatesEnum,
+  Sandbox,
+  SandboxState,
+} from '@daytonaio/api-client'
+
+const stateEnumToSandboxState: Record<ListSandboxesPaginatedStatesEnum, SandboxState> = {
+  [ListSandboxesPaginatedStatesEnum.CREATING]: SandboxState.CREATING,
+  [ListSandboxesPaginatedStatesEnum.RESTORING]: SandboxState.RESTORING,
+  [ListSandboxesPaginatedStatesEnum.STARTING]: SandboxState.STARTING,
+  [ListSandboxesPaginatedStatesEnum.STARTED]: SandboxState.STARTED,
+  [ListSandboxesPaginatedStatesEnum.STOPPING]: SandboxState.STOPPING,
+  [ListSandboxesPaginatedStatesEnum.STOPPED]: SandboxState.STOPPED,
+  [ListSandboxesPaginatedStatesEnum.ARCHIVING]: SandboxState.ARCHIVING,
+  [ListSandboxesPaginatedStatesEnum.ARCHIVED]: SandboxState.ARCHIVED,
+  [ListSandboxesPaginatedStatesEnum.DESTROYING]: SandboxState.DESTROYING,
+  [ListSandboxesPaginatedStatesEnum.ERROR]: SandboxState.ERROR,
+  [ListSandboxesPaginatedStatesEnum.BUILD_FAILED]: SandboxState.BUILD_FAILED,
+  [ListSandboxesPaginatedStatesEnum.PENDING_BUILD]: SandboxState.PENDING_BUILD,
+  [ListSandboxesPaginatedStatesEnum.BUILDING_SNAPSHOT]: SandboxState.BUILDING_SNAPSHOT,
+  [ListSandboxesPaginatedStatesEnum.UNKNOWN]: SandboxState.UNKNOWN,
+  [ListSandboxesPaginatedStatesEnum.PULLING_SNAPSHOT]: SandboxState.PULLING_SNAPSHOT,
+  [ListSandboxesPaginatedStatesEnum.RESIZING]: SandboxState.RESIZING,
+}
+
+export function matchesSandboxFilters(sandbox: Sandbox, filters: SandboxFilters): boolean {
+  if (filters.idOrName) {
+    const search = filters.idOrName.toLowerCase()
+    const matchesId = sandbox.id.toLowerCase().includes(search)
+    const matchesName = sandbox.name?.toLowerCase().includes(search)
+    if (!matchesId && !matchesName) return false
+  }
+
+  if (filters.states && filters.states.length > 0) {
+    const sandboxStates = filters.states.map((s) => stateEnumToSandboxState[s]).filter(Boolean)
+    if (!sandbox.state || !sandboxStates.includes(sandbox.state)) return false
+  }
+
+  if (filters.snapshots && filters.snapshots.length > 0) {
+    if (!sandbox.snapshot || !filters.snapshots.includes(sandbox.snapshot)) return false
+  }
+
+  if (filters.regions && filters.regions.length > 0) {
+    if (!sandbox.target || !filters.regions.includes(sandbox.target)) return false
+  }
+
+  if (filters.labels) {
+    const sandboxLabels = sandbox.labels || {}
+    for (const [key, value] of Object.entries(filters.labels)) {
+      if (sandboxLabels[key] !== value) return false
+    }
+  }
+
+  if (filters.minCpu !== undefined && sandbox.cpu < filters.minCpu) return false
+  if (filters.maxCpu !== undefined && sandbox.cpu > filters.maxCpu) return false
+  if (filters.minMemoryGiB !== undefined && sandbox.memory < filters.minMemoryGiB) return false
+  if (filters.maxMemoryGiB !== undefined && sandbox.memory > filters.maxMemoryGiB) return false
+  if (filters.minDiskGiB !== undefined && sandbox.disk < filters.minDiskGiB) return false
+  if (filters.maxDiskGiB !== undefined && sandbox.disk > filters.maxDiskGiB) return false
+
+  if (filters.lastEventAfter || filters.lastEventBefore) {
+    const lastEventTimestamp = sandbox.updatedAt ? new Date(sandbox.updatedAt).getTime() : Number.NaN
+    if (Number.isNaN(lastEventTimestamp)) return false
+
+    if (filters.lastEventAfter && lastEventTimestamp < filters.lastEventAfter.getTime()) return false
+    if (filters.lastEventBefore && lastEventTimestamp > filters.lastEventBefore.getTime()) return false
+  }
+
+  return true
+}
+
+function getSortValue(sandbox: Sandbox, field?: ListSandboxesPaginatedSortEnum): string | number | undefined {
+  switch (field) {
+    case ListSandboxesPaginatedSortEnum.ID:
+      return sandbox.id
+    case ListSandboxesPaginatedSortEnum.NAME:
+      return sandbox.name?.toLowerCase() ?? ''
+    case ListSandboxesPaginatedSortEnum.STATE:
+      return sandbox.state ?? ''
+    case ListSandboxesPaginatedSortEnum.SNAPSHOT:
+      return sandbox.snapshot ?? ''
+    case ListSandboxesPaginatedSortEnum.REGION:
+      return sandbox.target ?? ''
+    case ListSandboxesPaginatedSortEnum.CREATED_AT:
+      return sandbox.createdAt ? new Date(sandbox.createdAt).getTime() : 0
+    case ListSandboxesPaginatedSortEnum.UPDATED_AT:
+    default:
+      return sandbox.updatedAt ? new Date(sandbox.updatedAt).getTime() : 0
+  }
+}
+
+export function compareSandboxesBySorting(a: Sandbox, b: Sandbox, sorting: SandboxSorting): number {
+  const aVal = getSortValue(a, sorting.field)
+  const bVal = getSortValue(b, sorting.field)
+  const direction = sorting.direction === ListSandboxesPaginatedOrderEnum.ASC ? 1 : -1
+
+  if (aVal === undefined && bVal === undefined) return 0
+  if (aVal === undefined) return direction
+  if (bVal === undefined) return -direction
+
+  if (typeof aVal === 'string' && typeof bVal === 'string') {
+    return aVal.localeCompare(bVal) * direction
+  }
+
+  if (typeof aVal === 'number' && typeof bVal === 'number') {
+    return (aVal - bVal) * direction
+  }
+
+  return 0
+}

--- a/apps/dashboard/src/providers/SandboxListProvider/SandboxListContext.tsx
+++ b/apps/dashboard/src/providers/SandboxListProvider/SandboxListContext.tsx
@@ -12,6 +12,7 @@ export interface SandboxListContextValue {
   totalItems: number
   pageCount: number
   isLoading: boolean
+  isRefetching: boolean
   error: unknown | null
 
   pagination: { pageIndex: number; pageSize: number }

--- a/apps/dashboard/src/providers/SandboxListProvider/SandboxListContext.tsx
+++ b/apps/dashboard/src/providers/SandboxListProvider/SandboxListContext.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SandboxFilters, SandboxSorting } from '@/hooks/useSandboxes'
+import { Sandbox } from '@daytonaio/api-client'
+import { createContext } from 'react'
+
+export interface SandboxListContextValue {
+  sandboxes: Sandbox[]
+  totalItems: number
+  pageCount: number
+  isLoading: boolean
+  error: unknown | null
+
+  pagination: { pageIndex: number; pageSize: number }
+  onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
+
+  sorting: SandboxSorting
+  onSortingChange: (sorting: SandboxSorting) => void
+
+  filters: SandboxFilters
+  onFiltersChange: (filters: SandboxFilters) => void
+
+  handleRefresh: () => Promise<void>
+  isRefreshing: boolean
+
+  startSandbox: (sandboxId: string) => Promise<void>
+  recoverSandbox: (sandboxId: string) => Promise<void>
+  stopSandbox: (sandboxId: string) => Promise<void>
+  archiveSandbox: (sandboxId: string) => Promise<void>
+  deleteSandbox: (sandboxId: string) => Promise<void>
+}
+
+export const SandboxListContext = createContext<SandboxListContextValue | null>(null)

--- a/apps/dashboard/src/providers/SandboxListProvider/SandboxListServerPaginatedProvider.tsx
+++ b/apps/dashboard/src/providers/SandboxListProvider/SandboxListServerPaginatedProvider.tsx
@@ -1,0 +1,210 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SandboxListContext, SandboxListContextValue } from './SandboxListContext'
+import { useSandboxListMutations } from './useSandboxListMutations'
+import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { queryKeys } from '@/hooks/queries/queryKeys'
+import { useSandboxWsSync } from '@/hooks/useSandboxWsSync'
+import {
+  DEFAULT_SANDBOX_SORTING,
+  SandboxFilters,
+  SandboxQueryParams,
+  SandboxSorting,
+  useSandboxes,
+} from '@/hooks/useSandboxes'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { handleApiError } from '@/lib/error-handling'
+import { Sandbox, SandboxState } from '@daytonaio/api-client'
+import { QueryKey, useQueryClient } from '@tanstack/react-query'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+export const SandboxListServerPaginatedProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const queryClient = useQueryClient()
+  const { selectedOrganization } = useSelectedOrganization()
+
+  const [paginationParams, setPaginationParams] = useState({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  })
+
+  const handlePaginationChange = useCallback(({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
+    setPaginationParams({ pageIndex, pageSize })
+  }, [])
+
+  const [filters, setFilters] = useState<SandboxFilters>({})
+
+  const handleFiltersChange = useCallback((filters: SandboxFilters) => {
+    setFilters(filters)
+    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+  }, [])
+
+  const [sorting, setSorting] = useState<SandboxSorting>(DEFAULT_SANDBOX_SORTING)
+
+  const handleSortingChange = useCallback((sorting: SandboxSorting) => {
+    setSorting(sorting)
+    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+  }, [])
+
+  const queryParams = useMemo<SandboxQueryParams>(
+    () => ({
+      page: paginationParams.pageIndex + 1,
+      pageSize: paginationParams.pageSize,
+      filters,
+      sorting,
+    }),
+    [paginationParams, filters, sorting],
+  )
+
+  const baseQueryKey = useMemo<QueryKey>(
+    () => queryKeys.sandboxes.list(selectedOrganization?.id),
+    [selectedOrganization?.id],
+  )
+
+  const queryKey = useMemo<QueryKey>(
+    () => queryKeys.sandboxes.list(selectedOrganization?.id, queryParams),
+    [selectedOrganization?.id, queryParams],
+  )
+
+  const {
+    data: sandboxesData,
+    isLoading: sandboxesDataIsLoading,
+    error: sandboxesDataError,
+    refetch: refetchSandboxesData,
+  } = useSandboxes(queryKey, queryParams)
+
+  useEffect(() => {
+    if (sandboxesData?.items.length === 0 && paginationParams.pageIndex > 0) {
+      setPaginationParams((prev) => ({
+        ...prev,
+        pageIndex: prev.pageIndex - 1,
+      }))
+    }
+  }, [sandboxesData?.items.length, paginationParams.pageIndex])
+
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true)
+    try {
+      const result = await refetchSandboxesData()
+      if (result.error) {
+        throw result.error
+      }
+    } catch (error) {
+      handleApiError(error, 'Failed to refresh sandboxes')
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [refetchSandboxesData])
+
+  const updateSandboxInCache = useCallback(
+    (sandboxId: string, updates: Partial<Sandbox>) => {
+      queryClient.setQueryData(queryKey, (oldData: any) => {
+        if (!oldData) return oldData
+        return {
+          ...oldData,
+          items: oldData.items.map((sandbox: Sandbox) =>
+            sandbox.id === sandboxId ? { ...sandbox, ...updates } : sandbox,
+          ),
+        }
+      })
+    },
+    [queryClient, queryKey],
+  )
+
+  const markAllQueriesAsStale = useCallback(
+    (shouldRefetchActive = false) =>
+      queryClient.invalidateQueries({
+        queryKey: baseQueryKey,
+        refetchType: shouldRefetchActive ? 'active' : 'none',
+      }),
+    [queryClient, baseQueryKey],
+  )
+
+  const cancelOutgoingRefetches = useCallback(() => queryClient.cancelQueries({ queryKey }), [queryClient, queryKey])
+
+  const performSandboxStateOptimisticUpdate = useCallback(
+    (sandboxId: string, newState: SandboxState) => {
+      updateSandboxInCache(sandboxId, { state: newState })
+    },
+    [updateSandboxInCache],
+  )
+
+  const revertSandboxStateOptimisticUpdate = useCallback(
+    (sandboxId: string, previousState?: SandboxState) => {
+      if (!previousState) return
+      updateSandboxInCache(sandboxId, { state: previousState })
+    },
+    [updateSandboxInCache],
+  )
+
+  const getSandboxState = useCallback(
+    (sandboxId: string) => sandboxesData?.items.find((sandbox) => sandbox.id === sandboxId)?.state,
+    [sandboxesData?.items],
+  )
+
+  const shouldRefetchOnCreate = useMemo(() => {
+    const isFirstPage = paginationParams.pageIndex === 0
+    const isDefaultFilters = Object.keys(filters).length === 0
+    const isDefaultSorting =
+      sorting.field === DEFAULT_SANDBOX_SORTING.field && sorting.direction === DEFAULT_SANDBOX_SORTING.direction
+
+    return isFirstPage && isDefaultFilters && isDefaultSorting
+  }, [filters, paginationParams.pageIndex, sorting.direction, sorting.field])
+
+  useSandboxWsSync({ refetchOnCreate: shouldRefetchOnCreate })
+
+  const { startSandbox, recoverSandbox, stopSandbox, archiveSandbox, deleteSandbox } = useSandboxListMutations({
+    getSandboxState,
+    performSandboxStateOptimisticUpdate,
+    revertSandboxStateOptimisticUpdate,
+    cancelOutgoingRefetches,
+    markAllQueriesAsStale,
+  })
+
+  const value = useMemo<SandboxListContextValue>(
+    () => ({
+      sandboxes: sandboxesData?.items || [],
+      totalItems: sandboxesData?.total || 0,
+      pageCount: sandboxesData?.totalPages || 0,
+      isLoading: sandboxesDataIsLoading,
+      error: sandboxesDataError ?? null,
+      pagination: paginationParams,
+      onPaginationChange: handlePaginationChange,
+      sorting,
+      onSortingChange: handleSortingChange,
+      filters,
+      onFiltersChange: handleFiltersChange,
+      handleRefresh,
+      isRefreshing,
+      startSandbox,
+      recoverSandbox,
+      stopSandbox,
+      archiveSandbox,
+      deleteSandbox,
+    }),
+    [
+      sandboxesData,
+      sandboxesDataIsLoading,
+      sandboxesDataError,
+      paginationParams,
+      handlePaginationChange,
+      sorting,
+      handleSortingChange,
+      filters,
+      handleFiltersChange,
+      handleRefresh,
+      isRefreshing,
+      startSandbox,
+      recoverSandbox,
+      stopSandbox,
+      archiveSandbox,
+      deleteSandbox,
+    ],
+  )
+
+  return <SandboxListContext.Provider value={value}>{children}</SandboxListContext.Provider>
+}

--- a/apps/dashboard/src/providers/SandboxListProvider/SandboxListServerPaginatedProvider.tsx
+++ b/apps/dashboard/src/providers/SandboxListProvider/SandboxListServerPaginatedProvider.tsx
@@ -71,6 +71,7 @@ export const SandboxListServerPaginatedProvider: React.FC<{ children: React.Reac
   const {
     data: sandboxesData,
     isLoading: sandboxesDataIsLoading,
+    isFetching: sandboxesDataIsFetching,
     error: sandboxesDataError,
     refetch: refetchSandboxesData,
   } = useSandboxes(queryKey, queryParams)
@@ -171,6 +172,7 @@ export const SandboxListServerPaginatedProvider: React.FC<{ children: React.Reac
       totalItems: sandboxesData?.total || 0,
       pageCount: sandboxesData?.totalPages || 0,
       isLoading: sandboxesDataIsLoading,
+      isRefetching: sandboxesDataIsFetching && Boolean(sandboxesData),
       error: sandboxesDataError ?? null,
       pagination: paginationParams,
       onPaginationChange: handlePaginationChange,
@@ -189,6 +191,7 @@ export const SandboxListServerPaginatedProvider: React.FC<{ children: React.Reac
     [
       sandboxesData,
       sandboxesDataIsLoading,
+      sandboxesDataIsFetching,
       sandboxesDataError,
       paginationParams,
       handlePaginationChange,

--- a/apps/dashboard/src/providers/SandboxListProvider/index.tsx
+++ b/apps/dashboard/src/providers/SandboxListProvider/index.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import React from 'react'
+import { SandboxListClientPaginatedProvider } from './SandboxListClientPaginatedProvider'
+import { SandboxListServerPaginatedProvider } from './SandboxListServerPaginatedProvider'
+export { useSandboxListContext } from './useSandboxListContext'
+
+const useClientPagination = import.meta.env.VITE_CLIENT_SIDE_SANDBOX_PAGINATION === 'true'
+
+export const SandboxListProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  if (useClientPagination) {
+    return <SandboxListClientPaginatedProvider>{children}</SandboxListClientPaginatedProvider>
+  }
+
+  return <SandboxListServerPaginatedProvider>{children}</SandboxListServerPaginatedProvider>
+}

--- a/apps/dashboard/src/providers/SandboxListProvider/useSandboxListContext.ts
+++ b/apps/dashboard/src/providers/SandboxListProvider/useSandboxListContext.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { SandboxListContext, SandboxListContextValue } from './SandboxListContext'
+import { useContext } from 'react'
+
+export function useSandboxListContext(): SandboxListContextValue {
+  const context = useContext(SandboxListContext)
+  if (!context) {
+    throw new Error('useSandboxListContext must be used within a SandboxListProvider')
+  }
+  return context
+}

--- a/apps/dashboard/src/providers/SandboxListProvider/useSandboxListMutations.ts
+++ b/apps/dashboard/src/providers/SandboxListProvider/useSandboxListMutations.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useArchiveSandboxMutation } from '@/hooks/mutations/useArchiveSandboxMutation'
+import { useDeleteSandboxMutation } from '@/hooks/mutations/useDeleteSandboxMutation'
+import { useRecoverSandboxMutation } from '@/hooks/mutations/useRecoverSandboxMutation'
+import { useStartSandboxMutation } from '@/hooks/mutations/useStartSandboxMutation'
+import { useStopSandboxMutation } from '@/hooks/mutations/useStopSandboxMutation'
+import { SandboxMutationVariables } from '@/hooks/mutations/mutationKeys'
+import { SandboxState } from '@daytonaio/api-client'
+import { useCallback } from 'react'
+
+interface UseSandboxListMutationsOptions {
+  getSandboxState: (sandboxId: string) => SandboxState | undefined
+  performSandboxStateOptimisticUpdate: (sandboxId: string, newState: SandboxState) => void
+  revertSandboxStateOptimisticUpdate: (sandboxId: string, previousState?: SandboxState) => void
+  cancelOutgoingRefetches: () => Promise<void>
+  markAllQueriesAsStale: (shouldRefetchActive?: boolean) => Promise<void>
+}
+
+interface SandboxMutationContext {
+  previousState?: SandboxState
+}
+
+export function useSandboxListMutations({
+  getSandboxState,
+  performSandboxStateOptimisticUpdate,
+  revertSandboxStateOptimisticUpdate,
+  cancelOutgoingRefetches,
+  markAllQueriesAsStale,
+}: UseSandboxListMutationsOptions) {
+  const startMutation = useStartSandboxMutation()
+  const recoverMutation = useRecoverSandboxMutation()
+  const stopMutation = useStopSandboxMutation()
+  const archiveMutation = useArchiveSandboxMutation()
+  const deleteMutation = useDeleteSandboxMutation()
+
+  const runSandboxMutation = useCallback(
+    async ({
+      sandboxId,
+      optimisticState,
+      mutateAsync,
+    }: {
+      sandboxId: string
+      optimisticState: SandboxState
+      mutateAsync: (variables: SandboxMutationVariables) => Promise<void>
+    }) => {
+      await cancelOutgoingRefetches()
+
+      const context: SandboxMutationContext = {
+        previousState: getSandboxState(sandboxId),
+      }
+
+      performSandboxStateOptimisticUpdate(sandboxId, optimisticState)
+
+      try {
+        await mutateAsync({ sandboxId })
+      } catch (error) {
+        revertSandboxStateOptimisticUpdate(sandboxId, context.previousState)
+        throw error
+      }
+
+      await markAllQueriesAsStale()
+    },
+    [
+      cancelOutgoingRefetches,
+      getSandboxState,
+      markAllQueriesAsStale,
+      performSandboxStateOptimisticUpdate,
+      revertSandboxStateOptimisticUpdate,
+    ],
+  )
+
+  const startSandbox = useCallback(
+    async (sandboxId: string) => {
+      await runSandboxMutation({
+        sandboxId,
+        optimisticState: SandboxState.STARTING,
+        mutateAsync: startMutation.mutateAsync,
+      })
+    },
+    [runSandboxMutation, startMutation.mutateAsync],
+  )
+
+  const recoverSandbox = useCallback(
+    async (sandboxId: string) => {
+      await runSandboxMutation({
+        sandboxId,
+        optimisticState: SandboxState.STARTING,
+        mutateAsync: recoverMutation.mutateAsync,
+      })
+    },
+    [recoverMutation.mutateAsync, runSandboxMutation],
+  )
+
+  const stopSandbox = useCallback(
+    async (sandboxId: string) => {
+      await runSandboxMutation({
+        sandboxId,
+        optimisticState: SandboxState.STOPPING,
+        mutateAsync: stopMutation.mutateAsync,
+      })
+    },
+    [runSandboxMutation, stopMutation.mutateAsync],
+  )
+
+  const archiveSandbox = useCallback(
+    async (sandboxId: string) => {
+      await runSandboxMutation({
+        sandboxId,
+        optimisticState: SandboxState.ARCHIVING,
+        mutateAsync: archiveMutation.mutateAsync,
+      })
+    },
+    [archiveMutation.mutateAsync, runSandboxMutation],
+  )
+
+  const deleteSandbox = useCallback(
+    async (sandboxId: string) => {
+      await runSandboxMutation({
+        sandboxId,
+        optimisticState: SandboxState.DESTROYING,
+        mutateAsync: deleteMutation.mutateAsync,
+      })
+    },
+    [deleteMutation.mutateAsync, runSandboxMutation],
+  )
+
+  return {
+    startSandbox,
+    recoverSandbox,
+    stopSandbox,
+    archiveSandbox,
+    deleteSandbox,
+  }
+}

--- a/apps/dashboard/src/providers/SandboxListProvider/useSandboxListWsSync.ts
+++ b/apps/dashboard/src/providers/SandboxListProvider/useSandboxListWsSync.ts
@@ -20,12 +20,14 @@ interface SandboxDesiredStateUpdatedEvent {
 }
 
 interface UseSandboxListWsSyncOptions {
+  enabled?: boolean
   onSandboxCreated: (sandbox: Sandbox) => void
   onSandboxStateUpdated: (data: SandboxStateUpdatedEvent) => void
   onSandboxDesiredStateUpdated: (data: SandboxDesiredStateUpdatedEvent) => void
 }
 
 export function useSandboxListWsSync({
+  enabled = true,
   onSandboxCreated,
   onSandboxStateUpdated,
   onSandboxDesiredStateUpdated,
@@ -33,7 +35,7 @@ export function useSandboxListWsSync({
   const { notificationSocket } = useNotificationSocket()
 
   useEffect(() => {
-    if (!notificationSocket) {
+    if (!enabled || !notificationSocket) {
       return
     }
 
@@ -46,5 +48,5 @@ export function useSandboxListWsSync({
       notificationSocket.off('sandbox.state.updated', onSandboxStateUpdated)
       notificationSocket.off('sandbox.desired-state.updated', onSandboxDesiredStateUpdated)
     }
-  }, [notificationSocket, onSandboxCreated, onSandboxDesiredStateUpdated, onSandboxStateUpdated])
+  }, [enabled, notificationSocket, onSandboxCreated, onSandboxDesiredStateUpdated, onSandboxStateUpdated])
 }

--- a/apps/dashboard/src/providers/SandboxListProvider/useSandboxListWsSync.ts
+++ b/apps/dashboard/src/providers/SandboxListProvider/useSandboxListWsSync.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useNotificationSocket } from '@/hooks/useNotificationSocket'
+import { Sandbox, SandboxDesiredState, SandboxState } from '@daytonaio/api-client'
+import { useEffect } from 'react'
+
+interface SandboxStateUpdatedEvent {
+  sandbox: Sandbox
+  oldState: SandboxState
+  newState: SandboxState
+}
+
+interface SandboxDesiredStateUpdatedEvent {
+  sandbox: Sandbox
+  oldDesiredState: SandboxDesiredState
+  newDesiredState: SandboxDesiredState
+}
+
+interface UseSandboxListWsSyncOptions {
+  onSandboxCreated: (sandbox: Sandbox) => void
+  onSandboxStateUpdated: (data: SandboxStateUpdatedEvent) => void
+  onSandboxDesiredStateUpdated: (data: SandboxDesiredStateUpdatedEvent) => void
+}
+
+export function useSandboxListWsSync({
+  onSandboxCreated,
+  onSandboxStateUpdated,
+  onSandboxDesiredStateUpdated,
+}: UseSandboxListWsSyncOptions) {
+  const { notificationSocket } = useNotificationSocket()
+
+  useEffect(() => {
+    if (!notificationSocket) {
+      return
+    }
+
+    notificationSocket.on('sandbox.created', onSandboxCreated)
+    notificationSocket.on('sandbox.state.updated', onSandboxStateUpdated)
+    notificationSocket.on('sandbox.desired-state.updated', onSandboxDesiredStateUpdated)
+
+    return () => {
+      notificationSocket.off('sandbox.created', onSandboxCreated)
+      notificationSocket.off('sandbox.state.updated', onSandboxStateUpdated)
+      notificationSocket.off('sandbox.desired-state.updated', onSandboxDesiredStateUpdated)
+    }
+  }, [notificationSocket, onSandboxCreated, onSandboxDesiredStateUpdated, onSandboxStateUpdated])
+}

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -12,6 +12,7 @@ declare module '*.png' {
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
+  readonly VITE_CLIENT_SIDE_SANDBOX_PAGINATION?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
…ntations

## Description

Extracts data fetching into a provider with 2 implementations: server & client side.
Isolates client side implementation so it's easier to clean up in the future without touching the sandboxes page itself.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

