### PR TITLE
fix(sdk-python): fix unreachable error check in wait_for_resize/snapshot_complete()

### DIFF
--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -628,12 +628,12 @@ class AsyncSandbox(SandboxDto):
         while self.state == "resizing":
             await self.refresh_data()
 
-            if self.state != "resizing":
-                return
-
             if self.state in ["error", "build_failed"]:
                 err_msg = f"Sandbox {self.id} resize failed with state: {self.state}, error reason: {self.error_reason}"
                 raise DaytonaError(err_msg)
+
+            if self.state != "resizing":
+                return
 
             await asyncio.sleep(check_interval)
             if asyncio.get_event_loop().time() - start_time > 5:
@@ -761,13 +761,13 @@ class AsyncSandbox(SandboxDto):
         while self.state == "snapshotting":
             await self.refresh_data()
 
-            if self.state != "snapshotting":
-                return
-
             if self.state in ["error", "build_failed"]:
                 raise DaytonaError(
                     f"Sandbox {self.id} snapshot failed with state: {self.state}, error reason: {self.error_reason}"
                 )
+
+            if self.state != "snapshotting":
+                return
 
             await asyncio.sleep(check_interval)
             if asyncio.get_event_loop().time() - start_time > 5:

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -623,12 +623,12 @@ class Sandbox(SandboxDto):
         while self.state == "resizing":
             self.refresh_data()
 
-            if self.state != "resizing":
-                return
-
             if self.state in ["error", "build_failed"]:
                 err_msg = f"Sandbox {self.id} resize failed with state: {self.state}, error reason: {self.error_reason}"
                 raise DaytonaError(err_msg)
+
+            if self.state != "resizing":
+                return
 
             time.sleep(check_interval)
             if time.monotonic() - start_time > 5:
@@ -756,13 +756,13 @@ class Sandbox(SandboxDto):
         while self.state == "snapshotting":
             self.refresh_data()
 
-            if self.state != "snapshotting":
-                return
-
             if self.state in ["error", "build_failed"]:
                 raise DaytonaError(
                     f"Sandbox {self.id} snapshot failed with state: {self.state}, error reason: {self.error_reason}"
                 )
+
+            if self.state != "snapshotting":
+                return
 
             time.sleep(check_interval)
             if time.monotonic() - start_time > 5:


### PR DESCRIPTION
## What's broken

**Unreachable error check in `wait_for_resize_complete()` and `__wait_for_snapshot_complete()`**

In both methods, `if self.state != "resizing": return` (or `"snapshotting"`) fires before the error-state check. After `refresh_data()` updates `self.state`, any transition to `"error"` or `"build_failed"` triggers the early return first — making the `raise DaytonaError(...)` branch structurally unreachable dead code. A failed resize or snapshot silently returns success instead of raising.

Affected files (4 locations):
- `libs/sdk-python/src/daytona/_sync/sandbox.py:628` (resize), `:759` (snapshot)
- `libs/sdk-python/src/daytona/_async/sandbox.py:632` (resize), `:763` (snapshot)

## Root cause

Incorrect check ordering — the general "state changed" guard was placed before the specific error-state guard. The TypeScript SDK equivalent has these checks in the correct order.

## Fix

Swap the check order so error states are raised before the general early-return. Applied to all 4 locations (sync/async × resize/snapshot).

## How verified

- Dead code pattern confirmed in the installed package at `/opt/homebrew/lib/python3.13/site-packages/daytona/_sync/sandbox.py`
- Python AST parse clean on all modified files (0 syntax errors)
- Commit is DCO signed (`Signed-off-by` trailer present)

## Rebase note

Originally included two additional commits fixing label reading in `get()` and label writing in `_create()`. Both were superseded by refactors already merged to `main` (#4401 and the `_create()` label-writing refactor at `_async/daytona.py:437`). They were dropped during rebase.