### PR TITLE
feat(api): add skipstart option to sandbox recovery endpoint                                                                                                                          

### DIFF
--- a/apps/api/src/interceptors/metrics.interceptor.ts
+++ b/apps/api/src/interceptors/metrics.interceptor.ts
@@ -189,6 +189,9 @@ export class MetricsInterceptor implements NestInterceptor, OnApplicationShutdow
           case '/api/sandbox/:sandboxIdOrName/backup':
             this.captureCreateBackup(props, request.params.sandboxIdOrName)
             break
+          case '/api/sandbox/:sandboxIdOrName/recover':
+            this.captureRecoverSandbox(props, request.params.sandboxIdOrName, request.query?.skipStart === 'true')
+            break
           case '/api/sandbox/:sandboxIdOrName/snapshot':
             this.captureCreateSandboxSnapshot(props, request.params.sandboxIdOrName, request.body, response)
             break
@@ -665,6 +668,13 @@ export class MetricsInterceptor implements NestInterceptor, OnApplicationShutdow
   private captureCreateBackup(props: CommonCaptureProps, sandboxId: string) {
     this.capture('api_sandbox_backup_created', props, 'api_sandbox_backup_creation_failed', {
       sandbox_id: sandboxId,
+    })
+  }
+
+  private captureRecoverSandbox(props: CommonCaptureProps, sandboxId: string, skipStart: boolean) {
+    this.capture('api_sandbox_recovered', props, 'api_sandbox_recovery_failed', {
+      sandbox_id: sandboxId,
+      skip_start: skipStart,
     })
   }
 

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -445,6 +445,12 @@ export class SandboxController {
     description: 'ID or name of the sandbox',
     type: 'string',
   })
