### PR TITLE
fix(docs): openapi.json file paths

### DIFF
--- a/apps/docs/src/components/ApiReference.astro
+++ b/apps/docs/src/components/ApiReference.astro
@@ -26,7 +26,7 @@ function findWorkspaceRoot(startPath: string): string {
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const workspaceRoot = findWorkspaceRoot(__dirname)
-const mainApiPath = join(workspaceRoot, 'dist/apps/api/openapi.3.1.0.json')
+const mainApiPath = join(workspaceRoot, 'apps/docs/public/openapi.json')
 const mainApiSpecRaw = JSON.parse(fs.readFileSync(mainApiPath, 'utf-8'))
 const mainApiSpec = {
   ...mainApiSpecRaw,
@@ -35,7 +35,7 @@ const mainApiSpec = {
 
 const toolboxApiPath = join(
   workspaceRoot,
-  'apps/daemon/pkg/toolbox/docs/swagger.json'
+  'apps/docs/public/toolbox-openapi.json'
 )
 const toolboxApiSpecRaw = JSON.parse(fs.readFileSync(toolboxApiPath, 'utf-8'))
 const toolboxApiSpec = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken API reference in the docs by loading OpenAPI JSON from the `apps/docs/public` folder. This stops 404s in local and deployed docs.

- **Bug Fixes**
  - Main API path: `dist/apps/api/openapi.3.1.0.json` → `apps/docs/public/openapi.json`
  - Toolbox API path: `apps/daemon/pkg/toolbox/docs/swagger.json` → `apps/docs/public/toolbox-openapi.json`

<sup>Written for commit 1c653fecc4833946a37fd470ea19e4e462132170. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

