### PR TITLE
feat(api): add partial index for recoverable sandboxes

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1773936687553-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1773936687553-migration.ts
@@ -9,8 +9,8 @@ export class Migration1773936687553 implements MigrationInterface {
   name = 'Migration1773936687553'
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Note: not using CONCURRENTLY + skipping transactions because of reverting issue: https://github.com/typeorm/typeorm/issues/9981
-    await queryRunner.query(`CREATE INDEX "idx_sandbox_recoverable" ON "sandbox" ("id") WHERE recoverable = true`)
+    // Note: not using CONCURRENTLY because of reverting issue: https://github.com/typeorm/typeorm/issues/9981
+    await queryRunner.query(`CREATE INDEX "idx_sandbox_recoverable" ON "sandbox" ("id") WHERE "recoverable" = true`)
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/apps/api/src/migrations/pre-deploy/1773936687553-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1773936687553-migration.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1773936687553 implements MigrationInterface {
+  name = 'Migration1773936687553'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Note: not using CONCURRENTLY + skipping transactions because of reverting issue: https://github.com/typeorm/typeorm/issues/9981
+    await queryRunner.query(`CREATE INDEX "idx_sandbox_recoverable" ON "sandbox" ("id") WHERE recoverable = true`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_sandbox_recoverable"`)
+  }
+}

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -45,6 +45,9 @@ import { SandboxLastActivity } from './sandbox-last-activity.entity'
 @Index('sandbox_pending_idx', ['id'], {
   where: `"pending" = true`,
 })
+@Index('idx_sandbox_recoverable', ['id'], {
+  where: '"recoverable" = true',
+})
 @Index('idx_sandbox_authtoken', ['authToken'])
 @Index('sandbox_buildinfosnapshotref_idx', { synchronize: false })
 @Index('sandbox_labels_gin_full_idx', { synchronize: false })


### PR DESCRIPTION
## Description

Adds a partial index on the sandbox table for rows where recoverable is true. Only a minuscule fraction of rows match this condition, so the index is tiny and eliminates full table scans when querying recoverable sandboxes on draining runners. 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation