### PR TITLE
chore(dev): add kill-ports.sh script for killing dangling app runs

### DIFF
--- a/hack/kill-ports.sh
+++ b/hack/kill-ports.sh
@@ -4,6 +4,18 @@
 #
 set -euo pipefail
 
+if [ "$EUID" -ne 0 ]; then
+  echo "Error: this script must be run with sudo (runner runs as root)." >&2
+  exit 1
+fi
+
+for cmd in lsof ps; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' is not installed. Please install it and try again." >&2
+    exit 1
+  fi
+done
+
 PORTS=(
   3000  # dashboard
   3001  # api
@@ -16,23 +28,36 @@ PORTS=(
 echo "Daytona application ports: ${PORTS[*]}"
 echo ""
 
+declare -A SEEN_PIDS
 KILLED=0
+FAILED=0
 
 for PORT in "${PORTS[@]}"; do
   PIDS=$(lsof -ti ":$PORT" 2>/dev/null || true)
   if [ -n "$PIDS" ]; then
     for PID in $PIDS; do
+      if [[ -n "${SEEN_PIDS[$PID]+x}" ]]; then
+        continue
+      fi
+      SEEN_PIDS[$PID]=1
+
       PROC_NAME=$(ps -p "$PID" -o comm= 2>/dev/null || echo "unknown")
-      echo "Killing PID $PID ($PROC_NAME) on port $PORT"
-      kill -9 "$PID" 2>/dev/null || true
-      KILLED=$((KILLED + 1))
+      if kill -9 "$PID" 2>/dev/null; then
+        echo "Killed PID $PID ($PROC_NAME) on port $PORT"
+        KILLED=$((KILLED + 1))
+      else
+        echo "Failed to kill PID $PID ($PROC_NAME) on port $PORT — permission denied?" >&2
+        FAILED=$((FAILED + 1))
+      fi
     done
   fi
 done
 
-if [ "$KILLED" -eq 0 ]; then
+echo ""
+if [ "$KILLED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
   echo "No processes found on any application ports."
 else
-  echo ""
-  echo "Killed $KILLED process(es)."
+  [ "$KILLED" -gt 0 ] && echo "Killed $KILLED process(es)."
+  [ "$FAILED" -gt 0 ] && echo "Failed to kill $FAILED process(es)." >&2
+  [ "$FAILED" -gt 0 ] && exit 1
 fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `hack/kill-ports.sh` to quickly kill dangling processes on Daytona dev ports (3000, 3001, 3003, 3009, 4000, 4321) to prevent port conflicts during local development. The script requires sudo, checks for lsof/ps, de-duplicates PIDs across ports, force-kills them, prints a summary, and exits non-zero if any kill fails.

<sup>Written for commit fad9560efb63d8f2a2e0843f532ee1b687202fe1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

