### PR TITLE
fix(daemon): stop sync session commands from hanging on stdin

### DIFF
--- a/apps/daemon/pkg/session/execute.go
+++ b/apps/daemon/pkg/session/execute.go
@@ -55,12 +55,18 @@ func (s *SessionService) Execute(sessionId, cmdId, cmd string, async, isCombined
 
 	defer logFile.Close()
 
+	inputPipeCommand := `cat /dev/null > "$ip" &`
+	if async {
+		inputPipeCommand = `while :; do sleep 3600; done > "$ip" &`
+	}
+
 	cmdToExec := fmt.Sprintf(cmdWrapperFormat+"\n",
 		logFilePath, // %q  -> log
 		logDir,      // %q  -> dir
 		command.InputFilePath(session.Dir(s.configDir)), // %q  -> input
 		toOctalEscapes(log.STDOUT_PREFIX),               // %s  -> stdout prefix
 		toOctalEscapes(log.STDERR_PREFIX),               // %s  -> stderr prefix
+		inputPipeCommand,                                // %s  -> stdin behavior
 		cmd,                                             // %s  -> verbatim script body
 		exitCodeFilePath,                                // %q
 	)
@@ -157,12 +163,16 @@ var cmdWrapperFormat string = `
 	( while IFS= read -r line || [ -n "$line" ]; do printf '%s%%s\n' "$line"; done < "$sp" ) >> "$log" & r1=$!
 	( while IFS= read -r line || [ -n "$line" ]; do printf '%s%%s\n' "$line"; done < "$ep" ) >> "$log" & r2=$!
 
-	# Keep input FIFO open to prevent blocking when command opens stdin
-	sleep infinity > "$ip" &
+	# Sync commands should see EOF immediately; async commands keep stdin open for SendInput.
+	%s
+	ip_pid=$!
 
 	# Run your command
 	{ %s; } < "$ip" > "$sp" 2> "$ep"
 	echo "$?" >> %s
+
+	# Stop the stdin holder so it doesn't outlive the command
+	kill "$ip_pid" 2>/dev/null; wait "$ip_pid" 2>/dev/null
 
 	# drain labelers (cleanup via trap)
 	wait "$r1" "$r2"

--- a/apps/daemon/pkg/session/execute_test.go
+++ b/apps/daemon/pkg/session/execute_test.go
@@ -1,0 +1,154 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package session
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestSessionService(t *testing.T) *SessionService {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewSessionService(logger, t.TempDir(), 250*time.Millisecond, 25*time.Millisecond)
+}
+
+func waitForCommandExit(t *testing.T, svc *SessionService, sessionID, commandID string, timeout time.Duration) *Command {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		command, err := svc.GetSessionCommand(sessionID, commandID)
+		if err != nil {
+			t.Fatalf("get session command: %v", err)
+		}
+		if command.ExitCode != nil {
+			return command
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Fatalf("command %s did not exit within %s", commandID, timeout)
+	return nil
+}
+
+func waitForInputPipe(t *testing.T, svc *SessionService, sessionID, commandID string, timeout time.Duration) {
+	t.Helper()
+
+	session, ok := svc.sessions.Get(sessionID)
+	if !ok {
+		t.Fatalf("session %s not found", sessionID)
+	}
+
+	command, ok := session.commands.Get(commandID)
+	if !ok {
+		t.Fatalf("command %s not found", commandID)
+	}
+
+	inputPath := command.InputFilePath(session.Dir(svc.configDir))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(inputPath); err == nil {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Fatalf("input pipe %s was not created within %s", inputPath, timeout)
+}
+
+func TestExecuteSyncCommandGetsEOFOnStdin(t *testing.T) {
+	svc := newTestSessionService(t)
+	const sessionID = "sync-stdin"
+
+	if err := svc.Create(sessionID, false); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = svc.Delete(context.Background(), sessionID)
+	})
+
+	resultCh := make(chan *SessionExecute, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		result, err := svc.Execute(
+			sessionID,
+			"",
+			`if IFS= read -r line; then printf 'line:%s\n' "$line"; else printf 'eof\n'; fi`,
+			false,
+			true,
+			true,
+		)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resultCh <- result
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("execute sync command: %v", err)
+	case result := <-resultCh:
+		if result.ExitCode == nil || *result.ExitCode != 0 {
+			t.Fatalf("expected exit code 0, got %#v", result.ExitCode)
+		}
+		if result.Output == nil || !strings.Contains(*result.Output, "eof") {
+			t.Fatalf("expected output to contain eof, got %#v", result.Output)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sync session command hung waiting on stdin")
+	}
+}
+
+func TestExecuteAsyncCommandStillAcceptsInput(t *testing.T) {
+	svc := newTestSessionService(t)
+	const sessionID = "async-stdin"
+
+	if err := svc.Create(sessionID, false); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = svc.Delete(context.Background(), sessionID)
+	})
+
+	result, err := svc.Execute(
+		sessionID,
+		"",
+		`if IFS= read -r line; then printf 'line:%s\n' "$line"; else printf 'eof\n'; fi`,
+		true,
+		true,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("execute async command: %v", err)
+	}
+
+	waitForInputPipe(t, svc, sessionID, result.CommandId, 3*time.Second)
+
+	if err := svc.SendInput(sessionID, result.CommandId, "hello from test"); err != nil {
+		t.Fatalf("send input: %v", err)
+	}
+
+	command := waitForCommandExit(t, svc, sessionID, result.CommandId, 2*time.Second)
+	if command.ExitCode == nil || *command.ExitCode != 0 {
+		t.Fatalf("expected exit code 0, got %#v", command.ExitCode)
+	}
+
+	logs, err := svc.GetSessionCommandLogs(sessionID, result.CommandId, nil, nil, FetchLogsOptions{IsCombinedOutput: true})
+	if err != nil {
+		t.Fatalf("get session command logs: %v", err)
+	}
+
+	if !strings.Contains(string(logs), "line:hello from test") {
+		t.Fatalf("expected async command logs to contain sent input, got %q", string(logs))
+	}
+}


### PR DESCRIPTION
## Summary

Synchronous session commands currently keep their per-command stdin FIFO open, so commands that read from stdin never see EOF and can hang indefinitely.

This change only keeps stdin open for async session commands, which are the only ones that can actually receive later `SendInput()` calls. Sync commands now get EOF immediately instead of waiting forever.

I also replaced the async keep-open command with a portable long-running loop instead of `sleep infinity`.

Closes #3770.

## Testing

- `go test ./apps/daemon/pkg/session/...`
