### PR TITLE
fix(proxy): remove auth header after successful validation

### DIFF
--- a/apps/proxy/pkg/proxy/auth.go
+++ b/apps/proxy/pkg/proxy/auth.go
@@ -24,6 +24,8 @@ func (p *Proxy) Authenticate(ctx *gin.Context, sandboxIdOrSignedToken string, po
 		if err != nil {
 			authErrors = append(authErrors, fmt.Sprintf("Bearer token validation error: %v", err))
 		} else if isValid != nil && *isValid {
+			// If authentication successful, remove the Authorization header to prevent it from being forwarded to the sandbox
+			ctx.Request.Header.Del("Authorization")
 			return sandboxIdOrSignedToken, false, nil
 		} else {
 			authErrors = append(authErrors, "Bearer token is invalid")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
After validating a bearer token, the `proxy` now deletes the Authorization header so it isn’t forwarded to the sandbox. This prevents leaking credentials to sandboxed services and tightens request isolation.

<sup>Written for commit 79ae99643d9f094fec5c0e96221308121f7215e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

