### PR TITLE
fix(api): change timeout error to build failed

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -124,7 +124,7 @@ export class SandboxStartAction extends SandboxAction {
     if (sandbox.updatedAt && Date.now() - sandbox.updatedAt.getTime() > timeoutMs) {
       await this.updateSandboxState(
         sandbox,
-        SandboxState.ERROR,
+        SandboxState.BUILD_FAILED,
         lockCode,
         undefined,
         'Timeout while building snapshot on runner',


### PR DESCRIPTION
## Description

Changes the state of sandboxes whose declarative build times out to be "build_failed" instead of "error"

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation