### PR TITLE
fix(runner): treat code 255 as stopped

### DIFF
--- a/apps/runner/pkg/docker/state.go
+++ b/apps/runner/pkg/docker/state.go
@@ -56,7 +56,7 @@ func (d *DockerClient) getSandboxState(ctx context.Context, ct *container.Inspec
 		return enums.SandboxStateDestroying, nil
 
 	case container.StateExited:
-		if ct.State.ExitCode == 0 || ct.State.ExitCode == 137 || ct.State.ExitCode == 143 {
+		if ct.State.ExitCode == 0 || ct.State.ExitCode == 137 || ct.State.ExitCode == 143 || ct.State.ExitCode == 255 {
 			return enums.SandboxStateStopped, nil
 		}
 		return enums.SandboxStateError, fmt.Errorf("sandbox exited with code %d, reason: %s", ct.State.ExitCode, ct.State.Error)


### PR DESCRIPTION
## Description

When the docker container exists with 255 (usually during a "stop" action) - this PR makes it treated as stopped and lets the user start it normally instead of `sandbox exited with code 255, reason:`

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Docker exit code 255 as a stopped state in the runner, which commonly happens on a stop action.
This prevents “sandbox exited with code 255” errors and lets users start the sandbox normally.

<sup>Written for commit e6340b25b386f9ca26840d89749690354a4d18fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

