### PR TITLE
fixing unvalidated command execution vulnerability

### DIFF
--- a/apps/cli/mcp/tools/delete_file.go
+++ b/apps/cli/mcp/tools/delete_file.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
-	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/mark3labs/mcp-go/mcp"
 
 	log "github.com/sirupsen/logrus"
@@ -41,15 +40,13 @@ func DeleteFile(ctx context.Context, request mcp.CallToolRequest, args DeleteFil
 		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("filePath parameter is required")
 	}
 
-	// Execute delete command
-	execResponse, _, err := apiClient.ToolboxAPI.ExecuteCommandDeprecated(ctx, *args.Id).
-		ExecuteRequest(*apiclient.NewExecuteRequest(fmt.Sprintf("rm -rf %s", *args.FilePath))).
-		Execute()
+	// Use the toolbox file API instead of shell command interpolation.
+	_, err = apiClient.ToolboxAPI.DeleteFileDeprecated(ctx, *args.Id).Path(*args.FilePath).Execute()
 	if err != nil {
 		return &mcp.CallToolResult{IsError: true}, fmt.Errorf("error deleting file: %v", err)
 	}
 
 	log.Infof("Deleted file: %s", *args.FilePath)
 
-	return mcp.NewToolResultText(fmt.Sprintf("Deleted file: %s\nOutput: %s", *args.FilePath, execResponse.Result)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Deleted file: %s", *args.FilePath)), nil
 }

--- a/apps/cli/mcp/tools/execute_command.go
+++ b/apps/cli/mcp/tools/execute_command.go
@@ -50,12 +50,8 @@ func ExecuteCommand(ctx context.Context, request mcp.CallToolRequest, args Execu
 		return returnCommandError("Command must be a non-empty string", "ValueError")
 	}
 
-	// Process the command
+	// Keep the command raw and let toolbox enforce server-side command policy.
 	command := strings.TrimSpace(*args.Command)
-	if strings.Contains(command, "&&") || strings.HasPrefix(command, "cd ") {
-		// Wrap complex commands in /bin/sh -c
-		command = fmt.Sprintf("/bin/sh -c %s", shellQuote(command))
-	}
 
 	log.Infof("Executing command: %s", command)
 
@@ -121,10 +117,4 @@ func returnCommandError(message, errorType string) (*mcp.CallToolResult, error) 
 			},
 		},
 	}, nil
-}
-
-// Helper function to quote shell commands
-func shellQuote(s string) string {
-	// Simple shell quoting - wrap in single quotes and escape existing single quotes
-	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }

--- a/apps/daemon/pkg/toolbox/process/execute.go
+++ b/apps/daemon/pkg/toolbox/process/execute.go
@@ -16,6 +16,7 @@ import (
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
 
 	"github.com/daytonaio/daemon/pkg/common"
+	"github.com/daytonaio/daemon/pkg/toolbox/process/security"
 	"github.com/gin-gonic/gin"
 )
 
@@ -43,6 +44,26 @@ func ExecuteCommand(logger *slog.Logger) gin.HandlerFunc {
 			c.AbortWithError(http.StatusBadRequest, errors.New("empty command"))
 			return
 		}
+
+		if request.Cwd != nil {
+			if err := security.ValidateCwd(*request.Cwd); err != nil {
+				security.AuditCommandDecision(logger, "process.execute", request.Command, false, err.Error())
+				c.AbortWithError(http.StatusBadRequest, err)
+				return
+			}
+		}
+
+		if security.UnsafeCommandChecksDisabled() {
+			logger.Warn("unsafe command policy is disabled via DAYTONA_ALLOW_UNSAFE_COMMANDS")
+		} else {
+			if err := security.ValidateCommand(request.Command); err != nil {
+				security.AuditCommandDecision(logger, "process.execute", request.Command, false, err.Error())
+				c.AbortWithError(http.StatusBadRequest, err)
+				return
+			}
+		}
+
+		security.AuditCommandDecision(logger, "process.execute", request.Command, true, "")
 
 		// Pipe command via stdin to avoid OS ARG_MAX limits on large commands
 		cmd := exec.Command(common.GetShell())

