### PR TITLE
fix(api): handle sandbox operation conflict

### DIFF
--- a/apps/api/src/sandbox/errors/sandbox-conflict.error.ts
+++ b/apps/api/src/sandbox/errors/sandbox-conflict.error.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ConflictException } from '@nestjs/common'
+
+export class SandboxConflictError extends ConflictException {
+  constructor() {
+    super('Sandbox was modified by another operation')
+  }
+}

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -8,6 +8,7 @@ import { Cron, CronExpression } from '@nestjs/schedule'
 import { In, IsNull, MoreThanOrEqual, Not, Raw } from 'typeorm'
 import { randomUUID } from 'crypto'
 
+import { SandboxConflictError } from '../errors/sandbox-conflict.error'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { RunnerService } from '../services/runner.service'
@@ -855,6 +856,13 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             }
           }
         } catch (error) {
+          if (error instanceof SandboxConflictError) {
+            this.logger.warn(
+              `Sandbox ${sandboxId} was modified by another operation during sync, skipping error transition`,
+            )
+            break
+          }
+
           this.logger.error(`Error processing desired state for sandbox ${sandboxId}:`, error)
 
           const { recoverable, errorReason } = sanitizeSandboxError(error)

--- a/apps/api/src/sandbox/repositories/sandbox.repository.ts
+++ b/apps/api/src/sandbox/repositories/sandbox.repository.ts
@@ -5,7 +5,8 @@
 
 import { DataSource, FindOptionsWhere } from 'typeorm'
 import { Sandbox } from '../entities/sandbox.entity'
-import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { SandboxConflictError } from '../errors/sandbox-conflict.error'
 import { InjectDataSource } from '@nestjs/typeorm'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BaseRepository } from '../../common/repositories/base.repository'
@@ -103,7 +104,7 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
       { ...updateData, ...invariantChanges },
     )
     if (!result.affected) {
-      throw new ConflictException('Sandbox was modified by another operation, please try again')
+      throw new SandboxConflictError()
     }
     sandbox.updatedAt = new Date()
 
@@ -122,7 +123,7 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
    * @param params.updateData - The partial data to update.
    * @param params.whereCondition - The where condition to use for the update.
    *
-   * @throws {ConflictException} if the sandbox was modified by another operation
+   * @throws {SandboxConflictError} if the sandbox was modified by another operation
    */
   async updateWhere(
     id: string,
@@ -151,7 +152,7 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
       })
 
       if (!sandbox) {
-        throw new ConflictException('Sandbox was modified by another operation, please try again.')
+        throw new SandboxConflictError()
       }
 
       const previousSandbox = { ...sandbox }


### PR DESCRIPTION
## Description

Handle sandbox operation conflict in the state syncer instead of setting the sandbox to an errored state

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sandboxes from being marked errored when a concurrent operation modifies them during state sync. Adds `SandboxConflictError` so repository update conflicts are handled by the syncer with a warning and skipped error transition.

- **Bug Fixes**
  - Throw `SandboxConflictError` on repository update races and catch it in the sync loop to stop processing the current sandbox.

<sup>Written for commit 4f842cacb72e4f7326c9a63226658563be96c261. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

