### PR TITLE
fix(sdk-python): fix async download_files multipart header loss across chunk boundaries

### DIFF
--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -236,11 +236,16 @@ class AsyncFileSystem:
                     source: str | None = None
                     header_field = bytearray()
                     header_value = bytearray()
-                    part_headers: dict[str, str] = {}
+                    pending_headers: list[tuple[str, str]] = []
                     error_buffer = bytearray()
                     events: list[tuple[str, Any]] = []
 
                     def on_part_begin() -> None:
+                        # Keep callback-owned header state local and communicate via immutable
+                        # event payloads to avoid deferred-processing state races.
+                        pending_headers.clear()
+                        header_field.clear()
+                        header_value.clear()
                         events.append(("begin", None))
 
                     def on_header_field(data: bytes, start: int, end: int) -> None:
@@ -252,12 +257,12 @@ class AsyncFileSystem:
                     def on_header_end() -> None:
                         field = bytes(header_field).decode("utf-8", errors="ignore").lower()
                         value = bytes(header_value).decode("utf-8", errors="ignore")
-                        part_headers[field] = value
+                        pending_headers.append((field, value))
                         header_field.clear()
                         header_value.clear()
 
                     def on_headers_finished() -> None:
-                        events.append(("headers_finished", dict(part_headers)))
+                        events.append(("headers_finished", dict(pending_headers)))
 
                     def on_part_data(data: bytes, start: int, end: int) -> None:
                         events.append(("data", bytes(data[start:end])))
@@ -282,7 +287,6 @@ class AsyncFileSystem:
                         nonlocal writer, mode, source
                         for event_tag, event_payload in events:
                             if event_tag == "begin":
-                                part_headers.clear()
                                 error_buffer.clear()
                                 writer = None
                                 mode = None


### PR DESCRIPTION
Fixes #4363 

### Problem

The async `download_files` multipart parser shares a `part_headers` dict between synchronous `python_multipart` callbacks and deferred event processing. When a part's headers straddle a chunk boundary, the deferred `"begin"` handler clears headers that callbacks already stored, losing `content-disposition` and raising `"No source path found for this file"`.

The sync SDK is not affected because it processes everything inline in callbacks.

### Fix

Replace the shared `part_headers` dict with a callback-owned `pending_headers` list. Callbacks accumulate headers and pass them through the event queue as an immutable `dict` snapshot via `on_headers_finished`. Deferred event processing no longer touches header parsing state.

### Testing

Validated against live Daytona sandboxes with a minimal repro (see the issue #4363 ) that creates 900 files (10 MB total) and downloads them via `fs.download_files`:

- Unpatched SDK: 50/50 failed with `No source path found for this file`
- Patched (with this PR's fix) SDK: 50/50 passed, 900/900 files, 10,000,000 bytes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in async multipart parsing for `download_files` that dropped part headers across chunk boundaries, causing "No source path found for this file". Header parsing is now owned by `python_multipart` callbacks and passed as immutable snapshots, making downloads reliable.

- **Bug Fixes**
  - Replace shared `part_headers` with callback-owned `pending_headers`; send header snapshots via `on_headers_finished`.
  - Remove header clearing in deferred "begin" handler to prevent header loss when chunks split fields. Verified with a 900-file (10 MB) stress test: 10/10 passes.

<sup>Written for commit 989b31efead44bc3de8ea7a416b45a8993b1cea9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

