### PR TITLE
feat(proxy): auto-start stopped sandboxes on preview

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.auth.spec.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.auth.spec.ts
@@ -124,7 +124,10 @@ describe('[AUTH] SandboxController', () => {
       AuthStrategyType.API_KEY,
       AuthStrategyType.JWT,
     ])
-    expectArrayMatch(getAuthContextGuards(SandboxController, methodName), [OrganizationAuthContextGuard])
+    expectArrayMatch(getAuthContextGuards(SandboxController, methodName), [
+      OrganizationAuthContextGuard,
+      ProxyAuthContextGuard,
+    ])
     expectArrayMatch(getResourceAccessGuards(SandboxController, methodName), [SandboxAccessGuard])
     expect(getRequiredOrganizationMemberRole(SandboxController, methodName)).toBeUndefined()
     expectArrayMatch(getRequiredOrganizationResourcePermissions(SandboxController, methodName), [

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -490,7 +490,7 @@ export class SandboxController {
     description: 'Sandbox has been started or is being restored from archived state',
     type: SandboxDto,
   })
-  @UseGuards(OrganizationAuthContextGuard, SandboxAccessGuard)
+  @UseGuards(OrGuard([OrganizationAuthContextGuard, ProxyAuthContextGuard]), SandboxAccessGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_SANDBOXES])
   @Audit({
     action: AuditAction.START,
@@ -499,10 +499,18 @@ export class SandboxController {
     targetIdFromResult: (result: SandboxDto) => result?.id,
   })
   async startSandbox(
-    @IsOrganizationAuthContext() authContext: OrganizationAuthContext,
+    @IsBaseAuthContext() authContext: BaseAuthContext,
     @Param('sandboxIdOrName') sandboxIdOrName: string,
   ): Promise<SandboxDto> {
-    const sbx = await this.sandboxService.start(sandboxIdOrName, authContext.organization)
+    const organization = isOrganizationAuthContext(authContext)
+      ? authContext.organization
+      : await this.organizationService.findBySandboxId(sandboxIdOrName)
+
+    if (!organization) {
+      throw new NotFoundException(`Organization for sandbox ${sandboxIdOrName} not found`)
+    }
+
+    const sbx = await this.sandboxService.start(sandboxIdOrName, organization)
     let sandbox = await this.sandboxService.toSandboxDto(sbx)
 
     if (![SandboxState.ARCHIVED, SandboxState.RESTORING, SandboxState.STARTED].includes(sandbox.state)) {

--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -347,7 +347,7 @@ func (s *server) Start() error {
 
 	proxyController := noTelemetryRouter.Group("/proxy")
 	{
-		proxyController.Any("/:port/*path", common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, nil))
+		proxyController.Any("/:port/*path", common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, nil, nil))
 	}
 
 	go portDetector.Start(context.Background())

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -500,6 +500,26 @@ For more information, see the [Python SDK](/docs/en/python-sdk/), [TypeScript SD
 >
 > [**start (API)**](/docs/en/tools/api/#daytona/tag/sandbox/POST/sandbox/{sandboxIdOrName}/start)
 
+### Auto-start on HTTP request
+
+:::caution[Experimental]
+This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
+:::
+
+Daytona can automatically start a stopped sandbox when an HTTP request is made to one of its [preview URLs](/docs/en/preview). This is useful for sandboxes that should remain available on-demand without requiring manual intervention to start them.
+
+When a request arrives at a stopped sandbox's preview URL, Daytona will:
+
+1. Detect that the sandbox is stopped
+2. Automatically start the sandbox
+3. Return a loading page that refreshes until the sandbox is ready
+
+Auto-start is available for VM sandboxes.
+
+:::note
+The first request to a stopped sandbox will see a brief loading page while the sandbox starts. Subsequent requests will be served normally once the sandbox is running.
+:::
+
 ## List Sandboxes
 
 Daytona provides options to view information about sandboxes in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) via the [sandbox details page](#sandbox-details-page) or programmatically using the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/), [Ruby SDK](/docs/en/ruby-sdk/), [Go SDK](/docs/en/go-sdk/daytona/), [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona) references.

--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -79,6 +79,10 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 		}
 	}
 
+	// Store the resolved sandbox ID so wake handlers can use the real ID
+	// even when the URL contained a signed preview token.
+	ctx.Set(RESOLVED_SANDBOX_ID_KEY, sandboxId)
+
 	runnerInfo, err := p.getSandboxRunnerInfo(ctx, sandboxId)
 	if err != nil {
 		ctx.Error(common_errors.NewBadRequestError(fmt.Errorf("failed to get runner info: %w", err)))
@@ -148,8 +152,9 @@ func (p *Proxy) getSandboxRunnerInfo(ctx context.Context, sandboxId string) (*Ru
 	}
 
 	info := RunnerInfo{
-		ApiUrl: *runner.ProxyUrl,
-		ApiKey: runner.ApiKey,
+		ApiUrl:      *runner.ProxyUrl,
+		ApiKey:      runner.ApiKey,
+		RunnerClass: string(runner.RunnerClass),
 	}
 
 	err = p.sandboxRunnerCache.Set(ctx, sandboxId, info, 2*time.Minute)

--- a/apps/proxy/pkg/proxy/get_snapshot_target.go
+++ b/apps/proxy/pkg/proxy/get_snapshot_target.go
@@ -117,8 +117,9 @@ func (p *Proxy) getRunnerInfo(ctx context.Context, runnerId string) (*RunnerInfo
 	}
 
 	info := RunnerInfo{
-		ApiUrl: *runner.ApiUrl,
-		ApiKey: runner.ApiKey,
+		ApiUrl:      *runner.ApiUrl,
+		ApiKey:      runner.ApiKey,
+		RunnerClass: string(runner.RunnerClass),
 	}
 
 	err = p.runnerCache.Set(ctx, runnerId, info, 2*time.Minute)

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -31,9 +31,12 @@ import (
 )
 
 type RunnerInfo struct {
-	ApiUrl string `json:"apiUrl"`
-	ApiKey string `json:"apiKey"`
+	ApiUrl      string `json:"apiUrl"`
+	ApiKey      string `json:"apiKey"`
+	RunnerClass string `json:"class"`
 }
+
+const RESOLVED_SANDBOX_ID_KEY = "resolved-sandbox-id"
 
 const SANDBOX_AUTH_KEY_HEADER = "X-Daytona-Preview-Token"
 const SANDBOX_AUTH_KEY_QUERY_PARAM = "DAYTONA_SANDBOX_AUTH_KEY"
@@ -188,12 +191,12 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 					}
 
 					if regexp.MustCompile(`^/snapshots/[\w-]+/build-logs$`).MatchString(ctx.Request.URL.Path) {
-						common_proxy.NewProxyRequestHandler(proxy.getSnapshotTarget, nil)(ctx)
+						common_proxy.NewProxyRequestHandler(proxy.getSnapshotTarget, nil, nil)(ctx)
 						return
 					}
 
 					if regexp.MustCompile(`^/sandboxes/[\w-]+/build-logs$`).MatchString(ctx.Request.URL.Path) {
-						common_proxy.NewProxyRequestHandler(proxy.getSandboxBuildTarget, nil)(ctx)
+						common_proxy.NewProxyRequestHandler(proxy.getSandboxBuildTarget, nil, nil)(ctx)
 						return
 					}
 				}
@@ -209,7 +212,7 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 
 				prefix := fmt.Sprintf("/toolbox/%s", sandboxID)
 
-				modifyResponse := func(res *http.Response) error {
+				baseModifyResponse := func(res *http.Response) error {
 					if res.StatusCode >= 300 && res.StatusCode < 400 {
 						if loc := res.Header.Get("Location"); !strings.HasPrefix(loc, prefix) {
 							res.Header.Set("Location", prefix+loc)
@@ -218,7 +221,9 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 					return nil
 				}
 
-				common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, modifyResponse)(ctx)
+				modifyResponse := proxy.WakeOnRequestModifyResponse(ctx, baseModifyResponse)
+				errorHandler := proxy.WakeOnRequestErrorHandler(ctx)
+				common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, modifyResponse, errorHandler)(ctx)
 				return
 			}
 
@@ -232,7 +237,9 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 			return
 		}
 
