### PR TITLE
fix(daemon): force interpreting input as shell input

### DIFF
--- a/apps/daemon/pkg/toolbox/process/execute.go
+++ b/apps/daemon/pkg/toolbox/process/execute.go
@@ -45,7 +45,7 @@ func ExecuteCommand(logger *slog.Logger) gin.HandlerFunc {
 		}
 
 		// Pipe command via stdin to avoid OS ARG_MAX limits on large commands
-		cmd := exec.Command(common.GetShell())
+		cmd := exec.Command(common.GetShell(), "-s")
 		cmd.Stdin = strings.NewReader(request.Command)
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		if request.Cwd != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure stdin is interpreted as shell input when the daemon runs commands. Launch the shell with `-s` so piped commands execute reliably and large commands over stdin continue to work.

<sup>Written for commit e10f0d62d1d3abd1a0d3d201468ec50295283d65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

