### PR TITLE
feat(runner): always-allowed sandbox eagress CIDRs

### DIFF
--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -228,40 +228,41 @@ Below is a full list of environment variables with their default values:
 
 ### Runner
 
-| Variable                                | Type    | Default Value                     | Description                                           |
-| --------------------------------------- | ------- | --------------------------------- | ----------------------------------------------------- |
-| `DAYTONA_API_URL`                       | string  | `http://api:3000/api`             | Daytona API URL                                       |
-| `DAYTONA_RUNNER_TOKEN`                  | string  | `secret_api_token`                | Runner API authentication token                       |
-| `VERSION`                               | string  | `0.0.1`                           | Runner service version                                |
-| `OTEL_LOGGING_ENABLED`                  | boolean | `false`                           | Runner OpenTelemetry logging enabled                  |
-| `OTEL_TRACING_ENABLED`                  | boolean | `false`                           | Runner OpenTelemetry tracing enabled                  |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`           | string  | (empty)                           | Runner OpenTelemetry OTLP exporter endpoint           |
-| `OTEL_EXPORTER_OTLP_HEADERS`            | string  | (empty)                           | Runner OpenTelemetry OTLP exporter headers            |
-| `ENVIRONMENT`                           | string  | `development`                     | Application environment                               |
-| `API_PORT`                              | number  | `3003`                            | Runner API service port                               |
-| `LOG_FILE_PATH`                         | string  | `/home/daytona/runner/runner.log` | Path to runner log file                               |
-| `RESOURCE_LIMITS_DISABLED`              | boolean | `true`                            | Disable resource limits for sandboxes                 |
-| `AWS_ENDPOINT_URL`                      | string  | `http://minio:9000`               | AWS S3-compatible storage endpoint                    |
-| `AWS_REGION`                            | string  | `us-east-1`                       | AWS region                                            |
-| `AWS_ACCESS_KEY_ID`                     | string  | `minioadmin`                      | AWS access key ID                                     |
-| `AWS_SECRET_ACCESS_KEY`                 | string  | `minioadmin`                      | AWS secret access key                                 |
-| `AWS_DEFAULT_BUCKET`                    | string  | `daytona`                         | AWS default bucket name                               |
-| `DAEMON_START_TIMEOUT_SEC`              | number  | `60`                              | Daemon start timeout in seconds                       |
-| `SANDBOX_START_TIMEOUT_SEC`             | number  | `30`                              | Sandbox start timeout in seconds                      |
-| `USE_SNAPSHOT_ENTRYPOINT`               | boolean | `false`                           | Use snapshot entrypoint for sandbox                   |
-| `RUNNER_DOMAIN`                         | string  | (none)                            | Runner domain name (hostname for runner URLs)         |
-| `VOLUME_CLEANUP_INTERVAL`               | number  | `30s`                             | Volume cleanup interval in seconds (minimum: 10s)     |
-| `COLLECTOR_WINDOW_SIZE`                 | number  | `60`                              | Metrics collector window size (number of samples)     |
-| `CPU_USAGE_SNAPSHOT_INTERVAL`           | string  | `5s`                              | CPU usage snapshot interval duration (minimum: 1s)    |
-| `ALLOCATED_RESOURCES_SNAPSHOT_INTERVAL` | string  | `5s`                              | Allocated resources snapshot interval (minimum: 1s)   |
-| `POLL_TIMEOUT`                          | string  | `30s`                             | Poller service timeout duration (e.g., `30s`, `1m`)   |
-| `POLL_LIMIT`                            | number  | `10`                              | Maximum poll attempts per request (min: 1, max: 100)  |
-| `HEALTHCHECK_INTERVAL`                  | string  | `30s`                             | Interval between health checks (minimum: 10s)         |
-| `HEALTHCHECK_TIMEOUT`                   | string  | `10s`                             | Health check timeout duration                         |
-| `API_VERSION`                           | number  | `2`                               | Runner API version (default: 2)                       |
-| `SNAPSHOT_ERROR_CACHE_RETENTION`        | string  | `10m`                             | Snapshot error cache retention duration (minimum: 5m) |
-| `CONTAINER_NETWORK`                     | string  | (none)                            | Custom docker network for sandboxes                   |
-| `INTER_SANDBOX_NETWORK_ENABLED`         | boolean | `false`                           | Enable or disable inter-sandbox network connectivity  |
+| Variable                                | Type    | Default Value                     | Description                                                   |
+| --------------------------------------- | ------- | --------------------------------- | ------------------------------------------------------------- |
+| `DAYTONA_API_URL`                       | string  | `http://api:3000/api`             | Daytona API URL                                               |
+| `DAYTONA_RUNNER_TOKEN`                  | string  | `secret_api_token`                | Runner API authentication token                               |
+| `VERSION`                               | string  | `0.0.1`                           | Runner service version                                        |
+| `OTEL_LOGGING_ENABLED`                  | boolean | `false`                           | Runner OpenTelemetry logging enabled                          |
+| `OTEL_TRACING_ENABLED`                  | boolean | `false`                           | Runner OpenTelemetry tracing enabled                          |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`           | string  | (empty)                           | Runner OpenTelemetry OTLP exporter endpoint                   |
+| `OTEL_EXPORTER_OTLP_HEADERS`            | string  | (empty)                           | Runner OpenTelemetry OTLP exporter headers                    |
+| `ENVIRONMENT`                           | string  | `development`                     | Application environment                                       |
+| `API_PORT`                              | number  | `3003`                            | Runner API service port                                       |
+| `LOG_FILE_PATH`                         | string  | `/home/daytona/runner/runner.log` | Path to runner log file                                       |
+| `RESOURCE_LIMITS_DISABLED`              | boolean | `true`                            | Disable resource limits for sandboxes                         |
+| `AWS_ENDPOINT_URL`                      | string  | `http://minio:9000`               | AWS S3-compatible storage endpoint                            |
+| `AWS_REGION`                            | string  | `us-east-1`                       | AWS region                                                    |
+| `AWS_ACCESS_KEY_ID`                     | string  | `minioadmin`                      | AWS access key ID                                             |
+| `AWS_SECRET_ACCESS_KEY`                 | string  | `minioadmin`                      | AWS secret access key                                         |
+| `AWS_DEFAULT_BUCKET`                    | string  | `daytona`                         | AWS default bucket name                                       |
+| `DAEMON_START_TIMEOUT_SEC`              | number  | `60`                              | Daemon start timeout in seconds                               |
+| `SANDBOX_START_TIMEOUT_SEC`             | number  | `30`                              | Sandbox start timeout in seconds                              |
+| `USE_SNAPSHOT_ENTRYPOINT`               | boolean | `false`                           | Use snapshot entrypoint for sandbox                           |
+| `RUNNER_DOMAIN`                         | string  | (none)                            | Runner domain name (hostname for runner URLs)                 |
+| `VOLUME_CLEANUP_INTERVAL`               | number  | `30s`                             | Volume cleanup interval in seconds (minimum: 10s)             |
+| `COLLECTOR_WINDOW_SIZE`                 | number  | `60`                              | Metrics collector window size (number of samples)             |
+| `CPU_USAGE_SNAPSHOT_INTERVAL`           | string  | `5s`                              | CPU usage snapshot interval duration (minimum: 1s)            |
+| `ALLOCATED_RESOURCES_SNAPSHOT_INTERVAL` | string  | `5s`                              | Allocated resources snapshot interval (minimum: 1s)           |
+| `POLL_TIMEOUT`                          | string  | `30s`                             | Poller service timeout duration (e.g., `30s`, `1m`)           |
+| `POLL_LIMIT`                            | number  | `10`                              | Maximum poll attempts per request (min: 1, max: 100)          |
+| `HEALTHCHECK_INTERVAL`                  | string  | `30s`                             | Interval between health checks (minimum: 10s)                 |
+| `HEALTHCHECK_TIMEOUT`                   | string  | `10s`                             | Health check timeout duration                                 |
+| `API_VERSION`                           | number  | `2`                               | Runner API version (default: 2)                               |
+| `SNAPSHOT_ERROR_CACHE_RETENTION`        | string  | `10m`                             | Snapshot error cache retention duration (minimum: 5m)         |
+| `CONTAINER_NETWORK`                     | string  | (none)                            | Custom docker network for sandboxes                           |
+| `INTER_SANDBOX_NETWORK_ENABLED`         | boolean | `false`                           | Enable or disable inter-sandbox network connectivity          |
+| `NETWORK_ALLOWED_CIDRS`                 | string  | (none)                            | Comma-separated list of allowed CIDR blocks for all sandboxes |
 
 ### SSH Gateway
 

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	ApiVersion                         int           `envconfig:"API_VERSION" default:"2"`
 	InitializeDaemonTelemetry          bool          `envconfig:"INITIALIZE_DAEMON_TELEMETRY" default:"true"`
 	SnapshotErrorCacheRetention        time.Duration `envconfig:"SNAPSHOT_ERROR_CACHE_RETENTION" default:"10m" validate:"min=5m"`
