### PR TITLE
fix(api): sandbox runner join query uuid

### DIFF
--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -129,7 +129,7 @@ export class SnapshotService {
   private async readySnapshotRunnerExists(ref: string, regionId: string): Promise<boolean> {
     return await this.snapshotRunnerRepository
       .createQueryBuilder('sr')
-      .innerJoin('runner', 'r', 'r.id::text = sr."runnerId"::text')
+      .innerJoin('runner', 'r', 'r.id = sr."runnerId"::uuid')
       .where('sr."snapshotRef" = :ref', { ref })
       .andWhere('sr.state = :snapshotRunnerState', { snapshotRunnerState: SnapshotRunnerState.READY })
       .andWhere('r.region = :regionId', { regionId })
@@ -838,7 +838,7 @@ export class SnapshotService {
 
     const snapshotRunners = await this.snapshotRunnerRepository
       .createQueryBuilder('sr')
-      .innerJoin('runner', 'r', 'r.id::text = sr."runnerId"::text')
+      .innerJoin('runner', 'r', 'r.id = sr."runnerId"::uuid')
       .where('r.state = :runnerState', { runnerState: RunnerState.DECOMMISSIONED })
       .andWhere('sr."updatedAt" < :cutoff', { cutoff })
       .select('sr.id')


### PR DESCRIPTION
## Description

Changes parsing from text to uuid to improve the DB query performance when joining the runner and snapshot_runner tables in the snapshot service

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
