### PR TITLE
fix(api): truncate error message audit logs jobs

### DIFF
--- a/apps/api/src/audit/adapters/audit-opensearch.adapter.ts
+++ b/apps/api/src/audit/adapters/audit-opensearch.adapter.ts
@@ -170,6 +170,7 @@ export class AuditOpenSearchStorageAdapter implements AuditLogStorageAdapter, On
               action: { type: 'keyword' },
               targetType: { type: 'keyword' },
               statusCode: { type: 'integer' },
+              errorMessage: { type: 'text', index: false },
               createdAt: { type: 'date' },
             },
           },

--- a/apps/api/src/audit/interceptors/audit.interceptor.ts
+++ b/apps/api/src/audit/interceptors/audit.interceptor.ts
@@ -24,6 +24,7 @@ import { AuditService } from '../services/audit.service'
 import { AuthContext } from '../../common/interfaces/auth-context.interface'
 import { CustomHeaders } from '../../common/constants/header.constants'
 import { TypedConfigService } from '../../config/typed-config.service'
+import { truncateErrorMessage } from '../../common/utils/truncate-error-message'
 
 type RequestWithUser = Request & {
   user?: AuthContext
@@ -102,7 +103,9 @@ export class AuditInterceptor implements NestInterceptor {
         observer.complete()
       } catch (handlerError) {
         const errorMessage =
-          handlerError instanceof HttpException ? handlerError.message : 'An unexpected error occurred.'
+          handlerError instanceof HttpException
+            ? truncateErrorMessage(handlerError.message)
+            : 'An unexpected error occurred.'
         const statusCode = this.resolveErrorStatusCode(handlerError)
         await this.recordHandlerError(auditLog, errorMessage, statusCode)
 

--- a/apps/api/src/common/utils/truncate-error-message.ts
+++ b/apps/api/src/common/utils/truncate-error-message.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+const DEFAULT_MAX_LENGTH = 10_000
+const TRUNCATION_SEPARATOR = '\n\n... [truncated] ...\n\n'
+
+/**
+ * Truncates a long error message keeping the first line (to preserve the
+ * primary error) and as much of the tail as fits within {@link maxLength}.
+ */
+export function truncateErrorMessage(message: string, maxLength = DEFAULT_MAX_LENGTH): string {
+  if (!message || message.length <= maxLength) {
+    return message
+  }
+
+  const firstNewline = message.indexOf('\n')
+  const firstLine = firstNewline === -1 ? message : message.slice(0, firstNewline)
+
+  if (firstLine.length + TRUNCATION_SEPARATOR.length >= maxLength) {
+    return firstLine.slice(0, maxLength)
+  }
+
+  const tailBudget = maxLength - firstLine.length - TRUNCATION_SEPARATOR.length
+  const tail = message.slice(-tailBudget)
+
+  return firstLine + TRUNCATION_SEPARATOR + tail
+}

--- a/apps/api/src/sandbox/services/job.service.ts
+++ b/apps/api/src/sandbox/services/job.service.ts
@@ -16,6 +16,7 @@ import { Cron, CronExpression } from '@nestjs/schedule'
 import { JobStateHandlerService } from './job-state-handler.service'
 import { propagation, context as otelContext } from '@opentelemetry/api'
 import { PaginatedList } from '../../common/interfaces/paginated-list.interface'
+import { truncateErrorMessage } from '../../common/utils/truncate-error-message'
 
 const REDIS_BLOCKING_COMMAND_TIMEOUT_BUFFER_MS = 3_000
 
@@ -246,7 +247,7 @@ export class JobService {
 
     job.status = status
     if (errorMessage) {
-      job.errorMessage = errorMessage
+      job.errorMessage = truncateErrorMessage(errorMessage)
     }
 
     if (status === JobStatus.IN_PROGRESS && !job.startedAt) {


### PR DESCRIPTION
## Description

Adds a safeguard limit to the error message length for audit logs and jobs to 10k chars

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation