### PR TITLE
chore(security): add actionlint config + yarnrc integrity check

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - github-actions-runner-amd64
+    - github-actions-runner-arm

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -220,10 +220,11 @@ jobs:
       - name: Validate .yarnrc.yml
         run: |
           python3 <<'PY'
-          import re
           import sys
           from pathlib import Path
           from urllib.parse import urlparse
+
+          import yaml
 
           yarnrc = Path(".yarnrc.yml")
           if not yarnrc.exists():
@@ -233,21 +234,36 @@ jobs:
           trusted_hosts = {"registry.npmjs.org", "registry.yarnpkg.com"}
           errors = []
 
-          for lineno, line in enumerate(yarnrc.read_text(encoding="utf-8").splitlines(), 1):
-              without_comment = line.split("#", 1)[0]
+          try:
+              config = yaml.safe_load(yarnrc.read_text(encoding="utf-8")) or {}
+          except yaml.YAMLError as e:
+              print(f"::error::Failed to parse .yarnrc.yml: {e}")
+              sys.exit(1)
 
-              # Any URL-bearing registry key (top-level or under npmScopes) must use HTTPS and point to a trusted host
-              # Allow optional whitespace before the colon (YAML permits "key : value")
-              match = re.match(r"^\s*(npmRegistryServer|npmPublishRegistry)\s*:\s*(\S+)\s*$", without_comment)
-              if match:
-                  key, value = match.group(1), match.group(2).strip("'\"")
-                  parsed = urlparse(value)
-                  if parsed.scheme != "https" or parsed.hostname not in trusted_hosts:
-                      errors.append(f"Line {lineno}: {key} must use https and a trusted host, got: {value}")
+          def check_registry(key, value, location):
+              if not isinstance(value, str):
+                  errors.append(f"{location}.{key} is not a string: {value!r}")
+                  return
+              parsed = urlparse(value)
+              if parsed.scheme != "https" or parsed.hostname not in trusted_hosts:
+                  errors.append(f"{location}.{key} must use https and a trusted host, got: {value}")
 
-              # enableScripts at any indent with any common YAML truthy value opens postinstall attack vector
-              if re.match(r"^\s*enableScripts\s*:\s*(true|yes|on|1)\s*$", without_comment, re.IGNORECASE):
-                  errors.append(f"Line {lineno}: enableScripts enabled is a supply chain risk")
+          # Top-level registry overrides
+          for key in ("npmRegistryServer", "npmPublishRegistry"):
+              if key in config:
+                  check_registry(key, config[key], "root")
+
+          # Per-scope registry overrides
+          for scope, scope_config in (config.get("npmScopes") or {}).items():
+              if not isinstance(scope_config, dict):
+                  continue
+              for key in ("npmRegistryServer", "npmPublishRegistry"):
+                  if key in scope_config:
+                      check_registry(key, scope_config[key], f"npmScopes.{scope}")
+
+          # enableScripts (PyYAML returns proper Python bool for any YAML truthy form)
+          if config.get("enableScripts") is True:
+              errors.append("enableScripts: true is a supply chain risk -- postinstall scripts can execute arbitrary code")
 
           if errors:
               for e in errors:

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -219,14 +219,39 @@ jobs:
           persist-credentials: false
       - name: Validate .yarnrc.yml
         run: |
