### PR TITLE
feat(api,runner): marking archiving sandboxes as recoverable when backup fails

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -236,6 +236,7 @@ export class Sandbox {
     backupSnapshot?: string | null,
     backupRegistryId?: string | null,
     backupErrorReason?: string | null,
+    recoverable?: boolean,
   ): Partial<Sandbox> {
     const update: Partial<Sandbox> = {
       backupState,
@@ -268,6 +269,9 @@ export class Sandbox {
     }
     if (backupErrorReason !== undefined) {
       update.backupErrorReason = backupErrorReason
+    }
+    if (recoverable !== undefined) {
+      update.recoverable = recoverable
     }
     return update
   }

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -237,6 +237,7 @@ export class Sandbox {
     backupSnapshot?: string | null,
     backupRegistryId?: string | null,
     backupErrorReason?: string | null,
+    recoverable?: boolean,
   ): Partial<Sandbox> {
     const update: Partial<Sandbox> = {
       backupState,
@@ -269,6 +270,9 @@ export class Sandbox {
     }
     if (backupErrorReason !== undefined) {
       update.backupErrorReason = backupErrorReason
+    }
+    if (recoverable !== undefined) {
+      update.recoverable = recoverable
     }
     return update
   }

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -13,6 +13,7 @@ import { RunnerState } from '../enums/runner-state.enum'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { BackupState } from '../enums/backup-state.enum'
+import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/sandbox.constants'
@@ -435,12 +436,15 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
             )
             break
           }
+          // Only surface recoverable=true for user-initiated backups (archive).
+          const isUserInitiated = sandbox.desiredState === SandboxDesiredState.ARCHIVED
           await this.sandboxService.updateSandboxBackupState(
             sandbox.id,
             BackupState.ERROR,
             undefined,
             undefined,
             sandboxInfo.backupErrorReason,
+            (sandboxInfo.recoverable ?? false) && isUserInitiated,
           )
           break
         }

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -18,6 +18,7 @@ import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/sandbox.constants'
 import { fromAxiosError } from '../../common/utils/from-axios-error'
+import { sanitizeSandboxError } from '../utils/sanitize-error.util'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { OnEvent } from '@nestjs/event-emitter'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
@@ -73,6 +74,35 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
    * @param ttlSeconds - TTL for the retry counter in seconds (default: 300)
    * @returns true if should retry, false if max retries exceeded
    */
+  private async runnerIsDraining(sandbox: Sandbox): Promise<boolean> {
+    if (!sandbox.runnerId) return false
+    try {
+      const runner = await this.runnerService.findOne(sandbox.runnerId)
+      return runner?.draining === true
+    } catch {
+      return false
+    }
+  }
+
+  /** Route recoverable backup failures on draining runners into state=ERROR so /recover and
+   *  drain auto-recover (both gate on state=ERROR + recoverable=true) catch them. */
+  private async markErroredIfDraining(
+    sandbox: Sandbox,
+    errorReason: string | null,
+    recoverable: boolean,
+    isOnDrainingRunner: boolean,
+  ): Promise<void> {
+    if (!isOnDrainingRunner || !recoverable || sandbox.state === SandboxState.ERROR) return
+    // Mirror errorReason to backupErrorReason so the runner's DeduceRecoveryType matches either.
+    await this.sandboxRepository.updateWhere(sandbox.id, {
+      updateData: {
+        state: SandboxState.ERROR,
+        errorReason,
+      },
+      whereCondition: { state: sandbox.state },
+    })
+  }
+
   private async shouldRetry(key: string, maxRetries = 3, ttlSeconds = 300): Promise<boolean> {
     const retryCount = await this.redis.get(key)
     const currentCount = retryCount ? parseInt(retryCount) : 0
@@ -244,13 +274,18 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
                 await this.redis.setex(errorRetryKey, 300, '1')
               } else if (parseInt(errorRetryCount) > 10) {
                 this.logger.error(`Error processing backup for sandbox ${sandbox.id}:`, fromAxiosError(error))
+                const { recoverable, errorReason } = sanitizeSandboxError(error)
+                const isArchiveFlow = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+                const isOnDrainingRunner = await this.runnerIsDraining(sandbox)
                 await this.sandboxService.updateSandboxBackupState(
                   sandbox.id,
                   BackupState.ERROR,
                   undefined,
                   undefined,
-                  fromAxiosError(error).message,
+                  errorReason,
+                  recoverable && (isArchiveFlow || isOnDrainingRunner),
                 )
+                await this.markErroredIfDraining(sandbox, errorReason, recoverable, isOnDrainingRunner)
               } else {
                 await this.redis.setex(errorRetryKey, 300, errorRetryCount + 1)
               }
@@ -329,13 +364,18 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
                 await this.redis.setex(errorRetryKey, 300, '1')
               } else if (parseInt(errorRetryCount) > 10) {
                 this.logger.error(`Error processing backup for sandbox ${sandbox.id}:`, fromAxiosError(error))
+                const { recoverable, errorReason } = sanitizeSandboxError(error)
+                const isArchiveFlow = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+                const isOnDrainingRunner = await this.runnerIsDraining(sandbox)
                 await this.sandboxService.updateSandboxBackupState(
                   sandbox.id,
                   BackupState.ERROR,
                   undefined,
                   undefined,
-                  fromAxiosError(error).message,
+                  errorReason,
+                  recoverable && (isArchiveFlow || isOnDrainingRunner),
                 )
+                await this.markErroredIfDraining(sandbox, errorReason, recoverable, isOnDrainingRunner)
               } else {
                 await this.redis.setex(errorRetryKey, 300, errorRetryCount + 1)
               }
@@ -414,13 +454,18 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
                   `Error processing backup for errored sandbox ${sandbox.id} on draining runner:`,
                   fromAxiosError(error),
                 )
