### PR TITLE
fix(security): upgrade Alpine base from 3.18 (EOL) to 3.22

### DIFF
--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p dist/apps/otel-collector
 
 RUN yarn nx build otel-collector --configuration=production --nxBail=true
 
-FROM alpine:3.18 AS otel-collector
+FROM alpine:3.22 AS otel-collector
 
 RUN apk add --no-cache curl
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -40,7 +40,7 @@ ARG VERSION=0.0.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
   VERSION=$VERSION yarn nx build proxy --configuration=production --nxBail=true
 
-FROM alpine:3.18 AS proxy
+FROM alpine:3.22 AS proxy
 
 RUN apk add --no-cache curl
 

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -36,7 +36,7 @@ ARG VERSION=0.0.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
   VERSION=$VERSION yarn nx build snapshot-manager --configuration=production --nxBail=true
 
-FROM alpine:3.18 AS snapshot-manager
+FROM alpine:3.22 AS snapshot-manager
 
 RUN apk add --no-cache curl
 

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -36,7 +36,7 @@ COPY libs/api-client-go/ libs/api-client-go/
 
 RUN yarn nx build ssh-gateway --configuration=production --nxBail=true
 
-FROM alpine:3.18 AS ssh-gateway
+FROM alpine:3.22 AS ssh-gateway
 
 WORKDIR /usr/local/bin
 


### PR DESCRIPTION
## Summary

- Upgrade runtime base image from `alpine:3.18` (EOL Nov 2025) to `alpine:3.22` (current stable) for 4 Go services
- Alpine 3.18 no longer receives security patches for musl, busybox, or OpenSSL

## Changes

| Service | File |
|---------|------|
| proxy | `apps/proxy/Dockerfile` |
| ssh-gateway | `apps/ssh-gateway/Dockerfile` |
| snapshot-manager | `apps/snapshot-manager/Dockerfile` |
| otel-collector | `apps/otel-collector/Dockerfile` |

## Risk

Minimal -- these are statically compiled Go binaries copied into Alpine. No Alpine package dependencies beyond `curl` (used for healthchecks). No behavioral change expected.

## References

- Linear: [SEC-54](https://linear.app/daytona/issue/SEC-54)
- DSR-2026-0082 -- Comprehensive Security Review 2026-04-06

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade runtime base image for proxy, ssh-gateway, snapshot-manager, and otel-collector from `alpine:3.18` (EOL) to `alpine:3.22` to restore security updates. Addresses Linear SEC-54; minimal risk and no behavior change expected (static Go binaries; only `curl` installed).

<sup>Written for commit a5e0656e49df5359d65e6ec9e49c39a33142d15f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

