### PR TITLE
fix(api): return 503 when svix is not configured

### DIFF
--- a/apps/api/src/webhook/services/webhook.service.ts
+++ b/apps/api/src/webhook/services/webhook.service.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, Logger, OnModuleInit, NotFoundException } from '@nestjs/common'
+import { Injectable, Logger, OnModuleInit, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { Svix } from 'svix'
 import { Organization } from '../../organization/entities/organization.entity'
@@ -69,7 +69,7 @@ export class WebhookService implements OnModuleInit {
    */
   async createSvixApplication(organization: Organization): Promise<string> {
     if (!this.svix) {
-      throw new Error('Svix not configured')
+      throw new ServiceUnavailableException('Webhook service is not configured')
     }
 
     let existingWebhookInitialization = await this.getInitializationStatus(organization.id)
@@ -150,7 +150,7 @@ export class WebhookService implements OnModuleInit {
    */
   async getMessageAttempts(organizationId: string, messageId: string): Promise<any[]> {
     if (!this.svix) {
-      throw new Error('Svix not configured')
+      throw new ServiceUnavailableException('Webhook service is not configured')
     }
 
     try {
@@ -174,7 +174,7 @@ export class WebhookService implements OnModuleInit {
    */
   async getAppPortalAccess(organizationId: string): Promise<{ token: string; url: string }> {
     if (!this.svix) {
-      throw new Error('Svix not configured')
+      throw new ServiceUnavailableException('Webhook service is not configured')
     }
     try {
       const appPortalAccess = await this.svix.authentication.appPortalAccess(organizationId, {})


### PR DESCRIPTION
## Description

Self-hosting users without Svix configured reported noisy error logging in their deployments. The webhook service threw a    plain Error which the exception filter treated as an unexpected 500, logging full stack traces. This replaces those with ServiceUnavailableException so they return a clean 503 with no unnecessary log noise.  

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation