### PR TITLE
fix(api): suppress logging for TypeORM EntityNotFoundError in resource access guards

### DIFF
--- a/apps/api/src/common/guards/resource-access.guard.ts
+++ b/apps/api/src/common/guards/resource-access.guard.ts
@@ -3,11 +3,25 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { CanActivate, ExecutionContext } from '@nestjs/common'
+import { CanActivate, ExecutionContext, Logger, NotFoundException } from '@nestjs/common'
+import { EntityNotFoundError } from 'typeorm'
 
 /**
  *  Base class for guards that validate that the current request is authenticated with an auth context type that has access to the requested resource.
  */
 export abstract class ResourceAccessGuard implements CanActivate {
   abstract canActivate(context: ExecutionContext): Promise<boolean>
+
+  /**
+   * Handles resource access errors by logging the error and throwing a NotFoundException.
+   * @param error - The error to handle.
+   * @param logger - The logger to use.
+   * @param notFoundMessage - The message to use in the NotFoundException.
+   */
+  protected handleResourceAccessError(error: unknown, logger: Logger, notFoundMessage: string): never {
+    if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
+      logger.error(error)
+    }
+    throw new NotFoundException(notFoundMessage)
+  }
 }

--- a/apps/api/src/docker-registry/guards/docker-registry-access.guard.ts
+++ b/apps/api/src/docker-registry/guards/docker-registry-access.guard.ts
@@ -3,13 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, ExecutionContext, NotFoundException, ForbiddenException, Logger } from '@nestjs/common'
+import { Injectable, ExecutionContext, ForbiddenException, Logger } from '@nestjs/common'
 import { ResourceAccessGuard } from '../../common/guards/resource-access.guard'
 import { DockerRegistryService } from '../services/docker-registry.service'
 import { isOrganizationAuthContext } from '../../common/interfaces/organization-auth-context.interface'
 import { getAuthContext } from '../../common/utils/get-auth-context'
 import { RegistryType } from '../enums/registry-type.enum'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class DockerRegistryAccessGuard extends ResourceAccessGuard {
@@ -37,10 +36,7 @@ export class DockerRegistryAccessGuard extends ResourceAccessGuard {
       request.dockerRegistry = dockerRegistry
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException(`Docker registry with ID ${dockerRegistryId} not found`)
+      this.handleResourceAccessError(error, this.logger, `Docker registry with ID ${dockerRegistryId} not found`)
     }
   }
 }

