### PR TITLE
security: add supply chain package age quarantine

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 # Expose Astro dependencies for \`pnpm\` users
 shamefully-hoist=true
+
+# Supply chain: reject packages published less than 7 days ago (npm v11+ / pnpm v10.9+)
+min-release-age=7

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,6 @@
 enableInlineHunks: true
 
 nodeLinker: node-modules
+
+# Supply chain: reject packages published less than 7 days ago (10080 minutes)
+npmMinimalAgeGate: 10080

--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
     "vitest": "^1.3.1",
     "webpack-cli": "^5.1.4"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.13.0",
   "nx": {
     "includedScripts": []
   },


### PR DESCRIPTION
## Summary

- Upgrade Yarn from 4.6.0 to 4.13.0
- Enable `npmMinimalAgeGate: 10080` in `.yarnrc.yml` — rejects npm packages published less than 7 days ago
- Add `min-release-age=7` to `.npmrc` for npm/pnpm coverage (guide directories, ad-hoc usage)

## Why

Supply chain attacks via freshly-published malicious packages (typosquatting, account takeover) are a growing vector. A 7-day quarantine window lets the community detect and flag malicious packages before they reach our CI/CD or developer machines.

## Coverage

| Package Manager | Protected | Mechanism |
|---|---|---|
| Yarn 4.13 | Yes | `npmMinimalAgeGate: 10080` |
| npm / pnpm | Yes | `min-release-age=7` |
| Poetry | No | No equivalent exists |
| Go modules | N/A | Mitigated by sum.golang.org |
| Bundler | No | No equivalent exists |

## Verification

- `yarn config` confirms `npmMinimalAgeGate: 10080` sourced from `.yarnrc.yml`
- `yarn install --immutable` passes clean
- No lockfile changes required

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 7-day age gate for npm packages to block installs of freshly published packages and reduce supply-chain risk. Upgrade `yarn` to `4.13.0`, enable `npmMinimalAgeGate: 10080` in `.yarnrc.yml`, and set `min-release-age=7` in `.npmrc` for npm/pnpm.

<sup>Written for commit d94b712d24f8f86ee5cc3c48b0472de400e4fd96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

