### PR TITLE
fix(runner): return nil on sandbox not found

### DIFF
--- a/apps/runner/pkg/docker/state.go
+++ b/apps/runner/pkg/docker/state.go
@@ -23,7 +23,7 @@ func (d *DockerClient) GetSandboxState(ctx context.Context, sandboxId string) (e
 	ct, err := d.ContainerInspect(ctx, sandboxId)
 	if err != nil {
 		if common_errors.IsNotFoundError(err) {
-			return enums.SandboxStateDestroyed, err
+			return enums.SandboxStateDestroyed, nil
 		}
 		return enums.SandboxStateError, err
 	}
@@ -62,7 +62,7 @@ func (d *DockerClient) getSandboxState(ctx context.Context, ct *container.Inspec
 		return enums.SandboxStateError, fmt.Errorf("sandbox exited with code %d, reason: %s", ct.State.ExitCode, ct.State.Error)
 
 	case container.StateDead:
-		return enums.SandboxStateDestroyed, common_errors.NewNotFoundError(errors.New("sandbox is in dead state on runner"))
+		return enums.SandboxStateDestroyed, nil
 
 	default:
 		return enums.SandboxStateUnknown, nil


### PR DESCRIPTION
## Description

Return nil instead of 404-ing on sandbox not found on runner - fixes a regression from an earlier commit

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation