### PR TITLE
fix(api): uuid parsing 500 on snapshot actions

### DIFF
--- a/apps/api/src/sandbox/controllers/snapshot.controller.ts
+++ b/apps/api/src/sandbox/controllers/snapshot.controller.ts
@@ -22,6 +22,7 @@ import {
   RawBodyRequest,
   Next,
   ParseBoolPipe,
+  ParseUUIDPipe,
 } from '@nestjs/common'
 import { IncomingMessage, ServerResponse } from 'http'
 import { NextFunction } from 'express'
@@ -208,7 +209,7 @@ export class SnapshotController {
     targetType: AuditTarget.SNAPSHOT,
     targetIdFromRequest: (req) => req.params.id,
   })
-  async removeSnapshot(@Param('id') snapshotId: string): Promise<void> {
+  async removeSnapshot(@Param('id', ParseUUIDPipe) snapshotId: string): Promise<void> {
     await this.snapshotService.removeSnapshot(snapshotId)
   }
 
@@ -270,7 +271,7 @@ export class SnapshotController {
     },
   })
   async setSnapshotGeneralStatus(
-    @Param('id') snapshotId: string,
+    @Param('id', ParseUUIDPipe) snapshotId: string,
     @Body() dto: SetSnapshotGeneralStatusDto,
   ): Promise<SnapshotDto> {
     const snapshot = await this.snapshotService.setSnapshotGeneralStatus(snapshotId, dto.general)
@@ -415,7 +416,7 @@ export class SnapshotController {
     targetIdFromRequest: (req) => req.params.id,
   })
   async activateSnapshot(
-    @Param('id') snapshotId: string,
+    @Param('id', ParseUUIDPipe) snapshotId: string,
     @AuthContext() authContext: OrganizationAuthContext,
   ): Promise<SnapshotDto> {
     const snapshot = await this.snapshotService.activateSnapshot(snapshotId, authContext.organization)
@@ -443,7 +444,7 @@ export class SnapshotController {
     targetType: AuditTarget.SNAPSHOT,
     targetIdFromRequest: (req) => req.params.id,
   })
-  async deactivateSnapshot(@Param('id') snapshotId: string) {
+  async deactivateSnapshot(@Param('id', ParseUUIDPipe) snapshotId: string) {
     await this.snapshotService.deactivateSnapshot(snapshotId)
   }
 }


### PR DESCRIPTION
## Description

Fixes uuid parsing 500 response on snapshot delete by name where snapshot name exists for user

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500 errors on snapshot actions when a non-UUID `id` is provided by validating the path param and returning 400 Bad Request instead of crashing.

- **Bug Fixes**
  - Validate `id` with Nest’s ParseUUIDPipe on removeSnapshot, setSnapshotGeneralStatus, activateSnapshot, and deactivateSnapshot.
  - Invalid UUIDs now return 400 Bad Request.

<sup>Written for commit 6da47c4105b3639116b350cec1ec921e146478fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

