### PR TITLE
fix(ci): remediate template injection in workflow_dispatch workflows

### DIFF
--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -31,10 +31,18 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - name: Prepare
+      - name: Validate version format
         run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.Z-suffix)"
+            exit 1
+          fi
+
+      - name: Prepare
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,25 +140,29 @@ jobs:
 
       - name: Create and push sandbox manifest
         working-directory: ${{ runner.temp }}/digests/sandbox
+        env:
+          PUSH_LATEST: ${{ inputs.push_latest }}
         run: |
-          TAGS="-t ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION }}"
-          if [ "${{ inputs.push_latest }}" = "true" ]; then
-            TAGS="$TAGS -t ${{ env.REGISTRY_IMAGE }}:latest"
+          TAGS="-t ${REGISTRY_IMAGE}:${VERSION}"
+          if [ "$PUSH_LATEST" = "true" ]; then
+            TAGS="$TAGS -t ${REGISTRY_IMAGE}:latest"
           fi
           docker buildx imagetools create $TAGS \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
 
       - name: Create and push sandbox-slim manifest
         working-directory: ${{ runner.temp }}/digests/sandbox-slim
+        env:
+          PUSH_LATEST: ${{ inputs.push_latest }}
         run: |
-          TAGS="-t ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION }}-slim"
-          if [ "${{ inputs.push_latest }}" = "true" ]; then
-            TAGS="$TAGS -t ${{ env.REGISTRY_IMAGE }}:latest-slim"
+          TAGS="-t ${REGISTRY_IMAGE}:${VERSION}-slim"
+          if [ "$PUSH_LATEST" = "true" ]; then
+            TAGS="$TAGS -t ${REGISTRY_IMAGE}:latest-slim"
           fi
           docker buildx imagetools create $TAGS \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
 
       - name: Inspect images
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION }}
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION }}-slim
+          docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}"
+          docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}-slim"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate version format
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected vX.Y.Z or vX.Y.Z-suffix)"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -34,17 +41,17 @@ jobs:
 
       - name: Create release branch
         run: |
-          git checkout -b prepare-release-${{ inputs.version }}
+          git checkout -b "prepare-release-$VERSION"
 
       - name: Prepare release
         run: |
-          VERSION=${{ inputs.version }} yarn prepare-release
+          yarn prepare-release
 
       - name: Push branch and create PR
         run: |
-          git push origin prepare-release-${{ inputs.version }}
+          git push origin "prepare-release-$VERSION"
           gh pr create \
-            --title "chore: prepare release ${{ inputs.version }}" \
-            --body "Automated PR to prepare release ${{ inputs.version }}" \
+            --title "chore: prepare release $VERSION" \
+            --body "Automated PR to prepare release $VERSION" \
             --base main \
-            --head prepare-release-${{ inputs.version }}
+            --head "prepare-release-$VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,13 @@ jobs:
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
 
     steps:
+      - name: Validate version format
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected vX.Y.Z or vX.Y.Z-suffix)"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -46,10 +53,10 @@ jobs:
 
       - name: Tag Go modules
         run: |
-          git tag libs/api-client-go/${{ inputs.version }}
-          git tag libs/toolbox-api-client-go/${{ inputs.version }}
-          git tag libs/sdk-go/${{ inputs.version }}
-          git push origin libs/api-client-go/${{ inputs.version }} libs/toolbox-api-client-go/${{ inputs.version }} libs/sdk-go/${{ inputs.version }}
+          git tag "libs/api-client-go/$VERSION"
+          git tag "libs/toolbox-api-client-go/$VERSION"
+          git tag "libs/sdk-go/$VERSION"
+          git push origin "libs/api-client-go/$VERSION" "libs/toolbox-api-client-go/$VERSION" "libs/sdk-go/$VERSION"
 
       - name: Go work sync
         run: |
@@ -82,7 +89,7 @@ jobs:
           }' > apps/runner/package.json
 
       - name: Create release
-        run: yarn nx release ${{ inputs.version }} --skip-publish --verbose
+        run: yarn nx release "$VERSION" --skip-publish --verbose
 
   build_projects:
     needs: publish
