### PR TITLE
fix(docs): update support contact

### DIFF
--- a/apps/docs/src/components/Footer.astro
+++ b/apps/docs/src/components/Footer.astro
@@ -22,7 +22,7 @@ const releaseLink = `https://github.com/daytonaio/daytona/releases/tag/v${releas
       <Fragment set:html={textArrowIcon} />{
         Astro.locals.t('footer.needHelp' as any)
       } -
-      <a href="https://go.daytona.io/slack"
+      <a href="mailto:support@daytona.io"
         >{Astro.locals.t('footer.reachSupport' as any)}</a
       >
     </p>


### PR DESCRIPTION
## Description

Updates the support contact information.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docs footer to use email for support instead of Slack. Replaced the Slack link with mailto:support@daytona.io so users can reach support directly.

<sup>Written for commit ed4c5bcfc000d55623a4f29fb36361fa34ba2f93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

