### PR TITLE
fix(api): update org invitation status

### DIFF
--- a/apps/api/src/organization/controllers/organization-invitation.controller.ts
+++ b/apps/api/src/organization/controllers/organization-invitation.controller.ts
@@ -108,7 +108,11 @@ export class OrganizationInvitationController {
     @Param('invitationId') invitationId: string,
     @Body() updateOrganizationInvitationDto: UpdateOrganizationInvitationDto,
   ): Promise<OrganizationInvitationDto> {
-    const invitation = await this.organizationInvitationService.update(invitationId, updateOrganizationInvitationDto)
+    const invitation = await this.organizationInvitationService.update(
+      organizationId,
+      invitationId,
+      updateOrganizationInvitationDto,
+    )
     return OrganizationInvitationDto.fromOrganizationInvitation(invitation)
   }
 
@@ -161,6 +165,6 @@ export class OrganizationInvitationController {
     @Param('organizationId') organizationId: string,
     @Param('invitationId') invitationId: string,
   ): Promise<void> {
-    return this.organizationInvitationService.cancel(invitationId)
+    return this.organizationInvitationService.cancel(organizationId, invitationId)
   }
 }

--- a/apps/api/src/organization/services/organization-invitation.service.ts
+++ b/apps/api/src/organization/services/organization-invitation.service.ts
@@ -107,11 +107,12 @@ export class OrganizationInvitationService {
   }
 
   async update(
+    organizationId: string,
     invitationId: string,
     updateOrganizationInvitationDto: UpdateOrganizationInvitationDto,
   ): Promise<OrganizationInvitation> {
     const invitation = await this.organizationInvitationRepository.findOne({
-      where: { id: invitationId },
+      where: { id: invitationId, organizationId },
       relations: {
         organization: true,
         assignedRoles: true,
@@ -228,17 +229,22 @@ export class OrganizationInvitationService {
     await this.organizationInvitationRepository.save(invitation)
   }
 
-  async cancel(invitationId: string): Promise<void> {
-    const invitation = await this.prepareStatusUpdate(invitationId, OrganizationInvitationStatus.CANCELLED)
+  async cancel(organizationId: string, invitationId: string): Promise<void> {
+    const invitation = await this.prepareStatusUpdate(
+      invitationId,
+      OrganizationInvitationStatus.CANCELLED,
+      organizationId,
+    )
     await this.organizationInvitationRepository.save(invitation)
   }
 
   private async prepareStatusUpdate(
     invitationId: string,
     newStatus: OrganizationInvitationStatus,
+    organizationId?: string,
   ): Promise<OrganizationInvitation> {
     const invitation = await this.organizationInvitationRepository.findOne({
-      where: { id: invitationId },
+      where: { id: invitationId, ...(organizationId && { organizationId }) },
       relations: {
         organization: true,
         assignedRoles: true,


### PR DESCRIPTION
This pull request improves the security and correctness of organization invitation operations by ensuring that both the invitation ID and the associated organization ID are required for updating and canceling invitations. This change helps prevent unauthorized access or modification of invitations that do not belong to the specified organization.

Key changes:

**API Controller Updates:**

* Modified the `OrganizationInvitationController` to require both `organizationId` and `invitationId` parameters when updating or canceling an invitation, passing both to the service methods. [[1]](diffhunk://#diff-ce4a0da983d6a20c50eba8e3f2f5d3da157718cc724b7d471d39ab5938c25e48L111-R115) [[2]](diffhunk://#diff-ce4a0da983d6a20c50eba8e3f2f5d3da157718cc724b7d471d39ab5938c25e48L164-R168)

**Service Layer Updates:**

* Updated the `OrganizationInvitationService.update` method to accept `organizationId` and ensure the invitation being updated belongs to the correct organization.
* Updated the `OrganizationInvitationService.cancel` method and its internal logic to require and check `organizationId` when canceling an invitation, ensuring only invitations for the specified organization can be canceled.
* Adjusted the `prepareStatusUpdate` helper to optionally filter by `organizationId` when retrieving invitations, supporting the above changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `organizationId` when updating or canceling organization invitations to prevent cross-org access and ensure actions target the correct org.

- **Bug Fixes**
  - Controller now passes `organizationId` to `update` and `cancel`.
  - Service `update` and `cancel` include `organizationId` in repository lookups to enforce org scoping.
  - `prepareStatusUpdate` accepts an optional `organizationId` and filters when provided.

<sup>Written for commit 8d6ffcfc467387078faeb9329bdcff0f8536dedb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