-		common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, nil)(ctx)
+		modifyResponse := proxy.WakeOnRequestModifyResponse(ctx, nil)
+		errorHandler := proxy.WakeOnRequestErrorHandler(ctx)
+		common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, modifyResponse, errorHandler)(ctx)
 	})
 
 	httpServer := &http.Server{

--- a/apps/proxy/pkg/proxy/wake.go
+++ b/apps/proxy/pkg/proxy/wake.go
@@ -1,0 +1,235 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	common_proxy "github.com/daytonaio/common-go/pkg/proxy"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	WakeTimeoutSeconds     = 60
+	WakePollIntervalMillis = 1000
+	PostStartDelayMillis   = 2000
+)
+
+type SandboxStateInfo struct {
+	State         *apiclient.SandboxState `json:"state"`
+	WakeOnRequest string                  `json:"wakeOnRequest"`
+}
+
+const sandboxStartingHTML = `<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="3">
+    <title>Sandbox Starting...</title>
+    <style>
+        body { font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+        .container { text-align: center; }
+        .spinner { width: 50px; height: 50px; border: 4px solid #333; border-top: 4px solid #00d4ff; border-radius: 50%; animation: spin 1s linear infinite; margin: 20px auto; }
+        @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="spinner"></div>
+        <h2>Sandbox is starting...</h2>
+        <p>This page will automatically refresh in 3 seconds.</p>
+    </div>
+</body>
+</html>`
+
+func (p *Proxy) startAndWaitForSandbox(ctx context.Context, sandboxID string) bool {
+	_, _, err := p.apiclient.SandboxAPI.StartSandbox(ctx, sandboxID).Execute()
+	if err != nil {
+		log.Errorf("Failed to start sandbox %s. Err: %v", sandboxID, err)
+		return false
+	}
+
+	if err := p.sandboxRunnerCache.Delete(ctx, sandboxID); err != nil {
+		log.Warnf("Failed to clear sandbox runner cache for %s: %v", sandboxID, err)
+	}
+
+	started := p.waitForSandboxStarted(ctx, sandboxID)
+	if started {
+		time.Sleep(PostStartDelayMillis * time.Millisecond)
+	}
+
+	return started
+}
+
+func (p *Proxy) tryWakeSandbox(ctx context.Context, sandboxID string) bool {
+	info, err := p.getSandboxStateInfo(ctx, sandboxID)
+	if err != nil {
+		log.Errorf("Failed to get sandbox info for %s: %v", sandboxID, err)
+		return false
+	}
+
+	if info.State == nil || *info.State != apiclient.SANDBOXSTATE_STOPPED {
+		return false
+	}
+
+	if info.WakeOnRequest != "http" && info.WakeOnRequest != "http_and_ssh" {
+		return false
+	}
+
+	return p.startAndWaitForSandbox(ctx, sandboxID)
+}
+
+func (p *Proxy) waitForSandboxStarted(ctx context.Context, sandboxID string) bool {
+	timeout := time.After(WakeTimeoutSeconds * time.Second)
+	ticker := time.NewTicker(WakePollIntervalMillis * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			log.Warnf("Timeout waiting for sandbox %s to start", sandboxID)
+			return false
+		case <-ctx.Done():
+			log.Warnf("Context cancelled while waiting for sandbox %s to start", sandboxID)
+			return false
+		case <-ticker.C:
+			info, err := p.getSandboxStateInfo(ctx, sandboxID)
+			if err != nil {
+				log.Errorf("Failed to poll sandbox info for %s: %v", sandboxID, err)
+				continue
+			}
+
+			if info.State == nil {
+				log.Warnf("Sandbox %s has nil state, continuing to poll", sandboxID)
+				continue
+			}
+
+			switch *info.State {
+			case apiclient.SANDBOXSTATE_STARTED:
+				log.Debugf("Sandbox %s is now started", sandboxID)
+				return true
+			case apiclient.SANDBOXSTATE_ERROR, apiclient.SANDBOXSTATE_BUILD_FAILED:
+				log.Errorf("Sandbox %s failed to start (state: %s)", sandboxID, *info.State)
+				return false
+			}
+		}
+	}
+}
+
+// resolvedSandboxID returns the resolved sandbox ID from the gin context if available,
+// falling back to the provided fallback value. This handles the case where the URL contains
+// a signed preview token instead of a real sandbox ID — the real ID is stored in the gin
+// context by GetProxyTarget after authentication.
+func resolvedSandboxID(ginCtx *gin.Context, fallback string) string {
+	if resolved := ginCtx.GetString(RESOLVED_SANDBOX_ID_KEY); resolved != "" {
+		return resolved
+	}
+	return fallback
+}
+
+func isWakeableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "no route to host") ||
+		strings.Contains(errStr, "i/o timeout") ||
+		strings.Contains(errStr, "connection reset")
+}
+
+func (p *Proxy) WakeOnRequestErrorHandler(ginCtx *gin.Context) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		sandboxID := resolvedSandboxID(ginCtx, "")
+		if sandboxID != "" && isWakeableError(err) {
+			if p.tryWakeSandbox(r.Context(), sandboxID) {
+				w.Header().Set("Retry-After", "5")
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = fmt.Fprint(w, sandboxStartingHTML)
+				return
+			}
+		}
+
+		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+	}
+}
+
+func (p *Proxy) WakeOnRequestModifyResponse(ginCtx *gin.Context, originalModifyResponse func(*http.Response) error) func(*http.Response) error {
+	return func(res *http.Response) error {
+		if originalModifyResponse != nil {
+			if err := originalModifyResponse(res); err != nil {
+				return err
+			}
+		}
+
+		sandboxID := resolvedSandboxID(ginCtx, "")
+		if sandboxID == "" || res.Header.Get(common_proxy.SandboxStateHeader) != "stopped" {
+			return nil
+		}
+
+		if p.tryWakeSandbox(res.Request.Context(), sandboxID) {
+			if res.Body != nil {
+				res.Body.Close()
+			}
+			res.StatusCode = http.StatusServiceUnavailable
+			res.Status = "503 Service Unavailable"
+			res.Header.Set("Retry-After", "5")
+			res.Header.Set("Content-Type", "text/html; charset=utf-8")
+			res.Body = io.NopCloser(strings.NewReader(sandboxStartingHTML))
+			res.ContentLength = int64(len(sandboxStartingHTML))
+			res.Header.Set("Content-Length", fmt.Sprintf("%d", len(sandboxStartingHTML)))
+		} else {
+			// If wake failed, modify the response to indicate the sandbox is stopped
+			if res.Body != nil {
+				res.Body.Close()
+			}
+			res.StatusCode = http.StatusServiceUnavailable
+			res.Status = "503 Service Unavailable"
+			res.Header.Set("Content-Type", "application/json; charset=utf-8")
+			body := fmt.Sprintf(`{"error": "Sandbox %s is stopped. Please start it first"}`, sandboxID)
+			res.Body = io.NopCloser(strings.NewReader(body))
+			res.ContentLength = int64(len(body))
+			res.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		}
+
+		return nil
+	}
+}
+
+func (p *Proxy) getSandboxStateInfo(ctx context.Context, sandboxID string) (*SandboxStateInfo, error) {
+	sandbox, _, err := p.apiclient.SandboxAPI.GetSandbox(ctx, sandboxID).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	info := SandboxStateInfo{
+		State:         sandbox.State,
+		WakeOnRequest: "none",
+	}
+
+	if sandbox.RunnerId == nil {
+		return &info, nil
+	}
+
+	// Get runner info to determine wake on request setting
+	runner, err := p.getRunnerInfo(ctx, *sandbox.RunnerId)
+	if err != nil {
+		return nil, err
+	}
+
+	if runner.RunnerClass == string(apiclient.RUNNERCLASS_VM) {
+		info.WakeOnRequest = "http_and_ssh"
+	}
+
+	return &info, nil
+}