+                const { recoverable, errorReason } = sanitizeSandboxError(error)
+                const isArchiveFlow = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+                const isOnDrainingRunner = await this.runnerIsDraining(sandbox)
                 await this.sandboxService.updateSandboxBackupState(
                   sandbox.id,
                   BackupState.ERROR,
                   undefined,
                   undefined,
-                  fromAxiosError(error).message,
+                  errorReason,
+                  recoverable && (isArchiveFlow || isOnDrainingRunner),
                 )
+                await this.markErroredIfDraining(sandbox, errorReason, recoverable, isOnDrainingRunner)
               } else {
                 await this.redis.setex(errorRetryKey, 300, errorRetryCount + 1)
               }
@@ -554,15 +599,23 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
             )
             break
           }
-          // Only surface recoverable=true for user-initiated backups (archive).
-          const isUserInitiated = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+          // Surface recoverable=true for archive flows or any backup error on a draining runner.
+          const isArchiveFlow = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+          const isOnDrainingRunner = runner.draining === true
+          const recoverable = sandboxInfo.recoverable ?? false
           await this.sandboxService.updateSandboxBackupState(
             sandbox.id,
             BackupState.ERROR,
             undefined,
             undefined,
             sandboxInfo.backupErrorReason,
-            (sandboxInfo.recoverable ?? false) && isUserInitiated,
+            recoverable && (isArchiveFlow || isOnDrainingRunner),
+          )
+          await this.markErroredIfDraining(
+            sandbox,
+            sandboxInfo.backupErrorReason ?? null,
+            recoverable,
+            isOnDrainingRunner,
           )
           break
         }
@@ -588,13 +641,18 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
         // If still in progress or any other state, do nothing and wait for next sync
       }
     } catch (error) {
+      const { recoverable, errorReason } = sanitizeSandboxError(error)
+      const isArchiveFlow = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+      const isOnDrainingRunner = await this.runnerIsDraining(sandbox)
       await this.sandboxService.updateSandboxBackupState(
         sandbox.id,
         BackupState.ERROR,
         undefined,
         undefined,
-        fromAxiosError(error).message,
+        errorReason,
+        recoverable && (isArchiveFlow || isOnDrainingRunner),
       )
+      await this.markErroredIfDraining(sandbox, errorReason, recoverable, isOnDrainingRunner)
       throw error
     }
   }
@@ -651,13 +709,18 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
         await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.IN_PROGRESS)
         return
       }
+      const { recoverable, errorReason } = sanitizeSandboxError(error)
+      const isArchiveFlow = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+      const isOnDrainingRunner = await this.runnerIsDraining(sandbox)
       await this.sandboxService.updateSandboxBackupState(
         sandbox.id,
         BackupState.ERROR,
         undefined,
         undefined,
-        fromAxiosError(error).message,
+        errorReason,
+        recoverable && (isArchiveFlow || isOnDrainingRunner),
       )
+      await this.markErroredIfDraining(sandbox, errorReason, recoverable, isOnDrainingRunner)
       throw error
     } finally {
       await this.redisLockProvider.unlock(lockKey)

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -13,6 +13,7 @@ import { RunnerState } from '../enums/runner-state.enum'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { BackupState } from '../enums/backup-state.enum'
+import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/sandbox.constants'
@@ -554,12 +555,15 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
             )
             break
           }
+          // Only surface recoverable=true for user-initiated backups (archive).
+          const isUserInitiated = sandbox.desiredState === SandboxDesiredState.ARCHIVED
           await this.sandboxService.updateSandboxBackupState(
             sandbox.id,
             BackupState.ERROR,
             undefined,
             undefined,
             sandboxInfo.backupErrorReason,
+            (sandboxInfo.recoverable ?? false) && isUserInitiated,
           )
           break
         }

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -35,7 +35,6 @@ import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
 import { SandboxService } from '../services/sandbox.service'
 import { SandboxRepository } from '../repositories/sandbox.repository'
-import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 
 @Injectable()
 export class BackupManager implements TrackableJobExecutions, OnApplicationShutdown {

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
@@ -68,6 +68,13 @@ export class SandboxArchiveAction extends SandboxAction {
             lockCode,
             undefined,
             'Failed to archive sandbox after 3 retries',
+            undefined,
+            undefined,
+            // Preserve the recoverable flag set by backup.manager.ts on recoverable backup errors
+            // (e.g. "no space left on device"). Otherwise updateSandboxState defaults it to false
+            // when errorReason is provided, and the new flag-based /recover gate would reject
+            // a sandbox that is in fact recoverable via backupErrorReason.
+            sandbox.recoverable,
           )
         }
         await this.redis.del(archiveErrorRetryKey)
@@ -97,7 +104,16 @@ export class SandboxArchiveAction extends SandboxAction {
           this.logger.warn(`Transitioning sandbox ${sandbox.id} from ERROR to ARCHIVED state (runner draining)`)
         }
 
-        await this.updateSandboxState(sandbox, SandboxState.ARCHIVED, lockCode, null)
+        await this.updateSandboxState(
+          sandbox,
+          SandboxState.ARCHIVED,
+          lockCode,
+          null,
+          undefined,
+          undefined,
+          undefined,
+          false,
+        )
         return DONT_SYNC_AGAIN
       }
 
@@ -119,7 +135,19 @@ export class SandboxArchiveAction extends SandboxAction {
           this.logger.warn(`Transitioning sandbox ${sandbox.id} from ERROR to ARCHIVED state (runner draining)`)
         }
 
-        await this.updateSandboxState(sandbox, SandboxState.ARCHIVED, lockCode, null)
+        // Clear recoverable here: this is the only exit path for an archive flow that
+        // may have set recoverable=true on a backup failure (backup.manager.ts:447).
+        // Scheduled/ad-hoc backup completions must not touch the flag.
+        await this.updateSandboxState(
+          sandbox,
+          SandboxState.ARCHIVED,
+          lockCode,
+          null,
+          undefined,
+          undefined,
+          undefined,
+          false,
+        )
         return DONT_SYNC_AGAIN
       }
 

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
@@ -70,10 +70,7 @@ export class SandboxArchiveAction extends SandboxAction {
             'Failed to archive sandbox after 3 retries',
             undefined,
             undefined,
-            // Preserve the recoverable flag set by backup.manager.ts on recoverable backup errors
-            // (e.g. "no space left on device"). Otherwise updateSandboxState defaults it to false
-            // when errorReason is provided, and the new flag-based /recover gate would reject
-            // a sandbox that is in fact recoverable via backupErrorReason.
+            // Preserve recoverable; updateSandboxState would otherwise clear it once an errorReason is set.
             sandbox.recoverable,
           )
         }
