### PR TITLE
fix(sdk-ruby,daemon): fix code interpreter race conditions causing empty stdout

### DIFF
--- a/apps/daemon/pkg/toolbox/process/interpreter/repl_client.go
+++ b/apps/daemon/pkg/toolbox/process/interpreter/repl_client.go
@@ -47,7 +47,7 @@ func (c *Context) enqueueAndExecute(code string, envs map[string]string, timeout
 func (c *Context) processQueue() {
 	for job := range c.queue {
 		if job.ws != nil {
-			go c.attachWebSocket(job.ws)
+			c.attachWebSocket(job.ws)
 		}
 
 		result, err := c.executeCode(job.code, job.envs, job.timeout)
@@ -344,7 +344,6 @@ func (c *Context) handleChunk(chunk map[string]any) {
 			}
 		}
 		c.commandMu.Unlock()
-		return
 	}
 
 	// Stream to WebSocket client

--- a/apps/daemon/pkg/toolbox/process/interpreter/websocket.go
+++ b/apps/daemon/pkg/toolbox/process/interpreter/websocket.go
@@ -13,7 +13,9 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// attachWebSocket connects a WebSocket client to the interpreter context
+// attachWebSocket connects a WebSocket client to the interpreter context.
+// The client is ready to receive messages when this function returns.
+// Cleanup runs in a background goroutine after the client disconnects.
 func (c *Context) attachWebSocket(ws *websocket.Conn) {
 	pongCh := util.SetupWSKeepAlive(ws, c.logger)
 
@@ -49,17 +51,19 @@ func (c *Context) attachWebSocket(ws *websocket.Conn) {
 		}
 	}()
 
-	// Wait for clientWriter to exit (signals disconnection)
-	<-cl.done
+	// Clean up after the client disconnects (non-blocking)
+	go func() {
+		<-cl.done
 
-	c.mu.Lock()
-	if c.client != nil && c.client.id == cl.id {
-		c.client = nil
-	}
-	c.mu.Unlock()
+		c.mu.Lock()
+		if c.client != nil && c.client.id == cl.id {
+			c.client = nil
+		}
+		c.mu.Unlock()
 
-	cl.close()
-	c.logger.Debug("Client detached from interpreter context", "clientId", cl.id, "contextId", c.info.ID)
+		cl.close()
+		c.logger.Debug("Client detached from interpreter context", "clientId", cl.id, "contextId", c.info.ID)
+	}()
 }
 
 // clientWriter sends output messages to the WebSocket client

--- a/libs/sdk-ruby/lib/daytona/code_interpreter.rb
+++ b/libs/sdk-ruby/lib/daytona/code_interpreter.rb
@@ -103,15 +103,11 @@ module Daytona
         'Accept' => 'application/json'
       )
 
-      # Use queue for synchronization
       completion_queue = Queue.new
-      interpreter = self # Capture self for use in blocks
-      last_message_time = Time.now
-      message_mutex = Mutex.new
+      interpreter = self
 
       puts "[DEBUG] Connecting to WebSocket: #{ws_url}" if ENV['DEBUG']
 
-      # Connect to WebSocket and execute
       ws = WebSocket::Client::Simple.connect(ws_url, headers:)
 
       ws.on :open do
@@ -120,8 +116,6 @@ module Daytona
       end
 
       ws.on :message do |msg|
-        message_mutex.synchronize { last_message_time = Time.now }
-
         puts "[DEBUG] Received message (length=#{msg.data.length}): #{msg.data.inspect[0..200]}" if ENV['DEBUG']
 
         interpreter.send(:handle_message, msg.data, result, on_stdout, on_stderr, on_error, completion_queue)
@@ -146,72 +140,59 @@ module Daytona
         end
       end
 
-      # Wait for completion signal with idle timeout
-      # If timeout is specified, wait longer to detect actual timeout errors
-      # Otherwise use short idle timeout for normal completion
-      idle_timeout = timeout ? (timeout + 2.0) : 1.0
-      max_wait = (timeout || 300) + 3 # Add buffer to configured timeout
+      no_timeout = timeout.is_a?(Numeric) && timeout <= 0
+      max_wait = no_timeout ? nil : (timeout || 600) + 3
       start_time = Time.now
       completion_reason = nil
 
-      # Wait for completion or close event
       loop do
-        begin
-          completion = completion_queue.pop(true) # non-blocking
-          puts "[DEBUG] Got completion signal: #{completion[:type]}" if ENV['DEBUG']
-
-          # Control message (completed/interrupted) = normal completion
-          if completion[:type] == :completed
-            completion_reason = :completed
-            break
-          # If it's an error from close event (like timeout), raise it
-          elsif completion[:type] == :error_from_close
-            error_msg = completion[:error]
-            # Raise TimeoutError for timeout cases, regular Error for others
-            if error_msg.include?('timed out') || error_msg.include?('Execution timed out')
-              raise Sdk::TimeoutError, error_msg
-            end
-
-            raise Sdk::Error, error_msg
-
-          # Close event during execution (before control message) = likely timeout or error
-          elsif completion[:type] == :close
-            elapsed = Time.now - start_time
-            # If we got close near the timeout, it's likely a timeout
-            if timeout && elapsed >= timeout && elapsed < (timeout + 2)
-              raise Sdk::TimeoutError,
-                    'Execution timed out: operation exceeded the configured `timeout`. Provide a larger value if needed.'
-            end
-            # Otherwise normal close
-            completion_reason = :close
-            break
-          # WebSocket errors
-          elsif completion[:type] == :error && !completion[:error].message.include?('stream closed')
-            raise Sdk::Error, "WebSocket error: #{completion[:error].message}"
+        if max_wait
+          remaining = max_wait - (Time.now - start_time)
+          if remaining <= 0
+            ws.close
+            raise Sdk::TimeoutError,
+                  'Execution timed out: operation exceeded the configured `timeout`. Provide a larger value if needed.'
           end
