### PR TITLE
fix(dashboard): check permission before rendering create sandbox button

### DIFF
--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { OrganizationRolePermissionsEnum } from '@daytonaio/api-client'
 import { OrganizationSuspendedError } from '@/api/errors'
 import { PageContent, PageHeader, PageLayout, PageTitle } from '@/components/PageLayout'
 import { CreateSandboxSheet } from '@/components/Sandbox/CreateSandboxSheet'
@@ -63,7 +64,8 @@ const Sandboxes: React.FC = () => {
   const { notificationSocket } = useNotificationSocket()
   const config = useConfig()
   const queryClient = useQueryClient()
-  const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
+  const { selectedOrganization, authenticatedUserOrganizationMember, authenticatedUserHasPermission } =
+    useSelectedOrganization()
 
   // Pagination
 
@@ -934,7 +936,7 @@ const Sandboxes: React.FC = () => {
               </Button>
             </>
           )}
-          <CreateSandboxSheet />
+          {authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_SANDBOXES) && <CreateSandboxSheet />}
         </div>
       </PageHeader>
       <PageContent size="full" className="flex-1 max-h-[calc(100vh-65px)]">


### PR DESCRIPTION
This pull request updates the `Sandboxes` page to improve permission handling for creating sandboxes. The most important change is restricting access to the sandbox creation sheet based on user permissions, ensuring only authorized users can create sandboxes.

Permission handling improvements:

* Added import of `OrganizationRolePermissionsEnum` from `@daytonaio/api-client` to enable permission checks.
* Updated usage of `useSelectedOrganization` to include `authenticatedUserHasPermission`, allowing permission checks for the authenticated user.
* Restricted rendering of `CreateSandboxSheet` to users with the `WRITE_SANDBOXES` permission, preventing unauthorized access to sandbox creation.