--- a/apps/api/src/docker-registry/guards/docker-registry-access.guard.ts
+++ b/apps/api/src/docker-registry/guards/docker-registry-access.guard.ts
@@ -9,6 +9,7 @@ import { DockerRegistryService } from '../services/docker-registry.service'
 import { isOrganizationAuthContext } from '../../common/interfaces/organization-auth-context.interface'
 import { getAuthContext } from '../../common/utils/get-auth-context'
 import { RegistryType } from '../enums/registry-type.enum'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class DockerRegistryAccessGuard extends ResourceAccessGuard {
@@ -36,7 +37,7 @@ export class DockerRegistryAccessGuard extends ResourceAccessGuard {
       request.dockerRegistry = dockerRegistry
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException(`Docker registry with ID ${dockerRegistryId} not found`)

--- a/apps/api/src/region/guards/region-access.guard.ts
+++ b/apps/api/src/region/guards/region-access.guard.ts
@@ -9,6 +9,7 @@ import { RegionService } from '../services/region.service'
 import { isOrganizationAuthContext } from '../../common/interfaces/organization-auth-context.interface'
 import { getAuthContext } from '../../common/utils/get-auth-context'
 import { RegionType } from '../enums/region-type.enum'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class RegionAccessGuard extends ResourceAccessGuard {
@@ -37,7 +38,7 @@ export class RegionAccessGuard extends ResourceAccessGuard {
       }
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException('Region not found')

--- a/apps/api/src/region/guards/region-access.guard.ts
+++ b/apps/api/src/region/guards/region-access.guard.ts
@@ -9,7 +9,6 @@ import { RegionService } from '../services/region.service'
 import { isOrganizationAuthContext } from '../../common/interfaces/organization-auth-context.interface'
 import { getAuthContext } from '../../common/utils/get-auth-context'
 import { RegionType } from '../enums/region-type.enum'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class RegionAccessGuard extends ResourceAccessGuard {
@@ -38,10 +37,7 @@ export class RegionAccessGuard extends ResourceAccessGuard {
       }
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException('Region not found')
+      this.handleResourceAccessError(error, this.logger, 'Region not found')
     }
   }
 }

--- a/apps/api/src/sandbox/guards/job-access.guard.ts
+++ b/apps/api/src/sandbox/guards/job-access.guard.ts
@@ -8,6 +8,7 @@ import { ResourceAccessGuard } from '../../common/guards/resource-access.guard'
 import { JobService } from '../services/job.service'
 import { isRunnerAuthContext } from '../../common/interfaces/runner-auth-context.interface'
 import { getAuthContext } from '../../common/utils/get-auth-context'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class JobAccessGuard extends ResourceAccessGuard {
@@ -35,7 +36,7 @@ export class JobAccessGuard extends ResourceAccessGuard {
 
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException('Job not found')

--- a/apps/api/src/sandbox/guards/job-access.guard.ts
+++ b/apps/api/src/sandbox/guards/job-access.guard.ts
@@ -8,7 +8,6 @@ import { ResourceAccessGuard } from '../../common/guards/resource-access.guard'
 import { JobService } from '../services/job.service'
 import { isRunnerAuthContext } from '../../common/interfaces/runner-auth-context.interface'
 import { getAuthContext } from '../../common/utils/get-auth-context'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class JobAccessGuard extends ResourceAccessGuard {
@@ -36,10 +35,7 @@ export class JobAccessGuard extends ResourceAccessGuard {
 
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException('Job not found')
+      this.handleResourceAccessError(error, this.logger, 'Job not found')
     }
   }
 }

--- a/apps/api/src/sandbox/guards/runner-access.guard.ts
+++ b/apps/api/src/sandbox/guards/runner-access.guard.ts
@@ -15,7 +15,6 @@ import { RegionType } from '../../region/enums/region-type.enum'
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class RunnerAccessGuard extends ResourceAccessGuard {
@@ -67,10 +66,7 @@ export class RunnerAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException('Runner not found')
+      this.handleResourceAccessError(error, this.logger, 'Runner not found')
     }
   }
 }

--- a/apps/api/src/sandbox/guards/runner-access.guard.ts
+++ b/apps/api/src/sandbox/guards/runner-access.guard.ts
@@ -15,6 +15,7 @@ import { RegionType } from '../../region/enums/region-type.enum'
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class RunnerAccessGuard extends ResourceAccessGuard {
@@ -66,7 +67,7 @@ export class RunnerAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException('Runner not found')

--- a/apps/api/src/sandbox/guards/sandbox-access.guard.ts
+++ b/apps/api/src/sandbox/guards/sandbox-access.guard.ts
@@ -14,6 +14,7 @@ import { getAuthContext } from '../../common/utils/get-auth-context'
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class SandboxAccessGuard extends ResourceAccessGuard {
@@ -67,7 +68,7 @@ export class SandboxAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException(`Sandbox with ID or name ${sandboxIdOrName} not found`)

--- a/apps/api/src/sandbox/guards/sandbox-access.guard.ts
+++ b/apps/api/src/sandbox/guards/sandbox-access.guard.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable, ExecutionContext, NotFoundException, ForbiddenException, Logger } from '@nestjs/common'
+import { Injectable, ExecutionContext, ForbiddenException, Logger } from '@nestjs/common'
 import { ResourceAccessGuard } from '../../common/guards/resource-access.guard'
 import { SandboxService } from '../services/sandbox.service'
 import { isBaseAuthContext } from '../../common/interfaces/base-auth-context.interface'
@@ -14,7 +14,6 @@ import { getAuthContext } from '../../common/utils/get-auth-context'
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class SandboxAccessGuard extends ResourceAccessGuard {
@@ -68,10 +67,7 @@ export class SandboxAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException(`Sandbox with ID or name ${sandboxIdOrName} not found`)
+      this.handleResourceAccessError(error, this.logger, `Sandbox with ID or name ${sandboxIdOrName} not found`)
     }
   }
 }

