### PR TITLE
fix(sdk): default conn pool 100 to 250

### DIFF
--- a/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
@@ -429,7 +429,7 @@ Configuration options for initializing the Daytona client.
 - `target` _str | None_ - Target runner location for the Sandbox. Default region for the organization is used
   if not set here or in the environment variable `DAYTONA_TARGET`.
 - `connection_pool_maxsize` _int | None_ - Maximum number of simultaneous HTTP connections
-  the SDK will open. Defaults to 100. Set to `None` to remove the limit, which is
+  the SDK will open. Defaults to 250. Set to `None` to remove the limit, which is
   recommended when running many concurrent long-lived operations like `process.exec`.
 - `_experimental` _dict[str, any] | None_ - Configuration for experimental features.
   

--- a/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
@@ -378,7 +378,7 @@ Configuration options for initializing the Daytona client.
 - `target` _str | None_ - Target runner location for the Sandbox. Default region for the organization is used
   if not set here or in the environment variable `DAYTONA_TARGET`.
 - `connection_pool_maxsize` _int | None_ - Maximum number of simultaneous HTTP connections
-  the SDK will open. Defaults to 100. Set to `None` to remove the limit, which is
+  the SDK will open. Defaults to 250. Set to `None` to remove the limit, which is
   recommended when running many concurrent long-lived operations like `process.exec`.
 - `_experimental` _dict[str, any] | None_ - Configuration for experimental features.
   

--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -186,7 +186,7 @@ class AsyncDaytona:
 
         # Create API configuration without api_key
         configuration = Configuration(host=self._api_url)
-        pool_size = config.connection_pool_maxsize if config else 100
+        pool_size = config.connection_pool_maxsize if config else 250
         configuration.connection_pool_maxsize = pool_size  # pyright: ignore[reportAttributeAccessIssue]
         self._api_client: ApiClient = ApiClient(configuration)
         self._api_client.default_headers["Authorization"] = f"Bearer {self._api_key or self._jwt_token}"

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -186,7 +186,7 @@ class Daytona:
         configuration = Configuration(host=self._api_url)
         # When None, keep urllib3 default (cpu_count * 5) — unlike aiohttp,
         # urllib3 treats None as maxsize=1 which would hurt performance.
-        pool_size = config.connection_pool_maxsize if config else 100
+        pool_size = config.connection_pool_maxsize if config else 250
         if pool_size is not None:
             configuration.connection_pool_maxsize = pool_size
         self._api_client: ApiClient = ApiClient(configuration)

--- a/libs/sdk-python/src/daytona/common/daytona.py
+++ b/libs/sdk-python/src/daytona/common/daytona.py
@@ -61,7 +61,7 @@ class DaytonaConfig(BaseModel):
         target (str | None): Target runner location for the Sandbox. Default region for the organization is used
             if not set here or in the environment variable `DAYTONA_TARGET`.
         connection_pool_maxsize (int | None): Maximum number of simultaneous HTTP connections
-            the SDK will open. Defaults to 100. Set to `None` to remove the limit, which is
+            the SDK will open. Defaults to 250. Set to `None` to remove the limit, which is
             recommended when running many concurrent long-lived operations like `process.exec`.
         _experimental (dict[str, any] | None): Configuration for experimental features.
 
@@ -86,7 +86,7 @@ class DaytonaConfig(BaseModel):
     target: str | None = None
     jwt_token: str | None = None
     organization_id: str | None = None
-    connection_pool_maxsize: int | None = 100
+    connection_pool_maxsize: int | None = 250
     _experimental: Annotated[
         dict[str, object] | None,
         Field(


### PR DESCRIPTION
## Description

Increases the async python default connection pool max size from 100 to 250 which should handle most usecases and avoid connection drops with minimal client side overhead - if the number is exceeded, a warning will be shown with #4386 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation