### PR TITLE
fix(sdk-typescript): deserialize snapshot date fields

### DIFF
--- a/libs/sdk-typescript/src/Snapshot.ts
+++ b/libs/sdk-typescript/src/Snapshot.ts
@@ -71,6 +71,15 @@ export type CreateSnapshotParams = {
   regionId?: string
 }
 
+function parseSnapshotDates<T extends SnapshotDto>(snapshot: T): T {
+  return {
+    ...snapshot,
+    createdAt: new Date(snapshot.createdAt as unknown as string),
+    updatedAt: new Date(snapshot.updatedAt as unknown as string),
+    lastUsedAt: snapshot.lastUsedAt != null ? new Date(snapshot.lastUsedAt as unknown as string) : null,
+  }
+}
+
 /**
  * Service for managing Daytona Snapshots. Can be used to list, get, create and delete Snapshots.
  *
@@ -101,7 +110,7 @@ export class SnapshotService {
   async list(page?: number, limit?: number): Promise<PaginatedSnapshots> {
     const response = await this.snapshotsApi.getAllSnapshots(undefined, page, limit)
     return {
-      items: response.data.items.map((snapshot) => snapshot as Snapshot),
+      items: response.data.items.map((snapshot) => parseSnapshotDates(snapshot) as Snapshot),
       total: response.data.total,
       page: response.data.page,
       totalPages: response.data.totalPages,
@@ -123,7 +132,7 @@ export class SnapshotService {
   @WithInstrumentation()
   async get(name: string): Promise<Snapshot> {
     const response = await this.snapshotsApi.getSnapshot(name)
-    return response.data as Snapshot
+    return parseSnapshotDates(response.data) as Snapshot
   }
 
   /**
@@ -188,15 +197,17 @@ export class SnapshotService {
 
     createSnapshotReq.regionId = params.regionId || this.defaultRegionId
 
-    let createdSnapshot = (
+    const createdSnapshotResponse = (
       await this.snapshotsApi.createSnapshot(createSnapshotReq, undefined, {
         timeout: (options.timeout || 0) * 1000,
       })
     ).data
 
-    if (!createdSnapshot) {
+    if (!createdSnapshotResponse) {
       throw new DaytonaError("Failed to create snapshot. Didn't receive a snapshot from the server API.")
     }
+
+    let createdSnapshot = parseSnapshotDates(createdSnapshotResponse)
 
     const terminalStates: SnapshotState[] = [SnapshotState.ACTIVE, SnapshotState.ERROR, SnapshotState.BUILD_FAILED]
     const snapshotRef = { createdSnapshot: createdSnapshot }
@@ -267,7 +278,7 @@ export class SnapshotService {
    */
   @WithInstrumentation()
   async activate(snapshot: Snapshot): Promise<Snapshot> {
-    return (await this.snapshotsApi.activateSnapshot(snapshot.id)).data as Snapshot
+    return parseSnapshotDates((await this.snapshotsApi.activateSnapshot(snapshot.id)).data) as Snapshot
   }
 
   /**

--- a/libs/sdk-typescript/src/__tests__/snapshot.test.ts
+++ b/libs/sdk-typescript/src/__tests__/snapshot.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SnapshotState } from '@daytona/api-client'
+import { SnapshotService } from '../Snapshot'
+
+describe('SnapshotService', () => {
+  function snapshotPayload(overrides: Partial<ReturnType<typeof snapshotPayloadBase>> = {}) {
+    return {
+      ...snapshotPayloadBase(),
+      ...overrides,
+    }
+  }
+
+  function snapshotPayloadBase() {
+    return {
+      id: 'snap_123',
+      organizationId: 'org_123',
+      general: false,
+      name: 'demo',
+      imageName: 'img',
+      state: SnapshotState.ACTIVE,
+      size: 1,
+      entrypoint: [],
+      cpu: 1,
+      gpu: 0,
+      mem: 1,
+      disk: 1,
+      errorReason: '',
+      createdAt: '2025-09-16T17:56:53.000Z',
+      updatedAt: '2025-09-16T17:57:53.000Z',
+      lastUsedAt: '2025-09-16T17:58:53.000Z',
+    }
+  }
+
+  function newSnapshotService(overrides: Partial<ReturnType<typeof snapshotPayloadBase>> = {}) {
+    const snapshotsApi = {
+      getAllSnapshots: jest.fn().mockResolvedValue({
+        data: {
+          items: [snapshotPayload(overrides)],
+          total: 1,
+          page: 1,
+          totalPages: 1,
+        },
+      }),
+      getSnapshot: jest.fn().mockResolvedValue({ data: snapshotPayload(overrides) }),
+      createSnapshot: jest.fn().mockResolvedValue({ data: snapshotPayload(overrides) }),
+      activateSnapshot: jest.fn().mockResolvedValue({ data: snapshotPayload(overrides) }),
+    }
+
+    return {
+      service: new SnapshotService({} as never, snapshotsApi as never, {} as never),
+      snapshotsApi,
+    }
+  }
+
+  it('deserializes snapshot dates returned by list', async () => {
+    const { service } = newSnapshotService()
+
+    const result = await service.list()
+
+    expect(result.items[0].createdAt).toBeInstanceOf(Date)
+    expect(result.items[0].updatedAt).toBeInstanceOf(Date)
+    expect(result.items[0].lastUsedAt).toBeInstanceOf(Date)
+  })
+
+  it('deserializes snapshot dates returned by get', async () => {
+    const { service } = newSnapshotService()
+
+    const snapshot = await service.get('demo')
+
+    expect(snapshot.createdAt).toBeInstanceOf(Date)
+    expect(snapshot.updatedAt).toBeInstanceOf(Date)
+    expect(snapshot.lastUsedAt).toBeInstanceOf(Date)
+  })
+
+  it('deserializes snapshot dates returned by create', async () => {
+    const { service } = newSnapshotService()
+
+    const snapshot = await service.create({ name: 'demo', image: 'img' })
+
+    expect(snapshot.createdAt).toBeInstanceOf(Date)
+    expect(snapshot.updatedAt).toBeInstanceOf(Date)
+    expect(snapshot.lastUsedAt).toBeInstanceOf(Date)
+  })
+
+  it('deserializes snapshot dates returned by activate', async () => {
+    const { service } = newSnapshotService()
+
+    const snapshot = await service.activate({ id: 'snap_123' } as never)
+
+    expect(snapshot.createdAt).toBeInstanceOf(Date)
+    expect(snapshot.updatedAt).toBeInstanceOf(Date)
+    expect(snapshot.lastUsedAt).toBeInstanceOf(Date)
+  })
+
+  it('preserves null lastUsedAt values', async () => {
+    const { service } = newSnapshotService({ lastUsedAt: null })
+
+    const snapshot = await service.get('demo')
+
+    expect(snapshot.lastUsedAt).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #2421

`SnapshotDto` declares `createdAt`, `updatedAt`, and `lastUsedAt` as `Date`, but `SnapshotService` was returning the raw JSON strings from the API. That left `snapshot.list()`, `snapshot.get()`, `snapshot.create()`, and `snapshot.activate()` with runtime values that did not match their TypeScript types.

This change keeps the fix local to `SnapshotService` by parsing those date fields before the SDK returns snapshots to callers. `lastUsedAt` stays `null` when the API returns `null`.

Validation:
- `npx jest --runInBand --config '{"rootDir":".","testEnvironment":"node","transform":{"^.+\\\\.[tj]s$":["ts-jest",{"tsconfig":"libs/sdk-typescript/tsconfig.spec.json"}]},"moduleFileExtensions":["ts","js"],"moduleNameMapper":{"^@daytona/api-client$":"<rootDir>/libs/api-client/src/index.ts","^@daytona/toolbox-api-client$":"<rootDir>/libs/toolbox-api-client/src/index.ts","^@daytona/runner-api-client$":"<rootDir>/libs/runner-api-client/src/index.ts","^@daytona/analytics-api-client$":"<rootDir>/libs/analytics-api-client/src/index.ts","^@daytona/sdk$":"<rootDir>/libs/sdk-typescript/src/index.ts"}}' libs/sdk-typescript/src/__tests__/snapshot.test.ts libs/sdk-typescript/src/__tests__/errors.test.ts`\n- `npx tsc -p libs/sdk-typescript/tsconfig.lib.json --noEmit`\n- `npx tsc -p libs/sdk-typescript/tsconfig.spec.json --noEmit`\n- `yarn eslint libs/sdk-typescript/src/Snapshot.ts libs/sdk-typescript/src/__tests__/snapshot.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure snapshot date fields are deserialized to `Date` objects in the TypeScript SDK, aligning runtime values with `SnapshotDto` types. Applies to `list`, `get`, `create`, and `activate`.

- **Bug Fixes**
  - Parse `createdAt`, `updatedAt`, and `lastUsedAt` in `SnapshotService` before returning snapshots; keep `lastUsedAt` as `null` when provided by the API.
  - Added tests to verify date deserialization across `list`, `get`, `create`, and `activate`.

<sup>Written for commit cc3caded2bd5ae7718105d753921fb1933d724e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

