### PR TITLE
feat(docs): add markdown content negotiation

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -26,7 +26,8 @@ export default defineConfig({
   integrations: [
     react(),
     starlight({
-      title: 'Daytona',
+      prerender: false,
+      pagefind: false,
       favicon: '/favicon.ico',
       social: [
         {

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -26,6 +26,7 @@ export default defineConfig({
   integrations: [
     react(),
     starlight({
+      title: 'Daytona',
       prerender: false,
       pagefind: false,
       favicon: '/favicon.ico',

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -1,5 +1,11 @@
 import { defineMiddleware } from 'astro:middleware'
 
+import {
+  loadDocsMarkdownBody,
+  parseDocsContentPath,
+  preferredMarkdownPlainFormat,
+  shouldTryMarkdownPath,
+} from './utils/acceptMarkdownNegotiation'
 import { redirects } from './utils/redirects'
 
 function filterProxyHeaders(headers: Headers): Headers {

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -88,9 +88,10 @@ export const onRequest = defineMiddleware(
     }
 
     if (path === '/docs') {
-      const targetUrl = new URL('/docs/en', url)
+      const target = url.pathname.endsWith('/') ? '/docs/en/' : '/docs/en'
+      const targetUrl = new URL(target, url)
       targetUrl.search = url.search
-      return await proxyRequest(targetUrl)
+      return redirect(targetUrl.pathname + targetUrl.search, 302)
     }
 
     const docsPath = path.match(/^\/docs\/(.+)$/)

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -22,6 +22,25 @@ function filterProxyHeaders(headers: Headers): Headers {
   return filteredHeaders
 }
 
+/** Merge `Accept` into `Vary` so caches do not serve HTML for markdown requests or vice versa. */
+function withVaryAccept(response: Response): Response {
+  const headers = new Headers(response.headers)
+  const existing = headers.get('Vary')
+  if (existing) {
+    const parts = existing.split(',').map(s => s.trim().toLowerCase())
+    if (!parts.includes('accept')) {
+      headers.set('Vary', `${existing}, Accept`)
+    }
+  } else {
+    headers.set('Vary', 'Accept')
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
 export const onRequest = defineMiddleware(
   async ({ request, redirect }, next) => {
     const url = new URL(request.url)
@@ -66,26 +85,47 @@ export const onRequest = defineMiddleware(
       }
     }
 
-    if (path === '/docs') {
-      const targetUrl = new URL('/docs/en', url)
-      targetUrl.search = url.search
-      return await proxyRequest(targetUrl)
-    }
-
-    const docsPath = path.match(/^\/docs\/(.+)$/)
-    if (docsPath) {
-      const slug = docsPath[1]
-      const firstSegment = slug.split('/')[0]
-      const isLocalePrefixed = /^[a-z]{2}$/.test(firstSegment)
-      const looksLikeStaticAsset = /\.[^/]+$/.test(slug)
-
-      if (!isLocalePrefixed && !looksLikeStaticAsset) {
-        const targetUrl = new URL(`/docs/en/${slug}`, url)
-        targetUrl.search = url.search
-        return await proxyRequest(targetUrl)
+    const textFormat = preferredMarkdownPlainFormat(
+      request.headers.get('accept')
+    )
+    if (
+      textFormat &&
+      (request.method === 'GET' || request.method === 'HEAD') &&
+      shouldTryMarkdownPath(url.pathname)
+    ) {
+      const parsed = parseDocsContentPath(url.pathname)
+      if (parsed) {
+        const body = await loadDocsMarkdownBody(parsed)
+        if (body !== null) {
+          const contentType =
+            textFormat === 'plain'
+              ? 'text/plain; charset=utf-8'
+              : 'text/markdown; charset=utf-8'
+          const headers = {
+            'Content-Type': contentType,
+            'Cache-Control': 'public, max-age=300',
+            Vary: 'Accept',
+          } as const
+          if (request.method === 'HEAD') {
+            return new Response(null, { status: 200, headers })
+          }
+          return new Response(body, {
+            status: 200,
+            headers,
+          })
+        }
       }
     }
 
-    return next()
+    const isNegotiableDocsRequest =
+      (request.method === 'GET' || request.method === 'HEAD') &&
+      shouldTryMarkdownPath(url.pathname) &&
+      parseDocsContentPath(url.pathname) !== null
+
+    const response = await next()
+    if (isNegotiableDocsRequest) {
+      return withVaryAccept(response)
+    }
+    return response
   }
 )

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -22,29 +22,13 @@ function filterProxyHeaders(headers: Headers): Headers {
   return filteredHeaders
 }
 
-/** Merge `Accept` into `Vary` so caches do not serve HTML for markdown requests or vice versa. */
-function withVaryAccept(response: Response): Response {
-  const headers = new Headers(response.headers)
-  const existing = headers.get('Vary')
-  if (existing) {
-    const parts = existing.split(',').map(s => s.trim().toLowerCase())
-    if (!parts.includes('accept')) {
-      headers.set('Vary', `${existing}, Accept`)
-    }
-  } else {
-    headers.set('Vary', 'Accept')
-  }
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  })
-}
-
 export const onRequest = defineMiddleware(
   async ({ request, redirect }, next) => {
     const url = new URL(request.url)
     const path = url.pathname.replace(/\/$/, '')
+    const markdownFormat = preferredMarkdownPlainFormat(
+      request.headers.get('accept')
+    )
 
     const proxyRequest = async (targetUrl: URL): Promise<Response> => {
       try {
@@ -71,6 +55,24 @@ export const onRequest = defineMiddleware(
       return next(new Request(new URL('/docs/sitemap-index.xml', url), request))
     }
 
+    if (markdownFormat && shouldTryMarkdownPath(url.pathname)) {
+      const parsed = parseDocsContentPath(url.pathname)
+      if (parsed) {
+        const markdownBody = await loadDocsMarkdownBody(parsed)
+        if (markdownBody !== null) {
+          return new Response(markdownBody, {
+            status: 200,
+            headers: {
+              'content-type':
+                markdownFormat === 'markdown'
+                  ? 'text/markdown; charset=utf-8'
+                  : 'text/plain; charset=utf-8',
+            },
+          })
+        }
+      }
+    }
+
     // Match /docs/old-slug or /docs/{locale}/old-slug
     const match = path.match(/^\/docs(?:\/([a-z]{2}))?\/(.+)$/)
     if (match) {
@@ -85,47 +87,26 @@ export const onRequest = defineMiddleware(
       }
     }
 
-    const textFormat = preferredMarkdownPlainFormat(
-      request.headers.get('accept')
-    )
-    if (
-      textFormat &&
-      (request.method === 'GET' || request.method === 'HEAD') &&
-      shouldTryMarkdownPath(url.pathname)
-    ) {
-      const parsed = parseDocsContentPath(url.pathname)
-      if (parsed) {
-        const body = await loadDocsMarkdownBody(parsed)
-        if (body !== null) {
-          const contentType =
-            textFormat === 'plain'
-              ? 'text/plain; charset=utf-8'
-              : 'text/markdown; charset=utf-8'
-          const headers = {
-            'Content-Type': contentType,
-            'Cache-Control': 'public, max-age=300',
-            Vary: 'Accept',
-          } as const
-          if (request.method === 'HEAD') {
-            return new Response(null, { status: 200, headers })
-          }
-          return new Response(body, {
-            status: 200,
-            headers,
-          })
-        }
+    if (path === '/docs') {
+      const targetUrl = new URL('/docs/en', url)
+      targetUrl.search = url.search
+      return await proxyRequest(targetUrl)
+    }
+
+    const docsPath = path.match(/^\/docs\/(.+)$/)
+    if (docsPath) {
+      const slug = docsPath[1]
+      const firstSegment = slug.split('/')[0]
+      const isLocalePrefixed = /^[a-z]{2}$/.test(firstSegment)
+      const looksLikeStaticAsset = /\.[^/]+$/.test(slug)
+
+      if (!isLocalePrefixed && !looksLikeStaticAsset) {
+        const targetUrl = new URL(`/docs/en/${slug}`, url)
+        targetUrl.search = url.search
+        return await proxyRequest(targetUrl)
       }
     }
 
-    const isNegotiableDocsRequest =
-      (request.method === 'GET' || request.method === 'HEAD') &&
-      shouldTryMarkdownPath(url.pathname) &&
-      parseDocsContentPath(url.pathname) !== null
-
-    const response = await next()
-    if (isNegotiableDocsRequest) {
-      return withVaryAccept(response)
-    }
-    return response
+    return next()
   }
 )

--- a/apps/docs/src/utils/acceptMarkdownNegotiation.ts
+++ b/apps/docs/src/utils/acceptMarkdownNegotiation.ts
@@ -1,0 +1,187 @@
+import fsSync from 'node:fs'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import config from '../../gt.config.json'
+import { processMarkdownContent, rewriteLinksToMd } from './md.js'
+
+const defaultLocale = config.defaultLocale as string
+const locales = new Set<string>([defaultLocale, ...config.locales])
+
+let docsProjectRootCache: string | null = null
+
+/**
+ * Resolves the docs app root (folder containing src/content/docs). Nx or other runners may use
+ * monorepo cwd; production uses dist/apps/docs without src (prebuilt client/*.md only).
+ */
+function getDocsProjectRoot(): string {
+  if (docsProjectRootCache) return docsProjectRootCache
+  const candidates = [
+    process.cwd(),
+    path.join(process.cwd(), 'apps', 'docs'),
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..'),
+  ]
+  for (const root of candidates) {
+    if (fsSync.existsSync(path.join(root, 'src', 'content', 'docs'))) {
+      docsProjectRootCache = root
+      return root
+    }
+  }
+  docsProjectRootCache = process.cwd()
+  return docsProjectRootCache
+}
+
+function docsBaseUrl(): string {
+  const base = (import.meta.env.PUBLIC_WEB_URL || 'https://daytona.io').replace(
+    /\/$/,
+    ''
+  )
+  return `${base}/docs`
+}
+
+type AcceptEntry = { type: string; q: number; index: number }
+
+function parseAcceptHeader(accept: string): AcceptEntry[] {
+  return accept.split(',').map((part, index) => {
+    const bits = part
+      .trim()
+      .split(';')
+      .map(s => s.trim())
+    const type = (bits[0] || '').toLowerCase()
+    let q = 1
+    for (const p of bits.slice(1)) {
+      if (p.startsWith('q=')) {
+        const n = Number.parseFloat(p.slice(2))
+        if (!Number.isNaN(n)) q = n
+      }
+    }
+    return { type, q, index }
+  })
+}
+
+/**
+ * Returns whether the client prefers a raw text markdown or plain response over HTML,
+ * using q-values and header order (RFC 7231 style).
+ */
+export function preferredMarkdownPlainFormat(
+  acceptHeader: string | null
+): 'markdown' | 'plain' | null {
+  if (!acceptHeader?.trim()) return null
+
+  const entries = parseAcceptHeader(acceptHeader)
+    .filter(e => e.q > 0)
+    .sort((a, b) => b.q - a.q || a.index - b.index)
+
+  for (const { type } of entries) {
+    if (type === 'text/markdown' || type === 'text/x-markdown')
+      return 'markdown'
+    if (type === 'text/plain') return 'plain'
+    if (type === 'text/html' || type === 'application/xhtml+xml') return null
+  }
+
+  return null
+}
+
+export function shouldTryMarkdownPath(pathname: string): boolean {
+  if (!pathname.startsWith('/docs')) return false
+  if (pathname.startsWith('/docs/_astro')) return false
+
+  const trimmed = pathname.replace(/\/$/, '') || pathname
+  const last = trimmed.split('/').pop() || ''
+  if (last.includes('.') && !last.endsWith('/')) {
+    return false
+  }
+
+  return true
+}
+
+export type ParsedDocsPath = {
+  locale: string
+  relKey: string
+}
+
+/**
+ * Maps /docs[/locale]/[...rest] to locale and a slash-separated content key (no leading slash).
+ * Paths without a locale segment are treated as default locale (matches static English export).
+ */
+function isSafeDocRelKey(relKey: string): boolean {
+  if (!relKey) return true
+  return !relKey.split('/').some(s => s === '..' || s === '.')
+}
+
+export function parseDocsContentPath(pathname: string): ParsedDocsPath | null {
+  const raw = pathname.replace(/\/$/, '') || pathname
+  if (!raw.startsWith('/docs')) return null
+
+  let rest = raw.slice('/docs'.length).replace(/^\/+/, '')
+  if (!rest) {
+    return { locale: defaultLocale, relKey: '' }
+  }
+
+  const segments = rest.split('/').filter(Boolean)
+  const first = segments[0]
+  if (!first) {
+    return { locale: defaultLocale, relKey: '' }
+  }
+
+  if (locales.has(first)) {
+    const relKey = segments.slice(1).join('/')
+    if (!isSafeDocRelKey(relKey)) return null
+    return { locale: first, relKey }
+  }
+
+  const relKey = segments.join('/')
+  if (!isSafeDocRelKey(relKey)) return null
+  return { locale: defaultLocale, relKey }
+}
+
+function clientMarkdownPath(locale: string, relKey: string): string {
+  const fileName = relKey ? `${relKey}.md` : 'docs.md'
+  return path.join(getDocsProjectRoot(), 'client', locale, fileName)
+}
+
+function sourceDocCandidates(locale: string, relKey: string): string[] {
+  const base = path.join(getDocsProjectRoot(), 'src/content/docs', locale)
+  if (!relKey) {
+    return [path.join(base, 'index.mdx'), path.join(base, 'index.md')]
+  }
+  const nested = relKey.split('/').join(path.sep)
+  return [
+    path.join(base, `${nested}.mdx`),
+    path.join(base, `${nested}.md`),
+    path.join(base, nested, 'index.mdx'),
+    path.join(base, nested, 'index.md'),
+  ]
+}
+
+async function readFirstExisting(paths: string[]): Promise<string | null> {
+  for (const p of paths) {
+    try {
+      const buf = await fs.readFile(p, 'utf8')
+      return buf
+    } catch {
+      /* try next */
+    }
+  }
+  return null
+}
+
+export async function loadDocsMarkdownBody(
+  parsed: ParsedDocsPath
+): Promise<string | null> {
+  const { locale, relKey } = parsed
+
+  const prebuilt = await readFirstExisting([clientMarkdownPath(locale, relKey)])
+  if (prebuilt !== null) {
+    return prebuilt
+  }
+
+  const raw = await readFirstExisting(sourceDocCandidates(locale, relKey))
+  if (raw === null) {
+    return null
+  }
+
+  const cleaned = processMarkdownContent(raw)
+  return rewriteLinksToMd(cleaned, docsBaseUrl())
+}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Markdown content negotiation to docs so clients can request raw Markdown or plain text via the Accept header. HTML remains the default. Also fixes the `/docs` redirect.

- **New Features**
  - `Astro` middleware returns `text/markdown` (supports `text/x-markdown`) or `text/plain` based on Accept q-values; falls back to HTML.
  - Resolves from prebuilt client `.md` first, then source `.md(x)`; processes content, rewrites links, is locale-aware; skips assets/unsafe paths.
  - Updated `starlight` config to disable `prerender` and `pagefind`.

- **Bug Fixes**
  - `/docs` now redirects to `/docs/en` with a 302 and preserves trailing slashes (no proxy).

<sup>Written for commit 4d669fde8ecd12bdc982327ee4adfb2b9c08b29d. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





```
curl -H "Accept: text/markdown" "https://www.daytona.io/docs/"
```

```
curl -H "Accept: text/plain" "https://www.daytona.io/docs/"
```

```
curl -H "Accept: text/markdown" "http://localhost:4321/docs/"
```

```
curl -H "Accept: text/plain" "http://localhost:4321/docs/"
```

<img width="1499" height="722" alt="Screenshot 2026-04-02 at 23 36 03" src="https://github.com/user-attachments/assets/0f22e54b-ab37-4326-9996-e77bc3a1b877" />
