### PR TITLE
docs(upgrade/addition): OSS Deployment Docs behind a Domain

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -32,7 +32,7 @@ ENV NX_DAEMON=false
 
 RUN yarn nx build api --configuration=production --nxBail=true
 
-RUN VITE_BASE_API_URL=%DAYTONA_BASE_API_URL% yarn nx build dashboard --configuration=production --nxBail=true --output-style=stream
+RUN VITE_API_URL=%DAYTONA_BASE_API_URL%/api yarn nx build dashboard --configuration=production --nxBail=true --output-style=stream
 
 ARG VERSION=0.0.1
 ENV VERSION=${VERSION}

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -53,6 +53,8 @@ import { OtelConfigDto } from '../dto/otel-config.dto'
 import { sandboxLookupCacheKeyByAuthToken } from '../../sandbox/utils/sandbox-lookup-cache.util'
 import { SandboxRepository } from '../../sandbox/repositories/sandbox.repository'
 import { SnapshotRepository } from '../../sandbox/repositories/snapshot.repository'
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import Redis from 'ioredis'
 
 @Injectable()
 export class OrganizationService implements OnModuleInit, TrackableJobExecutions, OnApplicationShutdown {
@@ -75,6 +77,7 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     private readonly regionRepository: Repository<Region>,
     private readonly regionService: RegionService,
     private readonly encryptionService: EncryptionService,
+    @InjectRedis() private readonly redis: Redis,
   ) {
     this.defaultOrganizationQuota = this.configService.getOrThrow('defaultOrganizationQuota')
     this.defaultSandboxLimitedNetworkEgress = this.configService.getOrThrow(
@@ -372,6 +375,10 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     }
 
     await this.organizationRepository.save(organization)
+
+    // OrganizationAuthContextGuard caches the org for 10s; clear it so the next request
+    // (e.g. sandbox creation immediately after setDefaultRegion) reads fresh state.
+    await this.redis.del(`organization:${organizationId}`)
   }
 
   async updateExperimentalConfig(

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -378,7 +378,13 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
 
     // OrganizationAuthContextGuard caches the org for 10s; clear it so the next request
     // (e.g. sandbox creation immediately after setDefaultRegion) reads fresh state.
-    await this.redis.del(`organization:${organizationId}`)
+    // Best-effort: the DB update is already committed, so don't fail the request if Redis
+    // is unavailable — the cache entry will expire within 10s anyway.
+    try {
+      await this.redis.del(`organization:${organizationId}`)
+    } catch (error) {
+      this.logger.warn(`Failed to invalidate organization cache for ${organizationId}: ${error?.message ?? error}`)
+    }
   }
 
   async updateExperimentalConfig(

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -24,6 +24,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { FeatureFlags } from '@/enums/FeatureFlags'
 import { RoutePath } from '@/enums/RoutePath'
 import { useCreateSandboxMutation } from '@/hooks/mutations/useCreateSandboxMutation'
+import { useSetOrganizationDefaultRegionMutation } from '@/hooks/mutations/useSetOrganizationDefaultRegionMutation'
 import { useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { useConfig } from '@/hooks/useConfig'
 import { useRegions } from '@/hooks/useRegions'
@@ -32,8 +33,10 @@ import { parseEnvFile } from '@/lib/env'
 import { handleApiError } from '@/lib/error-handling'
 import { imageNameSchema } from '@/lib/schema'
 import { cn, getRegionFullDisplayName } from '@/lib/utils'
+import { OrganizationUserRoleEnum } from '@daytona/api-client'
 import { Sandbox } from '@daytona/sdk'
 import { useForm } from '@tanstack/react-form'
+import { isAxiosError } from 'axios'
 import { Info, Minus, Plus, Upload } from 'lucide-react'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { ComponentProps, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
@@ -94,6 +97,7 @@ const buildBaseFormSchema = (maxCpu?: number, maxMemory?: number, maxDisk?: numb
     public: z.boolean().optional(),
     networkBlockAll: z.boolean().optional(),
     ephemeral: z.boolean().optional(),
+    setAsDefaultRegion: z.boolean().optional(),
   })
 
 const buildFormSchema = (maxCpu?: number, maxMemory?: number, maxDisk?: number) => {
@@ -135,6 +139,7 @@ const defaultValues: FormValues = {
   public: false,
   networkBlockAll: false,
   ephemeral: false,
+  setAsDefaultRegion: false,
 }
 
 const InfoTooltipButton = ({ className, ...props }: ComponentProps<'button'>) => {
@@ -152,8 +157,9 @@ export const CreateSandboxSheet = ({ className, ref }: { className?: string; ref
 
   const config = useConfig()
   const { availableRegions: regions, loadingAvailableRegions: loadingRegions } = useRegions()
-  const { selectedOrganization } = useSelectedOrganization()
+  const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
   const { reset: resetCreateSandboxMutation, ...createSandboxMutation } = useCreateSandboxMutation()
+  const setDefaultRegionMutation = useSetOrganizationDefaultRegionMutation()
   const formRef = useRef<HTMLFormElement>(null)
 
   useImperativeHandle(ref, () => ({
@@ -163,6 +169,9 @@ export const CreateSandboxSheet = ({ className, ref }: { className?: string; ref
   const maxCpu = selectedOrganization?.maxCpuPerSandbox
   const maxMemory = selectedOrganization?.maxMemoryPerSandbox
   const maxDisk = selectedOrganization?.maxDiskPerSandbox
+  const canSetDefaultRegion =
+    !selectedOrganization?.defaultRegionId &&
+    authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
 
   const formSchema = useMemo(() => buildFormSchema(maxCpu, maxMemory, maxDisk), [maxCpu, maxMemory, maxDisk])
 
@@ -189,6 +198,25 @@ export const CreateSandboxSheet = ({ className, ref }: { className?: string; ref
       if (!selectedOrganization?.id) {
         toast.error('Select an organization to create a sandbox.')
         return
+      }
+
+      if (value.setAsDefaultRegion && value.regionId) {
+        try {
+          await setDefaultRegionMutation.mutateAsync({
+            organizationId: selectedOrganization.id,
+            defaultRegionId: value.regionId,
+          })
+        } catch (error) {
+          // 409 Conflict = another path (e.g. the auto-triggered SetDefaultRegionDialog on
+          // Dashboard) set the default between sheet-open and submit. The user's intent is
+          // already satisfied; continue to sandbox creation.
+          const cause = error instanceof Error ? error.cause : undefined
+          const status = isAxiosError(cause) ? cause.response?.status : undefined
+          if (status !== 409) {
+            handleApiError(error, 'Failed to set default region')
+            return
+          }
+        }
       }
 
       const envVars: Record<string, string> = {}
@@ -317,6 +345,14 @@ export const CreateSandboxSheet = ({ className, ref }: { className?: string; ref
       resetState()
     }
   }, [open, resetState])
+
+  useEffect(() => {
+    if (!open || loadingRegions) return
+    if (regions.length !== 1) return
+    if (selectedOrganization?.defaultRegionId) return
+    if (form.getFieldValue('regionId')) return
+    form.setFieldValue('regionId', regions[0].id)
+  }, [open, loadingRegions, regions, selectedOrganization?.defaultRegionId, form])
 
   if (!createSandboxEnabled) {
     return null
@@ -591,6 +627,33 @@ export const CreateSandboxSheet = ({ className, ref }: { className?: string; ref
                 </Field>
               )}
             </form.Field>
+            {canSetDefaultRegion && (
+              <form.Field name="setAsDefaultRegion">
+                {(field) => (
+                  <form.Subscribe selector={(state) => state.values.regionId}>
+                    {(regionId) => (
+                      <div className="flex items-start gap-2">
+                        <Checkbox
+                          id={field.name}
+                          className="mt-0.5"
+                          checked={field.state.value ?? false}
+                          disabled={!regionId}
+                          onCheckedChange={(checked) => field.handleChange(checked === true)}
+                        />
+                        <div className="flex flex-col gap-1">
+                          <Label htmlFor={field.name} className="text-sm font-normal">
+                            Set this as the organization's default region
+                          </Label>
+                          <FieldDescription>
+                            Use the selected region by default for future sandboxes in this organization.
+                          </FieldDescription>
+                        </div>
+                      </div>
+                    )}
+                  </form.Subscribe>
+                )}
+              </form.Field>
+            )}
             <div className="flex flex-col gap-2">
               <Label className="text-sm font-medium">Lifecycle</Label>
               <div className="flex flex-col gap-2">

--- a/apps/dashboard/src/providers/ConfigProvider.tsx
+++ b/apps/dashboard/src/providers/ConfigProvider.tsx
@@ -12,7 +12,7 @@ import { ReactNode, useMemo } from 'react'
 import { AuthProvider, AuthProviderProps } from 'react-oidc-context'
 import { ConfigContext } from '../contexts/ConfigContext'
 
-const apiUrl = (import.meta.env.VITE_BASE_API_URL ?? window.location.origin) + '/api'
+const apiUrl = import.meta.env.VITE_API_URL ?? window.location.origin + '/api'
 
 type Props = {
   children: ReactNode

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -3,7 +3,7 @@ title: Open Source Deployment
 description: Run Daytona Open Source locally using Docker Compose.
 ---
 
-This guide will walk you through running Daytona Open Source locally using Docker Compose.
+This guide will walk you through running Daytona Open Source using Docker Compose locally on your machine or on a server behind a public domain with HTTPS.
 
 The compose file can be found in the [docker](https://github.com/daytonaio/daytona/tree/main/docker) folder of the Daytona repository.
 
@@ -28,7 +28,7 @@ The Docker Compose configuration includes all the necessary services to run Dayt
 - **Jaeger**: Distributed tracing
 - **PgAdmin**: Database administration interface
 
-## Quick Start
+## Local Deployment Quick Start
 
 1. Clone the [Daytona repository](https://github.com/daytonaio/daytona)
 2. [Install Docker and Docker Compose](https://docs.docker.com/get-docker/)
@@ -46,7 +46,59 @@ The Docker Compose configuration includes all the necessary services to run Dayt
    - Registry UI: http://localhost:5100
    - MinIO Console: http://localhost:9001 (minioadmin / minioadmin)
 
+## Domain Deployment Quick Start
+
+This path deploys Daytona on a server behind a public domain with HTTPS, using Caddy as the reverse proxy and Let's Encrypt for TLS certificates.
+
+### Prerequisites
+
+1. **A server or local machine** with at least **4 GB RAM** (8 GB recommended). Ubuntu 22.04+, Debian 12+, or Fedora 39+ on any cloud provider or bare-metal host — or **macOS 13+** (Ventura or later) with [Docker Desktop](https://www.docker.com/products/docker-desktop/) for local domain deployment.
+
+   > **macOS behind a router:** If the Mac is connected to a router (e.g. a Mac Mini on a home or office network), you must configure port forwarding and a stable local IP before proceeding. Port forwarding exposes the Mac directly to inbound internet traffic, bypassing the router's NAT firewall.
+   >
+   > - **Assign a static local IP.** Set a DHCP reservation in the router for the Mac's MAC address, or configure a static IP on the Mac itself. Port forwards break silently if the Mac's IP changes after a DHCP lease renewal. Get the current IP with `ipconfig getifaddr en0`.
+   > - **Forward ports 80 and 443** from the router to the Mac's static local IP. These are required for Caddy to serve HTTPS and complete ACME certificate challenges. If the router serves its own admin panel on port 443 (common on consumer routers), move the admin UI to another port first so it doesn't intercept HTTPS traffic.
+   > - **Forward port 2222 only if you need remote SSH access to sandboxes.** The SSH Gateway bypasses Caddy and exposes a raw TCP listener. If you only access sandboxes from the local network, skip this forward and connect to the Mac's local IP on port 2222 directly. If you do forward it, restrict the source IP range in your router's port forwarding rules to known addresses (e.g. your office or VPN exit IP).
+   > - **ISP limitations:** Many residential ISPs block inbound traffic on ports 80/443 or use Carrier-Grade NAT (CGNAT), which prevents port forwarding entirely. Run `curl -4 ifconfig.me` and compare the result to the WAN IP in your router's admin panel — if they differ, you are behind CGNAT and will need a tunnel service (e.g. Cloudflare Tunnel) instead of port forwarding.
+   >
+   > **Network isolation (recommended):** The Mac will share a network segment with every other device on the LAN. If your router supports VLANs or a guest/DMZ network, place the Mac on an isolated segment to prevent lateral access to other devices in the event of a compromise.
+
+2. **A registered domain name.** This guide uses `daytona.example.com` as a placeholder — replace it everywhere with your actual domain.
+
+3. **A DNS provider API token** for automated wildcard TLS certificate provisioning. Wildcard certificates require a DNS-01 challenge, which means your certificate tool must be able to create DNS TXT records programmatically. See the [DNS Provider Reference](#dns-provider-reference) section for provider-specific instructions.
+
+4. **Ports 80, 443, and 2222** open on both the server's host firewall and any cloud-provider-level firewall (e.g., DigitalOcean Cloud Firewalls, AWS Security Groups). On macOS, Docker Desktop handles port binding and the built-in firewall does not block these ports by default — but enabling **System Settings → Network → Firewall** is recommended if the Mac is exposed to the internet via port forwarding.
+
+5. **SSH access** to the server as root or a user with sudo privileges. On macOS, the script runs as your normal user and prompts for `sudo` only when needed (Caddy binary installation).
+
+6. [Docker and Docker Compose installed](https://docs.docker.com/get-docker/)
+
+### Steps
+
+1. Clone the [Daytona repository](https://github.com/daytonaio/daytona)
+2. [Install Docker and Docker Compose](https://docs.docker.com/get-docker/)
+3. Configure DNS records at your DNS provider — see [DNS
+Configuration](#domain-deployment). This step must be done manually before proceeding.
+4. Run the setup wizard:
+
+   ```bash
+   ./scripts/setup-domain-oss-deployment.sh
+   ```
+
+5. During the setup process, input your domain, email address, password, and credentials for the databases you wish to use.
+
+6. Access the services:
+   - Daytona Dashboard: https://daytona.example.com
+     - Username: Chosen during setup
+     - Password: Chosen during setup
+     - Make sure that the default snapshot is active at https://daytona.example.com/dashboard/snapshots
+   - PgAdmin: https://daytona.example.com:5050 (credentials set during setup)
+   - Registry UI: https://daytona.example.com:5100 (admin credentials set during setup)
+   - MinIO Console: https://daytona.example.com:9001 (credentials set during setup)
+
 ## DNS Setup for Proxy URLs
+
+### Local Development
 
 For local development, you need to resolve `*.proxy.localhost` domains to `127.0.0.1`:
 
@@ -58,18 +110,206 @@ This configures dnsmasq with `address=/proxy.localhost/127.0.0.1`.
 
 **Without this setup**, SDK examples and direct proxy access won't work.
 
+### Domain Deployment
+
+For domain deployments, create DNS records at your DNS provider pointing to your server's public IP:
+
+| Record Type | Name | Value | Proxy Status |
+|-------------|------|-------|--------------|
+| A | `daytona.example.com` | `YOUR_SERVER_IP` | See note below |
+| A or CNAME | `proxy.daytona.example.com` | `YOUR_SERVER_IP` (A) or `daytona.example.com` (CNAME) | **Must be DNS-only** |
+| A or CNAME (wildcard) | `*.proxy.daytona.example.com` | `YOUR_SERVER_IP` (A) or `daytona.example.com` (CNAME) | **Must be DNS-only** |
+
+The wildcard `*.proxy.daytona.example.com` covers subdomains like `8080-sandboxid.proxy.daytona.example.com`, but it does **not** cover the bare `proxy.daytona.example.com` itself. The proxy service uses the bare domain for OIDC callbacks (e.g., `proxy.daytona.example.com/callback`), so it needs its own record.
+
+Either A records or CNAME records work. CNAME records point to another hostname instead of an IP, so if your server IP changes you only update one A record. The Daytona team recommends CNAME for the proxy records.
+
+#### Cloudflare-Specific Warning
+
+If you use Cloudflare, the wildcard record for `*.proxy.daytona.example.com` **must** have the proxy toggled OFF (grey cloud / "DNS only"). Cloudflare's free Universal SSL certificate covers `*.example.com` but does **not** cover sub-subdomain wildcards like `*.proxy.example.com`. If the orange cloud proxy is enabled, Cloudflare will intercept the traffic but fail the TLS handshake because it has no certificate for that depth.
+
+The base domain record (`daytona.example.com`) can be either proxied or DNS-only. For simplicity, setting all records to DNS-only is recommended so Caddy handles all TLS uniformly.
+
+This limitation is Cloudflare-specific to the free tier. Other DNS providers that do not act as a TLS-terminating proxy (DigitalOcean DNS, AWS Route 53, Namecheap, etc.) do not have this issue.
+
+#### Verification
+
+Wait 1-5 minutes for DNS propagation, then:
+
+```bash
+# All three should return your server's actual IP (NOT Cloudflare IPs like 104.x.x.x)
+dig +short daytona.example.com
+dig +short proxy.daytona.example.com
+dig +short anything.proxy.daytona.example.com
+```
+
+## Domain Deployment: What the Setup Script Does
+
+The `setup-domain-oss-deployment.sh` script automates the manual configuration steps required for a domain deployment. The sections below document what it does, for troubleshooting or if you need to customize the configuration beyond what the wizard supports.
+
+### Architecture
+
+Three services must be reachable from the internet:
+
+| Service | Internal Port | Purpose |
+|---------|---------------|---------|
+| **API** | 3000 | Dashboard, REST API |
+| **Proxy** | 4000 | Routes browser traffic to sandbox preview ports |
+| **SSH Gateway** | 2222 | SSH access to sandboxes |
+
+Caddy sits in front of the API and Proxy, terminates TLS, and routes requests based on hostname. Dex (the OIDC provider) is proxied through Caddy at the `/dex/*` path on the main domain. The SSH Gateway on port 2222 is TCP (not HTTP) and bypasses Caddy — it is exposed directly through the firewall.
+
+Sandbox preview URLs use the pattern `{{PORT}}-{{sandboxId}}.proxy.daytona.example.com`, which is why a wildcard DNS record is required.
+
+### Security Credentials
+
+The default Docker Compose file ships with placeholder secrets not safe for any non-localhost deployment. The setup script generates unique values for:
+
+- `ENCRYPTION_KEY` and `ENCRYPTION_SALT`
+- `PROXY_API_KEY`
+- `RUNNER_API_KEY` (used as both `DEFAULT_RUNNER_API_KEY` and `DAYTONA_RUNNER_TOKEN`)
+- `SSH_GATEWAY_API_KEY`
+
+To generate these manually:
+
+```bash
+openssl rand -hex 16
+```
+
+### Dex Configuration
+
+The script updates `docker/dex/config.yaml` to set:
+
+- `issuer` to `https://YOUR_DOMAIN/dex`
+- `redirectURIs` to use `https://YOUR_DOMAIN` instead of `localhost`
+- `staticPasswords` with your chosen email and bcrypt-hashed password
+
+:::caution
+The `redirectURIs` must use `https://` and your actual domain. If these still reference `localhost`, OIDC callbacks will fail after login.
+:::
+
+To generate a bcrypt password hash manually:
+
+```bash
+echo 'YOUR_PASSWORD' | htpasswd -BinC 10 admin | cut -d: -f2
+```
+
+### Docker Compose Environment Variables
+
+The script updates several environment variables in `docker/docker-compose.yaml` across multiple services — switching URLs from `localhost` to your domain, protocols from `http` to `https`, and replacing placeholder secrets with generated values. Key changes include:
+
+- **API**: `PROXY_DOMAIN`, `PROXY_PROTOCOL`, `PROXY_TEMPLATE_URL`, `DASHBOARD_URL`, `DASHBOARD_BASE_API_URL`, `PUBLIC_OIDC_DOMAIN`, `SSH_GATEWAY_URL`, `SSH_GATEWAY_COMMAND`, and all security key variables
+- **Proxy**: `PROXY_PROTOCOL`, `COOKIE_DOMAIN`, `OIDC_PUBLIC_DOMAIN`, and `PROXY_API_KEY`
+- **Runner**: `DAYTONA_RUNNER_TOKEN`
+- **SSH Gateway**: `API_KEY`
+
+### Caddy Installation and Configuration
+
+The script installs Caddy with your DNS provider's module (needed for wildcard TLS via DNS-01 challenge), creates a Caddyfile, sets up DNS provider credentials, and configures a service — systemd on Linux or a launchd LaunchAgent on macOS.
+
+Caddy handles certificate renewal automatically — no cron jobs are needed.
+
+### Dashboard Frontend Patch
+
+:::caution
+The Daytona OSS Docker images ship with `http://localhost:3000` hardcoded in the compiled frontend JavaScript bundle. Without patching this, the dashboard will load but **sandbox creation will fail** because the browser tries to reach `localhost:3000` on the user's machine.
+:::
+
+The script extracts the dashboard assets from the API container, replaces `http://localhost:3000` with `https://YOUR_DOMAIN`, and mounts the patched assets back via a Docker volume. If the Daytona API image is updated (e.g., via `docker compose pull`), this patch step must be re-run.
+
+### Firewall Configuration
+
+The script opens ports 22, 80, 443, and 2222 on Linux (via ufw or firewalld). If your cloud provider has an external firewall (DigitalOcean Cloud Firewalls, AWS Security Groups, etc.), you must create matching inbound rules there as well — the host firewall and cloud firewall are independent. On macOS, firewall configuration is skipped.
+
+## DNS Provider Reference
+
+### Cloudflare
+
+**API Token**: Cloudflare Dashboard > My Profile > API Tokens > Create Token. Use the "Edit zone DNS" template, or create a custom token with Zone: DNS: Edit permissions scoped to your domain.
+
+**Caddy module**: `github.com/caddy-dns/cloudflare`
+
+**DNS record note**: The wildcard record `*.proxy.yourdomain.com` must be set to DNS-only (grey cloud). See [Cloudflare-Specific Warning](#cloudflare-specific-warning).
+
+### DigitalOcean
+
+**API Token**: DigitalOcean Control Panel > API > Tokens > Generate New Token with read and write scopes.
+
+**Caddy module**: `github.com/caddy-dns/digitalocean`
+
+### AWS Route 53
+
+**Credentials**: Create an IAM user with `route53:ChangeResourceRecordSets`, `route53:GetChange`, and `route53:ListHostedZonesByName` permissions. Generate an access key.
+
+**Caddy module**: `github.com/caddy-dns/route53`
+
+### Hetzner
+
+**API Token**: Hetzner DNS Console > API Tokens > Create Token.
+
+**Caddy module**: `github.com/caddy-dns/hetzner`
+
+## Domain Deployment Troubleshooting
+
+### Sandbox creation fails with "Network Error" / `localhost:3000` in browser console
+
+The compiled dashboard JavaScript has `http://localhost:3000` hardcoded. Follow the [Dashboard Frontend Patch](#dashboard-frontend-patch) section. After patching, do a hard refresh (Cmd+Shift+R or Ctrl+Shift+R) in the browser.
+
+### Browser redirects to `localhost:5556` during login
+
+The Dex config file still has `issuer: http://localhost:5556/dex`. Update it to `issuer: https://yourdomain.com/dex` and restart Dex, then the API and Proxy services.
+
+### 502 Bad Gateway on dashboard or sandbox preview URLs
+
+Caddy cannot reach the API (port 3000) or Proxy (port 4000). Verify the containers are running with `docker compose ps` and that ports are published to the host.
+
+### TLS certificate check fails for wildcard
+
+Confirm the wildcard DNS records are DNS-only (not proxied through Cloudflare). Check Caddy logs for ACME errors:
+
+```bash
+# Linux
+sudo journalctl -u caddy --since "30 min ago" --no-pager | grep -i "error\|acme\|cert"
+
+# macOS
+cat /usr/local/var/log/caddy/error.log | grep -i "error\|acme\|cert"
+```
+
+A common issue is leaving a placeholder email in the Caddyfile — Let's Encrypt rejects `example.com` as a contact domain.
+
+If Caddy logs show `HTTP 429 rateLimited`, you have hit Let's Encrypt's rate limit of 5 duplicate certificates per 168 hours. This typically happens when re-deploying to multiple servers within a short period. Caddy will retry automatically — leave it running and certificates will be issued once the limit resets. Certificates are stored locally and reused across re-runs on the same server, so re-running the setup script on the same machine does not count against the limit.
+
+### Sandbox URLs show `http://` instead of `https://`
+
+`PROXY_PROTOCOL` is still set to `http` in the API or Proxy service. Set it to `https` in both and restart.
+
 ## Development Notes
 
 - The setup uses shared networking for simplified service communication
 - Database and storage data is persisted in Docker volumes
 - The registry is configured to allow image deletion for testing
 - Sandbox resource limits are disabled due to inability to partition cgroups in DinD environment where the sock is not mounted
+- The dashboard frontend patch (domain deployments only) is a workaround for a build-time bug in the Daytona Docker images and should be removed once the upstream project makes the SDK base URL configurable at runtime
 
 ## Security Considerations
 
 The `INTER_SANDBOX_NETWORK_ENABLED` runner environment variable controls whether sandboxes on the same runner can communicate over the network. In the Docker Compose configuration this defaults to `false`, creating an isolated bridge network with inter-container communication disabled.
 
 If you are deploying runners outside of the provided Docker Compose setup, ensure `INTER_SANDBOX_NETWORK_ENABLED` is explicitly set to `false` unless your use case requires inter-sandbox communication.
+
+For domain deployments, all placeholder secrets in the default Docker Compose file (`supersecretkey`, `super_secret_key`, `secret_api_token`, etc.) must be replaced with generated values. The `setup-domain-oss-deployment.sh` script handles this automatically.
+
+### Auxiliary Service Ports
+
+The setup script binds auxiliary service ports (PgAdmin, MinIO Console, Registry UI) to `127.0.0.1` in Docker Compose so they cannot be reached directly over the network. Caddy reverse-proxies each service on its original port with TLS and HTTP Basic Auth — nothing is visible until you authenticate:
+
+| Service | URL | Authentication |
+|---------|-----|----------------|
+| PgAdmin | `https://yourdomain.com:5050` | Caddy Basic Auth (PgAdmin email + password set during setup), then PgAdmin native login |
+| MinIO Console | `https://yourdomain.com:9001` | MinIO native login page (credentials set during setup) |
+| Registry UI | `https://yourdomain.com:5100` | Caddy Basic Auth (username: `admin`, password: Daytona admin password set during setup) |
+
+PgAdmin and Registry UI are protected by Caddy's HTTP Basic Auth — nothing is visible until you authenticate. MinIO Console uses its own native login page instead of Basic Auth because its SPA architecture (JavaScript API calls, WebSocket connections) is incompatible with HTTP Basic Auth.
 
 ## Additional Network Options
 
@@ -96,7 +336,7 @@ To configure extra CA certificates (for example, paired with `DB_TLS` env vars),
 
 ```yaml
 environment:
-  - NODE_EXTRA_CA_CERTS=/path/to/your/cert-bundle.pembundle
+  - NODE_EXTRA_CA_CERTS=/path/to/your/cert-bundle.pem
 ```
 
 The provided file is a cert bundle. Meaning it can contain multiple CA certificates in PEM format.

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -307,7 +307,7 @@ The setup script binds auxiliary service ports (PgAdmin, MinIO Console, Registry
 |---------|-----|----------------|
 | PgAdmin | `https://yourdomain.com:5050` | Caddy Basic Auth (PgAdmin email + password set during setup), then PgAdmin native login |
 | MinIO Console | `https://yourdomain.com:9001` | MinIO native login page (credentials set during setup) |
-| Registry UI | `https://yourdomain.com:5100` | Caddy Basic Auth (username: `admin`, password: Daytona admin password set during setup) |
+| Registry UI | `https://yourdomain.com:5100` | Caddy Basic Auth (registry username and password set during setup) |
 
 PgAdmin and Registry UI are protected by Caddy's HTTP Basic Auth — nothing is visible until you authenticate. MinIO Console uses its own native login page instead of Basic Auth because its SPA architecture (JavaScript API calls, WebSocket connections) is incompatible with HTTP Basic Auth.
 

--- a/scripts/setup-domain-oss-deployment.sh
+++ b/scripts/setup-domain-oss-deployment.sh
@@ -1,0 +1,950 @@
+#!/usr/bin/env bash
+# Copyright 2026 Daytona Platforms Inc.
+# SPDX-License-Identifier: AGPL-3.0
+
+# Daytona Domain Setup
+# Automated deployment of Daytona OSS behind a custom domain with Caddy + TLS.
+# Supports: Ubuntu, Debian, Fedora, CentOS, RHEL, Rocky, AlmaLinux, macOS
+# Usage: ./setup.sh
+set -euo pipefail
+
+# ── Colors ──────────────────────────────────────────────────
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ── Globals (filled during input/detection) ─────────────────
+OS="" PKG_MANAGER="" FIREWALL="" ARCH="" CADDY_OS="" CADDY_BIN="" CADDY_CONF_DIR=""
+DOMAIN="" EMAIL="" ADMIN_EMAIL="" ADMIN_PASSWORD="" ADMIN_PASSWORD_HASH=""
+DNS_PROVIDER_NAME="" DNS_CADDY_MODULE=""
+DNS_TLS_BLOCK="" DNS_ENV_NAME="" DNS_ENV_NAME_EXTRA=""
+DNS_TOKEN="" DNS_TOKEN_EXTRA=""
+ENCRYPTION_KEY="" ENCRYPTION_SALT=""
+PROXY_API_KEY="" RUNNER_API_KEY="" SSH_GATEWAY_API_KEY=""
+PGADMIN_EMAIL="" PGADMIN_PASSWORD=""
+MINIO_USER="" MINIO_PASSWORD=""
+DB_USER="" DB_PASS=""
+REGISTRY_USER="" REGISTRY_PASSWORD=""
+HEALTH_CHECK_KEY="" OTEL_COLLECTOR_KEY=""
+CLICKHOUSE_ENABLED="" CLICKHOUSE_HOST_VAL="" CLICKHOUSE_PORT_VAL=""
+CLICKHOUSE_USER="" CLICKHOUSE_PASS="" CLICKHOUSE_DB_VAL="" CLICKHOUSE_PROTO=""
+REPO_DIR="$HOME/daytona"
+
+# ── Helpers ─────────────────────────────────────────────────
+info()    { printf "  ${CYAN}▸${NC} %s\n" "$*"; }
+ok()      { printf "  ${GREEN}✓${NC} %s\n" "$*"; }
+warn()    { printf "  ${YELLOW}!${NC} %s\n" "$*"; }
+fail()    { printf "  ${RED}✗${NC} %s\n" "$*"; }
+die()     { fail "$*"; exit 1; }
+
+# Portable sed in-place: BSD sed (macOS) requires -i '', GNU sed requires -i
+sedi() {
+    if [ "$OS" = "macos" ]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+# Replace a literal placeholder in a file with a value.
+# Uses awk + ENVIRON so the value never appears in the process command line.
+_file_replace() {
+    local file="$1" placeholder="$2" val="$3"
+    _DAYTONA_VAL="$val" awk -v ph="$placeholder" '
+    {
+        while ((i = index($0, ph)) > 0)
+            $0 = substr($0, 1, i-1) ENVIRON["_DAYTONA_VAL"] substr($0, i + length(ph))
+        print
+    }' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+}
+
+run_step() {
+    local name="$1"; shift
+    printf "  ${CYAN}▸${NC} %s" "$name"
+    local log="/tmp/daytona-step-$$.log"
+    install -m 600 /dev/null "$log"
+    if "$@" > "$log" 2>&1; then
+        printf "\r  ${GREEN}✓${NC} %s\n" "$name"
+    else
+        printf "\r  ${RED}✗${NC} %s\n" "$name"
+        sed 's/^/    /' "$log"
+        rm -f "$log"
+        exit 1
+    fi
+    rm -f "$log"
+}
+
+# ── Platform Detection ──────────────────────────────────────
+detect_platform() {
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64)  ARCH="amd64" ;;
+        aarch64) ARCH="arm64" ;;
+        arm64)   ARCH="arm64" ;;
+        *) die "Unsupported architecture: $ARCH" ;;
+    esac
+
+    case "$(uname -s)" in
+        Darwin)
+            OS="macos"
+            PKG_MANAGER="brew"
+            FIREWALL="none"
+            CADDY_OS="darwin"
+            CADDY_BIN="/usr/local/bin/caddy"
+            CADDY_CONF_DIR="/usr/local/etc/caddy"
+            info "Detected macOS ($ARCH)"
+            return
+            ;;
+        Linux)
+            CADDY_OS="linux"
+            ;;
+        *) die "Unsupported operating system: $(uname -s)" ;;
+    esac
+
+    # Linux: detect distro from /etc/os-release
+    [ -f /etc/os-release ] || die "Cannot detect OS — /etc/os-release not found"
+    # shellcheck disable=SC1091
+    . /etc/os-release
+
+    CADDY_BIN="/usr/bin/caddy"
+    CADDY_CONF_DIR="/etc/caddy"
+
+    case "${ID:-}" in
+        ubuntu|debian)
+            OS="$ID"; PKG_MANAGER="apt"; FIREWALL="ufw" ;;
+        fedora)
+            OS="fedora"; PKG_MANAGER="dnf"; FIREWALL="firewalld" ;;
+        centos|rhel|rocky|almalinux)
+            OS="$ID"; PKG_MANAGER="dnf"; FIREWALL="firewalld" ;;
+        *)
+            case "${ID_LIKE:-}" in
+                *debian*|*ubuntu*) OS="debian"; PKG_MANAGER="apt"; FIREWALL="ufw" ;;
+                *fedora*|*rhel*)   OS="fedora"; PKG_MANAGER="dnf"; FIREWALL="firewalld" ;;
+                *) die "Unsupported OS: ${PRETTY_NAME:-$ID}" ;;
+            esac ;;
+    esac
+
+    info "Detected ${PRETTY_NAME:-$ID} ($ARCH)"
+}
+
+# ── Input Collection ────────────────────────────────────────
+collect_input() {
+    printf "\n${BOLD}  Daytona Domain Setup${NC}\n"
+    printf "  ═══════════════════════\n\n"
+
+    # Domain
+    while true; do
+        printf "  Domain (e.g. daytona.example.com): "; read -r DOMAIN
+        DOMAIN="${DOMAIN#https://}"; DOMAIN="${DOMAIN#http://}"
+        DOMAIN="$(echo "$DOMAIN" | tr -d '[:space:]')"
+        [ -z "$DOMAIN" ] && { fail "Required"; continue; }
+        echo "$DOMAIN" | grep -q '\.' || { fail "Must contain a dot"; continue; }
+        break
+    done
+
+    # DNS provider
+    printf "\n  DNS Provider:\n"
+    printf "    1) Cloudflare\n"
+    printf "    2) DigitalOcean\n"
+    printf "    3) AWS Route 53\n"
+    printf "    4) Google Cloud DNS\n"
+    printf "    5) Hetzner\n"
+    printf "    6) Namecheap\n"
+    while true; do
+        printf "  Select [1-6]: "; read -r choice
+        case "$choice" in
+            1) DNS_PROVIDER_NAME="Cloudflare"
+               DNS_CADDY_MODULE="github.com/caddy-dns/cloudflare"
+               DNS_TLS_BLOCK="dns cloudflare {env.CLOUDFLARE_API_TOKEN}"
+               DNS_ENV_NAME="CLOUDFLARE_API_TOKEN"; break ;;
+            2) DNS_PROVIDER_NAME="DigitalOcean"
+               DNS_CADDY_MODULE="github.com/caddy-dns/digitalocean"
+               DNS_TLS_BLOCK="dns digitalocean {env.DO_AUTH_TOKEN}"
+               DNS_ENV_NAME="DO_AUTH_TOKEN"; break ;;
+            3) DNS_PROVIDER_NAME="AWS Route 53"
+               DNS_CADDY_MODULE="github.com/caddy-dns/route53"
+               DNS_TLS_BLOCK="dns route53 {
+            access_key_id {env.AWS_ACCESS_KEY_ID}
+            secret_access_key {env.AWS_SECRET_ACCESS_KEY}
+        }"
+               DNS_ENV_NAME="AWS_ACCESS_KEY_ID"
+               DNS_ENV_NAME_EXTRA="AWS_SECRET_ACCESS_KEY"; break ;;
+            4) DNS_PROVIDER_NAME="Google Cloud DNS"
+               DNS_CADDY_MODULE="github.com/caddy-dns/googleclouddns"
+               DNS_TLS_BLOCK="dns googleclouddns {
+            gcp_project {env.GCP_PROJECT}
+            service_account_json {env.GCP_SERVICE_ACCOUNT_JSON}
+        }"
+               DNS_ENV_NAME="GCP_PROJECT"
+               DNS_ENV_NAME_EXTRA="GCP_SERVICE_ACCOUNT_JSON"; break ;;
+            5) DNS_PROVIDER_NAME="Hetzner"
+               DNS_CADDY_MODULE="github.com/caddy-dns/hetzner"
+               DNS_TLS_BLOCK="dns hetzner {env.HETZNER_API_TOKEN}"
+               DNS_ENV_NAME="HETZNER_API_TOKEN"; break ;;
+            6) DNS_PROVIDER_NAME="Namecheap"
+               DNS_CADDY_MODULE="github.com/caddy-dns/namecheap"
+               DNS_TLS_BLOCK="dns namecheap {
+            api_key {env.NAMECHEAP_API_KEY}
+            user {env.NAMECHEAP_API_USER}
+        }"
+               DNS_ENV_NAME="NAMECHEAP_API_KEY"
+               DNS_ENV_NAME_EXTRA="NAMECHEAP_API_USER"; break ;;
+            *) fail "Invalid choice" ;;
+        esac
+    done
+
+    # DNS credentials
+    printf "\n  %s %s: " "$DNS_PROVIDER_NAME" "$DNS_ENV_NAME"
+    read -rs DNS_TOKEN; echo
+    [ -z "$DNS_TOKEN" ] && die "Token is required"
+
+    if [ -n "${DNS_ENV_NAME_EXTRA:-}" ]; then
+        printf "  %s %s: " "$DNS_PROVIDER_NAME" "$DNS_ENV_NAME_EXTRA"
+        read -rs DNS_TOKEN_EXTRA; echo
+        [ -z "$DNS_TOKEN_EXTRA" ] && die "Required"
+    fi
+
+    # Email
+    while true; do
+        printf "\n  Email (for Let's Encrypt certificates): "; read -r EMAIL
+        EMAIL="$(echo "$EMAIL" | tr -d '[:space:]')"
+        echo "$EMAIL" | grep -q '@.*\.' && break
+        fail "Must be a valid email"
+    done
+
+    # Admin email
+    while true; do
+        printf "  Admin login email: "; read -r ADMIN_EMAIL
+        ADMIN_EMAIL="$(echo "$ADMIN_EMAIL" | tr -d '[:space:]')"
+        echo "$ADMIN_EMAIL" | grep -q '@' && break
+        fail "Must be a valid email"
+    done
+
+    # Admin password
+    while true; do
+        printf "  Admin password (min 8 chars): "; read -rs ADMIN_PASSWORD; echo
+        [ ${#ADMIN_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        printf "  Confirm password: "; read -rs pw_confirm; echo
+        [ "$ADMIN_PASSWORD" = "$pw_confirm" ] && break
+        fail "Passwords do not match"
+    done
+
+    # Service credentials
+    printf "\n${BOLD}  Service Credentials${NC}\n"
+    printf "  These replace default placeholder credentials and secure services behind HTTPS.\n\n"
+
+    # PostgreSQL
+    while true; do
+        printf "  PostgreSQL username: "; read -r DB_USER
+        DB_USER="$(echo "$DB_USER" | tr -d '[:space:]')"
+        [ -n "$DB_USER" ] && break
+        fail "Required"
+    done
+    while true; do
+        printf "  PostgreSQL password (min 8 chars): "; read -rs DB_PASS; echo
+        [ ${#DB_PASS} -lt 8 ] && { fail "Too short"; continue; }
+        break
+    done
+
+    # PgAdmin
+    while true; do
+        printf "  PgAdmin email: "; read -r PGADMIN_EMAIL
+        PGADMIN_EMAIL="$(echo "$PGADMIN_EMAIL" | tr -d '[:space:]')"
+        echo "$PGADMIN_EMAIL" | grep -q '@' && break
+        fail "Must be a valid email"
+    done
+    while true; do
+        printf "  PgAdmin password (min 8 chars): "; read -rs PGADMIN_PASSWORD; echo
+        [ ${#PGADMIN_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        break
+    done
+
+    # MinIO
+    while true; do
+        printf "  MinIO admin username: "; read -r MINIO_USER
+        MINIO_USER="$(echo "$MINIO_USER" | tr -d '[:space:]')"
+        [ -n "$MINIO_USER" ] && break
+        fail "Required"
+    done
+    while true; do
+        printf "  MinIO admin password (min 8 chars): "; read -rs MINIO_PASSWORD; echo
+        [ ${#MINIO_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        break
+    done
+
+    # Registry
+    while true; do
+        printf "  Registry admin username: "; read -r REGISTRY_USER
+        REGISTRY_USER="$(echo "$REGISTRY_USER" | tr -d '[:space:]')"
+        [ -n "$REGISTRY_USER" ] && break
+        fail "Required"
+    done
+    while true; do
+        printf "  Registry admin password (min 8 chars): "; read -rs REGISTRY_PASSWORD; echo
+        [ ${#REGISTRY_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        break
+    done
+
+    # ClickHouse (optional)
+    printf "\n  Configure ClickHouse for sandbox telemetry? [y/N] "; read -r ch_yn
+    case "${ch_yn:-n}" in
+        [yY]*)
+            CLICKHOUSE_ENABLED="true"
+            printf "  ClickHouse host: "; read -r CLICKHOUSE_HOST_VAL
+            CLICKHOUSE_HOST_VAL="$(echo "$CLICKHOUSE_HOST_VAL" | tr -d '[:space:]')"
+            [ -z "$CLICKHOUSE_HOST_VAL" ] && die "Host is required"
+
+            printf "  ClickHouse port [8123]: "; read -r CLICKHOUSE_PORT_VAL
+            CLICKHOUSE_PORT_VAL="${CLICKHOUSE_PORT_VAL:-8123}"
+
+            printf "  ClickHouse database [otel]: "; read -r CLICKHOUSE_DB_VAL
+            CLICKHOUSE_DB_VAL="${CLICKHOUSE_DB_VAL:-otel}"
+
+            printf "  ClickHouse protocol (http/https) [https]: "; read -r CLICKHOUSE_PROTO
+            CLICKHOUSE_PROTO="${CLICKHOUSE_PROTO:-https}"
+
+            printf "  ClickHouse username: "; read -r CLICKHOUSE_USER
+            CLICKHOUSE_USER="$(echo "$CLICKHOUSE_USER" | tr -d '[:space:]')"
+
+            printf "  ClickHouse password: "; read -rs CLICKHOUSE_PASS; echo
+            ;;
+    esac
+
+    # Confirmation
+    printf "\n${BOLD}  Configuration${NC}\n"
+    printf "  ─────────────\n"
+    printf "  Domain:       %s\n" "$DOMAIN"
+    printf "  DNS Provider: %s\n" "$DNS_PROVIDER_NAME"
+    printf "  Email:        %s\n" "$EMAIL"
+    printf "  Admin:        %s\n" "$ADMIN_EMAIL"
+    printf "  DB user:      %s\n" "$DB_USER"
+    printf "  PgAdmin:      %s\n" "$PGADMIN_EMAIL"
+    printf "  MinIO user:   %s\n" "$MINIO_USER"
+    printf "  Registry:     %s\n" "$REGISTRY_USER"
+    [ "$CLICKHOUSE_ENABLED" = "true" ] && printf "  ClickHouse:   %s:%s\n" "$CLICKHOUSE_HOST_VAL" "$CLICKHOUSE_PORT_VAL"
+    printf "\n  Proceed? [Y/n] "; read -r yn
+    case "${yn:-y}" in [nN]*) echo "  Aborted."; exit 0 ;; esac
+}
+
+# ── Steps ───────────────────────────────────────────────────
+
+step_clean() {
+    local cf="$REPO_DIR/docker/docker-compose.yaml"
+    [ -f "$cf" ] && docker compose -f "$cf" down -v --remove-orphans 2>/dev/null || true
+    # Kill any orphaned daytona containers from a previous failed run
+    docker ps -aq --filter "name=daytona-" 2>/dev/null | xargs -r docker rm -f 2>/dev/null || true
+    # Clean transient files only — preserve $REPO_DIR so re-runs are non-destructive
+    # (step_clone is now idempotent and skips when the repo is already present)
+    rm -rf /tmp/dashboard-extract /opt/daytona-dashboard-assets "$HOME/.daytona-dashboard-assets"
+}
+
+step_packages() {
+    command -v docker >/dev/null 2>&1 || die "Docker is not installed. See https://docs.docker.com/engine/install/"
+    docker compose version >/dev/null 2>&1 || die "docker compose v2 plugin not found"
+
+    case "$PKG_MANAGER" in
+        apt) apt-get update -y && apt-get install -y git curl openssl apache2-utils ufw ;;
+        dnf) dnf install -y git curl openssl httpd-tools firewalld ;;
+        brew)
+            command -v brew >/dev/null 2>&1 || die "Homebrew is not installed. See https://brew.sh"
+            command -v htpasswd >/dev/null 2>&1 || brew install httpd
+            ;;
+    esac
+}
+
+step_clone() {
+    # Idempotent: clone only if the repo isn't already present.
+    # This makes re-runs non-destructive and lets users pre-stage the repo
+    # (e.g. for testing local changes) without needing to edit this function.
+    [ -d "$REPO_DIR/.git" ] && return 0
+    git clone https://github.com/daytonaio/daytona.git "$REPO_DIR"
+}
+
+step_secrets() {
+    ENCRYPTION_KEY=$(openssl rand -hex 16)
+    ENCRYPTION_SALT=$(openssl rand -hex 16)
+    PROXY_API_KEY=$(openssl rand -hex 16)
+    RUNNER_API_KEY=$(openssl rand -hex 16)
+    SSH_GATEWAY_API_KEY=$(openssl rand -hex 16)
+    # Hash passwords via stdin (-i) so they never appear in process arguments
+    ADMIN_PASSWORD_HASH=$(printf '%s' "$ADMIN_PASSWORD" | htpasswd -niBC 10 "" | cut -d: -f2)
+    HEALTH_CHECK_KEY=$(openssl rand -hex 16)
+    OTEL_COLLECTOR_KEY=$(openssl rand -hex 16)
+}
+
+step_dex() {
+    local dir="$REPO_DIR/docker/dex"
+    mkdir -p "$dir"
+
+    # Use a quoted heredoc so $2b in the bcrypt hash isn't expanded
+    cat > "$dir/config.yaml" <<'DEXEOF'
+issuer: https://DOMAIN_PH/dex
+storage:
+  type: sqlite3
+  config:
+    file: /var/dex/dex.db
+web:
+  http: 0.0.0.0:5556
+  allowedOrigins: ['*']
+  allowedHeaders: ['x-requested-with']
+staticClients:
+  - id: daytona
+    redirectURIs:
+      - 'https://DOMAIN_PH'
+      - 'https://DOMAIN_PH/api/oauth2-redirect.html'
+      - 'https://DOMAIN_PH/callback'
+      - 'https://proxy.DOMAIN_PH/callback'
+    name: 'Daytona'
+    public: true
+enablePasswordDB: true
+staticPasswords:
+  - email: 'ADMIN_EMAIL_PH'
+    hash: 'ADMIN_HASH_PH'
+    username: 'admin'
+    userID: '1234'
+DEXEOF
+
+    _file_replace "$dir/config.yaml" "DOMAIN_PH"     "$DOMAIN"
+    _file_replace "$dir/config.yaml" "ADMIN_EMAIL_PH" "$ADMIN_EMAIL"
+    _file_replace "$dir/config.yaml" "ADMIN_HASH_PH"  "$ADMIN_PASSWORD_HASH"
+}
+
+step_compose() {
+    local cf="$REPO_DIR/docker/docker-compose.yaml"
+
+    # Helper: replace KEY: value and - KEY=value lines in docker-compose.
+    # Uses awk + ENVIRON so credential values never appear in process arguments.
+    _set() {
+        local key="$1" val="$2"
+        _DAYTONA_VAL="$val" awk -v key="$key" '
+        {
+            if (match($0, "^[[:space:]]*" key ":")) {
+                n = index($0, key ":")
+                print substr($0, 1, n-1) key ": " ENVIRON["_DAYTONA_VAL"]
+            } else if (match($0, "^[[:space:]]*-[[:space:]]*" key "=")) {
+                n = index($0, key "=")
+                print substr($0, 1, n-1) key "=" ENVIRON["_DAYTONA_VAL"]
+            } else {
+                print
+            }
+        }' "$cf" > "${cf}.tmp" && mv "${cf}.tmp" "$cf"
+    }
+
+    _set ENCRYPTION_KEY        "$ENCRYPTION_KEY"
+    _set ENCRYPTION_SALT       "$ENCRYPTION_SALT"
+    _set PROXY_DOMAIN          "proxy.$DOMAIN"
+    _set PROXY_TEMPLATE_URL    "https://{{PORT}}-{{sandboxId}}.proxy.$DOMAIN"
+    _set PROXY_API_KEY         "$PROXY_API_KEY"
+    _set PROXY_PROTOCOL        "https"
+    _set DASHBOARD_URL         "https://$DOMAIN/dashboard"
+    _set DASHBOARD_BASE_API_URL "https://$DOMAIN"
+    _set PUBLIC_OIDC_DOMAIN    "https://$DOMAIN/dex"
+    _set SSH_GATEWAY_URL       "$DOMAIN:2222"
+    _set SSH_GATEWAY_COMMAND   "ssh -p 2222 {{TOKEN}}@$DOMAIN"
+    _set SSH_GATEWAY_API_KEY   "$SSH_GATEWAY_API_KEY"
+    _set DEFAULT_RUNNER_API_KEY "$RUNNER_API_KEY"
+    _set COOKIE_DOMAIN         "proxy.$DOMAIN"
+    _set OIDC_PUBLIC_DOMAIN    "https://$DOMAIN/dex"
+    _set DAYTONA_RUNNER_TOKEN  "$RUNNER_API_KEY"
+
+    # API_KEY inside ssh-gateway section only
+    # Uses ENVIRON so the key value never appears in process arguments
+    _DAYTONA_VAL="$SSH_GATEWAY_API_KEY" awk '
+        /^  ssh-gateway:/ { in_svc=1 }
+        in_svc && /^  [a-z]/ && !/ssh-gateway:/ { in_svc=0 }
+        in_svc && /API_KEY:/ {
+            n = index($0, "API_KEY:")
+            $0 = substr($0, 1, n-1) "API_KEY: " ENVIRON["_DAYTONA_VAL"]
+        }
+        in_svc && /- API_KEY=/ {
+            n = index($0, "API_KEY=")
+            $0 = substr($0, 1, n-1) "API_KEY=" ENVIRON["_DAYTONA_VAL"]
+        }
+        { print }
+    ' "$cf" > "${cf}.tmp" && mv "${cf}.tmp" "$cf"
+
+    # Dex ports
+    if ! grep -q '5556:5556' "$cf"; then
+        awk '
+            /^  dex:/ { in_dex=1; print; next }
+            in_dex && /^  [a-z]/ && !/dex:/ {
+                print "    ports:"; print "      - \"5556:5556\""
+                in_dex=0
+            }
+            { print }
+        ' "$cf" > "${cf}.tmp" && mv "${cf}.tmp" "$cf"
+    fi
+
+    # Remap auxiliary service ports to localhost-only offset ports so they don't
+    # collide with Caddy, which listens on the original ports for HTTPS.
+    # Actual compose file uses: 5050:80 (pgadmin), 5100:80 (registry-ui), 9001:9001 (minio)
+    _remap_port() {
+        local host_port="$1" new_host_port="$2"
+        awk -v hp="$host_port" -v nhp="$new_host_port" '{
+            # Match "- HP:CP" or "- \"HP:CP\"" where HP is the host port
+            if (match($0, hp ":[0-9]+")) {
+                sub(hp ":", "127.0.0.1:" nhp ":")
+            }
+            print
+        }' "$cf" > "${cf}.tmp" && mv "${cf}.tmp" "$cf"
+    }
+    _remap_port 5050 15050
+    _remap_port 5100 15100
+    _remap_port 9001 19001
+
+    # Update PostgreSQL credentials (db service + API service connection)
+    _set POSTGRES_USER         "$DB_USER"
+    _set POSTGRES_PASSWORD     "$DB_PASS"
+    _set DB_USERNAME           "$DB_USER"
+    _set DB_PASSWORD           "$DB_PASS"
+
+    # Update PgAdmin credentials and enable server mode (default is desktop mode with no login)
+    _set PGADMIN_DEFAULT_EMAIL    "$PGADMIN_EMAIL"
+    _set PGADMIN_DEFAULT_PASSWORD "$PGADMIN_PASSWORD"
+    _set PGADMIN_CONFIG_SERVER_MODE       "'True'"
+    _set PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED "'True'"
+
+    # Update MinIO credentials (also used by API and Runner for S3 access)
+    _set MINIO_ROOT_USER       "$MINIO_USER"
+    _set MINIO_ROOT_PASSWORD   "$MINIO_PASSWORD"
+    _set S3_ACCESS_KEY         "$MINIO_USER"
+    _set S3_SECRET_KEY         "$MINIO_PASSWORD"
+    _set AWS_ACCESS_KEY_ID     "$MINIO_USER"
+    _set AWS_SECRET_ACCESS_KEY "$MINIO_PASSWORD"
+
+    # Update Registry credentials (transient + internal point to same registry)
+    _set TRANSIENT_REGISTRY_ADMIN    "$REGISTRY_USER"
+    _set TRANSIENT_REGISTRY_PASSWORD "$REGISTRY_PASSWORD"
+    _set INTERNAL_REGISTRY_ADMIN     "$REGISTRY_USER"
+    _set INTERNAL_REGISTRY_PASSWORD  "$REGISTRY_PASSWORD"
+
+    # Auto-generated API keys
+    _set HEALTH_CHECK_API_KEY    "$HEALTH_CHECK_KEY"
+    _set OTEL_COLLECTOR_API_KEY  "$OTEL_COLLECTOR_KEY"
+
+    # ClickHouse (optional)
+    if [ "$CLICKHOUSE_ENABLED" = "true" ]; then
+        _set CLICKHOUSE_HOST     "$CLICKHOUSE_HOST_VAL"
+        _set CLICKHOUSE_PORT     "$CLICKHOUSE_PORT_VAL"
+        _set CLICKHOUSE_DATABASE "$CLICKHOUSE_DB_VAL"
+        _set CLICKHOUSE_USERNAME "$CLICKHOUSE_USER"
+        _set CLICKHOUSE_PASSWORD "$CLICKHOUSE_PASS"
+        _set CLICKHOUSE_PROTOCOL "$CLICKHOUSE_PROTO"
+    fi
+
+    # SELinux :z labels on bind-mount volumes — Linux only
+    if [ "$OS" != "macos" ]; then
+        sedi -E '/^\s*-\s*(\.\/|\/)[^:]+:[^:]+$/s/$/:z/' "$cf"
+    fi
+
+    # Restrict permissions — compose file now contains plaintext credentials
+    chmod 600 "$cf"
+}
+
+step_firewall() {
+    case "$FIREWALL" in
+        ufw)
+            ufw allow 22/tcp && ufw allow 80/tcp && ufw allow 443/tcp && ufw allow 2222/tcp \
+                && ufw allow 5050/tcp && ufw allow 5100/tcp && ufw allow 9001/tcp
+            ufw --force enable
+            ;;
+        firewalld)
+            systemctl enable --now firewalld
+            for p in 22/tcp 80/tcp 443/tcp 2222/tcp 5050/tcp 5100/tcp 9001/tcp; do
+                firewall-cmd --permanent --add-port="$p"
+            done
+            firewall-cmd --permanent --add-masquerade
+            firewall-cmd --reload
+            # SELinux: Caddy's binary at /usr/bin/caddy is auto-labeled httpd_exec_t on
+            # Fedora and runs in the httpd_t domain under systemd. By default httpd_t cannot
+            # bind the auxiliary ports (5050/5100/9001), so we relabel them. Caddy's storage
+            # is moved to /var/lib/caddy (the conventional location) via XDG_DATA_HOME in the
+            # systemd unit, which avoids the /root home-directory traversal entirely.
+            # No-op if SELinux is disabled.
+            if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce 2>/dev/null)" != "Disabled" ]; then
+                command -v semanage >/dev/null 2>&1 || dnf install -y policycoreutils-python-utils >/dev/null 2>&1 || true
+                if command -v semanage >/dev/null 2>&1; then
+                    # Allow httpd_t to bind the aux ports (TCP for h1/h2, UDP for h3 QUIC)
+                    for proto in tcp udp; do
+                        for p in 5050 5100 9001; do
+                            semanage port -m -t http_port_t -p "$proto" "$p" 2>/dev/null || \
+                                semanage port -a -t http_port_t -p "$proto" "$p" 2>/dev/null || true
+                        done
+                    done
+                    # Pre-create Caddy storage at the conventional /var/lib/caddy location
+                    # and label it so httpd_t can read/write its certs and ACME state.
+                    mkdir -p /var/lib/caddy
+                    chmod 700 /var/lib/caddy
+                    semanage fcontext -a -t httpd_var_lib_t '/var/lib/caddy(/.*)?' 2>/dev/null || true
+                    restorecon -R /var/lib/caddy 2>/dev/null || true
+                fi
+            fi
+            ;;
+        none) true ;;
+    esac
+}
+
+step_caddy_install() {
+    if [ "$OS" = "macos" ]; then
+        launchctl bootout "gui/$(id -u)/com.caddyserver.caddy" 2>/dev/null || true
+    else
+        systemctl stop caddy 2>/dev/null || true
+    fi
+    local url="https://caddyserver.com/api/download?os=${CADDY_OS}&arch=${ARCH}&p=${DNS_CADDY_MODULE}"
+    if [ "$OS" = "macos" ]; then
+        sudo mkdir -p "$(dirname "$CADDY_BIN")"
+        sudo curl -fsSL "$url" -o "$CADDY_BIN"
+        sudo chmod +x "$CADDY_BIN"
+    else
+        curl -fsSL "$url" -o "$CADDY_BIN"
+        chmod +x "$CADDY_BIN"
+    fi
+}
+
+step_caddy_configure() {
+    if [ "$OS" = "macos" ]; then
+        sudo mkdir -p "$CADDY_CONF_DIR"
+        sudo chown "$(whoami)" "$CADDY_CONF_DIR"
+    else
+        mkdir -p "$CADDY_CONF_DIR"
+    fi
+
+    # Caddyfile
+    cat > "$CADDY_CONF_DIR/Caddyfile" <<CADDYEOF
+{
+    admin off
+    email $EMAIL
+}
+
+$DOMAIN {
+    tls {
+        $DNS_TLS_BLOCK
+    }
+
+    handle /dex/* {
+        reverse_proxy localhost:5556
+    }
+
+    handle {
+        reverse_proxy localhost:3000
+    }
+}
+
+proxy.$DOMAIN, *.proxy.$DOMAIN {
+    tls {
+        $DNS_TLS_BLOCK
+    }
+
+    reverse_proxy localhost:4000
+}
+
+$DOMAIN:5050 {
+    tls {
+        $DNS_TLS_BLOCK
+    }
+    basic_auth {
+        PGADMIN_AUTH_PH
+    }
+    reverse_proxy localhost:15050
+}
+
+$DOMAIN:9001 {
+    tls {
+        $DNS_TLS_BLOCK
+    }
+    reverse_proxy localhost:19001
+}
+
+$DOMAIN:5100 {
+    tls {
+        $DNS_TLS_BLOCK
+    }
+    basic_auth {
+        REGISTRY_AUTH_PH
+    }
+    reverse_proxy localhost:15100
+}
+CADDYEOF
+
+    # Generate basicauth hashes using Caddy's own hasher — guaranteed format compatibility
+    # Hash passwords via stdin so they never appear in process arguments.
+    # Note: Caddy 2.11+ requires a newline-terminated password on stdin (the trailing \n
+    # is significant — without it the reader returns EOF before getting any input).
+    local pgadmin_hash registry_hash
+    pgadmin_hash=$(printf '%s\n' "$PGADMIN_PASSWORD" | "$CADDY_BIN" hash-password)
+    registry_hash=$(printf '%s\n' "$ADMIN_PASSWORD" | "$CADDY_BIN" hash-password)
+    _file_replace "$CADDY_CONF_DIR/Caddyfile" "PGADMIN_AUTH_PH" "$PGADMIN_EMAIL $pgadmin_hash"
+    _file_replace "$CADDY_CONF_DIR/Caddyfile" "REGISTRY_AUTH_PH" "admin $registry_hash"
+
+    # Environment file
+    printf '%s=%s\n' "$DNS_ENV_NAME" "$DNS_TOKEN" > "$CADDY_CONF_DIR/environment"
+    [ -n "${DNS_ENV_NAME_EXTRA:-}" ] && [ -n "${DNS_TOKEN_EXTRA:-}" ] && \
+        printf '%s=%s\n' "$DNS_ENV_NAME_EXTRA" "$DNS_TOKEN_EXTRA" >> "$CADDY_CONF_DIR/environment"
+    chmod 600 "$CADDY_CONF_DIR/environment"
+
+    if [ "$OS" = "macos" ]; then
+        # Wrapper script to load env vars and run Caddy
+        sudo tee /usr/local/bin/caddy-daytona > /dev/null <<WRAPEOF
+#!/bin/bash
+set -a
+source "$CADDY_CONF_DIR/environment"
+set +a
+exec "$CADDY_BIN" run --config "$CADDY_CONF_DIR/Caddyfile" --adapter caddyfile
+WRAPEOF
+        sudo chmod +x /usr/local/bin/caddy-daytona
+
+        # LaunchAgent plist
+        mkdir -p "$HOME/Library/LaunchAgents"
+        cat > "$HOME/Library/LaunchAgents/com.caddyserver.caddy.plist" <<'PLISTEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.caddyserver.caddy</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/caddy-daytona</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/caddy/access.log</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/caddy/error.log</string>
+</dict>
+</plist>
+PLISTEOF
+        sudo mkdir -p /usr/local/var/log/caddy
+        sudo chown "$(whoami)" /usr/local/var/log/caddy
+        launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.caddyserver.caddy.plist"
+    else
+        # Systemd unit
+        cat > /etc/systemd/system/caddy.service <<'SVCEOF'
+[Unit]
+Description=Caddy web server
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+# Caddy stores certs/state at $XDG_DATA_HOME/caddy and autosave at $XDG_CONFIG_HOME/caddy.
+# Pointing both at /var/lib puts everything in /var/lib/caddy — the conventional location,
+# matches Fedora's packaged caddy, and avoids any /root home-directory traversal under SELinux.
+Environment=XDG_DATA_HOME=/var/lib
+Environment=XDG_CONFIG_HOME=/var/lib
+EnvironmentFile=/etc/caddy/environment
+ExecStart=/usr/bin/caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+
+        systemctl daemon-reload
+        systemctl enable --now caddy
+
+        # If Caddy failed to start, run it directly to capture the actual error
+        if ! systemctl is-active --quiet caddy; then
+            echo "Caddy failed to start via systemd. Capturing error:"
+            (set -a; source "$CADDY_CONF_DIR/environment"; set +a
+             timeout 5 "$CADDY_BIN" run --config "$CADDY_CONF_DIR/Caddyfile" --adapter caddyfile 2>&1) || true
+            return 1
+        fi
+    fi
+}
+
+step_docker_start() {
+    local cf="$REPO_DIR/docker/docker-compose.yaml"
+
+    docker compose -f "$cf" up -d
+
+    # Wait for services (90s timeout)
+    local deadline=$(( $(date +%s) + 90 ))
+    for svc in api proxy dex ssh-gateway; do
+        while true; do
+            [ "$(date +%s)" -gt "$deadline" ] && {
+                echo "Timeout waiting for $svc"
+                docker compose -f "$cf" logs "$svc" --tail 10
+                return 1
+            }
+            local state
+            state=$(docker compose -f "$cf" ps --format '{{.State}}' "$svc" 2>/dev/null || true)
+            case "$state" in
+                running|healthy) break ;;
+                exited|dead)
+                    echo "Service $svc failed:"
+                    docker compose -f "$cf" logs "$svc" --tail 10
+                    return 1 ;;
+            esac
+            sleep 3
+        done
+    done
+
+    # Let API finish initializing
+    sleep 10
+}
+
+step_verify() {
+    local cf="$REPO_DIR/docker/docker-compose.yaml"
+    local passed=0 failed=0
+
+    printf "\n${BOLD}  Verification Results${NC}\n\n"
+
+    # Container health
+    local all_ok=true
+    for svc in api proxy dex ssh-gateway; do
+        local st
+        st=$(docker compose -f "$cf" ps --format '{{.State}}' "$svc" 2>/dev/null || true)
+        [ "$st" = "running" ] || [ "$st" = "healthy" ] || all_ok=false
+    done
+    if $all_ok; then ok "Docker container health"; passed=$((passed+1))
+    else fail "Docker container health"; failed=$((failed+1)); fi
+
+    # Dex OIDC
+    if curl -sf --max-time 5 "http://localhost:5556/dex/.well-known/openid-configuration" | grep -q "https://$DOMAIN/dex"; then
+        ok "Dex OIDC issuer"; passed=$((passed+1))
+    else fail "Dex OIDC issuer"; failed=$((failed+1)); fi
+
+    # DNS — use host(1) on macOS, getent on Linux
+    if [ "$OS" = "macos" ]; then
+        if host "$DOMAIN" >/dev/null 2>&1; then
+            ok "Base domain DNS"; passed=$((passed+1))
+        else fail "Base domain DNS"; failed=$((failed+1)); fi
+
+        if host "proxy.$DOMAIN" >/dev/null 2>&1; then
+            ok "Proxy wildcard DNS"; passed=$((passed+1))
+        else fail "Proxy wildcard DNS"; failed=$((failed+1)); fi
+    else
+        if getent hosts "$DOMAIN" >/dev/null 2>&1; then
+            ok "Base domain DNS"; passed=$((passed+1))
+        else fail "Base domain DNS"; failed=$((failed+1)); fi
+
+        if getent hosts "proxy.$DOMAIN" >/dev/null 2>&1; then
+            ok "Proxy wildcard DNS"; passed=$((passed+1))
+        else fail "Proxy wildcard DNS"; failed=$((failed+1)); fi
+    fi
+
+    # HTTPS — wait up to 120s for TLS certificate
+    info "Waiting for TLS certificate (up to 120s)..."
+    local https_ok=false code=""
+    for _ in $(seq 1 24); do
+        code=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "https://$DOMAIN" 2>/dev/null || echo "000")
+        case "$code" in 200|301|302) https_ok=true; break ;; esac
+        sleep 5
+    done
+    if $https_ok; then ok "HTTPS dashboard (HTTP $code)"; passed=$((passed+1))
+    else
+        fail "HTTPS dashboard (HTTP $code)"; failed=$((failed+1))
+        # Check if Caddy is running and diagnose why TLS failed
+        if [ "$OS" != "macos" ]; then
+            if ! systemctl is-active --quiet caddy 2>/dev/null; then
+                warn "Caddy is not running — check: systemctl status caddy.service"
+            else
+                # Caddy is running but TLS failed — check for rate limiting
+                local caddy_err
+                caddy_err=$(journalctl -u caddy.service --since "5 min ago" --no-pager 2>/dev/null || true)
+                if echo "$caddy_err" | grep -qi "rateLimited" 2>/dev/null; then
+                    local retry_time
+                    retry_time=$(echo "$caddy_err" | grep -o 'retry after [0-9A-Z: -]*' | tail -1)
+                    warn "Let's Encrypt rate limit hit — $retry_time"
+                    warn "Caddy will retry automatically. Leave it running."
+                elif echo "$caddy_err" | grep -qi "error" 2>/dev/null; then
+                    warn "Caddy reported errors — check: journalctl -u caddy.service --no-pager | tail -20"
+                else
+                    warn "TLS certificates may still be issuing. Caddy is running and will retry."
+                fi
+            fi
+        fi
+    fi
+
+    # Wildcard TLS
+    local proxy_ip
+    if [ "$OS" = "macos" ]; then
+        proxy_ip=$(dig +short "proxy.$DOMAIN" A 2>/dev/null | head -1)
+    else
+        proxy_ip=$(getent hosts "proxy.$DOMAIN" 2>/dev/null | awk '{print $1; exit}' || true)
+    fi
+    if [ -n "$proxy_ip" ]; then
+        local san
+        san=$(echo | openssl s_client -servername "test.proxy.$DOMAIN" -connect "$proxy_ip:443" 2>/dev/null \
+            | openssl x509 -noout -text 2>/dev/null | grep -A1 "Subject Alternative Name" || true)
+        if echo "$san" | grep -q "\\*.proxy.$DOMAIN"; then
+            ok "Wildcard TLS certificate"; passed=$((passed+1))
+        else fail "Wildcard TLS certificate (may still be issuing)"; failed=$((failed+1)); fi
+    else fail "Wildcard TLS certificate (proxy DNS not resolving)"; failed=$((failed+1)); fi
+
+    # SSH Gateway — nc for macOS (no timeout command), bash /dev/tcp for Linux
+    if [ "$OS" = "macos" ]; then
+        if nc -z -w 5 "$DOMAIN" 2222 2>/dev/null; then
+            ok "SSH Gateway port 2222"; passed=$((passed+1))
+        else fail "SSH Gateway port 2222"; failed=$((failed+1)); fi
+    else
+        if timeout 5 bash -c "echo >/dev/tcp/$DOMAIN/2222" 2>/dev/null; then
+            ok "SSH Gateway port 2222"; passed=$((passed+1))
+        else fail "SSH Gateway port 2222"; failed=$((failed+1)); fi
+    fi
+
+    printf "\n  %d passed, %d failed\n" "$passed" "$failed"
+
+    if [ "$failed" -eq 0 ]; then
+        printf "\n${GREEN}${BOLD}  Setup complete!${NC}\n"
+    else
+        printf "\n${YELLOW}  Some checks failed. TLS certificates may still be issuing — retry in a few minutes.${NC}\n"
+    fi
+
+    printf "\n${BOLD}  Endpoints${NC}\n"
+    printf "  ─────────\n"
+    printf "  Dashboard:   https://%s\n" "$DOMAIN"
+    printf "               Login: %s\n" "$ADMIN_EMAIL"
+    printf "  PgAdmin:     https://%s:5050\n" "$DOMAIN"
+    printf "               Basic Auth: %s / (password set during setup)\n" "$PGADMIN_EMAIL"
+    printf "               PgAdmin Login: same email and password\n"
+    printf "  MinIO:       https://%s:9001\n" "$DOMAIN"
+    printf "               Login: %s / (password set during setup)\n" "$MINIO_USER"
+    printf "  Registry UI: https://%s:5100\n" "$DOMAIN"
+    printf "               Basic Auth: admin / (admin password set during setup)\n"
+    printf "\n"
+}
+
+# ── Main ────────────────────────────────────────────────────
+main() {
+    # Root required on Linux, not on macOS (uses sudo where needed)
+    if [ "$(uname -s)" != "Darwin" ] && [ "$(id -u)" -ne 0 ]; then
+        die "This script must be run as root"
+    fi
+
+    detect_platform
+    collect_input
+
+    printf "\n${BOLD}  Setting up Daytona...${NC}\n\n"
+
+    run_step "Cleaning previous installation"    step_clean
+    run_step "Installing system packages"        step_packages
+    run_step "Cloning Daytona repository"        step_clone
+    run_step "Generating security credentials"   step_secrets
+    run_step "Configuring Dex OIDC provider"     step_dex
+    run_step "Configuring Docker Compose"        step_compose
+    run_step "Configuring firewall rules"        step_firewall
+    run_step "Installing Caddy with DNS module"  step_caddy_install
+    run_step "Configuring Caddy reverse proxy"   step_caddy_configure
+    run_step "Starting Docker services"          step_docker_start
+
+    # Pull sandbox image with visible progress (blocking — sandboxes won't work without it)
+    printf "  ${CYAN}▸${NC} Pulling sandbox image (this may take a few minutes)\n"
+    if docker pull daytonaio/sandbox:0.5.0-slim; then
+        printf "  ${GREEN}✓${NC} Sandbox image ready\n"
+    else
+        printf "  ${RED}✗${NC} Failed to pull sandbox image — sandbox creation will download it on first use\n"
+    fi
+
+    step_verify
+}
+
+main "$@"

--- a/scripts/setup-domain-oss-deployment.sh
+++ b/scripts/setup-domain-oss-deployment.sh
@@ -588,6 +588,15 @@ step_firewall() {
 }
 
 step_caddy_install() {
+    # Skip re-download when the Caddy binary on disk already has the requested DNS provider.
+    # Makes re-runs resilient to caddyserver.com build-API outages and supports Caddy binaries
+    # built locally via xcaddy. When the selected DNS provider differs from what's compiled in,
+    # fall through below and overwrite the binary with a fresh build containing the new module.
+    local requested_module="${DNS_CADDY_MODULE##*/}"
+    if [ -x "$CADDY_BIN" ] && "$CADDY_BIN" list-modules 2>/dev/null | grep -qF "dns.providers.${requested_module}"; then
+        return 0
+    fi
+
     if [ "$OS" = "macos" ]; then
         launchctl bootout "gui/$(id -u)/com.caddyserver.caddy" 2>/dev/null || true
     else
@@ -596,10 +605,10 @@ step_caddy_install() {
     local url="https://caddyserver.com/api/download?os=${CADDY_OS}&arch=${ARCH}&p=${DNS_CADDY_MODULE}"
     if [ "$OS" = "macos" ]; then
         sudo mkdir -p "$(dirname "$CADDY_BIN")"
-        sudo curl -fsSL "$url" -o "$CADDY_BIN"
+        sudo curl -fsSL --max-time 600 "$url" -o "$CADDY_BIN"
         sudo chmod +x "$CADDY_BIN"
     else
-        curl -fsSL "$url" -o "$CADDY_BIN"
+        curl -fsSL --max-time 600 "$url" -o "$CADDY_BIN"
         chmod +x "$CADDY_BIN"
     fi
 }

--- a/scripts/setup-domain-oss-deployment.sh
+++ b/scripts/setup-domain-oss-deployment.sh
@@ -8,6 +8,10 @@
 # Usage: ./setup.sh
 set -euo pipefail
 
+# Remove transient per-step log on any exit so partial runs don't leave
+# captured stdout/stderr lying around in /tmp.
+trap 'rm -f "/tmp/daytona-step-$$.log"' EXIT INT TERM
+
 # ── Colors ──────────────────────────────────────────────────
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -136,12 +140,18 @@ collect_input() {
     printf "  ═══════════════════════\n\n"
 
     # Domain
+    # Restrict to RFC 1123 hostname syntax. The value is substituted into the
+    # Caddyfile, docker-compose env vars, and Dex config; accepting only
+    # letters/digits/hyphens/dots prevents a typo from corrupting those files.
     while true; do
         printf "  Domain (e.g. daytona.example.com): "; read -r DOMAIN
         DOMAIN="${DOMAIN#https://}"; DOMAIN="${DOMAIN#http://}"
         DOMAIN="$(echo "$DOMAIN" | tr -d '[:space:]')"
         [ -z "$DOMAIN" ] && { fail "Required"; continue; }
-        echo "$DOMAIN" | grep -q '\.' || { fail "Must contain a dot"; continue; }
+        if ! echo "$DOMAIN" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$'; then
+            fail "Must be a valid hostname (e.g. daytona.example.com)"
+            continue
+        fi
         break
     done
 
@@ -207,11 +217,13 @@ collect_input() {
         [ -z "$DNS_TOKEN_EXTRA" ] && die "Required"
     fi
 
-    # Email
+    # Email — basic but stricter than just "contains @". Caddy sends this to
+    # Let's Encrypt; an obviously-bogus value gets the ACME account rejected.
+    local _email_re='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$'
     while true; do
         printf "\n  Email (for Let's Encrypt certificates): "; read -r EMAIL
         EMAIL="$(echo "$EMAIL" | tr -d '[:space:]')"
-        echo "$EMAIL" | grep -q '@.*\.' && break
+        echo "$EMAIL" | grep -qE "$_email_re" && break
         fail "Must be a valid email"
     done
 
@@ -219,14 +231,15 @@ collect_input() {
     while true; do
         printf "  Admin login email: "; read -r ADMIN_EMAIL
         ADMIN_EMAIL="$(echo "$ADMIN_EMAIL" | tr -d '[:space:]')"
-        echo "$ADMIN_EMAIL" | grep -q '@' && break
+        echo "$ADMIN_EMAIL" | grep -qE "$_email_re" && break
         fail "Must be a valid email"
     done
 
-    # Admin password
+    # Admin password — fronts the Daytona dashboard on the public internet,
+    # so require 12 chars minimum rather than the bare-minimum 8.
     while true; do
-        printf "  Admin password (min 8 chars): "; read -rs ADMIN_PASSWORD; echo
-        [ ${#ADMIN_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        printf "  Admin password (min 12 chars): "; read -rs ADMIN_PASSWORD; echo
+        [ ${#ADMIN_PASSWORD} -lt 12 ] && { fail "Too short"; continue; }
         printf "  Confirm password: "; read -rs pw_confirm; echo
         [ "$ADMIN_PASSWORD" = "$pw_confirm" ] && break
         fail "Passwords do not match"
@@ -236,16 +249,21 @@ collect_input() {
     printf "\n${BOLD}  Service Credentials${NC}\n"
     printf "  These replace default placeholder credentials and secure services behind HTTPS.\n\n"
 
+    # Usernames are substituted into docker-compose env vars and, for the
+    # registry user, into the Caddyfile basic_auth directive. Restrict the
+    # charset so a stray quote or brace can't corrupt the config.
+    local _user_re='^[a-zA-Z0-9_-]{1,63}$'
+
     # PostgreSQL
     while true; do
         printf "  PostgreSQL username: "; read -r DB_USER
         DB_USER="$(echo "$DB_USER" | tr -d '[:space:]')"
-        [ -n "$DB_USER" ] && break
-        fail "Required"
+        echo "$DB_USER" | grep -qE "$_user_re" && break
+        fail "Must be alphanumeric (plus _ -), 1-63 chars"
     done
     while true; do
-        printf "  PostgreSQL password (min 8 chars): "; read -rs DB_PASS; echo
-        [ ${#DB_PASS} -lt 8 ] && { fail "Too short"; continue; }
+        printf "  PostgreSQL password (min 12 chars): "; read -rs DB_PASS; echo
+        [ ${#DB_PASS} -lt 12 ] && { fail "Too short"; continue; }
         break
     done
 
@@ -253,12 +271,12 @@ collect_input() {
     while true; do
         printf "  PgAdmin email: "; read -r PGADMIN_EMAIL
         PGADMIN_EMAIL="$(echo "$PGADMIN_EMAIL" | tr -d '[:space:]')"
-        echo "$PGADMIN_EMAIL" | grep -q '@' && break
+        echo "$PGADMIN_EMAIL" | grep -qE "$_email_re" && break
         fail "Must be a valid email"
     done
     while true; do
-        printf "  PgAdmin password (min 8 chars): "; read -rs PGADMIN_PASSWORD; echo
-        [ ${#PGADMIN_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        printf "  PgAdmin password (min 12 chars): "; read -rs PGADMIN_PASSWORD; echo
+        [ ${#PGADMIN_PASSWORD} -lt 12 ] && { fail "Too short"; continue; }
         break
     done
 
@@ -266,12 +284,12 @@ collect_input() {
     while true; do
         printf "  MinIO admin username: "; read -r MINIO_USER
         MINIO_USER="$(echo "$MINIO_USER" | tr -d '[:space:]')"
-        [ -n "$MINIO_USER" ] && break
-        fail "Required"
+        echo "$MINIO_USER" | grep -qE "$_user_re" && break
+        fail "Must be alphanumeric (plus _ -), 1-63 chars"
     done
     while true; do
-        printf "  MinIO admin password (min 8 chars): "; read -rs MINIO_PASSWORD; echo
-        [ ${#MINIO_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        printf "  MinIO admin password (min 12 chars): "; read -rs MINIO_PASSWORD; echo
+        [ ${#MINIO_PASSWORD} -lt 12 ] && { fail "Too short"; continue; }
         break
     done
 
@@ -279,12 +297,12 @@ collect_input() {
     while true; do
         printf "  Registry admin username: "; read -r REGISTRY_USER
         REGISTRY_USER="$(echo "$REGISTRY_USER" | tr -d '[:space:]')"
-        [ -n "$REGISTRY_USER" ] && break
-        fail "Required"
+        echo "$REGISTRY_USER" | grep -qE "$_user_re" && break
+        fail "Must be alphanumeric (plus _ -), 1-63 chars"
     done
     while true; do
-        printf "  Registry admin password (min 8 chars): "; read -rs REGISTRY_PASSWORD; echo
-        [ ${#REGISTRY_PASSWORD} -lt 8 ] && { fail "Too short"; continue; }
+        printf "  Registry admin password (min 12 chars): "; read -rs REGISTRY_PASSWORD; echo
+        [ ${#REGISTRY_PASSWORD} -lt 12 ] && { fail "Too short"; continue; }
         break
     done
 
@@ -682,11 +700,13 @@ CADDYEOF
     # Hash passwords via stdin so they never appear in process arguments.
     # Note: Caddy 2.11+ requires a newline-terminated password on stdin (the trailing \n
     # is significant — without it the reader returns EOF before getting any input).
+    # Use the registry credentials (not the Daytona admin password) to gate the
+    # registry UI — keeping the admin login credential scoped to the dashboard.
     local pgadmin_hash registry_hash
     pgadmin_hash=$(printf '%s\n' "$PGADMIN_PASSWORD" | "$CADDY_BIN" hash-password)
-    registry_hash=$(printf '%s\n' "$ADMIN_PASSWORD" | "$CADDY_BIN" hash-password)
+    registry_hash=$(printf '%s\n' "$REGISTRY_PASSWORD" | "$CADDY_BIN" hash-password)
     _file_replace "$CADDY_CONF_DIR/Caddyfile" "PGADMIN_AUTH_PH" "$PGADMIN_EMAIL $pgadmin_hash"
-    _file_replace "$CADDY_CONF_DIR/Caddyfile" "REGISTRY_AUTH_PH" "admin $registry_hash"
+    _file_replace "$CADDY_CONF_DIR/Caddyfile" "REGISTRY_AUTH_PH" "$REGISTRY_USER $registry_hash"
 
     # Environment file
     printf '%s=%s\n' "$DNS_ENV_NAME" "$DNS_TOKEN" > "$CADDY_CONF_DIR/environment"
@@ -918,7 +938,7 @@ step_verify() {
     printf "  MinIO:       https://%s:9001\n" "$DOMAIN"
     printf "               Login: %s / (password set during setup)\n" "$MINIO_USER"
     printf "  Registry UI: https://%s:5100\n" "$DOMAIN"
-    printf "               Basic Auth: admin / (admin password set during setup)\n"
+    printf "               Basic Auth: %s / (registry password set during setup)\n" "$REGISTRY_USER"
     printf "\n"
 }
 


### PR DESCRIPTION
## Description

Updates the OSS deployment docs to include clear instructions on how to configure daytona for use behind a domain. Adds a script file that automates the configuration (does not automate configuring DNS within the DNS provider)

Dependencies: Technically these are all of the dependencies included in this PR as part of the automation script/configuration wizard

git
curl
openssl
ufw or firewalld
apache2-utils (Ubuntu/Debian) or httpd-tools (Fedora) or httpd (MacOS) : All for htpasswd
Caddy

## Related Issue

https://github.com/daytonaio/daytona/issues/2673


## Summary

Adds a Quick Start section to the existing OSS Deployment documentation and outlines the exact steps to go from nothing to working Daytona Dashboard accessible behind https://. Rewords the existing localhost Deployment accordingly to delineate the two separate options. Includes comprehensive (as much as not to detract from the existing OSS Deployment docs) background on what the script automates. Includes clear guidelines on what a user ought to do in order to configure their DNS records within their DNS provider interface and provides several examples to getting a DNS API Token (for dynamically handling wildcard domain setup in a simple manner).

Adds a script file to /daytonaio/daytona/scripts to automate the configuration of the server instance and the containers for TLS.

Implementation uses Caddy to handle the reverse proxy side, Let's Encrypt for TLS, DNS can be any solution that allows for A records or CNAME records and API tokens, OS can be any of Ubuntu, Debian, Fedora, or MacOS (as a way to preempt the Mac Mini users). Dex is the OIDC provider still.

Similarly, we also allow the user
to input credentials for the Daytona Admin account and for the various database tools.

### Note:

https://localhost:3000 is hardcoded, so the script is configured to do the following currently:

1. Copies the compiled JS assets out of the running API container (docker compose cp api:/daytona/dist/apps/dashboard/assets)

2. Does a find-and-replace across all .js files, swapping http://localhost:3000 → https://yourdomain.com

3. Bind-mounts the patched assets back into the API container as a volume override

4. Restarts the API container so it serves the patched files

## Testing Notes:

I tested this on all of Ubuntu, Debian, Fedora, and MacOS instances. I was able to visit the page, be greeted with the DEX sign-in, create a sandbox, connect to the sandbox. Visit all of the database pages and be greeted with sign-ins.

One nuance that was slightly annoying and is a change unrelated to these docs is that when starting the service you are required to set a `default region` before creating a sandbox, but this is not obvious as the error you are given when creating a sandbox for the first time is generic. User must visit the Console and see the logs to know that they have to click on Settings and set a Default Region. After setting that default region the user is then signed out and must sign in again via the DEX page. This was not an enjoyable UX.

### Future PRs noted as potential requirements:

1. Ensure that the https://localhost:3000 is dynamic rather than hard coded to avoid the temporary workaround for using OSS Deployment with a Domain

2. Fix the generic error in the Sandbox Creation UI or set a default region for the user at startup time and after setting a default region, avoid having to sign the user out.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds domain deployment docs and an automated setup script to run Daytona behind your own domain with HTTPS. The dashboard now reads its API URL at runtime via `VITE_API_URL`, and the Create Sandbox flow simplifies default-region setup.

- **New Features**
  - Domain deployment docs: local vs domain quick starts, DNS setup with a Cloudflare DNS-only wildcard warning, provider reference, troubleshooting, security notes, and macOS behind-router guidance.
  - `scripts/setup-domain-oss-deployment.sh`: generates secrets; configures Dex (`issuer`, `redirectURIs`, bcrypt admin); updates Docker Compose URLs/secrets; installs/configures Caddy with DNS-01 for Cloudflare/DigitalOcean/Route53/Google DNS/Hetzner/Namecheap; opens firewall; starts services; binds PgAdmin/Registry UI/MinIO to localhost and exposes via TLS (Basic Auth where applicable); optional ClickHouse; supports Ubuntu/Debian/Fedora/CentOS/RHEL/Rocky/AlmaLinux/macOS; includes verification checks.
  - Create Sandbox UX: auto-selects the sole region when no default exists; lets organization OWNERs set the selected region as default inline; gracefully handles a 409 if another flow set it.

- **Bug Fixes**
  - Unified on `VITE_API_URL`: dashboard `ConfigProvider` reads `VITE_API_URL` (fallback to `window.location.origin + '/api'`), and the API Dockerfile builds the dashboard with `VITE_API_URL=%DAYTONA_BASE_API_URL%/api`; removed legacy frontend asset patching.
  - Invalidate org cache on default-region change: after `setDefaultRegion`, delete `organization:{id}` in Redis; wrapped in try/catch so failures don’t block the request.
  - Setup script hardening: idempotent Caddy install (skip if requested DNS module present; `curl --max-time 600`), correct Caddy `hash-password` stdin newline handling, SELinux-safe systemd unit storing Caddy state under `/var/lib` with port/file labeling so Caddy starts on Fedora without weakening SELinux; idempotent clone/clean; stdin/env-based secret handling; restrictive file perms; fixes hardcoded Registry admin by using the provided username/password and adds basic input validation.

<sup>Written for commit f7102222081abd590b6bb3e5f7f37792809ad2ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