+  @ApiQuery({
+    name: 'skipStart',
+    required: false,
+    type: Boolean,
+    description: 'If true, the sandbox is left in STOPPED after recovery instead of being started.',
+  })
   @ApiResponse({
     status: 200,
     description: 'Recovery initiated',
@@ -461,11 +467,12 @@ export class SandboxController {
   async recoverSandbox(
     @IsOrganizationAuthContext() authContext: OrganizationAuthContext,
     @Param('sandboxIdOrName') sandboxIdOrName: string,
+    @Query('skipStart', new ParseBoolPipe({ optional: true })) skipStart?: boolean,
   ): Promise<SandboxDto> {
-    const recoveredSandbox = await this.sandboxService.recover(sandboxIdOrName, authContext.organization)
+    const recoveredSandbox = await this.sandboxService.recover(sandboxIdOrName, authContext.organization, skipStart)
     let sandboxDto = await this.sandboxService.toSandboxDto(recoveredSandbox)
 
-    if (sandboxDto.state !== SandboxState.STARTED) {
+    if (!skipStart && sandboxDto.state !== SandboxState.STARTED) {
       sandboxDto = await this.waitForSandboxStarted(sandboxDto, 30)
     }
 

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -463,6 +463,11 @@ export class SandboxController {
     targetType: AuditTarget.SANDBOX,
     targetIdFromRequest: (req) => req.params.sandboxIdOrName,
     targetIdFromResult: (result: SandboxDto) => result?.id,
+    requestMetadata: {
+      query: (req) => ({
+        skipStart: req.query?.skipStart === 'true',
+      }),
+    },
   })
   async recoverSandbox(
     @IsOrganizationAuthContext() authContext: OrganizationAuthContext,

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1732,7 +1732,7 @@ export class SandboxService {
     return updatedSandbox
   }
 
-  async recover(sandboxIdOrName: string, organization: Organization): Promise<Sandbox> {
+  async recover(sandboxIdOrName: string, organization: Organization, skipStart = false): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
     if (sandbox.state !== SandboxState.ERROR) {
@@ -1779,6 +1779,10 @@ export class SandboxService {
       updateData,
       whereCondition: { state: SandboxState.ERROR },
     })
+
+    if (skipStart) {
+      return await this.findOneByIdOrName(sandbox.id, organization.id)
+    }
 
     // Now that sandbox is in STOPPED state, use the normal start flow
     // This handles quota validation, pending usage, event emission, etc.

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1775,13 +1775,13 @@ export class SandboxService {
       recoverable: false,
     }
 
-    await this.sandboxRepository.updateWhere(sandbox.id, {
+    const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
       updateData,
       whereCondition: { state: SandboxState.ERROR },
     })
 
     if (skipStart) {
-      return await this.findOneByIdOrName(sandbox.id, organization.id)
+      return updatedSandbox
     }
 
     // Now that sandbox is in STOPPED state, use the normal start flow

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -1996,6 +1996,15 @@ paths:
         schema:
           type: string
         style: simple
+      - description: "If true, the sandbox is left in STOPPED after recovery instead\
+          \ of being started."
+        explode: true
+        in: query
+        name: skipStart
+        required: false
+        schema:
+          type: boolean
+        style: form
       responses:
         "200":
           content:

--- a/libs/api-client-go/api_sandbox.go
+++ b/libs/api-client-go/api_sandbox.go
@@ -3984,11 +3984,18 @@ type SandboxAPIRecoverSandboxRequest struct {
 	ApiService SandboxAPI
 	sandboxIdOrName string
 	xDaytonaOrganizationID *string
+	skipStart *bool
 }
 
 // Use with JWT to specify the organization ID
 func (r SandboxAPIRecoverSandboxRequest) XDaytonaOrganizationID(xDaytonaOrganizationID string) SandboxAPIRecoverSandboxRequest {
 	r.xDaytonaOrganizationID = &xDaytonaOrganizationID
+	return r
+}
+
+// If true, the sandbox is left in STOPPED after recovery instead of being started.
+func (r SandboxAPIRecoverSandboxRequest) SkipStart(skipStart bool) SandboxAPIRecoverSandboxRequest {
+	r.skipStart = &skipStart
 	return r
 }
 
@@ -4033,6 +4040,9 @@ func (a *SandboxAPIService) RecoverSandboxExecute(r SandboxAPIRecoverSandboxRequ
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.skipStart != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "skipStart", r.skipStart, "form", "")
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/api/SandboxApi.java
@@ -4039,6 +4039,7 @@ public class SandboxApi {
      * Build call for recoverSandbox
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param skipStart If true, the sandbox is left in STOPPED after recovery instead of being started. (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -4049,7 +4050,7 @@ public class SandboxApi {
         <tr><td> 200 </td><td> Recovery initiated </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call recoverSandboxCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call recoverSandboxCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, @javax.annotation.Nullable Boolean skipStart, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -4074,6 +4075,10 @@ public class SandboxApi {
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (skipStart != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("skipStart", skipStart));
+        }
 
         final String[] localVarAccepts = {
             "application/json"
@@ -4100,13 +4105,13 @@ public class SandboxApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call recoverSandboxValidateBeforeCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call recoverSandboxValidateBeforeCall(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, @javax.annotation.Nullable Boolean skipStart, final ApiCallback _callback) throws ApiException {
         // verify the required parameter 'sandboxIdOrName' is set
         if (sandboxIdOrName == null) {
             throw new ApiException("Missing the required parameter 'sandboxIdOrName' when calling recoverSandbox(Async)");
         }
 
-        return recoverSandboxCall(sandboxIdOrName, xDaytonaOrganizationID, _callback);
+        return recoverSandboxCall(sandboxIdOrName, xDaytonaOrganizationID, skipStart, _callback);
 
     }
 
@@ -4115,6 +4120,7 @@ public class SandboxApi {
      * 
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param skipStart If true, the sandbox is left in STOPPED after recovery instead of being started. (optional)
      * @return Sandbox
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -4124,8 +4130,8 @@ public class SandboxApi {
         <tr><td> 200 </td><td> Recovery initiated </td><td>  -  </td></tr>
      </table>
      */
-    public Sandbox recoverSandbox(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
-        ApiResponse<Sandbox> localVarResp = recoverSandboxWithHttpInfo(sandboxIdOrName, xDaytonaOrganizationID);
+    public Sandbox recoverSandbox(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, @javax.annotation.Nullable Boolean skipStart) throws ApiException {
+        ApiResponse<Sandbox> localVarResp = recoverSandboxWithHttpInfo(sandboxIdOrName, xDaytonaOrganizationID, skipStart);
         return localVarResp.getData();
     }
 
@@ -4134,6 +4140,7 @@ public class SandboxApi {
      * 
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param skipStart If true, the sandbox is left in STOPPED after recovery instead of being started. (optional)
      * @return ApiResponse&lt;Sandbox&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -4143,8 +4150,8 @@ public class SandboxApi {
         <tr><td> 200 </td><td> Recovery initiated </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Sandbox> recoverSandboxWithHttpInfo(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
-        okhttp3.Call localVarCall = recoverSandboxValidateBeforeCall(sandboxIdOrName, xDaytonaOrganizationID, null);
+    public ApiResponse<Sandbox> recoverSandboxWithHttpInfo(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, @javax.annotation.Nullable Boolean skipStart) throws ApiException {
+        okhttp3.Call localVarCall = recoverSandboxValidateBeforeCall(sandboxIdOrName, xDaytonaOrganizationID, skipStart, null);
         Type localVarReturnType = new TypeToken<Sandbox>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -4154,6 +4161,7 @@ public class SandboxApi {
      * 
      * @param sandboxIdOrName ID or name of the sandbox (required)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param skipStart If true, the sandbox is left in STOPPED after recovery instead of being started. (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -4164,9 +4172,9 @@ public class SandboxApi {
         <tr><td> 200 </td><td> Recovery initiated </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call recoverSandboxAsync(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<Sandbox> _callback) throws ApiException {
+    public okhttp3.Call recoverSandboxAsync(@javax.annotation.Nonnull String sandboxIdOrName, @javax.annotation.Nullable String xDaytonaOrganizationID, @javax.annotation.Nullable Boolean skipStart, final ApiCallback<Sandbox> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = recoverSandboxValidateBeforeCall(sandboxIdOrName, xDaytonaOrganizationID, _callback);
+        okhttp3.Call localVarCall = recoverSandboxValidateBeforeCall(sandboxIdOrName, xDaytonaOrganizationID, skipStart, _callback);
         Type localVarReturnType = new TypeToken<Sandbox>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/api/SandboxApiTest.java
@@ -456,7 +456,8 @@ public class SandboxApiTest {
     public void recoverSandboxTest() throws ApiException {
         String sandboxIdOrName = null;
         String xDaytonaOrganizationID = null;
-        Sandbox response = api.recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID);
+        Boolean skipStart = null;
+        Sandbox response = api.recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID, skipStart);
         // TODO: test validations
     }
 

--- a/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/sandbox_api.py
@@ -8083,6 +8083,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        skip_start: Annotated[Optional[StrictBool], Field(description="If true, the sandbox is left in STOPPED after recovery instead of being started.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8103,6 +8104,8 @@ class SandboxApi:
         :type sandbox_id_or_name: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param skip_start: If true, the sandbox is left in STOPPED after recovery instead of being started.
+        :type skip_start: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8128,6 +8131,7 @@ class SandboxApi:
         _param = self._recover_sandbox_serialize(
             sandbox_id_or_name=sandbox_id_or_name,
             x_daytona_organization_id=x_daytona_organization_id,
+            skip_start=skip_start,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8153,6 +8157,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        skip_start: Annotated[Optional[StrictBool], Field(description="If true, the sandbox is left in STOPPED after recovery instead of being started.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8173,6 +8178,8 @@ class SandboxApi:
         :type sandbox_id_or_name: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param skip_start: If true, the sandbox is left in STOPPED after recovery instead of being started.
+        :type skip_start: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8198,6 +8205,7 @@ class SandboxApi:
         _param = self._recover_sandbox_serialize(
             sandbox_id_or_name=sandbox_id_or_name,
             x_daytona_organization_id=x_daytona_organization_id,
+            skip_start=skip_start,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8223,6 +8231,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        skip_start: Annotated[Optional[StrictBool], Field(description="If true, the sandbox is left in STOPPED after recovery instead of being started.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8243,6 +8252,8 @@ class SandboxApi:
         :type sandbox_id_or_name: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param skip_start: If true, the sandbox is left in STOPPED after recovery instead of being started.
+        :type skip_start: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8268,6 +8279,7 @@ class SandboxApi:
         _param = self._recover_sandbox_serialize(
             sandbox_id_or_name=sandbox_id_or_name,
             x_daytona_organization_id=x_daytona_organization_id,
+            skip_start=skip_start,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8288,6 +8300,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name,
         x_daytona_organization_id,
+        skip_start,
         _request_auth,
         _content_type,
         _headers,
@@ -8312,6 +8325,10 @@ class SandboxApi:
         if sandbox_id_or_name is not None:
             _path_params['sandboxIdOrName'] = sandbox_id_or_name
         # process the query parameters
+        if skip_start is not None:
+            
+            _query_params.append(('skipStart', skip_start))
+            
         # process the header parameters
         if x_daytona_organization_id is not None:
             _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id

--- a/libs/api-client-python/daytona_api_client/api/sandbox_api.py
+++ b/libs/api-client-python/daytona_api_client/api/sandbox_api.py
@@ -8083,6 +8083,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        skip_start: Annotated[Optional[StrictBool], Field(description="If true, the sandbox is left in STOPPED after recovery instead of being started.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8103,6 +8104,8 @@ class SandboxApi:
         :type sandbox_id_or_name: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param skip_start: If true, the sandbox is left in STOPPED after recovery instead of being started.
+        :type skip_start: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8128,6 +8131,7 @@ class SandboxApi:
         _param = self._recover_sandbox_serialize(
             sandbox_id_or_name=sandbox_id_or_name,
             x_daytona_organization_id=x_daytona_organization_id,
+            skip_start=skip_start,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8153,6 +8157,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        skip_start: Annotated[Optional[StrictBool], Field(description="If true, the sandbox is left in STOPPED after recovery instead of being started.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8173,6 +8178,8 @@ class SandboxApi:
         :type sandbox_id_or_name: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param skip_start: If true, the sandbox is left in STOPPED after recovery instead of being started.
+        :type skip_start: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8198,6 +8205,7 @@ class SandboxApi:
         _param = self._recover_sandbox_serialize(
             sandbox_id_or_name=sandbox_id_or_name,
             x_daytona_organization_id=x_daytona_organization_id,
+            skip_start=skip_start,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8223,6 +8231,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name: Annotated[StrictStr, Field(description="ID or name of the sandbox")],
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        skip_start: Annotated[Optional[StrictBool], Field(description="If true, the sandbox is left in STOPPED after recovery instead of being started.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8243,6 +8252,8 @@ class SandboxApi:
         :type sandbox_id_or_name: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
+        :param skip_start: If true, the sandbox is left in STOPPED after recovery instead of being started.
+        :type skip_start: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8268,6 +8279,7 @@ class SandboxApi:
         _param = self._recover_sandbox_serialize(
             sandbox_id_or_name=sandbox_id_or_name,
             x_daytona_organization_id=x_daytona_organization_id,
+            skip_start=skip_start,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8288,6 +8300,7 @@ class SandboxApi:
         self,
         sandbox_id_or_name,
         x_daytona_organization_id,
+        skip_start,
         _request_auth,
         _content_type,
         _headers,
@@ -8312,6 +8325,10 @@ class SandboxApi:
         if sandbox_id_or_name is not None:
             _path_params['sandboxIdOrName'] = sandbox_id_or_name
         # process the query parameters
+        if skip_start is not None:
+            
+            _query_params.append(('skipStart', skip_start))
+            
         # process the header parameters
         if x_daytona_organization_id is not None:
             _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id

--- a/libs/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
@@ -1930,6 +1930,7 @@ module DaytonaApiClient
     # @param sandbox_id_or_name [String] ID or name of the sandbox
     # @param [Hash] opts the optional parameters
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
+    # @option opts [Boolean] :skip_start If true, the sandbox is left in STOPPED after recovery instead of being started.
     # @return [Sandbox]
     def recover_sandbox(sandbox_id_or_name, opts = {})
       data, _status_code, _headers = recover_sandbox_with_http_info(sandbox_id_or_name, opts)
@@ -1940,6 +1941,7 @@ module DaytonaApiClient
     # @param sandbox_id_or_name [String] ID or name of the sandbox
     # @param [Hash] opts the optional parameters
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
+    # @option opts [Boolean] :skip_start If true, the sandbox is left in STOPPED after recovery instead of being started.
     # @return [Array<(Sandbox, Integer, Hash)>] Sandbox data, response status code and response headers
     def recover_sandbox_with_http_info(sandbox_id_or_name, opts = {})
       if @api_client.config.debugging
@@ -1954,6 +1956,7 @@ module DaytonaApiClient
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'skipStart'] = opts[:'skip_start'] if !opts[:'skip_start'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/libs/api-client/src/api/sandbox-api.ts
+++ b/libs/api-client/src/api/sandbox-api.ts
@@ -1473,10 +1473,11 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Recover sandbox from error state
          * @param {string} sandboxIdOrName ID or name of the sandbox
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {boolean} [skipStart] If true, the sandbox is left in STOPPED after recovery instead of being started.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        recoverSandbox: async (sandboxIdOrName: string, xDaytonaOrganizationID?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        recoverSandbox: async (sandboxIdOrName: string, xDaytonaOrganizationID?: string, skipStart?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'sandboxIdOrName' is not null or undefined
             assertParamExists('recoverSandbox', 'sandboxIdOrName', sandboxIdOrName)
             const localVarPath = `/sandbox/{sandboxIdOrName}/recover`
@@ -1497,6 +1498,10 @@ export const SandboxApiAxiosParamCreator = function (configuration?: Configurati
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             // authentication oauth2 required
+
+            if (skipStart !== undefined) {
+                localVarQueryParameter['skipStart'] = skipStart;
+            }
 
             localVarHeaderParameter['Accept'] = 'application/json';
 
@@ -2556,11 +2561,12 @@ export const SandboxApiFp = function(configuration?: Configuration) {
          * @summary Recover sandbox from error state
          * @param {string} sandboxIdOrName ID or name of the sandbox
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {boolean} [skipStart] If true, the sandbox is left in STOPPED after recovery instead of being started.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async recoverSandbox(sandboxIdOrName: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Sandbox>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID, options);
+        async recoverSandbox(sandboxIdOrName: string, xDaytonaOrganizationID?: string, skipStart?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Sandbox>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID, skipStart, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['SandboxApi.recoverSandbox']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -3104,11 +3110,12 @@ export const SandboxApiFactory = function (configuration?: Configuration, basePa
          * @summary Recover sandbox from error state
          * @param {string} sandboxIdOrName ID or name of the sandbox
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {boolean} [skipStart] If true, the sandbox is left in STOPPED after recovery instead of being started.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        recoverSandbox(sandboxIdOrName: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<Sandbox> {
-            return localVarFp.recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
+        recoverSandbox(sandboxIdOrName: string, xDaytonaOrganizationID?: string, skipStart?: boolean, options?: RawAxiosRequestConfig): AxiosPromise<Sandbox> {
+            return localVarFp.recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID, skipStart, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3634,11 +3641,12 @@ export class SandboxApi extends BaseAPI {
      * @summary Recover sandbox from error state
      * @param {string} sandboxIdOrName ID or name of the sandbox
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {boolean} [skipStart] If true, the sandbox is left in STOPPED after recovery instead of being started.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public recoverSandbox(sandboxIdOrName: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
-        return SandboxApiFp(this.configuration).recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID, options).then((request) => request(this.axios, this.basePath));
+    public recoverSandbox(sandboxIdOrName: string, xDaytonaOrganizationID?: string, skipStart?: boolean, options?: RawAxiosRequestConfig) {
+        return SandboxApiFp(this.configuration).recoverSandbox(sandboxIdOrName, xDaytonaOrganizationID, skipStart, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -278,8 +278,6 @@ export class Sandbox implements SandboxDto {
    *
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
    *                            Defaults to 60-second timeout.
-   * @param {boolean} [skipStart] - If true, the Sandbox is left in STOPPED after recovery instead of being started.
-   *                               Defaults to false.
    * @returns {Promise<void>}
    * @throws {DaytonaError} - `DaytonaError` - If Sandbox fails to recover or times out
    *
@@ -288,17 +286,14 @@ export class Sandbox implements SandboxDto {
    * await sandbox.recover();
    * console.log('Sandbox recovered successfully');
    */
-  public async recover(timeout = 60, skipStart = false): Promise<void> {
+  public async recover(timeout = 60): Promise<void> {
     if (timeout < 0) {
       throw new DaytonaValidationError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
-    const response = await this.sandboxApi.recoverSandbox(this.id, undefined, skipStart, { timeout: timeout * 1000 })
+    const response = await this.sandboxApi.recoverSandbox(this.id, undefined, undefined, { timeout: timeout * 1000 })
     this.processSandboxDto(response.data)
-    if (skipStart) {
-      return
-    }
     const timeElapsed = Date.now() - startTime
     await this.waitUntilStarted(timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout)
   }

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -278,6 +278,8 @@ export class Sandbox implements SandboxDto {
    *
    * @param {number} [timeout] - Maximum time to wait in seconds. 0 means no timeout.
    *                            Defaults to 60-second timeout.
+   * @param {boolean} [skipStart] - If true, the Sandbox is left in STOPPED after recovery instead of being started.
+   *                               Defaults to false.
    * @returns {Promise<void>}
    * @throws {DaytonaError} - `DaytonaError` - If Sandbox fails to recover or times out
    *
@@ -286,14 +288,17 @@ export class Sandbox implements SandboxDto {
    * await sandbox.recover();
    * console.log('Sandbox recovered successfully');
    */
-  public async recover(timeout = 60): Promise<void> {
+  public async recover(timeout = 60, skipStart = false): Promise<void> {
     if (timeout < 0) {
       throw new DaytonaValidationError('Timeout must be a non-negative number')
     }
 
     const startTime = Date.now()
-    const response = await this.sandboxApi.recoverSandbox(this.id, undefined, { timeout: timeout * 1000 })
+    const response = await this.sandboxApi.recoverSandbox(this.id, undefined, skipStart, { timeout: timeout * 1000 })
     this.processSandboxDto(response.data)
+    if (skipStart) {
+      return
+    }
     const timeElapsed = Date.now() - startTime
     await this.waitUntilStarted(timeout ? Math.max(0.001, timeout - timeElapsed / 1000) : timeout)
   }

--- a/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Sandbox.test.ts
@@ -130,7 +130,7 @@ describe('Sandbox', () => {
 
     await sandbox.recover(1)
 
-    expect(sandboxApi.recoverSandbox).toHaveBeenCalledWith('sb-1', undefined, { timeout: 1000 })
+    expect(sandboxApi.recoverSandbox).toHaveBeenCalledWith('sb-1', undefined, undefined, { timeout: 1000 })
     expect(sandbox.state).toBe('started')
   })
 


### PR DESCRIPTION
## Description

Adds an optional skipStart query parameter to POST /sandbox/:id/recover. When true, the sandbox is left in STOPPED after recovery instead of being auto-started; default behavior is unchanged. Regenerates the OpenAPI clients (TS, Python, Go, Java, Ruby).

Added PostHog tracking for `POST /sandbox/:id/recover` via MetricsInterceptor, emitting `api_sandbox_recovered` / `api_sandbox_recovery_failed` with `sandbox_id` and `skip_start`.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation