### PR TITLE
fix(docs): modify guides list container hover style

### DIFF
--- a/apps/docs/src/components/GuidesList.astro
+++ b/apps/docs/src/components/GuidesList.astro
@@ -119,8 +119,8 @@ const guides: GuideItem[] = navLinks.map(link => {
   }
 
   a:hover {
-    background: var(--secondary-text-color);
-    border-color: var(--secondary-text-color);
+    background: var(--cta-surface-neutral-primary);
+    border-color: var(--cta-surface-neutral-primary);
   }
 
   a * {
@@ -154,9 +154,5 @@ const guides: GuideItem[] = navLinks.map(link => {
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
-  }
-
-  a:hover .guide-description {
-    color: var(--primary-text-color);
   }
 </style>


### PR DESCRIPTION
Before:
<img width="739" height="182" alt="Screenshot 2026-04-20 at 23 22 53" src="https://github.com/user-attachments/assets/8c2ffe43-d038-4afa-8739-d0a130bf5d75" />

Now:
<img width="743" height="190" alt="Screenshot 2026-04-20 at 23 22 47" src="https://github.com/user-attachments/assets/c672bd01-690b-4f98-a871-ffd0af459514" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update guides list hover state to use the neutral CTA surface for the link container, improving contrast and matching the design system. Removed the description text color change on hover so only the background and border adjust.

<sup>Written for commit 7bf3e38830b4822876113ddf53512124fc43b4e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

