### PR TITLE
chore: fix go cache in actions

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -56,8 +56,7 @@ runs:
       with:
         go-version-file: go.work
         cache: ${{ inputs.go-cache }}
-        cache-dependency-path: |
-          **/go.sum
+        cache-dependency-path: "**/go.sum"
 
     - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       if: inputs.install-java == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
 
       - uses: ./.github/actions/setup-toolchain
         with:
+          go-cache: 'false'
           run-go-work-sync: 'false'
 
       - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Go caching in GitHub Actions and disables it in the release workflow to avoid unintended restores.

- **Bug Fixes**
  - Quote `cache-dependency-path: "**/go.sum"` in `./.github/actions/setup-toolchain` so `actions/setup-go` reads the glob correctly.
  - Set `go-cache: 'false'` in `release.yaml` to skip Go caching during releases.

<sup>Written for commit dc10d86d819f249715bc6d20de15f96023523697. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

