### PR TITLE
fix(api): allow region resource access to sandbox

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -79,6 +79,7 @@ import { Redis } from 'ioredis'
 import { SANDBOX_EVENT_CHANNEL } from '../../common/constants/constants'
 import { RequireFlagsEnabled } from '@openfeature/nestjs-sdk'
 import { FeatureFlags } from '../../common/constants/feature-flags'
+import { RegionSandboxAccessGuard } from '../guards/region-sandbox-access.guard'
 
 @ApiTags('sandbox')
 @Controller('sandbox')
@@ -364,7 +365,7 @@ export class SandboxController {
     description: 'Sandbox details',
     type: SandboxDto,
   })
-  @UseGuards(SandboxAccessGuard)
+  @UseGuards(OrGuard([SandboxAccessGuard, RegionSandboxAccessGuard]))
   async getSandbox(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('sandboxIdOrName') sandboxIdOrName: string,
@@ -725,7 +726,7 @@ export class SandboxController {
     status: 201,
     description: 'Last activity has been updated',
   })
-  @UseGuards(OrGuard([SandboxAccessGuard, ProxyGuard, SshGatewayGuard]))
+  @UseGuards(OrGuard([SandboxAccessGuard, ProxyGuard, SshGatewayGuard, RegionSandboxAccessGuard]))
   async updateLastActivity(@Param('sandboxId') sandboxId: string): Promise<void> {
     await this.sandboxService.updateLastActivityAt(sandboxId, new Date())
   }


### PR DESCRIPTION
## Description

Fixes a regression introduced with a previous auth guard refactor.
Region ssh gateway and proxy were missing access to update last activity and get sandbox.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
