### PR TITLE
feat(docs): add site url config

### DIFF
--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -18,17 +18,20 @@ COPY apps/docs/ apps/docs/
 COPY apps/api/ apps/api/
 COPY apps/daemon/pkg/toolbox/docs/swagger.json apps/daemon/pkg/toolbox/docs/swagger.json
 
+# Prevent local defaults from overriding CI-provided build variables.
+RUN rm -f apps/docs/.env
+
 # Lib dependencies (api imports runner-api-client)
 COPY libs/runner-api-client/ libs/runner-api-client/
 COPY libs/runner-proto/ libs/runner-proto/
 
 # Docs build arguments
-ENV PUBLIC_WEB_URL=https://daytona.io
 ARG PUBLIC_ALGOLIA_APP_ID
 ENV PUBLIC_ALGOLIA_APP_ID=${PUBLIC_ALGOLIA_APP_ID}
 ARG PUBLIC_ALGOLIA_API_KEY
 ENV PUBLIC_ALGOLIA_API_KEY=${PUBLIC_ALGOLIA_API_KEY}
 ARG PUBLIC_WEB_URL
+RUN test -n "${PUBLIC_WEB_URL}" || (echo "PUBLIC_WEB_URL build arg is required" && exit 1)
 ENV PUBLIC_WEB_URL=${PUBLIC_WEB_URL}
 ARG PUBLIC_ALGOLIA_DOCS_INDEX_NAME=docs
 ENV PUBLIC_ALGOLIA_DOCS_INDEX_NAME=${PUBLIC_ALGOLIA_DOCS_INDEX_NAME}

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -19,9 +19,21 @@ const jsonLightString = fs.readFileSync(
 const myThemeDark = ExpressiveCodeTheme.fromJSONString(jsonDarkString)
 const myThemeLight = ExpressiveCodeTheme.fromJSONString(jsonLightString)
 
+function hostFromUrl(value) {
+  if (!value) return null
+  try {
+    return new URL(value).hostname
+  } catch {
+    return null
+  }
+}
+
+const siteUrl = process.env.PUBLIC_WEB_URL || 'https://www.daytona.io'
+const siteHost = hostFromUrl(siteUrl)
+
 // https://astro.build/config
 export default defineConfig({
-  site: process.env.PUBLIC_WEB_URL,
+  site: siteUrl,
   base: '/docs',
   integrations: [
     react(),
@@ -72,6 +84,7 @@ export default defineConfig({
       { hostname: 'daytona.io' },
       { hostname: 'www.daytona.io' },
       { hostname: 'localhost' },
+      ...(siteHost ? [{ hostname: siteHost }] : []),
     ],
   },
   output: 'server',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the docs site URL configurable and enforced at build time. Uses PUBLIC_WEB_URL throughout and auto-allows its hostname for images.

- New Features
  - Astro reads `site` from `PUBLIC_WEB_URL` with a fallback to `https://www.daytona.io`.
  - Image allowlist now includes the hostname parsed from `PUBLIC_WEB_URL`, plus `daytona.io`, `www.daytona.io`, and `localhost`.
  - Docker build removes `apps/docs/.env` to avoid local overrides and fails if `PUBLIC_WEB_URL` is not provided.

- Migration
  - When building the docs image, pass: `--build-arg PUBLIC_WEB_URL=https://your-domain.tld`.

<sup>Written for commit 8423818f0ee76efd666768ea81ef705456f90953. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