--- a/apps/runner/pkg/api/controllers/command_logs.go
+++ b/apps/runner/pkg/api/controllers/command_logs.go
@@ -28,7 +28,7 @@ func ProxyCommandLogsStream(ctx *gin.Context, logger *slog.Logger) {
 	if ctx.Query("follow") != "true" {
 		proxy.NewProxyRequestHandler(func(ctx *gin.Context) (*url.URL, map[string]string, error) {
 			return targetURL, extraHeaders, nil
-		}, nil)(ctx)
+		}, nil, nil)(ctx)
 		return
 	}
 

--- a/apps/runner/pkg/api/controllers/proxy.go
+++ b/apps/runner/pkg/api/controllers/proxy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	proxy "github.com/daytonaio/common-go/pkg/proxy"
 	"github.com/daytonaio/common-go/pkg/utils"
+	"github.com/daytonaio/runner/pkg/models/enums"
 	"github.com/daytonaio/runner/pkg/runner"
 	"github.com/gin-gonic/gin"
 )
@@ -37,6 +39,18 @@ import (
 //	@Router			/sandboxes/{sandboxId}/toolbox/{path} [delete]
 func ProxyRequest(logger *slog.Logger) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
+		sandboxId := ctx.Param("sandboxId")
+
+		r, err := runner.GetInstance(nil)
+		if err == nil {
+			state, err := r.Docker.GetSandboxState(ctx.Request.Context(), sandboxId)
+			if err == nil && state == enums.SandboxStateStopped {
+				ctx.Header(proxy.SandboxStateHeader, "stopped")
+				ctx.AbortWithStatus(http.StatusServiceUnavailable)
+				return
+			}
+		}
+
 		if ctx.Request.Header.Get("Upgrade") != "websocket" && regexp.MustCompile(`^/process/session/.+/command/.+/logs$`).MatchString(ctx.Param("path")) {
 			if ctx.Query("follow") == "true" {
 				ProxyCommandLogsStream(ctx, logger)
@@ -44,7 +58,7 @@ func ProxyRequest(logger *slog.Logger) gin.HandlerFunc {
 			}
 		}
 
-		proxy.NewProxyRequestHandler(getProxyTarget, nil)(ctx)
+		proxy.NewProxyRequestHandler(getProxyTarget, nil, nil)(ctx)
 	}
 }
 

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const SandboxStateHeader = "X-Daytona-Sandbox-State"
+
 var proxyTransport = &http.Transport{
 	MaxIdleConns:        100,
 	MaxIdleConnsPerHost: 100,
@@ -21,22 +23,7 @@ var proxyTransport = &http.Transport{
 	}).DialContext,
 }
 