-        rescue ThreadError
-          # Queue is empty, check idle timeout
         end
 
-        # Check idle timeout (no messages for N seconds = completion)
-        time_since_last_message = message_mutex.synchronize { Time.now - last_message_time }
-        if time_since_last_message > idle_timeout
-          puts "[DEBUG] Idle timeout reached (#{idle_timeout}s), assuming completion" if ENV['DEBUG']
-          completion_reason = :idle_complete
-          break
-        end
+        completion = completion_queue.pop(timeout: max_wait ? remaining : nil)
 
-        # Check for absolute timeout (safety net)
-        if Time.now - start_time > max_wait
+        if completion.nil?
           ws.close
           raise Sdk::TimeoutError,
                 'Execution timed out: operation exceeded the configured `timeout`. Provide a larger value if needed.'
         end
 
-        sleep 0.05 # Check every 50ms
+        puts "[DEBUG] Got completion signal: #{completion[:type]}" if ENV['DEBUG']
+
+        if completion[:type] == :completed
+          completion_reason = :completed
+          break
+        elsif completion[:type] == :error_from_close
+          error_msg = completion[:error]
+          if error_msg.include?('timed out') || error_msg.include?('Execution timed out')
+            raise Sdk::TimeoutError, error_msg
+          end
+
+          raise Sdk::Error, error_msg
+        elsif completion[:type] == :close
+          elapsed = Time.now - start_time
+          if timeout && timeout > 0 && elapsed >= timeout && elapsed < (timeout + 2)
+            raise Sdk::TimeoutError,
+                  'Execution timed out: operation exceeded the configured `timeout`. Provide a larger value if needed.'
+          end
+          completion_reason = :close
+          break
+        elsif completion[:type] == :error
+          unless completion[:error].message.include?('stream closed')
+            raise Sdk::Error, "WebSocket error: #{completion[:error].message}"
+          end
+
+          completion_reason = :close
+          break
+        end
       end
 
-      # Close WebSocket if not already closed
       ws.close if completion_reason != :close
       sleep 0.05
 


### PR DESCRIPTION
## Summary

Fixes two race conditions in the code interpreter that caused intermittent E2E test failures across SDKs (empty `stdout` when state should persist across `runCode` calls).

## Changes

### Server-side: WebSocket attachment race (`apps/daemon/`)

**Root cause**: `processQueue()` launched `attachWebSocket` as a goroutine while `executeCode` started immediately. For fast executions, the Python worker produced stdout before `c.client` was set — `emitOutput()` silently dropped the message.

**Fix**: `attachWebSocket` now completes setup synchronously (client is ready to receive when it returns). The disconnect-cleanup portion runs in a background goroutine. Removed `go` from the call site in `processQueue`.

**Affected E2E**: TypeScript `runCode in custom context maintains isolated state` (and potentially any SDK test hitting the same timing window).

### Client-side: Ruby SDK idle timeout (`libs/sdk-ruby/`)

**Root cause**: `run_code` used a 1-second idle timeout (measured from method entry, before WebSocket connected) to heuristically detect completion. For code producing no stdout (e.g. `ci_var = 42`), the server's close event didn't arrive in time — the client gave up and closed the connection prematurely.

**Fix**: Replaced the polling loop, idle timeout, and mutex with a deterministic blocking `Queue#pop(timeout:)`. Completion now only happens when the server actually signals it (close event or timeout). ~30 lines of heuristic code removed.

**Affected E2E**: Ruby `maintains state across runs in default context`.

## Files changed

- `apps/daemon/pkg/toolbox/process/interpreter/repl_client.go` — removed `go` from `attachWebSocket` call
- `apps/daemon/pkg/toolbox/process/interpreter/websocket.go` — restructured `attachWebSocket` for synchronous setup
- `libs/sdk-ruby/lib/daytona/code_interpreter.rb` — replaced idle timeout with blocking queue wait

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes race conditions in the code interpreter that caused empty stdout and flaky tests. Also skips Nx cache in E2E builds to avoid stale artifacts.

- **Bug Fixes**
  - Daemon (`apps/daemon`): Made `attachWebSocket` synchronous so the client is ready before `executeCode`; moved disconnect cleanup to a background goroutine; removed the `go` call in `processQueue`; removed an early return in `handleChunk` so output always streams to the client.
  - Ruby SDK (`libs/sdk-ruby`): Replaced polling with blocking `Queue#pop(timeout:)`; treats `timeout <= 0` as no-timeout; raises `TimeoutError` consistently; ignores benign "stream closed"; avoids premature connection closure.
  - CI (`.github/workflows/e2e_pr_tests.yaml`): Added `--skip-nx-cache` to `yarn nx run-many` in E2E builds to prevent stale build output.

<sup>Written for commit 72bee5230ee27e2efba7b8fdb320df9ef877d845. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4586?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

