### PR TITLE
feat(api,runner): forward backup registry on recover and pull image if missing

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -542,7 +542,11 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             })
           }
 
-          await runnerAdapter.recoverSandbox(sandbox, true)
+          const backupRegistry = sandbox.backupRegistryId
+            ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
+            : undefined
+
+          await runnerAdapter.recoverSandbox(sandbox, backupRegistry, true)
 
           if (runner.apiVersion !== '2') {
             await this.sandboxRepository.updateWhere(sandbox.id, {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -119,7 +119,7 @@ export interface RunnerAdapter {
     registry?: DockerRegistry,
   ): Promise<void>
 
-  recoverSandbox(sandbox: Sandbox): Promise<void>
+  recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry): Promise<void>
 
   resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void>
 }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -121,7 +121,13 @@ export interface RunnerAdapter {
 
   recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry): Promise<void>
 
-  resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void>
+  resizeSandbox(
+    sandboxId: string,
+    cpu?: number,
+    memory?: number,
+    disk?: number,
+    registry?: DockerRegistry,
+  ): Promise<void>
 }
 
 @Injectable()

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -132,7 +132,13 @@ export interface RunnerAdapter {
 
   recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry, skipStart?: boolean): Promise<void>
 
-  resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void>
+  resizeSandbox(
+    sandboxId: string,
+    cpu?: number,
+    memory?: number,
+    disk?: number,
+    registry?: DockerRegistry,
+  ): Promise<void>
 }
 
 @Injectable()

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -130,7 +130,7 @@ export interface RunnerAdapter {
     registry?: DockerRegistry,
   ): Promise<CreateSandboxSnapshotResult | undefined>
 
-  recoverSandbox(sandbox: Sandbox, skipStart?: boolean): Promise<void>
+  recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry, skipStart?: boolean): Promise<void>
 
   resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void>
 }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -429,7 +429,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     throw new Error('createSnapshotFromSandbox is not supported for V0 runners')
   }
 
-  async recoverSandbox(sandbox: Sandbox): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -448,6 +448,14 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     }
     await this.sandboxApiClient.recover(sandbox.id, recoverSandboxDTO)
   }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -460,7 +460,25 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     await this.sandboxApiClient.recover(sandbox.id, recoverSandboxDTO)
   }
 
-  async resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void> {
-    await this.sandboxApiClient.resize(sandboxId, { cpu, memory, disk })
+  async resizeSandbox(
+    sandboxId: string,
+    cpu?: number,
+    memory?: number,
+    disk?: number,
+    registry?: DockerRegistry,
+  ): Promise<void> {
+    await this.sandboxApiClient.resize(sandboxId, {
+      cpu,
+      memory,
+      disk,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
+    })
   }
 }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -457,7 +457,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
   }
 
   // skipStart is a v2-only signal (carried in the job payload); v0's sync API has no equivalent.
-  async recoverSandbox(sandbox: Sandbox, _skipStart?: boolean): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry, _skipStart?: boolean): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -476,6 +476,14 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     }
     await this.sandboxApiClient.recover(sandbox.id, recoverSandboxDTO)
   }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -488,7 +488,25 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     await this.sandboxApiClient.recover(sandbox.id, recoverSandboxDTO)
   }
 
