### PR TITLE
feat(api,cli,dashboard,sdk,sdk): expose sandbox last activity timestamp

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1776430357681-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1776430357681-migration.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1776430357681 implements MigrationInterface {
+  name = 'Migration1776430357681'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Note: not using CONCURRENTLY + skipping transactions because of reverting issue: https://github.com/typeorm/typeorm/issues/9981
+    await queryRunner.query(`CREATE INDEX idx_sandbox_last_activity_at ON sandbox_last_activity ("lastActivityAt")`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX idx_sandbox_last_activity_at`)
+  }
+}

--- a/apps/api/src/sandbox/dto/list-sandboxes-query.dto.ts
+++ b/apps/api/src/sandbox/dto/list-sandboxes-query.dto.ts
@@ -19,6 +19,7 @@ export enum SandboxSortField {
   REGION = 'region',
   UPDATED_AT = 'updatedAt',
   CREATED_AT = 'createdAt',
+  LAST_ACTIVITY_AT = 'lastActivityAt',
 }
 
 export enum SandboxSortDirection {

--- a/apps/api/src/sandbox/dto/sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/sandbox.dto.ts
@@ -244,6 +244,14 @@ export class SandboxDto {
   updatedAt?: string
 
   @ApiPropertyOptional({
+    description: 'The last activity timestamp of the sandbox',
+    example: '2024-10-01T12:00:00Z',
+    required: false,
+  })
+  @IsOptional()
+  lastActivityAt?: string
+
+  @ApiPropertyOptional({
     description: 'The class of the sandbox',
     enum: SandboxClass,
     example: Object.values(SandboxClass)[0],
@@ -306,6 +314,9 @@ export class SandboxDto {
       class: sandbox.class,
       createdAt: sandbox.createdAt ? new Date(sandbox.createdAt).toISOString() : undefined,
       updatedAt: sandbox.updatedAt ? new Date(sandbox.updatedAt).toISOString() : undefined,
+      lastActivityAt: sandbox.lastActivityAt?.lastActivityAt
+        ? new Date(sandbox.lastActivityAt.lastActivityAt).toISOString()
+        : undefined,
       buildInfo: sandbox.buildInfo
         ? {
             dockerfileContent: sandbox.buildInfo.dockerfileContent,

--- a/apps/api/src/sandbox/repositories/sandbox.repository.ts
+++ b/apps/api/src/sandbox/repositories/sandbox.repository.ts
@@ -46,6 +46,8 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
     await this.dataSource.transaction(async (entityManager) => {
       await entityManager.insert(Sandbox, sandbox)
       await this.upsertLastActivity(entityManager, sandbox.id, sandbox.createdAt)
+      sandbox.lastActivityAt = { sandboxId: sandbox.id, lastActivityAt: sandbox.createdAt }
+
       if (parentId) {
         await entityManager.insert(SandboxFork, {
           parentId,
@@ -116,6 +118,7 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
 
       if (previousSandbox.state !== sandbox.state || previousSandbox.organizationId !== sandbox.organizationId) {
         await this.upsertLastActivity(entityManager, id, sandbox.updatedAt)
+        sandbox.lastActivityAt = { sandboxId: id, lastActivityAt: sandbox.updatedAt }
       }
     })
 
@@ -173,6 +176,7 @@ export class SandboxRepository extends BaseRepository<Sandbox> {
 
       if (previousSandbox.state !== sandbox.state || previousSandbox.organizationId !== sandbox.organizationId) {
         await this.upsertLastActivity(entityManager, id, sandbox.updatedAt)
+        sandbox.lastActivityAt = { sandboxId: id, lastActivityAt: sandbox.updatedAt }
       }
 
       this.emitUpdateEvents(sandbox, previousSandbox)

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1131,7 +1131,7 @@ export class SandboxService {
       },
     ]
 
-    return this.sandboxRepository.find({ where })
+    return this.sandboxRepository.find({ where, relations: ['lastActivityAt'] })
   }
 
   async findAll(
@@ -1196,7 +1196,11 @@ export class SandboxService {
     baseFindOptions.cpu = createRangeFilter(minCpu, maxCpu)
     baseFindOptions.mem = createRangeFilter(minMemoryGiB, maxMemoryGiB)
     baseFindOptions.disk = createRangeFilter(minDiskGiB, maxDiskGiB)
-    baseFindOptions.updatedAt = createRangeFilter(lastEventAfter, lastEventBefore)
+
+    const lastActivityFilter = createRangeFilter(lastEventAfter, lastEventBefore)
+    if (lastActivityFilter) {
+      baseFindOptions.lastActivityAt = { lastActivityAt: lastActivityFilter }
+    }
 
     const statesToInclude = (states || Object.values(SandboxState)).filter((state) => state !== SandboxState.DESTROYED)
     const errorStates = [SandboxState.ERROR, SandboxState.BUILD_FAILED]
@@ -1223,11 +1227,16 @@ export class SandboxService {
 
     const [items, total] = await this.sandboxRepository.findAndCount({
       where,
+      relations: ['lastActivityAt'],
       order: {
-        [sortField]: {
-          direction: sortDirection,
-          nulls: 'LAST',
-        },
+        ...(sortField === SandboxSortField.LAST_ACTIVITY_AT
+          ? { lastActivityAt: { lastActivityAt: { direction: sortDirection, nulls: 'LAST' } } }
+          : {
+              [sortField]: {
+                direction: sortDirection,
+                nulls: 'LAST',
+              },
+            }),
         ...(sortField !== SandboxSortField.CREATED_AT && { createdAt: 'DESC' }),
       },
       skip: (pageNum - 1) * limitNum,
@@ -1277,7 +1286,7 @@ export class SandboxService {
       where.state = In(states)
     }
 
-    let sandboxes = await this.sandboxRepository.find({ where })
+    let sandboxes = await this.sandboxRepository.find({ where, relations: ['lastActivityAt'] })
 
     if (skipReconcilingSandboxes) {
       sandboxes = sandboxes.filter((sandbox) => {
@@ -1295,7 +1304,7 @@ export class SandboxService {
     returnDestroyed?: boolean,
   ): Promise<Sandbox> {
     const stateFilter = returnDestroyed ? {} : { state: Not(SandboxState.DESTROYED) }
-    const relations: ['buildInfo'] = ['buildInfo']
+    const relations = ['buildInfo', 'lastActivityAt']
 
     // Try lookup by ID first
     let sandbox = await this.sandboxRepository.findOne({
@@ -1345,6 +1354,7 @@ export class SandboxService {
         id: sandboxId,
         ...(returnDestroyed ? {} : { state: Not(SandboxState.DESTROYED) }),
       },
+      relations: ['lastActivityAt'],
     })
 
     if (

--- a/apps/cli/views/sandbox/info.go
+++ b/apps/cli/views/sandbox/info.go
@@ -40,7 +40,9 @@ func RenderInfo(sandbox *apiclient.Sandbox, forceUnstyled bool) {
 		output += getInfoLine("Created", util.GetTimeSinceLabelFromString(*sandbox.CreatedAt)) + "\n"
 	}
 
-	if sandbox.UpdatedAt != nil {
+	if sandbox.LastActivityAt != nil {
+		output += getInfoLine("Last Event", util.GetTimeSinceLabelFromString(*sandbox.LastActivityAt)) + "\n"
+	} else if sandbox.UpdatedAt != nil {
 		output += getInfoLine("Last Event", util.GetTimeSinceLabelFromString(*sandbox.UpdatedAt)) + "\n"
 	}
 

--- a/apps/cli/views/sandbox/list.go
+++ b/apps/cli/views/sandbox/list.go
@@ -74,7 +74,9 @@ func getTableRowData(sandbox apiclient.Sandbox) *RowData {
 		rowData.Class = *sandbox.Class
 	}
 
-	if sandbox.UpdatedAt != nil {
+	if sandbox.LastActivityAt != nil {
+		rowData.LastEvent = util.GetTimeSinceLabelFromString(*sandbox.LastActivityAt)
+	} else if sandbox.UpdatedAt != nil {
 		rowData.LastEvent = util.GetTimeSinceLabelFromString(*sandbox.UpdatedAt)
 	}
 

--- a/apps/dashboard/src/components/SandboxDetailsSheet.tsx
+++ b/apps/dashboard/src/components/SandboxDetailsSheet.tsx
@@ -77,7 +77,7 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
   if (!sandbox) return null
 
   const getLastEvent = (sandbox: Sandbox): { date: Date; relativeTimeString: string } => {
-    return getRelativeTimeString(sandbox.updatedAt)
+    return getRelativeTimeString(sandbox.lastActivityAt ?? sandbox.updatedAt)
   }
 
   return (
@@ -262,7 +262,7 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
               <div>
                 <h3 className="text-sm text-muted-foreground">Last event</h3>
                 <p className="mt-1 text-sm font-medium">
-                  <TimestampTooltip timestamp={sandbox.updatedAt}>
+                  <TimestampTooltip timestamp={sandbox.lastActivityAt ?? sandbox.updatedAt}>
                     {getLastEvent(sandbox).relativeTimeString}
                   </TimestampTooltip>
                 </p>

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -381,5 +381,5 @@ function getDisplayName(sandbox: Sandbox): string {
 }
 
 function getLastEvent(sandbox: Sandbox): { date: Date; relativeTimeString: string } {
-  return getRelativeTimeString(sandbox.updatedAt)
+  return getRelativeTimeString(sandbox.lastActivityAt ?? sandbox.updatedAt)
 }

--- a/apps/dashboard/src/hooks/useSandboxes.ts
+++ b/apps/dashboard/src/hooks/useSandboxes.ts
@@ -37,7 +37,7 @@ export interface SandboxSorting {
 }
 
 export const DEFAULT_SANDBOX_SORTING: SandboxSorting = {
-  field: ListSandboxesPaginatedSortEnum.UPDATED_AT,
+  field: ListSandboxesPaginatedSortEnum.LAST_ACTIVITY_AT,
   direction: ListSandboxesPaginatedOrderEnum.DESC,
 }
 

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
@@ -44,6 +44,7 @@ Represents a Daytona Sandbox.
 - `build_info` _str_ - Build information for the Sandbox if it was created from dynamic build.
 - `created_at` _str_ - When the Sandbox was created.
 - `updated_at` _str_ - When the Sandbox was last updated.
+- `last_activity_at` _str_ - When the Sandbox last had activity.
 - `network_block_all` _bool_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _str_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
@@ -44,6 +44,7 @@ Represents a Daytona Sandbox.
 - `build_info` _str_ - Build information for the Sandbox if it was created from dynamic build.
 - `created_at` _str_ - When the Sandbox was created.
 - `updated_at` _str_ - When the Sandbox was last updated.
+- `last_activity_at` _str_ - When the Sandbox last had activity.
 - `network_block_all` _bool_ - Whether to block all network access for the Sandbox.
 - `network_allow_list` _str_ - Comma-separated list of allowed CIDR network addresses for the Sandbox.
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
@@ -319,7 +319,7 @@ def last_activity_at()
 
 **Returns**:
 
-- `String` - The last activity timestamp of the sandbox
+- `String, nil` - The last activity timestamp of the sandbox
 
 #### daemon_version()
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
@@ -310,6 +310,17 @@ def updated_at()
 
 - `String` - The last update timestamp of the sandbox
 
+#### last_activity_at()
+
+```ruby
+def last_activity_at()
+
+```
+
+**Returns**:
+
+- `String` - The last activity timestamp of the sandbox
+
 #### daemon_version()
 
 ```ruby

--- a/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/sandbox.mdx
@@ -319,7 +319,7 @@ def last_activity_at()
 
 **Returns**:
 
-- `String, nil` - The last activity timestamp of the sandbox
+- `String` - The last activity timestamp of the sandbox
 
 #### daemon_version()
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/sandbox.mdx
@@ -113,6 +113,13 @@ Represents a Daytona Sandbox.
     ```ts
     SandboxDto.labels
     ```
+- `lastActivityAt?` _string_ - When the Sandbox last had activity
+    
+    ##### Implementation of
+    
+    ```ts
+    SandboxDto.lastActivityAt
+    ```
 - `memory` _number_ - Amount of memory allocated to the Sandbox in GiB
     
     ##### Implementation of

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -1817,6 +1817,7 @@ paths:
           - region
           - updatedAt
           - createdAt
+          - lastActivityAt
           type: string
         style: form
       - description: Direction to sort by
@@ -10582,6 +10583,7 @@ components:
         memory: 4
         buildInfo: ""
         toolboxProxyUrl: https://proxy.app.daytona.io/toolbox
+        lastActivityAt: 2024-10-01T12:00:00Z
         autoStopInterval: 30
         organizationId: organization123
         createdAt: 2024-10-01T12:00:00Z
@@ -10749,6 +10751,10 @@ components:
           description: The last update timestamp of the sandbox
           example: 2024-10-01T12:00:00Z
           type: string
+        lastActivityAt:
+          description: The last activity timestamp of the sandbox
+          example: 2024-10-01T12:00:00Z
+          type: string
         class:
           deprecated: true
           description: The class of the sandbox
@@ -10795,6 +10801,7 @@ components:
         - memory: 4
           buildInfo: ""
           toolboxProxyUrl: https://proxy.app.daytona.io/toolbox
+          lastActivityAt: 2024-10-01T12:00:00Z
           autoStopInterval: 30
           organizationId: organization123
           createdAt: 2024-10-01T12:00:00Z
@@ -10835,6 +10842,7 @@ components:
         - memory: 4
           buildInfo: ""
           toolboxProxyUrl: https://proxy.app.daytona.io/toolbox
+          lastActivityAt: 2024-10-01T12:00:00Z
           autoStopInterval: 30
           organizationId: organization123
           createdAt: 2024-10-01T12:00:00Z
@@ -13578,6 +13586,7 @@ components:
         memory: 4
         buildInfo: ""
         toolboxProxyUrl: https://proxy.app.daytona.io/toolbox
+        lastActivityAt: 2024-10-01T12:00:00Z
         autoStopInterval: 30
         organizationId: organization123
         createdAt: 2024-10-01T12:00:00Z
@@ -13747,6 +13756,10 @@ components:
           type: string
         updatedAt:
           description: The last update timestamp of the sandbox
+          example: 2024-10-01T12:00:00Z
+          type: string
+        lastActivityAt:
+          description: The last activity timestamp of the sandbox
           example: 2024-10-01T12:00:00Z
           type: string
         class:

--- a/libs/api-client-go/model_sandbox.go
+++ b/libs/api-client-go/model_sandbox.go
@@ -77,6 +77,8 @@ type Sandbox struct {
 	CreatedAt *string `json:"createdAt,omitempty"`
 	// The last update timestamp of the sandbox
 	UpdatedAt *string `json:"updatedAt,omitempty"`
+	// The last activity timestamp of the sandbox
+	LastActivityAt *string `json:"lastActivityAt,omitempty"`
 	// The class of the sandbox
 	// Deprecated
 	Class *string `json:"class,omitempty"`
@@ -914,6 +916,38 @@ func (o *Sandbox) SetUpdatedAt(v string) {
 	o.UpdatedAt = &v
 }
 
+// GetLastActivityAt returns the LastActivityAt field value if set, zero value otherwise.
+func (o *Sandbox) GetLastActivityAt() string {
+	if o == nil || IsNil(o.LastActivityAt) {
+		var ret string
+		return ret
+	}
+	return *o.LastActivityAt
+}
+
+// GetLastActivityAtOk returns a tuple with the LastActivityAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Sandbox) GetLastActivityAtOk() (*string, bool) {
+	if o == nil || IsNil(o.LastActivityAt) {
+		return nil, false
+	}
+	return o.LastActivityAt, true
+}
+
+// HasLastActivityAt returns a boolean if a field has been set.
+func (o *Sandbox) HasLastActivityAt() bool {
+	if o != nil && !IsNil(o.LastActivityAt) {
+		return true
+	}
+
+	return false
+}
+
+// SetLastActivityAt gets a reference to the given string and assigns it to the LastActivityAt field.
+func (o *Sandbox) SetLastActivityAt(v string) {
+	o.LastActivityAt = &v
+}
+
 // GetClass returns the Class field value if set, zero value otherwise.
 // Deprecated
 func (o *Sandbox) GetClass() string {
@@ -1105,6 +1139,9 @@ func (o Sandbox) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.UpdatedAt) {
 		toSerialize["updatedAt"] = o.UpdatedAt
 	}
+	if !IsNil(o.LastActivityAt) {
+		toSerialize["lastActivityAt"] = o.LastActivityAt
+	}
 	if !IsNil(o.Class) {
 		toSerialize["class"] = o.Class
 	}
@@ -1199,6 +1236,7 @@ func (o *Sandbox) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "buildInfo")
 		delete(additionalProperties, "createdAt")
 		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "lastActivityAt")
 		delete(additionalProperties, "class")
 		delete(additionalProperties, "daemonVersion")
 		delete(additionalProperties, "runnerId")

--- a/libs/api-client-go/model_workspace.go
+++ b/libs/api-client-go/model_workspace.go
@@ -77,6 +77,8 @@ type Workspace struct {
 	CreatedAt *string `json:"createdAt,omitempty"`
 	// The last update timestamp of the sandbox
 	UpdatedAt *string `json:"updatedAt,omitempty"`
+	// The last activity timestamp of the sandbox
+	LastActivityAt *string `json:"lastActivityAt,omitempty"`
 	// The class of the sandbox
 	// Deprecated
 	Class *string `json:"class,omitempty"`
@@ -922,6 +924,38 @@ func (o *Workspace) SetUpdatedAt(v string) {
 	o.UpdatedAt = &v
 }
 
+// GetLastActivityAt returns the LastActivityAt field value if set, zero value otherwise.
+func (o *Workspace) GetLastActivityAt() string {
+	if o == nil || IsNil(o.LastActivityAt) {
+		var ret string
+		return ret
+	}
+	return *o.LastActivityAt
+}
+
+// GetLastActivityAtOk returns a tuple with the LastActivityAt field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Workspace) GetLastActivityAtOk() (*string, bool) {
+	if o == nil || IsNil(o.LastActivityAt) {
+		return nil, false
+	}
+	return o.LastActivityAt, true
+}
+
+// HasLastActivityAt returns a boolean if a field has been set.
+func (o *Workspace) HasLastActivityAt() bool {
+	if o != nil && !IsNil(o.LastActivityAt) {
+		return true
+	}
+
+	return false
+}
+
+// SetLastActivityAt gets a reference to the given string and assigns it to the LastActivityAt field.
+func (o *Workspace) SetLastActivityAt(v string) {
+	o.LastActivityAt = &v
+}
+
 // GetClass returns the Class field value if set, zero value otherwise.
 // Deprecated
 func (o *Workspace) GetClass() string {
@@ -1241,6 +1275,9 @@ func (o Workspace) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.UpdatedAt) {
 		toSerialize["updatedAt"] = o.UpdatedAt
 	}
