### PR TITLE
fix(api): reorder runner controller routes

### DIFF
--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -139,6 +139,50 @@ export class RunnerController {
     return this.runnerService.findOneFullOrFail(runnerContext.runnerId)
   }
 
+  @Get('/by-sandbox/:sandboxId')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get runner by sandbox ID',
+    operationId: 'getRunnerBySandboxId',
+  })
+  @ApiResponse({
+    status: 200,
+    type: RunnerFullDto,
+  })
+  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard, RegionSandboxAccessGuard]))
+  @RequiredApiRole([SystemRole.ADMIN])
+  async getRunnerBySandboxId(@Param('sandboxId') sandboxId: string): Promise<RunnerFullDto> {
+    const runner = await this.runnerService.findBySandboxId(sandboxId)
+
+    if (!runner) {
+      throw new NotFoundException('Runner not found')
+    }
+
+    return RunnerFullDto.fromRunner(runner)
+  }
+
+  @Get('/by-snapshot-ref')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get runners by snapshot ref',
+    operationId: 'getRunnersBySnapshotRef',
+  })
+  @ApiResponse({
+    status: 200,
+    type: [RunnerSnapshotDto],
+  })
+  @ApiQuery({
+    name: 'ref',
+    description: 'Snapshot ref',
+    type: String,
+    required: true,
+  })
+  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard]))
+  @RequiredApiRole([SystemRole.ADMIN, 'proxy', 'ssh-gateway'])
+  async getRunnersBySnapshotRef(@Query('ref') ref: string): Promise<RunnerSnapshotDto[]> {
+    return this.runnerService.getRunnersBySnapshotRef(ref)
+  }
+
   @Get(':id')
   @HttpCode(200)
   @ApiOperation({
@@ -301,50 +345,6 @@ export class RunnerController {
   @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async delete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return this.runnerService.remove(id)
-  }
-
-  @Get('/by-sandbox/:sandboxId')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get runner by sandbox ID',
-    operationId: 'getRunnerBySandboxId',
-  })
-  @ApiResponse({
-    status: 200,
-    type: RunnerFullDto,
-  })
-  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard, RegionSandboxAccessGuard]))
-  @RequiredApiRole([SystemRole.ADMIN])
-  async getRunnerBySandboxId(@Param('sandboxId') sandboxId: string): Promise<RunnerFullDto> {
-    const runner = await this.runnerService.findBySandboxId(sandboxId)
-
-    if (!runner) {
-      throw new NotFoundException('Runner not found')
-    }
-
-    return RunnerFullDto.fromRunner(runner)
-  }
-
-  @Get('/by-snapshot-ref')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get runners by snapshot ref',
-    operationId: 'getRunnersBySnapshotRef',
-  })
-  @ApiResponse({
-    status: 200,
-    type: [RunnerSnapshotDto],
-  })
-  @ApiQuery({
-    name: 'ref',
-    description: 'Snapshot ref',
-    type: String,
-    required: true,
-  })
-  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard]))
-  @RequiredApiRole([SystemRole.ADMIN, 'proxy', 'ssh-gateway'])
-  async getRunnersBySnapshotRef(@Query('ref') ref: string): Promise<RunnerSnapshotDto[]> {
-    return this.runnerService.getRunnersBySnapshotRef(ref)
   }
 
   @Post('healthcheck')

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -3076,6 +3076,63 @@ paths:
       summary: Get info for authenticated runner
       tags:
       - runners
+  /runners/by-sandbox/{sandboxId}:
+    get:
+      operationId: getRunnerBySandboxId
+      parameters:
+      - explode: false
+        in: path
+        name: sandboxId
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunnerFull'
+          description: ""
+      security:
+      - bearer: []
+      - oauth2:
+        - openid
+        - profile
+        - email
+      summary: Get runner by sandbox ID
+      tags:
+      - runners
+  /runners/by-snapshot-ref:
+    get:
+      operationId: getRunnersBySnapshotRef
+      parameters:
+      - description: Snapshot ref
+        explode: true
+        in: query
+        name: ref
+        required: true
+        schema:
+          type: string
+        style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/RunnerSnapshotDto'
+                type: array
+          description: ""
+      security:
+      - bearer: []
+      - oauth2:
+        - openid
+        - profile
+        - email
+      summary: Get runners by snapshot ref
+      tags:
+      - runners
   /runners/{id}:
     delete:
       operationId: deleteRunner
@@ -3241,63 +3298,6 @@ paths:
         - profile
         - email
       summary: Update runner draining status