@@ -129,25 +136,25 @@ jobs:
 
       - name: Upload runner to release assets
         run: |
-          gh release upload ${{ inputs.version }} dist/apps/runner-amd64#daytona-runner-${{ inputs.version }}-amd64 --clobber
+          gh release upload "$VERSION" "dist/apps/runner-amd64#daytona-runner-${VERSION}-amd64" --clobber
 
       - name: Upload runner .deb to release assets
         run: |
           DEB_VERSION="${VERSION#v}"
-          gh release upload ${{ inputs.version }} "dist/apps/runner-deb/daytona-runner_${DEB_VERSION}_amd64.deb#daytona-runner-${DEB_VERSION}-amd64.deb" --clobber
+          gh release upload "$VERSION" "dist/apps/runner-deb/daytona-runner_${DEB_VERSION}_amd64.deb#daytona-runner-${DEB_VERSION}-amd64.deb" --clobber
 
       - name: Upload daemon to release assets
         run: |
-          gh release upload ${{ inputs.version }} dist/apps/daemon-amd64#daytona-daemon-${{ inputs.version }}-amd64 --clobber
+          gh release upload "$VERSION" "dist/apps/daemon-amd64#daytona-daemon-${VERSION}-amd64" --clobber
 
       - name: Upload CLI to release assets
         run: |
-          gh release upload ${{ inputs.version }} dist/apps/cli/daytona-linux-amd64#daytona-cli-${{ inputs.version }}-linux-amd64 --clobber
-          gh release upload ${{ inputs.version }} dist/apps/cli/daytona-linux-arm64#daytona-cli-${{ inputs.version }}-linux-arm64 --clobber
-          gh release upload ${{ inputs.version }} dist/apps/cli/daytona-darwin-amd64#daytona-cli-${{ inputs.version }}-darwin-amd64 --clobber
-          gh release upload ${{ inputs.version }} dist/apps/cli/daytona-darwin-arm64#daytona-cli-${{ inputs.version }}-darwin-arm64 --clobber
-          gh release upload ${{ inputs.version }} dist/apps/cli/daytona-windows-amd64.exe#daytona-cli-${{ inputs.version }}-windows-amd64.exe --clobber
-          gh release upload ${{ inputs.version }} dist/apps/cli/daytona-windows-arm64.exe#daytona-cli-${{ inputs.version }}-windows-arm64.exe --clobber
+          gh release upload "$VERSION" "dist/apps/cli/daytona-linux-amd64#daytona-cli-${VERSION}-linux-amd64" --clobber
+          gh release upload "$VERSION" "dist/apps/cli/daytona-linux-arm64#daytona-cli-${VERSION}-linux-arm64" --clobber
+          gh release upload "$VERSION" "dist/apps/cli/daytona-darwin-amd64#daytona-cli-${VERSION}-darwin-amd64" --clobber
+          gh release upload "$VERSION" "dist/apps/cli/daytona-darwin-arm64#daytona-cli-${VERSION}-darwin-arm64" --clobber
+          gh release upload "$VERSION" "dist/apps/cli/daytona-windows-amd64.exe#daytona-cli-${VERSION}-windows-amd64.exe" --clobber
+          gh release upload "$VERSION" "dist/apps/cli/daytona-windows-arm64.exe#daytona-cli-${VERSION}-windows-arm64.exe" --clobber
 
       - name: Upload computer-use artifact
         uses: actions/upload-artifact@v4
@@ -234,8 +241,10 @@ jobs:
       - run: yarn install --immutable
 
       - name: Publish docker images
+        env:
+          ARCH: -${{ matrix.arch }}
         run: |
-          VERSION=${{ inputs.version }} ARCH="-${{ matrix.arch }}" yarn docker:production
+          yarn docker:production
 
   # Push combined manifest
   docker_push_manifest:
@@ -266,7 +275,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Push manifest
         run: |
-          VERSION=${{ inputs.version }} yarn push-manifest
+          yarn push-manifest
 
   sync_gosum:
     needs: build_projects
@@ -306,19 +315,19 @@ jobs:
 
       - name: Sync go.sum and create PR
         run: |
