### PR TITLE
fix(toolbox): add RFC 5987 encoding for Unicode filenames in multipart downloads

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/download_files.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files.go
@@ -176,8 +176,8 @@ func classifyDownloadPathError(ctx *gin.Context, path string) *common.ErrorRespo
 }
 
 func multipartContentDisposition(formName string, path string) string {
-	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\r", "", "\n", "").Replace(path)
-	return fmt.Sprintf(`form-data; name="%s"; filename="%s"`, formName, escaped)
+	return fmt.Sprintf(`form-data; name="%s"; filename="%s"; filename*=utf-8''%s`,
+		formName, toLatin1(path), encodeRFC5987(path))
 }
 
 func classifyPathStatError(path string, err error) (int, string, string) {
@@ -221,4 +221,49 @@ func newFileDownloadErrorResponse(
 		Path:       path,
 		Method:     ctx.Request.Method,
 	}
+}
+
+// toLatin1 replaces characters outside ISO-8859-1 with '_'.
+func toLatin1(s string) string {
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\r", "", "\n", "", "\x00", "").Replace(s)
+	var buf []byte
+	for _, r := range escaped {
+		if r <= 0xFF {
+			buf = append(buf, byte(r))
+		} else {
+			buf = append(buf, '_')
+		}
+	}
+	return string(buf)
+}
+
+// encodeRFC5987 percent-encodes per RFC 5987 attr-char rules.
+// Safe: alphanumerics and !#$&+-.^_`|~ — everything else is encoded.
+func encodeRFC5987(s string) string {
+	var buf []byte
+	for _, b := range []byte(s) {
+		if isAttrChar(b) {
+			buf = append(buf, b)
+		} else {
+			buf = append(buf, fmt.Sprintf("%%%02X", b)...)
+		}
+	}
+	return string(buf)
+}
+
+// isAttrChar reports whether b is in the RFC 5987 attr-char safe set.
+func isAttrChar(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z':
+		return true
+	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= '0' && b <= '9':
+		return true
+	}
+	switch b {
+	case '!', '#', '$', '&', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	}
+	return false
 }

--- a/apps/daemon/pkg/toolbox/fs/download_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files_test.go
@@ -111,6 +111,72 @@ func TestClassifyPathStatError(t *testing.T) {
 	})
 }
 
+func TestToLatin1(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"hello.txt", "hello.txt"},
+		{"hello\u0000.txt", "hello.txt"},
+		{"hello\x00.txt", "hello.txt"},
+		{"café", "caf\xe9"},
+		{"日本語.txt", "___.txt"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := toLatin1(tt.in); got != tt.want {
+				t.Errorf("toLatin1(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncodeRFC5987(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"hello.txt", "hello.txt"},
+		{"hello\x00.txt", "hello%00.txt"},
+		{"café", "caf%C3%A9"},
+		{"日本語", "%E6%97%A5%E6%9C%AC%E8%AA%9E"},
+		{"file (1).txt", "file%20%281%29.txt"},
+		{"a&b+c-d", "a&b+c-d"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := encodeRFC5987(tt.in); got != tt.want {
+				t.Errorf("encodeRFC5987(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMultipartContentDisposition(t *testing.T) {
+	t.Run("ascii path", func(t *testing.T) {
+		got := multipartContentDisposition("file", "hello.txt")
+		want := `form-data; name="file"; filename="hello.txt"; filename*=utf-8''hello.txt`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unicode path", func(t *testing.T) {
+		got := multipartContentDisposition("file", "日本語.txt")
+		if !strings.Contains(got, `filename="___.txt"`) {
+			t.Errorf("expected latin1 fallback filename, got %q", got)
+		}
+		if !strings.Contains(got, `filename*=utf-8''%E6%97%A5%E6%9C%AC%E8%AA%9E.txt`) {
+			t.Errorf("expected RFC 5987 encoded filename*, got %q", got)
+		}
+	})
+
+	t.Run("escapes quotes and backslashes", func(t *testing.T) {
+		got := multipartContentDisposition("file", `a"b\c`)
+		if !strings.Contains(got, `filename="a\"b\\c"; filename*=utf-8''a%22b%5Cc`) {
+			t.Errorf("expected escaped filename, got %q", got)
+		}
+	})
+}
+
 func TestWriteErrorPart(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
Fixes #4323

The sandbox daemon now properly encodes Unicode filenames using RFC 5987 (RFC 2231) format in multipart responses, making them compatible with python-multipart parser used in the Python SDK since #3787.

**Changes:**
- Add RFC 5987 encoding for non-ASCII filenames in Content-Disposition headers
- Ensure both  (ASCII fallback) and  (UTF-8) parameters are set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode Unicode filenames in multipart Content-Disposition using RFC 5987 `filename*` with a Latin-1-safe `filename` fallback, so non-ASCII downloads parse correctly with the Python SDK’s `python-multipart`. Fixes #4323.

- **Bug Fixes**
  - Set both `filename` (Latin-1 fallback; escapes quotes/backslashes; strips CR/LF/NULL; non-Latin-1 → `_`) and `filename*` (UTF-8 with RFC 5987 percent-encoding).
  - Apply to both `file` and `error` parts; add tests for `toLatin1`, RFC 5987 encoding, and header formatting (ASCII, Unicode, escaping).

<sup>Written for commit 7b6fd3c235af397b2643d682d4d8f80bd08e22f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

