### PR TITLE
fix(dashboard): make failed payment invoices payable

### DIFF
--- a/apps/dashboard/src/components/Invoices/columns.tsx
+++ b/apps/dashboard/src/components/Invoices/columns.tsx
@@ -182,9 +182,10 @@ export function getColumns({ onViewInvoice, onVoidInvoice, onPayInvoice }: GetCo
       size: 100,
       enableHiding: false,
       cell: ({ row }) => {
-        const isPayable = row.original.paymentStatus === 'pending' && row.original.status === 'finalized'
         const isViewable = Boolean(row.original.fileUrl)
         const isVoidable =
+          row.original.status === 'finalized' && ['pending', 'failed'].includes(row.original.paymentStatus)
+        const isPayable =
           row.original.status === 'finalized' && ['pending', 'failed'].includes(row.original.paymentStatus)
 
         return (


### PR DESCRIPTION
## Description

Fixes invoices payable check - failed payment invoices are payable too.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invoice payable logic in the dashboard: finalized invoices with pending or failed payment status are now payable. The Pay action now appears for failed payments, matching voiding behavior.

<sup>Written for commit a2d2d7c111d022e022dd69c96669954285464a83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

