### PR TITLE
fix(api): null snapshot size

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -30,7 +30,7 @@ import { TrackJobExecution } from '../../common/decorators/track-job-execution.d
 import { setTimeout as sleep } from 'timers/promises'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
-import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
+import { RunnerAdapterFactory, SnapshotDigestResponse } from '../runner-adapter/runnerAdapter'
 import { SnapshotStateError } from '../errors/snapshot-state-error'
 import { SnapshotEvents } from '../constants/snapshot-events'
 import { SnapshotCreatedEvent } from '../events/snapshot-created.event'
@@ -785,11 +785,22 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       return DONT_SYNC_AGAIN
     }
 
+    let inspectedSnapshotDigest: SnapshotDigestResponse | undefined
     try {
-      await runnerAdapter.inspectSnapshotInRegistry(snapshot.ref, internalRegistry)
+      inspectedSnapshotDigest = await runnerAdapter.inspectSnapshotInRegistry(snapshot.ref, internalRegistry)
     } catch (error) {
       this.logger.error(`Failed to inspect snapshot ${snapshot.ref} in registry: ${error}`)
       return DONT_SYNC_AGAIN
+    }
+
+    if (snapshot.size == null && typeof inspectedSnapshotDigest?.sizeGB === 'number') {
+      await this.processSnapshotDigest(
+        snapshot,
+        internalRegistry,
+        snapshotInfoResponse.hash,
+        inspectedSnapshotDigest.sizeGB,
+        snapshotInfoResponse.entrypoint,
+      )
     }
 
     try {
@@ -823,6 +834,12 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     } else {
       await this.runnerService.createSnapshotRunnerEntry(runner.id, snapshot.ref, SnapshotRunnerState.READY)
     }
+
+    if (snapshot.size == null) {
+      this.logger.warn(`Snapshot ${snapshot.id} has no resolved size yet; deferring activation`)
+      return DONT_SYNC_AGAIN
+    }
+
     await this.updateSnapshotState(snapshot, SnapshotState.ACTIVE)
 
     // Best effort removal of old snapshot from transient registry
@@ -1209,7 +1226,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     snapshot: Snapshot,
     internalRegistry: DockerRegistry,
     hash: string,
-    sizeGB: number,
+    sizeGB?: number,
     entrypoint?: string[] | string,
   ) {
     const updateData: Partial<Snapshot> = {}
@@ -1219,7 +1236,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       updateData.ref = `${sanitizedUrl}/${internalRegistry.project || 'daytona'}/daytona-${hash}:daytona`
     }
 
-    if (!snapshot.size) {
+    if (snapshot.size == null && typeof sizeGB === 'number') {
       const organization = await this.organizationService.findOne(snapshot.organizationId)
       if (!organization) {
         throw new NotFoundException(`Organization with ID ${snapshot.organizationId} not found`)


### PR DESCRIPTION
## Description

Fixes some instances where the snapshot size properties stays at null

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cases where snapshot size remained null by using the registry inspect result and deferring activation until size is resolved. Prevents READY/ACTIVE snapshots with missing size metadata.

- **Bug Fixes**
  - Capture `SnapshotDigestResponse` from `inspectSnapshotInRegistry` and pass `sizeGB` to `processSnapshotDigest`.
  - Defer activation and log a warning if `snapshot.size` is still null after processing.
  - Update `processSnapshotDigest` to accept optional `sizeGB` and set size only when it’s a number.

<sup>Written for commit e2eab72339366fe8e64a0d8df79b121cb3726590. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4588?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

