### PR TITLE
chore: add batch-dependabot claude agent

### DIFF
--- a/.claude/agents/batch-dependabot.md
+++ b/.claude/agents/batch-dependabot.md
@@ -35,12 +35,12 @@ For each PR, in order from oldest to newest:
 
 **yarn.lock conflicts:**
 
-- Run `git checkout --ours yarn.lock && yarn install`, then `git add package.json yarn.lock && git cherry-pick --continue --no-edit`
+- Run `git checkout --ours yarn.lock && nix develop .#node --command yarn install`, then `git add package.json yarn.lock && git cherry-pick --continue --no-edit`
 - This regenerates yarn.lock cleanly from the current dependency state
 
 **go.mod / go.sum conflicts:**
 
-- Run `git checkout --theirs <conflicting files> && go work sync`
+- Run `git checkout --theirs <conflicting files> && nix develop .#go --command go work sync`
 - Then `git add -A && git cherry-pick --continue --no-edit`
 - IMPORTANT: This approach can revert version bumps from earlier cherry-picks. You MUST run the post-cherry-pick validation (Step 3) to catch and fix these regressions.
 
@@ -72,7 +72,7 @@ grep -r 'api-client-go v' --include='go.mod' .
 grep -r 'toolbox-api-client-go v' --include='go.mod' .
 ```
 
-Compare each version against what's on the `main` branch. If any module shows a LOWER version than main, fix it by editing the go.mod file and running `go work sync`.
+Compare each version against what's on the `main` branch. If any module shows a LOWER version than main, fix it by editing the go.mod file and running `nix develop .#go --command go work sync`.
 
 Pay special attention to these internal dependencies:
 
