### PR TITLE
fix(computer-use): normalize named keys to lowercase before KeyTap

### DIFF
--- a/libs/computer-use/pkg/computeruse/keyboard.go
+++ b/libs/computer-use/pkg/computeruse/keyboard.go
@@ -1,6 +1,5 @@
 // Copyright 2025 Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
-
 package computeruse
 
 import (
@@ -11,29 +10,37 @@ import (
 	"github.com/go-vgo/robotgo"
 )
 
+// normalizeKey lowercases multi-character named keys (e.g. "Escape" -> "escape")
+// so that robotgo does not add an unwanted shift modifier.
+// Single-character keys like "A" are left unchanged so shift+a still works.
+func normalizeKey(key string) string {
+	if len([]rune(key)) == 1 {
+		return key
+	}
+	return strings.ToLower(key)
+}
+
 func (u *ComputerUse) TypeText(req *computeruse.KeyboardTypeRequest) (*computeruse.Empty, error) {
 	if req.Delay > 0 {
 		robotgo.TypeStr(req.Text, req.Delay)
 	} else {
 		robotgo.TypeStr(req.Text)
 	}
-
 	return new(computeruse.Empty), nil
 }
 
 func (u *ComputerUse) PressKey(req *computeruse.KeyboardPressRequest) (*computeruse.Empty, error) {
 	if len(req.Modifiers) > 0 {
-		err := robotgo.KeyTap(req.Key, req.Modifiers)
+		err := robotgo.KeyTap(normalizeKey(req.Key), req.Modifiers)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		err := robotgo.KeyTap(req.Key)
+		err := robotgo.KeyTap(normalizeKey(req.Key))
 		if err != nil {
 			return nil, err
 		}
 	}
-
 	return new(computeruse.Empty), nil
 }
 
@@ -42,14 +49,11 @@ func (u *ComputerUse) PressHotkey(req *computeruse.KeyboardHotkeyRequest) (*comp
 	if len(keys) < 2 {
 		return nil, fmt.Errorf("invalid hotkey format")
 	}
-
-	mainKey := keys[len(keys)-1]
+	mainKey := normalizeKey(keys[len(keys)-1])
 	modifiers := keys[:len(keys)-1]
-
 	err := robotgo.KeyTap(mainKey, modifiers)
 	if err != nil {
 		return nil, err
 	}
-
 	return new(computeruse.Empty), nil
 }


### PR DESCRIPTION
Named keys like `Escape`, `ESC`, or `ESCAPE` were producing `shift+escape` 
instead of plain `escape` because robotgo applies a shift modifier when the 
first character of the key name is uppercase.

Added a `normalizeKey()` helper in the computer-use keyboard layer that 
lowercases multi-character named keys before passing them to `robotgo.KeyTap`. 
Single-character keys like `A` are left unchanged so that `shift+a` behaviour 
is preserved.

## Documentation:
- Dono boxes unchecked rehne do (koi doc change nahi)

## Related Issue(s):
- This PR addresses issue #4417

## Notes:
```
The fix is contained entirely within normalizeKey() in 
libs/computer-use/pkg/computeruse/keyboard.go
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowercase multi-character named keys before `robotgo.KeyTap` to avoid implicit Shift (e.g., "Escape" -> "escape"); single-character keys stay as-is so shift+letter still works. Applies to both single key presses and hotkeys (fixes #4417).

<sup>Written for commit c2d345d69400f09b8199148b47414b00c285085c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

