### PR TITLE
feat(sdk-python): add optional WebSocket handshake concurrency limit

### DIFF
--- a/apps/docs/src/content/docs/en/python-sdk/async/async-code-interpreter.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-code-interpreter.mdx
@@ -22,7 +22,8 @@ or execute the appropriate command directly in the sandbox terminal.
 #### AsyncCodeInterpreter.\_\_init\_\_
 
 ```python
-def __init__(api_client: InterpreterApi)
+def __init__(api_client: InterpreterApi,
+             ws_handshake_semaphore: asyncio.Semaphore | None = None)
 ```
 
 Initialize a new AsyncCodeInterpreter instance.

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-daytona.mdx
@@ -66,6 +66,10 @@ If no config is provided, reads from environment variables:
 - `DAYTONA_API_KEY`: Required API key for authentication
 - `DAYTONA_API_URL`: Required api URL
 - `DAYTONA_TARGET`: Optional target environment (if not provided, default region for the organization is used)
+- `DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES`: Optional limit on concurrent WebSocket
+handshakes. Only useful for workloads that open hundreds of WebSocket connections
+simultaneously (e.g. creating 500+ PTY sessions in a single burst). When set,
+the SDK queues excess handshakes until a slot is available. Disabled by default.
 
 **Arguments**:
 

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-process.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-process.mdx
@@ -14,7 +14,9 @@ Handles process and code execution within a Sandbox.
 #### AsyncProcess.\_\_init\_\_
 
 ```python
-def __init__(language: str, api_client: ProcessApi)
+def __init__(language: str,
+             api_client: ProcessApi,
+             ws_handshake_semaphore: asyncio.Semaphore | None = None)
 ```
 
 Initialize a new Process instance.

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-sandbox.mdx
@@ -55,7 +55,8 @@ def __init__(sandbox_dto: SandboxDto,
              toolbox_api: ApiClient,
              sandbox_api: SandboxApi,
              language: str,
-             pool_tracker: AsyncPoolSaturationTracker | None = None)
+             pool_tracker: AsyncPoolSaturationTracker | None = None,
+             ws_handshake_semaphore: asyncio.Semaphore | None = None)
 ```
 
 Initialize a new Sandbox instance.

--- a/apps/docs/src/content/docs/en/python-sdk/sync/code-interpreter.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/code-interpreter.mdx
@@ -22,7 +22,8 @@ or execute the appropriate command directly in the sandbox terminal.
 #### CodeInterpreter.\_\_init\_\_
 
 ```python
-def __init__(api_client: InterpreterApi)
+def __init__(api_client: InterpreterApi,
+             ws_handshake_semaphore: threading.Semaphore | None = None)
 ```
 
 Initialize a new CodeInterpreter instance.

--- a/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/daytona.mdx
@@ -63,6 +63,10 @@ If no config is provided, reads from environment variables:
 - `DAYTONA_API_KEY`: Required API key for authentication
 - `DAYTONA_API_URL`: Required api URL
 - `DAYTONA_TARGET`: Optional target environment (if not provided, default region for the organization is used)
+- `DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES`: Optional limit on concurrent WebSocket
+handshakes. Only useful for workloads that open hundreds of WebSocket connections
+simultaneously (e.g. creating 500+ PTY sessions in a single burst). When set,
+the SDK queues excess handshakes until a slot is available. Disabled by default.
 
 **Arguments**:
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/process.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/process.mdx
@@ -14,7 +14,9 @@ Handles process and code execution within a Sandbox.
 #### Process.\_\_init\_\_
 
 ```python
-def __init__(language: str, api_client: ProcessApi)
+def __init__(language: str,
+             api_client: ProcessApi,
+             ws_handshake_semaphore: threading.Semaphore | None = None)
 ```
 
 Initialize a new Process instance.

--- a/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/sandbox.mdx
@@ -51,8 +51,11 @@ Represents a Daytona Sandbox.
 #### Sandbox.\_\_init\_\_
 
 ```python
-def __init__(sandbox_dto: SandboxDto, toolbox_api: ApiClient,
-             sandbox_api: SandboxApi, language: str)
+def __init__(sandbox_dto: SandboxDto,
+             toolbox_api: ApiClient,
+             sandbox_api: SandboxApi,
+             language: str,
+             ws_handshake_semaphore: threading.Semaphore | None = None)
 ```
 
 Initialize a new Sandbox instance.

--- a/libs/sdk-python/src/daytona/_async/code_interpreter.py
+++ b/libs/sdk-python/src/daytona/_async/code_interpreter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 
@@ -34,6 +35,7 @@ class AsyncCodeInterpreter:
     def __init__(
         self,
         api_client: InterpreterApi,
+        ws_handshake_semaphore: asyncio.Semaphore | None = None,
     ):
         """Initialize a new AsyncCodeInterpreter instance.
 
@@ -41,6 +43,7 @@ class AsyncCodeInterpreter:
             api_client: API client for interpreter operations.
         """
         self._api_client: InterpreterApi = api_client
+        self._ws_handshake_semaphore: asyncio.Semaphore | None = ws_handshake_semaphore
 
     @intercept_errors(message_prefix="Failed to run code: ")
     async def run_code(
@@ -116,51 +119,62 @@ class AsyncCodeInterpreter:
         result = ExecutionResult()
 
         try:
-            async with connect(url, additional_headers=headers) as websocket:
-                # Send execution request as first message
-                request: dict[str, str | int | dict[str, str]] = {"code": code}
-                if context is not None:
-                    request["contextId"] = context.id
-                if envs is not None:
-                    request["envs"] = envs
-                if timeout is not None:
-                    request["timeout"] = timeout
+            if self._ws_handshake_semaphore is not None:
+                _ = await self._ws_handshake_semaphore.acquire()
+            _sem_released = False
+            try:
+                async with connect(url, additional_headers=headers) as websocket:
+                    if self._ws_handshake_semaphore is not None:
+                        self._ws_handshake_semaphore.release()
+                        _sem_released = True
 
-                await websocket.send(json.dumps(request))
+                    # Send execution request as first message
+                    request: dict[str, str | int | dict[str, str]] = {"code": code}
+                    if context is not None:
+                        request["contextId"] = context.id
+                    if envs is not None:
+                        request["envs"] = envs
+                    if timeout is not None:
+                        request["timeout"] = timeout
 
-                # Process streaming chunks
-                while True:
-                    try:
-                        message = await websocket.recv()
-                        chunk = json.loads(message)
-                        chunk_type = chunk.get("type")
+                    await websocket.send(json.dumps(request))
 
-                        if chunk_type == "stdout":
-                            stdout = chunk.get("text", "")
-                            if on_stdout:
-                                _ = on_stdout(OutputMessage(output=stdout))
-                            result.stdout += stdout
+                    # Process streaming chunks
+                    while True:
+                        try:
+                            message = await websocket.recv()
+                            chunk = json.loads(message)
+                            chunk_type = chunk.get("type")
 
-                        elif chunk_type == "stderr":
-                            stderr = chunk.get("text", "")
-                            if on_stderr:
-                                _ = on_stderr(OutputMessage(output=stderr))
-                            result.stderr += stderr
+                            if chunk_type == "stdout":
+                                stdout = chunk.get("text", "")
+                                if on_stdout:
+                                    _ = on_stdout(OutputMessage(output=stdout))
+                                result.stdout += stdout
 
-                        elif chunk_type == "error":
-                            error = ExecutionError(
-                                name=chunk.get("name", ""),
-                                value=chunk.get("value", ""),
-                                traceback=chunk.get("traceback", ""),
-                            )
-                            result.error = error
-                            if on_error:
-                                _ = on_error(error)
+                            elif chunk_type == "stderr":
+                                stderr = chunk.get("text", "")
+                                if on_stderr:
+                                    _ = on_stderr(OutputMessage(output=stderr))
+                                result.stderr += stderr
 
-                    except ConnectionClosed as e:
-                        if isinstance(e, ConnectionClosedOK):
-                            break
-                        self._raise_from_ws_close(e)
+                            elif chunk_type == "error":
+                                error = ExecutionError(
+                                    name=chunk.get("name", ""),
+                                    value=chunk.get("value", ""),
+                                    traceback=chunk.get("traceback", ""),
+                                )
+                                result.error = error
+                                if on_error:
+                                    _ = on_error(error)
+
+                        except ConnectionClosed as e:
+                            if isinstance(e, ConnectionClosedOK):
+                                break
+                            self._raise_from_ws_close(e)
+            finally:
+                if self._ws_handshake_semaphore is not None and not _sem_released:
+                    self._ws_handshake_semaphore.release()
 
         except ConnectionClosed as e:
             if isinstance(e, ConnectionClosedOK):

--- a/libs/sdk-python/src/daytona/_async/daytona.py
+++ b/libs/sdk-python/src/daytona/_async/daytona.py
@@ -112,6 +112,10 @@ class AsyncDaytona:
         - `DAYTONA_API_KEY`: Required API key for authentication
         - `DAYTONA_API_URL`: Required api URL
         - `DAYTONA_TARGET`: Optional target environment (if not provided, default region for the organization is used)
+        - `DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES`: Optional limit on concurrent WebSocket
+          handshakes. Only useful for workloads that open hundreds of WebSocket connections
+          simultaneously (e.g. creating 500+ PTY sessions in a single burst). When set,
+          the SDK queues excess handshakes until a slot is available. Disabled by default.
 
         Args:
             config (DaytonaConfig | None): Object containing api_key, api_url, and target.
@@ -213,6 +217,11 @@ class AsyncDaytona:
             self._api_client.default_headers["X-Daytona-Organization-ID"] = self._organization_id
 
         self._pool_tracker: AsyncPoolSaturationTracker = AsyncPoolSaturationTracker(pool_size)
+
+        ws_concurrency_str = (env_reader or DaytonaEnvReader()).get("DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES")
+        self._ws_handshake_semaphore: asyncio.Semaphore | None = (
+            asyncio.Semaphore(int(ws_concurrency_str)) if ws_concurrency_str is not None else None
+        )
 
         # Initialize API clients with the api_client instance
         self._sandbox_api: SandboxApi = SandboxApi(self._api_client)
@@ -529,6 +538,7 @@ class AsyncDaytona:
             self._sandbox_api,
             validated_language.value,
             self._pool_tracker,
+            ws_handshake_semaphore=self._ws_handshake_semaphore,
         )
 
         if sandbox.state != SandboxState.STARTED:
@@ -591,6 +601,7 @@ class AsyncDaytona:
             self._sandbox_api,
             language,
             self._pool_tracker,
+            ws_handshake_semaphore=self._ws_handshake_semaphore,
         )
 
     @intercept_errors(message_prefix="Failed to list sandboxes: ")
@@ -633,6 +644,7 @@ class AsyncDaytona:
                     self._sandbox_api,
                     language,
                     self._pool_tracker,
+                    ws_handshake_semaphore=self._ws_handshake_semaphore,
                 )
             )
 

--- a/libs/sdk-python/src/daytona/_async/process.py
+++ b/libs/sdk-python/src/daytona/_async/process.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import asyncio
 import re
 from collections.abc import Awaitable, Callable
 
@@ -46,6 +47,7 @@ class AsyncProcess:
         self,
         language: str,
         api_client: ProcessApi,
+        ws_handshake_semaphore: asyncio.Semaphore | None = None,
     ):
         """Initialize a new Process instance.
 
@@ -54,6 +56,7 @@ class AsyncProcess:
         """
         self._language: str = language
         self._api_client: ProcessApi = api_client
+        self._ws_handshake_semaphore: asyncio.Semaphore | None = ws_handshake_semaphore
 
     @intercept_errors(message_prefix="Failed to execute command: ")
     @with_instrumentation()
@@ -430,8 +433,18 @@ class AsyncProcess:
 
         url = re.sub(r"^http", "ws", url)
 
-        async with websockets.connect(url, additional_headers=headers) as ws:
-            await std_demux_stream(ws, on_stdout, on_stderr)
+        if self._ws_handshake_semaphore is not None:
+            _ = await self._ws_handshake_semaphore.acquire()
+        _sem_released = False
+        try:
+            async with websockets.connect(url, additional_headers=headers) as ws:
+                if self._ws_handshake_semaphore is not None:
+                    self._ws_handshake_semaphore.release()
+                    _sem_released = True
+                await std_demux_stream(ws, on_stdout, on_stderr)
+        finally:
+            if self._ws_handshake_semaphore is not None and not _sem_released:
+                self._ws_handshake_semaphore.release()
 
     @intercept_errors(message_prefix="Failed to get entrypoint logs: ")
     @with_instrumentation()
@@ -482,8 +495,18 @@ class AsyncProcess:
 
         url = re.sub(r"^http", "ws", url)
 
-        async with websockets.connect(url, additional_headers=headers) as ws:
-            await std_demux_stream(ws, on_stdout, on_stderr)
+        if self._ws_handshake_semaphore is not None:
+            _ = await self._ws_handshake_semaphore.acquire()
+        _sem_released = False
+        try:
+            async with websockets.connect(url, additional_headers=headers) as ws:
+                if self._ws_handshake_semaphore is not None:
+                    self._ws_handshake_semaphore.release()
+                    _sem_released = True
+                await std_demux_stream(ws, on_stdout, on_stderr)
+        finally:
+            if self._ws_handshake_semaphore is not None and not _sem_released:
+                self._ws_handshake_semaphore.release()
 
     @intercept_errors(message_prefix="Failed to send session command input: ")
     async def send_session_command_input(self, session_id: str, command_id: str, data: str) -> None:
@@ -614,7 +637,13 @@ class AsyncProcess:
         )
         url = re.sub(r"^http", "ws", url)
 
-        ws = await connect(url, additional_headers=headers)
+        if self._ws_handshake_semaphore is not None:
+            _ = await self._ws_handshake_semaphore.acquire()
+        try:
+            ws = await connect(url, additional_headers=headers)
+        finally:
+            if self._ws_handshake_semaphore is not None:
+                self._ws_handshake_semaphore.release()
 
         # Create resize and kill handlers
         async def resize_handler(pty_size: PtySize) -> PtySessionInfo:

--- a/libs/sdk-python/src/daytona/_async/sandbox.py
+++ b/libs/sdk-python/src/daytona/_async/sandbox.py
@@ -104,6 +104,7 @@ class AsyncSandbox(SandboxDto):
         sandbox_api: SandboxApi,
         language: str,
         pool_tracker: AsyncPoolSaturationTracker | None = None,
+        ws_handshake_semaphore: asyncio.Semaphore | None = None,
     ):
         """Initialize a new Sandbox instance.
 
@@ -124,9 +125,9 @@ class AsyncSandbox(SandboxDto):
 
         self._fs = AsyncFileSystem(FileSystemApi(self._toolbox_api))
         self._git = AsyncGit(GitApi(self._toolbox_api))
-        self._process = AsyncProcess(language, ProcessApi(self._toolbox_api))
+        self._process = AsyncProcess(language, ProcessApi(self._toolbox_api), ws_handshake_semaphore)
         self._computer_use = AsyncComputerUse(ComputerUseApi(self._toolbox_api))
-        self._code_interpreter = AsyncCodeInterpreter(InterpreterApi(self._toolbox_api))
+        self._code_interpreter = AsyncCodeInterpreter(InterpreterApi(self._toolbox_api), ws_handshake_semaphore)
         self._info_api: InfoApi = InfoApi(self._toolbox_api)
 
     @property
@@ -721,6 +722,7 @@ class AsyncSandbox(SandboxDto):
             self._toolbox_api._api_client,
             self._sandbox_api,
             language,
+            ws_handshake_semaphore=self._process._ws_handshake_semaphore,
         )
         await forked.wait_for_sandbox_start(timeout=0)
         return forked

--- a/libs/sdk-python/src/daytona/_sync/code_interpreter.py
+++ b/libs/sdk-python/src/daytona/_sync/code_interpreter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 
 from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 from websockets.sync.client import connect
@@ -34,6 +35,7 @@ class CodeInterpreter:
     def __init__(
         self,
         api_client: InterpreterApi,
+        ws_handshake_semaphore: threading.Semaphore | None = None,
     ):
         """Initialize a new CodeInterpreter instance.
 
@@ -41,6 +43,7 @@ class CodeInterpreter:
             api_client: API client for interpreter operations.
         """
         self._api_client: InterpreterApi = api_client
+        self._ws_handshake_semaphore: threading.Semaphore | None = ws_handshake_semaphore
 
     @intercept_errors(message_prefix="Failed to run code: ")
     def run_code(
@@ -116,51 +119,62 @@ class CodeInterpreter:
         result = ExecutionResult()
 
         try:
-            with connect(url, additional_headers=headers) as websocket:
-                # Send execution request as first message
-                request: dict[str, str | int | dict[str, str]] = {"code": code}
-                if context is not None:
-                    request["contextId"] = context.id
-                if envs is not None:
-                    request["envs"] = envs
-                if timeout is not None:
-                    request["timeout"] = timeout
+            if self._ws_handshake_semaphore is not None:
+                _ = self._ws_handshake_semaphore.acquire()
+            _sem_released = False
+            try:
+                with connect(url, additional_headers=headers) as websocket:
+                    if self._ws_handshake_semaphore is not None:
+                        self._ws_handshake_semaphore.release()
+                        _sem_released = True
 
-                websocket.send(json.dumps(request))
+                    # Send execution request as first message
+                    request: dict[str, str | int | dict[str, str]] = {"code": code}
+                    if context is not None:
+                        request["contextId"] = context.id
+                    if envs is not None:
+                        request["envs"] = envs
+                    if timeout is not None:
+                        request["timeout"] = timeout
 
-                # Process streaming chunks
-                while True:
-                    try:
-                        message = websocket.recv()
-                        chunk = json.loads(message)
-                        chunk_type = chunk.get("type")
+                    websocket.send(json.dumps(request))
 
-                        if chunk_type == "stdout":
-                            stdout = chunk.get("text", "")
-                            if on_stdout:
-                                _ = on_stdout(OutputMessage(output=stdout))
-                            result.stdout += stdout
+                    # Process streaming chunks
+                    while True:
+                        try:
+                            message = websocket.recv()
+                            chunk = json.loads(message)
+                            chunk_type = chunk.get("type")
 
-                        elif chunk_type == "stderr":
-                            stderr = chunk.get("text", "")
-                            if on_stderr:
-                                _ = on_stderr(OutputMessage(output=stderr))
-                            result.stderr += stderr
+                            if chunk_type == "stdout":
+                                stdout = chunk.get("text", "")
+                                if on_stdout:
+                                    _ = on_stdout(OutputMessage(output=stdout))
+                                result.stdout += stdout
 
-                        elif chunk_type == "error":
-                            error = ExecutionError(
-                                name=chunk.get("name", ""),
-                                value=chunk.get("value", ""),
-                                traceback=chunk.get("traceback", ""),
-                            )
-                            result.error = error
-                            if on_error:
-                                _ = on_error(error)
+                            elif chunk_type == "stderr":
+                                stderr = chunk.get("text", "")
+                                if on_stderr:
+                                    _ = on_stderr(OutputMessage(output=stderr))
+                                result.stderr += stderr
 
-                    except ConnectionClosed as e:
-                        if isinstance(e, ConnectionClosedOK):
-                            break
-                        self._raise_from_ws_close(e)
+                            elif chunk_type == "error":
+                                error = ExecutionError(
+                                    name=chunk.get("name", ""),
+                                    value=chunk.get("value", ""),
+                                    traceback=chunk.get("traceback", ""),
+                                )
+                                result.error = error
+                                if on_error:
+                                    _ = on_error(error)
+
+                        except ConnectionClosed as e:
+                            if isinstance(e, ConnectionClosedOK):
+                                break
+                            self._raise_from_ws_close(e)
+            finally:
+                if self._ws_handshake_semaphore is not None and not _sem_released:
+                    self._ws_handshake_semaphore.release()
 
         except ConnectionClosed as e:
             if isinstance(e, ConnectionClosedOK):

--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 import time
 import warnings
 from copy import deepcopy
@@ -110,6 +111,10 @@ class Daytona:
         - `DAYTONA_API_KEY`: Required API key for authentication
         - `DAYTONA_API_URL`: Required api URL
         - `DAYTONA_TARGET`: Optional target environment (if not provided, default region for the organization is used)
+        - `DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES`: Optional limit on concurrent WebSocket
+          handshakes. Only useful for workloads that open hundreds of WebSocket connections
+          simultaneously (e.g. creating 500+ PTY sessions in a single burst). When set,
+          the SDK queues excess handshakes until a slot is available. Disabled by default.
 
         Args:
             config (DaytonaConfig | None): Object containing api_key, api_url, and target.
@@ -212,6 +217,11 @@ class Daytona:
             if not self._organization_id:
                 raise DaytonaAuthenticationError("Organization ID is required when using JWT token")
             self._api_client.default_headers["X-Daytona-Organization-ID"] = self._organization_id
+
+        ws_concurrency_str = (env_reader or DaytonaEnvReader()).get("DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES")
+        self._ws_handshake_semaphore: threading.Semaphore | None = (
+            threading.Semaphore(int(ws_concurrency_str)) if ws_concurrency_str is not None else None
+        )
 
         # Initialize API clients with the api_client instance
         self._sandbox_api: SandboxApi = SandboxApi(self._api_client)
@@ -475,6 +485,7 @@ class Daytona:
             self._toolbox_api_client,
             self._sandbox_api,
             validated_language.value,
+            ws_handshake_semaphore=self._ws_handshake_semaphore,
         )
 
         if sandbox.state != SandboxState.STARTED:
@@ -536,6 +547,7 @@ class Daytona:
             self._toolbox_api_client,
             self._sandbox_api,
             language,
+            ws_handshake_semaphore=self._ws_handshake_semaphore,
         )
 
     @intercept_errors(message_prefix="Failed to list sandboxes: ")
@@ -577,6 +589,7 @@ class Daytona:
                     self._toolbox_api_client,
                     self._sandbox_api,
                     language,
+                    ws_handshake_semaphore=self._ws_handshake_semaphore,
                 )
             )
 

--- a/libs/sdk-python/src/daytona/_sync/process.py
+++ b/libs/sdk-python/src/daytona/_sync/process.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import threading
 
 import websockets
 from websockets.sync.client import connect
@@ -46,6 +47,7 @@ class Process:
         self,
         language: str,
         api_client: ProcessApi,
+        ws_handshake_semaphore: threading.Semaphore | None = None,
     ):
         """Initialize a new Process instance.
 
@@ -54,6 +56,7 @@ class Process:
         """
         self._language: str = language
         self._api_client: ProcessApi = api_client
+        self._ws_handshake_semaphore: threading.Semaphore | None = ws_handshake_semaphore
 
     @intercept_errors(message_prefix="Failed to execute command: ")
     @with_instrumentation()
@@ -430,8 +433,18 @@ class Process:
 
         url = re.sub(r"^http", "ws", url)
 
-        async with websockets.connect(url, additional_headers=headers) as ws:
-            await std_demux_stream(ws, on_stdout, on_stderr)
+        if self._ws_handshake_semaphore is not None:
+            _ = self._ws_handshake_semaphore.acquire()
+        _sem_released = False
+        try:
+            async with websockets.connect(url, additional_headers=headers) as ws:
+                if self._ws_handshake_semaphore is not None:
+                    self._ws_handshake_semaphore.release()
+                    _sem_released = True
+                await std_demux_stream(ws, on_stdout, on_stderr)
+        finally:
+            if self._ws_handshake_semaphore is not None and not _sem_released:
+                self._ws_handshake_semaphore.release()
 
     @intercept_errors(message_prefix="Failed to get entrypoint logs: ")
     @with_instrumentation()
@@ -482,8 +495,18 @@ class Process:
 
         url = re.sub(r"^http", "ws", url)
 
-        async with websockets.connect(url, additional_headers=headers) as ws:
-            await std_demux_stream(ws, on_stdout, on_stderr)
+        if self._ws_handshake_semaphore is not None:
+            _ = self._ws_handshake_semaphore.acquire()
+        _sem_released = False
+        try:
+            async with websockets.connect(url, additional_headers=headers) as ws:
+                if self._ws_handshake_semaphore is not None:
+                    self._ws_handshake_semaphore.release()
+                    _sem_released = True
+                await std_demux_stream(ws, on_stdout, on_stderr)
+        finally:
+            if self._ws_handshake_semaphore is not None and not _sem_released:
+                self._ws_handshake_semaphore.release()
 
     @intercept_errors(message_prefix="Failed to send session command input: ")
     def send_session_command_input(self, session_id: str, command_id: str, data: str) -> None:
@@ -609,7 +632,13 @@ class Process:
         )
         url = re.sub(r"^http", "ws", url)
 
-        ws = connect(url, additional_headers=headers)
+        if self._ws_handshake_semaphore is not None:
+            _ = self._ws_handshake_semaphore.acquire()
+        try:
+            ws = connect(url, additional_headers=headers)
+        finally:
+            if self._ws_handshake_semaphore is not None:
+                self._ws_handshake_semaphore.release()
 
         # Create resize and kill handlers
         def resize_handler(pty_size: PtySize) -> PtySessionInfo:

--- a/libs/sdk-python/src/daytona/_sync/sandbox.py
+++ b/libs/sdk-python/src/daytona/_sync/sandbox.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 
 from deprecated import deprecated
@@ -103,6 +104,7 @@ class Sandbox(SandboxDto):
         toolbox_api: ApiClient,
         sandbox_api: SandboxApi,
         language: str,
+        ws_handshake_semaphore: threading.Semaphore | None = None,
     ):
         """Initialize a new Sandbox instance.
 
@@ -121,9 +123,9 @@ class Sandbox(SandboxDto):
 
         self._fs = FileSystem(FileSystemApi(self._toolbox_api))
         self._git = Git(GitApi(self._toolbox_api))
-        self._process = Process(language, ProcessApi(self._toolbox_api))
+        self._process = Process(language, ProcessApi(self._toolbox_api), ws_handshake_semaphore)
         self._computer_use = ComputerUse(ComputerUseApi(self._toolbox_api))
-        self._code_interpreter = CodeInterpreter(InterpreterApi(self._toolbox_api))
+        self._code_interpreter = CodeInterpreter(InterpreterApi(self._toolbox_api), ws_handshake_semaphore)
         self._info_api: InfoApi = InfoApi(self._toolbox_api)
 
     @property
@@ -716,6 +718,7 @@ class Sandbox(SandboxDto):
             self._toolbox_api._api_client,
             self._sandbox_api,
             language,
+            ws_handshake_semaphore=self._process._ws_handshake_semaphore,
         )
         forked.wait_for_sandbox_start(timeout=0)
         return forked


### PR DESCRIPTION
## Summary

Adds an opt-in WebSocket handshake concurrency limit to the Python SDK (both async and sync). When enabled, the SDK caps how many WebSocket connections (PTY, log streaming, code interpreter) can be in the handshake phase at the same time, queuing the rest until a slot opens.

Disabled by default. Users opt in by setting the environment variable:

```
DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES=100
```

## Context

Users would sometimes see `timed out during opening handshake` errors when running highly intensive workloads of spinning up 800+ PTY sessions at the same moment. The Python SDK fires all WebSocket handshakes simultaneously via `asyncio.gather`, which under burst load can exceed what the connection path can handle within the handshake timeout window.

This change provides a client-side opt-in mitigation that allows users to cap the burst rate of new WebSocket handshakes.

## Changes

- **`_async/process.py`, `_sync/process.py`**: All 3 WebSocket connect calls per file (PTY connect, 2× log streaming) are gated by an optional semaphore. The semaphore is acquired before the handshake and released immediately after the connection is established — it does not gate the lifetime of the WebSocket.
- **`_async/code_interpreter.py`, `_sync/code_interpreter.py`**: Same handshake gating for the code interpreter WebSocket.
- **`_async/daytona.py`, `_sync/daytona.py`**: Read `DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES` from env and create an `asyncio.Semaphore` / `threading.Semaphore` respectively. Passed through to sandboxes.
- **`_async/sandbox.py`, `_sync/sandbox.py`**: Accept and forward the semaphore to `Process` and `CodeInterpreter`.

## How it works

```
DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES=100 python my_script.py
```

With this set, at most 100 WebSocket handshakes will be in flight at any moment. The 101st caller waits until one of the first 100 completes its handshake (not its entire session — just the TCP+TLS+HTTP-Upgrade phase). This spreads burst load over time without affecting total throughput for long-lived connections.

When the env var is not set, behavior is unchanged — no throttling.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional WebSocket handshake concurrency limit to the Python SDK (async and sync) to reduce “opening handshake timed out” errors under heavy burst loads. Opt-in via `DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES`; it throttles only the handshake phase, not the connection lifetime.

- **New Features**
  - New env var `DAYTONA_WS_MAX_CONCURRENT_HANDSHAKES` caps concurrent handshakes; disabled by default.
  - Applies to PTY, log streaming, and code interpreter websockets; uses a semaphore released right after connect.
  - Limit is read in `Daytona` and passed to `Sandbox`, `Process`, and `CodeInterpreter` (async and sync).
  - Docs updated to describe the env var and new optional constructor parameters.

<sup>Written for commit 3e337f3d972e99936555f4b7b907e8375b0966e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

