### PR TITLE
fix: pin 21 unpinned action(s), extract 1 unsafe expression to env var

### DIFF
--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -11,19 +11,19 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4
       - name: Set up QEMU for multi-architecture builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Setup Docker buildx for multi-architecture builds
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           use: true
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and release devcontainer Multi-Platform
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
         env:
           # see: https://github.com/devcontainers/ci/issues/191#issuecomment-1603857155
           BUILDX_NO_DEFAULT_ATTESTATIONS: true

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -40,10 +40,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.io
           username: daytonaio
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push sandbox by digest
         id: build-sandbox
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./images/sandbox
           file: ./images/sandbox/Dockerfile
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build and push sandbox-slim by digest
         id: build-sandbox-slim
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./images/sandbox-slim
           file: ./images/sandbox-slim/Dockerfile
@@ -121,10 +121,10 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.io
           username: daytonaio

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -70,7 +70,7 @@ jobs:
           cache: true
           cache-dependency-path: '**/go.sum'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.6.2
           working-directory: ${{ matrix.working-directory }}
@@ -98,7 +98,7 @@ jobs:
           go fmt ./...
           git diff --exit-code '**/*.go' || (echo "Code is not formatted! Please run 'go fmt ./...' and commit" && exit 1)
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.6.2
           working-directory: libs/computer-use
@@ -170,14 +170,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check AGPL License Headers
-        uses: apache/skywalking-eyes/header@main
+        uses: apache/skywalking-eyes/header@8c96ee223558797cdd9eba82c0919258e1cf2dad # main
         with:
           token: ${{ github.token }}
           config: .licenserc.yaml
           mode: 'check'
 
       - name: Check Apache License Headers
-        uses: apache/skywalking-eyes/header@main
+        uses: apache/skywalking-eyes/header@8c96ee223558797cdd9eba82c0919258e1cf2dad # main
         with:
           token: ${{ github.token }}
           config: .licenserc-clients.yaml

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-toolchain
-      - uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
+      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           run-go-work-sync: 'false'
 
-      - uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
+      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
         run: |
@@ -96,7 +96,7 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-toolchain
-      - uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
+      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Install gettext
         run: sudo apt-get install -y gettext
@@ -219,7 +219,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Project dependencies
         run: corepack enable
@@ -285,7 +285,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
+      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
         run: |

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           install-swag: 'false'
-      - uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
+      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
         run: |
@@ -75,6 +75,9 @@ jobs:
       - name: Update version
         run: |
           curl -f -X POST -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUBBOT_TOKEN }}" \
+          -H "Authorization: Bearer ${GITHUBBOT_TOKEN}" \
           https://api.github.com/repos/daytonaio/homebrew-cli/dispatches \
           -d "{\"event_type\": \"update-version\", \"client_payload\": {\"version\": \"${{ env.VERSION }}\"}}"
+
+        env:
+          GITHUBBOT_TOKEN: ${{ secrets.GITHUBBOT_TOKEN }}

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: generaltranslation/translate@v0
+      - uses: generaltranslation/translate@5d317803006bc9f21ee9baef68eb04ede5c9709a # v0
         with:
           gt_api_key: ${{ secrets.GT_API_KEY }}
           gt_project_id: ${{ secrets.GT_PROJECT_ID }}


### PR DESCRIPTION
Hey @Tpuljak, I'm sorry about the mess. The amend broke the branch history so I had to resubmit. Signoff is included this time. Same fixes as #4229 and #4226. I promise this is the last one.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts unsafe expressions from `run:` blocks into `env:` mappings, protecting against tag-poisoning supply chain attacks and shell injection.

- Pin 21 unpinned actions to full 40-character SHAs
- Add version comments for readability
- Extract 1 unsafe expression to env var

## Security Context

Mutable tags like `@v3` or `@latest` can be silently modified if the upstream repository is compromised. In March 2025, the tj-actions/changed-files attack demonstrated this exact vector. Attackers force-pushed version tags to point to malicious commits, and every workflow referencing those tags silently executed attacker code. SHA-pinning eliminates this attack vector entirely.

For more context: https://x.com/vigilance_one/status/2036581210663616729

## How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` — original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `$ENV_VAR` in the script
- No workflow logic, triggers, or permissions are modified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub Actions by pinning 21 unpinned actions to commit SHAs and moving one unsafe expression to an env var. This mitigates tag-poisoning and shell injection without changing workflow behavior.

- **Dependencies**
  - Pinned `docker/*` actions, `devcontainers/ci`, `docker/build-push-action`, `golangci/golangci-lint-action`, `apache/skywalking-eyes/header`, `dev-hanz-ops/install-gh-cli-action`, and `generaltranslation/translate` to SHAs with version comments.

- **Refactors**
  - In `sdk_publish.yaml`, moved `${{ secrets.GITHUBBOT_TOKEN }}` from `run:` to `env:` and referenced it as `${GITHUBBOT_TOKEN}`.

<sup>Written for commit bad66e702790f5ddc7d17b79e3b9deddc7037c34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

