### PR TITLE
chore(ci): invalidate Nx build cache when set-version changes package version

### DIFF
--- a/libs/opencode-plugin/project.json
+++ b/libs/opencode-plugin/project.json
@@ -18,7 +18,11 @@
     },
     "build": {
       "executor": "@nx/js:tsc",
-      "inputs": ["default", "{projectRoot}/package.json"],
+      "inputs": [
+        "default",
+        "{projectRoot}/package.json",
+        { "dependentTasksOutputFiles": "**/*", "transitive": true }
+      ],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/opencode-plugin",

--- a/libs/opencode-plugin/project.json
+++ b/libs/opencode-plugin/project.json
@@ -18,11 +18,7 @@
     },
     "build": {
       "executor": "@nx/js:tsc",
-      "inputs": [
-        "default",
-        "{projectRoot}/package.json",
-        { "dependentTasksOutputFiles": "**/*", "transitive": true }
-      ],
+      "inputs": ["default", "{projectRoot}/package.json", { "dependentTasksOutputFiles": "**/*", "transitive": true }],
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/opencode-plugin",

--- a/libs/sdk-java/project.json
+++ b/libs/sdk-java/project.json
@@ -17,11 +17,21 @@
       "options": {
         "cwd": "{projectRoot}",
         "command": "V=${MAVEN_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; if [ -n \"$V\" ]; then sed -i \"s/^version = .*/version = \\\"$V\\\"/\" build.gradle.kts && echo \"sdk-java version: $V\"; else echo \"sdk-java version: unchanged\"; fi"
-      }
+      },
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/build.gradle.kts",
+        { "env": "MAVEN_PKG_VERSION" },
+        { "env": "DEFAULT_PACKAGE_VERSION" }
+      ],
+      "outputs": ["{projectRoot}/build.gradle.kts"]
     },
     "build": {
       "executor": "nx:run-commands",
-      "inputs": ["default"],
+      "inputs": [
+        "default",
+        { "dependentTasksOutputFiles": "**/*", "transitive": true }
+      ],
       "outputs": ["{projectRoot}/build"],
       "options": {
         "cwd": "{projectRoot}",


### PR DESCRIPTION
### Problem

During the SDK publish workflow, `set-version` targets run and update package versions, but `build` targets return **stale remote cache hits** — producing artifacts with the old version. This caused `opencode-plugin:publish` to fail because npm rejected the already-published version.

**CI evidence** ([run #70603841338](https://github.com/daytonaio/daytona/actions/runs/24189840072/job/70603841338)):
```
opencode-plugin:set-version  →  Cache Miss     (ran, changed version)
sdk-java:set-version         →  Cache Miss     (ran, changed to 0.163.0)
opencode-plugin:build        →  Remote Cache Hit  ← stale
sdk-java:build               →  Remote Cache Hit  ← stale
```

### Root Cause

Both projects override `inputs` on their `build` targets, which **replaces** the target defaults — dropping `{ "dependentTasksOutputFiles": "**/*", "transitive": true }`. Without this, Nx computes the build hash at task graph construction time (before `set-version` modifies files) and matches a stale remote cache entry.

Additionally, `sdk-java:set-version` had zero cache configuration — no `cache`, `inputs`, or `outputs` — so even with `dependentTasksOutputFiles` on `build`, Nx wouldn't know what files to track.

### Changes

**`libs/opencode-plugin/project.json`**
- Added `{ "dependentTasksOutputFiles": "**/*", "transitive": true }` to `build` inputs

**`libs/sdk-java/project.json`**
- Added `cache: true`, `inputs`, and `outputs` to `set-version` (was completely unconfigured)
- Added `{ "dependentTasksOutputFiles": "**/*", "transitive": true }` to `build` inputs

### Not affected

Audited all 14 projects with `set-version`. The remaining 12 either don't override `inputs` on `build` (inheriting target defaults which include `dependentTasksOutputFiles`), have `build` not depending on `set-version`, or already include it correctly (`api-client-ruby`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Nx invalidates the build cache when `set-version` bumps versions to prevent stale build artifacts during publish. Adds dependent-task outputs to `build` inputs and enables caching for `sdk-java:set-version`.

- **Bug Fixes**
  - `libs/opencode-plugin`: added `{"dependentTasksOutputFiles": "**/*", "transitive": true}` to `build` inputs for `@nx/js:tsc`.
  - `libs/sdk-java`: enabled caching for `set-version` with inputs (`build.gradle.kts`, `MAVEN_PKG_VERSION`, `DEFAULT_PACKAGE_VERSION`) and outputs (`build.gradle.kts`); added `{"dependentTasksOutputFiles": "**/*", "transitive": true}` to `build` inputs for `nx:run-commands`.
  - Audited other `set-version` projects; no changes needed.

<sup>Written for commit 6957151d5181d8ab2c18b4f52b75884780132c37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

