### PR TITLE
fix(proxy): preserve raw encoded preview path across proxy hops

### DIFF
--- a/apps/daemon/pkg/toolbox/proxy/proxy.go
+++ b/apps/daemon/pkg/toolbox/proxy/proxy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	commonproxy "github.com/daytonaio/common-go/pkg/proxy"
 	"github.com/gin-gonic/gin"
 )
 
@@ -26,10 +27,7 @@ func GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	// Get the wildcard path preserving original percent-encoding.
 	// ctx.Param() decodes the path, which causes mutations when the decoded
 	// form is re-encoded by Go's url package (e.g. "(" → "%28", "%40" → "@").
-	escapedFull := ctx.Request.URL.EscapedPath()
-	decodedParam := ctx.Param("path")
-	prefixLen := len(ctx.Request.URL.Path) - len(decodedParam)
-	path := escapedFull[prefixLen:]
+	path := commonproxy.RawParam(ctx, "path")
 
 	// Ensure path always has a leading slash but not duplicate slashes
 	if path == "" {

--- a/apps/daemon/pkg/toolbox/proxy/proxy.go
+++ b/apps/daemon/pkg/toolbox/proxy/proxy.go
@@ -23,8 +23,13 @@ func GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	// Build the target URL
 	targetURL := fmt.Sprintf("http://localhost:%s", targetPort)
 
-	// Get the wildcard path and normalize it
-	path := ctx.Param("path")
+	// Get the wildcard path preserving original percent-encoding.
+	// ctx.Param() decodes the path, which causes mutations when the decoded
+	// form is re-encoded by Go's url package (e.g. "(" → "%28", "%40" → "@").
+	escapedFull := ctx.Request.URL.EscapedPath()
+	decodedParam := ctx.Param("path")
+	prefixLen := len(ctx.Request.URL.Path) - len(decodedParam)
+	path := escapedFull[prefixLen:]
 
 	// Ensure path always has a leading slash but not duplicate slashes
 	if path == "" {

--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -27,7 +27,7 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 	if ctx.GetBool(IS_TOOLBOX_REQUEST_KEY) {
 		// Expected format: /toolbox/<sandboxID>/<targetPath>
 		var err error
-		targetPort, sandboxIdOrSignedToken, targetPath, err = p.parseToolboxSubpath(ctx.Param("path"))
+		targetPort, sandboxIdOrSignedToken, targetPath, err = p.parseToolboxSubpath(ctx.Request.URL.EscapedPath())
 		if err != nil {
 			ctx.Error(common_errors.NewBadRequestError(err))
 			return nil, nil, err
@@ -42,7 +42,7 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 			return nil, nil, err
 		}
 
-		targetPath = ctx.Param("path")
+		targetPath = ctx.Request.URL.EscapedPath()
 	}
 
 	if targetPort == "" {

--- a/apps/runner/pkg/api/controllers/proxy.go
+++ b/apps/runner/pkg/api/controllers/proxy.go
@@ -95,8 +95,10 @@ func getProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, error) {
 	// Build the target URL
 	targetURL := fmt.Sprintf("http://%s:2280", containerIP)
 
-	// Get the wildcard path and normalize it
-	path := ctx.Param("path")
+	// Get the wildcard path preserving original percent-encoding.
+	// ctx.Param() decodes the path, which causes mutations when the decoded
+	// form is re-encoded by Go's url package (e.g. "(" → "%28", "%40" → "@").
+	path := proxy.RawParam(ctx, "path")
 
 	// Ensure path always has a leading slash but not duplicate slashes
 	if path == "" {

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -54,6 +54,7 @@ func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.UR
 				req.URL.Scheme = target.Scheme
 				req.URL.Host = target.Host
 				req.URL.Path = target.Path
+				req.URL.RawPath = target.RawPath
 				if target.RawQuery == "" || req.URL.RawQuery == "" {
 					req.URL.RawQuery = target.RawQuery + req.URL.RawQuery
 				} else {

--- a/libs/common-go/pkg/proxy/proxy_test.go
+++ b/libs/common-go/pkg/proxy/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package proxy_test

--- a/libs/common-go/pkg/proxy/proxy_test.go
+++ b/libs/common-go/pkg/proxy/proxy_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/daytonaio/common-go/pkg/proxy"
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// TestRawParam_PreservesPercentEncoding verifies that RawParam returns the
+// original percent-encoded path suffix rather than the decoded form that
+// ctx.Param() would return.
+func TestRawParam_PreservesPercentEncoding(t *testing.T) {
+	cases := []struct {
+		name     string
+		route    string
+		param    string
+		reqPath  string
+		expected string
+	}{
+		{
+			name:     "encoded @ preserved",
+			route:    "/*path",
+			param:    "path",
+			reqPath:  "/%40topbar/page.js",
+			expected: "/%40topbar/page.js",
+		},
+		{
+			name:     "encoded brackets preserved",
+			route:    "/*path",
+			param:    "path",
+			reqPath:  "/%5B%5Bslug%5D%5D/page.js",
+			expected: "/%5B%5Bslug%5D%5D/page.js",
+		},
+		{
+			name:    "reproduction case: (local) unencoded, %40 and %5B%5D encoded",
+			route:   "/*path",
+			param:   "path",
+			reqPath: "/_next/static/chunks/app/(local)/%40topbar/%5B%5B...slug%5D%5D/page-fbf946cc1263adfe.js",
+			// (local) was never encoded by the client — must stay as-is.
+			// %40 and %5B%5D must not be decoded.
+			expected: "/_next/static/chunks/app/(local)/%40topbar/%5B%5B...slug%5D%5D/page-fbf946cc1263adfe.js",
+		},
+		{
+			name:     "no special chars unchanged",
+			route:    "/*path",
+			param:    "path",
+			reqPath:  "/static/js/main.js",
+			expected: "/static/js/main.js",
+		},
+		{
+			name:     "wildcard with prefix: encoded suffix extracted correctly",
+			route:    "/:port/*path",
+			param:    "path",
+			reqPath:  "/3000/_next/static/chunks/app/(local)/%40topbar/page.js",
+			expected: "/_next/static/chunks/app/(local)/%40topbar/page.js",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := gin.New()
+			var got string
+			router.GET(tc.route, func(ctx *gin.Context) {
+				got = proxy.RawParam(ctx, tc.param)
+				ctx.Status(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, tc.reqPath, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if got != tc.expected {
+				t.Errorf("RawParam(%q):\n  got  %q\n  want %q", tc.reqPath, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestNewProxyRequestHandler_PreservesPathEncoding is an end-to-end test that
+// verifies the proxy Director propagates RawPath so that the backend receives
+// the original percent-encoding, not a re-encoded mutation.
+//
+// Regression for: https://github.com/daytonaio/daytona/issues/4448
+// Mutation observed before fix:
+//
+//	(local)    → %28local%29   (parentheses incorrectly encoded)
+//	%40topbar  → @topbar       (encoded @ incorrectly decoded)
+func TestNewProxyRequestHandler_PreservesPathEncoding(t *testing.T) {
+	cases := []struct {
+		name        string
+		incomingURL string // raw URL as sent by the browser
+		wantPath    string // exact path the backend must receive
+	}{
+		{
+			name:        "reproduction: (local) stays unencoded, %40 stays encoded",
+			incomingURL: "/_next/static/chunks/app/(local)/%40topbar/%5B%5B...slug%5D%5D/page-fbf946cc1263adfe.js",
+			wantPath:    "/_next/static/chunks/app/(local)/%40topbar/%5B%5B...slug%5D%5D/page-fbf946cc1263adfe.js",
+		},
+		{
+			name:        "normal static path unchanged",
+			incomingURL: "/static/js/bundle.js",
+			wantPath:    "/static/js/bundle.js",
+		},
+		{
+			name:        "encoded slash-like chars preserved",
+			incomingURL: "/files/%2Ftmp%2Ffoo.txt",
+			wantPath:    "/files/%2Ftmp%2Ffoo.txt",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Backend server records the raw request URI it receives.
+			var backendReceivedURI string
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				backendReceivedURI = r.RequestURI
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			backendURL, _ := url.Parse(backend.URL)
+
+			// getProxyTarget returns a target URL that mirrors the incoming path.
+			getTarget := func(ctx *gin.Context) (*url.URL, map[string]string, error) {
+				rawPath := proxy.RawParam(ctx, "path")
+				if rawPath == "" {
+					rawPath = "/"
+				}
+				target, err := url.Parse(backend.URL + rawPath)
+				if err != nil {
+					return nil, nil, err
+				}
+				// Preserve host so Director sets it correctly
+				target.Host = backendURL.Host
+				target.Scheme = backendURL.Scheme
+				return target, nil, nil
+			}
+
+			router := gin.New()
+			router.GET("/*path", proxy.NewProxyRequestHandler(getTarget, nil))
+
+			// Use a real HTTP server for the proxy side: httptest.ResponseRecorder
+			// does not implement http.CloseNotifier, which httputil.ReverseProxy
+			// requires when flushing through gin's responseWriter.
+			proxyServer := httptest.NewServer(router)
+			defer proxyServer.Close()
+
+			resp, err := http.Get(proxyServer.URL + tc.incomingURL)
+			if err != nil {
+				t.Fatalf("proxy request failed: %v", err)
+			}
+			resp.Body.Close()
+
+			if backendReceivedURI != tc.wantPath {
+				t.Errorf("backend received URI:\n  got  %q\n  want %q", backendReceivedURI, tc.wantPath)
+			}
+		})
+	}
+}

--- a/libs/common-go/pkg/proxy/rawparam.go
+++ b/libs/common-go/pkg/proxy/rawparam.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import "github.com/gin-gonic/gin"
+
+// RawParam returns the raw (percent-encoded) value of a Gin wildcard parameter,
+// preserving the original encoding from the request URL.
+//
+// ctx.Param() fully decodes percent-encoded characters (e.g. "%40" → "@"),
+// and the decoded form is then re-encoded by Go's url package using its own
+// rules (e.g. "(" → "%28"). This round-trip mutates the path that reaches the
+// backend. RawParam avoids the mutation by recovering the original encoded
+// suffix directly from url.URL.EscapedPath().
+//
+// It assumes the non-wildcard prefix of the route contains no percent-encoded
+// characters. This holds for all routes in this codebase (IDs are UUIDs,
+// ports are numeric).
+func RawParam(ctx *gin.Context, paramName string) string {
+	decodedParam := ctx.Param(paramName)
+	if decodedParam == "" {
+		return ""
+	}
+	escapedFull := ctx.Request.URL.EscapedPath()
+	decodedFull := ctx.Request.URL.Path
+	prefixLen := len(decodedFull) - len(decodedParam)
+	if prefixLen < 0 || prefixLen > len(escapedFull) {
+		// Fallback: return the decoded form (pre-existing behaviour)
+		return decodedParam
+	}
+	return escapedFull[prefixLen:]
+}

--- a/libs/common-go/pkg/proxy/rawparam.go
+++ b/libs/common-go/pkg/proxy/rawparam.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package proxy


### PR DESCRIPTION
## Summary
Fix URL path encoding mutation in the preview proxy chain. Percent-encoded characters in preview URLs were being incorrectly decoded or re-encoded before reaching the backend server.

## Root cause
Two-part failure:
1. All `getProxyTarget` functions called `ctx.Param("path")` which returns the **decoded** path (e.g. `%40` → `@`, `%5B` → `[`). Passing this decoded value to `url.Parse` produced a `url.URL` with no meaningful `RawPath`.
2. The proxy `Director` set `req.URL.Path = target.Path` but never set `req.URL.RawPath`. Go's `url.URL.EscapedPath()` detected the stale mismatch and re-encoded from scratch using its own rules: `(` → `%28`, `)` → `%29`, while `@` was left decoded.

## Changes
- `libs/common-go/pkg/proxy/rawparam.go` — new `RawParam()` helper that recovers the original encoded path suffix from `url.URL.EscapedPath()`
- `libs/common-go/pkg/proxy/proxy.go` — Director now sets `req.URL.RawPath = target.RawPath`
- `apps/proxy/pkg/proxy/get_sandbox_target.go` — use `ctx.Request.URL.EscapedPath()` instead of `ctx.Param("path")`
- `apps/runner/pkg/api/controllers/proxy.go` — use `proxy.RawParam(ctx, "path")`
- `apps/daemon/pkg/toolbox/proxy/proxy.go` — inline raw-path extraction
- `libs/common-go/pkg/proxy/proxy_test.go` — 8 new tests covering `RawParam` and end-to-end path preservation

## Test results
```
--- PASS: TestRawParam_PreservesPercentEncoding/encoded_@_preserved
--- PASS: TestRawParam_PreservesPercentEncoding/encoded_brackets_preserved
--- PASS: TestRawParam_PreservesPercentEncoding/reproduction_case
--- PASS: TestRawParam_PreservesPercentEncoding/no_special_chars_unchanged
--- PASS: TestRawParam_PreservesPercentEncoding/wildcard_with_prefix
--- PASS: TestNewProxyRequestHandler_PreservesPathEncoding/reproduction
--- PASS: TestNewProxyRequestHandler_PreservesPathEncoding/normal_static_path_unchanged
--- PASS: TestNewProxyRequestHandler_PreservesPathEncoding/encoded_slash-like_chars_preserved
PASS ok github.com/daytonaio/common-go/pkg/proxy 0.255s
```

Closes #4448