### PR TITLE
refactor(dashboard): bring back client side pagination for sandboxes

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/SandboxTableActions.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableActions.tsx
@@ -5,6 +5,7 @@
 
 import { FeatureFlags } from '@/enums/FeatureFlags'
 import { RoutePath } from '@/enums/RoutePath'
+import { useRegions } from '@/hooks/useRegions'
 import { SandboxState } from '@daytona/api-client'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { Terminal, MoreVertical, Play, Square, Loader2, Wrench } from 'lucide-react'
@@ -42,6 +43,8 @@ export function SandboxTableActions({
 }: SandboxTableActionsProps) {
   const navigate = useNavigate()
   const linuxVmEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_LINUX_VM)
+  const { getRegionName } = useRegions()
+  const isExperimentalRegion = (getRegionName(sandbox.target) ?? '').toLowerCase() === 'experimental'
 
   const menuItems = useMemo(() => {
     const items = []
@@ -98,7 +101,11 @@ export function SandboxTableActions({
         })
       }
 
-      if (linuxVmEnabled && (sandbox.state === SandboxState.STARTED || sandbox.state === SandboxState.STOPPED)) {
+      if (
+        linuxVmEnabled &&
+        isExperimentalRegion &&
+        (sandbox.state === SandboxState.STARTED || sandbox.state === SandboxState.STOPPED)
+      ) {
         items.push({
           key: 'create-snapshot',
           label: 'Create Snapshot',
@@ -114,7 +121,7 @@ export function SandboxTableActions({
         })
       }
 
-      if (linuxVmEnabled) {
+      if (linuxVmEnabled && isExperimentalRegion) {
         items.push({
           key: 'view-forks',
           label: 'View Fork Tree',
@@ -174,6 +181,8 @@ export function SandboxTableActions({
     onFork,
     onViewForks,
     linuxVmEnabled,
+    isExperimentalRegion,
+    sandbox.target,
     navigate,
   ])
 

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
@@ -58,14 +58,11 @@ const RESOURCE_FILTERS = [
 
 export function SandboxTableHeader({
   table,
+  labelOptions,
   regionOptions,
   regionsDataIsLoading,
   snapshots,
-  snapshotsDataIsLoading,
-  snapshotsDataHasMore,
-  onChangeSnapshotSearchValue,
-  onRefresh,
-  isRefreshing = false,
+  loadingSnapshots,
 }: SandboxTableHeaderProps) {
   const [open, setOpen] = React.useState(false)
   const currentSort = table.getState().sorting[0]?.id || ''
@@ -79,19 +76,14 @@ export function SandboxTableHeader({
   ]
 
   return (
-    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-      <div className="flex flex-wrap gap-2 items-center">
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center mb-4">
+      <div className="flex gap-2 items-center">
         <DebouncedInput
           value={(table.getColumn('name')?.getFilterValue() as string) ?? ''}
           onChange={(value) => table.getColumn('name')?.setFilterValue(value)}
-          placeholder="Search by Name or UUID"
-          className="w-[240px]"
+          placeholder="Search by Name"
+          className="max-w-[200px]"
         />
-
-        <Button variant="outline" onClick={onRefresh} disabled={isRefreshing} className="flex items-center gap-2">
-          <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-          Refresh
-        </Button>
 
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
@@ -211,9 +203,7 @@ export function SandboxTableHeader({
                     value={(table.getColumn('snapshot')?.getFilterValue() as string[]) || []}
                     onFilterChange={(value) => table.getColumn('snapshot')?.setFilterValue(value)}
                     snapshots={snapshots}
-                    isLoading={snapshotsDataIsLoading}
-                    hasMore={snapshotsDataHasMore}
-                    onChangeSnapshotSearchValue={onChangeSnapshotSearchValue}
+                    loadingSnapshots={loadingSnapshots}
                   />
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
@@ -261,6 +251,7 @@ export function SandboxTableHeader({
                   <LabelFilter
                     value={(table.getColumn('labels')?.getFilterValue() as string[]) || []}
                     onFilterChange={(value) => table.getColumn('labels')?.setFilterValue(value)}
+                    options={labelOptions}
                   />
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
@@ -273,7 +264,7 @@ export function SandboxTableHeader({
               <DropdownMenuPortal>
                 <DropdownMenuSubContent className="p-3 w-92">
                   <LastEventFilter
-                    onFilterChange={(value) => table.getColumn('lastEvent')?.setFilterValue(value)}
+                    onFilterChange={(value: Date[] | undefined) => table.getColumn('lastEvent')?.setFilterValue(value)}
                     value={(table.getColumn('lastEvent')?.getFilterValue() as Date[]) || []}
                   />
                 </DropdownMenuSubContent>
@@ -296,9 +287,7 @@ export function SandboxTableHeader({
             value={(table.getColumn('snapshot')?.getFilterValue() as string[]) || []}
             onFilterChange={(value) => table.getColumn('snapshot')?.setFilterValue(value)}
             snapshots={snapshots}
-            isLoading={snapshotsDataIsLoading}
-            hasMore={snapshotsDataHasMore}
-            onChangeSnapshotSearchValue={onChangeSnapshotSearchValue}
+            loadingSnapshots={loadingSnapshots}
           />
         )}
 
@@ -327,6 +316,7 @@ export function SandboxTableHeader({
           <LabelFilterIndicator
             value={(table.getColumn('labels')?.getFilterValue() as string[]) || []}
             onFilterChange={(value) => table.getColumn('labels')?.setFilterValue(value)}
+            options={labelOptions}
           />
         )}
 

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -3,16 +3,19 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import React from 'react'
 import { formatTimestamp, getRelativeTimeString } from '@/lib/utils'
 import { Sandbox, SandboxDesiredState, SandboxState } from '@daytona/api-client'
 import { ColumnDef } from '@tanstack/react-table'
 import { ArrowDown, ArrowUp } from 'lucide-react'
-import React from 'react'
 import { EllipsisWithTooltip } from '../EllipsisWithTooltip'
 import { Checkbox } from '../ui/checkbox'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { SandboxState as SandboxStateComponent } from './SandboxState'
 import { SandboxTableActions } from './SandboxTableActions'
+import { STATE_PRIORITY_ORDER } from './constants'
+import { ResourceFilterValue } from './filters/ResourceFilter'
+import { arrayIncludesFilter, arrayIntersectionFilter, resourceRangeFilter, dateRangeFilter } from './filters/utils'
 
 interface SortableHeaderProps {
   column: any
@@ -178,6 +181,17 @@ export function getColumns({
         </div>
       ),
       accessorKey: 'state',
+      sortingFn: (rowA, rowB) => {
+        const stateA = rowA.original.state || SandboxState.UNKNOWN
+        const stateB = rowB.original.state || SandboxState.UNKNOWN
+
+        if (stateA === stateB) {
+          return 0
+        }
+
+        return STATE_PRIORITY_ORDER[stateA] - STATE_PRIORITY_ORDER[stateB]
+      },
+      filterFn: (row, id, value) => arrayIncludesFilter(row, id, value),
     },
     {
       id: 'snapshot',
@@ -199,6 +213,7 @@ export function getColumns({
         )
       },
       accessorKey: 'snapshot',
+      filterFn: (row, id, value) => arrayIncludesFilter(row, id, value),
     },
     {
       id: 'region',
@@ -216,6 +231,7 @@ export function getColumns({
         )
       },
       accessorKey: 'target',
+      filterFn: (row, id, value) => arrayIncludesFilter(row, id, value),
     },
     {
       id: 'resources',
@@ -242,6 +258,7 @@ export function getColumns({
           </div>
         )
       },
+      filterFn: (row, id, value: ResourceFilterValue) => resourceRangeFilter(row, value),
     },
     {
       id: 'labels',
@@ -277,6 +294,7 @@ export function getColumns({
         )
       },
       accessorFn: (row) => Object.entries(row.labels ?? {}).map(([key, value]) => `${key}: ${value}`),
+      filterFn: (row, id, value) => arrayIntersectionFilter(row, id, value),
     },
     {
       id: 'lastEvent',
@@ -286,6 +304,7 @@ export function getColumns({
       header: ({ column }) => {
         return <SortableHeader column={column} label="Last Event" />
       },
+      filterFn: (row, id, value) => dateRangeFilter(row, id, value),
       accessorFn: (row) => getLastEvent(row).date,
       cell: ({ row }) => {
         const lastEvent = getLastEvent(row.original)
@@ -304,6 +323,7 @@ export function getColumns({
       header: ({ column }) => {
         return <SortableHeader column={column} label="Created At" />
       },
+      accessorFn: (row) => (row.createdAt ? new Date(row.createdAt) : new Date()),
       cell: ({ row }) => {
         const timestamp = formatTimestamp(row.original.createdAt)
         return (

--- a/apps/dashboard/src/components/SandboxTable/constants.ts
+++ b/apps/dashboard/src/components/SandboxTable/constants.ts
@@ -7,6 +7,46 @@ import { SandboxState } from '@daytona/api-client'
 import { CheckCircle, Circle, AlertTriangle, Timer, Archive } from 'lucide-react'
 import { FacetedFilterOption } from './types'
 
+const STATE_PRIORITY_ORDER_ARRAY = [
+  SandboxState.STARTED,
+  SandboxState.BUILDING_SNAPSHOT,
+  SandboxState.PENDING_BUILD,
+  SandboxState.RESTORING,
+  SandboxState.ERROR,
+  SandboxState.BUILD_FAILED,
+  SandboxState.STOPPED,
+  SandboxState.ARCHIVED,
+  SandboxState.CREATING,
+  SandboxState.STARTING,
+  SandboxState.STOPPING,
+  SandboxState.DESTROYING,
+  SandboxState.DESTROYED,
+  SandboxState.PULLING_SNAPSHOT,
+  SandboxState.UNKNOWN,
+] as const
+
+const STATE_COLOR_MAPPING = {
+  [SandboxState.STARTED]: 'text-green-500',
+  [SandboxState.STOPPED]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.ERROR]: 'text-red-500',
+  [SandboxState.BUILD_FAILED]: 'text-red-500',
+  [SandboxState.BUILDING_SNAPSHOT]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.PENDING_BUILD]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.RESTORING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.ARCHIVED]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.CREATING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.STARTING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.STOPPING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.DESTROYING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.DESTROYED]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.PULLING_SNAPSHOT]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.UNKNOWN]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.ARCHIVING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.RESIZING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.SNAPSHOTTING]: 'text-gray-800 dark:text-gray-200',
+  [SandboxState.FORKING]: 'text-gray-800 dark:text-gray-200',
+} as const
+
 const STATE_LABEL_MAPPING: Record<SandboxState, string> = {
   [SandboxState.STARTED]: 'Started',
   [SandboxState.STOPPED]: 'Stopped',
@@ -28,6 +68,12 @@ const STATE_LABEL_MAPPING: Record<SandboxState, string> = {
   [SandboxState.SNAPSHOTTING]: 'Snapshotting',
   [SandboxState.FORKING]: 'Forking',
 }
+
+export const STATE_PRIORITY_ORDER: Record<SandboxState, number> = Object.fromEntries(
+  STATE_PRIORITY_ORDER_ARRAY.map((state, index) => [state, index + 1]),
+) as Record<SandboxState, number>
+
+export const STATE_COLORS: Record<SandboxState, string> = STATE_COLOR_MAPPING
 
 export const STATUSES: FacetedFilterOption[] = [
   {

--- a/apps/dashboard/src/components/SandboxTable/filters/LabelFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/LabelFilter.tsx
@@ -3,19 +3,24 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { Plus, Trash2, X } from 'lucide-react'
-import { useState } from 'react'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { Command, CommandList, CommandGroup, CommandItem, CommandInput } from '@/components/ui/command'
+import { cn } from '@/lib/utils'
+import { Check } from 'lucide-react'
+import { FacetedFilterOption } from '@/components/ui/data-table-faceted-filter'
+import { X } from 'lucide-react'
 
 interface LabelFilterProps {
   value: string[]
   onFilterChange: (value: string[] | undefined) => void
+  options: FacetedFilterOption[]
 }
 
-export function LabelFilterIndicator({ value, onFilterChange }: Pick<LabelFilterProps, 'value' | 'onFilterChange'>) {
+export function LabelFilterIndicator({
+  value,
+  onFilterChange,
+  options,
+}: Pick<LabelFilterProps, 'value' | 'onFilterChange' | 'options'>) {
   return (
     <div className="flex items-center h-6 gap-0.5 rounded-sm border border-border bg-muted/80 hover:bg-muted/50 text-sm">
       <Popover>
@@ -23,8 +28,8 @@ export function LabelFilterIndicator({ value, onFilterChange }: Pick<LabelFilter
           Labels: <span className="text-primary font-medium">{value.length} selected</span>
         </PopoverTrigger>
 
-        <PopoverContent className="p-0 w-[320px]" align="start">
-          <LabelFilter value={value} onFilterChange={onFilterChange} />
+        <PopoverContent className="p-0 w-[240px]" align="start">
+          <LabelFilter value={value} onFilterChange={onFilterChange} options={options} />
         </PopoverContent>
       </Popover>
 
@@ -35,118 +40,51 @@ export function LabelFilterIndicator({ value, onFilterChange }: Pick<LabelFilter
   )
 }
 
-export function LabelFilter({ value, onFilterChange }: LabelFilterProps) {
-  const [newKey, setNewKey] = useState('')
-  const [newValue, setNewValue] = useState('')
-
-  // Convert string array back to key-value pairs for display
-  const labelPairs = value.map((labelString) => {
-    const [key, ...valueParts] = labelString.split(': ')
-    return { key: key || '', value: valueParts.join(': ') || '' }
-  })
-
-  const addKeyValuePair = () => {
-    if (newKey.trim() && newValue.trim()) {
-      const newLabelString = `${newKey.trim()}: ${newValue.trim()}`
-      const updatedValue = [...value, newLabelString]
-      onFilterChange(updatedValue)
-      setNewKey('')
-      setNewValue('')
-    }
-  }
-
-  const removeKeyValuePair = (index: number) => {
-    const updatedValue = value.filter((_, i) => i !== index)
-    onFilterChange(updatedValue.length > 0 ? updatedValue : undefined)
-  }
-
-  const clearAll = () => {
-    onFilterChange(undefined)
-  }
-
+export function LabelFilter({ value, onFilterChange, options }: LabelFilterProps) {
   return (
-    <div className="p-3 space-y-3">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h4 className="text-sm font-medium">Labels</h4>
-        <button className="text-sm text-muted-foreground hover:text-primary pl-2" onClick={clearAll}>
+    <Command>
+      <div className="flex items-center gap-2 justify-between p-2">
+        <CommandInput placeholder="Filter by label..." className="border border-border rounded-md h-8" />
+        <button
+          className="text-sm text-muted-foreground hover:text-primary px-2"
+          onClick={() => onFilterChange(undefined)}
+        >
           Clear
         </button>
       </div>
-
-      {/* Current key-value pairs */}
-      {labelPairs.length > 0 && (
-        <div className="space-y-2">
-          <div className="space-y-1 max-h-32 overflow-y-auto">
-            {labelPairs.map((pair, index) => (
-              <div key={index} className="flex items-center gap-2 p-2 bg-muted/50 rounded-sm">
-                <div className="flex-1 flex items-center gap-1 text-sm min-w-0">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="truncate flex-shrink-0 max-w-[50%] rounded-sm bg-blue-100 dark:bg-blue-950 text-blue-800 dark:text-blue-200 px-1 cursor-default">
-                        {pair.key}
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="max-w-[300px] break-words">{pair.key}</p>
-                    </TooltipContent>
-                  </Tooltip>
-
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="truncate flex-1 text-muted-foreground cursor-default">{pair.value}</span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p className="max-w-[300px] break-words">{pair.value}</p>
-                    </TooltipContent>
-                  </Tooltip>
+      <CommandList>
+        <CommandGroup>
+          {options.map((option) => (
+            <CommandItem
+              key={option.value}
+              onSelect={() => {
+                const newValue = value.includes(option.value)
+                  ? value.filter((v) => v !== option.value)
+                  : [...value, option.value]
+                onFilterChange(newValue.length > 0 ? newValue : undefined)
+              }}
+            >
+              <div className="flex items-center">
+                <div
+                  className={cn(
+                    'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                    value.includes(option.value)
+                      ? 'bg-primary text-primary-foreground'
+                      : 'opacity-50 [&_svg]:invisible',
+                  )}
+                >
+                  <Check className={cn('h-4 w-4')} />
                 </div>
-                <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => removeKeyValuePair(index)}>
-                  <Trash2 className="h-3 w-3" />
-                </Button>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+                <div className="truncate max-w-md rounded-sm bg-blue-100 dark:bg-blue-950 text-blue-800 dark:text-blue-200 px-1">
+                  {option.label.split(':')[0]}
+                </div>
 
-      {/* Add new key-value pair */}
-      <div className="space-y-2">
-        <div className="space-y-2">
-          <Input
-            placeholder="Key"
-            value={newKey}
-            onChange={(e) => setNewKey(e.target.value)}
-            className="h-8"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && newKey.trim() && newValue.trim()) {
-                addKeyValuePair()
-              }
-            }}
-          />
-          <Input
-            placeholder="Value"
-            value={newValue}
-            onChange={(e) => setNewValue(e.target.value)}
-            className="h-8"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && newKey.trim() && newValue.trim()) {
-                addKeyValuePair()
-              }
-            }}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full h-8"
-            onClick={addKeyValuePair}
-            disabled={!newKey.trim() || !newValue.trim()}
-          >
-            <Plus className="h-3 w-3 mr-1" />
-            Add Label
-          </Button>
-        </div>
-      </div>
-    </div>
+                <span className="ml-2 text-muted-foreground">{option.label.split(':')[1]}</span>
+              </div>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
   )
 }

--- a/apps/dashboard/src/components/SandboxTable/filters/LastEventFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/LastEventFilter.tsx
@@ -13,8 +13,8 @@ import { format } from 'date-fns'
 import { CalendarIcon, X } from 'lucide-react'
 
 interface LastEventFilterProps {
-  value: (Date | undefined)[]
-  onFilterChange: (value: (Date | undefined)[] | undefined) => void
+  value: Date[]
+  onFilterChange: (value: Date[] | undefined) => void
 }
 
 export function LastEventFilterIndicator({ value, onFilterChange }: LastEventFilterProps) {
@@ -24,12 +24,7 @@ export function LastEventFilterIndicator({ value, onFilterChange }: LastEventFil
         <PopoverTrigger className="max-w-[220px] overflow-hidden text-ellipsis whitespace-nowrap text-muted-foreground px-2">
           Last Event:{' '}
           <span className="text-primary font-medium">
-            {value.some((d) => d !== undefined)
-              ? `${value
-                  .filter((d): d is Date => d !== undefined)
-                  .map((d) => format(d, 'PPP'))
-                  .join(' - ')}`
-              : ''}
+            {value.length > 0 ? `${value.map((d) => format(d, 'PPP')).join(' - ')}` : ''}
           </span>
         </PopoverTrigger>
         <PopoverContent className="p-3 w-auto" align="start">
@@ -45,8 +40,8 @@ export function LastEventFilterIndicator({ value, onFilterChange }: LastEventFil
 }
 
 interface LastEventFilterContentProps {
-  onFilterChange: (value: (Date | undefined)[] | undefined) => void
-  value: (Date | undefined)[]
+  onFilterChange: (value: Date[] | undefined) => void
+  value: Date[]
 }
 
 export function LastEventFilter({ onFilterChange, value }: LastEventFilterContentProps) {
@@ -55,16 +50,14 @@ export function LastEventFilter({ onFilterChange, value }: LastEventFilterConten
 
   const handleFromDateSelect = (selectedDate: Date | undefined) => {
     setFromDate(selectedDate)
-    const dates = [selectedDate, toDate]
-    const hasAnyDate = dates.some((date) => date !== undefined)
-    onFilterChange(hasAnyDate ? dates : undefined)
+    const dates = [selectedDate, toDate].filter(Boolean) as Date[]
+    onFilterChange(dates.length > 0 ? dates : undefined)
   }
 
   const handleToDateSelect = (selectedDate: Date | undefined) => {
     setToDate(selectedDate)
-    const dates = [fromDate, selectedDate]
-    const hasAnyDate = dates.some((date) => date !== undefined)
-    onFilterChange(hasAnyDate ? dates : undefined)
+    const dates = [fromDate, selectedDate].filter(Boolean) as Date[]
+    onFilterChange(dates.length > 0 ? dates : undefined)
   }
 
   const handleClear = () => {

--- a/apps/dashboard/src/components/SandboxTable/filters/SnapshotFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/SnapshotFilter.tsx
@@ -13,6 +13,7 @@ import {
   CommandList,
 } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Skeleton } from '@/components/ui/skeleton'
 import { SnapshotDto } from '@daytona/api-client'
 import { Loader2, X } from 'lucide-react'
 import { useState } from 'react'
@@ -21,19 +22,10 @@ interface SnapshotFilterProps {
   value: string[]
   onFilterChange: (value: string[] | undefined) => void
   snapshots: SnapshotDto[]
-  isLoading: boolean
-  hasMore?: boolean
-  onChangeSnapshotSearchValue: (name?: string) => void
+  loadingSnapshots: boolean
 }
 
-export function SnapshotFilterIndicator({
-  value,
-  onFilterChange,
-  snapshots,
-  isLoading,
-  hasMore,
-  onChangeSnapshotSearchValue,
-}: SnapshotFilterProps) {
+export function SnapshotFilterIndicator({ value, onFilterChange, snapshots, loadingSnapshots }: SnapshotFilterProps) {
   return (
     <div className="flex items-center h-6 gap-0.5 rounded-sm border border-border bg-muted/80 hover:bg-muted/50 text-sm">
       <Popover>
@@ -46,9 +38,7 @@ export function SnapshotFilterIndicator({
             value={value}
             onFilterChange={onFilterChange}
             snapshots={snapshots}
-            isLoading={isLoading}
-            hasMore={hasMore}
-            onChangeSnapshotSearchValue={onChangeSnapshotSearchValue}
+            loadingSnapshots={loadingSnapshots}
           />
         </PopoverContent>
       </Popover>
@@ -60,16 +50,7 @@ export function SnapshotFilterIndicator({
   )
 }
 
-export function SnapshotFilter({
-  value,
-  onFilterChange,
-  snapshots,
-  isLoading,
-  hasMore,
-  onChangeSnapshotSearchValue,
-}: SnapshotFilterProps) {
-  const [searchValue, setSearchValue] = useState('')
-
+export function SnapshotFilter({ value, onFilterChange, snapshots, loadingSnapshots }: SnapshotFilterProps) {
   const handleSelect = (snapshotName: string) => {
     const newValue = value.includes(snapshotName)
       ? value.filter((name) => name !== snapshotName)
@@ -77,45 +58,27 @@ export function SnapshotFilter({
     onFilterChange(newValue.length > 0 ? newValue : undefined)
   }
 
-  const handleSearchChange = (search: string | number) => {
-    const searchStr = String(search)
-    setSearchValue(searchStr)
-    if (onChangeSnapshotSearchValue) {
-      onChangeSnapshotSearchValue(searchStr || undefined)
-    }
-  }
-
   return (
     <Command>
-      <CommandInput placeholder="Search..." className="" value={searchValue} onValueChange={setSearchValue}>
-        <CommandInputButton
-          onClick={() => {
-            onFilterChange(undefined)
-            setSearchValue('')
-            if (onChangeSnapshotSearchValue) {
-              onChangeSnapshotSearchValue(undefined)
-            }
-          }}
+      <div className="flex items-center gap-2 justify-between p-2">
+        <CommandInput placeholder="Filter by snapshot..." className="border border-border rounded-md h-8" />
+        <button
+          className="text-sm text-muted-foreground hover:text-primary px-2"
+          onClick={() => onFilterChange(undefined)}
         >
           Clear
-        </CommandInputButton>
-      </CommandInput>
-      {hasMore && (
-        <div className="px-2 pb-2 mt-2">
-          <div className="text-xs text-muted-foreground bg-muted/50 rounded px-2 py-1">
-            Please refine your search to see more Snapshots.
-          </div>
-        </div>
-      )}
+        </button>
+      </div>
       <CommandList>
-        {isLoading ? (
-          <div className="flex items-center justify-center py-6">
-            <Loader2 className="h-4 w-4 animate-spin mr-2" />
-            <span className="text-sm text-muted-foreground">Loading Snapshots...</span>
+        {loadingSnapshots ? (
+          <div className="p-1">
+            <Skeleton className="h-8 w-full mb-1" />
+            <Skeleton className="h-8 w-full mb-1" />
+            <Skeleton className="h-8 w-full" />
           </div>
         ) : (
           <>
-            <CommandEmpty>No Snapshots found.</CommandEmpty>
+            <CommandEmpty>No snapshots found.</CommandEmpty>
             <CommandGroup>
               {snapshots.map((snapshot) => (
                 <CommandCheckboxItem

--- a/apps/dashboard/src/components/SandboxTable/filters/utils.ts
+++ b/apps/dashboard/src/components/SandboxTable/filters/utils.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Row } from '@tanstack/react-table'
+import { ResourceFilterValue } from './ResourceFilter'
+
+export function arrayIncludesFilter<TData>(row: Row<TData>, id: string, value: string[]): boolean {
+  return value.includes(row.getValue(id) as string)
+}
+
+export function arrayIntersectionFilter<TData>(row: Row<TData>, id: string, value: string[]): boolean {
+  const cellValues = row.getValue(id) as string[]
+  return value.some((filterValue) => cellValues.includes(filterValue))
+}
+
+export function resourceRangeFilter<TData>(row: Row<TData>, value: ResourceFilterValue): boolean {
+  if (!value) return true
+
+  const { cpu, memory, disk } = row.original as any
+
+  if (value.cpu) {
+    if (value.cpu.min !== undefined && cpu < value.cpu.min) return false
+    if (value.cpu.max !== undefined && cpu > value.cpu.max) return false
+  }
+
+  if (value.memory) {
+    if (value.memory.min !== undefined && memory < value.memory.min) return false
+    if (value.memory.max !== undefined && memory > value.memory.max) return false
+  }
+
+  if (value.disk) {
+    if (value.disk.min !== undefined && disk < value.disk.min) return false
+    if (value.disk.max !== undefined && disk > value.disk.max) return false
+  }
+
+  return true
+}
+
+export function dateRangeFilter<TData>(row: Row<TData>, id: string, value: Date[]): boolean {
+  if (!value) return true
+
+  const date = row.getValue(id) as Date
+  const [start, end] = value
+
+  if ((start || end) && !date) return false
+
+  if (start && !end) {
+    return date.getTime() >= start.getTime()
+  } else if (!start && end) {
+    return date.getTime() <= end.getTime()
+  } else if (start && end) {
+    return date.getTime() >= start.getTime() && date.getTime() <= end.getTime()
+  } else return true
+}

--- a/apps/dashboard/src/components/SandboxTable/index.tsx
+++ b/apps/dashboard/src/components/SandboxTable/index.tsx
@@ -37,9 +37,7 @@ export function SandboxTable({
   sandboxStateIsTransitioning,
   loading,
   snapshots,
-  snapshotsDataIsLoading,
-  snapshotsDataHasMore,
-  onChangeSnapshotSearchValue,
+  loadingSnapshots,
   regionsData,
   regionsDataIsLoading,
   getRegionName,
@@ -56,17 +54,7 @@ export function SandboxTable({
   handleCreateSshAccess,
   handleRevokeSshAccess,
   handleScreenRecordings,
-  handleRefresh,
-  isRefreshing,
   onRowClick,
-  pagination,
-  pageCount,
-  totalItems,
-  onPaginationChange,
-  sorting,
-  onSortingChange,
-  filters,
-  onFiltersChange,
   handleRecover,
   handleCreateSnapshot,
   handleFork,
@@ -77,11 +65,12 @@ export function SandboxTable({
   const writePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_SANDBOXES)
   const deletePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_SANDBOXES)
 
-  const { table, regionOptions } = useSandboxTable({
+  const { table, labelOptions, regionOptions } = useSandboxTable({
     data,
     sandboxIsLoading,
     writePermitted,
     deletePermitted,
+    regionsData,
     handleStart,
     handleStop,
     handleDelete,
@@ -91,14 +80,6 @@ export function SandboxTable({
     handleCreateSshAccess,
     handleRevokeSshAccess,
     handleScreenRecordings,
-    pagination,
-    pageCount,
-    onPaginationChange,
-    sorting,
-    onSortingChange,
-    filters,
-    onFiltersChange,
-    regionsData,
     handleRecover,
     getRegionName,
     handleCreateSnapshot,
@@ -176,14 +157,11 @@ export function SandboxTable({
     <>
       <SandboxTableHeader
         table={table}
+        labelOptions={labelOptions}
         regionOptions={regionOptions}
         regionsDataIsLoading={regionsDataIsLoading}
         snapshots={snapshots}
-        snapshotsDataIsLoading={snapshotsDataIsLoading}
-        snapshotsDataHasMore={snapshotsDataHasMore}
-        onChangeSnapshotSearchValue={onChangeSnapshotSearchValue}
-        onRefresh={handleRefresh}
-        isRefreshing={isRefreshing}
+        loadingSnapshots={loadingSnapshots}
       />
 
       <Table className="border-separate border-spacing-0" style={{ tableLayout: 'fixed', width: '100%' }}>
@@ -280,7 +258,7 @@ export function SandboxTable({
       </Table>
 
       <div className="flex items-center justify-end relative">
-        <Pagination className="pb-2 pt-6" table={table} entityName="Sandboxes" totalItems={totalItems} />
+        <Pagination className="pb-2 pt-6" table={table} selectionEnabled={deletePermitted} entityName="Sandboxes" />
 
         <AnimatePresence>
           {hasSelection && (

--- a/apps/dashboard/src/components/SandboxTable/types.ts
+++ b/apps/dashboard/src/components/SandboxTable/types.ts
@@ -3,17 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { DEFAULT_SANDBOX_SORTING, SandboxFilters, SandboxSorting } from '@/hooks/useSandboxes'
-import {
-  ListSandboxesPaginatedOrderEnum,
-  ListSandboxesPaginatedSortEnum,
-  ListSandboxesPaginatedStatesEnum,
-  Region,
-  Sandbox,
-  SandboxState,
-  SnapshotDto,
-} from '@daytona/api-client'
-import { ColumnFiltersState, SortingState, Table } from '@tanstack/react-table'
+import { Region, Sandbox, SandboxState, SnapshotDto } from '@daytona/api-client'
+import { Table } from '@tanstack/react-table'
 
 export interface SandboxTableProps {
   data: Sandbox[]
@@ -21,9 +12,7 @@ export interface SandboxTableProps {
   sandboxStateIsTransitioning: Record<string, boolean>
   loading: boolean
   snapshots: SnapshotDto[]
-  snapshotsDataIsLoading: boolean
-  snapshotsDataHasMore?: boolean
-  onChangeSnapshotSearchValue: (name?: string) => void
+  loadingSnapshots: boolean
   regionsData: Region[]
   regionsDataIsLoading: boolean
   getRegionName: (regionId: string) => string | undefined
@@ -39,20 +28,7 @@ export interface SandboxTableProps {
   getWebTerminalUrl: (id: string) => Promise<string | null>
   handleCreateSshAccess: (id: string) => void
   handleRevokeSshAccess: (id: string) => void
-  handleRefresh: () => void
-  isRefreshing?: boolean
   onRowClick?: (sandbox: Sandbox) => void
-  pagination: {
-    pageIndex: number
-    pageSize: number
-  }
-  pageCount: number
-  totalItems: number
-  onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-  sorting: SandboxSorting
-  onSortingChange: (sorting: SandboxSorting) => void
-  filters: SandboxFilters
-  onFiltersChange: (filters: SandboxFilters) => void
   handleRecover: (id: string) => void
   handleScreenRecordings: (id: string) => void
   handleCreateSnapshot: (id: string) => void
@@ -83,236 +59,15 @@ export interface SandboxTableActionsProps {
 
 export interface SandboxTableHeaderProps {
   table: Table<Sandbox>
+  labelOptions: FacetedFilterOption[]
   regionOptions: FacetedFilterOption[]
   regionsDataIsLoading: boolean
   snapshots: SnapshotDto[]
-  snapshotsDataIsLoading: boolean
-  snapshotsDataHasMore?: boolean
-  onChangeSnapshotSearchValue: (name?: string) => void
-  onRefresh: () => void
-  isRefreshing?: boolean
+  loadingSnapshots: boolean
 }
 
 export interface FacetedFilterOption {
   label: string
   value: string | SandboxState
   icon?: any
-}
-
-export const convertTableSortingToApiSorting = (sorting: SortingState): SandboxSorting => {
-  if (!sorting.length) {
-    return DEFAULT_SANDBOX_SORTING
-  }
-
-  const sort = sorting[0]
-  let field: ListSandboxesPaginatedSortEnum
-
-  switch (sort.id) {
-    case 'name':
-      field = ListSandboxesPaginatedSortEnum.NAME
-      break
-    case 'state':
-      field = ListSandboxesPaginatedSortEnum.STATE
-      break
-    case 'snapshot':
-      field = ListSandboxesPaginatedSortEnum.SNAPSHOT
-      break
-    case 'region':
-    case 'target':
-      field = ListSandboxesPaginatedSortEnum.REGION
-      break
-    case 'lastEvent':
-    case 'updatedAt':
-      field = ListSandboxesPaginatedSortEnum.UPDATED_AT
-      break
-    case 'createdAt':
-    default:
-      field = ListSandboxesPaginatedSortEnum.CREATED_AT
-      break
-  }
-
-  return {
-    field,
-    direction: sort.desc ? ListSandboxesPaginatedOrderEnum.DESC : ListSandboxesPaginatedOrderEnum.ASC,
-  }
-}
-
-export const convertTableFiltersToApiFilters = (columnFilters: ColumnFiltersState): SandboxFilters => {
-  const filters: SandboxFilters = {}
-
-  columnFilters.forEach((filter) => {
-    switch (filter.id) {
-      case 'name':
-        if (filter.value && typeof filter.value === 'string') {
-          filters.idOrName = filter.value
-        }
-        break
-      case 'state':
-        if (Array.isArray(filter.value) && filter.value.length > 0) {
-          filters.states = filter.value as ListSandboxesPaginatedStatesEnum[]
-        }
-        break
-      case 'snapshot':
-        if (Array.isArray(filter.value) && filter.value.length > 0) {
-          filters.snapshots = filter.value as string[]
-        }
-        break
-      case 'region':
-      case 'target':
-        if (Array.isArray(filter.value) && filter.value.length > 0) {
-          filters.regions = filter.value as string[]
-        }
-        break
-      case 'labels':
-        if (Array.isArray(filter.value) && filter.value.length > 0) {
-          const labelObj: Record<string, string> = {}
-          filter.value.forEach((label: string) => {
-            const [key, value] = label.split(': ')
-            if (key && value) {
-              labelObj[key] = value
-            }
-          })
-          if (Object.keys(labelObj).length > 0) {
-            filters.labels = labelObj
-          }
-        }
-        break
-      case 'resources':
-        if (filter.value && typeof filter.value === 'object') {
-          const resourceValue = filter.value as {
-            cpu?: { min?: number; max?: number }
-            memory?: { min?: number; max?: number }
-            disk?: { min?: number; max?: number }
-          }
-
-          if (resourceValue.cpu?.min !== undefined) {
-            filters.minCpu = resourceValue.cpu.min
-          }
-          if (resourceValue.cpu?.max !== undefined) {
-            filters.maxCpu = resourceValue.cpu.max
-          }
-          if (resourceValue.memory?.min !== undefined) {
-            filters.minMemoryGiB = resourceValue.memory.min
-          }
-          if (resourceValue.memory?.max !== undefined) {
-            filters.maxMemoryGiB = resourceValue.memory.max
-          }
-          if (resourceValue.disk?.min !== undefined) {
-            filters.minDiskGiB = resourceValue.disk.min
-          }
-          if (resourceValue.disk?.max !== undefined) {
-            filters.maxDiskGiB = resourceValue.disk.max
-          }
-        }
-        break
-      case 'lastEvent':
-        if (Array.isArray(filter.value) && filter.value.length > 0) {
-          const dateRange = filter.value as (Date | undefined)[]
-          if (dateRange[0]) {
-            filters.lastEventAfter = dateRange[0]
-          }
-          if (dateRange[1]) {
-            filters.lastEventBefore = dateRange[1]
-          }
-        }
-        break
-    }
-  })
-
-  return filters
-}
-
-export const convertApiSortingToTableSorting = (sorting: SandboxSorting): SortingState => {
-  if (!sorting.field || !sorting.direction) {
-    return [{ id: 'lastEvent', desc: true }]
-  }
-
-  let id: string
-  switch (sorting.field) {
-    case ListSandboxesPaginatedSortEnum.NAME:
-      id = 'name'
-      break
-    case ListSandboxesPaginatedSortEnum.STATE:
-      id = 'state'
-      break
-    case ListSandboxesPaginatedSortEnum.SNAPSHOT:
-      id = 'snapshot'
-      break
-    case ListSandboxesPaginatedSortEnum.REGION:
-      id = 'region'
-      break
-    case ListSandboxesPaginatedSortEnum.UPDATED_AT:
-      id = 'lastEvent'
-      break
-    case ListSandboxesPaginatedSortEnum.CREATED_AT:
-    default:
-      id = 'createdAt'
-      break
-  }
-
-  return [{ id, desc: sorting.direction === ListSandboxesPaginatedOrderEnum.DESC }]
-}
-
-export const convertApiFiltersToTableFilters = (filters: SandboxFilters): ColumnFiltersState => {
-  const columnFilters: ColumnFiltersState = []
-
-  if (filters.idOrName) {
-    columnFilters.push({ id: 'name', value: filters.idOrName })
-  }
-
-  if (filters.states && filters.states.length > 0) {
-    columnFilters.push({ id: 'state', value: filters.states })
-  }
-
-  if (filters.snapshots && filters.snapshots.length > 0) {
-    columnFilters.push({ id: 'snapshot', value: filters.snapshots })
-  }
-
-  if (filters.regions && filters.regions.length > 0) {
-    columnFilters.push({ id: 'region', value: filters.regions })
-  }
-
-  if (filters.labels && Object.keys(filters.labels).length > 0) {
-    const labelArray = Object.entries(filters.labels).map(([key, value]) => `${key}: ${value}`)
-    columnFilters.push({ id: 'labels', value: labelArray })
-  }
-
-  // Convert resource filters back to table format
-  const resourceValue: {
-    cpu?: { min?: number; max?: number }
-    memory?: { min?: number; max?: number }
-    disk?: { min?: number; max?: number }
-  } = {}
-
-  if (filters.minCpu !== undefined || filters.maxCpu !== undefined) {
-    resourceValue.cpu = {}
-    if (filters.minCpu !== undefined) resourceValue.cpu.min = filters.minCpu
-    if (filters.maxCpu !== undefined) resourceValue.cpu.max = filters.maxCpu
-  }
-
-  if (filters.minMemoryGiB !== undefined || filters.maxMemoryGiB !== undefined) {
-    resourceValue.memory = {}
-    if (filters.minMemoryGiB !== undefined) resourceValue.memory.min = filters.minMemoryGiB
-    if (filters.maxMemoryGiB !== undefined) resourceValue.memory.max = filters.maxMemoryGiB
-  }
-
-  if (filters.minDiskGiB !== undefined || filters.maxDiskGiB !== undefined) {
-    resourceValue.disk = {}
-    if (filters.minDiskGiB !== undefined) resourceValue.disk.min = filters.minDiskGiB
-    if (filters.maxDiskGiB !== undefined) resourceValue.disk.max = filters.maxDiskGiB
-  }
-
-  if (Object.keys(resourceValue).length > 0) {
-    columnFilters.push({ id: 'resources', value: resourceValue })
-  }
-
-  // Convert date range filters back to table format
-  if (filters.lastEventAfter || filters.lastEventBefore) {
-    const dateRange: (Date | undefined)[] = [undefined, undefined]
-    if (filters.lastEventAfter) dateRange[0] = filters.lastEventAfter
-    if (filters.lastEventBefore) dateRange[1] = filters.lastEventBefore
-    columnFilters.push({ id: 'lastEvent', value: dateRange })
-  }
-
-  return columnFilters
 }

--- a/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
+++ b/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
@@ -5,23 +5,21 @@
 
 import { Sandbox, Region } from '@daytona/api-client'
 import {
+  ColumnFiltersState,
+  SortingState,
   useReactTable,
   getCoreRowModel,
   getFacetedRowModel,
   getFacetedUniqueValues,
+  getFilteredRowModel,
   getPaginationRowModel,
+  getSortedRowModel,
   VisibilityState,
 } from '@tanstack/react-table'
 import { useMemo, useState, useEffect } from 'react'
+import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { FacetedFilterOption } from './types'
 import { getColumns } from './columns'
-import {
-  convertApiSortingToTableSorting,
-  convertApiFiltersToTableFilters,
-  convertTableSortingToApiSorting,
-  convertTableFiltersToApiFilters,
-} from './types'
-import { SandboxFilters, SandboxSorting } from '@/hooks/useSandboxes'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { getRegionFullDisplayName } from '@/lib/utils'
@@ -40,16 +38,6 @@ interface UseSandboxTableProps {
   handleCreateSshAccess: (id: string) => void
   handleRevokeSshAccess: (id: string) => void
   handleScreenRecordings: (id: string) => void
-  pagination: {
-    pageIndex: number
-    pageSize: number
-  }
-  pageCount: number
-  onPaginationChange: (pagination: { pageIndex: number; pageSize: number }) => void
-  sorting: SandboxSorting
-  onSortingChange: (sorting: SandboxSorting) => void
-  filters: SandboxFilters
-  onFiltersChange: (filters: SandboxFilters) => void
   regionsData: Region[]
   handleRecover: (id: string) => void
   getRegionName: (regionId: string) => string | undefined
@@ -72,13 +60,6 @@ export function useSandboxTable({
   handleCreateSshAccess,
   handleRevokeSshAccess,
   handleScreenRecordings,
-  pagination,
-  pageCount,
-  onPaginationChange,
-  sorting,
-  onSortingChange,
-  filters,
-  onFiltersChange,
   regionsData,
   handleRecover,
   getRegionName,
@@ -103,9 +84,23 @@ export function useSandboxTable({
     setLocalStorageItem(LocalStorageKey.SandboxTableColumnVisibility, JSON.stringify(columnVisibility))
   }, [columnVisibility])
 
-  // Convert API sorting and filters to table format for internal use
-  const tableSorting = useMemo(() => convertApiSortingToTableSorting(sorting), [sorting])
-  const tableFilters = useMemo(() => convertApiFiltersToTableFilters(filters), [filters])
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: 'lastEvent',
+      desc: true,
+    },
+  ])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+
+  const labelOptions: FacetedFilterOption[] = useMemo(() => {
+    const labels = new Set<string>()
+    data.forEach((sandbox) => {
+      Object.entries(sandbox.labels ?? {}).forEach(([key, value]) => {
+        labels.add(`${key}: ${value}`)
+      })
+    })
+    return Array.from(labels).map((label) => ({ label, value: label }))
+  }, [data])
 
   const regionOptions: FacetedFilterOption[] = useMemo(() => {
     return regionsData.map((region) => ({
@@ -159,36 +154,18 @@ export function useSandboxTable({
   const table = useReactTable({
     data,
     columns,
-    manualFiltering: true,
-    onColumnFiltersChange: (updater) => {
-      const newTableFilters = typeof updater === 'function' ? updater(table.getState().columnFilters) : updater
-      const newApiFilters = convertTableFiltersToApiFilters(newTableFilters)
-      onFiltersChange(newApiFilters)
-    },
+    onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
-    manualSorting: true,
-    onSortingChange: (updater) => {
-      const newTableSorting = typeof updater === 'function' ? updater(table.getState().sorting) : updater
-      const newApiSorting = convertTableSortingToApiSorting(newTableSorting)
-      onSortingChange(newApiSorting)
-    },
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
-    manualPagination: true,
-    pageCount: pageCount,
-    onPaginationChange: (updater) => {
-      const newPagination = typeof updater === 'function' ? updater(table.getState().pagination) : updater
-      onPaginationChange(newPagination)
-    },
-    getPaginationRowModel: getPaginationRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
     state: {
-      sorting: tableSorting,
-      columnFilters: tableFilters,
+      sorting,
+      columnFilters,
       columnVisibility,
-      pagination: {
-        pageIndex: pagination.pageIndex,
-        pageSize: pagination.pageSize,
-      },
     },
     onColumnVisibilityChange: setColumnVisibility,
     defaultColumn: {
@@ -196,10 +173,18 @@ export function useSandboxTable({
     },
     enableRowSelection: deletePermitted,
     getRowId: (row) => row.id,
+    initialState: {
+      pagination: {
+        pageSize: DEFAULT_PAGE_SIZE,
+      },
+    },
   })
 
   return {
     table,
+    labelOptions,
     regionOptions,
+    sorting,
+    columnFilters,
   }
 }

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -3,15 +3,19 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { OrganizationRolePermissionsEnum } from '@daytona/api-client'
 import { OrganizationSuspendedError } from '@/api/errors'
-import { type CommandConfig, useRegisterCommands } from '@/components/CommandPalette'
+import { SandboxTable } from '@/components/SandboxTable'
+import { toast } from 'sonner'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from 'react-oidc-context'
 import { ForkTreeDialog } from '@/components/ForkTreeDialog'
 import { PageContent, PageHeader, PageLayout, PageTitle } from '@/components/PageLayout'
 import { RecursiveDeleteDialog } from '@/components/RecursiveDeleteDialog'
 import { CreateSandboxSheet } from '@/components/Sandbox/CreateSandboxSheet'
 import SandboxDetailsSheet from '@/components/SandboxDetailsSheet'
-import { SandboxTable } from '@/components/SandboxTable'
+import { type CommandConfig, useRegisterCommands } from '@/components/CommandPalette'
 import { CreateSshAccessSheet } from '@/components/sandboxes/CreateSshAccessSheet'
 import { RevokeSshAccessDialog } from '@/components/sandboxes/RevokeSshAccessDialog'
 import {
@@ -27,188 +31,32 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { DAYTONA_DOCS_URL } from '@/constants/ExternalLinks'
-import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { RoutePath } from '@/enums/RoutePath'
-import { SnapshotFilters, SnapshotQueryParams, useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
 import { useRegions } from '@/hooks/useRegions'
-import {
-  DEFAULT_SANDBOX_SORTING,
-  getSandboxesQueryKey,
-  SandboxFilters,
-  SandboxQueryParams,
-  SandboxSorting,
-  useSandboxes,
-} from '@/hooks/useSandboxes'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { createBulkActionToast } from '@/lib/bulk-action-toast'
 import { handleApiError } from '@/lib/error-handling'
 import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { formatDuration, pluralize } from '@/lib/utils'
-import { OrganizationUserRoleEnum, Sandbox, SandboxDesiredState, SandboxState } from '@daytona/api-client'
-import { QueryKey, useQueryClient } from '@tanstack/react-query'
+import { OrganizationUserRoleEnum, Sandbox, SandboxDesiredState, SandboxState, SnapshotDto } from '@daytona/api-client'
 import { PlusIcon } from 'lucide-react'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useAuth } from 'react-oidc-context'
-import { useNavigate } from 'react-router-dom'
-import { toast } from 'sonner'
 
 const Sandboxes: React.FC = () => {
-  const { sandboxApi, apiKeyApi, toolboxApi } = useApi()
+  const { sandboxApi, apiKeyApi, toolboxApi, snapshotApi } = useApi()
   const { user } = useAuth()
-  const navigate = useNavigate()
   const { notificationSocket } = useNotificationSocket()
   const config = useConfig()
-  const queryClient = useQueryClient()
-  const { selectedOrganization, authenticatedUserOrganizationMember, authenticatedUserHasPermission } =
-    useSelectedOrganization()
 
-  // Pagination
-
-  const [paginationParams, setPaginationParams] = useState({
-    pageIndex: 0,
-    pageSize: DEFAULT_PAGE_SIZE,
-  })
-
-  const handlePaginationChange = useCallback(({ pageIndex, pageSize }: { pageIndex: number; pageSize: number }) => {
-    setPaginationParams({ pageIndex, pageSize })
-  }, [])
-
-  // Filters
-
-  const [filters, setFilters] = useState<SandboxFilters>({})
-
-  const handleFiltersChange = useCallback((filters: SandboxFilters) => {
-    setFilters(filters)
-    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [])
-
-  // Sorting
-
-  const [sorting, setSorting] = useState<SandboxSorting>(DEFAULT_SANDBOX_SORTING)
-
-  const handleSortingChange = useCallback((sorting: SandboxSorting) => {
-    setSorting(sorting)
-    setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [])
-
-  // Sandboxes Data
-
-  const queryParams = useMemo<SandboxQueryParams>(
-    () => ({
-      page: paginationParams.pageIndex + 1, // 1-indexed
-      pageSize: paginationParams.pageSize,
-      filters: filters,
-      sorting: sorting,
-    }),
-    [paginationParams, filters, sorting],
-  )
-
-  const baseQueryKey = useMemo<QueryKey>(
-    () => getSandboxesQueryKey(selectedOrganization?.id),
-    [selectedOrganization?.id],
-  )
-
-  const queryKey = useMemo<QueryKey>(
-    () => getSandboxesQueryKey(selectedOrganization?.id, queryParams),
-    [selectedOrganization?.id, queryParams],
-  )
-
-  const {
-    data: sandboxesData,
-    isLoading: sandboxesDataIsLoading,
-    error: sandboxesDataError,
-    refetch: refetchSandboxesData,
-  } = useSandboxes(queryKey, queryParams)
-
-  useEffect(() => {
-    if (sandboxesDataError) {
-      handleApiError(sandboxesDataError, 'Failed to fetch sandboxes')
-    }
-  }, [sandboxesDataError])
-
-  const updateSandboxInCache = useCallback(
-    (sandboxId: string, updates: Partial<Sandbox>) => {
-      queryClient.setQueryData(queryKey, (oldData: any) => {
-        if (!oldData) return oldData
-        return {
-          ...oldData,
-          items: oldData.items.map((sandbox: Sandbox) =>
-            sandbox.id === sandboxId ? { ...sandbox, ...updates } : sandbox,
-          ),
-        }
-      })
-    },
-    [queryClient, queryKey],
-  )
-
-  /**
-   * Marks all sandbox queries for this organization as stale.
-   *
-   * Useful when sandbox event occurs and we don't have a good way of knowing for which combination of query parameters the sandbox would be shown.
-   *
-   * @param shouldRefetchActiveQueries If true, only active queries will be refetched. Otherwise, no queries will be refetched.
-   */
-  const markAllSandboxQueriesAsStale = useCallback(
-    async (shouldRefetchActiveQueries = false) => {
-      queryClient.invalidateQueries({
-        queryKey: baseQueryKey,
-        refetchType: shouldRefetchActiveQueries ? 'active' : 'none',
-      })
-    },
-    [queryClient, baseQueryKey],
-  )
-
-  /**
-   * Aborts all outgoing refetches for the provided key.
-   *
-   * Useful for preventing refetches from overwriting optimistic updates.
-   *
-   * @param queryKey
-   */
-  const cancelQueryRefetches = useCallback(
-    async (queryKey: QueryKey) => {
-      queryClient.cancelQueries({ queryKey })
-    },
-    [queryClient],
-  )
-
-  // Go to previous page if there are no items on the current page
-
-  useEffect(() => {
-    if (sandboxesData?.items.length === 0 && paginationParams.pageIndex > 0) {
-      setPaginationParams((prev) => ({
-        ...prev,
-        pageIndex: prev.pageIndex - 1,
-      }))
-    }
-  }, [sandboxesData?.items.length, paginationParams.pageIndex])
-
-  // Ephemeral Sandbox States
-
-  const [sandboxIsLoading, setSandboxIsLoading] = useState<Record<string, boolean>>({})
-  const [sandboxStateIsTransitioning, setSandboxStateIsTransitioning] = useState<Record<string, boolean>>({}) // display transition animation
-
-  // Manual Refreshing
-
-  const [sandboxDataIsRefreshing, setSandboxDataIsRefreshing] = useState(false)
-
-  const handleRefresh = useCallback(async () => {
-    setSandboxDataIsRefreshing(true)
-    try {
-      await refetchSandboxesData()
-    } catch (error) {
-      handleApiError(error, 'Failed to refresh sandboxes')
-    } finally {
-      setSandboxDataIsRefreshing(false)
-    }
-  }, [refetchSandboxesData])
-
-  // Delete Sandbox Dialog
-
+  const [sandboxes, setSandboxes] = useState<Sandbox[]>([])
+  const [snapshots, setSnapshots] = useState<SnapshotDto[]>([])
+  const [loadingSandboxes, setLoadingSandboxes] = useState<Record<string, boolean>>({})
+  const [transitioningSandboxes, setTransitioningSandboxes] = useState<Record<string, boolean>>({})
+  const [loadingTable, setLoadingTable] = useState(true)
+  const [loadingSnapshots, setLoadingSnapshots] = useState(true)
   const [sandboxToDelete, setSandboxToDelete] = useState<string | null>(null)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
 
@@ -230,7 +78,7 @@ const Sandboxes: React.FC = () => {
     try {
       await sandboxApi.forkSandbox(id, {}, selectedOrganization?.id)
       toast.success('Fork started')
-      await refetchSandboxesData()
+      await fetchSandboxes()
     } catch {
       toast.error('Failed to fork sandbox')
     }
@@ -258,107 +106,83 @@ const Sandboxes: React.FC = () => {
 
   const [selectedSandbox, setSelectedSandbox] = useState<Sandbox | null>(null)
   const [showSandboxDetails, setShowSandboxDetails] = useState(false)
-
-  useEffect(() => {
-    if (!selectedSandbox || !sandboxesData?.items) {
-      return
-    }
-
-    const selectedSandboxInData = sandboxesData.items.find((s) => s.id === selectedSandbox.id)
-
-    if (!selectedSandboxInData) {
-      setSelectedSandbox(null)
-      setShowSandboxDetails(false)
-      return
-    }
-
-    if (selectedSandboxInData !== selectedSandbox) {
-      setSelectedSandbox(selectedSandboxInData)
-    }
-  }, [sandboxesData?.items, selectedSandbox])
-
-  const performSandboxStateOptimisticUpdate = useCallback(
-    (sandboxId: string, newState: SandboxState) => {
-      updateSandboxInCache(sandboxId, { state: newState })
-
-      if (selectedSandbox?.id === sandboxId) {
-        setSelectedSandbox((prev) => (prev ? { ...prev, state: newState } : null))
-      }
-    },
-    [updateSandboxInCache, selectedSandbox?.id],
-  )
-
-  const revertSandboxStateOptimisticUpdate = useCallback(
-    (sandboxId: string, previousState?: SandboxState) => {
-      if (!previousState) {
-        return
-      }
-
-      updateSandboxInCache(sandboxId, { state: previousState })
-
-      if (selectedSandbox?.id === sandboxId) {
-        setSelectedSandbox((prev) => (prev ? { ...prev, state: previousState } : null))
-      }
-    },
-    [updateSandboxInCache, selectedSandbox?.id],
-  )
-
-  // SSH Access Dialogs
-
   const [showCreateSshDialog, setShowCreateSshDialog] = useState(false)
   const [showRevokeSshDialog, setShowRevokeSshDialog] = useState(false)
   const [sshSandboxId, setSshSandboxId] = useState<string>('')
   const createSandboxSheetRef = useRef<{ open: () => void }>(null)
 
-  // Snapshot Filter
-
-  const [snapshotFilters, setSnapshotFilters] = useState<SnapshotFilters>({})
-
-  const handleSnapshotFiltersChange = useCallback((filters: Partial<SnapshotFilters>) => {
-    setSnapshotFilters((prev) => ({ ...prev, ...filters }))
-  }, [])
-
-  const snapshotsQueryParams = useMemo<SnapshotQueryParams>(
-    () => ({
-      page: 1,
-      pageSize: 100,
-      filters: snapshotFilters,
-    }),
-    [snapshotFilters],
-  )
-
-  const {
-    data: snapshotsData,
-    isLoading: snapshotsDataIsLoading,
-    error: snapshotsDataError,
-  } = useSnapshotsQuery(snapshotsQueryParams)
-
-  const snapshotsDataHasMore = useMemo(() => {
-    return snapshotsData && snapshotsData.totalPages > 1
-  }, [snapshotsData])
-
-  useEffect(() => {
-    if (snapshotsDataError) {
-      handleApiError(snapshotsDataError, 'Failed to fetch snapshots')
-    }
-  }, [snapshotsDataError])
-
   // Region Filter
 
   const { availableRegions: regionsData, loadingAvailableRegions: regionsDataIsLoading, getRegionName } = useRegions()
 
-  // Subscribe to Sandbox Events
+  const navigate = useNavigate()
+
+  const { selectedOrganization, authenticatedUserOrganizationMember, authenticatedUserHasPermission } =
+    useSelectedOrganization()
+
+  const fetchSnapshots = useCallback(async () => {
+    if (!selectedOrganization) {
+      return
+    }
+    setLoadingSnapshots(true)
+    try {
+      // TODO: Implement snapshot search by input
+      // e.g. "Search to load more results"
+      const response = await snapshotApi.getAllSnapshots(selectedOrganization.id)
+      setSnapshots(response.data.items ?? [])
+    } catch (error) {
+      console.error('Failed to fetch snapshots', error)
+    } finally {
+      setLoadingSnapshots(false)
+    }
+  }, [selectedOrganization, snapshotApi])
+
+  const fetchSandboxes = useCallback(
+    async (showTableLoadingState = true) => {
+      if (!selectedOrganization) {
+        return
+      }
+      if (showTableLoadingState) {
+        setLoadingTable(true)
+      }
+      try {
+        const sandboxes = (await sandboxApi.listSandboxes(selectedOrganization.id)).data
+        setSandboxes(sandboxes)
+      } catch (error) {
+        handleApiError(error, 'Failed to fetch sandboxes')
+      } finally {
+        setLoadingTable(false)
+      }
+    },
+    [sandboxApi, selectedOrganization],
+  )
 
   useEffect(() => {
-    const handleSandboxCreatedEvent = (_sandbox: Sandbox) => {
-      const isFirstPage = paginationParams.pageIndex === 0
-      const isDefaultFilters = Object.keys(filters).length === 0
-      const isDefaultSorting =
-        sorting.field === DEFAULT_SANDBOX_SORTING.field && sorting.direction === DEFAULT_SANDBOX_SORTING.direction
+    fetchSandboxes()
+    fetchSnapshots()
+  }, [fetchSandboxes, fetchSnapshots])
 
-      const shouldRefetchActiveQueries = isFirstPage && isDefaultFilters && isDefaultSorting
+  useEffect(() => {
+    if (selectedSandbox) {
+      const updatedSandbox = sandboxes.find((s) => s.id === selectedSandbox.id)
+      if (updatedSandbox && updatedSandbox !== selectedSandbox) {
+        setSelectedSandbox(updatedSandbox)
+      }
+    }
+  }, [sandboxes, selectedSandbox])
 
-      markAllSandboxQueriesAsStale(shouldRefetchActiveQueries)
+  useEffect(() => {
+    if (selectedSandbox && !sandboxes.some((s) => s.id === selectedSandbox.id)) {
+      setSelectedSandbox(null)
+      setShowSandboxDetails(false)
+    }
+  }, [sandboxes, selectedSandbox])
+
+  useEffect(() => {
+    const handleSandboxCreatedEvent = (sandbox: Sandbox) => {
+      if (!sandboxes.some((s) => s.id === sandbox.id)) {
+        setSandboxes((prev) => [sandbox, ...prev])
+      }
     }
 
     const handleSandboxStateUpdatedEvent = (data: {
@@ -366,25 +190,13 @@ const Sandboxes: React.FC = () => {
       oldState: SandboxState
       newState: SandboxState
     }) => {
-      // warm pool sandboxes
-      if (data.oldState === data.newState && data.newState === SandboxState.STARTED) {
-        handleSandboxCreatedEvent(data.sandbox)
-        return
+      if (data.newState === SandboxState.DESTROYED) {
+        setSandboxes((prev) => prev.filter((s) => s.id !== data.sandbox.id))
+      } else if (!sandboxes.some((s) => s.id === data.sandbox.id)) {
+        setSandboxes((prev) => [data.sandbox, ...prev])
+      } else {
+        setSandboxes((prev) => prev.map((s) => (s.id === data.sandbox.id ? data.sandbox : s)))
       }
-
-      let updatedState = data.newState
-
-      // error,build_failed | destroyed should be displayed as destroyed in the UI
-      if (
-        data.sandbox.desiredState === SandboxDesiredState.DESTROYED &&
-        (data.newState === SandboxState.ERROR || data.newState === SandboxState.BUILD_FAILED)
-      ) {
-        updatedState = SandboxState.DESTROYED
-      }
-
-      performSandboxStateOptimisticUpdate(data.sandbox.id, updatedState)
-
-      markAllSandboxQueriesAsStale()
     }
 
     const handleSandboxDesiredStateUpdatedEvent = (data: {
@@ -392,19 +204,13 @@ const Sandboxes: React.FC = () => {
       oldDesiredState: SandboxDesiredState
       newDesiredState: SandboxDesiredState
     }) => {
-      // error,build_failed | destroyed should be displayed as destroyed in the UI
-
-      if (data.newDesiredState !== SandboxDesiredState.DESTROYED) {
-        return
+      if (
+        data.newDesiredState === SandboxDesiredState.DESTROYED &&
+        data.sandbox.state &&
+        ([SandboxState.ERROR, SandboxState.BUILD_FAILED] as SandboxState[]).includes(data.sandbox.state)
+      ) {
+        setSandboxes((prev) => prev.filter((s) => s.id !== data.sandbox.id))
       }
-
-      if (data.sandbox.state !== SandboxState.ERROR && data.sandbox.state !== SandboxState.BUILD_FAILED) {
-        return
-      }
-
-      performSandboxStateOptimisticUpdate(data.sandbox.id, SandboxState.DESTROYED)
-
-      markAllSandboxQueriesAsStale()
     }
 
     if (!notificationSocket) {
@@ -420,32 +226,24 @@ const Sandboxes: React.FC = () => {
       notificationSocket.off('sandbox.state.updated', handleSandboxStateUpdatedEvent)
       notificationSocket.off('sandbox.desired-state.updated', handleSandboxDesiredStateUpdatedEvent)
     }
-  }, [
-    filters,
-    markAllSandboxQueriesAsStale,
-    notificationSocket,
-    paginationParams.pageIndex,
-    performSandboxStateOptimisticUpdate,
-    sorting.direction,
-    sorting.field,
-  ])
-
-  // Sandbox Action Handlers
+  }, [notificationSocket, sandboxes])
 
   const handleStart = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+    setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
+    setTransitioningSandboxes((prev) => ({ ...prev, [id]: true }))
 
-    const sandboxToStart = sandboxesData?.items.find((s) => s.id === id)
+    const sandboxToStart = sandboxes.find((s) => s.id === id)
     const previousState = sandboxToStart?.state
 
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.STARTING)
+    setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: SandboxState.STARTING } : s)))
+
+    if (selectedSandbox?.id === id) {
+      setSelectedSandbox((prev) => (prev ? { ...prev, state: SandboxState.STARTING } : null))
+    }
 
     try {
       await sandboxApi.startSandbox(id, selectedOrganization?.id)
       toast.success(`Starting sandbox with ID: ${id}`)
-      await markAllSandboxQueriesAsStale()
     } catch (error) {
       handleApiError(error, 'Failed to start sandbox', {
         action:
@@ -457,49 +255,53 @@ const Sandboxes: React.FC = () => {
             </Button>
           ) : undefined,
       })
-      revertSandboxStateOptimisticUpdate(id, previousState)
+      setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: previousState } : s)))
+      if (selectedSandbox?.id === id && previousState) {
+        setSelectedSandbox((prev) => (prev ? { ...prev, state: previousState } : null))
+      }
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+      setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
       setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
+        setTransitioningSandboxes((prev) => ({ ...prev, [id]: false }))
       }, 2000)
     }
   }
 
   const handleRecover = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+    setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
+    setTransitioningSandboxes((prev) => ({ ...prev, [id]: true }))
 
-    const sandboxToRecover = sandboxesData?.items.find((s) => s.id === id)
+    const sandboxToRecover = sandboxes.find((s) => s.id === id)
     const previousState = sandboxToRecover?.state
 
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.STARTING)
+    setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: SandboxState.STARTING } : s)))
 
     try {
       await sandboxApi.recoverSandbox(id, selectedOrganization?.id)
       toast.success('Sandbox recovered. Restarting...')
-      await markAllSandboxQueriesAsStale()
     } catch (error) {
       handleApiError(error, 'Failed to recover sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
+      setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: previousState } : s)))
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+      setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
       setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
+        setTransitioningSandboxes((prev) => ({ ...prev, [id]: false }))
       }, 2000)
     }
   }
 
   const handleStop = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+    setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
+    setTransitioningSandboxes((prev) => ({ ...prev, [id]: true }))
 
-    const sandboxToStop = sandboxesData?.items.find((s) => s.id === id)
+    const sandboxToStop = sandboxes.find((s) => s.id === id)
     const previousState = sandboxToStop?.state
 
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.STOPPING)
+    setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: SandboxState.STOPPING } : s)))
+
+    if (selectedSandbox?.id === id) {
+      setSelectedSandbox((prev) => (prev ? { ...prev, state: SandboxState.STOPPING } : null))
+    }
 
     try {
       await sandboxApi.stopSandbox(id, selectedOrganization?.id)
@@ -511,27 +313,31 @@ const Sandboxes: React.FC = () => {
             }
           : undefined,
       )
-      await markAllSandboxQueriesAsStale()
     } catch (error) {
       handleApiError(error, 'Failed to stop sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
+      setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: previousState } : s)))
+      if (selectedSandbox?.id === id && previousState) {
+        setSelectedSandbox((prev) => (prev ? { ...prev, state: previousState } : null))
+      }
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+      setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
       setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
+        setTransitioningSandboxes((prev) => ({ ...prev, [id]: false }))
       }, 2000)
     }
   }
 
   const handleDelete = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+    setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
 
-    const sandboxToDelete = sandboxesData?.items.find((s) => s.id === id)
+    const sandboxToDelete = sandboxes.find((s) => s.id === id)
     const previousState = sandboxToDelete?.state
 
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.DESTROYING)
+    setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: SandboxState.DESTROYING } : s)))
+
+    if (selectedSandbox?.id === id) {
+      setSelectedSandbox((prev) => (prev ? { ...prev, state: SandboxState.DESTROYING } : null))
+    }
 
     try {
       await sandboxApi.deleteSandbox(id, selectedOrganization?.id)
@@ -544,43 +350,64 @@ const Sandboxes: React.FC = () => {
       }
 
       toast.success(`Deleting sandbox with ID:  ${id}`)
-
-      await markAllSandboxQueriesAsStale()
     } catch (error) {
       handleApiError(error, 'Failed to delete sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
+      setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: previousState } : s)))
+      if (selectedSandbox?.id === id && previousState) {
+        setSelectedSandbox((prev) => (prev ? { ...prev, state: previousState } : null))
+      }
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-      setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-      }, 2000)
+      setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
     }
   }
 
   const handleArchive = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-    setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+    setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
 
-    const sandboxToArchive = sandboxesData?.items.find((s) => s.id === id)
+    const sandboxToArchive = sandboxes.find((s) => s.id === id)
     const previousState = sandboxToArchive?.state
 
-    await cancelQueryRefetches(queryKey)
-    performSandboxStateOptimisticUpdate(id, SandboxState.ARCHIVING)
+    setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: SandboxState.ARCHIVING } : s)))
+
+    if (selectedSandbox?.id === id) {
+      setSelectedSandbox((prev) => (prev ? { ...prev, state: SandboxState.ARCHIVING } : null))
+    }
 
     try {
       await sandboxApi.archiveSandbox(id, selectedOrganization?.id)
       toast.success(`Archiving sandbox with ID: ${id}`)
-      await markAllSandboxQueriesAsStale()
     } catch (error) {
       handleApiError(error, 'Failed to archive sandbox')
-      revertSandboxStateOptimisticUpdate(id, previousState)
+      setSandboxes((prev) => prev.map((s) => (s.id === id ? { ...s, state: previousState } : s)))
+      if (selectedSandbox?.id === id && previousState) {
+        setSelectedSandbox((prev) => (prev ? { ...prev, state: previousState } : null))
+      }
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
-      setTimeout(() => {
-        setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
-      }, 2000)
+      setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
     }
   }
+
+  const performSandboxStateOptimisticUpdate = useCallback(
+    (sandboxId: string, newState: SandboxState) => {
+      if (selectedSandbox?.id === sandboxId) {
+        setSelectedSandbox((prev) => (prev ? { ...prev, state: newState } : null))
+      }
+    },
+    [selectedSandbox?.id],
+  )
+
+  const revertSandboxStateOptimisticUpdate = useCallback(
+    (sandboxId: string, previousState?: SandboxState) => {
+      if (!previousState) {
+        return
+      }
+
+      if (selectedSandbox?.id === sandboxId) {
+        setSelectedSandbox((prev) => (prev ? { ...prev, state: previousState } : null))
+      }
+    },
+    [selectedSandbox?.id],
+  )
 
   // todo(rpavlini): we should refactor this and move to react-query mutations
   const executeBulkAction = useCallback(
@@ -602,9 +429,7 @@ const Sandboxes: React.FC = () => {
         canceledTitle: string
       }
     }) => {
-      await cancelQueryRefetches(queryKey)
-
-      const previousStatesById = new Map((sandboxesData?.items ?? []).map((sandbox) => [sandbox.id, sandbox.state]))
+      const previousStatesById = new Map((sandboxes ?? []).map((sandbox) => [sandbox.id, sandbox.state]))
 
       let isCancelled = false
       let processedCount = 0
@@ -629,8 +454,10 @@ const Sandboxes: React.FC = () => {
             action: { label: 'Cancel', onClick: onCancel },
           })
 
-          setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
-          setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
+          setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
+          // setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
+          setTransitioningSandboxes((prev) => ({ ...prev, [id]: true }))
+          // setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: true }))
           performSandboxStateOptimisticUpdate(id, optimisticState)
 
           try {
@@ -641,14 +468,13 @@ const Sandboxes: React.FC = () => {
             revertSandboxStateOptimisticUpdate(id, previousStatesById.get(id))
             console.error(`${actionName} sandbox failed`, id, error)
           } finally {
-            setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+            setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
             setTimeout(() => {
-              setSandboxStateIsTransitioning((prev) => ({ ...prev, [id]: false }))
+              setTransitioningSandboxes((prev) => ({ ...prev, [id]: false }))
             }, 2000)
           }
         }
 
-        await markAllSandboxQueriesAsStale()
         bulkToast.result({ successCount, failureCount }, toastMessages)
       } catch (error) {
         console.error(`${actionName} sandboxes failed`, error)
@@ -657,14 +483,7 @@ const Sandboxes: React.FC = () => {
 
       return { successCount, failureCount }
     },
-    [
-      cancelQueryRefetches,
-      queryKey,
-      sandboxesData?.items,
-      performSandboxStateOptimisticUpdate,
-      revertSandboxStateOptimisticUpdate,
-      markAllSandboxQueriesAsStale,
-    ],
+    [sandboxes, performSandboxStateOptimisticUpdate, revertSandboxStateOptimisticUpdate],
   )
 
   const handleBulkStart = (ids: string[]) =>
@@ -733,11 +552,11 @@ const Sandboxes: React.FC = () => {
 
   const getPortPreviewUrl = useCallback(
     async (sandboxId: string, port: number): Promise<string> => {
-      setSandboxIsLoading((prev) => ({ ...prev, [sandboxId]: true }))
+      setLoadingSandboxes((prev) => ({ ...prev, [sandboxId]: true }))
       try {
         return (await sandboxApi.getSignedPortPreviewUrl(sandboxId, port, selectedOrganization?.id)).data.url
       } finally {
-        setSandboxIsLoading((prev) => ({ ...prev, [sandboxId]: false }))
+        setLoadingSandboxes((prev) => ({ ...prev, [sandboxId]: false }))
       }
     },
     [sandboxApi, selectedOrganization],
@@ -754,7 +573,7 @@ const Sandboxes: React.FC = () => {
   }
 
   const handleVnc = async (id: string) => {
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
+    setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
 
     // Notify user immediately that we're checking VNC status
     toast.info('Checking VNC desktop status...')
@@ -833,7 +652,7 @@ const Sandboxes: React.FC = () => {
     } catch (error) {
       handleApiError(error, 'Failed to check VNC status')
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+      setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
     }
   }
 
@@ -851,13 +670,13 @@ const Sandboxes: React.FC = () => {
 
   const handleScreenRecordings = async (id: string) => {
     // Check if sandbox is started
-    const sandbox = sandboxesData?.items?.find((s) => s.id === id)
+    const sandbox = sandboxes.find((s) => s.id === id)
     if (!sandbox || sandbox.state !== SandboxState.STARTED) {
       toast.error('Sandbox must be started to access Screen Recordings')
       return
     }
 
-    setSandboxIsLoading((prev) => ({ ...prev, [id]: true }))
+    setLoadingSandboxes((prev) => ({ ...prev, [id]: true }))
     try {
       const portPreviewUrl = await getPortPreviewUrl(id, 33333)
       window.open(portPreviewUrl, '_blank')
@@ -865,7 +684,7 @@ const Sandboxes: React.FC = () => {
     } catch (error) {
       handleApiError(error, 'Failed to open Screen Recordings')
     } finally {
-      setSandboxIsLoading((prev) => ({ ...prev, [id]: false }))
+      setLoadingSandboxes((prev) => ({ ...prev, [id]: false }))
     }
   }
 
@@ -904,7 +723,6 @@ const Sandboxes: React.FC = () => {
 
   // Redirect user to the onboarding page if they haven't created an api key yet
   // Perform only once per user
-
   useEffect(() => {
     const onboardIfNeeded = async () => {
       if (!selectedOrganization) {
@@ -939,13 +757,25 @@ const Sandboxes: React.FC = () => {
       <PageHeader>
         <PageTitle>Sandboxes</PageTitle>
         <div className="flex items-center gap-2 ml-auto">
-          {canCreateSandbox && <CreateSandboxSheet ref={createSandboxSheetRef} />}
+          {!loadingTable && sandboxes.length === 0 && (
+            <>
+              <Button variant="link" className="text-primary" onClick={() => navigate(RoutePath.ONBOARDING)} size="sm">
+                Onboarding guide
+              </Button>
+              <Button variant="link" className="text-primary" asChild size="sm">
+                <a href={DAYTONA_DOCS_URL} target="_blank" rel="noopener noreferrer" className="text-primary">
+                  Docs
+                </a>
+              </Button>
+            </>
+          )}
+          {canCreateSandbox && <CreateSandboxSheet />}
         </div>
       </PageHeader>
       <PageContent size="full" className="flex-1 max-h-[calc(100vh-65px)]">
         <SandboxTable
-          sandboxIsLoading={sandboxIsLoading}
-          sandboxStateIsTransitioning={sandboxStateIsTransitioning}
+          sandboxIsLoading={loadingSandboxes}
+          sandboxStateIsTransitioning={transitioningSandboxes}
           handleStart={handleStart}
           handleStop={handleStop}
           handleDelete={openDeleteDialog}
@@ -958,31 +788,16 @@ const Sandboxes: React.FC = () => {
           getWebTerminalUrl={getWebTerminalUrl}
           handleCreateSshAccess={openCreateSshDialog}
           handleRevokeSshAccess={openRevokeSshDialog}
-          handleRefresh={handleRefresh}
-          isRefreshing={sandboxDataIsRefreshing}
-          data={sandboxesData?.items || []}
-          loading={sandboxesDataIsLoading}
-          snapshots={snapshotsData?.items || []}
-          snapshotsDataIsLoading={snapshotsDataIsLoading}
-          snapshotsDataHasMore={snapshotsDataHasMore}
-          onChangeSnapshotSearchValue={(name?: string) => handleSnapshotFiltersChange({ name })}
-          regionsData={regionsData || []}
-          regionsDataIsLoading={regionsDataIsLoading}
+          data={sandboxes}
+          loading={loadingTable}
+          snapshots={snapshots}
           onRowClick={(sandbox: Sandbox) => {
             setSelectedSandbox(sandbox)
             setShowSandboxDetails(true)
           }}
-          pageCount={sandboxesData?.totalPages || 0}
-          totalItems={sandboxesData?.total || 0}
-          onPaginationChange={handlePaginationChange}
-          pagination={{
-            pageIndex: paginationParams.pageIndex,
-            pageSize: paginationParams.pageSize,
-          }}
-          sorting={sorting}
-          onSortingChange={handleSortingChange}
-          filters={filters}
-          onFiltersChange={handleFiltersChange}
+          loadingSnapshots={loadingSnapshots}
+          regionsData={regionsData}
+          regionsDataIsLoading={regionsDataIsLoading}
           handleRecover={handleRecover}
           getRegionName={getRegionName}
           handleScreenRecordings={handleScreenRecordings}
@@ -1013,9 +828,9 @@ const Sandboxes: React.FC = () => {
                 <AlertDialogAction
                   variant="destructive"
                   onClick={() => handleDelete(sandboxToDelete)}
-                  disabled={sandboxIsLoading[sandboxToDelete]}
+                  disabled={loadingSandboxes[sandboxToDelete]}
                 >
-                  {sandboxIsLoading[sandboxToDelete] ? 'Deleting...' : 'Delete'}
+                  {loadingSandboxes[sandboxToDelete] ? 'Deleting...' : 'Delete'}
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
@@ -1100,7 +915,7 @@ const Sandboxes: React.FC = () => {
           sandbox={selectedSandbox}
           open={showSandboxDetails}
           onOpenChange={setShowSandboxDetails}
-          sandboxIsLoading={sandboxIsLoading}
+          sandboxIsLoading={loadingSandboxes}
           handleStart={handleStart}
           handleStop={handleStop}
           handleDelete={async (id) => {
@@ -1129,7 +944,7 @@ const Sandboxes: React.FC = () => {
             open={!!recursiveDeleteSandboxId}
             onClose={() => setRecursiveDeleteSandboxId(null)}
             onDeleted={async () => {
-              await markAllSandboxQueriesAsStale(true)
+              await fetchSandboxes()
             }}
           />
         )}

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -769,7 +769,7 @@ const Sandboxes: React.FC = () => {
               </Button>
             </>
           )}
-          {canCreateSandbox && <CreateSandboxSheet />}
+          {canCreateSandbox && <CreateSandboxSheet ref={createSandboxSheetRef} />}
         </div>
       </PageHeader>
       <PageContent size="full" className="flex-1 max-h-[calc(100vh-65px)]">


### PR DESCRIPTION
## Description

Refactors the sandbox page to use client side pagination. 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores client-side pagination, sorting, and filtering for Sandboxes for a faster, simpler table. Moves data fetching to the page and updates filters and actions for a smoother experience.

- **New Features**
  - Client-side pagination, sorting, and filtering with initial sort on Last Event.
  - New filters: status, region, snapshot, labels (multi-select from existing labels), resources (range), and last event date range.
  - State column sorts by priority; added state label/color constants.
  - Snapshot and fork actions are shown only for sandboxes in the “experimental” region when `SANDBOX_LINUX_VM` is enabled.

- **Refactors**
  - Replaced server-side pagination/filters with local state on the Sandboxes page; fetches all sandboxes and snapshots once and keeps them in sync via socket events.
  - Optimistic UI updates for start/stop/archive/delete with lightweight loading/transition states.
  - Simplified header: removed manual Refresh, search is “Name” only, smaller inputs; streamlined snapshot and label filter UIs.
  - Fixed missing Create Sandbox sheet ref so it can be opened programmatically.

<sup>Written for commit d6aa49cfbf3fa70df2245338904fe15f3d46ed08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



