### PR TITLE
fix(docs): add proxy origin handling and header requests filtering

### DIFF
--- a/apps/docs/src/i18n/routing.ts
+++ b/apps/docs/src/i18n/routing.ts
@@ -57,6 +57,16 @@ export function isLocalizedPath(slug: string | undefined): boolean {
  * production, preferring it would fetch prod HTML while the browser URL stays
  * on localhost; root-relative asset paths would then hit the dev server wrong
  */
+function originFromSiteConfig(site: string): string | null {
+  const trimmed = site.trim()
+  if (!trimmed) return null
+  try {
+    return new URL(trimmed).origin
+  } catch {
+    return null
+  }
+}
+
 function getProxyOrigin(request: Request): string {
   const reqUrl = new URL(request.url)
   const host = reqUrl.hostname
@@ -73,8 +83,9 @@ function getProxyOrigin(request: Request): string {
     (typeof process !== 'undefined' && process.env.PUBLIC_WEB_URL) ||
     ''
 
-  if (isLoopback && typeof site === 'string' && site.length > 0) {
-    return new URL(site).origin
+  if (isLoopback && typeof site === 'string') {
+    const fromSite = originFromSiteConfig(site)
+    if (fromSite) return fromSite
   }
 
   return reqUrl.origin


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes docs i18n self-fetch by choosing the right proxy origin, safely parsing site config, and forwarding only safe headers. Prevents localhost ECONNREFUSED and misrouted requests when `PUBLIC_WEB_URL`/`SITE` is set.

- **Bug Fixes**
  - Pick proxy origin: dev uses request origin; prod loopback prefers parsed `PUBLIC_WEB_URL`/`SITE`; else request origin.
  - Parse site URL (trim, validate, use only `origin`); also supports `process.env.PUBLIC_WEB_URL`.
  - Forward safe headers only (drops Host and hop-by-hop); no body for GET/HEAD.

<sup>Written for commit d16a512ef704cb2ab584ff1cf5de2a47776b760c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

