### PR TITLE
zero-downtime runner reload handling

### DIFF
--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -237,6 +238,9 @@ func run() int {
 		return 2
 	}
 
+	var executorService *executor.Executor
+	var pollerDone chan struct{}
+
 	if cfg.ApiVersion == 2 {
 		healthcheckService, err := healthcheck.NewService(&healthcheck.HealthcheckServiceConfig{
 			Interval:   cfg.HealthcheckInterval,
@@ -259,7 +263,7 @@ func run() int {
 			healthcheckService.Start(ctx)
 		}()
 
-		executorService, err := executor.NewExecutor(&executor.ExecutorConfig{
+		executorService, err = executor.NewExecutor(&executor.ExecutorConfig{
 			Logger:    logger,
 			Docker:    dockerClient,
 			Collector: metricsCollector,
@@ -280,9 +284,11 @@ func run() int {
 			return 2
 		}
 
+		pollerDone = make(chan struct{})
 		go func() {
 			logger.Info("Starting poller service")
 			pollerService.Start(ctx)
+			close(pollerDone)
 		}()
 	}
 
@@ -312,8 +318,59 @@ func run() int {
 		return 1
 	case <-interruptChannel:
 		logger.Info("Signal received, shutting down")
+		// Release the ports immediately so a new runner instance can
+		// bind during zero-downtime deploy.
 		apiServer.Stop()
-		logger.Info("Shutdown complete")
+		if sshGatewayService != nil {
+			sshGatewayService.Stop()
+		}
+		// Cancel context to stop the poller and other background services
+		cancel()
+
+		shutdownTimeout := 5 * time.Minute
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer shutdownCancel()
+
+		// Drain poller, in-flight HTTP requests and jobs in parallel.
+		done := make(chan struct{})
+		go func() {
+			// Wait for the poller to fully stop so no new jobs are
+			// submitted before we drain in-flight work.
+			if pollerDone != nil {
+				<-pollerDone
+			}
+
+			var wg sync.WaitGroup
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				logger.Info("Waiting for in-flight HTTP requests to complete")
+				apiServer.Shutdown(shutdownCtx)
+				logger.Info("All HTTP requests completed")
+			}()
+
+			if executorService != nil {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					logger.Info("Waiting for in-flight jobs to complete")
+					executorService.Wait()
+					logger.Info("All jobs completed")
+				}()
+			}
+
+			wg.Wait()
+			close(done)
+		}()
+
+		// A second signal during drain forces immediate exit.
+		select {
+		case <-done:
+			logger.Info("Shutdown complete")
+		case <-interruptChannel:
+			logger.Info("Second signal received, forcing shutdown")
+		}
 		return 143 // SIGTERM
 	case err := <-monitorErrChan:
 		logger.Error("Docker monitor error", "error", err)

--- a/apps/runner/go.mod
+++ b/apps/runner/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.49.0
+	golang.org/x/sys v0.42.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -149,7 +150,6 @@ require (
 	golang.org/x/arch v0.20.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect

--- a/apps/runner/pkg/api/server.go
+++ b/apps/runner/pkg/api/server.go
@@ -20,7 +20,10 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"time"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/daytonaio/runner/cmd/runner/config"
 	"github.com/daytonaio/runner/internal"
@@ -72,6 +75,8 @@ type ApiServer struct {
 	tlsKeyFile  string
 	enableTLS   bool
 	httpServer  *http.Server
+	listener    net.Listener
+	mu          sync.Mutex
 	router      *gin.Engine
 	logRequests bool
 }
@@ -81,11 +86,6 @@ func (a *ApiServer) Start(ctx context.Context) error {
 	docs.SwaggerInfo.Title = "Daytona Runner API"
 	docs.SwaggerInfo.BasePath = "/"
 	docs.SwaggerInfo.Version = internal.Version
-
-	_, err := net.Dial("tcp", fmt.Sprintf(":%d", a.apiPort))
-	if err == nil {
-		return fmt.Errorf("cannot start API server, port %d is already in use", a.apiPort)
-	}
 
 	binding.Validator = new(DefaultValidator)
 
@@ -164,7 +164,20 @@ func (a *ApiServer) Start(ctx context.Context) error {
 		Handler: a.router,
 	}
 
-	listener, err := net.Listen("tcp", a.httpServer.Addr)
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var setsockoptErr error
+			err := c.Control(func(fd uintptr) {
+				setsockoptErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+			})
+			if err != nil {
+				return err
+			}
+			return setsockoptErr
+		},
+	}
+	var err error
+	a.listener, err = lc.Listen(ctx, "tcp", a.httpServer.Addr)
 	if err != nil {
 		return err
 	}
@@ -173,19 +186,34 @@ func (a *ApiServer) Start(ctx context.Context) error {
 	go func() {
 		if a.enableTLS {
 			// Start HTTPS server
-			errChan <- a.httpServer.ServeTLS(listener, a.tlsCertFile, a.tlsKeyFile)
+			errChan <- a.httpServer.ServeTLS(a.listener, a.tlsCertFile, a.tlsKeyFile)
 		} else {
 			// Start HTTP server
-			errChan <- a.httpServer.Serve(listener)
+			errChan <- a.httpServer.Serve(a.listener)
 		}
 	}()
 
 	return <-errChan
 }
 
+// Stop closes the listener to release the port immediately, allowing a new
+// runner instance to bind during zero-downtime deploy. In-flight requests
+// continue to be served until Shutdown is called.
 func (a *ApiServer) Stop() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.listener != nil {
+		a.listener.Close()
+		a.listener = nil
+	}
+}
+
+// Shutdown gracefully drains in-flight HTTP requests. The provided context
+// controls how long to wait before forcefully closing connections.
+func (a *ApiServer) Shutdown(ctx context.Context) {
+	if a.httpServer == nil {
+		return
+	}
 	if err := a.httpServer.Shutdown(ctx); err != nil {
 		a.logger.Error("Failed to shutdown API server", "error", err)
 	}

--- a/apps/runner/pkg/runner/v2/executor/executor.go
+++ b/apps/runner/pkg/runner/v2/executor/executor.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -37,6 +38,7 @@ type Executor struct {
 	client    *apiclient.APIClient
 	docker    *docker.DockerClient
 	collector *metrics.Collector
+	wg        sync.WaitGroup
 }
 
 // NewExecutor creates a new job executor
@@ -54,8 +56,26 @@ func NewExecutor(cfg *ExecutorConfig) (*Executor, error) {
 	}, nil
 }
 
-// Execute processes a job and updates its status
+// Wait blocks until all in-flight jobs have completed.
+func (e *Executor) Wait() {
+	e.wg.Wait()
+}
+
+// Execute spawns a goroutine to process a job. The WaitGroup counter is
+// incremented synchronously so that Wait cannot return before the job
+// goroutine is scheduled.
 func (e *Executor) Execute(ctx context.Context, job *apiclient.Job) {
+	e.wg.Add(1)
+	go e.execute(ctx, job)
+}
+
+func (e *Executor) execute(ctx context.Context, job *apiclient.Job) {
+	defer e.wg.Done()
+
+	// Detach from the parent context so that cancellation (e.g. SIGTERM)
+	// does not abort running jobs.
+	ctx = context.WithoutCancel(ctx)
+
 	// Extract trace context from job to continue distributed trace
 	ctx = e.extractTraceContext(ctx, job)
 

--- a/apps/runner/pkg/runner/v2/poller/poller.go
+++ b/apps/runner/pkg/runner/v2/poller/poller.go
@@ -58,7 +58,7 @@ func (s *Service) Start(ctx context.Context) {
 		if inProgressJobs != nil && len(inProgressJobs.Items) > 0 {
 			s.log.InfoContext(ctx, "Found IN_PROGRESS jobs", "count", len(inProgressJobs.Items))
 			for _, job := range inProgressJobs.Items {
-				go s.executor.Execute(ctx, &job)
+				s.executor.Execute(ctx, &job)
 			}
 		} else {
 			s.log.InfoContext(ctx, "No IN_PROGRESS jobs found")
@@ -86,8 +86,8 @@ func (s *Service) Start(ctx context.Context) {
 			if len(jobs) > 0 {
 				s.log.DebugContext(ctx, "Received jobs", "count", len(jobs))
 				for _, job := range jobs {
-					// Execute job in goroutine for parallel processing
-					go s.executor.Execute(ctx, &job)
+					// Execute job via executor (runs asynchronously for parallel processing)
+					s.executor.Execute(ctx, &job)
 				}
 			}
 		}

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -10,16 +10,21 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/daytonaio/runner/pkg/docker"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sys/unix"
 )
 
 type Service struct {
 	log          *slog.Logger
 	dockerClient *docker.DockerClient
 	port         int
+	listener     net.Listener
+	mu           sync.Mutex
 }
 
 func NewService(logger *slog.Logger, dockerClient *docker.DockerClient) *Service {
@@ -81,27 +86,67 @@ func (s *Service) Start(ctx context.Context) error {
 
 	serverConfig.AddHostKey(hostKey)
 
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var setsockoptErr error
+			err := c.Control(func(fd uintptr) {
+				setsockoptErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+			})
+			if err != nil {
+				return err
+			}
+			return setsockoptErr
+		},
+	}
+
+	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", s.port))
 	if err != nil {
 		return fmt.Errorf("failed to listen on port %d: %w", s.port, err)
 	}
+
+	s.mu.Lock()
+	s.listener = listener
+	s.mu.Unlock()
+
 	defer listener.Close()
 
 	s.log.InfoContext(ctx, "SSH Gateway listening on port", "port", s.port)
 
 	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-			conn, err := listener.Accept()
-			if err != nil {
-				s.log.WarnContext(ctx, "Failed to accept incoming connection", "error", err)
-				continue
+		conn, err := listener.Accept()
+		if err != nil {
+			// Listener was closed via Stop() or context cancelled — clean exit.
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
 			}
 
-			go s.handleConnection(conn, serverConfig)
+			s.mu.Lock()
+			stopped := s.listener == nil
+			s.mu.Unlock()
+			if stopped {
+				return nil
+			}
+
+			// Transient error (e.g. EMFILE) — log and retry.
+			s.log.WarnContext(ctx, "Failed to accept incoming connection", "error", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
 		}
+
+		go s.handleConnection(conn, serverConfig)
+	}
+}
+
+// Stop closes the listener so the port is released immediately,
+// allowing a new runner instance to bind during zero-downtime deploy.
+func (s *Service) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.listener != nil {
+		s.listener.Close()
+		s.listener = nil
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables zero-downtime runner reloads by releasing API/SSH ports immediately and draining HTTP requests and jobs on SIGTERM. New instances can bind right away while the old one finishes work.

- **New Features**
  - API server and SSH gateway bind with `SO_REUSEPORT`; `Stop` closes listeners to free ports, `Shutdown` drains in-flight HTTP with a caller-provided context.
  - On SIGTERM: stop accepting HTTP/SSH, cancel background services, wait for the poller to exit, then drain HTTP and jobs in parallel with a 5m timeout; a second SIGTERM forces exit.
  - Executor tracks jobs via a `WaitGroup`; `Execute` runs work in its own goroutine with a detached context; the poller calls `Execute` directly so all jobs are tracked.

- **Dependencies**
  - Add direct `golang.org/x/sys` for socket options.

<sup>Written for commit 8490ffdcf8036c019bfa0cc145ccfc5e11ed02a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

