### PR TITLE
feat(docs): add auto-stop behavior and update lifecycle state references

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1209,13 +1209,13 @@ The inactivity timer resets only for specific external interactions:
 - Updates to [sandbox lifecycle states](#sandbox-lifecycle)
 - Network requests through [sandbox previews](/docs/en/preview)
 - Active [SSH connections](/docs/en/ssh-access)
-- API calls to the [Daytona Toolbox SDK](/docs/en/tools/api/#daytona-toolbox)
+- API requests to the [Daytona Toolbox SDK](/docs/en/tools/api/#daytona-toolbox)
 
 #### What does not reset the timer
 
 The following do not reset the timer:
 
-- SDK calls that are not toolbox actions
+- SDK requests that are not toolbox actions
 - Background scripts (e.g., `npm run dev` run as a fire-and-forget command)
 - Long-running tasks without external interaction
 - Processes that don't involve active monitoring


### PR DESCRIPTION
## Description

Documents new auto-stop behavior and updates lifecycle state references.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies sandbox auto-stop behavior and what does vs doesn’t reset the inactivity timer. Adds in-page anchors, notes that lifecycle state updates, preview URL requests, and API requests to the Daytona Toolbox SDK reset the timer, and reiterates that internal processes alone won’t keep a sandbox running; minor wording tweaks for consistency.

<sup>Written for commit ed287058afbd5fbf2852bbe82a61ae8e47ad3b82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

