### PR TITLE
fix(docs): handle proxy request fallback

### DIFF
--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -22,19 +22,24 @@ export const onRequest = defineMiddleware(
     const path = url.pathname.replace(/\/$/, '')
 
     const proxyRequest = async (targetUrl: URL): Promise<Response> => {
-      const response = await fetch(targetUrl.toString(), {
-        method: request.method,
-        body:
-          request.method === 'GET' || request.method === 'HEAD'
-            ? undefined
-            : request.body,
-      })
+      try {
+        const response = await fetch(targetUrl.toString(), {
+          method: request.method,
+          body:
+            request.method === 'GET' || request.method === 'HEAD'
+              ? undefined
+              : request.body,
+        })
 
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: filterProxyHeaders(response.headers),
-      })
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: filterProxyHeaders(response.headers),
+        })
+      } catch {
+        // During prerender the target server doesn't exist yet; fall through
+        return next()
+      }
     }
 
     if (path === '/docs/sitemap.xml') {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a safe fallback in the docs middleware proxy so builds don’t fail when the target server isn’t available during prerender. If the upstream fetch throws, we fall through to the next handler instead of erroring.

<sup>Written for commit ade6950437d1d3ef4b0ab2a474a03f8f1afb2db8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

