### PR TITLE
feat(docs): add robots.txt

### DIFF
--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.daytona.io/docs/sitemap-index.xml
+Content-Signal: ai-train=yes, search=yes, ai-input=yes


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add robots.txt for the docs site to allow indexing and improve crawler discovery. It allows all user-agents, links to https://www.daytona.io/docs/sitemap-index.xml, and sets content signals (ai-train=yes, search=yes, ai-input=yes).

<sup>Written for commit 7c1b29de8a3383e9dd3f7a60ea63bb4750ae2852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

