### PR TITLE
fix(sdk-python): retry request on stale connection

### DIFF
--- a/libs/sdk-python/pyproject.toml
+++ b/libs/sdk-python/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "opentelemetry-api>=1.27.0,<2.0.0",
     "opentelemetry-sdk>=1.27.0,<2.0.0",
     "opentelemetry-exporter-otlp-proto-http>=1.27.0,<2.0.0",
-    "opentelemetry-instrumentation-aiohttp-client>=0.59b0"
+    "opentelemetry-instrumentation-aiohttp-client>=0.59b0",
+    "urllib3>=2.1.0,<3.0.0"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -53,6 +53,7 @@ from ..common.daytona import (
 from ..common.errors import DaytonaError
 from ..common.image import Image
 from ..common.protocols import SandboxCodeToolbox
+from ..internal.urllib3_retry import RemoteDisconnectedRetry
 from .sandbox import PaginatedSandboxes, Sandbox
 from .snapshot import SnapshotService
 from .volume import VolumeService
@@ -671,6 +672,15 @@ class Daytona:
         assert isinstance(self._api_client.configuration, Configuration)
         config = deepcopy(self._api_client.configuration)
         config.host = ""
+        # Retry only on RemoteDisconnected (stale pool connections).
+        # The daemon may close idle connections; urllib3 would normally not retry
+        # POST, causing RemoteDisconnected to propagate. Using a targeted subclass
+        # (instead of urllib3.Retry with allowed_methods=None) avoids also retrying
+        # IncompleteRead, where the server already started processing and sending a
+        # response — retrying that would execute the operation a second time.
+        config.retries = RemoteDisconnectedRetry(  # pyright: ignore[reportAttributeAccessIssue]
+            total=3, raise_on_status=False
+        )
         toolbox_api_client = ToolboxApiClient(config)
         toolbox_api_client.default_headers = deepcopy(cast(dict[str, str], self._api_client.default_headers))
 

--- a/libs/sdk-python/src/daytona/internal/urllib3_retry.py
+++ b/libs/sdk-python/src/daytona/internal/urllib3_retry.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import http.client
+
+import urllib3
+from typing_extensions import override
+
+
+class RemoteDisconnectedRetry(urllib3.Retry):
+    """urllib3.Retry subclass that retries RemoteDisconnected on any HTTP method.
+
+    urllib3 classifies both RemoteDisconnected and IncompleteRead as "read errors"
+    (ProtocolError) and, by default, only retries them for idempotent methods (GET,
+    HEAD, etc.) — not POST.
+
+    RemoteDisconnected ("Remote end closed connection without response") means the
+    server sent zero bytes, so the request was never processed (stale connection
+    pool). Retrying on any HTTP method is safe.
+
+    IncompleteRead means the server already started sending a response, so it did
+    process the request. We must NOT retry POST on IncompleteRead to avoid executing
+    an operation twice.
+
+    Note: in an extremely rare case the daemon (sandbox) could crash after
+    processing a request but before writing any response bytes, which would
+    also surface as RemoteDisconnected. However, this is not a practical
+    concern — if the daemon crashes, it will be down when the retry arrives,
+    so the retried request will fail with a connection error rather than
+    executing the operation a second time.
+
+    Implementation: we override ``_is_read_error`` to return ``False`` for
+    RemoteDisconnected. This causes urllib3's ``increment()`` to fall into the
+    generic "other error" branch, which retries regardless of HTTP method.
+    All other errors (IncompleteRead, ReadTimeoutError, etc.) keep their
+    default behavior.  No mutable state, so this is thread-safe.
+    """
+
+    @override
+    def _is_read_error(self, err: Exception) -> bool:
+        if _is_remote_disconnected(err):
+            return False
+        return super()._is_read_error(err)
+
+
+def _is_remote_disconnected(err: Exception) -> bool:
+    """Return True if ``err`` is a ProtocolError wrapping RemoteDisconnected."""
+    if not isinstance(err, urllib3.exceptions.ProtocolError):
+        return False
+    cause = err.args[1] if len(err.args) > 1 else None
+    return isinstance(cause, http.client.RemoteDisconnected)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1168,6 +1168,7 @@ pydantic = ">=2.4.2,<3.0.0"
 python-multipart = ">=0.0.15,<0.1.0"
 toml = ">=0.10.0,<0.11.0"
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.10\""}
+urllib3 = ">=2.1.0,<3.0.0"
 websockets = ">=15.0.0,<16.0.0"
 
 [package.source]


### PR DESCRIPTION
## Problem

Python SDK users intermittently get `RemoteDisconnected: Remote end closed connection without response` errors on toolbox API calls (`exec`, `create_session`, file operations, etc.). This happens when the daemon or infrastructure (load balancers, TLS terminators) closes an idle HTTP connection, but urllib3 still tries to reuse it from its connection pool. Since toolbox API calls use POST, and urllib3 only retries idempotent methods (GET, HEAD, etc.) by default, the stale-connection error propagates to the user.

## Fix

Add `RemoteDisconnectedRetry`, a `urllib3.Retry` subclass that allows POST retries **only** for `RemoteDisconnected` — not for `IncompleteRead` or other `ProtocolError` variants where the server already started processing the request.

It works by overriding `_is_read_error()` to return `False` for `RemoteDisconnected`, which causes urllib3's retry loop to fall into the generic "other error" branch that retries regardless of HTTP method.

The retry is configured on the toolbox API client only (not the main API client), with `total=3`.

## Why not retry all `ProtocolError`?

`ProtocolError` wraps two distinct cases:
- **`RemoteDisconnected`** — server sent zero response bytes → stale pool connection, safe to retry
- **`IncompleteRead`** — server started sending a response → request was processed, retrying could duplicate side effects

Using `urllib3.Retry(allowed_methods=None)` would retry both, which is unsafe for POST.

## Edge case

In theory, the daemon could crash after processing a request but before writing any response bytes, also surfacing as `RemoteDisconnected`. In practice this is not a concern — if the daemon crashes, it will be down when the retry arrives, so the retried request fails with a connection error rather than executing twice.