### PR TITLE
fix(api): reset backup state on v2 sandbox start/create/recover

### DIFF
--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -113,6 +113,9 @@ export class JobStateHandlerService {
         )
         updateData.state = SandboxState.STARTED
         updateData.errorReason = null
+        if ([BackupState.ERROR, BackupState.COMPLETED].includes(sandbox.backupState)) {
+          Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.NONE))
+        }
         const metadata = job.getResultMetadata()
         if (metadata?.daemonVersion && typeof metadata.daemonVersion === 'string') {
           updateData.daemonVersion = metadata.daemonVersion
@@ -155,6 +158,9 @@ export class JobStateHandlerService {
         this.logger.debug(`START_SANDBOX job ${job.id} completed successfully, marking sandbox ${sandboxId} as STARTED`)
         updateData.state = SandboxState.STARTED
         updateData.errorReason = null
+        if ([BackupState.ERROR, BackupState.COMPLETED].includes(sandbox.backupState)) {
+          Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.NONE))
+        }
         const metadata = job.getResultMetadata()
         if (metadata?.daemonVersion && typeof metadata.daemonVersion === 'string') {
           updateData.daemonVersion = metadata.daemonVersion
@@ -443,6 +449,9 @@ export class JobStateHandlerService {
         )
         updateData.state = SandboxState.STARTED
         updateData.errorReason = null
+        if ([BackupState.ERROR, BackupState.COMPLETED].includes(sandbox.backupState)) {
+          Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.NONE))
+        }
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`RECOVER_SANDBOX job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
         updateData.state = SandboxState.ERROR


### PR DESCRIPTION
## Summary

- When a v2 runner sandbox starts, the `backupState` was not being reset to `NONE` after successful start
- The v0 flow correctly resets backup state in `SandboxStartAction.handleRunnerSandboxStartedStateCheck`, but the v2 job completion handlers did not
- This caused `backupState` to remain `COMPLETED` or `ERROR` indefinitely, leading to incorrect state in subsequent operations like runner transfer decisions and backup scheduling

## Changes

Add `BackupState.NONE` reset in three job completion handlers when sandbox reaches `STARTED` state:
- `handleCreateSandboxJobCompletion`
- `handleStartSandboxJobCompletion`  
- `handleRecoverSandboxJobCompletion`

This aligns v2 behavior with the existing v0 flow in `SandboxStartAction` (line 571).

## Test plan

- [ ] Verify that after a v2 sandbox successfully starts, `backupState` is reset to `NONE` and `backupSnapshot` is cleared
- [ ] Verify that after a v2 sandbox is recovered, `backupState` is reset to `NONE`
- [ ] Verify that ad-hoc backup scheduling correctly picks up v2 sandboxes after they've been started
- [ ] Verify existing v0 runner behavior is unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset `backupState` to NONE when v2 sandboxes reach STARTED for create/start/recover flows. Prevents stale COMPLETED/ERROR states from affecting runner transfers and backup scheduling.

- **Bug Fixes**
  - Updated v2 job completion handlers (`create`, `start`, `recover`) to set `backupState: NONE` and clear snapshot when sandbox becomes STARTED, but only if it was `COMPLETED` or `ERROR`.
  - Aligns v2 behavior with v0 `SandboxStartAction.handleRunnerSandboxStartedStateCheck`.

<sup>Written for commit cf2d25fda20c02f6731289da23add851bc780772. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

