### PR TITLE
fix(dashboard): ws sandbox details invalidation

### DIFF
--- a/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
@@ -30,7 +30,7 @@ import { useApi } from '@/hooks/useApi'
 import { useConfig } from '@/hooks/useConfig'
 import { useMatchMedia } from '@/hooks/useMatchMedia'
 import { useRegions } from '@/hooks/useRegions'
-import { useSandboxWsSync } from '@/hooks/useSandboxWsSync'
+import { useSandboxDetailsWsSync } from '@/hooks/useSandboxWsSync'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import { isStoppable, isTransitioning } from '@/lib/utils/sandbox'
@@ -85,12 +85,12 @@ export default function SandboxDetails() {
   const { data: sandbox, isLoading, isError, error, refetch, isFetching } = useSandboxQuery(sandboxId ?? '')
   const isNotFound = isError && isAxiosError(error.cause) && error.cause?.status === 404
 
-  useSandboxWsSync({ sandboxId })
+  useSandboxDetailsWsSync(sandboxId)
 
-  const startMutation = useStartSandboxMutation()
-  const stopMutation = useStopSandboxMutation()
-  const archiveMutation = useArchiveSandboxMutation()
-  const recoverMutation = useRecoverSandboxMutation()
+  const startMutation = useStartSandboxMutation({ invalidate: false })
+  const stopMutation = useStopSandboxMutation({ invalidate: false })
+  const archiveMutation = useArchiveSandboxMutation({ invalidate: false })
+  const recoverMutation = useRecoverSandboxMutation({ invalidate: false })
   const deleteMutation = useDeleteSandboxMutation()
 
   const writePermitted = authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_SANDBOXES)

--- a/apps/dashboard/src/components/sandboxes/SandboxHeader.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxHeader.tsx
@@ -18,8 +18,8 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { Spinner } from '@/components/ui/spinner'
 import { isArchivable, isRecoverable, isStartable, isStoppable } from '@/lib/utils/sandbox'
