### PR TITLE
Various minor API improvements

### DIFF
--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -540,9 +540,38 @@ export class DockerRegistryService {
       return this.createTemporaryRegistryConfig(parsedImage.registry)
     } else {
       // Image has no registry prefix (e.g., "alpine:3.21")
-      // Create temporary Docker Hub config
+      // Check if organization has a Docker Hub registry configured with credentials
+      if (organizationId) {
+        const dockerHubRegistry = await this.findDockerHubRegistryForOrganization(organizationId)
+        if (dockerHubRegistry) {
+          return dockerHubRegistry
+        }
+      }
+      // Fall back to temporary Docker Hub config for public images
       return this.createTemporaryRegistryConfig('docker.io')
     }
+  }
+
+  /**
+   * Finds a Docker Hub registry configured for the given organization.
+   */
+  private async findDockerHubRegistryForOrganization(organizationId: string): Promise<DockerRegistry | null> {
+    const registries = await this.dockerRegistryRepository.find({
+      where: {
+        organizationId: organizationId,
+        registryType: RegistryType.ORGANIZATION,
+      },
+    })
+
+    // Look for a Docker Hub registry (url contains docker.io)
+    for (const registry of registries) {
+      const strippedUrl = registry.url.replace(/^(https?:\/\/)/, '')
+      if (strippedUrl === 'docker.io' || strippedUrl.startsWith('docker.io/')) {
+        return registry
+      }
+    }
+
+    return null
   }
 
   /**
@@ -553,8 +582,17 @@ export class DockerRegistryService {
    * @returns The matching registry, or null if no match is found.
    */
   private findRegistryByUrlMatch(registries: DockerRegistry[], targetString: string): DockerRegistry | null {
-    for (const registry of registries) {
-      const strippedUrl = registry.url.replace(/^(https?:\/\/)/, '').replace(/\/+$/, '')
+    // Prioritize ORGANIZATION registries over others
+    // This ensures user-configured credentials take precedence over shared internal ones
+    const priority: Partial<Record<RegistryType, number>> = {
+      [RegistryType.ORGANIZATION]: 0,
+    }
+    const sortedRegistries = [...registries].sort(
+      (a, b) => (priority[a.registryType] ?? 1) - (priority[b.registryType] ?? 1),
+    )
+
+    for (const registry of sortedRegistries) {
+      const strippedUrl = registry.url.replace(/^(https?:\/\/)/, '')
       if (targetString.startsWith(strippedUrl)) {
         // Ensure match is at a proper boundary (followed by '/', ':', or end-of-string)
         // to prevent "registry.depot.dev" from matching "registry.depot.dev-evil.com/..."

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -34,6 +34,7 @@ import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
 import { SandboxService } from '../services/sandbox.service'
 import { SandboxRepository } from '../repositories/sandbox.repository'
+import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 
 @Injectable()
 export class BackupManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -65,6 +66,26 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
   }
 
+  /**
+   * Increments a retry counter in Redis and returns whether the operation should be retried.
+   * @param key - The Redis key for the retry counter
+   * @param maxRetries - Maximum number of retries allowed (default: 3)
+   * @param ttlSeconds - TTL for the retry counter in seconds (default: 300)
+   * @returns true if should retry, false if max retries exceeded
+   */
+  private async shouldRetry(key: string, maxRetries = 3, ttlSeconds = 300): Promise<boolean> {
+    const retryCount = await this.redis.get(key)
+    const currentCount = retryCount ? parseInt(retryCount) : 0
+
+    if (currentCount >= maxRetries) {
+      await this.redis.del(key)
+      return false
+    }
+
+    await this.redis.setex(key, ttlSeconds, String(currentCount + 1))
+    return true
+  }
+
   //  todo: make frequency configurable or more efficient
   @Cron(CronExpression.EVERY_5_MINUTES, { name: 'ad-hoc-backup-check' })
   @TrackJobExecution()
@@ -89,6 +110,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
               runnerId: runner.id,
               organizationId: Not(SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION),
               state: SandboxState.STARTED,
+              desiredState: Not(SandboxDesiredState.DESTROYED),
               backupState: In([BackupState.NONE, BackupState.COMPLETED]),
               lastBackupAt: Or(IsNull(), LessThan(new Date(Date.now() - 1 * 60 * 60 * 1000))),
               autoDeleteInterval: Not(0),
@@ -96,8 +118,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
             order: {
               lastBackupAt: 'ASC',
             },
-            //  todo: increase this number when backup is stable
-            take: 10,
+            take: 25,
           })
 
           await Promise.all(
@@ -132,7 +153,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-backup-states' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-backup-states', waitForCompletion: true })
   @TrackJobExecution()
   @LogExecution('check-backup-states')
   @WithInstrumentation()