-          # Fail if any registry override points outside trusted hosts
-          if grep -E "npmRegistryServer|npmScopes" .yarnrc.yml 2>/dev/null | grep -vE "registry\.(npmjs|yarnpkg)\.(org|com)"; then
-            echo "::error::Suspicious registry override detected in .yarnrc.yml"
-            exit 1
-          fi
-          # Fail if enableScripts is explicitly enabled (opens postinstall attack vector)
-          if grep -qE "^enableScripts:\s*true" .yarnrc.yml 2>/dev/null; then
-            echo "::error::enableScripts: true is a supply chain risk -- remove or add exception with review"
-            exit 1
-          fi
-          echo "OK -- .yarnrc.yml passes integrity check"
+          python3 <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+          from urllib.parse import urlparse
+
+          yarnrc = Path(".yarnrc.yml")
+          if not yarnrc.exists():
+              print("OK -- .yarnrc.yml not present")
+              sys.exit(0)
+
+          trusted_hosts = {"registry.npmjs.org", "registry.yarnpkg.com"}
+          errors = []
+
+          for lineno, line in enumerate(yarnrc.read_text(encoding="utf-8").splitlines(), 1):
+              without_comment = line.split("#", 1)[0]
+
+              # Any URL-bearing registry key (top-level or under npmScopes) must point to a trusted host
+              match = re.match(r"^\s*(npmRegistryServer|npmPublishRegistry):\s*(\S+)\s*$", without_comment)
+              if match:
+                  key, value = match.group(1), match.group(2).strip("'\"")
+                  parsed = urlparse(value)
+                  if parsed.scheme not in {"http", "https"} or parsed.hostname not in trusted_hosts:
+                      errors.append(f"Line {lineno}: {key} points to untrusted host: {value}")
+
+              # enableScripts: true at any indent level opens postinstall attack vector
+              if re.match(r"^\s*enableScripts:\s*true\s*$", without_comment):
+                  errors.append(f"Line {lineno}: enableScripts: true is a supply chain risk")
+
+          if errors:
+              for e in errors:
+                  print(f"::error::{e}")
+              sys.exit(1)
+
+          print("OK -- .yarnrc.yml passes integrity check")
+          PY

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -209,3 +209,24 @@ jobs:
           token: ${{ github.token }}
           config: .licenserc-clients.yaml
           mode: 'check'
+
+  yarnrc-lint:
+    name: Yarnrc integrity check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Validate .yarnrc.yml
+        run: |
+          # Fail if any registry override points outside trusted hosts
+          if grep -E "npmRegistryServer|npmScopes" .yarnrc.yml 2>/dev/null | grep -vE "registry\.(npmjs|yarnpkg)\.(org|com)"; then
+            echo "::error::Suspicious registry override detected in .yarnrc.yml"
+            exit 1
+          fi
+          # Fail if enableScripts is explicitly enabled (opens postinstall attack vector)
+          if grep -qE "^enableScripts:\s*true" .yarnrc.yml 2>/dev/null; then
+            echo "::error::enableScripts: true is a supply chain risk -- remove or add exception with review"
+            exit 1
+          fi
+          echo "OK -- .yarnrc.yml passes integrity check"

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -236,17 +236,17 @@ jobs:
           for lineno, line in enumerate(yarnrc.read_text(encoding="utf-8").splitlines(), 1):
               without_comment = line.split("#", 1)[0]
 
-              # Any URL-bearing registry key (top-level or under npmScopes) must point to a trusted host
+              # Any URL-bearing registry key (top-level or under npmScopes) must use HTTPS and point to a trusted host
               match = re.match(r"^\s*(npmRegistryServer|npmPublishRegistry):\s*(\S+)\s*$", without_comment)
               if match:
                   key, value = match.group(1), match.group(2).strip("'\"")
                   parsed = urlparse(value)
-                  if parsed.scheme not in {"http", "https"} or parsed.hostname not in trusted_hosts:
-                      errors.append(f"Line {lineno}: {key} points to untrusted host: {value}")
+                  if parsed.scheme != "https" or parsed.hostname not in trusted_hosts:
+                      errors.append(f"Line {lineno}: {key} must use https and a trusted host, got: {value}")
 
-              # enableScripts: true at any indent level opens postinstall attack vector
-              if re.match(r"^\s*enableScripts:\s*true\s*$", without_comment):
-                  errors.append(f"Line {lineno}: enableScripts: true is a supply chain risk")
+              # enableScripts at any indent with any common YAML truthy value opens postinstall attack vector
+              if re.match(r"^\s*enableScripts:\s*(true|yes|on|1)\s*$", without_comment, re.IGNORECASE):
+                  errors.append(f"Line {lineno}: enableScripts enabled is a supply chain risk")
 
           if errors:
               for e in errors:

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -217,6 +217,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Ensure PyYAML available
+        run: sudo apt-get install -y -q python3-yaml
       - name: Validate .yarnrc.yml
         run: |
           python3 <<'PY'
@@ -235,10 +237,28 @@ jobs:
           errors = []
 
           try:
