### PR TITLE
feat(docs): add go sdk examples for signed preview url

### DIFF
--- a/apps/docs/src/content/docs/en/preview.mdx
+++ b/apps/docs/src/content/docs/en/preview.mdx
@@ -169,13 +169,34 @@ puts "Token: #{signed_url.token}"
 ```
 
 </TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+// Create a signed preview URL that expires in 3600 seconds (1 hour)
+signedPreview, err := sandbox.GetSignedPreviewLink(ctx, 3000, 3600)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("URL: %s\n", signedPreview.URL)   // Token is embedded in the URL
+fmt.Printf("Token: %s\n", signedPreview.Token) // Can be used to revoke access
+
+// Revoke the token before expiry if needed
+if err := sandbox.ExpireSignedPreviewLink(ctx, 3000, signedPreview.Token); err != nil {
+    log.Fatal(err)
+}
+```
+
+</TabItem>
 <TabItem label="CLI" icon="seti:shell">
+
 ```bash
 daytona preview-url <sandbox-name> --port 3000 --expires 3600
 ```
 
 </TabItem>
 <TabItem label="API" icon="seti:json">
+
 ```bash
 curl 'https://app.daytona.io/api/sandbox/{sandboxId}/ports/3000/signed-preview-url?expiresInSeconds=3600' \
   --header 'Authorization: Bearer <API_KEY>'
@@ -184,13 +205,17 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxId}/ports/3000/signed-preview-u
 </TabItem>
 </Tabs>
 
-For more information, see the [Python SDK](/docs/en/python-sdk/sync/sandbox), [TypeScript SDK](/docs/en/typescript-sdk/sandbox), [Ruby SDK](/docs/en/ruby-sdk/sandbox), and [API](/docs/en/tools/api/#daytona/tag/sandbox) references:
+For more information, see the [Python SDK](/docs/en/python-sdk/sync/sandbox), [TypeScript SDK](/docs/en/typescript-sdk/sandbox), [Ruby SDK](/docs/en/ruby-sdk/sandbox), [Go SDK](/docs/en/go-sdk/daytona), and [API](/docs/en/tools/api/#daytona/tag/sandbox) references:
 
 > [**create_signed_preview_url (Python SDK)**](/docs/en/python-sdk/sync/sandbox#sandboxcreate_signed_preview_url)
 >
 > [**getSignedPreviewUrl (TypeScript SDK)**](/docs/en/typescript-sdk/sandbox#getsignedpreviewurl)
 >
 > [**create_signed_preview_url (Ruby SDK)**](/docs/en/ruby-sdk/sandbox#create_signed_preview_url)
+>
+> [**GetSignedPreviewLink (Go SDK)**](/docs/en/go-sdk/daytona#Sandbox.GetSignedPreviewLink)
+>
+> [**ExpireSignedPreviewLink (Go SDK)**](/docs/en/go-sdk/daytona#Sandbox.ExpireSignedPreviewLink)
 >
 > [**Get Signed Preview URL (API)**](/docs/en/tools/api/#daytona/tag/sandbox/GET/sandbox/{sandboxIdOrName}/ports/{port}/signed-preview-url)
 


### PR DESCRIPTION
## Description

Documents Go SDK examples for signed preview URL generation.

## Related Issue(s)

This PR addresses issue #4084
This PR addresses pull request #4211


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Go SDK` examples for creating and revoking signed preview URLs in the preview docs. This adds a Go tab and links to Go SDK references to make it easy for Go users to generate and expire links.

- **New Features**
  - Added a Go tab showing `Sandbox.GetSignedPreviewLink` and `Sandbox.ExpireSignedPreviewLink` usage.
  - Linked to the `Go SDK` reference pages in the “More information” section.

<sup>Written for commit d2eb6407bd22b9c49d935416ab0d018b33691248. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

