### PR TITLE
fix(computer-use): fix scroll action blocking indefinitely

### DIFF
--- a/libs/computer-use/pkg/computeruse/mouse.go
+++ b/libs/computer-use/pkg/computeruse/mouse.go
@@ -136,7 +136,7 @@ func (u *ComputerUse) Drag(req *computeruse.MouseDragRequest) (*computeruse.Mous
 
 func (u *ComputerUse) Scroll(req *computeruse.MouseScrollRequest) (*computeruse.ScrollResponse, error) {
 	// Default amount if not specified
-	if req.Amount == 0 {
+	if req.Amount <= 0 {
 		req.Amount = 3
 	}
 


### PR DESCRIPTION
Fixes #3659

### Summary

`robotgo.ScrollSmooth` takes `(delta, iterations, delayMs)` as arguments. The original call was `ScrollSmooth(amount, 0)`, passing `0` as the iteration count. Inside robotgo, the loop counter starts at 0, gets incremented to 1 before the first comparison, and then never equals `num=0` again, resulting in an infinite loop.

The fix passes the correct arguments: `ScrollSmooth(±1, amount, 10)`, scrolling by +1 for "up" or -1 for "down" per iteration, repeating `amount` times, with 10ms between each step. The sign of the first argument controls the scroll direction in robotgo, while `amount` is now correctly used as the iteration count rather than the delta.

Additionally, negative `amount` values are now clamped to the default (3), since a negative iteration count would cause the same infinite loop through the same mechanism.

### Changes

- `libs/computer-use/pkg/computeruse/mouse.go`: Fix `ScrollSmooth` parameters and clamp `amount <= 0` to default

### Test plan

Ran the existing scroll subtest under `xvfb-run` with a 30s timeout:

```bash
env GOCACHE=/tmp/daytona-go-build-cache \
xvfb-run -a go test ./libs/computer-use \
  -run 'TestComputerUsePlugin/MouseControlMethods/Scroll' \
  -timeout 30s -count=1
```

- **With fix:** passes in ~1.8s
- **Without fix:** times out at 30s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scroll actions hanging by passing correct args to `robotgo.ScrollSmooth` and clamping invalid amounts. Scrolling now runs finite iterations with a small delay and correct direction.

- **Bug Fixes**
  - Replace `ScrollSmooth(amount, 0)` with `ScrollSmooth(±1, amount, 10)` to set direction, iterations, and delay.
  - Clamp `amount <= 0` to `3` to avoid zero/negative iterations causing an infinite loop.

<sup>Written for commit f706054c60dcd4ff63ef1e6604613dceb4b55d42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

