### PR TITLE
fix(api): undefined reading id on snapshot remove event

### DIFF
--- a/apps/api/src/sandbox/subscribers/snapshot.subscriber.ts
+++ b/apps/api/src/sandbox/subscribers/snapshot.subscriber.ts
@@ -42,6 +42,9 @@ export class SnapshotSubscriber implements EntitySubscriberInterface<Snapshot> {
   }
 
   beforeRemove(event: RemoveEvent<Snapshot>) {
+    if (!event.databaseEntity) {
+      return
+    }
     this.eventEmitter.emit(SnapshotEvents.REMOVED, new SnapshotRemovedEvent(event.databaseEntity as Snapshot))
   }
 }


### PR DESCRIPTION
## Description

Adds a handler for:

```
[14:34:22.630] ERROR: Cannot read properties of undefined (reading 'id') {"trace_id":"<redacted>","span_id":"<redacted>","trace_flags":"01","context":"Event"}
    err: {
      "type": "Error",
      "message": "Cannot read properties of undefined (reading 'id')",
      "stack":
          TypeError: Cannot read properties of undefined (reading 'id')
              at Function.fromSnapshot (/home/ubuntu/daytona/dist/apps/api/webpack:/apps/api/src/sandbox/dto/snapshot.dto.ts:97:20)
              at NotificationService.handleSnapshotRemoved (/home/ubuntu/daytona/dist/apps/api/webpack:/apps/api/src/notification/services/notification.service.ts:77:29)
              at EventSubscribersLoader.wrapFunctionInTryCatchBlocks (/home/ubuntu/daytona/node_modules/@nestjs/event-emitter/lib/event-subscribers.loader.ts:190:40)
              at EventEmitter.<anonymous> (/home/ubuntu/daytona/node_modules/@nestjs/event-emitter/lib/event-subscribers.loader.ts:103:18)
              at EventEmitter.emit (/home/ubuntu/daytona/node_modules/@nestjs/event-emitter/node_modules/eventemitter2/lib/eventemitter2.js:1041:22)
              at SnapshotSubscriber.beforeRemove (/home/ubuntu/daytona/dist/apps/api/webpack:/apps/api/src/sandbox/subscribers/snapshot.subscriber.ts:45:23)
              at /home/ubuntu/daytona/src/subscriber/Broadcaster.ts:246:56
              at Array.forEach (<anonymous>)
              at Broadcaster.broadcastBeforeRemoveEvent (/home/ubuntu/daytona/src/subscriber/Broadcaster.ts:241:53)
              at /home/ubuntu/daytona/src/persistence/SubjectExecutor.ts:259:46
    }
```

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent TypeError when removing a snapshot by returning early if `event.databaseEntity` is missing in `SnapshotSubscriber.beforeRemove`. Stops emitting `SnapshotEvents.REMOVED` with undefined data and eliminates "Cannot read properties of undefined (reading 'id')" errors.

<sup>Written for commit 6b95b1068b54e94db8950bcef1d142517ee0979e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

