### PR TITLE
fix(runner): handle pulling snapshot on create

### DIFF
--- a/apps/runner/go.mod
+++ b/apps/runner/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.4
+	github.com/tidwall/hashmap v1.8.1
 	github.com/vishvananda/netlink v1.3.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
@@ -102,6 +103,7 @@ require (
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/apps/runner/go.sum
+++ b/apps/runner/go.sum
@@ -203,6 +203,8 @@ github.com/swaggo/gin-swagger v1.6.0 h1:y8sxvQ3E20/RCyrXeFfg60r6H0Z+SwpTjMYsMm+z
 github.com/swaggo/gin-swagger v1.6.0/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
 github.com/swaggo/swag v1.16.4 h1:clWJtd9LStiG3VeijiCfOVODP6VpHtKdQy9ELFG3s1A=
 github.com/swaggo/swag v1.16.4/go.mod h1:VBsHJRsDvfYvqoiMKnsdwhNV9LEMHgEDZcyVYX0sxPg=
+github.com/tidwall/hashmap v1.8.1 h1:hXNzBfSJ2Jwvt0lbkWD59O/r3OfatSIcbuWT0VKEVns=
+github.com/tidwall/hashmap v1.8.1/go.mod h1:v+0qJrJn7l+l2dB8+fAFpC62p2G0SMP2Teu8ejkebg8=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
@@ -220,6 +222,9 @@ github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZla
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.63.0 h1:5kSIJ0y8ckZZKoDhZHdVtcyjVi6rXyAwyaR8mp4zLbg=

--- a/apps/runner/pkg/common/tracker.go
+++ b/apps/runner/pkg/common/tracker.go
@@ -1,0 +1,33 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"sync"
+
+	"github.com/tidwall/hashmap"
+)
+
+type Tracker[K comparable] struct {
+	mu  sync.RWMutex
+	set hashmap.Set[K]
+}
+
+func (t *Tracker[K]) Add(entry K) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.set.Insert(entry)
+}
+
+func (t *Tracker[K]) Remove(entry K) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.set.Delete(entry)
+}
+
+func (t *Tracker[K]) Contains(entry K) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.set.Contains(entry)
+}

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/daytonaio/common-go/pkg/utils"
 	"github.com/daytonaio/runner/pkg/cache"
+	"github.com/daytonaio/runner/pkg/common"
 	"github.com/daytonaio/runner/pkg/netrules"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
