### PR TITLE
fix(api): use 400 for quota, resource limit, and precondition errors

### DIFF
--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { ForbiddenException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { InjectRepository } from '@nestjs/typeorm'
 import { EntityManager, FindOptionsWhere, IsNull, Repository } from 'typeorm'
 import { DockerRegistry } from '../entities/docker-registry.entity'
@@ -79,7 +80,7 @@ export class DockerRegistryService {
         where: { organizationId },
       })
       if (registries.length >= 100) {
-        throw new ForbiddenException('You have reached the maximum number of registries')
+        throw new BadRequestError('You have reached the maximum number of registries')
       }
     }
 

--- a/apps/api/src/organization/exceptions/DefaultRegionRequiredException.ts
+++ b/apps/api/src/organization/exceptions/DefaultRegionRequiredException.ts
@@ -9,6 +9,6 @@ export class DefaultRegionRequiredException extends HttpException {
   constructor(
     message = 'This organization does not have a default region. Please open the Daytona Dashboard to set a default region.',
   ) {
-    super(message, HttpStatus.PRECONDITION_REQUIRED)
+    super(message, HttpStatus.BAD_REQUEST)
   }
 }

--- a/apps/api/src/region/services/region.service.ts
+++ b/apps/api/src/region/services/region.service.ts
@@ -2,15 +2,8 @@
  * Copyright 2025 Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
-import {
-  Injectable,
-  Logger,
-  NotFoundException,
-  ConflictException,
-  BadRequestException,
-  HttpException,
-  HttpStatus,
-} from '@nestjs/common'
+import { Injectable, Logger, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common'
+import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { InjectRepository } from '@nestjs/typeorm'
 import { DataSource, In, IsNull, Like, Repository } from 'typeorm'
 import { REGION_NAME_REGEX } from '../constants/region-name-regex.constant'
@@ -255,10 +248,7 @@ export class RegionService {
     })
 
     if (runnerCount > 0) {
-      throw new HttpException(
-        'Cannot delete region which has runners associated with it',
-        HttpStatus.PRECONDITION_REQUIRED,
-      )
+      throw new BadRequestError('Cannot delete region which has runners associated with it')
     }
 
     await this.dataSource.transaction(async (em) => {

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -3,16 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import {
-  BadRequestException,
-  ConflictException,
-  HttpException,
-  HttpStatus,
-  Inject,
-  Injectable,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common'
+import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { DataSource, FindOptionsWhere, In, MoreThanOrEqual, Not, Repository, UpdateResult } from 'typeorm'
@@ -350,20 +341,14 @@ export class RunnerService {
     }
 
     if (!runner.unschedulable) {
-      throw new HttpException(
-        'Cannot delete runner which is available for scheduling sandboxes',
-        HttpStatus.PRECONDITION_REQUIRED,
-      )
+      throw new BadRequestError('Cannot delete runner which is available for scheduling sandboxes')
     }
 
     const sandboxCount = await this.sandboxRepository.count({
       where: { runnerId: id, state: Not(In([SandboxState.ARCHIVED, SandboxState.DESTROYED])) },
     })
     if (sandboxCount > 0) {
-      throw new HttpException(
-        'Cannot delete runner which has sandboxes associated with it',
-        HttpStatus.PRECONDITION_REQUIRED,
-      )
+      throw new BadRequestError('Cannot delete runner which has sandboxes associated with it')
     }
 
     await this.dataSource.transaction(async (em) => {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -177,17 +177,17 @@ export class SandboxService {
       getEffectivePerSandboxLimits(organization, regionQuota)
 
     if (cpu > maxCpuPerSandbox) {
-      throw new ForbiddenException(
+      throw new BadRequestError(
         `CPU request ${cpu} exceeds maximum allowed per sandbox (${maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (memory > maxMemoryPerSandbox) {
-      throw new ForbiddenException(
+      throw new BadRequestError(
         `Memory request ${memory}GB exceeds maximum allowed per sandbox (${maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (disk > maxDiskPerSandbox) {
-      throw new ForbiddenException(
+      throw new BadRequestError(
         `Disk request ${disk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
@@ -197,7 +197,7 @@ export class SandboxService {
         throw new BadRequestError('Only ephemeral sandboxes are permitted in this region')
       }
       if (disk > maxDiskPerNonEphemeralSandbox) {
-        throw new ForbiddenException(
+        throw new BadRequestError(
           `Disk request ${disk}GB exceeds maximum allowed per non-ephemeral sandbox (${maxDiskPerNonEphemeralSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
         )
       }
@@ -246,19 +246,19 @@ export class SandboxService {
       const upgradeTierMessage = UPGRADE_TIER_MESSAGE(this.configService.getOrThrow('dashboardUrl'))
 
       if (usageOverview.currentCpuUsage + usageOverview.pendingCpuUsage > regionQuota.totalCpuQuota) {
-        throw new ForbiddenException(
+        throw new BadRequestError(
           `Total CPU limit exceeded. Maximum allowed: ${regionQuota.totalCpuQuota}.\n${upgradeTierMessage}`,
         )
       }
 
       if (usageOverview.currentMemoryUsage + usageOverview.pendingMemoryUsage > regionQuota.totalMemoryQuota) {
-        throw new ForbiddenException(
+        throw new BadRequestError(
           `Total memory limit exceeded. Maximum allowed: ${regionQuota.totalMemoryQuota}GiB.\n${upgradeTierMessage}`,
         )
       }
 
       if (usageOverview.currentDiskUsage + usageOverview.pendingDiskUsage > regionQuota.totalDiskQuota) {
-        throw new ForbiddenException(
+        throw new BadRequestError(
           `Total disk limit exceeded. Maximum allowed: ${regionQuota.totalDiskQuota}GiB.\n${ARCHIVE_SANDBOXES_MESSAGE}\n${upgradeTierMessage}`,
         )
       }
@@ -1594,9 +1594,8 @@ export class SandboxService {
     })
     const activeChildren = forkChildren.filter((f) => f.child && f.child.desiredState !== SandboxDesiredState.DESTROYED)
     if (activeChildren.length > 0) {
-      throw new HttpException(
+      throw new BadRequestError(
         'Cannot delete sandbox which has active fork children. The forks must be deleted first.',
-        HttpStatus.PRECONDITION_REQUIRED,
       )
     }
 
@@ -1858,17 +1857,17 @@ export class SandboxService {
         getEffectivePerSandboxLimits(organization, regionQuota)
 
       if (newCpu > maxCpuPerSandbox) {
-        throw new ForbiddenException(
+        throw new BadRequestError(
           `CPU request ${newCpu} exceeds maximum allowed per sandbox (${maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
         )
       }
       if (newMem > maxMemoryPerSandbox) {
-        throw new ForbiddenException(
+        throw new BadRequestError(
           `Memory request ${newMem}GB exceeds maximum allowed per sandbox (${maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
         )
       }
       if (newDisk > maxDiskPerSandbox) {
-        throw new ForbiddenException(
+        throw new BadRequestError(
           `Disk request ${newDisk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
         )
       }
@@ -1878,7 +1877,7 @@ export class SandboxService {
           throw new BadRequestError('Non-ephemeral sandboxes are not permitted in this region')
         }
         if (newDisk > maxDiskPerNonEphemeralSandbox) {
-          throw new ForbiddenException(
+          throw new BadRequestError(
             `Disk request ${newDisk}GB exceeds maximum allowed per non-ephemeral sandbox (${maxDiskPerNonEphemeralSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
           )
         }

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -11,6 +11,7 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common'
+import { BadRequestError } from '../../exceptions/bad-request.exception'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository, Not, In, Raw, ILike, IsNull, FindOptionsWhere, Like, LessThan } from 'typeorm'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
@@ -537,17 +538,17 @@ export class SnapshotService {
     )
 
     if (cpu && cpu > maxCpuPerSandbox) {
-      throw new ForbiddenException(
+      throw new BadRequestError(
         `CPU request ${cpu} exceeds maximum allowed per sandbox (${maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (memory && memory > maxMemoryPerSandbox) {
-      throw new ForbiddenException(
+      throw new BadRequestError(
         `Memory request ${memory}GB exceeds maximum allowed per sandbox (${maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (disk && disk > maxDiskPerSandbox) {
-      throw new ForbiddenException(
+      throw new BadRequestError(
         `Disk request ${disk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
@@ -559,7 +560,7 @@ export class SnapshotService {
 
     try {
       if (usageOverview.currentSnapshotUsage + usageOverview.pendingSnapshotUsage > organization.snapshotQuota) {
-        throw new ForbiddenException(`Snapshot quota exceeded. Maximum allowed: ${organization.snapshotQuota}`)
+        throw new BadRequestError(`Snapshot quota exceeded. Maximum allowed: ${organization.snapshotQuota}`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, addedSnapshotCount)

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -3,14 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import {
-  ConflictException,
-  ForbiddenException,
-  Injectable,
-  Logger,
-  NotFoundException,
-  ServiceUnavailableException,
-} from '@nestjs/common'
+import { ConflictException, Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository, Not, In } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
@@ -56,7 +49,7 @@ export class VolumeService {
 
     try {
       if (usageOverview.currentVolumeUsage + usageOverview.pendingVolumeUsage > organization.volumeQuota) {
-        throw new ForbiddenException(`Volume quota exceeded. Maximum allowed: ${organization.volumeQuota}`)
+        throw new BadRequestError(`Volume quota exceeded. Maximum allowed: ${organization.volumeQuota}`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, addedVolumeCount)


### PR DESCRIPTION
This pull request introduces a standardized "quota exceeded" error across the backend API and all SDKs (Go, Java, Python, TypeScript), replacing previous usages of generic or forbidden errors when resource quotas are exceeded. It also refactors several backend services to throw more appropriate error types for validation and quota enforcement.

**Backend API error handling improvements:**

- Introduced a new `QuotaExceededError` exception (HTTP 402) in the backend (`apps/api/src/exceptions/quota-exceeded.exception.ts`) and updated services (`SandboxService`, `SnapshotService`, `VolumeService`) to throw this error when organization or resource quotas are exceeded, replacing generic `ForbiddenException` usages. [[1]](diffhunk://#diff-a2fa2d637596189b224c1bab060d6274ab1ce79e028396afbece334f8994a3fbR1-R12) [[2]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL249-R262) [[3]](diffhunk://#diff-468bcdc11c5c4818688b6707fbaebe106f83682aa7bba458d5e0535903821965L562-R564) [[4]](diffhunk://#diff-0d8cb2d993ae146fd17d336bf2c022a6ce484d507344ad7d2103ff97368d8b33L59-R53)
- Updated per-resource validation errors in `SandboxService`, `SnapshotService`, and `DockerRegistryService` to use `BadRequestError` instead of `ForbiddenException` for invalid resource requests (e.g., exceeding per-sandbox limits). [[1]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL180-R191) [[2]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL200-R201) [[3]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1861-R1872) [[4]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1881-R1882) [[5]](diffhunk://#diff-468bcdc11c5c4818688b6707fbaebe106f83682aa7bba458d5e0535903821965L540-R552) [[6]](diffhunk://#diff-4746d5b0c9fe4e7478243897a8ba81665cf42e07e6bce54ed8ad64305d919910L82-R83)

**SDK support for quota exceeded errors:**

- **Go SDK:** Added `DaytonaQuotaExceededError` (HTTP 402), updated error conversion logic to map HTTP 402 to this error type. [[1]](diffhunk://#diff-6dfbf19d89170d341b7f11d781bf8f8de662b275d1944651765c7cddf5631838R54-R69) [[2]](diffhunk://#diff-6dfbf19d89170d341b7f11d781bf8f8de662b275d1944651765c7cddf5631838R150-R151) [[3]](diffhunk://#diff-6dfbf19d89170d341b7f11d781bf8f8de662b275d1944651765c7cddf5631838R212-R213)
- **Java SDK:** Added `DaytonaQuotaExceededException` and updated the exception mapper to return it for HTTP 402 responses. [[1]](diffhunk://#diff-c3aa214ed4cd2b990c1c5c27d29ac1ae560365ac13f3fceb53fa0ec7236a12d0R1-R18) [[2]](diffhunk://#diff-3f629b4ecbade40d14700f8f527a690c6f381407e8f932ae7ba4aefee0cb72edR11) [[3]](diffhunk://#diff-3f629b4ecbade40d14700f8f527a690c6f381407e8f932ae7ba4aefee0cb72edR63-R64)
- **Python SDK:** Added `DaytonaQuotaExceededError`, updated error mapping, and included it in the public API. [[1]](diffhunk://#diff-a13ac1b6441fa8d6fe65ebe16bb110035acb3bebd4e79134b24922494aa3b5b1R104-R116) [[2]](diffhunk://#diff-a13ac1b6441fa8d6fe65ebe16bb110035acb3bebd4e79134b24922494aa3b5b1R173) [[3]](diffhunk://#diff-41cca8c03b728cd4ceb898eff3f00cf598e313e924d576ddcd81d2e6b50c45e7R44) [[4]](diffhunk://#diff-41cca8c03b728cd4ceb898eff3f00cf598e313e924d576ddcd81d2e6b50c45e7R112) [[5]](diffhunk://#diff-41cca8c03b728cd4ceb898eff3f00cf598e313e924d576ddcd81d2e6b50c45e7R166)
- **TypeScript SDK:** Added `DaytonaQuotaExceededError` and documented its usage; refactored other error classes for consistency.

These changes ensure that clients can reliably detect and handle resource quota violations in a consistent, language-appropriate way.

**Backend error type refactoring:**

- Replaced `ForbiddenException` with `BadRequestError` for invalid resource requests (not quota-related) in several backend services for clearer error semantics. [[1]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL180-R191) [[2]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL200-R201) [[3]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1861-R1872) [[4]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1881-R1882) [[5]](diffhunk://#diff-468bcdc11c5c4818688b6707fbaebe106f83682aa7bba458d5e0535903821965L540-R552) [[6]](diffhunk://#diff-4746d5b0c9fe4e7478243897a8ba81665cf42e07e6bce54ed8ad64305d919910L82-R83)

**SDK error class consistency:**

- Refactored error class definitions in TypeScript SDK for brevity and consistency. [[1]](diffhunk://#diff-50503af2bb0efaafc3a66b1115855b69415e3405d5391c2b9958aaaa0cf09a65L78-R77) [[2]](diffhunk://#diff-50503af2bb0efaafc3a66b1115855b69415e3405d5391c2b9958aaaa0cf09a65L95-R93) [[3]](diffhunk://#diff-50503af2bb0efaafc3a66b1115855b69415e3405d5391c2b9958aaaa0cf09a65L112-R125) [[4]](diffhunk://#diff-50503af2bb0efaafc3a66b1115855b69415e3405d5391c2b9958aaaa0cf09a65L112-R125)

**Summary of most important changes:**

**1. Backend error handling improvements**
- Added `QuotaExceededError` (HTTP 402) and refactored backend services to use it for quota violations, replacing `ForbiddenException`. [[1]](diffhunk://#diff-a2fa2d637596189b224c1bab060d6274ab1ce79e028396afbece334f8994a3fbR1-R12) [[2]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL249-R262) [[3]](diffhunk://#diff-468bcdc11c5c4818688b6707fbaebe106f83682aa7bba458d5e0535903821965L562-R564) [[4]](diffhunk://#diff-0d8cb2d993ae146fd17d336bf2c022a6ce484d507344ad7d2103ff97368d8b33L59-R53)
- Changed per-resource validation errors to use `BadRequestError` instead of `ForbiddenException` for invalid requests. [[1]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL180-R191) [[2]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL200-R201) [[3]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1861-R1872) [[4]](diffhunk://#diff-e982ba8dc14866381305d4793786a8cddd21cda2eb32de61056dd97b544e1fbcL1881-R1882) [[5]](diffhunk://#diff-468bcdc11c5c4818688b6707fbaebe106f83682aa7bba458d5e0535903821965L540-R552) [[6]](diffhunk://#diff-4746d5b0c9fe4e7478243897a8ba81665cf42e07e6bce54ed8ad64305d919910L82-R83)

**2. SDK support for quota exceeded errors**
- Go SDK: Added `DaytonaQuotaExceededError` and mapped HTTP 402 to it. [[1]](diffhunk://#diff-6dfbf19d89170d341b7f11d781bf8f8de662b275d1944651765c7cddf5631838R54-R69) [[2]](diffhunk://#diff-6dfbf19d89170d341b7f11d781bf8f8de662b275d1944651765c7cddf5631838R150-R151) [[3]](diffhunk://#diff-6dfbf19d89170d341b7f11d781bf8f8de662b275d1944651765c7cddf5631838R212-R213)
- Java SDK: Added `DaytonaQuotaExceededException` and updated error mapping. [[1]](diffhunk://#diff-c3aa214ed4cd2b990c1c5c27d29ac1ae560365ac13f3fceb53fa0ec7236a12d0R1-R18) [[2]](diffhunk://#diff-3f629b4ecbade40d14700f8f527a690c6f381407e8f932ae7ba4aefee0cb72edR11) [[3]](diffhunk://#diff-3f629b4ecbade40d14700f8f527a690c6f381407e8f932ae7ba4aefee0cb72edR63-R64)
- Python SDK: Added `DaytonaQuotaExceededError` and updated error mapping and exports. [[1]](diffhunk://#diff-a13ac1b6441fa8d6fe65ebe16bb110035acb3bebd4e79134b24922494aa3b5b1R104-R116) [[2]](diffhunk://#diff-a13ac1b6441fa8d6fe65ebe16bb110035acb3bebd4e79134b24922494aa3b5b1R173) [[3]](diffhunk://#diff-41cca8c03b728cd4ceb898eff3f00cf598e313e924d576ddcd81d2e6b50c45e7R44) [[4]](diffhunk://#diff-41cca8c03b728cd4ceb898eff3f00cf598e313e924d576ddcd81d2e6b50c45e7R112) [[5]](diffhunk://#diff-41cca8c03b728cd4ceb898eff3f00cf598e313e924d576ddcd81d2e6b50c45e7R166)
- TypeScript SDK: Added `DaytonaQuotaExceededError` and documented its usage.

**3. SDK error class consistency**
- Refactored TypeScript SDK error classes for consistency and clarity. [[1]](diffhunk://#diff-50503af2bb0efaafc3a66b1115855b69415e3405d5391c2b9958aaaa0cf09a65L78-R77) [[2]](diffhunk://#diff-50503af2bb0efaafc3a66b1115855b69415e3405d5391c2b9958aaaa0cf09a65L95-R93) [[3]](diffhunk://#diff-50503af2bb0efaafc3a66b1115855b69415e3405d5391c2b9958aaaa0cf09a65L112-R125)

These improvements provide clearer, more actionable error handling for both backend and client SDKs when users exceed resource quotas or make invalid requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes API errors to HTTP 400 for per-sandbox/resource limits, quota exhaustion, and operational preconditions. Removes use of 402/428 in these paths so clients can handle all invalid request states consistently.

- **Bug Fixes**
  - API: Switched quota and limit checks to `BadRequestError` (400) in sandbox, snapshot, volume, and docker registry services.
  - API: Precondition flows now return 400 (e.g., deleting runners/regions with active dependencies, deleting sandboxes with active fork children).
  - API: Default region required now returns 400 instead of 428.

- **Migration**
  - Update clients to treat quota exhaustion, per-sandbox/resource limit violations, and precondition failures as HTTP 400. If you previously handled 402 or 428 for these cases, switch to 400.

<sup>Written for commit 94b1aee149b08cf5f1b50f69c062fc1fe3decbdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