-              config = yaml.safe_load(yarnrc.read_text(encoding="utf-8")) or {}
+              config = yaml.safe_load(yarnrc.read_text(encoding="utf-8"))
           except yaml.YAMLError as e:
               print(f"::error::Failed to parse .yarnrc.yml: {e}")
               sys.exit(1)
+
+          if config is None:
+              config = {}
+          elif not isinstance(config, dict):
+              print(f"::error::.yarnrc.yml must contain a top-level mapping, got: {type(config).__name__}")
+              sys.exit(1)
+
+          def is_truthy(value):
+              """Match Python True, integer 1, or any common YAML truthy string."""
+              if value is True:
+                  return True
+              if isinstance(value, bool):
+                  return False
+              if isinstance(value, int) and value == 1:
+                  return True
+              if isinstance(value, str) and value.strip().lower() in {"true", "yes", "on", "1"}:
+                  return True
+              return False
 
           def check_registry(key, value, location):
               if not isinstance(value, str):
@@ -254,16 +274,24 @@ jobs:
                   check_registry(key, config[key], "root")
 
           # Per-scope registry overrides
-          for scope, scope_config in (config.get("npmScopes") or {}).items():
+          npm_scopes = config.get("npmScopes")
+          if npm_scopes is None:
+              npm_scopes = {}
+          elif not isinstance(npm_scopes, dict):
+              errors.append(f"root.npmScopes must be a mapping, got: {type(npm_scopes).__name__}")
+              npm_scopes = {}
+
+          for scope, scope_config in npm_scopes.items():
               if not isinstance(scope_config, dict):
+                  errors.append(f"npmScopes.{scope} must be a mapping, got: {type(scope_config).__name__}")
                   continue
               for key in ("npmRegistryServer", "npmPublishRegistry"):
                   if key in scope_config:
                       check_registry(key, scope_config[key], f"npmScopes.{scope}")
 
-          # enableScripts (PyYAML returns proper Python bool for any YAML truthy form)
-          if config.get("enableScripts") is True:
-              errors.append("enableScripts: true is a supply chain risk -- postinstall scripts can execute arbitrary code")
+          # enableScripts (catches Python True, int 1, and YAML truthy strings)
+          if is_truthy(config.get("enableScripts")):
+              errors.append("enableScripts is enabled -- postinstall scripts can execute arbitrary code")
 
           if errors:
               for e in errors:

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -237,7 +237,8 @@ jobs:
               without_comment = line.split("#", 1)[0]
 
               # Any URL-bearing registry key (top-level or under npmScopes) must use HTTPS and point to a trusted host
-              match = re.match(r"^\s*(npmRegistryServer|npmPublishRegistry):\s*(\S+)\s*$", without_comment)
+              # Allow optional whitespace before the colon (YAML permits "key : value")
+              match = re.match(r"^\s*(npmRegistryServer|npmPublishRegistry)\s*:\s*(\S+)\s*$", without_comment)
               if match:
                   key, value = match.group(1), match.group(2).strip("'\"")
                   parsed = urlparse(value)
@@ -245,7 +246,7 @@ jobs:
                       errors.append(f"Line {lineno}: {key} must use https and a trusted host, got: {value}")
 
               # enableScripts at any indent with any common YAML truthy value opens postinstall attack vector
-              if re.match(r"^\s*enableScripts:\s*(true|yes|on|1)\s*$", without_comment, re.IGNORECASE):
+              if re.match(r"^\s*enableScripts\s*:\s*(true|yes|on|1)\s*$", without_comment, re.IGNORECASE):
                   errors.append(f"Line {lineno}: enableScripts enabled is a supply chain risk")
 
           if errors:

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -230,8 +230,8 @@ jobs:
 
           yarnrc = Path(".yarnrc.yml")
           if not yarnrc.exists():
-              print("OK -- .yarnrc.yml not present")
-              sys.exit(0)
+              print("::error::.yarnrc.yml is required and must not be removed -- it carries supply chain hardening (npmMinimalAgeGate, etc.)")
+              sys.exit(1)
 
           trusted_hosts = {"registry.npmjs.org", "registry.yarnpkg.com"}
           errors = []

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -288,10 +288,29 @@ jobs:
               for key in ("npmRegistryServer", "npmPublishRegistry"):
                   if key in scope_config:
                       check_registry(key, scope_config[key], f"npmScopes.{scope}")
