### PR TITLE
feat(playground): advanced target and snapshot options

### DIFF
--- a/apps/dashboard/src/components/Playground/Sandbox/CodeSnippets/python.ts
+++ b/apps/dashboard/src/components/Playground/Sandbox/CodeSnippets/python.ts
@@ -4,14 +4,14 @@
  */
 
 import { CodeSnippetGenerator } from './types'
-import { joinGroupedSections } from './utils'
+import { escapeSnippetPyDoubleQuotedString, joinGroupedSections } from './utils'
 
 export const PythonSnippetGenerator: CodeSnippetGenerator = {
   getImports(p) {
     return (
       [
         'from daytona import Daytona',
-        p.actions.useConfigObject ? 'DaytonaConfig' : '',
+        p.actions.useConfigObject || p.config.useCustomSandboxTarget ? 'DaytonaConfig' : '',
         p.config.useSandboxCreateParams
           ? p.config.createSandboxFromSnapshot
             ? 'CreateSandboxFromSnapshotParams'
@@ -31,6 +31,12 @@ export const PythonSnippetGenerator: CodeSnippetGenerator = {
   },
 
   getClientInit(p) {
+    if (p.config.useCustomSandboxTarget && p.config.customSandboxTargetId) {
+      return [
+        '# Initialize the Daytona client',
+        `daytona = Daytona(DaytonaConfig(target="${escapeSnippetPyDoubleQuotedString(p.config.customSandboxTargetId)}"))`,
+      ].join('\n')
+    }
     return ['# Initialize the Daytona client', `daytona = Daytona(${p.actions.useConfigObject ? 'config' : ''})`]
       .filter(Boolean)
       .join('\n')

--- a/apps/dashboard/src/components/Playground/Sandbox/CodeSnippets/typescript.ts
+++ b/apps/dashboard/src/components/Playground/Sandbox/CodeSnippets/typescript.ts
@@ -4,7 +4,7 @@
  */
 
 import { CodeSnippetGenerator } from './types'
-import { joinGroupedSections } from './utils'
+import { escapeSnippetTsSingleQuotedString, joinGroupedSections } from './utils'
 
 export const TypeScriptSnippetGenerator: CodeSnippetGenerator = {
   getImports(p) {
@@ -25,6 +25,12 @@ export const TypeScriptSnippetGenerator: CodeSnippetGenerator = {
   },
 
   getClientInit(p) {
+    if (p.config.useCustomSandboxTarget && p.config.customSandboxTargetId) {
+      return [
+        '\t// Initialize the Daytona client',
+        `\tconst daytona = new Daytona({ target: '${escapeSnippetTsSingleQuotedString(p.config.customSandboxTargetId)}' })`,
+      ].join('\n')
+    }
     return [
       '\t// Initialize the Daytona client',
       `\tconst daytona = new Daytona(${p.actions.useConfigObject ? 'config' : ''})`,

--- a/apps/dashboard/src/components/Playground/Sandbox/CodeSnippets/utils.ts
+++ b/apps/dashboard/src/components/Playground/Sandbox/CodeSnippets/utils.ts
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+export function escapeSnippetTsSingleQuotedString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+}
+
+export function escapeSnippetPyDoubleQuotedString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
 /**
  * Joins grouped code snippet sections with consistent spacing.
  * Each non-empty section gets a `\n\n` prefix, producing a blank line between sections.

--- a/apps/dashboard/src/components/Playground/Sandbox/Parameters/Management.tsx
+++ b/apps/dashboard/src/components/Playground/Sandbox/Parameters/Management.tsx
@@ -4,21 +4,23 @@
  */
 
 import { Tooltip } from '@/components/Tooltip'
+import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
-import { SANDBOX_SNAPSHOT_DEFAULT_VALUE } from '@/constants/Playground'
+import { SANDBOX_SNAPSHOT_DEFAULT_VALUE, SANDBOX_TARGET_DEFAULT_VALUE } from '@/constants/Playground'
 import { NumberParameterFormItem, ParameterFormItem } from '@/contexts/PlaygroundContext'
 import { usePlayground } from '@/hooks/usePlayground'
+import { useRegions } from '@/hooks/useRegions'
 import { getLanguageCodeToRun } from '@/lib/playground'
+import { cn, getRegionFullDisplayName } from '@/lib/utils'
 import { SnapshotDto } from '@daytonaio/api-client'
 import { CodeLanguage, Resources } from '@daytonaio/sdk'
-import { HelpCircleIcon } from 'lucide-react'
+import { ChevronDownIcon, HelpCircleIcon } from 'lucide-react'
 import InlineInputFormControl from '../../Inputs/InlineInputFormControl'
 import FormNumberInput from '../../Inputs/NumberInput'
 import FormSelectInput from '../../Inputs/SelectInput'
 import StackedInputFormControl from '../../Inputs/StackedInputFormControl'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
-// TODO - Currently, snapshot selection is not supported in the Playground, so props are hardcoded to an empty array and false for loading. We keep snapshot parts commented to enable it in future if requested by users. Also, sandbox creation and code snippet generation suppoort snapshot selection, so they will work when snapshot selection is enabled in the UI without requiring any additional changes. Currently, the snapshot value is fixed to 'Default'
 type SandboxManagementParametersProps = {
   snapshotsData: Array<SnapshotDto>
   snapshotsLoading: boolean
@@ -29,8 +31,12 @@ const SandboxManagementParameters: React.FC<SandboxManagementParametersProps> = 
   snapshotsLoading,
 }) => {
   const { sandboxParametersState, setSandboxParameterValue } = usePlayground()
+  const { availableRegions: regions, loadingAvailableRegions: regionsLoading } = useRegions()
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+
   const sandboxLanguage = sandboxParametersState['language']
   const sandboxSnapshotName = sandboxParametersState['snapshotName']
+  const sandboxTarget = sandboxParametersState['sandboxTarget']
   const resources = sandboxParametersState['resources']
   const sandboxFromImageParams = sandboxParametersState['createSandboxBaseParams']
 
@@ -40,13 +46,18 @@ const SandboxManagementParameters: React.FC<SandboxManagementParametersProps> = 
     placeholder: 'Select sandbox language',
   }
 
-  // const sandboxSnapshotFormData: ParameterFormItem = {
-  //   label: 'Snapshot',
-  //   key: 'snapshotName',
-  //   placeholder: 'Select sandbox snapshot',
-  // }
+  const targetFormData: ParameterFormItem = {
+    label: 'Target',
+    key: 'sandboxTarget',
+    placeholder: 'Select sandbox target',
+  }
 
-  // Available languages
+  const sandboxSnapshotFormData: ParameterFormItem = {
+    label: 'Snapshot',
+    key: 'snapshotName',
+    placeholder: 'Select sandbox snapshot',
+  }
+
   const languageOptions = [
     {
       value: CodeLanguage.PYTHON,
@@ -75,14 +86,47 @@ const SandboxManagementParameters: React.FC<SandboxManagementParametersProps> = 
     { label: 'Delete (min)', key: 'autoDeleteInterval', min: -1, max: Infinity, placeholder: '' },
   ]
 
-  // Change code to run based on selected sandbox language
   useEffect(() => {
     setSandboxParameterValue('codeRunParams', {
       languageCode: getLanguageCodeToRun(sandboxParametersState.language),
     })
   }, [sandboxParametersState.language, setSandboxParameterValue])
 
+  useEffect(() => {
+    if (regionsLoading) return
+    if (!sandboxTarget || sandboxTarget === SANDBOX_TARGET_DEFAULT_VALUE) return
+    const exists = regions.some((r) => r.id === sandboxTarget)
+    if (!exists) {
+      setSandboxParameterValue('sandboxTarget', SANDBOX_TARGET_DEFAULT_VALUE)
+    }
+  }, [regions, regionsLoading, sandboxTarget, setSandboxParameterValue])
+
+  useEffect(() => {
+    if (snapshotsLoading) return
+    if (!sandboxSnapshotName || sandboxSnapshotName === SANDBOX_SNAPSHOT_DEFAULT_VALUE) return
+    const exists = snapshotsData.some((s) => s.name === sandboxSnapshotName)
+    if (!exists) {
+      setSandboxParameterValue('snapshotName', SANDBOX_SNAPSHOT_DEFAULT_VALUE)
+    }
+  }, [snapshotsData, snapshotsLoading, sandboxSnapshotName, setSandboxParameterValue])
+
   const nonDefaultSnapshotSelected = sandboxSnapshotName && sandboxSnapshotName !== SANDBOX_SNAPSHOT_DEFAULT_VALUE
+
+  const targetSelectOptions = [
+    { value: SANDBOX_TARGET_DEFAULT_VALUE, label: 'Default (organization)' },
+    ...regions.map((region) => ({
+      value: region.id,
+      label: getRegionFullDisplayName(region),
+    })),
+  ]
+
+  const snapshotSelectOptions = [
+    { value: SANDBOX_SNAPSHOT_DEFAULT_VALUE, label: 'Default' },
+    ...snapshotsData.map((snapshot) => ({
+      value: snapshot.name,
+      label: snapshot.name,
+    })),
+  ]
 
   return (
     <>
@@ -96,23 +140,54 @@ const SandboxManagementParameters: React.FC<SandboxManagementParametersProps> = 
           }}
         />
       </StackedInputFormControl>
-      {/* <StackedInputFormControl formItem={sandboxSnapshotFormData}>
-        <FormSelectInput
-          selectOptions={[
-            { value: SANDBOX_SNAPSHOT_DEFAULT_VALUE, label: 'Default' },
-            ...snapshotsData.map((snapshot) => ({
-              value: snapshot.name,
-              label: snapshot.name,
-            })),
-          ]}
-          loading={snapshotsLoading}
-          selectValue={sandboxSnapshotName}
-          formItem={sandboxSnapshotFormData}
-          onChangeHandler={(snapshotName) => {
-            setSandboxParameterValue(sandboxSnapshotFormData.key as 'snapshotName', snapshotName)
-          }}
-        />
-      </StackedInputFormControl> */}
+
+      <div className="space-y-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-auto px-0 py-1 text-muted-foreground hover:text-foreground"
+          aria-expanded={advancedOpen}
+          aria-controls="playground-advanced-options"
+          onClick={() => setAdvancedOpen((o) => !o)}
+        >
+          <ChevronDownIcon
+            className={cn('mr-1 size-4 shrink-0 transition-transform', advancedOpen && 'rotate-180')}
+            aria-hidden
+          />
+          Advanced options
+        </Button>
+        {advancedOpen && (
+          <div id="playground-advanced-options" className="space-y-4 border-l-2 border-muted pl-3">
+            <StackedInputFormControl formItem={targetFormData}>
+              <FormSelectInput
+                selectOptions={targetSelectOptions}
+                loading={regionsLoading}
+                selectValue={sandboxTarget ?? SANDBOX_TARGET_DEFAULT_VALUE}
+                formItem={targetFormData}
+                onChangeHandler={(value) => {
+                  setSandboxParameterValue('sandboxTarget', value)
+                }}
+              />
+            </StackedInputFormControl>
+            <p className="text-xs text-muted-foreground -mt-2">
+              Region for sandbox creation. If not set, your organization default is used.
+            </p>
+            <StackedInputFormControl formItem={sandboxSnapshotFormData}>
+              <FormSelectInput
+                selectOptions={snapshotSelectOptions}
+                loading={snapshotsLoading}
+                selectValue={sandboxSnapshotName ?? SANDBOX_SNAPSHOT_DEFAULT_VALUE}
+                formItem={sandboxSnapshotFormData}
+                onChangeHandler={(snapshotName) => {
+                  setSandboxParameterValue('snapshotName', snapshotName)
+                }}
+              />
+            </StackedInputFormControl>
+          </div>
+        )}
+      </div>
+
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <Label htmlFor="resources" className="text-sm text-muted-foreground">
@@ -126,7 +201,7 @@ const SandboxManagementParameters: React.FC<SandboxManagementParametersProps> = 
                 </div>
               }
               label={
-                <button className="rounded-full">
+                <button type="button" className="rounded-full">
                   <HelpCircleIcon className="h-4 w-4 text-muted-foreground" />
                 </button>
               }

--- a/apps/dashboard/src/components/Playground/Sandbox/Parameters/index.tsx
+++ b/apps/dashboard/src/components/Playground/Sandbox/Parameters/index.tsx
@@ -6,6 +6,7 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Switch } from '@/components/ui/switch'
 import { SandboxParametersSections } from '@/enums/Playground'
+import { useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { usePlayground } from '@/hooks/usePlayground'
 import { cn } from '@/lib/utils'
 import { BoltIcon, FolderIcon, GitBranchIcon, SquareTerminalIcon } from 'lucide-react'
@@ -32,19 +33,11 @@ const SandboxParameters = ({ className }: { className?: string }) => {
   const { openedParametersSections, setOpenedParametersSections, enabledSections, enableSection, disableSection } =
     usePlayground()
 
-  // TODO - Currently, snapshot selection is not supported in the Playground, so we are using empty array and false for loading. We keep to code commented to enable it in future if requested by users.
-  // const { snapshotApi } = useApi()
-  // const { selectedOrganization } = useSelectedOrganization()
-
-  // const { data: snapshotsData = [], isLoading: snapshotsLoading } = useQuery({
-  //   queryKey: ['snapshots', selectedOrganization?.id, 'all'],
-  //   queryFn: async () => {
-  //     if (!selectedOrganization) return []
-  //     const response = await snapshotApi.getAllSnapshots(selectedOrganization.id)
-  //     return response.data.items
-  //   },
-  //   enabled: !!selectedOrganization,
-  // })
+  const { data: snapshotsResponse, isLoading: snapshotsLoading } = useSnapshotsQuery({
+    page: 1,
+    pageSize: 100,
+  })
+  const snapshotsData = snapshotsResponse?.items ?? []
 
   return (
     <div className={cn('flex flex-col gap-6', className)}>
@@ -102,7 +95,7 @@ const SandboxParameters = ({ className }: { className?: string }) => {
                     {section.value === SandboxParametersSections.FILE_SYSTEM && <SandboxFileSystem />}
                     {section.value === SandboxParametersSections.GIT_OPERATIONS && <SandboxGitOperations />}
                     {section.value === SandboxParametersSections.SANDBOX_MANAGEMENT && (
-                      <SandboxManagementParameters snapshotsData={[]} snapshotsLoading={false} />
+                      <SandboxManagementParameters snapshotsData={snapshotsData} snapshotsLoading={snapshotsLoading} />
                     )}
                     {section.value === SandboxParametersSections.PROCESS_CODE_EXECUTION && (
                       <SandboxProcessCodeExecution />

--- a/apps/dashboard/src/constants/Playground.ts
+++ b/apps/dashboard/src/constants/Playground.ts
@@ -10,3 +10,5 @@ export const DEFAULT_MEMORY_RESOURCES = 1
 export const DEFAULT_DISK_RESOURCES = 3
 
 export const SANDBOX_SNAPSHOT_DEFAULT_VALUE = 'Default'
+
+export const SANDBOX_TARGET_DEFAULT_VALUE = 'Default'

--- a/apps/dashboard/src/contexts/PlaygroundContext.tsx
+++ b/apps/dashboard/src/contexts/PlaygroundContext.tsx
@@ -186,6 +186,7 @@ export type ProcessCodeExecutionOperationsActionFormData<T extends CodeRunParams
 export interface SandboxParams {
   language?: CodeLanguage
   snapshotName?: string
+  sandboxTarget?: string
   resources: Resources
   createSandboxBaseParams: CreateSandboxBaseParams
   // File system operations params
@@ -280,6 +281,8 @@ export type SandboxParametersInfo = {
   useAutoDeleteInterval: boolean
   useSandboxCreateParams: boolean
   useCustomSandboxSnapshotName: boolean
+  useCustomSandboxTarget: boolean
+  customSandboxTargetId: string | undefined
   createSandboxFromImage: boolean
   createSandboxFromSnapshot: boolean
   createSandboxParams: CreateSandboxBaseParams | CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams

--- a/apps/dashboard/src/hooks/useSandboxSession.ts
+++ b/apps/dashboard/src/hooks/useSandboxSession.ts
@@ -27,6 +27,7 @@ const DEFAULT_URL_EXPIRY_SECONDS = 600
 export type UseSandboxSessionOptions = {
   scope?: string
   createParams?: CreateSandboxParams
+  target?: string
   terminal?: boolean
   vnc?: boolean
   notify?: { sandbox?: boolean; terminal?: boolean; vnc?: boolean }
@@ -79,6 +80,7 @@ export function useSandboxSession(options?: UseSandboxSessionOptions): UseSandbo
   const {
     scope,
     createParams,
+    target,
     terminal = false,
     vnc = false,
     notify,
@@ -97,8 +99,9 @@ export function useSandboxSession(options?: UseSandboxSessionOptions): UseSandbo
       jwtToken: user.access_token,
       apiUrl: import.meta.env.VITE_API_URL,
       organizationId: selectedOrganization.id,
+      ...(target ? { target } : {}),
     })
-  }, [user?.access_token, selectedOrganization?.id])
+  }, [user?.access_token, selectedOrganization?.id, target])
 
   const createMutation = useMutation<Sandbox, Error, CreateSandboxParams | undefined>({
     mutationKey: ['create-sandbox', scope ?? 'default'],

--- a/apps/dashboard/src/providers/PlaygroundProvider.tsx
+++ b/apps/dashboard/src/providers/PlaygroundProvider.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_DISK_RESOURCES,
   DEFAULT_MEMORY_RESOURCES,
   SANDBOX_SNAPSHOT_DEFAULT_VALUE,
+  SANDBOX_TARGET_DEFAULT_VALUE,
 } from '@/constants/Playground'
 import {
   ActionRuntimeError,
@@ -75,6 +76,7 @@ export const PlaygroundProvider: React.FC<{ children: React.ReactNode }> = ({ ch
 
   const [sandboxParametersState, setSandboxParametersState] = useState<SandboxParams>({
     snapshotName: SANDBOX_SNAPSHOT_DEFAULT_VALUE,
+    sandboxTarget: SANDBOX_TARGET_DEFAULT_VALUE,
     resources: {
       cpu: DEFAULT_CPU_RESOURCES,
       memory: DEFAULT_MEMORY_RESOURCES,
@@ -317,6 +319,12 @@ export const PlaygroundProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     const createSandboxFromImageParams: CreateSandboxFromImageParams = { image: Image.debianSlim('3.13') } // Default and fixed image if CreateSandboxFromImageParams are used
     const snapshotName = sandboxParametersState['snapshotName']
     const useCustomSandboxSnapshotName = snapshotName !== undefined && snapshotName !== SANDBOX_SNAPSHOT_DEFAULT_VALUE
+    const sandboxTarget = sandboxParametersState['sandboxTarget']
+    const useCustomSandboxTarget =
+      typeof sandboxTarget === 'string' &&
+      sandboxTarget !== SANDBOX_TARGET_DEFAULT_VALUE &&
+      sandboxTarget.length > 0
+    const customSandboxTargetId = useCustomSandboxTarget ? sandboxTarget : undefined
     const createSandboxFromSnapshotParams: CreateSandboxFromSnapshotParams = {
       snapshot: useCustomSandboxSnapshotName ? snapshotName : undefined,
     }
@@ -372,6 +380,8 @@ export const PlaygroundProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       useAutoDeleteInterval,
       useSandboxCreateParams,
       useCustomSandboxSnapshotName,
+      useCustomSandboxTarget,
+      customSandboxTargetId,
       createSandboxFromImage,
       createSandboxFromSnapshot,
       createSandboxParams,

--- a/apps/dashboard/src/providers/PlaygroundSandboxProvider.tsx
+++ b/apps/dashboard/src/providers/PlaygroundSandboxProvider.tsx
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { SANDBOX_TARGET_DEFAULT_VALUE } from '@/constants/Playground'
 import { PlaygroundCategories } from '@/enums/Playground'
 import { useDeepCompareMemo } from '@/hooks/useDeepCompareMemo'
 import { usePlayground } from '@/hooks/usePlayground'
 import { useSandboxSession, UseSandboxSessionResult } from '@/hooks/useSandboxSession'
-import { createContext, useEffect, useRef } from 'react'
+import { createContext, useEffect, useMemo, useRef } from 'react'
 
 export const PlaygroundSandboxContext = createContext<UseSandboxSessionResult | null>(null)
 
@@ -15,13 +16,20 @@ export const PlaygroundSandboxProvider: React.FC<{
   activeTab: PlaygroundCategories
   children: React.ReactNode
 }> = ({ activeTab, children }) => {
-  const { getSandboxParametersInfo } = usePlayground()
+  const { sandboxParametersState, getSandboxParametersInfo } = usePlayground()
   const { createSandboxParams } = getSandboxParametersInfo()
   const stableCreateParams = useDeepCompareMemo(createSandboxParams)
+
+  const target = useMemo(() => {
+    const t = sandboxParametersState.sandboxTarget
+    if (!t || t === SANDBOX_TARGET_DEFAULT_VALUE) return undefined
+    return t
+  }, [sandboxParametersState.sandboxTarget])
 
   const session = useSandboxSession({
     scope: 'playground',
     createParams: stableCreateParams,
+    target,
     terminal: true,
     vnc: true,
     notify: { vnc: activeTab === PlaygroundCategories.VNC },


### PR DESCRIPTION
### description

- Playground Sandbox Advanced options: choose target and snapshot; wired to creation and code snippets.

### Documentation

[ ] This change requires a documentation update
[ ] I have made corresponding changes to the documentation

### Related Issue(s)

Closes #4330


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds advanced options to the Playground Sandbox to choose a target (region) and a snapshot. These choices feed into sandbox creation and update the TypeScript/Python code snippets.

- **New Features**
  - Advanced options panel with Target and Snapshot selects.
  - Target options populated from regions; Snapshot options from `useSnapshotsQuery`.
  - Validates selections and falls back to defaults when items are unavailable.
  - Sandbox creation supports a custom target via `useSandboxSession({ target })`; provider passes it when set.
  - Code snippets add `DaytonaConfig` with `target` when chosen; added safe string escaping for TS and Python.
  - Context/state: added `sandboxTarget`, `useCustomSandboxTarget`, and `customSandboxTargetId`; new `SANDBOX_TARGET_DEFAULT_VALUE` constant.

<sup>Written for commit 50b07b7deaf7b9ceace803254e2efdab2f66f458. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

