### PR TITLE
fix(api): load snapshot regions before emitting state update events

### DIFF
--- a/apps/api/src/sandbox/repositories/snapshot.repository.ts
+++ b/apps/api/src/sandbox/repositories/snapshot.repository.ts
@@ -6,7 +6,7 @@
 import { DataSource } from 'typeorm'
 import { Snapshot } from '../entities/snapshot.entity'
 import { SnapshotRegion } from '../entities/snapshot-region.entity'
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectDataSource } from '@nestjs/typeorm'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { BaseRepository } from '../../common/repositories/base.repository'
@@ -17,6 +17,8 @@ import { SnapshotConflictError } from '../errors/snapshot-conflict.error'
 
 @Injectable()
 export class SnapshotRepository extends BaseRepository<Snapshot> {
+  private readonly logger = new Logger(SnapshotRepository.name)
+
   constructor(@InjectDataSource() dataSource: DataSource, eventEmitter: EventEmitter2) {
     super(dataSource, eventEmitter, Snapshot)
   }
@@ -98,9 +100,13 @@ export class SnapshotRepository extends BaseRepository<Snapshot> {
   private async emitUpdateEvents(updatedSnapshot: Snapshot, previousSnapshot: Pick<Snapshot, 'state'>): Promise<void> {
     if (previousSnapshot.state !== updatedSnapshot.state) {
       if (!updatedSnapshot.snapshotRegions) {
-        updatedSnapshot.snapshotRegions = await this.dataSource
-          .getRepository(SnapshotRegion)
-          .find({ where: { snapshotId: updatedSnapshot.id } })
+        try {
+          updatedSnapshot.snapshotRegions = await this.dataSource
+            .getRepository(SnapshotRegion)
+            .find({ where: { snapshotId: updatedSnapshot.id } })
+        } catch (error) {
+          this.logger.error(`Failed to load snapshot regions for event, snapshot ID ${updatedSnapshot.id}: ${error}`)
+        }
       }
 
       this.eventEmitter.emit(

--- a/apps/api/src/sandbox/repositories/snapshot.repository.ts
+++ b/apps/api/src/sandbox/repositories/snapshot.repository.ts
@@ -84,7 +84,7 @@ export class SnapshotRepository extends BaseRepository<Snapshot> {
       snapshot.updatedAt = new Date()
     })
 
-    this.emitUpdateEvents(snapshot, previousSnapshot)
+    await this.emitUpdateEvents(snapshot, previousSnapshot)
 
     return snapshot
   }
@@ -95,8 +95,14 @@ export class SnapshotRepository extends BaseRepository<Snapshot> {
     return removed
   }
 
-  private emitUpdateEvents(updatedSnapshot: Snapshot, previousSnapshot: Pick<Snapshot, 'state'>): void {
+  private async emitUpdateEvents(updatedSnapshot: Snapshot, previousSnapshot: Pick<Snapshot, 'state'>): Promise<void> {
     if (previousSnapshot.state !== updatedSnapshot.state) {
+      if (!updatedSnapshot.snapshotRegions) {
+        updatedSnapshot.snapshotRegions = await this.dataSource
+          .getRepository(SnapshotRegion)
+          .find({ where: { snapshotId: updatedSnapshot.id } })
+      }
+
       this.eventEmitter.emit(
         SnapshotEvents.STATE_UPDATED,
         new SnapshotStateUpdatedEvent(updatedSnapshot, previousSnapshot.state, updatedSnapshot.state),


### PR DESCRIPTION
This pull request makes improvements to the `SnapshotRepository` class by ensuring that update events are emitted asynchronously and that `snapshotRegions` are loaded if missing before emitting state update events. These changes help prevent potential bugs due to missing data and improve the reliability of event handling.

**Event emission improvements:**

* Changed the `emitUpdateEvents` method to be asynchronous (`async`) and updated its invocation to use `await`, ensuring that any asynchronous operations inside the method complete before proceeding. [[1]](diffhunk://#diff-0413e13a901c3e349c9c3ae50af742d22538444c2f328a47366a899993c6f353L87-R87) [[2]](diffhunk://#diff-0413e13a901c3e349c9c3ae50af742d22538444c2f328a47366a899993c6f353L98-R105)

**Data consistency:**

* Added logic to load `snapshotRegions` from the database if they are not already present on the `updatedSnapshot` before emitting a state update event. This ensures that event consumers always receive complete snapshot data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure snapshot state update events include `snapshotRegions` and wait for async work to finish before continuing. This prevents missing region data for event consumers and improves reliability.

- **Bug Fixes**
  - Load `snapshotRegions` from the database when missing before emitting `STATE_UPDATED`, and log failures if the fetch fails.
  - Make `emitUpdateEvents` async and await it in `update`.

<sup>Written for commit 0052e25166b428abfe0cb53ab7c1288fa53fa7ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

