### PR TITLE
fix(api): guard for get single sandbox

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -365,7 +365,7 @@ export class SandboxController {
     description: 'Sandbox details',
     type: SandboxDto,
   })
-  @UseGuards(OrGuard([SandboxAccessGuard, RegionSandboxAccessGuard]))
+  @UseGuards(SandboxAccessGuard)
   async getSandbox(
     @AuthContext() authContext: OrganizationAuthContext,
     @Param('sandboxIdOrName') sandboxIdOrName: string,

--- a/apps/api/src/sandbox/guards/sandbox-access.guard.ts
+++ b/apps/api/src/sandbox/guards/sandbox-access.guard.ts
@@ -10,8 +10,11 @@ import { isRunnerContext, RunnerContext } from '../../common/interfaces/runner-c
 import { SystemRole } from '../../user/enums/system-role.enum'
 import { isProxyContext } from '../../common/interfaces/proxy-context.interface'
 import { isSshGatewayContext } from '../../common/interfaces/ssh-gateway-context.interface'
-import { isRegionProxyContext } from '../../common/interfaces/region-proxy.interface'
-import { isRegionSSHGatewayContext } from '../../common/interfaces/region-ssh-gateway.interface'
+import { isRegionProxyContext, RegionProxyContext } from '../../common/interfaces/region-proxy.interface'
+import {
+  isRegionSSHGatewayContext,
+  RegionSSHGatewayContext,
+} from '../../common/interfaces/region-ssh-gateway.interface'
 
 @Injectable()
 export class SandboxAccessGuard implements CanActivate {
@@ -39,8 +42,13 @@ export class SandboxAccessGuard implements CanActivate {
         }
         case isRegionProxyContext(authContext):
         case isRegionSSHGatewayContext(authContext): {
-          // Use RegionSandboxAccessGuard to check access instead
-          return false
+          // For region proxy/ssh gateway authentication, verify that the runner's region ID matches the region ID
+          const regionContext = authContext as RegionProxyContext | RegionSSHGatewayContext
+          const sandboxRegionId = await this.sandboxService.getRegionId(sandboxIdOrName)
+          if (sandboxRegionId !== regionContext.regionId) {
+            throw new ForbiddenException(`Sandbox region ID does not match region ${regionContext.role} region ID`)
+          }
+          break
         }
         case isProxyContext(authContext):
         case isSshGatewayContext(authContext):


### PR DESCRIPTION
Fixes a regression introduced with a previous fix for allowing region service accounts access to a single sandbox.
For non-existing sandboxes, the status code would be 403 instead of 404.