### PR TITLE
fix(toolbox): return empty search_files results (#3772)

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/search_files.go
+++ b/apps/daemon/pkg/toolbox/fs/search_files.go
@@ -32,7 +32,7 @@ func SearchFiles(c *gin.Context) {
 		return
 	}
 
-	var matches []string
+	matches := []string{}
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return filepath.SkipDir


### PR DESCRIPTION
## Description

Fix the toolbox `search_files` response so it always returns an empty array when no files match.

Issue #3772 came from the Go handler returning a nil contract and caused Python client validation errors when Harbor searched empty or missing directories during result download.

This change initializes `matches` as an empty slice in `apps/daemon/pkg/toolbox/fs/search_files.go`, so the response serializes as `{"files":[]}`. The OpenAPI schema already described `files` as a required array, so no schema change or client-side workaround is needed.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #3772 