### PR TITLE
feat(opencode-plugin): support custom images and snapshots

### DIFF
--- a/libs/opencode-plugin/.opencode/plugin/daytona/core/session-manager.ts
+++ b/libs/opencode-plugin/.opencode/plugin/daytona/core/session-manager.ts
@@ -10,7 +10,7 @@
 
 import { Daytona, type Sandbox } from '@daytona/sdk'
 import { logger } from './logger'
-import type { SessionSandboxMap, SandboxInfo } from './types'
+import type { SessionSandboxMap, SandboxCreationParams, SandboxInfo } from './types'
 import { SessionGitManager } from '../git/session-git-manager'
 import { DaytonaSandboxGitManager } from '../git/sandbox-git-manager'
 import { ProjectDataStorage } from './project-data-storage'
@@ -23,11 +23,13 @@ export class DaytonaSessionManager {
   private sessionSandboxes: SessionSandboxMap
   private currentProjectId?: string
   public readonly repoPath: string
+  private readonly sandboxCreationParams?: SandboxCreationParams
 
-  constructor(apiKey: string, storageDir: string, repoPath: string) {
+  constructor(apiKey: string, storageDir: string, repoPath: string, sandboxCreationParams?: SandboxCreationParams) {
     this.apiKey = apiKey
     this.dataStorage = new ProjectDataStorage(storageDir)
     this.repoPath = repoPath
+    this.sandboxCreationParams = sandboxCreationParams
     this.sessionSandboxes = new Map()
   }
 
@@ -170,7 +172,12 @@ export class DaytonaSessionManager {
     const waitingLog = setTimeout(() => {
       logger.warn(`Daytona create still waiting after ${Date.now() - createStart}ms (sessionId=${sessionId})`)
     }, 15_000)
-    const sandbox = await daytona.create().finally(() => clearTimeout(waitingLog))
+    const createPromise = this.sandboxCreationParams
+      ? 'image' in this.sandboxCreationParams
+        ? daytona.create({ image: this.sandboxCreationParams.image })
+        : daytona.create({ snapshot: this.sandboxCreationParams.snapshot })
+      : daytona.create()
+    const sandbox = await createPromise.finally(() => clearTimeout(waitingLog))
     logger.info(`Daytona create done sessionId=${sessionId} sandboxId=${sandbox.id} in ${Date.now() - createStart}ms`)
     this.sessionSandboxes.set(sessionId, sandbox)
 

--- a/libs/opencode-plugin/.opencode/plugin/daytona/core/types.ts
+++ b/libs/opencode-plugin/.opencode/plugin/daytona/core/types.ts
@@ -65,6 +65,54 @@ export type ProjectSessionData = {
 
 export type SessionSandboxMap = Map<string, Sandbox | SandboxInfo>
 
+export type SandboxCreationParams =
+  | {
+      image: string
+    }
+  | {
+      snapshot: string
+    }
+
+export type DaytonaPluginOptions = Record<string, unknown> & {
+  image?: unknown
+  snapshot?: unknown
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+export function resolveSandboxCreationParams(options?: DaytonaPluginOptions): SandboxCreationParams | undefined {
+  const pluginOptions = (options ?? {}) as DaytonaPluginOptions
+  const configuredImage = normalizeOptionalString(pluginOptions.image)
+  const configuredSnapshot = normalizeOptionalString(pluginOptions.snapshot)
+  const envImage = normalizeOptionalString(process.env.DAYTONA_SANDBOX_IMAGE)
+  const envSnapshot = normalizeOptionalString(process.env.DAYTONA_SANDBOX_SNAPSHOT)
+  const image = envImage ?? configuredImage
+  const snapshot = envSnapshot ?? configuredSnapshot
+
+  if (image && snapshot) {
+    throw new Error(
+      'Configure only one of image or snapshot for the Daytona OpenCode plugin. DAYTONA_SANDBOX_IMAGE and DAYTONA_SANDBOX_SNAPSHOT are mutually exclusive.',
+    )
+  }
+
+  if (image) {
+    return { image }
+  }
+
+  if (snapshot) {
+    return { snapshot }
+  }
+
+  return undefined
+}
+
 // Daytona plugin constants
 
 export const LOG_LEVEL_INFO: LogLevel = 'INFO'

--- a/libs/opencode-plugin/.opencode/plugin/daytona/index.ts
+++ b/libs/opencode-plugin/.opencode/plugin/daytona/index.ts
@@ -29,6 +29,7 @@ import type { PluginInput } from '@opencode-ai/plugin'
 import { setLogFilePath } from './core/logger'
 import { DaytonaSessionManager } from './core/session-manager'
 import { toast } from './core/toast'
+import { resolveSandboxCreationParams, type DaytonaPluginOptions } from './core/types'
 import { customTools } from './plugins/custom-tools'
 import { eventHandlers } from './plugins/session-events'
 import { systemPromptTransform } from './plugins/system-transform'
@@ -40,10 +41,15 @@ const STORAGE_DIR = join(xdgData, 'opencode', 'storage', 'daytona')
 const REPO_PATH = '/home/daytona/project'
 
 setLogFilePath(LOG_FILE)
-const sessionManager = new DaytonaSessionManager(process.env.DAYTONA_API_KEY || '', STORAGE_DIR, REPO_PATH)
 
-async function daytonaPlugin(ctx: PluginInput) {
+async function daytonaPlugin(ctx: PluginInput, options?: DaytonaPluginOptions) {
   toast.initialize(ctx.client?.tui)
+  const sessionManager = new DaytonaSessionManager(
+    process.env.DAYTONA_API_KEY || '',
+    STORAGE_DIR,
+    REPO_PATH,
+    resolveSandboxCreationParams(options),
+  )
   return {
     tool: await customTools(ctx, sessionManager),
     event: await eventHandlers(ctx, sessionManager, REPO_PATH),

--- a/libs/opencode-plugin/README.md
+++ b/libs/opencode-plugin/README.md
@@ -18,7 +18,14 @@ To add the plugin to a project, edit `opencode.json` in the project directory:
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@daytona/opencode"]
+  "plugin": [
+    [
+      "@daytona/opencode",
+      {
+        "image": "debian:12.9"
+      }
+    ]
+  ]
 }
 ```
 
@@ -30,10 +37,35 @@ To install the plugin globally, edit `~/.config/opencode/opencode.json`.
 
 This plugin requires a [Daytona account](https://www.daytona.io/) and [Daytona API key](https://app.daytona.io/dashboard/keys) to create sandboxes.
 
-Set your Daytona API key and URL as environment variables:
+Set your Daytona API key as an environment variable:
 
 ```bash
 export DAYTONA_API_KEY="your-api-key"
+```
+
+To create sandboxes from a custom base image or a snapshot, set one of these optional environment variables:
+
+```bash
+export DAYTONA_SANDBOX_IMAGE="debian:12.9"
+export DAYTONA_SANDBOX_SNAPSHOT="my-snapshot"
+```
+
+Only set one of `DAYTONA_SANDBOX_IMAGE` or `DAYTONA_SANDBOX_SNAPSHOT` at a time. If either env var is set, it overrides the plugin options in `opencode.json`.
+
+You can also configure the plugin directly in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    [
+      "@daytona/opencode",
+      {
+        "snapshot": "my-snapshot"
+      }
+    ]
+  ]
+}
 ```
 
 Or create a `.env` file in your project root:


### PR DESCRIPTION
## Summary
- allow the OpenCode plugin to create sandboxes from a configured image or snapshot
- support flat plugin options (`image` / `snapshot`) and environment variable overrides
- document the new OpenCode plugin configuration in the README

## Verification
- corepack yarn nx build opencode-plugin

Closes #4256

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for creating Daytona sandboxes from a specific image or snapshot in the `@daytona/opencode` plugin, configurable via plugin options or environment variables. Keeps default behavior when not configured and documents how to use it. Addresses #4256.

- **New Features**
  - Accept `image` or `snapshot` plugin options; pass through to Daytona create.
  - Support env vars `DAYTONA_SANDBOX_IMAGE` and `DAYTONA_SANDBOX_SNAPSHOT`; env overrides options.
  - Enforce mutual exclusivity (error if both are set).
  - Updated README with examples and setup notes.

<sup>Written for commit 2a34f83a0a2c784a686f0c60eaf59f0213bc5116. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

