### PR TITLE
fix(daemon): write session exit code after output labelers drain

### DIFF
--- a/apps/daemon/pkg/session/execute.go
+++ b/apps/daemon/pkg/session/execute.go
@@ -174,13 +174,18 @@ var cmdWrapperFormat string = `
 
 	# Run your command from file (avoids heredoc parsing issues with pipe-fed shells)
 	{ . %q; } < "$ip" > "$sp" 2> "$ep"
-	echo "$?" >> %q
+	_ec=$?
 
 	# Stop the stdin holder so it doesn't outlive the command
 	kill "$ip_pid" 2>/dev/null; wait "$ip_pid" 2>/dev/null
 
 	# drain labelers (cleanup via trap)
 	wait "$r1" "$r2"
+
+	# Write exit code only after labelers have flushed all output to the log file.
+	# Previously echo "$?" ran before wait, creating a race where clients polling
+	# the exit-code file would read an empty/incomplete log.
+	echo "$_ec" >> %q
 
 	# Ensure unlink even if the waits failed
 	cleanup


### PR DESCRIPTION
The shell wrapper wrote the exit-code file immediately after command
completion, before the background labeler processes finished flushing
stdout/stderr to the log file. Clients polling for exit_code would
then read an empty or partial log.

Capture exit code in a variable and defer the file write until after
wait $r1 $r2 completes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write the session exit code only after stdout/stderr labelers finish flushing, so clients don’t read empty or partial logs. Capture the exit code in a variable and write it after `wait` for `r1` and `r2` completes.

<sup>Written for commit d66db2f9316cdbe441ac7d8942215a1f7403ac13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

