### PR TITLE
feat(api,dashboard): filter runners by region

### DIFF
--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -233,6 +233,12 @@ export class RunnerController {
     summary: 'List all runners',
     operationId: 'listRunners',
   })
+  @ApiQuery({
+    name: 'regionId',
+    description: 'Filter runners by region ID',
+    type: String,
+    required: false,
+  })
   @ApiResponse({
     status: 200,
     type: [RunnerDto],
@@ -240,7 +246,24 @@ export class RunnerController {
   @ApiHeader(CustomHeaders.ORGANIZATION_ID)
   @UseGuards(OrganizationAuthContextGuard)
   @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.READ_RUNNERS])
-  async findAll(@IsOrganizationAuthContext() authContext: OrganizationAuthContext): Promise<RunnerDto[]> {
+  async findAll(
+    @IsOrganizationAuthContext() authContext: OrganizationAuthContext,
+    @Query('regionId') regionId?: string,
+  ): Promise<RunnerDto[]> {
+    if (regionId) {
+      // validate that the runner region is a custom region owned by the organization
+      const region = await this.regionService.findOne(regionId)
+
+      if (!region || region.organizationId !== authContext.organizationId) {
+        throw new NotFoundException('Region not found')
+      }
+
+      if (region.regionType !== RegionType.CUSTOM) {
+        throw new ForbiddenException('Filtering by region ID is only supported for custom regions')
+      }
+
+      return this.runnerService.findAllByRegion(regionId)
+    }
     return this.runnerService.findAllByOrganization(authContext.organizationId, RegionType.CUSTOM)
   }
 

--- a/apps/dashboard/src/pages/Runners.tsx
+++ b/apps/dashboard/src/pages/Runners.tsx
@@ -65,7 +65,7 @@ const Runners: React.FC = () => {
         setLoadingRunnersData(true)
       }
       try {
-        const response = (await runnersApi.listRunners(selectedOrganization.id)).data
+        const response = (await runnersApi.listRunners(undefined, selectedOrganization.id)).data
         setRunners(response || [])
       } catch (error) {
         handleApiError(error, 'Failed to fetch runners')

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -3196,6 +3196,14 @@ paths:
     get:
       operationId: listRunners
       parameters:
+      - description: Filter runners by region ID
+        explode: true
+        in: query
+        name: regionId
+        required: false
+        schema:
+          type: string
+        style: form
       - description: Use with JWT to specify the organization ID
         explode: false
         in: header

--- a/libs/api-client-go/api_runners.go
+++ b/libs/api-client-go/api_runners.go
@@ -904,7 +904,14 @@ func (a *RunnersAPIService) GetRunnersBySnapshotRefExecute(r RunnersAPIGetRunner
 type RunnersAPIListRunnersRequest struct {
 	ctx context.Context
 	ApiService RunnersAPI
+	regionId *string
 	xDaytonaOrganizationID *string
+}
+
+// Filter runners by region ID
+func (r RunnersAPIListRunnersRequest) RegionId(regionId string) RunnersAPIListRunnersRequest {
+	r.regionId = &regionId
+	return r
 }
 
 // Use with JWT to specify the organization ID
@@ -951,6 +958,9 @@ func (a *RunnersAPIService) ListRunnersExecute(r RunnersAPIListRunnersRequest) (
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.regionId != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "regionId", r.regionId, "form", "")
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/api/RunnersApi.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/api/RunnersApi.java
@@ -983,6 +983,7 @@ public class RunnersApi {
     }
     /**
      * Build call for listRunners
+     * @param regionId Filter runners by region ID (optional)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
@@ -994,7 +995,7 @@ public class RunnersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call listRunnersCall(@javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call listRunnersCall(@javax.annotation.Nullable String regionId, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -1018,6 +1019,10 @@ public class RunnersApi {
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (regionId != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("regionId", regionId));
+        }
 
         final String[] localVarAccepts = {
             "application/json"
@@ -1044,14 +1049,15 @@ public class RunnersApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call listRunnersValidateBeforeCall(@javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
-        return listRunnersCall(xDaytonaOrganizationID, _callback);
+    private okhttp3.Call listRunnersValidateBeforeCall(@javax.annotation.Nullable String regionId, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+        return listRunnersCall(regionId, xDaytonaOrganizationID, _callback);
 
     }
 
     /**
      * List all runners
      * 
+     * @param regionId Filter runners by region ID (optional)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
      * @return List&lt;Runner&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -1062,14 +1068,15 @@ public class RunnersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
      </table>
      */
-    public List<Runner> listRunners(@javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
-        ApiResponse<List<Runner>> localVarResp = listRunnersWithHttpInfo(xDaytonaOrganizationID);
+    public List<Runner> listRunners(@javax.annotation.Nullable String regionId, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+        ApiResponse<List<Runner>> localVarResp = listRunnersWithHttpInfo(regionId, xDaytonaOrganizationID);
         return localVarResp.getData();
     }
 
     /**
      * List all runners
      * 
+     * @param regionId Filter runners by region ID (optional)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
      * @return ApiResponse&lt;List&lt;Runner&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -1080,8 +1087,8 @@ public class RunnersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<List<Runner>> listRunnersWithHttpInfo(@javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
-        okhttp3.Call localVarCall = listRunnersValidateBeforeCall(xDaytonaOrganizationID, null);
+    public ApiResponse<List<Runner>> listRunnersWithHttpInfo(@javax.annotation.Nullable String regionId, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+        okhttp3.Call localVarCall = listRunnersValidateBeforeCall(regionId, xDaytonaOrganizationID, null);
         Type localVarReturnType = new TypeToken<List<Runner>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -1089,6 +1096,7 @@ public class RunnersApi {
     /**
      * List all runners (asynchronously)
      * 
+     * @param regionId Filter runners by region ID (optional)
      * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
@@ -1100,9 +1108,9 @@ public class RunnersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call listRunnersAsync(@javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<List<Runner>> _callback) throws ApiException {
+    public okhttp3.Call listRunnersAsync(@javax.annotation.Nullable String regionId, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<List<Runner>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = listRunnersValidateBeforeCall(xDaytonaOrganizationID, _callback);
+        okhttp3.Call localVarCall = listRunnersValidateBeforeCall(regionId, xDaytonaOrganizationID, _callback);
         Type localVarReturnType = new TypeToken<List<Runner>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/api/RunnersApiTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/api/RunnersApiTest.java
@@ -129,8 +129,9 @@ public class RunnersApiTest {
      */
     @Test
     public void listRunnersTest() throws ApiException {
+        String regionId = null;
         String xDaytonaOrganizationID = null;
-        List<Runner> response = api.listRunners(xDaytonaOrganizationID);
+        List<Runner> response = api.listRunners(regionId, xDaytonaOrganizationID);
         // TODO: test validations
     }
 

--- a/libs/api-client-python-async/daytona_api_client_async/api/runners_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/runners_api.py
@@ -1898,6 +1898,7 @@ class RunnersApi:
     @validate_call
     async def list_runners(
         self,
+        region_id: Annotated[Optional[StrictStr], Field(description="Filter runners by region ID")] = None,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
         _request_timeout: Union[
             None,
@@ -1915,6 +1916,8 @@ class RunnersApi:
         """List all runners
 
 
+        :param region_id: Filter runners by region ID
+        :type region_id: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1940,6 +1943,7 @@ class RunnersApi:
         """ # noqa: E501
 
         _param = self._list_runners_serialize(
+            region_id=region_id,
             x_daytona_organization_id=x_daytona_organization_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1964,6 +1968,7 @@ class RunnersApi:
     @validate_call
     async def list_runners_with_http_info(
         self,
+        region_id: Annotated[Optional[StrictStr], Field(description="Filter runners by region ID")] = None,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
         _request_timeout: Union[
             None,
@@ -1981,6 +1986,8 @@ class RunnersApi:
         """List all runners
 
 
+        :param region_id: Filter runners by region ID
+        :type region_id: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2006,6 +2013,7 @@ class RunnersApi:
         """ # noqa: E501
 
         _param = self._list_runners_serialize(
+            region_id=region_id,
             x_daytona_organization_id=x_daytona_organization_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2030,6 +2038,7 @@ class RunnersApi:
     @validate_call
     async def list_runners_without_preload_content(
         self,
+        region_id: Annotated[Optional[StrictStr], Field(description="Filter runners by region ID")] = None,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
         _request_timeout: Union[
             None,
@@ -2047,6 +2056,8 @@ class RunnersApi:
         """List all runners
 
 
+        :param region_id: Filter runners by region ID
+        :type region_id: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2072,6 +2083,7 @@ class RunnersApi:
         """ # noqa: E501
 
         _param = self._list_runners_serialize(
+            region_id=region_id,
             x_daytona_organization_id=x_daytona_organization_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2091,6 +2103,7 @@ class RunnersApi:
 
     def _list_runners_serialize(
         self,
+        region_id,
         x_daytona_organization_id,
         _request_auth,
         _content_type,
@@ -2114,6 +2127,10 @@ class RunnersApi:
 
         # process the path parameters
         # process the query parameters
+        if region_id is not None:
+            
+            _query_params.append(('regionId', region_id))
+            
         # process the header parameters
         if x_daytona_organization_id is not None:
             _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id

--- a/libs/api-client-python/daytona_api_client/api/runners_api.py
+++ b/libs/api-client-python/daytona_api_client/api/runners_api.py
@@ -1898,6 +1898,7 @@ class RunnersApi:
     @validate_call
     def list_runners(
         self,
+        region_id: Annotated[Optional[StrictStr], Field(description="Filter runners by region ID")] = None,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
         _request_timeout: Union[
             None,
@@ -1915,6 +1916,8 @@ class RunnersApi:
         """List all runners
 
 
+        :param region_id: Filter runners by region ID
+        :type region_id: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
         :param _request_timeout: timeout setting for this request. If one
@@ -1940,6 +1943,7 @@ class RunnersApi:
         """ # noqa: E501
 
         _param = self._list_runners_serialize(
+            region_id=region_id,
             x_daytona_organization_id=x_daytona_organization_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1964,6 +1968,7 @@ class RunnersApi:
     @validate_call
     def list_runners_with_http_info(
         self,
+        region_id: Annotated[Optional[StrictStr], Field(description="Filter runners by region ID")] = None,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
         _request_timeout: Union[
             None,
@@ -1981,6 +1986,8 @@ class RunnersApi:
         """List all runners
 
 
+        :param region_id: Filter runners by region ID
+        :type region_id: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2006,6 +2013,7 @@ class RunnersApi:
         """ # noqa: E501
 
         _param = self._list_runners_serialize(
+            region_id=region_id,
             x_daytona_organization_id=x_daytona_organization_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2030,6 +2038,7 @@ class RunnersApi:
     @validate_call
     def list_runners_without_preload_content(
         self,
+        region_id: Annotated[Optional[StrictStr], Field(description="Filter runners by region ID")] = None,
         x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
         _request_timeout: Union[
             None,
@@ -2047,6 +2056,8 @@ class RunnersApi:
         """List all runners
 
 
+        :param region_id: Filter runners by region ID
+        :type region_id: str
         :param x_daytona_organization_id: Use with JWT to specify the organization ID
         :type x_daytona_organization_id: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2072,6 +2083,7 @@ class RunnersApi:
         """ # noqa: E501
 
         _param = self._list_runners_serialize(
+            region_id=region_id,
             x_daytona_organization_id=x_daytona_organization_id,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -2091,6 +2103,7 @@ class RunnersApi:
 
     def _list_runners_serialize(
         self,
+        region_id,
         x_daytona_organization_id,
         _request_auth,
         _content_type,
@@ -2114,6 +2127,10 @@ class RunnersApi:
 
         # process the path parameters
         # process the query parameters
+        if region_id is not None:
+            
+            _query_params.append(('regionId', region_id))
+            
         # process the header parameters
         if x_daytona_organization_id is not None:
             _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id

--- a/libs/api-client-ruby/lib/daytona_api_client/api/runners_api.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/api/runners_api.rb
@@ -455,6 +455,7 @@ module DaytonaApiClient
 
     # List all runners
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :region_id Filter runners by region ID
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
     # @return [Array<Runner>]
     def list_runners(opts = {})
@@ -464,6 +465,7 @@ module DaytonaApiClient
 
     # List all runners
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :region_id Filter runners by region ID
     # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
     # @return [Array<(Array<Runner>, Integer, Hash)>] Array<Runner> data, response status code and response headers
     def list_runners_with_http_info(opts = {})
@@ -475,6 +477,7 @@ module DaytonaApiClient
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'regionId'] = opts[:'region_id'] if !opts[:'region_id'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/libs/api-client/src/api/runners-api.ts
+++ b/libs/api-client/src/api/runners-api.ts
@@ -332,11 +332,12 @@ export const RunnersApiAxiosParamCreator = function (configuration?: Configurati
         /**
          * 
          * @summary List all runners
+         * @param {string} [regionId] Filter runners by region ID
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listRunners: async (xDaytonaOrganizationID?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listRunners: async (regionId?: string, xDaytonaOrganizationID?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/runners`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -354,6 +355,10 @@ export const RunnersApiAxiosParamCreator = function (configuration?: Configurati
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
             // authentication oauth2 required
+
+            if (regionId !== undefined) {
+                localVarQueryParameter['regionId'] = regionId;
+            }
 
             localVarHeaderParameter['Accept'] = 'application/json';
 
@@ -602,12 +607,13 @@ export const RunnersApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary List all runners
+         * @param {string} [regionId] Filter runners by region ID
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listRunners(xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Runner>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listRunners(xDaytonaOrganizationID, options);
+        async listRunners(regionId?: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Runner>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listRunners(regionId, xDaytonaOrganizationID, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['RunnersApi.listRunners']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -737,12 +743,13 @@ export const RunnersApiFactory = function (configuration?: Configuration, basePa
         /**
          * 
          * @summary List all runners
+         * @param {string} [regionId] Filter runners by region ID
          * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listRunners(xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<Array<Runner>> {
-            return localVarFp.listRunners(xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
+        listRunners(regionId?: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<Array<Runner>> {
+            return localVarFp.listRunners(regionId, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
         },
         /**
          * Endpoint for version 2 runners to send healthcheck and metrics. Updates lastChecked timestamp and runner metrics.
@@ -865,12 +872,13 @@ export class RunnersApi extends BaseAPI {
     /**
      * 
      * @summary List all runners
+     * @param {string} [regionId] Filter runners by region ID
      * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public listRunners(xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
-        return RunnersApiFp(this.configuration).listRunners(xDaytonaOrganizationID, options).then((request) => request(this.axios, this.basePath));
+    public listRunners(regionId?: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
+        return RunnersApiFp(this.configuration).listRunners(regionId, xDaytonaOrganizationID, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
This pull request introduces support for filtering runners by region ID across the API, backend, and all client SDKs (TypeScript, Go, Java, and Python). It updates the API endpoint, controller logic, OpenAPI specification, and client libraries to accept an optional `regionId` parameter, allowing users to retrieve runners specific to a given custom region. The changes also ensure proper validation and error handling when filtering by region.

**API and Backend Enhancements:**

* Added an optional `regionId` query parameter to the `listRunners` endpoint in the OpenAPI spec, enabling filtering of runners by region.
* Updated the `RunnerController` in the backend to handle the `regionId` parameter, including validation to ensure the region is custom and belongs to the organization, and appropriate error handling if not.

**Client SDK Updates:**

* **Go SDK:**  
  - Extended the `RunnersAPIListRunnersRequest` struct and related methods to support the `regionId` parameter in requests. [[1]](diffhunk://#diff-6822ffc6be9bf7fa874a8f3b0d190bb8e54b500220fea5b5b9de2b797a4a0ec3R907-R916) [[2]](diffhunk://#diff-6822ffc6be9bf7fa874a8f3b0d190bb8e54b500220fea5b5b9de2b797a4a0ec3R961-R963)
* **Java SDK:**  
  - Modified the `RunnersApi` methods and signatures to accept an optional `regionId` parameter for listing runners, and updated the corresponding test. [[1]](diffhunk://#diff-f85193dd7b463c6ffea84b26569a23bedb1aa506291b2d43f03bbd4a244c702eR986) [[2]](diffhunk://#diff-f85193dd7b463c6ffea84b26569a23bedb1aa506291b2d43f03bbd4a244c702eL997-R998) [[3]](diffhunk://#diff-f85193dd7b463c6ffea84b26569a23bedb1aa506291b2d43f03bbd4a244c702eR1023-R1026) [[4]](diffhunk://#diff-f85193dd7b463c6ffea84b26569a23bedb1aa506291b2d43f03bbd4a244c702eL1047-R1060) [[5]](diffhunk://#diff-f85193dd7b463c6ffea84b26569a23bedb1aa506291b2d43f03bbd4a244c702eL1065-R1079) [[6]](diffhunk://#diff-f85193dd7b463c6ffea84b26569a23bedb1aa506291b2d43f03bbd4a244c702eL1083-R1099) [[7]](diffhunk://#diff-f85193dd7b463c6ffea84b26569a23bedb1aa506291b2d43f03bbd4a244c702eL1103-R1113) [[8]](diffhunk://#diff-2d3c4e70236032daaa4f3b0b11d3661e7a166a9048a7e1f2eaf84cefee169cadR132-R134)
* **Python SDKs (sync and async):**  
  - Updated both sync and async `list_runners` methods to accept and serialize the `region_id` parameter, including documentation and serialization logic. [[1]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R1902) [[2]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R1920-R1921) [[3]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R1947) [[4]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R1972) [[5]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R1990-R1991) [[6]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R2017) [[7]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R2042) [[8]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R2060-R2061) [[9]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R2087) [[10]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R2107) [[11]](diffhunk://#diff-869a20b9b38d4d4e9c995efe38596bd7699596f1dda953a454287e963320f6c2R2131-R2134) [[12]](diffhunk://#diff-694bdbb2fe7c058ac4e9de5c0927b0cfb62566e4c3917a4627c72045a2c006c4R1902) [[13]](diffhunk://#diff-694bdbb2fe7c058ac4e9de5c0927b0cfb62566e4c3917a4627c72045a2c006c4R1920-R1921) [[14]](diffhunk://#diff-694bdbb2fe7c058ac4e9de5c0927b0cfb62566e4c3917a4627c72045a2c006c4R1947) [[15]](diffhunk://#diff-694bdbb2fe7c058ac4e9de5c0927b0cfb62566e4c3917a4627c72045a2c006c4R1972)

**Frontend Update:**

* Updated the dashboard frontend to call the new signature of the `listRunners` API, passing `undefined` for `regionId` by default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `regionId` filter to `GET /runners` across the API and SDKs. This lets users fetch runners for a specific custom region; behavior without a filter is unchanged.

- **New Features**
  - API: `GET /runners` accepts optional `regionId`. Validates the region belongs to the org and is custom; returns 404/403 otherwise. Uses region-based query when provided; otherwise lists org custom runners.
  - Spec and SDKs updated: TypeScript, Go, Java, Python (sync/async), Ruby.
  - Dashboard updated to call the new `listRunners` signature (passes `undefined` for `regionId` by default).

- **Migration**
  - TypeScript: `listRunners(regionId?: string, xDaytonaOrganizationID?: string)`
  - Java: `listRunners(String regionId, String xDaytonaOrganizationID)` and async variant
  - Go: `ListRunners()` request supports `.RegionId("<id>")`
  - Python: `list_runners(region_id=None, x_daytona_organization_id=None)` (sync and async)
  - Ruby: `list_runners(region_id: "<id>", x_daytona_organization_id: "...")`

<sup>Written for commit 0d977d4a83bbfb44cf3ae378d040ba249d6efcc0. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4529?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

