### PR TITLE
fix(daemon): preemptive CU error detection

### DIFF
--- a/apps/daemon/pkg/toolbox/computeruse/manager/manager.go
+++ b/apps/daemon/pkg/toolbox/computeruse/manager/manager.go
@@ -257,6 +257,15 @@ func GetComputerUse(logger *slog.Logger, path string) (computeruse.IComputerUse,
 		pluginName = strings.TrimSuffix(pluginName, ".exe")
 	}
 
+	// Pre-flight check: detect critical issues (missing shared libraries, wrong
+	// architecture, permission errors) before starting the go-plugin client.
+	// When the plugin binary exits immediately, go-plugin panics due to a
+	// WaitGroup race condition in its goroutine, crashing the entire daemon.
+	pluginErr := detectPluginError(logger, path)
+	if pluginErr != nil && pluginErr.Type != "plugin" {
+		return nil, fmt.Errorf("failed to start computer-use plugin - detailed error\n[type]: %s - [error]: %s - [details]: %s", pluginErr.Type, pluginErr.Message, pluginErr.Details)
+	}
+
 	hclogger := hclog.New(&hclog.LoggerOptions{
 		Name: pluginName,
 		// Output: log.New().WriterLevel(log.DebugLevel),


### PR DESCRIPTION
## Description

Adds preemptive CU plugin error detection, avoids an edge case that caused the daemon to crash on init

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation