### PR TITLE
fix(sdk-python,sdk-typescript,sdk-ruby): use printf instead of echo for env var decoding

### DIFF
--- a/libs/sdk-python/src/daytona/_async/process.py
+++ b/libs/sdk-python/src/daytona/_async/process.py
@@ -140,7 +140,7 @@ class AsyncProcess:
             safe_env_exports = (
                 " ".join(
                     [
-                        f"""export {key}="$(echo '{base64.b64encode(value.encode()).decode()}' | base64 -d)";"""
+                        f"""export {key}="$(printf '%s' '{base64.b64encode(value.encode()).decode()}' | base64 -d)";"""
                         for key, value in env.items()
                     ]
                 )

--- a/libs/sdk-python/src/daytona/_sync/process.py
+++ b/libs/sdk-python/src/daytona/_sync/process.py
@@ -139,7 +139,7 @@ class Process:
             safe_env_exports = (
                 " ".join(
                     [
-                        f"""export {key}="$(echo '{base64.b64encode(value.encode()).decode()}' | base64 -d)";"""
+                        f"""export {key}="$(printf '%s' '{base64.b64encode(value.encode()).decode()}' | base64 -d)";"""
                         for key, value in env.items()
                     ]
                 )

--- a/libs/sdk-ruby/lib/daytona/process.rb
+++ b/libs/sdk-ruby/lib/daytona/process.rb
@@ -63,7 +63,7 @@ module Daytona
           end
         end
         safe_env_exports = env.map do |key, value|
-          "export #{key}=\"$(echo '#{Base64.strict_encode64(value)}' | base64 -d)\""
+          "export #{key}=\"$(printf '%s' '#{Base64.strict_encode64(value)}' | base64 -d)\""
         end.join('; ')
         command = "#{safe_env_exports}; #{command}"
       end

--- a/libs/sdk-typescript/src/Process.ts
+++ b/libs/sdk-typescript/src/Process.ts
@@ -110,7 +110,7 @@ export class Process {
         Object.entries(env)
           .map(([key, value]) => {
             const encodedValue = Buffer.from(value).toString('base64')
-            return `export ${key}="$(echo '${encodedValue}' | base64 -d)"`
+            return `export ${key}="$(printf '%s' '${encodedValue}' | base64 -d)"`
           })
           .join('; ') + '; '
       command = `${safeEnvExports}${command}`


### PR DESCRIPTION
Replace `echo` with `printf '%s'` when base64-decoding env var values
in exec(). `printf '%s'` is POSIX-defined with consistent behavior
across all shells, while `echo` can interpret escape sequences in some
environments (e.g. zsh, BusyBox) making it less portable.

Affects Python, TypeScript, and Ruby SDKs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch env var decoding in exec() to use `printf '%s'` instead of `echo` for consistent behavior across shells. Affects `sdk-python`, `sdk-typescript`, and `sdk-ruby`.

- **Bug Fixes**
  - Prevents escape-sequence interpretation in some shells (e.g., zsh, BusyBox) when piping to `base64 -d`, improving portability and avoiding corrupted values.

<sup>Written for commit bbb5e9ec008c1305031c1c098508ad884de07053. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

