### PR TITLE
feat(api,runner): cancel image processing

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -358,6 +358,8 @@ export class Sandbox {
             SandboxState.BUILD_FAILED,
             SandboxState.ARCHIVING,
             SandboxState.PENDING_BUILD,
+            SandboxState.BUILDING_SNAPSHOT,
+            SandboxState.PULLING_SNAPSHOT,
           ].includes(this.state)
         ) {
           break

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
@@ -4,6 +4,7 @@
  */
 
 import { Injectable } from '@nestjs/common'
+import { Not, In } from 'typeorm'
 import { Sandbox } from '../../entities/sandbox.entity'
 import { SandboxState } from '../../enums/sandbox-state.enum'
 import { DONT_SYNC_AGAIN, SandboxAction, SyncState, SYNC_AGAIN } from './sandbox.action'
@@ -44,6 +45,37 @@ export class SandboxDestroyAction extends SandboxAction {
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
     try {
+      if (sandbox.state === SandboxState.BUILDING_SNAPSHOT || sandbox.state === SandboxState.PULLING_SNAPSHOT) {
+        let snapshotRef = sandbox.snapshot
+        if (!snapshotRef) {
+          const fullSandbox = await this.sandboxRepository.findOne({
+            where: { id: sandbox.id },
+            relations: ['buildInfo'],
+          })
+          snapshotRef = fullSandbox?.buildInfo?.snapshotRef
+        }
+
+        // Skip if another sandbox is building/pulling the same snapshot on that runner
+        if (snapshotRef) {
+          const otherBuildingSandbox = await this.sandboxRepository.findOne({
+            where: {
+              id: Not(sandbox.id),
+              runnerId: sandbox.runnerId,
+              state: In([SandboxState.BUILDING_SNAPSHOT, SandboxState.PULLING_SNAPSHOT]),
+              buildInfo: { snapshotRef },
+            },
+            relations: ['buildInfo'],
+          })
+          if (otherBuildingSandbox) {
+            snapshotRef = undefined
+          }
+        }
+
+        await runnerAdapter.destroySandbox(sandbox.id, snapshotRef)
+        await this.updateSandboxState(sandbox, SandboxState.DESTROYED, lockCode)
+        return DONT_SYNC_AGAIN
+      }
+
       const sandboxInfo = await runnerAdapter.sandboxInfo(sandbox.id)
 
       if (sandboxInfo.state === SandboxState.DESTROYED) {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -81,7 +81,7 @@ export interface RunnerAdapter {
     skipStart?: boolean,
   ): Promise<StartSandboxResponse | undefined>
   stopSandbox(sandboxId: string, force?: boolean): Promise<void>
-  destroySandbox(sandboxId: string): Promise<void>
+  destroySandbox(sandboxId: string, snapshotRef?: string): Promise<void>
   createBackup(sandbox: Sandbox, backupSnapshotName: string, registry?: DockerRegistry): Promise<void>
 
   removeSnapshot(snapshotName: string): Promise<void>

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -259,8 +259,8 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     await this.sandboxApiClient.stop(sandboxId, { force })
   }
 
-  async destroySandbox(sandboxId: string): Promise<void> {
-    await this.sandboxApiClient.destroy(sandboxId)
+  async destroySandbox(sandboxId: string, snapshotRef?: string): Promise<void> {
+    await this.sandboxApiClient.destroy(sandboxId, snapshotRef)
   }
 
   async createBackup(sandbox: Sandbox, backupSnapshotName: string, registry?: DockerRegistry): Promise<void> {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -7,7 +7,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { create, toJson } from '@bufbuild/protobuf'
 import { SnapshotSandboxPayloadSchema, ForkSandboxPayloadSchema, RegistrySchema } from '@daytona/runner-proto'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository, IsNull, Not } from 'typeorm'
+import { Repository, IsNull, Not, In } from 'typeorm'
 import {
   RunnerAdapter,
   RunnerInfo,
@@ -217,10 +217,45 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created STOP_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async destroySandbox(sandboxId: string): Promise<void> {
-    await this.jobService.createJob(null, JobType.DESTROY_SANDBOX, this.runner.id, ResourceType.SANDBOX, sandboxId)
+  async destroySandbox(sandboxId: string, snapshotRef?: string): Promise<void> {
+    if (snapshotRef) {
+      await this.cancelIncompleteSnapshotJob(snapshotRef).catch((e) =>
+        this.logger.warn(`Failed to cancel image processing job for ${snapshotRef}: ${e.message}`),
+      )
+    }
+
+    const payload = snapshotRef ? { snapshotRef } : undefined
+
+    await this.jobService.createJob(
+      null,
+      JobType.DESTROY_SANDBOX,
+      this.runner.id,
+      ResourceType.SANDBOX,
+      sandboxId,
+      payload,
+    )
 
     this.logger.debug(`Created DESTROY_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
+  }
+
+  private async cancelIncompleteSnapshotJob(snapshotRef: string): Promise<void> {
+    const incompleteJob = await this.jobRepository.findOne({
+      where: {
+        runnerId: this.runner.id,
+        resourceType: ResourceType.SNAPSHOT,
+        resourceId: snapshotRef,
+        completedAt: IsNull(),
+        type: In([JobType.BUILD_SNAPSHOT, JobType.PULL_SNAPSHOT]),
+      },
+      order: { createdAt: 'DESC' },
+    })
+
+    if (incompleteJob) {
+      await this.jobService.updateJobStatus(incompleteJob.id, JobStatus.FAILED, 'Image processing cancelled')
+      this.logger.debug(
+        `Cancelled ${incompleteJob.type} job ${incompleteJob.id} for ${snapshotRef} on runner ${this.runner.id}`,
+      )
+    }
   }
 
   async recoverSandbox(sandbox: Sandbox): Promise<void> {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1565,7 +1565,12 @@ export class SandboxService {
   async destroy(sandboxIdOrName: string, organizationId?: string): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organizationId)
 
-    if (sandbox.pending && sandbox.state !== SandboxState.PENDING_BUILD) {
+    if (
+      sandbox.pending &&
+      sandbox.state !== SandboxState.PENDING_BUILD &&
+      sandbox.state !== SandboxState.BUILDING_SNAPSHOT &&
+      sandbox.state !== SandboxState.PULLING_SNAPSHOT
+    ) {
       throw new StateChangeInProgressError()
     }
 

--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -67,6 +67,7 @@ func Create(ctx *gin.Context) {
 //	@Description	Destroy sandbox
 //	@Produce		json
 //	@Param			sandboxId	path		string	true	"Sandbox ID"
+//	@Param			snapshot	query		string	false	"Snapshot reference to cancel image processing for"
 //	@Success		200			{string}	string	"Sandbox destroyed"
 //	@Failure		400			{object}	common_errors.ErrorResponse
 //	@Failure		401			{object}	common_errors.ErrorResponse
@@ -83,6 +84,10 @@ func Destroy(ctx *gin.Context) {
 	if err != nil {
 		ctx.Error(err)
 		return
+	}
+
+	if snapshot := ctx.Query("snapshot"); snapshot != "" {
+		runner.Docker.CancelImageProcessing(snapshot)
 	}
 
 	err = runner.Docker.Destroy(ctx.Request.Context(), sandboxId)

--- a/apps/runner/pkg/api/controllers/snapshot.go
+++ b/apps/runner/pkg/api/controllers/snapshot.go
@@ -270,6 +270,8 @@ func RemoveSnapshot(logger *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
+		runner.Docker.CancelImageProcessing(snapshot)
+
 		err = runner.Docker.RemoveImage(ctx.Request.Context(), snapshot, true)
 		if err != nil {
 			ctx.Error(err)

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -263,6 +263,12 @@ const docTemplate = `{
                         "name": "sandboxId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Snapshot reference to cancel image processing for",
+                        "name": "snapshot",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -235,6 +235,12 @@
             "name": "sandboxId",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "Snapshot reference to cancel image processing for",
+            "name": "snapshot",
+            "in": "query"
           }
         ],
         "responses": {

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -581,6 +581,10 @@ paths:
           name: sandboxId
           required: true
           type: string
+        - description: Snapshot reference to cancel image processing for
+          in: query
+          name: snapshot
+          type: string
       produces:
         - application/json
       responses:

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -151,6 +151,20 @@ func (d *DockerClient) ApiClient() client.APIClient {
 
 const RUNNER_BRIDGE_NETWORK_NAME = "runner-bridge"
 
+func (d *DockerClient) CancelImageProcessing(snapshotRef string) bool {
+	if cancelFn, ok := d.imageProcessingCancels.LoadAndDelete(snapshotRef); ok {
+		fn, ok := cancelFn.(context.CancelFunc)
+		if !ok {
+			d.logger.Error("Unexpected type in imageProcessingCancels", "snapshotRef", snapshotRef)
+			return false
+		}
+		fn()
+		d.logger.Info("Cancelled image processing", "snapshotRef", snapshotRef)
+		return true
+	}
+	return false
+}
+
 type DockerClient struct {
 	apiClient                    client.APIClient
 	backupInfoCache              *cache.BackupInfoCache
@@ -182,4 +196,5 @@ type DockerClient struct {
 	initializeDaemonTelemetry    bool
 	filesystem                   string
 	interSandboxNetworkEnabled   bool
+	imageProcessingCancels       sync.Map // map[string]context.CancelFunc keyed by snapshot ref
 }

--- a/apps/runner/pkg/docker/image_build.go
+++ b/apps/runner/pkg/docker/image_build.go
@@ -26,15 +26,22 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 		return fmt.Errorf("invalid image format: must contain exactly one colon (e.g., 'myimage:1.0')")
 	}
 
-	d.logger.InfoContext(ctx, "Building image")
+	buildCtx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		d.imageProcessingCancels.Delete(buildImageDto.Snapshot)
+	}()
+	d.imageProcessingCancels.Store(buildImageDto.Snapshot, cancel)
+
+	d.logger.InfoContext(buildCtx, "Building image")
 
 	// Check if image already exists
-	exists, err := d.ImageExists(ctx, buildImageDto.Snapshot, true)
+	exists, err := d.ImageExists(buildCtx, buildImageDto.Snapshot, true)
 	if err != nil {
 		return fmt.Errorf("failed to check if image exists: %w", err)
 	}
 	if exists {
-		d.logger.InfoContext(ctx, "Image already built")
+		d.logger.InfoContext(buildCtx, "Image already built")
 		return nil
 	}
 
@@ -66,12 +73,12 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 		// Process each hash and extract the corresponding tar file
 		for _, hash := range buildImageDto.Context {
 			// Get the tar file from object storage
-			tarData, err := storageClient.GetObject(ctx, buildImageDto.OrganizationId, hash)
+			tarData, err := storageClient.GetObject(buildCtx, buildImageDto.OrganizationId, hash)
 			if err != nil {
 				return fmt.Errorf("failed to get tar from storage with hash %s: %w", hash, err)
 			}
 
-			d.logger.InfoContext(ctx, "Processing context file with hash", "hash", hash, "bytes", len(tarData))
+			d.logger.InfoContext(buildCtx, "Processing context file with hash", "hash", hash, "bytes", len(tarData))
 
 			if len(tarData) == 0 {
 				return fmt.Errorf("empty tar file received for hash %s", hash)
@@ -86,8 +93,7 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 					break // End of tar archive
 				}
 				if err != nil {
-					d.logger.WarnContext(ctx, "Error reading tar with hash", "hash", hash, "error", err)
-					// Skip this tar file and continue with the next one
+					d.logger.WarnContext(buildCtx, "Error reading tar with hash", "hash", hash, "error", err)
 					break
 				}
 
@@ -99,8 +105,8 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 				fileContent := new(bytes.Buffer)
 				_, err = io.Copy(fileContent, tarReader)
 				if err != nil {
-					d.logger.WarnContext(ctx, "Failed to read file from tar", "file", header.Name, "error", err)
-					continue // Skip this file and continue with the next one
+					d.logger.WarnContext(buildCtx, "Failed to read file from tar", "file", header.Name, "error", err)
+					continue
 				}
 
 				buildHeader := &tar.Header{
@@ -110,16 +116,16 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 				}
 
 				if err := tarWriter.WriteHeader(buildHeader); err != nil {
-					d.logger.WarnContext(ctx, "Failed to write tar header", "file", header.Name, "error", err)
+					d.logger.WarnContext(buildCtx, "Failed to write tar header", "file", header.Name, "error", err)
 					continue
 				}
 
 				if _, err := tarWriter.Write(fileContent.Bytes()); err != nil {
-					d.logger.WarnContext(ctx, "Failed to write file to tar", "file", header.Name, "error", err)
+					d.logger.WarnContext(buildCtx, "Failed to write file to tar", "file", header.Name, "error", err)
 					continue
 				}
 
-				d.logger.InfoContext(ctx, "Added file to build context", "file", header.Name)
+				d.logger.InfoContext(buildCtx, "Added file to build context", "file", header.Name)
 			}
 		}
 	}
@@ -128,7 +134,7 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 		return fmt.Errorf("finalize build context tar: %w", err)
 	}
 
-	buildContext := io.NopCloser(buildContextTar)
+	dockerBuildContext := io.NopCloser(buildContextTar)
 
 	var authConfigs map[string]docker_registry.AuthConfig
 
@@ -184,7 +190,7 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		d.logger.ErrorContext(ctx, "Failed to open log file", "error", err)
+		d.logger.ErrorContext(buildCtx, "Failed to open log file", "error", err)
 	} else {
 		defer logFile.Close()
 		writer = io.MultiWriter(&log.DebugLogWriter{}, logFile)
@@ -192,15 +198,15 @@ func (d *DockerClient) BuildImage(ctx context.Context, buildImageDto dto.BuildSn
 
 	switch config.GetBuildEngine() {
 	case "legacy":
-		err = d.runDockerImageBuildLegacy(ctx, buildContext, buildOpts, writer)
+		err = d.runDockerImageBuildLegacy(buildCtx, dockerBuildContext, buildOpts, writer)
 	default:
-		err = d.runDockerImageBuildWithBuildKitSession(ctx, buildContext, buildOpts, writer)
+		err = d.runDockerImageBuildWithBuildKitSession(buildCtx, dockerBuildContext, buildOpts, writer)
 	}
 	if err != nil {
 		return err
 	}
 
-	d.logger.InfoContext(ctx, "Image built successfully")
+	d.logger.InfoContext(buildCtx, "Image built successfully")
 
 	return nil
 }

--- a/apps/runner/pkg/docker/image_pull.go
+++ b/apps/runner/pkg/docker/image_pull.go
@@ -22,6 +22,13 @@ import (
 func (d *DockerClient) PullImage(ctx context.Context, imageName string, reg *dto.RegistryDTO, sandboxId *string) (*image.InspectResponse, error) {
 	defer timer.Timer()()
 
+	pullCtx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		d.imageProcessingCancels.Delete(imageName)
+	}()
+	d.imageProcessingCancels.Store(imageName, cancel)
+
 	tag := "latest"
 	lastColonIndex := strings.LastIndex(imageName, ":")
 	if lastColonIndex != -1 {
@@ -29,20 +36,20 @@ func (d *DockerClient) PullImage(ctx context.Context, imageName string, reg *dto
 	}
 
 	if tag != "latest" {
-		inspect, err := d.apiClient.ImageInspect(ctx, imageName)
+		inspect, err := d.apiClient.ImageInspect(pullCtx, imageName)
 		if err == nil {
 			return &inspect, nil
 		}
 	}
 
-	d.logger.InfoContext(ctx, "Pulling image", "imageName", imageName)
+	d.logger.InfoContext(pullCtx, "Pulling image", "imageName", imageName)
 
 	if sandboxId != nil {
 		d.pullTracker.Add(*sandboxId)
 		defer d.pullTracker.Remove(*sandboxId)
 	}
 
-	responseBody, err := d.apiClient.ImagePull(ctx, imageName, image.PullOptions{
+	responseBody, err := d.apiClient.ImagePull(pullCtx, imageName, image.PullOptions{
 		RegistryAuth: getRegistryAuth(reg),
 		Platform:     "linux/amd64",
 	})
@@ -56,9 +63,9 @@ func (d *DockerClient) PullImage(ctx context.Context, imageName string, reg *dto
 		return nil, err
 	}
 
-	d.logger.InfoContext(ctx, "Image pulled successfully", "imageName", imageName)
+	d.logger.InfoContext(pullCtx, "Image pulled successfully", "imageName", imageName)
 
-	inspect, err := d.apiClient.ImageInspect(ctx, imageName)
+	inspect, err := d.apiClient.ImageInspect(pullCtx, imageName)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/runner/pkg/runner/v2/executor/sandbox.go
+++ b/apps/runner/pkg/runner/v2/executor/sandbox.go
@@ -65,7 +65,18 @@ func (e *Executor) stopSandbox(ctx context.Context, job *apiclient.Job) (any, er
 	return nil, nil
 }
 
+type DestroySandboxPayload struct {
+	SnapshotRef string `json:"snapshotRef,omitempty"`
+}
+
 func (e *Executor) destroySandbox(ctx context.Context, job *apiclient.Job) (any, error) {
+	if job.Payload != nil && *job.Payload != "" {
+		var payload DestroySandboxPayload
+		if err := e.parsePayload(job.Payload, &payload); err == nil && payload.SnapshotRef != "" {
+			e.docker.CancelImageProcessing(payload.SnapshotRef)
+		}
+	}
+
 	err := e.docker.Destroy(ctx, job.ResourceId)
 	if err != nil {
 		common.ContainerOperationCount.WithLabelValues("destroy", string(common.PrometheusOperationStatusFailure)).Inc()

--- a/apps/runner/pkg/runner/v2/executor/snapshot.go
+++ b/apps/runner/pkg/runner/v2/executor/snapshot.go
@@ -69,6 +69,8 @@ func (e *Executor) pullSnapshot(ctx context.Context, job *apiclient.Job) (any, e
 }
 
 func (e *Executor) removeSnapshot(ctx context.Context, job *apiclient.Job) (any, error) {
+	e.docker.CancelImageProcessing(job.ResourceId)
+
 	return nil, e.docker.RemoveImage(ctx, job.ResourceId, true)
 }
 

--- a/libs/runner-api-client/src/api/sandbox-api.ts
+++ b/libs/runner-api-client/src/api/sandbox-api.ts
@@ -135,10 +135,11 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
          * Destroy sandbox
          * @summary Destroy sandbox
          * @param {string} sandboxId Sandbox ID
+         * @param {string} [snapshot] Snapshot reference to cancel image processing for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        destroy: async (sandboxId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        destroy: async (sandboxId: string, snapshot?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'sandboxId' is not null or undefined
             assertParamExists('destroy', 'sandboxId', sandboxId)
             const localVarPath = `/sandboxes/{sandboxId}/destroy`
@@ -156,6 +157,10 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
 
             // authentication Bearer required
             await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            if (snapshot !== undefined) {
+                localVarQueryParameter['snapshot'] = snapshot;
+            }
 
 
     
@@ -542,11 +547,12 @@ export const SandboxApiFp = function(configuration?: Configuration) {
          * Destroy sandbox
          * @summary Destroy sandbox
          * @param {string} sandboxId Sandbox ID
+         * @param {string} [snapshot] Snapshot reference to cancel image processing for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async destroy(sandboxId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.destroy(sandboxId, options);
+        async destroy(sandboxId: string, snapshot?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.destroy(sandboxId, snapshot, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['SandboxApi.destroy']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -697,11 +703,12 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
          * Destroy sandbox
          * @summary Destroy sandbox
          * @param {string} sandboxId Sandbox ID
+         * @param {string} [snapshot] Snapshot reference to cancel image processing for
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        destroy(sandboxId: string, options?: RawAxiosRequestConfig): AxiosPromise<string> {
-            return localVarFp.destroy(sandboxId, options).then((request) => request(axios, basePath));
+        destroy(sandboxId: string, snapshot?: string, options?: RawAxiosRequestConfig): AxiosPromise<string> {
+            return localVarFp.destroy(sandboxId, snapshot, options).then((request) => request(axios, basePath));
         },
         /**
          * Get sandbox network settings
@@ -829,12 +836,13 @@ export class SandboxApi extends BaseAPI {
      * Destroy sandbox
      * @summary Destroy sandbox
      * @param {string} sandboxId Sandbox ID
+     * @param {string} [snapshot] Snapshot reference to cancel image processing for
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof SandboxApi
      */
-    public destroy(sandboxId: string, options?: RawAxiosRequestConfig) {
-        return SandboxApiFp(this.configuration).destroy(sandboxId, options).then((request) => request(this.axios, this.basePath));
+    public destroy(sandboxId: string, snapshot?: string, options?: RawAxiosRequestConfig) {
+        return SandboxApiFp(this.configuration).destroy(sandboxId, snapshot, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## Description

Implements methods for cancelling image processing for sandbox and snapshot declarative builds / pulls. This also allows deleting sandboxes that are in a BUILDING_SNAPSHOT state

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
