### PR TITLE
feat(api,dashboard): surface per-sandbox resource limits in region usage overview

### DIFF
--- a/apps/api/src/organization/dto/organization-usage-overview.dto.ts
+++ b/apps/api/src/organization/dto/organization-usage-overview.dto.ts
@@ -24,6 +24,18 @@ export class RegionUsageOverviewDto {
   totalDiskQuota: number
   @ApiProperty()
   currentDiskUsage: number
+
+  @ApiProperty({ nullable: true })
+  maxCpuPerSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxMemoryPerSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxDiskPerSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxDiskPerNonEphemeralSandbox: number | null
 }
 
 @ApiSchema({ name: 'OrganizationUsageOverview' })

--- a/apps/api/src/organization/services/organization-usage.service.ts
+++ b/apps/api/src/organization/services/organization-usage.service.ts
@@ -110,6 +110,10 @@ export class OrganizationUsageService {
           currentCpuUsage: sandboxUsage.currentCpuUsage,
           currentMemoryUsage: sandboxUsage.currentMemoryUsage,
           currentDiskUsage: sandboxUsage.currentDiskUsage,
+          maxCpuPerSandbox: rq.maxCpuPerSandbox,
+          maxMemoryPerSandbox: rq.maxMemoryPerSandbox,
+          maxDiskPerSandbox: rq.maxDiskPerSandbox,
+          maxDiskPerNonEphemeralSandbox: rq.maxDiskPerNonEphemeralSandbox,
         }
 
         return usage

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -173,9 +173,22 @@ export default function Limits() {
                   description="Resources limit per sandbox."
                   className="border-t border-border"
                   rateLimits={[
-                    { label: 'Compute', value: selectedOrganization?.maxCpuPerSandbox, unit: 'vCPU' },
-                    { label: 'Memory', value: selectedOrganization?.maxMemoryPerSandbox, unit: 'GiB' },
-                    { label: 'Storage', value: selectedOrganization?.maxDiskPerSandbox, unit: 'GiB' },
+                    {
+                      label: 'Compute',
+                      value: currentRegionUsageOverview?.maxCpuPerSandbox ?? selectedOrganization?.maxCpuPerSandbox,
+                      unit: 'vCPU',
+                    },
+                    {
+                      label: 'Memory',
+                      value:
+                        currentRegionUsageOverview?.maxMemoryPerSandbox ?? selectedOrganization?.maxMemoryPerSandbox,
+                      unit: 'GiB',
+                    },
+                    {
+                      label: 'Storage',
+                      value: currentRegionUsageOverview?.maxDiskPerSandbox ?? selectedOrganization?.maxDiskPerSandbox,
+                      unit: 'GiB',
+                    },
                   ]}
                 />
 

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9754,10 +9754,14 @@ components:
     RegionUsageOverview:
       example:
         totalCpuQuota: 0.8008281904610115
+        maxCpuPerSandbox: 7.061401241503109
+        maxDiskPerSandbox: 3.616076749251911
+        maxDiskPerNonEphemeralSandbox: 2.027123023002322
         regionId: regionId
         currentDiskUsage: 2.3021358869347655
         currentMemoryUsage: 5.962133916683182
         currentCpuUsage: 6.027456183070403
+        maxMemoryPerSandbox: 9.301444243932576
         totalMemoryQuota: 1.4658129805029452
         totalDiskQuota: 5.637376656633329
       properties:
@@ -9775,10 +9779,26 @@ components:
           type: number
         currentDiskUsage:
           type: number
+        maxCpuPerSandbox:
+          nullable: true
+          type: number
+        maxMemoryPerSandbox:
+          nullable: true
+          type: number
+        maxDiskPerSandbox:
+          nullable: true
+          type: number
+        maxDiskPerNonEphemeralSandbox:
+          nullable: true
+          type: number
       required:
       - currentCpuUsage
       - currentDiskUsage
       - currentMemoryUsage
+      - maxCpuPerSandbox
+      - maxDiskPerNonEphemeralSandbox
+      - maxDiskPerSandbox
+      - maxMemoryPerSandbox
       - regionId
       - totalCpuQuota
       - totalDiskQuota
@@ -9786,23 +9806,31 @@ components:
       type: object
     OrganizationUsageOverview:
       example:
-        totalSnapshotQuota: 7.061401241503109
-        currentVolumeUsage: 2.027123023002322
-        totalVolumeQuota: 3.616076749251911
-        currentSnapshotUsage: 9.301444243932576
+        totalSnapshotQuota: 4.145608029883936
+        currentVolumeUsage: 1.0246457001441578
+        totalVolumeQuota: 1.2315135367772556
+        currentSnapshotUsage: 7.386281948385884
         regionUsage:
         - totalCpuQuota: 0.8008281904610115
+          maxCpuPerSandbox: 7.061401241503109
+          maxDiskPerSandbox: 3.616076749251911
+          maxDiskPerNonEphemeralSandbox: 2.027123023002322
           regionId: regionId
           currentDiskUsage: 2.3021358869347655
           currentMemoryUsage: 5.962133916683182
           currentCpuUsage: 6.027456183070403
+          maxMemoryPerSandbox: 9.301444243932576
           totalMemoryQuota: 1.4658129805029452
           totalDiskQuota: 5.637376656633329
         - totalCpuQuota: 0.8008281904610115
+          maxCpuPerSandbox: 7.061401241503109
+          maxDiskPerSandbox: 3.616076749251911
+          maxDiskPerNonEphemeralSandbox: 2.027123023002322
           regionId: regionId
           currentDiskUsage: 2.3021358869347655
           currentMemoryUsage: 5.962133916683182
           currentCpuUsage: 6.027456183070403
+          maxMemoryPerSandbox: 9.301444243932576
           totalMemoryQuota: 1.4658129805029452
           totalDiskQuota: 5.637376656633329
       properties:

--- a/libs/api-client-go/model_region_usage_overview.go
+++ b/libs/api-client-go/model_region_usage_overview.go
@@ -28,6 +28,10 @@ type RegionUsageOverview struct {
 	CurrentMemoryUsage float32 `json:"currentMemoryUsage"`
 	TotalDiskQuota float32 `json:"totalDiskQuota"`
 	CurrentDiskUsage float32 `json:"currentDiskUsage"`
+	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
+	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
+	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
+	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -37,7 +41,7 @@ type _RegionUsageOverview RegionUsageOverview
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUsage float32, totalMemoryQuota float32, currentMemoryUsage float32, totalDiskQuota float32, currentDiskUsage float32) *RegionUsageOverview {
+func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUsage float32, totalMemoryQuota float32, currentMemoryUsage float32, totalDiskQuota float32, currentDiskUsage float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionUsageOverview {
 	this := RegionUsageOverview{}
 	this.RegionId = regionId
 	this.TotalCpuQuota = totalCpuQuota
@@ -46,6 +50,10 @@ func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUs
 	this.CurrentMemoryUsage = currentMemoryUsage
 	this.TotalDiskQuota = totalDiskQuota
 	this.CurrentDiskUsage = currentDiskUsage
+	this.MaxCpuPerSandbox = maxCpuPerSandbox
+	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
+	this.MaxDiskPerSandbox = maxDiskPerSandbox
+	this.MaxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
 	return &this
 }
 
@@ -225,6 +233,110 @@ func (o *RegionUsageOverview) SetCurrentDiskUsage(v float32) {
 	o.CurrentDiskUsage = v
 }
 
+// GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionUsageOverview) GetMaxCpuPerSandbox() float32 {
+	if o == nil || o.MaxCpuPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxCpuPerSandbox.Get()
+}
+
+// GetMaxCpuPerSandboxOk returns a tuple with the MaxCpuPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionUsageOverview) GetMaxCpuPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxCpuPerSandbox.Get(), o.MaxCpuPerSandbox.IsSet()
+}
+
+// SetMaxCpuPerSandbox sets field value
+func (o *RegionUsageOverview) SetMaxCpuPerSandbox(v float32) {
+	o.MaxCpuPerSandbox.Set(&v)
+}
+
+// GetMaxMemoryPerSandbox returns the MaxMemoryPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionUsageOverview) GetMaxMemoryPerSandbox() float32 {
+	if o == nil || o.MaxMemoryPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxMemoryPerSandbox.Get()
+}
+
+// GetMaxMemoryPerSandboxOk returns a tuple with the MaxMemoryPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionUsageOverview) GetMaxMemoryPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxMemoryPerSandbox.Get(), o.MaxMemoryPerSandbox.IsSet()
+}
+
+// SetMaxMemoryPerSandbox sets field value
+func (o *RegionUsageOverview) SetMaxMemoryPerSandbox(v float32) {
+	o.MaxMemoryPerSandbox.Set(&v)
+}
+
+// GetMaxDiskPerSandbox returns the MaxDiskPerSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionUsageOverview) GetMaxDiskPerSandbox() float32 {
+	if o == nil || o.MaxDiskPerSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerSandbox.Get()
+}
+
+// GetMaxDiskPerSandboxOk returns a tuple with the MaxDiskPerSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionUsageOverview) GetMaxDiskPerSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerSandbox.Get(), o.MaxDiskPerSandbox.IsSet()
+}
+
+// SetMaxDiskPerSandbox sets field value
+func (o *RegionUsageOverview) SetMaxDiskPerSandbox(v float32) {
+	o.MaxDiskPerSandbox.Set(&v)
+}
+
+// GetMaxDiskPerNonEphemeralSandbox returns the MaxDiskPerNonEphemeralSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionUsageOverview) GetMaxDiskPerNonEphemeralSandbox() float32 {
+	if o == nil || o.MaxDiskPerNonEphemeralSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerNonEphemeralSandbox.Get()
+}
+
+// GetMaxDiskPerNonEphemeralSandboxOk returns a tuple with the MaxDiskPerNonEphemeralSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionUsageOverview) GetMaxDiskPerNonEphemeralSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerNonEphemeralSandbox.Get(), o.MaxDiskPerNonEphemeralSandbox.IsSet()
+}
+
+// SetMaxDiskPerNonEphemeralSandbox sets field value
+func (o *RegionUsageOverview) SetMaxDiskPerNonEphemeralSandbox(v float32) {
+	o.MaxDiskPerNonEphemeralSandbox.Set(&v)
+}
+
 func (o RegionUsageOverview) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -242,6 +354,10 @@ func (o RegionUsageOverview) ToMap() (map[string]interface{}, error) {
 	toSerialize["currentMemoryUsage"] = o.CurrentMemoryUsage
 	toSerialize["totalDiskQuota"] = o.TotalDiskQuota
 	toSerialize["currentDiskUsage"] = o.CurrentDiskUsage
+	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
+	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
+	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
+	toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -262,6 +378,10 @@ func (o *RegionUsageOverview) UnmarshalJSON(data []byte) (err error) {
 		"currentMemoryUsage",
 		"totalDiskQuota",
 		"currentDiskUsage",
+		"maxCpuPerSandbox",
+		"maxMemoryPerSandbox",
+		"maxDiskPerSandbox",
+		"maxDiskPerNonEphemeralSandbox",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -298,6 +418,10 @@ func (o *RegionUsageOverview) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "currentMemoryUsage")
 		delete(additionalProperties, "totalDiskQuota")
 		delete(additionalProperties, "currentDiskUsage")
+		delete(additionalProperties, "maxCpuPerSandbox")
+		delete(additionalProperties, "maxMemoryPerSandbox")
+		delete(additionalProperties, "maxDiskPerSandbox")
+		delete(additionalProperties, "maxDiskPerNonEphemeralSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionUsageOverview.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionUsageOverview.java
@@ -86,6 +86,26 @@ public class RegionUsageOverview {
   @javax.annotation.Nonnull
   private BigDecimal currentDiskUsage;
 
+  public static final String SERIALIZED_NAME_MAX_CPU_PER_SANDBOX = "maxCpuPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxCpuPerSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_MEMORY_PER_SANDBOX = "maxMemoryPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_MEMORY_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxMemoryPerSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_SANDBOX = "maxDiskPerSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_NON_EPHEMERAL_SANDBOX = "maxDiskPerNonEphemeralSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_NON_EPHEMERAL_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerNonEphemeralSandbox;
+
   public RegionUsageOverview() {
   }
 
@@ -221,6 +241,82 @@ public class RegionUsageOverview {
     this.currentDiskUsage = currentDiskUsage;
   }
 
+
+  public RegionUsageOverview maxCpuPerSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerSandbox) {
+    this.maxCpuPerSandbox = maxCpuPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxCpuPerSandbox
+   * @return maxCpuPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxCpuPerSandbox() {
+    return maxCpuPerSandbox;
+  }
+
+  public void setMaxCpuPerSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerSandbox) {
+    this.maxCpuPerSandbox = maxCpuPerSandbox;
+  }
+
+
+  public RegionUsageOverview maxMemoryPerSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerSandbox) {
+    this.maxMemoryPerSandbox = maxMemoryPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxMemoryPerSandbox
+   * @return maxMemoryPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxMemoryPerSandbox() {
+    return maxMemoryPerSandbox;
+  }
+
+  public void setMaxMemoryPerSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerSandbox) {
+    this.maxMemoryPerSandbox = maxMemoryPerSandbox;
+  }
+
+
+  public RegionUsageOverview maxDiskPerSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerSandbox) {
+    this.maxDiskPerSandbox = maxDiskPerSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerSandbox
+   * @return maxDiskPerSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerSandbox() {
+    return maxDiskPerSandbox;
+  }
+
+  public void setMaxDiskPerSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerSandbox) {
+    this.maxDiskPerSandbox = maxDiskPerSandbox;
+  }
+
+
+  public RegionUsageOverview maxDiskPerNonEphemeralSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerNonEphemeralSandbox) {
+    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerNonEphemeralSandbox
+   * @return maxDiskPerNonEphemeralSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerNonEphemeralSandbox() {
+    return maxDiskPerNonEphemeralSandbox;
+  }
+
+  public void setMaxDiskPerNonEphemeralSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerNonEphemeralSandbox) {
+    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -282,13 +378,17 @@ public class RegionUsageOverview {
         Objects.equals(this.totalMemoryQuota, regionUsageOverview.totalMemoryQuota) &&
         Objects.equals(this.currentMemoryUsage, regionUsageOverview.currentMemoryUsage) &&
         Objects.equals(this.totalDiskQuota, regionUsageOverview.totalDiskQuota) &&
-        Objects.equals(this.currentDiskUsage, regionUsageOverview.currentDiskUsage)&&
+        Objects.equals(this.currentDiskUsage, regionUsageOverview.currentDiskUsage) &&
+        Objects.equals(this.maxCpuPerSandbox, regionUsageOverview.maxCpuPerSandbox) &&
+        Objects.equals(this.maxMemoryPerSandbox, regionUsageOverview.maxMemoryPerSandbox) &&
+        Objects.equals(this.maxDiskPerSandbox, regionUsageOverview.maxDiskPerSandbox) &&
+        Objects.equals(this.maxDiskPerNonEphemeralSandbox, regionUsageOverview.maxDiskPerNonEphemeralSandbox)&&
         Objects.equals(this.additionalProperties, regionUsageOverview.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(regionId, totalCpuQuota, currentCpuUsage, totalMemoryQuota, currentMemoryUsage, totalDiskQuota, currentDiskUsage, additionalProperties);
+    return Objects.hash(regionId, totalCpuQuota, currentCpuUsage, totalMemoryQuota, currentMemoryUsage, totalDiskQuota, currentDiskUsage, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
   }
 
   @Override
@@ -302,6 +402,10 @@ public class RegionUsageOverview {
     sb.append("    currentMemoryUsage: ").append(toIndentedString(currentMemoryUsage)).append("\n");
     sb.append("    totalDiskQuota: ").append(toIndentedString(totalDiskQuota)).append("\n");
     sb.append("    currentDiskUsage: ").append(toIndentedString(currentDiskUsage)).append("\n");
+    sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
+    sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
+    sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
+    sb.append("    maxDiskPerNonEphemeralSandbox: ").append(toIndentedString(maxDiskPerNonEphemeralSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -332,6 +436,10 @@ public class RegionUsageOverview {
     openapiFields.add("currentMemoryUsage");
     openapiFields.add("totalDiskQuota");
     openapiFields.add("currentDiskUsage");
+    openapiFields.add("maxCpuPerSandbox");
+    openapiFields.add("maxMemoryPerSandbox");
+    openapiFields.add("maxDiskPerSandbox");
+    openapiFields.add("maxDiskPerNonEphemeralSandbox");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -342,6 +450,10 @@ public class RegionUsageOverview {
     openapiRequiredFields.add("currentMemoryUsage");
     openapiRequiredFields.add("totalDiskQuota");
     openapiRequiredFields.add("currentDiskUsage");
+    openapiRequiredFields.add("maxCpuPerSandbox");
+    openapiRequiredFields.add("maxMemoryPerSandbox");
+    openapiRequiredFields.add("maxDiskPerSandbox");
+    openapiRequiredFields.add("maxDiskPerNonEphemeralSandbox");
   }
 
   /**

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionUsageOverviewTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionUsageOverviewTest.java
@@ -94,4 +94,36 @@ public class RegionUsageOverviewTest {
         // TODO: test currentDiskUsage
     }
 
+    /**
+     * Test the property 'maxCpuPerSandbox'
+     */
+    @Test
+    public void maxCpuPerSandboxTest() {
+        // TODO: test maxCpuPerSandbox
+    }
+
+    /**
+     * Test the property 'maxMemoryPerSandbox'
+     */
+    @Test
+    public void maxMemoryPerSandboxTest() {
+        // TODO: test maxMemoryPerSandbox
+    }
+
+    /**
+     * Test the property 'maxDiskPerSandbox'
+     */
+    @Test
+    public void maxDiskPerSandboxTest() {
+        // TODO: test maxDiskPerSandbox
+    }
+
+    /**
+     * Test the property 'maxDiskPerNonEphemeralSandbox'
+     */
+    @Test
+    public void maxDiskPerNonEphemeralSandboxTest() {
+        // TODO: test maxDiskPerNonEphemeralSandbox
+    }
+
 }

--- a/libs/api-client-python-async/daytona_api_client_async/models/region_usage_overview.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/region_usage_overview.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -37,8 +37,12 @@ class RegionUsageOverview(BaseModel):
     current_memory_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentMemoryUsage")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
     current_disk_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentDiskUsage")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage"]
+    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -85,6 +89,26 @@ class RegionUsageOverview(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if max_cpu_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerSandbox'] = None
+
+        # set to None if max_memory_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_sandbox is None and "max_memory_per_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerSandbox'] = None
+
+        # set to None if max_disk_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerSandbox'] = None
+
+        # set to None if max_disk_per_non_ephemeral_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerNonEphemeralSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -103,7 +127,11 @@ class RegionUsageOverview(BaseModel):
             "total_memory_quota": obj.get("totalMemoryQuota"),
             "current_memory_usage": obj.get("currentMemoryUsage"),
             "total_disk_quota": obj.get("totalDiskQuota"),
-            "current_disk_usage": obj.get("currentDiskUsage")
+            "current_disk_usage": obj.get("currentDiskUsage"),
+            "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
+            "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/region_usage_overview.py
+++ b/libs/api-client-python/daytona_api_client/models/region_usage_overview.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -37,8 +37,12 @@ class RegionUsageOverview(BaseModel):
     current_memory_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentMemoryUsage")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
     current_disk_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentDiskUsage")
+    max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
+    max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
+    max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
+    max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage"]
+    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -85,6 +89,26 @@ class RegionUsageOverview(BaseModel):
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
 
+        # set to None if max_cpu_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerSandbox'] = None
+
+        # set to None if max_memory_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_sandbox is None and "max_memory_per_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerSandbox'] = None
+
+        # set to None if max_disk_per_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_sandbox is None and "max_disk_per_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerSandbox'] = None
+
+        # set to None if max_disk_per_non_ephemeral_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerNonEphemeralSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -103,7 +127,11 @@ class RegionUsageOverview(BaseModel):
             "total_memory_quota": obj.get("totalMemoryQuota"),
             "current_memory_usage": obj.get("currentMemoryUsage"),
             "total_disk_quota": obj.get("totalDiskQuota"),
-            "current_disk_usage": obj.get("currentDiskUsage")
+            "current_disk_usage": obj.get("currentDiskUsage"),
+            "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
+            "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
+            "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-ruby/lib/daytona_api_client/models/region_usage_overview.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/region_usage_overview.rb
@@ -29,6 +29,14 @@ module DaytonaApiClient
 
     attr_accessor :current_disk_usage
 
+    attr_accessor :max_cpu_per_sandbox
+
+    attr_accessor :max_memory_per_sandbox
+
+    attr_accessor :max_disk_per_sandbox
+
+    attr_accessor :max_disk_per_non_ephemeral_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -38,7 +46,11 @@ module DaytonaApiClient
         :'total_memory_quota' => :'totalMemoryQuota',
         :'current_memory_usage' => :'currentMemoryUsage',
         :'total_disk_quota' => :'totalDiskQuota',
-        :'current_disk_usage' => :'currentDiskUsage'
+        :'current_disk_usage' => :'currentDiskUsage',
+        :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
+        :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
+        :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
+        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox'
       }
     end
 
@@ -61,13 +73,21 @@ module DaytonaApiClient
         :'total_memory_quota' => :'Float',
         :'current_memory_usage' => :'Float',
         :'total_disk_quota' => :'Float',
-        :'current_disk_usage' => :'Float'
+        :'current_disk_usage' => :'Float',
+        :'max_cpu_per_sandbox' => :'Float',
+        :'max_memory_per_sandbox' => :'Float',
+        :'max_disk_per_sandbox' => :'Float',
+        :'max_disk_per_non_ephemeral_sandbox' => :'Float'
       }
     end
 
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
+        :'max_cpu_per_sandbox',
+        :'max_memory_per_sandbox',
+        :'max_disk_per_sandbox',
+        :'max_disk_per_non_ephemeral_sandbox'
       ])
     end
 
@@ -127,6 +147,30 @@ module DaytonaApiClient
         self.current_disk_usage = attributes[:'current_disk_usage']
       else
         self.current_disk_usage = nil
+      end
+
+      if attributes.key?(:'max_cpu_per_sandbox')
+        self.max_cpu_per_sandbox = attributes[:'max_cpu_per_sandbox']
+      else
+        self.max_cpu_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_memory_per_sandbox')
+        self.max_memory_per_sandbox = attributes[:'max_memory_per_sandbox']
+      else
+        self.max_memory_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_disk_per_sandbox')
+        self.max_disk_per_sandbox = attributes[:'max_disk_per_sandbox']
+      else
+        self.max_disk_per_sandbox = nil
+      end
+
+      if attributes.key?(:'max_disk_per_non_ephemeral_sandbox')
+        self.max_disk_per_non_ephemeral_sandbox = attributes[:'max_disk_per_non_ephemeral_sandbox']
+      else
+        self.max_disk_per_non_ephemeral_sandbox = nil
       end
     end
 
@@ -261,7 +305,11 @@ module DaytonaApiClient
           total_memory_quota == o.total_memory_quota &&
           current_memory_usage == o.current_memory_usage &&
           total_disk_quota == o.total_disk_quota &&
-          current_disk_usage == o.current_disk_usage
+          current_disk_usage == o.current_disk_usage &&
+          max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
+          max_memory_per_sandbox == o.max_memory_per_sandbox &&
+          max_disk_per_sandbox == o.max_disk_per_sandbox &&
+          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox
     end
 
     # @see the `==` method
@@ -273,7 +321,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [region_id, total_cpu_quota, current_cpu_usage, total_memory_quota, current_memory_usage, total_disk_quota, current_disk_usage].hash
+      [region_id, total_cpu_quota, current_cpu_usage, total_memory_quota, current_memory_usage, total_disk_quota, current_disk_usage, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/models/region-usage-overview.ts
+++ b/libs/api-client/src/models/region-usage-overview.ts
@@ -62,5 +62,29 @@ export interface RegionUsageOverview {
      * @memberof RegionUsageOverview
      */
     'currentDiskUsage': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionUsageOverview
+     */
+    'maxCpuPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionUsageOverview
+     */
+    'maxMemoryPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionUsageOverview
+     */
+    'maxDiskPerSandbox': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof RegionUsageOverview
+     */
+    'maxDiskPerNonEphemeralSandbox': number | null;
 }
 


### PR DESCRIPTION
This pull request adds support for exposing per-sandbox resource limits in the region usage overview across the API, OpenAPI spec, Go and Java API clients, and the dashboard UI. These changes ensure that the maximum allowed CPU, memory, and disk per sandbox (including non-ephemeral sandboxes) are available and correctly displayed throughout the stack.

**API and DTO changes:**
- Added new fields to `RegionUsageOverviewDto` for `maxCpuPerSandbox`, `maxMemoryPerSandbox`, `maxDiskPerSandbox`, and `maxDiskPerNonEphemeralSandbox`, all nullable, to represent per-sandbox resource limits.
- Updated `OrganizationUsageService` to populate the new per-sandbox resource limit fields when constructing region usage overview responses.

**OpenAPI and client library updates:**
- Updated the OpenAPI spec (`openapi.yaml`) to include the new fields in the `RegionUsageOverview` schema, mark them as required, and provide example values. [[1]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR9757-R9764) [[2]](diffhunk://#diff-3a0654e3e4add2635e008de7273fe432b8a7c8dae5c7326ce5c9976e4a46ed4bR9782-R9833)
- Extended the Go API client model (`model_region_usage_overview.go`) to include the new fields, update serialization/deserialization logic, and adjust the constructor and getters/setters accordingly. [[1]](diffhunk://#diff-f47ddb8fd10dec68d58b8ee6bb1ff4873cdc5c9e832ecf615d80fdfa1d652ae0R31-R34) [[2]](diffhunk://#diff-f47ddb8fd10dec68d58b8ee6bb1ff4873cdc5c9e832ecf615d80fdfa1d652ae0L40-R44) [[3]](diffhunk://#diff-f47ddb8fd10dec68d58b8ee6bb1ff4873cdc5c9e832ecf615d80fdfa1d652ae0R53-R56) [[4]](diffhunk://#diff-f47ddb8fd10dec68d58b8ee6bb1ff4873cdc5c9e832ecf615d80fdfa1d652ae0R236-R339) [[5]](diffhunk://#diff-f47ddb8fd10dec68d58b8ee6bb1ff4873cdc5c9e832ecf615d80fdfa1d652ae0R357-R360) [[6]](diffhunk://#diff-f47ddb8fd10dec68d58b8ee6bb1ff4873cdc5c9e832ecf615d80fdfa1d652ae0R381-R384) [[7]](diffhunk://#diff-f47ddb8fd10dec68d58b8ee6bb1ff4873cdc5c9e832ecf615d80fdfa1d652ae0R421-R424)
- Extended the Java API client model (`RegionUsageOverview.java`) to include the new fields, update equals/hashCode/toString, and add them to the OpenAPI required fields set. [[1]](diffhunk://#diff-2e10c25cf78433339046810efc851ae9dd7468595b0567257774ac2336d65040R89-R108) [[2]](diffhunk://#diff-2e10c25cf78433339046810efc851ae9dd7468595b0567257774ac2336d65040R244-R319) [[3]](diffhunk://#diff-2e10c25cf78433339046810efc851ae9dd7468595b0567257774ac2336d65040R382-R391) [[4]](diffhunk://#diff-2e10c25cf78433339046810efc851ae9dd7468595b0567257774ac2336d65040R405-R408) [[5]](diffhunk://#diff-2e10c25cf78433339046810efc851ae9dd7468595b0567257774ac2336d65040R439-R442) [[6]](diffhunk://#diff-2e10c25cf78433339046810efc851ae9dd7468595b0567257774ac2336d65040R453-R456)

**Dashboard UI update:**
- Updated the `Limits` page to prefer per-region per-sandbox limits from `currentRegionUsageOverview` if available, falling back to organization-wide values otherwise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose per-sandbox resource limits (CPU, memory, and storage) per region across the API and dashboard. Adds nullable limits to `RegionUsageOverview` and shows them on the Limits page with an org-wide fallback.

- **New Features**
  - API: Added `maxCpuPerSandbox`, `maxMemoryPerSandbox`, `maxDiskPerSandbox`, `maxDiskPerNonEphemeralSandbox` (nullable) to `RegionUsageOverviewDto` and populate them in `OrganizationUsageService`.
  - OpenAPI/Clients: Updated `RegionUsageOverview` in `openapi.yaml` (fields are required but nullable) and regenerated clients in Go, Java, Python (sync/async), Ruby, and TS.
  - Dashboard: `Limits` page now prefers per-region per-sandbox limits from `currentRegionUsageOverview`, falling back to organization-level values.

- **Migration**
  - Regenerate API clients and handle the new nullable fields.
  - Go: `RegionUsageOverview` constructor now includes four `NullableFloat32` params for the new limits.
  - Java: New limits are included in the required fields set (values may be null).

<sup>Written for commit fd2ffff654d0546f3a04b026ec055e5715f18d7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

