### PR TITLE
Support Docker Compose public access on VMs

### DIFF
--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -47,6 +47,27 @@ The Docker Compose configuration includes all the necessary services to run Dayt
    - Registry UI: http://localhost:5100
    - MinIO Console: http://localhost:9001 (minioadmin / minioadmin)
 
+## Running On A VM
+
+If you want to access Daytona from outside the VM, export the public host of the VM and a wildcard-capable proxy host before starting Compose.
+
+For a VM that only has a public IP, `sslip.io` is the simplest option:
+
+```bash
+export DAYTONA_PUBLIC_HOST=203.0.113.10
+export DAYTONA_PROXY_HOST=203-0-113-10.sslip.io
+docker compose -f docker/docker-compose.yaml up -d
+```
+
+With that configuration:
+
+- Dashboard is served at `http://203.0.113.10:3000`
+- Dex is served at `http://203.0.113.10:5556/dex`
+- Preview URLs are served at `http://<port>-<sandbox-id>.203-0-113-10.sslip.io:4000`
+- SSH access uses `ssh -p 2222 <token>@203.0.113.10`
+
+`DAYTONA_PROXY_HOST` must resolve wildcard subdomains. A raw IP address is not enough for preview URLs because Daytona publishes per-sandbox hosts like `<port>-<sandbox-id>.<proxy-host>`.
+
 ## DNS Setup for Proxy URLs
 
 For local development, you need to resolve `*.proxy.localhost` domains to `127.0.0.1`:
@@ -133,7 +154,7 @@ Below is a full list of environment variables with their default values:
 | `OIDC_MANAGEMENT_API_AUDIENCE`             | string  | (empty)                                              | OIDC management API audience                                                                         |
 | `DEFAULT_SNAPSHOT`                         | string  | `daytonaio/sandbox:0.4.3`                            | Default sandbox snapshot image                                                                       |
 | `DASHBOARD_URL`                            | string  | `http://localhost:3000/dashboard`                    | Dashboard URL                                                                                        |
-| `DASHBOARD_BASE_API_URL`                   | string  | `http://localhost:3000`                              | Dashboard base API URL                                                                               |
+| `DASHBOARD_BASE_API_URL`                   | string  | (empty)                                              | Dashboard base API URL. When empty, the dashboard uses the same origin and calls `/api`.            |
 | `POSTHOG_API_KEY`                          | string  | `phc_bYtEsdMDrNLydXPD4tufkBrHKgfO2zbycM30LOowYNv`    | PostHog API key for analytics                                                                        |
 | `POSTHOG_HOST`                             | string  | `https://d18ag4dodbta3l.cloudfront.net`              | PostHog host URL                                                                                     |
 | `POSTHOG_ENVIRONMENT`                      | string  | `local`                                              | PostHog environment identifier                                                                       |

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,6 +40,27 @@ The Docker Compose configuration includes all the necessary services to run Dayt
    - Registry UI: http://localhost:5100
    - MinIO Console: http://localhost:9001 (minioadmin / minioadmin)
 
+## Running On A VM
+
+If you want to access Daytona from outside the VM, export the public host of the VM and a wildcard-capable proxy host before starting Compose.
+
+For a VM that only has a public IP, `sslip.io` is the simplest option:
+
+```bash
+export DAYTONA_PUBLIC_HOST=203.0.113.10
+export DAYTONA_PROXY_HOST=203-0-113-10.sslip.io
+docker compose -f docker/docker-compose.yaml up -d
+```
+
+With that configuration:
+
+- Dashboard is served at `http://203.0.113.10:3000`
+- Dex is served at `http://203.0.113.10:5556/dex`
+- Preview URLs are served at `http://<port>-<sandbox-id>.203-0-113-10.sslip.io:4000`
+- SSH access uses `ssh -p 2222 <token>@203.0.113.10`
+
+`DAYTONA_PROXY_HOST` must resolve wildcard subdomains. A raw IP address is not enough for preview URLs because Daytona publishes per-sandbox hosts like `<port>-<sandbox-id>.<proxy-host>`.
+
 ## DNS Setup for Proxy URLs
 
 For local development, you need to resolve `*.proxy.localhost` domains to `127.0.0.1`:

