### PR TITLE
fix(runner): pass inter-sandbox network enabled configuration

### DIFF
--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -160,6 +160,7 @@ func run() int {
 		BackupTimeoutMin:             cfg.BackupTimeoutMin,
 		SnapshotPullTimeout:          cfg.SnapshotPullTimeout,
 		InitializeDaemonTelemetry:    cfg.InitializeDaemonTelemetry,
+		InterSandboxNetworkEnabled:   cfg.InterSandboxNetworkEnabled,
 	})
 	if err != nil {
 		logger.Error("Error creating Docker client wrapper", "error", err)


### PR DESCRIPTION
## Description

Pass missing configuration property to docker client.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