-  async resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void> {
-    await this.sandboxApiClient.resize(sandboxId, { cpu, memory, disk })
+  async resizeSandbox(
+    sandboxId: string,
+    cpu?: number,
+    memory?: number,
+    disk?: number,
+    registry?: DockerRegistry,
+  ): Promise<void> {
+    await this.sandboxApiClient.resize(sandboxId, {
+      cpu,
+      memory,
+      disk,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
+    })
   }
 }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -223,7 +223,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created DESTROY_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async recoverSandbox(sandbox: Sandbox): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -242,6 +242,14 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     }
     await this.jobService.createJob(
       null,

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -594,11 +594,25 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created SNAPSHOT_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void> {
+  async resizeSandbox(
+    sandboxId: string,
+    cpu?: number,
+    memory?: number,
+    disk?: number,
+    registry?: DockerRegistry,
+  ): Promise<void> {
     await this.jobService.createJob(null, JobType.RESIZE_SANDBOX, this.runner.id, ResourceType.SANDBOX, sandboxId, {
       cpu,
       memory,
       disk,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     })
 
     this.logger.debug(`Created RESIZE_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -595,11 +595,25 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created SNAPSHOT_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void> {
+  async resizeSandbox(
+    sandboxId: string,
+    cpu?: number,
+    memory?: number,
+    disk?: number,
+    registry?: DockerRegistry,
+  ): Promise<void> {
     await this.jobService.createJob(null, JobType.RESIZE_SANDBOX, this.runner.id, ResourceType.SANDBOX, sandboxId, {
       cpu,
       memory,
       disk,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     })
 
     this.logger.debug(`Created RESIZE_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -223,7 +223,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created DESTROY_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async recoverSandbox(sandbox: Sandbox, skipStart = false): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry, skipStart = false): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -242,6 +242,14 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
+      registry: registry
+        ? {
+            project: registry.project,
+            url: registry.url.replace(/^(https?:\/\/)/, ''),
+            username: registry.username,
+            password: registry.password,
+          }
+        : undefined,
     }
     // skipStart is API-side metadata for the job-completion handler; the runner ignores extra fields.
     await this.jobService.createJob(null, JobType.RECOVER_SANDBOX, this.runner.id, ResourceType.SANDBOX, sandbox.id, {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1744,6 +1744,12 @@ export class SandboxService {
       ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
       : undefined
 
+    if (sandbox.backupRegistryId && !backupRegistry) {
+      this.logger.warn(
+        `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
+      )
+    }
+
     try {
       await runnerAdapter.recoverSandbox(sandbox, backupRegistry)
     } catch (error) {
@@ -1932,7 +1938,17 @@ export class SandboxService {
       try {
         const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
-        await runnerAdapter.resizeSandbox(sandbox.id, resizeDto.cpu, resizeDto.memory, resizeDto.disk)
+        const backupRegistry = sandbox.backupRegistryId
+          ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
+          : undefined
+
+        if (sandbox.backupRegistryId && !backupRegistry) {
+          this.logger.warn(
+            `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
+          )
+        }
+
+        await runnerAdapter.resizeSandbox(sandbox.id, resizeDto.cpu, resizeDto.memory, resizeDto.disk, backupRegistry)
 
         // For V0 runners, update resources immediately (subscriber emits STATE_UPDATED)
         // For V2 runners, job handler will update resources on completion

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1740,8 +1740,12 @@ export class SandboxService {
 
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
+    const backupRegistry = sandbox.backupRegistryId
+      ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
+      : undefined
+
     try {
-      await runnerAdapter.recoverSandbox(sandbox)
+      await runnerAdapter.recoverSandbox(sandbox, backupRegistry)
     } catch (error) {
       if (error instanceof Error && error.message.includes('storage cannot be further expanded')) {
         const errorMsg = `Sandbox storage cannot be further expanded. Maximum expansion of ${(sandbox.disk * 0.1).toFixed(2)}GB (10% of original ${sandbox.disk.toFixed(2)}GB) has been reached. Please contact support for further assistance.`

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1929,8 +1929,12 @@ export class SandboxService {
 
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
+      const backupRegistry = sandbox.backupRegistryId
+        ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
+        : undefined
+
       try {
-        await runnerAdapter.recoverSandbox(sandbox, skipStart)
+        await runnerAdapter.recoverSandbox(sandbox, backupRegistry, skipStart)
       } catch (error) {
         if (error instanceof Error && error.message.includes('storage cannot be further expanded')) {
           throw new ForbiddenException(

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1933,6 +1933,12 @@ export class SandboxService {
         ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
         : undefined
 
+    if (sandbox.backupRegistryId && !backupRegistry) {
+      this.logger.warn(
+        `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
+      )
+    }
+
       try {
         await runnerAdapter.recoverSandbox(sandbox, backupRegistry, skipStart)
       } catch (error) {
@@ -2140,7 +2146,17 @@ export class SandboxService {
       try {
         const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
-        await runnerAdapter.resizeSandbox(sandbox.id, resizeDto.cpu, resizeDto.memory, resizeDto.disk)
+        const backupRegistry = sandbox.backupRegistryId
+          ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
+          : undefined
+
+        if (sandbox.backupRegistryId && !backupRegistry) {
+          this.logger.warn(
+            `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
+          )
+        }
+
+        await runnerAdapter.resizeSandbox(sandbox.id, resizeDto.cpu, resizeDto.memory, resizeDto.disk, backupRegistry)
 
         // For V0 runners, update resources immediately (subscriber emits STATE_UPDATED)
         // For V2 runners, job handler will update resources on completion

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1933,11 +1933,11 @@ export class SandboxService {
         ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
         : undefined
 
-    if (sandbox.backupRegistryId && !backupRegistry) {
-      this.logger.warn(
-        `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
-      )
-    }
+      if (sandbox.backupRegistryId && !backupRegistry) {
+        this.logger.warn(
+          `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
+        )
+      }
 
       try {
         await runnerAdapter.recoverSandbox(sandbox, backupRegistry, skipStart)

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1754,6 +1754,9 @@ const docTemplate = `{
                 "memory": {
                     "type": "integer",
                     "minimum": 1
+                },
+                "registry": {
+                    "$ref": "#/definitions/RegistryDTO"
                 }
             }
         },

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1695,6 +1695,9 @@ const docTemplate = `{
                 "osUser": {
                     "type": "string"
                 },
+                "registry": {
+                    "$ref": "#/definitions/RegistryDTO"
+                },
                 "snapshot": {
                     "type": "string"
                 },

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1843,6 +1843,9 @@ const docTemplate = `{
                 "memory": {
                     "type": "integer",
                     "minimum": 1
+                },
+                "registry": {
+                    "$ref": "#/definitions/RegistryDTO"
                 }
             }
         },

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1787,6 +1787,9 @@ const docTemplate = `{
                 "osUser": {
                     "type": "string"
                 },
+                "registry": {
+                    "$ref": "#/definitions/RegistryDTO"
+                },
                 "snapshot": {
                     "type": "string"
                 },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1579,6 +1579,9 @@
         "osUser": {
           "type": "string"
         },
+        "registry": {
+          "$ref": "#/definitions/RegistryDTO"
+        },
         "snapshot": {
           "type": "string"
         },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1636,6 +1636,9 @@
         "memory": {
           "type": "integer",
           "minimum": 1
+        },
+        "registry": {
+          "$ref": "#/definitions/RegistryDTO"
         }
       }
     },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1664,6 +1664,9 @@
         "osUser": {
           "type": "string"
         },
+        "registry": {
+          "$ref": "#/definitions/RegistryDTO"
+        },
         "snapshot": {
           "type": "string"
         },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1718,6 +1718,9 @@
         "memory": {
           "type": "integer",
           "minimum": 1
+        },
+        "registry": {
+          "$ref": "#/definitions/RegistryDTO"
         }
       }
     },

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -233,6 +233,8 @@ definitions:
       memory:
         minimum: 1
         type: integer
+      registry:
+        $ref: '#/definitions/RegistryDTO'
     type: object
   RunnerInfoResponseDTO:
     properties:

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -188,6 +188,8 @@ definitions:
         type: boolean
       osUser:
         type: string
+      registry:
+        $ref: '#/definitions/RegistryDTO'
       snapshot:
         type: string
       storageQuota:

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -244,6 +244,8 @@ definitions:
       memory:
         minimum: 1
         type: integer
+      registry:
+        $ref: '#/definitions/RegistryDTO'
     type: object
   RunnerInfoResponseDTO:
     properties:

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -201,6 +201,8 @@ definitions:
         type: boolean
       osUser:
         type: string
+      registry:
+        $ref: '#/definitions/RegistryDTO'
       snapshot:
         type: string
       storageQuota:

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -57,6 +57,7 @@ type RecoverSandboxDTO struct {
 	NetworkAllowList  *string           `json:"networkAllowList,omitempty"`
 	ErrorReason       string            `json:"errorReason" validate:"required"`
 	BackupErrorReason string            `json:"backupErrorReason,omitempty"`
+	Registry          *RegistryDTO      `json:"registry,omitempty"`
 } //	@name	RecoverSandboxDTO
 
 type IsRecoverableDTO struct {

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -30,10 +30,11 @@ type CreateSandboxDTO struct {
 } //	@name	CreateSandboxDTO
 
 type ResizeSandboxDTO struct {
-	Cpu    int64 `json:"cpu,omitempty" validate:"omitempty,min=1"`
-	Gpu    int64 `json:"gpu,omitempty" validate:"omitempty,min=0"`
-	Memory int64 `json:"memory,omitempty" validate:"omitempty,min=1"`
-	Disk   int64 `json:"disk,omitempty" validate:"omitempty,min=1"`
+	Cpu      int64        `json:"cpu,omitempty" validate:"omitempty,min=1"`
+	Gpu      int64        `json:"gpu,omitempty" validate:"omitempty,min=0"`
+	Memory   int64        `json:"memory,omitempty" validate:"omitempty,min=1"`
+	Disk     int64        `json:"disk,omitempty" validate:"omitempty,min=1"`
+	Registry *RegistryDTO `json:"registry,omitempty"`
 } //	@name	ResizeSandboxDTO
 
 type UpdateNetworkSettingsDTO struct {

--- a/apps/runner/pkg/docker/recover.go
+++ b/apps/runner/pkg/docker/recover.go
@@ -21,7 +21,7 @@ func (d *DockerClient) RecoverSandbox(ctx context.Context, sandboxId string, rec
 
 	switch recoveryType {
 	case models.RecoveryTypeStorageExpansion:
-		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota), recoverDto)
+		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota), recoverDto.Registry)
 	default:
 		return fmt.Errorf("unsupported recovery type: %s", recoveryType)
 	}

--- a/apps/runner/pkg/docker/recover.go
+++ b/apps/runner/pkg/docker/recover.go
@@ -21,7 +21,7 @@ func (d *DockerClient) RecoverSandbox(ctx context.Context, sandboxId string, rec
 
 	switch recoveryType {
 	case models.RecoveryTypeStorageExpansion:
-		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota))
+		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota), recoverDto)
 	default:
 		return fmt.Errorf("unsupported recovery type: %s", recoveryType)
 	}

--- a/apps/runner/pkg/docker/recover_from_storage_limit.go
+++ b/apps/runner/pkg/docker/recover_from_storage_limit.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
 )
 
 // RecoverFromStorageLimit attempts to recover a sandbox from storage limit issues
 // by expanding its storage quota by creating new ones with 100MB increments up to 10% of original.
-func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64) error {
+func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, recoverDto dto.RecoverSandboxDTO) error {
 	originalContainer, err := d.ContainerInspect(ctx, sandboxId)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container: %w", err)
@@ -59,5 +60,5 @@ func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId st
 		}
 	}
 
-	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery")
+	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", recoverDto.Registry)
 }

--- a/apps/runner/pkg/docker/recover_from_storage_limit.go
+++ b/apps/runner/pkg/docker/recover_from_storage_limit.go
@@ -13,7 +13,7 @@ import (
 
 // RecoverFromStorageLimit attempts to recover a sandbox from storage limit issues
 // by expanding its storage quota by creating new ones with 100MB increments up to 10% of original.
-func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, recoverDto dto.RecoverSandboxDTO) error {
+func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, registry *dto.RegistryDTO) error {
 	originalContainer, err := d.ContainerInspect(ctx, sandboxId)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container: %w", err)
@@ -60,5 +60,5 @@ func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId st
 		}
 	}
 
-	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", recoverDto.Registry)
+	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", registry)
 }

--- a/apps/runner/pkg/docker/recover_from_storage_limit.go
+++ b/apps/runner/pkg/docker/recover_from_storage_limit.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
 )
 
 // RecoverFromStorageLimit attempts to recover a sandbox from storage limit issues
 // by expanding its storage quota by 5% of the original quota per attempt, up to 10% total.
-func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64) error {
+func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, recoverDto dto.RecoverSandboxDTO) error {
 	originalContainer, err := d.ContainerInspect(ctx, sandboxId)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container: %w", err)
@@ -59,5 +60,5 @@ func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId st
 		}
 	}
 
-	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery")
+	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", recoverDto.Registry)
 }

--- a/apps/runner/pkg/docker/recover_from_storage_limit.go
+++ b/apps/runner/pkg/docker/recover_from_storage_limit.go
@@ -13,7 +13,7 @@ import (
 
 // RecoverFromStorageLimit attempts to recover a sandbox from storage limit issues
 // by expanding its storage quota by 5% of the original quota per attempt, up to 10% total.
-func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, recoverDto dto.RecoverSandboxDTO) error {
+func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, registry *dto.RegistryDTO) error {
 	originalContainer, err := d.ContainerInspect(ctx, sandboxId)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container: %w", err)
@@ -60,5 +60,5 @@ func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId st
 		}
 	}
 
-	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", recoverDto.Registry)
+	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", registry)
 }

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -30,7 +30,7 @@ func (d *DockerClient) Resize(ctx context.Context, sandboxId string, sandboxDto 
 			return fmt.Errorf("disk resize requires stopped container")
 		}
 
-		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize", nil)
+		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize", sandboxDto.Registry)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 		}
 	}
 
-	resolvedImage, err := d.resolveContainerImage(ctx, originalContainer, registry)
+	resolvedImage, err := d.resolveContainerImage(ctx, sandboxId, originalContainer, registry)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func (d *DockerClient) copyContainerOverlayData(ctx context.Context, oldContaine
 	return common.RsyncCopy(copyCtx, d.logger, oldContainerOverlayPath, newUpperDir)
 }
 
-func (d *DockerClient) resolveContainerImage(ctx context.Context, originalContainer *container.InspectResponse, registry *dto.RegistryDTO) (string, error) {
+func (d *DockerClient) resolveContainerImage(ctx context.Context, sandboxId string, originalContainer *container.InspectResponse, registry *dto.RegistryDTO) (string, error) {
 	imageRef := originalContainer.Config.Image
 
 	_, err := d.apiClient.ImageInspect(ctx, imageRef)
@@ -232,12 +232,12 @@ func (d *DockerClient) resolveContainerImage(ctx context.Context, originalContai
 	}
 
 	if registry == nil {
-		return "", fmt.Errorf("image %s not available locally and no registry provided", imageRef)
+		return "", fmt.Errorf("image %s is not available locally", imageRef)
 	}
 	d.logger.WarnContext(ctx, "Image not found locally, pulling from registry before resize",
 		"containerName", originalContainer.Name, "imageRef", imageRef)
-	if _, pullErr := d.PullImage(ctx, imageRef, registry, nil); pullErr != nil {
-		return "", fmt.Errorf("image %s not available locally and pull failed: %w", imageRef, pullErr)
+	if _, pullErr := d.PullImage(ctx, imageRef, registry, &sandboxId); pullErr != nil {
+		return "", fmt.Errorf("image %s not available locally and pull from registry failed: %w", imageRef, pullErr)
 	}
 	return imageRef, nil
 }

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/daytonaio/common-go/pkg/utils"
 	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
@@ -29,7 +30,7 @@ func (d *DockerClient) Resize(ctx context.Context, sandboxId string, sandboxDto 
 			return fmt.Errorf("disk resize requires stopped container")
 		}
 
-		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize")
+		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize", nil)
 		if err != nil {
 			return err
 		}
@@ -67,7 +68,7 @@ func (d *DockerClient) Resize(ctx context.Context, sandboxId string, sandboxDto 
 // Optionally updates CPU/memory at the same time (0 = don't change).
 // Used by both storage recovery and disk resize.
 // Container must be stopped before calling this function.
-func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string, newStorageGB float64, cpu int64, memory int64, operationName string) error {
+func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string, newStorageGB float64, cpu int64, memory int64, operationName string, registry *dto.RegistryDTO) error {
 	if d.filesystem != "xfs" {
 		return fmt.Errorf("%s requires XFS filesystem, current filesystem: %s", operationName, d.filesystem)
 	}
@@ -88,6 +89,12 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 		}
 	}
 
+	resolvedImage, err := d.resolveContainerImage(ctx, originalContainer, registry)
+	if err != nil {
+		return err
+	}
+	originalContainer.Config.Image = resolvedImage
+
 	// Rename container after validation checks to reduce error handling complexity
 	timestamp := time.Now().Unix()
 	oldName := fmt.Sprintf("%s-%s-%d", sandboxId, operationName, timestamp)
@@ -96,16 +103,6 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 	err = d.apiClient.ContainerRename(ctx, sandboxId, oldName)
 	if err != nil {
 		return fmt.Errorf("failed to rename container: %w", err)
-	}
-
-	// Ensure the image is available for container recreation.
-	// If the image tag was pruned (e.g., declarative-build or backup snapshot),
-	// fall back to the image ID — Docker retains layers while the container exists.
-	imageRef := originalContainer.Config.Image
-	imageExists, _ := d.ImageExists(ctx, imageRef, true)
-	if !imageExists {
-		d.logger.Warn("Image is not found by tag, falling back to image ID", "imageRef", imageRef, "imageID", originalContainer.Image)
-		originalContainer.Config.Image = originalContainer.Image
 	}
 
 	// Create new container with new storage
@@ -211,4 +208,36 @@ func (d *DockerClient) copyContainerOverlayData(ctx context.Context, oldContaine
 	defer cancel()
 
 	return common.RsyncCopy(copyCtx, d.logger, oldContainerOverlayPath, newUpperDir)
+}
+
+func (d *DockerClient) resolveContainerImage(ctx context.Context, originalContainer *container.InspectResponse, registry *dto.RegistryDTO) (string, error) {
+	imageRef := originalContainer.Config.Image
+
+	_, err := d.apiClient.ImageInspect(ctx, imageRef)
+	if err == nil {
+		return imageRef, nil
+	}
+	if !errdefs.IsNotFound(err) {
+		return "", fmt.Errorf("failed to inspect image %s: %w", imageRef, err)
+	}
+
+	_, idErr := d.apiClient.ImageInspect(ctx, originalContainer.Image)
+	if idErr == nil {
+		d.logger.WarnContext(ctx, "Image not found by tag, falling back to image ID",
+			"imageRef", imageRef, "imageID", originalContainer.Image)
+		return originalContainer.Image, nil
+	}
+	if !errdefs.IsNotFound(idErr) {
+		return "", fmt.Errorf("failed to inspect image by ID %s: %w", originalContainer.Image, idErr)
+	}
+
+	if registry == nil {
+		return "", fmt.Errorf("image %s not available locally and no registry provided", imageRef)
+	}
+	d.logger.WarnContext(ctx, "Image not found locally, pulling from registry before resize",
+		"containerName", originalContainer.Name, "imageRef", imageRef)
+	if _, pullErr := d.PullImage(ctx, imageRef, registry, nil); pullErr != nil {
+		return "", fmt.Errorf("image %s not available locally and pull failed: %w", imageRef, pullErr)
+	}
+	return imageRef, nil
 }

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -16,6 +16,9 @@
 // May contain unused imports in some cases
 // @ts-ignore
 import type { DtoVolumeDTO } from './dto-volume-dto';
+// May contain unused imports in some cases
+// @ts-ignore
+import type { RegistryDTO } from './registry-dto';
 
 /**
  * 
@@ -83,6 +86,12 @@ export interface RecoverSandboxDTO {
      * @memberof RecoverSandboxDTO
      */
     'osUser': string;
+    /**
+     * 
+     * @type {RegistryDTO}
+     * @memberof RecoverSandboxDTO
+     */
+    'registry'?: RegistryDTO;
     /**
      * 
      * @type {string}

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -16,6 +16,9 @@
 // May contain unused imports in some cases
 // @ts-ignore
 import type { DtoVolumeDTO } from './dto-volume-dto';
+// May contain unused imports in some cases
+// @ts-ignore
+import type { RegistryDTO } from './registry-dto';
 
 export interface RecoverSandboxDTO {
     'backupErrorReason'?: string;
@@ -28,6 +31,7 @@ export interface RecoverSandboxDTO {
     'networkAllowList'?: string;
     'networkBlockAll'?: boolean;
     'osUser': string;
+    'registry'?: RegistryDTO;
     'snapshot'?: string;
     'storageQuota'?: number;
     'userId': string;

--- a/libs/runner-api-client/src/models/resize-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/resize-sandbox-dto.ts
@@ -13,6 +13,9 @@
  */
 
 
+// May contain unused imports in some cases
+// @ts-ignore
+import type { RegistryDTO } from './registry-dto';
 
 /**
  * 
@@ -44,5 +47,11 @@ export interface ResizeSandboxDTO {
      * @memberof ResizeSandboxDTO
      */
     'memory'?: number;
+    /**
+     * 
+     * @type {RegistryDTO}
+     * @memberof ResizeSandboxDTO
+     */
+    'registry'?: RegistryDTO;
 }
 

--- a/libs/runner-api-client/src/models/resize-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/resize-sandbox-dto.ts
@@ -22,11 +22,6 @@ export interface ResizeSandboxDTO {
     'disk'?: number;
     'gpu'?: number;
     'memory'?: number;
-    /**
-     * 
-     * @type {RegistryDTO}
-     * @memberof ResizeSandboxDTO
-     */
     'registry'?: RegistryDTO;
 }
 

--- a/libs/runner-api-client/src/models/resize-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/resize-sandbox-dto.ts
@@ -13,11 +13,20 @@
  */
 
 
+// May contain unused imports in some cases
+// @ts-ignore
+import type { RegistryDTO } from './registry-dto';
 
 export interface ResizeSandboxDTO {
     'cpu'?: number;
     'disk'?: number;
     'gpu'?: number;
     'memory'?: number;
+    /**
+     * 
+     * @type {RegistryDTO}
+     * @memberof ResizeSandboxDTO
+     */
+    'registry'?: RegistryDTO;
 }
 


### PR DESCRIPTION
## Description

When a backup pushes a snapshot to the registry, the runner may later prune the local image, so recover fails with a missing   image. This forwards the sandbox's backupRegistryId creds to the runner, which now resolves via ImageInspect (tag, then ID) and, as a last resort, pulls from the registry before recreating the container.  

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation