### PR TITLE
fix(sdk): read process.env for SERVERLESS runtime in getEnvVar

### DIFF
--- a/libs/sdk-typescript/src/utils/Runtime.ts
+++ b/libs/sdk-typescript/src/utils/Runtime.ts
@@ -53,7 +53,7 @@ export const RUNTIME =
             : Runtime.UNKNOWN
 
 export function getEnvVar(name: string): string | undefined {
-  if (RUNTIME === Runtime.NODE || RUNTIME === Runtime.BUN) {
+  if (RUNTIME === Runtime.NODE || RUNTIME === Runtime.BUN || RUNTIME === Runtime.SERVERLESS) {
     return process.env[name]
   }
   if (RUNTIME === Runtime.DENO) {

--- a/libs/sdk-typescript/src/utils/Runtime.ts
+++ b/libs/sdk-typescript/src/utils/Runtime.ts
@@ -53,7 +53,7 @@ export const RUNTIME =
             : Runtime.UNKNOWN
 
 export function getEnvVar(name: string): string | undefined {
-  if (RUNTIME === Runtime.NODE || RUNTIME === Runtime.BUN || RUNTIME === Runtime.SERVERLESS) {
+  if (typeof process !== 'undefined' && process.env) {
     return process.env[name]
   }
   if (RUNTIME === Runtime.DENO) {


### PR DESCRIPTION
## Summary

Adds `Runtime.SERVERLESS` to the `process.env` check in `getEnvVar()` so that environment variables like `DAYTONA_API_KEY`, `DAYTONA_API_URL`, and `DAYTONA_TARGET` are automatically read on serverless runtimes such as Cloudflare Workers with `nodejs_compat`.

## Problem

The `getEnvVar()` function only reads `process.env` for `NODE` and `BUN` runtimes. When running on Cloudflare Workers with the `nodejs_compat` flag (detected as `SERVERLESS` runtime), `process.env` is fully supported but `getEnvVar()` returns `undefined`, causing `new Daytona()` to fail with `DaytonaAuthenticationError: Organization ID is required when using JWT token`.

## Changes

- Added `Runtime.SERVERLESS` to the first condition in `getEnvVar()` alongside `NODE` and `BUN`
- This is safe because the serverless runtime detection already requires `process` to be available

## Testing

- Cloudflare Workers with `nodejs_compat` + `DAYTONA_API_KEY` set: `new Daytona()` now picks up the API key
- Node/Bun/Deno: unchanged behavior

Closes #4484

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `getEnvVar()` to read `process.env` whenever `process` is available, not only in `NODE`/`BUN`. This ensures `DAYTONA_API_KEY`, `DAYTONA_API_URL`, and `DAYTONA_TARGET` are picked up on serverless platforms like Cloudflare Workers with `nodejs_compat`, fixing Daytona auth errors.

<sup>Written for commit d00b7d836e7f36395b5ccd47551ff58050af0b06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

