### PR TITLE
test(api): enforce explicit auth configuration on all controller endpoints

### DIFF
--- a/apps/api/src/api-key/api-key.controller.auth.spec.ts
+++ b/apps/api/src/api-key/api-key.controller.auth.spec.ts
@@ -13,12 +13,14 @@ import {
   getRequiredOrganizationMemberRole,
   getRequiredOrganizationResourcePermissions,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] ApiKeyController', () => {
   const trackMethod = createCoverageTracker(ApiKeyController)
   it('createApiKey', () => {
     const methodName = trackMethod('createApiKey')
+    expect(isPublicEndpoint(ApiKeyController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(ApiKeyController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(ApiKeyController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(ApiKeyController, methodName)).toBeUndefined()
@@ -27,6 +29,7 @@ describe('[AUTH] ApiKeyController', () => {
 
   it('getApiKeys', () => {
     const methodName = trackMethod('getApiKeys')
+    expect(isPublicEndpoint(ApiKeyController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(ApiKeyController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(ApiKeyController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(ApiKeyController, methodName)).toBeUndefined()
@@ -35,6 +38,7 @@ describe('[AUTH] ApiKeyController', () => {
 
   it('getCurrentApiKey', () => {
     const methodName = trackMethod('getCurrentApiKey')
+    expect(isPublicEndpoint(ApiKeyController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(ApiKeyController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(ApiKeyController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(ApiKeyController, methodName)).toBeUndefined()
@@ -43,6 +47,7 @@ describe('[AUTH] ApiKeyController', () => {
 
   it('getApiKey', () => {
     const methodName = trackMethod('getApiKey')
+    expect(isPublicEndpoint(ApiKeyController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(ApiKeyController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(ApiKeyController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(ApiKeyController, methodName)).toBeUndefined()
@@ -51,6 +56,7 @@ describe('[AUTH] ApiKeyController', () => {
 
   it('deleteApiKey', () => {
     const methodName = trackMethod('deleteApiKey')
+    expect(isPublicEndpoint(ApiKeyController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(ApiKeyController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(ApiKeyController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(ApiKeyController, methodName)).toBeUndefined()
@@ -59,6 +65,7 @@ describe('[AUTH] ApiKeyController', () => {
 
   it('deleteApiKeyForUser', () => {
     const methodName = trackMethod('deleteApiKeyForUser')
+    expect(isPublicEndpoint(ApiKeyController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(ApiKeyController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(ApiKeyController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(ApiKeyController, methodName)).toBeUndefined()

--- a/apps/api/src/audit/controllers/audit.controller.auth.spec.ts
+++ b/apps/api/src/audit/controllers/audit.controller.auth.spec.ts
@@ -14,6 +14,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] AuditController', () => {
@@ -21,6 +22,7 @@ describe('[AUTH] AuditController', () => {
 
   it('getOrganizationLogs', () => {
     const methodName = trackMethod('getOrganizationLogs')
+    expect(isPublicEndpoint(AuditController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(AuditController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,

--- a/apps/api/src/config/config.controller.auth.spec.ts
+++ b/apps/api/src/config/config.controller.auth.spec.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ConfigController } from './config.controller'
+import {
+  getAuthContextGuards,
+  getAllowedAuthStrategies,
+  expectArrayMatch,
+  createCoverageTracker,
+  isPublicEndpoint,
+} from '../test/helpers/controller-metadata.helper'
+
+describe('[AUTH] ConfigController', () => {
+  const trackMethod = createCoverageTracker(ConfigController)
+
+  it('getConfig', () => {
+    const methodName = trackMethod('getConfig')
+    expect(isPublicEndpoint(ConfigController, methodName)).toBe(true)
+    expectArrayMatch(getAllowedAuthStrategies(ConfigController, methodName), [])
+    expectArrayMatch(getAuthContextGuards(ConfigController, methodName), [])
+  })
+})

--- a/apps/api/src/docker-registry/controllers/docker-registry.controller.auth.spec.ts
+++ b/apps/api/src/docker-registry/controllers/docker-registry.controller.auth.spec.ts
@@ -16,6 +16,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] DockerRegistryController', () => {
@@ -23,6 +24,7 @@ describe('[AUTH] DockerRegistryController', () => {
 
   it('create', () => {
     const methodName = trackMethod('create')
+    expect(isPublicEndpoint(DockerRegistryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(DockerRegistryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -36,6 +38,7 @@ describe('[AUTH] DockerRegistryController', () => {
 
   it('findAll', () => {
     const methodName = trackMethod('findAll')
+    expect(isPublicEndpoint(DockerRegistryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(DockerRegistryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -47,6 +50,7 @@ describe('[AUTH] DockerRegistryController', () => {
 
   it('getTransientPushAccess', () => {
     const methodName = trackMethod('getTransientPushAccess')
+    expect(isPublicEndpoint(DockerRegistryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(DockerRegistryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -58,6 +62,7 @@ describe('[AUTH] DockerRegistryController', () => {
 
   it('findOne', () => {
     const methodName = trackMethod('findOne')
+    expect(isPublicEndpoint(DockerRegistryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(DockerRegistryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -70,6 +75,7 @@ describe('[AUTH] DockerRegistryController', () => {
 
   it('update', () => {
     const methodName = trackMethod('update')
+    expect(isPublicEndpoint(DockerRegistryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(DockerRegistryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -84,6 +90,7 @@ describe('[AUTH] DockerRegistryController', () => {
 
   it('remove', () => {
     const methodName = trackMethod('remove')
+    expect(isPublicEndpoint(DockerRegistryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(DockerRegistryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,

--- a/apps/api/src/health/health.controller.auth.spec.ts
+++ b/apps/api/src/health/health.controller.auth.spec.ts
@@ -11,6 +11,7 @@ import {
   getAllowedAuthStrategies,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] HealthController', () => {
@@ -18,12 +19,14 @@ describe('[AUTH] HealthController', () => {
 
   it('live', () => {
     const methodName = trackMethod('live')
+    expect(isPublicEndpoint(HealthController, methodName)).toBe(true)
     expectArrayMatch(getAllowedAuthStrategies(HealthController, methodName), [])
     expectArrayMatch(getAuthContextGuards(HealthController, methodName), [])
   })
 
   it('check', () => {
     const methodName = trackMethod('check')
+    expect(isPublicEndpoint(HealthController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(HealthController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(HealthController, methodName), [HealthCheckAuthContextGuard])
   })

--- a/apps/api/src/object-storage/controllers/object-storage.controller.auth.spec.ts
+++ b/apps/api/src/object-storage/controllers/object-storage.controller.auth.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ObjectStorageController } from './object-storage.controller'
+import { OrganizationAuthContextGuard } from '../../organization/guards/organization-auth-context.guard'
+import { AuthStrategyType } from '../../auth/enums/auth-strategy-type.enum'
+import {
+  getAuthContextGuards,
+  getAllowedAuthStrategies,
+  expectArrayMatch,
+  createCoverageTracker,
+  isPublicEndpoint,
+} from '../../test/helpers/controller-metadata.helper'
+
+describe('[AUTH] ObjectStorageController', () => {
+  const trackMethod = createCoverageTracker(ObjectStorageController)
+
+  it('getPushAccess', () => {
+    const methodName = trackMethod('getPushAccess')
+    expect(isPublicEndpoint(ObjectStorageController, methodName)).toBe(false)
+    expectArrayMatch(getAllowedAuthStrategies(ObjectStorageController, methodName), [
+      AuthStrategyType.API_KEY,
+      AuthStrategyType.JWT,
+    ])
+    expectArrayMatch(getAuthContextGuards(ObjectStorageController, methodName), [OrganizationAuthContextGuard])
+  })
+})

--- a/apps/api/src/organization/controllers/organization-invitation.controller.auth.spec.ts
+++ b/apps/api/src/organization/controllers/organization-invitation.controller.auth.spec.ts
@@ -13,6 +13,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
 
@@ -21,6 +22,7 @@ describe('[AUTH] OrganizationInvitationController', () => {
 
   it('create', () => {
     const methodName = trackMethod('create')
+    expect(isPublicEndpoint(OrganizationInvitationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationInvitationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationInvitationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationInvitationController, methodName)).toBe(
@@ -30,6 +32,7 @@ describe('[AUTH] OrganizationInvitationController', () => {
 
   it('update', () => {
     const methodName = trackMethod('update')
+    expect(isPublicEndpoint(OrganizationInvitationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationInvitationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationInvitationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationInvitationController, methodName)).toBe(
@@ -39,6 +42,7 @@ describe('[AUTH] OrganizationInvitationController', () => {
 
   it('findPending', () => {
     const methodName = trackMethod('findPending')
+    expect(isPublicEndpoint(OrganizationInvitationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationInvitationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationInvitationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationInvitationController, methodName)).toBeUndefined()
@@ -47,6 +51,7 @@ describe('[AUTH] OrganizationInvitationController', () => {
 
   it('cancel', () => {
     const methodName = trackMethod('cancel')
+    expect(isPublicEndpoint(OrganizationInvitationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationInvitationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationInvitationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationInvitationController, methodName)).toBe(

--- a/apps/api/src/organization/controllers/organization-region.controller.auth.spec.ts
+++ b/apps/api/src/organization/controllers/organization-region.controller.auth.spec.ts
@@ -16,6 +16,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] OrganizationRegionController', () => {
@@ -23,6 +24,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('listAvailableRegions', () => {
     const methodName = trackMethod('listAvailableRegions')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -34,6 +36,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('createRegion', () => {
     const methodName = trackMethod('createRegion')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -47,6 +50,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('getRegionById', () => {
     const methodName = trackMethod('getRegionById')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -59,6 +63,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('deleteRegion', () => {
     const methodName = trackMethod('deleteRegion')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -73,6 +78,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('regenerateProxyApiKey', () => {
     const methodName = trackMethod('regenerateProxyApiKey')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -87,6 +93,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('updateRegion', () => {
     const methodName = trackMethod('updateRegion')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -101,6 +108,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('regenerateSshGatewayApiKey', () => {
     const methodName = trackMethod('regenerateSshGatewayApiKey')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -115,6 +123,7 @@ describe('[AUTH] OrganizationRegionController', () => {
 
   it('regenerateSnapshotManagerCredentials', () => {
     const methodName = trackMethod('regenerateSnapshotManagerCredentials')
+    expect(isPublicEndpoint(OrganizationRegionController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRegionController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,

--- a/apps/api/src/organization/controllers/organization-role.controller.auth.spec.ts
+++ b/apps/api/src/organization/controllers/organization-role.controller.auth.spec.ts
@@ -13,6 +13,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
 
@@ -21,6 +22,7 @@ describe('[AUTH] OrganizationRoleController', () => {
 
   it('create', () => {
     const methodName = trackMethod('create')
+    expect(isPublicEndpoint(OrganizationRoleController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRoleController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationRoleController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationRoleController, methodName)).toBe(OrganizationMemberRole.OWNER)
@@ -28,6 +30,7 @@ describe('[AUTH] OrganizationRoleController', () => {
 
   it('findAll', () => {
     const methodName = trackMethod('findAll')
+    expect(isPublicEndpoint(OrganizationRoleController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRoleController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationRoleController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationRoleController, methodName)).toBeUndefined()
@@ -36,6 +39,7 @@ describe('[AUTH] OrganizationRoleController', () => {
 
   it('updateRole', () => {
     const methodName = trackMethod('updateRole')
+    expect(isPublicEndpoint(OrganizationRoleController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRoleController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationRoleController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationRoleController, methodName)).toBe(OrganizationMemberRole.OWNER)
@@ -43,6 +47,7 @@ describe('[AUTH] OrganizationRoleController', () => {
 
   it('delete', () => {
     const methodName = trackMethod('delete')
+    expect(isPublicEndpoint(OrganizationRoleController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationRoleController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationRoleController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationRoleController, methodName)).toBe(OrganizationMemberRole.OWNER)

--- a/apps/api/src/organization/controllers/organization-user.controller.auth.spec.ts
+++ b/apps/api/src/organization/controllers/organization-user.controller.auth.spec.ts
@@ -13,6 +13,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 import { OrganizationMemberRole } from '../enums/organization-member-role.enum'
 
@@ -21,6 +22,7 @@ describe('[AUTH] OrganizationUserController', () => {
 
   it('findAll', () => {
     const methodName = trackMethod('findAll')
+    expect(isPublicEndpoint(OrganizationUserController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationUserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationUserController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationUserController, methodName)).toBeUndefined()
@@ -29,6 +31,7 @@ describe('[AUTH] OrganizationUserController', () => {
 
   it('updateAccess', () => {
     const methodName = trackMethod('updateAccess')
+    expect(isPublicEndpoint(OrganizationUserController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationUserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationUserController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationUserController, methodName)).toBe(OrganizationMemberRole.OWNER)
@@ -36,6 +39,7 @@ describe('[AUTH] OrganizationUserController', () => {
 
   it('delete', () => {
     const methodName = trackMethod('delete')
+    expect(isPublicEndpoint(OrganizationUserController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationUserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationUserController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationUserController, methodName)).toBe(OrganizationMemberRole.OWNER)

--- a/apps/api/src/organization/controllers/organization.controller.auth.spec.ts
+++ b/apps/api/src/organization/controllers/organization.controller.auth.spec.ts
@@ -16,6 +16,7 @@ import {
   expectArrayMatch,
   getRequiredSystemRole,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 import { SystemRole } from '../../user/enums/system-role.enum'
 import { UserAuthContextGuard } from '../../user/guards/user-auth-context.guard'
@@ -25,36 +26,42 @@ describe('[AUTH] OrganizationController', () => {
 
   it('findInvitationsByUser', () => {
     const methodName = trackMethod('findInvitationsByUser')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [UserAuthContextGuard])
   })
 
   it('getInvitationsCountByUser', () => {
     const methodName = trackMethod('getInvitationsCountByUser')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [UserAuthContextGuard])
   })
 
   it('acceptInvitation', () => {
     const methodName = trackMethod('acceptInvitation')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [UserAuthContextGuard])
   })
 
   it('declineInvitation', () => {
     const methodName = trackMethod('declineInvitation')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [UserAuthContextGuard])
   })
 
   it('create', () => {
     const methodName = trackMethod('create')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [UserAuthContextGuard])
   })
 
   it('setDefaultRegion', () => {
     const methodName = trackMethod('setDefaultRegion')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationController, methodName)).toBe(OrganizationMemberRole.OWNER)
@@ -62,12 +69,14 @@ describe('[AUTH] OrganizationController', () => {
 
   it('findAll', () => {
     const methodName = trackMethod('findAll')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [UserAuthContextGuard])
   })
 
   it('findOne', () => {
     const methodName = trackMethod('findOne')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationController, methodName)).toBeUndefined()
@@ -76,6 +85,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('delete', () => {
     const methodName = trackMethod('delete')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationController, methodName)).toBe(OrganizationMemberRole.OWNER)
@@ -83,6 +93,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('getUsageOverview', () => {
     const methodName = trackMethod('getUsageOverview')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationController, methodName)).toBeUndefined()
@@ -91,6 +102,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('leave', () => {
     const methodName = trackMethod('leave')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationController, methodName)).toBeUndefined()
@@ -99,6 +111,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('updateOrganizationQuota', () => {
     const methodName = trackMethod('updateOrganizationQuota')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [])
     expect(getRequiredSystemRole(OrganizationController, methodName)).toBe(SystemRole.ADMIN)
@@ -106,6 +119,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('updateOrganizationRegionQuota', () => {
     const methodName = trackMethod('updateOrganizationRegionQuota')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [])
     expect(getRequiredSystemRole(OrganizationController, methodName)).toBe(SystemRole.ADMIN)
@@ -113,6 +127,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('suspend', () => {
     const methodName = trackMethod('suspend')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [])
     expect(getRequiredSystemRole(OrganizationController, methodName)).toBe(SystemRole.ADMIN)
@@ -120,6 +135,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('unsuspend', () => {
     const methodName = trackMethod('unsuspend')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [])
     expect(getRequiredSystemRole(OrganizationController, methodName)).toBe(SystemRole.ADMIN)
@@ -127,12 +143,14 @@ describe('[AUTH] OrganizationController', () => {
 
   it('getOtelConfigBySandboxAuthToken', () => {
     const methodName = trackMethod('getOtelConfigBySandboxAuthToken')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [OtelCollectorAuthContextGuard])
   })
 
   it('updateSandboxDefaultLimitedNetworkEgress', () => {
     const methodName = trackMethod('updateSandboxDefaultLimitedNetworkEgress')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [])
     expect(getRequiredSystemRole(OrganizationController, methodName)).toBe(SystemRole.ADMIN)
@@ -140,6 +158,7 @@ describe('[AUTH] OrganizationController', () => {
 
   it('updateExperimentalConfig', () => {
     const methodName = trackMethod('updateExperimentalConfig')
+    expect(isPublicEndpoint(OrganizationController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(OrganizationController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(OrganizationController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(OrganizationController, methodName)).toBe(OrganizationMemberRole.OWNER)

--- a/apps/api/src/region/controllers/region.controller.auth.spec.ts
+++ b/apps/api/src/region/controllers/region.controller.auth.spec.ts
@@ -9,6 +9,7 @@ import {
   getAllowedAuthStrategies,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] RegionController', () => {
@@ -16,6 +17,7 @@ describe('[AUTH] RegionController', () => {
 
   it('listRegions', () => {
     const methodName = trackMethod('listRegions')
+    expect(isPublicEndpoint(RegionController, methodName)).toBe(true)
     expectArrayMatch(getAllowedAuthStrategies(RegionController, methodName), [])
     expectArrayMatch(getAuthContextGuards(RegionController, methodName), [])
   })

--- a/apps/api/src/sandbox-telemetry/controllers/sandbox-telemetry.controller.auth.spec.ts
+++ b/apps/api/src/sandbox-telemetry/controllers/sandbox-telemetry.controller.auth.spec.ts
@@ -13,6 +13,7 @@ import {
   getAllowedAuthStrategies,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] SandboxTelemetryController', () => {
@@ -20,6 +21,7 @@ describe('[AUTH] SandboxTelemetryController', () => {
 
   it('getSandboxLogs', () => {
     const methodName = trackMethod('getSandboxLogs')
+    expect(isPublicEndpoint(SandboxTelemetryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxTelemetryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -30,6 +32,7 @@ describe('[AUTH] SandboxTelemetryController', () => {
 
   it('getSandboxTraces', () => {
     const methodName = trackMethod('getSandboxTraces')
+    expect(isPublicEndpoint(SandboxTelemetryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxTelemetryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -40,6 +43,7 @@ describe('[AUTH] SandboxTelemetryController', () => {
 
   it('getSandboxTraceSpans', () => {
     const methodName = trackMethod('getSandboxTraceSpans')
+    expect(isPublicEndpoint(SandboxTelemetryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxTelemetryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -50,6 +54,7 @@ describe('[AUTH] SandboxTelemetryController', () => {
 
   it('getSandboxMetrics', () => {
     const methodName = trackMethod('getSandboxMetrics')
+    expect(isPublicEndpoint(SandboxTelemetryController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxTelemetryController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,

--- a/apps/api/src/sandbox/controllers/job.controller.auth.spec.ts
+++ b/apps/api/src/sandbox/controllers/job.controller.auth.spec.ts
@@ -13,6 +13,7 @@ import {
   getResourceAccessGuards,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] JobController', () => {
@@ -20,18 +21,21 @@ describe('[AUTH] JobController', () => {
 
   it('listJobs', () => {
     const methodName = trackMethod('listJobs')
+    expect(isPublicEndpoint(JobController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(JobController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(JobController, methodName), [RunnerAuthContextGuard])
   })
 
   it('pollJobs', () => {
     const methodName = trackMethod('pollJobs')
+    expect(isPublicEndpoint(JobController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(JobController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(JobController, methodName), [RunnerAuthContextGuard])
   })
 
   it('getJob', () => {
     const methodName = trackMethod('getJob')
+    expect(isPublicEndpoint(JobController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(JobController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(JobController, methodName), [RunnerAuthContextGuard])
     expectArrayMatch(getResourceAccessGuards(JobController, methodName), [JobAccessGuard])
@@ -39,6 +43,7 @@ describe('[AUTH] JobController', () => {
 
   it('updateJobStatus', () => {
     const methodName = trackMethod('updateJobStatus')
+    expect(isPublicEndpoint(JobController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(JobController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(JobController, methodName), [RunnerAuthContextGuard])
     expectArrayMatch(getResourceAccessGuards(JobController, methodName), [JobAccessGuard])

--- a/apps/api/src/sandbox/controllers/preview.controller.auth.spec.ts
+++ b/apps/api/src/sandbox/controllers/preview.controller.auth.spec.ts
@@ -11,6 +11,7 @@ import {
   getAllowedAuthStrategies,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] PreviewController', () => {
@@ -18,18 +19,21 @@ describe('[AUTH] PreviewController', () => {
 
   it('isSandboxPublic', () => {
     const methodName = trackMethod('isSandboxPublic')
+    expect(isPublicEndpoint(PreviewController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(PreviewController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(PreviewController, methodName), [ProxyAuthContextGuard])
   })
 
   it('isValidAuthToken', () => {
     const methodName = trackMethod('isValidAuthToken')
+    expect(isPublicEndpoint(PreviewController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(PreviewController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(PreviewController, methodName), [ProxyAuthContextGuard])
   })
 
   it('hasSandboxAccess', () => {
     const methodName = trackMethod('hasSandboxAccess')
+    expect(isPublicEndpoint(PreviewController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(PreviewController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -39,6 +43,7 @@ describe('[AUTH] PreviewController', () => {
 
   it('getSandboxIdFromSignedPreviewUrlToken', () => {
     const methodName = trackMethod('getSandboxIdFromSignedPreviewUrlToken')
+    expect(isPublicEndpoint(PreviewController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(PreviewController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(PreviewController, methodName), [ProxyAuthContextGuard])
   })

--- a/apps/api/src/sandbox/controllers/runner.controller.auth.spec.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.auth.spec.ts
@@ -20,6 +20,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] RunnerController', () => {
@@ -27,6 +28,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('create', () => {
     const methodName = trackMethod('create')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -40,12 +42,14 @@ describe('[AUTH] RunnerController', () => {
 
   it('getInfoForAuthenticatedRunner', () => {
     const methodName = trackMethod('getInfoForAuthenticatedRunner')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(RunnerController, methodName), [RunnerAuthContextGuard])
   })
 
   it('getRunnerBySandboxId', () => {
     const methodName = trackMethod('getRunnerBySandboxId')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(RunnerController, methodName), [
       ProxyAuthContextGuard,
@@ -56,6 +60,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('getRunnersBySnapshotRef', () => {
     const methodName = trackMethod('getRunnersBySnapshotRef')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(RunnerController, methodName), [
       ProxyAuthContextGuard,
@@ -65,6 +70,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('getRunnerById', () => {
     const methodName = trackMethod('getRunnerById')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -79,6 +85,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('getRunnerByIdFull', () => {
     const methodName = trackMethod('getRunnerByIdFull')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(RunnerController, methodName), [
       ProxyAuthContextGuard,
@@ -89,6 +96,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('findAll', () => {
     const methodName = trackMethod('findAll')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -102,6 +110,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('updateSchedulingStatus', () => {
     const methodName = trackMethod('updateSchedulingStatus')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -116,6 +125,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('updateDrainingStatus', () => {
     const methodName = trackMethod('updateDrainingStatus')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -130,6 +140,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('delete', () => {
     const methodName = trackMethod('delete')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -144,6 +155,7 @@ describe('[AUTH] RunnerController', () => {
 
   it('runnerHealthcheck', () => {
     const methodName = trackMethod('runnerHealthcheck')
+    expect(isPublicEndpoint(RunnerController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(RunnerController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(RunnerController, methodName), [RunnerAuthContextGuard])
   })

--- a/apps/api/src/sandbox/controllers/sandbox.controller.auth.spec.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.auth.spec.ts
@@ -19,6 +19,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] SandboxController', () => {
@@ -26,6 +27,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('listSandboxes', () => {
     const methodName = trackMethod('listSandboxes')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -37,6 +39,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('listSandboxesPaginated', () => {
     const methodName = trackMethod('listSandboxesPaginated')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -48,6 +51,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('createSandbox', () => {
     const methodName = trackMethod('createSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -61,12 +65,14 @@ describe('[AUTH] SandboxController', () => {
 
   it('getSandboxesForRunner', () => {
     const methodName = trackMethod('getSandboxesForRunner')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(SandboxController, methodName), [RunnerAuthContextGuard])
   })
 
   it('getSandbox', () => {
     const methodName = trackMethod('getSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -83,6 +89,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('deleteSandbox', () => {
     const methodName = trackMethod('deleteSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -97,6 +104,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('recoverSandbox', () => {
     const methodName = trackMethod('recoverSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -111,6 +119,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('startSandbox', () => {
     const methodName = trackMethod('startSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -125,6 +134,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('stopSandbox', () => {
     const methodName = trackMethod('stopSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -139,6 +149,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('resizeSandbox', () => {
     const methodName = trackMethod('resizeSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -153,6 +164,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('replaceLabels', () => {
     const methodName = trackMethod('replaceLabels')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -167,6 +179,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('updateSandboxState', () => {
     const methodName = trackMethod('updateSandboxState')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(SandboxController, methodName), [RunnerAuthContextGuard])
     expectArrayMatch(getResourceAccessGuards(SandboxController, methodName), [SandboxAccessGuard])
@@ -174,6 +187,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('createBackup', () => {
     const methodName = trackMethod('createBackup')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -188,6 +202,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('updatePublicStatus', () => {
     const methodName = trackMethod('updatePublicStatus')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -202,6 +217,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('updateLastActivity', () => {
     const methodName = trackMethod('updateLastActivity')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -218,6 +234,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('setAutostopInterval', () => {
     const methodName = trackMethod('setAutostopInterval')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -232,6 +249,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('setAutoArchiveInterval', () => {
     const methodName = trackMethod('setAutoArchiveInterval')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -246,6 +264,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('setAutoDeleteInterval', () => {
     const methodName = trackMethod('setAutoDeleteInterval')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -260,6 +279,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('archiveSandbox', () => {
     const methodName = trackMethod('archiveSandbox')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -274,6 +294,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('getPortPreviewUrl', () => {
     const methodName = trackMethod('getPortPreviewUrl')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -286,6 +307,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('getSignedPortPreviewUrl', () => {
     const methodName = trackMethod('getSignedPortPreviewUrl')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -298,6 +320,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('expireSignedPortPreviewUrl', () => {
     const methodName = trackMethod('expireSignedPortPreviewUrl')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -310,6 +333,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('getBuildLogs', () => {
     const methodName = trackMethod('getBuildLogs')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -322,6 +346,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('getBuildLogsUrl', () => {
     const methodName = trackMethod('getBuildLogsUrl')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -334,6 +359,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('createSshAccess', () => {
     const methodName = trackMethod('createSshAccess')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -348,6 +374,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('revokeSshAccess', () => {
     const methodName = trackMethod('revokeSshAccess')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -362,12 +389,14 @@ describe('[AUTH] SandboxController', () => {
 
   it('validateSshAccess', () => {
     const methodName = trackMethod('validateSshAccess')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(SandboxController, methodName), [SshGatewayAuthContextGuard])
   })
 
   it('getToolboxProxyUrl', () => {
     const methodName = trackMethod('getToolboxProxyUrl')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -380,6 +409,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('getOrganizationBySandboxId', () => {
     const methodName = trackMethod('getOrganizationBySandboxId')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(SandboxController, methodName), [ProxyAuthContextGuard])
     expectArrayMatch(getResourceAccessGuards(SandboxController, methodName), [SandboxAccessGuard])
@@ -387,6 +417,7 @@ describe('[AUTH] SandboxController', () => {
 
   it('getRegionQuotaBySandboxId', () => {
     const methodName = trackMethod('getRegionQuotaBySandboxId')
+    expect(isPublicEndpoint(SandboxController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SandboxController, methodName), [AuthStrategyType.API_KEY])
     expectArrayMatch(getAuthContextGuards(SandboxController, methodName), [ProxyAuthContextGuard])
     expectArrayMatch(getResourceAccessGuards(SandboxController, methodName), [SandboxAccessGuard])

--- a/apps/api/src/sandbox/controllers/snapshot.controller.auth.spec.ts
+++ b/apps/api/src/sandbox/controllers/snapshot.controller.auth.spec.ts
@@ -17,6 +17,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] SnapshotController', () => {
@@ -24,6 +25,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('createSnapshot', () => {
     const methodName = trackMethod('createSnapshot')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -37,6 +39,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('getSnapshot', () => {
     const methodName = trackMethod('getSnapshot')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -49,6 +52,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('removeSnapshot', () => {
     const methodName = trackMethod('removeSnapshot')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -63,6 +67,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('getAllSnapshots', () => {
     const methodName = trackMethod('getAllSnapshots')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -74,6 +79,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('getSnapshotBuildLogs', () => {
     const methodName = trackMethod('getSnapshotBuildLogs')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -86,6 +92,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('getSnapshotBuildLogsUrl', () => {
     const methodName = trackMethod('getSnapshotBuildLogsUrl')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -98,6 +105,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('activateSnapshot', () => {
     const methodName = trackMethod('activateSnapshot')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -112,6 +120,7 @@ describe('[AUTH] SnapshotController', () => {
 
   it('deactivateSnapshot', () => {
     const methodName = trackMethod('deactivateSnapshot')
+    expect(isPublicEndpoint(SnapshotController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(SnapshotController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,

--- a/apps/api/src/sandbox/controllers/volume.controller.auth.spec.ts
+++ b/apps/api/src/sandbox/controllers/volume.controller.auth.spec.ts
@@ -16,6 +16,7 @@ import {
   getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] VolumeController', () => {
@@ -23,6 +24,7 @@ describe('[AUTH] VolumeController', () => {
 
   it('listVolumes', () => {
     const methodName = trackMethod('listVolumes')
+    expect(isPublicEndpoint(VolumeController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(VolumeController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -36,6 +38,7 @@ describe('[AUTH] VolumeController', () => {
 
   it('createVolume', () => {
     const methodName = trackMethod('createVolume')
+    expect(isPublicEndpoint(VolumeController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(VolumeController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -49,6 +52,7 @@ describe('[AUTH] VolumeController', () => {
 
   it('getVolume', () => {
     const methodName = trackMethod('getVolume')
+    expect(isPublicEndpoint(VolumeController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(VolumeController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -63,6 +67,7 @@ describe('[AUTH] VolumeController', () => {
 
   it('deleteVolume', () => {
     const methodName = trackMethod('deleteVolume')
+    expect(isPublicEndpoint(VolumeController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(VolumeController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -77,6 +82,7 @@ describe('[AUTH] VolumeController', () => {
 
   it('getVolumeByName', () => {
     const methodName = trackMethod('getVolumeByName')
+    expect(isPublicEndpoint(VolumeController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(VolumeController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,

--- a/apps/api/src/test/helpers/controller-metadata.helper.ts
+++ b/apps/api/src/test/helpers/controller-metadata.helper.ts
@@ -10,6 +10,7 @@ import { AuthContextGuard } from '../../common/guards/auth-context.guard'
 import { ResourceAccessGuard } from '../../common/guards/resource-access.guard'
 import { AuthStrategy } from '../../auth/decorators/auth-strategy.decorator'
 import { AuthStrategyType } from '../../auth/enums/auth-strategy-type.enum'
+import { IS_PUBLIC_KEY } from '../../auth/decorators/public.decorator'
 import { RequiredSystemRole } from '../../user/decorators/required-system-role.decorator'
 import { SystemRole } from '../../user/enums/system-role.enum'
 import { RequiredOrganizationMemberRole } from '../../organization/decorators/required-organization-member-role.decorator'
@@ -214,27 +215,57 @@ export function getRequiredOrganizationResourcePermissions(
 }
 
 /**
+ * Returns `true` if the controller method or class is decorated with `@Public()`.
+ *
+ * Checks method-level metadata first, then falls back to class-level.
+ */
+export function isPublicEndpoint(controller: ControllerType): boolean
+export function isPublicEndpoint<T extends object>(controller: Type<T>, methodName: keyof T & string): boolean
+export function isPublicEndpoint(controller: ControllerType, methodName?: string): boolean {
+  if (methodName) {
+    assertMethodExists(controller, methodName)
+    const method = (controller.prototype as Record<string, unknown>)[methodName]
+    if (typeof method === 'function') {
+      const methodPublic = Reflect.getMetadata(IS_PUBLIC_KEY, method) as boolean | undefined
+      if (methodPublic !== undefined) return methodPublic
+    }
+  }
+
+  return (Reflect.getMetadata(IS_PUBLIC_KEY, controller) as boolean | undefined) ?? false
+}
+
+/**
  * Gets the names of the route handlers on a controller.
  */
-function getRouteHandlerNames(controller: ControllerType): string[] {
+function getRouteHandlerNames<T extends object>(controller: Type<T>): (keyof T & string)[] {
   return Object.getOwnPropertyNames(controller.prototype).filter((name) => {
     if (name === 'constructor') return false
     const method = (controller.prototype as Record<string, unknown>)[name]
     return typeof method === 'function' && Reflect.getMetadata(PATH_METADATA, method) !== undefined
-  })
+  }) as (keyof T & string)[]
 }
 
 /**
- * Registers an afterAll hook that fails if any route handler on the controller was not tested.
+ * Registers an afterAll hook that fails if any route handler on the controller was not tested or is not explicitly configured with `@AuthStrategy()` or `@Public()`.
  */
 export function createCoverageTracker<T extends object>(controller: Type<T>) {
   const tested = new Set<string>()
 
   afterAll(() => {
     const handlers = getRouteHandlerNames(controller)
+
     const untested = handlers.filter((h) => !tested.has(h))
     if (untested.length > 0) {
       throw new Error(`Untested route handlers on ${controller.name}: ${untested.join(', ')}.`)
+    }
+
+    const misconfigured = handlers.filter((h) => {
+      return getAllowedAuthStrategies(controller, h).length === 0 && !isPublicEndpoint(controller, h)
+    })
+    if (misconfigured.length > 0) {
+      throw new Error(
+        `Misconfigured route handlers on ${controller.name} have no @AuthStrategy() and no @Public(): ${misconfigured.join(', ')}.`,
+      )
     }
   })
 

--- a/apps/api/src/user/user.controller.auth.spec.ts
+++ b/apps/api/src/user/user.controller.auth.spec.ts
@@ -10,6 +10,7 @@ import {
   getAllowedAuthStrategies,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../test/helpers/controller-metadata.helper'
 import { UserAuthContextGuard } from './guards/user-auth-context.guard'
 
@@ -18,6 +19,7 @@ describe('[AUTH] UserController', () => {
 
   it('getAuthenticatedUser', () => {
     const methodName = trackMethod('getAuthenticatedUser')
+    expect(isPublicEndpoint(UserController, methodName)).toBe(false)
 
     expectArrayMatch(getAllowedAuthStrategies(UserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(UserController, methodName), [UserAuthContextGuard])
@@ -25,24 +27,28 @@ describe('[AUTH] UserController', () => {
 
   it('getAvailableAccountProviders', () => {
     const methodName = trackMethod('getAvailableAccountProviders')
+    expect(isPublicEndpoint(UserController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(UserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(UserController, methodName), [UserAuthContextGuard])
   })
 
   it('linkAccount', () => {
     const methodName = trackMethod('linkAccount')
+    expect(isPublicEndpoint(UserController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(UserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(UserController, methodName), [UserAuthContextGuard])
   })
 
   it('unlinkAccount', () => {
     const methodName = trackMethod('unlinkAccount')
+    expect(isPublicEndpoint(UserController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(UserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(UserController, methodName), [UserAuthContextGuard])
   })
 
   it('enrollInSmsMfa', () => {
     const methodName = trackMethod('enrollInSmsMfa')
+    expect(isPublicEndpoint(UserController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(UserController, methodName), [AuthStrategyType.JWT])
     expectArrayMatch(getAuthContextGuards(UserController, methodName), [UserAuthContextGuard])
   })

--- a/apps/api/src/webhook/controllers/webhook.controller.auth.spec.ts
+++ b/apps/api/src/webhook/controllers/webhook.controller.auth.spec.ts
@@ -11,6 +11,7 @@ import {
   getAllowedAuthStrategies,
   expectArrayMatch,
   createCoverageTracker,
+  isPublicEndpoint,
 } from '../../test/helpers/controller-metadata.helper'
 
 describe('[AUTH] WebhookController', () => {
@@ -18,6 +19,7 @@ describe('[AUTH] WebhookController', () => {
 
   it('getAppPortalAccess', () => {
     const methodName = trackMethod('getAppPortalAccess')
+    expect(isPublicEndpoint(WebhookController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(WebhookController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
@@ -27,6 +29,7 @@ describe('[AUTH] WebhookController', () => {
 
   it('getInitializationStatus', () => {
     const methodName = trackMethod('getInitializationStatus')
+    expect(isPublicEndpoint(WebhookController, methodName)).toBe(false)
     expectArrayMatch(getAllowedAuthStrategies(WebhookController, methodName), [
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,


### PR DESCRIPTION
This pull request enhances the authentication tests for multiple API controllers by adding explicit checks for whether each endpoint is public or not using the `isPublicEndpoint` helper. It also introduces new test files for `ConfigController` and `ObjectStorageController` to ensure their authentication metadata is properly validated. These changes improve test coverage and clarity around endpoint security.

Additionally, the createCoverageTracker afterAll hook now enforces that every route handler has an explicit auth configuration — either an `@AuthStrategy()` decorator (applied method-level or controller-level) or a `@Public()` decorator. If an endpoint has neither, the test suite fails with a descriptive error message identifying the misconfigured handlers. This acts as a safety net against developers accidentally adding new endpoints without declaring their auth requirements, which could result in silently unprotected or ambiguously configured routes reaching production.

**Authentication Test Improvements:**

* Added `isPublicEndpoint` checks to all relevant test cases in the following controller authentication spec files:
  - `api-key.controller.auth.spec.ts` [[1]](diffhunk://#diff-bed4b264204d7a62836e9f101560763dcce401b2f38e503dcb840a8d486d0e40R16-R23) [[2]](diffhunk://#diff-bed4b264204d7a62836e9f101560763dcce401b2f38e503dcb840a8d486d0e40R32) [[3]](diffhunk://#diff-bed4b264204d7a62836e9f101560763dcce401b2f38e503dcb840a8d486d0e40R41) [[4]](diffhunk://#diff-bed4b264204d7a62836e9f101560763dcce401b2f38e503dcb840a8d486d0e40R50) [[5]](diffhunk://#diff-bed4b264204d7a62836e9f101560763dcce401b2f38e503dcb840a8d486d0e40R59) [[6]](diffhunk://#diff-bed4b264204d7a62836e9f101560763dcce401b2f38e503dcb840a8d486d0e40R68)
  - `audit.controller.auth.spec.ts`
  - `docker-registry.controller.auth.spec.ts` [[1]](diffhunk://#diff-b9e99fd24cd265ab82b2118e0d8757c78343177f97f7009db4188e4108b65237R19-R27) [[2]](diffhunk://#diff-b9e99fd24cd265ab82b2118e0d8757c78343177f97f7009db4188e4108b65237R41) [[3]](diffhunk://#diff-b9e99fd24cd265ab82b2118e0d8757c78343177f97f7009db4188e4108b65237R53) [[4]](diffhunk://#diff-b9e99fd24cd265ab82b2118e0d8757c78343177f97f7009db4188e4108b65237R65) [[5]](diffhunk://#diff-b9e99fd24cd265ab82b2118e0d8757c78343177f97f7009db4188e4108b65237R78) [[6]](diffhunk://#diff-b9e99fd24cd265ab82b2118e0d8757c78343177f97f7009db4188e4108b65237R93)
  - `health.controller.auth.spec.ts`
  - `organization-invitation.controller.auth.spec.ts` [[1]](diffhunk://#diff-60bf5b27c774d3cb57b8d82faa74c6b50f709743adffa21306065c37b6fb8c24R16) [[2]](diffhunk://#diff-60bf5b27c774d3cb57b8d82faa74c6b50f709743adffa21306065c37b6fb8c24R25) [[3]](diffhunk://#diff-60bf5b27c774d3cb57b8d82faa74c6b50f709743adffa21306065c37b6fb8c24R35) [[4]](diffhunk://#diff-60bf5b27c774d3cb57b8d82faa74c6b50f709743adffa21306065c37b6fb8c24R45) [[5]](diffhunk://#diff-60bf5b27c774d3cb57b8d82faa74c6b50f709743adffa21306065c37b6fb8c24R54)
  - `organization-region.controller.auth.spec.ts` [[1]](diffhunk://#diff-876d771093c91df58907eb6f3b8cb9a16f9befa353a36173186187f77af36907R19-R27) [[2]](diffhunk://#diff-876d771093c91df58907eb6f3b8cb9a16f9befa353a36173186187f77af36907R39) [[3]](diffhunk://#diff-876d771093c91df58907eb6f3b8cb9a16f9befa353a36173186187f77af36907R53) [[4]](diffhunk://#diff-876d771093c91df58907eb6f3b8cb9a16f9befa353a36173186187f77af36907R66) [[5]](diffhunk://#diff-876d771093c91df58907eb6f3b8cb9a16f9befa353a36173186187f77af36907R81) [[6]](diffhunk://#diff-876d771093c91df58907eb6f3b8cb9a16f9befa353a36173186187f77af36907R96) [[7]](diffhunk://#diff-876d771093c91df58907eb6f3b8cb9a16f9befa353a36173186187f77af36907R111)

**New Test Files:**

* Added `config.controller.auth.spec.ts` with tests for `ConfigController`, including checks for public endpoint status and allowed authentication strategies/guards.
* Added `object-storage.controller.auth.spec.ts` with tests for `ObjectStorageController`, validating endpoint security and auth requirements.

These changes make the authentication requirements of each endpoint more explicit and verifiable in tests, helping to prevent accidental exposure of endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces explicit auth configuration on every API controller endpoint via tests, and adds public/private checks to prevent unprotected routes. Adds new auth tests for `ConfigController` and `ObjectStorageController`.

- **New Features**
  - Added `isPublicEndpoint` assertions across controller auth specs.
  - Updated `createCoverageTracker` to fail when a route lacks `@AuthStrategy()` or `@Public()`, and when handlers are untested.
  - Added `config.controller.auth.spec.ts` to confirm `getConfig` is public.
  - Added `object-storage.controller.auth.spec.ts` to confirm `getPushAccess` requires `API_KEY`/`JWT` and `OrganizationAuthContextGuard`.
  - Explicitly tested public endpoints like `HealthController.live` and `RegionController.listRegions`; all other endpoints now assert non-public as expected.

- **Migration**
  - When adding a new route, annotate it with `@AuthStrategy(...)` or `@Public()`. Tests will fail if missing.

<sup>Written for commit fb893c2b8a9b37ac98066adeea9aa88f399343f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

