### PR TITLE
fix(docs): update sandbox forking state and rules

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1042,9 +1042,9 @@ For more information, see the [Python SDK](/docs/en/python-sdk/sync/sandbox#sand
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to fork sandboxes. Forking creates a duplicate of your sandbox's filesystem and memory, and copies it into a new sandbox. The new sandbox is fully independent: it can be started, stopped, and deleted without affecting the original. 
+Daytona provides methods to fork sandboxes. Forking creates a duplicate of your sandbox's filesystem and memory, and copies it into a new sandbox. The new sandbox is fully independent: it can be started, stopped, and deleted without affecting the original. The sandbox must be in started state before forking.
 
-Daytona tracks the parent-child relationship in a fork tree, so you can always trace a fork's lineage back to the sandbox it was created from. You can fork a fork, building out branches as needed. If the parent sandbox is deleted, all its forks continue to run unaffected.
+Daytona tracks the parent-child relationship in a fork tree, so you can always trace a fork's lineage back to the sandbox it was created from. You can fork a fork, building out branches as needed. The parent sandbox cannot be deleted while it has active fork children.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click the three-dot menu (**⋮**) next to the sandbox you want to fork
@@ -1056,9 +1056,6 @@ Daytona tracks the parent-child relationship in a fork tree, so you can always t
 ```python
 # Fork sandbox through the Sandbox instance
 forked = sandbox._experimental_fork(name="my-forked-sandbox")
-
-# Or use the Daytona helper method
-forked = daytona._experimental_fork(sandbox, name="my-forked-sandbox")
 ```
 
 </TabItem>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated sandbox forking docs to match current behavior: forking requires a started sandbox, and a parent with active forks cannot be deleted. Removed the deprecated `daytona._experimental_fork` example; only the `sandbox._experimental_fork` API is shown.

<sup>Written for commit fe2dd40105913f5a2ce65b9d852f801e0fe39edf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

