### PR TITLE
fix(docs): modify locale handling routes

### DIFF
--- a/apps/docs/server/index.mjs
+++ b/apps/docs/server/index.mjs
@@ -41,7 +41,8 @@ app.use('/docs', express.static('client/'))
 app.use((req, res, next) => {
   const match = req.path.match(/^\/docs\/([a-zA-Z][^/.]*)(\/.*)?$/)
   if (match && !knownLocales.has(match[1])) {
-    req.url = `/docs/en/${match[1]}${match[2] || '/'}`
+    const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : ''
+    req.url = `/docs/${gtConfig.defaultLocale}/${match[1]}${match[2] || '/'}${qs}`
   }
   next()
 })

--- a/apps/docs/server/index.mjs
+++ b/apps/docs/server/index.mjs
@@ -1,8 +1,14 @@
+import { createRequire } from 'module'
+
 import express from 'express'
 
 import { handler as ssrHandler } from '../server/entry.mjs'
 import { env } from './util/environment.mjs'
 import { redirects as slugRedirects } from './util/redirects.mjs'
+
+const require = createRequire(import.meta.url)
+const gtConfig = require('../gt.config.json')
+const knownLocales = new Set(gtConfig.locales)
 
 // Full-path redirect map from the shared URL map (slug redirects)
 const redirects = Object.fromEntries(
@@ -32,6 +38,13 @@ app.use((req, res, next) => {
   next()
 })
 app.use('/docs', express.static('client/'))
+app.use((req, res, next) => {
+  const match = req.path.match(/^\/docs\/([a-zA-Z][^/.]*)(\/.*)?$/)
+  if (match && !knownLocales.has(match[1])) {
+    req.url = `/docs/en/${match[1]}${match[2] || '/'}`
+  }
+  next()
+})
 app.use(ssrHandler)
 app.use((req, res) => {
   res.sendFile('404.html', { root: 'client/' })

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -1,26 +1,40 @@
 import { defineMiddleware } from 'astro:middleware'
 
+import config from '../gt.config.json'
 import { redirects } from './utils/redirects'
 
-export const onRequest = defineMiddleware(({ request, redirect }, next) => {
-  const url = new URL(request.url)
-  const path = url.pathname.replace(/\/$/, '')
+const knownLocales = new Set(config.locales)
 
-  if (path === '/docs/sitemap.xml') {
-    return next(new Request(new URL('/docs/sitemap-index.xml', url), request))
-  }
+export const onRequest = defineMiddleware(
+  ({ request, redirect, rewrite }, next) => {
+    const url = new URL(request.url)
+    const path = url.pathname.replace(/\/$/, '')
 
-  // Match /docs/old-slug or /docs/{locale}/old-slug
-  const match = path.match(/^\/docs(?:\/([a-z]{2}))?\/(.+)$/)
-  if (match) {
-    const locale = match[1]
-    const slug = match[2]
-    const newSlug = redirects[slug]
-    if (newSlug) {
-      const target = locale ? `/docs/${locale}/${newSlug}` : `/docs/${newSlug}`
-      return redirect(target, 301)
+    if (path === '/docs/sitemap.xml') {
+      return next(new Request(new URL('/docs/sitemap-index.xml', url), request))
     }
-  }
 
-  return next()
-})
+    // Match /docs/old-slug or /docs/{locale}/old-slug
+    const match = path.match(/^\/docs(?:\/([a-z]{2}))?\/(.+)$/)
+    if (match) {
+      const locale = match[1]
+      const slug = match[2]
+      const newSlug = redirects[slug]
+      if (newSlug) {
+        const target = locale
+          ? `/docs/${locale}/${newSlug}`
+          : `/docs/${newSlug}`
+        return redirect(target, 301)
+      }
+    }
+
+    const localeMatch = path.match(/^\/docs\/([a-zA-Z][^/.]*)(\/.*)?$/)
+    if (localeMatch && !knownLocales.has(localeMatch[1])) {
+      return rewrite(
+        `/docs/${config.defaultLocale}/${localeMatch[1]}${localeMatch[2] || '/'}`
+      )
+    }
+
+    return next()
+  }
+)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes docs locale routing by rewriting non-locale paths to the default locale. Prevents 404s and keeps slug redirects working across the `express` server and Astro middleware.

- **Bug Fixes**
  - Use `gt.config.json` to derive `knownLocales` and `defaultLocale`.
  - Rewrite `/docs/<non-locale>/...` to `/docs/<defaultLocale>/<non-locale>/...` (internal rewrite; preserves query strings; no external redirect).
  - Keep locale-aware slug redirects working for both `/docs/<slug>` and `/docs/<locale>/<slug>`.
  - Continue redirecting `/docs/sitemap.xml` to `/docs/sitemap-index.xml`.

<sup>Written for commit 982679edb9ddf86da83ae963181b829f97cd73fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

