### PR TITLE
fix: wrap command execution in bash -c for proper exit codes

### DIFF
--- a/apps/daemon/pkg/toolbox/process/execute.go
+++ b/apps/daemon/pkg/toolbox/process/execute.go
@@ -4,11 +4,11 @@
 package process
 
 import (
-	"bytes"
 	"errors"
 	"log/slog"
 	"net/http"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -34,13 +34,12 @@ func ExecuteCommand(logger *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
-		cmdParts := parseCommand(request.Command)
-		if len(cmdParts) == 0 {
+		if strings.TrimSpace(request.Command) == "" {
 			c.AbortWithError(http.StatusBadRequest, errors.New("empty command"))
 			return
 		}
 
-		cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+		cmd := exec.Command("bash", "-c", request.Command)
 		if request.Cwd != nil {
 			cmd.Dir = *request.Cwd
 		}
@@ -102,38 +101,3 @@ func ExecuteCommand(logger *slog.Logger) gin.HandlerFunc {
 	}
 }
 
-// parseCommand splits a command string properly handling quotes
-func parseCommand(command string) []string {
-	var args []string
-	var current bytes.Buffer
-	var inQuotes bool
-	var quoteChar rune
-
-	for _, r := range command {
-		switch {
-		case r == '"' || r == '\'':
-			if !inQuotes {
-				inQuotes = true
-				quoteChar = r
-			} else if quoteChar == r {
-				inQuotes = false
-				quoteChar = 0
-			} else {
-				current.WriteRune(r)
-			}
-		case r == ' ' && !inQuotes:
-			if current.Len() > 0 {
-				args = append(args, current.String())
-				current.Reset()
-			}
-		default:
-			current.WriteRune(r)
-		}
-	}
-
-	if current.Len() > 0 {
-		args = append(args, current.String())
-	}
-
-	return args
-}

--- a/apps/daemon/pkg/toolbox/process/execute_test.go
+++ b/apps/daemon/pkg/toolbox/process/execute_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package process
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	logger := slog.Default()
+	r.POST("/process/execute", ExecuteCommand(logger))
+	return r
+}
+
+func executeRequest(t *testing.T, router *gin.Engine, req ExecuteRequest) ExecuteResponse {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	httpReq, _ := http.NewRequest("POST", "/process/execute", bytes.NewBuffer(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, httpReq)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ExecuteResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	return resp
+}
+
+func TestExecuteCommand_NotFound(t *testing.T) {
+	router := setupRouter()
+	resp := executeRequest(t, router, ExecuteRequest{
+		Command: "nonexistent_command_xyz_12345",
+	})
+
+	if resp.ExitCode != 127 {
+		t.Errorf("expected exit code 127 for command not found, got %d", resp.ExitCode)
+	}
+}
+
+func TestExecuteCommand_Success(t *testing.T) {
+	router := setupRouter()
+	resp := executeRequest(t, router, ExecuteRequest{
+		Command: "echo hello",
+	})
+
+	if resp.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", resp.ExitCode)
+	}
+	if resp.Result != "hello\n" {
+		t.Errorf("expected 'hello\\n', got %q", resp.Result)
+	}
+}
+
+func TestExecuteCommand_ExitCode(t *testing.T) {
+	router := setupRouter()
+	resp := executeRequest(t, router, ExecuteRequest{
+		Command: "exit 42",
+	})
+
+	if resp.ExitCode != 42 {
+		t.Errorf("expected exit code 42, got %d", resp.ExitCode)
+	}
+}
+
+func TestExecuteCommand_Pipe(t *testing.T) {
+	router := setupRouter()
+	resp := executeRequest(t, router, ExecuteRequest{
+		Command: "echo hello | grep hello",
+	})
+
+	if resp.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", resp.ExitCode)
+	}
+	if resp.Result != "hello\n" {
+		t.Errorf("expected 'hello\\n', got %q", resp.Result)
+	}
+}


### PR DESCRIPTION
## Description

Wrap command execution in `bash -c` to get proper exit codes from the shell. Previously, `exec.Command` was called directly with parsed command parts, which caused Go to return exit code -1 when a command binary was not found, instead of the standard shell exit code 127.

Changes:
- Replace `exec.Command(cmdParts[0], cmdParts[1:]...)` with `exec.Command("bash", "-c", request.Command)`
- Remove the `parseCommand()` helper (no longer needed since bash handles parsing)
- Simplify the empty command check to validate `request.Command` directly

This also fixes shell features like pipes that previously required manual parsing.

## Documentation

- [ ] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

Fixes #2283

## Screenshots

N/A

## Notes

Added unit tests covering:
- Command not found returns exit code 127
- Successful command returns exit code 0
- Custom exit codes are preserved (e.g. `exit 42` → 42)
- Pipe commands work correctly (`echo hello | grep hello`)