### PR TITLE
chore(security): add credential cleanup to self-hosted runner jobs

### DIFF
--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -119,6 +119,7 @@ jobs:
         if: always()
         run: |
           docker logout docker.io 2>/dev/null || true
+          docker logout ghcr.io 2>/dev/null || true
 
   docker_manifest:
     needs: docker_build
@@ -183,3 +184,4 @@ jobs:
         if: always()
         run: |
           docker logout docker.io 2>/dev/null || true
+          docker logout ghcr.io 2>/dev/null || true

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -115,6 +115,11 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          docker logout docker.io 2>/dev/null || true
+
   docker_manifest:
     needs: docker_build
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -173,3 +173,8 @@ jobs:
         run: |
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}"
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}-slim"
+
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          docker logout docker.io 2>/dev/null || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
         run: |
           git config --global --unset-all user.name 2>/dev/null || true
           git config --global --unset-all user.email 2>/dev/null || true
-          git config --global --unset-all safe.directory 2>/dev/null || true
+          git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
 
   build_projects:
@@ -206,7 +206,7 @@ jobs:
         run: |
           git config --global --unset-all user.name 2>/dev/null || true
           git config --global --unset-all user.email 2>/dev/null || true
-          git config --global --unset-all safe.directory 2>/dev/null || true
+          git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
 
   # Separately build docker images for AMD64 and ARM64
@@ -401,5 +401,5 @@ jobs:
         run: |
           git config --global --unset-all user.name 2>/dev/null || true
           git config --global --unset-all user.email 2>/dev/null || true
-          git config --global --unset-all safe.directory 2>/dev/null || true
+          git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,14 @@ jobs:
       - name: Create release
         run: yarn nx release "$VERSION" --skip-publish --verbose
 
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          git config --global --unset-all user.name 2>/dev/null || true
+          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --unset-all safe.directory 2>/dev/null || true
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
+
   build_projects:
     needs: publish
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
@@ -193,6 +201,14 @@ jobs:
           retention-days: 1
           overwrite: true
 
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          git config --global --unset-all user.name 2>/dev/null || true
+          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --unset-all safe.directory 2>/dev/null || true
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
+
   # Separately build docker images for AMD64 and ARM64
   docker_build:
     needs: build_projects
@@ -273,6 +289,11 @@ jobs:
           ARCH: -${{ matrix.arch }}
         run: |
           yarn docker:production
+
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          docker logout docker.io 2>/dev/null || true
 
   # Push combined manifest
   docker_push_manifest:
@@ -374,3 +395,11 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          git config --global --unset-all user.name 2>/dev/null || true
+          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --unset-all safe.directory 2>/dev/null || true
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -294,6 +294,7 @@ jobs:
         if: always()
         run: |
           docker logout docker.io 2>/dev/null || true
+          docker logout ghcr.io 2>/dev/null || true
 
   # Push combined manifest
   docker_push_manifest:
@@ -331,6 +332,12 @@ jobs:
       - name: Push manifest
         run: |
           yarn push-manifest
+
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          docker logout docker.io 2>/dev/null || true
+          docker logout ghcr.io 2>/dev/null || true
 
   sync_gosum:
     needs: build_projects

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,8 +103,8 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: |
-          git config --global --unset-all user.name 2>/dev/null || true
-          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.name "Daytona Release Bot" 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.email "daytona-release@users.noreply.github.com" 2>/dev/null || true
           git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
 
@@ -204,8 +204,8 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: |
-          git config --global --unset-all user.name 2>/dev/null || true
-          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.name "Daytona Release Bot" 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.email "daytona-release@users.noreply.github.com" 2>/dev/null || true
           git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
 
@@ -406,7 +406,7 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: |
-          git config --global --unset-all user.name 2>/dev/null || true
-          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.name "Daytona Release Bot" 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.email "daytona-release@users.noreply.github.com" 2>/dev/null || true
           git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -93,9 +93,11 @@ jobs:
         run: |
           rm -f ~/.gem/credentials 2>/dev/null || true
           docker logout docker.io 2>/dev/null || true