-          git checkout -b sync-gosum-${{ inputs.version }}
+          git checkout -b "sync-gosum-$VERSION"
           GONOSUMDB=github.com/daytonaio/daytona go work sync
           if git diff --quiet -- **/go.sum; then
             echo "No go.sum changes detected; skipping commit and PR creation."
           else
             git add **/go.sum
-            git commit -s -m "chore: sync go.sum for ${{ inputs.version }}"
-            git push origin sync-gosum-${{ inputs.version }}
+            git commit -s -m "chore: sync go.sum for $VERSION"
+            git push origin "sync-gosum-$VERSION"
             gh pr create \
-              --title "chore: sync go.sum for ${{ inputs.version }}" \
-              --body "Automated PR to sync go.sum after release ${{ inputs.version }}" \
+              --title "chore: sync go.sum for $VERSION" \
+              --body "Automated PR to sync go.sum after release $VERSION" \
               --base main \
-              --head sync-gosum-${{ inputs.version }}
+              --head "sync-gosum-$VERSION"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -37,6 +37,13 @@ jobs:
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
 
     steps:
+      - name: Validate version format
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected vX.Y.Z or vX.Y.Z-suffix)"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -77,7 +84,7 @@ jobs:
           curl -f -X POST -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${GITHUBBOT_TOKEN}" \
           https://api.github.com/repos/daytonaio/homebrew-cli/dispatches \
-          -d "{\"event_type\": \"update-version\", \"client_payload\": {\"version\": \"${{ env.VERSION }}\"}}"
+          -d "{\"event_type\": \"update-version\", \"client_payload\": {\"version\": \"$VERSION\"}}"
 
         env:
           GITHUBBOT_TOKEN: ${{ secrets.GITHUBBOT_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace all `${{ inputs.* }}` and `${{ env.* }}` expressions in `run:` blocks with shell variable references to prevent code injection via GitHub Actions template expansion
- Add version format validation step to all `workflow_dispatch` workflows (`prepare-release`, `release`, `sdk_publish`, `default_image_publish`)
- Remove redundant inline `VERSION=${{ inputs.version }}` assignments where workflow-level `env:` already provides it
- Move `${{ matrix.platform }}`, `${{ matrix.arch }}`, `${{ inputs.push_latest }}` to step-level `env:` vars

## Context

Security audit identified 44 instances of template injection (zizmor `error[template-injection]`) across workflow `run:` blocks. `${{ }}` expressions are expanded by GitHub Actions before the shell executes — if the expanded value contains shell metacharacters, they execute as commands. All affected workflows already define `VERSION` at workflow-level `env:`, so the fix is mechanical: reference the shell variable instead of the YAML expression.

Validated against all 173 existing release tags — zero false positives on the version regex.

## Verification

```
actionlint                     # No new errors (only pre-existing runner-label + shellcheck)
zizmor template-injection      # 44 → 6 errors (remaining 6 are setup-toolchain boolean inputs — accepted risk)
```

## Test plan

- [ ] Verify `actionlint` passes with no new errors
- [ ] Verify `zizmor` template-injection error count drops from 44 to 6
- [ ] Trigger `prepare-release` with a test version to confirm `$VERSION` resolves correctly
- [ ] Review that no `${{ inputs.version }}` remains in any `run:` block in modified files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remediates template injection in `workflow_dispatch` workflows by switching from `${{ }}` expansions in `run:` blocks to shell variables and adding version format validation. Reduces command injection risk and standardizes version handling across release pipelines.

- **Bug Fixes**
  - Replaced `${{ inputs.* }}`/`${{ env.* }}` in `run:` with shell vars (e.g., `$VERSION`, `$REGISTRY_IMAGE`) and proper quoting.
  - Added version regex validation to `prepare-release`, `release`, `sdk_publish`, and `default_image_publish`.
  - Moved `matrix`/input values to step `env` (`PLATFORM`, `ARCH`, `PUSH_LATEST`); removed redundant `VERSION=...` inline assignments.
  - Updated tag, manifest, and asset upload commands to use shell vars; reduced `zizmor` template-injection findings from 44 to 6 (remaining booleans are accepted).

<sup>Written for commit 309eb35eea2b0bb8db71ace4afd4f4506c76b7a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

