### PR TITLE
fix(api): snapshot reactivation grace period

### DIFF
--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -628,6 +628,13 @@ export class SnapshotService {
         throw new BadRequestException(`Snapshot ${snapshotId} cannot be activated - it is in ${snapshot.state} state`)
       }
 
+      const activationCooldownMs = 10 * 60 * 1000
+      const recentlyDeactivated = Date.now() - snapshot.updatedAt.getTime() < activationCooldownMs
+
+      if (recentlyDeactivated) {
+        throw new BadRequestException('Snapshot deactivation is still in progress. Please try again in a few minutes.')
+      }
+
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
       const regionId = snapshot.snapshotRegions?.[0]?.regionId


### PR DESCRIPTION
## Description

Adds a snapshot reactivation grace period to prevent spam

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 10-minute cooldown after snapshot deactivation to block immediate reactivation and reduce spam. The API now returns a 400 error with a clear message if activation is attempted within the cooldown.

<sup>Written for commit 6261c11674ce690d9bd5c2c99b49dd00028ffec9. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

