### PR TITLE
fix(snapshot): remove sleep infinity Dockerfile fallback; align entry

### DIFF
--- a/apps/api/src/sandbox/dto/create-snapshot.dto.ts
+++ b/apps/api/src/sandbox/dto/create-snapshot.dto.ts
@@ -25,8 +25,8 @@ export class CreateSnapshotDto {
   imageName?: string
 
   @ApiPropertyOptional({
-    description: 'The entrypoint command for the snapshot',
-    example: 'sleep infinity',
+    description: 'Override the container entrypoint for this snapshot. If omitted, the image default is used.',
+    example: ['nginx', '-g', 'daemon off;'],
   })
   @IsString({
     each: true,

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -704,7 +704,6 @@ export class SnapshotService {
     }
   }
 
-  // TODO: revise/cleanup
   getEntrypointFromDockerfile(dockerfileContent: string): string[] {
     // Match ENTRYPOINT with either a string or JSON array
     const matches = [...dockerfileContent.matchAll(/ENTRYPOINT\s+(.*)/g)]
@@ -723,7 +722,7 @@ export class SnapshotService {
       }
     }
 
-    return ['sleep', 'infinity']
+    return []
   }
 
   /**

--- a/apps/cli/cmd/snapshot/create.go
+++ b/apps/cli/cmd/snapshot/create.go
@@ -139,7 +139,7 @@ var (
 )
 
 func init() {
-	CreateCmd.Flags().StringVarP(&entrypointFlag, "entrypoint", "e", "", "The entrypoint command for the snapshot")
+	CreateCmd.Flags().StringVarP(&entrypointFlag, "entrypoint", "e", "", "Override the container entrypoint; omit to use the image default")
 	CreateCmd.Flags().StringVarP(&imageNameFlag, "image", "i", "", "The image name for the snapshot")
 	CreateCmd.Flags().StringVarP(&dockerfilePathFlag, "dockerfile", "f", "", "Path to Dockerfile to build")
 	CreateCmd.Flags().StringArrayVarP(&contextFlag, "context", "c", []string{}, "Files or directories to include in the build context (can be specified multiple times). If not provided, context will be automatically determined from COPY/ADD commands in the Dockerfile")

--- a/apps/cli/docs/daytona_snapshot_create.md
+++ b/apps/cli/docs/daytona_snapshot_create.md
@@ -13,7 +13,7 @@ daytona snapshot create [SNAPSHOT] [flags]
       --cpu int32             CPU cores that will be allocated to the underlying sandboxes (default: 1)
       --disk int32            Disk space that will be allocated to the underlying sandboxes in GB (default: 3)
   -f, --dockerfile string     Path to Dockerfile to build
-  -e, --entrypoint string     The entrypoint command for the snapshot
+  -e, --entrypoint string     Override the container entrypoint; omit to use the image default
   -i, --image string          The image name for the snapshot
       --memory int32          Memory that will be allocated to the underlying sandboxes in GB (default: 1)
       --region string         ID of the region where the snapshot will be available (defaults to organization default region)

--- a/apps/cli/hack/docs/daytona_snapshot_create.yaml
+++ b/apps/cli/hack/docs/daytona_snapshot_create.yaml
@@ -20,7 +20,7 @@ options:
     usage: Path to Dockerfile to build
   - name: entrypoint
     shorthand: e
-    usage: The entrypoint command for the snapshot
+    usage: Override the container entrypoint; omit to use the image default
   - name: image
     shorthand: i
     usage: The image name for the snapshot

--- a/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
@@ -303,11 +303,9 @@ export const CreateSnapshotSheet = ({ className, ref }: { className?: string; re
                     value={field.state.value ?? ''}
                     onBlur={field.handleBlur}
                     onChange={(e) => field.handleChange(e.target.value)}
-                    placeholder="sleep infinity"
                   />
                   <FieldDescription>
-                    Ensure that the entrypoint is a long running command. If not provided, or if the snapshot does not
-                    have an entrypoint, 'sleep infinity' will be used as the default.
+                    Optional. Overrides the image entrypoint. Leave empty to use the image default.
                   </FieldDescription>
                 </Field>
               )}

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -45,7 +45,7 @@ Snapshots can be created using:
 
 - **Snapshot name**: Identifier used to reference the snapshot in the SDK or CLI.
 - **Image**: Base image for the snapshot. Must include either a tag or a digest (e.g., **`ubuntu:22.04`**). The **`latest`** tag is not allowed. Since images tagged `latest` get frequent updates, only specific tags are supported. Same applies to tags such as `lts` or `stable`, and we recommend avoiding those when defining an image to prevent unexpected behavior.
-- **Entrypoint** (optional): The entrypoint command for the snapshot. Ensure that the entrypoint is a long-running command. If not provided, or if the snapshot does not have an entrypoint, `sleep infinity` will be used as the default.
+- **Entrypoint** (optional): Override the container entrypoint for this snapshot. If omitted, the image default is used.
 - [**Resources**](/docs/en/sandboxes#resources) (optional): The resources you want the underlying Sandboxes to have. By default, Daytona Sandboxes use **1 vCPU**, **1GiB memory**, and **3GiB storage**.
 
 <Tabs>

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -350,7 +350,7 @@ __Flags__
 | `--cpu` |  | CPU cores that will be allocated to the underlying sandboxes (default: 1) |
 | `--disk` |  | Disk space that will be allocated to the underlying sandboxes in GB (default: 3) |
 | `--dockerfile` | `-f` | Path to Dockerfile to build |
-| `--entrypoint` | `-e` | The entrypoint command for the snapshot |
+| `--entrypoint` | `-e` | Override the container entrypoint; omit to use the image default |
 | `--image` | `-i` | The image name for the snapshot |
 | `--memory` |  | Memory that will be allocated to the underlying sandboxes in GB (default: 1) |
 | `--region` |  | ID of the region where the snapshot will be available (defaults to organization default region) |

--- a/apps/docs/src/content/docs/ja/snapshots.mdx
+++ b/apps/docs/src/content/docs/ja/snapshots.mdx
@@ -15,7 +15,7 @@ import Label from '@components/Label.astro'
 
 スナップショットのイメージには、Docker Hub の `alpine:3.21.3` や `debian:12.10` のような公開イメージの名前とタグ、または別の公開コンテナレジストリ（例: `my-public-registry.com/custom-alpine:3.21`）のイメージを指定できます。
 
-entrypoint フィールドは任意です。イメージに長時間稼働する entrypoint がない場合、Daytona は自動的に `sleep infinity` を実行して、作成直後にコンテナが即時終了しないようにします。
+entrypoint フィールドは任意です。省略した場合はイメージの既定のエントリポイントが使われます。
 
 :::note
 `latest` タグのイメージは頻繁に更新されるため、特定のタグ（例: `0.1.0`）のみがサポートされます。同様に、`lts` や `stable` といったタグも避けることを推奨します。

--- a/apps/runner/pkg/docker/start.go
+++ b/apps/runner/pkg/docker/start.go
@@ -115,7 +115,7 @@ func (d *DockerClient) waitForContainerRunning(ctx context.Context, containerId 
 	for {
 		select {
 		case <-timeoutCtx.Done():
-			return nil, errors.New("timeout waiting for the sandbox to start - please ensure that your entrypoint is long-running")
+			return nil, errors.New("timeout waiting for the sandbox container to start")
 		case <-ticker.C:
 			c, err := d.ContainerInspect(timeoutCtx, containerId)
 			if err != nil {

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -13090,7 +13090,10 @@ components:
         memory: 1
         buildInfo: ""
         regionId: regionId
-        entrypoint: sleep infinity
+        entrypoint:
+          - nginx
+          - -g
+          - daemon off;
         name: ubuntu-4vcpu-8ram-100gb
         cpu: 1
         gpu: 0
@@ -13104,8 +13107,11 @@ components:
           example: ubuntu:22.04
           type: string
         entrypoint:
-          description: The entrypoint command for the snapshot
-          example: sleep infinity
+          description: Override the container entrypoint for this snapshot. If omitted, the image default is used.
+          example:
+            - nginx
+            - -g
+            - daemon off;
           items:
             type: string
           type: array

--- a/libs/api-client-go/model_create_snapshot.go
+++ b/libs/api-client-go/model_create_snapshot.go
@@ -25,7 +25,7 @@ type CreateSnapshot struct {
 	Name string `json:"name"`
 	// The image name of the snapshot
 	ImageName *string `json:"imageName,omitempty"`
-	// The entrypoint command for the snapshot
+	// Override the container entrypoint for this snapshot. If omitted, the image default is used.
 	Entrypoint []string `json:"entrypoint,omitempty"`
 	// Whether the snapshot is general
 	General *bool `json:"general,omitempty"`

--- a/libs/api-client-python-async/daytona_api_client_async/models/create_snapshot.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/create_snapshot.py
@@ -33,7 +33,7 @@ class CreateSnapshot(BaseModel):
     """ # noqa: E501
     name: StrictStr = Field(description="The name of the snapshot")
     image_name: Optional[StrictStr] = Field(default=None, description="The image name of the snapshot", serialization_alias="imageName")
-    entrypoint: Optional[List[StrictStr]] = Field(default=None, description="The entrypoint command for the snapshot")
+    entrypoint: Optional[List[StrictStr]] = Field(default=None, description="Override the container entrypoint for this snapshot. If omitted, the image default is used.")
     general: Optional[StrictBool] = Field(default=None, description="Whether the snapshot is general")
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the resulting sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the resulting sandbox")

--- a/libs/api-client-python/daytona_api_client/models/create_snapshot.py
+++ b/libs/api-client-python/daytona_api_client/models/create_snapshot.py
@@ -33,7 +33,7 @@ class CreateSnapshot(BaseModel):
     """ # noqa: E501
     name: StrictStr = Field(description="The name of the snapshot")
     image_name: Optional[StrictStr] = Field(default=None, description="The image name of the snapshot", serialization_alias="imageName")
-    entrypoint: Optional[List[StrictStr]] = Field(default=None, description="The entrypoint command for the snapshot")
+    entrypoint: Optional[List[StrictStr]] = Field(default=None, description="Override the container entrypoint for this snapshot. If omitted, the image default is used.")
     general: Optional[StrictBool] = Field(default=None, description="Whether the snapshot is general")
     cpu: Optional[StrictInt] = Field(default=None, description="CPU cores allocated to the resulting sandbox")
     gpu: Optional[StrictInt] = Field(default=None, description="GPU units allocated to the resulting sandbox")

--- a/libs/api-client-ruby/lib/daytona_api_client/models/create_snapshot.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/create_snapshot.rb
@@ -21,7 +21,7 @@ module DaytonaApiClient
     # The image name of the snapshot
     attr_accessor :image_name
 
-    # The entrypoint command for the snapshot
+    # Override the container entrypoint for this snapshot. If omitted, the image default is used.
     attr_accessor :entrypoint
 
     # Whether the snapshot is general

--- a/libs/api-client/src/models/create-snapshot.ts
+++ b/libs/api-client/src/models/create-snapshot.ts
@@ -36,7 +36,7 @@ export interface CreateSnapshot {
      */
     'imageName'?: string;
     /**
-     * The entrypoint command for the snapshot
+     * Override the container entrypoint for this snapshot. If omitted, the image default is used.
      * @type {Array<string>}
      * @memberof CreateSnapshot
      */

--- a/libs/sdk-go/pkg/types/types.go
+++ b/libs/sdk-go/pkg/types/types.go
@@ -80,6 +80,7 @@ type CreateSnapshotParams struct {
 	Name           string
 	Image          any // string or *Image
 	Resources      *Resources
+	// Entrypoint overrides the container entrypoint. If empty, the image default is used.
 	Entrypoint     []string
 	SkipValidation *bool
 }

--- a/libs/sdk-python/src/daytona/common/snapshot.py
+++ b/libs/sdk-python/src/daytona/common/snapshot.py
@@ -26,7 +26,7 @@ class Snapshot(SyncSnapshotDto):
         image_name (str): Name of the Image of the Snapshot.
         state (str): State of the Snapshot.
         size (float | int | None): Size of the Snapshot.
-        entrypoint (list[str] | None): Entrypoint of the Snapshot.
+        entrypoint (list[str] | None): Container entrypoint override; if None, the image default is used.
         cpu (float | int): CPU of the Snapshot.
         gpu (float | int): GPU of the Snapshot.
         mem (float | int): Memory of the Snapshot in GiB.
@@ -68,7 +68,7 @@ class CreateSnapshotParams(BaseModel):
             it should be available on some registry. If an Image instance is provided,
             it will be used to create a new image in Daytona.
         resources (Resources | None): Resources of the snapshot.
-        entrypoint (list[str] | None): Entrypoint of the snapshot.
+        entrypoint (list[str] | None): Optional. Overrides the container entrypoint; if omitted, the image default is used.
         region_id (str | None): ID of the region where the snapshot will be available.
             Defaults to organization default region if not specified.
     """

--- a/libs/sdk-ruby/lib/daytona/common/snapshot.rb
+++ b/libs/sdk-ruby/lib/daytona/common/snapshot.rb
@@ -13,7 +13,7 @@ module Daytona
     # @return [Daytona::Resources, nil] Resources of the snapshot
     attr_reader :resources
 
-    # @return [Array<String>, nil] Entrypoint of the snapshot
+    # @return [Array<String>, nil] Optional. Overrides the container entrypoint; if nil, the image default is used
     attr_reader :entrypoint
 
     # @return [String, nil] ID of the region where the snapshot will be available.
@@ -23,7 +23,7 @@ module Daytona
     # @param name [String] Name of the snapshot
     # @param image [String, Daytona::Image] Image of the snapshot
     # @param resources [Daytona::Resources, nil] Resources of the snapshot
-    # @param entrypoint [Array<String>, nil] Entrypoint of the snapshot
+    # @param entrypoint [Array<String>, nil] Optional. Overrides the container entrypoint; if omitted, the image default is used
     # @param region_id [String, nil] ID of the region where the snapshot will be available
     def initialize(name:, image:, resources: nil, entrypoint: nil, region_id: nil)
       @name = name
@@ -56,7 +56,7 @@ module Daytona
     # @return [Float, nil] Size of the Snapshot
     attr_reader :size
 
-    # @return [Array<String>, nil] Entrypoint of the Snapshot
+    # @return [Array<String>, nil] Container entrypoint override; nil means the image default
     attr_reader :entrypoint
 
     # @return [Float] CPU of the Snapshot

--- a/libs/sdk-typescript/src/Snapshot.ts
+++ b/libs/sdk-typescript/src/Snapshot.ts
@@ -60,7 +60,7 @@ export interface PaginatedSnapshots extends Omit<PaginatedSnapshotsDto, 'items'>
  * @property {string | Image} image - Image of the snapshot. If a string is provided, it should be available on some registry.
  * If an Image instance is provided, it will be used to create a new image in Daytona.
  * @property {Resources} resources - Resources of the snapshot.
- * @property {string[]} entrypoint - Entrypoint of the snapshot.
+ * @property {string[]} [entrypoint] - Optional. Overrides the container entrypoint; if omitted, the image default is used.
  * @property {string} regionId - ID of the region where the snapshot will be available. Defaults to organization default region if not specified.
  */
 export type CreateSnapshotParams = {


### PR DESCRIPTION
fix : #4273

### description

- Drop sleep infinity when a Dockerfile has no ENTRYPOINT; optional entrypoint copy updated across API, dashboard, docs, CLI, and clients.

### Documentation

[x] This change requires a documentation update
[x] I have made corresponding changes to the documentation

### Notes
Replace #X with the real issue id.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `sleep infinity` fallback when a Dockerfile has no ENTRYPOINT. Entrypoint is now an optional override; if omitted, the image’s default entrypoint is used.

- **Bug Fixes**
  - `apps/api`: `getEntrypointFromDockerfile` returns an empty array when no ENTRYPOINT; DTO description updated.
  - `apps/cli` and `apps/dashboard`: entrypoint help and field text clarified as an optional override.
  - `apps/runner`: simplified container start timeout message.
  - Docs (`en`, `ja`), OpenAPI, clients (`go`, `python`, `ruby`, `ts`), and SDKs aligned descriptions and examples.

- **Migration**
  - If you relied on an implicit long-running entrypoint, set an explicit `entrypoint` for snapshots that need to keep the container running.

<sup>Written for commit ce51cb947b2e0fca6b5edf37a96d6bb8c485314f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