+              # Per-scope enableScripts (defense in depth for future Yarn versions)
+              if is_truthy(scope_config.get("enableScripts")):
+                  errors.append(f"npmScopes.{scope}.enableScripts is enabled -- postinstall scripts execute arbitrary code")
 
           # enableScripts (catches Python True, int 1, and YAML truthy strings)
           if is_truthy(config.get("enableScripts")):
               errors.append("enableScripts is enabled -- postinstall scripts can execute arbitrary code")
+
+          # unsafeHttpWhitelist undermines the HTTPS enforcement -- block entirely
+          unsafe_whitelist = config.get("unsafeHttpWhitelist")
+          if unsafe_whitelist:
+              errors.append(f"unsafeHttpWhitelist must be unset or empty, got: {unsafe_whitelist!r} -- bypasses HTTPS enforcement")
+
+          # yarnPath must be absent (Corepack) or vendored under .yarn/releases/
+          yarn_path = config.get("yarnPath")
+          if yarn_path is not None:
+              if not isinstance(yarn_path, str) or not yarn_path.startswith(".yarn/releases/"):
+                  errors.append(f"yarnPath must start with '.yarn/releases/' (or be absent to use Corepack), got: {yarn_path!r}")
+
+          # plugins execute arbitrary code on every yarn invocation -- block entirely
+          plugins = config.get("plugins")
+          if plugins:
+              errors.append(f"plugins must be unset or empty, got: {plugins!r} -- plugins execute arbitrary code. Add explicit allowlist to this check if needed.")
 
           if errors:
               for e in errors:

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -222,6 +222,7 @@ jobs:
       - name: Validate .yarnrc.yml
         run: |
           python3 <<'PY'
+          import posixpath
           import sys
           from pathlib import Path
           from urllib.parse import urlparse
@@ -296,21 +297,28 @@ jobs:
           if is_truthy(config.get("enableScripts")):
               errors.append("enableScripts is enabled -- postinstall scripts can execute arbitrary code")
 
-          # unsafeHttpWhitelist undermines the HTTPS enforcement -- block entirely
-          unsafe_whitelist = config.get("unsafeHttpWhitelist")
-          if unsafe_whitelist:
-              errors.append(f"unsafeHttpWhitelist must be unset or empty, got: {unsafe_whitelist!r} -- bypasses HTTPS enforcement")
+          # unsafeHttpWhitelist undermines the HTTPS enforcement -- only allow absent/null or exactly []
+          if "unsafeHttpWhitelist" in config:
+              unsafe_whitelist = config["unsafeHttpWhitelist"]
+              if unsafe_whitelist is not None and unsafe_whitelist != []:
+                  errors.append(f"unsafeHttpWhitelist must be absent or an empty list, got: {unsafe_whitelist!r} -- bypasses HTTPS enforcement")
 
-          # yarnPath must be absent (Corepack) or vendored under .yarn/releases/
-          yarn_path = config.get("yarnPath")
-          if yarn_path is not None:
-              if not isinstance(yarn_path, str) or not yarn_path.startswith(".yarn/releases/"):
-                  errors.append(f"yarnPath must start with '.yarn/releases/' (or be absent to use Corepack), got: {yarn_path!r}")
+          # yarnPath must be absent (Corepack) or a normalized path under .yarn/releases/
+          if "yarnPath" in config:
+              yarn_path = config["yarnPath"]
+              if not isinstance(yarn_path, str):
+                  errors.append(f"yarnPath must be a string, got: {yarn_path!r}")
+              else:
+                  # Normalize to resolve any .. segments, then confirm it's under .yarn/releases/
+                  normalized = posixpath.normpath(yarn_path)
+                  if ".." in yarn_path.split("/") or not normalized.startswith(".yarn/releases/"):
+                      errors.append(f"yarnPath must resolve to a path under '.yarn/releases/' (no traversal, no absolute paths), got: {yarn_path!r}")
 
