### PR TITLE
fix(proxy): hanging connections timeout variable

### DIFF
--- a/apps/proxy/cmd/proxy/config/config.go
+++ b/apps/proxy/cmd/proxy/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	ToolboxOnlyMode       bool               `envconfig:"TOOLBOX_ONLY_MODE"`
 	PreviewWarningEnabled bool               `envconfig:"PREVIEW_WARNING_ENABLED"`
 	ShutdownTimeoutSec    int                `envconfig:"SHUTDOWN_TIMEOUT_SEC"`
+	ApiClientTimeoutSec   int                `envconfig:"API_CLIENT_TIMEOUT_SEC"`
 	ApiClient             *apiclient.APIClient
 }
 
@@ -80,6 +81,10 @@ func GetConfig() (*Config, error) {
 		config.ShutdownTimeoutSec = 60 * 60 // default to 1 hour
 	}
 
+	if config.ApiClientTimeoutSec == 0 {
+		config.ApiClientTimeoutSec = 60
+	}
+
 	if config.Redis != nil {
 		if config.Redis.Host == nil || *config.Redis.Host == "" {
 			config.Redis = nil
@@ -99,6 +104,7 @@ func GetConfig() (*Config, error) {
 
 	config.ApiClient.GetConfig().HTTPClient = &http.Client{
 		Transport: http.DefaultTransport,
+		Timeout:   time.Duration(config.ApiClientTimeoutSec) * time.Second,
 	}
 
 	ctx := context.Background()

--- a/apps/proxy/pkg/proxy/auth_callback.go
+++ b/apps/proxy/pkg/proxy/auth_callback.go
@@ -217,6 +217,7 @@ func (p *Proxy) getUserApiClient(ctx context.Context, authToken string) *apiclie
 			URL: p.config.DaytonaApiUrl,
 		},
 	}
+	clientConfig.HTTPClient = p.userAPIHTTPClient
 	clientConfig.AddDefaultHeader("Authorization", "Bearer "+authToken)
 	if ginCtx, ok := ctx.(*gin.Context); ok {
 		clientConfig.AddDefaultHeader("X-Forwarded-For", ginCtx.ClientIP())

--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -305,36 +305,11 @@ func (p *Proxy) parseHost(host string) (targetPort string, sandboxIdOrSignedToke
 // updateLastActivity updates the last activity timestamp for a sandbox.
 // If shouldPollUpdate is true, it starts a goroutine that updates every 50 seconds.
 func (p *Proxy) updateLastActivity(ctx context.Context, sandboxId string, shouldPollUpdate bool, doneCh chan struct{}) {
-	// Prevent frequent updates by caching the last update
-	cached, err := p.sandboxLastActivityUpdateCache.Has(ctx, sandboxId)
-	if err != nil {
-		// If cache doesn't work, skip the update to avoid spamming the API
-		log.Errorf("failed to check last activity update cache for sandbox %s: %v", sandboxId, err)
-		return
-	}
-
-	// Poll interval is 50 seconds to avoid spamming the API which will also cache updates for 45 seconds
 	pollInterval := 50 * time.Second
 
-	if !cached {
-		_, err := p.apiclient.SandboxAPI.UpdateLastActivity(ctx, sandboxId).Execute()
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return
-			}
-			log.Errorf("failed to update last activity for sandbox %s: %v", sandboxId, err)
-			return
-		}
-
-		// Expire a bit before the poll interval to avoid skipping one interval
-		err = p.sandboxLastActivityUpdateCache.Set(ctx, sandboxId, true, pollInterval-5*time.Second)
-		if err != nil {
-			log.Errorf("failed to set last activity update cache for sandbox %s: %v", sandboxId, err)
-		}
-	}
+	p.doActivityUpdate(ctx, sandboxId, pollInterval)
 
 	if shouldPollUpdate {
-		// Update keep alive every pollInterval until stopped
 		go func() {
 			ticker := time.NewTicker(pollInterval)
 			defer ticker.Stop()
@@ -342,12 +317,52 @@ func (p *Proxy) updateLastActivity(ctx context.Context, sandboxId string, should
 			for {
 				select {
 				case <-ticker.C:
-					p.updateLastActivity(context.WithoutCancel(ctx), sandboxId, false, doneCh)
+					tickCtx, cancel := context.WithTimeout(context.Background(), time.Duration(p.config.ApiClientTimeoutSec)*time.Second)
+					done := make(chan struct{})
+					go func() {
+						defer close(done)
+						p.doActivityUpdate(tickCtx, sandboxId, pollInterval)
+					}()
+					select {
+					case <-done:
+						cancel()
+					case <-doneCh:
+						cancel()
+						return
+					}
 				case <-doneCh:
 					return
 				}
 			}
 		}()
+	}
+}
+
+func (p *Proxy) doActivityUpdate(ctx context.Context, sandboxId string, pollInterval time.Duration) {
+	cacheCtx := context.WithoutCancel(ctx)
+
+	cached, err := p.sandboxLastActivityUpdateCache.Has(cacheCtx, sandboxId)
+	if err != nil {
+		log.Errorf("failed to check last activity update cache for sandbox %s: %v", sandboxId, err)
+		return
+	}
+
+	if cached {
+		return
+	}
+
+	_, err = p.apiclient.SandboxAPI.UpdateLastActivity(ctx, sandboxId).Execute()
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		log.Errorf("failed to update last activity for sandbox %s: %v", sandboxId, err)
+		return
+	}
+
+	err = p.sandboxLastActivityUpdateCache.Set(cacheCtx, sandboxId, true, pollInterval-5*time.Second)
+	if err != nil {
+		log.Errorf("failed to set last activity update cache for sandbox %s: %v", sandboxId, err)
 	}
 }
 

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -61,6 +61,7 @@ type Proxy struct {
 	cookieDomain *string
 
 	apiclient                      *apiclient.APIClient
+	userAPIHTTPClient              *http.Client
 	runnerCache                    common_cache.ICache[RunnerInfo]
 	sandboxRunnerCache             common_cache.ICache[RunnerInfo]
 	sandboxPublicCache             common_cache.ICache[bool]
@@ -80,6 +81,10 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 	}
 
 	proxy.apiclient = config.ApiClient
+	proxy.userAPIHTTPClient = &http.Client{
+		Transport: http.DefaultTransport,
+		Timeout:   time.Duration(config.ApiClientTimeoutSec) * time.Second,
+	}
 
 	if config.Redis != nil {
 		var err error

--- a/libs/common-go/go.mod
+++ b/libs/common-go/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/redis/go-redis/v9 v9.10.0
+	github.com/sirupsen/logrus v1.9.3
 	go.opentelemetry.io/contrib/bridges/otelslog v0.13.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.64.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.64.0

--- a/libs/common-go/go.sum
+++ b/libs/common-go/go.sum
@@ -89,6 +89,7 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.25.12 h1:e7PvW/0RmJ8p8vPGJH4jvNkOyLmbkXgXW4m6ZPic6CY=
 github.com/shirou/gopsutil/v4 v4.25.12/go.mod h1:EivAfP5x2EhLp2ovdpKSozecVXn1TmuG7SMzs/Wh4PU=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -8,17 +8,43 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 var proxyTransport = &http.Transport{
 	MaxIdleConns:        100,
 	MaxIdleConnsPerHost: 100,
+	TLSHandshakeTimeout: 10 * time.Second,
 	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}).DialContext,
+}
+
+var proxyBufPool = &bufferPool{
+	pool: sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 32*1024)
+			return &b
+		},
+	},
+}
+
+type bufferPool struct {
+	pool sync.Pool
+}
+
+func (bp *bufferPool) Get() []byte {
+	buf := bp.pool.Get().(*[]byte)
+	return *buf
+}
+
+func (bp *bufferPool) Put(b []byte) {
+	bp.pool.Put(&b)
 }
 
 // ProxyRequest handles proxying requests to a sandbox's container
