### PR TITLE
feat(proxy): reduce invalid auth cache TTL

### DIFF
--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -257,7 +257,11 @@ func (p *Proxy) validateAndCache(
 		return nil, validationErr
 	}
 
-	if err := p.sandboxAuthKeyValidCache.Set(ctx, cacheKey, isValid, 2*time.Minute); err != nil {
+	cacheTTL := 2 * time.Minute
+	if !isValid {
+		cacheTTL = 5 * time.Second
+	}
+	if err := p.sandboxAuthKeyValidCache.Set(ctx, cacheKey, isValid, cacheTTL); err != nil {
 		log.Errorf("Failed to set sandbox auth key valid in cache: %v", err)
 	}
 


### PR DESCRIPTION
## Description

Reduce invalid auth cache TTL for sandbox auth key from 2 minutes to 5 seconds

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shorten the cache TTL for invalid sandbox auth key validations from 2 minutes to 5 seconds, while keeping valid results at 2 minutes. This reduces stale negative caches and lets clients retry quickly after a failed auth attempt.

<sup>Written for commit 47d5456982ab922c3938712ff1e75d24edae192b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

