### PR TITLE
fix(api): prefer last entrypoint on build

### DIFF
--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -694,7 +694,8 @@ export class SnapshotService {
   // TODO: revise/cleanup
   getEntrypointFromDockerfile(dockerfileContent: string): string[] {
     // Match ENTRYPOINT with either a string or JSON array
-    const entrypointMatch = dockerfileContent.match(/ENTRYPOINT\s+(.*)/)
+    const matches = [...dockerfileContent.matchAll(/ENTRYPOINT\s+(.*)/g)]
+    const entrypointMatch = matches.length ? matches[matches.length - 1] : null
     if (entrypointMatch) {
       const rawEntrypoint = entrypointMatch[1].trim()
       try {


### PR DESCRIPTION
## Description

If a user were to create a sandbox from a dockerfile (declarative build) and pass an `.entrypoint()` through the SDK, the override wouldn't previously work and would instead default to the first regex match

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes entrypoint resolution for Dockerfile builds by selecting the last ENTRYPOINT directive. This makes `.entrypoint()` overrides work and matches Docker’s behavior with multiple ENTRYPOINTs.

- **Bug Fixes**
  - Use `matchAll` and pick the last `ENTRYPOINT` match in `getEntrypointFromDockerfile`.
  - Prevents defaulting to the first match when creating sandboxes from Dockerfiles via the SDK.

<sup>Written for commit faaa4ae17a2c36719e5e47d01fe043aee115b44c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