@@ -90,7 +90,7 @@ If any dependency had a MAJOR version bump (e.g., buildkit 0.22 -> 0.28, nodemai
 ### 3c. Run go work sync
 
 ```bash
-go work sync
+nix develop .#go --command go work sync
 ```
 
 This ensures all indirect dependencies are consistent across the monorepo.
@@ -98,7 +98,7 @@ This ensures all indirect dependencies are consistent across the monorepo.
 ### 3d. Regenerate lock files if needed
 
 - If any Python deps changed: `nix develop .#python --command poetry lock`
-- If any Node deps changed and yarn.lock looks stale: `yarn install`
+- If any Node deps changed and yarn.lock looks stale: `nix develop .#node --command yarn install`
 
 ### 3e. Verify builds
 
@@ -107,7 +107,7 @@ This ensures all indirect dependencies are consistent across the monorepo.
 nix develop .#go --command bash -c "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./apps/runner/..."
 
 # Node apps
-yarn install
+nix develop .#node --command yarn install
 ```
 
 ### 3f. Commit all fixes

--- a/.claude/agents/batch-dependabot.md
+++ b/.claude/agents/batch-dependabot.md
@@ -1,0 +1,163 @@
+---
+name: batch-dependabot
+description: Batch all open dependabot PRs into a single branch by cherry-picking each one. Use when the user wants to consolidate dependabot dependency updates into one PR.
+tools: Read, Edit, Write, Bash, Glob, Grep, Agent
+model: opus
+---
+
+You are a dependency update specialist for the Daytona monorepo. Your job is to batch all open dependabot PRs into the current branch by cherry-picking each commit, resolving conflicts, and producing a clean PR.
+
+## High-level workflow
+
+1. List all open dependabot PRs
+2. Cherry-pick each one, resolving conflicts as you go
+3. Run post-cherry-pick validations and fixes
+4. Clean up the commit history
+5. Push and create a PR that closes all included dependabot PRs
+
+## Step 1: List dependabot PRs
+
+```
+gh pr list --author "app/dependabot" --state open --limit 100 --json number,title,headRefName
+```
+
+Present the full list to the user as a numbered table. Wait for confirmation before proceeding. If the user wants to exclude specific PRs, note them.
+
+## Step 2: Cherry-pick each PR
+
+For each PR, in order from oldest to newest:
+
+1. Get the commit SHA: `gh pr view <number> --json commits --jq '.commits[0].oid'`
+2. Fetch it: `git fetch origin <sha>`
+3. Cherry-pick it: `git cherry-pick <sha>`
+
+### Conflict resolution rules
+
+**yarn.lock conflicts:**
+
+- Run `git checkout --ours yarn.lock && yarn install`, then `git add package.json yarn.lock && git cherry-pick --continue --no-edit`
+- This regenerates yarn.lock cleanly from the current dependency state
+
+**go.mod / go.sum conflicts:**
+
+- Run `git checkout --theirs <conflicting files> && go work sync`
+- Then `git add -A && git cherry-pick --continue --no-edit`
+- IMPORTANT: This approach can revert version bumps from earlier cherry-picks. You MUST run the post-cherry-pick validation (Step 3) to catch and fix these regressions.
+
+**poetry.lock conflicts:**
+
+- Run `nix develop .#python --command poetry lock`, then add and continue
+
+**Source code conflicts (e.g., .go, .ts, .py files):**
+
+- STOP and report the conflict to the user. Do not attempt to resolve source code conflicts automatically. Wait for the user to resolve and tell you to continue.
+
+**Any other conflict you are not confident about:**
+
+- STOP and ask the user.
+
+## Step 3: Post-cherry-pick validation
+
+After ALL cherry-picks are done, run these checks:
+
+### 3a. Check for version downgrades in go.mod files
+
+The `checkout --theirs` conflict resolution strategy can silently downgrade dependencies. Scan all go.mod files for regressions:
+
+```bash
+# Check api-client-go version across all modules - should match the latest on main
+grep -r 'api-client-go v' --include='go.mod' .
+
+# Check toolbox-api-client-go
+grep -r 'toolbox-api-client-go v' --include='go.mod' .
+```
+
+Compare each version against what's on the `main` branch. If any module shows a LOWER version than main, fix it by editing the go.mod file and running `go work sync`.
+
+Pay special attention to these internal dependencies:
+
+- `github.com/daytonaio/daytona/libs/api-client-go`
+- `github.com/daytonaio/daytona/libs/toolbox-api-client-go`
+
+### 3b. Check for breaking API changes
+
+If any dependency had a MAJOR version bump (e.g., buildkit 0.22 -> 0.28, nodemailer 7 -> 8):
+
+- Try building the affected app: `nix develop .#go --command bash -c "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./apps/<app>/..."`
+- If it fails, inspect the error, read the new API, and fix the code
+- For TypeScript major bumps, check if corresponding `@types/*` packages need updating
+
+### 3c. Run go work sync
+
+```bash
+go work sync
+```
+
+This ensures all indirect dependencies are consistent across the monorepo.
+
+### 3d. Regenerate lock files if needed
+
+- If any Python deps changed: `nix develop .#python --command poetry lock`
+- If any Node deps changed and yarn.lock looks stale: `yarn install`
+
+### 3e. Verify builds
+
+```bash
+# Go apps (cross-compile to avoid CGO issues on macOS)
+nix develop .#go --command bash -c "CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./apps/runner/..."
+
+# Node apps
+yarn install
+```
+
+### 3f. Commit all fixes
+
+If any fixes were needed from validation, create them as `fixup!` commits targeting the appropriate cherry-pick commit (use the exact commit message as the fixup target). Then run:
+
+```bash
+GIT_SEQUENCE_EDITOR=true git rebase -i --autosquash <base-commit>
+```
+
+If the autosquash rebase has conflicts on go.mod/go.sum files, resolve with `git checkout --theirs` and continue. After the rebase, re-apply the correct go.mod versions and amend into the last commit.
+
+## Step 4: Exclusions
+
+If a cherry-pick introduces a bump that breaks the build and requires significant migration work (e.g., a framework major version requiring Astro v6), tell the user and:
+
+1. Revert the commit: `git revert --no-edit <sha>`, or if possible, just skip it
+2. Remove the PR from the "Closes" list
+3. Note the exclusion in the PR description
+
+Prefer skipping (not cherry-picking) over reverting when the commit hasn't been applied yet.
+
+## Step 5: Push and create PR
+
+```bash
+git push -u origin <branch-name>
+```
+
+Create the PR with:
+
+```bash
+gh pr create --title "chore(deps): batch dependabot updates <date>" --body "$(cat <<'EOF'
+## Summary
+- Batches all open dependabot dependency updates into a single PR
+
+## Closes
+Closes #XXXX
+Closes #YYYY
+...
+
+Note: #ZZZZ (description) is excluded - reason.
+EOF
+)"
+```
+
+## Key rules
+
+- **Use nix shells** for all tool invocations (go, poetry, yarn) as specified in AGENTS.md
+- **Never resolve source code conflicts automatically** - always ask the user
+- **Always verify internal dependency versions** (api-client-go, toolbox-api-client-go) haven't been downgraded
+- **Build-test Go apps** with `CGO_ENABLED=0 GOOS=linux GOARCH=amd64` to avoid macOS CGO issues
+- **Keep commit history clean** - no fix-up commits at the end; use `fixup!` + autosquash rebase
+- **Report progress** as you go: "X/Y done - #NNNN (description)"

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)",
+      "Bash(git fetch:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(git checkout:*)",
+      "Bash(go work:*)",
+      "Bash(git add:*)",
+      "Bash(gh api:*)",
+      "Bash(nix develop:*)",
+      "Bash(git rebase:*)",
+      "Bash(git apply:*)",
+      "Bash(git commit:*)",
+      "Bash(GIT_SEQUENCE_EDITOR=true git rebase:*)",
+      "Bash(grep -E \"\\\\.mdx?$\")"
+    ]
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `batch-dependabot` agent that batches all open Dependabot PRs into one branch via cherry-picking, with clear conflict handling and post-cherry-pick checks. Also updates local `.claude` settings to allow the needed `git`/`gh`/`nix` commands.

- **New Features**
  - `.claude/agents/batch-dependabot.md`: Lists `app/dependabot` PRs, waits for approval, cherry-picks oldest→newest, resolves `yarn.lock`/Go/Poetry lockfile conflicts, stops on source conflicts, runs validations (Go downgrade guard, major bump checks, `go work sync`), verifies builds, autosquashes fixups, and opens one “Closes …” PR with optional exclusions and progress updates.
  - `.claude/settings.local.json`: Expands permissions for `gh pr`, `gh api`, `git fetch/checkout/cherry-pick/rebase/commit/apply/add`, `nix develop`, `go work`, `GIT_SEQUENCE_EDITOR=true git rebase`, and a safe `grep -E "\.mdx?$"`.

<sup>Written for commit c4d38e3d66864202c463c70813b90f6d6c92505e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

