### PR TITLE
fix(dashboard): filter unknown api key permission

### DIFF
--- a/apps/dashboard/src/pages/Keys.tsx
+++ b/apps/dashboard/src/pages/Keys.tsx
@@ -31,7 +31,9 @@ const Keys: React.FC = () => {
       return []
     }
     if (authenticatedUserOrganizationMember.role === OrganizationUserRoleEnum.OWNER) {
-      return Object.values(CreateApiKeyPermissionsEnum)
+      return Object.values(CreateApiKeyPermissionsEnum).filter(
+        (value) => value !== CreateApiKeyPermissionsEnum.UNKNOWN_DEFAULT_OPEN_API,
+      )
     }
     return Array.from(new Set(authenticatedUserOrganizationMember.assignedRoles.flatMap((role) => role.permissions)))
   }, [authenticatedUserOrganizationMember])


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide `CreateApiKeyPermissionsEnum.UNKNOWN_DEFAULT_OPEN_API` from API key permission options for organization owners on the Keys page to prevent invalid selections.

<sup>Written for commit a7266afe9e02e4ea8f449d4f0177209e857ff9d6. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4587?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

