### PR TITLE
fix(runner): successful stop on sandbox destroyed

### DIFF
--- a/apps/runner/pkg/docker/stop.go
+++ b/apps/runner/pkg/docker/stop.go
@@ -20,6 +20,11 @@ func (d *DockerClient) Stop(ctx context.Context, containerId string, force bool)
 		return nil
 	}
 
+	if err == nil && (state == enums.SandboxStateDestroyed || state == enums.SandboxStateDestroying) {
+		d.logger.DebugContext(ctx, "Sandbox is being destroyed or already destroyed, treating stop as successful", "containerId", containerId, "state", state)
+		return nil
+	}
+
 	if err != nil {
 		d.logger.WarnContext(ctx, "Failed to get sandbox state", "containerId", containerId, "error", err)
 		d.logger.WarnContext(ctx, "Continuing with stop operation")


### PR DESCRIPTION
## Description

Makes the runner return success if the underlying sandbox is destroyed (or destroying?). This handles some edge cases where destroy and stop are called onto a sandbox simultaneously

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return success from `Stop` in `apps/runner/pkg/docker` when the sandbox is Destroyed or Destroying. This avoids spurious stop failures during concurrent destroy/stop operations.

<sup>Written for commit 4a4bba54cc42d1f3cd3a2ad019259a7ff4e4cb9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

