### PR TITLE
chore(ci): add content write perms to docker_build job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,7 +200,7 @@ jobs:
           - runner: [self-hosted, Linux, ARM64, github-actions-runner-arm]
             arch: arm64
     permissions:
-      contents: read
+      contents: write
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix release permissions by granting `contents: write` to the `docker_build` job in `.github/workflows/release.yaml`. This enables creating/updating releases and uploading assets during publish.

<sup>Written for commit 5bc1eaef5f78fd15068bb2707128e718a4d8688c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

