### PR TITLE
docs: add security considerations to OSS deployment guide

### DIFF
--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -66,6 +66,12 @@ This configures dnsmasq with `address=/proxy.localhost/127.0.0.1`.
 - The registry is configured to allow image deletion for testing
 - Sandbox resource limits are disabled due to inability to partition cgroups in DinD environment where the sock is not mounted
 
+## Security Considerations
+
+The `INTER_SANDBOX_NETWORK_ENABLED` runner environment variable controls whether sandboxes on the same runner can communicate over the network. In the Docker Compose configuration this defaults to `false`, creating an isolated bridge network with inter-container communication disabled.
+
+If you are deploying runners outside of the provided Docker Compose setup, ensure `INTER_SANDBOX_NETWORK_ENABLED` is explicitly set to `false` unless your use case requires inter-sandbox communication.
+
 ## Additional Network Options
 
 ### HTTP Proxy


### PR DESCRIPTION
## Summary

- Adds a "Security Considerations" section to the OSS deployment documentation (`oss-deployment.mdx`)
- Documents the `INTER_SANDBOX_NETWORK_ENABLED` runner environment variable and its default behavior in Docker Compose (inter-container communication disabled)
- Advises operators deploying runners outside of the provided Docker Compose setup to explicitly set `INTER_SANDBOX_NETWORK_ENABLED=false` unless inter-sandbox communication is required

## Context

The Docker Compose configuration already defaults `INTER_SANDBOX_NETWORK_ENABLED` to `false`, but operators standing up runners independently may not be aware of this setting. This section makes the security implication explicit in the deployment guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Security Considerations section to the OSS deployment guide to clarify runner network isolation and safer defaults. Documents `INTER_SANDBOX_NETWORK_ENABLED` (defaults to `false` in Docker Compose) and advises setting it to `false` when deploying runners outside Compose unless inter-sandbox networking is required.

<sup>Written for commit 93cc04f95a8f6b3be4915997777fc6710661b229. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

