### PR TITLE
chore(security): add Dependabot coverage for setup-toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,15 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-toolchain
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

- Adds Dependabot `github-actions` ecosystem entry for `.github/actions/setup-toolchain` composite action
- The composite action references 5 external actions (setup-go, setup-java, setup-python, setup-ruby, setup-node, cache) that were not covered by Dependabot version update scans
- Addresses CWE-1104 finding from GHA security audit

## Context

The existing `dependabot.yml` only scans `directory: /` for GitHub Actions, which covers workflow files but misses actions referenced inside composite actions in subdirectories. All actions in `setup-toolchain` are SHA-pinned, but without Dependabot coverage they won't receive automated version bump PRs.