### PR TITLE
feat(sdk): add experimental fork and createSnapshot methods to all SDKs

### DIFF
--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -224,6 +224,10 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(s \*Sandbox\) Archive\(ctx context.Context\) error](<#Sandbox.Archive>)
   - [func \(s \*Sandbox\) Delete\(ctx context.Context\) error](<#Sandbox.Delete>)
   - [func \(s \*Sandbox\) DeleteWithTimeout\(ctx context.Context, timeout time.Duration\) error](<#Sandbox.DeleteWithTimeout>)
+  - [func \(s \*Sandbox\) ExperimentalCreateSnapshot\(ctx context.Context, name string\) error](<#Sandbox.ExperimentalCreateSnapshot>)
+  - [func \(s \*Sandbox\) ExperimentalCreateSnapshotWithTimeout\(ctx context.Context, name string, timeout time.Duration\) error](<#Sandbox.ExperimentalCreateSnapshotWithTimeout>)
+  - [func \(s \*Sandbox\) ExperimentalFork\(ctx context.Context, name \*string\) \(\*Sandbox, error\)](<#Sandbox.ExperimentalFork>)
+  - [func \(s \*Sandbox\) ExperimentalForkWithTimeout\(ctx context.Context, name \*string, timeout time.Duration\) \(\*Sandbox, error\)](<#Sandbox.ExperimentalForkWithTimeout>)
   - [func \(s \*Sandbox\) ExpireSignedPreviewLink\(ctx context.Context, port int, token string\) error](<#Sandbox.ExpireSignedPreviewLink>)
   - [func \(s \*Sandbox\) GetPreviewLink\(ctx context.Context, port int\) \(\*types.PreviewLink, error\)](<#Sandbox.GetPreviewLink>)
   - [func \(s \*Sandbox\) GetSignedPreviewLink\(ctx context.Context, port int, expiresInSeconds int\) \(\*types.SignedPreviewLink, error\)](<#Sandbox.GetSignedPreviewLink>)
@@ -3786,6 +3790,83 @@ Example:
 
 ```
 err := sandbox.DeleteWithTimeout(ctx, 2*time.Minute)
+```
+
+<a name="Sandbox.ExperimentalCreateSnapshot"></a>
+### func \(\*Sandbox\) ExperimentalCreateSnapshot
+
+```go
+func (s *Sandbox) ExperimentalCreateSnapshot(ctx context.Context, name string) error
+```
+
+ExperimentalCreateSnapshot creates a snapshot from the current state of the sandbox with a default timeout of 60 seconds.
+
+This captures the sandbox's filesystem into a reusable snapshot that can be used to create new sandboxes. The sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+
+Example:
+
+```
+err := sandbox.ExperimentalCreateSnapshot(ctx, "my-snapshot")
+if err != nil {
+    return err
+}
+```
+
+<a name="Sandbox.ExperimentalCreateSnapshotWithTimeout"></a>
+### func \(\*Sandbox\) ExperimentalCreateSnapshotWithTimeout
+
+```go
+func (s *Sandbox) ExperimentalCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error
+```
+
+ExperimentalCreateSnapshotWithTimeout creates a snapshot from the current state of the sandbox with a custom timeout. 0 means no timeout.
+
+Example:
+
+```
+err := sandbox.ExperimentalCreateSnapshotWithTimeout(ctx, "my-snapshot", 2*time.Minute)
+```
+
+<a name="Sandbox.ExperimentalFork"></a>
+### func \(\*Sandbox\) ExperimentalFork
+
+```go
+func (s *Sandbox) ExperimentalFork(ctx context.Context, name *string) (*Sandbox, error)
+```
+
+ExperimentalFork forks the sandbox with a default timeout of 60 seconds, creating a new sandbox with an identical filesystem.
+
+The forked sandbox is a copy\-on\-write clone of the original. It starts with the same disk contents but operates independently from that point on. ExperimentalFork waits for the new sandbox to reach the "started" state before returning.
+
+Example:
+
+```
+forked, err := sandbox.ExperimentalFork(ctx, nil)
+if err != nil {
+    return err
+}
+fmt.Printf("Forked sandbox: %s\n", forked.ID)
+```
+
+<a name="Sandbox.ExperimentalForkWithTimeout"></a>
+### func \(\*Sandbox\) ExperimentalForkWithTimeout
+
+```go
+func (s *Sandbox) ExperimentalForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error)
+```
+
+ExperimentalForkWithTimeout forks the sandbox with a custom timeout, creating a new sandbox with an identical filesystem.
+
+The forked sandbox is a copy\-on\-write clone of the original. It starts with the same disk contents but operates independently from that point on. ExperimentalForkWithTimeout waits for the new sandbox to reach the "started" state before returning. 0 means no timeout.
+
+Example:
+
+```
+forked, err := sandbox.ExperimentalForkWithTimeout(ctx, nil, 2*time.Minute)
+if err != nil {
+    return err
+}
+fmt.Printf("Forked sandbox: %s\n", forked.ID)
 ```
 
 <a name="Sandbox.ExpireSignedPreviewLink"></a>

--- a/apps/docs/src/content/docs/en/java-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/sandbox.mdx
@@ -249,6 +249,76 @@ Refreshes local Sandbox fields from latest API state.
 
 - `DaytonaException` - if refresh fails
 
+#### experimentalFork()
+```java
+public Sandbox experimentalFork()
+```
+
+Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+Uses default timeout of 60 seconds.
+
+**Returns**:
+
+- `Sandbox` - the forked `Sandbox` in started state
+
+**Throws**:
+
+- `DaytonaException` - if the fork operation fails or times out
+
+#### experimentalFork()
+```java
+public Sandbox experimentalFork(String name, long timeoutSeconds)
+```
+
+Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+The forked Sandbox is a copy-on-write clone of the original.
+
+**Parameters**:
+
+- `name` _String_ - optional name for the forked Sandbox; `null` for auto-generated
+- `timeoutSeconds` _long_ - maximum seconds to wait for the forked Sandbox to start; `0` disables timeout
+
+**Returns**:
+
+- `Sandbox` - the forked `Sandbox` in started state
+
+**Throws**:
+
+- `DaytonaException` - if the fork operation fails or times out
+
+#### experimentalCreateSnapshot()
+```java
+public void experimentalCreateSnapshot(String name)
+```
+
+Creates a snapshot from the current state of this Sandbox.
+Uses default timeout of 60 seconds.
+
+**Parameters**:
+
+- `name` _String_ - name for the new snapshot
+
+**Throws**:
+
+- `DaytonaException` - if the snapshot operation fails
+
+#### experimentalCreateSnapshot()
+```java
+public void experimentalCreateSnapshot(String name, long timeoutSeconds)
+```
+
+Creates a snapshot from the current state of this Sandbox.
+The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+
+**Parameters**:
+
+- `name` _String_ - name for the new snapshot
+- `timeoutSeconds` _long_ - reserved timeout parameter for parity with other SDKs
+
+**Throws**:
+
+- `DaytonaException` - if the snapshot operation fails
+
 #### getId()
 ```java
 public String getId()

--- a/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
@@ -899,3 +899,42 @@ Treats destroyed as stopped to cover ephemeral sandboxes that are automatically 
 **Returns**:
 
 - `void`
+
+#### experimental_fork()
+
+```ruby
+def experimental_fork(name:, timeout:)
+
+```
+
+Forks the Sandbox, creating a new Sandbox with an identical filesystem.
+The forked Sandbox is a copy-on-write clone of the original. It starts
+with the same disk contents but operates independently from that point on.
+
+**Parameters**:
+
+- `name` _String, nil_ - Optional name for the forked Sandbox
+- `timeout` _Numeric_ - Maximum wait time in seconds (defaults to 60 s)
+
+**Returns**:
+
+- `Daytona:Sandbox` - The forked Sandbox
+
+#### experimental_create_snapshot()
+
+```ruby
+def experimental_create_snapshot(name:, timeout:)
+
+```
+
+Creates a snapshot from the current state of the Sandbox.
+The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+
+**Parameters**:
+
+- `name` _String_ - Name for the new snapshot
+- `timeout` _Numeric_ - Maximum wait time in seconds (defaults to 60 s)
+
+**Returns**:
+
+- `void`

--- a/libs/sdk-go/pkg/daytona/sandbox.go
+++ b/libs/sdk-go/pkg/daytona/sandbox.go
@@ -703,6 +703,182 @@ func (s *Sandbox) doSetAutoDeleteInterval(ctx context.Context, intervalMinutes *
 	return nil
 }
 
+// ExperimentalFork forks the sandbox with a default timeout of 60 seconds,
+// creating a new sandbox with an identical filesystem.
+//
+// The forked sandbox is a copy-on-write clone of the original. It starts
+// with the same disk contents but operates independently from that point on.
+// ExperimentalFork waits for the new sandbox to reach the "started" state before returning.
+//
+// Example:
+//
+//	forked, err := sandbox.ExperimentalFork(ctx, nil)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("Forked sandbox: %s\n", forked.ID)
+func (s *Sandbox) ExperimentalFork(ctx context.Context, name *string) (*Sandbox, error) {
+	return withInstrumentation(ctx, s.otel, "Sandbox", "ExperimentalFork", func(ctx context.Context) (*Sandbox, error) {
+		return s.ExperimentalForkWithTimeout(ctx, name, 60*time.Second)
+	})
+}
+
+// ExperimentalForkWithTimeout forks the sandbox with a custom timeout,
+// creating a new sandbox with an identical filesystem.
+//
+// The forked sandbox is a copy-on-write clone of the original. It starts
+// with the same disk contents but operates independently from that point on.
+// ExperimentalForkWithTimeout waits for the new sandbox to reach the "started" state before returning.
+// 0 means no timeout.
+//
+// Example:
+//
+//	forked, err := sandbox.ExperimentalForkWithTimeout(ctx, nil, 2*time.Minute)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("Forked sandbox: %s\n", forked.ID)
+func (s *Sandbox) ExperimentalForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error) {
+	return withInstrumentation(ctx, s.otel, "Sandbox", "ExperimentalForkWithTimeout", func(ctx context.Context) (*Sandbox, error) {
+		return s.doExperimentalForkWithTimeout(ctx, name, timeout)
+	})
+}
+
+func (s *Sandbox) doExperimentalForkWithTimeout(ctx context.Context, name *string, timeout time.Duration) (*Sandbox, error) {
+	if timeout < 0 {
+		return nil, errors.NewDaytonaError("Timeout must be a non-negative number", 0, nil)
+	}
+
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	forkReq := apiclient.NewForkSandbox()
+	if name != nil {
+		forkReq.SetName(*name)
+	}
+
+	authCtx := s.client.getAuthContext(ctx)
+	sandboxResp, httpResp, err := s.client.apiClient.SandboxAPI.ForkSandbox(authCtx, s.ID).ForkSandbox(*forkReq).Execute()
+	if err != nil {
+		return nil, errors.ConvertAPIError(err, httpResp)
+	}
+
+	toolboxClient, err := s.client.createToolboxClient(sandboxResp.GetToolboxProxyUrl(), sandboxResp.GetId())
+	if err != nil {
+		return nil, err
+	}
+
+	autoArchiveInterval := 0
+	if sandboxResp.AutoArchiveInterval != nil {
+		autoArchiveInterval = int(*sandboxResp.AutoArchiveInterval)
+	}
+
+	autoDeleteInterval := 0
+	if sandboxResp.AutoDeleteInterval != nil {
+		autoDeleteInterval = int(*sandboxResp.AutoDeleteInterval)
+	}
+
+	forked := NewSandbox(s.client, toolboxClient, sandboxResp.GetId(), sandboxResp.GetName(), sandboxResp.GetState(), sandboxResp.GetTarget(), autoArchiveInterval, autoDeleteInterval, sandboxResp.GetNetworkBlockAll(), sandboxResp.NetworkAllowList)
+
+	if err := forked.WaitForStart(ctx, timeout); err != nil {
+		return nil, err
+	}
+
+	return forked, nil
+}
+
+// ExperimentalCreateSnapshot creates a snapshot from the current state of the sandbox
+// with a default timeout of 60 seconds.
+//
+// This captures the sandbox's filesystem into a reusable snapshot that can be
+// used to create new sandboxes. The sandbox will temporarily enter a
+// 'snapshotting' state and return to its previous state when complete.
+//
+// Example:
+//
+//	err := sandbox.ExperimentalCreateSnapshot(ctx, "my-snapshot")
+//	if err != nil {
+//	    return err
+//	}
+func (s *Sandbox) ExperimentalCreateSnapshot(ctx context.Context, name string) error {
+	return withInstrumentationVoid(ctx, s.otel, "Sandbox", "ExperimentalCreateSnapshot", func(ctx context.Context) error {
+		return s.ExperimentalCreateSnapshotWithTimeout(ctx, name, 60*time.Second)
+	})
+}
+
+// ExperimentalCreateSnapshotWithTimeout creates a snapshot from the current state of the sandbox
+// with a custom timeout. 0 means no timeout.
+//
+// Example:
+//
+//	err := sandbox.ExperimentalCreateSnapshotWithTimeout(ctx, "my-snapshot", 2*time.Minute)
+func (s *Sandbox) ExperimentalCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error {
+	return withInstrumentationVoid(ctx, s.otel, "Sandbox", "ExperimentalCreateSnapshotWithTimeout", func(ctx context.Context) error {
+		return s.doExperimentalCreateSnapshotWithTimeout(ctx, name, timeout)
+	})
+}
+
+func (s *Sandbox) doExperimentalCreateSnapshotWithTimeout(ctx context.Context, name string, timeout time.Duration) error {
+	if timeout < 0 {
+		return errors.NewDaytonaError("Timeout must be a non-negative number", 0, nil)
+	}
+
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	req := apiclient.NewCreateSandboxSnapshot(name)
+
+	authCtx := s.client.getAuthContext(ctx)
+	_, httpResp, err := s.client.apiClient.SandboxAPI.CreateSandboxSnapshot(authCtx, s.ID).CreateSandboxSnapshot(*req).Execute()
+	if err != nil {
+		return errors.ConvertAPIError(err, httpResp)
+	}
+
+	if err := s.RefreshData(ctx); err != nil {
+		return err
+	}
+
+	return s.waitForSnapshotComplete(ctx)
+}
+
+func (s *Sandbox) waitForSnapshotComplete(ctx context.Context) error {
+	checkInterval := 100 * time.Millisecond
+	startTime := time.Now()
+
+	for s.State == apiclient.SANDBOXSTATE_SNAPSHOTTING {
+		if err := s.RefreshData(ctx); err != nil {
+			return err
+		}
+
+		if s.State == apiclient.SANDBOXSTATE_ERROR || s.State == apiclient.SANDBOXSTATE_BUILD_FAILED {
+			return errors.NewDaytonaError(
+				fmt.Sprintf("Sandbox %s snapshot failed with state: %s", s.ID, s.State), 0, nil,
+			)
+		}
+
+		if s.State != apiclient.SANDBOXSTATE_SNAPSHOTTING {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.NewDaytonaError("Sandbox snapshot did not complete within the timeout period", 0, nil)
+		case <-time.After(checkInterval):
+		}
+
+		if time.Since(startTime) > 5*time.Second {
+			checkInterval = min(time.Duration(float64(checkInterval)*1.1), 1*time.Second)
+		}
+	}
+	return nil
+}
+
 // Resize resizes the sandbox resources with a default timeout of 60 seconds.
 //
 // Changes the CPU, memory, or disk allocation for the sandbox. Resizing a started

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java
@@ -4,6 +4,8 @@
 package io.daytona.sdk;
 
 import io.daytona.api.client.api.SandboxApi;
+import io.daytona.api.client.model.CreateSandboxSnapshot;
+import io.daytona.api.client.model.ForkSandbox;
 import io.daytona.api.client.model.SandboxLabels;
 import io.daytona.api.client.model.ToolboxProxyUrl;
 import io.daytona.sdk.exception.DaytonaException;
@@ -20,6 +22,7 @@ import java.util.Map;
  */
 public class Sandbox {
     private final SandboxApi sandboxApi;
+    private final DaytonaConfig config;
     private final io.daytona.toolbox.client.ApiClient toolboxApiClient;
     private final io.daytona.toolbox.client.api.InfoApi infoApi;
     private final String apiKey;
@@ -53,6 +56,7 @@ public class Sandbox {
 
     Sandbox(SandboxApi sandboxApi, DaytonaConfig config, io.daytona.api.client.model.Sandbox data) {
         this.sandboxApi = sandboxApi;
+        this.config = config;
         this.apiKey = config.getApiKey();
         updateFromModel(data);
 
@@ -354,6 +358,88 @@ public class Sandbox {
             output = output.substring(0, output.length() - 1);
         }
         return output;
+    }
+
+    /**
+     * Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+     * Uses default timeout of 60 seconds.
+     *
+     * @return the forked {@link Sandbox} in started state
+     * @throws DaytonaException if the fork operation fails or times out
+     */
+    public Sandbox experimentalFork() {
+        return experimentalFork(null, 60);
+    }
+
+    /**
+     * Forks this Sandbox, creating a new Sandbox with an identical filesystem.
+     * The forked Sandbox is a copy-on-write clone of the original.
+     *
+     * @param name optional name for the forked Sandbox; {@code null} for auto-generated
+     * @param timeoutSeconds maximum seconds to wait for the forked Sandbox to start; {@code 0} disables timeout
+     * @return the forked {@link Sandbox} in started state
+     * @throws DaytonaException if the fork operation fails or times out
+     */
+    public Sandbox experimentalFork(String name, long timeoutSeconds) {
+        ForkSandbox forkReq = new ForkSandbox();
+        if (name != null) {
+            forkReq.setName(name);
+        }
+        io.daytona.api.client.model.Sandbox response = ExceptionMapper.callMain(
+            () -> sandboxApi.forkSandbox(id, forkReq, null)
+        );
+        Sandbox forked = new Sandbox(sandboxApi, config, response);
+        forked.waitUntilStarted(timeoutSeconds);
+        return forked;
+    }
+
+    /**
+     * Creates a snapshot from the current state of this Sandbox.
+     * Uses default timeout of 60 seconds.
+     *
+     * @param name name for the new snapshot
+     * @throws DaytonaException if the snapshot operation fails
+     */
+    public void experimentalCreateSnapshot(String name) {
+        experimentalCreateSnapshot(name, 60);
+    }
+
+    /**
+     * Creates a snapshot from the current state of this Sandbox.
+     * The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+     *
+     * @param name name for the new snapshot
+     * @param timeoutSeconds reserved timeout parameter for parity with other SDKs
+     * @throws DaytonaException if the snapshot operation fails
+     */
+    public void experimentalCreateSnapshot(String name, long timeoutSeconds) {
+        CreateSandboxSnapshot req = new CreateSandboxSnapshot();
+        req.setName(name);
+        ExceptionMapper.callMain(() -> sandboxApi.createSandboxSnapshot(id, req, null));
+        refreshData();
+        waitForSnapshotComplete(timeoutSeconds);
+    }
+
+    private void waitForSnapshotComplete(long timeoutSeconds) {
+        long startedAt = System.currentTimeMillis();
+        while ("snapshotting".equalsIgnoreCase(state)) {
+            refreshData();
+            if ("error".equalsIgnoreCase(state) || "build_failed".equalsIgnoreCase(state)) {
+                throw new DaytonaException("Sandbox snapshot failed with state: " + state);
+            }
+            if (!"snapshotting".equalsIgnoreCase(state)) {
+                return;
+            }
+            if (timeoutSeconds > 0 && (System.currentTimeMillis() - startedAt) > timeoutSeconds * 1000L) {
+                throw new DaytonaException("Sandbox snapshot did not complete before timeout");
+            }
+            try {
+                Thread.sleep(250);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new DaytonaException("Interrupted while waiting for snapshot complete", e);
+            }
+        }
     }
 
     /**

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -7,7 +7,7 @@ import asyncio
 from deprecated import deprecated
 from pydantic import ConfigDict, PrivateAttr
 
-from daytona_api_client_async import BuildInfo
+from daytona_api_client_async import BuildInfo, CreateSandboxSnapshot, ForkSandbox
 from daytona_api_client_async import PaginatedSandboxes as PaginatedSandboxesDto
 from daytona_api_client_async import PortPreviewUrl, ResizeSandbox
 from daytona_api_client_async import Sandbox as SandboxDto
@@ -683,6 +683,94 @@ class AsyncSandbox(SandboxDto):
             ```
         """
         await self._sandbox_api.update_last_activity(self.id)
+
+    @intercept_errors(message_prefix="Failed to fork sandbox: ")
+    @with_timeout()
+    @with_instrumentation()
+    async def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "AsyncSandbox":
+        """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
+
+        The forked Sandbox is a copy-on-write clone of the original. It starts
+        with the same disk contents but operates independently from that point on.
+
+        Args:
+            name (str | None): Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+            timeout (float | None): Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+
+        Returns:
+            AsyncSandbox: The forked Sandbox.
+
+        Raises:
+            DaytonaError: If the fork operation fails or times out.
+
+        Example:
+            ```python
+            sandbox = await daytona.get("my-sandbox")
+            forked = await sandbox._experimental_fork(name="my-fork")
+            print(f"Forked sandbox: {forked.id}")
+            ```
+        """
+        sandbox_dto = await self._sandbox_api.fork_sandbox(
+            self.id, ForkSandbox(name=name), _request_timeout=http_timeout(timeout)
+        )
+
+        forked = AsyncSandbox(
+            sandbox_dto,
+            self._toolbox_api._api_client,
+            self._sandbox_api,
+            self._code_toolbox,
+        )
+        await forked.wait_for_sandbox_start(timeout=0)
+        return forked
+
+    @intercept_errors(message_prefix="Failed to create snapshot: ")
+    @with_timeout()
+    @with_instrumentation()
+    async def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+        """Creates a snapshot from the current state of the Sandbox.
+
+        This captures the Sandbox's filesystem into a reusable snapshot that can be
+        used to create new Sandboxes. The Sandbox will temporarily enter a
+        'snapshotting' state and return to its previous state when complete.
+
+        Args:
+            name (str): Name for the new snapshot.
+            timeout (float | None): Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+
+        Raises:
+            DaytonaError: If the snapshot operation fails or times out.
+
+        Example:
+            ```python
+            sandbox = await daytona.get("my-sandbox")
+            await sandbox._experimental_create_snapshot("my-snapshot")
+            print("Snapshot created successfully")
+            ```
+        """
+        _ = await self._sandbox_api.create_sandbox_snapshot(
+            self.id, CreateSandboxSnapshot(name=name), _request_timeout=http_timeout(timeout)
+        )
+        await self.refresh_data()
+        await self.__wait_for_snapshot_complete()
+
+    async def __wait_for_snapshot_complete(self) -> None:
+        check_interval = 0.1
+        start_time = asyncio.get_event_loop().time()
+
+        while self.state == "snapshotting":
+            await self.refresh_data()
+
+            if self.state != "snapshotting":
+                return
+
+            if self.state in ["error", "build_failed"]:
+                raise DaytonaError(
+                    f"Sandbox {self.id} snapshot failed with state: {self.state}, error reason: {self.error_reason}"
+                )
+
+            await asyncio.sleep(check_interval)
+            if asyncio.get_event_loop().time() - start_time > 5:
+                check_interval = min(check_interval * 1.1, 1.0)
 
     def __process_sandbox_dto(self, sandbox_dto: SandboxDto) -> None:
         self.id: str = sandbox_dto.id

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -8,7 +8,7 @@ import time
 from deprecated import deprecated
 from pydantic import ConfigDict, PrivateAttr
 
-from daytona_api_client import BuildInfo
+from daytona_api_client import BuildInfo, CreateSandboxSnapshot, ForkSandbox
 from daytona_api_client import PaginatedSandboxes as PaginatedSandboxesDto
 from daytona_api_client import PortPreviewUrl, ResizeSandbox
 from daytona_api_client import Sandbox as SandboxDto
@@ -679,6 +679,94 @@ class Sandbox(SandboxDto):
             ```
         """
         self._sandbox_api.update_last_activity(self.id)
+
+    @intercept_errors(message_prefix="Failed to fork sandbox: ")
+    @with_timeout()
+    @with_instrumentation()
+    def _experimental_fork(self, name: str | None = None, timeout: float | None = 60) -> "Sandbox":
+        """Forks the Sandbox, creating a new Sandbox with an identical filesystem.
+
+        The forked Sandbox is a copy-on-write clone of the original. It starts
+        with the same disk contents but operates independently from that point on.
+
+        Args:
+            name (str | None): Optional name for the forked Sandbox. If not provided, a unique name will be generated.
+            timeout (float | None): Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+
+        Returns:
+            Sandbox: The forked Sandbox.
+
+        Raises:
+            DaytonaError: If the fork operation fails or times out.
+
+        Example:
+            ```python
+            sandbox = daytona.get("my-sandbox")
+            forked = sandbox._experimental_fork(name="my-fork")
+            print(f"Forked sandbox: {forked.id}")
+            ```
+        """
+        sandbox_dto = self._sandbox_api.fork_sandbox(
+            self.id, ForkSandbox(name=name), _request_timeout=http_timeout(timeout)
+        )
+
+        forked = Sandbox(
+            sandbox_dto,
+            self._toolbox_api._api_client,
+            self._sandbox_api,
+            self._code_toolbox,
+        )
+        forked.wait_for_sandbox_start(timeout=0)
+        return forked
+
+    @intercept_errors(message_prefix="Failed to create snapshot: ")
+    @with_timeout()
+    @with_instrumentation()
+    def _experimental_create_snapshot(self, name: str, timeout: float | None = 60) -> None:
+        """Creates a snapshot from the current state of the Sandbox.
+
+        This captures the Sandbox's filesystem into a reusable snapshot that can be
+        used to create new Sandboxes. The Sandbox will temporarily enter a
+        'snapshotting' state and return to its previous state when complete.
+
+        Args:
+            name (str): Name for the new snapshot.
+            timeout (float | None): Maximum time to wait in seconds. 0 means no timeout. Default is 60 seconds.
+
+        Raises:
+            DaytonaError: If the snapshot operation fails or times out.
+
+        Example:
+            ```python
+            sandbox = daytona.get("my-sandbox")
+            sandbox._experimental_create_snapshot("my-snapshot")
+            print("Snapshot created successfully")
+            ```
+        """
+        _ = self._sandbox_api.create_sandbox_snapshot(
+            self.id, CreateSandboxSnapshot(name=name), _request_timeout=http_timeout(timeout)
+        )
+        self.refresh_data()
+        self.__wait_for_snapshot_complete()
+
+    def __wait_for_snapshot_complete(self) -> None:
+        check_interval = 0.1
+        start_time = time.monotonic()
+
+        while self.state == "snapshotting":
+            self.refresh_data()
+
+            if self.state != "snapshotting":
+                return
+
+            if self.state in ["error", "build_failed"]:
+                raise DaytonaError(
+                    f"Sandbox {self.id} snapshot failed with state: {self.state}, error reason: {self.error_reason}"
+                )
+
+            time.sleep(check_interval)
+            if time.monotonic() - start_time > 5:
+                check_interval = min(check_interval * 1.1, 1.0)
 
     def __process_sandbox_dto(self, sandbox_dto: SandboxDto) -> None:
         self.id: str = sandbox_dto.id

--- a/libs/sdk-ruby/lib/daytona/sandbox.rb
+++ b/libs/sdk-ruby/lib/daytona/sandbox.rb
@@ -465,12 +465,59 @@ module Daytona
                                                                  DaytonaApiClient::SandboxState::DESTROYED])
     end
 
+    # Forks the Sandbox, creating a new Sandbox with an identical filesystem.
+    # The forked Sandbox is a copy-on-write clone of the original. It starts
+    # with the same disk contents but operates independently from that point on.
+    #
+    # @param name [String, nil] Optional name for the forked Sandbox
+    # @param timeout [Numeric] Maximum wait time in seconds (defaults to 60 s)
+    # @return [Daytona::Sandbox] The forked Sandbox
+    def experimental_fork(name: nil, timeout: DEFAULT_TIMEOUT) # rubocop:disable Metrics/MethodLength
+      forked_dto = nil
+      with_timeout(
+        timeout:,
+        message: "Sandbox #{id} fork failed to become ready within the #{timeout} seconds timeout period",
+        setup: proc {
+          forked_dto = sandbox_api.fork_sandbox(id, DaytonaApiClient::ForkSandbox.new(name:))
+        }
+      ) do
+        forked = Sandbox.new(
+          sandbox_dto: forked_dto,
+          config:,
+          sandbox_api:,
+          code_toolbox:,
+          otel_state:
+        )
+        forked.send(:wait_for_states, operation: OPERATION_START,
+                                      target_states: [DaytonaApiClient::SandboxState::STARTED])
+        return forked
+      end
+    end
+
+    # Creates a snapshot from the current state of the Sandbox.
+    # The Sandbox will temporarily enter a 'snapshotting' state and return to its previous state when complete.
+    #
+    # @param name [String] Name for the new snapshot
+    # @param timeout [Numeric] Maximum wait time in seconds (defaults to 60 s)
+    # @return [void]
+    def experimental_create_snapshot(name:, timeout: DEFAULT_TIMEOUT)
+      with_timeout(
+        timeout:,
+        message: "Sandbox #{id} snapshot failed within the #{timeout} seconds timeout period",
+        setup: proc {
+          sandbox_api.create_sandbox_snapshot(id, DaytonaApiClient::CreateSandboxSnapshot.new(name:))
+          refresh
+        }
+      ) { wait_for_snapshot_complete }
+    end
+
     instrument :archive, :auto_archive_interval=, :auto_delete_interval=, :auto_stop_interval=,
                :create_ssh_access, :delete, :get_user_home_dir, :get_work_dir, :labels=,
                :preview_url, :create_signed_preview_url, :expire_signed_preview_url,
                :refresh, :refresh_activity, :revoke_ssh_access, :start, :recover, :stop,
                :create_lsp_server, :validate_ssh_access, :wait_for_sandbox_start,
                :wait_for_sandbox_stop, :resize, :wait_for_resize_complete,
+               :experimental_fork, :experimental_create_snapshot,
                component: 'Sandbox'
 
     private
@@ -593,5 +640,25 @@ module Daytona
 
     OPERATION_RESIZE = :resize
     private_constant :OPERATION_RESIZE
+
+    def wait_for_snapshot_complete
+      interval = INITIAL_POLL_INTERVAL
+      start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      while state == DaytonaApiClient::SandboxState::SNAPSHOTTING
+        refresh
+
+        if [DaytonaApiClient::SandboxState::ERROR, DaytonaApiClient::SandboxState::BUILD_FAILED].include?(state)
+          raise Sdk::Error,
+                "Sandbox #{id} snapshot failed with state: #{state}, error reason: #{error_reason}"
+        end
+
+        break if state != DaytonaApiClient::SandboxState::SNAPSHOTTING
+
+        sleep(interval)
+        if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start_time > 5
+          interval = [interval * BACKOFF_MULTIPLIER, MAX_POLL_INTERVAL].min
+        end
+      end
+    end
   end
 end

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -358,6 +358,7 @@ export class Sandbox implements SandboxDto {
       throw new DaytonaValidationError('Timeout must be a non-negative number')
     }
 
+    const startTime = Date.now()
     const response = await this.sandboxApi.forkSandbox(this.id, { name: params?.name }, undefined, {
       timeout: timeout * 1000,
     })
@@ -366,13 +367,18 @@ export class Sandbox implements SandboxDto {
     const language = sandboxDto.labels && sandboxDto.labels['code-toolbox-language']
     const codeToolbox = Daytona.getCodeToolbox(language as CodeLanguage)
 
-    return new Sandbox(
+    const forkedSandbox = new Sandbox(
       sandboxDto,
       structuredClone(this.clientConfig),
       Daytona.createAxiosInstance(),
       this.sandboxApi,
       codeToolbox,
     )
+
+    const timeElapsed = Date.now() - startTime
+    await forkedSandbox.waitUntilStarted(timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout)
+
+    return forkedSandbox
   }
 
   /**
@@ -400,12 +406,46 @@ export class Sandbox implements SandboxDto {
       throw new DaytonaValidationError('Timeout must be a non-negative number')
     }
 
+    const startTime = Date.now()
     const req: CreateSandboxSnapshot = { name }
     await this.sandboxApi.createSandboxSnapshot(this.id, req, undefined, {
       timeout: timeout * 1000,
     })
 
     await this.refreshData()
+
+    const timeElapsed = Date.now() - startTime
+    const remainingTimeout = timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout
+    await this.waitForSnapshotComplete(remainingTimeout)
+  }
+
+  private async waitForSnapshotComplete(timeout: number) {
+    let checkInterval = 100
+    const startTime = Date.now()
+
+    while (this.state === SandboxState.SNAPSHOTTING) {
+      await this.refreshData()
+
+      // @ts-expect-error this.refreshData() can modify this.state so this check is fine
+      if (this.state === SandboxState.ERROR || this.state === SandboxState.BUILD_FAILED) {
+        throw new DaytonaError(
+          `Sandbox ${this.id} snapshot failed with state: ${this.state}, error reason: ${this.errorReason}`,
+        )
+      }
+
+      if (this.state !== SandboxState.SNAPSHOTTING) {
+        return
+      }
+
+      if (timeout !== 0 && Date.now() - startTime > timeout * 1000) {
+        throw new DaytonaTimeoutError('Sandbox snapshot did not complete within the timeout period')
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, checkInterval))
+      if (Date.now() - startTime > 5000) {
+        checkInterval = Math.min(checkInterval * 1.1, 1000)
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This pull request introduces new experimental snapshot and fork functionality to the Sandbox APIs across the Go, Java, Python, and Ruby SDKs, and updates their documentation accordingly. These new methods allow users to programmatically create snapshots of sandboxes and fork sandboxes with copy-on-write semantics, both with optional timeout controls. The documentation for each SDK has been updated to describe these features and provide usage examples.

**New Experimental Sandbox Features**

*Go SDK:*
- Added `ExperimentalFork` and `ExperimentalForkWithTimeout` methods to the `Sandbox` type, enabling copy-on-write sandbox forking with optional timeout. (`libs/sdk-go/pkg/daytona/sandbox.go`, [libs/sdk-go/pkg/daytona/sandbox.goR706-R881](diffhunk://#diff-5cf4dd9faff10b798701bde2f779f8302185b7dc820d1838fed1324ff785af20R706-R881))
- Added `ExperimentalCreateSnapshot` and `ExperimentalCreateSnapshotWithTimeout` methods to the `Sandbox` type, allowing snapshot creation from the current sandbox state with optional timeout. (`libs/sdk-go/pkg/daytona/sandbox.go`, [libs/sdk-go/pkg/daytona/sandbox.goR706-R881](diffhunk://#diff-5cf4dd9faff10b798701bde2f779f8302185b7dc820d1838fed1324ff785af20R706-R881))

*Java SDK:*
- Added `experimentalFork()` and `experimentalFork(String name, long timeoutSeconds)` methods to the `Sandbox` class for forking sandboxes. (`libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java`, [libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.javaR363-R444](diffhunk://#diff-09a2a882afc6907c82fd0147d3ba171e88440d106103994138d93db416300185R363-R444))
- Added `experimentalCreateSnapshot(String name)` and `experimentalCreateSnapshot(String name, long timeoutSeconds)` methods for snapshot creation. (`libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java`, [libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.javaR363-R444](diffhunk://#diff-09a2a882afc6907c82fd0147d3ba171e88440d106103994138d93db416300185R363-R444))
- Updated constructor and imports to support new functionality. (`libs/sdk-java/src/main/java/io/daytona/sdk/Sandbox.java`, [[1]](diffhunk://#diff-09a2a882afc6907c82fd0147d3ba171e88440d106103994138d93db416300185R7-R8) [[2]](diffhunk://#diff-09a2a882afc6907c82fd0147d3ba171e88440d106103994138d93db416300185R25) [[3]](diffhunk://#diff-09a2a882afc6907c82fd0147d3ba171e88440d106103994138d93db416300185R59)

*Python SDK (Async):*
- Added `_experimental_fork` and `_experimental_create_snapshot` async methods to `AsyncSandbox` for forking and snapshotting, with timeout support and error handling. (`libs/sdk-python/src/daytona/_async/sandbox.py`, [libs/sdk-python/src/daytona/_async/sandbox.pyR687-R774](diffhunk://#diff-787267d0ecd792f045780a19fd4643e56f3875bc2e37d952e41ccd63175c600cR687-R774))
- Updated imports for new API models. (`libs/sdk-python/src/daytona/_async/sandbox.py`, [libs/sdk-python/src/daytona/_async/sandbox.pyL10-R10](diffhunk://#diff-787267d0ecd792f045780a19fd4643e56f3875bc2e37d952e41ccd63175c600cL10-R10))

*Ruby SDK:*
- Documented new `experimental_fork` and `experimental_create_snapshot` methods for the Ruby SDK, supporting forking and snapshotting with timeout parameters. (`apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx`, [apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdxR902-R940](diffhunk://#diff-5811b99ccd661af76805032ee7759d0bfe108cb85415bd5911a30cb657778a01R902-R940))

**Documentation Updates**

- Expanded Go SDK documentation to describe and provide examples for the new experimental fork and snapshot methods. (`apps/docs/src/content/docs/en/go-sdk/daytona.mdx`, [[1]](diffhunk://#diff-62aa40607d5bec5d0a9997b4451ff8a745b71b72be61fe0f79fc3972e4963180R227-R230) [[2]](diffhunk://#diff-62aa40607d5bec5d0a9997b4451ff8a745b71b72be61fe0f79fc3972e4963180R3795-R3871)
- Added Java SDK documentation for the new experimental methods, including usage, parameters, return values, and exceptions. (`apps/docs/src/content/docs/en/java-sdk/sandbox.mdx`, [apps/docs/src/content/docs/en/java-sdk/sandbox.mdxR252-R321](diffhunk://#diff-94ffff6149905f90f018d2cfa524ed85ba462711a64392044aaf882454af7429R252-R321))

These changes provide advanced users with new ways to manage sandbox state and lifecycle, and ensure all SDKs and their documentation are consistent and up to date with these experimental capabilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds experimental fork and snapshot APIs to all SDKs so users can clone sandboxes (copy-on-write) and create snapshots programmatically. Fork waits until the new sandbox starts; snapshot waits until completion, both with a default 60s timeout and optional custom timeout.

- **New Features**
  - Go: `Sandbox.ExperimentalFork`, `ExperimentalForkWithTimeout`, `ExperimentalCreateSnapshot`, `ExperimentalCreateSnapshotWithTimeout` with start/snapshot wait and timeout validation.
  - Java: `Sandbox.experimentalFork()`, `experimentalFork(String,long)`, `experimentalCreateSnapshot(String)`, `experimentalCreateSnapshot(String,long)`; waits for start/snapshot, 0 disables timeout where applicable.
  - Python (`_async` and `_sync`): `_experimental_fork(name?, timeout?)`, `_experimental_create_snapshot(name, timeout?)` with error handling and wait loops.
  - Ruby: `experimental_fork(name: nil, timeout:)`, `experimental_create_snapshot(name:, timeout:)` with wait and backoff.
  - TypeScript: `experimentalFork` and `experimentalCreateSnapshot` now wait for start/snapshot and honor remaining timeout.

- **Documentation**
  - Go docs: added method references and examples for fork/snapshot.
  - Java docs: added usage, params, returns, and errors for new methods.
  - Ruby docs: added usage notes and parameters for experimental methods.

<sup>Written for commit 82036c151addcb4bdd02b762f0d9759a1f285ba6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

