### PR TITLE
chore(security): replace deprecated dev-hanz-ops/install-gh-cli-action

### DIFF
--- a/.github/actions/install-gh-cli/action.yml
+++ b/.github/actions/install-gh-cli/action.yml
@@ -14,7 +14,18 @@ runs:
           exit 0
         fi
 
+        # Require Debian/Ubuntu tooling -- fail loudly on unsupported runners
+        for tool in apt-get dpkg sudo; do
+          if ! command -v "$tool" >/dev/null 2>&1; then
+            echo "::error::Required tool '$tool' not found. This action only supports Debian/Ubuntu runners."
+            exit 1
+          fi
+        done
+
         echo "Installing gh CLI via GitHub's apt repository..."
+
+        # Refresh apt index first (runners may have stale/empty package lists)
+        sudo apt-get update
 
         # Ensure wget is available (needed to fetch the signing key)
         if ! command -v wget >/dev/null 2>&1; then
@@ -29,6 +40,17 @@ runs:
         # Verify the keyring was written successfully (guard against silent pipe failures)
         if [ ! -s /etc/apt/keyrings/githubcli-archive-keyring.gpg ]; then
           echo "::error::Failed to fetch GitHub CLI signing key"
+          exit 1
+        fi
+
+        # Verify the keyring contains GitHub's published signing key fingerprint.
+        # The keyring bundles multiple keys (GitHub keeps older valid keys for compatibility),
+        # so we check membership rather than position. If GitHub retires this key, update the
+        # expected fingerprint here after verifying via an out-of-band source.
+        EXPECTED_FINGERPRINT="2C6106201985B60E6C7AC87323F3D4EA75716059"
+        if ! gpg --show-keys --with-colons /etc/apt/keyrings/githubcli-archive-keyring.gpg 2>/dev/null \
+          | awk -F: '/^fpr:/ {print $10}' | grep -qx "$EXPECTED_FINGERPRINT"; then
+          echo "::error::Expected GPG fingerprint $EXPECTED_FINGERPRINT not found in keyring"
           exit 1
         fi
 

--- a/.github/actions/install-gh-cli/action.yml
+++ b/.github/actions/install-gh-cli/action.yml
@@ -1,0 +1,44 @@
+name: 'Install gh CLI'
+description: 'Install GitHub CLI via apt if not already present (idempotent on self-hosted runners).'
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure gh CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if command -v gh >/dev/null 2>&1; then
+          echo "gh already installed: $(gh --version | head -n 1)"
+          exit 0
+        fi
+
+        echo "Installing gh CLI via GitHub's apt repository..."
+
+        # Ensure wget is available (needed to fetch the signing key)
+        if ! command -v wget >/dev/null 2>&1; then
+          sudo apt-get install -y wget
+        fi
+
+        # Add GitHub's signed apt repository (official install instructions)
+        sudo mkdir -p -m 755 /etc/apt/keyrings
+        wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+          | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+
+        # Verify the keyring was written successfully (guard against silent pipe failures)
+        if [ ! -s /etc/apt/keyrings/githubcli-archive-keyring.gpg ]; then
+          echo "::error::Failed to fetch GitHub CLI signing key"
+          exit 1
+        fi
+
+        sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+          | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends gh
+
+        # Refresh shell's command lookup cache so freshly-installed gh is found
+        hash -r
+        gh --version

--- a/.github/actions/install-gh-cli/action.yml
+++ b/.github/actions/install-gh-cli/action.yml
@@ -27,9 +27,14 @@ runs:
         # Refresh apt index first (runners may have stale/empty package lists)
         sudo apt-get update
 