--- a/apps/daemon/pkg/toolbox/process/security/policy.go
+++ b/apps/daemon/pkg/toolbox/process/security/policy.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package security
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const MaxCommandLength = 4096
+
+var forbiddenTokens = []string{"&&", "||", ";", "|", "`", "$(", ">", "<", "\n", "\r", "\x00"}
+
+var allowedExecutables = map[string]struct{}{
+	"awk": {}, "bash": {}, "cat": {}, "chmod": {}, "chown": {}, "cp": {}, "curl": {}, "cut": {},
+	"date": {}, "df": {}, "du": {}, "echo": {}, "env": {}, "find": {}, "git": {}, "go": {},
+	"grep": {}, "gunzip": {}, "gzip": {}, "head": {}, "id": {}, "ls": {}, "make": {}, "mkdir": {},
+	"mv": {}, "node": {}, "nohup": {}, "npm": {}, "pip": {}, "pip3": {}, "pnpm": {}, "printenv": {},
+	"pwd": {}, "python": {}, "python3": {}, "rm": {}, "sed": {}, "sh": {}, "sleep": {}, "sort": {},
+	"stat": {}, "tail": {}, "tar": {}, "touch": {}, "tr": {}, "uname": {}, "uniq": {}, "unzip": {},
+	"wc": {}, "wget": {}, "which": {}, "whoami": {}, "yarn": {}, "zip": {}, "zsh": {},
+}
+
+func UnsafeCommandChecksDisabled() bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv("DAYTONA_ALLOW_UNSAFE_COMMANDS")))
+	return value == "1" || value == "true" || value == "yes"
+}
+
+func ValidateCommand(command string) error {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return fmt.Errorf("empty command")
+	}
+
+	if len(trimmed) > MaxCommandLength {
+		return fmt.Errorf("command exceeds %d characters", MaxCommandLength)
+	}
+
+	for _, token := range forbiddenTokens {
+		if strings.Contains(trimmed, token) {
+			return fmt.Errorf("command contains forbidden token %q", token)
+		}
+	}
+
+	parts := strings.Fields(trimmed)
+	if len(parts) == 0 {
+		return fmt.Errorf("empty command")
+	}
+
+	executable := filepath.Base(parts[0])
+	if _, ok := allowedExecutables[executable]; !ok {
+		return fmt.Errorf("executable %q is not allowlisted", executable)
+	}
+
+	return nil
+}
+
+func ValidateCwd(cwd string) error {
+	if strings.Contains(cwd, "\x00") || strings.Contains(cwd, "\n") || strings.Contains(cwd, "\r") {
+		return fmt.Errorf("invalid cwd: contains control characters")
+	}
+
+	if strings.TrimSpace(cwd) == "" {
+		return fmt.Errorf("invalid cwd: empty path")
+	}
+
+	return nil
+}
+
+func AuditCommandDecision(logger *slog.Logger, source string, command string, allowed bool, reason string) {
+	hash := sha256.Sum256([]byte(command))
+	commandHash := fmt.Sprintf("%x", hash[:8])
+
+	cmd := strings.TrimSpace(command)
+	parts := strings.Fields(cmd)
+	executable := ""
+	if len(parts) > 0 {
+		executable = filepath.Base(parts[0])
+	}
+
+	if allowed {
+		logger.Info("command policy accepted",
+			"source", source,
+			"command_hash", commandHash,
+			"executable", executable,
+		)
+		return
+	}
+
+	logger.Warn("command policy denied",
+		"source", source,
+		"command_hash", commandHash,
+		"executable", executable,
+		"reason", reason,
+	)
+}

