### PR TITLE
fix(runner): preserve sparse files during rsync copy 

### DIFF
--- a/apps/runner/pkg/common/rsync.go
+++ b/apps/runner/pkg/common/rsync.go
@@ -13,22 +13,23 @@ import (
 )
 
 // RsyncCopy copies files from srcPath to destPath using rsync with full attribute preservation.
-// It uses rsync with -aAX flags to preserve permissions, ownership, timestamps, symlinks,
-// devices, ACLs, and extended attributes.
+// It uses rsync with -aAXS flags to preserve permissions, ownership, timestamps, symlinks,
+// devices, ACLs, extended attributes, and sparse file efficiency.
 //
-// The timeout parameter specifies how long to wait for the rsync operation to complete.
+// Timeouts are controlled via the passed context.Context deadline (e.g. context.WithTimeout).
 // Trailing slashes are automatically added to paths to ensure contents are copied, not directories.
 func RsyncCopy(ctx context.Context, logger *slog.Logger, srcPath, destPath string) error {
 	logger.DebugContext(ctx, "rsync copy", "source", srcPath, "destination", destPath)
 
-	// Use rsync with -aAX flags:
+	// Use rsync with -aAXS flags:
 	// -a = archive mode (preserves permissions, ownership, timestamps, symlinks, devices)
 	// -A = preserve ACLs
 	// -X = preserve extended attributes (xattrs)
+	// -S = handle sparse files efficiently (avoids inflating sparse files to full size)
 	// Trailing slashes ensure we copy contents, not the directory itself
 	src := filepath.Clean(srcPath) + "/"
 	dest := filepath.Clean(destPath) + "/"
-	rsyncCmd := exec.CommandContext(ctx, "rsync", "-aAX", src, dest)
+	rsyncCmd := exec.CommandContext(ctx, "rsync", "-aAXS", src, dest)
 
 	var rsyncOut strings.Builder
 	var rsyncErr strings.Builder


### PR DESCRIPTION
Rsync was inflating sparse files to their full apparent size during container disk resize, causing XFS quota overflow. A container with 1.2GB of actual data but 26GB of sparse files would fail to resize even to 16GB. Adding the -S flag to rsync preserves sparsity on the destination.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve sparse files during `rsync` copy by using `-aAXS`, avoiding inflated file sizes and XFS quota overflow during container disk resize.

<sup>Written for commit 924dc0f3dd592680db8de3fe2d30a746d4316ee7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