-      tags:
-      - runners
-  /runners/by-sandbox/{sandboxId}:
-    get:
-      operationId: getRunnerBySandboxId
-      parameters:
-      - explode: false
-        in: path
-        name: sandboxId
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunnerFull'
-          description: ""
-      security:
-      - bearer: []
-      - oauth2:
-        - openid
-        - profile
-        - email
-      summary: Get runner by sandbox ID
-      tags:
-      - runners
-  /runners/by-snapshot-ref:
-    get:
-      operationId: getRunnersBySnapshotRef
-      parameters:
-      - description: Snapshot ref
-        explode: true
-        in: query
-        name: ref
-        required: true
-        schema:
-          type: string
-        style: form
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/RunnerSnapshotDto'
-                type: array
-          description: ""
-      security:
-      - bearer: []
-      - oauth2:
-        - openid
-        - profile
-        - email
-      summary: Get runners by snapshot ref
       tags:
       - runners
   /runners/healthcheck:
@@ -11330,6 +11330,28 @@ components:
       - updatedAt
       - version
       type: object
+    RunnerSnapshotDto:
+      example:
+        runnerDomain: runner.example.com
+        runnerId: 123e4567-e89b-12d3-a456-426614174000
+        runnerSnapshotId: 123e4567-e89b-12d3-a456-426614174000
+      properties:
+        runnerSnapshotId:
+          description: Runner snapshot ID
+          example: 123e4567-e89b-12d3-a456-426614174000
+          type: string
+        runnerId:
+          description: Runner ID
+          example: 123e4567-e89b-12d3-a456-426614174000
+          type: string
+        runnerDomain:
+          description: Runner domain
+          example: runner.example.com
+          type: string
+      required:
+      - runnerId
+      - runnerSnapshotId
+      type: object
     Runner:
       example:
         currentStartedSandboxes: 5
@@ -11496,28 +11518,6 @@ components:
       - unschedulable
       - updatedAt
       - version
-      type: object
-    RunnerSnapshotDto:
-      example:
-        runnerDomain: runner.example.com
-        runnerId: 123e4567-e89b-12d3-a456-426614174000
-        runnerSnapshotId: 123e4567-e89b-12d3-a456-426614174000
-      properties:
-        runnerSnapshotId:
-          description: Runner snapshot ID
-          example: 123e4567-e89b-12d3-a456-426614174000
-          type: string
-        runnerId:
-          description: Runner ID
-          example: 123e4567-e89b-12d3-a456-426614174000
-          type: string
-        runnerDomain:
-          description: Runner domain
-          example: runner.example.com
-          type: string
-      required:
-      - runnerId
-      - runnerSnapshotId
       type: object
     RunnerHealthMetrics:
       properties:


### PR DESCRIPTION
This pull request reintroduces two API endpoints for retrieving runner information by sandbox ID and by snapshot reference, which had previously been removed. The changes update both the backend controller (`runner.controller.ts`) and the OpenAPI specification (`openapi.yaml`) to support these endpoints. Additionally, the `RunnerSnapshotDto` schema is restored in the API documentation.

**API Endpoint Restoration:**

* Re-added the `GET /runners/by-sandbox/{sandboxId}` endpoint to fetch a runner by its associated sandbox ID in both the controller (`runner.controller.ts`) and OpenAPI spec (`openapi.yaml`). [[1]](diffhunk://#diff-64212dd108cf34b5a04683e77a1160b19e07a09129ca7cbaa9c54f323f53dd39R142-R185) [[2]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR3079-R3135)
* Re-added the `GET /runners/by-snapshot-ref?ref=...` endpoint to fetch runners by a snapshot reference, including controller logic and OpenAPI documentation. [[1]](diffhunk://#diff-64212dd108cf34b5a04683e77a1160b19e07a09129ca7cbaa9c54f323f53dd39R142-R185) [[2]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR3079-R3135)

**API Schema Restoration:**

* Restored the `RunnerSnapshotDto` schema definition in the OpenAPI spec to document the response structure for the snapshot ref endpoint.

**Cleanup of Redundant Removals:**

* Removed duplicate deletions of the endpoints and schema from the OpenAPI spec, ensuring the documentation matches the restored functionality. [[1]](diffhunk://#diff-64212dd108cf34b5a04683e77a1160b19e07a09129ca7cbaa9c54f323f53dd39L306-L349) [[2]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bL3246-L3302) [[3]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bL11500-L11521)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered runner routes to prevent the generic `:id` route from shadowing specific paths. Restored GET `/runners/by-sandbox/{sandboxId}` and GET `/runners/by-snapshot-ref`, and updated `openapi.yaml` (including `RunnerSnapshotDto`).

- **Bug Fixes**
  - Moved the two GET handlers above `:id` to ensure correct routing.
  - Re-added OpenAPI paths and restored the `RunnerSnapshotDto` schema so clients can query by sandbox ID and snapshot ref again.

<sup>Written for commit 33733952856f1c42125f144007cb93c4734ae97b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

