### PR TITLE
fix(opencode-plugin): derive SSH gateway from sshCommand for self-hosted support

### DIFF
--- a/libs/opencode-plugin/.opencode/plugin/daytona/git/session-git-manager.ts
+++ b/libs/opencode-plugin/.opencode/plugin/daytona/git/session-git-manager.ts
@@ -45,7 +45,8 @@ export class SessionGitManager {
 
   private async getSshUrl(): Promise<string> {
     const sshAccess = await this.sandbox.createSshAccess(10)
-    return `ssh://${sshAccess.token}@ssh.app.daytona.io${this.repoPath}`
+    const gateway = process.env.DAYTONA_SSH_GATEWAY_URL || 'ssh.app.daytona.io'
+    return `ssh://${sshAccess.token}@${gateway}${this.repoPath}`
   }
 
   /**

--- a/libs/opencode-plugin/.opencode/plugin/daytona/git/session-git-manager.ts
+++ b/libs/opencode-plugin/.opencode/plugin/daytona/git/session-git-manager.ts
@@ -45,6 +45,15 @@ export class SessionGitManager {
 
   private async getSshUrl(): Promise<string> {
     const sshAccess = await this.sandbox.createSshAccess(10)
+    // sshCommand format: "ssh [-p PORT] TOKEN@HOST"
+    // Parse it to derive the correct host/port for any deployment (local or cloud).
+    const match = sshAccess.sshCommand.match(/ssh(?:\s+-p\s+(\d+))?\s+\S+@(\S+)/)
+    if (match) {
+      const port = match[1] ? `:${match[1]}` : ''
+      const host = match[2]
+      return `ssh://${sshAccess.token}@${host}${port}${this.repoPath}`
+    }
+    // Fallback: env var or cloud default
     const gateway = process.env.DAYTONA_SSH_GATEWAY_URL || 'ssh.app.daytona.io'
     return `ssh://${sshAccess.token}@${gateway}${this.repoPath}`
   }


### PR DESCRIPTION
## Problem

The SSH gateway URL in the opencode plugin was hardcoded to \`ssh.app.daytona.io\`:

\`\`\`ts
return \`ssh://\${sshAccess.token}@ssh.app.daytona.io\${this.repoPath}\`
\`\`\`

This completely breaks git sync for anyone running Daytona self-hosted (Docker Compose, on-prem), since their SSH gateway is at a different address (e.g. \`localhost:2222\`).

## Fix

Parse the connection details directly from \`SshAccessDto.sshCommand\` that the API already returns — the API knows the correct host and port for any deployment, so we use it as the authoritative source:

\`\`\`ts
private async getSshUrl(): Promise<string> {
  const sshAccess = await this.sandbox.createSshAccess(10)
  // sshCommand format: "ssh [-p PORT] TOKEN@HOST"
  // Parse it to derive the correct host/port for any deployment (local or cloud).
  const match = sshAccess.sshCommand.match(/ssh(?:\s+-p\s+(\d+))?\s+\S+@(\S+)/)
  if (match) {
    const port = match[1] ? \`:${match[1]}\` : ''
    const host = match[2]
    return \`ssh://\${sshAccess.token}@\${host}\${port}\${this.repoPath}\`
  }
  // Fallback: env var or cloud default
  const gateway = process.env.DAYTONA_SSH_GATEWAY_URL || 'ssh.app.daytona.io'
  return \`ssh://\${sshAccess.token}@\${gateway}\${this.repoPath}\`
}
\`\`\`

This is zero-config — cloud users, self-hosted users, and custom-port deployments all get the right URL automatically without setting any environment variables.

The \`DAYTONA_SSH_GATEWAY_URL\` env var is kept only as a last-resort fallback if \`sshCommand\` is ever missing or unparseable.

## Test plan

- [x] Self-hosted (Docker Compose): \`sshCommand\` returns \`ssh -p 2222 TOKEN@localhost\` → parses to \`ssh://TOKEN@localhost:2222/path\` → git sync works
- [x] Cloud: \`sshCommand\` returns \`ssh TOKEN@ssh.app.daytona.io\` → parses to \`ssh://TOKEN@ssh.app.daytona.io/path\` → existing behaviour unchanged
- [x] Fallback: if \`sshCommand\` doesn't match regex → falls back to \`DAYTONA_SSH_GATEWAY_URL\` or \`ssh.app.daytona.io\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)