### PR TITLE
fix(api): remove early return in resize sandbox job success handler

### DIFF
--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -578,7 +578,6 @@ export class JobStateHandlerService {
           memDeltaForQuota,
           diskDeltaForQuota,
         )
-        return
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`RESIZE_SANDBOX job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
 


### PR DESCRIPTION
## Description

The RESIZE_SANDBOX success handler had an early `return` after calling `updateQuotaUsage` with the new CPU/memory/disk deltas. This caused any logic after the quota update to be skipped when a resize job completed successfully. The `return` was likely left over from a refactor — the `else if (FAILED)` branch below handles failures correctly, but the success path was bailing out prematurely. Removing it allows the success handler to fall through and complete the full post-resize flow.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation