### PR TITLE
fix(daemon): closing pty session panic

### DIFF
--- a/apps/daemon/pkg/toolbox/process/pty/types.go
+++ b/apps/daemon/pkg/toolbox/process/pty/types.go
@@ -36,7 +36,8 @@ type PTYManager struct {
 type wsClient struct {
 	id        string
 	conn      *websocket.Conn
-	send      chan []byte // outbound queue for this client (PTY -> WS)
+	send      chan []byte   // outbound queue for this client (PTY -> WS)
+	done      chan struct{} // closed when the client is shutting down
 	closeOnce sync.Once
 }
 

--- a/apps/daemon/pkg/toolbox/process/pty/websocket.go
+++ b/apps/daemon/pkg/toolbox/process/pty/websocket.go
@@ -18,6 +18,7 @@ func (s *PTYSession) attachWebSocket(ws *websocket.Conn) {
 		id:   uuid.NewString(),
 		conn: ws,
 		send: make(chan []byte, 256), // if full, drop slow client
+		done: make(chan struct{}),
 	}
 
 	// Register client FIRST so it can receive PTY output via broadcast
@@ -55,10 +56,9 @@ func (s *PTYSession) clientWriter(cl *wsClient) {
 		select {
 		case <-s.ctx.Done():
 			return
-		case b, ok := <-cl.send:
-			if !ok {
-				return
-			}
+		case <-cl.done:
+			return
+		case b := <-cl.send:
 			_ = cl.conn.SetWriteDeadline(time.Now().Add(writeWait))
 			if err := cl.conn.WriteMessage(websocket.BinaryMessage, b); err != nil {
 				return
@@ -98,6 +98,8 @@ func (s *PTYSession) broadcast(b []byte) {
 	for id, cl := range s.clients.Items() {
 		select {
 		case cl.send <- b:
+		case <-cl.done:
+			// client is shutting down, skip
 		default:
 			// client's outbound queue is full -> drop the client
 			go func(id string, cl *wsClient) {

--- a/apps/daemon/pkg/toolbox/process/pty/ws_client.go
+++ b/apps/daemon/pkg/toolbox/process/pty/ws_client.go
@@ -5,7 +5,7 @@ package pty
 
 func (cl *wsClient) close() {
 	cl.closeOnce.Do(func() {
-		close(cl.send)
+		close(cl.done)
 		_ = cl.conn.Close()
 	})
 }


### PR DESCRIPTION
## Description

Fixes the panic that caused sandboxes to error with `sandbox exited with code 2, reason:` during the stop action - the cause was the handling of pty session close. Separate temporary commit is the reproduction

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Screenshots

```
2026-03-16T05:02:53Z INF Incoming request component=toolbox_server request.time=2026-03-16T05:02:05.864Z request.method=GET request.host=172.20.0.43:2280 request.path=/process/pty/claude-1773637324419-39vtq7/connect request.query="" request.params=map[sessionId:claude-1773637324419-39vtq7] request.route=/process/pty/:sessionId/connect request.referer="" request.ip=9.163.66.62 request.length=0 response.time=2026-03-16T05:02:53.485Z response.latency=47.621730499s response.status=200 response.length=0 id=952bfb7a-2543-4caf-80fe-ea3ffc92c5ac
panic: send on closed channel

goroutine 125762 [running]:
github.com/daytonaio/daemon/pkg/toolbox/process/pty.(*PTYSession).broadcast(0xc001b8b2b0, {0xc001c68018, 0x14, 0x14})
	/workspaces/daytona/apps/daemon/pkg/toolbox/process/pty/websocket.go:100 +0x13c
github.com/daytonaio/daemon/pkg/toolbox/process/pty.(*PTYSession).ptyReadLoop(0xc001b8b2b0)
	/workspaces/daytona/apps/daemon/pkg/toolbox/process/pty/session.go:166 +0xd7
created by github.com/daytonaio/daemon/pkg/toolbox/process/pty.(*PTYSession).start in goroutine 125757
	/workspaces/daytona/apps/daemon/pkg/toolbox/process/pty/session.go:74 +0x6cc

```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a panic when closing PTY sessions that caused sandboxes to exit with code 2 during stop. The shutdown now uses a `done` signal and updates broadcast/writer paths to avoid “send on closed channel” races.

- **Bug Fixes**
  - Use `done` on `wsClient` shutdown instead of closing `send`; `clientWriter` exits on `done`.
  - Update `broadcast` to skip closing clients and keep dropping slow ones safely.
  - Add focused concurrency tests to reproduce the panic and verify the fix.

<sup>Written for commit a7c7bced2ea410557ba0944313734e4ec06dee3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

