### PR TITLE
docs: fix stale repo-relative links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,8 @@ Follow the following steps to ensure your contribution goes smoothly.
 1. Configure your development environment by either following the guide below.
 1. [Fork](https://help.github.com/articles/working-with-forks/) the GitHub Repository allowing you to make the changes in your own copy of the repository.
 1. Create a [GitHub issue](https://github.com/daytonaio/daytona/issues) if one doesn't exist already.
-1. [Prepare your changes](/PREPARING_YOUR_CHANGES.md) and ensure your commits are descriptive. The document contains an optional commit template, if desired.
-1. Ensure that you sign off on all your commits to comply with the DCO v1.1. We have more details in [Prepare your changes](/PREPARING_YOUR_CHANGES.md).
+1. [Prepare your changes](./PREPARING_YOUR_CHANGES.md) and ensure your commits are descriptive. The document contains an optional commit template, if desired.
+1. Ensure that you sign off on all your commits to comply with the DCO v1.1. We have more details in [Prepare your changes](./PREPARING_YOUR_CHANGES.md).
 1. Ensure to generate new docs after making command related changes, by running `./hack/generate-cli-docs.sh` in the daytona root directory.
 1. Ensure to generate a new API client after making changes related to the API spec, by running `./hack/swagger.sh` in the daytona root directory.
 1. Ensure that you are using `yarn` as the package manager for any Node.js dependencies.

--- a/libs/sdk-python/README.md
+++ b/libs/sdk-python/README.md
@@ -169,6 +169,6 @@ completions = lsp.completions('path/to/file.py', {"line": 10, "character": 15})
 
 ## Contributing
 
-Daytona is Open Source under the [Apache License 2.0](/libs/sdk-python/LICENSE), and is the [copyright of its contributors](/NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](/CONTRIBUTING.md) to get started.
+Daytona is Open Source under the [Apache License 2.0](./LICENSE), and is the [copyright of its contributors](../../NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](../../CONTRIBUTING.md) to get started.
 
-Code in [\_sync](/libs/sdk-python/src/daytona/_sync/) directory shouldn't be edited directly. It should be generated from the corresponding async code in the [\_async](/libs/sdk-python/src/daytona/_async/) directory using the [sync_generator.py](/libs/sdk-python/scripts/sync_generator.py) script.
+Code in [\_sync](./src/daytona/_sync/) directory shouldn't be edited directly. It should be generated from the corresponding async code in the [\_async](./src/daytona/_async/) directory using the SDK generation scripts in the [scripts](./scripts/) directory.

--- a/libs/sdk-ruby/README.md
+++ b/libs/sdk-ruby/README.md
@@ -185,4 +185,4 @@ completions = lsp_server.completions(
 
 ## Contributing
 
-Daytona is Open Source under the [Apache License 2.0](https://github.com/daytonaio/daytona/blob/main/libs/sdk-ruby/LICENSE), and is the [copyright of its contributors](https://github.com/daytonaio/daytona/blob/main/NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](/CONTRIBUTING.md) to get started.
+Daytona is Open Source under the [Apache License 2.0](https://github.com/daytonaio/daytona/blob/main/libs/sdk-ruby/LICENSE), and is the [copyright of its contributors](https://github.com/daytonaio/daytona/blob/main/NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](../../CONTRIBUTING.md) to get started.

--- a/libs/sdk-typescript/README.md
+++ b/libs/sdk-typescript/README.md
@@ -177,4 +177,4 @@ const completions = await lsp.completions('path/to/file.ts', {
 
 ## Contributing
 
-Daytona is Open Source under the [Apache License 2.0](/libs/sdk-typescript//LICENSE), and is the [copyright of its contributors](/NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](/CONTRIBUTING.md) to get started.
+Daytona is Open Source under the [Apache License 2.0](./LICENSE), and is the [copyright of its contributors](../../NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](../../CONTRIBUTING.md) to get started.


### PR DESCRIPTION
## Description

This PR fixes a small set of stale repository-internal links in contributor-facing documentation.

It updates:
- `CONTRIBUTING.md`
- `libs/sdk-python/README.md`
- `libs/sdk-ruby/README.md`
- `libs/sdk-typescript/README.md`

Specifically, it replaces broken root-relative paths with working repo-relative links to the current files and directories.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

N/A

## Screenshots

N/A

## Notes

This is a docs-only change. I verified the updated repository-internal links against the current tree before opening the PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale internal links by replacing root-relative paths with repo-relative links. Updates CONTRIBUTING.md and SDK READMEs (Python, Ruby, TypeScript); links now resolve on GitHub and the Python README clarifies sync-generation via the scripts directory.

<sup>Written for commit 9c31100ffc5cababd259e216aee6b0efd4a91fb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

