### PR TITLE
chore: add zip to CI system dependencies for Java Maven Central publish

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -90,7 +90,7 @@ runs:
     - name: System dependencies
       shell: bash
       run: |
-        sudo apt-get update && sudo apt-get install -y gcc libx11-dev libxtst-dev
+        sudo apt-get update && sudo apt-get install -y gcc libx11-dev libxtst-dev zip
         if [[ "${{ inputs.install-node }}" == 'true' || "${{ inputs.run-yarn-install }}" == 'true' ]]; then
           corepack enable
         fi


### PR DESCRIPTION
## Summary

- Add `zip` to system dependencies in the shared `setup-toolchain` CI action

## Problem

Java publish targets (`api-client-java`, `toolbox-api-client-java`, `sdk-java`) fail in CI with:

```
/bin/sh: 1: zip: not found
```

The Gradle build and GPG signing succeed, but the post-build step that bundles artifacts for Maven Central upload (`zip -r ../central-bundle.zip .`) fails because `zip` is not installed on the runner.

**Failed run:** https://github.com/daytonaio/daytona/actions/runs/23952037565/job/69861601618

## Fix

Added `zip` to the existing `apt-get install` in `.github/actions/setup-toolchain/action.yml`, alongside the other system dependencies (`gcc`, `libx11-dev`, `libxtst-dev`).

This fixes all 3 Java publish targets since they all flow through this shared action.

## Changed files

- `.github/actions/setup-toolchain/action.yml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `zip` to CI system dependencies in `.github/actions/setup-toolchain/action.yml` to fix Java publish jobs. Ensures the Maven Central bundling step (`zip -r`) succeeds on runners.

<sup>Written for commit c0994e2c72eaa9f286ec5bd06c5569ccedb9b779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

