### PR TITLE
fix: prewarm OpenAPI Generator JAR to prevent CI race condition

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -159,6 +159,8 @@ jobs:
           go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@v1.1.0
           echo -e 'DEFAULT_PACKAGE_VERSION=0.0.0-dev\nDEFAULT_GEM_VERSION=0.0.0.pre.dev\n\nPYPI_PKG_VERSION=\nNPM_PKG_VERSION=\nNPM_TAG=\nPYPI_TOKEN=\nNPM_TOKEN=' > .env
           mkdir -p dist/apps/api
+          openapi_version="$(node -e "console.log(require('./openapitools.json')['generator-cli'].version)")"
+          yarn openapi-generator-cli version-manager set "$openapi_version"
           yarn generate:api-client
           yarn lint:fix
           yarn format


### PR DESCRIPTION
Fixes #4247

## Problem
The `generate:api-client` job fails nondeterministically because Nx runs multiple OpenAPI Generator tasks in parallel, and they compete to download the same JAR file. One process wins, the other fails with a non-zero exit code.

## Solution
Added two lines before `yarn generate:api-client` in the CI workflow to prewarm the JAR:
- Read the OpenAPI Generator version from `openapitools.json`
- Download it once with `version-manager set` before parallel tasks start

This ensures all parallel tasks find the JAR already cached, eliminating the race.

## Testing
The fix will be validated by the CI pipeline itself - the job that was failing should now pass consistently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prewarm the OpenAPI Generator JAR in CI to remove a race when Nx runs parallel tasks, making `generate:api-client` consistent and reliable. The JAR is downloaded once before generation so all tasks hit the cache.

- **Bug Fixes**
  - Read the generator version from `openapitools.json`, then run `openapi-generator-cli version-manager set` before `yarn generate:api-client` to pre-download the JAR and prevent parallel download races.

<sup>Written for commit 55d8c57ee588955a74d45a773239880e6ce2f402. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

