### PR TITLE
chore(ci): ensure go.work.sum generated in docker build job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -237,7 +237,9 @@ jobs:
           node-version: 22
 
       - name: Generate go.work.sum
-        run: GONOSUMDB=github.com/daytonaio/daytona go work sync
+        run: |
+          GONOSUMDB=github.com/daytonaio/daytona go work sync
+          touch go.work.sum
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Generate go.work.sum in the release Docker build job to prevent missing checksum file errors and flaky builds. Runs go work sync and then ensures the file exists before building.

<sup>Written for commit 98459310aa1243b41888c633ce4849e29b96f40a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

