### PR TITLE
fix(api): raw update on sandbox sync error

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -884,7 +884,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
           }
 
           // Update sandbox to error state without safeguards
-          await this.sandboxRepository.update(sandboxId, { updateData }, true)
+          await this.sandboxRepository.updateWhere(sandboxId, { updateData, whereCondition: {} })
 
           // Break sync loop since sandbox is in error state.
           break


### PR DESCRIPTION
## Description

Raw update on sandbox error state update to prevent concurrency checks from failing the operation. If a sandbox is errored, it should be unconditionally set to error state.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force-update sandbox error state during sync by removing repository safeguards and conditions. Ensures errored sandboxes are marked and the sync loop stops immediately.

- **Bug Fixes**
  - Use unconditional update via `sandboxRepository.updateWhere(sandboxId, { updateData, whereCondition: {} })` so the error state is set even if concurrency checks would block it.

<sup>Written for commit b5637304114cc59169527d31933a36a47b4a7ad4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