+	if !IsNil(o.LastActivityAt) {
+		toSerialize["lastActivityAt"] = o.LastActivityAt
+	}
 	if !IsNil(o.Class) {
 		toSerialize["class"] = o.Class
 	}
@@ -1347,6 +1384,7 @@ func (o *Workspace) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "buildInfo")
 		delete(additionalProperties, "createdAt")
 		delete(additionalProperties, "updatedAt")
+		delete(additionalProperties, "lastActivityAt")
 		delete(additionalProperties, "class")
 		delete(additionalProperties, "daemonVersion")
 		delete(additionalProperties, "runnerId")

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -257,6 +257,11 @@ public class Sandbox {
   @javax.annotation.Nullable
   private String updatedAt;
 
+  public static final String SERIALIZED_NAME_LAST_ACTIVITY_AT = "lastActivityAt";
+  @SerializedName(SERIALIZED_NAME_LAST_ACTIVITY_AT)
+  @javax.annotation.Nullable
+  private String lastActivityAt;
+
   /**
    * The class of the sandbox
    */
@@ -891,6 +896,25 @@ public class Sandbox {
   }
 
 
+  public Sandbox lastActivityAt(@javax.annotation.Nullable String lastActivityAt) {
+    this.lastActivityAt = lastActivityAt;
+    return this;
+  }
+
+  /**
+   * The last activity timestamp of the sandbox
+   * @return lastActivityAt
+   */
+  @javax.annotation.Nullable
+  public String getLastActivityAt() {
+    return lastActivityAt;
+  }
+
+  public void setLastActivityAt(@javax.annotation.Nullable String lastActivityAt) {
+    this.lastActivityAt = lastActivityAt;
+  }
+
+
   @Deprecated
   public Sandbox propertyClass(@javax.annotation.Nullable PropertyClassEnum propertyClass) {
     this.propertyClass = propertyClass;
@@ -1053,6 +1077,7 @@ public class Sandbox {
         Objects.equals(this.buildInfo, sandbox.buildInfo) &&
         Objects.equals(this.createdAt, sandbox.createdAt) &&
         Objects.equals(this.updatedAt, sandbox.updatedAt) &&
+        Objects.equals(this.lastActivityAt, sandbox.lastActivityAt) &&
         Objects.equals(this.propertyClass, sandbox.propertyClass) &&
         Objects.equals(this.daemonVersion, sandbox.daemonVersion) &&
         Objects.equals(this.runnerId, sandbox.runnerId) &&
@@ -1062,7 +1087,7 @@ public class Sandbox {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, target, cpu, gpu, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, createdAt, updatedAt, propertyClass, daemonVersion, runnerId, toolboxProxyUrl, additionalProperties);
+    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, target, cpu, gpu, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, propertyClass, daemonVersion, runnerId, toolboxProxyUrl, additionalProperties);
   }
 
   @Override
@@ -1097,6 +1122,7 @@ public class Sandbox {
     sb.append("    buildInfo: ").append(toIndentedString(buildInfo)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    lastActivityAt: ").append(toIndentedString(lastActivityAt)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
     sb.append("    daemonVersion: ").append(toIndentedString(daemonVersion)).append("\n");
     sb.append("    runnerId: ").append(toIndentedString(runnerId)).append("\n");
@@ -1152,6 +1178,7 @@ public class Sandbox {
     openapiFields.add("buildInfo");
     openapiFields.add("createdAt");
     openapiFields.add("updatedAt");
+    openapiFields.add("lastActivityAt");
     openapiFields.add("class");
     openapiFields.add("daemonVersion");
     openapiFields.add("runnerId");
@@ -1260,6 +1287,9 @@ public class Sandbox {
       }
       if ((jsonObj.get("updatedAt") != null && !jsonObj.get("updatedAt").isJsonNull()) && !jsonObj.get("updatedAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `updatedAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("updatedAt").toString()));
+      }
+      if ((jsonObj.get("lastActivityAt") != null && !jsonObj.get("lastActivityAt").isJsonNull()) && !jsonObj.get("lastActivityAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field `lastActivityAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("lastActivityAt").toString()));
       }
       if ((jsonObj.get("class") != null && !jsonObj.get("class").isJsonNull()) && !jsonObj.get("class").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `class` to be a primitive type in the JSON string but got `%s`", jsonObj.get("class").toString()));

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Workspace.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Workspace.java
@@ -258,6 +258,11 @@ public class Workspace {
   @javax.annotation.Nullable
   private String updatedAt;
 
+  public static final String SERIALIZED_NAME_LAST_ACTIVITY_AT = "lastActivityAt";
+  @SerializedName(SERIALIZED_NAME_LAST_ACTIVITY_AT)
+  @javax.annotation.Nullable
+  private String lastActivityAt;
+
   /**
    * The class of the sandbox
    */
@@ -970,6 +975,25 @@ public class Workspace {
   }
 
 
+  public Workspace lastActivityAt(@javax.annotation.Nullable String lastActivityAt) {
+    this.lastActivityAt = lastActivityAt;
+    return this;
+  }
+
+  /**
+   * The last activity timestamp of the sandbox
+   * @return lastActivityAt
+   */
+  @javax.annotation.Nullable
+  public String getLastActivityAt() {
+    return lastActivityAt;
+  }
+
+  public void setLastActivityAt(@javax.annotation.Nullable String lastActivityAt) {
+    this.lastActivityAt = lastActivityAt;
+  }
+
+
   @Deprecated
   public Workspace propertyClass(@javax.annotation.Nullable PropertyClassEnum propertyClass) {
     this.propertyClass = propertyClass;
@@ -1208,6 +1232,7 @@ public class Workspace {
         Objects.equals(this.buildInfo, workspace.buildInfo) &&
         Objects.equals(this.createdAt, workspace.createdAt) &&
         Objects.equals(this.updatedAt, workspace.updatedAt) &&
+        Objects.equals(this.lastActivityAt, workspace.lastActivityAt) &&
         Objects.equals(this.propertyClass, workspace.propertyClass) &&
         Objects.equals(this.daemonVersion, workspace.daemonVersion) &&
         Objects.equals(this.runnerId, workspace.runnerId) &&
@@ -1221,7 +1246,7 @@ public class Workspace {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, target, cpu, gpu, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, createdAt, updatedAt, propertyClass, daemonVersion, runnerId, toolboxProxyUrl, image, snapshotState, snapshotCreatedAt, info, additionalProperties);
+    return Objects.hash(id, organizationId, name, snapshot, user, env, labels, _public, networkBlockAll, networkAllowList, target, cpu, gpu, memory, disk, state, desiredState, errorReason, recoverable, backupState, backupCreatedAt, autoStopInterval, autoArchiveInterval, autoDeleteInterval, volumes, buildInfo, createdAt, updatedAt, lastActivityAt, propertyClass, daemonVersion, runnerId, toolboxProxyUrl, image, snapshotState, snapshotCreatedAt, info, additionalProperties);
   }
 
   @Override
@@ -1256,6 +1281,7 @@ public class Workspace {
     sb.append("    buildInfo: ").append(toIndentedString(buildInfo)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    lastActivityAt: ").append(toIndentedString(lastActivityAt)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
     sb.append("    daemonVersion: ").append(toIndentedString(daemonVersion)).append("\n");
     sb.append("    runnerId: ").append(toIndentedString(runnerId)).append("\n");
@@ -1315,6 +1341,7 @@ public class Workspace {
     openapiFields.add("buildInfo");
     openapiFields.add("createdAt");
     openapiFields.add("updatedAt");
+    openapiFields.add("lastActivityAt");
     openapiFields.add("class");
     openapiFields.add("daemonVersion");
     openapiFields.add("runnerId");
@@ -1427,6 +1454,9 @@ public class Workspace {
       }
       if ((jsonObj.get("updatedAt") != null && !jsonObj.get("updatedAt").isJsonNull()) && !jsonObj.get("updatedAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `updatedAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("updatedAt").toString()));
+      }
+      if ((jsonObj.get("lastActivityAt") != null && !jsonObj.get("lastActivityAt").isJsonNull()) && !jsonObj.get("lastActivityAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field `lastActivityAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("lastActivityAt").toString()));
       }
       if ((jsonObj.get("class") != null && !jsonObj.get("class").isJsonNull()) && !jsonObj.get("class").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `class` to be a primitive type in the JSON string but got `%s`", jsonObj.get("class").toString()));

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxTest.java
@@ -271,6 +271,14 @@ public class SandboxTest {
     }
 
     /**
+     * Test the property 'lastActivityAt'
+     */
+    @Test
+    public void lastActivityAtTest() {
+        // TODO: test lastActivityAt
+    }
+
+    /**
      * Test the property 'propertyClass'
      */
     @Test

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/WorkspaceTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/WorkspaceTest.java
@@ -272,6 +272,14 @@ public class WorkspaceTest {
     }
 
     /**
+     * Test the property 'lastActivityAt'
+     */
+    @Test
+    public void lastActivityAtTest() {
+        // TODO: test lastActivityAt
+    }
+
+    /**
      * Test the property 'propertyClass'
      */
     @Test

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox.py
@@ -62,12 +62,13 @@ class Sandbox(BaseModel):
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
+    last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     var_class: Optional[StrictStr] = Field(default=None, description="The class of the sandbox", serialization_alias="class")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     runner_id: Optional[StrictStr] = Field(default=None, description="The runner ID of the sandbox", serialization_alias="runnerId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl"]
 
     @field_validator('backup_state')
     def backup_state_validate_enum(cls, value):
@@ -184,6 +185,7 @@ class Sandbox(BaseModel):
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
+            "last_activity_at": obj.get("lastActivityAt"),
             "var_class": obj.get("class"),
             "daemon_version": obj.get("daemonVersion"),
             "runner_id": obj.get("runnerId"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/workspace.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/workspace.py
@@ -63,6 +63,7 @@ class Workspace(BaseModel):
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
+    last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     var_class: Optional[StrictStr] = Field(default=None, description="The class of the sandbox", serialization_alias="class")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     runner_id: Optional[StrictStr] = Field(default=None, description="The runner ID of the sandbox", serialization_alias="runnerId")
@@ -72,7 +73,7 @@ class Workspace(BaseModel):
     snapshot_created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the last snapshot", serialization_alias="snapshotCreatedAt")
     info: Optional[SandboxInfo] = Field(default=None, description="Additional information about the sandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl", "image", "snapshotState", "snapshotCreatedAt", "info"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl", "image", "snapshotState", "snapshotCreatedAt", "info"]
 
     @field_validator('backup_state')
     def backup_state_validate_enum(cls, value):
@@ -202,6 +203,7 @@ class Workspace(BaseModel):
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
+            "last_activity_at": obj.get("lastActivityAt"),
             "var_class": obj.get("class"),
             "daemon_version": obj.get("daemonVersion"),
             "runner_id": obj.get("runnerId"),

--- a/libs/api-client-python/daytona_api_client/models/sandbox.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox.py
@@ -62,12 +62,13 @@ class Sandbox(BaseModel):
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
+    last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     var_class: Optional[StrictStr] = Field(default=None, description="The class of the sandbox", serialization_alias="class")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     runner_id: Optional[StrictStr] = Field(default=None, description="The runner ID of the sandbox", serialization_alias="runnerId")
     toolbox_proxy_url: StrictStr = Field(description="The toolbox proxy URL for the sandbox", serialization_alias="toolboxProxyUrl")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl"]
 
     @field_validator('backup_state')
     def backup_state_validate_enum(cls, value):
@@ -184,6 +185,7 @@ class Sandbox(BaseModel):
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
+            "last_activity_at": obj.get("lastActivityAt"),
             "var_class": obj.get("class"),
             "daemon_version": obj.get("daemonVersion"),
             "runner_id": obj.get("runnerId"),

--- a/libs/api-client-python/daytona_api_client/models/workspace.py
+++ b/libs/api-client-python/daytona_api_client/models/workspace.py
@@ -63,6 +63,7 @@ class Workspace(BaseModel):
     build_info: Optional[BuildInfo] = Field(default=None, description="Build information for the sandbox", serialization_alias="buildInfo")
     created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the sandbox", serialization_alias="createdAt")
     updated_at: Optional[StrictStr] = Field(default=None, description="The last update timestamp of the sandbox", serialization_alias="updatedAt")
+    last_activity_at: Optional[StrictStr] = Field(default=None, description="The last activity timestamp of the sandbox", serialization_alias="lastActivityAt")
     var_class: Optional[StrictStr] = Field(default=None, description="The class of the sandbox", serialization_alias="class")
     daemon_version: Optional[StrictStr] = Field(default=None, description="The version of the daemon running in the sandbox", serialization_alias="daemonVersion")
     runner_id: Optional[StrictStr] = Field(default=None, description="The runner ID of the sandbox", serialization_alias="runnerId")
@@ -72,7 +73,7 @@ class Workspace(BaseModel):
     snapshot_created_at: Optional[StrictStr] = Field(default=None, description="The creation timestamp of the last snapshot", serialization_alias="snapshotCreatedAt")
     info: Optional[SandboxInfo] = Field(default=None, description="Additional information about the sandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl", "image", "snapshotState", "snapshotCreatedAt", "info"]
+    __properties: ClassVar[List[str]] = ["id", "organizationId", "name", "snapshot", "user", "env", "labels", "public", "networkBlockAll", "networkAllowList", "target", "cpu", "gpu", "memory", "disk", "state", "desiredState", "errorReason", "recoverable", "backupState", "backupCreatedAt", "autoStopInterval", "autoArchiveInterval", "autoDeleteInterval", "volumes", "buildInfo", "createdAt", "updatedAt", "lastActivityAt", "class", "daemonVersion", "runnerId", "toolboxProxyUrl", "image", "snapshotState", "snapshotCreatedAt", "info"]
 
     @field_validator('backup_state')
     def backup_state_validate_enum(cls, value):
@@ -202,6 +203,7 @@ class Workspace(BaseModel):
             "build_info": BuildInfo.from_dict(obj["buildInfo"]) if obj.get("buildInfo") is not None else None,
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
+            "last_activity_at": obj.get("lastActivityAt"),
             "var_class": obj.get("class"),
             "daemon_version": obj.get("daemonVersion"),
             "runner_id": obj.get("runnerId"),

--- a/libs/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/api/sandbox_api.rb
@@ -1858,7 +1858,7 @@ module DaytonaApiClient
         fail ArgumentError, 'invalid value for "opts[:"max_disk_gi_b"]" when calling SandboxApi.list_sandboxes_paginated, must be greater than or equal to 1.'
       end
 
-      allowable_values = ["id", "name", "state", "snapshot", "region", "updatedAt", "createdAt"]
+      allowable_values = ["id", "name", "state", "snapshot", "region", "updatedAt", "createdAt", "lastActivityAt"]
       if @api_client.config.client_side_validation && opts[:'sort'] && !allowable_values.include?(opts[:'sort'])
         fail ArgumentError, "invalid value for \"sort\", must be one of #{allowable_values}"
       end

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -99,6 +99,9 @@ module DaytonaApiClient
     # The last update timestamp of the sandbox
     attr_accessor :updated_at
 
+    # The last activity timestamp of the sandbox
+    attr_accessor :last_activity_at
+
     # The class of the sandbox
     attr_accessor :_class
 
@@ -164,6 +167,7 @@ module DaytonaApiClient
         :'build_info' => :'buildInfo',
         :'created_at' => :'createdAt',
         :'updated_at' => :'updatedAt',
+        :'last_activity_at' => :'lastActivityAt',
         :'_class' => :'class',
         :'daemon_version' => :'daemonVersion',
         :'runner_id' => :'runnerId',
@@ -212,6 +216,7 @@ module DaytonaApiClient
         :'build_info' => :'BuildInfo',
         :'created_at' => :'String',
         :'updated_at' => :'String',
+        :'last_activity_at' => :'String',
         :'_class' => :'String',
         :'daemon_version' => :'String',
         :'runner_id' => :'String',
@@ -383,6 +388,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'updated_at')
         self.updated_at = attributes[:'updated_at']
+      end
+
+      if attributes.key?(:'last_activity_at')
+        self.last_activity_at = attributes[:'last_activity_at']
       end
 
       if attributes.key?(:'_class')
@@ -686,6 +695,7 @@ module DaytonaApiClient
           build_info == o.build_info &&
           created_at == o.created_at &&
           updated_at == o.updated_at &&
+          last_activity_at == o.last_activity_at &&
           _class == o._class &&
           daemon_version == o.daemon_version &&
           runner_id == o.runner_id &&
@@ -701,7 +711,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, target, cpu, gpu, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, created_at, updated_at, _class, daemon_version, runner_id, toolbox_proxy_url].hash
+      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, target, cpu, gpu, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, created_at, updated_at, last_activity_at, _class, daemon_version, runner_id, toolbox_proxy_url].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/workspace.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/workspace.rb
@@ -99,6 +99,9 @@ module DaytonaApiClient
     # The last update timestamp of the sandbox
     attr_accessor :updated_at
 
+    # The last activity timestamp of the sandbox
+    attr_accessor :last_activity_at
+
     # The class of the sandbox
     attr_accessor :_class
 
@@ -176,6 +179,7 @@ module DaytonaApiClient
         :'build_info' => :'buildInfo',
         :'created_at' => :'createdAt',
         :'updated_at' => :'updatedAt',
+        :'last_activity_at' => :'lastActivityAt',
         :'_class' => :'class',
         :'daemon_version' => :'daemonVersion',
         :'runner_id' => :'runnerId',
@@ -228,6 +232,7 @@ module DaytonaApiClient
         :'build_info' => :'BuildInfo',
         :'created_at' => :'String',
         :'updated_at' => :'String',
+        :'last_activity_at' => :'String',
         :'_class' => :'String',
         :'daemon_version' => :'String',
         :'runner_id' => :'String',
@@ -403,6 +408,10 @@ module DaytonaApiClient
 
       if attributes.key?(:'updated_at')
         self.updated_at = attributes[:'updated_at']
+      end
+
+      if attributes.key?(:'last_activity_at')
+        self.last_activity_at = attributes[:'last_activity_at']
       end
 
       if attributes.key?(:'_class')
@@ -734,6 +743,7 @@ module DaytonaApiClient
           build_info == o.build_info &&
           created_at == o.created_at &&
           updated_at == o.updated_at &&
+          last_activity_at == o.last_activity_at &&
           _class == o._class &&
           daemon_version == o.daemon_version &&
           runner_id == o.runner_id &&
@@ -753,7 +763,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, target, cpu, gpu, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, created_at, updated_at, _class, daemon_version, runner_id, toolbox_proxy_url, image, snapshot_state, snapshot_created_at, info].hash
+      [id, organization_id, name, snapshot, user, env, labels, public, network_block_all, network_allow_list, target, cpu, gpu, memory, disk, state, desired_state, error_reason, recoverable, backup_state, backup_created_at, auto_stop_interval, auto_archive_interval, auto_delete_interval, volumes, build_info, created_at, updated_at, last_activity_at, _class, daemon_version, runner_id, toolbox_proxy_url, image, snapshot_state, snapshot_created_at, info].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/api/sandbox-api.ts
+++ b/libs/api-client/src/api/sandbox-api.ts
@@ -3806,7 +3806,8 @@ export const ListSandboxesPaginatedSortEnum = {
     SNAPSHOT: 'snapshot',
     REGION: 'region',
     UPDATED_AT: 'updatedAt',
-    CREATED_AT: 'createdAt'
+    CREATED_AT: 'createdAt',
+    LAST_ACTIVITY_AT: 'lastActivityAt'
 } as const;
 export type ListSandboxesPaginatedSortEnum = typeof ListSandboxesPaginatedSortEnum[keyof typeof ListSandboxesPaginatedSortEnum];
 /**

--- a/libs/api-client/src/models/sandbox.ts
+++ b/libs/api-client/src/models/sandbox.ts
@@ -201,6 +201,12 @@ export interface Sandbox {
      */
     'updatedAt'?: string;
     /**
+     * The last activity timestamp of the sandbox
+     * @type {string}
+     * @memberof Sandbox
+     */
+    'lastActivityAt'?: string;
+    /**
      * The class of the sandbox
      * @type {string}
      * @memberof Sandbox

--- a/libs/api-client/src/models/workspace.ts
+++ b/libs/api-client/src/models/workspace.ts
@@ -204,6 +204,12 @@ export interface Workspace {
      */
     'updatedAt'?: string;
     /**
+     * The last activity timestamp of the sandbox
+     * @type {string}
+     * @memberof Workspace
+     */
+    'lastActivityAt'?: string;
+    /**
      * The class of the sandbox
      * @type {string}
      * @memberof Workspace

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -83,6 +83,7 @@ class AsyncSandbox(SandboxDto):
         build_info (str): Build information for the Sandbox if it was created from dynamic build.
         created_at (str): When the Sandbox was created.
         updated_at (str): When the Sandbox was last updated.
+        last_activity_at (str): When the Sandbox last had activity.
         network_block_all (bool): Whether to block all network access for the Sandbox.
         network_allow_list (str): Comma-separated list of allowed CIDR network addresses for the Sandbox.
     """
@@ -799,6 +800,7 @@ class AsyncSandbox(SandboxDto):
         self.build_info: BuildInfo | None = sandbox_dto.build_info
         self.created_at: str | None = sandbox_dto.created_at
         self.updated_at: str | None = sandbox_dto.updated_at
+        self.last_activity_at: str | None = sandbox_dto.last_activity_at
         self.network_block_all: bool = sandbox_dto.network_block_all
         self.network_allow_list: str | None = sandbox_dto.network_allow_list
         self.toolbox_proxy_url: str = sandbox_dto.toolbox_proxy_url

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -83,6 +83,7 @@ class Sandbox(SandboxDto):
         build_info (str): Build information for the Sandbox if it was created from dynamic build.
         created_at (str): When the Sandbox was created.
         updated_at (str): When the Sandbox was last updated.
+        last_activity_at (str): When the Sandbox last had activity.
         network_block_all (bool): Whether to block all network access for the Sandbox.
         network_allow_list (str): Comma-separated list of allowed CIDR network addresses for the Sandbox.
     """
@@ -794,6 +795,7 @@ class Sandbox(SandboxDto):
         self.build_info: BuildInfo | None = sandbox_dto.build_info
         self.created_at: str | None = sandbox_dto.created_at
         self.updated_at: str | None = sandbox_dto.updated_at
+        self.last_activity_at: str | None = sandbox_dto.last_activity_at
         self.network_block_all: bool = sandbox_dto.network_block_all
         self.network_allow_list: str | None = sandbox_dto.network_allow_list
         self.toolbox_proxy_url: str = sandbox_dto.toolbox_proxy_url

--- a/libs/sdk-ruby/lib/daytona/sandbox.rb
+++ b/libs/sdk-ruby/lib/daytona/sandbox.rb
@@ -87,6 +87,9 @@ module Daytona
     # @return [String] The last update timestamp of the sandbox
     attr_reader :updated_at
 
+    # @return [String] The last activity timestamp of the sandbox
+    attr_reader :last_activity_at
+
     # @return [String] The version of the daemon running in the sandbox
     attr_reader :daemon_version
 
@@ -564,6 +567,7 @@ module Daytona
       @build_info = sandbox_dto.build_info
       @created_at = sandbox_dto.created_at
       @updated_at = sandbox_dto.updated_at
+      @last_activity_at = sandbox_dto.last_activity_at
       @daemon_version = sandbox_dto.daemon_version
       @network_block_all = sandbox_dto.network_block_all
       @network_allow_list = sandbox_dto.network_allow_list

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -74,6 +74,7 @@ import { WithInstrumentation } from './utils/otel.decorator'
  * @property {BuildInfo} [buildInfo] - Build information for the Sandbox if it was created from dynamic build
  * @property {string} [createdAt] - When the Sandbox was created
  * @property {string} [updatedAt] - When the Sandbox was last updated
+ * @property {string} [lastActivityAt] - When the Sandbox last had activity
  * @property {boolean} networkBlockAll - Whether to block all network access for the Sandbox
  * @property {string} [networkAllowList] - Comma-separated list of allowed CIDR network addresses for the Sandbox
  *
@@ -111,6 +112,7 @@ export class Sandbox implements SandboxDto {
   public buildInfo?: BuildInfo
   public createdAt?: string
   public updatedAt?: string
+  public lastActivityAt?: string
   public networkBlockAll!: boolean
   public networkAllowList?: string
   public toolboxProxyUrl: string
@@ -846,6 +848,7 @@ export class Sandbox implements SandboxDto {
     this.buildInfo = sandboxDto.buildInfo
     this.createdAt = sandboxDto.createdAt
     this.updatedAt = sandboxDto.updatedAt
+    this.lastActivityAt = sandboxDto.lastActivityAt
     this.networkBlockAll = sandboxDto.networkBlockAll
     this.networkAllowList = sandboxDto.networkAllowList
     this.toolboxProxyUrl = sandboxDto.toolboxProxyUrl


### PR DESCRIPTION
This pull request introduces support for tracking and exposing the "last activity" timestamp (`lastActivityAt`) for sandboxes throughout the Daytona platform. This new field is now available in the API, database, SDKs, CLI, dashboard, and documentation, and is used for sorting and filtering sandboxes based on their most recent activity.

The most important changes are:

**API and Database Enhancements:**
* Added a `lastActivityAt` field to the `SandboxDto` and included it in API responses, query filters, and sorting options. A new database index was created on the `sandbox_last_activity.lastActivityAt` column to support efficient queries. [[1]](diffhunk://#diff-2d017e9b8afcf38f900bfa8d1f2afc466316b31443f020df3862708a6716e866R246-R253) [[2]](diffhunk://#diff-2d017e9b8afcf38f900bfa8d1f2afc466316b31443f020df3862708a6716e866R317-R319) [[3]](diffhunk://#diff-f86c7bbca320ff58624ca7cede3f4b3a83444ecdfbacb31b7b3cc041bbb36ef7R22) [[4]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1199-R1203) [[5]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcR1230-R1239) [[6]](diffhunk://#diff-8e8a0c61150e2e236fb72095bdc036da4c19a4cbc76a71e46185b84684c47321R1-R19)
* Updated the `SandboxService` to join and utilize the `lastActivityAt` relation in all relevant queries and lookups, ensuring the field is always available when fetching sandboxes. [[1]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1134-R1134) [[2]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1280-R1289) [[3]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1298-R1307) [[4]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcR1357)

**SDK and OpenAPI Updates:**
* Extended the OpenAPI schema and Go SDK (`model_sandbox.go`, `model_workspace.go`) to include the `lastActivityAt` field, with getter/setter methods and serialization logic. [[1]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR10754-R10757) [[2]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR10586) [[3]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR10804) [[4]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR10845) [[5]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR13589) [[6]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR13761-R13764) [[7]](diffhunk://#diff-788d0ccb8ea8195eaf2bdd5cc64e5262724e57de92918668d48c75f830c81b05R80-R81) [[8]](diffhunk://#diff-788d0ccb8ea8195eaf2bdd5cc64e5262724e57de92918668d48c75f830c81b05R919-R950) [[9]](diffhunk://#diff-788d0ccb8ea8195eaf2bdd5cc64e5262724e57de92918668d48c75f830c81b05R1142-R1144) [[10]](diffhunk://#diff-788d0ccb8ea8195eaf2bdd5cc64e5262724e57de92918668d48c75f830c81b05R1239) [[11]](diffhunk://#diff-afa140fdf7e80d25a822254e0972ee421d8038dbb0428ae690b1562d207857aaR80-R81)

**CLI and Dashboard Improvements:**
* Updated the CLI and dashboard to display the "Last Event" based on `lastActivityAt` if present, falling back to `updatedAt` otherwise, and defaulted sandbox sorting to use `lastActivityAt`. [[1]](diffhunk://#diff-2ec0999b82f057b653cb56bf77dffe3e27f53e4189ffaee6031e314221ee9288L43-R45) [[2]](diffhunk://#diff-013262281092802f84d90863676e0ee31b29318fed31599e6db8ca8f67995d74L77-R79) [[3]](diffhunk://#diff-aa01e32c652e463b6067f8bde6793115234326cf23e02d8975ee42de3796aef4L80-R80) [[4]](diffhunk://#diff-aa01e32c652e463b6067f8bde6793115234326cf23e02d8975ee42de3796aef4L265-R265) [[5]](diffhunk://#diff-3f26730a2e0b17155ccb4d26431f2bc9c73088eae38aa4366424a5c512eba383L384-R384) [[6]](diffhunk://#diff-01936bd0cd93dd712ac292133c92f7c063036c3ac00720c5dce413453a4a8f7fL40-R40)

**Documentation:**
* Updated SDK and API documentation across Python, Ruby, and TypeScript to describe the new `lastActivityAt` field and its usage. [[1]](diffhunk://#diff-edb562d28c0e0a3f8a4ac30a26de71acba6b68512fba34d53edeeb6e2884efdfR47) [[2]](diffhunk://#diff-c7055252a08f201157fae29027720470cd5f8c1eabb2840a375a1a6ee01e4ec7R47) [[3]](diffhunk://#diff-5811b99ccd661af76805032ee7759d0bfe108cb85415bd5911a30cb657778a01R313-R323) [[4]](diffhunk://#diff-7f2139c85b29f65f3f537711594c49280c6f041228eead1bb8a7d61ed5b88e7dR116-R122)

These changes collectively provide a more accurate and user-friendly way to track and interact with sandboxes based on their most recent activity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a new `lastActivityAt` timestamp for sandboxes across the platform to power accurate “Last Event” display and sorting/filtering by recent activity.

- **New Features**
  - API: Added `SandboxDto.lastActivityAt`, enabled `sort=lastActivityAt` and last-event date filtering; service preloads the `lastActivityAt` relation and orders by it; repository populates the relation on create/update; added pre-deploy index on `sandbox_last_activity("lastActivityAt")`.
  - Dashboard/CLI: Show “Last Event” using `lastActivityAt` (fallback to `updatedAt`); dashboard default sort switched to `lastActivityAt` (DESC).
  - SDKs/OpenAPI: Added `lastActivityAt` to Sandbox and Workspace models in Go, Java, Python (sync/async), Ruby, and TypeScript; OpenAPI updated; Ruby API client allows `sort=lastActivityAt`.
  - Docs: Updated Python, Ruby, and TypeScript SDK docs for the new field.

- **Migration**
  - Run the pre-deploy migration to create index `idx_sandbox_last_activity_at` on `sandbox_last_activity("lastActivityAt")`.

<sup>Written for commit bce83a4100f3b6a9a28703ab235dccff4c227960. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

