### PR TITLE
feat(docs): redirect sitemap.xml to sitemap-index.xml

### DIFF
--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -6,6 +6,10 @@ export const onRequest = defineMiddleware(({ request, redirect }, next) => {
   const url = new URL(request.url)
   const path = url.pathname.replace(/\/$/, '')
 
+  if (path === '/docs/sitemap.xml') {
+    return next(new Request(new URL('/docs/sitemap-index.xml', url), request))
+  }
+
   // Match /docs/old-slug or /docs/{locale}/old-slug
   const match = path.match(/^\/docs(?:\/([a-z]{2}))?\/(.+)$/)
   if (match) {


### PR DESCRIPTION
## Description

Redirects sitemap.xml to sitemap-index.xml.

With the current middleware change, this is what happens:

- Request: /docs/sitemap.xml
- Middleware intercepts it
- Middleware internally rewrites it to `/docs/sitemap-index.xml`
- Response body is the sitemap index content
- URL in the client stays `/docs/sitemap.xml`
- Status is normal success (not a redirect status)

For a human or crawler/agent, `/docs/sitemap.xml` works as the public entrypoint, but it is served by the existing sitemap-index route behind the scenes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve /docs/sitemap.xml by internally rewriting to /docs/sitemap-index.xml. Crawlers can use /docs/sitemap.xml as the entry point without a visible redirect.

<sup>Written for commit d079ccf3c1626546e9a023caa1a1682ef223b3fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

