### PR TITLE
fix(api): avoid in-place snapshot mutation in sandbox state sync

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -387,12 +387,11 @@ export class SandboxStartAction extends SandboxAction {
 
     const result = await runnerAdapter.createSandbox(
       sandbox,
+      snapshotRef,
       internalRegistry,
       entrypoint,
       metadata,
       this.configService.get('sandboxOtel.endpointUrl'),
-      undefined,
-      snapshotRef,
     )
 
     await this.updateSandboxState(sandbox, SandboxState.CREATING, lockCode, undefined, undefined, result?.daemonVersion)
@@ -832,12 +831,11 @@ export class SandboxStartAction extends SandboxAction {
 
     await runnerAdapter.createSandbox(
       sandbox,
+      validBackup,
       registry,
       undefined,
       metadata,
       this.configService.get('sandboxOtel.endpointUrl'),
-      undefined,
-      validBackup,
     )
     return null
   }

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -573,12 +573,12 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       // Pass undefined for entrypoint as the backup snapshot already has it baked in and use skipStart
       await newRunnerAdapter.createSandbox(
         sandbox,
+        sandbox.backupSnapshot,
         registry,
         undefined,
         metadata,
         undefined,
         true,
-        sandbox.backupSnapshot,
       )
       this.logger.debug(`Created sandbox ${sandbox.id} on new runner ${newRunnerId} with skipStart`)
     } catch (e) {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -67,12 +67,12 @@ export interface RunnerAdapter {
   sandboxInfo(sandboxId: string): Promise<RunnerSandboxInfo>
   createSandbox(
     sandbox: Sandbox,
+    snapshotRef: string,
     registry?: DockerRegistry,
     entrypoint?: string[],
     metadata?: { [key: string]: string },
     otelEndpoint?: string,
     skipStart?: boolean,
-    snapshotRef?: string,
   ): Promise<StartSandboxResponse | undefined>
   startSandbox(
     sandboxId: string,

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -187,17 +187,17 @@ export class RunnerAdapterV0 implements RunnerAdapter {
 
   async createSandbox(
     sandbox: Sandbox,
+    snapshotRef: string,
     registry?: DockerRegistry,
     entrypoint?: string[],
     metadata?: { [key: string]: string },
     otelEndpoint?: string,
     skipStart?: boolean,
-    snapshotRef?: string,
   ): Promise<StartSandboxResponse | undefined> {
     const createSandboxDto: CreateSandboxDTO = {
       id: sandbox.id,
       userId: sandbox.organizationId,
-      snapshot: snapshotRef ?? sandbox.snapshot,
+      snapshot: snapshotRef,
       osUser: sandbox.osUser,
       cpuQuota: sandbox.cpu,
       gpuQuota: sandbox.gpu,

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -135,17 +135,17 @@ export class RunnerAdapterV2 implements RunnerAdapter {
 
   async createSandbox(
     sandbox: Sandbox,
+    snapshotRef: string,
     registry?: DockerRegistry,
     entrypoint?: string[],
     metadata?: { [key: string]: string },
     otelEndpoint?: string,
     skipStart?: boolean,
-    snapshotRef?: string,
   ): Promise<StartSandboxResponse | undefined> {
     const payload: CreateSandboxDTO = {
       id: sandbox.id,
       userId: sandbox.organizationId,
-      snapshot: snapshotRef ?? sandbox.snapshot,
+      snapshot: snapshotRef,
       osUser: sandbox.osUser,
       cpuQuota: sandbox.cpu,
       gpuQuota: sandbox.gpu,


### PR DESCRIPTION
This pull request refactors how the snapshot reference is passed and used throughout the sandbox creation and restoration process. Instead of mutating the `sandbox.snapshot` property directly, the snapshot reference is now passed explicitly as a parameter to the `createSandbox` method and its adapters. This change improves code clarity and reduces side effects when managing sandbox state.

**Snapshot handling improvements:**

* The `createSandbox` method in the `RunnerAdapter` interface and its implementations (`RunnerAdapterV0` and `RunnerAdapterV2`) now accept an explicit `snapshotRef` parameter, which is used for the snapshot reference instead of relying on the mutable `sandbox.snapshot` property.
* In `SandboxStartAction`, the logic is updated to compute and pass the correct `snapshotRef` to `createSandbox`, without mutating `sandbox.snapshot`. This applies both to normal startup and when restoring from a backup. 
* In `SandboxManager`, the code no longer temporarily overwrites `sandbox.snapshot` when restoring from a backup. Instead, the backup snapshot reference is passed directly to `createSandbox`. 

These changes make snapshot management more explicit and robust, reducing the risk of bugs related to unintended state mutations.