### PR TITLE
fix(daemon): session exec silent no-op after sandbox restart

### DIFF
--- a/apps/daemon/pkg/common/get_shell.go
+++ b/apps/daemon/pkg/common/get_shell.go
@@ -39,3 +39,17 @@ func GetShell() string {
 
 	return "sh"
 }
+
+// GetShellArgs returns the shell path and no-init flags to prevent the shell
+// from reading init files that may consume stdin bytes or run exit.
+func GetShellArgs() []string {
+	shell := GetShell()
+	switch {
+	case shell == "zsh", strings.HasSuffix(shell, "/zsh"):
+		return []string{shell, "-f"}
+	case shell == "bash", strings.HasSuffix(shell, "/bash"):
+		return []string{shell, "--norc", "--noprofile"}
+	default:
+		return []string{shell}
+	}
+}

--- a/apps/daemon/pkg/common/get_shell_test.go
+++ b/apps/daemon/pkg/common/get_shell_test.go
@@ -1,0 +1,38 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"testing"
+)
+
+func TestSessionShellStartsWithNoInitFlags(t *testing.T) {
+	args := GetShellArgs()
+	if len(args) == 0 {
+		t.Fatal("GetShellArgs() returned empty slice")
+	}
+
+	shell := args[0]
+	switch shell {
+	case "/usr/bin/zsh", "/bin/zsh":
+		if len(args) < 2 {
+			t.Fatalf("expected no-init flag for zsh %q, got only the shell path", shell)
+		}
+		if args[1] != "-f" {
+			t.Fatalf("expected -f for zsh %q, got %q", shell, args[1])
+		}
+	case "/usr/bin/bash", "/bin/bash":
+		if len(args) < 3 {
+			t.Fatalf("expected --norc --noprofile for bash %q, got %v", shell, args)
+		}
+		if args[1] != "--norc" || args[2] != "--noprofile" {
+			t.Fatalf("expected --norc --noprofile for bash %q, got %v", shell, args[1:])
+		}
+	default:
+		// Other shells get no extra flags — just the shell path is acceptable.
+		if len(args) != 1 {
+			t.Fatalf("expected only shell path for %q, got %v", shell, args)
+		}
+	}
+}

--- a/apps/daemon/pkg/session/create.go
+++ b/apps/daemon/pkg/session/create.go
@@ -19,7 +19,8 @@ import (
 func (s *SessionService) Create(sessionId string, isLegacy bool) error {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cmd := exec.CommandContext(ctx, common.GetShell())
+	shellArgs := common.GetShellArgs()
+	cmd := exec.CommandContext(ctx, shellArgs[0], shellArgs[1:]...)
 	cmd.Env = os.Environ()
 
 	if isLegacy {
@@ -58,6 +59,11 @@ func (s *SessionService) Create(sessionId string, isLegacy bool) error {
 		cancel:      cancel,
 	}
 	s.sessions.Set(sessionId, session)
+
+	go func() {
+		_ = cmd.Wait()
+		session.dead.Store(true)
+	}()
 
 	err = os.MkdirAll(session.Dir(s.configDir), 0755)
 	if err != nil {

--- a/apps/daemon/pkg/session/execute.go
+++ b/apps/daemon/pkg/session/execute.go
@@ -26,6 +26,10 @@ func (s *SessionService) Execute(sessionId, cmdId, cmd string, async, isCombined
 		return nil, common_errors.NewNotFoundError(errors.New("session not found"))
 	}
 
+	if session.dead.Load() {
+		return nil, common_errors.NewBadRequestError(errors.New("session shell has exited; create a new session"))
+	}
+
 	if cmdId == util.EmptyCommandID {
 		cmdId = uuid.NewString()
 	}

--- a/apps/daemon/pkg/session/execute_test.go
+++ b/apps/daemon/pkg/session/execute_test.go
@@ -156,6 +156,45 @@ func TestExecuteSyncHeredoc(t *testing.T) {
 	}
 }
 
+func TestExecuteOnDeadSessionReturnsError(t *testing.T) {
+	svc := newTestSessionService(t)
+	const sessionID = "dead-session"
+
+	if err := svc.Create(sessionID, false); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = svc.Delete(context.Background(), sessionID)
+	})
+
+	session, ok := svc.sessions.Get(sessionID)
+	if !ok {
+		t.Fatalf("session %s not found in map", sessionID)
+	}
+
+	// Kill the shell process and wait for the liveness goroutine to mark it dead.
+	if err := session.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill shell process: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if session.dead.Load() {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	if !session.dead.Load() {
+		t.Fatal("session was not marked dead within 2s after process kill")
+	}
+
+	_, err := svc.Execute(sessionID, "", "echo hello", false, true, false, false)
+	if err == nil {
+		t.Fatal("expected error executing on dead session, got nil")
+	}
+}
+
 func TestExecuteAsyncCommandStillAcceptsInput(t *testing.T) {
 	svc := newTestSessionService(t)
 	const sessionID = "async-stdin"

--- a/apps/daemon/pkg/session/types.go
+++ b/apps/daemon/pkg/session/types.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 
 	cmap "github.com/orcaman/concurrent-map/v2"
 )
@@ -19,6 +20,7 @@ type session struct {
 	commands    cmap.ConcurrentMap[string, *Command]
 	ctx         context.Context
 	cancel      context.CancelFunc
+	dead        atomic.Bool
 }
 
 func (s *session) Dir(configDir string) string {


### PR DESCRIPTION
## Summary

Fixes #4520 — `POST /process/session/{id}/exec` returns 202 Accepted but the command never runs after a sandbox auto-stop + restart.

**Root causes identified through live reproduction on a real sandbox:**

- **Shell init files consuming stdin** (`GetShell()` prefers zsh; zsh reads `.zshenv`/`.zprofile` even when stdin is a pipe — can consume the command wrapper bytes or call `exit` before the shell enters its exec loop)
- **No shell liveness detection** — if the shell dies for any reason (init-file `exit`, OOM kill, SIGHUP, `mkfifo || exit 1` in the wrapper), subsequent `Execute()` calls write to the OS pipe buffer (no EPIPE while < 64KB), return 202, and the command is silently dropped forever

## Changes

| File | Change |
|---|---|
| `pkg/common/get_shell.go` | Add `GetShellArgs()` returning shell + no-init flags (`-f` for zsh, `--norc --noprofile` for bash) |
| `pkg/session/create.go` | Use `GetShellArgs()` to start shell; add goroutine that calls `cmd.Wait()` and sets `session.dead = true` |
| `pkg/session/types.go` | Add `dead atomic.Bool` field to `session` struct |
| `pkg/session/execute.go` | Check `session.dead` before writing to stdin; return clear 400 error instead of silent 202 |
| `pkg/common/get_shell_test.go` | Unit test for `GetShellArgs()` no-init flags |
| `pkg/session/execute_test.go` | Test: exec on dead session returns error (not panic/silent 202) |

## Test plan

- [x] `TestSessionShellStartsWithNoInitFlags` — `GetShellArgs()` returns correct no-init flag per shell
- [x] `TestExecuteOnDeadSessionReturnsError` — killing the shell process causes next `Execute()` to return 400 within 2s
- [x] Existing session tests pass (`TestExecuteSyncCommandGetsEOFOnStdin`, `TestExecuteSyncHeredoc`, `TestExecuteAsyncCommandStillAcceptsInput`)
- [x] Live sandbox reproduction: fresh session after stop/start executes correctly
