### PR TITLE
fix(api): failed auth rate limit block

### DIFF
--- a/apps/api/src/auth/failed-auth-tracker.service.ts
+++ b/apps/api/src/auth/failed-auth-tracker.service.ts
@@ -45,7 +45,21 @@ export class FailedAuthTrackerService {
       const hitKey = `${keyPrefix}{${key}:${throttlerName}}:hits`
       const blockedKey = `${keyPrefix}{${key}:${throttlerName}}:blocked`
 
-      // Increment hits
+      // Fast path: if already blocked, reject immediately with a single GET
+      const blocked = await this.redis.get(blockedKey)
+      if (blocked) {
+        const blockedTtl = await this.redis.pttl(blockedKey)
+        const retryAfter = Math.max(1, Math.ceil(blockedTtl / 1000))
+        setRateLimitHeaders(response, {
+          throttlerName,
+          limit,
+          remaining: 0,
+          resetSeconds: retryAfter,
+          retryAfterSeconds: retryAfter,
+        })
+        throw new ThrottlerException()
+      }
+
       const hits = await this.redis.incr(hitKey)
       if (hits === 1) {
         await this.redis.pexpire(hitKey, ttl)

--- a/apps/api/src/filters/all-exceptions.filter.ts
+++ b/apps/api/src/filters/all-exceptions.filter.ts
@@ -16,6 +16,7 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common'
+import { ThrottlerException } from '@nestjs/throttler'
 import { FailedAuthTrackerService } from '../auth/failed-auth-tracker.service'
 
 @Catch()
@@ -44,8 +45,12 @@ export class AllExceptionsFilter implements ExceptionFilter {
     if (exception instanceof UnauthorizedException) {
       try {
         await this.failedAuthTracker.incrementFailedAuth(request, response)
-      } catch (error) {
-        this.logger.error('Failed to track authentication failure:', error)
+      } catch (trackingError) {
+        if (trackingError instanceof ThrottlerException) {
+          exception = trackingError
+        } else {
+          this.logger.error('Failed to track authentication failure:', trackingError)
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Fail early on the failed auth rate limit guard
Skip logging on the API and fixes the response status code

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on the failed-auth rate limit and return a proper 429 with rate-limit headers while reducing noisy auth logs.

- **Bug Fixes**
  - Added an early blocked check that sets rate-limit headers and throws `ThrottlerException` without incrementing hits.
  - Updated the global exception filter to propagate `ThrottlerException` (429) instead of `UnauthorizedException` and skip logging for these cases.
  - Set accurate Retry-After and remaining limits using the block TTL.

<sup>Written for commit 6b5194d5cce65f298ea4b8cafd57fd25f8fdce6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

