### PR TITLE
feat(api): add per-sandbox resource limits to region quota

### DIFF
--- a/apps/api/src/interceptors/metrics.interceptor.ts
+++ b/apps/api/src/interceptors/metrics.interceptor.ts
@@ -813,6 +813,11 @@ export class MetricsInterceptor implements NestInterceptor, OnApplicationShutdow
       organization_region_total_cpu_quota: request.totalCpuQuota,
       organization_region_total_memory_quota_mb: request.totalMemoryQuota ? request.totalMemoryQuota * 1024 : null,
       organization_region_total_disk_quota_gb: request.totalDiskQuota,
+      organization_region_max_cpu_per_sandbox: request.maxCpuPerSandbox,
+      organization_region_max_memory_per_sandbox: request.maxMemoryPerSandbox
+        ? request.maxMemoryPerSandbox * 1024
+        : null,
+      organization_region_max_disk_per_sandbox_gb: request.maxDiskPerSandbox,
     })
   }
 

--- a/apps/api/src/interceptors/metrics.interceptor.ts
+++ b/apps/api/src/interceptors/metrics.interceptor.ts
@@ -814,10 +814,11 @@ export class MetricsInterceptor implements NestInterceptor, OnApplicationShutdow
       organization_region_total_memory_quota_mb: request.totalMemoryQuota ? request.totalMemoryQuota * 1024 : null,
       organization_region_total_disk_quota_gb: request.totalDiskQuota,
       organization_region_max_cpu_per_sandbox: request.maxCpuPerSandbox,
-      organization_region_max_memory_per_sandbox: request.maxMemoryPerSandbox
+      organization_region_max_memory_per_sandbox_mb: request.maxMemoryPerSandbox
         ? request.maxMemoryPerSandbox * 1024
         : null,
       organization_region_max_disk_per_sandbox_gb: request.maxDiskPerSandbox,
+      organization_region_max_disk_per_non_ephemeral_sandbox_gb: request.maxDiskPerNonEphemeralSandbox,
     })
   }
 

--- a/apps/api/src/migrations/pre-deploy/1776247555874-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1776247555874-migration.ts
@@ -12,11 +12,13 @@ export class Migration1776247555874 implements MigrationInterface {
     await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_cpu_per_sandbox" integer`)
     await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_memory_per_sandbox" integer`)
     await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_disk_per_sandbox" integer`)
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_disk_per_non_ephemeral_sandbox" integer`)
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_disk_per_sandbox"`)
     await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_memory_per_sandbox"`)
     await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_cpu_per_sandbox"`)
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_disk_per_non_ephemeral_sandbox"`)
   }
 }

--- a/apps/api/src/migrations/pre-deploy/1776247555874-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1776247555874-migration.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1776247555874 implements MigrationInterface {
+  name = 'Migration1776247555874'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_cpu_per_sandbox" integer`)
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_memory_per_sandbox" integer`)
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_disk_per_sandbox" integer`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_disk_per_sandbox"`)
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_memory_per_sandbox"`)
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_cpu_per_sandbox"`)
+  }
+}

--- a/apps/api/src/organization/dto/region-quota.dto.ts
+++ b/apps/api/src/organization/dto/region-quota.dto.ts
@@ -32,6 +32,9 @@ export class RegionQuotaDto {
   @ApiProperty({ nullable: true })
   maxDiskPerSandbox: number | null
 
+  @ApiProperty({ nullable: true })
+  maxDiskPerNonEphemeralSandbox: number | null
+
   constructor(regionQuota: RegionQuota) {
     this.organizationId = regionQuota.organizationId
     this.regionId = regionQuota.regionId
@@ -41,5 +44,6 @@ export class RegionQuotaDto {
     this.maxCpuPerSandbox = regionQuota.maxCpuPerSandbox
     this.maxMemoryPerSandbox = regionQuota.maxMemoryPerSandbox
     this.maxDiskPerSandbox = regionQuota.maxDiskPerSandbox
+    this.maxDiskPerNonEphemeralSandbox = regionQuota.maxDiskPerNonEphemeralSandbox
   }
 }

--- a/apps/api/src/organization/dto/region-quota.dto.ts
+++ b/apps/api/src/organization/dto/region-quota.dto.ts
@@ -23,11 +23,23 @@ export class RegionQuotaDto {
   @ApiProperty()
   totalDiskQuota: number
 
+  @ApiProperty({ nullable: true })
+  maxCpuPerSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxMemoryPerSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxDiskPerSandbox: number | null
+
   constructor(regionQuota: RegionQuota) {
     this.organizationId = regionQuota.organizationId
     this.regionId = regionQuota.regionId
     this.totalCpuQuota = regionQuota.totalCpuQuota
     this.totalMemoryQuota = regionQuota.totalMemoryQuota
     this.totalDiskQuota = regionQuota.totalDiskQuota
+    this.maxCpuPerSandbox = regionQuota.maxCpuPerSandbox
+    this.maxMemoryPerSandbox = regionQuota.maxMemoryPerSandbox
+    this.maxDiskPerSandbox = regionQuota.maxDiskPerSandbox
   }
 }

--- a/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
@@ -24,4 +24,7 @@ export class UpdateOrganizationRegionQuotaDto {
 
   @ApiProperty({ nullable: true })
   maxDiskPerSandbox?: number | null
+
+  @ApiProperty({ nullable: true })
+  maxDiskPerNonEphemeralSandbox?: number | null
 }

--- a/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 
 @ApiSchema({ name: 'UpdateOrganizationRegionQuota' })
 export class UpdateOrganizationRegionQuotaDto {
@@ -16,15 +16,15 @@ export class UpdateOrganizationRegionQuotaDto {
   @ApiProperty({ nullable: true })
   totalDiskQuota?: number
 
-  @ApiProperty({ nullable: true })
+  @ApiPropertyOptional({ nullable: true })
   maxCpuPerSandbox?: number | null
 
-  @ApiProperty({ nullable: true })
+  @ApiPropertyOptional({ nullable: true })
   maxMemoryPerSandbox?: number | null
 
-  @ApiProperty({ nullable: true })
+  @ApiPropertyOptional({ nullable: true })
   maxDiskPerSandbox?: number | null
 
-  @ApiProperty({ nullable: true })
+  @ApiPropertyOptional({ nullable: true })
   maxDiskPerNonEphemeralSandbox?: number | null
 }

--- a/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
@@ -15,4 +15,13 @@ export class UpdateOrganizationRegionQuotaDto {
 
   @ApiProperty({ nullable: true })
   totalDiskQuota?: number
+
+  @ApiProperty({ nullable: true })
+  maxCpuPerSandbox?: number | null
+
+  @ApiProperty({ nullable: true })
+  maxMemoryPerSandbox?: number | null
+
+  @ApiProperty({ nullable: true })
+  maxDiskPerSandbox?: number | null
 }

--- a/apps/api/src/organization/entities/region-quota.entity.ts
+++ b/apps/api/src/organization/entities/region-quota.entity.ts
@@ -62,6 +62,18 @@ export class RegionQuota {
   })
   maxDiskPerSandbox: number | null
 
+  /**
+   * The maximum disk size allowed for non-ephemeral sandboxes.
+   * If `null`, fallback to `maxDiskPerSandbox`.
+   * If `0`, non-ephemeral sandboxes are not permitted in this region.
+   */
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: 'max_disk_per_non_ephemeral_sandbox',
+  })
+  maxDiskPerNonEphemeralSandbox: number | null
+
   @CreateDateColumn({
     type: 'timestamp with time zone',
   })
@@ -81,6 +93,7 @@ export class RegionQuota {
     maxCpuPerSandbox: number | null = null,
     maxMemoryPerSandbox: number | null = null,
     maxDiskPerSandbox: number | null = null,
+    maxDiskPerNonEphemeralSandbox: number | null = null,
   ) {
     this.organizationId = organizationId
     this.regionId = regionId
@@ -90,5 +103,6 @@ export class RegionQuota {
     this.maxCpuPerSandbox = maxCpuPerSandbox
     this.maxMemoryPerSandbox = maxMemoryPerSandbox
     this.maxDiskPerSandbox = maxDiskPerSandbox
+    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
   }
 }

--- a/apps/api/src/organization/entities/region-quota.entity.ts
+++ b/apps/api/src/organization/entities/region-quota.entity.ts
@@ -41,6 +41,27 @@ export class RegionQuota {
   })
   totalDiskQuota: number
 
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: 'max_cpu_per_sandbox',
+  })
+  maxCpuPerSandbox: number | null
+
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: 'max_memory_per_sandbox',
+  })
+  maxMemoryPerSandbox: number | null
+
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: 'max_disk_per_sandbox',
+  })
+  maxDiskPerSandbox: number | null
+
   @CreateDateColumn({
     type: 'timestamp with time zone',
   })
@@ -57,11 +78,17 @@ export class RegionQuota {
     totalCpuQuota: number,
     totalMemoryQuota: number,
     totalDiskQuota: number,
+    maxCpuPerSandbox: number | null = null,
+    maxMemoryPerSandbox: number | null = null,
+    maxDiskPerSandbox: number | null = null,
   ) {
     this.organizationId = organizationId
     this.regionId = regionId
     this.totalCpuQuota = totalCpuQuota
     this.totalMemoryQuota = totalMemoryQuota
     this.totalDiskQuota = totalDiskQuota
+    this.maxCpuPerSandbox = maxCpuPerSandbox
+    this.maxMemoryPerSandbox = maxMemoryPerSandbox
+    this.maxDiskPerSandbox = maxDiskPerSandbox
   }
 }

--- a/apps/api/src/organization/services/org-metrics-exporter.service.ts
+++ b/apps/api/src/organization/services/org-metrics-exporter.service.ts
@@ -96,6 +96,10 @@ export class OrgMetricsExporterService {
         totalCpuQuota: -1,
         totalMemoryQuota: -1,
         totalDiskQuota: -1,
+        maxCpuPerSandbox: null,
+        maxMemoryPerSandbox: null,
+        maxDiskPerSandbox: null,
+        maxDiskPerNonEphemeralSandbox: null,
       })
     }
 

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -208,9 +208,19 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     regionQuota.totalCpuQuota = updateDto.totalCpuQuota ?? regionQuota.totalCpuQuota
     regionQuota.totalMemoryQuota = updateDto.totalMemoryQuota ?? regionQuota.totalMemoryQuota
     regionQuota.totalDiskQuota = updateDto.totalDiskQuota ?? regionQuota.totalDiskQuota
-    regionQuota.maxCpuPerSandbox = updateDto.maxCpuPerSandbox ?? regionQuota.maxCpuPerSandbox
-    regionQuota.maxMemoryPerSandbox = updateDto.maxMemoryPerSandbox ?? regionQuota.maxMemoryPerSandbox
-    regionQuota.maxDiskPerSandbox = updateDto.maxDiskPerSandbox ?? regionQuota.maxDiskPerSandbox
+
+    if (updateDto.maxCpuPerSandbox !== undefined) {
+      regionQuota.maxCpuPerSandbox = updateDto.maxCpuPerSandbox
+    }
+    if (updateDto.maxMemoryPerSandbox !== undefined) {
+      regionQuota.maxMemoryPerSandbox = updateDto.maxMemoryPerSandbox
+    }
+    if (updateDto.maxDiskPerSandbox !== undefined) {
+      regionQuota.maxDiskPerSandbox = updateDto.maxDiskPerSandbox
+    }
+    if (updateDto.maxDiskPerNonEphemeralSandbox !== undefined) {
+      regionQuota.maxDiskPerNonEphemeralSandbox = updateDto.maxDiskPerNonEphemeralSandbox
+    }
 
     await this.regionQuotaRepository.save(regionQuota)
   }

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -208,6 +208,9 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     regionQuota.totalCpuQuota = updateDto.totalCpuQuota ?? regionQuota.totalCpuQuota
     regionQuota.totalMemoryQuota = updateDto.totalMemoryQuota ?? regionQuota.totalMemoryQuota
     regionQuota.totalDiskQuota = updateDto.totalDiskQuota ?? regionQuota.totalDiskQuota
+    regionQuota.maxCpuPerSandbox = updateDto.maxCpuPerSandbox ?? regionQuota.maxCpuPerSandbox
+    regionQuota.maxMemoryPerSandbox = updateDto.maxMemoryPerSandbox ?? regionQuota.maxMemoryPerSandbox
+    regionQuota.maxDiskPerSandbox = updateDto.maxDiskPerSandbox ?? regionQuota.maxDiskPerSandbox
 
     await this.regionQuotaRepository.save(regionQuota)
   }

