### PR TITLE
fix(docs): modify markdown headings spacing

### DIFF
--- a/apps/docs/src/styles/components/markdown.scss
+++ b/apps/docs/src/styles/components/markdown.scss
@@ -78,6 +78,17 @@
     margin: 24px 0;
   }
 
+  > :is(h2[id], h3[id], h4[id], h5[id], .sl-heading-wrapper) + :not(
+      p,
+      h2,
+      h3,
+      h4,
+      h5,
+      .sl-heading-wrapper
+    ) {
+    margin-top: 24px;
+  }
+
   > hr {
     margin: 40px 0;
   }


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/54f54bd9-d9cc-4d0a-935e-57db6846fd6e) | ![After](https://github.com/user-attachments/assets/1df5081d-1fb8-4bdd-a1d9-1c5171ec756e) |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inconsistent spacing after markdown headings in docs to improve readability. Adds a 24px top margin to non-paragraph elements that follow h2–h5 or `.sl-heading-wrapper`, preventing cramped lists, images, and code blocks.

<sup>Written for commit a955a4ed5d3c96e60510ff4395db6b09c5e444be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

