### PR TITLE
fix(api): validate registry credentials before save

### DIFF
--- a/apps/api/src/docker-registry/providers/docker-registry.provider.interface.ts
+++ b/apps/api/src/docker-registry/providers/docker-registry.provider.interface.ts
@@ -5,7 +5,27 @@
 
 export const DOCKER_REGISTRY_PROVIDER = 'DOCKER_REGISTRY_PROVIDER'
 
+export const enum RegistryCredentialsValidationErrorCode {
+  INVALID_CREDENTIALS = 'INVALID_CREDENTIALS',
+  UNREACHABLE = 'UNREACHABLE',
+  UNSUPPORTED_CHALLENGE = 'UNSUPPORTED_CHALLENGE',
+  UNVERIFIED_CREDENTIALS = 'UNVERIFIED_CREDENTIALS',
+}
+
+export class RegistryCredentialsValidationError extends Error {
+  constructor(
+    public readonly code: RegistryCredentialsValidationErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'RegistryCredentialsValidationError'
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
 export interface IDockerRegistryProvider {
+  validateCredentials(baseUrl: string, auth: { username: string; password: string }): Promise<void>
+
   createRobotAccount(
     url: string,
     auth: { username: string; password: string },

--- a/apps/api/src/docker-registry/providers/docker-registry.provider.ts
+++ b/apps/api/src/docker-registry/providers/docker-registry.provider.ts
@@ -167,7 +167,7 @@ export class DockerRegistryProvider implements IDockerRegistryProvider {
     // Prevent SSRF: only follow HTTPS realm URLs (or HTTP for localhost).
     const scheme = tokenUrl.protocol
     const hostname = tokenUrl.hostname
-    if (scheme !== 'https:' && !(scheme === 'http:' && (hostname === 'localhost' || hostname === '127.0.0.1'))) {
+    if (scheme !== 'https:' && !(scheme === 'http:' && (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === 'registry'))) {
       throw new RegistryCredentialsValidationError(
         RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
         `Registry Bearer realm uses disallowed scheme: ${scheme}`,

--- a/apps/api/src/docker-registry/providers/docker-registry.provider.ts
+++ b/apps/api/src/docker-registry/providers/docker-registry.provider.ts
@@ -167,7 +167,10 @@ export class DockerRegistryProvider implements IDockerRegistryProvider {
     // Prevent SSRF: only follow HTTPS realm URLs (or HTTP for localhost).
     const scheme = tokenUrl.protocol
     const hostname = tokenUrl.hostname
-    if (scheme !== 'https:' && !(scheme === 'http:' && (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === 'registry'))) {
+    if (
+      scheme !== 'https:' &&
+      !(scheme === 'http:' && (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === 'registry'))
+    ) {
       throw new RegistryCredentialsValidationError(
         RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
         `Registry Bearer realm uses disallowed scheme: ${scheme}`,

--- a/apps/api/src/docker-registry/providers/docker-registry.provider.ts
+++ b/apps/api/src/docker-registry/providers/docker-registry.provider.ts
@@ -154,7 +154,26 @@ export class DockerRegistryProvider implements IDockerRegistryProvider {
       )
     }
 
-    const tokenUrl = new URL(realm)
+    let tokenUrl: URL
+    try {
+      tokenUrl = new URL(realm)
+    } catch {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
+        'Registry Bearer challenge included an invalid realm URL',
+      )
+    }
+
+    // Prevent SSRF: only follow HTTPS realm URLs (or HTTP for localhost).
+    const scheme = tokenUrl.protocol
+    const hostname = tokenUrl.hostname
+    if (scheme !== 'https:' && !(scheme === 'http:' && (hostname === 'localhost' || hostname === '127.0.0.1'))) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
+        `Registry Bearer realm uses disallowed scheme: ${scheme}`,
+      )
+    }
+
     const service = challenge.params.get('service')?.[0]
     const scopes = challenge.params.get('scope') ?? []
 

--- a/apps/api/src/docker-registry/providers/docker-registry.provider.ts
+++ b/apps/api/src/docker-registry/providers/docker-registry.provider.ts
@@ -5,12 +5,67 @@
 
 import { Injectable } from '@nestjs/common'
 import { HttpService } from '@nestjs/axios'
+import { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { firstValueFrom } from 'rxjs'
-import { IDockerRegistryProvider } from './docker-registry.provider.interface'
+import {
+  IDockerRegistryProvider,
+  RegistryCredentialsValidationError,
+  RegistryCredentialsValidationErrorCode,
+} from './docker-registry.provider.interface'
+
+const VALIDATION_TIMEOUT_MS = 5000
+
+interface RegistryAuthChallenge {
+  scheme: string
+  params: Map<string, string[]>
+}
 
 @Injectable()
 export class DockerRegistryProvider implements IDockerRegistryProvider {
   constructor(private readonly httpService: HttpService) {}
+
+  async validateCredentials(baseUrl: string, auth: { username: string; password: string }): Promise<void> {
+    const registryUrl = `${baseUrl.replace(/\/+$/, '')}/v2/`
+    const challengeResponse = await this.request({
+      method: 'get',
+      url: registryUrl,
+    })
+
+    // A public or misconfigured registry can return 200 without challenging us.
+    // In that case the submitted credentials were never proven, so we must reject.
+    if (challengeResponse.status === 200) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNVERIFIED_CREDENTIALS,
+        'Registry is reachable but submitted credentials could not be verified',
+      )
+    }
+
+    // A secured registry should challenge unauthenticated /v2/ with 401.
+    // Any other status means we can't perform a trustworthy auth check.
+    if (challengeResponse.status !== 401) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNREACHABLE,
+        `Registry returned unexpected status ${challengeResponse.status} during validation`,
+      )
+    }
+
+    const challenge = this.parseAuthenticateChallenge(challengeResponse)
+
+    if (challenge.scheme === 'basic') {
+      await this.validateBasicChallenge(registryUrl, auth)
+      return
+    }
+
+    if (challenge.scheme === 'bearer') {
+      await this.validateBearerChallenge(registryUrl, auth, challenge)
+      return
+    }
+
+    throw new RegistryCredentialsValidationError(
+      RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
+      `Unsupported registry authentication scheme: ${challenge.scheme}`,
+    )
+  }
 
   async createRobotAccount(
     url: string,
@@ -48,6 +103,180 @@ export class DockerRegistryProvider implements IDockerRegistryProvider {
         return // Artifact not found, consider it a success
       }
       throw error
+    }
+  }
+
+  /**
+   * Retries the registry probe using HTTP Basic authentication.
+   */
+  private async validateBasicChallenge(
+    registryUrl: string,
+    auth: { username: string; password: string },
+  ): Promise<void> {
+    const response = await this.request({
+      method: 'get',
+      url: registryUrl,
+      auth,
+    })
+
+    // Basic auth is valid once the authenticated retry is accepted.
+    if (response.status === 200) {
+      return
+    }
+
+    // The registry challenged us, we retried with credentials, and it still refused.
+    if (response.status === 401 || response.status === 403) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.INVALID_CREDENTIALS,
+        'Registry rejected the submitted credentials',
+      )
+    }
+
+    throw new RegistryCredentialsValidationError(
+      RegistryCredentialsValidationErrorCode.UNVERIFIED_CREDENTIALS,
+      `Registry returned unexpected status ${response.status} after Basic authentication`,
+    )
+  }
+
+  /**
+   * Completes the token-service challenge, then retries the registry probe with a Bearer token.
+   */
+  private async validateBearerChallenge(
+    registryUrl: string,
+    auth: { username: string; password: string },
+    challenge: RegistryAuthChallenge,
+  ): Promise<void> {
+    const realm = challenge.params.get('realm')?.[0]
+    if (!realm) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
+        'Registry Bearer challenge did not include a realm',
+      )
+    }
+
+    const tokenUrl = new URL(realm)
+    const service = challenge.params.get('service')?.[0]
+    const scopes = challenge.params.get('scope') ?? []
+
+    if (service) {
+      tokenUrl.searchParams.set('service', service)
+    }
+
+    for (const scope of scopes) {
+      tokenUrl.searchParams.append('scope', scope)
+    }
+
+    const tokenResponse = await this.request({
+      method: 'get',
+      url: tokenUrl.toString(),
+      auth,
+    })
+
+    // The token service refused the submitted username/password.
+    if (tokenResponse.status === 401 || tokenResponse.status === 403) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.INVALID_CREDENTIALS,
+        'Token service rejected the submitted credentials',
+      )
+    }
+
+    if (tokenResponse.status !== 200) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNVERIFIED_CREDENTIALS,
+        `Token service returned unexpected status ${tokenResponse.status}`,
+      )
+    }
+
+    const token = tokenResponse.data?.token ?? tokenResponse.data?.access_token
+    if (!token || typeof token !== 'string') {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
+        'Token service did not return a usable Bearer token',
+      )
+    }
+
+    const response = await this.request({
+      method: 'get',
+      url: registryUrl,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+    // Bearer auth is valid once the registry accepts the token-backed retry.
+    if (response.status === 200) {
+      return
+    }
+
+    // The registry challenged us, we exchanged the credentials for a token, and the retry still failed.
+    if (response.status === 401 || response.status === 403) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.INVALID_CREDENTIALS,
+        'Registry rejected the token generated from the submitted credentials',
+      )
+    }
+
+    throw new RegistryCredentialsValidationError(
+      RegistryCredentialsValidationErrorCode.UNVERIFIED_CREDENTIALS,
+      `Registry returned unexpected status ${response.status} after Bearer authentication`,
+    )
+  }
+
+  /**
+   * Parses the registry auth challenge and preserves repeated keys such as scope.
+   */
+  private parseAuthenticateChallenge(response: AxiosResponse): RegistryAuthChallenge {
+    const rawHeader = response.headers['www-authenticate']
+    const header = Array.isArray(rawHeader) ? rawHeader.find((value) => typeof value === 'string') : rawHeader
+
+    if (typeof header !== 'string' || header.length === 0) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
+        'Registry did not provide a usable WWW-Authenticate challenge',
+      )
+    }
+
+    const schemeMatch = header.match(/^\s*([A-Za-z]+)\s+/)
+    if (!schemeMatch) {
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE,
+        'Registry authentication challenge is malformed',
+      )
+    }
+
+    const params = new Map<string, string[]>()
+    const paramPattern = /([A-Za-z][A-Za-z0-9_-]*)="([^"]*)"/g
+    let match: RegExpExecArray | null
+
+    while ((match = paramPattern.exec(header)) !== null) {
+      const [, key, value] = match
+      params.set(key.toLowerCase(), [...(params.get(key.toLowerCase()) ?? []), value])
+    }
+
+    return {
+      scheme: schemeMatch[1].toLowerCase(),
+      params,
+    }
+  }
+
+  /**
+   * Sends a registry-validation HTTP request and converts transport failures into typed errors.
+   */
+  private async request(config: AxiosRequestConfig): Promise<AxiosResponse> {
+    try {
+      return await firstValueFrom(
+        this.httpService.request({
+          ...config,
+          timeout: VALIDATION_TIMEOUT_MS,
+          validateStatus: () => true,
+        }),
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new RegistryCredentialsValidationError(
+        RegistryCredentialsValidationErrorCode.UNREACHABLE,
+        `Registry validation request failed: ${message}`,
+      )
     }
   }
 }

