### PR TITLE
fix(api): add ssl config to migration data source

### DIFF
--- a/apps/api/src/migrations/data-source.ts
+++ b/apps/api/src/migrations/data-source.ts
@@ -29,7 +29,6 @@ export const baseDataSourceOptions: DataSourceOptions = {
           rejectUnauthorized: process.env.DB_TLS_REJECT_UNAUTHORIZED !== 'false',
         }
       : false,
-  extra: {},
 }
 
 const AppDataSource = new DataSource({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds SSL/TLS support to the API migrations data source so migrations can run against TLS-required databases and avoid connection errors. TLS is off by default and controlled by `DB_TLS_ENABLED` and `DB_TLS_REJECT_UNAUTHORIZED`.

- **Migration**
  - Set `DB_TLS_ENABLED=true` to enable TLS for migrations.
  - To allow self-signed certs, set `DB_TLS_REJECT_UNAUTHORIZED=false` (defaults to true).

<sup>Written for commit a2ffa8eee699273fdeb3ecabe5de13e19e7e6834. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

