### PR TITLE
fix(computer-use): region screenshot query parsing and input validation

### DIFF
--- a/apps/daemon/pkg/toolbox/computeruse/interface.go
+++ b/apps/daemon/pkg/toolbox/computeruse/interface.go
@@ -4,6 +4,7 @@
 package computeruse
 
 import (
+	"fmt"
 	"net/http"
 	"net/rpc"
 	"strconv"
@@ -227,6 +228,167 @@ type ProcessRequest struct {
 
 type Empty struct{} //	@name	Empty
 
+func parseRequiredIntQuery(c *gin.Context, key string) (int, error) {
+	value, ok := c.GetQuery(key)
+	if !ok {
+		return 0, fmt.Errorf("missing required query parameter: %s", key)
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid query parameter %s: must be an integer", key)
+	}
+
+	return parsed, nil
+}
+
+func parseRequiredPositiveIntQuery(c *gin.Context, key string) (int, error) {
+	parsed, err := parseRequiredIntQuery(c, key)
+	if err != nil {
+		return 0, err
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("invalid query parameter %s: must be greater than zero", key)
+	}
+
+	return parsed, nil
+}
+
+func parseBoolQueryValue(key, value string) (bool, error) {
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid query parameter %s: must be a boolean", key)
+	}
+
+	return parsed, nil
+}
+
+func parseShowCursorQuery(c *gin.Context) (bool, error) {
+	if value, ok := c.GetQuery("show_cursor"); ok {
+		return parseBoolQueryValue("show_cursor", value)
+	}
+	if value, ok := c.GetQuery("showCursor"); ok {
+		return parseBoolQueryValue("showCursor", value)
+	}
+
+	return false, nil
+}
+
+func parseOptionalQualityQuery(c *gin.Context) (int, error) {
+	value, ok := c.GetQuery("quality")
+	if !ok {
+		return 85, nil
+	}
+
+	quality, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid query parameter quality: must be an integer")
+	}
+	if quality < 1 || quality > 100 {
+		return 0, fmt.Errorf("invalid query parameter quality: must be between 1 and 100")
+	}
+
+	return quality, nil
+}
+
+func parseOptionalScaleQuery(c *gin.Context) (float64, error) {
+	value, ok := c.GetQuery("scale")
+	if !ok {
+		return 1.0, nil
+	}
+
+	scale, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid query parameter scale: must be a number")
+	}
+	if scale < 0.1 || scale > 1.0 {
+		return 0, fmt.Errorf("invalid query parameter scale: must be between 0.1 and 1.0")
+	}
+
+	return scale, nil
+}
+
+func parseRegionScreenshotRequest(c *gin.Context) (*RegionScreenshotRequest, error) {
+	x, err := parseRequiredIntQuery(c, "x")
+	if err != nil {
+		return nil, err
+	}
+	y, err := parseRequiredIntQuery(c, "y")
+	if err != nil {
+		return nil, err
+	}
+	width, err := parseRequiredPositiveIntQuery(c, "width")
+	if err != nil {
+		return nil, err
+	}
+	height, err := parseRequiredPositiveIntQuery(c, "height")
+	if err != nil {
+		return nil, err
+	}
+	showCursor, err := parseShowCursorQuery(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegionScreenshotRequest{
+		Position: Position{
+			X: x,
+			Y: y,
+		},
+		Size: Size{
+			Width:  width,
+			Height: height,
+		},
+		ShowCursor: showCursor,
+	}, nil
+}
+
+func parseCompressedScreenshotRequest(c *gin.Context) (*CompressedScreenshotRequest, error) {
+	showCursor, err := parseShowCursorQuery(c)
+	if err != nil {
+		return nil, err
+	}
+	quality, err := parseOptionalQualityQuery(c)
+	if err != nil {
+		return nil, err
+	}
+	scale, err := parseOptionalScaleQuery(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CompressedScreenshotRequest{
+		ShowCursor: showCursor,
+		Format:     c.DefaultQuery("format", "png"),
+		Quality:    quality,
+		Scale:      scale,
+	}, nil
+}
+
+func parseCompressedRegionScreenshotRequest(c *gin.Context) (*CompressedRegionScreenshotRequest, error) {
+	regionReq, err := parseRegionScreenshotRequest(c)
+	if err != nil {
+		return nil, err
+	}
+	quality, err := parseOptionalQualityQuery(c)
+	if err != nil {
+		return nil, err
+	}
+	scale, err := parseOptionalScaleQuery(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CompressedRegionScreenshotRequest{
+		Position:   regionReq.Position,
+		Size:       regionReq.Size,
+		ShowCursor: regionReq.ShowCursor,
+		Format:     c.DefaultQuery("format", "png"),
+		Quality:    quality,
+		Scale:      scale,
+	}, nil
+}
+
 func (p *ComputerUsePlugin) Server(*plugin.MuxBroker) (any, error) {
 	return &ComputerUseRPCServer{Impl: p.Impl}, nil
 }
@@ -248,8 +410,14 @@ func (p *ComputerUsePlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (any, err
 //	@id				TakeScreenshot
 func WrapScreenshotHandler(fn func(*ScreenshotRequest) (*ScreenshotResponse, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		showCursor, err := parseShowCursorQuery(c)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
 		req := &ScreenshotRequest{
-			ShowCursor: c.Query("showCursor") == "true",
+			ShowCursor: showCursor,
 		}
 		response, err := fn(req)
 		if err != nil {
@@ -277,14 +445,13 @@ func WrapScreenshotHandler(fn func(*ScreenshotRequest) (*ScreenshotResponse, err
 //	@id				TakeRegionScreenshot
 func WrapRegionScreenshotHandler(fn func(*RegionScreenshotRequest) (*ScreenshotResponse, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var req RegionScreenshotRequest
-		if err := c.ShouldBindQuery(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid parameters"})
+		req, err := parseRegionScreenshotRequest(c)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		req.ShowCursor = c.Query("showCursor") == "true"
 
-		response, err := fn(&req)
+		response, err := fn(req)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -309,25 +476,10 @@ func WrapRegionScreenshotHandler(fn func(*RegionScreenshotRequest) (*ScreenshotR
 //	@id				TakeCompressedScreenshot
 func WrapCompressedScreenshotHandler(fn func(*CompressedScreenshotRequest) (*ScreenshotResponse, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		req := &CompressedScreenshotRequest{
-			ShowCursor: c.Query("showCursor") == "true",
-			Format:     c.Query("format"),
-			Quality:    85,
-			Scale:      1.0,
-		}
-
-		// Parse quality
-		if qualityStr := c.Query("quality"); qualityStr != "" {
-			if quality, err := strconv.Atoi(qualityStr); err == nil && quality >= 1 && quality <= 100 {
-				req.Quality = quality
-			}
-		}
-
-		// Parse scale
-		if scaleStr := c.Query("scale"); scaleStr != "" {
-			if scale, err := strconv.ParseFloat(scaleStr, 64); err == nil && scale >= 0.1 && scale <= 1.0 {
-				req.Scale = scale
-			}
+		req, err := parseCompressedScreenshotRequest(c)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
 
 		response, err := fn(req)
@@ -359,31 +511,13 @@ func WrapCompressedScreenshotHandler(fn func(*CompressedScreenshotRequest) (*Scr
 //	@id				TakeCompressedRegionScreenshot
 func WrapCompressedRegionScreenshotHandler(fn func(*CompressedRegionScreenshotRequest) (*ScreenshotResponse, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var req CompressedRegionScreenshotRequest
-		if err := c.ShouldBindQuery(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid parameters"})
+		req, err := parseCompressedRegionScreenshotRequest(c)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		req.ShowCursor = c.Query("showCursor") == "true"
-		req.Format = c.Query("format")
-		req.Quality = 85
-		req.Scale = 1.0
 
-		// Parse quality
-		if qualityStr := c.Query("quality"); qualityStr != "" {
-			if quality, err := strconv.Atoi(qualityStr); err == nil && quality >= 1 && quality <= 100 {
-				req.Quality = quality
-			}
-		}
-
-		// Parse scale
-		if scaleStr := c.Query("scale"); scaleStr != "" {
-			if scale, err := strconv.ParseFloat(scaleStr, 64); err == nil && scale >= 0.1 && scale <= 1.0 {
-				req.Scale = scale
-			}
-		}
-
-		response, err := fn(&req)
+		response, err := fn(req)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return

--- a/apps/daemon/pkg/toolbox/computeruse/interface_test.go
+++ b/apps/daemon/pkg/toolbox/computeruse/interface_test.go
@@ -1,0 +1,414 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package computeruse
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeComputerUse struct {
+	screenshotReq       *ScreenshotRequest
+	regionReq           *RegionScreenshotRequest
+	compressedReq       *CompressedScreenshotRequest
+	compressedRegionReq *CompressedRegionScreenshotRequest
+}
+
+func (f *fakeComputerUse) TakeScreenshot(req *ScreenshotRequest) (*ScreenshotResponse, error) {
+	f.screenshotReq = req
+	return &ScreenshotResponse{Screenshot: "ok"}, nil
+}
+
+func (f *fakeComputerUse) TakeRegionScreenshot(req *RegionScreenshotRequest) (*ScreenshotResponse, error) {
+	f.regionReq = req
+	return &ScreenshotResponse{Screenshot: "ok"}, nil
+}
+
+func (f *fakeComputerUse) TakeCompressedScreenshot(req *CompressedScreenshotRequest) (*ScreenshotResponse, error) {
+	f.compressedReq = req
+	return &ScreenshotResponse{Screenshot: "ok"}, nil
+}
+
+func (f *fakeComputerUse) TakeCompressedRegionScreenshot(req *CompressedRegionScreenshotRequest) (*ScreenshotResponse, error) {
+	f.compressedRegionReq = req
+	return &ScreenshotResponse{Screenshot: "ok"}, nil
+}
+
+func newScreenshotTestRouter(t *testing.T, fake *fakeComputerUse) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.GET("/computeruse/screenshot", WrapScreenshotHandler(fake.TakeScreenshot))
+	r.GET("/computeruse/screenshot/region", WrapRegionScreenshotHandler(fake.TakeRegionScreenshot))
+	r.GET("/computeruse/screenshot/compressed", WrapCompressedScreenshotHandler(fake.TakeCompressedScreenshot))
+	r.GET("/computeruse/screenshot/region/compressed", WrapCompressedRegionScreenshotHandler(fake.TakeCompressedRegionScreenshot))
+	return r
+}
+
+func performScreenshotRequest(router *gin.Engine, path string) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	router.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestWrapRegionScreenshotHandlerParsesLowercaseQueryParams(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region?x=0&y=0&width=200&height=200")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.regionReq)
+	assert.Equal(t, 0, fake.regionReq.X)
+	assert.Equal(t, 0, fake.regionReq.Y)
+	assert.Equal(t, 200, fake.regionReq.Width)
+	assert.Equal(t, 200, fake.regionReq.Height)
+}
+
+func TestWrapCompressedRegionScreenshotHandlerParsesLowercaseQueryParams(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&format=png&quality=80&scale=1")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.compressedRegionReq)
+	assert.Equal(t, 0, fake.compressedRegionReq.X)
+	assert.Equal(t, 0, fake.compressedRegionReq.Y)
+	assert.Equal(t, 200, fake.compressedRegionReq.Width)
+	assert.Equal(t, 200, fake.compressedRegionReq.Height)
+	assert.Equal(t, "png", fake.compressedRegionReq.Format)
+	assert.Equal(t, 80, fake.compressedRegionReq.Quality)
+	assert.Equal(t, 1.0, fake.compressedRegionReq.Scale)
+}
+
+func TestWrapRegionScreenshotHandlerRejectsMissingDimensions(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "missing width",
+			path: "/computeruse/screenshot/region?x=0&y=0&height=200",
+		},
+		{
+			name: "missing height",
+			path: "/computeruse/screenshot/region?x=0&y=0&width=200",
+		},
+		{
+			name: "compressed missing width",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&height=200",
+		},
+		{
+			name: "compressed missing height",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeComputerUse{}
+			router := newScreenshotTestRouter(t, fake)
+
+			rr := performScreenshotRequest(router, tt.path)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Nil(t, fake.regionReq)
+			assert.Nil(t, fake.compressedRegionReq)
+		})
+	}
+}
+
+func TestWrapRegionScreenshotHandlerRejectsInvalidDimensions(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "zero width",
+			path: "/computeruse/screenshot/region?x=0&y=0&width=0&height=200",
+		},
+		{
+			name: "zero height",
+			path: "/computeruse/screenshot/region?x=0&y=0&width=200&height=0",
+		},
+		{
+			name: "negative width",
+			path: "/computeruse/screenshot/region?x=0&y=0&width=-1&height=200",
+		},
+		{
+			name: "negative height",
+			path: "/computeruse/screenshot/region?x=0&y=0&width=200&height=-1",
+		},
+		{
+			name: "compressed zero width",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=0&height=200",
+		},
+		{
+			name: "compressed zero height",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=0",
+		},
+		{
+			name: "compressed negative width",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=-1&height=200",
+		},
+		{
+			name: "compressed negative height",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeComputerUse{}
+			router := newScreenshotTestRouter(t, fake)
+
+			rr := performScreenshotRequest(router, tt.path)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Nil(t, fake.regionReq)
+			assert.Nil(t, fake.compressedRegionReq)
+		})
+	}
+}
+
+func TestWrapRegionScreenshotHandlerParsesShowCursor(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region?x=0&y=0&width=200&height=200&showCursor=true")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.regionReq)
+	assert.True(t, fake.regionReq.ShowCursor)
+}
+
+func TestWrapRegionScreenshotHandlerParsesShowCursorSnakeCaseAlias(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region?x=0&y=0&width=200&height=200&show_cursor=true")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.regionReq)
+	assert.True(t, fake.regionReq.ShowCursor)
+}
+
+func TestWrapScreenshotHandlerParsesShowCursor(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot?showCursor=true")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.screenshotReq)
+	assert.True(t, fake.screenshotReq.ShowCursor)
+}
+
+func TestWrapCompressedScreenshotHandlerParsesShowCursor(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/compressed?showCursor=true")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.compressedReq)
+	assert.True(t, fake.compressedReq.ShowCursor)
+}
+
+func TestWrapCompressedRegionScreenshotHandlerParsesShowCursor(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&showCursor=true")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.compressedRegionReq)
+	assert.True(t, fake.compressedRegionReq.ShowCursor)
+}
+
+func TestWrapScreenshotHandlerRejectsInvalidShowCursor(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot?showCursor=yes")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Nil(t, fake.screenshotReq)
+}
+
+func TestWrapScreenshotHandlerRejectsInvalidShowCursorSnakeCaseAlias(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot?show_cursor=yes")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Nil(t, fake.screenshotReq)
+}
+
+func TestWrapCompressedScreenshotHandlerRejectsInvalidShowCursor(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/compressed?showCursor=yes")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Nil(t, fake.compressedReq)
+}
+
+func TestWrapRegionScreenshotHandlerAllowsNegativeCoordinates(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region?x=-100&y=-100&width=100&height=100")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.regionReq)
+	assert.Equal(t, -100, fake.regionReq.X)
+	assert.Equal(t, -100, fake.regionReq.Y)
+	assert.Equal(t, 100, fake.regionReq.Width)
+	assert.Equal(t, 100, fake.regionReq.Height)
+}
+
+func TestWrapCompressedRegionScreenshotHandlerValidatesCompressionOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "quality non-integer",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&quality=abc",
+		},
+		{
+			name: "quality too low",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&quality=0",
+		},
+		{
+			name: "quality too high",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&quality=200",
+		},
+		{
+			name: "scale non-float",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&scale=abc",
+		},
+		{
+			name: "scale too low",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&scale=0",
+		},
+		{
+			name: "scale too high",
+			path: "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&scale=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeComputerUse{}
+			router := newScreenshotTestRouter(t, fake)
+
+			rr := performScreenshotRequest(router, tt.path)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Nil(t, fake.compressedRegionReq)
+		})
+	}
+}
+
+func TestWrapCompressedScreenshotHandlerValidatesCompressionOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "quality non-integer",
+			path: "/computeruse/screenshot/compressed?quality=abc",
+		},
+		{
+			name: "quality too low",
+			path: "/computeruse/screenshot/compressed?quality=0",
+		},
+		{
+			name: "quality too high",
+			path: "/computeruse/screenshot/compressed?quality=200",
+		},
+		{
+			name: "scale non-float",
+			path: "/computeruse/screenshot/compressed?scale=abc",
+		},
+		{
+			name: "scale too low",
+			path: "/computeruse/screenshot/compressed?scale=0",
+		},
+		{
+			name: "scale too high",
+			path: "/computeruse/screenshot/compressed?scale=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeComputerUse{}
+			router := newScreenshotTestRouter(t, fake)
+
+			rr := performScreenshotRequest(router, tt.path)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Nil(t, fake.compressedReq)
+		})
+	}
+}
+
+func TestWrapCompressedRegionScreenshotHandlerParsesValidCompressionOptions(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region/compressed?x=0&y=0&width=200&height=200&quality=80&scale=0.5")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.compressedRegionReq)
+	assert.Equal(t, "png", fake.compressedRegionReq.Format)
+	assert.Equal(t, 80, fake.compressedRegionReq.Quality)
+	assert.Equal(t, 0.5, fake.compressedRegionReq.Scale)
+}
+
+func TestWrapCompressedScreenshotHandlerParsesValidCompressionOptions(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/compressed?quality=80&scale=0.5")
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, fake.compressedReq)
+	assert.Equal(t, "png", fake.compressedReq.Format)
+	assert.Equal(t, 80, fake.compressedReq.Quality)
+	assert.Equal(t, 0.5, fake.compressedReq.Scale)
+}
+
+func TestWrapRegionScreenshotHandlerRejectsTitleCaseQueryParams(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region?X=0&Y=0&Width=200&Height=200")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Nil(t, fake.regionReq)
+}
+
+func TestWrapCompressedRegionScreenshotHandlerRejectsTitleCaseQueryParams(t *testing.T) {
+	fake := &fakeComputerUse{}
+	router := newScreenshotTestRouter(t, fake)
+
+	rr := performScreenshotRequest(router, "/computeruse/screenshot/region/compressed?X=0&Y=0&Width=200&Height=200")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Nil(t, fake.compressedRegionReq)
+}

--- a/libs/computer-use/pkg/computeruse/display.go
+++ b/libs/computer-use/pkg/computeruse/display.go
@@ -6,6 +6,7 @@ package computeruse
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"image"
 	"image/draw"
 	"image/jpeg"
@@ -18,7 +19,7 @@ import (
 
 // ImageCompressionParams holds parameters for image compression
 type ImageCompressionParams struct {
-	Format  string  // "png", "jpeg", "webp"
+	Format  string  // "png" or "jpeg"
 	Quality int     // 1-100 for JPEG quality
 	Scale   float64 // 0.1-1.0 for scaling down
 }
@@ -67,8 +68,18 @@ func scaleImage(img *image.RGBA, scale float64) image.Image {
 
 	// Simple nearest neighbor scaling
 	oldBounds := img.Bounds()
+	if oldBounds.Dx() <= 0 || oldBounds.Dy() <= 0 {
+		return img
+	}
+
 	newWidth := int(float64(oldBounds.Dx()) * scale)
 	newHeight := int(float64(oldBounds.Dy()) * scale)
+	if newWidth < 1 {
+		newWidth = 1
+	}
+	if newHeight < 1 {
+		newHeight = 1
+	}
 
 	scaledImg := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
 
@@ -140,10 +151,14 @@ func (u *ComputerUse) TakeCompressedRegionScreenshot(req *computeruse.Compressed
 		Scale:   req.Scale,
 	}
 
+	if err := validateScreenshotRegion(req.Width, req.Height); err != nil {
+		return nil, err
+	}
+
 	rect := image.Rect(req.X, req.Y, req.X+req.Width, req.Y+req.Height)
 	img, err := screenshot.CaptureRect(rect)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to capture screenshot region x=%d y=%d width=%d height=%d: %w", req.X, req.Y, req.Width, req.Height, err)
 	}
 
 	// Convert to RGBA for drawing

--- a/libs/computer-use/pkg/computeruse/display_test.go
+++ b/libs/computer-use/pkg/computeruse/display_test.go
@@ -1,0 +1,20 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package computeruse
+
+import (
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScaleImageKeepsTinyPositiveImagesNonZero(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+
+	scaled := scaleImage(img, 0.1)
+
+	assert.Equal(t, 1, scaled.Bounds().Dx())
+	assert.Equal(t, 1, scaled.Bounds().Dy())
+}

--- a/libs/computer-use/pkg/computeruse/screenshot.go
+++ b/libs/computer-use/pkg/computeruse/screenshot.go
@@ -6,6 +6,7 @@ package computeruse
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"image"
 	"image/color"
 	"image/draw"
@@ -17,6 +18,14 @@ import (
 	"github.com/kbinani/screenshot"
 	log "github.com/sirupsen/logrus"
 )
+
+func validateScreenshotRegion(width, height int) error {
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("invalid screenshot region: width and height must be greater than zero")
+	}
+
+	return nil
+}
 
 // drawCursor draws a simple cursor at the given position
 func drawCursor(img *image.RGBA, x, y int) {
@@ -128,11 +137,14 @@ func (u *ComputerUse) TakeRegionScreenshot(req *computeruse.RegionScreenshotRequ
 	display := os.Getenv("DISPLAY")
 	log.Infof("TakeRegionScreenshot: DISPLAY=%s", display)
 
+	if err := validateScreenshotRegion(req.Width, req.Height); err != nil {
+		return nil, err
+	}
+
 	rect := image.Rect(req.X, req.Y, req.X+req.Width, req.Y+req.Height)
 	img, err := screenshot.CaptureRect(rect)
 	if err != nil {
-		log.Errorf("TakeRegionScreenshot error: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to capture screenshot region x=%d y=%d width=%d height=%d: %w", req.X, req.Y, req.Width, req.Height, err)
 	}
 
 	// Convert to RGBA for drawing


### PR DESCRIPTION
## Summary

Fixes #3660. Region screenshot calls from any of the generated SDK clients were failing with `400 png: invalid format: invalid image size: 0x0`. The reason: SDKs send the dimensions as lowercase query parameters (`?x=…&y=…&width=…&height=…`), but the daemon was matching them against the Go struct fields case-sensitively (`X`, `Y`, `Width`, `Height`). Nothing matched, every dimension defaulted to zero, and the encoder rejected the resulting `0x0` capture region.

The fix rewrites the region handlers to read each query parameter explicitly instead of relying on the framework's automatic query binding, and requires `width`/`height` to be present and positive. The screenshot plugin itself also rejects zero or negative dimensions before they reach the encoder, and capture errors are wrapped with the requested rect coordinates so failures past that point are easier to diagnose.

Also added some related hardening:

- `show_cursor` (the snake_case key the public SDK actually sends, previously silently ignored) is now honored alongside `showCursor`.
- Malformed or out-of-range `quality`/`scale` values now return `400` instead of silently falling back to defaults of `quality=85` / `scale=1.0`.
- `scaleImage` clamps scaled output dimensions to at least `1x1` so tiny positive-size inputs no longer truncate to a `0x0` image.

Adds focused Gin handler regression tests covering the lowercase request shape, missing/zero/negative dimensions, the `show_cursor` alias path, and the new strict `quality`/`scale` validation.

### Root cause of #3660 

Reproduced live against a sandbox with the deployed daemon. Same SDK call, only the query-key casing differs:

```text
GET /computeruse/screenshot/region?x=0&y=0&width=200&height=200
  → 400  {"error":"png: invalid format: invalid image size: 0x0"}

GET /computeruse/screenshot/region?X=0&Y=0&Width=200&Height=200
  → 200  9033 bytes (valid PNG of the requested 200x200 region)
```

## Changes

- Replace `ShouldBindQuery` in region screenshot handlers with explicit query parsing for:
  - required `x`, `y`, `width`, `height`
  - optional `showCursor`
  - compressed-region `format`, `quality`, and `scale`
- Route the full-screen compressed handler through the same shared helpers (`parseCompressedScreenshotRequest`) so all four screenshot handlers parse `showCursor`, `format`, `quality`, and `scale` uniformly. The previous inline silent-fallback parsing in `WrapCompressedScreenshotHandler` is removed, eliminating duplicated `85`/`1.0` defaults.
- Validate region dimensions at the HTTP layer:
  - `width` and `height` are required
  - `width` and `height` must be greater than zero
  - negative `x` and `y` are still allowed for multi-display coordinate layouts
- Accept both `show_cursor` (public API contract) and `showCursor` (daemon contract) on all four screenshot handlers, with strict validation on whichever key is sent. Previously the daemon only read `showCursor`, so the SDK-issued `show_cursor=...` was silently dropped end-to-end. Precedence is `show_cursor` first, falling back to `showCursor`.
- Strict-validate `quality` and `scale` on **both** compressed endpoints (full-screen and region) instead of silently falling back to defaults.
- Add plugin-side guards before region `screenshot.CaptureRect` calls so zero or negative dimensions return:
  - `invalid screenshot region: width and height must be greater than zero`
- Wrap region capture errors with request context for easier diagnosis.
- Clamp scaled image output dimensions to at least `1x1` when scaling a positive-size image.

## Tests

- Add Gin handler tests for the daemon computer-use screenshot endpoints, covering:
  - generated-client-style lowercase region query params
  - compressed region query params
  - missing dimensions
  - zero and negative dimensions
  - negative coordinates
  - valid and invalid `showCursor`
  - `show_cursor` snake_case alias (happy path and invalid value)
  - `quality` and `scale` validation on both compressed endpoints (full-screen and region), plus a happy-path test for each
- Add a `scaleImage` regression test for tiny positive inputs that would otherwise truncate to `0x0`.

## Behavior Changes

- Region screenshot endpoints now return `400` for missing or malformed `x`/`y`/`width`/`height`, or for zero/negative `width`/`height`. Negative `x`/`y` remain allowed for multi-display coordinate layouts.
- Both compressed endpoints now return `400` for malformed or out-of-range `quality` and `scale`. The full-screen path used to silently fall back to `quality=85` / `scale=1.0`.
- All screenshot endpoints now return `400` for malformed `showCursor`/`show_cursor` instead of silently treating them as false. `show_cursor=...` was previously dropped entirely (the daemon only read `showCursor`); it is now honored.

## Validation

`go test` passes for both `apps/daemon/pkg/toolbox/computeruse/...` and `libs/computer-use/pkg/computeruse/...`. The lowercase-query regression test reproduces #3660's exact request shape.
