### PR TITLE
Fix toolbox listFiles route to accept /files and /files/

### DIFF
--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -168,6 +168,7 @@ func (s *server) Start() error {
 	{
 		// read operations
 		fsController.GET("/", fs.ListFiles)
+		fsController.GET("", fs.ListFiles)
 		fsController.GET("/download", fs.DownloadFile)
 		fsController.POST("/bulk-download", fs.DownloadFiles)
 		fsController.GET("/find", fs.FindInFiles)

--- a/apps/daemon/pkg/toolbox/server_test.go
+++ b/apps/daemon/pkg/toolbox/server_test.go
@@ -1,0 +1,63 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package toolbox
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/daytonaio/daytona/apps/daemon/pkg/toolbox/fs"
+)
+
+func TestFilesRoutesAcceptSlashAndNoSlash(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+
+	fsController := r.Group("/files")
+	{
+		fsController.GET("/", fs.ListFiles)
+		fsController.GET("", fs.ListFiles)
+	}
+
+	tempDir := t.TempDir()
+
+	check := func(path string) int {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	statusNoSlash := check("/files?path=" + tempDir)
+	statusSlash := check("/files/?path=" + tempDir)
+
+	if statusNoSlash != http.StatusOK {
+		t.Fatalf("GET /files returned status %d, want %d", statusNoSlash, http.StatusOK)
+	}
+
+	if statusSlash != http.StatusOK {
+		t.Fatalf("GET /files/ returned status %d, want %d", statusSlash, http.StatusOK)
+	}
+}
+
+func TestNewServerConstructs(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	s := NewServer(ServerConfig{
+		Logger:    logger,
+		WorkDir:   t.TempDir(),
+		SandboxId: "test-sandbox",
+		ConfigDir: t.TempDir(),
+	})
+
+	if s == nil {
+		t.Fatal("NewServer returned nil")
+	}
+}

--- a/apps/daemon/pkg/toolbox/server_test.go
+++ b/apps/daemon/pkg/toolbox/server_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/daytonaio/daytona/apps/daemon/pkg/toolbox/fs"
+	"github.com/daytonaio/daemon/pkg/toolbox/fs"
 )
 
 func TestFilesRoutesAcceptSlashAndNoSlash(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes a trailing-slash route mismatch in the toolbox daemon for filesystem listing. The TypeScript SDK-generated toolbox client calls `GET /files?path=...`, but the reported daemon behavior only recognized `GET /files/?path=...`, which caused `sandbox.fs.listFiles(path)` to return `404 page not found` for valid directories. [web:275]

To preserve compatibility with the existing generated client and avoid client/version skew, this change registers both `GET /files` and `GET /files/` to the same `fs.ListFiles` handler in `apps/daemon/pkg/toolbox/server.go`. [web:275]

This PR also adds a regression test in `apps/daemon/pkg/toolbox/server_test.go` to verify that both route forms return `200 OK` for an existing directory path. Daytona’s PR preparation guide asks for focused changes with tests, and this PR keeps the fix scoped to the reported route mismatch. [web:299]

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #4542. [web:275]

## Screenshots

Not applicable.

## Notes

I was not able to run Go tests locally on this machine because `go` was not available in `PATH`, so I’m relying on CI to validate the change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept both `/files` and `/files/` in the toolbox daemon to stop 404s from SDK list-directory calls. Fixes #4542 (Linear web-275).

- **Bug Fixes**
  - Map `GET /files` and `GET /files/` to `fs.ListFiles` in `apps/daemon/pkg/toolbox/server.go`.
  - Add tests for both paths and a `NewServer` construction check in `apps/daemon/pkg/toolbox/server_test.go`.
  - Fix test import path.

<sup>Written for commit 1f4ce2575b9828e9655da52a698df515abb6c2cc. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

