### PR TITLE
fix(api,cli): serialize nullable snapshot fields as null instead of omitting them

### DIFF
--- a/apps/api/src/sandbox/dto/snapshot.dto.ts
+++ b/apps/api/src/sandbox/dto/snapshot.dto.ts
@@ -32,10 +32,10 @@ export class SnapshotDto {
   state: SnapshotState
 
   @ApiProperty({ nullable: true })
-  size?: number
+  size: number | null
 
   @ApiProperty({ nullable: true })
-  entrypoint?: string[]
+  entrypoint: string[] | null
 
   @ApiProperty()
   cpu: number
@@ -50,7 +50,7 @@ export class SnapshotDto {
   disk: number
 
   @ApiProperty({ nullable: true })
-  errorReason?: string
+  errorReason: string | null
 
   @ApiProperty()
   createdAt: Date
@@ -59,7 +59,7 @@ export class SnapshotDto {
   updatedAt: Date
 
   @ApiProperty({ nullable: true })
-  lastUsedAt?: Date
+  lastUsedAt: Date | null
 
   @ApiPropertyOptional({
     description: 'Build information for the snapshot',
@@ -97,16 +97,16 @@ export class SnapshotDto {
       name: snapshot.name,
       imageName: snapshot.imageName,
       state: snapshot.state,
-      size: snapshot.size,
-      entrypoint: snapshot.entrypoint,
+      size: snapshot.size ?? null,
+      entrypoint: snapshot.entrypoint ?? null,
       cpu: snapshot.cpu,
       gpu: snapshot.gpu,
       mem: snapshot.mem,
       disk: snapshot.disk,
-      errorReason: snapshot.errorReason,
+      errorReason: snapshot.errorReason ?? null,
       createdAt: snapshot.createdAt,
       updatedAt: snapshot.updatedAt,
-      lastUsedAt: snapshot.lastUsedAt,
+      lastUsedAt: snapshot.lastUsedAt ?? null,
       buildInfo: snapshot.buildInfo
         ? {
             dockerfileContent: snapshot.buildInfo.dockerfileContent,

--- a/apps/cli/apiclient/error_handler.go
+++ b/apps/cli/apiclient/error_handler.go
@@ -23,6 +23,11 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 
 	defer res.Body.Close()
 
+	// 2xx: error is client-side (e.g. decode failure), not a server error
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return requestErr
+	}
+
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Fixes `daytona snapshot push` fataling with a raw JSON dump on successful snapshot creation.

```
time="2026-04-09T21:36:46Z" level=fatal msg="{\"id\":\"394a8dd8-...\",\"state\":\"pending\",\"cpu\":2,...}"
```

## Root Cause

PR #4284 (`refactor(api): custom snapshot repository`) changed `createFromPull` from `this.snapshotRepository.save(snapshot)` to `this.snapshotRepository.insert(snapshot)`. TypeORM's `.save()` returns the entity reloaded from the DB (nullable columns come back as explicit `null`), while the custom `.insert()` returns the same in-memory object (unset fields remain `undefined`).

`JSON.stringify` omits `undefined` keys, so the API response stopped including `size`, `entrypoint`, `errorReason`, and `lastUsedAt`. The generated Go API client's `UnmarshalJSON` requires these keys (per the OpenAPI spec: `@ApiProperty({ nullable: true })` = required + nullable), so the decode fails. The CLI's `HandleErrorResponse` then reads the successful 2xx response body, can't parse it as an error, and falls back to dumping the raw snapshot JSON — which `log.Fatal` formats as the cryptic output above.

## Changes

**`apps/api/src/sandbox/dto/snapshot.dto.ts`** (primary fix)
- Changed 4 nullable field types from `?: T` to `: T | null` to match the OpenAPI contract
- `fromSnapshot()` now uses `?? null` for these fields — ensures JSON always includes the keys with explicit `null` values regardless of whether the entity came from `.save()`, `.insert()`, or any other source

**`apps/cli/apiclient/error_handler.go`** (defensive fix)
- `HandleErrorResponse` now returns the original error on 2xx responses instead of misinterpreting the response body as an error message
- Before: `level=fatal msg="{\"id\":\"394a8dd8-...\"}"`
- After: `level=fatal msg="no value given for required property size"`

## Testing

Reproduced against prod (`app.daytona.io`) and verified fix against local API:

| Response | Go client `UnmarshalJSON` |
|---|---|
| Prod (missing fields): `{"id":"...","state":"pending","cpu":1,...}` | ❌ `no value given for required property size` |
| Fixed (explicit nulls): `{"id":"...","size":null,"entrypoint":null,...}` | ✅ `OK` |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize nullable snapshot fields as explicit nulls in API responses to match the OpenAPI contract and stop `daytona snapshot push` from crashing on success. Also improve the CLI error handler to return the original decode error on 2xx responses.

- **Bug Fixes**
  - API: In `SnapshotDto`, changed `size`, `entrypoint`, `errorReason`, and `lastUsedAt` to `T | null` and set them with `?? null` in `fromSnapshot()` so JSON always includes these keys, even after `insert()`.
  - CLI: `HandleErrorResponse` now returns the original error for 2xx responses instead of dumping the raw response body.

<sup>Written for commit af1104b21a03495b193cfdcb9131c48f960ed6b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