-          # plugins execute arbitrary code on every yarn invocation -- block entirely
-          plugins = config.get("plugins")
-          if plugins:
-              errors.append(f"plugins must be unset or empty, got: {plugins!r} -- plugins execute arbitrary code. Add explicit allowlist to this check if needed.")
+          # plugins execute arbitrary code on every yarn invocation -- only allow absent/null or exactly []
+          if "plugins" in config:
+              plugins = config["plugins"]
+              if plugins is not None and plugins != []:
+                  errors.append(f"plugins must be absent or an empty list, got: {plugins!r} -- plugins execute arbitrary code. Add explicit allowlist to this check if needed.")
 
           if errors:
               for e in errors:


### PR DESCRIPTION
## Summary

Two config hygiene improvements bundled into one PR (final Phase 1 items).

### 1.8a: actionlint config

Create `.github/actionlint.yaml` to register our custom self-hosted runner labels (`github-actions-runner-amd64`, `github-actions-runner-arm`). Silences 8 spurious `runner-label` warnings per `actionlint` run.

### 1.8b: yarnrc integrity check

Add a `yarnrc-lint` job to `pr_checks.yaml` that fails CI if `.yarnrc.yml` contains any of the following Yarn 4 attack vectors:

| Check | Rule | Attack blocked |
|---|---|---|
| **Required file** | `.yarnrc.yml` must exist | Deletion bypass of Yarn hardening (npmMinimalAgeGate, etc.) |
| **Registry URLs** | `npmRegistryServer` / `npmPublishRegistry` (top-level + per-scope) must use HTTPS and point to `registry.npmjs.org` or `registry.yarnpkg.com` (exact hostname via urlparse) | Malicious registry redirect, subdomain bypass, HTTP downgrade |
| **unsafeHttpWhitelist** | Must be unset or empty | Bypasses HTTPS enforcement by allowlisting HTTP hosts |
| **yarnPath** | Must be absent (Corepack) or start with `.yarn/releases/` | Attacker redirecting Yarn binary to malicious script = RCE on every `yarn` invocation |
| **plugins** | Must be unset or empty | Yarn 4 plugins execute arbitrary JS on every yarn command = RCE |
| **enableScripts** (top-level) | Must be absent / false (catches `True`/`1`/`yes`/`on`/`"true"`) | Postinstall scripts execute arbitrary code |
| **enableScripts** (per-scope) | Same check under each `npmScopes.<scope>` | Defense-in-depth for future Yarn versions |

Uses PyYAML (installed via `sudo apt-get install -y -q python3-yaml`) with `urllib.parse.urlparse` for exact hostname comparison.

**Why not lockfile-lint?** Investigation confirmed `lockfile-lint` only supports Yarn v1 and npm -- not Yarn 4 (Berry) or pnpm. Yarn 4 uses content-addressed `checksum:` fields instead of per-package `resolved:` URLs, so the threat model differs. The actual Yarn 4 attack vectors are `.yarnrc.yml` manipulation -- this check closes them.

**Yarn 4 native protections already in place:**
- `checksum:` field = content-addressed integrity (tamper-resistant)
- `yarn install --immutable` in CI = prevents lockfile drift
- Registry controlled via `.yarnrc.yml` (now protected by this check)

## Context

Final items of Phase 1 tactical hardening (SEC-61). After merge, Phase 1 is complete and we move to Phase 2 (environments, CODEOWNERS, rulesets).

## Verification

Tested the check against malicious inputs -- all caught:
- HTTP registry (`http://registry.npmjs.org`) -> rejected
- Subdomain bypass (`https://registry.npmjs.org.evil.example`) -> rejected
- Scoped registry override (`npmScopes.mycorp.npmRegistryServer: https://evil.com`) -> rejected
- Indented/case-variant `enableScripts` (`TRUE`, `yes`, `on`, `1`, `"true"`) -> rejected
- `.yarnrc.yml` deleted -> rejected
- `unsafeHttpWhitelist: ["*"]` -> rejected
- `yarnPath: ./scripts/yarn.cjs` -> rejected
- `plugins: [{path: ./evil.cjs}]` -> rejected
- Per-scope `npmScopes.mycorp.enableScripts: true` -> rejected
- Valid `yarnPath: .yarn/releases/yarn-4.13.0.cjs` -> passes
- Empty `plugins: []` -> passes
- Current `.yarnrc.yml` -> passes

`actionlint` passes, zero runner-label warnings (down from 8).