### PR TITLE
fix(api): remove state lock on job completion

### DIFF
--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -39,7 +39,7 @@ export class JobStateHandlerService {
     @InjectRepository(SnapshotRunner)
     private readonly snapshotRunnerRepository: Repository<SnapshotRunner>,
     private readonly organizationUsageService: OrganizationUsageService,
-    protected readonly redisLockProvider: RedisLockProvider,
+    private readonly redisLockProvider: RedisLockProvider,
   ) {}
 
   /**


### PR DESCRIPTION
## Description

Removes the sandbox state code lock on job completion. Prevents race condition updates after the job is done.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
