### PR TITLE
chore(dev): disable node_modules file watchers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "files.watcherExclude": {
     "**/libs/*api-client*/**": true,
-    "**/node_modules/*/**": true
+    "**/node_modules/**": true
   }
 }

--- a/apps/api/webpack.config.js
+++ b/apps/api/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = composePlugins(
     config.mode = process.env.NODE_ENV
 
     config.watchOptions = {
-      ignored: ['**/node_modules'],
+      ignored: /node_modules/,
     }
     return config
   },

--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -26,7 +26,7 @@ export default defineConfig((mode) => ({
       },
     },
     watch: {
-      ignored: ['**/node_modules'],
+      ignored: ['**/node_modules/**'],
     },
   },
   plugins: [


### PR DESCRIPTION
## Description

Disables `node_modules` file watchers in api, dashboard and vscode.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