@@ -64,7 +90,14 @@ func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.UR
 				}
 			},
 			Transport:      proxyTransport,
+			BufferPool:     proxyBufPool,
 			ModifyResponse: modifyResponse,
+			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+				log.Warnf("proxy error for %s%s: %v", r.Host, r.URL.Path, err)
+				if !ctx.IsAborted() {
+					ctx.AbortWithStatus(http.StatusBadGateway)
+				}
+			},
 		}
 
 		reverseProxy.ServeHTTP(ctx.Writer, ctx.Request)


### PR DESCRIPTION
## Description

Adds handlers on the proxy for hanging connections and context cancels during last activity updates
Also adds a buffer pool for recycling allocations instead of allocating a new fresh batch each request

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hanging proxy connections by enforcing request timeouts and adding a proper error handler. Makes sandbox last-activity updates resilient to cancellations and reduces proxy memory allocations.

- **Bug Fixes**
  - Add `API_CLIENT_TIMEOUT_SEC` (default 60s) and apply it to both the global and per-user API clients.
  - Make sandbox last-activity updates timeout-bound and cancellable; polling stops cleanly on `doneCh`.
  - Return 502 on reverse-proxy transport errors instead of hanging.

- **Refactors**
  - Extract `doActivityUpdate` and use a non-cancelled cache context to prevent missed cache writes.
  - Add a shared `BufferPool` for `httputil.ReverseProxy` and tune `http.Transport` timeouts (TLS handshake and dial) to reduce leaks and allocations.

<sup>Written for commit 7d83cf1c65f53f1f148395ea5b806b98027cfbd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

