### PR TITLE
fix(daemon): wsClient write mutex

### DIFF
--- a/apps/daemon/pkg/toolbox/process/pty/types.go
+++ b/apps/daemon/pkg/toolbox/process/pty/types.go
@@ -39,6 +39,7 @@ type wsClient struct {
 	send      chan []byte   // outbound queue for this client (PTY -> WS)
 	done      chan struct{} // closed when the client is shutting down
 	closeOnce sync.Once
+	writeMu   sync.Mutex // serializes all writes to conn
 }
 
 // PTYSession represents a single PTY session with multi-client support

--- a/apps/daemon/pkg/toolbox/process/pty/websocket.go
+++ b/apps/daemon/pkg/toolbox/process/pty/websocket.go
@@ -35,7 +35,7 @@ func (s *PTYSession) attachWebSocket(ws *websocket.Conn) {
 		"status": "connected",
 	}
 	if successJSON, err := json.Marshal(successMsg); err == nil {
-		_ = ws.WriteMessage(websocket.TextMessage, successJSON)
+		_ = cl.writeMessage(websocket.TextMessage, successJSON)
 	}
 
 	// reader (this client -> PTY); blocks until disconnect
@@ -59,8 +59,11 @@ func (s *PTYSession) clientWriter(cl *wsClient) {
 		case <-cl.done:
 			return
 		case b := <-cl.send:
+			cl.writeMu.Lock()
 			_ = cl.conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := cl.conn.WriteMessage(websocket.BinaryMessage, b); err != nil {
+			err := cl.conn.WriteMessage(websocket.BinaryMessage, b)
+			cl.writeMu.Unlock()
+			if err != nil {
 				return
 			}
 		}
@@ -83,7 +86,7 @@ func (s *PTYSession) clientReader(cl *wsClient) {
 		// Send all message data to PTY (text or binary)
 		if err := s.sendToPTY(data); err != nil {
 			// Send error to client and close connection
-			_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
+			_ = cl.writeMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
 				websocket.CloseInternalServerErr, "PTY session unavailable",
 			))
 			return
@@ -103,7 +106,7 @@ func (s *PTYSession) broadcast(b []byte) {
 		default:
 			// client's outbound queue is full -> drop the client
 			go func(id string, cl *wsClient) {
-				_ = cl.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
+				_ = cl.writeMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
 					websocket.ClosePolicyViolation, "slow consumer",
 				))
 				cl.close()
@@ -160,7 +163,7 @@ func (s *PTYSession) closeClientsWithExitCode(exitCode int, exitReason string) {
 
 	s.clientsMu.Lock()
 	for id, cl := range s.clients.Items() {
-		_ = cl.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
+		_ = cl.writeMessage(websocket.CloseMessage, websocket.FormatCloseMessage(
 			wsCloseCode, string(closeJSON),
 		))
 		cl.close()

--- a/apps/daemon/pkg/toolbox/process/pty/ws_client.go
+++ b/apps/daemon/pkg/toolbox/process/pty/ws_client.go
@@ -3,6 +3,14 @@
 
 package pty
 
+// writeMessage serializes all writes to the underlying websocket connection.
+// gorilla/websocket does not support concurrent writers.
+func (cl *wsClient) writeMessage(messageType int, data []byte) error {
+	cl.writeMu.Lock()
+	defer cl.writeMu.Unlock()
+	return cl.conn.WriteMessage(messageType, data)
+}
+
 func (cl *wsClient) close() {
 	cl.closeOnce.Do(func() {
 		close(cl.done)


### PR DESCRIPTION
## Description

Fix for a concurrent websocket write in the daemon

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

```
panic: concurrent write to websocket connection

goroutine 273 [running]:
github.com/gorilla/websocket.(*messageWriter).flushFrame(...)
    /go/pkg/mod/github.com/gorilla/websocket@v1.5.3/conn.go:617
github.com/gorilla/websocket.(*Conn).WriteMessage(...)
    /go/pkg/mod/github.com/gorilla/websocket@v1.5.3/conn.go:770
github.com/daytonaio/daemon/pkg/toolbox/process/pty.(*PTYSession).closeClientsWithExitCode(...)
    /workspaces/daytona/apps/daemon/pkg/toolbox/process/pty/websocket.go:163
github.com/daytonaio/daemon/pkg/toolbox/process/pty.(*PTYSession).start.func1()
    /workspaces/daytona/apps/daemon/pkg/toolbox/process/pty/session.go:116

created by github.com/daytonaio/daemon/pkg/toolbox/process/pty.(*PTYSession).start
    /workspaces/daytona/apps/daemon/pkg/toolbox/process/pty/session.go:80
```