--- a/apps/api/src/organization/utils/sandbox-limits.util.ts
+++ b/apps/api/src/organization/utils/sandbox-limits.util.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Organization } from '../entities/organization.entity'
+import { RegionQuotaDto } from '../dto/region-quota.dto'
+
+/**
+ * Get the effective per-sandbox limits for an organization and region quota.
+ * If the region quota is set, the region limits are used. Otherwise, the organization limits are used.
+ *
+ * @param organization - The organization to get the limits for.
+ * @param regionQuota - The region quota to get the limits for.
+ * @returns The effective per-sandbox limits.
+ */
+export function getEffectivePerSandboxLimits(
+  organization: Organization,
+  regionQuota: RegionQuotaDto | null | undefined,
+): { maxCpuPerSandbox: number; maxMemoryPerSandbox: number; maxDiskPerSandbox: number } {
+  return {
+    maxCpuPerSandbox: regionQuota?.maxCpuPerSandbox ?? organization.maxCpuPerSandbox,
+    maxMemoryPerSandbox: regionQuota?.maxMemoryPerSandbox ?? organization.maxMemoryPerSandbox,
+    maxDiskPerSandbox: regionQuota?.maxDiskPerSandbox ?? organization.maxDiskPerSandbox,
+  }
+}

--- a/apps/api/src/organization/utils/sandbox-limits.util.ts
+++ b/apps/api/src/organization/utils/sandbox-limits.util.ts
@@ -17,10 +17,16 @@ import { RegionQuotaDto } from '../dto/region-quota.dto'
 export function getEffectivePerSandboxLimits(
   organization: Organization,
   regionQuota: RegionQuotaDto | null | undefined,
-): { maxCpuPerSandbox: number; maxMemoryPerSandbox: number; maxDiskPerSandbox: number } {
+): {
+  maxCpuPerSandbox: number
+  maxMemoryPerSandbox: number
+  maxDiskPerSandbox: number
+  maxDiskPerNonEphemeralSandbox: number | null
+} {
   return {
     maxCpuPerSandbox: regionQuota?.maxCpuPerSandbox ?? organization.maxCpuPerSandbox,
     maxMemoryPerSandbox: regionQuota?.maxMemoryPerSandbox ?? organization.maxMemoryPerSandbox,
     maxDiskPerSandbox: regionQuota?.maxDiskPerSandbox ?? organization.maxDiskPerSandbox,
+    maxDiskPerNonEphemeralSandbox: regionQuota?.maxDiskPerNonEphemeralSandbox ?? null,
   }
 }

--- a/apps/api/src/organization/utils/sandbox-limits.util.ts
+++ b/apps/api/src/organization/utils/sandbox-limits.util.ts
@@ -7,8 +7,8 @@ import { Organization } from '../entities/organization.entity'
 import { RegionQuotaDto } from '../dto/region-quota.dto'
 
 /**
- * Get the effective per-sandbox limits for an organization and region quota.
- * If the region quota is set, the region limits are used. Otherwise, the organization limits are used.
+ * Get the effective per-sandbox limits.
+ * If the region quota limit is set, it overrides the organization limit.
  *
  * @param organization - The organization to get the limits for.
  * @param regionQuota - The region quota to get the limits for.

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -42,6 +42,7 @@ import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { BackupState } from '../enums/backup-state.enum'
 import { OnAsyncEvent } from '../../common/decorators/on-async-event.decorator'
 import { sanitizeSandboxError } from '../utils/sanitize-error.util'
+import { isEphemeral } from '../utils/ephemeral.util'
 import { Sandbox } from '../entities/sandbox.entity'
 import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
@@ -130,8 +131,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
 
               let updateData: Partial<Sandbox> = {}
 
-              //  if auto-delete interval is 0, delete the sandbox immediately
-              if (sandbox.autoDeleteInterval === 0) {
+              if (isEphemeral(sandbox)) {
                 updateData = Sandbox.getSoftDeleteUpdate(sandbox)
               } else {
                 updateData.pending = true

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -87,6 +87,7 @@ import { DefaultRegionRequiredException } from '../../organization/exceptions/De
 import { SnapshotService } from './snapshot.service'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { RegionType } from '../../region/enums/region-type.enum'
+import { getEffectivePerSandboxLimits } from '../../organization/utils/sandbox-limits.util'
 import { SandboxCreatedEvent } from '../events/sandbox-create.event'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
@@ -163,20 +164,29 @@ export class SandboxService {
     pendingMemoryIncremented: boolean
     pendingDiskIncremented: boolean
   }> {
+    const regionQuota = region.enforceQuotas
+      ? await this.organizationService.getRegionQuota(organization.id, region.id)
+      : null
+
     // validate per-sandbox quotas
-    if (cpu > organization.maxCpuPerSandbox) {
+    const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox } = getEffectivePerSandboxLimits(
+      organization,
+      regionQuota,
+    )
+
+    if (cpu > maxCpuPerSandbox) {
       throw new ForbiddenException(
-        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+        `CPU request ${cpu} exceeds maximum allowed per sandbox (${maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
-    if (memory > organization.maxMemoryPerSandbox) {
+    if (memory > maxMemoryPerSandbox) {
       throw new ForbiddenException(
-        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
-    if (disk > organization.maxDiskPerSandbox) {
+    if (disk > maxDiskPerSandbox) {
       throw new ForbiddenException(
-        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
 
@@ -188,8 +198,6 @@ export class SandboxService {
         pendingDiskIncremented: false,
       }
     }
-
-    const regionQuota = await this.organizationService.getRegionQuota(organization.id, region.id)
 
     if (!regionQuota) {
       if (region.regionType === RegionType.SHARED) {
@@ -1789,20 +1797,28 @@ export class SandboxService {
       // Validate organization quotas for the new resource values
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
-      // Validate per-sandbox quotas with total new values
-      if (newCpu > organization.maxCpuPerSandbox) {
+      const regionQuota = region.enforceQuotas
+        ? await this.organizationService.getRegionQuota(organization.id, region.id)
+        : null
+
+      const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox } = getEffectivePerSandboxLimits(
+        organization,
+        regionQuota,
+      )
+
+      if (newCpu > maxCpuPerSandbox) {
         throw new ForbiddenException(
-          `CPU request ${newCpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+          `CPU request ${newCpu} exceeds maximum allowed per sandbox (${maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
         )
       }
-      if (newMem > organization.maxMemoryPerSandbox) {
+      if (newMem > maxMemoryPerSandbox) {
         throw new ForbiddenException(
-          `Memory request ${newMem}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+          `Memory request ${newMem}GB exceeds maximum allowed per sandbox (${maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
         )
       }
-      if (newDisk > organization.maxDiskPerSandbox) {
+      if (newDisk > maxDiskPerSandbox) {
         throw new ForbiddenException(
-          `Disk request ${newDisk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+          `Disk request ${newDisk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
         )
       }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -79,6 +79,7 @@ import { RedisLockProvider } from '../common/redis-lock.provider'
 import { customAlphabet as customNanoid, nanoid, urlAlphabet } from 'nanoid'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { validateMountPaths, validateSubpaths } from '../utils/volume-mount-path-validation.util'
+import { isEphemeral } from '../utils/ephemeral.util'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
 import { PortPreviewUrlDto, SignedPortPreviewUrlDto } from '../dto/port-preview-url.dto'
@@ -158,6 +159,7 @@ export class SandboxService {
     cpu: number,
     memory: number,
     disk: number,
+    ephemeral: boolean,
     excludeSandboxId?: string,
   ): Promise<{
     pendingCpuIncremented: boolean
@@ -169,10 +171,8 @@ export class SandboxService {
       : null
 
     // validate per-sandbox quotas
-    const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox } = getEffectivePerSandboxLimits(
-      organization,
-      regionQuota,
-    )
+    const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox } =
+      getEffectivePerSandboxLimits(organization, regionQuota)
 
     if (cpu > maxCpuPerSandbox) {
       throw new ForbiddenException(
@@ -188,6 +188,17 @@ export class SandboxService {
       throw new ForbiddenException(
         `Disk request ${disk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
+    }
+
+    if (!ephemeral && maxDiskPerNonEphemeralSandbox !== null) {
+      if (maxDiskPerNonEphemeralSandbox === 0) {
+        throw new BadRequestError('Only ephemeral sandboxes are permitted in this region')
+      }
+      if (disk > maxDiskPerNonEphemeralSandbox) {
+        throw new ForbiddenException(
+          `Disk request ${disk}GB exceeds maximum allowed per non-ephemeral sandbox (${maxDiskPerNonEphemeralSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+        )
+      }
     }
 
     // e.g. region belonging to an organization
@@ -308,7 +319,7 @@ export class SandboxService {
       throw new StateChangeInProgressError()
     }
 
-    if (sandbox.autoDeleteInterval === 0) {
+    if (isEphemeral(sandbox)) {
       throw new SandboxError('Ephemeral sandboxes cannot be archived')
     }
 
@@ -449,7 +460,7 @@ export class SandboxService {
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
       const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
-        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk)
+        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk, isEphemeral(createSandboxDto))
 
       if (pendingCpuIncremented) {
         pendingCpuIncrement = cpu
@@ -659,7 +670,7 @@ export class SandboxService {
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
       const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
-        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk)
+        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk, isEphemeral(createSandboxDto))
 
       if (pendingCpuIncremented) {
         pendingCpuIncrement = cpu
@@ -799,7 +810,7 @@ export class SandboxService {
   async createBackup(sandboxIdOrName: string, organizationId?: string): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organizationId)
 
-    if (sandbox.autoDeleteInterval === 0) {
+    if (isEphemeral(sandbox)) {
       throw new SandboxError('Ephemeral sandboxes cannot be backed up')
     }
 
@@ -876,6 +887,7 @@ export class SandboxService {
           forkedSandbox.cpu,
           forkedSandbox.mem,
           forkedSandbox.disk,
+          isEphemeral(forkedSandbox),
         )
 
       if (pendingCpuIncremented) {
@@ -1606,7 +1618,15 @@ export class SandboxService {
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
       const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
-        await this.validateOrganizationQuotas(organization, region, sandbox.cpu, sandbox.mem, sandbox.disk, sandbox.id)
+        await this.validateOrganizationQuotas(
+          organization,
+          region,
+          sandbox.cpu,
+          sandbox.mem,
+          sandbox.disk,
+          isEphemeral(sandbox),
+          sandbox.id,
+        )
 
       if (pendingCpuIncremented) {
         pendingCpuIncrement = sandbox.cpu
@@ -1663,7 +1683,7 @@ export class SandboxService {
 
     const updateData: Partial<Sandbox> = {
       pending: true,
-      desiredState: sandbox.autoDeleteInterval === 0 ? SandboxDesiredState.DESTROYED : SandboxDesiredState.STOPPED,
+      desiredState: isEphemeral(sandbox) ? SandboxDesiredState.DESTROYED : SandboxDesiredState.STOPPED,
     }
 
     const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
@@ -1671,7 +1691,7 @@ export class SandboxService {
       whereCondition: { pending: false, state: sandbox.state },
     })
 
-    if (sandbox.autoDeleteInterval === 0) {
+    if (isEphemeral(sandbox)) {
       this.eventEmitter.emit(SandboxEvents.DESTROYED, new SandboxDestroyedEvent(updatedSandbox))
     } else {
       this.eventEmitter.emit(SandboxEvents.STOPPED, new SandboxStoppedEvent(updatedSandbox, force))
@@ -1801,10 +1821,8 @@ export class SandboxService {
         ? await this.organizationService.getRegionQuota(organization.id, region.id)
         : null
 
-      const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox } = getEffectivePerSandboxLimits(
-        organization,
-        regionQuota,
-      )
+      const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox } =
+        getEffectivePerSandboxLimits(organization, regionQuota)
 
       if (newCpu > maxCpuPerSandbox) {
         throw new ForbiddenException(
@@ -1822,6 +1840,17 @@ export class SandboxService {
         )
       }
 
+      if (!isEphemeral(sandbox) && maxDiskPerNonEphemeralSandbox !== null) {
+        if (maxDiskPerNonEphemeralSandbox === 0) {
+          throw new BadRequestError('Non-ephemeral sandboxes are not permitted in this region')
+        }
+        if (newDisk > maxDiskPerNonEphemeralSandbox) {
+          throw new ForbiddenException(
+            `Disk request ${newDisk}GB exceeds maximum allowed per non-ephemeral sandbox (${maxDiskPerNonEphemeralSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+          )
+        }
+      }
+
       // For cold resize, cpu/memory don't affect quota until sandbox is STARTED.
       // For hot resize, track all deltas (positive reserves quota, negative frees quota for others).
       const cpuDeltaForQuota = isHotResize ? newCpu - sandbox.cpu : 0
@@ -1837,6 +1866,7 @@ export class SandboxService {
             cpuDeltaForQuota,
             memDeltaForQuota,
             diskDeltaForQuota,
+            isEphemeral(sandbox),
           )
 
         if (pendingCpuIncremented) {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -89,6 +89,7 @@ import { SnapshotService } from './snapshot.service'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { RegionType } from '../../region/enums/region-type.enum'
 import { getEffectivePerSandboxLimits } from '../../organization/utils/sandbox-limits.util'
+import { RegionQuotaDto } from '../../organization/dto/region-quota.dto'
 import { SandboxCreatedEvent } from '../events/sandbox-create.event'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
@@ -161,14 +162,15 @@ export class SandboxService {
     disk: number,
     ephemeral: boolean,
     excludeSandboxId?: string,
+    regionQuota?: RegionQuotaDto | null,
   ): Promise<{
     pendingCpuIncremented: boolean
     pendingMemoryIncremented: boolean
     pendingDiskIncremented: boolean
   }> {
-    const regionQuota = region.enforceQuotas
-      ? await this.organizationService.getRegionQuota(organization.id, region.id)
-      : null
+    if (!regionQuota && region.enforceQuotas) {
+      regionQuota = await this.organizationService.getRegionQuota(organization.id, region.id)
+    }
 
     // validate per-sandbox quotas
     const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox } =
@@ -1052,7 +1054,19 @@ export class SandboxService {
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
-      const { pendingSnapshotCountIncremented } = await this.snapshotService.validateOrganizationQuotas(organization, 1)
+      const region = await this.regionService.findOne(sandbox.region)
+      if (!region) {
+        throw new NotFoundException(`Region with ID ${sandbox.region} not found`)
+      }
+
+      const { pendingSnapshotCountIncremented } = await this.snapshotService.validateOrganizationQuotas(
+        organization,
+        region,
+        1,
+        sandbox.cpu,
+        sandbox.mem,
+        sandbox.disk,
+      )
 
       if (pendingSnapshotCountIncremented) {
         pendingSnapshotCountIncrement = 1
@@ -1867,6 +1881,8 @@ export class SandboxService {
             memDeltaForQuota,
             diskDeltaForQuota,
             isEphemeral(sandbox),
+            undefined,
+            regionQuota,
           )
 
         if (pendingCpuIncremented) {

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -36,6 +36,7 @@ import { OrganizationUsageService } from '../../organization/services/organizati
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { SnapshotSortDirection, SnapshotSortField } from '../dto/list-snapshots-query.dto'
 import { PER_SANDBOX_LIMIT_MESSAGE } from '../../common/constants/error-messages'
+import { getEffectivePerSandboxLimits } from '../../organization/utils/sandbox-limits.util'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { DefaultRegionRequiredException } from '../../organization/exceptions/DefaultRegionRequiredException'
 import { Region } from '../../region/entities/region.entity'
@@ -176,6 +177,7 @@ export class SnapshotService {
         createSnapshotDto.cpu,
         createSnapshotDto.memory,
         createSnapshotDto.disk,
+        regionId,
       )
 
       if (pendingSnapshotCountIncremented) {
@@ -243,6 +245,7 @@ export class SnapshotService {
         createSnapshotDto.cpu,
         createSnapshotDto.memory,
         createSnapshotDto.disk,
+        regionId,
       )
 
       if (pendingSnapshotCountIncremented) {
@@ -519,23 +522,31 @@ export class SnapshotService {
     cpu?: number,
     memory?: number,
     disk?: number,
+    regionId?: string,
   ): Promise<{
     pendingSnapshotCountIncremented: boolean
   }> {
+    const regionQuota = regionId ? await this.organizationService.getRegionQuota(organization.id, regionId) : null
+
     // validate per-sandbox quotas
-    if (cpu && cpu > organization.maxCpuPerSandbox) {
+    const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox } = getEffectivePerSandboxLimits(
+      organization,
+      regionQuota,
+    )
+
+    if (cpu && cpu > maxCpuPerSandbox) {
       throw new ForbiddenException(
-        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+        `CPU request ${cpu} exceeds maximum allowed per sandbox (${maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
-    if (memory && memory > organization.maxMemoryPerSandbox) {
+    if (memory && memory > maxMemoryPerSandbox) {
       throw new ForbiddenException(
-        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
-    if (disk && disk > organization.maxDiskPerSandbox) {
+    if (disk && disk > maxDiskPerSandbox) {
       throw new ForbiddenException(
-        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
+        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
 

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -144,7 +144,7 @@ export class SnapshotService {
       throw new DefaultRegionRequiredException()
     }
 
-    const regionId = await this.getValidatedOrDefaultRegionId(organization, createSnapshotDto.regionId)
+    const region = await this.getValidatedOrDefaultRegion(organization, createSnapshotDto.regionId)
 
     let pendingSnapshotCountIncrement: number | undefined
 
@@ -173,11 +173,11 @@ export class SnapshotService {
 
       const { pendingSnapshotCountIncremented } = await this.validateOrganizationQuotas(
         organization,
+        region,
         newSnapshotCount,
         createSnapshotDto.cpu,
         createSnapshotDto.memory,
         createSnapshotDto.disk,
-        regionId,
       )
 
       if (pendingSnapshotCountIncremented) {
@@ -196,7 +196,7 @@ export class SnapshotService {
           state,
           ref,
           general,
-          snapshotRegions: [{ snapshotId, regionId }],
+          snapshotRegions: [{ snapshotId, regionId: region.id }],
         })
 
         const insertedSnapshot = await this.snapshotRepository.insert(snapshot)
@@ -224,7 +224,7 @@ export class SnapshotService {
       throw new DefaultRegionRequiredException()
     }
 
-    const regionId = await this.getValidatedOrDefaultRegionId(organization, createSnapshotDto.regionId)
+    const region = await this.getValidatedOrDefaultRegion(organization, createSnapshotDto.regionId)
 
     let pendingSnapshotCountIncrement: number | undefined
     let entrypoint: string[] | undefined = undefined
@@ -241,11 +241,11 @@ export class SnapshotService {
 
       const { pendingSnapshotCountIncremented } = await this.validateOrganizationQuotas(
         organization,
+        region,
         newSnapshotCount,
         createSnapshotDto.cpu,
         createSnapshotDto.memory,
         createSnapshotDto.disk,
-        regionId,
       )
 
       if (pendingSnapshotCountIncremented) {
@@ -264,7 +264,7 @@ export class SnapshotService {
         mem: createSnapshotDto.memory, // Map memory to mem
         state: SnapshotState.PENDING,
         general,
-        snapshotRegions: [{ snapshotId, regionId }],
+        snapshotRegions: [{ snapshotId, regionId: region.id }],
       })
 
       const buildSnapshotRef = generateBuildSnapshotRef(
@@ -292,13 +292,13 @@ export class SnapshotService {
         snapshot.buildInfo = buildInfoEntity
       }
 
-      const internalRegistry = await this.dockerRegistryService.getAvailableInternalRegistry(regionId)
+      const internalRegistry = await this.dockerRegistryService.getAvailableInternalRegistry(region.id)
       if (!internalRegistry) {
         throw new Error('No internal registry found for snapshot')
       }
       snapshot.ref = `${internalRegistry.url.replace(/^(https?:\/\/)/, '')}/${internalRegistry.project || 'daytona'}/${buildSnapshotRef}`
 
-      const exists = await this.readySnapshotRunnerExists(snapshot.ref, regionId)
+      const exists = await this.readySnapshotRunnerExists(snapshot.ref, region.id)
 
       if (exists) {
         const existingSnapshot = await this.snapshotRepository.findOne({
@@ -518,15 +518,17 @@ export class SnapshotService {
 
   async validateOrganizationQuotas(
     organization: Organization,
+    region: Region,
     addedSnapshotCount: number,
     cpu?: number,
     memory?: number,
     disk?: number,
-    regionId?: string,
   ): Promise<{
     pendingSnapshotCountIncremented: boolean
   }> {
-    const regionQuota = regionId ? await this.organizationService.getRegionQuota(organization.id, regionId) : null
+    const regionQuota = region.enforceQuotas
+      ? await this.organizationService.getRegionQuota(organization.id, region.id)
+      : null
 
     // validate per-sandbox quotas
     const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox } = getEffectivePerSandboxLimits(
@@ -610,6 +612,7 @@ export class SnapshotService {
     try {
       const snapshot = await this.snapshotRepository.findOne({
         where: { id: snapshotId },
+        relations: ['snapshotRegions'],
       })
 
       if (!snapshot) {
@@ -626,10 +629,18 @@ export class SnapshotService {
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
+      const regionId = snapshot.snapshotRegions?.[0]?.regionId
+      const region = regionId ? await this.regionRepository.findOne({ where: { id: regionId } }) : undefined
+
+      if (!region) {
+        throw new NotFoundException(`Region for snapshot ${snapshotId} not found`)
+      }
+
       const activatedSnapshotCount = 1
 
       const { pendingSnapshotCountIncremented } = await this.validateOrganizationQuotas(
         organization,
+        region,
         activatedSnapshotCount,
         snapshot.cpu,
         snapshot.mem,
@@ -762,12 +773,22 @@ export class SnapshotService {
    *
    * @param organization - The organization which is creating the snapshot.
    * @param regionId - The requested region ID. If omitted, the organization's default region is used.
-   * @returns The validated region ID
+   * @returns The validated region
    * @throws {NotFoundException} If the requested region is not available to the organization
    */