@@ -145,6 +166,9 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
 
     try {
+      // PENDING only — IN_PROGRESS is handled by checkBackupStatesInProgress so a slow
+      // in-progress poll can't block fresh PENDING backups. distinctOn(runnerId) caps
+      // each runner to one PENDING sandbox per tick to spread load across the fleet.
       const sandboxes = await this.sandboxRepository
         .createQueryBuilder('sandbox')
         .innerJoin('runner', 'r', 'r.id = sandbox.runnerId')
@@ -152,8 +176,9 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
           states: [SandboxState.ARCHIVING, SandboxState.STARTED, SandboxState.STOPPED],
         })
         .andWhere('sandbox.backupState IN (:...backupStates)', {
-          backupStates: [BackupState.PENDING, BackupState.IN_PROGRESS],
+          backupStates: [BackupState.PENDING],
         })
+        .andWhere('sandbox.desiredState != :destroyed', { destroyed: SandboxDesiredState.DESTROYED })
         .andWhere('r.state = :ready', { ready: RunnerState.READY })
         // Prioritize manual archival action, then auto-archive poller, then ad-hoc backup poller
         .addSelect(
@@ -167,15 +192,27 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
           `,
           'state_priority',
         )
+        .addSelect(
+          `
+          CASE sandbox."backupState"
+            WHEN :in_progress THEN 1
+            ELSE 999
+          END
+          `,
+          'backup_state_priority',
+        )
         .setParameters({
+          in_progress: BackupState.IN_PROGRESS,
           archiving: SandboxState.ARCHIVING,
           stopped: SandboxState.STOPPED,
           started: SandboxState.STARTED,
         })
-        .orderBy('state_priority', 'ASC')
+        .distinctOn(['sandbox.runnerId'])
+        .orderBy('sandbox.runnerId', 'ASC')
+        .addOrderBy('backup_state_priority', 'ASC')
+        .addOrderBy('state_priority', 'ASC')
         .addOrderBy('sandbox.lastBackupAt', 'ASC', 'NULLS FIRST') // Process sandboxes with no backups first
-        .addOrderBy('sandbox.createdAt', 'ASC') // For equal lastBackupAt, process older sandboxes first
-        .take(100)
+        .take(250)
         .getMany()
 
       await Promise.allSettled(
@@ -198,6 +235,87 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
                   await this.handlePendingBackup(sandbox)
                   break
                 }
+              }
+            } catch (error) {
+              //  if error, retry 10 times
+              const errorRetryKey = `${lockKey}-error-retry`
+              const errorRetryCount = await this.redis.get(errorRetryKey)
+              if (!errorRetryCount) {
+                await this.redis.setex(errorRetryKey, 300, '1')
+              } else if (parseInt(errorRetryCount) > 10) {
+                this.logger.error(`Error processing backup for sandbox ${sandbox.id}:`, fromAxiosError(error))
+                await this.sandboxService.updateSandboxBackupState(
+                  sandbox.id,
+                  BackupState.ERROR,
+                  undefined,
+                  undefined,
+                  fromAxiosError(error).message,
+                )
+              } else {
+                await this.redis.setex(errorRetryKey, 300, errorRetryCount + 1)
+              }
+            }
+          } catch (error) {
+            this.logger.error(`Error processing backup for sandbox ${s.id}:`, error)
+          } finally {
+            await this.redisLockProvider.unlock(lockKey)
+          }
+        }),
+      )
+    } catch (error) {
+      this.logger.error(`Error processing backups: `, error)
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
+  }
+
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-backup-states-in-progress', waitForCompletion: true })
+  @TrackJobExecution()
+  @WithInstrumentation()
+  @LogExecution('check-backup-states-in-progress')
+  async checkBackupStatesInProgress(): Promise<void> {
+    //  lock the sync to only run one instance at a time
+    const lockKey = 'check-backup-states-in-progress'
+    const hasLock = await this.redisLockProvider.lock(lockKey, 10)
+    if (!hasLock) {
+      return
+    }
+
+    try {
+      // Random ordering avoids head-of-line blocking on a slow runner repeatedly
+      // returning the same in-progress sandboxes.
+      const sandboxes = await this.sandboxRepository
+        .createQueryBuilder('sandbox')
+        .addSelect('RANDOM()', 'rand')
+        .innerJoin('runner', 'r', 'r.id = sandbox.runnerId')
+        .where('sandbox.state IN (:...states)', {
+          states: [SandboxState.ARCHIVING, SandboxState.STARTED, SandboxState.STOPPED],
+        })
+        .andWhere('sandbox.backupState IN (:...backupStates)', {
+          backupStates: [BackupState.IN_PROGRESS],
+        })
+        .andWhere('sandbox.desiredState != :destroyed', { destroyed: SandboxDesiredState.DESTROYED })
+        .andWhere('r.state = :ready', { ready: RunnerState.READY })
+        .orderBy('rand')
+        .take(200)
+        .getMany()
+
+      await Promise.allSettled(
+        sandboxes.map(async (s) => {
+          const lockKey = `sandbox-backup-${s.id}`
+          const hasLock = await this.redisLockProvider.lock(lockKey, 60)
+          if (!hasLock) {
+            return
+          }
+
+          try {
+            //  get the latest sandbox state
+            const sandbox = await this.sandboxRepository.findOneByOrFail({
+              id: s.id,
+            })
+
+            try {
+              switch (sandbox.backupState) {
                 case BackupState.IN_PROGRESS: {
                   await this.checkBackupProgress(sandbox)
                   break
@@ -338,6 +456,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
         .innerJoin('runner', 'r', 'r.id = sandbox.runnerId')
         .where('sandbox.state IN (:...states)', { states: [SandboxState.ARCHIVING, SandboxState.STOPPED] })
         .andWhere('sandbox.backupState = :none', { none: BackupState.NONE })
+        .andWhere('sandbox.desiredState != :destroyed', { destroyed: SandboxDesiredState.DESTROYED })
         .andWhere('r.state = :ready', { ready: RunnerState.READY })
         .take(100)
         .getMany()
@@ -445,9 +564,22 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
           break
         }
         // If backup state is none, retry the backup process by setting the backup state to pending
-        // This can happen if the runner is restarted or the operation is cancelled
+        // This can happen if the runner is restarted or the operation is cancelled.
+        // Bound the retries so a runner stuck reporting NONE doesn't loop forever.
         case BackupState.NONE: {
-          await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.PENDING)
+          const noneRetryKey = `sandbox-backup-${sandbox.id}-none-retry`
+          if (await this.shouldRetry(noneRetryKey)) {
+            await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.PENDING)
+          } else {
+            this.logger.error(`Backup for sandbox ${sandbox.id} failed: runner repeatedly reports no backup state`)
+            await this.sandboxService.updateSandboxBackupState(
+              sandbox.id,
+              BackupState.ERROR,
+              undefined,
+              undefined,
+              'Backup failed: runner repeatedly reports no backup state',
+            )
+          }
           break
         }
         // If still in progress or any other state, do nothing and wait for next sync

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -54,6 +54,8 @@ import Redis from 'ioredis'
 import { InjectDataSource } from '@nestjs/typeorm'
 import { DataSource } from 'typeorm'
 
+export const SYNC_INSTANCE_STATE_LOCK_KEY = 'sync-instance-state-'
+
 @Injectable()
 export class SandboxManager implements TrackableJobExecutions, OnApplicationShutdown {
   activeJobs = new Set<string>()
@@ -661,89 +663,118 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     }
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-states' })
+  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-states-per-runner-locked' })
   @TrackJobExecution()
   @WithInstrumentation()
-  @LogExecution('sync-states')
+  @LogExecution('sync-states-per-runner-locked')
   async syncStates(): Promise<void> {
-    const globalLockKey = 'sync-states'
-    const lockTtl = 10 * 60 // seconds (10 min)
-    if (!(await this.redisLockProvider.lock(globalLockKey, lockTtl))) {
-      return
-    }
+    const readyRunners = await this.runnerService.findAllReady()
 
-    try {
-      const queryBuilder = this.sandboxRepository
-        .createQueryBuilder('sandbox')
-        .select(['sandbox.id'])
-        .leftJoin('sandbox_last_activity', 'activity', 'activity."sandboxId" = sandbox.id')
-        .where('sandbox.state NOT IN (:...excludedStates)', {
-          excludedStates: [
-            SandboxState.DESTROYED,
-            SandboxState.ERROR,
-            SandboxState.BUILD_FAILED,
-            SandboxState.RESIZING,
-            SandboxState.FORKING,
-            SandboxState.SNAPSHOTTING,
-          ],
-        })
-        .andWhere('sandbox."desiredState"::text != sandbox.state::text')
-        .andWhere('sandbox."desiredState"::text != :archived', { archived: SandboxDesiredState.ARCHIVED })
-        .orderBy('activity."lastActivityAt"', 'DESC', 'NULLS LAST')
+    const runnerIds: (string | null)[] = [null, ...readyRunners.map((r) => r.id)]
+    const lockTtl = 5 * 60 // seconds
 
-      const stream = await queryBuilder.stream()
-      let processedCount = 0
-      const maxProcessPerRun = 1000
-      const pendingProcesses: Promise<void>[] = []
-
-      try {
-        await new Promise<void>((resolve, reject) => {
-          stream.on('data', async (row: any) => {
-            if (processedCount >= maxProcessPerRun) {
-              resolve()
-              return
-            }
-
-            const lockKey = getStateChangeLockKey(row.sandbox_id)
-            if (await this.redisLockProvider.isLocked(lockKey)) {
-              // Sandbox is already being processed, skip it
-              return
-            }
-
-            // Process sandbox asynchronously but track the promise
-            const processPromise = this.syncInstanceState(row.sandbox_id).catch((err) => {
-              this.logger.error(`Error syncing sandbox state for ${row.sandbox_id}`, err)
-            })
-            pendingProcesses.push(processPromise)
-            processedCount++
-
-            // Limit concurrent processing to avoid overwhelming the system
-            if (pendingProcesses.length >= 10) {
-              stream.pause()
-              Promise.allSettled(pendingProcesses.splice(0, pendingProcesses.length))
-                .then(() => stream.resume())
-                .catch(reject)
-            }
-          })
-
-          stream.on('end', () => {
-            Promise.allSettled(pendingProcesses)
-              .then(() => {
-                resolve()
-              })
-              .catch(reject)
-          })
-
-          stream.on('error', reject)
-        })
-      } finally {
-        if (!stream.destroyed) {
-          stream.destroy()
+    await Promise.all(
+      runnerIds.map(async (runnerId) => {
+        const runnerLockKey = `sync-states:${runnerId ?? 'unassigned'}`
+        if (!(await this.redisLockProvider.lock(runnerLockKey, lockTtl))) {
+          return
         }
-      }
-    } finally {
-      await this.redisLockProvider.unlock(globalLockKey)
-    }
+
+        try {
+          const maxSandboxesPerRunner = runnerId === null ? 250 : 50
+
+          const sandboxes = await this.sandboxRepository.find({
+            where: {
+              runnerId: runnerId === null ? IsNull() : runnerId,
+              state: Not(SandboxState.RESTORING),
+              pending: true,
+            },
+            select: ['id'],
+            take: maxSandboxesPerRunner,
+          })
+
+          const pendingProcesses: Promise<void>[] = []
+          const concurrencyLimit = 10
+
+          for (const sandbox of sandboxes) {
+            const lockKey = getStateChangeLockKey(sandbox.id)
+            if (await this.redisLockProvider.isLocked(lockKey)) {
+              continue
+            }
+
+            const processPromise = this.syncInstanceState(sandbox.id)
+            pendingProcesses.push(processPromise)
+
+            if (pendingProcesses.length >= concurrencyLimit) {
+              await Promise.allSettled(pendingProcesses.splice(0, pendingProcesses.length))
+            }
+          }
+
+          if (pendingProcesses.length > 0) {
+            await Promise.allSettled(pendingProcesses)
+          }
+        } finally {
+          await this.redisLockProvider.unlock(runnerLockKey)
+        }
+      }),
+    )
+  }
+
+  // RESTORING is split out so it gets its own faster cadence and its own per-runner locks,
+  // and is not blocked by the longer-lived state syncs above.
+  @Cron(CronExpression.EVERY_5_SECONDS, { name: 'sync-restoring-states' })
+  @TrackJobExecution()
+  @WithInstrumentation()
+  @LogExecution('sync-restoring-states')
+  async syncRestoringStates(): Promise<void> {
+    const readyRunners = await this.runnerService.findAllReady()
+
+    const runnerIds: string[] = readyRunners.map((r) => r.id)
+    const lockTtl = 60 // seconds (1 minute)
+
+    await Promise.all(
+      runnerIds.map(async (runnerId) => {
+        const runnerLockKey = `sync-restoring-states:${runnerId}`
+        if (!(await this.redisLockProvider.lock(runnerLockKey, lockTtl))) {
+          return
+        }
+
+        try {
+          const sandboxes = await this.sandboxRepository.find({
+            where: {
+              runnerId,
+              state: SandboxState.RESTORING,
+              pending: true,
+            },
+            select: ['id'],
+            take: 50,
+          })
+
+          const pendingProcesses: Promise<void>[] = []
+          const concurrencyLimit = 10
+
+          for (const sandbox of sandboxes) {
+            const lockKey = getStateChangeLockKey(sandbox.id)
+            if (await this.redisLockProvider.isLocked(lockKey)) {
+              continue
+            }
+
+            const processPromise = this.syncInstanceState(sandbox.id)
+            pendingProcesses.push(processPromise)
+
+            if (pendingProcesses.length >= concurrencyLimit) {
+              await Promise.allSettled(pendingProcesses.splice(0, pendingProcesses.length))
+            }
+          }
+
+          if (pendingProcesses.length > 0) {
+            await Promise.allSettled(pendingProcesses)
+          }
+        } finally {
+          await this.redisLockProvider.unlock(runnerLockKey)
+        }
+      }),
+    )
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-archived-desired-states' })
@@ -790,7 +821,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         desiredState: SandboxDesiredState.ARCHIVED,
         backupState: BackupState.COMPLETED,
       },
-      take: 100,
+      take: 200,
       order: {
         updatedAt: 'ASC',
       },

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -1205,10 +1205,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
 
     try {
-      // Dedicated regions get a much shorter staleness window so we don't pin disk space
-      // on small fleets when an org stops using a snapshot.
       const stalenessDays = this.configService.getOrThrow('buildInfoSnapshotRunnerStalenessDays')
-      const stalenessInterval = `(CASE WHEN r.region IN (:dedicatedElementor, :dedicatedRL) THEN interval '2 days' ELSE interval '${stalenessDays} days' END)`
+      const stalenessInterval = `interval '${stalenessDays} days'`
 
       const staleEntries = await this.snapshotRunnerRepository
         .createQueryBuilder('sr')
@@ -1219,10 +1217,6 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         .andWhere(`bi.lastUsedAt < now() - ${stalenessInterval}`)
         .andWhere(`sr.updatedAt < now() - ${stalenessInterval}`)
         .andWhere("sr.snapshotRef LIKE 'daytona-%'")
-        .setParameters({
-          dedicatedElementor: ELEMENTOR_DEDICATED_REGION,
-          dedicatedRL: RL_REGION,
-        })
         .limit(500)
         .getMany()
 

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -6,8 +6,8 @@
 import { Injectable, Logger, NotFoundException, OnApplicationShutdown } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { In, IsNull, Not, Repository } from 'typeorm'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
+import { In, IsNull, LessThan, Not, Repository } from 'typeorm'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { Snapshot } from '../entities/snapshot.entity'
 import { SnapshotState } from '../enums/snapshot-state.enum'
@@ -45,6 +45,7 @@ import { SandboxRepository } from '../repositories/sandbox.repository'
 import { SnapshotInfoResponse } from '@daytona/runner-api-client'
 import { SnapshotActivatedEvent } from '../events/snapshot-activated.event'
 import { TypedConfigService } from '../../config/typed-config.service'
+import { RegionType } from '../../region/enums/region-type.enum'
 
 /** Fisher-Yates shuffle — uniform random permutation in O(n). */
 function shuffleArray<T>(array: T[]): T[] {
@@ -60,6 +61,7 @@ const SYNC_AGAIN = 'sync-again'
 const DONT_SYNC_AGAIN = 'dont-sync-again'
 const DEFAULT_SNAPSHOT_DEACTIVATION_TIMEOUT_MINUTES = 14 * 24 * 60 // 14 days
 type SyncState = typeof SYNC_AGAIN | typeof DONT_SYNC_AGAIN
+const BASE_PROPAGATION_FACTOR = 1 / 3
 
 @Injectable()
 export class SnapshotManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -97,6 +99,60 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'scale-down-runner-snapshots', waitForCompletion: true })
+  @TrackJobExecution()
+  @LogExecution('scale-down-runner-snapshots')
+  @WithInstrumentation()
+  async scaleDownRunnerSnapshots() {
+    const lockKey = 'scale-down-runner-snapshots-lock'
+    const lockTtl = 3 * 60 // seconds (3 min)
+    if (!(await this.redisLockProvider.lock(lockKey, lockTtl))) {
+      return
+    }
+
+    const skip = (await this.redis.get('scale-down-runner-snapshots-skip')) || 0
+
+    const snapshots = await this.snapshotRepository
+      .createQueryBuilder('snapshot')
+      .innerJoin('organization', 'org', 'org.id = snapshot.organizationId')
+      .innerJoin('region_quota', 'rq', 'rq."organizationId" = org.id AND rq."regionId" = org."defaultRegionId"')
+      .select(['snapshot.*', 'rq.total_cpu_quota'])
+      .where('snapshot.state = :snapshotState', { snapshotState: SnapshotState.ACTIVE })
+      .andWhere('org.suspended = false')
+      .orderBy('snapshot.createdAt', 'ASC')
+      .limit(50)
+      .offset(Number(skip))
+      .getRawMany()
+
+    if (snapshots.length === 0) {
+      await this.redisLockProvider.unlock(lockKey)
+      await this.redis.set('scale-down-runner-snapshots-skip', 0)
+      return
+    }
+
+    await this.redis.set('scale-down-runner-snapshots-skip', Number(skip) + snapshots.length)
+
+    const results = await Promise.allSettled(
+      snapshots.map(async (snapshot) => {
+        const regions = await this.snapshotService.getSnapshotRegions(snapshot.id)
+
+        const sharedRegionIds = regions
+          .filter((r) => r.organizationId === null && r.regionType === RegionType.SHARED)
+          .map((r) => r.id)
+
+        return this.scaleDownSnapshotFromRunners(snapshot, sharedRegionIds)
+      }),
+    )
+
+    results.forEach((result) => {
+      if (result.status === 'rejected') {
+        this.logger.error(`Error scaling down snapshot from runners: ${fromAxiosError(result.reason)}`)
+      }
+    })
+
+    await this.redisLockProvider.unlock(lockKey)
+  }
+
   @Cron(CronExpression.EVERY_5_SECONDS, { name: 'sync-runner-snapshots', waitForCompletion: true })
   @TrackJobExecution()
   @LogExecution('sync-runner-snapshots')
@@ -116,8 +172,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       .where('snapshot.state = :snapshotState', { snapshotState: SnapshotState.ACTIVE })
       .andWhere('org.suspended = false')
       .orderBy('snapshot.createdAt', 'ASC')
-      .take(100)
-      .skip(Number(skip))
+      .limit(150)
+      .offset(Number(skip))
       .getMany()
 
     if (snapshots.length === 0) {
@@ -151,7 +207,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     await this.redisLockProvider.unlock(lockKey)
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-runner-snapshot-states', waitForCompletion: true })
+  @Cron(CronExpression.EVERY_5_SECONDS, { name: 'sync-runner-snapshot-states', waitForCompletion: true })
   @TrackJobExecution()
   @LogExecution('sync-runner-snapshot-states')
   @WithInstrumentation()
@@ -168,14 +224,57 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     const runnerSnapshots = await this.snapshotRunnerRepository
       .createQueryBuilder('snapshotRunner')
       .where({
-        state: In([
-          SnapshotRunnerState.PULLING_SNAPSHOT,
-          SnapshotRunnerState.BUILDING_SNAPSHOT,
-          SnapshotRunnerState.REMOVING,
-        ]),
+        state: In([SnapshotRunnerState.PULLING_SNAPSHOT, SnapshotRunnerState.BUILDING_SNAPSHOT]),
       })
       .orderBy('RANDOM()')
       .take(100)
+      .getMany()
+
+    await Promise.allSettled(
+      runnerSnapshots.map((snapshotRunner) => {
+        return this.syncRunnerSnapshotState(snapshotRunner).catch((err) => {
+          if (err.code !== 'ECONNRESET') {
+            if (err instanceof RunnerNotReadyError) {
+              this.logger.debug(
+                `Runner ${snapshotRunner.runnerId} is not ready while trying to sync snapshot runner ${snapshotRunner.id}: ${err}`,
+              )
+              return
+            }
+            this.logger.error(`Error syncing runner snapshot state ${snapshotRunner.id}: ${fromAxiosError(err)}`)
+            this.snapshotRunnerRepository.update(snapshotRunner.id, {
+              state: SnapshotRunnerState.ERROR,
+              errorReason: fromAxiosError(err).message,
+            })
+          }
+        })
+      }),
+    )
+
+    await this.redisLockProvider.unlock(lockKey)
+  }
+
+  // REMOVING is split out to its own cron with its own lock so it doesn't compete with
+  // the higher-priority PULLING/BUILDING states. We additionally wait at least 3 minutes
+  // since the last update to give in-flight removals a chance to settle on the runner.
+  @Cron(CronExpression.EVERY_5_SECONDS, { name: 'sync-removing-runner-snapshot-states' })
+  @TrackJobExecution()
+  @LogExecution('sync-removing-runner-snapshot-states')
+  @WithInstrumentation()
+  async syncRemovingRunnerSnapshotStates() {
+    const lockKey = 'sync-removing-runner-snapshot-states-lock'
+    if (!(await this.redisLockProvider.lock(lockKey, 120))) {
+      return
+    }
+
+    const threeMinutesAgo = new Date(Date.now() - 3 * 60 * 1000)
+    const runnerSnapshots = await this.snapshotRunnerRepository
+      .createQueryBuilder('snapshotRunner')
+      .where({
+        state: SnapshotRunnerState.REMOVING,
+        updatedAt: LessThan(threeMinutesAgo),
+      })
+      .orderBy('RANDOM()')
+      .take(200)
       .getMany()
 
     await Promise.allSettled(
@@ -291,7 +390,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       // respect the propagation limit for shared runners
       const sharedRunnersPropagateLimit = Math.max(
         0,
-        Math.ceil(sharedRunners.length / 3) - sharedSnapshotRunnersDistinctRunnersIds.size,
+        Math.ceil(sharedRunners.length * BASE_PROPAGATION_FACTOR) - sharedSnapshotRunnersDistinctRunnersIds.size,
       )
       runnersToPropagateTo.push(...shuffleArray(unallocatedSharedRunners).slice(0, sharedRunnersPropagateLimit))
 
@@ -345,6 +444,80 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       })
     } catch (err) {
       this.logger.error(err)
+    }
+  }
+
+  async scaleDownSnapshotFromRunners(
+    snapshot: Snapshot,
+    sharedRegionIds: string[],
+    propagationFactor: number = BASE_PROPAGATION_FACTOR,
+  ): Promise<number> {
+    try {
+      if (sharedRegionIds.length === 0) {
+        return 0
+      }
+
+      // Get all shared runners in the regions
+      const sharedRunners = await this.runnerRepository.find({
+        where: {
+          state: RunnerState.READY,
+          unschedulable: Not(true),
+          region: In(sharedRegionIds),
+        },
+      })
+
+      const sharedRunnerIds = sharedRunners.map((runner) => runner.id)
+
+      if (sharedRunnerIds.length === 0) {
+        return 0
+      }
+
+      // Get all snapshot runners in READY state for shared runners (excluding those created in the last hour)
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+      const sharedSnapshotRunners = await this.snapshotRunnerRepository.find({
+        where: {
+          snapshotRef: snapshot.ref,
+          state: SnapshotRunnerState.READY,
+          runnerId: In(sharedRunnerIds),
+          createdAt: LessThan(oneHourAgo),
+        },
+      })
+
+      // Calculate the maximum allowed number of snapshot runners (same formula as propagation)
+      const maxSharedSnapshotRunners = Math.ceil(propagationFactor * sharedRunners.length)
+
+      // Only scale down if the propagated amount exceeds the limit by more than 15%
+      const scaleDownThreshold = Math.ceil(maxSharedSnapshotRunners * 1.15)
+      const excessCount = sharedSnapshotRunners.length - maxSharedSnapshotRunners
+
+      if (sharedSnapshotRunners.length > scaleDownThreshold) {
+        // Sort by createdAt ascending (oldest first) to remove oldest ones
+        const sortedSnapshotRunners = sharedSnapshotRunners.sort(
+          (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+        )
+
+        // Take the excess ones to remove
+        const snapshotRunnersToRemove = sortedSnapshotRunners.slice(0, excessCount)
+
+        await Promise.allSettled(
+          snapshotRunnersToRemove.map(async (snapshotRunner) => {
+            await this.snapshotRunnerRepository.update(snapshotRunner.id, {
+              state: SnapshotRunnerState.REMOVING,
+            })
+          }),
+        )
+
+        this.logger.log(
+          `Marked ${snapshotRunnersToRemove.length} snapshot runners for removal for snapshot ${snapshot.ref}`,
+        )
+
+        return snapshotRunnersToRemove.length
+      }
+
+      return 0
+    } catch (err) {
+      this.logger.error(`Error scaling down snapshot ${snapshot.ref}: ${fromAxiosError(err)}`)
+      return 0
     }
   }
 
@@ -727,8 +900,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
   }
 
   async handleCheckInitialRunnerSnapshot(snapshot: Snapshot): Promise<SyncState> {
-    // Check for timeout - allow up to 30 minutes
-    const timeoutMinutes = 30
+    // Check for timeout - allow up to 60 minutes
+    const timeoutMinutes = 60
     const timeoutMs = timeoutMinutes * 60 * 1000
     if (Date.now() - snapshot.updatedAt.getTime() > timeoutMs) {
       await this.updateSnapshotState(snapshot, SnapshotState.ERROR, 'Timeout processing snapshot on initial runner')
@@ -846,8 +1019,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
   }
 
   async processPullOnInitialRunner(snapshot: Snapshot, runner: Runner) {
-    // Check for timeout - allow up to 30 minutes
-    const timeoutMinutes = 30
+    // Check for timeout - allow up to 60 minutes
+    const timeoutMinutes = 60
     const timeoutMs = timeoutMinutes * 60 * 1000
     if (Date.now() - snapshot.updatedAt.getTime() > timeoutMs) {
       await this.updateSnapshotState(
@@ -1032,18 +1205,24 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
 
     try {
+      // Dedicated regions get a much shorter staleness window so we don't pin disk space
+      // on small fleets when an org stops using a snapshot.
+      const stalenessDays = this.configService.getOrThrow('buildInfoSnapshotRunnerStalenessDays')
+      const stalenessInterval = `(CASE WHEN r.region IN (:dedicatedElementor, :dedicatedRL) THEN interval '2 days' ELSE interval '${stalenessDays} days' END)`
+
       const staleEntries = await this.snapshotRunnerRepository
         .createQueryBuilder('sr')
         .select('sr.id')
         .innerJoin(BuildInfo, 'bi', 'sr."snapshotRef" = bi."snapshotRef"')
+        .innerJoin('runner', 'r', 'r.id = sr."runnerId"::uuid')
         .where('sr.state = :readyState', { readyState: SnapshotRunnerState.READY })
-        .andWhere(
-          `bi.lastUsedAt < now() - interval '${this.configService.getOrThrow('buildInfoSnapshotRunnerStalenessDays')} days'`,
-        )
-        .andWhere(
-          `sr.updatedAt < now() - interval '${this.configService.getOrThrow('buildInfoSnapshotRunnerStalenessDays')} days'`,
-        )
+        .andWhere(`bi.lastUsedAt < now() - ${stalenessInterval}`)
+        .andWhere(`sr.updatedAt < now() - ${stalenessInterval}`)
         .andWhere("sr.snapshotRef LIKE 'daytona-%'")
+        .setParameters({
+          dedicatedElementor: ELEMENTOR_DEDICATED_REGION,
+          dedicatedRL: RL_REGION,
+        })
         .limit(500)
         .getMany()
 
@@ -1145,7 +1324,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
-  @Cron(CronExpression.EVERY_10_MINUTES, { name: 'cleanup-inactive-snapshots-from-runners' })
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'cleanup-inactive-snapshots-from-runners' })
   @TrackJobExecution()
   @LogExecution('cleanup-inactive-snapshots-from-runners')
   @WithInstrumentation()
@@ -1184,6 +1363,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
             activeState: SnapshotState.ACTIVE,
           },
         )
+        .orderBy('snapshot."updatedAt"', 'DESC')
         .take(100)
         .getRawMany()
 

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -105,7 +105,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       headers: {
         Authorization: `Bearer ${runner.apiKey}`,
       },
-      timeout: 1 * 60 * 60 * 1000, // 1 hour
+      timeout: 15 * 60 * 1000, // 15 minutes
     })
 
     const retryErrorMap = new WeakMap<AxiosError, string>()

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -172,7 +172,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     await this.redisLockProvider.unlock('close-and-reopen-usage-periods')
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'archive-usage-periods' })
+  @Cron(CronExpression.EVERY_5_SECONDS, { name: 'archive-usage-periods' })
   @TrackJobExecution()
   @LogExecution('archive-usage-periods')
   @WithInstrumentation()
@@ -190,7 +190,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         order: {
           startAt: 'ASC',
         },
-        take: 1000,
+        take: 5000,
       })
 
       if (usagePeriods.length === 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves reliability and throughput across backups, snapshots, and sandbox state sync, and prefers org Docker Hub creds for prefix‑less images. Also speeds up usage period archiving to reduce backlog.

- **New Features**
  - Prefer organization Docker Hub (`docker.io`) credentials for images without a registry prefix; fall back to public. ORGANIZATION registries are prioritized when matching URLs.
  - Scale down propagated snapshot runners in shared regions: cap to ~33% of the fleet and mark excess READY runners (older than 1h) for removal.

- **Bug Fixes**
  - Backups: split processing by state (PENDING vs IN_PROGRESS), skip `desiredState=DESTROYED`, bound `NONE` retries, larger batches, per‑sandbox error retries, and randomize in‑progress checks to avoid head‑of‑line blocking.
  - Sandbox states: per‑runner locked sync to spread load, a fast 5s cron for RESTORING, and a larger ARCHIVED processing batch.
  - Snapshots: faster 5s polling for pull/build, dedicated REMOVING cron (after 3m staleness), longer 60m timeouts for initial pulls, region‑aware cleanup windows, and minute‑level cleanup cadence.
  - Runner adapter v0: HTTP timeout set to 15 minutes to avoid long‑hanging requests.
  - Usage: archive periods every 5s with batches up to 5000.

<sup>Written for commit e51e9aeb9217b492af626dc3da696c1b5e2186d9. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4589?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

