### PR TITLE
fix(api): add missing build timeout handler

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -409,6 +409,14 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         return
       }
     }
+
+    const timeoutMinutes = 120
+    const timeoutMs = timeoutMinutes * 60 * 1000
+    if (Date.now() - snapshotRunner.updatedAt.getTime() > timeoutMs) {
+      snapshotRunner.state = SnapshotRunnerState.ERROR
+      snapshotRunner.errorReason = 'Timeout while building snapshot on runner'
+      await this.snapshotRunnerRepository.save(snapshotRunner)
+    }
   }
 
   // Pulls stopped sandboxes' backup snapshots to another runner to prepare for reassignment during draining


### PR DESCRIPTION
## Description

Adds missing handle for declarative build timeout, uses same generous timeout as async jobs

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
