### PR TITLE
fix(daemon): source session commands from file

### DIFF
--- a/apps/daemon/pkg/session/execute.go
+++ b/apps/daemon/pkg/session/execute.go
@@ -55,6 +55,11 @@ func (s *SessionService) Execute(sessionId, cmdId, cmd string, async, isCombined
 
 	defer logFile.Close()
 
+	cmdFilePath := filepath.Join(logDir, "cmd.sh")
+	if err := os.WriteFile(cmdFilePath, []byte(cmd), 0600); err != nil {
+		return nil, common_errors.NewBadRequestError(fmt.Errorf("failed to write command file: %w", err))
+	}
+
 	inputPipeCommand := `cat /dev/null > "$ip" &`
 	if async {
 		inputPipeCommand = `while :; do sleep 3600; done > "$ip" &`
@@ -67,7 +72,7 @@ func (s *SessionService) Execute(sessionId, cmdId, cmd string, async, isCombined
 		toOctalEscapes(log.STDOUT_PREFIX),               // %s  -> stdout prefix
 		toOctalEscapes(log.STDERR_PREFIX),               // %s  -> stderr prefix
 		inputPipeCommand,                                // %s  -> stdin behavior
-		cmd,                                             // %s  -> verbatim script body
+		cmdFilePath,                                     // %q  -> command file path
 		exitCodeFilePath,                                // %q
 	)
 
@@ -167,9 +172,9 @@ var cmdWrapperFormat string = `
 	%s
 	ip_pid=$!
 
-	# Run your command
-	{ %s; } < "$ip" > "$sp" 2> "$ep"
-	echo "$?" >> %s
+	# Run your command from file (avoids heredoc parsing issues with pipe-fed shells)
+	{ . %q; } < "$ip" > "$sp" 2> "$ep"
+	echo "$?" >> %q
 
 	# Stop the stdin holder so it doesn't outlive the command
 	kill "$ip_pid" 2>/dev/null; wait "$ip_pid" 2>/dev/null

--- a/apps/daemon/pkg/session/execute_test.go
+++ b/apps/daemon/pkg/session/execute_test.go
@@ -109,6 +109,51 @@ func TestExecuteSyncCommandGetsEOFOnStdin(t *testing.T) {
 	}
 }
 
+func TestExecuteSyncHeredoc(t *testing.T) {
+	svc := newTestSessionService(t)
+	const sessionID = "heredoc-test"
+
+	if err := svc.Create(sessionID, false); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = svc.Delete(context.Background(), sessionID)
+	})
+
+	resultCh := make(chan *SessionExecute, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		result, err := svc.Execute(
+			sessionID,
+			"",
+			"cat <<'__EOF__'\nhello from heredoc\n__EOF__",
+			false,
+			true,
+			true,
+		)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resultCh <- result
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("execute heredoc command: %v", err)
+	case result := <-resultCh:
+		if result.ExitCode == nil || *result.ExitCode != 0 {
+			t.Fatalf("expected exit code 0, got %#v", result.ExitCode)
+		}
+		if result.Output == nil || !strings.Contains(*result.Output, "hello from heredoc") {
+			t.Fatalf("expected heredoc output, got %#v", result.Output)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("heredoc command hung")
+	}
+}
+
 func TestExecuteAsyncCommandStillAcceptsInput(t *testing.T) {
 	svc := newTestSessionService(t)
 	const sessionID = "async-stdin"


### PR DESCRIPTION
closes #4230 

## Summary

Fixes heredoc commands hanging when executed via the session API. The root cause is that the session command wrapper inlines the user's command directly into the shell script written to the session's stdin pipe:

```sh
{ USER_CMD; } < "$ip" > "$sp" 2> "$ep"
```

This breaks heredocs in two ways:
1. The `; }` ends up on the same line as the heredoc terminator, so the shell never recognizes it
2. Bash specifically has trouble parsing heredoc bodies from a long-lived stdin pipe inside a redirected compound command (works in zsh, fails in bash — which is why slim images are affected but default snapshots are not)

The fix writes the user command to a temp file (`cmd.sh`) and sources it instead of inlining:

```sh
{ . "/path/to/cmd.sh"; } < "$ip" > "$sp" 2> "$ep"
```

This decouples heredoc parsing from the session stdin pipe. The file lives in the existing per-command directory and is cleaned up automatically on session delete.

## What changed

- `apps/daemon/pkg/session/execute.go` — write command to file, source it in the wrapper
- `apps/daemon/pkg/session/execute_test.go` — add heredoc regression test