-	NetworkAllowedDomains              string        `envconfig:"NETWORK_ALLOWED_DOMAINS"`
+	NetworkAllowedCIDRs                string        `envconfig:"NETWORK_ALLOWED_CIDRS"`
 }
 
 var DEFAULT_API_PORT int = 8080

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	ApiVersion                         int           `envconfig:"API_VERSION" default:"2"`
 	InitializeDaemonTelemetry          bool          `envconfig:"INITIALIZE_DAEMON_TELEMETRY" default:"true"`
 	SnapshotErrorCacheRetention        time.Duration `envconfig:"SNAPSHOT_ERROR_CACHE_RETENTION" default:"10m" validate:"min=5m"`
+	NetworkAllowedDomains              string        `envconfig:"NETWORK_ALLOWED_DOMAINS"`
 }
 
 var DEFAULT_API_PORT int = 8080

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -113,22 +112,14 @@ func run() int {
 		return 2
 	}
 
-	// Resolve allowed domains for network rules
-	var allowedDomains []string
-	if cfg.NetworkAllowedDomains != "" {
-		for _, d := range strings.Split(cfg.NetworkAllowedDomains, ",") {
-			d = strings.TrimSpace(d)
-			if d != "" {
-				allowedDomains = append(allowedDomains, d)
-			}
-		}
-		if len(allowedDomains) == 0 {
-			logger.Warn("NETWORK_ALLOWED_DOMAINS is set but no valid domains were parsed; check for misconfiguration", "value", cfg.NetworkAllowedDomains)
-		}
+	// Parse allowed CIDRs for network rules
+	allowedCIDRs, err := netrules.ParseCIDRList(cfg.NetworkAllowedCIDRs)
+	if err != nil {
+		logger.Error("Failed to parse NETWORK_ALLOWED_CIDRS", "error", err)
+		return 2
 	}
-	allowedCIDRs := netrules.ResolveDomainsToCIDRs(allowedDomains, logger)
 	if len(allowedCIDRs) > 0 {
-		logger.Info("Resolved allowed domains for network rules", "domains", allowedDomains, "cidrs", allowedCIDRs)
+		logger.Info("Loaded allowed CIDRs for network rules", "cidrs", allowedCIDRs)
 	}
 
 	// Initialize net rules manager

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -112,9 +113,24 @@ func run() int {
 		return 2
 	}
 
+	// Resolve allowed domains for network rules
+	var allowedDomains []string
+	if cfg.NetworkAllowedDomains != "" {
+		for _, d := range strings.Split(cfg.NetworkAllowedDomains, ",") {
+			d = strings.TrimSpace(d)
+			if d != "" {
+				allowedDomains = append(allowedDomains, d)
+			}
+		}
+	}
+	allowedCIDRs := netrules.ResolveDomainsToCIDRs(allowedDomains, logger)
+	if len(allowedCIDRs) > 0 {
+		logger.Info("Resolved allowed domains for network rules", "domains", allowedDomains, "cidrs", allowedCIDRs)
+	}
+
 	// Initialize net rules manager
 	persistent := cfg.Environment != "development"
-	netRulesManager, err := netrules.NewNetRulesManager(logger, persistent)
+	netRulesManager, err := netrules.NewNetRulesManager(logger, persistent, allowedCIDRs)
 	if err != nil {
 		logger.Error("Failed to initialize net rules manager", "error", err)
 		return 2

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -122,6 +122,9 @@ func run() int {
 				allowedDomains = append(allowedDomains, d)
 			}
 		}
+		if len(allowedDomains) == 0 {
+			logger.Warn("NETWORK_ALLOWED_DOMAINS is set but no valid domains were parsed; check for misconfiguration", "value", cfg.NetworkAllowedDomains)
+		}
 	}
 	allowedCIDRs := netrules.ResolveDomainsToCIDRs(allowedDomains, logger)
 	if len(allowedCIDRs) > 0 {

--- a/apps/runner/pkg/netrules/netrules.go
+++ b/apps/runner/pkg/netrules/netrules.go
@@ -51,9 +51,45 @@ func NewNetRulesManager(logger *slog.Logger, persistent bool, allowedCIDRs []*ne
 }
 
 func (manager *NetRulesManager) Start() error {
+	if err := manager.ensureAllowedChain(); err != nil {
+		return err
+	}
+
 	// Start periodic reconciliation
 	if manager.persistent {
 		go manager.persistRulesLoop()
+	}
+
+	return nil
+}
+
+// ensureAllowedChain creates (or replaces) the shared DAYTONA-ALLOWED chain
+// that holds always-allowed domain CIDRs. Per-sandbox chains jump here via
+// -g (goto) so that a RETURN propagates back to DOCKER-USER.
+func (manager *NetRulesManager) ensureAllowedChain() error {
+	if len(manager.allowedCIDRs) == 0 {
+		return nil
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+
+	// Create the chain (ignore "already exists")
+	if err := manager.ipt.NewChain("filter", AllowedChainName); err != nil {
+		if !strings.Contains(err.Error(), "Chain already exists") {
+			return err
+		}
+	}
+
+	// Rebuild from scratch so the rule set matches the current CIDR list
+	if err := manager.ipt.ClearChain("filter", AllowedChainName); err != nil {
+		return err
+	}
+
+	for _, cidr := range manager.allowedCIDRs {
+		if err := manager.ipt.AppendUnique("filter", AllowedChainName, "-j", "RETURN", "-d", cidr.String(), "-p", "all"); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/apps/runner/pkg/netrules/netrules.go
+++ b/apps/runner/pkg/netrules/netrules.go
@@ -64,8 +64,9 @@ func (manager *NetRulesManager) Start() error {
 }
 
 // ensureAllowedChain creates (or replaces) the shared DAYTONA-ALLOWED chain
-// that holds always-allowed domain CIDRs. Per-sandbox chains jump here via
-// -g (goto) so that a RETURN propagates back to DOCKER-USER.
+// that holds always-allowed CIDRs. Per-sandbox chains jump here via -j; the
+// shared chain uses ACCEPT so matching packets are allowed immediately, while
+// unmatched packets return to the sandbox chain and hit its DROP rule.
 func (manager *NetRulesManager) ensureAllowedChain() error {
 	if len(manager.allowedCIDRs) == 0 {
 		return nil

--- a/apps/runner/pkg/netrules/netrules.go
+++ b/apps/runner/pkg/netrules/netrules.go
@@ -87,7 +87,7 @@ func (manager *NetRulesManager) ensureAllowedChain() error {
 	}
 
 	for _, cidr := range manager.allowedCIDRs {
-		if err := manager.ipt.AppendUnique("filter", AllowedChainName, "-j", "RETURN", "-d", cidr.String(), "-p", "all"); err != nil {
+		if err := manager.ipt.AppendUnique("filter", AllowedChainName, "-j", "ACCEPT", "-d", cidr.String(), "-p", "all"); err != nil {
 			return err
 		}
 	}

--- a/apps/runner/pkg/netrules/netrules.go
+++ b/apps/runner/pkg/netrules/netrules.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"os/exec"
 	"strings"
 	"sync"
@@ -17,16 +18,17 @@ import (
 
 // NetRulesManager provides thread-safe operations for managing network rules
 type NetRulesManager struct {
-	log        *slog.Logger
-	ipt        *iptables.IPTables
-	mu         sync.Mutex
-	persistent bool
-	ctx        context.Context
-	cancel     context.CancelFunc
+	log          *slog.Logger
+	ipt          *iptables.IPTables
+	mu           sync.Mutex
+	persistent   bool
+	allowedCIDRs []*net.IPNet
+	ctx          context.Context
+	cancel       context.CancelFunc
 }
 
 // NewNetRulesManager creates a new instance of NetRulesManager
-func NewNetRulesManager(logger *slog.Logger, persistent bool) (*NetRulesManager, error) {
+func NewNetRulesManager(logger *slog.Logger, persistent bool, allowedCIDRs []*net.IPNet) (*NetRulesManager, error) {
 	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	if err != nil {
 		return nil, err
@@ -39,11 +41,12 @@ func NewNetRulesManager(logger *slog.Logger, persistent bool) (*NetRulesManager,
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &NetRulesManager{
-		log:        logger.With(slog.String("component", "netrules_manager")),
-		ipt:        ipt,
-		persistent: persistent,
-		ctx:        ctx,
-		cancel:     cancel,
+		log:          logger.With(slog.String("component", "netrules_manager")),
+		ipt:          ipt,
+		persistent:   persistent,
+		allowedCIDRs: allowedCIDRs,
+		ctx:          ctx,
+		cancel:       cancel,
 	}, nil
 }
 

--- a/apps/runner/pkg/netrules/set.go
+++ b/apps/runner/pkg/netrules/set.go
@@ -30,6 +30,11 @@ func (manager *NetRulesManager) SetNetworkRules(name string, sourceIp string, ne
 		return err
 	}
 
+	// Allow DNS (UDP port 53) so containers can resolve domain names
+	if err := manager.ipt.AppendUnique("filter", chainName, "-j", "RETURN", "-p", "udp", "--dport", "53"); err != nil {
+		return err
+	}
+
 	// Add rules to allow traffic from the specified networks
 	for _, network := range allowedNetworks {
 		if err := manager.ipt.AppendUnique("filter", chainName, "-j", "RETURN", "-d", network.String(), "-p", "all"); err != nil {
@@ -37,10 +42,11 @@ func (manager *NetRulesManager) SetNetworkRules(name string, sourceIp string, ne
 		}
 	}
 
-	// Jump to the shared always-allowed chain (uses goto so that RETURN
-	// propagates back to DOCKER-USER, matching the per-sandbox RETURN semantics)
+	// Jump to the shared always-allowed chain. The shared chain uses ACCEPT
+	// for matching CIDRs (immediately allowing the packet), while unmatched
+	// packets return here and fall through to the DROP rule below.
 	if len(manager.allowedCIDRs) > 0 {
-		if err := manager.ipt.AppendUnique("filter", chainName, "-g", AllowedChainName, "-p", "all"); err != nil {
+		if err := manager.ipt.AppendUnique("filter", chainName, "-j", AllowedChainName, "-p", "all"); err != nil {
 			return err
 		}
 	}

--- a/apps/runner/pkg/netrules/set.go
+++ b/apps/runner/pkg/netrules/set.go
@@ -37,9 +37,10 @@ func (manager *NetRulesManager) SetNetworkRules(name string, sourceIp string, ne
 		}
 	}
 
-	// Add rules for always-allowed domains (resolved at startup)
-	for _, cidr := range manager.allowedCIDRs {
-		if err := manager.ipt.AppendUnique("filter", chainName, "-j", "RETURN", "-d", cidr.String(), "-p", "all"); err != nil {
+	// Jump to the shared always-allowed chain (uses goto so that RETURN
+	// propagates back to DOCKER-USER, matching the per-sandbox RETURN semantics)
+	if len(manager.allowedCIDRs) > 0 {
+		if err := manager.ipt.AppendUnique("filter", chainName, "-g", AllowedChainName, "-p", "all"); err != nil {
 			return err
 		}
 	}

--- a/apps/runner/pkg/netrules/set.go
+++ b/apps/runner/pkg/netrules/set.go
@@ -37,6 +37,13 @@ func (manager *NetRulesManager) SetNetworkRules(name string, sourceIp string, ne
 		}
 	}
 
+	// Add rules for always-allowed domains (resolved at startup)
+	for _, cidr := range manager.allowedCIDRs {
+		if err := manager.ipt.AppendUnique("filter", chainName, "-j", "RETURN", "-d", cidr.String(), "-p", "all"); err != nil {
+			return err
+		}
+	}
+
 	// Add a final rule to block all other traffic
 	if err := manager.ipt.AppendUnique("filter", chainName, "-j", "DROP", "-p", "all"); err != nil {
 		return err

--- a/apps/runner/pkg/netrules/utils.go
+++ b/apps/runner/pkg/netrules/utils.go
@@ -13,6 +13,8 @@ import (
 const (
 	// ChainPrefix is the prefix used for all Daytona sandbox chains
 	ChainPrefix = "DAYTONA-SB-"
+	// AllowedChainName is the shared chain for always-allowed domain CIDRs
+	AllowedChainName = "DAYTONA-ALLOWED"
 )
 
 // ParseCidrNetworks parses a comma-separated list of CIDR networks and returns them as an array

--- a/apps/runner/pkg/netrules/utils.go
+++ b/apps/runner/pkg/netrules/utils.go
@@ -5,7 +5,6 @@ package netrules
 
 import (
 	"fmt"
-	"log/slog"
 	"net"
 	"strings"
 )
@@ -52,45 +51,10 @@ func ParseRuleArguments(rule string) ([]string, error) {
 	return nil, fmt.Errorf("invalid rule format: %s", rule)
 }
 
-// ResolveDomainsToCIDRs resolves a list of domain names to /32 CIDRs.
-// Logs a warning for domains that fail to resolve but does not return an error.
-func ResolveDomainsToCIDRs(domains []string, logger *slog.Logger) []*net.IPNet {
-	seen := make(map[string]bool)
-	var cidrs []*net.IPNet
-
-	for _, domain := range domains {
-		ips, err := net.LookupHost(domain)
-		if err != nil {
-			logger.Warn("Failed to resolve allowed domain", "domain", domain, "error", err)
-			continue
-		}
-
-		for _, ipStr := range ips {
-			ip := net.ParseIP(ipStr)
-			if ip == nil {
-				continue
-			}
-
-			// Only use IPv4 addresses (iptables manager uses ProtocolIPv4)
-			ip4 := ip.To4()
-			if ip4 == nil {
-				continue
-			}
-
-			ip4Str := ip4.String()
-			if seen[ip4Str] {
-				continue
-			}
-			seen[ip4Str] = true
-
-			cidrs = append(cidrs, &net.IPNet{
-				IP:   ip4,
-				Mask: net.CIDRMask(32, 32),
-			})
-		}
-	}
-
-	return cidrs
+// ParseCIDRList parses a comma-separated list of CIDR networks.
+// Returns nil with no error when the input is empty.
+func ParseCIDRList(networks string) ([]*net.IPNet, error) {
+	return parseCidrNetworks(networks)
 }
 
 // formatChainName adds the DAYTONA-SB- prefix to a chain name if it doesn't already have it

--- a/apps/runner/pkg/netrules/utils.go
+++ b/apps/runner/pkg/netrules/utils.go
@@ -75,10 +75,11 @@ func ResolveDomainsToCIDRs(domains []string, logger *slog.Logger) []*net.IPNet {
 				continue
 			}
 
-			if seen[ipStr] {
+			ip4Str := ip4.String()
+			if seen[ip4Str] {
 				continue
 			}
-			seen[ipStr] = true
+			seen[ip4Str] = true
 
 			cidrs = append(cidrs, &net.IPNet{
 				IP:   ip4,

--- a/apps/runner/pkg/netrules/utils.go
+++ b/apps/runner/pkg/netrules/utils.go
@@ -5,6 +5,7 @@ package netrules
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 )
@@ -47,6 +48,46 @@ func ParseRuleArguments(rule string) ([]string, error) {
 		}
 	}
 	return nil, fmt.Errorf("invalid rule format: %s", rule)
+}
+
+// ResolveDomainsToCIDRs resolves a list of domain names to /32 CIDRs.
+// Logs a warning for domains that fail to resolve but does not return an error.
+func ResolveDomainsToCIDRs(domains []string, logger *slog.Logger) []*net.IPNet {
+	seen := make(map[string]bool)
+	var cidrs []*net.IPNet
+
+	for _, domain := range domains {
+		ips, err := net.LookupHost(domain)
+		if err != nil {
+			logger.Warn("Failed to resolve allowed domain", "domain", domain, "error", err)
+			continue
+		}
+
+		for _, ipStr := range ips {
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				continue
+			}
+
+			// Only use IPv4 addresses (iptables manager uses ProtocolIPv4)
+			ip4 := ip.To4()
+			if ip4 == nil {
+				continue
+			}
+
+			if seen[ipStr] {
+				continue
+			}
+			seen[ipStr] = true
+
+			cidrs = append(cidrs, &net.IPNet{
+				IP:   ip4,
+				Mask: net.CIDRMask(32, 32),
+			})
+		}
+	}
+
+	return cidrs
 }
 
 // formatChainName adds the DAYTONA-SB- prefix to a chain name if it doesn't already have it


### PR DESCRIPTION
This pull request adds support for specifying a list of always-allowed CIDR blocks for network sandboxing in the runner. A new environment variable, `NETWORK_ALLOWED_CIDRS`, is introduced, which allows administrators to define CIDR ranges that are permitted for all sandboxes. The implementation updates the network rules manager to parse and enforce these CIDRs using a dedicated iptables chain.

**Runner configuration and documentation:**

* Added the `NETWORK_ALLOWED_CIDRS` environment variable to the runner configuration (`Config` struct in `config.go`) and documented it in the OSS deployment environment variables table. This variable accepts a comma-separated list of CIDR blocks that will be allowed for all sandboxes. [[1]](diffhunk://#diff-897f5f6b9a5f707a2cc3086ece27ebe2e369d726853832598203b43934df8b59R62) [[2]](diffhunk://#diff-897dea4d79635400e8ceb68bb542973f6738c11ac7222d2dacf612dbb36835e6R265)

**Network rules management:**

* Updated the runner startup (`main.go`) to parse the `NETWORK_ALLOWED_CIDRS` value and pass the parsed CIDRs to the network rules manager. Errors in parsing will cause the runner to exit with a log message.
* Modified the `NetRulesManager` to accept and store the allowed CIDRs, and to create a shared `DAYTONA-ALLOWED` iptables chain containing rules to always allow traffic to these CIDRs. This chain is referenced in each sandbox's chain to ensure consistent allow-listing. [[1]](diffhunk://#diff-2417a2e24ef5bfbec6042b27c3bb28f303cca753fefdd5109c79e1a30c9c267eR25-R31) [[2]](diffhunk://#diff-2417a2e24ef5bfbec6042b27c3bb28f303cca753fefdd5109c79e1a30c9c267eR47-R57) [[3]](diffhunk://#diff-2417a2e24ef5bfbec6042b27c3bb28f303cca753fefdd5109c79e1a30c9c267eR66-R97) [[4]](diffhunk://#diff-ab22876d626f8c6e833946ff51931e4fe5070d3f60b0a25759835bb0c4a500cdR40-R47) [[5]](diffhunk://#diff-bf9108909de02fef04f8af19ad1f3f04c9037eb2bb1f7494a54ad8dd477ffcd9R15-R16)

**Utility and parsing functions:**

* Added a utility function `ParseCIDRList` for parsing the comma-separated list of CIDRs, returning a slice of `*net.IPNet`.

**Note**

This is important for allowing metrics exports for sandboxes with restricted network access