### PR TITLE
docs: fix docs README notice link

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -135,4 +135,4 @@ main().catch(console.error)
 
 ## Contributing
 
-Daytona is Open Source under the [GNU AFFERO GENERAL PUBLIC LICENSE](LICENSE), and is the [copyright of its contributors](NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](CONTRIBUTING.md) to get started.
+Daytona is Open Source under the [GNU AFFERO GENERAL PUBLIC LICENSE](LICENSE), and is the [copyright of its contributors](../../NOTICE). If you would like to contribute to the software, read the Developer Certificate of Origin Version 1.1 (https://developercertificate.org/). Afterwards, navigate to the [contributing guide](CONTRIBUTING.md) to get started.


### PR DESCRIPTION
## Description

This PR fixes a broken repository-internal link in `apps/docs/README.md`.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

N/A

## Screenshots

N/A

## Notes

The docs app README linked `NOTICE` as if it lived inside `apps/docs/`, but the actual file lives at the repository root. This updates the link to the working repo-relative path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken `NOTICE` link in `apps/docs/README.md` by updating it to the repo-root path `../../NOTICE`.

<sup>Written for commit 79cc1ea18ee29f2b31c5de58ae8b720c895a0853. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