-  private async getValidatedOrDefaultRegionId(organization: Organization, regionId?: string): Promise<string> {
+  private async getValidatedOrDefaultRegion(organization: Organization, regionId?: string): Promise<Region> {
+    if (!organization.defaultRegionId) {
+      throw new DefaultRegionRequiredException()
+    }
+
+    regionId = regionId?.trim()
+
     if (!regionId) {
-      return organization.defaultRegionId
+      const region = await this.regionService.findOne(organization.defaultRegionId)
+      if (!region) {
+        throw new NotFoundException('Default region not found')
+      }
+      return region
     }
 
     const region = await this.regionRepository.findOne({
@@ -780,17 +801,17 @@ export class SnapshotService {
 
     const availableRegions = await this.organizationService.listAvailableRegions(organization.id)
 
-    if (!availableRegions.some((r) => r.id === regionId)) {
+    if (!availableRegions.some((r) => r.id === region.id)) {
       if (region.regionType === RegionType.SHARED) {
         // region is public, but the organization does not have a quota for it
-        throw new ForbiddenException(`Region ${regionId} is not available to the organization`)
+        throw new ForbiddenException(`Region ${region.id} is not available to the organization`)
       } else {
         // region is not public, respond as if the region was not found
-        throw new NotFoundException('Region not found')
+        throw new NotFoundException(`Region ${region.id} not found`)
       }
     }
 
-    return regionId
+    return region
   }
 
   /**

--- a/apps/api/src/sandbox/utils/ephemeral.util.ts
+++ b/apps/api/src/sandbox/utils/ephemeral.util.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export function isEphemeral(sandbox: { autoDeleteInterval?: number }): boolean {
+  return sandbox.autoDeleteInterval === 0
+}

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9927,10 +9927,6 @@ components:
           nullable: true
           type: number
       required:
-      - maxCpuPerSandbox
-      - maxDiskPerNonEphemeralSandbox
-      - maxDiskPerSandbox
-      - maxMemoryPerSandbox
       - totalCpuQuota
       - totalDiskQuota
       - totalMemoryQuota

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9898,6 +9898,9 @@ components:
     UpdateOrganizationRegionQuota:
       example:
         totalCpuQuota: 0.8008281904610115
+        maxCpuPerSandbox: 5.962133916683182
+        maxDiskPerSandbox: 2.3021358869347655
+        maxMemoryPerSandbox: 5.637376656633329
         totalMemoryQuota: 6.027456183070403
         totalDiskQuota: 1.4658129805029452
       properties:
@@ -9910,7 +9913,19 @@ components:
         totalDiskQuota:
           nullable: true
           type: number
+        maxCpuPerSandbox:
+          nullable: true
+          type: number
+        maxMemoryPerSandbox:
+          nullable: true
+          type: number
+        maxDiskPerSandbox:
+          nullable: true
+          type: number
       required:
+      - maxCpuPerSandbox
+      - maxDiskPerSandbox
+      - maxMemoryPerSandbox
       - totalCpuQuota
       - totalDiskQuota
       - totalMemoryQuota
@@ -11262,7 +11277,10 @@ components:
       example:
         organizationId: organizationId
         totalCpuQuota: 0.8008281904610115
+        maxCpuPerSandbox: 5.962133916683182
+        maxDiskPerSandbox: 2.3021358869347655
         regionId: regionId
+        maxMemoryPerSandbox: 5.637376656633329
         totalMemoryQuota: 6.027456183070403
         totalDiskQuota: 1.4658129805029452
       properties:
@@ -11276,7 +11294,19 @@ components:
           type: number
         totalDiskQuota:
           type: number
+        maxCpuPerSandbox:
+          nullable: true
+          type: number
+        maxMemoryPerSandbox:
+          nullable: true
+          type: number
+        maxDiskPerSandbox:
+          nullable: true
+          type: number
       required:
+      - maxCpuPerSandbox
+      - maxDiskPerSandbox
+      - maxMemoryPerSandbox
       - organizationId
       - regionId
       - totalCpuQuota

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9900,6 +9900,7 @@ components:
         totalCpuQuota: 0.8008281904610115
         maxCpuPerSandbox: 5.962133916683182
         maxDiskPerSandbox: 2.3021358869347655
+        maxDiskPerNonEphemeralSandbox: 7.061401241503109
         maxMemoryPerSandbox: 5.637376656633329
         totalMemoryQuota: 6.027456183070403
         totalDiskQuota: 1.4658129805029452
@@ -9922,8 +9923,12 @@ components:
         maxDiskPerSandbox:
           nullable: true
           type: number
+        maxDiskPerNonEphemeralSandbox:
+          nullable: true
+          type: number
       required:
       - maxCpuPerSandbox
+      - maxDiskPerNonEphemeralSandbox
       - maxDiskPerSandbox
       - maxMemoryPerSandbox
       - totalCpuQuota
@@ -11279,6 +11284,7 @@ components:
         totalCpuQuota: 0.8008281904610115
         maxCpuPerSandbox: 5.962133916683182
         maxDiskPerSandbox: 2.3021358869347655
+        maxDiskPerNonEphemeralSandbox: 7.061401241503109
         regionId: regionId
         maxMemoryPerSandbox: 5.637376656633329
         totalMemoryQuota: 6.027456183070403
@@ -11303,8 +11309,12 @@ components:
         maxDiskPerSandbox:
           nullable: true
           type: number
+        maxDiskPerNonEphemeralSandbox:
+          nullable: true
+          type: number
       required:
       - maxCpuPerSandbox
+      - maxDiskPerNonEphemeralSandbox
       - maxDiskPerSandbox
       - maxMemoryPerSandbox
       - organizationId

--- a/libs/api-client-go/model_region_quota.go
+++ b/libs/api-client-go/model_region_quota.go
@@ -29,6 +29,7 @@ type RegionQuota struct {
 	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
+	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -38,7 +39,7 @@ type _RegionQuota RegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32) *RegionQuota {
+func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionQuota {
 	this := RegionQuota{}
 	this.OrganizationId = organizationId
 	this.RegionId = regionId
@@ -48,6 +49,7 @@ func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float3
 	this.MaxCpuPerSandbox = maxCpuPerSandbox
 	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
 	this.MaxDiskPerSandbox = maxDiskPerSandbox
+	this.MaxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
 	return &this
 }
 
@@ -257,6 +259,32 @@ func (o *RegionQuota) SetMaxDiskPerSandbox(v float32) {
 	o.MaxDiskPerSandbox.Set(&v)
 }
 
+// GetMaxDiskPerNonEphemeralSandbox returns the MaxDiskPerNonEphemeralSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionQuota) GetMaxDiskPerNonEphemeralSandbox() float32 {
+	if o == nil || o.MaxDiskPerNonEphemeralSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerNonEphemeralSandbox.Get()
+}
+
+// GetMaxDiskPerNonEphemeralSandboxOk returns a tuple with the MaxDiskPerNonEphemeralSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionQuota) GetMaxDiskPerNonEphemeralSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerNonEphemeralSandbox.Get(), o.MaxDiskPerNonEphemeralSandbox.IsSet()
+}
+
+// SetMaxDiskPerNonEphemeralSandbox sets field value
+func (o *RegionQuota) SetMaxDiskPerNonEphemeralSandbox(v float32) {
+	o.MaxDiskPerNonEphemeralSandbox.Set(&v)
+}
+
 func (o RegionQuota) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -275,6 +303,7 @@ func (o RegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
 	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
 	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
+	toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -296,6 +325,7 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"maxCpuPerSandbox",
 		"maxMemoryPerSandbox",
 		"maxDiskPerSandbox",
+		"maxDiskPerNonEphemeralSandbox",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -333,6 +363,7 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "maxCpuPerSandbox")
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")
+		delete(additionalProperties, "maxDiskPerNonEphemeralSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-go/model_region_quota.go
+++ b/libs/api-client-go/model_region_quota.go
@@ -26,6 +26,9 @@ type RegionQuota struct {
 	TotalCpuQuota float32 `json:"totalCpuQuota"`
 	TotalMemoryQuota float32 `json:"totalMemoryQuota"`
 	TotalDiskQuota float32 `json:"totalDiskQuota"`
+	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
+	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
+	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -35,13 +38,16 @@ type _RegionQuota RegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32) *RegionQuota {
+func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32) *RegionQuota {
 	this := RegionQuota{}
 	this.OrganizationId = organizationId
 	this.RegionId = regionId
 	this.TotalCpuQuota = totalCpuQuota
 	this.TotalMemoryQuota = totalMemoryQuota
 	this.TotalDiskQuota = totalDiskQuota
+	this.MaxCpuPerSandbox = maxCpuPerSandbox
+	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
+	this.MaxDiskPerSandbox = maxDiskPerSandbox
 	return &this
 }
 
@@ -173,6 +179,84 @@ func (o *RegionQuota) SetTotalDiskQuota(v float32) {
 	o.TotalDiskQuota = v
 }
 
+// GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionQuota) GetMaxCpuPerSandbox() float32 {
+	if o == nil || o.MaxCpuPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxCpuPerSandbox.Get()
+}
+
+// GetMaxCpuPerSandboxOk returns a tuple with the MaxCpuPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionQuota) GetMaxCpuPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxCpuPerSandbox.Get(), o.MaxCpuPerSandbox.IsSet()
+}
+
+// SetMaxCpuPerSandbox sets field value
+func (o *RegionQuota) SetMaxCpuPerSandbox(v float32) {
+	o.MaxCpuPerSandbox.Set(&v)
+}
+
+// GetMaxMemoryPerSandbox returns the MaxMemoryPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionQuota) GetMaxMemoryPerSandbox() float32 {
+	if o == nil || o.MaxMemoryPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxMemoryPerSandbox.Get()
+}
+
+// GetMaxMemoryPerSandboxOk returns a tuple with the MaxMemoryPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionQuota) GetMaxMemoryPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxMemoryPerSandbox.Get(), o.MaxMemoryPerSandbox.IsSet()
+}
+
+// SetMaxMemoryPerSandbox sets field value
+func (o *RegionQuota) SetMaxMemoryPerSandbox(v float32) {
+	o.MaxMemoryPerSandbox.Set(&v)
+}
+
+// GetMaxDiskPerSandbox returns the MaxDiskPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionQuota) GetMaxDiskPerSandbox() float32 {
+	if o == nil || o.MaxDiskPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerSandbox.Get()
+}
+
+// GetMaxDiskPerSandboxOk returns a tuple with the MaxDiskPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionQuota) GetMaxDiskPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerSandbox.Get(), o.MaxDiskPerSandbox.IsSet()
+}
+
+// SetMaxDiskPerSandbox sets field value
+func (o *RegionQuota) SetMaxDiskPerSandbox(v float32) {
+	o.MaxDiskPerSandbox.Set(&v)
+}
+
 func (o RegionQuota) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -188,6 +272,9 @@ func (o RegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["totalCpuQuota"] = o.TotalCpuQuota
 	toSerialize["totalMemoryQuota"] = o.TotalMemoryQuota
 	toSerialize["totalDiskQuota"] = o.TotalDiskQuota
+	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
+	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
+	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -206,6 +293,9 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"totalCpuQuota",
 		"totalMemoryQuota",
 		"totalDiskQuota",
+		"maxCpuPerSandbox",
+		"maxMemoryPerSandbox",
+		"maxDiskPerSandbox",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -240,6 +330,9 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "totalCpuQuota")
 		delete(additionalProperties, "totalMemoryQuota")
 		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "maxCpuPerSandbox")
+		delete(additionalProperties, "maxMemoryPerSandbox")
+		delete(additionalProperties, "maxDiskPerSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-go/model_update_organization_region_quota.go
+++ b/libs/api-client-go/model_update_organization_region_quota.go
@@ -24,6 +24,9 @@ type UpdateOrganizationRegionQuota struct {
 	TotalCpuQuota NullableFloat32 `json:"totalCpuQuota"`
 	TotalMemoryQuota NullableFloat32 `json:"totalMemoryQuota"`
 	TotalDiskQuota NullableFloat32 `json:"totalDiskQuota"`
+	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
+	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
+	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -33,11 +36,14 @@ type _UpdateOrganizationRegionQuota UpdateOrganizationRegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32) *UpdateOrganizationRegionQuota {
+func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32) *UpdateOrganizationRegionQuota {
 	this := UpdateOrganizationRegionQuota{}
 	this.TotalCpuQuota = totalCpuQuota
 	this.TotalMemoryQuota = totalMemoryQuota
 	this.TotalDiskQuota = totalDiskQuota
+	this.MaxCpuPerSandbox = maxCpuPerSandbox
+	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
+	this.MaxDiskPerSandbox = maxDiskPerSandbox
 	return &this
 }
 
@@ -127,6 +133,84 @@ func (o *UpdateOrganizationRegionQuota) SetTotalDiskQuota(v float32) {
 	o.TotalDiskQuota.Set(&v)
 }
 
+// GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxCpuPerSandbox() float32 {
+	if o == nil || o.MaxCpuPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxCpuPerSandbox.Get()
+}
+
+// GetMaxCpuPerSandboxOk returns a tuple with the MaxCpuPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxCpuPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxCpuPerSandbox.Get(), o.MaxCpuPerSandbox.IsSet()
+}
+
+// SetMaxCpuPerSandbox sets field value
+func (o *UpdateOrganizationRegionQuota) SetMaxCpuPerSandbox(v float32) {
+	o.MaxCpuPerSandbox.Set(&v)
+}
+
+// GetMaxMemoryPerSandbox returns the MaxMemoryPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxMemoryPerSandbox() float32 {
+	if o == nil || o.MaxMemoryPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxMemoryPerSandbox.Get()
+}
+
+// GetMaxMemoryPerSandboxOk returns a tuple with the MaxMemoryPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxMemoryPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxMemoryPerSandbox.Get(), o.MaxMemoryPerSandbox.IsSet()
+}
+
+// SetMaxMemoryPerSandbox sets field value
+func (o *UpdateOrganizationRegionQuota) SetMaxMemoryPerSandbox(v float32) {
+	o.MaxMemoryPerSandbox.Set(&v)
+}
+
+// GetMaxDiskPerSandbox returns the MaxDiskPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerSandbox() float32 {
+	if o == nil || o.MaxDiskPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerSandbox.Get()
+}
+
+// GetMaxDiskPerSandboxOk returns a tuple with the MaxDiskPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerSandbox.Get(), o.MaxDiskPerSandbox.IsSet()
+}
+
+// SetMaxDiskPerSandbox sets field value
+func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerSandbox(v float32) {
+	o.MaxDiskPerSandbox.Set(&v)
+}
+
 func (o UpdateOrganizationRegionQuota) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -140,6 +224,9 @@ func (o UpdateOrganizationRegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["totalCpuQuota"] = o.TotalCpuQuota.Get()
 	toSerialize["totalMemoryQuota"] = o.TotalMemoryQuota.Get()
 	toSerialize["totalDiskQuota"] = o.TotalDiskQuota.Get()
+	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
+	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
+	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -156,6 +243,9 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"totalCpuQuota",
 		"totalMemoryQuota",
 		"totalDiskQuota",
+		"maxCpuPerSandbox",
+		"maxMemoryPerSandbox",
+		"maxDiskPerSandbox",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -188,6 +278,9 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "totalCpuQuota")
 		delete(additionalProperties, "totalMemoryQuota")
 		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "maxCpuPerSandbox")
+		delete(additionalProperties, "maxMemoryPerSandbox")
+		delete(additionalProperties, "maxDiskPerSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-go/model_update_organization_region_quota.go
+++ b/libs/api-client-go/model_update_organization_region_quota.go
@@ -27,6 +27,7 @@ type UpdateOrganizationRegionQuota struct {
 	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
+	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -36,7 +37,7 @@ type _UpdateOrganizationRegionQuota UpdateOrganizationRegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32) *UpdateOrganizationRegionQuota {
+func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *UpdateOrganizationRegionQuota {
 	this := UpdateOrganizationRegionQuota{}
 	this.TotalCpuQuota = totalCpuQuota
 	this.TotalMemoryQuota = totalMemoryQuota
@@ -44,6 +45,7 @@ func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemory
 	this.MaxCpuPerSandbox = maxCpuPerSandbox
 	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
 	this.MaxDiskPerSandbox = maxDiskPerSandbox
+	this.MaxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
 	return &this
 }
 
@@ -211,6 +213,32 @@ func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerSandbox(v float32) {
 	o.MaxDiskPerSandbox.Set(&v)
 }
 
+// GetMaxDiskPerNonEphemeralSandbox returns the MaxDiskPerNonEphemeralSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerNonEphemeralSandbox() float32 {
+	if o == nil || o.MaxDiskPerNonEphemeralSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerNonEphemeralSandbox.Get()
+}
+
+// GetMaxDiskPerNonEphemeralSandboxOk returns a tuple with the MaxDiskPerNonEphemeralSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerNonEphemeralSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerNonEphemeralSandbox.Get(), o.MaxDiskPerNonEphemeralSandbox.IsSet()
+}
+
+// SetMaxDiskPerNonEphemeralSandbox sets field value
+func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerNonEphemeralSandbox(v float32) {
+	o.MaxDiskPerNonEphemeralSandbox.Set(&v)
+}
+
 func (o UpdateOrganizationRegionQuota) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -227,6 +255,7 @@ func (o UpdateOrganizationRegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
 	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
 	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
+	toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -246,6 +275,7 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"maxCpuPerSandbox",
 		"maxMemoryPerSandbox",
 		"maxDiskPerSandbox",
+		"maxDiskPerNonEphemeralSandbox",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -281,6 +311,7 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "maxCpuPerSandbox")
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")
+		delete(additionalProperties, "maxDiskPerNonEphemeralSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-go/model_update_organization_region_quota.go
+++ b/libs/api-client-go/model_update_organization_region_quota.go
@@ -24,10 +24,10 @@ type UpdateOrganizationRegionQuota struct {
 	TotalCpuQuota NullableFloat32 `json:"totalCpuQuota"`
 	TotalMemoryQuota NullableFloat32 `json:"totalMemoryQuota"`
 	TotalDiskQuota NullableFloat32 `json:"totalDiskQuota"`
-	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
-	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
-	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
-	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox"`
+	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox,omitempty"`
+	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox,omitempty"`
+	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox,omitempty"`
+	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -37,15 +37,11 @@ type _UpdateOrganizationRegionQuota UpdateOrganizationRegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *UpdateOrganizationRegionQuota {
+func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32) *UpdateOrganizationRegionQuota {
 	this := UpdateOrganizationRegionQuota{}
 	this.TotalCpuQuota = totalCpuQuota
 	this.TotalMemoryQuota = totalMemoryQuota
 	this.TotalDiskQuota = totalDiskQuota
-	this.MaxCpuPerSandbox = maxCpuPerSandbox
-	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
-	this.MaxDiskPerSandbox = maxDiskPerSandbox
-	this.MaxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
 	return &this
 }
 
@@ -135,18 +131,16 @@ func (o *UpdateOrganizationRegionQuota) SetTotalDiskQuota(v float32) {
 	o.TotalDiskQuota.Set(&v)
 }
 
-// GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value
-// If the value is explicit nil, the zero value for float32 will be returned
+// GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *UpdateOrganizationRegionQuota) GetMaxCpuPerSandbox() float32 {
-	if o == nil || o.MaxCpuPerSandbox.Get() == nil {
+	if o == nil || IsNil(o.MaxCpuPerSandbox.Get()) {
 		var ret float32
 		return ret
 	}
-
 	return *o.MaxCpuPerSandbox.Get()
 }
 
-// GetMaxCpuPerSandboxOk returns a tuple with the MaxCpuPerSandbox field value
+// GetMaxCpuPerSandboxOk returns a tuple with the MaxCpuPerSandbox field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *UpdateOrganizationRegionQuota) GetMaxCpuPerSandboxOk() (*float32, bool) {
@@ -156,23 +150,39 @@ func (o *UpdateOrganizationRegionQuota) GetMaxCpuPerSandboxOk() (*float32, bool)
 	return o.MaxCpuPerSandbox.Get(), o.MaxCpuPerSandbox.IsSet()
 }
 
-// SetMaxCpuPerSandbox sets field value
+// HasMaxCpuPerSandbox returns a boolean if a field has been set.
+func (o *UpdateOrganizationRegionQuota) HasMaxCpuPerSandbox() bool {
+	if o != nil && o.MaxCpuPerSandbox.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxCpuPerSandbox gets a reference to the given NullableFloat32 and assigns it to the MaxCpuPerSandbox field.
 func (o *UpdateOrganizationRegionQuota) SetMaxCpuPerSandbox(v float32) {
 	o.MaxCpuPerSandbox.Set(&v)
 }
+// SetMaxCpuPerSandboxNil sets the value for MaxCpuPerSandbox to be an explicit nil
+func (o *UpdateOrganizationRegionQuota) SetMaxCpuPerSandboxNil() {
+	o.MaxCpuPerSandbox.Set(nil)
+}
 
-// GetMaxMemoryPerSandbox returns the MaxMemoryPerSandbox field value
-// If the value is explicit nil, the zero value for float32 will be returned
+// UnsetMaxCpuPerSandbox ensures that no value is present for MaxCpuPerSandbox, not even an explicit nil
+func (o *UpdateOrganizationRegionQuota) UnsetMaxCpuPerSandbox() {
+	o.MaxCpuPerSandbox.Unset()
+}
+
+// GetMaxMemoryPerSandbox returns the MaxMemoryPerSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *UpdateOrganizationRegionQuota) GetMaxMemoryPerSandbox() float32 {
-	if o == nil || o.MaxMemoryPerSandbox.Get() == nil {
+	if o == nil || IsNil(o.MaxMemoryPerSandbox.Get()) {
 		var ret float32
 		return ret
 	}
-
 	return *o.MaxMemoryPerSandbox.Get()
 }
 
-// GetMaxMemoryPerSandboxOk returns a tuple with the MaxMemoryPerSandbox field value
+// GetMaxMemoryPerSandboxOk returns a tuple with the MaxMemoryPerSandbox field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *UpdateOrganizationRegionQuota) GetMaxMemoryPerSandboxOk() (*float32, bool) {
@@ -182,23 +192,39 @@ func (o *UpdateOrganizationRegionQuota) GetMaxMemoryPerSandboxOk() (*float32, bo
 	return o.MaxMemoryPerSandbox.Get(), o.MaxMemoryPerSandbox.IsSet()
 }
 
-// SetMaxMemoryPerSandbox sets field value
+// HasMaxMemoryPerSandbox returns a boolean if a field has been set.
+func (o *UpdateOrganizationRegionQuota) HasMaxMemoryPerSandbox() bool {
+	if o != nil && o.MaxMemoryPerSandbox.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxMemoryPerSandbox gets a reference to the given NullableFloat32 and assigns it to the MaxMemoryPerSandbox field.
 func (o *UpdateOrganizationRegionQuota) SetMaxMemoryPerSandbox(v float32) {
 	o.MaxMemoryPerSandbox.Set(&v)
 }
+// SetMaxMemoryPerSandboxNil sets the value for MaxMemoryPerSandbox to be an explicit nil
+func (o *UpdateOrganizationRegionQuota) SetMaxMemoryPerSandboxNil() {
+	o.MaxMemoryPerSandbox.Set(nil)
+}
 
-// GetMaxDiskPerSandbox returns the MaxDiskPerSandbox field value
-// If the value is explicit nil, the zero value for float32 will be returned
+// UnsetMaxMemoryPerSandbox ensures that no value is present for MaxMemoryPerSandbox, not even an explicit nil
+func (o *UpdateOrganizationRegionQuota) UnsetMaxMemoryPerSandbox() {
+	o.MaxMemoryPerSandbox.Unset()
+}
+
+// GetMaxDiskPerSandbox returns the MaxDiskPerSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerSandbox() float32 {
-	if o == nil || o.MaxDiskPerSandbox.Get() == nil {
+	if o == nil || IsNil(o.MaxDiskPerSandbox.Get()) {
 		var ret float32
 		return ret
 	}
-
 	return *o.MaxDiskPerSandbox.Get()
 }
 
-// GetMaxDiskPerSandboxOk returns a tuple with the MaxDiskPerSandbox field value
+// GetMaxDiskPerSandboxOk returns a tuple with the MaxDiskPerSandbox field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerSandboxOk() (*float32, bool) {
@@ -208,23 +234,39 @@ func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerSandboxOk() (*float32, bool
 	return o.MaxDiskPerSandbox.Get(), o.MaxDiskPerSandbox.IsSet()
 }
 
-// SetMaxDiskPerSandbox sets field value
+// HasMaxDiskPerSandbox returns a boolean if a field has been set.
+func (o *UpdateOrganizationRegionQuota) HasMaxDiskPerSandbox() bool {
+	if o != nil && o.MaxDiskPerSandbox.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxDiskPerSandbox gets a reference to the given NullableFloat32 and assigns it to the MaxDiskPerSandbox field.
 func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerSandbox(v float32) {
 	o.MaxDiskPerSandbox.Set(&v)
 }
+// SetMaxDiskPerSandboxNil sets the value for MaxDiskPerSandbox to be an explicit nil
+func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerSandboxNil() {
+	o.MaxDiskPerSandbox.Set(nil)
+}
 
-// GetMaxDiskPerNonEphemeralSandbox returns the MaxDiskPerNonEphemeralSandbox field value
-// If the value is explicit nil, the zero value for float32 will be returned
+// UnsetMaxDiskPerSandbox ensures that no value is present for MaxDiskPerSandbox, not even an explicit nil
+func (o *UpdateOrganizationRegionQuota) UnsetMaxDiskPerSandbox() {
+	o.MaxDiskPerSandbox.Unset()
+}
+
+// GetMaxDiskPerNonEphemeralSandbox returns the MaxDiskPerNonEphemeralSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerNonEphemeralSandbox() float32 {
-	if o == nil || o.MaxDiskPerNonEphemeralSandbox.Get() == nil {
+	if o == nil || IsNil(o.MaxDiskPerNonEphemeralSandbox.Get()) {
 		var ret float32
 		return ret
 	}
-
 	return *o.MaxDiskPerNonEphemeralSandbox.Get()
 }
 
-// GetMaxDiskPerNonEphemeralSandboxOk returns a tuple with the MaxDiskPerNonEphemeralSandbox field value
+// GetMaxDiskPerNonEphemeralSandboxOk returns a tuple with the MaxDiskPerNonEphemeralSandbox field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerNonEphemeralSandboxOk() (*float32, bool) {
@@ -234,9 +276,27 @@ func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerNonEphemeralSandboxOk() (*f
 	return o.MaxDiskPerNonEphemeralSandbox.Get(), o.MaxDiskPerNonEphemeralSandbox.IsSet()
 }
 
-// SetMaxDiskPerNonEphemeralSandbox sets field value
+// HasMaxDiskPerNonEphemeralSandbox returns a boolean if a field has been set.
+func (o *UpdateOrganizationRegionQuota) HasMaxDiskPerNonEphemeralSandbox() bool {
+	if o != nil && o.MaxDiskPerNonEphemeralSandbox.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxDiskPerNonEphemeralSandbox gets a reference to the given NullableFloat32 and assigns it to the MaxDiskPerNonEphemeralSandbox field.
 func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerNonEphemeralSandbox(v float32) {
 	o.MaxDiskPerNonEphemeralSandbox.Set(&v)
+}
+// SetMaxDiskPerNonEphemeralSandboxNil sets the value for MaxDiskPerNonEphemeralSandbox to be an explicit nil
+func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerNonEphemeralSandboxNil() {
+	o.MaxDiskPerNonEphemeralSandbox.Set(nil)
+}
+
+// UnsetMaxDiskPerNonEphemeralSandbox ensures that no value is present for MaxDiskPerNonEphemeralSandbox, not even an explicit nil
+func (o *UpdateOrganizationRegionQuota) UnsetMaxDiskPerNonEphemeralSandbox() {
+	o.MaxDiskPerNonEphemeralSandbox.Unset()
 }
 
 func (o UpdateOrganizationRegionQuota) MarshalJSON() ([]byte, error) {
@@ -252,10 +312,18 @@ func (o UpdateOrganizationRegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["totalCpuQuota"] = o.TotalCpuQuota.Get()
 	toSerialize["totalMemoryQuota"] = o.TotalMemoryQuota.Get()
 	toSerialize["totalDiskQuota"] = o.TotalDiskQuota.Get()
-	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
-	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
-	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
-	toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
+	if o.MaxCpuPerSandbox.IsSet() {
+		toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
+	}
+	if o.MaxMemoryPerSandbox.IsSet() {
+		toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
+	}
+	if o.MaxDiskPerSandbox.IsSet() {
+		toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
+	}
+	if o.MaxDiskPerNonEphemeralSandbox.IsSet() {
+		toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -272,10 +340,6 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"totalCpuQuota",
 		"totalMemoryQuota",
 		"totalDiskQuota",
-		"maxCpuPerSandbox",
-		"maxMemoryPerSandbox",
-		"maxDiskPerSandbox",
-		"maxDiskPerNonEphemeralSandbox",
 	}
 
 	allProperties := make(map[string]interface{})

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
@@ -91,6 +91,11 @@ public class RegionQuota {
   @javax.annotation.Nullable
   private BigDecimal maxDiskPerSandbox;
 
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_NON_EPHEMERAL_SANDBOX = "maxDiskPerNonEphemeralSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_NON_EPHEMERAL_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerNonEphemeralSandbox;
+
   public RegionQuota() {
   }
 
@@ -245,6 +250,25 @@ public class RegionQuota {
     this.maxDiskPerSandbox = maxDiskPerSandbox;
   }
 
+
+  public RegionQuota maxDiskPerNonEphemeralSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerNonEphemeralSandbox) {
+    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerNonEphemeralSandbox
+   * @return maxDiskPerNonEphemeralSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerNonEphemeralSandbox() {
+    return maxDiskPerNonEphemeralSandbox;
+  }
+
+  public void setMaxDiskPerNonEphemeralSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerNonEphemeralSandbox) {
+    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -307,13 +331,14 @@ public class RegionQuota {
         Objects.equals(this.totalDiskQuota, regionQuota.totalDiskQuota) &&
         Objects.equals(this.maxCpuPerSandbox, regionQuota.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, regionQuota.maxMemoryPerSandbox) &&
-        Objects.equals(this.maxDiskPerSandbox, regionQuota.maxDiskPerSandbox)&&
+        Objects.equals(this.maxDiskPerSandbox, regionQuota.maxDiskPerSandbox) &&
+        Objects.equals(this.maxDiskPerNonEphemeralSandbox, regionQuota.maxDiskPerNonEphemeralSandbox)&&
         Objects.equals(this.additionalProperties, regionQuota.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, additionalProperties);
+    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
   }
 
   @Override
@@ -328,6 +353,7 @@ public class RegionQuota {
     sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
+    sb.append("    maxDiskPerNonEphemeralSandbox: ").append(toIndentedString(maxDiskPerNonEphemeralSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -359,6 +385,7 @@ public class RegionQuota {
     openapiFields.add("maxCpuPerSandbox");
     openapiFields.add("maxMemoryPerSandbox");
     openapiFields.add("maxDiskPerSandbox");
+    openapiFields.add("maxDiskPerNonEphemeralSandbox");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -370,6 +397,7 @@ public class RegionQuota {
     openapiRequiredFields.add("maxCpuPerSandbox");
     openapiRequiredFields.add("maxMemoryPerSandbox");
     openapiRequiredFields.add("maxDiskPerSandbox");
+    openapiRequiredFields.add("maxDiskPerNonEphemeralSandbox");
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
@@ -76,6 +76,21 @@ public class RegionQuota {
   @javax.annotation.Nonnull
   private BigDecimal totalDiskQuota;
 
+  public static final String SERIALIZED_NAME_MAX_CPU_PER_SANDBOX = "maxCpuPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxCpuPerSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_MEMORY_PER_SANDBOX = "maxMemoryPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_MEMORY_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxMemoryPerSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_SANDBOX = "maxDiskPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerSandbox;
+
   public RegionQuota() {
   }
 
@@ -173,6 +188,63 @@ public class RegionQuota {
     this.totalDiskQuota = totalDiskQuota;
   }
 
+
+  public RegionQuota maxCpuPerSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerSandbox) {
+    this.maxCpuPerSandbox = maxCpuPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxCpuPerSandbox
+   * @return maxCpuPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxCpuPerSandbox() {
+    return maxCpuPerSandbox;
+  }
+
+  public void setMaxCpuPerSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerSandbox) {
+    this.maxCpuPerSandbox = maxCpuPerSandbox;
+  }
+
+
+  public RegionQuota maxMemoryPerSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerSandbox) {
+    this.maxMemoryPerSandbox = maxMemoryPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxMemoryPerSandbox
+   * @return maxMemoryPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxMemoryPerSandbox() {
+    return maxMemoryPerSandbox;
+  }
+
+  public void setMaxMemoryPerSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerSandbox) {
+    this.maxMemoryPerSandbox = maxMemoryPerSandbox;
+  }
+
+
+  public RegionQuota maxDiskPerSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerSandbox) {
+    this.maxDiskPerSandbox = maxDiskPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerSandbox
+   * @return maxDiskPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerSandbox() {
+    return maxDiskPerSandbox;
+  }
+
+  public void setMaxDiskPerSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerSandbox) {
+    this.maxDiskPerSandbox = maxDiskPerSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -232,13 +304,16 @@ public class RegionQuota {
         Objects.equals(this.regionId, regionQuota.regionId) &&
         Objects.equals(this.totalCpuQuota, regionQuota.totalCpuQuota) &&
         Objects.equals(this.totalMemoryQuota, regionQuota.totalMemoryQuota) &&
-        Objects.equals(this.totalDiskQuota, regionQuota.totalDiskQuota)&&
+        Objects.equals(this.totalDiskQuota, regionQuota.totalDiskQuota) &&
+        Objects.equals(this.maxCpuPerSandbox, regionQuota.maxCpuPerSandbox) &&
+        Objects.equals(this.maxMemoryPerSandbox, regionQuota.maxMemoryPerSandbox) &&
+        Objects.equals(this.maxDiskPerSandbox, regionQuota.maxDiskPerSandbox)&&
         Objects.equals(this.additionalProperties, regionQuota.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, additionalProperties);
+    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, additionalProperties);
   }
 
   @Override
@@ -250,6 +325,9 @@ public class RegionQuota {
     sb.append("    totalCpuQuota: ").append(toIndentedString(totalCpuQuota)).append("\n");
     sb.append("    totalMemoryQuota: ").append(toIndentedString(totalMemoryQuota)).append("\n");
     sb.append("    totalDiskQuota: ").append(toIndentedString(totalDiskQuota)).append("\n");
+    sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
+    sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
+    sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -278,6 +356,9 @@ public class RegionQuota {
     openapiFields.add("totalCpuQuota");
     openapiFields.add("totalMemoryQuota");
     openapiFields.add("totalDiskQuota");
+    openapiFields.add("maxCpuPerSandbox");
+    openapiFields.add("maxMemoryPerSandbox");
+    openapiFields.add("maxDiskPerSandbox");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -286,6 +367,9 @@ public class RegionQuota {
     openapiRequiredFields.add("totalCpuQuota");
     openapiRequiredFields.add("totalMemoryQuota");
     openapiRequiredFields.add("totalDiskQuota");
+    openapiRequiredFields.add("maxCpuPerSandbox");
+    openapiRequiredFields.add("maxMemoryPerSandbox");
+    openapiRequiredFields.add("maxDiskPerSandbox");
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -286,9 +287,20 @@ public class UpdateOrganizationRegionQuota {
         Objects.equals(this.additionalProperties, updateOrganizationRegionQuota.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -338,10 +350,6 @@ public class UpdateOrganizationRegionQuota {
     openapiRequiredFields.add("totalCpuQuota");
     openapiRequiredFields.add("totalMemoryQuota");
     openapiRequiredFields.add("totalDiskQuota");
-    openapiRequiredFields.add("maxCpuPerSandbox");
-    openapiRequiredFields.add("maxMemoryPerSandbox");
-    openapiRequiredFields.add("maxDiskPerSandbox");
-    openapiRequiredFields.add("maxDiskPerNonEphemeralSandbox");
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
@@ -66,6 +66,21 @@ public class UpdateOrganizationRegionQuota {
   @javax.annotation.Nullable
   private BigDecimal totalDiskQuota;
 
+  public static final String SERIALIZED_NAME_MAX_CPU_PER_SANDBOX = "maxCpuPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxCpuPerSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_MEMORY_PER_SANDBOX = "maxMemoryPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_MEMORY_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxMemoryPerSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_SANDBOX = "maxDiskPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerSandbox;
+
   public UpdateOrganizationRegionQuota() {
   }
 
@@ -125,6 +140,63 @@ public class UpdateOrganizationRegionQuota {
     this.totalDiskQuota = totalDiskQuota;
   }
 
+
+  public UpdateOrganizationRegionQuota maxCpuPerSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerSandbox) {
+    this.maxCpuPerSandbox = maxCpuPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxCpuPerSandbox
+   * @return maxCpuPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxCpuPerSandbox() {
+    return maxCpuPerSandbox;
+  }
+
+  public void setMaxCpuPerSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerSandbox) {
+    this.maxCpuPerSandbox = maxCpuPerSandbox;
+  }
+
+
+  public UpdateOrganizationRegionQuota maxMemoryPerSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerSandbox) {
+    this.maxMemoryPerSandbox = maxMemoryPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxMemoryPerSandbox
+   * @return maxMemoryPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxMemoryPerSandbox() {
+    return maxMemoryPerSandbox;
+  }
+
+  public void setMaxMemoryPerSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerSandbox) {
+    this.maxMemoryPerSandbox = maxMemoryPerSandbox;
+  }
+
+
+  public UpdateOrganizationRegionQuota maxDiskPerSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerSandbox) {
+    this.maxDiskPerSandbox = maxDiskPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerSandbox
+   * @return maxDiskPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerSandbox() {
+    return maxDiskPerSandbox;
+  }
+
+  public void setMaxDiskPerSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerSandbox) {
+    this.maxDiskPerSandbox = maxDiskPerSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -182,13 +254,16 @@ public class UpdateOrganizationRegionQuota {
     UpdateOrganizationRegionQuota updateOrganizationRegionQuota = (UpdateOrganizationRegionQuota) o;
     return Objects.equals(this.totalCpuQuota, updateOrganizationRegionQuota.totalCpuQuota) &&
         Objects.equals(this.totalMemoryQuota, updateOrganizationRegionQuota.totalMemoryQuota) &&
-        Objects.equals(this.totalDiskQuota, updateOrganizationRegionQuota.totalDiskQuota)&&
+        Objects.equals(this.totalDiskQuota, updateOrganizationRegionQuota.totalDiskQuota) &&
+        Objects.equals(this.maxCpuPerSandbox, updateOrganizationRegionQuota.maxCpuPerSandbox) &&
+        Objects.equals(this.maxMemoryPerSandbox, updateOrganizationRegionQuota.maxMemoryPerSandbox) &&
+        Objects.equals(this.maxDiskPerSandbox, updateOrganizationRegionQuota.maxDiskPerSandbox)&&
         Objects.equals(this.additionalProperties, updateOrganizationRegionQuota.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, additionalProperties);
+    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, additionalProperties);
   }
 
   @Override
@@ -198,6 +273,9 @@ public class UpdateOrganizationRegionQuota {
     sb.append("    totalCpuQuota: ").append(toIndentedString(totalCpuQuota)).append("\n");
     sb.append("    totalMemoryQuota: ").append(toIndentedString(totalMemoryQuota)).append("\n");
     sb.append("    totalDiskQuota: ").append(toIndentedString(totalDiskQuota)).append("\n");
+    sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
+    sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
+    sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -224,12 +302,18 @@ public class UpdateOrganizationRegionQuota {
     openapiFields.add("totalCpuQuota");
     openapiFields.add("totalMemoryQuota");
     openapiFields.add("totalDiskQuota");
+    openapiFields.add("maxCpuPerSandbox");
+    openapiFields.add("maxMemoryPerSandbox");
+    openapiFields.add("maxDiskPerSandbox");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
     openapiRequiredFields.add("totalCpuQuota");
     openapiRequiredFields.add("totalMemoryQuota");
     openapiRequiredFields.add("totalDiskQuota");
+    openapiRequiredFields.add("maxCpuPerSandbox");
+    openapiRequiredFields.add("maxMemoryPerSandbox");
+    openapiRequiredFields.add("maxDiskPerSandbox");
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
@@ -81,6 +81,11 @@ public class UpdateOrganizationRegionQuota {
   @javax.annotation.Nullable
   private BigDecimal maxDiskPerSandbox;
 
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_NON_EPHEMERAL_SANDBOX = "maxDiskPerNonEphemeralSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_NON_EPHEMERAL_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerNonEphemeralSandbox;
+
   public UpdateOrganizationRegionQuota() {
   }
 
@@ -197,6 +202,25 @@ public class UpdateOrganizationRegionQuota {
     this.maxDiskPerSandbox = maxDiskPerSandbox;
   }
 
+
+  public UpdateOrganizationRegionQuota maxDiskPerNonEphemeralSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerNonEphemeralSandbox) {
+    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerNonEphemeralSandbox
+   * @return maxDiskPerNonEphemeralSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerNonEphemeralSandbox() {
+    return maxDiskPerNonEphemeralSandbox;
+  }
+
+  public void setMaxDiskPerNonEphemeralSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerNonEphemeralSandbox) {
+    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -257,13 +281,14 @@ public class UpdateOrganizationRegionQuota {
         Objects.equals(this.totalDiskQuota, updateOrganizationRegionQuota.totalDiskQuota) &&
         Objects.equals(this.maxCpuPerSandbox, updateOrganizationRegionQuota.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, updateOrganizationRegionQuota.maxMemoryPerSandbox) &&
-        Objects.equals(this.maxDiskPerSandbox, updateOrganizationRegionQuota.maxDiskPerSandbox)&&
+        Objects.equals(this.maxDiskPerSandbox, updateOrganizationRegionQuota.maxDiskPerSandbox) &&
+        Objects.equals(this.maxDiskPerNonEphemeralSandbox, updateOrganizationRegionQuota.maxDiskPerNonEphemeralSandbox)&&
         Objects.equals(this.additionalProperties, updateOrganizationRegionQuota.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, additionalProperties);
+    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
   }
 
   @Override
@@ -276,6 +301,7 @@ public class UpdateOrganizationRegionQuota {
     sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
+    sb.append("    maxDiskPerNonEphemeralSandbox: ").append(toIndentedString(maxDiskPerNonEphemeralSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -305,6 +331,7 @@ public class UpdateOrganizationRegionQuota {
     openapiFields.add("maxCpuPerSandbox");
     openapiFields.add("maxMemoryPerSandbox");
     openapiFields.add("maxDiskPerSandbox");
+    openapiFields.add("maxDiskPerNonEphemeralSandbox");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -314,6 +341,7 @@ public class UpdateOrganizationRegionQuota {
     openapiRequiredFields.add("maxCpuPerSandbox");
     openapiRequiredFields.add("maxMemoryPerSandbox");
     openapiRequiredFields.add("maxDiskPerSandbox");
+    openapiRequiredFields.add("maxDiskPerNonEphemeralSandbox");
   }
 
   /**

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
@@ -102,4 +102,12 @@ public class RegionQuotaTest {
         // TODO: test maxDiskPerSandbox
     }
 
+    /**
+     * Test the property 'maxDiskPerNonEphemeralSandbox'
+     */
+    @Test
+    public void maxDiskPerNonEphemeralSandboxTest() {
+        // TODO: test maxDiskPerNonEphemeralSandbox
+    }
+
 }

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
@@ -78,4 +78,28 @@ public class RegionQuotaTest {
         // TODO: test totalDiskQuota
     }
 
+    /**
+     * Test the property 'maxCpuPerSandbox'
+     */
+    @Test
+    public void maxCpuPerSandboxTest() {
+        // TODO: test maxCpuPerSandbox
+    }
+
+    /**
+     * Test the property 'maxMemoryPerSandbox'
+     */
+    @Test
+    public void maxMemoryPerSandboxTest() {
+        // TODO: test maxMemoryPerSandbox
+    }
+
+    /**
+     * Test the property 'maxDiskPerSandbox'
+     */
+    @Test
+    public void maxDiskPerSandboxTest() {
+        // TODO: test maxDiskPerSandbox
+    }
+
 }

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
@@ -62,4 +62,28 @@ public class UpdateOrganizationRegionQuotaTest {
         // TODO: test totalDiskQuota
     }
 
+    /**
+     * Test the property 'maxCpuPerSandbox'
+     */
+    @Test
+    public void maxCpuPerSandboxTest() {
+        // TODO: test maxCpuPerSandbox
+    }
+
+    /**
+     * Test the property 'maxMemoryPerSandbox'
+     */
+    @Test
+    public void maxMemoryPerSandboxTest() {
+        // TODO: test maxMemoryPerSandbox
+    }
+
+    /**
+     * Test the property 'maxDiskPerSandbox'
+     */
+    @Test
+    public void maxDiskPerSandboxTest() {
+        // TODO: test maxDiskPerSandbox
+    }
+
 }

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
@@ -86,4 +86,12 @@ public class UpdateOrganizationRegionQuotaTest {
         // TODO: test maxDiskPerSandbox
     }
 
+    /**
+     * Test the property 'maxDiskPerNonEphemeralSandbox'
+     */
+    @Test
+    public void maxDiskPerNonEphemeralSandboxTest() {
+        // TODO: test maxDiskPerNonEphemeralSandbox
+    }
+
 }

--- a/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -35,8 +35,11 @@ class RegionQuota(BaseModel):
     total_cpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -83,6 +86,21 @@ class RegionQuota(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if max_cpu_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerSandbox'] = None
+
+        # set to None if max_memory_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_sandbox is None and "max_memory_per_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerSandbox'] = None
+
+        # set to None if max_disk_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -99,7 +117,10 @@ class RegionQuota(BaseModel):
             "region_id": obj.get("regionId"),
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
-            "total_disk_quota": obj.get("totalDiskQuota")
+            "total_disk_quota": obj.get("totalDiskQuota"),
+            "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
+            "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
@@ -38,8 +38,9 @@ class RegionQuota(BaseModel):
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,6 +102,11 @@ class RegionQuota(BaseModel):
         if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
             _dict['maxDiskPerSandbox'] = None
 
+        # set to None if max_disk_per_non_ephemeral_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerNonEphemeralSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -120,7 +126,8 @@ class RegionQuota(BaseModel):
             "total_disk_quota": obj.get("totalDiskQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
-            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
@@ -36,8 +36,9 @@ class UpdateOrganizationRegionQuota(BaseModel):
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -114,6 +115,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
             _dict['maxDiskPerSandbox'] = None
 
+        # set to None if max_disk_per_non_ephemeral_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerNonEphemeralSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -131,7 +137,8 @@ class UpdateOrganizationRegionQuota(BaseModel):
             "total_disk_quota": obj.get("totalDiskQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
-            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
@@ -33,10 +33,10 @@ class UpdateOrganizationRegionQuota(BaseModel):
     total_cpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalDiskQuota")
-    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
-    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
-    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
-    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 

--- a/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
@@ -33,8 +33,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
     total_cpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalDiskQuota")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,6 +99,21 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.total_disk_quota is None and "total_disk_quota" in self.model_fields_set:
             _dict['totalDiskQuota'] = None
 
+        # set to None if max_cpu_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerSandbox'] = None
+
+        # set to None if max_memory_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_sandbox is None and "max_memory_per_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerSandbox'] = None
+
+        # set to None if max_disk_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -110,7 +128,10 @@ class UpdateOrganizationRegionQuota(BaseModel):
         _obj = cls.model_validate({
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
-            "total_disk_quota": obj.get("totalDiskQuota")
+            "total_disk_quota": obj.get("totalDiskQuota"),
+            "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
+            "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/region_quota.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -35,8 +35,11 @@ class RegionQuota(BaseModel):
     total_cpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -83,6 +86,21 @@ class RegionQuota(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if max_cpu_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerSandbox'] = None
+
+        # set to None if max_memory_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_sandbox is None and "max_memory_per_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerSandbox'] = None
+
+        # set to None if max_disk_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -99,7 +117,10 @@ class RegionQuota(BaseModel):
             "region_id": obj.get("regionId"),
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
-            "total_disk_quota": obj.get("totalDiskQuota")
+            "total_disk_quota": obj.get("totalDiskQuota"),
+            "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
+            "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/region_quota.py
@@ -38,8 +38,9 @@ class RegionQuota(BaseModel):
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,6 +102,11 @@ class RegionQuota(BaseModel):
         if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
             _dict['maxDiskPerSandbox'] = None
 
+        # set to None if max_disk_per_non_ephemeral_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerNonEphemeralSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -120,7 +126,8 @@ class RegionQuota(BaseModel):
             "total_disk_quota": obj.get("totalDiskQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
-            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
@@ -36,8 +36,9 @@ class UpdateOrganizationRegionQuota(BaseModel):
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -114,6 +115,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
             _dict['maxDiskPerSandbox'] = None
 
+        # set to None if max_disk_per_non_ephemeral_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerNonEphemeralSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -131,7 +137,8 @@ class UpdateOrganizationRegionQuota(BaseModel):
             "total_disk_quota": obj.get("totalDiskQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
-            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
@@ -33,10 +33,10 @@ class UpdateOrganizationRegionQuota(BaseModel):
     total_cpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalDiskQuota")
-    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
-    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
-    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
-    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 

--- a/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
@@ -33,8 +33,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
     total_cpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalDiskQuota")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,6 +99,21 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.total_disk_quota is None and "total_disk_quota" in self.model_fields_set:
             _dict['totalDiskQuota'] = None
 
+        # set to None if max_cpu_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerSandbox'] = None
+
+        # set to None if max_memory_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_sandbox is None and "max_memory_per_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerSandbox'] = None
+
+        # set to None if max_disk_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -110,7 +128,10 @@ class UpdateOrganizationRegionQuota(BaseModel):
         _obj = cls.model_validate({
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
-            "total_disk_quota": obj.get("totalDiskQuota")
+            "total_disk_quota": obj.get("totalDiskQuota"),
+            "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
+            "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
@@ -31,6 +31,8 @@ module DaytonaApiClient
 
     attr_accessor :max_disk_per_sandbox
 
+    attr_accessor :max_disk_per_non_ephemeral_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -41,7 +43,8 @@ module DaytonaApiClient
         :'total_disk_quota' => :'totalDiskQuota',
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
-        :'max_disk_per_sandbox' => :'maxDiskPerSandbox'
+        :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
+        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox'
       }
     end
 
@@ -65,7 +68,8 @@ module DaytonaApiClient
         :'total_disk_quota' => :'Float',
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
-        :'max_disk_per_sandbox' => :'Float'
+        :'max_disk_per_sandbox' => :'Float',
+        :'max_disk_per_non_ephemeral_sandbox' => :'Float'
       }
     end
 
@@ -74,7 +78,8 @@ module DaytonaApiClient
       Set.new([
         :'max_cpu_per_sandbox',
         :'max_memory_per_sandbox',
-        :'max_disk_per_sandbox'
+        :'max_disk_per_sandbox',
+        :'max_disk_per_non_ephemeral_sandbox'
       ])
     end
 
@@ -140,6 +145,12 @@ module DaytonaApiClient
         self.max_disk_per_sandbox = attributes[:'max_disk_per_sandbox']
       else
         self.max_disk_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_disk_per_non_ephemeral_sandbox')
+        self.max_disk_per_non_ephemeral_sandbox = attributes[:'max_disk_per_non_ephemeral_sandbox']
+      else
+        self.max_disk_per_non_ephemeral_sandbox = nil
       end
     end
 
@@ -245,7 +256,8 @@ module DaytonaApiClient
           total_disk_quota == o.total_disk_quota &&
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
-          max_disk_per_sandbox == o.max_disk_per_sandbox
+          max_disk_per_sandbox == o.max_disk_per_sandbox &&
+          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox
     end
 
     # @see the `==` method
@@ -257,7 +269,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox].hash
+      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
@@ -25,6 +25,12 @@ module DaytonaApiClient
 
     attr_accessor :total_disk_quota
 
+    attr_accessor :max_cpu_per_sandbox
+
+    attr_accessor :max_memory_per_sandbox
+
+    attr_accessor :max_disk_per_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -32,7 +38,10 @@ module DaytonaApiClient
         :'region_id' => :'regionId',
         :'total_cpu_quota' => :'totalCpuQuota',
         :'total_memory_quota' => :'totalMemoryQuota',
-        :'total_disk_quota' => :'totalDiskQuota'
+        :'total_disk_quota' => :'totalDiskQuota',
+        :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
+        :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
+        :'max_disk_per_sandbox' => :'maxDiskPerSandbox'
       }
     end
 
@@ -53,13 +62,19 @@ module DaytonaApiClient
         :'region_id' => :'String',
         :'total_cpu_quota' => :'Float',
         :'total_memory_quota' => :'Float',
-        :'total_disk_quota' => :'Float'
+        :'total_disk_quota' => :'Float',
+        :'max_cpu_per_sandbox' => :'Float',
+        :'max_memory_per_sandbox' => :'Float',
+        :'max_disk_per_sandbox' => :'Float'
       }
     end
 
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
+        :'max_cpu_per_sandbox',
+        :'max_memory_per_sandbox',
+        :'max_disk_per_sandbox'
       ])
     end
 
@@ -107,6 +122,24 @@ module DaytonaApiClient
         self.total_disk_quota = attributes[:'total_disk_quota']
       else
         self.total_disk_quota = nil
+      end
+
+      if attributes.key?(:'max_cpu_per_sandbox')
+        self.max_cpu_per_sandbox = attributes[:'max_cpu_per_sandbox']
+      else
+        self.max_cpu_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_memory_per_sandbox')
+        self.max_memory_per_sandbox = attributes[:'max_memory_per_sandbox']
+      else
+        self.max_memory_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_disk_per_sandbox')
+        self.max_disk_per_sandbox = attributes[:'max_disk_per_sandbox']
+      else
+        self.max_disk_per_sandbox = nil
       end
     end
 
@@ -209,7 +242,10 @@ module DaytonaApiClient
           region_id == o.region_id &&
           total_cpu_quota == o.total_cpu_quota &&
           total_memory_quota == o.total_memory_quota &&
-          total_disk_quota == o.total_disk_quota
+          total_disk_quota == o.total_disk_quota &&
+          max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
+          max_memory_per_sandbox == o.max_memory_per_sandbox &&
+          max_disk_per_sandbox == o.max_disk_per_sandbox
     end
 
     # @see the `==` method
@@ -221,7 +257,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota].hash
+      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
@@ -27,6 +27,8 @@ module DaytonaApiClient
 
     attr_accessor :max_disk_per_sandbox
 
+    attr_accessor :max_disk_per_non_ephemeral_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -35,7 +37,8 @@ module DaytonaApiClient
         :'total_disk_quota' => :'totalDiskQuota',
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
-        :'max_disk_per_sandbox' => :'maxDiskPerSandbox'
+        :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
+        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox'
       }
     end
 
@@ -57,7 +60,8 @@ module DaytonaApiClient
         :'total_disk_quota' => :'Float',
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
-        :'max_disk_per_sandbox' => :'Float'
+        :'max_disk_per_sandbox' => :'Float',
+        :'max_disk_per_non_ephemeral_sandbox' => :'Float'
       }
     end
 
@@ -69,7 +73,8 @@ module DaytonaApiClient
         :'total_disk_quota',
         :'max_cpu_per_sandbox',
         :'max_memory_per_sandbox',
-        :'max_disk_per_sandbox'
+        :'max_disk_per_sandbox',
+        :'max_disk_per_non_ephemeral_sandbox'
       ])
     end
 
