### PR TITLE
fix(api): typeorm param passing in cron query

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -1160,7 +1160,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       const queryResult = await this.snapshotRepository
         .createQueryBuilder('snapshot')
         .select('snapshot."ref"')
-        .where('snapshot.state = :snapshotState', { snapshotState: SnapshotState.INACTIVE })
+        .where('snapshot.state = :inactiveState', { inactiveState: SnapshotState.INACTIVE })
         .andWhere('snapshot."ref" IS NOT NULL')
         .andWhereExists(
           this.snapshotRunnerRepository
@@ -1177,11 +1177,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
               .createQueryBuilder('s')
               .select('1')
               .where('s."ref" = snapshot."ref"')
-              .andWhere('s.state = :snapshotState')
+              .andWhere('s.state = :activeState')
             return `NOT EXISTS (${query.getQuery()})`
           },
           {
-            snapshotState: SnapshotState.ACTIVE,
+            activeState: SnapshotState.ACTIVE,
           },
         )
         .take(100)


### PR DESCRIPTION
## Description

Fixes an issue related to passing a parameter with the same name to the query in typeorm

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a `typeorm` parameter name collision in the inactive snapshot cron query so the correct state values are bound and the right snapshots are selected.

- **Bug Fixes**
  - Use distinct params: `inactiveState` for the outer filter and `activeState` for the subquery.
  - Ensures only INACTIVE snapshots with a ref and no ACTIVE snapshot with the same ref are returned.

<sup>Written for commit 705a08fe3c82da32017baa48724078cd62a8970a. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4578?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

