### PR TITLE
fix(api): preview access redis key

### DIFF
--- a/apps/api/src/sandbox/controllers/preview.controller.ts
+++ b/apps/api/src/sandbox/controllers/preview.controller.ts
@@ -143,7 +143,7 @@ export class PreviewController {
     const sandbox = await this.sandboxService.findOne(sandboxId)
     const hasAccess = await this.organizationUserService.exists(sandbox.organizationId, userId)
     if (!hasAccess) {
-      await this.redis.setex(`preview:token:${sandboxId}:${userId}`, 3, '0')
+      await this.redis.setex(`preview:access:${sandboxId}:${userId}`, 3, '0')
       throw new NotFoundException(`Sandbox with ID ${sandboxId} not found`)
     }
     //  if user has access, keep it in cache longer


### PR DESCRIPTION
## Description

Fixes wrong redis key being used for sandbox access failure

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Redis key used for caching failed sandbox access checks by switching from `preview:token:${sandboxId}:${userId}` to `preview:access:${sandboxId}:${userId}`. This stores deny-cache entries under the correct namespace for consistent access control behavior.

<sup>Written for commit fa201f5b0cf6bb03ec7b8b7263de41e2f7047234. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

