### PR TITLE
chore(security): scope secrets to job/step level to reduce blast radius

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -10,12 +10,12 @@ on:
 
 env:
   VERSION: ${{ inputs.version }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Validate version format
@@ -49,6 +49,8 @@ jobs:
           yarn prepare-release
 
       - name: Push branch and create PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push origin "prepare-release-$VERSION"
           gh pr create \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,21 +10,16 @@ on:
 
 env:
   VERSION: ${{ inputs.version }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-  DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
-  DAYTONA_AUTH0_DOMAIN: ${{ secrets.DAYTONA_AUTH0_DOMAIN }}
-  DAYTONA_AUTH0_CLIENT_ID: ${{ secrets.DAYTONA_AUTH0_CLIENT_ID }}
-  DAYTONA_AUTH0_CALLBACK_PORT: ${{ secrets.DAYTONA_AUTH0_CALLBACK_PORT }}
-  DAYTONA_AUTH0_CLIENT_SECRET: ${{ secrets.DAYTONA_AUTH0_CLIENT_SECRET }}
-  DAYTONA_AUTH0_AUDIENCE: ${{ secrets.DAYTONA_AUTH0_AUDIENCE }}
   POETRY_VIRTUALENVS_IN_PROJECT: true
   GONOSUMDB: github.com/daytonaio/daytona
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
   publish:
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Validate version format
@@ -95,6 +90,15 @@ jobs:
   build_projects:
     needs: publish
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+      DAYTONA_AUTH0_DOMAIN: ${{ secrets.DAYTONA_AUTH0_DOMAIN }}
+      DAYTONA_AUTH0_CLIENT_ID: ${{ secrets.DAYTONA_AUTH0_CLIENT_ID }}
+      DAYTONA_AUTH0_CALLBACK_PORT: ${{ secrets.DAYTONA_AUTH0_CALLBACK_PORT }}
+      DAYTONA_AUTH0_CLIENT_SECRET: ${{ secrets.DAYTONA_AUTH0_CLIENT_SECRET }}
+      DAYTONA_AUTH0_AUDIENCE: ${{ secrets.DAYTONA_AUTH0_AUDIENCE }}
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -184,6 +188,8 @@ jobs:
             arch: amd64
           - runner: [self-hosted, Linux, ARM64, github-actions-runner-arm]
             arch: arm64
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -251,6 +257,8 @@ jobs:
   docker_push_manifest:
     needs: docker_build
     runs-on: ubuntu-latest
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -281,6 +289,8 @@ jobs:
   sync_gosum:
     needs: build_projects
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -31,19 +31,20 @@ env:
   RUBYGEMS_PKG_VERSION: ${{ inputs.rubygems_pkg_version || inputs.version}}
   MAVEN_PKG_VERSION: ${{ inputs.maven_pkg_version || inputs.version}}
   NPM_TAG: ${{ inputs.npm_tag }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-  RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-  MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-  MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-  MAVEN_GPG_SIGNING_KEY: ${{ secrets.MAVEN_GPG_SIGNING_KEY }}
-  MAVEN_GPG_SIGNING_PASSWORD: ${{ secrets.MAVEN_GPG_SIGNING_PASSWORD }}
   POETRY_VIRTUALENVS_IN_PROJECT: true
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:
   publish:
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      MAVEN_GPG_SIGNING_KEY: ${{ secrets.MAVEN_GPG_SIGNING_KEY }}
+      MAVEN_GPG_SIGNING_PASSWORD: ${{ secrets.MAVEN_GPG_SIGNING_PASSWORD }}
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
     steps:
       - name: Validate version format


### PR DESCRIPTION
## Summary

- Move secrets from workflow-level `env:` to job-level or step-level, scoped to only the jobs/steps that consume them
- `release.yaml`: Auth0 secrets + GITHUB_TOKEN moved to `publish` and `build_projects` job-level env; `NX_CLOUD_ACCESS_TOKEN` added to all 5 yarn-using jobs (publish, build_projects, docker_build, docker_push_manifest, sync_gosum)
- `sdk_publish.yaml`: NPM, PyPI, RubyGems, Maven tokens + NX_CLOUD_ACCESS_TOKEN moved from workflow env to `publish` job-level env
- `prepare-release.yaml`: GITHUB_TOKEN moved to step-level on "Push branch and create PR" step; NX_CLOUD_ACCESS_TOKEN to job-level

## Context

Security audit findings F1 (Critical), F2 (Critical), F6 (High): secrets at workflow-level `env:` are available to every step in every job. If any step is compromised (supply chain attack on an unpinned action, malicious dependency), all secrets are exfiltrable -- including `DAYTONA_AUTH0_CLIENT_SECRET` and package registry tokens.

Moving secrets to job/step level means a compromised step in `docker_build` can no longer access Auth0 credentials, and a compromised step in `update-homebrew-tap` can no longer access NPM/PyPI/RubyGems/Maven tokens.

Runtime behavior is identical -- same env vars, same values, same steps.

## Verification

```
actionlint           # No new errors
zizmor               # No regression
grep secrets in workflow-level env blocks: 0/0/0 across all 3 files
```

## Test plan

- [ ] Verify `actionlint` passes with no new errors
- [ ] Verify workflow-level `env:` blocks contain zero `secrets.*` references
- [ ] Trigger a test release to confirm secrets are accessible at job/step level