### PR TITLE
fix: README.md go example references wrong package for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,13 @@ import (
  "time"
 
  "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+ "github.com/daytonaio/daytona/libs/sdk-go/pkg/options"
  "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
 )
 
 func main() {
  // Initialize the Daytona client with DAYTONA_API_KEY in env
-  // Alternative is to use daytona.NewClientWithConfig(...) for more specific config
+ // Alternative is to use daytona.NewClientWithConfig(...) for more specific config
  client, err := daytona.NewClient()
  if err != nil {
   log.Fatalf("Failed to create client: %v", err)
@@ -163,7 +164,7 @@ func main() {
   },
  }
 
- sandbox, err := client.Create(ctx, params, daytona.WithTimeout(90*time.Second))
+ sandbox, err := client.Create(ctx, params, options.WithTimeout(90*time.Second))
  if err != nil {
   log.Fatalf("Failed to create sandbox: %v", err)
  }


### PR DESCRIPTION
Playing around with Daytona I've noticed that the README.md example for Golang (presumably) uses wrong package for WithTimeout function rendering the example non-compilable.

## Description

Update the go example in README.md with the properly referenced WithTimeout function. Currently, the documentation uses WithTimeout as part of the daytona package while in reality the WithTimeout function is part of the options package.

This commit rectifies this issue.

## Documentation

- [X] This change requires a documentation update
- [X] I have made corresponding changes to the documentation

## Related Issue(s)

N/A

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