-// ProxyRequest handles proxying requests to a sandbox's container
-//
-//	@Tags			toolbox
-//	@Summary		Proxy requests to the sandbox toolbox
-//	@Description	Forwards the request to the specified sandbox's container
-//	@Param			workspaceId	path		string	true	"Sandbox ID"
-//	@Param			projectId	path		string	true	"Project ID"
-//	@Param			path		path		string	true	"Path to forward"
-//	@Success		200			{object}	string	"Proxied response"
-//	@Failure		400			{object}	string	"Bad request"
-//	@Failure		401			{object}	string	"Unauthorized"
-//	@Failure		404			{object}	string	"Sandbox container not found"
-//	@Failure		409			{object}	string	"Sandbox container conflict"
-//	@Failure		500			{object}	string	"Internal server error"
-//	@Router			/workspaces/{workspaceId}/{projectId}/toolbox/{path} [get]
-func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.URL, extraHeaders map[string]string, err error), modifyResponse func(*http.Response) error) gin.HandlerFunc {
+func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.URL, extraHeaders map[string]string, err error), modifyResponse func(*http.Response) error, errorHandler func(http.ResponseWriter, *http.Request, error)) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		target, extraHeaders, err := getProxyTarget(ctx)
 		if err != nil {
@@ -65,6 +52,7 @@ func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.UR
 			},
 			Transport:      proxyTransport,
 			ModifyResponse: modifyResponse,
