### PR TITLE
fix(playground): prevent empty sandbox params inside code snippets

### DIFF
--- a/apps/dashboard/src/providers/PlaygroundProvider.tsx
+++ b/apps/dashboard/src/providers/PlaygroundProvider.tsx
@@ -324,15 +324,15 @@ export const PlaygroundProvider: React.FC<{ children: React.ReactNode }> = ({ ch
 
     // Create from base image if default resource values are not used
     // Snapshot parameter has precedence over resources and createSandboxFromImage
-    const createSandboxFromImage = !useDefaultResourceValues && !createSandboxFromSnapshot
+    const createSandboxFromImage = !useDefaultResourceValues && !useCustomSandboxSnapshotName
 
-    // We specify resources for sandbox creation if there is any specified resource value which has value different from the default one and createSandboxFromSnapshot is false
-    const useResources = !createSandboxFromSnapshot && resourceValuesExist && !useDefaultResourceValues
+    // We specify resources for sandbox creation if there is any specified resource value which has value different from the default one and useCustomSandboxSnapshotName is false
+    const useResources = !useCustomSandboxSnapshotName && resourceValuesExist && !useDefaultResourceValues
     const useSandboxCreateParams =
       useLanguageParam ||
       useResources ||
       createSandboxParamsExist ||
-      createSandboxFromSnapshot ||
+      useCustomSandboxSnapshotName ||
       createSandboxFromImage
 
     if (createSandboxFromImage) {


### PR DESCRIPTION
## Description

Noticed a bug inside the playground which results in unnecessary display of empty sandbox params inside sandbox creation code snippet.

This can be seen from the image below where all sandbox creation params are set to default values, but `CreateSandboxFromSnapshotParams` in Python and params object inside TS are shown with no actual param values inside them.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

<img width="1214" height="516" alt="Screenshot 2026-03-13 at 15 25 05" src="https://github.com/user-attachments/assets/bebc0053-1670-41ce-b547-bf08a075a799" />

