### PR TITLE
chore(security): expand CODEOWNERS coverage for CI/CD and supply chain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,26 @@
-# CODEOWNERS — Daytona
+# CODEOWNERS -- Daytona
 # These owners are automatically requested for review on PRs that modify the listed files.
+# Multiple owners = OR semantics (any one can approve).
+# Enforcement: the "Security baseline" Ruleset requires CODEOWNERS review on main,
+# so listed owners must approve before merge.
 
-# Security and compliance policies
-SECURITY.md          @aprojic
-CODE_OF_CONDUCT.md   @aprojic
+# Security and compliance policies (CISO-owned)
+SECURITY.md                @daytonaio/security
+CODE_OF_CONDUCT.md         @daytonaio/security
+
+# CI/CD pipelines and composite actions
+.github/workflows/         @daytonaio/security @Tpuljak
+.github/actions/           @daytonaio/security @Tpuljak
+
+# Dependency and supply chain configuration
+.github/dependabot.yml     @daytonaio/security @Tpuljak
+.yarnrc.yml                @daytonaio/security @Tpuljak
+.npmrc                     @daytonaio/security @Tpuljak
+
+# Linting and license enforcement (security-relevant)
+.github/actionlint.yaml    @daytonaio/security @Tpuljak
+.licenserc.yaml            @daytonaio/security @Tpuljak
+.licenserc-clients.yaml    @daytonaio/security @Tpuljak
+
+# CODEOWNERS itself (must protect itself)
+.github/CODEOWNERS         @daytonaio/security @Tpuljak


### PR DESCRIPTION
## Summary

Expand `.github/CODEOWNERS` so any PR that modifies CI/CD pipelines, supply chain configs, or security-sensitive files auto-requests review from the security team. Paired with the `Security baseline` Ruleset (already live in evaluate mode) this enforces review before merge.

## Before

Only 2 files covered:
```
SECURITY.md          @aprojic
CODE_OF_CONDUCT.md   @aprojic
```

## After

Two-tier ownership model:

| Tier | Files | Owners |
|---|---|---|
| **Policy docs (CISO-owned)** | `SECURITY.md`, `CODE_OF_CONDUCT.md` | `@daytonaio/security` |
| **CI/CD + supply chain** | `.github/workflows/`, `.github/actions/`, `.github/dependabot.yml`, `.github/actionlint.yaml`, `.github/CODEOWNERS`, `.yarnrc.yml`, `.npmrc`, `.licenserc.yaml`, `.licenserc-clients.yaml` | `@daytonaio/security @Tpuljak` (OR) |

## Design decisions

- **Team-based ownership** -- `@daytonaio/security` (closed, visible team under `daytona`). Easy to add/remove reviewers via team membership without editing this file.
- **Toma as co-owner for technical paths** -- engineering lead, reviewed/merged all Phase 1 PRs. Prevents bottleneck if security reviewer is unavailable. Kept OFF policy docs (SECURITY.md, CoC) since those are CISO-owned compliance artifacts.
- **CODEOWNERS self-protecting** -- attacker can't remove the protection without triggering review of the removal.
- **OR semantics** (multiple owners on one line) -- any one can approve. For hard-gated dual approval on high-stakes workflows, use GitHub Environments with Required reviewers (Phase 2.1), not CODEOWNERS.

## What this DOES and does NOT do

|  | This PR |
|--|--|
| Auto-request review from listed owners on matching PRs | ✅ |
| Block merge without approval (via `Security baseline` Ruleset) | ✅ (once Ruleset is flipped from `evaluate` → `active`) |

## Context

Phase 2.2 of GHA security hardening (SEC-61). Phase 1 (tactical hardening) complete with PR #4486 merged. Ruleset `Security baseline` already created in evaluate mode, requires CODEOWNERS review + status checks including `Yarnrc integrity check`.

## Verification

- `cat .github/CODEOWNERS` -- verified syntactically valid, all paths exist in the repo
- `@daytonaio/security` team exists and is visible (closed, not secret)
- After merge: open a PR touching `.github/workflows/` -- should auto-request review from both `@daytonaio/security` and `@Tpuljak`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand `.github/CODEOWNERS` so changes to CI/CD, supply chain config, and other security‑sensitive files trigger a security review. Policy docs are owned by `@daytonaio/security`; technical paths are co‑owned by `@daytonaio/security` and `@Tpuljak` for auto‑requested reviews and ruleset enforcement.

- **New Features**
  - CI/CD: `.github/workflows/`, `.github/actions/`
  - Supply chain: `.github/dependabot.yml`, `.yarnrc.yml`, `.npmrc`
  - Lint/license and self‑protection: `.github/actionlint.yaml`, `.licenserc*.yaml`, `.github/CODEOWNERS`

<sup>Written for commit e712e179a6ad55eaf8c724ea0608e5e91803bc3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

