### PR TITLE
chore(security): add permissions blocks and checkout hardening

### DIFF
--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -4,12 +4,19 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up QEMU for multi-architecture builds
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Setup Docker buildx for multi-architecture builds

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -12,6 +12,8 @@ on:
         type: boolean
         default: true
 
+permissions: {}
+
 env:
   VERSION: ${{ inputs.version }}
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
@@ -29,6 +31,8 @@ jobs:
             platform: linux/amd64
 
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
 
     steps:
       - name: Validate version format
@@ -46,6 +50,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -112,6 +118,7 @@ jobs:
   docker_manifest:
     needs: docker_build
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    permissions: {}
 
     steps:
       - name: Download sandbox digests

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.work
@@ -38,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -65,6 +69,8 @@ jobs:
         working-directory: [apps/daemon, apps/runner, apps/cli, apps/proxy, libs/sdk-go, apps/otel-collector/exporter]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.work
@@ -87,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.work
@@ -110,6 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -138,6 +148,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
         with:
           run-go-work-sync: 'false'
@@ -159,6 +171,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
       - name: Build all
         run: |
@@ -169,6 +183,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check AGPL License Headers
         uses: apache/skywalking-eyes/header@8c96ee223558797cdd9eba82c0919258e1cf2dad # main

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -8,12 +8,17 @@ on:
         required: true
         default: 'v0.0.0-dev'
 
+permissions: {}
+
 env:
   VERSION: ${{ inputs.version }}
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -30,6 +35,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-toolchain
       - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
@@ -52,6 +58,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
           git push origin "prepare-release-$VERSION"
           gh pr create \
             --title "chore: prepare release $VERSION" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
         required: true
         default: 'v0.0.0-dev'
 
+permissions: {}
+
 env:
   VERSION: ${{ inputs.version }}
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
@@ -17,6 +19,8 @@ env:
 jobs:
   publish:
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
@@ -34,6 +38,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-toolchain
         with:
@@ -42,10 +47,13 @@ jobs:
       - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
           git config --global user.name "Daytona Release Bot"
           git config --global user.email "daytona-release@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
 
       - name: Tag Go modules
         run: |
@@ -90,6 +98,8 @@ jobs:
   build_projects:
     needs: publish
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
@@ -106,6 +116,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-toolchain
       - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
@@ -188,6 +199,8 @@ jobs:
             arch: amd64
           - runner: [self-hosted, Linux, ARM64, github-actions-runner-arm]
             arch: arm64
+    permissions:
+      contents: read
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -197,6 +210,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download computer-use artifact
         uses: actions/download-artifact@v4
@@ -257,11 +271,15 @@ jobs:
   docker_push_manifest:
     needs: docker_build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -289,6 +307,9 @@ jobs:
   sync_gosum:
     needs: build_projects
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
@@ -298,6 +319,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -308,9 +330,12 @@ jobs:
       - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "Daytona Release Bot"
           git config --global user.email "daytona-release@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
 
       - name: Project dependencies
         run: corepack enable

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -33,9 +33,13 @@ env:
   NPM_TAG: ${{ inputs.npm_tag }}
   POETRY_VIRTUALENVS_IN_PROJECT: true
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    permissions:
+      contents: read
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
@@ -59,6 +63,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-toolchain
         with:
@@ -87,6 +92,7 @@ jobs:
     if: ${{ inputs.npm_tag == 'latest' }}
     needs: publish
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    permissions: {}
     name: Update Homebrew CLI tap
     steps:
       - name: Update version

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   translate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: {}` (deny-all) at workflow level on all 7 workflows
- Add explicit per-job permission grants following least privilege
- Add `persist-credentials: false` to 17 of 18 `actions/checkout` instances
- Jobs that do `git push` use explicit `git remote set-url` with step-scoped `GITHUB_TOKEN`

## Per-workflow changes

| Workflow | Workflow permissions | Job permissions |
|---|---|---|
| `build_devcontainer.yaml` | `{}` | build: `contents: read`, `packages: write` |
| `default_image_publish.yaml` | `{}` | docker_build: `contents: read`, docker_manifest: `{}` |
| `pr_checks.yaml` | `contents: read` (unchanged) | inherited |
| `prepare-release.yaml` | `{}` | prepare: `contents: write`, `pull-requests: write` |
| `release.yaml` | `{}` | publish: `contents: write`, build_projects: `contents: write`, docker_build: `contents: read`, docker_push_manifest: `contents: read`, sync_gosum: `contents: write` + `pull-requests: write` |
| `sdk_publish.yaml` | `{}` | publish: `contents: read`, update-homebrew-tap: `{}` |
| `translate.yaml` | `{}` | translate: `contents: write`, `pull-requests: write` (unchanged) |

## Checkout hardening

`persist-credentials: false` added to all checkouts except `translate.yaml` (the GT Translate action needs checkout credentials to create PRs).

For jobs that require `git push`, auth is configured explicitly:
```yaml
- name: Configure git
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
```

## Context

Phase 1.3 + 1.6 of the GHA security hardening strategy. Addresses zizmor findings for `excessive-permissions` (14 instances) and `artipacked` (18 instances).

## Verification

- `actionlint` -- no new errors (only pre-existing shellcheck + custom runner label warnings)
- All workflow-level `env:` blocks contain zero `secrets.*` references
- 17/18 checkouts have `persist-credentials: false`

## Test plan

- [ ] PR checks workflow passes (validates pr_checks.yaml permissions)
- [ ] Trigger test release to validate git push works with explicit auth
- [ ] Verify devcontainer image build still pushes to GHCR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub Actions by default-denying workflow permissions and granting least-privilege per job. Disabled checkout credential persistence and switched to explicit, step-scoped `GITHUB_TOKEN` for pushes.

- **Refactors**
  - Set `permissions: {}` at workflow level on all workflows; `pr_checks.yaml` stays at `contents: read`.
  - Added explicit per-job permissions (read/write only where needed).
  - Set `persist-credentials: false` on 17/18 `actions/checkout` (kept enabled in `translate.yaml` for PR creation).
  - Configured `git remote set-url` with `GITHUB_TOKEN` in push steps.
  - Resolves zizmor findings for `excessive-permissions` (14) and `artipacked` (18); `actionlint` clean.

<sup>Written for commit 5ce432bf08ca8ea34ba14a85eb9f492377dde746. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

