### PR TITLE
fix(computer-use): translate control characters and honor delay in keyboard.type()

### DIFF
--- a/libs/computer-use/pkg/computeruse/keyboard.go
+++ b/libs/computer-use/pkg/computeruse/keyboard.go
@@ -6,19 +6,90 @@ package computeruse
 import (
 	"fmt"
 	"strings"
+	"time"
+	"unicode"
 
 	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
 	"github.com/go-vgo/robotgo"
 )
 
+type typingActionType int
+
+const (
+	typingActionText typingActionType = iota
+	typingActionEnter
+)
+
+type typingAction struct {
+	kind typingActionType
+	text string
+}
+
 func (u *ComputerUse) TypeText(req *computeruse.KeyboardTypeRequest) (*computeruse.Empty, error) {
-	if req.Delay > 0 {
-		robotgo.TypeStr(req.Text, req.Delay)
-	} else {
-		robotgo.TypeStr(req.Text)
+	actions, err := buildTypingActions(req.Text)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, action := range actions {
+		switch action.kind {
+		case typingActionText:
+			if req.Delay > 0 {
+				robotgo.TypeStr(action.text, 0, req.Delay)
+			} else {
+				robotgo.TypeStr(action.text)
+			}
+		case typingActionEnter:
+			if err := robotgo.KeyTap("enter"); err != nil {
+				return nil, err
+			}
+			if req.Delay > 0 {
+				time.Sleep(time.Duration(req.Delay) * time.Millisecond)
+			}
+		}
 	}
 
 	return new(computeruse.Empty), nil
+}
+
+func buildTypingActions(text string) ([]typingAction, error) {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+
+	actions := make([]typingAction, 0)
+	var currentText strings.Builder
+
+	flushText := func() {
+		if currentText.Len() == 0 {
+			return
+		}
+		actions = append(actions, typingAction{
+			kind: typingActionText,
+			text: currentText.String(),
+		})
+		currentText.Reset()
+	}
+
+	for _, r := range text {
+		switch r {
+		case '\n', '\r':
+			flushText()
+			actions = append(actions, typingAction{kind: typingActionEnter})
+		case '\t':
+			return nil, fmt.Errorf(
+				"keyboard.type does not translate '\\t' to Tab; use keyboard.press(\"tab\") for Tab key events",
+			)
+		case '\u2028', '\u2029':
+			return nil, fmt.Errorf("unsupported separator character in keyboard.type: U+%04X", r)
+		default:
+			if unicode.IsControl(r) {
+				return nil, fmt.Errorf("unsupported control character in keyboard.type: U+%04X", r)
+			}
+			currentText.WriteRune(r)
+		}
+	}
+
+	flushText()
+	return actions, nil
 }
 
 func (u *ComputerUse) PressKey(req *computeruse.KeyboardPressRequest) (*computeruse.Empty, error) {

--- a/libs/computer-use/pkg/computeruse/keyboard_test.go
+++ b/libs/computer-use/pkg/computeruse/keyboard_test.go
@@ -1,0 +1,58 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package computeruse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTypingActions(t *testing.T) {
+	t.Run("groups printable text and normalizes CRLF", func(t *testing.T) {
+		actions, err := buildTypingActions("line one\nline two\r\nline three")
+		require.NoError(t, err)
+		assert.Equal(t, []typingAction{
+			{kind: typingActionText, text: "line one"},
+			{kind: typingActionEnter},
+			{kind: typingActionText, text: "line two"},
+			{kind: typingActionEnter},
+			{kind: typingActionText, text: "line three"},
+		}, actions)
+	})
+
+	t.Run("rejects unsupported control characters", func(t *testing.T) {
+		_, err := buildTypingActions("hello\vworld")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported control character")
+		assert.Contains(t, err.Error(), "U+000B")
+	})
+
+	t.Run("rejects unicode line separators", func(t *testing.T) {
+		_, err := buildTypingActions("hello\u2028world")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported separator character")
+		assert.Contains(t, err.Error(), "U+2028")
+	})
+
+	t.Run("rejects tab characters", func(t *testing.T) {
+		_, err := buildTypingActions("hello\tworld")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not translate '\\t' to Tab")
+		assert.Contains(t, err.Error(), `keyboard.press("tab")`)
+	})
+
+	t.Run("returns no actions for unsupported input", func(t *testing.T) {
+		actions, err := buildTypingActions("hello\fworld")
+		require.Error(t, err)
+		assert.Nil(t, actions)
+	})
+
+	t.Run("returns no actions for empty input", func(t *testing.T) {
+		actions, err := buildTypingActions("")
+		require.NoError(t, err)
+		assert.Empty(t, actions)
+	})
+}


### PR DESCRIPTION
Two bugs in `sandbox.computer_use.keyboard.type()`, both rooted in how the typing primitive delegated to `robotgo`.

Closes #4553.
Closes #4554.

## What changed

Both fixes are in **`libs/computer-use/pkg/computeruse/keyboard.go`**.

### Control character handling (#4553)

`TypeText` no longer forwards arbitrary text to `robotgo.TypeStr`. Instead, the input is scanned into a sequence of `typingAction`s by a new `buildTypingActions` helper, and each action is executed separately:

- `\n` and `\r` translate to `robotgo.KeyTap("enter")`. `\r\n` is normalized to `\n` before scanning so CRLF doesn't double-press.
- `\t` is rejected with an actionable error pointing at `keyboard.press("tab")`. Unlike `\n` (whose dominant semantic is text-entry "insert line break"), Tab's dominant semantic is focus navigation, so translating it would risk silently redirecting the rest of the string to a different focused element. Callers who actually want a Tab keypress opt in explicitly via `press`.
- Printable runs are accumulated and typed in a single `robotgo.TypeStr` call, so there's no per-character perf regression.
- `\u2028` / `\u2029` (Unicode line/paragraph separators) and all other control characters (caught via `unicode.IsControl`) are rejected up front with a `U+XXXX` error. No partial typing happens if the input contains any unsupported char.

### `delay` parameter (#4554)

The `delay` parameter is now actually applied. The bug was `robotgo.TypeStr(req.Text, req.Delay)` passing the delay as the `pid` argument; the fix passes it in the correct position (`robotgo.TypeStr(text, 0, req.Delay)`). The same delay is also slept after each synthetic Enter keypress, so inter-keystroke pacing is consistent across typed text and newlines.

## Tests

New test file `libs/computer-use/pkg/computeruse/keyboard_test.go` covers `buildTypingActions`:

- groups printable text and normalizes CRLF
- rejects unsupported C0 control characters (`\v`, `\f`, etc.)
- rejects Unicode line/paragraph separators
- rejects `\t` with the actionable error (checks that the message mentions both `'\t'` and `keyboard.press("tab")`)
- returns no actions for unsupported input (guarantees no partial typing)
- returns no actions for empty input

All pass; `go build ./...` clean.

## Heads-up: behavior change
Previously, control characters like `\t`, `\v`, `\f`, `\x00`, `\x1b`, `\x7f` (and others) were silently dropped. They now return an error. Anyone (like an empty set) relying on the old silent-strip behavior will see a new error.
