### PR TITLE
chore(security): add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# Copyright Daytona Platforms Inc.
+# SPDX-License-Identifier: AGPL-3.0
 version: 2
 updates:
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` to auto-maintain SHA-pinned GitHub Actions references via weekly grouped PRs.

## Config

- **Ecosystem:** `github-actions` only (npm/pip/go/ruby already covered by Dependabot security alerts)
- **Schedule:** Weekly on Monday
- **Grouping:** All action updates in a single PR (not 9+ individual PRs)
- **Commit prefix:** `chore(deps)` (conventional commits)

## Context

Phase 1.8c of GHA security hardening (SEC-61). All actions were SHA-pinned in PR #4408, but without Dependabot those pins will drift as maintainers release patches. This config ensures automated PRs keep them current.

## Verification

- Dependabot should create its first grouped PR within ~1 week
- Check Settings > Code security > Dependabot to confirm `github-actions` ecosystem is active