### PR TITLE
fix(sdk-typescript): add missing awaits in delete() and waitUntilStopped()

### DIFF
--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -455,7 +455,7 @@ export class Sandbox implements SandboxDto {
   @WithInstrumentation()
   public async delete(timeout = 60): Promise<void> {
     await this.sandboxApi.deleteSandbox(this.id, undefined, { timeout: timeout * 1000 })
-    this.refreshDataSafe()
+    await this.refreshDataSafe()
   }
 
   /**

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -524,7 +524,7 @@ export class Sandbox implements SandboxDto {
 
     // Treat destroyed as stopped to cover ephemeral sandboxes that are automatically deleted after stopping
     while (this.state !== 'stopped' && this.state !== 'destroyed') {
-      this.refreshDataSafe()
+      await this.refreshDataSafe()
 
       // @ts-expect-error this.refreshData() can modify this.state so this check is fine
       if (this.state === 'stopped' || this.state === 'destroyed') {


### PR DESCRIPTION
## What's broken

**Bug 1 — `Sandbox.delete()` returns before state is refreshed**

`delete()` calls `this.refreshDataSafe()` without `await`. The returned Promise is discarded (fire-and-forget), so `delete()` resolves before the sandbox state is updated. Any caller checking `sandbox.state` immediately after `delete()` observes stale data — e.g., `"started"` instead of `"destroyed"`.

**Bug 2 — `waitUntilStopped()` polling loop never updates state**

Inside the `while` loop, `this.refreshDataSafe()` is called without `await`. Because the HTTP request is never awaited, `this.state` is never updated between iterations. The loop spins until the timeout fires without ever observing the actual sandbox state, making `waitUntilStopped()` effectively non-functional for any caller relying on it to detect stopped/destroyed state.

## Root cause

Both call sites omit `await` on an `async` method. In TypeScript/JavaScript, calling an async function without `await` silently discards the Promise — no error is thrown, but the work is never completed before the caller proceeds.

The same method is called correctly elsewhere: `stop()` uses `await this.refreshDataSafe()` at `Sandbox.ts:331`, and `waitUntilStarted()` uses `await this.refreshData()` in its equivalent loop at `Sandbox.ts:482`. The two broken call sites were oversights.

## Fix

Add `await` before `this.refreshDataSafe()` at both call sites:

- `libs/sdk-typescript/src/Sandbox.ts:458` — `Sandbox.delete()`
- `libs/sdk-typescript/src/Sandbox.ts:527` — `waitUntilStopped()` poll loop

## How verified

- Source analysis confirmed the missing `await` at both call sites and cross-referenced against the correct usages in `stop()` and `waitUntilStarted()`
- `tsc --noEmit` ran clean (0 type errors introduced) — note: `sdk-typescript` has no `test` target in `project.json`, so `tsc --noEmit` was used as the type-level gate
- Both commits are DCO signed (`Signed-off-by` trailer present)