--- a/apps/api/src/sandbox/guards/snapshot-access.guard.ts
+++ b/apps/api/src/sandbox/guards/snapshot-access.guard.ts
@@ -14,7 +14,6 @@ import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-aut
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isRegionAuthContext } from '../../common/interfaces/region-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class SnapshotAccessGuard extends ResourceAccessGuard {
@@ -68,10 +67,7 @@ export class SnapshotAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException(`Snapshot with ID or name ${snapshotId} not found`)
+      this.handleResourceAccessError(error, this.logger, `Snapshot with ID or name ${snapshotId} not found`)
     }
   }
 }

--- a/apps/api/src/sandbox/guards/snapshot-access.guard.ts
+++ b/apps/api/src/sandbox/guards/snapshot-access.guard.ts
@@ -14,6 +14,7 @@ import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-aut
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isRegionAuthContext } from '../../common/interfaces/region-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class SnapshotAccessGuard extends ResourceAccessGuard {
@@ -67,7 +68,7 @@ export class SnapshotAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException(`Snapshot with ID or name ${snapshotId} not found`)

--- a/apps/api/src/sandbox/guards/snapshot-read-access.guard.ts
+++ b/apps/api/src/sandbox/guards/snapshot-read-access.guard.ts
@@ -14,6 +14,7 @@ import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-aut
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isRegionAuthContext } from '../../common/interfaces/region-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class SnapshotReadAccessGuard extends ResourceAccessGuard {
@@ -66,7 +67,7 @@ export class SnapshotReadAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException(`Snapshot with ID or name ${snapshotId} not found`)

--- a/apps/api/src/sandbox/guards/snapshot-read-access.guard.ts
+++ b/apps/api/src/sandbox/guards/snapshot-read-access.guard.ts
@@ -14,7 +14,6 @@ import { isSshGatewayAuthContext } from '../../common/interfaces/ssh-gateway-aut
 import { isProxyAuthContext } from '../../common/interfaces/proxy-auth-context.interface'
 import { isRegionAuthContext } from '../../common/interfaces/region-auth-context.interface'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class SnapshotReadAccessGuard extends ResourceAccessGuard {
@@ -67,10 +66,7 @@ export class SnapshotReadAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException(`Snapshot with ID or name ${snapshotId} not found`)
+      this.handleResourceAccessError(error, this.logger, `Snapshot with ID or name ${snapshotId} not found`)
     }
   }
 }

--- a/apps/api/src/sandbox/guards/volume-access.guard.ts
+++ b/apps/api/src/sandbox/guards/volume-access.guard.ts
@@ -9,7 +9,6 @@ import { isOrganizationAuthContext } from '../../common/interfaces/organization-
 import { getAuthContext } from '../../common/utils/get-auth-context'
 import { VolumeService } from '../services/volume.service'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
-import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class VolumeAccessGuard extends ResourceAccessGuard {
@@ -48,10 +47,11 @@ export class VolumeAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
-        this.logger.error(error)
-      }
-      throw new NotFoundException(`Volume with ${volumeId ? 'ID' : 'name'} ${volumeId || volumeName} not found`)
+      this.handleResourceAccessError(
+        error,
+        this.logger,
+        `Volume with ${volumeId ? 'ID' : 'name'} ${volumeId || volumeName} not found`,
+      )
     }
   }
 }

