### PR TITLE
Quiet Mode & Progress Toggle for Snapshot Push

### DIFF
--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var PushCmd = &cobra.Command{
@@ -33,6 +35,11 @@ var PushCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		sourceImage := args[0]
+
+		isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+		isCI := isCIEnvironment()
+		showOutput := !quietFlag
+		showDynamicProgress := !quietFlag && !noProgressFlag && !isCI && isTTY
 
 		err := common.ValidateImageName(sourceImage)
 		if err != nil {
@@ -111,7 +118,16 @@ var PushCmd = &cobra.Command{
 		}
 		defer pushReader.Close()
 
-		err = jsonmessage.DisplayJSONMessagesStream(pushReader, os.Stdout, 0, true, nil)
+		if showOutput && !showDynamicProgress {
+			views_common.RenderInfoMessage("Pushing snapshot...")
+		}
+
+		pushOutput := io.Writer(os.Stdout)
+		if quietFlag {
+			pushOutput = io.Discard
+		}
+
+		err = jsonmessage.DisplayJSONMessagesStream(pushReader, pushOutput, 0, showDynamicProgress, nil)
 		if err != nil {
 			return err
 		}
@@ -153,27 +169,47 @@ var PushCmd = &cobra.Command{
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
-		views_common.RenderInfoMessageBold(fmt.Sprintf("Successfully pushed %s to Daytona", sourceImage))
+		if showOutput {
+			views_common.RenderInfoMessageBold(fmt.Sprintf("Successfully pushed %s to Daytona", sourceImage))
+		}
 
-		err = views_util.WithInlineSpinner("Waiting for the snapshot to be validated", func() error {
-			return common.AwaitSnapshotState(ctx, apiClient, nameFlag, apiclient.SNAPSHOTSTATE_ACTIVE)
-		})
+		if showOutput && showDynamicProgress {
+			err = views_util.WithInlineSpinner("Waiting for the snapshot to be validated", func() error {
+				return common.AwaitSnapshotState(ctx, apiClient, nameFlag, apiclient.SNAPSHOTSTATE_ACTIVE)
+			})
+		} else {
+			if showOutput {
+				views_common.RenderInfoMessage("Waiting for the snapshot to be validated...")
+			}
+			err = common.AwaitSnapshotState(ctx, apiClient, nameFlag, apiclient.SNAPSHOTSTATE_ACTIVE)
+		}
 		if err != nil {
 			return err
 		}
 
-		views_common.RenderInfoMessage(fmt.Sprintf("%s  Use '%s' to create a new sandbox using this snapshot", views_common.Checkmark, nameFlag))
+		if showOutput {
+			views_common.RenderInfoMessage(fmt.Sprintf("%s  Use '%s' to create a new sandbox using this snapshot", views_common.Checkmark, nameFlag))
+		}
 		return nil
 	},
 }
 
 var (
-	nameFlag string
+	nameFlag       string
+	quietFlag      bool
+	noProgressFlag bool
 )
+
+func isCIEnvironment() bool {
+	ci := strings.TrimSpace(strings.ToLower(os.Getenv("CI")))
+	return ci != "" && ci != "0" && ci != "false"
+}
 
 func init() {
 	PushCmd.Flags().StringVarP(&entrypointFlag, "entrypoint", "e", "", "The entrypoint command for the image")
 	PushCmd.Flags().StringVarP(&nameFlag, "name", "n", "", "Specify the Snapshot name")
+	PushCmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress all non-error output")
+	PushCmd.Flags().BoolVar(&noProgressFlag, "no-progress", false, "Disable dynamic progress output and animations")
 	PushCmd.Flags().Int32Var(&cpuFlag, "cpu", 0, "CPU cores that will be allocated to the underlying sandboxes (default: 1)")
 	PushCmd.Flags().Int32Var(&memoryFlag, "memory", 0, "Memory that will be allocated to the underlying sandboxes in GB (default: 1)")
 	PushCmd.Flags().Int32Var(&diskFlag, "disk", 0, "Disk space that will be allocated to the underlying sandboxes in GB (default: 3)")

--- a/apps/cli/cmd/snapshot/push.go
+++ b/apps/cli/cmd/snapshot/push.go
@@ -127,7 +127,7 @@ var PushCmd = &cobra.Command{
 			pushOutput = io.Discard
 		}
 
-		err = jsonmessage.DisplayJSONMessagesStream(pushReader, pushOutput, 0, showDynamicProgress, nil)
+		err = jsonmessage.DisplayJSONMessagesStream(pushReader, pushOutput, os.Stdout.Fd(), showDynamicProgress, nil)
 		if err != nil {
 			return err
 		}

--- a/apps/cli/docs/daytona_snapshot_push.md
+++ b/apps/cli/docs/daytona_snapshot_push.md
@@ -18,6 +18,8 @@ daytona snapshot push [SNAPSHOT] [flags]
   -e, --entrypoint string   The entrypoint command for the image
       --memory int32        Memory that will be allocated to the underlying sandboxes in GB (default: 1)
   -n, --name string         Specify the Snapshot name
+      --no-progress         Disable dynamic progress output and animations
+  -q, --quiet               Suppress all non-error output
       --region string       ID of the region where the snapshot will be available (defaults to organization default region)
 ```
 

--- a/apps/cli/hack/docs/daytona_snapshot_push.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_push.yaml
@@ -22,6 +22,13 @@ options:
   - name: name
     shorthand: 'n'
     usage: Specify the Snapshot name
+  - name: no-progress
+    default_value: 'false'
+    usage: Disable dynamic progress output and animations
+  - name: quiet
+    shorthand: q
+    default_value: 'false'
+    usage: Suppress all non-error output
   - name: region
     usage: |
       ID of the region where the snapshot will be available (defaults to organization default region)

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -402,6 +402,8 @@ __Flags__
 | `--entrypoint` | `-e` | The entrypoint command for the image |
 | `--memory` |  | Memory that will be allocated to the underlying sandboxes in GB (default: 1) |
 | `--name` | `-n` | Specify the Snapshot name |
+| `--no-progress` |  | Disable dynamic progress output and animations |
+| `--quiet` | `-q` | Suppress all non-error output |
 | `--region` |  | ID of the region where the snapshot will be available (defaults to organization default region) |
 | `--help` |  | help for daytona |
 


### PR DESCRIPTION
## Description

This PR introduces support for quiet mode and progress output control in `daytona snapshot push`, improving usability in CI pipelines and non-interactive environments.

---

### The Problem
- Dynamic progress bars and spinners are not CI-friendly
- Non-TTY environments (logs, scripts) render output poorly
- No way to suppress output for automation workflows
- Causes noisy logs and poor DX in pipelines

---

### The Fix / Proposed Solution
- Added `--quiet` (`-q`) flag:
  - Suppresses all non-error output
- Added `--no-progress` flag:
  - Disables dynamic progress/spinner output
- Implemented automatic fallback:
  - If `CI=true`, disable dynamic output
  - If stdout is not a TTY, disable dynamic output
- Maintained existing interactive behavior by default

---

### Benefits
- Cleaner CI/CD logs
- Better automation compatibility
- Improved developer experience
- Backward-compatible behavior
- Predictable output across environments

---

### Acceptance Criteria

- [x] daytona snapshot push --no-progress completes successfully without rendering dynamic bars.

- [x] daytona snapshot push --quiet completes successfully with zero standard output (exit code 0 on success).

- [x] When running in a CI environment (simulated via CI=true or piped output), the CLI defaults to a non-interactive output mode.

- [x] Docs updated to reflect new flags for automation workflows.

- Verified compilation using:
  ```bash
  go test ./cmd/snapshot/...
  
  
## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #3599 

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
