### PR TITLE
fix(docs): modify locale handling routes (v2)

### DIFF
--- a/apps/docs/src/content/docs/en/guides/openclaw/index.mdx
+++ b/apps/docs/src/content/docs/en/guides/openclaw/index.mdx
@@ -2,7 +2,6 @@
 title: OpenClaw Guides
 description: Guides for running OpenClaw with Daytona
 tableOfContents: false
-slug: en/guides/openclaw
 ---
 
 import GuidesList from '@components/GuidesList.astro'

--- a/apps/docs/src/content/docs/en/guides/opencode/index.mdx
+++ b/apps/docs/src/content/docs/en/guides/opencode/index.mdx
@@ -2,7 +2,6 @@
 title: OpenCode Guides
 description: Guides for running OpenCode with Daytona sandboxes
 tableOfContents: false
-slug: en/guides/opencode
 ---
 
 import GuidesList from '@components/GuidesList.astro'

--- a/apps/docs/src/i18n/routing.ts
+++ b/apps/docs/src/i18n/routing.ts
@@ -99,24 +99,11 @@ function getProxyOrigin(request: Request): string {
 
 /**
  * Headers safe to forward when fetching another path on the public site.
- * Drops Host and hop-by-hop headers so the URL's host is used (SNI / routing).
+ * Leave request headers empty to avoid accessing `Astro.request.headers`
+ * when proxying into prerendered static routes.
  */
-function headersForProxyFetch(originalRequest: Request): Headers {
-  const out = new Headers()
-  const skip = new Set([
-    'host',
-    'connection',
-    'keep-alive',
-    'proxy-connection',
-    'transfer-encoding',
-    'upgrade',
-  ])
-  originalRequest.headers.forEach((value, key) => {
-    if (!skip.has(key.toLowerCase())) {
-      out.set(key, value)
-    }
-  })
-  return out
+function headersForProxyFetch(): Headers {
+  return new Headers()
 }
 
 /**
@@ -132,7 +119,7 @@ export async function proxyLocalizedContent(
 
     const response = await fetch(targetUrl.toString(), {
       method: originalRequest.method,
-      headers: headersForProxyFetch(originalRequest),
+      headers: headersForProxyFetch(),
       body:
         originalRequest.method === 'GET' || originalRequest.method === 'HEAD'
           ? undefined
@@ -172,6 +159,8 @@ export async function handleLanguageRouting(
   slug = '',
   redirectFn: (path: string) => Response
 ): Promise<Response> {
+  const normalizedSlug = slug.replace(/^\/+|\/+$/g, '')
+
   const serveCustom404 = async (): Promise<Response> => {
     const response = await proxyLocalizedContent('/docs/404', request)
     return new Response(response.body, {
@@ -181,18 +170,15 @@ export async function handleLanguageRouting(
     })
   }
 
-  if (isLocalizedPath(slug)) return await serveCustom404()
+  if (isLocalizedPath(normalizedSlug)) return await serveCustom404()
 
   const preferredLanguage = getPreferredLanguage(request)
 
-  if (preferredLanguage !== defaultLocale) {
-    return redirectFn(`/docs/${preferredLanguage}/${slug}`)
+  if (normalizedSlug) {
+    // For unprefixed docs paths, use the default locale canonical URL.
+    // This avoids SSR self-fetch loops that can incorrectly produce 404.
+    return redirectFn(`/docs/${defaultLocale}/${normalizedSlug}`)
   }
 
-  const response = await proxyLocalizedContent(
-    `/docs/${defaultLocale}/${slug}`,
-    request
-  )
-  if (response.status === 404) return await serveCustom404()
-  return response
+  return redirectFn(`/docs/${preferredLanguage}`)
 }

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -2,25 +2,79 @@ import { defineMiddleware } from 'astro:middleware'
 
 import { redirects } from './utils/redirects'
 
-export const onRequest = defineMiddleware(({ request, redirect }, next) => {
-  const url = new URL(request.url)
-  const path = url.pathname.replace(/\/$/, '')
-
-  if (path === '/docs/sitemap.xml') {
-    return next(new Request(new URL('/docs/sitemap-index.xml', url), request))
-  }
-
-  // Match /docs/old-slug or /docs/{locale}/old-slug
-  const match = path.match(/^\/docs(?:\/([a-z]{2}))?\/(.+)$/)
-  if (match) {
-    const locale = match[1]
-    const slug = match[2]
-    const newSlug = redirects[slug]
-    if (newSlug) {
-      const target = locale ? `/docs/${locale}/${newSlug}` : `/docs/${newSlug}`
-      return redirect(target, 301)
+function filterProxyHeaders(headers: Headers): Headers {
+  const filteredHeaders = new Headers()
+  for (const [key, value] of headers.entries()) {
+    if (
+      !['content-encoding', 'content-length', 'transfer-encoding'].includes(
+        key.toLowerCase()
+      )
+    ) {
+      filteredHeaders.set(key, value)
     }
   }
+  return filteredHeaders
+}
 
-  return next()
-})
+export const onRequest = defineMiddleware(
+  async ({ request, redirect }, next) => {
+    const url = new URL(request.url)
+    const path = url.pathname.replace(/\/$/, '')
+
+    const proxyRequest = async (targetUrl: URL): Promise<Response> => {
+      const response = await fetch(targetUrl.toString(), {
+        method: request.method,
+        body:
+          request.method === 'GET' || request.method === 'HEAD'
+            ? undefined
+            : request.body,
+      })
+
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: filterProxyHeaders(response.headers),
+      })
+    }
+
+    if (path === '/docs/sitemap.xml') {
+      return next(new Request(new URL('/docs/sitemap-index.xml', url), request))
+    }
+
+    // Match /docs/old-slug or /docs/{locale}/old-slug
+    const match = path.match(/^\/docs(?:\/([a-z]{2}))?\/(.+)$/)
+    if (match) {
+      const locale = match[1]
+      const slug = match[2]
+      const newSlug = redirects[slug]
+      if (newSlug) {
+        const target = locale
+          ? `/docs/${locale}/${newSlug}`
+          : `/docs/${newSlug}`
+        return redirect(target, 301)
+      }
+    }
+
+    if (path === '/docs') {
+      const targetUrl = new URL('/docs/en', url)
+      targetUrl.search = url.search
+      return await proxyRequest(targetUrl)
+    }
+
+    const docsPath = path.match(/^\/docs\/(.+)$/)
+    if (docsPath) {
+      const slug = docsPath[1]
+      const firstSegment = slug.split('/')[0]
+      const isLocalePrefixed = /^[a-z]{2}$/.test(firstSegment)
+      const looksLikeStaticAsset = /\.[^/]+$/.test(slug)
+
+      if (!isLocalePrefixed && !looksLikeStaticAsset) {
+        const targetUrl = new URL(`/docs/en/${slug}`, url)
+        targetUrl.search = url.search
+        return await proxyRequest(targetUrl)
+      }
+    }
+
+    return next()
+  }
+)


### PR DESCRIPTION
Duplicates but fixes https://github.com/daytonaio/daytona/pull/4533

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes docs locale routing by proxying unprefixed `/docs` paths to the default `en` content and tightening proxy/header handling to stop prerendered-page 404 loops. Also removes hardcoded slugs from the OpenClaw and OpenCode guides.

- **Bug Fixes**
  - Proxy `/docs` and unprefixed `/docs/{slug}` to `/docs/en[...]` (query preserved) to avoid SSR self-fetch and 404s.
  - Stop forwarding request headers when proxying localized content to avoid accessing `Astro.request.headers` on static routes.
  - Filter `content-encoding`, `content-length`, and `transfer-encoding` from proxied responses.
  - Normalize slugs and return the custom 404 for invalid locale-prefixed paths.

<sup>Written for commit c19d27dca62e8552e08a78da1ac75f4e3d59b923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