@@ -135,9 +132,7 @@ export class SandboxArchiveAction extends SandboxAction {
           this.logger.warn(`Transitioning sandbox ${sandbox.id} from ERROR to ARCHIVED state (runner draining)`)
         }
 
-        // Clear recoverable here: this is the only exit path for an archive flow that
-        // may have set recoverable=true on a backup failure (backup.manager.ts:447).
-        // Scheduled/ad-hoc backup completions must not touch the flag.
+        // Archive succeeded — clear any recoverable flag carried over from a prior backup failure.
         await this.updateSandboxState(
           sandbox,
           SandboxState.ARCHIVED,

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -21,6 +21,7 @@ export interface RunnerSandboxInfo {
   backupState?: BackupState
   backupSnapshot?: string
   backupErrorReason?: string
+  recoverable?: boolean
 }
 
 export interface RunnerSnapshotInfo {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -182,6 +182,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       backupState: this.convertBackupState(sandboxInfo.data.backupState),
       backupSnapshot: sandboxInfo.data.backupSnapshot,
       backupErrorReason: sandboxInfo.data.backupError,
+      recoverable: sandboxInfo.data.recoverable,
       daemonVersion: sandboxInfo.data.daemonVersion,
     }
   }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -181,6 +181,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       backupState: this.convertBackupState(sandboxInfo.data.backupState),
       backupSnapshot: sandboxInfo.data.backupSnapshot,
       backupErrorReason: sandboxInfo.data.backupError,
+      recoverable: sandboxInfo.data.recoverable,
       daemonVersion: sandboxInfo.data.daemonVersion,
     }
   }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -114,6 +114,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       state,
       backupState: sandbox.backupState,
       backupErrorReason: sandbox.backupErrorReason,
+      recoverable: sandbox.recoverable,
       daemonVersion,
     }
   }

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -476,7 +476,7 @@ export class JobStateHandlerService {
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`CREATE_BACKUP job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
         const { recoverable, errorReason } = sanitizeSandboxError(job.errorMessage)
-        // Only surface recoverable=true for user-initiated backups (archive), so
+        // Only surface recoverable=true for user-initiated backups (archive)
         const isUserInitiated = sandbox.desiredState === SandboxDesiredState.ARCHIVED
         Object.assign(
           updateData,

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -475,9 +475,19 @@ export class JobStateHandlerService {
         Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.COMPLETED))
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`CREATE_BACKUP job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
+        const { recoverable, errorReason } = sanitizeSandboxError(job.errorMessage)
+        // Only surface recoverable=true for user-initiated backups (archive), so
+        const isUserInitiated = sandbox.desiredState === SandboxDesiredState.ARCHIVED
         Object.assign(
           updateData,
-          Sandbox.getBackupStateUpdate(sandbox, BackupState.ERROR, undefined, undefined, job.errorMessage),
+          Sandbox.getBackupStateUpdate(
+            sandbox,
+            BackupState.ERROR,
+            undefined,
+            undefined,
+            errorReason,
+            recoverable && isUserInitiated,
+          ),
         )
       }
 

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -28,7 +28,7 @@ import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxStartedEvent } from '../events/sandbox-started.event'
 import { persistSnapshotFromSandbox } from '../utils/persist-snapshot-from-sandbox.util'