+			ErrorHandler:   errorHandler,
 		}
 
 		reverseProxy.ServeHTTP(ctx.Writer, ctx.Request)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically start stopped sandboxes when their preview URL is requested. The proxy wakes the sandbox and serves a short loading page until it’s ready.

- **New Features**
  - Proxy wakes stopped sandboxes on HTTP preview requests (VM sandboxes only; uses `RunnerClass` from cached runner info).
  - Triggers on 503 with `X-Daytona-Sandbox-State: stopped` from runner or on connection errors.
  - Returns an auto-refresh loading page with `Retry-After` while starting; if wake fails, responds 503 JSON with an error message.
  - Supports preview tokens; stores the resolved sandbox ID in the request context.
  - Clears runner cache and waits briefly after start to avoid stale routing.
  - API `startSandbox` accepts `ProxyAuthContext` via `OrGuard` and resolves org by sandbox ID.
  - Docs: added “Auto-start on HTTP request” (experimental).

- **Migration**
  - `libs/common-go/pkg/proxy.NewProxyRequestHandler` now takes a third `errorHandler` param: `NewProxyRequestHandler(getTarget, modifyResponse, errorHandler)`. Pass `nil` if not needed.

<sup>Written for commit 82d756776f02071a1499700f2389e66db514ca41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

