### PR TITLE
fix(ssh-gateway): remove sensitive tokens from log output

### DIFF
--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -109,7 +109,7 @@ func main() {
 
 	log.Printf("Host key loaded from SSH_HOST_KEY environment variable (base64 decoded)")
 	log.Printf("Private key loaded from SSH_PRIVATE_KEY environment variable (base64 decoded)")
-	log.Printf("Public key generated: %s", string(ssh.MarshalAuthorizedKey(publicKey)))
+	log.Printf("Public key generated successfully")
 
 	log.Printf("Starting SSH Gateway on port %d", port)
 	if err := gateway.Start(); err != nil {
@@ -174,8 +174,6 @@ func (g *SSHGateway) handleConnection(conn net.Conn, serverConfig *ssh.ServerCon
 		return
 	}
 
-	log.Printf("Validating token: %s", token)
-
 	// Validate the token using the API
 	validation, _, err := g.apiClient.SandboxAPI.ValidateSshAccess(context.Background()).Token(token).Execute()
 	if err != nil {
@@ -185,7 +183,7 @@ func (g *SSHGateway) handleConnection(conn net.Conn, serverConfig *ssh.ServerCon
 	}
 
 	if !validation.Valid {
-		log.Printf("Invalid token: %s", token)
+		log.Printf("Invalid token provided")
 		conn.Close()
 		return
 	}


### PR DESCRIPTION
## Summary
- Remove SSH access token values from log statements to prevent credential exposure in centralized logging
- Replace full public key logging at startup with confirmation message

## Test plan
- [ ] Verify SSH gateway builds and starts
- [ ] Confirm token values no longer appear in logs on connection attempts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove sensitive SSH token values and public key material from `ssh-gateway` logs, replacing them with generic messages to prevent credential exposure.

<sup>Written for commit b191832617189b44d395ae14e683330c63ccdd6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

