### PR TITLE
Fix broken link in README.md (Getting Started)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm install @daytonaio/sdk
 
 1. Create an account at https://app.daytona.io
 1. Generate a [new API key](https://app.daytona.io/dashboard/keys)
-1. Follow the [Getting Started docs](https://www.daytona.io/docs/getting-started/) to start using the Daytona SDK
+1. Follow the [Getting Started docs](https://www.daytona.io/docs/en/getting-started/) to start using the Daytona SDK
 
 ## Creating your first Sandbox
 


### PR DESCRIPTION
## Description

I noticed that the link to the `Getting Started` section in README.md was broken.

This seems to be a regression caused by #2123 , which introduced localized document paths. The docsUrlPattern was updated to `/docs/[locale]/`, but the link in the README had not been updated to reflect this change.

https://github.com/daytonaio/daytona/pull/2123/changes#diff-4ace9e176997c74ee8438d608c69371967e64be3dc9292480573086ded9996a9R25

This PR fixes the link by including the appropriate locale in the path.
## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

## Screenshots


## Notes