+          docker logout ghcr.io 2>/dev/null || true
           git config --global --unset-all user.name 2>/dev/null || true
           git config --global --unset-all user.email 2>/dev/null || true
           git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
 
   update-homebrew-tap:
     if: ${{ inputs.npm_tag == 'latest' }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -95,7 +95,7 @@ jobs:
           docker logout docker.io 2>/dev/null || true
           git config --global --unset-all user.name 2>/dev/null || true
           git config --global --unset-all user.email 2>/dev/null || true
-          git config --global --unset-all safe.directory 2>/dev/null || true
+          git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 
   update-homebrew-tap:
     if: ${{ inputs.npm_tag == 'latest' }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: |
-          rm -f ~/.gem/credentials
+          rm -f ~/.gem/credentials 2>/dev/null || true
           docker logout docker.io 2>/dev/null || true
           git config --global --unset-all user.name 2>/dev/null || true
           git config --global --unset-all user.email 2>/dev/null || true

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -94,8 +94,8 @@ jobs:
           rm -f ~/.gem/credentials 2>/dev/null || true
           docker logout docker.io 2>/dev/null || true
           docker logout ghcr.io 2>/dev/null || true
-          git config --global --unset-all user.name 2>/dev/null || true
-          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.name "Daytona Release Bot" 2>/dev/null || true
+          git config --global --fixed-value --unset-all user.email "daytona-release@users.noreply.github.com" 2>/dev/null || true
           git config --global --fixed-value --unset-all safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}" 2>/dev/null || true
 

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -88,6 +88,15 @@ jobs:
           source "$(poetry env info --path)/bin/activate"
           yarn publish
 
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          rm -f ~/.gem/credentials
+          docker logout docker.io 2>/dev/null || true
+          git config --global --unset-all user.name 2>/dev/null || true
+          git config --global --unset-all user.email 2>/dev/null || true
+          git config --global --unset-all safe.directory 2>/dev/null || true
+
   update-homebrew-tap:
     if: ${{ inputs.npm_tag == 'latest' }}
     needs: publish


### PR DESCRIPTION
## Summary

Add `if: always()` credential cleanup steps to all jobs that write secrets to the filesystem. Prevents credential persistence between workflow runs on shared runners.

## Problem

Self-hosted runners (unlike GitHub-hosted `ubuntu-latest`) persist filesystem state between jobs. After a release or SDK publish, the following credentials remain on disk:

| Credential | Location | Written by |
|---|---|---|
| RubyGems API key | `~/.gem/credentials` | sdk_publish / publish |
| Docker Hub auth | `~/.docker/config.json` | docker/login-action |
| Git identity + GITHUB_TOKEN | `~/.gitconfig` + `.git/config` remote URL | Configure git + persist-credentials workaround |

If a subsequent job from a different workflow, PR, or even a different repository in the org runs on the same runner, it inherits access to these credentials.

This was observed in practice: daytonaio/daytona-ai#304 (sync_gosum) picked up 30 stale files from the runner's working directory, including `.env` and workflow files.

## Changes

Add a "Cleanup credentials" step as the last step in each affected job:

| Workflow | Job | Runner | Cleanup |
|---|---|---|---|
| `sdk_publish.yaml` | publish | self-hosted | Remove `~/.gem/credentials`, Docker logout (docker.io + ghcr.io), clear git config, reset remote URL |
| `release.yaml` | publish | self-hosted | Clear git config, reset remote URL |
| `release.yaml` | build_projects | self-hosted | Clear git config, reset remote URL |
| `release.yaml` | docker_build | self-hosted | Docker logout (docker.io + ghcr.io) |
| `release.yaml` | docker_push_manifest | ubuntu-latest | Docker logout (docker.io + ghcr.io) |
| `release.yaml` | sync_gosum | self-hosted | Clear git config, reset remote URL |
| `default_image_publish.yaml` | docker_build | self-hosted | Docker logout (docker.io + ghcr.io) |
| `default_image_publish.yaml` | docker_manifest | self-hosted | Docker logout (docker.io + ghcr.io) |

Workflows on ephemeral runners (`pr_checks.yaml`, `e2e_pr_tests.yaml`, `build_devcontainer.yaml`, `prepare-release.yaml`) are not affected -- the runner is destroyed after each job. `docker_push_manifest` runs on `ubuntu-latest` but cleanup is included for defense-in-depth.

## Design decisions

- **`if: always()`** -- cleanup runs even if the job fails mid-way (e.g., failed Docker push still cleans up login)
- **`2>/dev/null || true`** -- cleanup never fails the job, even if the credential was never written
- **`git remote set-url` to plain HTTPS** -- strips the `x-access-token:<GITHUB_TOKEN>@` from the remote URL
- **`--fixed-value` for git config unset** -- only removes the specific bot identity values, not pre-existing global config on shared runners
- **Docker logout covers both `docker.io` and `ghcr.io`** -- prod images push to ghcr.io
- **No cleanup on `update-homebrew-tap`** -- that job only uses `curl` with a step-scoped secret, writes nothing to disk

## Context

Phase 1.7 of GHA security hardening (SEC-61). This is the second-to-last Phase 1 item.

## Verification

- `actionlint` passes with no new errors
- No functional changes -- cleanup only runs after all work is complete
- All cleanup commands are idempotent and non-destructive