@@ -89,6 +90,7 @@ func NewDockerClient(config DockerClientConfig) (*DockerClient, error) {
 	return &DockerClient{
 		apiClient:                    config.ApiClient,
 		backupInfoCache:              config.BackupInfoCache,
+		pullTracker:                  &common.Tracker[string]{},
 		logger:                       logger,
 		awsRegion:                    config.AWSRegion,
 		awsEndpointUrl:               config.AWSEndpointUrl,
@@ -118,6 +120,7 @@ func (d *DockerClient) ApiClient() client.APIClient {
 type DockerClient struct {
 	apiClient                    client.APIClient
 	backupInfoCache              *cache.BackupInfoCache
+	pullTracker                  *common.Tracker[string]
 	logger                       *slog.Logger
 	awsRegion                    string
 	awsEndpointUrl               string

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -39,7 +39,11 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		return "", "", err
 	}
 
-	if state == enums.SandboxStateStarted || state == enums.SandboxStatePullingSnapshot || state == enums.SandboxStateStarting {
+	if state == enums.SandboxStatePullingSnapshot {
+		return "", "", common_errors.NewConflictError(fmt.Errorf("sandbox %s is currently pulling snapshot", sandboxDto.Id))
+	}
+
+	if state == enums.SandboxStateStarted || state == enums.SandboxStateStarting {
 		c, err := d.ContainerInspect(ctx, sandboxDto.Id)
 		if err != nil {
 			return "", "", err
@@ -77,10 +81,13 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		return sandboxDto.Id, daemonVersion, nil
 	}
 
+	d.pullTracker.Add(sandboxDto.Id)
 	image, err := d.PullImage(ctx, sandboxDto.Snapshot, sandboxDto.Registry)
 	if err != nil {
+		d.pullTracker.Remove(sandboxDto.Id)
 		return "", "", err
 	}
+	d.pullTracker.Remove(sandboxDto.Id)
 
 	err = d.validateImageArchitecture(image)
 	if err != nil {

--- a/apps/runner/pkg/docker/state.go
+++ b/apps/runner/pkg/docker/state.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/daytonaio/runner/pkg/models/enums"
 	"github.com/docker/docker/api/types/container"
@@ -18,6 +17,10 @@ import (
 func (d *DockerClient) GetSandboxState(ctx context.Context, sandboxId string) (enums.SandboxState, error) {
 	if sandboxId == "" {
 		return enums.SandboxStateUnknown, nil
+	}
+
+	if d.pullTracker.Contains(sandboxId) {
+		return enums.SandboxStatePullingSnapshot, nil
 	}
 
 	ct, err := d.ContainerInspect(ctx, sandboxId)
@@ -41,9 +44,6 @@ func (d *DockerClient) getSandboxState(ctx context.Context, ct *container.Inspec
 		return enums.SandboxStateCreating, nil
 
 	case container.StateRunning:
-		if d.isContainerPullingImage(ctx, ct.ID) {
-			return enums.SandboxStatePullingSnapshot, nil
-		}
 		return enums.SandboxStateStarted, nil
 
 	case container.StatePaused:
@@ -67,28 +67,4 @@ func (d *DockerClient) getSandboxState(ctx context.Context, ct *container.Inspec
 	default:
 		return enums.SandboxStateUnknown, nil
 	}
-}
-
-// isContainerPullingImage checks if the container is still in image pulling phase
-func (d *DockerClient) isContainerPullingImage(ctx context.Context, containerId string) bool {
-	options := container.LogsOptions{
-		ShowStdout: true,
-		ShowStderr: true,
-		Tail:       "10", // Look at last 10 lines
-	}
-
-	logs, err := d.apiClient.ContainerLogs(ctx, containerId, options)
-	if err != nil {
-		return false
-	}
-	defer logs.Close()
-
-	// Read logs and check for pull messages
-	buf := make([]byte, 1024)
-	n, _ := logs.Read(buf)
-	logContent := string(buf[:n])
-
-	return strings.Contains(logContent, "Pulling from") ||
-		strings.Contains(logContent, "Downloading") ||
-		strings.Contains(logContent, "Extracting")
 }


### PR DESCRIPTION
## Description

This pull request introduces a new generic `Tracker` utility for managing sets of items in a thread-safe way, and refactors the Docker client to use this tracker for monitoring sandbox image pulls. This results in a more robust and efficient mechanism for tracking the state of sandbox creation, specifically during image pulling, and removes the previous log-based detection logic.

**Core functionality improvements:**

* Added a new generic `Tracker` type in `pkg/common/tracker.go` using `tidwall/hashmap` for efficient, thread-safe set operations. This will be used to track ongoing operations such as image pulls.
* Updated the Docker client (`pkg/docker/client.go`) to include a `pullTracker` field of type `*common.Tracker[string]`, and initialized it in the constructor. [[1]](diffhunk://#diff-4465978f21c6dd3dced203f2229b76621e249d9811744eced0f6437bd8d70159R123) [[2]](diffhunk://#diff-4465978f21c6dd3dced203f2229b76621e249d9811744eced0f6437bd8d70159R93) [[3]](diffhunk://#diff-4465978f21c6dd3dced203f2229b76621e249d9811744eced0f6437bd8d70159R15)

**Refactoring of sandbox state tracking:**

* Replaced the previous log-based method for detecting if a container is pulling an image with the new `pullTracker` mechanism. The sandbox state now directly checks if its ID is being tracked as "pulling snapshot" rather than parsing container logs. [[1]](diffhunk://#diff-e23dceba0c365aa9d322e65c43eb50f6d726a343366ae96d87c26e67a035dcffR22-R25) [[2]](diffhunk://#diff-e23dceba0c365aa9d322e65c43eb50f6d726a343366ae96d87c26e67a035dcffL44-L46) [[3]](diffhunk://#diff-e23dceba0c365aa9d322e65c43eb50f6d726a343366ae96d87c26e67a035dcffL71-L94)
* Updated the sandbox creation flow to add and remove the sandbox ID from the tracker at appropriate points during image pulling, ensuring accurate state reflection.

**Dependency updates:**

* Added `github.com/tidwall/hashmap` and `github.com/zeebo/xxh3` as new dependencies in `go.mod` to support the new tracker utility. [[1]](diffhunk://#diff-d72644f71e115f9c18208b79d865a0d45ac1dcc3a14b109eabb622154f253617R26) [[2]](diffhunk://#diff-d72644f71e115f9c18208b79d865a0d45ac1dcc3a14b109eabb622154f253617R105)

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track snapshot pulls during sandbox creation with a thread-safe in-memory tracker instead of parsing container logs. This fixes flaky detection and reliably reports the pulling state while images download.

- **Refactors**
  - Added `Tracker` in `pkg/common/tracker.go` using `github.com/tidwall/hashmap` for a thread-safe set.
  - Introduced `pullTracker` in the Docker client; add/remove sandbox ID around `PullImage` in `create`.
  - `GetSandboxState` now checks `pullTracker.Contains(id)` and removes log-based pull detection.

- **Dependencies**
  - Added `github.com/tidwall/hashmap` and `github.com/zeebo/xxh3`.

<sup>Written for commit 42b1f9adbdc26220e795011be2fd5775427e1ff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

