### PR TITLE
feat(docs): expand volume creation and mounting

### DIFF
--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -102,7 +102,7 @@ For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SD
 
 ## Mount volumes
 
-Daytona provides an option to mount a volume to a sandbox. Daytona mounts volumes by listing them on sandbox creation. Once a volume is created, it can be mounted to a sandbox by specifying it in the `CreateSandboxFromSnapshotParams` object. For per-user or multi-tenant data, pass `subpath` so only the specified folder inside the volume is visible at `mount_path`.
+Daytona provides an option to mount a volume to a sandbox. Once a volume is created, it can be mounted to a sandbox by specifying it in the `CreateSandboxFromSnapshotParams` object. For per-user or multi-tenant data, pass `subpath` so only the specified folder inside the volume is visible at `mount_path`.
 
 Mount the entire volume (omit `subpath`) when every sandbox that uses that volume should see the same tree, for example shared assets or single-tenant workloads.
 

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -13,7 +13,7 @@ Volumes are FUSE-based mounts that provide shared file access across Daytona San
 
 ## Create volumes
 
-Daytona provides methods to create volumes using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/volumes) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/sandbox), [TypeScript](/docs/en/typescript-sdk/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox) **SDKs**, [CLI](/docs/en/tools/cli#daytona-create), or [API](/docs/en/tools/api#daytona/tag/sandbox).
+Daytona provides methods to create volumes using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/volumes) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/volume), [TypeScript](/docs/en/typescript-sdk/volume), [Ruby](/docs/en/ruby-sdk/volume/), [Go](/docs/en/go-sdk/daytona/#type-volumeservice) **SDKs**, [CLI](/docs/en/tools/cli#daytona-create), or [API](/docs/en/tools/api#daytona/tag/sandbox).
 
 For persistent per-user, per-tenant, or per-workspace storage, use one shared volume per use case, environment, or project (for example a volume for staging and another for production), and set a dedicated `subpath` when you create each sandbox. The sandbox sees only that prefix inside the volume; it cannot access sibling subpaths.
 

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -13,7 +13,7 @@ Volumes are FUSE-based mounts that provide shared file access across Daytona San
 
 ## Create volumes
 
-Daytona provides methods to create volumes create sandboxes using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/volumes) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/sandbox), [TypeScript](/docs/en/typescript-sdk/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox) **SDKs**, [CLI](/docs/en/tools/cli#daytona-create), or [API](/docs/en/tools/api#daytona/tag/sandbox).
+Daytona provides methods to create volumes using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/volumes) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/sandbox), [TypeScript](/docs/en/typescript-sdk/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox) **SDKs**, [CLI](/docs/en/tools/cli#daytona-create), or [API](/docs/en/tools/api#daytona/tag/sandbox).
 
 For persistent per-user, per-tenant, or per-workspace storage, use one shared volume per use case, environment, or project (for example a volume for staging and another for production), and set a dedicated `subpath` when you create each sandbox. The sandbox sees only that prefix inside the volume; it cannot access sibling subpaths.
 

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -13,13 +13,19 @@ Volumes are FUSE-based mounts that provide shared file access across Daytona San
 
 ## Create volumes
 
-Daytona provides volumes as a shared storage solution for sandboxes. To create a volume:
+Daytona provides methods to create volumes create sandboxes using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/volumes) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/sandbox), [TypeScript](/docs/en/typescript-sdk/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox) **SDKs**, [CLI](/docs/en/tools/cli#daytona-create), or [API](/docs/en/tools/api#daytona/tag/sandbox).
+
+For persistent per-user, per-tenant, or per-workspace storage, use one shared volume per use case, environment, or project (for example a volume for staging and another for production), and set a dedicated `subpath` when you create each sandbox. The sandbox sees only that prefix inside the volume; it cannot access sibling subpaths.
+
+This is the default pattern we recommend because it:
+
+- stays within the per-organization volume [limits](#pricing--limits)
+- avoids mounting a separate volume for every user or sandbox
+- continues to provide strong isolation at the mount boundary
 
 1. Navigate to [Daytona Volumes ↗](https://app.daytona.io/dashboard/volumes)
 2. Click the **Create Volume** button
 3. Enter the volume name
-
-The following snippets demonstrate how to create a volume using the Daytona SDK:
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -33,8 +39,8 @@ volume = daytona.volume.create("my-awesome-volume")
 <TabItem label="TypeScript" icon="seti:typescript">
 
 ```typescript
-const daytona = new Daytona();
-const volume = await daytona.volume.create("my-awesome-volume");
+const daytona = new Daytona()
+const volume = await daytona.volume.create('my-awesome-volume')
 ```
 
 </TabItem>
@@ -96,21 +102,22 @@ For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SD
 
 ## Mount volumes
 
-Daytona provides an option to mount a volume to a sandbox. Once a volume is created, it can be mounted to a sandbox by specifying it in the `CreateSandboxFromSnapshotParams` object. Volume mount paths must meet the following requirements:
+Daytona provides an option to mount a volume to a sandbox. Daytona mounts volumes by listing them on sandbox creation. Once a volume is created, it can be mounted to a sandbox by specifying it in the `CreateSandboxFromSnapshotParams` object. For per-user or multi-tenant data, pass `subpath` so only the specified folder inside the volume is visible at `mount_path`.
 
-- **Must be absolute paths**: Mount paths must start with `/` (e.g., `/home/daytona/volume`)
-- **Cannot be root directory**: Cannot mount to `/` or `//`
-- **No relative path components**: Cannot contain `/../`, `/./`, or end with `/..` or `/.`
-- **No consecutive slashes**: Cannot contain multiple consecutive slashes like `//` (except at the beginning)
-- **Cannot mount to system directories**: The following system directories are prohibited: `/proc`, `/sys`, `/dev`, `/boot`, `/etc`, `/bin`, `/sbin`, `/lib`, `/lib64`
+Mount the entire volume (omit `subpath`) when every sandbox that uses that volume should see the same tree, for example shared assets or single-tenant workloads.
 
-The following snippets demonstrate how to mount a volume to a sandbox:
+Volume mount paths must meet the following requirements:
+
+- **Must be absolute paths**: mount paths must start with `/` (e.g., `/home/daytona/volume`)
+- **Cannot be root directory**: cannot mount to `/` or `//`
+- **No relative path components**: cannot contain `/../`, `/./`, or end with `/..` or `/.`
+- **No consecutive slashes**: cannot contain multiple consecutive slashes like `//` (except at the beginning)
+- **Cannot mount to system directories**: the following system directories are prohibited: `/proc`, `/sys`, `/dev`, `/boot`, `/etc`, `/bin`, `/sbin`, `/lib`, `/lib64`
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
 ```python
-import os
 from daytona import CreateSandboxFromSnapshotParams, Daytona, VolumeMount
 
 daytona = Daytona()
@@ -118,22 +125,21 @@ daytona = Daytona()
 # Create a new volume or get an existing one
 volume = daytona.volume.get("my-volume", create=True)
 
-# Mount the volume to the sandbox
-mount_dir_1 = "/home/daytona/volume"
+mount_dir = "/home/daytona/volume"
 
+# Recommended for per-user / per-tenant data: one volume, unique subpath per sandbox
 params = CreateSandboxFromSnapshotParams(
     language="python",
-    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir_1)],
+    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir, subpath="users/alice")],
 )
 sandbox = daytona.create(params)
 
-# Mount a specific subpath within the volume
-# This is useful for isolating data or implementing multi-tenancy
-params = CreateSandboxFromSnapshotParams(
+# Entire volume at mount path (omit subpath) when all sandboxes should share the same tree
+params_full = CreateSandboxFromSnapshotParams(
     language="python",
-    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir_1, subpath="users/alice")],
+    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir)],
 )
-sandbox2 = daytona.create(params)
+sandbox_shared = daytona.create(params_full)
 ```
 
 </TabItem>
@@ -144,25 +150,21 @@ import { Daytona } from '@daytona/sdk'
 import path from 'path'
 
 const daytona = new Daytona()
-
-//  Create a new volume or get an existing one
 const volume = await daytona.volume.get('my-volume', true)
+const mountDir = '/home/daytona/volume'
 
-// Mount the volume to the sandbox
-const mountDir1 = '/home/daytona/volume'
-
-const sandbox1 = await daytona.create({
-  language: 'typescript',
-  volumes: [{ volumeId: volume.id, mountPath: mountDir1 }],
-})
-
-// Mount a specific subpath within the volume
-// This is useful for isolating data or implementing multi-tenancy
-const sandbox2 = await daytona.create({
+// Recommended for per-user / per-tenant data: one volume, unique subpath per sandbox
+const sandbox = await daytona.create({
   language: 'typescript',
   volumes: [
-    { volumeId: volume.id, mountPath: mountDir1, subpath: 'users/alice' },
+    { volumeId: volume.id, mountPath: mountDir, subpath: 'users/alice' },
   ],
+})
+
+// Entire volume at mount path (omit subpath) when all sandboxes should share the same tree
+const sandboxShared = await daytona.create({
+  language: 'typescript',
+  volumes: [{ volumeId: volume.id, mountPath: mountDir }],
 })
 ```
 
@@ -173,22 +175,11 @@ const sandbox2 = await daytona.create({
 require 'daytona'
 
 daytona = Daytona::Daytona.new
-
-# Create a new volume or get an existing one
 volume = daytona.volume.get('my-volume', create: true)
-
-# Mount the volume to the sandbox
 mount_dir = '/home/daytona/volume'
 
+# Recommended for per-user / per-tenant data: one volume, unique subpath per sandbox
 params = Daytona::CreateSandboxFromSnapshotParams.new(
-  language: Daytona::CodeLanguage::PYTHON,
-  volumes: [DaytonaApiClient::SandboxVolume.new(volume_id: volume.id, mount_path: mount_dir)]
-)
-sandbox = daytona.create(params)
-
-# Mount a specific subpath within the volume
-# This is useful for isolating data or implementing multi-tenancy
-params2 = Daytona::CreateSandboxFromSnapshotParams.new(
   language: Daytona::CodeLanguage::PYTHON,
   volumes: [DaytonaApiClient::SandboxVolume.new(
     volume_id: volume.id,
@@ -196,7 +187,14 @@ params2 = Daytona::CreateSandboxFromSnapshotParams.new(
     subpath: 'users/alice'
   )]
 )
-sandbox2 = daytona.create(params2)
+sandbox = daytona.create(params)
+
+# Entire volume at mount path (omit subpath) when all sandboxes should share the same tree
+params_shared = Daytona::CreateSandboxFromSnapshotParams.new(
+  language: Daytona::CodeLanguage::PYTHON,
+  volumes: [DaytonaApiClient::SandboxVolume.new(volume_id: volume.id, mount_path: mount_dir)]
+)
+sandbox_shared = daytona.create(params_shared)
 ```
 
 </TabItem>
@@ -226,14 +224,15 @@ if err != nil {
 	}
 }
 
-// Mount the volume to the sandbox
 mountDir := "/home/daytona/volume"
 
-sandbox1, err := client.Create(context.Background(), types.SnapshotParams{
+// Recommended for per-user / per-tenant data: one volume, unique subpath per sandbox
+subpath := "users/alice"
+sandbox, err := client.Create(context.Background(), types.SnapshotParams{
 	SandboxBaseParams: types.SandboxBaseParams{
 		Language: types.CodeLanguagePython,
 		Volumes: []types.VolumeMount{
-			{VolumeID: volume.ID, MountPath: mountDir},
+			{VolumeID: volume.ID, MountPath: mountDir, Subpath: &subpath},
 		},
 	},
 })
@@ -241,14 +240,12 @@ if err != nil {
 	log.Fatal(err)
 }
 
-// Mount a specific subpath within the volume
-// This is useful for isolating data or implementing multi-tenancy
-subpath := "users/alice"
-sandbox2, err := client.Create(context.Background(), types.SnapshotParams{
+// Entire volume at mount path (omit Subpath) when all sandboxes should share the same tree
+_, err = client.Create(context.Background(), types.SnapshotParams{
 	SandboxBaseParams: types.SandboxBaseParams{
 		Language: types.CodeLanguagePython,
 		Volumes: []types.VolumeMount{
-			{VolumeID: volume.ID, MountPath: mountDir, Subpath: &subpath},
+			{VolumeID: volume.ID, MountPath: mountDir},
 		},
 	},
 })
@@ -265,6 +262,8 @@ daytona volume create my-volume
 daytona create --volume my-volume:/home/daytona/volume
 ```
 
+The `--volume` flag accepts `VOLUME_NAME:MOUNT_PATH` only. For a **subpath** mount, use a [SDK](#mount-volumes) or the [API](#mount-volumes) and set `subpath` on the volume entry.
+
 </TabItem>
 <TabItem label="API" icon="seti:json">
 
@@ -277,11 +276,14 @@ curl 'https://app.daytona.io/api/sandbox' \
   "volumes": [
     {
       "volumeId": "<VOLUME_ID>",
-      "mountPath": "/home/daytona/volume"
+      "mountPath": "/home/daytona/volume",
+      "subpath": "users/alice"
     }
   ]
 }'
 ```
+
+Omit `subpath` to mount the full volume at `mountPath`.
 
 </TabItem>
 </Tabs>
@@ -321,11 +323,14 @@ sandbox.delete()
 
 ```typescript
 // Write to a file in the mounted volume using the Sandbox file system API
-await sandbox1.fs.uploadFile(Buffer.from('Hello from Daytona volume!'), '/home/daytona/volume/example.txt')
+await sandbox.fs.uploadFile(
+  Buffer.from('Hello from Daytona volume!'),
+  '/home/daytona/volume/example.txt'
+)
 
 // When you're done with the sandbox, you can remove it
 // The volume will persist even after the sandbox is removed
-await daytona.delete(sandbox1)
+await daytona.delete(sandbox)
 ```
 
 </TabItem>
@@ -339,6 +344,7 @@ sandbox.fs.upload_file('Hello from Daytona volume!', '/home/daytona/volume/examp
 # The volume will persist even after the sandbox is removed
 daytona.delete(sandbox)
 ```
+
 </TabItem>
 <TabItem label="Go" icon="seti:go">
 
@@ -349,14 +355,14 @@ import (
 )
 
 // Write to a file in the mounted volume
-err := sandbox1.FileSystem.UploadFile(context.Background(), []byte("Hello from Daytona volume!"), "/home/daytona/volume/example.txt")
+err := sandbox.FileSystem.UploadFile(context.Background(), []byte("Hello from Daytona volume!"), "/home/daytona/volume/example.txt")
 if err != nil {
     log.Fatal(err)
 }
 
 // When you're done with the sandbox, you can remove it
 // The volume will persist even after the sandbox is removed
-err = sandbox1.Delete(context.Background())
+err = sandbox.Delete(context.Background())
 if err != nil {
     log.Fatal(err)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded and clarified volume creation and mounting docs with a recommended `subpath` pattern for per-user and multi-tenant storage. Added the Dashboard flow and guidance on when to mount the full volume.

- **Docs**
  - Recommend one shared volume with a unique `subpath` per sandbox; explain when to mount the full volume.
  - Add Dashboard flow and refresh examples for Python, TypeScript (`@daytonaio/sdk`), Ruby, Go, CLI, and API; include `subpath` and fix SDK links/anchors.
  - Clarify mount path rules and prohibited directories.
  - Note CLI `--volume` supports `VOLUME_NAME:MOUNT_PATH` only; use SDK/API for `subpath`.

<sup>Written for commit b0279bc1645d5081c1ee8a2b4308da63ec9cc1d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

