### PR TITLE
feat(api): limit concurrent builds per org

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1773273600000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1773273600000-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1773273600000 implements MigrationInterface {
+  name = 'Migration1773273600000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "organization" ADD "max_concurrent_builds" integer NOT NULL DEFAULT 100`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN "max_concurrent_builds"`)
+  }
+}

--- a/apps/api/src/organization/entities/organization.entity.ts
+++ b/apps/api/src/organization/entities/organization.entity.ts
@@ -77,6 +77,13 @@ export class Organization {
 
   @Column({
     type: 'int',
+    default: 100,
+    name: 'max_concurrent_builds',
+  })
+  maxConcurrentBuilds: number
+
+  @Column({
+    type: 'int',
     nullable: true,
     name: 'authenticated_rate_limit',
   })

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -164,100 +164,134 @@ export class SandboxStartAction extends SandboxAction {
     lockCode: LockCode,
     isBuild = false,
   ): Promise<SyncState> {
-    // Get snapshot reference based on whether it's a pull or build operation
-    let snapshotRef: string
+    const pendingKey = isBuild ? `org-build-pending:${sandbox.organizationId}` : undefined
+    let buildSlotReserved = false
 
-    if (isBuild) {
-      snapshotRef = sandbox.buildInfo.snapshotRef
-    } else {
-      const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
-      snapshotRef = snapshot.ref
-    }
-
-    const declarativeBuildScoreThreshold = this.configService.get('runnerScore.thresholds.declarativeBuild')
-
-    // Try to assign an available runner with the snapshot already available
     try {
-      const runner = await this.runnerService.getRandomAvailableRunner({
-        regions: [sandbox.region],
-        sandboxClass: sandbox.class,
-        snapshotRef: snapshotRef,
-        ...(isBuild &&
-          declarativeBuildScoreThreshold !== undefined && {
-            availabilityScoreThreshold: declarativeBuildScoreThreshold,
-          }),
-      })
-      if (runner) {
-        await this.updateSandboxState(sandbox, SandboxState.UNKNOWN, lockCode, runner.id)
-        return SYNC_AGAIN
-      }
-    } catch {
-      // Continue to next assignment method
-    }
+      if (pendingKey) {
+        const pendingCount = await this.redis.incr(pendingKey)
+        await this.redis.expire(pendingKey, 7200)
+        buildSlotReserved = true
 
-    // Try to assign an available runner that is currently processing the snapshot
-    const snapshotRunners = await this.runnerService.getSnapshotRunners(snapshotRef)
-    const targetState = isBuild ? SnapshotRunnerState.BUILDING_SNAPSHOT : SnapshotRunnerState.PULLING_SNAPSHOT
-    const targetSandboxState = isBuild ? SandboxState.BUILDING_SNAPSHOT : SandboxState.PULLING_SNAPSHOT
-    const errorSandboxState = isBuild ? SandboxState.BUILD_FAILED : SandboxState.ERROR
-
-    for (const snapshotRunner of snapshotRunners) {
-      // Consider removing the runner usage rate check or improving it
-      const runner = await this.runnerService.findOneOrFail(snapshotRunner.runnerId)
-
-      if (snapshotRunner.state === SnapshotRunnerState.ERROR) {
-        await this.updateSandboxState(sandbox, errorSandboxState, lockCode, runner.id, snapshotRunner.errorReason)
-        return DONT_SYNC_AGAIN
-      }
-
-      if (runner.unschedulable || runner.draining || runner.state !== RunnerState.READY) {
-        continue
-      }
-
-      if (declarativeBuildScoreThreshold === undefined || runner.availabilityScore >= declarativeBuildScoreThreshold) {
-        if (snapshotRunner.state === targetState) {
-          await this.updateSandboxState(sandbox, targetSandboxState, lockCode, runner.id)
-          return SYNC_AGAIN
+        const org = await this.organizationService.findOne(sandbox.organizationId)
+        const maxBuilds = org?.maxConcurrentBuilds ?? 100
+        const activeBuilds = await this.runnerService.getOrgActiveBuildCount(sandbox.organizationId)
+        if (activeBuilds + pendingCount > maxBuilds) {
+          this.logger.debug(
+            `Org ${sandbox.organizationId} has ${activeBuilds} active + ${pendingCount} pending / ${maxBuilds} max concurrent builds, deferring sandbox ${sandbox.id}`,
+          )
+          return DONT_SYNC_AGAIN
         }
       }
-    }
 
-    // Get excluded runner IDs based on operation type
-    const excludedRunnerIds = await (isBuild
-      ? this.runnerService.getRunnersWithMultipleSnapshotsBuilding()
-      : this.runnerService.getRunnersWithMultipleSnapshotsPulling())
+      // Get snapshot reference based on whether it's a pull or build operation
+      let snapshotRef: string
 
-    // Try to assign an available runner to start processing the snapshot
-    let runner: Runner
+      if (isBuild) {
+        snapshotRef = sandbox.buildInfo.snapshotRef
+      } else {
+        const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
+        snapshotRef = snapshot.ref
+      }
 
-    try {
-      runner = await this.runnerService.getRandomAvailableRunner({
-        regions: [sandbox.region],
-        sandboxClass: sandbox.class,
-        excludedRunnerIds: excludedRunnerIds,
-        ...(isBuild &&
-          declarativeBuildScoreThreshold !== undefined && {
-            availabilityScoreThreshold: declarativeBuildScoreThreshold,
-          }),
-      })
-    } catch {
-      // TODO: reconsider the timeout here
-      // No runners available, wait for 3 seconds and retry
-      await new Promise((resolve) => setTimeout(resolve, 3000))
+      const declarativeBuildScoreThreshold = this.configService.get('runnerScore.thresholds.declarativeBuild')
+
+      // Try to assign an available runner with the snapshot already available
+      try {
+        const runner = await this.runnerService.getRandomAvailableRunner({
+          regions: [sandbox.region],
+          sandboxClass: sandbox.class,
+          snapshotRef: snapshotRef,
+          ...(isBuild &&
+            declarativeBuildScoreThreshold !== undefined && {
+              availabilityScoreThreshold: declarativeBuildScoreThreshold,
+            }),
+        })
+        if (runner) {
+          await this.updateSandboxState(sandbox, SandboxState.UNKNOWN, lockCode, runner.id)
+          return SYNC_AGAIN
+        }
+      } catch {
+        // Continue to next assignment method
+      }
+
+      // Try to assign an available runner that is currently processing the snapshot
+      const snapshotRunners = await this.runnerService.getSnapshotRunners(snapshotRef)
+      const targetState = isBuild ? SnapshotRunnerState.BUILDING_SNAPSHOT : SnapshotRunnerState.PULLING_SNAPSHOT
+      const targetSandboxState = isBuild ? SandboxState.BUILDING_SNAPSHOT : SandboxState.PULLING_SNAPSHOT
+      const errorSandboxState = isBuild ? SandboxState.BUILD_FAILED : SandboxState.ERROR
+
+      for (const snapshotRunner of snapshotRunners) {
+        // Consider removing the runner usage rate check or improving it
+        const runner = await this.runnerService.findOneOrFail(snapshotRunner.runnerId)
+
+        if (snapshotRunner.state === SnapshotRunnerState.ERROR) {
+          await this.updateSandboxState(sandbox, errorSandboxState, lockCode, runner.id, snapshotRunner.errorReason)
+          return DONT_SYNC_AGAIN
+        }
+
+        if (runner.unschedulable || runner.draining || runner.state !== RunnerState.READY) {
+          continue
+        }
+
+        if (
+          declarativeBuildScoreThreshold === undefined ||
+          runner.availabilityScore >= declarativeBuildScoreThreshold
+        ) {
+          if (snapshotRunner.state === targetState) {
+            await this.updateSandboxState(sandbox, targetSandboxState, lockCode, runner.id)
+            return SYNC_AGAIN
+          }
+        }
+      }
+
+      // Get excluded runner IDs based on operation type
+      const excludedRunnerIds = await (isBuild
+        ? this.runnerService.getRunnersWithMultipleSnapshotsBuilding()
+        : this.runnerService.getRunnersWithMultipleSnapshotsPulling())
+
+      // Try to assign an available runner to start processing the snapshot
+      let runner: Runner
+
+      try {
+        runner = await this.runnerService.getRandomAvailableRunner({
+          regions: [sandbox.region],
+          sandboxClass: sandbox.class,
+          excludedRunnerIds: excludedRunnerIds,
+          ...(isBuild &&
+            declarativeBuildScoreThreshold !== undefined && {
+              availabilityScoreThreshold: declarativeBuildScoreThreshold,
+            }),
+        })
+      } catch {
+        // TODO: reconsider the timeout here
+        // No runners available, wait for 3 seconds and retry
+        await new Promise((resolve) => setTimeout(resolve, 3000))
+        return SYNC_AGAIN
+      }
+
+      if (isBuild) {
+        this.buildOnRunner(sandbox.buildInfo, runner, sandbox.organizationId)
+        await this.updateSandboxState(sandbox, SandboxState.BUILDING_SNAPSHOT, lockCode, runner.id)
+        buildSlotReserved = false
+        await this.redis.decr(pendingKey)
+      } else {
+        const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
+        await this.runnerService.createSnapshotRunnerEntry(
+          runner.id,
+          snapshot.ref,
+          SnapshotRunnerState.PULLING_SNAPSHOT,
+        )
+        this.pullSnapshotToRunner(snapshot, runner)
+        await this.updateSandboxState(sandbox, SandboxState.PULLING_SNAPSHOT, lockCode, runner.id)
+      }
+
       return SYNC_AGAIN
+    } finally {
+      if (buildSlotReserved && pendingKey) {
+        await this.redis.decr(pendingKey)
+      }
     }
-
-    if (isBuild) {
-      this.buildOnRunner(sandbox.buildInfo, runner, sandbox.organizationId)
-      await this.updateSandboxState(sandbox, SandboxState.BUILDING_SNAPSHOT, lockCode, runner.id)
-    } else {
-      const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
-      await this.runnerService.createSnapshotRunnerEntry(runner.id, snapshot.ref, SnapshotRunnerState.PULLING_SNAPSHOT)
-      this.pullSnapshotToRunner(snapshot, runner)
-      await this.updateSandboxState(sandbox, SandboxState.PULLING_SNAPSHOT, lockCode, runner.id)
-    }
-
-    return SYNC_AGAIN
   }
 
   async pullSnapshotToRunner(snapshot: Snapshot, runner: Runner) {

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -891,87 +891,115 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
   }
 
   async handleSnapshotStatePending(snapshot: Snapshot): Promise<SyncState> {
-    let initialRunner: Runner | undefined = undefined
+    const pendingKey =
+      snapshot.buildInfo && snapshot.organizationId ? `org-build-pending:${snapshot.organizationId}` : undefined
+    let buildSlotReserved = false
 
-    if (!snapshot.initialRunnerId) {
-      // TODO: get only runners where the base snapshot is available (extract from buildInfo)
-      const excludedRunnerIds = snapshot.buildInfo
-        ? await this.runnerService.getRunnersWithMultipleSnapshotsBuilding()
-        : await this.runnerService.getRunnersWithMultipleSnapshotsPulling()
+    try {
+      if (pendingKey) {
+        const pendingCount = await this.redis.incr(pendingKey)
+        await this.redis.expire(pendingKey, 7200)
+        buildSlotReserved = true
 
-      try {
-        const regions = await this.snapshotService.getSnapshotRegions(snapshot.id)
-        if (!regions.length) {
-          throw new Error('No regions found for snapshot')
+        const org = await this.organizationService.findOne(snapshot.organizationId)
+        const maxBuilds = org?.maxConcurrentBuilds ?? 100
+        const activeBuilds = await this.runnerService.getOrgActiveBuildCount(snapshot.organizationId)
+        if (activeBuilds + pendingCount > maxBuilds) {
+          this.logger.debug(
+            `Org ${snapshot.organizationId} has ${activeBuilds} active + ${pendingCount} pending / ${maxBuilds} max concurrent builds, deferring snapshot ${snapshot.id}`,
+          )
+          return DONT_SYNC_AGAIN
         }
-
-        initialRunner = await this.runnerService.getRandomAvailableRunner({
-          regions: regions.map((region) => region.id),
-          excludedRunnerIds: excludedRunnerIds,
-        })
-      } catch (error) {
-        this.logger.warn(`Failed to get initial runner: ${fromAxiosError(error)}`)
       }
 
-      if (!initialRunner) {
-        // No runners available, retry later
-        return DONT_SYNC_AGAIN
-      }
+      let initialRunner: Runner | undefined = undefined
 
-      snapshot.initialRunnerId = initialRunner.id
-      await this.snapshotRepository.save(snapshot)
-    } else {
-      initialRunner = await this.runnerService.findOneOrFail(snapshot.initialRunnerId)
-    }
+      if (!snapshot.initialRunnerId) {
+        // TODO: get only runners where the base snapshot is available (extract from buildInfo)
+        const excludedRunnerIds = snapshot.buildInfo
+          ? await this.runnerService.getRunnersWithMultipleSnapshotsBuilding()
+          : await this.runnerService.getRunnersWithMultipleSnapshotsPulling()
 
-    if (snapshot.buildInfo) {
-      await this.updateSnapshotState(snapshot.id, SnapshotState.BUILDING)
-      await this.runnerService.createSnapshotRunnerEntry(
-        initialRunner.id,
-        snapshot.buildInfo.snapshotRef,
-        SnapshotRunnerState.BUILDING_SNAPSHOT,
-      )
-      await this.processBuildOnRunner(snapshot, initialRunner)
-    } else {
-      if (!snapshot.ref) {
-        const runnerAdapter = await this.runnerAdapterFactory.create(initialRunner)
-        const registry = await this.dockerRegistryService.findRegistryByImageName(
-          snapshot.imageName,
-          initialRunner.region,
-          snapshot.organizationId,
-        )
+        try {
+          const regions = await this.snapshotService.getSnapshotRegions(snapshot.id)
+          if (!regions.length) {
+            throw new Error('No regions found for snapshot')
+          }
 
-        const image = parseDockerImage(snapshot.imageName)
-        if (registry && !image.registry) {
-          image.registry = registry.url.replace(/^(https?:\/\/)/, '')
-        }
-        const imageName = image.getFullName()
-
-        const internalRegistry = await this.dockerRegistryService.getAvailableInternalRegistry(initialRunner.region)
-        if (!internalRegistry) {
-          throw new Error('No internal registry found for snapshot')
+          initialRunner = await this.runnerService.getRandomAvailableRunner({
+            regions: regions.map((region) => region.id),
+            excludedRunnerIds: excludedRunnerIds,
+          })
+        } catch (error) {
+          this.logger.warn(`Failed to get initial runner: ${fromAxiosError(error)}`)
         }
 
-        const snapshotDigestResponse = await runnerAdapter.inspectSnapshotInRegistry(imageName, registry)
-        await this.processSnapshotDigest(
-          snapshot,
-          internalRegistry,
-          snapshotDigestResponse.hash,
-          snapshotDigestResponse.sizeGB,
-        )
+        if (!initialRunner) {
+          // No runners available, retry later
+          return DONT_SYNC_AGAIN
+        }
+
+        snapshot.initialRunnerId = initialRunner.id
         await this.snapshotRepository.save(snapshot)
+      } else {
+        initialRunner = await this.runnerService.findOneOrFail(snapshot.initialRunnerId)
       }
 
-      await this.updateSnapshotState(snapshot.id, SnapshotState.PULLING)
-      await this.runnerService.createSnapshotRunnerEntry(
-        initialRunner.id,
-        snapshot.ref,
-        SnapshotRunnerState.PULLING_SNAPSHOT,
-      )
-      await this.processPullOnInitialRunner(snapshot, initialRunner)
-    }
+      if (snapshot.buildInfo) {
+        await this.updateSnapshotState(snapshot.id, SnapshotState.BUILDING)
+        await this.runnerService.createSnapshotRunnerEntry(
+          initialRunner.id,
+          snapshot.buildInfo.snapshotRef,
+          SnapshotRunnerState.BUILDING_SNAPSHOT,
+        )
+        buildSlotReserved = false
+        await this.redis.decr(pendingKey)
+        await this.processBuildOnRunner(snapshot, initialRunner)
+      } else {
+        if (!snapshot.ref) {
+          const runnerAdapter = await this.runnerAdapterFactory.create(initialRunner)
+          const registry = await this.dockerRegistryService.findRegistryByImageName(
+            snapshot.imageName,
+            initialRunner.region,
+            snapshot.organizationId,
+          )
 
-    return SYNC_AGAIN
+          const image = parseDockerImage(snapshot.imageName)
+          if (registry && !image.registry) {
+            image.registry = registry.url.replace(/^(https?:\/\/)/, '')
+          }
+          const imageName = image.getFullName()
+
+          const internalRegistry = await this.dockerRegistryService.getAvailableInternalRegistry(initialRunner.region)
+          if (!internalRegistry) {
+            throw new Error('No internal registry found for snapshot')
+          }
+
+          const snapshotDigestResponse = await runnerAdapter.inspectSnapshotInRegistry(imageName, registry)
+          await this.processSnapshotDigest(
+            snapshot,
+            internalRegistry,
+            snapshotDigestResponse.hash,
+            snapshotDigestResponse.sizeGB,
+          )
+          await this.snapshotRepository.save(snapshot)
+        }
+
+        await this.updateSnapshotState(snapshot.id, SnapshotState.PULLING)
+        await this.runnerService.createSnapshotRunnerEntry(
+          initialRunner.id,
+          snapshot.ref,
+          SnapshotRunnerState.PULLING_SNAPSHOT,
+        )
+        await this.processPullOnInitialRunner(snapshot, initialRunner)
+      }
+
+      return SYNC_AGAIN
+    } finally {
+      if (buildSlotReserved && pendingKey) {
+        await this.redis.decr(pendingKey)
+      }
+    }
   }
 
   private async updateSnapshotState(snapshotId: string, state: SnapshotState, errorReason?: string) {

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -25,6 +25,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { SnapshotRunner } from '../entities/snapshot-runner.entity'
 import { SnapshotRunnerState } from '../enums/snapshot-runner-state.enum'
+import { SnapshotState } from '../enums/snapshot-state.enum'
 import { RunnerSnapshotDto } from '../dto/runner-snapshot.dto'
 import { RunnerAdapterFactory, RunnerInfo } from '../runner-adapter/runnerAdapter'
 import { RedisLockProvider } from '../common/redis-lock.provider'
@@ -821,6 +822,27 @@ export class RunnerService {
       .getRawMany()
 
     return runners.map((item) => item.runnerId)
+  }
+
+  async getOrgActiveBuildCount(organizationId: string): Promise<number> {
+    const [sandboxResult, snapshotResult] = await Promise.all([
+      this.sandboxRepository
+        .createQueryBuilder('sandbox')
+        .select('COUNT(DISTINCT sandbox.buildInfoSnapshotRef)', 'count')
+        .where('sandbox.state = :state', { state: SandboxState.BUILDING_SNAPSHOT })
+        .andWhere('sandbox.organizationId = :organizationId', { organizationId })
+        .andWhere('sandbox.buildInfoSnapshotRef IS NOT NULL')
+        .getRawOne(),
+      this.snapshotRepository
+        .createQueryBuilder('snapshot')
+        .select('COUNT(DISTINCT snapshot.buildInfoSnapshotRef)', 'count')
+        .where('snapshot.state = :state', { state: SnapshotState.BUILDING })
+        .andWhere('snapshot.organizationId = :organizationId', { organizationId })
+        .andWhere('snapshot.buildInfoSnapshotRef IS NOT NULL')
+        .getRawOne(),
+    ])
+
+    return parseInt(sandboxResult?.count ?? '0', 10) + parseInt(snapshotResult?.count ?? '0', 10)
   }
 
   async getRunnersWithMultipleSnapshotsPulling(maxSnapshotCount = 6): Promise<string[]> {


### PR DESCRIPTION
## Description

Adds a limit for concurrent declarative builds per organization (includes the snapshot builds as well) - they are not rejected, but will instead stay in the pending state until the current builds finish

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation