### PR TITLE
fix(toolbox): add RFC 5987 Content-Disposition encoding to single-file download

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/download_file.go
+++ b/apps/daemon/pkg/toolbox/fs/download_file.go
@@ -58,7 +58,9 @@ func DownloadFile(c *gin.Context) {
 
 	c.Header("Content-Description", "File Transfer")
 	c.Header("Content-Type", "application/octet-stream")
-	c.Header("Content-Disposition", "attachment; filename="+filepath.Base(absPath))
+	filename := filepath.Base(absPath)
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=utf-8''%s`,
+		toLatin1(filename), encodeRFC5987(filename)))
 	c.Header("Content-Transfer-Encoding", "binary")
 	c.Header("Expires", "0")
 	c.Header("Cache-Control", "must-revalidate")

--- a/apps/daemon/pkg/toolbox/fs/download_file_test.go
+++ b/apps/daemon/pkg/toolbox/fs/download_file_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package fs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func downloadFileContext(t *testing.T, filePath string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/files/download?path="+url.QueryEscape(filePath), nil)
+	DownloadFile(ctx)
+	return recorder
+}
+
+func TestDownloadFileContentDisposition(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("ascii filename sets both filename and filename*", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "hello.txt")
+		if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		recorder := downloadFileContext(t, filePath)
+
+		got := recorder.Header().Get("Content-Disposition")
+		want := `attachment; filename="hello.txt"; filename*=utf-8''hello.txt`
+		if got != want {
+			t.Errorf("Content-Disposition = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unicode filename uses latin1 fallback and RFC 5987 encoding", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "日本語.txt")
+		if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		recorder := downloadFileContext(t, filePath)
+
+		got := recorder.Header().Get("Content-Disposition")
+		if !strings.Contains(got, `filename="___.txt"`) {
+			t.Errorf("expected latin1 fallback filename, got %q", got)
+		}
+		if !strings.Contains(got, `filename*=utf-8''%E6%97%A5%E6%9C%AC%E8%AA%9E.txt`) {
+			t.Errorf("expected RFC 5987 encoded filename*, got %q", got)
+		}
+	})
+
+	t.Run("filename with special characters is properly encoded", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "file (1).txt")
+		if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		recorder := downloadFileContext(t, filePath)
+
+		got := recorder.Header().Get("Content-Disposition")
+		if !strings.Contains(got, `filename*=utf-8''file%20%281%29.txt`) {
+			t.Errorf("expected percent-encoded filename*, got %q", got)
+		}
+	})
+
+	t.Run("control characters in filename are replaced", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "hello\tworld.txt")
+		if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		recorder := downloadFileContext(t, filePath)
+
+		got := recorder.Header().Get("Content-Disposition")
+		if !strings.Contains(got, `filename="hello_world.txt"`) {
+			t.Errorf("expected tab replaced with underscore in filename, got %q", got)
+		}
+	})
+
+	t.Run("missing path returns 400", func(t *testing.T) {
+		recorder := downloadFileContext(t, "")
+
+		if recorder.Code != http.StatusBadRequest {
+			t.Errorf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
+		}
+	})
+
+	t.Run("nonexistent file returns 404", func(t *testing.T) {
+		recorder := downloadFileContext(t, "/tmp/nonexistent-file-xyz.txt")
+
+		if recorder.Code != http.StatusNotFound {
+			t.Errorf("expected status %d, got %d", http.StatusNotFound, recorder.Code)
+		}
+	})
+
+	t.Run("directory path returns 400", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		recorder := downloadFileContext(t, tempDir)
+
+		if recorder.Code != http.StatusBadRequest {
+			t.Errorf("expected status %d, got %d", http.StatusBadRequest, recorder.Code)
+		}
+	})
+}

--- a/apps/daemon/pkg/toolbox/fs/download_file_test.go
+++ b/apps/daemon/pkg/toolbox/fs/download_file_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package fs
@@ -100,7 +100,8 @@ func TestDownloadFileContentDisposition(t *testing.T) {
 	})
 
 	t.Run("nonexistent file returns 404", func(t *testing.T) {
-		recorder := downloadFileContext(t, "/tmp/nonexistent-file-xyz.txt")
+		missingPath := filepath.Join(t.TempDir(), "does-not-exist.txt")
+		recorder := downloadFileContext(t, missingPath)
 
 		if recorder.Code != http.StatusNotFound {
 			t.Errorf("expected status %d, got %d", http.StatusNotFound, recorder.Code)

--- a/apps/daemon/pkg/toolbox/fs/download_file_test.go
+++ b/apps/daemon/pkg/toolbox/fs/download_file_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -77,6 +78,9 @@ func TestDownloadFileContentDisposition(t *testing.T) {
 	})
 
 	t.Run("control characters in filename are replaced", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows filesystems reject control characters in filenames")
+		}
 		tempDir := t.TempDir()
 		filePath := filepath.Join(tempDir, "hello\tworld.txt")
 		if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {

--- a/apps/daemon/pkg/toolbox/fs/download_files.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files.go
@@ -228,10 +228,12 @@ func toLatin1(s string) string {
 	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\r", "", "\n", "", "\x00", "").Replace(s)
 	var buf []byte
 	for _, r := range escaped {
-		if r <= 0xFF {
-			buf = append(buf, byte(r))
-		} else {
+		if r > 0xFF {
 			buf = append(buf, '_')
+		} else if r < 0x20 || r == 0x7F {
+			buf = append(buf, '_')
+		} else {
+			buf = append(buf, byte(r))
 		}
 	}
 	return string(buf)

--- a/apps/daemon/pkg/toolbox/fs/download_files.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files.go
@@ -223,7 +223,9 @@ func newFileDownloadErrorResponse(
 	}
 }
 
-// toLatin1 replaces characters outside ISO-8859-1 with '_'.
+// toLatin1 sanitizes s for use in a quoted Content-Disposition filename= parameter.
+// It escapes backslashes and double quotes, strips CR/LF/NUL, replaces C0 control
+// characters (0x01-0x1F), DEL (0x7F), and non-Latin1 (>0xFF) runes with '_'.
 func toLatin1(s string) string {
 	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\r", "", "\n", "", "\x00", "").Replace(s)
 	var buf []byte

--- a/apps/daemon/pkg/toolbox/fs/download_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files_test.go
@@ -118,6 +118,9 @@ func TestToLatin1(t *testing.T) {
 		{"hello\x00.txt", "hello.txt"},
 		{"café", "caf\xe9"},
 		{"日本語.txt", "___.txt"},
+		{"hello\tworld.txt", "hello_world.txt"},
+		{"bell\x07.txt", "bell_.txt"},
+		{"del\x7f.txt", "del_.txt"},
 		{"", ""},
 	}
 


### PR DESCRIPTION
## Summary

The single-file download endpoint (`/files/download`) constructs the `Content-Disposition` header by concatenating the raw filename without quoting or encoding:

```go
c.Header("Content-Disposition", "attachment; filename="+filepath.Base(absPath))
```

This was identified during the weekly security code review. PR #4331 correctly applied RFC 5987 encoding to the **bulk download** endpoint (`/files/bulk-download`), but the original single-file endpoint was missed — it has been unprotected since the toolbox was introduced in PR #1775 (April 2025).

### What this PR does

1. **Applies RFC 5987 `Content-Disposition` encoding to the single-file download endpoint** (`download_file.go`), reusing the existing `toLatin1()` + `encodeRFC5987()` helpers from `download_files.go`. The header now includes both a Latin-1 fallback `filename=` and a properly percent-encoded `filename*=utf-8''...` parameter, matching the bulk download endpoint.

2. **Hardens the shared `toLatin1()` helper** (`download_files.go`) to also reject C0 control characters (0x01-0x1F) and DEL (0x7F), replacing them with `_`. Previously it only stripped CR, LF, and NUL. On POSIX filesystems, bytes like tab (`\t`), BEL (`\x07`), and ESC (`\x1B`) are legal in filenames and would have passed through unfiltered into the quoted `filename="..."` value. This hardening applies to **both** the single-file and bulk download endpoints.

3. **Adds comprehensive tests:**
   - New `download_file_test.go` (7 test cases): ASCII filenames, Unicode with Latin-1 fallback, special characters, control character regression, missing path, nonexistent file, directory path
   - New `TestToLatin1` cases in `download_files_test.go`: tab, BEL, DEL control characters

### Security context

- **CWE-113**: HTTP Response Splitting / Header Injection
- **Attack surface**: Sandbox filenames are attacker-controlled. Go's `net/http` blocks `\r\n` in header values (preventing full response splitting), but header value corruption via unquoted/unencoded filenames remained possible.
- **Impact**: Medium -- limited to header value corruption within the daemon's toolbox API, contained within the sandbox isolation boundary.

### Files changed

| File | Change |
|------|--------|
| `apps/daemon/pkg/toolbox/fs/download_file.go` | RFC 5987 Content-Disposition encoding |
| `apps/daemon/pkg/toolbox/fs/download_files.go` | Harden `toLatin1()` control char filtering |
| `apps/daemon/pkg/toolbox/fs/download_files_test.go` | Add control char test cases |
| `apps/daemon/pkg/toolbox/fs/download_file_test.go` | New: endpoint-level tests |

## Test plan

- [x] `go test ./apps/daemon/pkg/toolbox/fs/ -v` -- all 25 tests pass
- [x] `go build ./apps/daemon/...` -- compiles clean
- [x] Pre-commit hooks (gofmt) pass