### PR TITLE
fix(api): parse resize job payload

### DIFF
--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -551,7 +551,7 @@ export class JobStateHandlerService {
       }
 
       // Calculate deltas before updating sandbox
-      const payload = job.payload as { cpu?: number; memory?: number; disk?: number }
+      const payload = job.getPayload<{ cpu?: number; memory?: number; disk?: number }>() ?? {}
 
       // For cold resize (previousState === STOPPED), cpu/memory don't affect org quota.
       const isHotResize = previousState === SandboxState.STARTED


### PR DESCRIPTION
## Description

The resize job handler was casting the raw JSON string payload directly to an object, so resource values were always      undefined and sandboxes kept their old CPU/memory/disk after a resize. Switched to `job.getPayload()` which properly parses the JSON string, matching how other job handlers already access payload data. 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation