### PR TITLE
Persist Pagination "Items Per Page" Selection in Dashboard

### DIFF
--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -4,7 +4,8 @@
  */
 
 import { CREATE_API_KEY_PERMISSIONS_GROUPS } from '@/constants/CreateApiKeyPermissionsGroups'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { getRelativeTimeString } from '@/lib/utils'
 import { ApiKeyList, ApiKeyListPermissionsEnum, CreateApiKeyPermissionsEnum } from '@daytonaio/api-client'
 
@@ -47,21 +48,19 @@ interface DataTableProps {
 
 export function ApiKeyTable({ data, loading, isLoadingKey, onRevoke }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
+  const { paginationParams, handlePaginationChange } = usePersistedPageSize(LocalStorageKey.PaginationPageSize_ApiKeys)
   const columns = getColumns({ onRevoke, isLoadingKey })
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: handlePaginationChange,
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     state: {
       sorting,
-    },
-    initialState: {
-      pagination: {
-        pageSize: DEFAULT_PAGE_SIZE,
-      },
+      pagination: paginationParams,
     },
   })
 

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationInvitationTable.tsx
@@ -21,7 +21,8 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { TableHeader, TableRow, TableHead, TableBody, TableCell, Table } from '@/components/ui/table'
 import { CancelOrganizationInvitationDialog } from '@/components/OrganizationMembers/CancelOrganizationInvitationDialog'
 import { UpdateOrganizationInvitationDialog } from './UpdateOrganizationInvitationDialog'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { TableEmptyState } from '../TableEmptyState'
 
 interface DataTableProps {
@@ -48,6 +49,9 @@ export function OrganizationInvitationTable({
   loadingInvitationAction,
 }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
+  const { paginationParams, handlePaginationChange } = usePersistedPageSize(
+    LocalStorageKey.PaginationPageSize_MemberInvitations,
+  )
   const [invitationToCancel, setInvitationToCancel] = useState<string | null>(null)
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false)
   const [invitationToUpdate, setInvitationToUpdate] = useState<OrganizationInvitation | null>(null)
@@ -94,15 +98,12 @@ export function OrganizationInvitationTable({
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: handlePaginationChange,
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     state: {
       sorting,
-    },
-    initialState: {
-      pagination: {
-        pageSize: DEFAULT_PAGE_SIZE,
-      },
+      pagination: paginationParams,
     },
   })
 

--- a/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/OrganizationMemberTable.tsx
@@ -22,7 +22,8 @@ import { TableHeader, TableRow, TableHead, TableBody, TableCell, Table } from '@
 import { RemoveOrganizationMemberDialog } from '@/components/OrganizationMembers/RemoveOrganizationMemberDialog'
 import { UpdateOrganizationMemberAccess } from '@/components/OrganizationMembers/UpdateOrganizationMemberAccessDialog'
 import { capitalize } from '@/lib/utils'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { TableEmptyState } from '../TableEmptyState'
 
 interface DataTableProps {
@@ -47,6 +48,7 @@ export function OrganizationMemberTable({
   ownerMode,
 }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([])
+  const { paginationParams, handlePaginationChange } = usePersistedPageSize(LocalStorageKey.PaginationPageSize_Members)
   const [memberToUpdate, setMemberToUpdate] = useState<OrganizationUser | null>(null)
   const [isUpdateMemberAccessDialogOpen, setIsUpdateMemberAccessDialogOpen] = useState(false)
   const [memberToRemove, setMemberToRemove] = useState<string | null>(null)
@@ -73,15 +75,12 @@ export function OrganizationMemberTable({
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: handlePaginationChange,
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     state: {
       sorting,
-    },
-    initialState: {
-      pagination: {
-        pageSize: DEFAULT_PAGE_SIZE,
-      },
+      pagination: paginationParams,
     },
   })
 

--- a/apps/dashboard/src/components/RegistryTable.tsx
+++ b/apps/dashboard/src/components/RegistryTable.tsx
@@ -27,7 +27,8 @@ import {
 import { DialogTrigger } from './ui/dialog'
 import { Pagination } from './Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { TableEmptyState } from './TableEmptyState'
 
 interface DataTableProps {
@@ -39,6 +40,9 @@ interface DataTableProps {
 
 export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProps) {
   const { authenticatedUserHasPermission } = useSelectedOrganization()
+  const { paginationParams, handlePaginationChange } = usePersistedPageSize(
+    LocalStorageKey.PaginationPageSize_Registries,
+  )
 
   const writePermitted = useMemo(
     () => authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_REGISTRIES),
@@ -57,15 +61,12 @@ export function RegistryTable({ data, loading, onDelete, onEdit }: DataTableProp
     columns,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: handlePaginationChange,
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     state: {
       sorting,
-    },
-    initialState: {
-      pagination: {
-        pageSize: DEFAULT_PAGE_SIZE,
-      },
+      pagination: paginationParams,
     },
   })
 

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -12,7 +12,8 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { getRelativeTimeString } from '@/lib/utils'
 import { OrganizationRolePermissionsEnum, VolumeDto, VolumeState } from '@daytonaio/api-client'
@@ -43,6 +44,7 @@ interface VolumeTableProps {
 
 export function VolumeTable({ data, loading, processingVolumeAction, onDelete, onBulkDelete }: VolumeTableProps) {
   const { authenticatedUserHasPermission } = useSelectedOrganization()
+  const { paginationParams, handlePaginationChange } = usePersistedPageSize(LocalStorageKey.PaginationPageSize_Volumes)
 
   const deletePermitted = useMemo(
     () => authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_VOLUMES),
@@ -63,6 +65,7 @@ export function VolumeTable({ data, loading, processingVolumeAction, onDelete, o
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: handlePaginationChange,
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     getFacetedRowModel: getFacetedRowModel(),
@@ -71,14 +74,10 @@ export function VolumeTable({ data, loading, processingVolumeAction, onDelete, o
     state: {
       sorting,
       columnFilters,
+      pagination: paginationParams,
     },
     enableRowSelection: true,
     getRowId: (row) => row.id,
-    initialState: {
-      pagination: {
-        pageSize: DEFAULT_PAGE_SIZE,
-      },
-    },
   })
   const [bulkDeleteConfirmationOpen, setBulkDeleteConfirmationOpen] = useState(false)
 

--- a/apps/dashboard/src/enums/LocalStorageKey.ts
+++ b/apps/dashboard/src/enums/LocalStorageKey.ts
@@ -8,4 +8,12 @@ export enum LocalStorageKey {
   SkipOnboardingPrefix = 'SkipOnboarding_',
   AnnouncementBannerDismissed = 'AnnouncementBannerDismissed',
   SandboxTableColumnVisibility = 'SandboxTableColumnVisibility',
+  PaginationPageSize_Sandboxes = 'PaginationPageSize_Sandboxes',
+  PaginationPageSize_Snapshots = 'PaginationPageSize_Snapshots',
+  PaginationPageSize_AuditLogs = 'PaginationPageSize_AuditLogs',
+  PaginationPageSize_Registries = 'PaginationPageSize_Registries',
+  PaginationPageSize_Volumes = 'PaginationPageSize_Volumes',
+  PaginationPageSize_ApiKeys = 'PaginationPageSize_ApiKeys',
+  PaginationPageSize_Members = 'PaginationPageSize_Members',
+  PaginationPageSize_MemberInvitations = 'PaginationPageSize_MemberInvitations',
 }

--- a/apps/dashboard/src/hooks/usePersistedPageSize.ts
+++ b/apps/dashboard/src/hooks/usePersistedPageSize.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
+import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
+import { PaginationState, Updater } from '@tanstack/react-table'
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+type PageSizeStorageKey =
+  | LocalStorageKey.PaginationPageSize_Sandboxes
+  | LocalStorageKey.PaginationPageSize_Snapshots
+  | LocalStorageKey.PaginationPageSize_AuditLogs
+  | LocalStorageKey.PaginationPageSize_Registries
+  | LocalStorageKey.PaginationPageSize_Volumes
+  | LocalStorageKey.PaginationPageSize_ApiKeys
+  | LocalStorageKey.PaginationPageSize_Members
+  | LocalStorageKey.PaginationPageSize_MemberInvitations
+
+function getPersistedPageSize(key: PageSizeStorageKey): number {
+  const stored = getLocalStorageItem(key)
+  if (stored) {
+    const parsed = parseInt(stored, 10)
+    if (!isNaN(parsed) && PAGE_SIZE_OPTIONS.includes(parsed as (typeof PAGE_SIZE_OPTIONS)[number])) {
+      return parsed
+    }
+  }
+  return DEFAULT_PAGE_SIZE
+}
+
+export function usePersistedPageSize(key: PageSizeStorageKey) {
+  const [paginationParams, setInternalPaginationParams] = useState(() => ({
+    pageIndex: 0,
+    pageSize: getPersistedPageSize(key),
+  }))
+
+  // Use ref to track previous page size to avoid stale closures
+  const prevPageSizeRef = useRef(paginationParams.pageSize)
+
+  const handlePaginationChange = useCallback(
+    (updaterOrValue: Updater<PaginationState>) => {
+      setInternalPaginationParams((prev) => {
+        const newValue = typeof updaterOrValue === 'function' ? updaterOrValue(prev) : updaterOrValue
+
+        if (newValue.pageSize !== prevPageSizeRef.current) {
+          setLocalStorageItem(key, newValue.pageSize.toString())
+          prevPageSizeRef.current = newValue.pageSize
+        }
+
+        return newValue
+      })
+    },
+    [key],
+  )
+
+  const setPaginationParams = useCallback(
+    (
+      value:
+        | { pageIndex: number; pageSize: number }
+        | ((prev: { pageIndex: number; pageSize: number }) => { pageIndex: number; pageSize: number }),
+    ) => {
+      setInternalPaginationParams((prev) => {
+        const newValue = typeof value === 'function' ? value(prev) : value
+        if (newValue.pageSize !== prevPageSizeRef.current) {
+          setLocalStorageItem(key, newValue.pageSize.toString())
+          prevPageSizeRef.current = newValue.pageSize
+        }
+        return newValue
+      })
+    },
+    [key],
+  )
+
+  return useMemo(
+    () => ({
+      paginationParams,
+      setPaginationParams,
+      handlePaginationChange,
+    }),
+    [paginationParams, setPaginationParams, handlePaginationChange],
+  )
+}

--- a/apps/dashboard/src/pages/AuditLogs.tsx
+++ b/apps/dashboard/src/pages/AuditLogs.tsx
@@ -8,12 +8,11 @@ import { PageContent, PageHeader, PageLayout, PageTitle } from '@/components/Pag
 import { DateRangePicker, DateRangePickerRef, QuickRangesConfig } from '@/components/ui/date-range-picker'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '@/constants/Pagination'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { useApi } from '@/hooks/useApi'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
-import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { PaginatedAuditLogs } from '@daytonaio/api-client'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { DateRange } from 'react-day-picker'
@@ -36,16 +35,7 @@ const AuditLogs: React.FC = () => {
 
   const { selectedOrganization } = useSelectedOrganization()
 
-  const [paginationParams, setPaginationParams] = useState(() => {
-    const stored = getLocalStorageItem(LocalStorageKey.PaginationPageSize_AuditLogs)
-    if (stored) {
-      const parsed = parseInt(stored, 10)
-      if (!isNaN(parsed) && PAGE_SIZE_OPTIONS.includes(parsed as (typeof PAGE_SIZE_OPTIONS)[number])) {
-        return { pageIndex: 0, pageSize: parsed }
-      }
-    }
-    return { pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE }
-  })
+  const { paginationParams, setPaginationParams } = usePersistedPageSize(LocalStorageKey.PaginationPageSize_AuditLogs)
   const [currentCursor, setCurrentCursor] = useState<string | undefined>(undefined)
   const [cursorHistory, setCursorHistory] = useState<string[]>([])
 
@@ -96,8 +86,7 @@ const AuditLogs: React.FC = () => {
   const handlePaginationChange = useCallback(
     ({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
       if (pageSize !== paginationParams.pageSize) {
-        // Persist page size and reset to first page when changing page size
-        setLocalStorageItem(LocalStorageKey.PaginationPageSize_AuditLogs, pageSize.toString())
+        // Reset to first page when changing page size
         setPaginationParams({ pageIndex: 0, pageSize })
         setCurrentCursor(undefined)
         setCursorHistory([])
@@ -136,7 +125,14 @@ const AuditLogs: React.FC = () => {
       }
       setLoadingData(true)
     },
-    [paginationParams.pageIndex, paginationParams.pageSize, data.nextToken, currentCursor, cursorHistory],
+    [
+      paginationParams.pageIndex,
+      paginationParams.pageSize,
+      data.nextToken,
+      currentCursor,
+      cursorHistory,
+      setPaginationParams,
+    ],
   )
 
   useEffect(() => {
@@ -159,7 +155,7 @@ const AuditLogs: React.FC = () => {
         pageIndex: prev.pageIndex - 1,
       }))
     }
-  }, [data.items.length, paginationParams.pageIndex])
+  }, [data.items.length, paginationParams.pageIndex, setPaginationParams])
 
   const handleAutoRefreshChange = useCallback(
     (enabled: boolean) => {
@@ -172,13 +168,16 @@ const AuditLogs: React.FC = () => {
     [fetchData],
   )
 
-  const handleDateRangeChange = useCallback((range: DateRange) => {
-    setDateRange(range)
-    setPaginationParams((prev) => ({ pageIndex: 0, pageSize: prev.pageSize }))
-    setCurrentCursor(undefined)
-    setCursorHistory([])
-    setData((prev) => ({ ...prev, page: 1, nextToken: undefined }))
-  }, [])
+  const handleDateRangeChange = useCallback(
+    (range: DateRange) => {
+      setDateRange(range)
+      setPaginationParams((prev) => ({ pageIndex: 0, pageSize: prev.pageSize }))
+      setCurrentCursor(undefined)
+      setCursorHistory([])
+      setData((prev) => ({ ...prev, page: 1, nextToken: undefined }))
+    },
+    [setPaginationParams],
+  )
 
   return (
     <PageLayout>

--- a/apps/dashboard/src/pages/AuditLogs.tsx
+++ b/apps/dashboard/src/pages/AuditLogs.tsx
@@ -8,10 +8,12 @@ import { PageContent, PageHeader, PageLayout, PageTitle } from '@/components/Pag
 import { DateRangePicker, DateRangePickerRef, QuickRangesConfig } from '@/components/ui/date-range-picker'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { useApi } from '@/hooks/useApi'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
+import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { PaginatedAuditLogs } from '@daytonaio/api-client'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { DateRange } from 'react-day-picker'
@@ -34,9 +36,15 @@ const AuditLogs: React.FC = () => {
 
   const { selectedOrganization } = useSelectedOrganization()
 
-  const [paginationParams, setPaginationParams] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_PAGE_SIZE,
+  const [paginationParams, setPaginationParams] = useState(() => {
+    const stored = getLocalStorageItem(LocalStorageKey.PaginationPageSize_AuditLogs)
+    if (stored) {
+      const parsed = parseInt(stored, 10)
+      if (!isNaN(parsed) && PAGE_SIZE_OPTIONS.includes(parsed as (typeof PAGE_SIZE_OPTIONS)[number])) {
+        return { pageIndex: 0, pageSize: parsed }
+      }
+    }
+    return { pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE }
   })
   const [currentCursor, setCurrentCursor] = useState<string | undefined>(undefined)
   const [cursorHistory, setCursorHistory] = useState<string[]>([])
@@ -88,7 +96,8 @@ const AuditLogs: React.FC = () => {
   const handlePaginationChange = useCallback(
     ({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
       if (pageSize !== paginationParams.pageSize) {
-        // Reset to first page when changing page size
+        // Persist page size and reset to first page when changing page size
+        setLocalStorageItem(LocalStorageKey.PaginationPageSize_AuditLogs, pageSize.toString())
         setPaginationParams({ pageIndex: 0, pageSize })
         setCurrentCursor(undefined)
         setCursorHistory([])
@@ -165,7 +174,7 @@ const AuditLogs: React.FC = () => {
 
   const handleDateRangeChange = useCallback((range: DateRange) => {
     setDateRange(range)
-    setPaginationParams({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE })
+    setPaginationParams((prev) => ({ pageIndex: 0, pageSize: prev.pageSize }))
     setCurrentCursor(undefined)
     setCursorHistory([])
     setData((prev) => ({ ...prev, page: 1, nextToken: undefined }))

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -20,13 +20,13 @@ import {
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { DAYTONA_DOCS_URL } from '@/constants/ExternalLinks'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { RoutePath } from '@/enums/RoutePath'
 import { SnapshotFilters, SnapshotQueryParams, useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { useRegions } from '@/hooks/useRegions'
 import {
   DEFAULT_SANDBOX_SORTING,
@@ -66,32 +66,33 @@ const Sandboxes: React.FC = () => {
 
   // Pagination
 
-  const [paginationParams, setPaginationParams] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_PAGE_SIZE,
-  })
-
-  const handlePaginationChange = useCallback(({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
-    setPaginationParams({ pageIndex, pageSize })
-  }, [])
+  const { paginationParams, setPaginationParams, handlePaginationChange } = usePersistedPageSize(
+    LocalStorageKey.PaginationPageSize_Sandboxes,
+  )
 
   // Filters
 
   const [filters, setFilters] = useState<SandboxFilters>({})
 
-  const handleFiltersChange = useCallback((filters: SandboxFilters) => {
-    setFilters(filters)
-    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [])
+  const handleFiltersChange = useCallback(
+    (filters: SandboxFilters) => {
+      setFilters(filters)
+      setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+    },
+    [setPaginationParams],
+  )
 
   // Sorting
 
   const [sorting, setSorting] = useState<SandboxSorting>(DEFAULT_SANDBOX_SORTING)
 
-  const handleSortingChange = useCallback((sorting: SandboxSorting) => {
-    setSorting(sorting)
-    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [])
+  const handleSortingChange = useCallback(
+    (sorting: SandboxSorting) => {
+      setSorting(sorting)
+      setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+    },
+    [setPaginationParams],
+  )
 
   // Sandboxes Data
 
@@ -183,7 +184,7 @@ const Sandboxes: React.FC = () => {
         pageIndex: prev.pageIndex - 1,
       }))
     }
-  }, [sandboxesData?.items.length, paginationParams.pageIndex])
+  }, [sandboxesData?.items.length, paginationParams.pageIndex, setPaginationParams])
 
   // Ephemeral Sandbox States
 

--- a/apps/dashboard/src/pages/Snapshots.tsx
+++ b/apps/dashboard/src/pages/Snapshots.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
+import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { queryKeys } from '@/hooks/queries/queryKeys'
 import {
   DEFAULT_SNAPSHOT_SORTING,
@@ -26,6 +26,7 @@ import {
 } from '@/hooks/queries/useSnapshotsQuery'
 import { useApi } from '@/hooks/useApi'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
+import { usePersistedPageSize } from '@/hooks/usePersistedPageSize'
 import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { createBulkActionToast } from '@/lib/bulk-action-toast'
@@ -48,10 +49,9 @@ const Snapshots: React.FC = () => {
 
   const { selectedOrganization, authenticatedUserHasPermission } = useSelectedOrganization()
 
-  const [paginationParams, setPaginationParams] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_PAGE_SIZE,
-  })
+  const { paginationParams, setPaginationParams, handlePaginationChange } = usePersistedPageSize(
+    LocalStorageKey.PaginationPageSize_Snapshots,
+  )
 
   const [sorting, setSorting] = useState<SnapshotSorting>(DEFAULT_SNAPSHOT_SORTING)
 
@@ -106,14 +106,13 @@ const Snapshots: React.FC = () => {
     [queryClient, baseQueryKey],
   )
 
-  const handlePaginationChange = useCallback(({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
-    setPaginationParams({ pageIndex, pageSize })
-  }, [])
-
-  const handleSortingChange = useCallback((newSorting: SnapshotSorting) => {
-    setSorting(newSorting)
-    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [])
+  const handleSortingChange = useCallback(
+    (newSorting: SnapshotSorting) => {
+      setSorting(newSorting)
+      setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+    },
+    [setPaginationParams],
+  )
 
   useEffect(() => {
     const handleSnapshotCreatedEvent = () => {
@@ -154,7 +153,7 @@ const Snapshots: React.FC = () => {
         pageIndex: prev.pageIndex - 1,
       }))
     }
-  }, [snapshotsData?.items.length, paginationParams.pageIndex])
+  }, [snapshotsData?.items.length, paginationParams.pageIndex, setPaginationParams])
 
   const handleDelete = async (snapshot: SnapshotDto) => {
     setLoadingSnapshots((prev) => ({ ...prev, [snapshot.id]: true }))


### PR DESCRIPTION
## Description

This PR standardizes and fixes pagination page-size behavior across all Dashboard resource lists. It ensures that the user’s “items per page” preference is persisted across refreshes and sessions, eliminating repeated manual adjustments.

---

### The Problem
- Pagination size was not consistently persisted across Dashboard views.
- Some tables relied on static `initialState.pagination.pageSize`, causing resets to default (10).
- TanStack `onPaginationChange` handler mismatch (object vs updater function) caused inconsistent updates.
- Users experienced:
  - Page size resetting on refresh/navigation
  - Flickering from default → preferred value
  - Inconsistent behavior across different resources

---

### The Fix / Proposed Solution
- Centralized pagination persistence using `usePersistedPageSize`
- Added per-resource localStorage keys:
  - Registries, Volumes, API Keys, Members, Member Invitations
- Wired all affected tables to shared persisted pagination state:
  - Removed local default-only pagination usage
  - Connected `state.pagination` and `onPaginationChange`
- Fixed TanStack compatibility:
  - Added support for both direct object updates and updater functions
- Ensured persistence triggers on all page-size updates

---

### Benefits
- Page size persists across refresh and sessions
- Independent preferences per resource type
- No UI flicker or reset on initial load
- Consistent pagination UX across all Dashboard lists
- Improved developer experience for power users managing large datasets

---

### Acceptance Criteria
[x] Page size persists after refresh  
[x] Per-resource pagination preferences are maintained  
[x] No flicker/reset to default on load  
[x] API calls respect stored page size  


## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #4123 

## Screenshots


https://github.com/user-attachments/assets/445c7a10-4aa3-47ee-a0ff-5b445ef602ee


## Notes

The table state updates immediately, stores correctly in local storage, and survives refresh/session maintaining "items per page" selection.