### PR TITLE
feat: add Ruby and Go onboarding snippets

### DIFF
--- a/apps/dashboard/src/pages/Onboarding.tsx
+++ b/apps/dashboard/src/pages/Onboarding.tsx
@@ -28,7 +28,7 @@ const Onboarding: React.FC = () => {
   const { selectedOrganization, onSelectOrganization, authenticatedUserHasPermission } = useSelectedOrganization()
   const navigate = useNavigate()
 
-  const [language, setLanguage] = useState<'typescript' | 'python'>('python')
+  const [language, setLanguage] = useState<'typescript' | 'python' | 'ruby' | 'go'>('python')
   const [apiKeyName, setApiKeyName] = useState('')
   const [apiKeyPermissions, setApiKeyPermissions] = useState<CreateApiKeyPermissionsEnum[]>([])
   const [createdApiKey, setCreatedApiKey] = useState<ApiKeyResponse | null>(null)
@@ -123,19 +123,33 @@ const Onboarding: React.FC = () => {
               <p className="text-muted-foreground">Install and get your Sandboxes running.</p>
             </div>
             <div className="flex items-center space-x-2">
-              <Tabs value={language} onValueChange={(value) => setLanguage(value as 'typescript' | 'python')}>
+              <Tabs value={language} onValueChange={(value) => setLanguage(value as 'typescript' | 'python' | 'ruby' | 'go')}>
                 <TabsList className="bg-foreground/10 p-0 rounded-none">
                   <TabsTrigger
                     value="python"
-                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full"
+                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full gap-2"
                   >
                     <img src={pythonIcon} alt="Python" className="w-4 h-4" />
+                    <span>Python</span>
                   </TabsTrigger>
                   <TabsTrigger
                     value="typescript"
-                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full"
+                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full gap-2"
                   >
                     <img src={typescriptIcon} alt="TypeScript" className="w-4 h-4" />
+                    <span>TypeScript</span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="ruby"
+                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full"
+                  >
+                    Ruby
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="go"
+                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full"
+                  >
+                    Go
                   </TabsTrigger>
                 </TabsList>
               </Tabs>
@@ -359,6 +373,67 @@ if response.exit_code != 0:
   print(f"Error: {response.exit_code} {response.result}")
 else:
     print(response.result)
+  `,
+  },
+  ruby: {
+    install: `gem install daytona`,
+    run: `ruby main.rb`,
+    example: `require 'daytona'
+
+# Define the configuration
+config = Daytona::Config.new(api_key: 'your-api-key')
+
+# Initialize the Daytona client
+daytona = Daytona::Daytona.new(config)
+
+# Create the Sandbox instance
+sandbox = daytona.create
+
+# Run the code securely inside the Sandbox
+response = sandbox.process.code_run(code: 'print("Hello World from code!")')
+if response.exit_code != 0
+  puts "Error: #{response.exit_code} #{response.result}"
+else
+  puts response.result
+end
+  `,
+  },
+  go: {
+    install: `go get github.com/daytonaio/daytona/libs/sdk-go`,
+    run: `go run main.go`,
+    example: `package main
+
+import (
+  "context"
+  "fmt"
+  "log"
+
+  "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+  "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+  config := &types.DaytonaConfig{
+    ApiKey: "your-api-key",
+  }
+
+  client, err := daytona.NewClientWithConfig(config)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  sandbox, err := client.Create(context.Background(), nil)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  response, err := sandbox.Process.ExecuteCommand(context.Background(), "echo 'Hello World from code!'")
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  fmt.Println(response.Result)
+}
   `,
   },
 }

--- a/apps/dashboard/src/pages/Onboarding.tsx
+++ b/apps/dashboard/src/pages/Onboarding.tsx
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import pythonIcon from '@/assets/python.svg'
-import typescriptIcon from '@/assets/typescript.svg'
 import CodeBlock from '@/components/CodeBlock'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -127,17 +125,15 @@ const Onboarding: React.FC = () => {
                 <TabsList className="bg-foreground/10 p-0 rounded-none">
                   <TabsTrigger
                     value="python"
-                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full gap-2"
+                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full"
                   >
-                    <img src={pythonIcon} alt="Python" className="w-4 h-4" />
-                    <span>Python</span>
+                    Python
                   </TabsTrigger>
                   <TabsTrigger
                     value="typescript"
-                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full gap-2"
+                    className="data-[state=active]:bg-transparent data-[state=active]:text-foreground border-b-2 data-[state=active]:border-primary rounded-none h-full"
                   >
-                    <img src={typescriptIcon} alt="TypeScript" className="w-4 h-4" />
-                    <span>TypeScript</span>
+                    TypeScript
                   </TabsTrigger>
                   <TabsTrigger
                     value="ruby"

--- a/apps/dashboard/src/pages/Onboarding.tsx
+++ b/apps/dashboard/src/pages/Onboarding.tsx
@@ -410,7 +410,7 @@ import (
 
 func main() {
   config := &types.DaytonaConfig{
-    ApiKey: "your-api-key",
+    APIKey: "your-api-key",
   }
 
   client, err := daytona.NewClientWithConfig(config)


### PR DESCRIPTION
## Summary
- add Ruby and Go as onboarding language options in the dashboard
- provide install, example, and run snippets for both SDKs alongside Python and TypeScript
- keep the onboarding flow unchanged while broadening SDK coverage

## Testing
- git diff --check
- frontend lint/build not run locally because this worktree does not have node_modules installed

Fixes #4196

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Ruby and Go onboarding options with install/run/example snippets (Ruby `daytona`; Go `github.com/daytonaio/daytona/libs/sdk-go`). Switch Python/TypeScript tab icons to text for consistent tabs, and fix the Go example to use the correct `APIKey`; fixes #4196.

<sup>Written for commit 1ce9f3fbe838a6a13e81de29200a05db419b245a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

