### PR TITLE
fix(opencode-plugin): install git in slim sandbox before running git commands

### DIFF
--- a/libs/opencode-plugin/.opencode/plugin/daytona/git/sandbox-git-manager.ts
+++ b/libs/opencode-plugin/.opencode/plugin/daytona/git/sandbox-git-manager.ts
@@ -18,6 +18,9 @@ export class DaytonaSandboxGitManager {
 
   async ensureRepo(): Promise<void> {
     await this.ensureDirectory()
+    await this.sandbox.process.executeCommand(
+      'sudo apt-get update -qq && sudo apt-get install -y git 2>/dev/null || true',
+    )
     const isGit = await this.sandbox.process.executeCommand('git rev-parse --is-inside-work-tree', this.repoPath)
     if (!isGit || isGit.result.trim() !== 'true') {
       await this.sandbox.process.executeCommand('git init', this.repoPath)


### PR DESCRIPTION
## Problem

The default sandbox image (`daytonaio/sandbox` slim variant) does not include `git`. All git operations inside the sandbox fail silently with:

```
/usr/bin/bash: line 1: git: command not found
```

This causes `ensureRepo()` to never successfully initialise the git repository, breaking the entire git sync feature for users of the slim image.

Tracked in #4437.

## Fix

Install `git` via `apt-get` at the start of `ensureRepo()`, before any git commands are run:

```ts
async ensureRepo(): Promise<void> {
  await this.ensureDirectory()
  await this.sandbox.process.executeCommand(
    'sudo apt-get update -qq && sudo apt-get install -y git 2>/dev/null || true'
  )
  // ... rest of git init logic
}
```

- `apt-get update` is required first because the slim image has an empty package cache
- `sudo` is needed because the default sandbox user (`daytona`) is non-root
- `2>/dev/null || true` suppresses noise and makes the step non-fatal — if git is already installed (full image), this is a no-op

## Test plan

- [x] Slim image (`daytonaio/sandbox:*-slim`): git is installed on first `ensureRepo()` call → subsequent git commands succeed
- [x] Full image: `apt-get install git` is a no-op (already installed) → no regression
- [x] End-to-end: git sync (`push` + `pull`) completes successfully after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix git operations failing in slim sandboxes by installing `git` at the start of `ensureRepo()`. This restores repo init and git sync.

- **Bug Fixes**
  - Run `sudo apt-get update -qq && sudo apt-get install -y git 2>/dev/null || true` before any git commands.
  - No-op on full images; safe to rerun and keeps logs quiet.

<sup>Written for commit 10453bf79952e132123fecd8eb1984eb9681173c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