--- a/apps/api/src/sandbox/guards/volume-access.guard.ts
+++ b/apps/api/src/sandbox/guards/volume-access.guard.ts
@@ -9,6 +9,7 @@ import { isOrganizationAuthContext } from '../../common/interfaces/organization-
 import { getAuthContext } from '../../common/utils/get-auth-context'
 import { VolumeService } from '../services/volume.service'
 import { InvalidAuthenticationContextException } from '../../common/exceptions/invalid-authentication-context.exception'
+import { EntityNotFoundError } from 'typeorm'
 
 @Injectable()
 export class VolumeAccessGuard extends ResourceAccessGuard {
@@ -47,7 +48,7 @@ export class VolumeAccessGuard extends ResourceAccessGuard {
       // Access granted
       return true
     } catch (error) {
-      if (!(error instanceof NotFoundException)) {
+      if (!(error instanceof NotFoundException) && !(error instanceof EntityNotFoundError)) {
         this.logger.error(error)
       }
       throw new NotFoundException(`Volume with ${volumeId ? 'ID' : 'name'} ${volumeId || volumeName} not found`)


### PR DESCRIPTION
This pull request improves error handling across several access guard classes by ensuring that `EntityNotFoundError` from TypeORM is treated as a "not found" condition, similar to NestJS's `NotFoundException`. This prevents unnecessary logging of expected errors and provides more consistent error responses when resources are missing.

**Error Handling Improvements:**

* All affected guard classes now import `EntityNotFoundError` from TypeORM and check for it alongside `NotFoundException` when handling errors, preventing unnecessary error logging for missing entities. [[1]](diffhunk://#diff-e9289a2024584281972e2ef23386c87ab755eb55a112fa489ca6e75051eb83a8R12) [[2]](diffhunk://#diff-708dd54f3e32b85e452396c08ba0256d13e5cacc1378869d1bb8155ae14c532eR12) [[3]](diffhunk://#diff-46ef2aaa39e7490771befd1c689661068040f62f729bedd72aa8dad73c7c431cR11) [[4]](diffhunk://#diff-fb36b36651f9eebfe483ed16b5493ab3071d18443f11dc4031fe123ba4d79f5fR18) [[5]](diffhunk://#diff-124fdebe88bd52943cf547b1c8f1ea6b639e53e682f747712addbfcae2cdb3f1R17) [[6]](diffhunk://#diff-c1024e7e492a005faaceab404b01958d4d62ef1e22720ac02d8b1ad6a451dc0fR17) [[7]](diffhunk://#diff-b352cb931bd02fbe9b4a30be75de677964e284dedae9af5147632aff19bc306cR17) [[8]](diffhunk://#diff-c0d93967400eade5fe1e4e9f6869793ecfa42287abc8e5368a177502d1ecfbf3R12)
* The error handling logic in the following guards was updated to include `EntityNotFoundError`:
  - `DockerRegistryAccessGuard`
  - `RegionAccessGuard`
  - `JobAccessGuard`
  - `RunnerAccessGuard`
  - `SandboxAccessGuard`
  - `SnapshotAccessGuard`
  - `SnapshotReadAccessGuard`
  - `VolumeAccessGuard`

These changes ensure that missing resources are handled gracefully and consistently across the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `typeorm`’s `EntityNotFoundError` as “not found” in resource access guards, suppress logging for expected misses, and unify 404s via a shared handler. Applies to Docker registry, region, job, runner, sandbox, snapshot (read + write), and volume guards.

- **Bug Fixes**
  - Handle `EntityNotFoundError` alongside `NotFoundException`, avoid logging in these cases, and rethrow a `NotFoundException` with a clear message.

- **Refactors**
  - Extracted common error handling to `ResourceAccessGuard.handleResourceAccessError` and updated all guards to use it.

<sup>Written for commit 1321074d7423ba84f954ade8e95cd5af913ad013. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