-import { Sandbox } from '@daytona/api-client'
-import { ArrowLeft, MoreHorizontal, Play, RefreshCw, Square, Wrench } from 'lucide-react'
+import { Sandbox, SandboxDesiredState, SandboxState as SandboxStateType } from '@daytona/api-client'
+import { Archive, ArrowLeft, MoreHorizontal, Play, RefreshCw, Square, Wrench } from 'lucide-react'
 
 interface SandboxHeaderProps {
   sandbox: Sandbox | undefined
@@ -41,6 +41,40 @@ interface SandboxHeaderProps {
   mutations: { start: boolean; stop: boolean; archive: boolean; recover: boolean }
 }
 
+type PrimaryActionKind = 'start' | 'stop' | 'recover' | 'archive' | null
+
+function getPrimaryActionKind(sandbox: Sandbox): PrimaryActionKind {
+  if (sandbox.recoverable && isRecoverable(sandbox)) {
+    return 'recover'
+  }
+
+  if (sandbox.state === SandboxStateType.STARTING || sandbox.state === SandboxStateType.STOPPING) {
+    if (sandbox.desiredState === SandboxDesiredState.STARTED) {
+      return 'start'
+    }
+
+    if (sandbox.desiredState === SandboxDesiredState.STOPPED) {
+      return 'stop'
+    }
+  }
+
+  if (sandbox.state === SandboxStateType.ARCHIVING && sandbox.desiredState === SandboxDesiredState.ARCHIVED) {
+    return 'archive'
+  }
+
+  switch (sandbox.state) {
+    case SandboxStateType.STOPPED:
+    case SandboxStateType.ARCHIVED:
+      return 'start'
+    case SandboxStateType.STARTED:
+      return 'stop'
+    case SandboxStateType.RESTORING:
+      return 'recover'
+    default:
+      return null
+  }
+}
+
 export function SandboxHeader({
   sandbox,
   isLoading,
@@ -60,6 +94,8 @@ export function SandboxHeader({
   onScreenRecordings,
   mutations,
 }: SandboxHeaderProps) {
+  const primaryActionKind = sandbox ? getPrimaryActionKind(sandbox) : null
+
   return (
     <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 min-w-0 px-4 sm:px-5 py-2 border-b border-border shrink-0">
       <div className="flex items-center gap-2 min-w-0">
@@ -97,27 +133,33 @@ export function SandboxHeader({
             <div className="flex items-center gap-2">
               {writePermitted && (
                 <ButtonGroup>
-                  {isStartable(sandbox) && !sandbox.recoverable && (
+                  {primaryActionKind === 'start' && (
                     <Button variant="outline" size="sm" onClick={onStart} disabled={actionsDisabled}>
-                      {mutations.start ? <Spinner className="size-4" /> : <Play className="size-4" />}
+                      <Play className="size-4" />
                       Start
                     </Button>
                   )}
-                  {isStoppable(sandbox) && (
+                  {primaryActionKind === 'stop' && (
                     <Button variant="outline" size="sm" onClick={onStop} disabled={actionsDisabled}>
-                      {mutations.stop ? <Spinner className="size-4" /> : <Square className="size-4" />}
+                      <Square className="size-4" />
                       Stop
                     </Button>
                   )}
-                  {isRecoverable(sandbox) && (
+                  {primaryActionKind === 'recover' && (
                     <Button variant="outline" size="sm" onClick={onRecover} disabled={actionsDisabled}>
-                      {mutations.recover ? <Spinner className="size-4" /> : <Wrench className="size-4" />}
+                      <Wrench className="size-4" />
                       Recover
+                    </Button>
+                  )}
+                  {primaryActionKind === 'archive' && (
+                    <Button variant="outline" size="sm" onClick={onArchive} disabled={actionsDisabled}>
+                      <Archive className="size-4" />
+                      Archive
                     </Button>
                   )}
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="icon-sm" aria-label="More actions">
+                      <Button variant="outline" size="icon-sm" aria-label="More actions" disabled={actionsDisabled}>
                         <MoreHorizontal className="size-4" />
                       </Button>
                     </DropdownMenuTrigger>

--- a/apps/dashboard/src/hooks/mutations/useArchiveSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useArchiveSandboxMutation.ts
@@ -12,7 +12,11 @@ interface ArchiveSandboxVariables {
   sandboxId: string
 }
 
-export const useArchiveSandboxMutation = () => {
+interface UseArchiveSandboxMutationOptions {
+  invalidate?: boolean
+}
+
+export const useArchiveSandboxMutation = ({ invalidate = true }: UseArchiveSandboxMutationOptions = {}) => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
@@ -22,6 +26,10 @@ export const useArchiveSandboxMutation = () => {
       await sandboxApi.archiveSandbox(sandboxId, selectedOrganization?.id)
     },
     onSuccess: (_, { sandboxId }) => {
+      if (!invalidate) {
+        return
+      }
+
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })

--- a/apps/dashboard/src/hooks/mutations/useRecoverSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useRecoverSandboxMutation.ts
@@ -12,7 +12,11 @@ interface RecoverSandboxVariables {
   sandboxId: string
 }
 
-export const useRecoverSandboxMutation = () => {
+interface UseRecoverSandboxMutationOptions {
+  invalidate?: boolean
+}
+
+export const useRecoverSandboxMutation = ({ invalidate = true }: UseRecoverSandboxMutationOptions = {}) => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
@@ -22,6 +26,10 @@ export const useRecoverSandboxMutation = () => {
       await sandboxApi.recoverSandbox(sandboxId, selectedOrganization?.id)
     },
     onSuccess: (_, { sandboxId }) => {
+      if (!invalidate) {
+        return
+      }
+
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })

--- a/apps/dashboard/src/hooks/mutations/useStartSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useStartSandboxMutation.ts
@@ -12,7 +12,11 @@ interface StartSandboxVariables {
   sandboxId: string
 }
 
-export const useStartSandboxMutation = () => {
+interface UseStartSandboxMutationOptions {
+  invalidate?: boolean
+}
+
+export const useStartSandboxMutation = ({ invalidate = true }: UseStartSandboxMutationOptions = {}) => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
@@ -22,6 +26,10 @@ export const useStartSandboxMutation = () => {
       await sandboxApi.startSandbox(sandboxId, selectedOrganization?.id)
     },
     onSuccess: (_, { sandboxId }) => {
+      if (!invalidate) {
+        return
+      }
+
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })

--- a/apps/dashboard/src/hooks/mutations/useStopSandboxMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useStopSandboxMutation.ts
@@ -12,7 +12,11 @@ interface StopSandboxVariables {
   sandboxId: string
 }
 
-export const useStopSandboxMutation = () => {
+interface UseStopSandboxMutationOptions {
+  invalidate?: boolean
+}
+
+export const useStopSandboxMutation = ({ invalidate = true }: UseStopSandboxMutationOptions = {}) => {
   const { sandboxApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
@@ -22,6 +26,10 @@ export const useStopSandboxMutation = () => {
       await sandboxApi.stopSandbox(sandboxId, selectedOrganization?.id)
     },
     onSuccess: (_, { sandboxId }) => {
+      if (!invalidate) {
+        return
+      }
+
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId),
       })

--- a/apps/dashboard/src/hooks/useSandboxWsSync.ts
+++ b/apps/dashboard/src/hooks/useSandboxWsSync.ts
@@ -11,13 +11,14 @@ import type { QueryKey } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useRef } from 'react'
 
-interface UseSandboxWsSyncOptions<TData> {
+interface UseSandboxWsSyncOptions {
+  enabled?: boolean
   sandboxId?: string
   queryKey: QueryKey
-  sync: (oldData: TData | undefined, sandbox: Sandbox) => TData | undefined
+  sync: (oldData: Sandbox | undefined, sandbox: Sandbox) => Sandbox | undefined
 }
 
-export function useSandboxWsSync({ sandboxId, queryKey, sync }: UseSandboxWsSyncOptions<Sandbox>) {
+export function useSandboxWsSync({ enabled = true, sandboxId, queryKey, sync }: UseSandboxWsSyncOptions) {
   const { notificationSocket } = useNotificationSocket()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
@@ -28,7 +29,7 @@ export function useSandboxWsSync({ sandboxId, queryKey, sync }: UseSandboxWsSync
   syncRef.current = sync
 
   useEffect(() => {
-    if (!notificationSocket || !selectedOrganization?.id) return
+    if (!enabled || !notificationSocket || !selectedOrganization?.id || !sandboxId) return
 
     const cancelSandboxQuery = () => {
       queryClient.cancelQueries({
@@ -69,13 +70,14 @@ export function useSandboxWsSync({ sandboxId, queryKey, sync }: UseSandboxWsSync
       notificationSocket.off('sandbox.state.updated', handleStateUpdated)
       notificationSocket.off('sandbox.desired-state.updated', handleDesiredStateUpdated)
     }
-  }, [notificationSocket, selectedOrganization?.id, sandboxId, queryClient])
+  }, [enabled, notificationSocket, selectedOrganization?.id, sandboxId, queryClient])
 }
 
 export function useSandboxDetailsWsSync(sandboxId?: string) {
   const { selectedOrganization } = useSelectedOrganization()
 
   useSandboxWsSync({
+    enabled: Boolean(selectedOrganization?.id && sandboxId),
     sandboxId,
     queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId ?? ''),
     sync: (oldData, sandbox) => {

--- a/apps/dashboard/src/hooks/useSandboxWsSync.ts
+++ b/apps/dashboard/src/hooks/useSandboxWsSync.ts
@@ -4,109 +4,60 @@
  */
 
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
-import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { getSandboxesQueryKey } from '@/hooks/useSandboxes'
 import { queryKeys } from '@/hooks/queries/queryKeys'
-import { PaginatedSandboxes, Sandbox, SandboxDesiredState, SandboxState } from '@daytona/api-client'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { Sandbox, SandboxState } from '@daytona/api-client'
+import type { QueryKey } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
-interface UseSandboxWsSyncOptions {
+interface UseSandboxWsSyncOptions<TData> {
   sandboxId?: string
-  refetchOnCreate?: boolean
+  queryKey: QueryKey
+  sync: (oldData: TData | undefined, sandbox: Sandbox) => TData | undefined
 }
 
-export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSandboxWsSyncOptions = {}) {
+export function useSandboxWsSync({ sandboxId, queryKey, sync }: UseSandboxWsSyncOptions<Sandbox>) {
   const { notificationSocket } = useNotificationSocket()
   const { selectedOrganization } = useSelectedOrganization()
   const queryClient = useQueryClient()
+  const queryKeyRef = useRef(queryKey)
+  const syncRef = useRef(sync)
+
+  queryKeyRef.current = queryKey
+  syncRef.current = sync
 
   useEffect(() => {
     if (!notificationSocket || !selectedOrganization?.id) return
 
-    const orgId = selectedOrganization.id
-
-    const updateStateInListCache = (targetId: string, state: SandboxState) => {
-      queryClient.setQueriesData<PaginatedSandboxes>({ queryKey: getSandboxesQueryKey(orgId) }, (oldData) => {
-        if (!oldData) return oldData
-        return {
-          ...oldData,
-          items: oldData.items.map((s) => (s.id === targetId ? { ...s, state } : s)),
-        }
+    const cancelSandboxQuery = () => {
+      queryClient.cancelQueries({
+        queryKey: queryKeyRef.current,
       })
     }
 
-    const updateStateInDetailCache = (targetId: string, state: SandboxState) => {
-      queryClient.setQueryData<Sandbox>(queryKeys.sandboxes.detail(orgId, targetId), (oldData) => {
-        if (!oldData) return oldData
-        return { ...oldData, state }
-      })
+    const syncSandboxInCache = (sandbox: Sandbox) => {
+      queryClient.setQueryData<Sandbox>(queryKeyRef.current, (oldData) => syncRef.current(oldData, sandbox))
     }
 
-    const optimisticUpdate = (targetId: string, state: SandboxState) => {
-      updateStateInListCache(targetId, state)
-      if (sandboxId) {
-        updateStateInDetailCache(targetId, state)
-      }
+    const syncSandboxFromEvent = async (sandbox: Sandbox) => {
+      cancelSandboxQuery()
+      syncSandboxInCache(sandbox)
     }
 
-    const invalidate = () => {
-      queryClient.invalidateQueries({
-        queryKey: getSandboxesQueryKey(orgId),
-        refetchType: 'none',
-      })
-
-      if (sandboxId) {
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.sandboxes.detail(orgId, sandboxId),
-        })
-      }
+    const handleCreated = async (sandbox: Sandbox) => {
+      if (sandboxId && sandbox.id !== sandboxId) return
+      await syncSandboxFromEvent(sandbox)
     }
 
-    const handleCreated = (_sandbox: Sandbox) => {
-      if (sandboxId) return
-
-      queryClient.invalidateQueries({
-        queryKey: getSandboxesQueryKey(orgId),
-        refetchType: refetchOnCreate ? 'active' : 'none',
-      })
-    }
-
-    const handleStateUpdated = (data: { sandbox: Sandbox; oldState: SandboxState; newState: SandboxState }) => {
+    const handleStateUpdated = async (data: { sandbox: Sandbox; oldState: SandboxState; newState: SandboxState }) => {
       if (sandboxId && data.sandbox.id !== sandboxId) return
-
-      // warm pool sandboxes — treat as created
-      if (data.oldState === data.newState && data.newState === SandboxState.STARTED) {
-        handleCreated(data.sandbox)
-        return
-      }
-
-      let updatedState = data.newState
-
-      // error/build_failed with desiredState=DESTROYED should display as destroyed
-      if (
-        data.sandbox.desiredState === SandboxDesiredState.DESTROYED &&
-        (data.newState === SandboxState.ERROR || data.newState === SandboxState.BUILD_FAILED)
-      ) {
-        updatedState = SandboxState.DESTROYED
-      }
-
-      optimisticUpdate(data.sandbox.id, updatedState)
-      invalidate()
+      await syncSandboxFromEvent(data.sandbox)
     }
 
-    const handleDesiredStateUpdated = (data: {
-      sandbox: Sandbox
-      oldDesiredState: SandboxDesiredState
-      newDesiredState: SandboxDesiredState
-    }) => {
+    const handleDesiredStateUpdated = async (data: { sandbox: Sandbox }) => {
       if (sandboxId && data.sandbox.id !== sandboxId) return
-
-      if (data.newDesiredState !== SandboxDesiredState.DESTROYED) return
-      if (data.sandbox.state !== SandboxState.ERROR && data.sandbox.state !== SandboxState.BUILD_FAILED) return
-
-      optimisticUpdate(data.sandbox.id, SandboxState.DESTROYED)
-      invalidate()
+      await syncSandboxFromEvent(data.sandbox)
     }
 
     notificationSocket.on('sandbox.created', handleCreated)
@@ -118,5 +69,24 @@ export function useSandboxWsSync({ sandboxId, refetchOnCreate = false }: UseSand
       notificationSocket.off('sandbox.state.updated', handleStateUpdated)
       notificationSocket.off('sandbox.desired-state.updated', handleDesiredStateUpdated)
     }
-  }, [notificationSocket, selectedOrganization?.id, sandboxId, refetchOnCreate, queryClient])
+  }, [notificationSocket, selectedOrganization?.id, sandboxId, queryClient])
+}
+
+export function useSandboxDetailsWsSync(sandboxId?: string) {
+  const { selectedOrganization } = useSelectedOrganization()
+
+  useSandboxWsSync({
+    sandboxId,
+    queryKey: queryKeys.sandboxes.detail(selectedOrganization?.id ?? '', sandboxId ?? ''),
+    sync: (oldData, sandbox) => {
+      if (!oldData) {
+        return sandbox
+      }
+
+      return {
+        ...oldData,
+        ...sandbox,
+      }
+    },
+  })
 }


### PR DESCRIPTION
## Description

Fixes sandbox details page websocket query cache invalidation.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale and flickering state on the Sandbox Details page by syncing WebSocket events directly into the details query instead of invalidating it. Start/stop/recover/archive transitions now update instantly and accurately.

- **Bug Fixes**
  - Added `useSandboxDetailsWsSync` to merge WS sandbox payloads into the details query and cancel in‑flight fetches to avoid races.
  - Disabled automatic invalidation in start/stop/archive/recover mutations on the details page; WS now drives live state.
  - `SandboxHeader` computes a single primary action from `state`/`desiredState` (including Archive) to prevent wrong or missing buttons during transitions.

- **Refactors**
  - Generalized `useSandboxWsSync` to accept a `queryKey` and `sync` function for targeted cache updates.
  - Simplified header buttons (static icons; “More actions” disabled during transitions).

<sup>Written for commit 9eaf879c918d8603cd36145a054d8b531ba6aa91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

