### PR TITLE
refactor(api): sandbox state in progress response

### DIFF
--- a/apps/api/src/exceptions/state-change-in-progress.exception.ts
+++ b/apps/api/src/exceptions/state-change-in-progress.exception.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpException, HttpStatus } from '@nestjs/common'
+
+export class StateChangeInProgressError extends HttpException {
+  constructor(message = 'Sandbox state change in progress') {
+    super(message, HttpStatus.CONFLICT)
+  }
+}

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -14,6 +14,7 @@ import { SandboxClass } from '../enums/sandbox-class.enum'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { RunnerService } from './runner.service'
 import { SandboxError } from '../../exceptions/sandbox-error.exception'
+import { StateChangeInProgressError } from '../../exceptions/state-change-in-progress.exception'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { BackupState } from '../enums/backup-state.enum'
@@ -272,7 +273,7 @@ export class SandboxService {
     this.assertSandboxNotErrored(sandbox)
 
     if (String(sandbox.state) !== String(sandbox.desiredState)) {
-      throw new SandboxError('State change in progress')
+      throw new StateChangeInProgressError()
     }
 
     if (sandbox.state !== SandboxState.STOPPED) {
@@ -280,7 +281,7 @@ export class SandboxService {
     }
 
     if (sandbox.pending) {
-      throw new SandboxError('Sandbox state change in progress')
+      throw new StateChangeInProgressError()
     }
 
     if (sandbox.autoDeleteInterval === 0) {
@@ -1236,7 +1237,7 @@ export class SandboxService {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organizationId)
 
     if (sandbox.pending && sandbox.state !== SandboxState.PENDING_BUILD) {
-      throw new SandboxError('Sandbox state change in progress')
+      throw new StateChangeInProgressError()
     }
 
     const updateData = Sandbox.getSoftDeleteUpdate(sandbox)
@@ -1275,7 +1276,7 @@ export class SandboxService {
           sandbox.desiredState !== SandboxDesiredState.ARCHIVED ||
           (sandbox.state !== SandboxState.STOPPED && sandbox.state !== SandboxState.ARCHIVING)
         ) {
-          throw new SandboxError('State change in progress')
+          throw new StateChangeInProgressError()
         }
       }
 
@@ -1284,7 +1285,7 @@ export class SandboxService {
       }
 
       if (sandbox.pending) {
-        throw new SandboxError('Sandbox state change in progress')
+        throw new StateChangeInProgressError()
       }
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
@@ -1334,7 +1335,7 @@ export class SandboxService {
     this.assertSandboxNotErrored(sandbox)
 
     if (String(sandbox.state) !== String(sandbox.desiredState)) {
-      throw new SandboxError('State change in progress')
+      throw new StateChangeInProgressError()
     }
 
     if (sandbox.state !== SandboxState.STARTED) {
@@ -1342,7 +1343,7 @@ export class SandboxService {
     }
 
     if (sandbox.pending) {
-      throw new SandboxError('Sandbox state change in progress')
+      throw new StateChangeInProgressError()
     }
 
     const updateData: Partial<Sandbox> = {
@@ -1372,7 +1373,7 @@ export class SandboxService {
     }
 
     if (sandbox.pending) {
-      throw new SandboxError('Sandbox state change in progress')
+      throw new StateChangeInProgressError()
     }
 
     // Validate runner exists
@@ -1436,7 +1437,7 @@ export class SandboxService {
       }
 
       if (sandbox.pending) {
-        throw new SandboxError('Sandbox state change in progress')
+        throw new StateChangeInProgressError()
       }
 
       // If no resize parameters provided, throw error


### PR DESCRIPTION
## Description

Moves "Sandbox state change in progress" error to a separate file and changes it from bad request 400 to conflict 409

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch sandbox “state change in progress” responses to a dedicated `StateChangeInProgressError` that returns HTTP 409 Conflict instead of 400, and move the logic into its own exception class.

- **Refactors**
  - Added `StateChangeInProgressError` (409 Conflict) in `exceptions/state-change-in-progress.exception.ts`.
  - Replaced `SandboxError` with the new exception in `SandboxService` for in-progress state transitions.

- **Migration**
  - Update clients to handle 409 Conflict for in-progress sandbox state changes (was 400).

<sup>Written for commit 7acc1e97f62e4a03322db79c274cfb6e5385ea5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