@@ -124,6 +129,12 @@ module DaytonaApiClient
       else
         self.max_disk_per_sandbox = nil
       end
+
+      if attributes.key?(:'max_disk_per_non_ephemeral_sandbox')
+        self.max_disk_per_non_ephemeral_sandbox = attributes[:'max_disk_per_non_ephemeral_sandbox']
+      else
+        self.max_disk_per_non_ephemeral_sandbox = nil
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -151,7 +162,8 @@ module DaytonaApiClient
           total_disk_quota == o.total_disk_quota &&
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
-          max_disk_per_sandbox == o.max_disk_per_sandbox
+          max_disk_per_sandbox == o.max_disk_per_sandbox &&
+          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox
     end
 
     # @see the `==` method
@@ -163,7 +175,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox].hash
+      [total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
@@ -21,12 +21,21 @@ module DaytonaApiClient
 
     attr_accessor :total_disk_quota
 
+    attr_accessor :max_cpu_per_sandbox
+
+    attr_accessor :max_memory_per_sandbox
+
+    attr_accessor :max_disk_per_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'total_cpu_quota' => :'totalCpuQuota',
         :'total_memory_quota' => :'totalMemoryQuota',
-        :'total_disk_quota' => :'totalDiskQuota'
+        :'total_disk_quota' => :'totalDiskQuota',
+        :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
+        :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
+        :'max_disk_per_sandbox' => :'maxDiskPerSandbox'
       }
     end
 
