### PR TITLE
Redact SSH access tokens from gateway logs

### DIFF
--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -109,7 +109,7 @@ func main() {
 
 	log.Printf("Host key loaded from SSH_HOST_KEY environment variable (base64 decoded)")
 	log.Printf("Private key loaded from SSH_PRIVATE_KEY environment variable (base64 decoded)")
-	log.Printf("Public key generated: %s", string(ssh.MarshalAuthorizedKey(publicKey)))
+	log.Printf("Public key generated successfully")
 
 	log.Printf("Starting SSH Gateway on port %d", port)
 	if err := gateway.Start(); err != nil {
@@ -174,7 +174,7 @@ func (g *SSHGateway) handleConnection(conn net.Conn, serverConfig *ssh.ServerCon
 		return
 	}
 
-	log.Printf("Validating token: %s", token)
+	log.Printf("Validating token: ...%s", token[len(token)-4:])
 
 	// Validate the token using the API
 	validation, _, err := g.apiClient.SandboxAPI.ValidateSshAccess(context.Background()).Token(token).Execute()
@@ -185,7 +185,7 @@ func (g *SSHGateway) handleConnection(conn net.Conn, serverConfig *ssh.ServerCon
 	}
 
 	if !validation.Valid {
-		log.Printf("Invalid token: %s", token)
+		log.Printf("Invalid token: ...%s", token[len(token)-4:])
 		conn.Close()
 		return
 	}


### PR DESCRIPTION
## Summary
- Truncate SSH access tokens to last 4 characters in log output (tokens have up to 60-min validity and were logged in full plaintext)
- Remove public key material from startup logs

## Test plan
- [ ] Verify SSH gateway builds and starts
- [ ] Confirm log output shows `Validating token: ...xxxx` instead of full token
- [ ] Confirm startup log shows `Public key generated successfully` without key material

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redact SSH access tokens in SSH gateway logs by showing only the last 4 characters in validation and error messages. Remove public key material from startup logs and replace it with a generic success message to avoid leaking credentials.

<sup>Written for commit 7c242ecefe2be0c4286f547cff74e178c4bc64be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

