### PR TITLE
fix(cli): surface actionable hint on 403 Forbidden for all API calls

### DIFF
--- a/apps/cli/apiclient/error_handler.go
+++ b/apps/cli/apiclient/error_handler.go
@@ -62,5 +62,9 @@ func HandleErrorResponse(res *http.Response, requestErr error) error {
 		errMessage += " - run 'daytona login' to reauthenticate"
 	}
 
+	if res.StatusCode == http.StatusForbidden {
+		errMessage += " - check that your API key has sufficient permissions for this action"
+	}
+
 	return errors.New(errMessage)
 }

--- a/apps/cli/apiclient/error_handler_test.go
+++ b/apps/cli/apiclient/error_handler_test.go
@@ -1,0 +1,132 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package apiclient_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/daytonaio/daytona/cli/apiclient"
+)
+
+func response(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestHandleErrorResponse_403_PermissionsHint(t *testing.T) {
+	t.Run("reproduction case: 403 appends permissions hint", func(t *testing.T) {
+		res := response(http.StatusForbidden, `{"error":"Forbidden"}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "check that your API key has sufficient permissions for this action") {
+			t.Errorf("expected permissions hint in error, got: %q", err.Error())
+		}
+	})
+
+	t.Run("403 with message field appends both message and hint", func(t *testing.T) {
+		res := response(http.StatusForbidden, `{"error":"Forbidden","message":"snapshot push requires write access"}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "snapshot push requires write access") {
+			t.Errorf("expected server message in error, got: %q", msg)
+		}
+		if !strings.Contains(msg, "check that your API key has sufficient permissions for this action") {
+			t.Errorf("expected permissions hint in error, got: %q", msg)
+		}
+	})
+
+	t.Run("403 with array message field appends hint", func(t *testing.T) {
+		res := response(http.StatusForbidden, `{"error":"Forbidden","message":["scope missing: snapshots"]}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "check that your API key has sufficient permissions for this action") {
+			t.Errorf("expected permissions hint in error, got: %q", err.Error())
+		}
+	})
+
+	t.Run("403 with empty error field falls back to raw body and appends hint", func(t *testing.T) {
+		res := response(http.StatusForbidden, `{"error":"","message":"forbidden"}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "check that your API key has sufficient permissions for this action") {
+			t.Errorf("expected permissions hint in error, got: %q", err.Error())
+		}
+	})
+}
+
+func TestHandleErrorResponse_UnchangedBehavior(t *testing.T) {
+	t.Run("401 still appends reauthentication hint", func(t *testing.T) {
+		res := response(http.StatusUnauthorized, `{"error":"Unauthorized"}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "run 'daytona login' to reauthenticate") {
+			t.Errorf("expected reauth hint in 401 error, got: %q", err.Error())
+		}
+	})
+
+	t.Run("401 does not include permissions hint", func(t *testing.T) {
+		res := response(http.StatusUnauthorized, `{"error":"Unauthorized"}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if strings.Contains(err.Error(), "check that your API key has sufficient permissions") {
+			t.Errorf("401 error should not contain permissions hint, got: %q", err.Error())
+		}
+	})
+
+	t.Run("403 does not include reauthentication hint", func(t *testing.T) {
+		res := response(http.StatusForbidden, `{"error":"Forbidden"}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if strings.Contains(err.Error(), "run 'daytona login' to reauthenticate") {
+			t.Errorf("403 error should not contain reauth hint, got: %q", err.Error())
+		}
+	})
+
+	t.Run("500 returns error without any hint", func(t *testing.T) {
+		res := response(http.StatusInternalServerError, `{"error":"Internal Server Error"}`)
+		err := apiclient.HandleErrorResponse(res, nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		if strings.Contains(msg, "daytona login") || strings.Contains(msg, "check that your API key") {
+			t.Errorf("500 error should contain no hint, got: %q", msg)
+		}
+	})
+
+	t.Run("nil response returns the original request error", func(t *testing.T) {
+		err := apiclient.HandleErrorResponse(nil, io.ErrUnexpectedEOF)
+		if err != io.ErrUnexpectedEOF {
+			t.Errorf("expected original error, got: %v", err)
+		}
+	})
+
+	t.Run("2xx with client error returns the original error unchanged", func(t *testing.T) {
+		res := response(http.StatusOK, `{}`)
+		err := apiclient.HandleErrorResponse(res, io.ErrUnexpectedEOF)
+		if err != io.ErrUnexpectedEOF {
+			t.Errorf("expected original error for 2xx, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- When any CLI command (`snapshot push`, `snapshot create`, `snapshot list`, `snapshot delete`, or any other) receives a 403 from the API, the error message now includes: `- check that your API key has sufficient permissions for this action`
- Single-point fix in `HandleErrorResponse` — covers all current and future CLI commands automatically

## Root cause
`apps/cli/apiclient/error_handler.go` had a status-specific branch only for 401 (Unauthorized), appending a reauthentication hint. There was no corresponding branch for 403 (Forbidden). All snapshot CLI commands funnel API errors through this single function, so a 403 from an under-scoped API key surfaced only the raw server error body with no actionable guidance.

## Changes
- `apps/cli/apiclient/error_handler.go` — add `http.StatusForbidden` branch mirroring the existing 401 pattern (+4 lines)
- `apps/cli/apiclient/error_handler_test.go` — new: reproduction case, message-field variants, array message, empty error fallback, and full unchanged-behaviour coverage for 401/500/nil/2xx

## Test results
```
--- PASS: TestHandleErrorResponse_403_PermissionsHint/reproduction_case:_403_appends_permissions_hint
--- PASS: TestHandleErrorResponse_403_PermissionsHint/403_with_message_field_appends_both_message_and_hint
--- PASS: TestHandleErrorResponse_403_PermissionsHint/403_with_array_message_field_appends_hint
--- PASS: TestHandleErrorResponse_403_PermissionsHint/403_with_empty_error_field_falls_back_to_raw_body_and_appends_hint
--- PASS: TestHandleErrorResponse_UnchangedBehavior/401_still_appends_reauthentication_hint
--- PASS: TestHandleErrorResponse_UnchangedBehavior/401_does_not_include_permissions_hint
--- PASS: TestHandleErrorResponse_UnchangedBehavior/403_does_not_include_reauthentication_hint
--- PASS: TestHandleErrorResponse_UnchangedBehavior/500_returns_error_without_any_hint
--- PASS: TestHandleErrorResponse_UnchangedBehavior/nil_response_returns_the_original_request_error
--- PASS: TestHandleErrorResponse_UnchangedBehavior/2xx_with_client_error_returns_the_original_error_unchanged
PASS ok  github.com/daytonaio/daytona/cli/apiclient 0.335s
```

## Risk / rollback
- **Blast radius:** zero — only the error-message string is extended for 403 responses; no control flow changed
- **Rollback:** revert the 4-line addition in `error_handler.go`

Closes #3564