### PR TITLE
fix(api): assigning sandbox to bad runner

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -206,13 +206,20 @@ export class SandboxStartAction extends SandboxAction {
     for (const snapshotRunner of snapshotRunners) {
       // Consider removing the runner usage rate check or improving it
       const runner = await this.runnerService.findOneOrFail(snapshotRunner.runnerId)
+
+      if (snapshotRunner.state === SnapshotRunnerState.ERROR) {
+        await this.updateSandboxState(sandbox, errorSandboxState, lockCode, runner.id, snapshotRunner.errorReason)
+        return DONT_SYNC_AGAIN
+      }
+
+      if (runner.unschedulable || runner.draining || runner.state !== RunnerState.READY) {
+        continue
+      }
+
       if (declarativeBuildScoreThreshold === undefined || runner.availabilityScore >= declarativeBuildScoreThreshold) {
         if (snapshotRunner.state === targetState) {
           await this.updateSandboxState(sandbox, targetSandboxState, lockCode, runner.id)
           return SYNC_AGAIN
-        } else if (snapshotRunner.state === SnapshotRunnerState.ERROR) {
-          await this.updateSandboxState(sandbox, errorSandboxState, lockCode, runner.id, snapshotRunner.errorReason)
-          return DONT_SYNC_AGAIN
         }
       }
     }


### PR DESCRIPTION
## Description

Fixes a case in the declarative builder where sandboxes would get assigned to a runner that should be out of the assignment pool

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
