### PR TITLE
fix(dashboard): sort tiers before rendering

### DIFF
--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -35,7 +35,7 @@ export default function Limits() {
   const tiersQuery = useTiersQuery()
 
   const organizationTier = organizationTierQuery.data
-  const tiers = tiersQuery.data
+  const tiers = tiersQuery.data?.sort((a, b) => a.tier - b.tier)
   const wallet = walletQuery.data
 
   const { getRegionName } = useRegions()


### PR DESCRIPTION
## Description

Sorts tiers returned by billing before rendering.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort tiers by their numeric `tier` before rendering on the Limits page. Ensures a consistent ascending order and prevents misordered display when the billing API returns unsorted data.

<sup>Written for commit ea7eece46005513113c67405168b565fdbca9d1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

