### PR TITLE
fix(dashboard): left-align create button to prevent overlap with widget

### DIFF
--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -900,7 +900,7 @@ export const CreateSandboxSheet = ({ className }: { className?: string }) => {
             </div>
           </form>
         </ScrollArea>
-        <SheetFooter className="p-5 pt-3 border-t border-border">
+        <SheetFooter className="p-5 pt-3 border-t border-border sm:justify-start">
           <form.Subscribe
             selector={(state) => [state.canSubmit, state.isSubmitting]}
             children={([canSubmit, isSubmitting]) => (


### PR DESCRIPTION
## Description

<img width="502" height="149" alt="Screenshot 2026-03-17 at 12 17 53" src="https://github.com/user-attachments/assets/8a917ed1-9683-442c-9b39-ac68af8f480b" />


## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Left-aligns the Create Sandbox button in the dashboard sheet to prevent overlap with the adjacent widget on small screens. Adds `sm:justify-start` to the `SheetFooter` so actions no longer collide with the widget.

<sup>Written for commit ae359a2efd05f95925f768089129e9df459612de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