-import { RunnerService } from './runner.service'
+import { Runner } from '../entities/runner.entity'
 
 /**
  * Service for handling entity state updates based on job completion (v2 runners only).
@@ -46,17 +46,17 @@ export class JobStateHandlerService {
     private readonly organizationUsageService: OrganizationUsageService,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly eventEmitter: EventEmitter2,
-    private readonly runnerService: RunnerService,
+    @InjectRepository(Runner)
+    private readonly runnerRepository: Repository<Runner>,
   ) {}
 
   private async runnerIsDraining(sandbox: Sandbox): Promise<boolean> {
     if (!sandbox.runnerId) return false
-    try {
-      const runner = await this.runnerService.findOne(sandbox.runnerId)
-      return runner?.draining === true
-    } catch {
-      return false
-    }
+    const runner = await this.runnerRepository.findOne({
+      where: { id: sandbox.runnerId },
+      select: ['draining'],
+    })
+    return runner?.draining === true
   }
 
   /**

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -28,6 +28,7 @@ import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxStartedEvent } from '../events/sandbox-started.event'
 import { persistSnapshotFromSandbox } from '../utils/persist-snapshot-from-sandbox.util'
+import { RunnerService } from './runner.service'
 
 /**
  * Service for handling entity state updates based on job completion (v2 runners only).
@@ -45,7 +46,18 @@ export class JobStateHandlerService {
     private readonly organizationUsageService: OrganizationUsageService,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly eventEmitter: EventEmitter2,
+    private readonly runnerService: RunnerService,
   ) {}
+
+  private async runnerIsDraining(sandbox: Sandbox): Promise<boolean> {
+    if (!sandbox.runnerId) return false
+    try {
+      const runner = await this.runnerService.findOne(sandbox.runnerId)
+      return runner?.draining === true
+    } catch {
+      return false
+    }
+  }
 
   /**
    * Handle job completion and update entity state accordingly.
@@ -476,8 +488,9 @@ export class JobStateHandlerService {
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`CREATE_BACKUP job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
         const { recoverable, errorReason } = sanitizeSandboxError(job.errorMessage)
-        // Only surface recoverable=true for user-initiated backups (archive)
-        const isUserInitiated = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+        // Surface recoverable=true for archive flows or any backup error on a draining runner.
+        const isArchiveFlow = sandbox.desiredState === SandboxDesiredState.ARCHIVED
+        const isOnDrainingRunner = await this.runnerIsDraining(sandbox)
         Object.assign(
           updateData,
           Sandbox.getBackupStateUpdate(
@@ -486,9 +499,14 @@ export class JobStateHandlerService {
             undefined,
             undefined,
             errorReason,
-            recoverable && isUserInitiated,
+            recoverable && (isArchiveFlow || isOnDrainingRunner),
           ),
         )
+        // Route into ERROR so /recover and drain auto-recover (gated on state=ERROR + recoverable) handle it.
+        if (isOnDrainingRunner && recoverable && sandbox.state !== SandboxState.ERROR) {
+          updateData.state = SandboxState.ERROR
+          updateData.errorReason = errorReason
+        }
       }
 
       await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -52,11 +52,15 @@ export class JobStateHandlerService {
 
   private async runnerIsDraining(sandbox: Sandbox): Promise<boolean> {
     if (!sandbox.runnerId) return false
-    const runner = await this.runnerRepository.findOne({
-      where: { id: sandbox.runnerId },
-      select: ['draining'],
-    })
-    return runner?.draining === true
+    try {
+      const runner = await this.runnerRepository.findOne({
+        where: { id: sandbox.runnerId },
+        select: ['draining'],
+      })
+      return runner?.draining === true
+    } catch {
+      return false
+    }
   }
 
   /**

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1717,8 +1717,8 @@ export class SandboxService {
   async recover(sandboxIdOrName: string, organization: Organization): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
-    if (sandbox.state !== SandboxState.ERROR) {
-      throw new BadRequestError('Sandbox must be in error state to recover')
+    if (!sandbox.recoverable) {
+      throw new BadRequestError('Sandbox is not in a recoverable state')
     }
 
     if (sandbox.pending) {
@@ -1757,9 +1757,15 @@ export class SandboxService {
       recoverable: false,
     }
 
+    if (sandbox.backupState === BackupState.ERROR) {
+      updateData.backupState = BackupState.NONE
+      updateData.backupErrorReason = null
+      updateData.backupSnapshot = null
+    }
+
     await this.sandboxRepository.updateWhere(sandbox.id, {
       updateData,
-      whereCondition: { state: SandboxState.ERROR },
+      whereCondition: { recoverable: true, pending: false, state: sandbox.state },
     })
 
     // Now that sandbox is in STOPPED state, use the normal start flow
@@ -2537,6 +2543,7 @@ export class SandboxService {
     backupSnapshot?: string | null,
     backupRegistryId?: string | null,
     backupErrorReason?: string | null,
+    recoverable?: boolean,
   ): Promise<void> {
     const sandboxToUpdate = await this.sandboxRepository.findOneByOrFail({
       id: sandboxId,
@@ -2548,6 +2555,7 @@ export class SandboxService {
       backupSnapshot,
       backupRegistryId,
       backupErrorReason,
+      recoverable,
     )
 
     await this.sandboxRepository.update(sandboxId, { updateData, entity: sandboxToUpdate })

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1755,11 +1755,12 @@ export class SandboxService {
       desiredState: SandboxDesiredState.STOPPED,
       errorReason: null,
       recoverable: false,
+      // Clear transient backup state so the poller won't resume a retry post-recover.
+      backupState: BackupState.NONE,
+      backupErrorReason: null,
     }
-
+    // Only wipe the snapshot pointer on a failed backup — a COMPLETED one is still valid.
     if (sandbox.backupState === BackupState.ERROR) {
-      updateData.backupState = BackupState.NONE
-      updateData.backupErrorReason = null
       updateData.backupSnapshot = null
     }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1964,11 +1964,13 @@ export class SandboxService {
         desiredState: SandboxDesiredState.STOPPED,
         errorReason: null,
         recoverable: false,
+        // Clear transient backup state so the poller won't resume a retry post-recover.
+        backupState: BackupState.NONE,
+        backupErrorReason: null,
       }
 
+      // Only wipe the snapshot pointer on a failed backup — a COMPLETED one is still valid.
       if (sandbox.backupState === BackupState.ERROR) {
-        updateData.backupState = BackupState.NONE
-        updateData.backupErrorReason = null
         updateData.backupSnapshot = null
       }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1863,6 +1863,10 @@ export class SandboxService {
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
+        if (!sandbox.recoverable) {
+      throw new BadRequestError('Sandbox is not in a recoverable state')
+    }
+
     const region = await this.regionService.findOne(sandbox.region)
     if (!region) {
       throw new NotFoundException(`Region with ID ${sandbox.region} not found`)
@@ -1955,14 +1959,22 @@ export class SandboxService {
         return sandbox
       }
 
+      const updateData: Partial<Sandbox> = {
+        state: SandboxState.STOPPED,
+        desiredState: SandboxDesiredState.STOPPED,
+        errorReason: null,
+        recoverable: false,
+      }
+
+      if (sandbox.backupState === BackupState.ERROR) {
+        updateData.backupState = BackupState.NONE
+        updateData.backupErrorReason = null
+        updateData.backupSnapshot = null
+      }
+
       const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
-        updateData: {
-          state: SandboxState.STOPPED,
-          desiredState: SandboxDesiredState.STOPPED,
-          errorReason: null,
-          recoverable: false,
-        },
-        whereCondition: { state: SandboxState.ERROR },
+        updateData,
+        whereCondition: { recoverable: true, pending: false, state: sandbox.state  },
       })
 
       if (skipStart) {
@@ -2898,6 +2910,7 @@ export class SandboxService {
     backupSnapshot?: string | null,
     backupRegistryId?: string | null,
     backupErrorReason?: string | null,
+    recoverable?: boolean,
   ): Promise<void> {
     const sandboxToUpdate = await this.sandboxRepository.findOneByOrFail({
       id: sandboxId,
@@ -2909,6 +2922,7 @@ export class SandboxService {
       backupSnapshot,
       backupRegistryId,
       backupErrorReason,
+      recoverable,
     )
 
     await this.sandboxRepository.update(sandboxId, { updateData, entity: sandboxToUpdate })

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1863,7 +1863,7 @@ export class SandboxService {
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
-        if (!sandbox.recoverable) {
+    if (!sandbox.recoverable) {
       throw new BadRequestError('Sandbox is not in a recoverable state')
     }
 
@@ -1976,7 +1976,7 @@ export class SandboxService {
 
       const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
         updateData,
-        whereCondition: { recoverable: true, pending: false, state: sandbox.state  },
+        whereCondition: { recoverable: true, pending: false, state: sandbox.state },
       })
 
       if (skipStart) {

--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -401,6 +401,7 @@ func Info(ctx *gin.Context) {
 		BackupState:    info.BackupState,
 		BackupSnapshot: info.BackupSnapshot,
 		BackupError:    info.BackupErrorReason,
+		Recoverable:    info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
 		DaemonVersion:  daemonVersion,
 	})
 }
@@ -410,6 +411,7 @@ type SandboxInfoResponse struct {
 	BackupState    enums.BackupState  `json:"backupState"`
 	BackupSnapshot string             `json:"backupSnapshot,omitempty"`
 	BackupError    *string            `json:"backupError,omitempty"`
+	Recoverable    bool               `json:"recoverable"`
 	DaemonVersion  *string            `json:"daemonVersion,omitempty"`
 } //	@name	SandboxInfoResponse
 

--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -401,8 +401,10 @@ func Info(ctx *gin.Context) {
 		BackupState:    info.BackupState,
 		BackupSnapshot: info.BackupSnapshot,
 		BackupError:    info.BackupErrorReason,
-		Recoverable:    info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
-		DaemonVersion:  daemonVersion,
+		// Recoverable reports only whether the error class is recoverable.
+		// The API gates user-facing exposure via archive intent (isUserInitiated).
+		Recoverable:   info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
+		DaemonVersion: daemonVersion,
 	})
 }
 

--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -450,8 +450,7 @@ func Info(ctx *gin.Context) {
 		BackupState:    info.BackupState,
 		BackupSnapshot: info.BackupSnapshot,
 		BackupError:    info.BackupErrorReason,
-		// Recoverable reports only whether the error class is recoverable.
-		// The API gates user-facing exposure via archive intent (isUserInitiated).
+		// Reports only whether the error class is recoverable; the API decides whether to surface it.
 		Recoverable:   info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
 		DaemonVersion: daemonVersion,
 	})

--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -450,6 +450,7 @@ func Info(ctx *gin.Context) {
 		BackupState:    info.BackupState,
 		BackupSnapshot: info.BackupSnapshot,
 		BackupError:    info.BackupErrorReason,
+		Recoverable:    info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
 		DaemonVersion:  daemonVersion,
 	})
 }
@@ -459,6 +460,7 @@ type SandboxInfoResponse struct {
 	BackupState    enums.BackupState  `json:"backupState"`
 	BackupSnapshot string             `json:"backupSnapshot,omitempty"`
 	BackupError    *string            `json:"backupError,omitempty"`
+	Recoverable    bool               `json:"recoverable"`
 	DaemonVersion  *string            `json:"daemonVersion,omitempty"`
 } //	@name	SandboxInfoResponse
 

--- a/apps/runner/pkg/api/controllers/sandbox.go
+++ b/apps/runner/pkg/api/controllers/sandbox.go
@@ -450,8 +450,10 @@ func Info(ctx *gin.Context) {
 		BackupState:    info.BackupState,
 		BackupSnapshot: info.BackupSnapshot,
 		BackupError:    info.BackupErrorReason,
-		Recoverable:    info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
-		DaemonVersion:  daemonVersion,
+		// Recoverable reports only whether the error class is recoverable.
+		// The API gates user-facing exposure via archive intent (isUserInitiated).
+		Recoverable:   info.BackupErrorReason != nil && common.IsRecoverable(*info.BackupErrorReason),
+		DaemonVersion: daemonVersion,
 	})
 }
 

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1654,7 +1654,6 @@ const docTemplate = `{
         "RecoverSandboxDTO": {
             "type": "object",
             "required": [
-                "errorReason",
                 "osUser",
                 "userId"
             ],
@@ -1673,6 +1672,7 @@ const docTemplate = `{
                     }
                 },
                 "errorReason": {
+                    "description": "At least one of ErrorReason or BackupErrorReason must deduce a recovery type in\napps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the\ncaller can send only whichever one is populated (archive-backup failures leave\nerrorReason null on the API side).",
                     "type": "string"
                 },
                 "fromVolumeId": {

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1836,6 +1836,9 @@ const docTemplate = `{
                 "daemonVersion": {
                     "type": "string"
                 },
+                "recoverable": {
+                    "type": "boolean"
+                },
                 "state": {
                     "$ref": "#/definitions/enums.SandboxState"
                 }

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1764,7 +1764,7 @@ const docTemplate = `{
                     }
                 },
                 "errorReason": {
-                    "description": "At least one of ErrorReason or BackupErrorReason must deduce a recovery type in\napps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the\ncaller can send only whichever one is populated (archive-backup failures leave\nerrorReason null on the API side).",
+                    "description": "At least one of ErrorReason or BackupErrorReason must yield a recovery type; both are optional.",
                     "type": "string"
                 },
                 "fromVolumeId": {

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1746,7 +1746,6 @@ const docTemplate = `{
         "RecoverSandboxDTO": {
             "type": "object",
             "required": [
-                "errorReason",
                 "osUser",
                 "userId"
             ],
@@ -1765,6 +1764,7 @@ const docTemplate = `{
                     }
                 },
                 "errorReason": {
+                    "description": "At least one of ErrorReason or BackupErrorReason must deduce a recovery type in\napps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the\ncaller can send only whichever one is populated (archive-backup failures leave\nerrorReason null on the API side).",
                     "type": "string"
                 },
                 "fromVolumeId": {

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1934,6 +1934,9 @@ const docTemplate = `{
                 "daemonVersion": {
                     "type": "string"
                 },
+                "recoverable": {
+                    "type": "boolean"
+                },
                 "state": {
                     "$ref": "#/definitions/enums.SandboxState"
                 }

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1715,6 +1715,9 @@
         "daemonVersion": {
           "type": "string"
         },
+        "recoverable": {
+          "type": "boolean"
+        },
         "state": {
           "$ref": "#/definitions/enums.SandboxState"
         }

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1541,7 +1541,7 @@
     },
     "RecoverSandboxDTO": {
       "type": "object",
-      "required": ["errorReason", "osUser", "userId"],
+      "required": ["osUser", "userId"],
       "properties": {
         "backupErrorReason": {
           "type": "string"
@@ -1557,6 +1557,7 @@
           }
         },
         "errorReason": {
+          "description": "At least one of ErrorReason or BackupErrorReason must deduce a recovery type in\napps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the\ncaller can send only whichever one is populated (archive-backup failures leave\nerrorReason null on the API side).",
           "type": "string"
         },
         "fromVolumeId": {

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1806,6 +1806,9 @@
         "daemonVersion": {
           "type": "string"
         },
+        "recoverable": {
+          "type": "boolean"
+        },
         "state": {
           "$ref": "#/definitions/enums.SandboxState"
         }

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1642,7 +1642,7 @@
           }
         },
         "errorReason": {
-          "description": "At least one of ErrorReason or BackupErrorReason must deduce a recovery type in\napps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the\ncaller can send only whichever one is populated (archive-backup failures leave\nerrorReason null on the API side).",
+          "description": "At least one of ErrorReason or BackupErrorReason must yield a recovery type; both are optional.",
           "type": "string"
         },
         "fromVolumeId": {

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1626,7 +1626,7 @@
     },
     "RecoverSandboxDTO": {
       "type": "object",
-      "required": ["errorReason", "osUser", "userId"],
+      "required": ["osUser", "userId"],
       "properties": {
         "backupErrorReason": {
           "type": "string"
@@ -1642,6 +1642,7 @@
           }
         },
         "errorReason": {
+          "description": "At least one of ErrorReason or BackupErrorReason must deduce a recovery type in\napps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the\ncaller can send only whichever one is populated (archive-backup failures leave\nerrorReason null on the API side).",
           "type": "string"
         },
         "fromVolumeId": {

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -286,6 +286,8 @@ definitions:
         $ref: '#/definitions/enums.BackupState'
       daemonVersion:
         type: string
+      recoverable:
+        type: boolean
       state:
         $ref: '#/definitions/enums.SandboxState'
     type: object

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -173,6 +173,11 @@ definitions:
           type: string
         type: object
       errorReason:
+        description: |-
+          At least one of ErrorReason or BackupErrorReason must deduce a recovery type in
+          apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the
+          caller can send only whichever one is populated (archive-backup failures leave
+          errorReason null on the API side).
         type: string
       fromVolumeId:
         type: string
@@ -200,7 +205,6 @@ definitions:
           $ref: '#/definitions/dto.VolumeDTO'
         type: array
     required:
-      - errorReason
       - osUser
       - userId
     type: object

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -186,11 +186,8 @@ definitions:
           type: string
         type: object
       errorReason:
-        description: |-
-          At least one of ErrorReason or BackupErrorReason must deduce a recovery type in
-          apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the
-          caller can send only whichever one is populated (archive-backup failures leave
-          errorReason null on the API side).
+        description: At least one of ErrorReason or BackupErrorReason must yield a
+          recovery type; both are optional.
         type: string
       fromVolumeId:
         type: string

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -303,6 +303,8 @@ definitions:
         $ref: '#/definitions/enums.BackupState'
       daemonVersion:
         type: string
+      recoverable:
+        type: boolean
       state:
         $ref: '#/definitions/enums.SandboxState'
     type: object

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -186,6 +186,11 @@ definitions:
           type: string
         type: object
       errorReason:
+        description: |-
+          At least one of ErrorReason or BackupErrorReason must deduce a recovery type in
+          apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the
+          caller can send only whichever one is populated (archive-backup failures leave
+          errorReason null on the API side).
         type: string
       fromVolumeId:
         type: string
@@ -215,7 +220,6 @@ definitions:
           $ref: '#/definitions/dto.VolumeDTO'
         type: array
     required:
-      - errorReason
       - osUser
       - userId
     type: object

--- a/apps/runner/pkg/api/dto/info.go
+++ b/apps/runner/pkg/api/dto/info.go
@@ -19,7 +19,7 @@ type RunnerServiceInfo struct {
 	ServiceName string  `json:"serviceName" validate:"required"`
 	Healthy     bool    `json:"healthy" validate:"required"`
 	ErrorReason *string `json:"errorReason,omitempty"`
-} // @name RunnerServiceInfo
+} //	@name	RunnerServiceInfo
 
 type RunnerInfoResponseDTO struct {
 	ServiceHealth []*RunnerServiceInfo `json:"serviceHealth,omitempty"`

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -43,20 +43,24 @@ type UpdateNetworkSettingsDTO struct {
 } //	@name	UpdateNetworkSettingsDTO
 
 type RecoverSandboxDTO struct {
-	FromVolumeId      string            `json:"fromVolumeId,omitempty"`
-	UserId            string            `json:"userId" validate:"required"`
-	Snapshot          *string           `json:"snapshot,omitempty"`
-	OsUser            string            `json:"osUser" validate:"required"`
-	CpuQuota          int64             `json:"cpuQuota" validate:"min=1"`
-	GpuQuota          int64             `json:"gpuQuota" validate:"min=0"`
-	MemoryQuota       int64             `json:"memoryQuota" validate:"min=1"`
-	StorageQuota      int64             `json:"storageQuota" validate:"min=1"`
-	Env               map[string]string `json:"env,omitempty"`
-	Volumes           []VolumeDTO       `json:"volumes,omitempty"`
-	NetworkBlockAll   *bool             `json:"networkBlockAll,omitempty"`
-	NetworkAllowList  *string           `json:"networkAllowList,omitempty"`
-	ErrorReason       string            `json:"errorReason" validate:"required"`
-	BackupErrorReason string            `json:"backupErrorReason,omitempty"`
+	FromVolumeId     string            `json:"fromVolumeId,omitempty"`
+	UserId           string            `json:"userId" validate:"required"`
+	Snapshot         *string           `json:"snapshot,omitempty"`
+	OsUser           string            `json:"osUser" validate:"required"`
+	CpuQuota         int64             `json:"cpuQuota" validate:"min=1"`
+	GpuQuota         int64             `json:"gpuQuota" validate:"min=0"`
+	MemoryQuota      int64             `json:"memoryQuota" validate:"min=1"`
+	StorageQuota     int64             `json:"storageQuota" validate:"min=1"`
+	Env              map[string]string `json:"env,omitempty"`
+	Volumes          []VolumeDTO       `json:"volumes,omitempty"`
+	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`
+	NetworkAllowList *string           `json:"networkAllowList,omitempty"`
+	// At least one of ErrorReason or BackupErrorReason must deduce a recovery type in
+	// apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the
+	// caller can send only whichever one is populated (archive-backup failures leave
+	// errorReason null on the API side).
+	ErrorReason       string `json:"errorReason,omitempty"`
+	BackupErrorReason string `json:"backupErrorReason,omitempty"`
 } //	@name	RecoverSandboxDTO
 
 type IsRecoverableDTO struct {

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -44,20 +44,24 @@ type UpdateNetworkSettingsDTO struct {
 } //	@name	UpdateNetworkSettingsDTO
 
 type RecoverSandboxDTO struct {
-	FromVolumeId      string            `json:"fromVolumeId,omitempty"`
-	UserId            string            `json:"userId" validate:"required"`
-	Snapshot          *string           `json:"snapshot,omitempty"`
-	OsUser            string            `json:"osUser" validate:"required"`
-	CpuQuota          int64             `json:"cpuQuota" validate:"min=1"`
-	GpuQuota          int64             `json:"gpuQuota" validate:"min=0"`
-	MemoryQuota       int64             `json:"memoryQuota" validate:"min=1"`
-	StorageQuota      int64             `json:"storageQuota" validate:"min=1"`
-	Env               map[string]string `json:"env,omitempty"`
-	Volumes           []VolumeDTO       `json:"volumes,omitempty"`
-	NetworkBlockAll   *bool             `json:"networkBlockAll,omitempty"`
-	NetworkAllowList  *string           `json:"networkAllowList,omitempty"`
-	ErrorReason       string            `json:"errorReason" validate:"required"`
-	BackupErrorReason string            `json:"backupErrorReason,omitempty"`
+	FromVolumeId     string            `json:"fromVolumeId,omitempty"`
+	UserId           string            `json:"userId" validate:"required"`
+	Snapshot         *string           `json:"snapshot,omitempty"`
+	OsUser           string            `json:"osUser" validate:"required"`
+	CpuQuota         int64             `json:"cpuQuota" validate:"min=1"`
+	GpuQuota         int64             `json:"gpuQuota" validate:"min=0"`
+	MemoryQuota      int64             `json:"memoryQuota" validate:"min=1"`
+	StorageQuota     int64             `json:"storageQuota" validate:"min=1"`
+	Env              map[string]string `json:"env,omitempty"`
+	Volumes          []VolumeDTO       `json:"volumes,omitempty"`
+	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`
+	NetworkAllowList *string           `json:"networkAllowList,omitempty"`
+	// At least one of ErrorReason or BackupErrorReason must deduce a recovery type in
+	// apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the
+	// caller can send only whichever one is populated (archive-backup failures leave
+	// errorReason null on the API side).
+	ErrorReason       string 			`json:"errorReason,omitempty"`
+	BackupErrorReason string 			`json:"backupErrorReason,omitempty"`
 	Registry          *RegistryDTO      `json:"registry,omitempty"`
 } //	@name	RecoverSandboxDTO
 

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -60,9 +60,9 @@ type RecoverSandboxDTO struct {
 	// apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the
 	// caller can send only whichever one is populated (archive-backup failures leave
 	// errorReason null on the API side).
-	ErrorReason       string 			`json:"errorReason,omitempty"`
-	BackupErrorReason string 			`json:"backupErrorReason,omitempty"`
-	Registry          *RegistryDTO      `json:"registry,omitempty"`
+	ErrorReason       string       `json:"errorReason,omitempty"`
+	BackupErrorReason string       `json:"backupErrorReason,omitempty"`
+	Registry          *RegistryDTO `json:"registry,omitempty"`
 } //	@name	RecoverSandboxDTO
 
 type IsRecoverableDTO struct {

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -56,10 +56,7 @@ type RecoverSandboxDTO struct {
 	Volumes          []VolumeDTO       `json:"volumes,omitempty"`
 	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`
 	NetworkAllowList *string           `json:"networkAllowList,omitempty"`
-	// At least one of ErrorReason or BackupErrorReason must deduce a recovery type in
-	// apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the
-	// caller can send only whichever one is populated (archive-backup failures leave
-	// errorReason null on the API side).
+	// At least one of ErrorReason or BackupErrorReason must yield a recovery type; both are optional.
 	ErrorReason       string       `json:"errorReason,omitempty"`
 	BackupErrorReason string       `json:"backupErrorReason,omitempty"`
 	Registry          *RegistryDTO `json:"registry,omitempty"`

--- a/apps/runner/pkg/docker/recover.go
+++ b/apps/runner/pkg/docker/recover.go
@@ -13,10 +13,13 @@ import (
 )
 
 func (d *DockerClient) RecoverSandbox(ctx context.Context, sandboxId string, recoverDto dto.RecoverSandboxDTO) error {
-	// Deduce recovery type from error reason
+	// Deduce recovery type from error reason, falling back to backup error reason
 	recoveryType := common.DeduceRecoveryType(recoverDto.ErrorReason)
 	if recoveryType == models.UnknownRecoveryType {
-		return fmt.Errorf("unable to deduce recovery type from error reason: %s", recoverDto.ErrorReason)
+		recoveryType = common.DeduceRecoveryType(recoverDto.BackupErrorReason)
+	}
+	if recoveryType == models.UnknownRecoveryType {
+		return fmt.Errorf("unable to deduce recovery type from error reason: %s, backup error reason: %s", recoverDto.ErrorReason, recoverDto.BackupErrorReason)
 	}
 
 	switch recoveryType {

--- a/apps/runner/pkg/runner/v2/executor/backup.go
+++ b/apps/runner/pkg/runner/v2/executor/backup.go
@@ -11,6 +11,7 @@ import (
 
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/daytonaio/runner/pkg/api/dto"
+	"github.com/daytonaio/runner/pkg/common"
 )
 
 func (e *Executor) createBackup(ctx context.Context, job *apiclient.Job) (any, error) {
@@ -21,5 +22,8 @@ func (e *Executor) createBackup(ctx context.Context, job *apiclient.Job) (any, e
 	}
 
 	// TODO: is state cache needed?
-	return nil, e.docker.CreateBackup(ctx, job.ResourceId, createBackupDto)
+	if err := e.docker.CreateBackup(ctx, job.ResourceId, createBackupDto); err != nil {
+		return nil, common.FormatRecoverableError(err)
+	}
+	return nil, nil
 }

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -42,11 +42,11 @@ export interface RecoverSandboxDTO {
      */
     'env'?: { [key: string]: string; };
     /**
-     * 
+     * At least one of ErrorReason or BackupErrorReason must deduce a recovery type in apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the caller can send only whichever one is populated (archive-backup failures leave errorReason null on the API side).
      * @type {string}
      * @memberof RecoverSandboxDTO
      */
