### PR TITLE
feat(api): decommissioned snapshot runner cleanup

### DIFF
--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -828,4 +828,30 @@ export class SnapshotService {
       this.logger.debug(`Cleaned up ${result.affected} failed snapshot runners`)
     }
   }
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'cleanup-decommissioned-snapshot-runners' })
+  @LogExecution('cleanup-decommissioned-snapshot-runners')
+  @WithInstrumentation()
+  async cleanupDecommissionedSnapshotRunners() {
+    const cutoff = new Date()
+    cutoff.setHours(cutoff.getHours() - 1)
+
+    const snapshotRunners = await this.snapshotRunnerRepository
+      .createQueryBuilder('sr')
+      .innerJoin('runner', 'r', 'r.id::text = sr."runnerId"::text')
+      .where('r.state = :runnerState', { runnerState: RunnerState.DECOMMISSIONED })
+      .andWhere('sr."updatedAt" < :cutoff', { cutoff })
+      .select('sr.id')
+      .take(500)
+      .getMany()
+
+    if (snapshotRunners.length === 0) {
+      return
+    }
+
+    const ids = snapshotRunners.map((sr) => sr.id)
+    await this.snapshotRunnerRepository.delete(ids)
+
+    this.logger.debug(`Cleaned up ${ids.length} snapshot runners from decommissioned runners`)
+  }
 }


### PR DESCRIPTION
## Description

A cron that gradually cleans up `snapshot_runner` database entries of runners that had been decommissioned

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cron job that runs every minute to clean up stale snapshot runner records tied to decommissioned runners. This keeps the `snapshot_runner` table lean and reduces noise.

- **New Features**
  - Deletes up to 500 `snapshot_runner` rows per run older than 1 hour.
  - Targets runners with `RunnerState.DECOMMISSIONED` via an inner join on the `runner` table.
  - Adds execution logging and instrumentation for visibility.

<sup>Written for commit c675529381d9b7a1f9eb9c54bdd5603125340cc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

