### PR TITLE
fix(runner): image name from resource id in remove snapshot

### DIFF
--- a/apps/runner/pkg/runner/v2/executor/snapshot.go
+++ b/apps/runner/pkg/runner/v2/executor/snapshot.go
@@ -7,7 +7,6 @@ package executor
 
 import (
 	"context"
-	"errors"
 
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/daytonaio/runner/pkg/api/dto"
@@ -70,11 +69,7 @@ func (e *Executor) pullSnapshot(ctx context.Context, job *apiclient.Job) (any, e
 }
 
 func (e *Executor) removeSnapshot(ctx context.Context, job *apiclient.Job) (any, error) {
-	if job.Payload == nil || *job.Payload == "" {
-		return nil, errors.New("payload is required")
-	}
-
-	return nil, e.docker.RemoveImage(ctx, *job.Payload, true)
+	return nil, e.docker.RemoveImage(ctx, job.ResourceId, true)
 }
 
 func (e *Executor) inspectSnapshotInRegistry(ctx context.Context, job *apiclient.Job) (any, error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use `job.ResourceId` as the image name when removing snapshots instead of `job.Payload`. This prevents empty-payload errors and ensures the correct image is deleted.

- **Bug Fixes**
  - Switch `removeSnapshot` to use `job.ResourceId` when calling Docker image removal.
  - Remove the payload presence check to avoid unnecessary failures.

<sup>Written for commit 5cf84371b00958e212ef72a87a2684ab825d88c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