@@ -45,7 +54,10 @@ module DaytonaApiClient
       {
         :'total_cpu_quota' => :'Float',
         :'total_memory_quota' => :'Float',
-        :'total_disk_quota' => :'Float'
+        :'total_disk_quota' => :'Float',
+        :'max_cpu_per_sandbox' => :'Float',
+        :'max_memory_per_sandbox' => :'Float',
+        :'max_disk_per_sandbox' => :'Float'
       }
     end
 
@@ -54,7 +66,10 @@ module DaytonaApiClient
       Set.new([
         :'total_cpu_quota',
         :'total_memory_quota',
-        :'total_disk_quota'
+        :'total_disk_quota',
+        :'max_cpu_per_sandbox',
+        :'max_memory_per_sandbox',
+        :'max_disk_per_sandbox'
       ])
     end
 
@@ -91,6 +106,24 @@ module DaytonaApiClient
       else
         self.total_disk_quota = nil
       end
+
+      if attributes.key?(:'max_cpu_per_sandbox')
+        self.max_cpu_per_sandbox = attributes[:'max_cpu_per_sandbox']
+      else
+        self.max_cpu_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_memory_per_sandbox')
+        self.max_memory_per_sandbox = attributes[:'max_memory_per_sandbox']
+      else
+        self.max_memory_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_disk_per_sandbox')
+        self.max_disk_per_sandbox = attributes[:'max_disk_per_sandbox']
+      else
+        self.max_disk_per_sandbox = nil
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -115,7 +148,10 @@ module DaytonaApiClient
       self.class == o.class &&
           total_cpu_quota == o.total_cpu_quota &&
           total_memory_quota == o.total_memory_quota &&
