### PR TITLE
fix: use RFC 5987 encoding for multipart filename

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/download_files.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files.go
@@ -177,7 +177,7 @@ func classifyDownloadPathError(ctx *gin.Context, path string) *common.ErrorRespo
 
 func multipartContentDisposition(formName string, path string) string {
 	return fmt.Sprintf(`form-data; name="%s"; filename="%s"; filename*=utf-8''%s`,
-		formName, toLatin1(path), encodeRFC5987(path))
+		formName, encodeRFC5987(path), encodeRFC5987(path))
 }
 
 func classifyPathStatError(path string, err error) (int, string, string) {


### PR DESCRIPTION
The toLatin1() function replaced non-latin1 chars with '_', breaking downloads of files with Unicode names. Now uses encodeRFC5987() which properly handles any Unicode char in filenames.

The fix is simple: replace toLatin1(path) with encodeRFC5987(path) in the multipart Content-Disposition header.

Fixes #4323

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use RFC 5987 encoding for multipart filenames to preserve Unicode names in downloads. Prevents underscores replacing non‑Latin‑1 chars and fixes #4323.

- **Bug Fixes**
  - Replaced `toLatin1(path)` with `encodeRFC5987(path)` for both `filename` and `filename*` in the `Content-Disposition` header.

<sup>Written for commit d9aa79420a8f4b9deab2b34ba045bbd790f241f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

