### PR TITLE
fix: build local otel-collector image in self-hosted Docker Compose o…

### DIFF
--- a/docker/docker-compose.build.override.yaml
+++ b/docker/docker-compose.build.override.yaml
@@ -5,7 +5,7 @@ services:
       context: ../
       dockerfile: apps/api/Dockerfile
       target: daytona
-  
+
   proxy:
     build:
       context: ../
@@ -23,3 +23,8 @@ services:
       context: ../
       dockerfile: apps/ssh-gateway/Dockerfile
       target: ssh-gateway
+
+  otel-collector:
+    build:
+      context: ../
+      dockerfile: apps/otel-collector/Dockerfile


### PR DESCRIPTION
…verride

## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the local OpenTelemetry Collector image via the self-hosted Docker Compose build override so the stack uses a local `otel-collector` and avoids missing image/tag errors.

- **Bug Fixes**
  - Added build config for `otel-collector` in docker/docker-compose.build.override.yaml (context ../, Dockerfile apps/otel-collector/Dockerfile).

<sup>Written for commit 84d3cf98a6f09934ef1311044b00268fb4fde79d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