--- a/apps/api/src/docker-registry/providers/mock-docker-registry.provider.ts
+++ b/apps/api/src/docker-registry/providers/mock-docker-registry.provider.ts
@@ -6,6 +6,10 @@
 import { IDockerRegistryProvider } from './docker-registry.provider.interface'
 
 export class MockDockerRegistryProvider implements IDockerRegistryProvider {
+  async validateCredentials(): Promise<void> {
+    return Promise.resolve()
+  }
+
   async createRobotAccount(): Promise<{ name: string; secret: string }> {
     return {
       name: 'mock-robot',

--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -88,10 +88,13 @@ export class DockerRegistryService {
     }
 
     const normalizedUrl = normalizeRegistryUrl(createDto.url)
-    await this.validateRegistryCredentials(normalizedUrl, {
-      username: createDto.username,
-      password: createDto.password,
-    })
+
+    if (createDto.registryType === RegistryType.ORGANIZATION) {
+      await this.validateRegistryCredentials(normalizedUrl, {
+        username: createDto.username,
+        password: createDto.password,
+      })
+    }
 
     const registry = repository.create({
       ...createDto,

--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -143,7 +143,7 @@ export class DockerRegistryService {
       registry.username !== updateDto.username ||
       registry.password !== effectivePassword
 
-    if (credentialsChanged) {
+    if (credentialsChanged && registry.registryType === RegistryType.ORGANIZATION) {
       await this.validateRegistryCredentials(normalizedUrl, {
         username: updateDto.username,
         password: effectivePassword,

--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ForbiddenException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ForbiddenException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { EntityManager, FindOptionsWhere, IsNull, Repository } from 'typeorm'
 import { DockerRegistry } from '../entities/docker-registry.entity'
@@ -14,6 +14,8 @@ import { RegistryPushAccessDto } from '../../sandbox/dto/registry-push-access-dt
 import {
   DOCKER_REGISTRY_PROVIDER,
   IDockerRegistryProvider,
+  RegistryCredentialsValidationError,
+  RegistryCredentialsValidationErrorCode,
 } from './../../docker-registry/providers/docker-registry.provider.interface'
 import { RegistryType } from './../../docker-registry/enums/registry-type.enum'
 import { parseDockerImage, checkDockerfileHasRegistryPrefix } from '../../common/utils/docker-image.util'
@@ -85,9 +87,15 @@ export class DockerRegistryService {
       }
     }
 
+    const normalizedUrl = normalizeRegistryUrl(createDto.url)
+    await this.validateRegistryCredentials(normalizedUrl, {
+      username: createDto.username,
+      password: createDto.password,
+    })
+
     const registry = repository.create({
       ...createDto,
-      url: normalizeRegistryUrl(createDto.url),
+      url: normalizedUrl,
       region: createDto.regionId,
       organizationId,
       isFallback,
@@ -125,12 +133,24 @@ export class DockerRegistryService {
       throw new NotFoundException(`Docker registry with ID ${registryId} not found`)
     }
 
-    registry.name = updateDto.name
-    registry.url = normalizeRegistryUrl(updateDto.url)
-    registry.username = updateDto.username
-    if (updateDto.password) {
-      registry.password = updateDto.password
+    const normalizedUrl = normalizeRegistryUrl(updateDto.url)
+    const effectivePassword = updateDto.password || registry.password
+    const credentialsChanged =
+      registry.url !== normalizedUrl ||
+      registry.username !== updateDto.username ||
+      registry.password !== effectivePassword
+
+    if (credentialsChanged) {
+      await this.validateRegistryCredentials(normalizedUrl, {
+        username: updateDto.username,
+        password: effectivePassword,
+      })
     }
+
+    registry.name = updateDto.name
+    registry.url = normalizedUrl
+    registry.username = updateDto.username
+    registry.password = effectivePassword
     registry.project = updateDto.project
 
     return this.dockerRegistryRepository.save(registry)
@@ -521,6 +541,53 @@ export class DockerRegistryService {
     }
 
     return registry.url.startsWith('http') ? registry.url : `https://${registry.url}`
+  }
+
+  /**
+   * Validates registry credentials before persisting them.
+   */
+  private async validateRegistryCredentials(url: string, auth: { username: string; password: string }): Promise<void> {
+    const probeUrl = this.getRegistryValidationUrl(url)
+
+    try {
+      await this.dockerRegistryProvider.validateCredentials(probeUrl, auth)
+    } catch (error) {
+      if (!(error instanceof RegistryCredentialsValidationError)) {
+        throw error
+      }
+
+      switch (error.code) {
+        case RegistryCredentialsValidationErrorCode.INVALID_CREDENTIALS:
+          throw new BadRequestException('Invalid registry credentials')
+        case RegistryCredentialsValidationErrorCode.UNREACHABLE:
+          throw new BadRequestException('Registry could not be reached')
+        case RegistryCredentialsValidationErrorCode.UNSUPPORTED_CHALLENGE:
+          throw new BadRequestException('Registry authentication challenge is unsupported or malformed')
+        case RegistryCredentialsValidationErrorCode.UNVERIFIED_CREDENTIALS:
+          throw new BadRequestException('Registry is reachable but submitted credentials could not be verified')
+      }
+
+      throw error
+    }
+  }
+
+  /**
+   * Builds the base URL used to probe the registry auth challenge.
+   */
+  private getRegistryValidationUrl(url: string): string {
+    if (url === DOCKER_HUB_URL) {
+      return `https://${DOCKER_HUB_REGISTRY}`
+    }
+
+    if (url.startsWith('localhost:') || url.startsWith('registry:')) {
+      return `http://${url}`
+    }
+
+    if (url.startsWith('localhost') || url.startsWith('127.0.0.1')) {
+      return `http://${url}`
+    }
+
+    return url.startsWith('http') ? url : `https://${url}`
   }
 
   public async findRegistryByImageName(


### PR DESCRIPTION
## Description

This change adds pre-save registry credential validation to the Add Registry and registry update flows in the API.

Before a registry is saved, the API now probes `GET /v2/` without auth, follows the registry's advertised authentication challenge, and retries the probe with the submitted credentials. The registry is only saved if the authenticated retry succeeds. This prevents unreachable registries or invalid credentials from being stored.

Implementation details:
- extends the docker registry provider interface with `validateCredentials(...)`
- implements Basic and Bearer auth challenge handling in the registry provider
- validates credentials before create
- validates credentials before update when the effective auth tuple changes
- uses `https://registry-1.docker.io` for Docker Hub validation while continuing to store `docker.io`

No new external dependencies were added.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #2117

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate container registry credentials before save to stop storing unreachable registries or bad creds. Supports #2117 by verifying credentials server-side and failing fast with clear errors.

- **New Features**
  - Probes `/v2/` without auth, follows `WWW-Authenticate` (Basic/Bearer), retries with submitted creds; saves only if verified.
  - Adds `validateCredentials(...)` with 5s timeout and typed errors; maps failures to 400s (invalid, unreachable, unsupported, unverifiable).
  - Runs for ORGANIZATION registries on create, and on update only when URL/username/password effectively change.
  - Handles Docker Hub alias and local/dev registries: validate via `https://registry-1.docker.io` but store `docker.io`; probe over `http` for `localhost`, `127.0.0.1`, or `registry`.
  - Hardens Bearer flow: validates realm URL and scheme (HTTPS, or HTTP for localhost/127.0.0.1/registry); rejects invalid/malicious realms to prevent SSRF and avoid 500s.

<sup>Written for commit 02c630d9c0311d9bdc08833b9e4ba35e58dc97e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

