### PR TITLE
Add isort known_first_party config to fix local/CI import-order parity

### DIFF
--- a/guides/python/langchain/data-analysis/anthropic/data_analysis.py
+++ b/guides/python/langchain/data-analysis/anthropic/data_analysis.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """LangChain data analysis example using Daytona sandboxes."""
+
 import base64
 
 from dotenv import load_dotenv

--- a/libs/sdk-python/src/daytona/_async/code_interpreter.py
+++ b/libs/sdk-python/src/daytona/_async/code_interpreter.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import json
 import re
 
-from daytona_toolbox_api_client_async import CreateContextRequest, InterpreterApi, InterpreterContext
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
+
+from daytona_toolbox_api_client_async import CreateContextRequest, InterpreterApi, InterpreterContext
 
 from .._utils.errors import intercept_errors
 from ..common.code_interpreter import ExecutionError, ExecutionResult, OutputMessage

--- a/libs/sdk-python/src/daytona/_async/computer_use.py
+++ b/libs/sdk-python/src/daytona/_async/computer_use.py
@@ -7,6 +7,7 @@ import os
 
 import aiofiles
 import httpx
+
 from daytona_toolbox_api_client_async import (
     ComputerUseApi,
     ComputerUseStartResponse,

--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -10,6 +10,14 @@ from importlib.metadata import version
 from types import TracebackType
 from typing import Callable, cast, overload
 
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.semconv.attributes import service_attributes
+
 from daytona_api_client_async import (
     ApiClient,
     ConfigApi,
@@ -24,13 +32,6 @@ from daytona_api_client_async import (
 )
 from daytona_api_client_async import VolumesApi as VolumesApi
 from daytona_toolbox_api_client_async import ApiClient as ToolboxApiClient
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.semconv.attributes import service_attributes
 
 from .._utils.enum import to_enum
 from .._utils.env import DaytonaEnvReader

--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -11,6 +11,8 @@ import aiofiles
 import aiofiles.os
 import httpx
 from aiofiles.threadpool.binary import AsyncBufferedIOBase
+from python_multipart.multipart import MultipartParser, parse_options_header
+
 from daytona_toolbox_api_client_async import (
     FileInfo,
     FilesDownloadRequest,
@@ -20,7 +22,6 @@ from daytona_toolbox_api_client_async import (
     ReplaceResult,
     SearchFilesResponse,
 )
-from python_multipart.multipart import MultipartParser, parse_options_header
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/_async/lsp_server.py
+++ b/libs/sdk-python/src/daytona/_async/lsp_server.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from deprecated import deprecated
+
 from daytona_toolbox_api_client_async import (
     CompletionList,
     LspApi,
@@ -12,7 +14,6 @@ from daytona_toolbox_api_client_async import (
     LspServerRequest,
     LspSymbol,
 )
-from deprecated import deprecated
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/_async/process.py
+++ b/libs/sdk-python/src/daytona/_async/process.py
@@ -9,6 +9,8 @@ from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 import websockets
+from websockets.asyncio.client import connect
+
 from daytona_toolbox_api_client_async import (
     Command,
     CreateSessionRequest,
@@ -20,7 +22,6 @@ from daytona_toolbox_api_client_async import (
     Session,
     SessionSendInputRequest,
 )
-from websockets.asyncio.client import connect
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import asyncio
 
+from deprecated import deprecated
+from pydantic import ConfigDict, PrivateAttr
+
 from daytona_api_client_async import BuildInfo
 from daytona_api_client_async import PaginatedSandboxes as PaginatedSandboxesDto
 from daytona_api_client_async import PortPreviewUrl, ResizeSandbox
@@ -27,8 +30,6 @@ from daytona_toolbox_api_client_async import (
     LspApi,
     ProcessApi,
 )
-from deprecated import deprecated
-from pydantic import ConfigDict, PrivateAttr
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/_sync/code_interpreter.py
+++ b/libs/sdk-python/src/daytona/_sync/code_interpreter.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import json
 import re
 
-from daytona_toolbox_api_client import CreateContextRequest, InterpreterApi, InterpreterContext
 from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 from websockets.sync.client import connect
+
+from daytona_toolbox_api_client import CreateContextRequest, InterpreterApi, InterpreterContext
 
 from .._utils.errors import intercept_errors
 from ..common.code_interpreter import ExecutionError, ExecutionResult, OutputMessage

--- a/libs/sdk-python/src/daytona/_sync/computer_use.py
+++ b/libs/sdk-python/src/daytona/_sync/computer_use.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 
 import httpx
+
 from daytona_toolbox_api_client import (
     ComputerUseApi,
     ComputerUseStartResponse,

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -11,6 +11,14 @@ from copy import deepcopy
 from importlib.metadata import version
 from typing import Callable, cast, overload
 
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.semconv.attributes import service_attributes
+
 from daytona_api_client import (
     ApiClient,
     ConfigApi,
@@ -25,13 +33,6 @@ from daytona_api_client import (
 )
 from daytona_api_client import VolumesApi as VolumesApi
 from daytona_toolbox_api_client import ApiClient as ToolboxApiClient
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.semconv.attributes import service_attributes
 
 from .._utils.enum import to_enum
 from .._utils.env import DaytonaEnvReader

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -9,6 +9,8 @@ from contextlib import ExitStack
 from typing import overload
 
 import httpx
+from python_multipart.multipart import MultipartParser, parse_options_header
+
 from daytona_toolbox_api_client import (
     FileInfo,
     FilesDownloadRequest,
@@ -18,7 +20,6 @@ from daytona_toolbox_api_client import (
     ReplaceResult,
     SearchFilesResponse,
 )
-from python_multipart.multipart import MultipartParser, parse_options_header
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/_sync/lsp_server.py
+++ b/libs/sdk-python/src/daytona/_sync/lsp_server.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from deprecated import deprecated
+
 from daytona_toolbox_api_client import (
     CompletionList,
     LspApi,
@@ -12,7 +14,6 @@ from daytona_toolbox_api_client import (
     LspServerRequest,
     LspSymbol,
 )
-from deprecated import deprecated
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/_sync/process.py
+++ b/libs/sdk-python/src/daytona/_sync/process.py
@@ -8,6 +8,8 @@ import json
 import re
 
 import websockets
+from websockets.sync.client import connect
+
 from daytona_toolbox_api_client import (
     Command,
     CreateSessionRequest,
@@ -19,7 +21,6 @@ from daytona_toolbox_api_client import (
     Session,
     SessionSendInputRequest,
 )
-from websockets.sync.client import connect
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 
 import time
 
+from deprecated import deprecated
+from pydantic import ConfigDict, PrivateAttr
+
 from daytona_api_client import BuildInfo
 from daytona_api_client import PaginatedSandboxes as PaginatedSandboxesDto
 from daytona_api_client import PortPreviewUrl, ResizeSandbox
@@ -28,8 +31,6 @@ from daytona_toolbox_api_client import (
     LspApi,
     ProcessApi,
 )
-from deprecated import deprecated
-from pydantic import ConfigDict, PrivateAttr
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation

--- a/libs/sdk-python/src/daytona/common/process.py
+++ b/libs/sdk-python/src/daytona/common/process.py
@@ -9,10 +9,11 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import ClassVar, TypeVar, Union
 
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
 from daytona_toolbox_api_client import SessionExecuteRequest as ApiSessionExecuteRequest
 from daytona_toolbox_api_client import SessionExecuteResponse as ApiSessionExecuteResponse
 from daytona_toolbox_api_client_async import SessionExecuteRequest as AsyncApiSessionExecuteRequest
-from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .charts import Chart
 

--- a/libs/sdk-python/src/daytona/common/snapshot.py
+++ b/libs/sdk-python/src/daytona/common/snapshot.py
@@ -3,12 +3,13 @@
 
 from __future__ import annotations
 
+from pydantic import BaseModel
+
 from daytona_api_client import BuildInfo
 from daytona_api_client import PaginatedSnapshots as PaginatedSnapshotsDto
 from daytona_api_client import SnapshotDto as SyncSnapshotDto
 from daytona_api_client_async import BuildInfo as AsyncBuildInfo
 from daytona_api_client_async import SnapshotDto as AsyncSnapshotDto
-from pydantic import BaseModel
 
 from .image import Image
 from .sandbox import Resources

--- a/libs/sdk-python/src/daytona/handle/async_pty_handle.py
+++ b/libs/sdk-python/src/daytona/handle/async_pty_handle.py
@@ -10,8 +10,9 @@ from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 import websockets
-from daytona_toolbox_api_client_async import PtySessionInfo
 from websockets.asyncio.connection import Connection
+
+from daytona_toolbox_api_client_async import PtySessionInfo
 
 from ..common.errors import DaytonaError
 from ..common.pty import PtyResult, PtySize

--- a/libs/sdk-python/src/daytona/handle/pty_handle.py
+++ b/libs/sdk-python/src/daytona/handle/pty_handle.py
@@ -8,9 +8,10 @@ import time
 from collections.abc import Callable, Generator
 from typing import Any, cast
 
-from daytona_toolbox_api_client import PtySessionInfo
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from websockets.sync.client import ClientConnection
+
+from daytona_toolbox_api_client import PtySessionInfo
 
 from ..common.errors import DaytonaError
 from ..common.pty import PtyResult, PtySize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ reportPrivateUsage = "none"
 reportMissingTypeStubs = "none"
 reportExplicitAny = "none"
 
+[tool.isort]
+known_first_party = ["daytona", "daytona_api_client", "daytona_api_client_async", "daytona_toolbox_api_client", "daytona_toolbox_api_client_async"]
+
 [tool.black]
 target-version = ['py310']
 line-length = 120


### PR DESCRIPTION
## Summary

Add `[tool.isort]` section with `known_first_party` listing all local path dependencies to `pyproject.toml`, and run `yarn format:py` to apply the new configuration.

## Problem

`isort` (via `yarn format:py`) relies on automatic first-party package detection, which can misclassify `daytona` and its companion packages as third-party depending on the Python environment (e.g., Python 3.10 in devcontainer vs 3.12 in CI). Meanwhile, `pylint` (via `yarn lint:py`) enforces `C0411` and treats them as first-party. When the two disagree, running format locally produces import ordering that CI lint rejects.

## Fix

```toml
[tool.isort]
known_first_party = ["daytona", "daytona_api_client", "daytona_api_client_async", "daytona_toolbox_api_client", "daytona_toolbox_api_client_async"]
```

All local path dependencies are included. `yarn format:py` has been run to apply the new ordering across all Python files in libs, examples, and guides.

Closes #4248