### PR TITLE
fix(api): handle transient errors in jwt strategy

### DIFF
--- a/apps/api/src/auth/api-key.strategy.ts
+++ b/apps/api/src/auth/api-key.strategy.ts
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import {
-  Injectable,
-  UnauthorizedException,
-  ServiceUnavailableException,
-  HttpException,
-  Logger,
-  OnModuleInit,
-} from '@nestjs/common'
+import { Injectable, UnauthorizedException, Logger, OnModuleInit } from '@nestjs/common'
 import { PassportStrategy } from '@nestjs/passport'
 import { Strategy } from 'passport-http-bearer'
 import { ApiKeyService } from '../api-key/api-key.service'
@@ -34,6 +27,7 @@ import { RegionProxyAuthContext } from '../common/interfaces/region-proxy-auth-c
 import { RegionSSHGatewayAuthContext } from '../common/interfaces/region-ssh-gateway-auth-context.interface'
 import { OtelCollectorAuthContext } from '../common/interfaces/otel-collector-auth-context.interface'
 import { HealthCheckAuthContext } from '../common/interfaces/health-check-auth-context.interface'
+import { handleAuthError } from './utils/handle-auth-error.util'
 
 type ApiKeyAuthContext =
   | UserAuthContext
@@ -158,7 +152,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, AuthStrategyType.
         organizationId: apiKey.organizationId,
       } satisfies UserAuthContext
     } catch (error) {
-      this.handleError(error, 'Error validating user API key')
+      handleAuthError(error, 'Error validating user API key')
     }
 
     /**
@@ -174,7 +168,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, AuthStrategyType.
         } satisfies RunnerAuthContext
       }
     } catch (error) {
-      this.handleError(error, 'Error validating runner API key')
+      handleAuthError(error, 'Error validating runner API key')
     }
 
     /**
@@ -189,7 +183,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, AuthStrategyType.
         } satisfies RegionProxyAuthContext
       }
     } catch (error) {
-      this.handleError(error, 'Error validating region proxy API key')
+      handleAuthError(error, 'Error validating region proxy API key')
     }
 
     /**
@@ -204,7 +198,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, AuthStrategyType.
         } satisfies RegionSSHGatewayAuthContext
       }
     } catch (error) {
-      this.handleError(error, 'Error validating region SSH gateway API key')
+      handleAuthError(error, 'Error validating region SSH gateway API key')
     }
 
     /**
@@ -252,12 +246,6 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, AuthStrategyType.
     } catch (error) {
       this.logger.error('Error getting or parsing API key cache:', error)
       return null
-    }
-  }
-
-  private handleError(error: unknown, message: string): void {
-    if (!(error instanceof HttpException)) {
-      throw new ServiceUnavailableException(message, { cause: error })
     }
   }
 

--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -111,6 +111,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         organizationId,
       } satisfies UserAuthContext
     } catch (error) {
+      this.logger.debug(`Error validating JWT for user ${userId}:`, error)
       handleAuthError(error, `Error validating JWT for user ${userId}`)
     }
 

--- a/apps/api/src/auth/jwt.strategy.ts
+++ b/apps/api/src/auth/jwt.strategy.ts
@@ -14,6 +14,7 @@ import { AuthStrategyType } from './enums/auth-strategy-type.enum'
 import { RequestWithAuthMetadata } from './interfaces/request-with-auth-metadata.interface'
 import { CustomHeaders } from '../common/constants/header.constants'
 import { TypedConfigService } from '../config/typed-config.service'
+import { handleAuthError } from './utils/handle-auth-error.util'
 
 interface JwtStrategyConfig {
   jwksUri: string
@@ -110,7 +111,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         organizationId,
       } satisfies UserAuthContext
     } catch (error) {
-      this.logger.error(`JWT validation failed for user ${userId}:`, error)
+      handleAuthError(error, `Error validating JWT for user ${userId}`)
     }
 
     return null

--- a/apps/api/src/auth/utils/handle-auth-error.util.ts
+++ b/apps/api/src/auth/utils/handle-auth-error.util.ts
@@ -6,7 +6,7 @@
 import { HttpException, ServiceUnavailableException } from '@nestjs/common'
 
 export function handleAuthError(error: unknown, message: string): void {
-  if (!(error instanceof HttpException)) {
+  if (!(error instanceof HttpException) || error.getStatus() >= 500) {
     throw new ServiceUnavailableException(message, { cause: error })
   }
 }

--- a/apps/api/src/auth/utils/handle-auth-error.util.ts
+++ b/apps/api/src/auth/utils/handle-auth-error.util.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { HttpException, ServiceUnavailableException } from '@nestjs/common'
+
+export function handleAuthError(error: unknown, message: string): void {
+  if (!(error instanceof HttpException)) {
+    throw new ServiceUnavailableException(message, { cause: error })
+  }
+}


### PR DESCRIPTION
This pull request refactors the authentication error handling logic in the API key and JWT strategies. The main improvement is the extraction of repeated error handling code into a reusable utility function, resulting in cleaner and more maintainable code.

**Authentication error handling refactor:**

* Introduced a new utility function `handleAuthError` in `apps/api/src/auth/utils/handle-auth-error.util.ts` to centralize and standardize error handling for authentication errors.
* Updated `ApiKeyStrategy` in `apps/api/src/auth/api-key.strategy.ts` to use the new `handleAuthError` utility instead of its own `handleError` method, and removed the now-unnecessary private method. [[1]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L161-R155) [[2]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L177-R171) [[3]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L192-R186) [[4]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L207-R201) [[5]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L258-L263)
* Updated `JwtStrategy` in `apps/api/src/auth/jwt.strategy.ts` to use `handleAuthError` for consistent error handling.

**Imports cleanup:**

* Cleaned up imports in `apps/api/src/auth/api-key.strategy.ts` by removing unused exception imports and adding the new utility import. [[1]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4L6-R6) [[2]](diffhunk://#diff-609cc92ec6afaff8cef8c2f97e578917fee5a232142920a87482308acfea9bb4R30)
* Added the `handleAuthError` import to `apps/api/src/auth/jwt.strategy.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized auth error handling and fixed transient error behavior in the JWT strategy. Unexpected or 5xx errors now return 503 Service Unavailable for both JWT and API key auth.

- **Bug Fixes**
  - Added `handleAuthError` to standardize auth errors and convert non-`HttpException` and 5xx `HttpException` cases to `ServiceUnavailableException` (503).
  - Updated `JwtStrategy` to use `handleAuthError`; lowered failure log level to debug for less noise.
  - Updated `ApiKeyStrategy` to use the util and removed duplicate handler; minor import cleanup.

<sup>Written for commit 2d0ee0f3767f4e854b81ea30889f251a1e4641ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