--- a/apps/daemon/pkg/toolbox/process/security/policy_test.go
+++ b/apps/daemon/pkg/toolbox/process/security/policy_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package security
+
+import "testing"
+
+func TestValidateCommand_AllowsSimpleAllowlistedCommand(t *testing.T) {
+	err := ValidateCommand("ls -la /tmp")
+	if err != nil {
+		t.Fatalf("expected command to be allowed, got error: %v", err)
+	}
+}
+
+func TestValidateCommand_DeniesCommandChaining(t *testing.T) {
+	err := ValidateCommand("ls && whoami")
+	if err == nil {
+		t.Fatal("expected command with chaining token to be denied")
+	}
+}
+
+func TestValidateCommand_DeniesNonAllowlistedExecutable(t *testing.T) {
+	err := ValidateCommand("perl -e 'print 1'")
+	if err == nil {
+		t.Fatal("expected non-allowlisted executable to be denied")
+	}
+}
+
+func TestValidateCommand_DeniesTooLongCommand(t *testing.T) {
+	command := "echo "
+	for len(command) <= MaxCommandLength {
+		command += "a"
+	}
+
+	err := ValidateCommand(command)
+	if err == nil {
+		t.Fatal("expected overly long command to be denied")
+	}
+}
+
+func TestValidateCwd_DeniesControlCharacters(t *testing.T) {
+	err := ValidateCwd("/tmp\n")
+	if err == nil {
+		t.Fatal("expected cwd with control characters to be denied")
+	}
+}
+
+func TestValidateCwd_AllowsNormalPath(t *testing.T) {
+	err := ValidateCwd("/workspace/project")
+	if err != nil {
+		t.Fatalf("expected cwd to be allowed, got error: %v", err)
+	}
+}

--- a/apps/daemon/pkg/toolbox/process/session/execute.go
+++ b/apps/daemon/pkg/toolbox/process/session/execute.go
@@ -12,6 +12,7 @@ import (
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/internal/util"
 	"github.com/daytonaio/daemon/pkg/session"
+	"github.com/daytonaio/daemon/pkg/toolbox/process/security"
 	"github.com/gin-gonic/gin"
 )
 
@@ -48,6 +49,18 @@ func (s *SessionController) SessionExecuteCommand(c *gin.Context) {
 		c.AbortWithError(http.StatusBadRequest, errors.New("command cannot be empty"))
 		return
 	}
+
+	if security.UnsafeCommandChecksDisabled() {
+		s.logger.Warn("unsafe command policy is disabled via DAYTONA_ALLOW_UNSAFE_COMMANDS")
+	} else {
+		if err := security.ValidateCommand(request.Command); err != nil {
+			security.AuditCommandDecision(s.logger, "process.session.execute", request.Command, false, err.Error())
+			c.AbortWithError(http.StatusBadRequest, err)
+			return
+		}
+	}
+
+	security.AuditCommandDecision(s.logger, "process.session.execute", request.Command, true, "")
 
 	// Handle backward compatibility for "async" field
 	if request.Async {


### PR DESCRIPTION
the vulnerability was,
Unvalidated Command Execution via Workspace Operations

Files & Folders Involved:

pkg/workspace/ - Workspace management core
internal/runner/ - Command execution
pkg/execution/ - Script and command execution handlers
cmd/ - CLI command handlers
Vulnerability Details: The system executes arbitrary commands and scripts within workspaces without sufficient validation of input parameters. When users specify workspace commands, scripts, or configuration values, these are passed directly to shell execution contexts without proper sanitization or parameterization. This is particularly dangerous in:

Script execution paths where user-provided script content is evaluated
Workspace initialization commands that construct shell commands from user input
Configuration file parsing where values are interpolated into command strings
Why It's Major: An authenticated attacker (or compromised user account) can execute arbitrary commands on the system hosting the workspace, potentially leading to:

Full system compromise
Lateral movement to other workspaces/users
Data exfiltration
Persistent backdoors


here is what i did,

Implemented a security hardening pass that eliminates direct command-injection vectors and introduces strict policy enforcement at execution boundaries.

Added a centralized command policy in `policy.go`, along with tests in `policy_test.go`. The policy enforces:

* Maximum command length
* Blocking of forbidden shell control tokens (chaining, redirection, substitution)
* Executable allowlisting
* Validation against control characters in the working directory (cwd)
* An emergency compatibility override via `DAYTONA_ALLOW_UNSAFE_COMMANDS`

Enforced this policy across both daemon execution entry points (`execute.go`). Each execution path now audits every allow/deny decision, including command fingerprinting and executable metadata logging.

On the CLI/MCP side, removed unsafe shell wrapping in `execute_command.go` and replaced shell-based file deletion with API-driven, parameterized deletion in `delete_file.go`, eliminating the risk of path interpolation into `rm -rf`.

