### PR TITLE
fix(api): handle pulling snapshot state

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -642,6 +642,9 @@ export class SandboxStartAction extends SandboxAction {
         break
       }
       case SandboxState.PULLING_SNAPSHOT: {
+        if (await this.checkTimeoutError(sandbox, 30, 'Timeout while pulling snapshot')) {
+          return DONT_SYNC_AGAIN
+        }
         await this.updateSandboxState(sandbox, SandboxState.PULLING_SNAPSHOT, lockCode)
         break
       }


### PR DESCRIPTION
## Description

Properly handle the `pulling_snapshot` state the runner returns to the API instead of defaulting to the "error" state as before (during the sandbox start action)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle the runner’s `pulling_snapshot` state during sandbox start by setting `PULLING_SNAPSHOT` instead of error and adding a timeout check. On timeout, stop resyncing and report 'Timeout while pulling snapshot'.

<sup>Written for commit 7ccdcbf1d0d3f746a7bdb51ccd8c063edb3a9486. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

