### PR TITLE
Fix panic in case no args are provided to the daytona start command.

### DIFF
--- a/apps/cli/cmd/sandbox/start.go
+++ b/apps/cli/cmd/sandbox/start.go
@@ -15,12 +15,7 @@ import (
 var StartCmd = &cobra.Command{
 	Use:   "start [SANDBOX_ID] | [SANDBOX_NAME]",
 	Short: "Start a sandbox",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return fmt.Errorf("expected exactly one argument: [SANDBOX_ID] or [SANDBOX_NAME]")
-		}
-		return nil
-	},
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 

--- a/apps/cli/cmd/sandbox/start.go
+++ b/apps/cli/cmd/sandbox/start.go
@@ -15,7 +15,12 @@ import (
 var StartCmd = &cobra.Command{
 	Use:   "start [SANDBOX_ID] | [SANDBOX_NAME]",
 	Short: "Start a sandbox",
-	Args:  cobra.MaximumNArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("expected exactly one argument: [SANDBOX_ID] or [SANDBOX_NAME]")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 


### PR DESCRIPTION
## Description

Trying to use:
```
daytona start (no_args)
```
causes a panic since the no args constraint is not being checked for and that leads to the panic due to the indexing non-existing slice element: 
```
sandboxIdOrNameArg := args[0]
```

stack trace:
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/daytonaio/daytona/cli/cmd/sandbox.init.func9(0x2c48bed6d208, {0x155fc60, 0x0, 0x0})
        /home/<user>/projects/daytona/apps/cli/cmd/sandbox/start.go:27 +0x3bd
github.com/spf13/cobra.(*Command).execute(0x2c48bed6d208, {0x155fc60, 0x0, 0x0})
        /home/<user>/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015 +0xf02
github.com/spf13/cobra.(*Command).ExecuteC(0x1515c00)
        /home/<user>/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x9db
github.com/spf13/cobra.(*Command).Execute(0x1515c00)
        /home/<user>/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071 +0x32
main.main()
        /home/<user>/projects/daytona/apps/cli/main.go:101 +0xb1
```

This commit fixes this issue by providing a custom cobra validation that enforces exactly one argument (as expected) and printing a custom validation error that would be hopefully be more helpful for the user.


## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.
