### PR TITLE
fix(api): reduce log spam on archive

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
@@ -92,7 +92,6 @@ export class SandboxArchiveAction extends SandboxAction {
 
     try {
       const sandboxInfo = await runnerAdapter.sandboxInfo(sandbox.id)
-      this.logger.log(`sandbox info from runner: state: ${sandboxInfo.state}, backupState: ${sandboxInfo.backupState}`)
       if (sandboxInfo.state === SandboxState.DESTROYED) {
         if (isFromErrorState) {
           this.logger.warn(`Transitioning sandbox ${sandbox.id} from ERROR to ARCHIVED state (runner draining)`)


### PR DESCRIPTION
## Description

This pull request makes a minor change to the logging behavior in the `SandboxArchiveAction` class by removing a log statement that reported the sandbox state and backup state.

- Logging:
  * Removed a log statement that output the sandbox's state and backup state in the `SandboxArchiveAction` class (`sandbox-archive.action.ts`).

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