-    'errorReason': string;
+    'errorReason'?: string;
     /**
      * 
      * @type {string}

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -26,15 +26,8 @@ export interface RecoverSandboxDTO {
     'env'?: { [key: string]: string; };
     /**
      * At least one of ErrorReason or BackupErrorReason must deduce a recovery type in apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the caller can send only whichever one is populated (archive-backup failures leave errorReason null on the API side).
-     * @type {string}
-     * @memberof RecoverSandboxDTO
      */
     'errorReason'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof RecoverSandboxDTO
-     */
     'fromVolumeId'?: string;
     'gpuQuota'?: number;
     'memoryQuota'?: number;

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -25,7 +25,7 @@ export interface RecoverSandboxDTO {
     'cpuQuota'?: number;
     'env'?: { [key: string]: string; };
     /**
-     * At least one of ErrorReason or BackupErrorReason must deduce a recovery type in apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the caller can send only whichever one is populated (archive-backup failures leave errorReason null on the API side).
+     * At least one of ErrorReason or BackupErrorReason must yield a recovery type; both are optional.
      */
     'errorReason'?: string;
     'fromVolumeId'?: string;

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -24,7 +24,17 @@ export interface RecoverSandboxDTO {
     'backupErrorReason'?: string;
     'cpuQuota'?: number;
     'env'?: { [key: string]: string; };
-    'errorReason': string;
+    /**
+     * At least one of ErrorReason or BackupErrorReason must deduce a recovery type in apps/runner/pkg/docker/recover.go; both are optional at the DTO level so that the caller can send only whichever one is populated (archive-backup failures leave errorReason null on the API side).
+     * @type {string}
+     * @memberof RecoverSandboxDTO
+     */
+    'errorReason'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof RecoverSandboxDTO
+     */
     'fromVolumeId'?: string;
     'gpuQuota'?: number;
     'memoryQuota'?: number;

--- a/libs/runner-api-client/src/models/sandbox-info-response.ts
+++ b/libs/runner-api-client/src/models/sandbox-info-response.ts
@@ -52,6 +52,12 @@ export interface SandboxInfoResponse {
     'daemonVersion'?: string;
     /**
      * 
+     * @type {boolean}
+     * @memberof SandboxInfoResponse
+     */
+    'recoverable'?: boolean;
+    /**
+     * 
      * @type {EnumsSandboxState}
      * @memberof SandboxInfoResponse
      */

--- a/libs/runner-api-client/src/models/sandbox-info-response.ts
+++ b/libs/runner-api-client/src/models/sandbox-info-response.ts
@@ -25,17 +25,7 @@ export interface SandboxInfoResponse {
     'backupSnapshot'?: string;
     'backupState'?: EnumsBackupState;
     'daemonVersion'?: string;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof SandboxInfoResponse
-     */
     'recoverable'?: boolean;
-    /**
-     * 
-     * @type {EnumsSandboxState}
-     * @memberof SandboxInfoResponse
-     */
     'state'?: EnumsSandboxState;
 }
 

--- a/libs/runner-api-client/src/models/sandbox-info-response.ts
+++ b/libs/runner-api-client/src/models/sandbox-info-response.ts
@@ -25,6 +25,17 @@ export interface SandboxInfoResponse {
     'backupSnapshot'?: string;
     'backupState'?: EnumsBackupState;
     'daemonVersion'?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SandboxInfoResponse
+     */
+    'recoverable'?: boolean;
+    /**
+     * 
+     * @type {EnumsSandboxState}
+     * @memberof SandboxInfoResponse
+     */
     'state'?: EnumsSandboxState;
 }
 


### PR DESCRIPTION
## Description

When a user-initiated archive fails with a recoverable backup error (e.g., out of disk), the runner now surfaces recoverable on /info and wraps the error so the API can mark the sandbox recoverable. The recover endpoint no longer requires state=ERROR - it gates on the flag, clears stale backup state, and lets users retry. Auto-stop and scheduled backup failures never surface as recoverable.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation