### PR TITLE
fix(docs): modify sandbox snapshot description

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -934,7 +934,7 @@ The fork tree displays each sandbox in the hierarchy along with its current stat
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to create [snapshots](/docs/en/snapshots) from sandboxes. Snapshots are immutable copies of a sandbox's filesystem that can be used to create new sandboxes.
+Daytona provides methods to create [snapshots](/docs/en/snapshots) from sandboxes. A snapshot captures an immutable, point-in-time copy of a sandbox's filesystem and memory that you can use as a base to create new sandboxes, effectively templating a known-good environment for reuse. You can think of it as a checkpoint you can restore from whenever you need a clean, identical starting point.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the sandbox snapshot docs to explain that a snapshot is an immutable, point-in-time copy of both filesystem and memory. It can be reused as a template/checkpoint to create identical sandboxes.

<sup>Written for commit e8bec0f381d6d726b654a883632766555839de47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