-        # Ensure wget is available (needed to fetch the signing key)
-        if ! command -v wget >/dev/null 2>&1; then
-          sudo apt-get install -y wget
+        # Ensure prerequisites are available:
+        # - wget: fetch the signing key
+        # - gpg (from gnupg): verify the key fingerprint below
+        missing_pkgs=()
+        command -v wget >/dev/null 2>&1 || missing_pkgs+=(wget)
+        command -v gpg  >/dev/null 2>&1 || missing_pkgs+=(gnupg)
+        if [ ${#missing_pkgs[@]} -gt 0 ]; then
+          sudo apt-get install -y --no-install-recommends "${missing_pkgs[@]}"
         fi
 
         # Add GitHub's signed apt repository (official install instructions)

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -38,7 +38,6 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-toolchain
-      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,8 +45,6 @@ jobs:
           go-cache: 'false'
           run-go-work-sync: 'false'
 
-      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
-
       - name: Configure git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,7 +130,7 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-toolchain
-      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
+      - uses: ./.github/actions/install-gh-cli
 
       - name: Install gettext
         run: sudo apt-get install -y gettext
@@ -362,7 +360,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
+      - uses: ./.github/actions/install-gh-cli
 
       - name: Configure git
         env:

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -68,7 +68,6 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           install-swag: 'false'
-      - uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

Replace the `dev-hanz-ops/install-gh-cli-action@v0.2.1` (Node.js 20, abandoned upstream) with a local composite action that installs `gh` via GitHub's official apt repository.

## Why

GitHub is deprecating Node.js 20 for actions runtime:
- **June 2, 2026:** default switches to node24
- **September 16, 2026:** node20 removed entirely

`dev-hanz-ops/install-gh-cli-action` is:
- Pinned to node20 ([action.yml#L16-L17](https://github.com/dev-hanz-ops/install-gh-cli-action/blob/main/action.yml))
- Functionally abandoned -- last release Jan 2025 (14 months ago), [upstream issue #13](https://github.com/dev-hanz-ops/install-gh-cli-action/issues/13) requesting node24 migration has been open a month with no activity
- Just a 28-line wrapper around a download -- minimal value for the trust surface it adds
- Pinned to gh 2.14.2 (from late 2022) -- nearly 3 years stale

## Audit of current usage

5 action uses across 3 workflows. **Two were dead code** -- the job never called `gh`:

| Location | Job | Runner | gh called? | Action taken |
|----------|-----|--------|------------|--------------|
| `prepare-release.yaml:41` | prepare | `ubuntu-latest` | ✅ `gh pr create` | **Removed** (ubuntu-latest pre-installs gh) |
| `release.yaml:48` | publish | self-hosted | ❌ dead code | **Removed** |
| `release.yaml:135` | build_projects | self-hosted | ✅ `gh release upload` ×9 | **Replaced** with `./.github/actions/install-gh-cli` |
| `release.yaml:365` | sync_gosum | self-hosted | ✅ `gh pr create` | **Replaced** with `./.github/actions/install-gh-cli` |
| `sdk_publish.yaml:71` | publish | self-hosted | ❌ dead code | **Removed** |

## New composite action

Path: `.github/actions/install-gh-cli/action.yml`

- **Idempotent:** fast-path early exit if `gh` is already installed (no-op on self-hosted runners after first install)
- **Integrity verified:** installs from GitHub's GPG-signed apt repository
- **Hardened shell:** `set -euo pipefail`, explicit keyring non-empty check, `hash -r` to refresh PATH cache
- **Multi-arch:** `dpkg --print-architecture` auto-detects amd64 / arm64 (matches our self-hosted runner matrix)
- **Fails loudly:** ends with `gh --version` so any silent install failure surfaces immediately

## Why not `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`

That env var papers over the deprecation by forcing node24 runtime on node20-declared actions. Doesn't fix our root problem (abandoned upstream). Removing the action entirely is strictly better.

## Risk analysis

| Risk | Mitigation |
|------|------------|
| gh install fails on runner (network, GPG, apt) | `gh --version` at end fails loudly. `pipefail` + keyring-size check prevent silent failures. |
| gh behavior difference (2.14.2 vs latest) | We only use `gh pr create` and `gh release upload` -- both stable APIs since gh 2.0. No breaking flag changes. |
| Release pipeline breakage (business critical) | **Required: pre-release test via `workflow_dispatch` with a test version tag (e.g., `v0.0.0-rc-testgh`) before the next production release.** |
| Rollback | Single self-contained PR. `gh pr revert` restores previous behavior. |

## Verification

- ✅ `actionlint .github/workflows/*.yaml .github/actions/install-gh-cli/action.yml` -- no errors
- ✅ `grep -r "dev-hanz-ops" .github/` -- zero matches
- ✅ All 11 `gh release upload` / `gh pr create` call sites still intact
- ✅ Only the 2 self-hosted jobs that actually use `gh` reference the new composite action

## Pre-release test required before next production release

Trigger `release.yaml` via `workflow_dispatch` with a test version (e.g., `v0.0.0-rc-testgh`). Verify:
1. `Ensure gh CLI` step either installs successfully or hits fast path
2. `gh release upload` steps succeed in `build_projects`
3. `gh pr create` succeeds in `sync_gosum`

## Closes

Resolves the node20 deprecation warning for `dev-hanz-ops/install-gh-cli-action`. The separate deprecation for `generaltranslation/translate` is tracked in #4507 (upstream-dependent, can't fix on our side).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `dev-hanz-ops/install-gh-cli-action` with a local composite action that installs `gh` from GitHub’s apt repo, and removed dead installs. Hardened the installer with fingerprint verification, Debian/Ubuntu prechecks, and auto‑installs `wget`/`gnupg`; removed the Node 20–pinned dependency to keep `gh` current on self‑hosted runners.

- **Refactors**
  - Added `.github/actions/install-gh-cli` (idempotent apt install; apt index refresh; installs `wget`/`gnupg` if missing; GPG fingerprint check; Debian/Ubuntu tool precheck; multi‑arch; ends with `gh --version`).
  - Swapped into `release.yaml` jobs `build_projects` and `sync_gosum`.
  - Removed unused installs in `prepare-release.yaml`, `sdk_publish.yaml`, and the `release.yaml` publish job (Ubuntu runners already have `gh`).

- **Migration**
  - Trigger `release.yaml` via `workflow_dispatch` with a test tag (e.g., `v0.0.0-rc-testgh`) and confirm:
    - `Ensure gh CLI` step installs or fast‑paths.
    - `gh release upload` and `gh pr create` succeed.

<sup>Written for commit c4a4442868190664bec642bbeb573a50ae76e945. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