-          total_disk_quota == o.total_disk_quota
+          total_disk_quota == o.total_disk_quota &&
+          max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
+          max_memory_per_sandbox == o.max_memory_per_sandbox &&
+          max_disk_per_sandbox == o.max_disk_per_sandbox
     end
 
     # @see the `==` method
@@ -127,7 +163,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [total_cpu_quota, total_memory_quota, total_disk_quota].hash
+      [total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
@@ -114,26 +114,18 @@ module DaytonaApiClient
 
       if attributes.key?(:'max_cpu_per_sandbox')
         self.max_cpu_per_sandbox = attributes[:'max_cpu_per_sandbox']
-      else
-        self.max_cpu_per_sandbox = nil
       end
 
       if attributes.key?(:'max_memory_per_sandbox')
         self.max_memory_per_sandbox = attributes[:'max_memory_per_sandbox']
-      else
-        self.max_memory_per_sandbox = nil
       end
 
       if attributes.key?(:'max_disk_per_sandbox')
         self.max_disk_per_sandbox = attributes[:'max_disk_per_sandbox']
-      else
-        self.max_disk_per_sandbox = nil
       end
 
       if attributes.key?(:'max_disk_per_non_ephemeral_sandbox')
         self.max_disk_per_non_ephemeral_sandbox = attributes[:'max_disk_per_non_ephemeral_sandbox']
-      else
-        self.max_disk_per_non_ephemeral_sandbox = nil
       end
     end
 

--- a/libs/api-client/src/models/region-quota.ts
+++ b/libs/api-client/src/models/region-quota.ts
@@ -68,5 +68,11 @@ export interface RegionQuota {
      * @memberof RegionQuota
      */
     'maxDiskPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionQuota
+     */
+    'maxDiskPerNonEphemeralSandbox': number | null;
 }
 

--- a/libs/api-client/src/models/region-quota.ts
+++ b/libs/api-client/src/models/region-quota.ts
@@ -50,5 +50,23 @@ export interface RegionQuota {
      * @memberof RegionQuota
      */
     'totalDiskQuota': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionQuota
+     */
+    'maxCpuPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionQuota
+     */
+    'maxMemoryPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionQuota
+     */
+    'maxDiskPerSandbox': number | null;
 }
 

--- a/libs/api-client/src/models/update-organization-region-quota.ts
+++ b/libs/api-client/src/models/update-organization-region-quota.ts
@@ -56,5 +56,11 @@ export interface UpdateOrganizationRegionQuota {
      * @memberof UpdateOrganizationRegionQuota
      */
     'maxDiskPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof UpdateOrganizationRegionQuota
+     */
+    'maxDiskPerNonEphemeralSandbox': number | null;
 }
 

--- a/libs/api-client/src/models/update-organization-region-quota.ts
+++ b/libs/api-client/src/models/update-organization-region-quota.ts
@@ -38,5 +38,23 @@ export interface UpdateOrganizationRegionQuota {
      * @memberof UpdateOrganizationRegionQuota
      */
     'totalDiskQuota': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof UpdateOrganizationRegionQuota
+     */
+    'maxCpuPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof UpdateOrganizationRegionQuota
+     */
+    'maxMemoryPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof UpdateOrganizationRegionQuota
+     */
+    'maxDiskPerSandbox': number | null;
 }
 

--- a/libs/api-client/src/models/update-organization-region-quota.ts
+++ b/libs/api-client/src/models/update-organization-region-quota.ts
@@ -43,24 +43,24 @@ export interface UpdateOrganizationRegionQuota {
      * @type {number}
      * @memberof UpdateOrganizationRegionQuota
      */
-    'maxCpuPerSandbox': number | null;
+    'maxCpuPerSandbox'?: number | null;
     /**
      * 
      * @type {number}
      * @memberof UpdateOrganizationRegionQuota
      */
-    'maxMemoryPerSandbox': number | null;
+    'maxMemoryPerSandbox'?: number | null;
     /**
      * 
      * @type {number}
      * @memberof UpdateOrganizationRegionQuota
      */
-    'maxDiskPerSandbox': number | null;
+    'maxDiskPerSandbox'?: number | null;
     /**
      * 
      * @type {number}
      * @memberof UpdateOrganizationRegionQuota
      */
-    'maxDiskPerNonEphemeralSandbox': number | null;
+    'maxDiskPerNonEphemeralSandbox'?: number | null;
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-sandbox CPU, memory, and disk limits at the region quota level, plus a max disk for non‑ephemeral sandboxes. Enforced on sandbox create/resize/restore and snapshot create/build/activate when region quotas are on; ephemerals auto‑destroy on stop and can’t be archived or backed up.

- **New Features**
  - DB: added nullable `max_cpu_per_sandbox`, `max_memory_per_sandbox`, `max_disk_per_sandbox`, and `max_disk_per_non_ephemeral_sandbox` to `region_quota`; DTO/entity and `OrganizationService` persist the new fields.
  - Enforcement: `getEffectivePerSandboxLimits` applies region overrides; `SandboxService` validates per‑sandbox limits and non‑ephemeral disk (0 disallows non‑ephemeral; null falls back to per‑sandbox disk), fetches region quota only when `region.enforceQuotas`, and enforces these checks during resize. `SnapshotService` resolves the effective region and enforces per‑sandbox limits on create/build/activate. Introduced `isEphemeral` and used for stop/backup/archive behavior.
  - Observability and API/SDKs: metrics emit new per‑sandbox fields (including nulls via `OrgMetricsExporter` and `MetricsInterceptor`); OpenAPI and clients (Go, Java, Python, Python‑async, Ruby, TypeScript) include `maxCpuPerSandbox`, `maxMemoryPerSandbox`, `maxDiskPerSandbox`, and `maxDiskPerNonEphemeralSandbox`.

- **Migration**
  - Run the pre-deploy migration `1776247555874-migration.ts`.

<sup>Written for commit fd45dc36f723244c657ca444e4c5cbf1c292bbd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

