### PR TITLE
fix(api): allow deletion of volumes stuck in error state

### DIFF
--- a/apps/api/src/sandbox/managers/volume.manager.ts
+++ b/apps/api/src/sandbox/managers/volume.manager.ts
@@ -254,7 +254,17 @@ export class VolumeManager
       await this.redis.setex(lockKey, 30, '1')
 
       // Delete bucket from Minio/S3
-      await deleteS3Bucket(this.s3Client, volume.getBucketName())
+      try {
+        await deleteS3Bucket(this.s3Client, volume.getBucketName())
+      } catch (error) {
+        if (error.name === 'NoSuchBucket') {
+          this.logger.warn(`Bucket for volume ${volume.id} does not exist, treating as already deleted`)
+        } else if (error.name === 'BucketNotEmpty') {
+          throw new Error('Volume deletion failed because the bucket is not empty. You may retry deletion.')
+        } else {
+          throw error
+        }
+      }
 
       // Refresh lock before final state update
       await this.redis.setex(lockKey, 30, '1')

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -142,8 +142,10 @@ export class VolumeService {
       throw new NotFoundException(`Volume with ID ${volumeId} not found`)
     }
 
-    if (volume.state !== VolumeState.READY) {
-      throw new BadRequestError(`Volume must be in '${VolumeState.READY}' state in order to be deleted`)
+    if (volume.state !== VolumeState.READY && volume.state !== VolumeState.ERROR) {
+      throw new BadRequestError(
+        `Volume must be in '${VolumeState.READY}' or '${VolumeState.ERROR}' state in order to be deleted`,
+      )
     }
 
     // Check if any non-destroyed sandboxes are using this volume


### PR DESCRIPTION
## Description

Volumes that entered the ERROR state during S3 bucket creation could never be deleted because the  delete guard only accepted READY state. This change relaxes the guard to also accept ERROR and adds targeted error handling in the delete flow. NoSuchBucket errors are treated as already-deleted so the volume record can be cleaned up. BucketNotEmpty errors are re-thrown with a clear message so the user knows they can retry once the bucket drains.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation