### PR TITLE
chore(security): close P0 url parser bypass + P1 content gutting in yarnrc-lint

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -223,9 +223,9 @@ jobs:
         run: |
           python3 <<'PY'
           import posixpath
+          import re
           import sys
           from pathlib import Path
-          from urllib.parse import urlparse
 
           import yaml
 
@@ -234,7 +234,22 @@ jobs:
               print("::error::.yarnrc.yml is required and must not be removed -- it carries supply chain hardening (npmMinimalAgeGate, etc.)")
               sys.exit(1)
 
-          trusted_hosts = {"registry.npmjs.org", "registry.yarnpkg.com"}
+          # Strict allowlist regex for trusted registry URLs.
+          # Using a regex instead of urlparse() avoids parser-differential bypasses
+          # (Python RFC 3986 vs Node.js WHATWG URL disagree on backslashes in special-scheme URLs,
+          # e.g. 'https://evil.com\@registry.npmjs.org/' -- urlparse sees registry.npmjs.org as host,
+          # Yarn's WHATWG parser sees evil.com as host).
+          TRUSTED_REGISTRY = re.compile(
+              r"^https://(registry\.npmjs\.org|registry\.yarnpkg\.com)(/.*)?$"
+          )
+
+          # Required hardening keys with minimum acceptable values.
+          # These must not be removed or weakened -- a malicious PR that strips them
+          # would pass a file-existence check but silently disable supply chain protection.
+          REQUIRED_KEYS = {
+              "npmMinimalAgeGate": 10080,  # 7 days in minutes
+          }
+
           errors = []
 
           try:
@@ -265,9 +280,23 @@ jobs:
               if not isinstance(value, str):
                   errors.append(f"{location}.{key} is not a string: {value!r}")
                   return
-              parsed = urlparse(value)
-              if parsed.scheme != "https" or parsed.hostname not in trusted_hosts:
-                  errors.append(f"{location}.{key} must use https and a trusted host, got: {value}")
+              # Reject any backslash outright -- Python and Node.js WHATWG URL parsers differ
+              # on backslash handling in special-scheme URLs, which can be exploited.
+              if "\\" in value or "%5c" in value.lower():
+                  errors.append(f"{location}.{key} contains backslash (parser differential bypass): {value!r}")
+                  return
+              if not TRUSTED_REGISTRY.match(value):
+                  errors.append(
+                      f"{location}.{key} must be a trusted registry URL "
+                      f"(https://registry.npmjs.org/ or https://registry.yarnpkg.com/), got: {value}"
+                  )
+
+          # Required hardening keys must be present and not weakened
+          for key, min_value in REQUIRED_KEYS.items():
+              if key not in config:
+                  errors.append(f"{key} is missing -- this supply chain hardening setting must not be removed")
+              elif not isinstance(config[key], int) or isinstance(config[key], bool) or config[key] < min_value:
+                  errors.append(f"{key} must be an integer >= {min_value}, got: {config[key]!r}")
 
           # Top-level registry overrides
           for key in ("npmRegistryServer", "npmPublishRegistry"):


### PR DESCRIPTION
## Summary

Two follow-up hardening additions to the yarnrc-lint check (merged in #4486). Addresses findings from pre-merge review that were deferred.

## P0: URL Parser Differential Bypass (Registry Redirect)

Python's `urlparse` (RFC 3986) and Node.js's WHATWG URL parser disagree on backslash handling in special-scheme URLs. This is a direct supply chain attack that bypassed the existing check:

**Payload:** `npmRegistryServer: "https://evil.com\@registry.npmjs.org/"`

- Python `urlparse`: `\` stays literal, `@` splits userinfo → hostname = `registry.npmjs.org` → **passed** our check
- Yarn (WHATWG): `\` treated as `/` on special scheme → hostname = `evil.com` → Yarn fetches packages from attacker-controlled host

**Fix:** Replaced `urlparse`-based hostname check with a strict allowlist regex that matches exact trusted registry URLs only. Added explicit rejection of literal backslashes (`\\`) and URL-encoded backslashes (`%5c` / `%5C`) as defense in depth.

```python
TRUSTED_REGISTRY = re.compile(
    r"^https://(registry\.npmjs\.org|registry\.yarnpkg\.com)(/.*)?$"
)
```

This eliminates the entire class of parser-differential attacks.

## P1: Stated Intent vs Actual Behavior (Content Gutting)

The check's own error message says `.yarnrc.yml is required and must not be removed -- it carries supply chain hardening (npmMinimalAgeGate, etc.)` but only validates **file existence**, not **content**.

A malicious PR could strip `npmMinimalAgeGate: 10080` entirely -- file still exists, no evil registries, no `enableScripts`. Check passes. Cooldown silently disabled.

**Fix:** Added `REQUIRED_KEYS` enforcement that fails if hardening settings are missing or weakened below their minimum acceptable values:

```python
REQUIRED_KEYS = {
    "npmMinimalAgeGate": 10080,  # 7 days in minutes
}
```

Catches both removal (`key not in config`) and weakening (e.g., `npmMinimalAgeGate: 1`, strings, booleans, nulls).

## Test Coverage (29 cases verified locally)

**P0 backslash bypasses:**
- Literal `\` in URL → caught (backslash check)
- `%5C` encoded (uppercase) → caught
- `%5c` encoded (lowercase) → caught

**P1 content gutting:**
- `npmMinimalAgeGate` missing → caught
- `npmMinimalAgeGate: 1` (weakened) → caught
- `npmMinimalAgeGate: 10079` (just below minimum) → caught
- `npmMinimalAgeGate: "10080"` (string) → caught
- `npmMinimalAgeGate: true` (bool) → caught (`isinstance(bool)` check before int, since `bool` is subclass of `int` in Python)
- `npmMinimalAgeGate: null` → caught

**Regex edge cases:**
- `https://registry.npmjs.org.evil.example/` (subdomain bypass) → caught
- `https://registry.npmjs.org@evil.com/` (userinfo trick) → caught
- `http://registry.npmjs.org/` (non-https) → caught
- `ftp://registry.npmjs.org/` (non-https) → caught
- `registry.npmjs.org` (no scheme) → caught
- `https://registry.npmjs.org/` → passes
- `https://registry.yarnpkg.com/` → passes
- `https://registry.npmjs.org/some/path` → passes
- `https://registry.npmjs.org` (no trailing slash) → passes

**yarnPath edge cases:**
- `yarnPath: ""` → caught (empty string not under `.yarn/releases/`)
- `yarnPath: null` → caught (not a string)
- `yarnPath: .yarn/releases-evil/yarn.cjs` → caught (prefix trick, requires `/` after `releases`)
- `yarnPath: /etc/passwd` → caught (absolute path)
- `yarnPath: ".yarn\\releases\\yarn.cjs"` → caught (Windows-style separator fails the prefix check)

**Misc:**
- Multiple bad registries at once → both caught
- `npmMinimalAgeGate: 999999999999` → passes (no upper bound)
- Empty `.yarnrc.yml` → caught (npmMinimalAgeGate missing)
- Comments-only file → caught (npmMinimalAgeGate missing)
- Unknown keys (e.g., `enableGlobalCache`) → ignored (we only validate known security-relevant keys)
- Current `.yarnrc.yml` in main → passes

**Static checks:** `actionlint` clean, Python syntax valid.

## Open follow-up (not this PR)

P1 "Branch Protection Gap" -- the yarnrc-lint job can itself be removed in a PR that also adds malicious config. Mitigation is to add `yarnrc-lint` as a required status check in branch protection (GitHub UI, ~30 seconds). Tracking separately under Phase 2 ruleset work.