### PR TITLE
fix(api): handle svix 404 error as not found exception

### DIFF
--- a/apps/api/src/webhook/services/webhook.service.ts
+++ b/apps/api/src/webhook/services/webhook.service.ts
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import { Injectable, Logger, OnModuleInit, NotFoundException } from '@nestjs/common'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { Svix } from 'svix'
 import { Organization } from '../../organization/entities/organization.entity'
 import { InjectRepository } from '@nestjs/typeorm'
 import { WebhookInitialization } from '../entities/webhook-initialization.entity'
 import { Repository } from 'typeorm'
-import { NotFoundException } from '@nestjs/common'
 
 @Injectable()
 export class WebhookService implements OnModuleInit {


### PR DESCRIPTION
## Description

Handles Svix 404 errors as not found exceptions. This prevents excessive errors logging in the all-exceptions filter and returns 404 to the client instead of 500.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