--- a/docker/dex/config.yaml
+++ b/docker/dex/config.yaml
@@ -1,5 +1,5 @@
-# config.yaml
-issuer: http://localhost:5556/dex
+# Dex config template. Rendered by docker/dex/render-config.sh.
+issuer: __DAYTONA_OIDC_ISSUER__
 storage:
   type: sqlite3
   config:
@@ -12,10 +12,10 @@ web:
 staticClients:
   - id: daytona
     redirectURIs:
-      - 'http://localhost:3000'
-      - 'http://localhost:3000/api/oauth2-redirect.html'
+      - '__DAYTONA_DASHBOARD_BASE_URL__'
+      - '__DAYTONA_DASHBOARD_BASE_URL__/api/oauth2-redirect.html'
       - 'http://localhost:3009/callback'
-      - 'http://proxy.localhost:4000/callback'
+      - '__DAYTONA_PROXY_BASE_URL__/callback'
     name: 'Daytona'
     public: true
 enablePasswordDB: true

--- a/docker/dex/render-config.sh
+++ b/docker/dex/render-config.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+
+template_path=${1:-/etc/dex/config.yaml.tmpl}
+output_path=${2:-/tmp/dex-config.yaml}
+
+require_env() {
+  var_name=$1
+  eval "value=\${$var_name:-}"
+  if [ -z "$value" ]; then
+    echo "Missing required environment variable: $var_name" >&2
+    exit 1
+  fi
+}
+
+escape_sed() {
+  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
+}
+
+require_env DAYTONA_DASHBOARD_BASE_URL
+require_env DAYTONA_PROXY_BASE_URL
+require_env DAYTONA_OIDC_ISSUER
+
+dashboard_base_url_escaped=$(escape_sed "$DAYTONA_DASHBOARD_BASE_URL")
+proxy_base_url_escaped=$(escape_sed "$DAYTONA_PROXY_BASE_URL")
+oidc_issuer_escaped=$(escape_sed "$DAYTONA_OIDC_ISSUER")
+
+sed \
+  -e "s/__DAYTONA_DASHBOARD_BASE_URL__/$dashboard_base_url_escaped/g" \
+  -e "s/__DAYTONA_PROXY_BASE_URL__/$proxy_base_url_escaped/g" \
+  -e "s/__DAYTONA_OIDC_ISSUER__/$oidc_issuer_escaped/g" \
+  "$template_path" > "$output_path"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   api:
     image: daytonaio/daytona-api
     ports:
-      - 3000:3000
+      - ${DAYTONA_PUBLIC_PORT:-3000}:3000
     environment:
       - OTEL_ENABLED=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
@@ -22,14 +22,14 @@ services:
       - REDIS_PORT=6379
       - OIDC_CLIENT_ID=daytona
       - OIDC_ISSUER_BASE_URL=http://dex:5556/dex
-      - PUBLIC_OIDC_DOMAIN=http://localhost:5556/dex
+      - PUBLIC_OIDC_DOMAIN=${DAYTONA_PUBLIC_PROTOCOL:-http}://${DAYTONA_PUBLIC_HOST:-localhost}:${DAYTONA_OIDC_PORT:-5556}/dex
       - OIDC_AUDIENCE=daytona
       - OIDC_MANAGEMENT_API_ENABLED=
       - OIDC_MANAGEMENT_API_CLIENT_ID=
       - OIDC_MANAGEMENT_API_CLIENT_SECRET=
       - OIDC_MANAGEMENT_API_AUDIENCE=
-      - DASHBOARD_URL=http://localhost:3000/dashboard
-      - DASHBOARD_BASE_API_URL=http://localhost:3000
+      - DASHBOARD_URL=${DAYTONA_PUBLIC_PROTOCOL:-http}://${DAYTONA_PUBLIC_HOST:-localhost}:${DAYTONA_PUBLIC_PORT:-3000}/dashboard
+      - DASHBOARD_BASE_API_URL=${DAYTONA_DASHBOARD_BASE_API_URL:-}
       - POSTHOG_API_KEY=phc_bYtEsdMDrNLydXPD4tufkBrHKgfO2zbycM30LOowYNv
       - POSTHOG_HOST=https://d18ag4dodbta3l.cloudfront.net
       - POSTHOG_ENVIRONMENT=local
