### PR TITLE
fix(api): skip JSON body parsing for non-JSON content types

### DIFF
--- a/apps/api/src/common/interceptors/content-type.interceptors.ts
+++ b/apps/api/src/common/interceptors/content-type.interceptors.ts
@@ -15,6 +15,14 @@ export class ContentTypeInterceptor implements NestInterceptor {
 
     // Check if we have raw body data but no parsed body
     if (request.readable) {
+      const contentType = request.get('content-type') || ''
+      const isJsonContentType =
+        !contentType || contentType.includes('application/json') || contentType.includes('text/json')
+
+      if (!isJsonContentType) {
+        return next.handle()
+      }
+
       // Create a promise to handle the body parsing
       await new Promise<void>((resolve, reject) => {
         let rawBody = ''
@@ -33,7 +41,7 @@ export class ContentTypeInterceptor implements NestInterceptor {
             }
             resolve()
           } catch (e) {
-            this.logger.error('Failed to parse JSON body:', e)
+            this.logger.warn('Failed to parse JSON body:', e)
             resolve() // Still resolve even on error to prevent hanging
           }
         })

--- a/apps/api/src/common/interceptors/content-type.interceptors.ts
+++ b/apps/api/src/common/interceptors/content-type.interceptors.ts
@@ -17,7 +17,9 @@ export class ContentTypeInterceptor implements NestInterceptor {
     if (request.readable) {
       const contentType = request.get('content-type') || ''
       const isJsonContentType =
-        !contentType || contentType.includes('application/json') || contentType.includes('text/json')
+        !contentType ||
+        contentType.toLowerCase().includes('application/json') ||
+        contentType.toLowerCase().includes('text/json')
 
       if (!isJsonContentType) {
         return next.handle()


### PR DESCRIPTION
This pull request updates the `ContentTypeInterceptor` to improve how it handles and logs incoming requests based on their content type. The main changes focus on ensuring that only JSON content types are parsed and that logging is less severe for JSON parsing errors.

**Content-Type Handling:**

* The interceptor now checks the `Content-Type` header and only attempts to parse the body if it is JSON (`application/json` or `text/json`). Non-JSON content types are passed through without parsing.

**Logging Improvements:**

* Changed the log level from `error` to `warn` when JSON body parsing fails, reducing log severity for expected parsing issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip JSON parsing for non-JSON requests in `ContentTypeInterceptor` to avoid unnecessary parsing and errors. JSON parse failures are now logged as warnings instead of errors.

- **Bug Fixes**
  - Parse only when `Content-Type` is missing or includes `application/json` or `text/json`; otherwise pass through.
  - Downgraded JSON parse failures from `error` to `warn`.

<sup>Written for commit 4e08717080e24a9aa34bd0e894bc687c8d00de29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