@@ -58,10 +58,10 @@ services:
       - ENVIRONMENT=docker-compose
       - MAX_AUTO_ARCHIVE_INTERVAL=43200
       - MAINTENANCE_MODE=false
-      - PROXY_DOMAIN=proxy.localhost:4000
-      - PROXY_PROTOCOL=http
+      - PROXY_DOMAIN=${DAYTONA_PROXY_HOST:-proxy.localhost}:${DAYTONA_PROXY_PORT:-4000}
+      - PROXY_PROTOCOL=${DAYTONA_PROXY_PROTOCOL:-http}
       - PROXY_API_KEY=super_secret_key
-      - PROXY_TEMPLATE_URL=http://{{PORT}}-{{sandboxId}}.proxy.localhost:4000
+      - PROXY_TEMPLATE_URL=${DAYTONA_PROXY_PROTOCOL:-http}://{{PORT}}-{{sandboxId}}.${DAYTONA_PROXY_HOST:-proxy.localhost}:${DAYTONA_PROXY_PORT:-4000}
       - DEFAULT_RUNNER_DOMAIN=runner:3003
       - DEFAULT_RUNNER_API_URL=http://runner:3003
       - DEFAULT_RUNNER_PROXY_URL=http://runner:3003
@@ -83,9 +83,9 @@ services:
       - DEFAULT_ORG_QUOTA_MAX_SNAPSHOT_SIZE=1000
       - DEFAULT_ORG_QUOTA_VOLUME_QUOTA=10000
       - SSH_GATEWAY_API_KEY=ssh_secret_api_token
-      - SSH_GATEWAY_COMMAND=ssh -p 2222 {{TOKEN}}@localhost
+      - SSH_GATEWAY_COMMAND=ssh -p ${DAYTONA_SSH_PORT:-2222} {{TOKEN}}@${DAYTONA_PUBLIC_HOST:-localhost}
       - SSH_GATEWAY_PUBLIC_KEY=c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFCZ1FEZUtocFdOYVhVNkpSMnJXekc1NlZJeksrcmsrdForcCtVUmwyeWF5cWRnZGg2bnVOL1NtVnJsYmV4MGlrRVZZemdRWUIwWno5M2dqOVhxSkd4WjJiMHVoSDFzNkp2bnhKZVdIK05rbjBNMzRiRjZkeVloZ3o4M0JaTitWcElJdnVDT1pxYWE4VnlRWjhPdjVLMU00enlmQnFCMld3ejcwZEVWUnFaMnVZckd5U0RqUUIrU3hRQ3phY0djb2JRQTFUd2QxdEJvSk5BaVpPWXFSU3d6TmNoTk5hZHlxSHRGdkZRQ0hhNjZWaVBmQ0FVUGt2cEN6ZGh3TmJGdVhGVWkxbnZOWkx4M056RU41M05LWUhZcWU3Y3dXZkI4QjBoRDhDd3hmSDd6T0o1b1RCMnBMVVlsUWpZRDNsN3k4SkFTbDZpYkpuR1A1SWczVXpZWlRIdUdkNzVXWktnNTRJTVROQlFPMWpJdE9HL0orUm1XbzB0YTdpRkF6ZExyL1BmbDdXTVMwbEZhSm9scTdUVmJLUG1JODFTOU04VEgrbXhLbGZ5b2NqZzhwSUdlQUllcEo3dXl1Vk1xT2wxeVVuSFNycDRlVEVlR0k3NlpCOFRoUzhkYnBLUTIvb2RYMHkwc3FSZDI0Y2lGdnM0dnZVaW80NFdYNlNWRG54dXpWRHc1Rzg9IGRheXRvbmFAMDQwNjZiZDIwY2Vi
-      - SSH_GATEWAY_URL=localhost:2222
+      - SSH_GATEWAY_URL=${DAYTONA_PUBLIC_HOST:-localhost}:${DAYTONA_SSH_PORT:-2222}
       - RUNNER_DECLARATIVE_BUILD_SCORE_THRESHOLD=10
       - RUNNER_AVAILABILITY_SCORE_THRESHOLD=10
       - RUNNER_START_SCORE_THRESHOLD=3
@@ -110,11 +110,12 @@ services:
       - DAYTONA_API_URL=http://api:3000/api
       - PROXY_PORT=4000
       - PROXY_API_KEY=super_secret_key
-      - PROXY_PROTOCOL=http
+      - PROXY_PROTOCOL=${DAYTONA_PROXY_PROTOCOL:-http}
+      - COOKIE_DOMAIN=${DAYTONA_PROXY_HOST:-proxy.localhost}
       - OIDC_CLIENT_ID=daytona
       - OIDC_CLIENT_SECRET=
       - OIDC_DOMAIN=http://dex:5556/dex
-      - OIDC_PUBLIC_DOMAIN=http://localhost:5556/dex
+      - OIDC_PUBLIC_DOMAIN=${DAYTONA_PUBLIC_PROTOCOL:-http}://${DAYTONA_PUBLIC_HOST:-localhost}:${DAYTONA_OIDC_PORT:-5556}/dex
       - OIDC_AUDIENCE=daytona
       - REDIS_HOST=redis
       - REDIS_PORT=6379
@@ -123,7 +124,7 @@ services:
     networks:
       - daytona-network
     ports:
-      - 4000:4000
+      - ${DAYTONA_PROXY_PORT:-4000}:4000
     restart: always
 
   runner:
@@ -162,19 +163,29 @@ services:
     networks:
       - daytona-network
     ports:
-      - 2222:2222
+      - ${DAYTONA_SSH_PORT:-2222}:2222
     restart: always
 
   dex:
     image: dexidp/dex:v2.42.0
+    environment:
+      - DAYTONA_DASHBOARD_BASE_URL=${DAYTONA_PUBLIC_PROTOCOL:-http}://${DAYTONA_PUBLIC_HOST:-localhost}:${DAYTONA_PUBLIC_PORT:-3000}
+      - DAYTONA_PROXY_BASE_URL=${DAYTONA_PROXY_PROTOCOL:-http}://${DAYTONA_PROXY_HOST:-proxy.localhost}:${DAYTONA_PROXY_PORT:-4000}
+      - DAYTONA_OIDC_ISSUER=${DAYTONA_PUBLIC_PROTOCOL:-http}://${DAYTONA_PUBLIC_HOST:-localhost}:${DAYTONA_OIDC_PORT:-5556}/dex
     volumes:
-      - ./dex/config.yaml:/etc/dex/config.yaml
+      - ./dex/config.yaml:/etc/dex/config.yaml.tmpl:ro
+      - ./dex/render-config.sh:/usr/local/bin/render-dex-config.sh:ro
       - dex_db:/var/dex
-    entrypoint: ['sh', '-c', 'touch /var/dex/dex.db && exec dex serve /etc/dex/config.yaml']
+    entrypoint:
+      [
+        'sh',
+        '-c',
+        'touch /var/dex/dex.db && /usr/local/bin/render-dex-config.sh /etc/dex/config.yaml.tmpl /tmp/dex-config.yaml && exec dex serve /tmp/dex-config.yaml',
+      ]
     networks:
       - daytona-network
     ports:
-      - 5556:5556
+      - ${DAYTONA_OIDC_PORT:-5556}:5556
     healthcheck:
       test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:5556/dex/.well-known/openid-configuration"]
 


### PR DESCRIPTION
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable public access for Docker Compose deployments on VMs by parameterizing public host/proxy and ports, and templating Dex config from environment variables. Documentation adds VM setup instructions and wildcard proxy guidance (e.g., `sslip.io`) so dashboard, Dex, previews, and SSH work from outside the VM.

- **New Features**
  - Compose accepts public host/proxy and ports via `DAYTONA_*` env vars for API, Dex, proxy, and SSH.
  - Dex config is rendered from a template at startup, with `issuer` and redirect URIs derived from env.
  - Preview URLs use a wildcard host via `PROXY_TEMPLATE_URL`; `COOKIE_DOMAIN` is set to the proxy host.
  - `DASHBOARD_BASE_API_URL` can be empty to use same-origin `/api`.

- **Migration**
  - On a VM, set `DAYTONA_PUBLIC_HOST` and a wildcard `DAYTONA_PROXY_HOST` (e.g., `203-0-113-10.sslip.io`) before `docker compose up`.
  - Use `DAYTONA_PUBLIC_PROTOCOL` and port vars as needed; previews require a wildcard-resolving proxy host.

<sup>Written for commit cded51ea0d4b63083edd31f032e71778e97133d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

