### PR TITLE
feat(sdk): expose file download stream across all SDKs

### DIFF
--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -131,6 +131,7 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(f \*FileSystemService\) CreateFolder\(ctx context.Context, path string, opts ...func\(\*options.CreateFolder\)\) error](<#FileSystemService.CreateFolder>)
   - [func \(f \*FileSystemService\) DeleteFile\(ctx context.Context, path string, recursive bool\) error](<#FileSystemService.DeleteFile>)
   - [func \(f \*FileSystemService\) DownloadFile\(ctx context.Context, remotePath string, localPath \*string\) \(\[\]byte, error\)](<#FileSystemService.DownloadFile>)
+  - [func \(f \*FileSystemService\) DownloadFileStream\(ctx context.Context, remotePath string\) \(io.ReadCloser, error\)](<#FileSystemService.DownloadFileStream>)
   - [func \(f \*FileSystemService\) FindFiles\(ctx context.Context, path, pattern string\) \(any, error\)](<#FileSystemService.FindFiles>)
   - [func \(f \*FileSystemService\) GetFileInfo\(ctx context.Context, path string\) \(\*types.FileInfo, error\)](<#FileSystemService.GetFileInfo>)
   - [func \(f \*FileSystemService\) ListFiles\(ctx context.Context, path string\) \(\[\]\*types.FileInfo, error\)](<#FileSystemService.ListFiles>)
@@ -1412,6 +1413,45 @@ data, err := sandbox.FileSystem.DownloadFile(ctx, "/home/user/file.txt", &localP
 ```
 
 Returns an error if the file doesn't exist or cannot be read.
+
+<a name="FileSystemService.DownloadFileStream"></a>
+### func \(\*FileSystemService\) DownloadFileStream
+
+```go
+func (f *FileSystemService) DownloadFileStream(ctx context.Context, remotePath string) (io.ReadCloser, error)
+```
+
+DownloadFileStream downloads a single file from the sandbox as a stream without buffering the entire file into memory. The returned [io.ReadCloser](<https://pkg.go.dev/io/#ReadCloser>) can be piped directly to an HTTP response, written to a file, or processed on the fly.
+
+The caller must close the returned [io.ReadCloser](<https://pkg.go.dev/io/#ReadCloser>) when done.
+
+Parameters:
+
+- remotePath: Path to the file in the sandbox. Relative paths are resolved based on the sandbox working directory.
+
+Returns an [io.ReadCloser](<https://pkg.go.dev/io/#ReadCloser>) streaming the file content.
+
+Example:
+
+```
+// Stream to an HTTP response
+stream, err := sandbox.FileSystem.DownloadFileStream(ctx, "workspace/report.pdf")
+if err != nil {
+    log.Fatal(err)
+}
+defer stream.Close()
+io.Copy(w, stream) // w is an http.ResponseWriter
+
+// Stream to a local file
+stream, err := sandbox.FileSystem.DownloadFileStream(ctx, "workspace/large-file.bin")
+if err != nil {
+    log.Fatal(err)
+}
+defer stream.Close()
+out, _ := os.Create("local-copy.bin")
+defer out.Close()
+io.Copy(out, stream)
+```
 
 <a name="FileSystemService.FindFiles"></a>
 ### func \(\*FileSystemService\) FindFiles

--- a/apps/docs/src/content/docs/en/go-sdk/errors.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/errors.mdx
@@ -14,6 +14,7 @@ import "github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
 
 - [func ConvertAPIError\(err error, httpResp \*http.Response\) error](<#ConvertAPIError>)
 - [func ConvertToolboxError\(err error, httpResp \*http.Response\) error](<#ConvertToolboxError>)
+- [func NewDaytonaErrorFromBody\(body \[\]byte, statusCode int, headers http.Header\) error](<#NewDaytonaErrorFromBody>)
 - [type DaytonaError](<#DaytonaError>)
   - [func NewDaytonaError\(message string, statusCode int, headers http.Header\) \*DaytonaError](<#NewDaytonaError>)
   - [func \(e \*DaytonaError\) Error\(\) string](<#DaytonaError.Error>)
@@ -45,6 +46,15 @@ func ConvertToolboxError(err error, httpResp *http.Response) error
 ```
 
 ConvertToolboxError converts toolbox\-api\-client\-go errors to SDK error types
+
+<a name="NewDaytonaErrorFromBody"></a>
+## func NewDaytonaErrorFromBody
+
+```go
+func NewDaytonaErrorFromBody(body []byte, statusCode int, headers http.Header) error
+```
+
+NewDaytonaErrorFromBody parses a JSON response body and maps the status code to the appropriate SDK error type. Falls back to the raw body as the message.
 
 <a name="DaytonaError"></a>
 ## type DaytonaError

--- a/apps/docs/src/content/docs/en/java-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/file-system.mdx
@@ -62,6 +62,52 @@ Downloads a file into memory.
 
 - `io.daytona.sdk.exception.DaytonaException` - if download or local read fails
 
+#### downloadFileStream()
+```java
+public InputStream downloadFileStream(String remotePath) throws io.daytona.sdk.exception.DaytonaException
+```
+
+Downloads a single file from the Sandbox as a stream without buffering the entire file
+into memory. The returned `InputStream` can be piped directly to an HTTP response,
+written to a file, or processed on the fly.
+
+The caller is responsible for closing the returned stream.
+
+**Parameters**:
+
+- `remotePath` _String_ - source file path in the Sandbox
+
+**Returns**:
+
+- `InputStream` - an `InputStream` streaming the file content
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if the file does not exist or access is denied
+
+#### downloadFileStream()
+```java
+public InputStream downloadFileStream(String remotePath, int timeoutSeconds) throws io.daytona.sdk.exception.DaytonaException
+```
+
+Downloads a single file from the Sandbox as a stream without buffering the entire file
+into memory, with a custom timeout.
+
+The caller is responsible for closing the returned stream.
+
+**Parameters**:
+
+- `remotePath` _String_ - source file path in the Sandbox
+- `timeoutSeconds` _int_ - timeout in seconds; 0 means no timeout
+
+**Returns**:
+
+- `InputStream` - an `InputStream` streaming the file content
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if the file does not exist or access is denied
+
 #### uploadFile()
 ```java
 public void uploadFile(byte[] content, String remotePath)

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-file-system.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-file-system.mdx
@@ -142,6 +142,50 @@ size_mb = os.path.getsize(local_path) / 1024 / 1024
 print(f"Size of the downloaded file {local_path}: {size_mb} MB")
 ```
 
+#### AsyncFileSystem.download\_file\_stream
+
+```python
+@intercept_errors(message_prefix="Failed to download file: ")
+@with_instrumentation()
+async def download_file_stream(remote_path: str,
+                               timeout: int = 30 * 60) -> AsyncIterator[bytes]
+```
+
+Downloads a single file from the Sandbox as a stream without buffering the entire file
+into memory. Returns an async iterator that yields file content in chunks, which can be piped
+directly to an HTTP response, written to a file incrementally, or processed on the fly.
+
+**Arguments**:
+
+- `remote_path` _str_ - Path to the file in the Sandbox. Relative paths are resolved based
+  on the sandbox working directory.
+- `timeout` _int_ - Timeout for the download operation in seconds. 0 means no timeout.
+  Default is 30 minutes.
+  
+
+**Returns**:
+
+- `AsyncIterator[bytes]` - An async iterator yielding chunks of file content as bytes.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the file does not exist or access is denied.
+  
+
+**Example**:
+
+```python
+# Stream to a local file without loading into memory
+async with aiofiles.open("local_copy.bin", "wb") as f:
+    async for chunk in await sandbox.fs.download_file_stream("workspace/large-file.bin"):
+        await f.write(chunk)
+
+# Stream to an HTTP response (FastAPI)
+return StreamingResponse(await sandbox.fs.download_file_stream("workspace/report.pdf"),
+                         media_type="application/pdf")
+```
+
 #### AsyncFileSystem.download\_files
 
 ```python
@@ -643,6 +687,16 @@ def create_file_download_error(response: FileDownloadResponse) -> DaytonaError
 ```
 
 Create the appropriate Daytona exception for a failed file download response.
+
+#### raise\_if\_stream\_error
+
+```python
+def raise_if_stream_error(remote_path: str, error_text: str | None,
+                          error_details: FileDownloadErrorDetails | None,
+                          received_file_data: bool) -> None
+```
+
+Raise the appropriate error after streaming a single-file multipart download.
 
 #### parse\_file\_download\_error\_payload
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/file-system.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/file-system.mdx
@@ -142,6 +142,50 @@ size_mb = os.path.getsize(local_path) / 1024 / 1024
 print(f"Size of the downloaded file {local_path}: {size_mb} MB")
 ```
 
+#### FileSystem.download\_file\_stream
+
+```python
+@intercept_errors(message_prefix="Failed to download file: ")
+@with_instrumentation()
+def download_file_stream(remote_path: str,
+                         timeout: int = 30 * 60) -> Iterator[bytes]
+```
+
+Downloads a single file from the Sandbox as a stream without buffering the entire file
+into memory. Returns an iterator that yields file content in chunks, which can be piped
+directly to an HTTP response, written to a file incrementally, or processed on the fly.
+
+**Arguments**:
+
+- `remote_path` _str_ - Path to the file in the Sandbox. Relative paths are resolved based
+  on the sandbox working directory.
+- `timeout` _int_ - Timeout for the download operation in seconds. 0 means no timeout.
+  Default is 30 minutes.
+  
+
+**Returns**:
+
+- `Iterator[bytes]` - An iterator yielding chunks of file content as bytes.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the file does not exist or access is denied.
+  
+
+**Example**:
+
+```python
+# Stream to a local file without loading into memory
+with open("local_copy.bin", "wb") as f:
+    for chunk in sandbox.fs.download_file_stream("workspace/large-file.bin"):
+        f.write(chunk)
+
+# Stream to an HTTP response (Flask)
+return Response(sandbox.fs.download_file_stream("workspace/report.pdf"),
+                mimetype="application/pdf")
+```
+
 #### FileSystem.download\_files
 
 ```python
@@ -640,6 +684,16 @@ def create_file_download_error(response: FileDownloadResponse) -> DaytonaError
 ```
 
 Create the appropriate Daytona exception for a failed file download response.
+
+#### raise\_if\_stream\_error
+
+```python
+def raise_if_stream_error(remote_path: str, error_text: str | None,
+                          error_details: FileDownloadErrorDetails | None,
+                          received_file_data: bool) -> None
+```
+
+Raise the appropriate error after streaming a single-file multipart download.
 
 #### parse\_file\_download\_error\_payload
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/file-system.mdx
@@ -236,6 +236,47 @@ puts "Size of the downloaded file: #{size_mb} MB"
 
 ```
 
+#### download_file_stream()
+
+```ruby
+def download_file_stream(remote_path, timeout:)
+
+```
+
+Downloads a single file from the Sandbox as a stream without buffering the entire
+file into memory. Yields file content in chunks to the given block, or returns an
+Enumerator if no block is given.
+
+**Parameters**:
+
+- `remote_path` _String_ - Path to the file in the Sandbox. Relative paths are resolved
+based on the sandbox working directory.
+- `timeout` _Integer_ - Timeout for the download operation in seconds. 0 means no timeout.
+Default is 30 minutes.
+
+**Returns**:
+
+- `Enumerator, nil` - An Enumerator yielding chunks if no block given, nil otherwise
+
+**Raises**:
+
+- `Daytona:Sdk:Error` - If the file does not exist or the operation fails
+
+**Examples:**
+
+```ruby
+File.open("local_copy.bin", "wb") do |f|
+  sandbox.fs.download_file_stream("workspace/large-file.bin") { |chunk| f.write(chunk) }
+end
+
+```
+
+```ruby
+content = sandbox.fs.download_file_stream("workspace/data.json").reduce(:+)
+puts content
+
+```
+
 #### upload_file()
 
 ```ruby

--- a/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
@@ -187,6 +187,47 @@ results.forEach(result => {
 
 ***
 
+#### downloadFileStream()
+
+```ts
+downloadFileStream(remotePath: string, timeout?: number): Promise<Readable>
+```
+
+Downloads a single file from the Sandbox as a readable stream without buffering
+the entire file into memory. The returned stream can be piped directly to an HTTP
+response, a file write stream, or any other writable destination.
+
+This method is only supported in Node.js-compatible runtimes (Node.js, Bun).
+Browser and serverless environments should use downloadFile instead.
+
+**Parameters**:
+
+- `remotePath` _string_ - Path to the file in the Sandbox. Relative paths are
+    resolved based on the sandbox working directory.
+- `timeout?` _number = ..._ - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+
+
+**Returns**:
+
+- `Promise<Readable>` - A Node.js Readable stream of the file content.
+
+**Examples:**
+
+```ts
+// Pipe directly to an HTTP response
+const stream = await sandbox.fs.downloadFileStream('outputs/report.pdf');
+stream.pipe(res);
+```
+
+```ts
+// Pipe to a local file
+import { createWriteStream } from 'fs';
+const stream = await sandbox.fs.downloadFileStream('outputs/data.csv');
+stream.pipe(createWriteStream('local-data.csv'));
+```
+
+***
+
 #### findFiles()
 
 ```ts

--- a/examples/go/filesystem/main.go
+++ b/examples/go/filesystem/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 	log.Printf("✓ Downloaded file content: %s\n", string(downloadedContent))
 
-	// Stream download — pipes file content without buffering in memory
+	// Stream download — process file content as chunks arrive
 	stream, err := sandbox.FileSystem.DownloadFileStream(ctx, testPath)
 	if err != nil {
 		log.Fatalf("Failed to stream download file: %v", err)

--- a/examples/go/filesystem/main.go
+++ b/examples/go/filesystem/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log"
 	"time"
 
@@ -64,6 +65,18 @@ func main() {
 		log.Fatalf("Failed to download file: %v", err)
 	}
 	log.Printf("✓ Downloaded file content: %s\n", string(downloadedContent))
+
+	// Stream download — pipes file content without buffering in memory
+	stream, err := sandbox.FileSystem.DownloadFileStream(ctx, testPath)
+	if err != nil {
+		log.Fatalf("Failed to stream download file: %v", err)
+	}
+	streamedContent, err := io.ReadAll(stream)
+	stream.Close()
+	if err != nil {
+		log.Fatalf("Failed to read stream: %v", err)
+	}
+	log.Printf("✓ Streamed file content: %s\n", string(streamedContent))
 
 	// Create a folder
 	folderPath := "/tmp/test-folder"

--- a/examples/java/file-operations/src/main/java/io/daytona/examples/FileOperations.java
+++ b/examples/java/file-operations/src/main/java/io/daytona/examples/FileOperations.java
@@ -33,6 +33,15 @@ public class FileOperations {
                 byte[] downloaded = sandbox.getFs().downloadFile("test-dir/hello.txt");
                 System.out.println("Content: " + new String(downloaded, StandardCharsets.UTF_8));
 
+                // Stream download — pipes file content without buffering in memory
+                System.out.println("Streaming download hello.txt");
+                try (java.io.InputStream stream = sandbox.getFs().downloadFileStream("test-dir/hello.txt")) {
+                    byte[] streamed = stream.readAllBytes();
+                    System.out.println("Streamed content: " + new String(streamed, StandardCharsets.UTF_8));
+                } catch (java.io.IOException e) {
+                    System.err.println("Stream download failed: " + e.getMessage());
+                }
+
                 System.out.println("Uploading config.json and replacing 'true' with 'false'");
                 String originalConfig = "{\"debug\": true, \"name\": \"demo\"}";
                 sandbox.getFs().uploadFile(originalConfig.getBytes(StandardCharsets.UTF_8), "test-dir/config.json");

--- a/examples/java/file-operations/src/main/java/io/daytona/examples/FileOperations.java
+++ b/examples/java/file-operations/src/main/java/io/daytona/examples/FileOperations.java
@@ -33,7 +33,7 @@ public class FileOperations {
                 byte[] downloaded = sandbox.getFs().downloadFile("test-dir/hello.txt");
                 System.out.println("Content: " + new String(downloaded, StandardCharsets.UTF_8));
 
-                // Stream download — pipes file content without buffering in memory
+                // Stream download — process file content as chunks arrive
                 System.out.println("Streaming download hello.txt");
                 try (java.io.InputStream stream = sandbox.getFs().downloadFileStream("test-dir/hello.txt")) {
                     byte[] streamed = stream.readAllBytes();

--- a/examples/python/file-operations/_async/main.py
+++ b/examples/python/file-operations/_async/main.py
@@ -91,7 +91,7 @@ async def main():
         config_content = await sandbox.fs.download_file(os.path.join(new_dir, "config.json"))
         print("Config content:", config_content.decode("utf-8"))
 
-        # Stream download — pipes file content without buffering in memory
+        # Stream download — process file content as chunks arrive
         print("\nStreaming download example:")
         stream = await sandbox.fs.download_file_stream(os.path.join(new_dir, "config.json"))
         streamed_chunks = [chunk async for chunk in stream]

--- a/examples/python/file-operations/_async/main.py
+++ b/examples/python/file-operations/_async/main.py
@@ -91,6 +91,12 @@ async def main():
         config_content = await sandbox.fs.download_file(os.path.join(new_dir, "config.json"))
         print("Config content:", config_content.decode("utf-8"))
 
+        # Stream download — pipes file content without buffering in memory
+        print("\nStreaming download example:")
+        stream = await sandbox.fs.download_file_stream(os.path.join(new_dir, "config.json"))
+        streamed_chunks = [chunk async for chunk in stream]
+        print("Streamed content:", b"".join(streamed_chunks).decode("utf-8"))
+
         # Create a report of all operations
         report_data = f"""
         Project Files Report:

--- a/examples/python/file-operations/main.py
+++ b/examples/python/file-operations/main.py
@@ -89,6 +89,11 @@ def main():
     config_content = sandbox.fs.download_file(os.path.join(new_dir, "config.json"))
     print("Config content:", config_content.decode("utf-8"))
 
+    # Stream download — pipes file content without buffering in memory
+    print("\nStreaming download example:")
+    streamed_chunks = list(sandbox.fs.download_file_stream(os.path.join(new_dir, "config.json")))
+    print("Streamed content:", b"".join(streamed_chunks).decode("utf-8"))
+
     # Create a report of all operations
     report_data = f"""
     Project Files Report:

--- a/examples/python/file-operations/main.py
+++ b/examples/python/file-operations/main.py
@@ -89,7 +89,7 @@ def main():
     config_content = sandbox.fs.download_file(os.path.join(new_dir, "config.json"))
     print("Config content:", config_content.decode("utf-8"))
 
-    # Stream download — pipes file content without buffering in memory
+    # Stream download — process file content as chunks arrive
     print("\nStreaming download example:")
     streamed_chunks = list(sandbox.fs.download_file_stream(os.path.join(new_dir, "config.json")))
     print("Streamed content:", b"".join(streamed_chunks).decode("utf-8"))

--- a/examples/ruby/file-operations/main.rb
+++ b/examples/ruby/file-operations/main.rb
@@ -63,7 +63,7 @@ file = sandbox.fs.download_file(File.join(project_files, 'example.txt'))
 puts "Content of example.txt: #{file.open.read}"
 puts "Size of the downloaded file: #{file.size} bytes"
 
-# Stream download — pipes file content without buffering in memory
+# Stream download — process file content as chunks arrive
 puts "\nStreaming download example:"
 chunks = []
 sandbox.fs.download_file_stream(File.join(project_files, 'config.json')) { |chunk| chunks << chunk }

--- a/examples/ruby/file-operations/main.rb
+++ b/examples/ruby/file-operations/main.rb
@@ -63,6 +63,12 @@ file = sandbox.fs.download_file(File.join(project_files, 'example.txt'))
 puts "Content of example.txt: #{file.open.read}"
 puts "Size of the downloaded file: #{file.size} bytes"
 
+# Stream download — pipes file content without buffering in memory
+puts "\nStreaming download example:"
+chunks = []
+sandbox.fs.download_file_stream(File.join(project_files, 'config.json')) { |chunk| chunks << chunk }
+puts "Streamed content: #{chunks.join}"
+
 # Cleanup
 File.delete('local-config.json') if File.exist?('local-config.json')
 File.delete('example.txt') if File.exist?('example.txt')

--- a/examples/typescript/file-operations/index.ts
+++ b/examples/typescript/file-operations/index.ts
@@ -104,7 +104,7 @@ async function main() {
     const reportBuffer = await sandbox.fs.downloadFile(path.join(newDir, 'config.json'))
     console.log('Config content:', reportBuffer.toString())
 
-    //  stream download — pipes file content without buffering in memory
+    //  stream download — process file content as chunks arrive
     console.log('\nStreaming download example:')
     const stream = await sandbox.fs.downloadFileStream(path.join(newDir, 'config.json'))
     const chunks: Buffer[] = []

--- a/examples/typescript/file-operations/index.ts
+++ b/examples/typescript/file-operations/index.ts
@@ -104,6 +104,17 @@ async function main() {
     const reportBuffer = await sandbox.fs.downloadFile(path.join(newDir, 'config.json'))
     console.log('Config content:', reportBuffer.toString())
 
+    //  stream download — pipes file content without buffering in memory
+    console.log('\nStreaming download example:')
+    const stream = await sandbox.fs.downloadFileStream(path.join(newDir, 'config.json'))
+    const chunks: Buffer[] = []
+    await new Promise<void>((resolve, reject) => {
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk))
+      stream.on('end', resolve)
+      stream.on('error', reject)
+    })
+    console.log('Streamed content:', Buffer.concat(chunks).toString())
+
     // Create a report of all operations
     const reportData = `
 Project Files Report:

--- a/libs/sdk-go/pkg/daytona/e2e_test.go
+++ b/libs/sdk-go/pkg/daytona/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -217,6 +218,16 @@ func TestE2E(t *testing.T) {
 		localData, localReadErr := os.ReadFile(localPath)
 		require.NoError(t, localReadErr)
 		assert.Equal(t, "hello world", string(localData))
+	})
+
+	t.Run("FileSystem/DownloadFileStream", func(t *testing.T) {
+		stream, err := sandbox.FileSystem.DownloadFileStream(ctx, helloPath)
+		require.NoError(t, err)
+		defer stream.Close()
+
+		data, err := io.ReadAll(stream)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(data))
 	})
 
 	t.Run("FileSystem/FindFiles", func(t *testing.T) {

--- a/libs/sdk-go/pkg/daytona/file_transfer.go
+++ b/libs/sdk-go/pkg/daytona/file_transfer.go
@@ -1,0 +1,116 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package daytona
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
+	"github.com/daytonaio/daytona/libs/toolbox-api-client-go"
+)
+
+type downloadStreamCloser struct {
+	partReader io.Reader
+	response   *http.Response
+}
+
+func (d *downloadStreamCloser) Read(p []byte) (int, error) {
+	return d.partReader.Read(p)
+}
+
+func (d *downloadStreamCloser) Close() error {
+	if d.response == nil || d.response.Body == nil {
+		return nil
+	}
+	return d.response.Body.Close()
+}
+
+func streamDownloadFile(cfg *toolbox.Configuration, remotePath string, ctx context.Context) (io.ReadCloser, error) {
+	if len(cfg.Servers) == 0 {
+		return nil, errors.NewDaytonaError("Toolbox client is not configured", 0, nil)
+	}
+
+	requestBody, err := json.Marshal(toolbox.NewFilesDownloadRequest([]string{remotePath}))
+	if err != nil {
+		return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to encode download request: %v", err), 0, nil)
+	}
+
+	endpoint := strings.TrimRight(cfg.Servers[0].URL, "/") + "/files/bulk-download"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to create download request: %v", err), 0, nil)
+	}
+
+	for key, value := range cfg.DefaultHeader {
+		req.Header.Set(key, value)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "multipart/form-data")
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to download file stream: %v", err), 0, nil)
+	}
+
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		defer resp.Body.Close()
+
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to read download error response: %v", readErr), resp.StatusCode, resp.Header)
+		}
+
+		return nil, errors.NewDaytonaErrorFromBody(body, resp.StatusCode, resp.Header)
+	}
+
+	_, params, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to parse multipart response: %v", err), resp.StatusCode, resp.Header)
+	}
+
+	boundary := params["boundary"]
+	if boundary == "" {
+		_ = resp.Body.Close()
+		return nil, errors.NewDaytonaError("Missing multipart boundary in download response", resp.StatusCode, resp.Header)
+	}
+
+	reader := multipart.NewReader(resp.Body, boundary)
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			_ = resp.Body.Close()
+			return nil, errors.NewDaytonaError("File stream not found in download response", resp.StatusCode, resp.Header)
+		}
+		if err != nil {
+			_ = resp.Body.Close()
+			return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to read multipart download response: %v", err), resp.StatusCode, resp.Header)
+		}
+
+		switch part.FormName() {
+		case "file":
+			return &downloadStreamCloser{partReader: part, response: resp}, nil
+		case "error":
+			body, readErr := io.ReadAll(part)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to read download error part: %v", readErr), resp.StatusCode, resp.Header)
+			}
+			return nil, errors.NewDaytonaErrorFromBody(body, resp.StatusCode, resp.Header)
+		}
+	}
+}

--- a/libs/sdk-go/pkg/daytona/filesystem.go
+++ b/libs/sdk-go/pkg/daytona/filesystem.go
@@ -241,6 +241,43 @@ func (f *FileSystemService) DownloadFile(ctx context.Context, remotePath string,
 	})
 }
 
+// DownloadFileStream downloads a single file from the sandbox as a stream without
+// buffering the entire file into memory. The returned [io.ReadCloser] can be piped
+// directly to an HTTP response, written to a file, or processed on the fly.
+//
+// The caller must close the returned [io.ReadCloser] when done.
+//
+// Parameters:
+//   - remotePath: Path to the file in the sandbox. Relative paths are resolved based
+//     on the sandbox working directory.
+//
+// Returns an [io.ReadCloser] streaming the file content.
+//
+// Example:
+//
+//	// Stream to an HTTP response
+//	stream, err := sandbox.FileSystem.DownloadFileStream(ctx, "workspace/report.pdf")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer stream.Close()
+//	io.Copy(w, stream) // w is an http.ResponseWriter
+//
+//	// Stream to a local file
+//	stream, err := sandbox.FileSystem.DownloadFileStream(ctx, "workspace/large-file.bin")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer stream.Close()
+//	out, _ := os.Create("local-copy.bin")
+//	defer out.Close()
+//	io.Copy(out, stream)
+func (f *FileSystemService) DownloadFileStream(ctx context.Context, remotePath string) (io.ReadCloser, error) {
+	return withInstrumentation(ctx, f.otel, "FileSystem", "DownloadFileStream", func(ctx context.Context) (io.ReadCloser, error) {
+		return streamDownloadFile(f.toolboxClient.GetConfig(), remotePath, ctx)
+	})
+}
+
 // UploadFile uploads a file to the sandbox.
 //
 // Parameters:

--- a/libs/sdk-go/pkg/daytona/filesystem_test.go
+++ b/libs/sdk-go/pkg/daytona/filesystem_test.go
@@ -6,14 +6,18 @@ package daytona
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	sdkerrors "github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/options"
 	toolbox "github.com/daytonaio/daytona/libs/toolbox-api-client-go"
 	"github.com/stretchr/testify/assert"
@@ -135,6 +139,97 @@ func TestDownloadFile(t *testing.T) {
 	data, err := fs.DownloadFile(ctx, "/home/user/file.txt", nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("file content here"), data)
+}
+
+func TestDownloadFileStream(t *testing.T) {
+	remotePath := "/home/user/file.txt"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/files/bulk-download", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "multipart/form-data", r.Header.Get("Accept"))
+		assert.Contains(t, r.Header.Get("Content-Type"), "application/json")
+
+		var reqBody struct {
+			Paths []string `json:"paths"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&reqBody))
+		assert.Equal(t, []string{remotePath}, reqBody.Paths)
+
+		mw := multipart.NewWriter(w)
+		w.Header().Set("Content-Type", mw.FormDataContentType())
+		part, err := mw.CreateFormFile("file", remotePath)
+		require.NoError(t, err)
+		_, err = part.Write([]byte("streamed file content"))
+		require.NoError(t, err)
+		require.NoError(t, mw.Close())
+	}))
+	defer server.Close()
+
+	client := createTestToolboxClient(server)
+	client.GetConfig().AddDefaultHeader("Authorization", "Bearer test-token")
+	fs := NewFileSystemService(client, nil)
+
+	stream, err := fs.DownloadFileStream(context.Background(), remotePath)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	data, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	assert.Equal(t, "streamed file content", string(data))
+}
+
+func TestDownloadFileStreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mw := multipart.NewWriter(w)
+		w.Header().Set("Content-Type", mw.FormDataContentType())
+		part, err := mw.CreatePart(textproto.MIMEHeader{
+			"Content-Disposition": {`form-data; name="error"`},
+			"Content-Type":        {"application/json"},
+		})
+		require.NoError(t, err)
+		require.NoError(t, json.NewEncoder(part).Encode(map[string]any{
+			"message":    "download failed",
+			"statusCode": http.StatusInternalServerError,
+			"code":       "DOWNLOAD_FAILED",
+		}))
+		require.NoError(t, mw.Close())
+	}))
+	defer server.Close()
+
+	fs := NewFileSystemService(createTestToolboxClient(server), nil)
+	stream, err := fs.DownloadFileStream(context.Background(), "/home/user/file.txt")
+	require.Nil(t, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "download failed")
+}
+
+func TestDownloadFileStreamNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mw := multipart.NewWriter(w)
+		w.Header().Set("Content-Type", mw.FormDataContentType())
+		part, err := mw.CreatePart(textproto.MIMEHeader{
+			"Content-Disposition": {`form-data; name="error"`},
+			"Content-Type":        {"application/json"},
+		})
+		require.NoError(t, err)
+		require.NoError(t, json.NewEncoder(part).Encode(map[string]any{
+			"message":    "file not found",
+			"statusCode": http.StatusNotFound,
+			"code":       "FILE_NOT_FOUND",
+		}))
+		require.NoError(t, mw.Close())
+	}))
+	defer server.Close()
+
+	fs := NewFileSystemService(createTestToolboxClient(server), nil)
+	stream, err := fs.DownloadFileStream(context.Background(), "/home/user/missing.txt")
+	require.Nil(t, stream)
+	require.Error(t, err)
+
+	var notFoundErr *sdkerrors.DaytonaNotFoundError
+	assert.ErrorAs(t, err, &notFoundErr)
+	assert.Contains(t, err.Error(), "file not found")
 }
 
 func TestMoveFiles(t *testing.T) {

--- a/libs/sdk-go/pkg/errors/errors.go
+++ b/libs/sdk-go/pkg/errors/errors.go
@@ -83,6 +83,46 @@ func NewDaytonaTimeoutError(message string) *DaytonaTimeoutError {
 	}
 }
 
+// NewDaytonaErrorFromBody parses a JSON response body and maps the status code
+// to the appropriate SDK error type. Falls back to the raw body as the message.
+func NewDaytonaErrorFromBody(body []byte, statusCode int, headers http.Header) error {
+	var message string
+
+	if len(body) > 0 {
+		var errResp struct {
+			Message    string `json:"message"`
+			Error      string `json:"error"`
+			StatusCode int    `json:"statusCode"`
+		}
+		if json.Unmarshal(body, &errResp) == nil {
+			if errResp.Message != "" {
+				message = errResp.Message
+			} else if errResp.Error != "" {
+				message = errResp.Error
+			}
+			if errResp.StatusCode != 0 {
+				statusCode = errResp.StatusCode
+			}
+		}
+		if message == "" {
+			message = string(body)
+		}
+	}
+
+	if message == "" {
+		message = "Download failed"
+	}
+
+	switch statusCode {
+	case http.StatusNotFound:
+		return NewDaytonaNotFoundError(message, headers)
+	case http.StatusTooManyRequests:
+		return NewDaytonaRateLimitError(message, headers)
+	default:
+		return NewDaytonaError(message, statusCode, headers)
+	}
+}
+
 // ConvertAPIError converts api-client-go errors to SDK error types
 func ConvertAPIError(err error, httpResp *http.Response) error {
 	if err == nil {

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/ExceptionMapper.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/ExceptionMapper.java
@@ -52,7 +52,7 @@ final class ExceptionMapper {
         }
     }
 
-    private static DaytonaException map(int statusCode, String responseBody) {
+    static DaytonaException map(int statusCode, String responseBody) {
         String message = extractMessage(responseBody, statusCode);
         switch (statusCode) {
             case 400:

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileSystem.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileSystem.java
@@ -9,11 +9,12 @@ import io.daytona.toolbox.client.model.ReplaceRequest;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.ArrayList;
 
 /**
  * File system operations facade for a specific Sandbox.
@@ -68,6 +69,36 @@ public class FileSystem {
         } catch (IOException e) {
             throw new io.daytona.sdk.exception.DaytonaException("Failed to read downloaded file", e);
         }
+    }
+
+    /**
+     * Downloads a single file from the Sandbox as a stream without buffering the entire file
+     * into memory. The returned {@link InputStream} can be piped directly to an HTTP response,
+     * written to a file, or processed on the fly.
+     *
+     * <p>The caller is responsible for closing the returned stream.
+     *
+     * @param remotePath source file path in the Sandbox
+     * @return an {@link InputStream} streaming the file content
+     * @throws io.daytona.sdk.exception.DaytonaException if the file does not exist or access is denied
+     */
+    public InputStream downloadFileStream(String remotePath) throws io.daytona.sdk.exception.DaytonaException {
+        return downloadFileStream(remotePath, FileTransfer.DEFAULT_DOWNLOAD_STREAM_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * Downloads a single file from the Sandbox as a stream without buffering the entire file
+     * into memory, with a custom timeout.
+     *
+     * <p>The caller is responsible for closing the returned stream.
+     *
+     * @param remotePath source file path in the Sandbox
+     * @param timeoutSeconds timeout in seconds; 0 means no timeout
+     * @return an {@link InputStream} streaming the file content
+     * @throws io.daytona.sdk.exception.DaytonaException if the file does not exist or access is denied
+     */
+    public InputStream downloadFileStream(String remotePath, int timeoutSeconds) throws io.daytona.sdk.exception.DaytonaException {
+        return FileTransfer.streamDownload(fileSystemApi, remotePath, timeoutSeconds);
     }
 
     /**

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
@@ -1,0 +1,346 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.daytona.toolbox.client.ApiClient;
+import io.daytona.toolbox.client.api.FileSystemApi;
+import io.daytona.toolbox.client.model.FilesDownloadRequest;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class FileTransfer {
+    static final int DEFAULT_DOWNLOAD_STREAM_TIMEOUT_SECONDS = 30 * 60;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Pattern BOUNDARY_PATTERN = Pattern.compile("boundary=\"?([^\";]+)\"?");
+    private static final Pattern PART_NAME_PATTERN = Pattern.compile("name=\"([^\"]+)\"");
+
+    private FileTransfer() {
+    }
+
+    static InputStream streamDownload(FileSystemApi fileSystemApi, String remotePath, int timeoutSeconds) throws io.daytona.sdk.exception.DaytonaException {
+        if (timeoutSeconds < 0) {
+            throw new io.daytona.sdk.exception.DaytonaException("Timeout must be non-negative");
+        }
+
+        ApiClient apiClient = fileSystemApi.getApiClient();
+        if (apiClient == null || apiClient.getBasePath() == null || apiClient.getBasePath().isEmpty()) {
+            throw new io.daytona.sdk.exception.DaytonaException("Toolbox client is not configured");
+        }
+
+        OkHttpClient httpClient = apiClient.getHttpClient();
+        if (httpClient == null) {
+            throw new io.daytona.sdk.exception.DaytonaException("Toolbox client is not configured");
+        }
+
+        OkHttpClient streamingClient = httpClient.newBuilder()
+                .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                .build();
+
+        Response response = null;
+        try {
+            Request request = buildDownloadFileStreamRequest(apiClient, remotePath);
+            response = streamingClient.newCall(request).execute();
+            return extractDownloadFileStream(response);
+        } catch (IOException e) {
+            if (response != null) {
+                response.close();
+            }
+            throw new io.daytona.sdk.exception.DaytonaException("Failed to download file stream", e);
+        }
+    }
+
+    private static Request buildDownloadFileStreamRequest(ApiClient apiClient, String remotePath) {
+        try {
+            RequestBody requestBody = apiClient.serialize(
+                    new FilesDownloadRequest().paths(Collections.singletonList(remotePath)),
+                    "application/json"
+            );
+
+            Map<String, String> headerParams = new HashMap<String, String>();
+            headerParams.put("Accept", "multipart/form-data");
+            headerParams.put("Content-Type", "application/json");
+
+            Request.Builder requestBuilder = new Request.Builder()
+                    .url(apiClient.getBasePath().replaceAll("/+$", "") + "/files/bulk-download")
+                    .post(requestBody);
+
+            apiClient.processHeaderParams(headerParams, requestBuilder);
+            apiClient.processCookieParams(new HashMap<String, String>(), requestBuilder);
+            return requestBuilder.build();
+        } catch (io.daytona.toolbox.client.ApiException e) {
+            throw ExceptionMapper.map(e.getCode(), e.getResponseBody());
+        }
+    }
+
+    private static InputStream extractDownloadFileStream(Response response) throws IOException {
+        ResponseBody responseBody = response.body();
+        if (responseBody == null) {
+            response.close();
+            throw new io.daytona.sdk.exception.DaytonaException("Download response body is empty");
+        }
+
+        if (!response.isSuccessful()) {
+            byte[] responseBytes = responseBody.bytes();
+            response.close();
+            throw parseDownloadError(responseBytes, response.code());
+        }
+
+        String boundary = extractBoundary(response.header("Content-Type"));
+        if (boundary == null || boundary.isEmpty()) {
+            response.close();
+            throw new io.daytona.sdk.exception.DaytonaException("Missing multipart boundary in download response");
+        }
+
+        BufferedInputStream bufferedStream = new BufferedInputStream(responseBody.byteStream());
+        try {
+            moveToFirstPart(bufferedStream, boundary);
+            Map<String, String> partHeaders = readPartHeaders(bufferedStream);
+            String partName = extractPartName(partHeaders.get("content-disposition"));
+            if ("file".equals(partName)) {
+                return new MultipartPartInputStream(bufferedStream, response, boundary);
+            }
+
+            if ("error".equals(partName)) {
+                try (InputStream errorStream = new MultipartPartInputStream(bufferedStream, response, boundary)) {
+                    throw parseDownloadError(errorStream.readAllBytes(), response.code());
+                }
+            }
+
+            response.close();
+            throw new io.daytona.sdk.exception.DaytonaException("File stream not found in download response");
+        } catch (IOException | RuntimeException e) {
+            response.close();
+            throw e;
+        }
+    }
+
+    private static void moveToFirstPart(BufferedInputStream inputStream, String boundary) throws IOException {
+        String expectedBoundary = "--" + boundary;
+        String closingBoundary = expectedBoundary + "--";
+        while (true) {
+            String line = readLine(inputStream);
+            if (line == null) {
+                throw new io.daytona.sdk.exception.DaytonaException("File stream not found in download response");
+            }
+            if (expectedBoundary.equals(line)) {
+                return;
+            }
+            if (closingBoundary.equals(line)) {
+                throw new io.daytona.sdk.exception.DaytonaException("File stream not found in download response");
+            }
+        }
+    }
+
+    private static Map<String, String> readPartHeaders(BufferedInputStream inputStream) throws IOException {
+        Map<String, String> headers = new HashMap<String, String>();
+        while (true) {
+            String line = readLine(inputStream);
+            if (line == null) {
+                throw new io.daytona.sdk.exception.DaytonaException("Unexpected end of multipart response");
+            }
+            if (line.isEmpty()) {
+                return headers;
+            }
+            int separatorIndex = line.indexOf(':');
+            if (separatorIndex > 0) {
+                headers.put(
+                        line.substring(0, separatorIndex).trim().toLowerCase(Locale.ROOT),
+                        line.substring(separatorIndex + 1).trim()
+                );
+            }
+        }
+    }
+
+    private static String readLine(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        boolean sawCarriageReturn = false;
+
+        while (true) {
+            int nextByte = inputStream.read();
+            if (nextByte == -1) {
+                if (sawCarriageReturn) {
+                    buffer.write('\r');
+                }
+                return buffer.size() == 0 ? null : buffer.toString(StandardCharsets.ISO_8859_1.name());
+            }
+            if (sawCarriageReturn) {
+                if (nextByte == '\n') {
+                    return buffer.toString(StandardCharsets.ISO_8859_1.name());
+                }
+                buffer.write('\r');
+                sawCarriageReturn = false;
+            }
+            if (nextByte == '\r') {
+                sawCarriageReturn = true;
+                continue;
+            }
+            if (nextByte == '\n') {
+                return buffer.toString(StandardCharsets.ISO_8859_1.name());
+            }
+            buffer.write(nextByte);
+        }
+    }
+
+    private static String extractBoundary(String contentType) {
+        if (contentType == null) {
+            return null;
+        }
+        Matcher matcher = BOUNDARY_PATTERN.matcher(contentType);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static String extractPartName(String contentDisposition) {
+        if (contentDisposition == null) {
+            return null;
+        }
+        Matcher matcher = PART_NAME_PATTERN.matcher(contentDisposition);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static io.daytona.sdk.exception.DaytonaException parseDownloadError(byte[] body, int fallbackStatusCode) {
+        String responseBody = body == null ? "" : new String(body, StandardCharsets.UTF_8).trim();
+        int statusCode = fallbackStatusCode;
+
+        if (!responseBody.isEmpty()) {
+            try {
+                JsonNode root = OBJECT_MAPPER.readTree(responseBody);
+                JsonNode statusCodeNode = root.get("statusCode");
+                if (statusCodeNode != null && statusCodeNode.canConvertToInt()) {
+                    statusCode = statusCodeNode.asInt();
+                }
+            } catch (IOException ignored) {
+            }
+        }
+
+        if (responseBody.isEmpty()) {
+            responseBody = "{\"message\":\"Download failed\"}";
+        }
+
+        return ExceptionMapper.map(statusCode, responseBody);
+    }
+
+    private static final class MultipartPartInputStream extends InputStream {
+        private final InputStream source;
+        private final Response response;
+        private final byte[] delimiter;
+        private final java.util.ArrayDeque<Integer> bufferedBytes = new java.util.ArrayDeque<Integer>();
+        private boolean sourceEnded;
+        private boolean finished;
+        private boolean closed;
+
+        private MultipartPartInputStream(InputStream source, Response response, String boundary) {
+            this.source = source;
+            this.response = response;
+            this.delimiter = ("\r\n--" + boundary).getBytes(StandardCharsets.ISO_8859_1);
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (finished || closed) {
+                return -1;
+            }
+
+            while (true) {
+                while (!sourceEnded && bufferedBytes.size() < delimiter.length) {
+                    int nextByte = source.read();
+                    if (nextByte == -1) {
+                        sourceEnded = true;
+                        break;
+                    }
+                    bufferedBytes.addLast(nextByte);
+                }
+
+                if (matchesDelimiter()) {
+                    bufferedBytes.clear();
+                    consumeBoundaryRemainder();
+                    finished = true;
+                    close();
+                    return -1;
+                }
+
+                if (!bufferedBytes.isEmpty()) {
+                    int value = bufferedBytes.removeFirst();
+                    if (sourceEnded && bufferedBytes.isEmpty()) {
+                        finished = true;
+                        close();
+                    }
+                    return value;
+                }
+
+                finished = true;
+                close();
+                return -1;
+            }
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            response.close();
+        }
+
+        private boolean matchesDelimiter() {
+            if (bufferedBytes.size() != delimiter.length) {
+                return false;
+            }
+
+            int index = 0;
+            for (Integer bufferedByte : bufferedBytes) {
+                if ((byte) bufferedByte.intValue() != delimiter[index]) {
+                    return false;
+                }
+                index++;
+            }
+            return true;
+        }
+
+        private void consumeBoundaryRemainder() throws IOException {
+            int nextByte = source.read();
+            if (nextByte == '-') {
+                source.read();
+                consumeUntilLineEnd();
+                return;
+            }
+            if (nextByte == '\r') {
+                int lineFeed = source.read();
+                if (lineFeed == '\n') {
+                    return;
+                }
+            }
+            if (nextByte != '\n' && nextByte != -1) {
+                consumeUntilLineEnd();
+            }
+        }
+
+        private void consumeUntilLineEnd() throws IOException {
+            int nextByte;
+            while ((nextByte = source.read()) != -1) {
+                if (nextByte == '\n') {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
@@ -293,6 +293,26 @@ final class FileTransfer {
         }
 
         @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (b == null) throw new NullPointerException();
+            if (off < 0 || len < 0 || len > b.length - off) throw new IndexOutOfBoundsException();
+            if (len == 0) return 0;
+
+            int first = read();
+            if (first == -1) return -1;
+            b[off] = (byte) first;
+
+            int i = 1;
+            while (i < len) {
+                int next = read();
+                if (next == -1) break;
+                b[off + i] = (byte) next;
+                i++;
+            }
+            return i;
+        }
+
+        @Override
         public void close() {
             if (closed) {
                 return;

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
@@ -239,10 +239,16 @@ final class FileTransfer {
     }
 
     private static final class MultipartPartInputStream extends InputStream {
+        private static final int BUF_SIZE = 8192;
+
         private final InputStream source;
         private final Response response;
         private final byte[] delimiter;
-        private final java.util.ArrayDeque<Integer> bufferedBytes = new java.util.ArrayDeque<Integer>();
+
+        private byte[] buf = new byte[BUF_SIZE];
+        private int pos;
+        private int limit;
+        private int delimiterAt = -1;
         private boolean sourceEnded;
         private boolean finished;
         private boolean closed;
@@ -255,112 +261,115 @@ final class FileTransfer {
 
         @Override
         public int read() throws IOException {
-            if (finished || closed) {
-                return -1;
-            }
+            byte[] single = new byte[1];
+            int n = read(single, 0, 1);
+            return n == -1 ? -1 : single[0] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (finished || closed) return -1;
+            if (b == null) throw new NullPointerException();
+            if (off < 0 || len < 0 || len > b.length - off) throw new IndexOutOfBoundsException();
+            if (len == 0) return 0;
 
             while (true) {
-                while (!sourceEnded && bufferedBytes.size() < delimiter.length) {
-                    int nextByte = source.read();
-                    if (nextByte == -1) {
-                        sourceEnded = true;
-                        break;
-                    }
-                    bufferedBytes.addLast(nextByte);
+                int safe = safeBytes();
+                if (safe > 0) {
+                    int n = Math.min(len, safe);
+                    System.arraycopy(buf, pos, b, off, n);
+                    pos += n;
+                    return n;
                 }
 
-                if (matchesDelimiter()) {
-                    bufferedBytes.clear();
-                    consumeBoundaryRemainder();
+                if (delimiterAt == pos) {
                     finished = true;
                     close();
                     return -1;
                 }
 
-                if (!bufferedBytes.isEmpty()) {
-                    int value = bufferedBytes.removeFirst();
-                    if (sourceEnded && bufferedBytes.isEmpty()) {
-                        finished = true;
-                        close();
-                    }
-                    return value;
+                if (sourceEnded && pos >= limit) {
+                    finished = true;
+                    close();
+                    return -1;
                 }
 
-                finished = true;
-                close();
-                return -1;
+                if (!fill()) {
+                    int remaining = limit - pos;
+                    if (remaining > 0) {
+                        int n = Math.min(len, remaining);
+                        System.arraycopy(buf, pos, b, off, n);
+                        pos += n;
+                        return n;
+                    }
+                    finished = true;
+                    close();
+                    return -1;
+                }
             }
-        }
-
-        @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            if (b == null) throw new NullPointerException();
-            if (off < 0 || len < 0 || len > b.length - off) throw new IndexOutOfBoundsException();
-            if (len == 0) return 0;
-
-            int first = read();
-            if (first == -1) return -1;
-            b[off] = (byte) first;
-
-            int i = 1;
-            while (i < len) {
-                int next = read();
-                if (next == -1) break;
-                b[off + i] = (byte) next;
-                i++;
-            }
-            return i;
         }
 
         @Override
         public void close() {
-            if (closed) {
-                return;
-            }
+            if (closed) return;
             closed = true;
             response.close();
         }
 
-        private boolean matchesDelimiter() {
-            if (bufferedBytes.size() != delimiter.length) {
-                return false;
-            }
+        private int safeBytes() {
+            int available = limit - pos;
+            if (available <= 0) return 0;
 
-            int index = 0;
-            for (Integer bufferedByte : bufferedBytes) {
-                if ((byte) bufferedByte.intValue() != delimiter[index]) {
-                    return false;
-                }
-                index++;
+            if (delimiterAt >= 0) return delimiterAt - pos;
+
+            if (sourceEnded) return available;
+
+            return Math.max(0, available - (delimiter.length - 1));
+        }
+
+        private boolean fill() throws IOException {
+            compact();
+            if (sourceEnded) return limit > 0;
+
+            int read = source.read(buf, limit, buf.length - limit);
+            if (read == -1) {
+                sourceEnded = true;
+                return limit > 0;
             }
+            limit += read;
+            scanForDelimiter();
             return true;
         }
 
-        private void consumeBoundaryRemainder() throws IOException {
-            int nextByte = source.read();
-            if (nextByte == '-') {
-                source.read();
-                consumeUntilLineEnd();
-                return;
+        private void compact() {
+            if (pos == 0) return;
+            int remaining = limit - pos;
+            if (remaining > 0) {
+                System.arraycopy(buf, pos, buf, 0, remaining);
             }
-            if (nextByte == '\r') {
-                int lineFeed = source.read();
-                if (lineFeed == '\n') {
+            if (delimiterAt >= 0) {
+                delimiterAt -= pos;
+            }
+            limit = remaining;
+            pos = 0;
+        }
+
+        private void scanForDelimiter() {
+            if (delimiterAt >= 0) return;
+            int end = limit - delimiter.length + 1;
+            for (int i = pos; i < end; i++) {
+                if (matchesAt(i)) {
+                    delimiterAt = i;
                     return;
                 }
-            }
-            if (nextByte != '\n' && nextByte != -1) {
-                consumeUntilLineEnd();
             }
         }
 
-        private void consumeUntilLineEnd() throws IOException {
-            int nextByte;
-            while ((nextByte = source.read()) != -1) {
-                if (nextByte == '\n') {
-                    return;
-                }
+        private boolean matchesAt(int offset) {
+            for (int j = 0; j < delimiter.length; j++) {
+                if (buf[offset + j] != delimiter[j]) return false;
             }
+            return true;
         }
     }
 }

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -252,6 +253,16 @@ class E2ETest {
         assertThat(sandbox.getFs().listFiles(fsDir + "/parent")).extracting(io.daytona.sdk.model.FileInfo::getName).contains("child");
         assertThat(new String(sandbox.getFs().downloadFile(fsDir + "/parent/child/nested.txt"), StandardCharsets.UTF_8))
                 .isEqualTo("nested-content");
+    }
+
+    @Test
+    @Order(13)
+    void fileSystemDownloadFileStreamWorks() throws Exception {
+        sandbox.getFs().uploadFile("stream content".getBytes(StandardCharsets.UTF_8), fsDir + "/stream.txt");
+
+        try (InputStream stream = sandbox.getFs().downloadFileStream(fsDir + "/stream.txt")) {
+            assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("stream content");
+        }
     }
 
     @Test

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/FileSystemTest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/FileSystemTest.java
@@ -11,6 +11,8 @@ import io.daytona.sdk.exception.DaytonaNotFoundException;
 import io.daytona.sdk.exception.DaytonaRateLimitException;
 import io.daytona.sdk.exception.DaytonaServerException;
 import io.daytona.sdk.model.FileInfo;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import io.daytona.toolbox.client.api.FileSystemApi;
 import io.daytona.toolbox.client.model.Match;
 import io.daytona.toolbox.client.model.ReplaceRequest;
@@ -26,7 +28,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
@@ -128,6 +132,59 @@ class FileSystemTest {
         when(fileSystemApi.downloadFile("/missing.txt")).thenReturn(null);
 
         assertThat(fileSystem.downloadFile("/missing.txt")).isEmpty();
+    }
+
+    @Test
+    void downloadFileStreamReturnsInputStream() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setHeader("Content-Type", "multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY")
+                    .setBody("--DAYTONA-FILE-BOUNDARY\r\n"
+                            + "Content-Disposition: form-data; name=\"file\"; filename=\"remote.txt\"\r\n"
+                            + "Content-Type: application/octet-stream\r\n"
+                            + "\r\n"
+                            + "streamed-content\r\n"
+                            + "--DAYTONA-FILE-BOUNDARY--\r\n"));
+
+            io.daytona.toolbox.client.ApiClient apiClient = new io.daytona.toolbox.client.ApiClient();
+            apiClient.setBasePath(server.url("/").toString());
+            apiClient.addDefaultHeader("Authorization", "Bearer secret");
+            FileSystem streamingFileSystem = new FileSystem(new FileSystemApi(apiClient));
+
+            try (InputStream stream = streamingFileSystem.downloadFileStream("/remote.txt", 45)) {
+                assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("streamed-content");
+            }
+
+            okhttp3.mockwebserver.RecordedRequest request = server.takeRequest();
+            assertThat(request.getMethod()).isEqualTo("POST");
+            assertThat(request.getPath()).isEqualTo("/files/bulk-download");
+            assertThat(request.getHeader("Authorization")).isEqualTo("Bearer secret");
+            assertThat(request.getHeader("Accept")).isEqualTo("multipart/form-data");
+            assertThat(request.getHeader("Content-Type")).startsWith("application/json");
+            assertThat(request.getBody().readUtf8()).isEqualTo("{\"paths\":[\"/remote.txt\"]}");
+        }
+    }
+
+    @Test
+    void downloadFileStreamThrowsOnErrorPart() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setHeader("Content-Type", "multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY")
+                    .setBody("--DAYTONA-FILE-BOUNDARY\r\n"
+                            + "Content-Disposition: form-data; name=\"error\"\r\n"
+                            + "Content-Type: application/json\r\n"
+                            + "\r\n"
+                            + "{\"message\":\"missing file\",\"statusCode\":404,\"code\":\"NotFound\"}\r\n"
+                            + "--DAYTONA-FILE-BOUNDARY--\r\n"));
+
+            io.daytona.toolbox.client.ApiClient apiClient = new io.daytona.toolbox.client.ApiClient();
+            apiClient.setBasePath(server.url("/").toString());
+            FileSystem streamingFileSystem = new FileSystem(new FileSystemApi(apiClient));
+
+            assertThatThrownBy(() -> streamingFileSystem.downloadFileStream("/missing.txt"))
+                    .isInstanceOf(DaytonaNotFoundException.class)
+                    .hasMessage("missing file");
+        }
     }
 
     @Test

--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import io
 import os
+from collections.abc import AsyncIterator
 from contextlib import ExitStack
-from typing import Any, overload
+from typing import Any, cast, overload
 
 import aiofiles
 import aiofiles.os
@@ -26,6 +27,7 @@ from daytona_toolbox_api_client_async import (
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from ..common.errors import DaytonaError
+from ..common.file_transfer import create_multipart_parser, parse_content_type_boundary, serialize_download_request
 from ..common.filesystem import (
     FileDownloadErrorDetails,
     FileDownloadRequest,
@@ -33,6 +35,7 @@ from ..common.filesystem import (
     FileUpload,
     create_file_download_error,
     parse_file_download_error_payload,
+    raise_if_stream_error,
 )
 
 
@@ -168,6 +171,173 @@ class AsyncFileSystem:
         if response.error:
             raise create_file_download_error(response)
         return None
+
+    @intercept_errors(message_prefix="Failed to download file: ")
+    @with_instrumentation()
+    async def download_file_stream(self, remote_path: str, timeout: int = 30 * 60) -> AsyncIterator[bytes]:
+        """Downloads a single file from the Sandbox as a stream without buffering the entire file
+        into memory. Returns an async iterator that yields file content in chunks, which can be piped
+        directly to an HTTP response, written to a file incrementally, or processed on the fly.
+
+        Args:
+            remote_path (str): Path to the file in the Sandbox. Relative paths are resolved based
+                on the sandbox working directory.
+            timeout (int): Timeout for the download operation in seconds. 0 means no timeout.
+                Default is 30 minutes.
+
+        Returns:
+            AsyncIterator[bytes]: An async iterator yielding chunks of file content as bytes.
+
+        Raises:
+            DaytonaError: If the file does not exist or access is denied.
+
+        Example:
+            ```python
+            # Stream to a local file without loading into memory
+            async with aiofiles.open("local_copy.bin", "wb") as f:
+                async for chunk in await sandbox.fs.download_file_stream("workspace/large-file.bin"):
+                    await f.write(chunk)
+
+            # Stream to an HTTP response (FastAPI)
+            return StreamingResponse(await sandbox.fs.download_file_stream("workspace/report.pdf"),
+                                     media_type="application/pdf")
+            ```
+        """
+
+        async def stream_generator() -> AsyncIterator[bytes]:
+            method, url, headers, body = serialize_download_request(self._api_client, remote_path)
+
+            mode: str | None = None
+            part_content_type: str | None = None
+            source: str | None = None
+            header_field = bytearray()
+            header_value = bytearray()
+            pending_headers: list[tuple[str, str]] = []
+            error_buffer = bytearray()
+            events: list[tuple[str, Any]] = []
+            file_chunks: list[bytes] = []
+            error_text: str | None = None
+            error_details: FileDownloadErrorDetails | None = None
+            received_file_data = False
+
+            def on_part_begin() -> None:
+                pending_headers.clear()
+                header_field.clear()
+                header_value.clear()
+                events.append(("begin", None))
+
+            def on_header_field(data: bytes, start: int, end: int) -> None:
+                header_field.extend(data[start:end])
+
+            def on_header_value(data: bytes, start: int, end: int) -> None:
+                header_value.extend(data[start:end])
+
+            def on_header_end() -> None:
+                field = bytes(header_field).decode("utf-8", errors="ignore").lower()
+                value = bytes(header_value).decode("utf-8", errors="ignore")
+                pending_headers.append((field, value))
+                header_field.clear()
+                header_value.clear()
+
+            def on_headers_finished() -> None:
+                events.append(("headers_finished", dict(pending_headers)))
+
+            def on_part_data(data: bytes, start: int, end: int) -> None:
+                events.append(("data", bytes(data[start:end])))
+
+            def on_part_end() -> None:
+                events.append(("end", None))
+
+            async def process_events() -> None:
+                nonlocal mode, part_content_type, source, error_text, error_details
+
+                for event_tag, event_payload in events:
+                    if event_tag == "begin":
+                        error_buffer.clear()
+                        mode = None
+                        part_content_type = None
+                        source = None
+
+                    elif event_tag == "headers_finished":
+                        hdrs = cast(dict[str, str], event_payload)
+                        cd = hdrs.get("content-disposition", "")
+                        _, cd_params = parse_options_header(cd)
+                        name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
+                        source = cd_params.get(b"filename", b"").decode("utf-8", errors="ignore") or None
+                        if not source:
+                            raise DaytonaError("No source path found for this file")
+                        part_content_type = hdrs.get("content-type")
+
+                        if name == "error":
+                            mode = "error"
+                        elif name == "file":
+                            mode = "file"
+
+                    elif event_tag == "data":
+                        part_data = event_payload
+                        if not isinstance(part_data, bytes):
+                            continue
+                        if mode == "error":
+                            error_buffer.extend(part_data)
+                        elif mode == "file":
+                            file_chunks.append(part_data)
+
+                    elif event_tag == "end":
+                        if mode == "error" and error_buffer:
+                            error_text, error_details = parse_file_download_error_payload(
+                                bytes(error_buffer),
+                                part_content_type,
+                            )
+                            error_buffer.clear()
+                        mode = None
+                        part_content_type = None
+                        source = None
+
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                async with client.stream(
+                    method,
+                    url,
+                    json=body,
+                    headers=headers,
+                ) as resp:
+                    _ = resp.raise_for_status()
+
+                    boundary = parse_content_type_boundary(resp.headers)
+                    parser = create_multipart_parser(
+                        boundary,
+                        on_part_begin,
+                        on_header_field,
+                        on_header_value,
+                        on_header_end,
+                        on_headers_finished,
+                        on_part_data,
+                        on_part_end,
+                    )
+
+                    async for chunk in resp.aiter_bytes(64 * 1024):
+                        events.clear()
+                        _ = parser.write(chunk)
+                        await process_events()
+                        if file_chunks:
+                            emitted_chunks = file_chunks.copy()
+                            file_chunks.clear()
+                            received_file_data = True
+                            for file_chunk in emitted_chunks:
+                                yield file_chunk
+
+                    events.clear()
+                    parser.finalize()
+                    await process_events()
+                    if file_chunks:
+                        emitted_chunks = file_chunks.copy()
+                        file_chunks.clear()
+                        received_file_data = True
+                        for file_chunk in emitted_chunks:
+                            yield file_chunk
+
+            raise_if_stream_error(remote_path, error_text, error_details, received_file_data)
+
+        return stream_generator()
 
     @intercept_errors(message_prefix="Failed to download files: ")
     @with_instrumentation()

--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -293,7 +293,8 @@ class AsyncFileSystem:
                         part_content_type = None
                         source = None
 
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            httpx_timeout = None if timeout == 0 else timeout
+            async with httpx.AsyncClient(timeout=httpx_timeout) as client:
                 async with client.stream(
                     method,
                     url,

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -268,7 +268,8 @@ class FileSystem:
                 part_content_type = None
                 source = None
 
-            with httpx.Client(timeout=timeout) as client:
+            httpx_timeout = None if timeout == 0 else timeout
+            with httpx.Client(timeout=httpx_timeout) as client:
                 with client.stream(
                     method,
                     url,

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import io
 import os
+from collections.abc import Iterator
 from contextlib import ExitStack
 from typing import overload
 
@@ -24,6 +25,7 @@ from daytona_toolbox_api_client import (
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from ..common.errors import DaytonaError
+from ..common.file_transfer import create_multipart_parser, parse_content_type_boundary, serialize_download_request
 from ..common.filesystem import (
     FileDownloadErrorDetails,
     FileDownloadRequest,
@@ -31,6 +33,7 @@ from ..common.filesystem import (
     FileUpload,
     create_file_download_error,
     parse_file_download_error_payload,
+    raise_if_stream_error,
 )
 
 
@@ -164,6 +167,146 @@ class FileSystem:
         if response.error:
             raise create_file_download_error(response)
         return None
+
+    @intercept_errors(message_prefix="Failed to download file: ")
+    @with_instrumentation()
+    def download_file_stream(self, remote_path: str, timeout: int = 30 * 60) -> Iterator[bytes]:
+        """Downloads a single file from the Sandbox as a stream without buffering the entire file
+        into memory. Returns an iterator that yields file content in chunks, which can be piped
+        directly to an HTTP response, written to a file incrementally, or processed on the fly.
+
+        Args:
+            remote_path (str): Path to the file in the Sandbox. Relative paths are resolved based
+                on the sandbox working directory.
+            timeout (int): Timeout for the download operation in seconds. 0 means no timeout.
+                Default is 30 minutes.
+
+        Returns:
+            Iterator[bytes]: An iterator yielding chunks of file content as bytes.
+
+        Raises:
+            DaytonaError: If the file does not exist or access is denied.
+
+        Example:
+            ```python
+            # Stream to a local file without loading into memory
+            with open("local_copy.bin", "wb") as f:
+                for chunk in sandbox.fs.download_file_stream("workspace/large-file.bin"):
+                    f.write(chunk)
+
+            # Stream to an HTTP response (Flask)
+            return Response(sandbox.fs.download_file_stream("workspace/report.pdf"),
+                            mimetype="application/pdf")
+            ```
+        """
+
+        def stream_generator() -> Iterator[bytes]:
+            method, url, headers, body = serialize_download_request(self._api_client, remote_path)
+
+            mode: str | None = None
+            part_content_type: str | None = None
+            source: str | None = None
+            header_field = bytearray()
+            header_value = bytearray()
+            part_headers: dict[str, str] = {}
+            error_buffer = bytearray()
+            file_chunks: list[bytes] = []
+            error_text: str | None = None
+            error_details: FileDownloadErrorDetails | None = None
+            received_file_data = False
+
+            def on_part_begin() -> None:
+                part_headers.clear()
+                header_field.clear()
+                header_value.clear()
+                error_buffer.clear()
+
+            def on_header_field(data: bytes, start: int, end: int) -> None:
+                header_field.extend(data[start:end])
+
+            def on_header_value(data: bytes, start: int, end: int) -> None:
+                header_value.extend(data[start:end])
+
+            def on_header_end() -> None:
+                field = bytes(header_field).decode("utf-8", errors="ignore").lower()
+                value = bytes(header_value).decode("utf-8", errors="ignore")
+                part_headers[field] = value
+                header_field.clear()
+                header_value.clear()
+
+            def on_headers_finished() -> None:
+                nonlocal mode, part_content_type, source
+                cd = part_headers.get("content-disposition", "")
+                _, cd_params = parse_options_header(cd)
+                name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
+                source = cd_params.get(b"filename", b"").decode("utf-8", errors="ignore") or None
+                if not source:
+                    raise DaytonaError("No source path found for this file")
+                part_content_type = part_headers.get("content-type")
+
+                if name == "error":
+                    mode = "error"
+                elif name == "file":
+                    mode = "file"
+
+            def on_part_data(data: bytes, start: int, end: int) -> None:
+                part_data = data[start:end]
+                if mode == "error":
+                    error_buffer.extend(part_data)
+                elif mode == "file":
+                    file_chunks.append(part_data)
+
+            def on_part_end() -> None:
+                nonlocal mode, part_content_type, source, error_text, error_details
+                if mode == "error" and error_buffer:
+                    error_text, error_details = parse_file_download_error_payload(
+                        bytes(error_buffer),
+                        part_content_type,
+                    )
+                    error_buffer.clear()
+                mode = None
+                part_content_type = None
+                source = None
+
+            with httpx.Client(timeout=timeout) as client:
+                with client.stream(
+                    method,
+                    url,
+                    json=body,
+                    headers=headers,
+                ) as resp:
+                    _ = resp.raise_for_status()
+
+                    boundary = parse_content_type_boundary(resp.headers)
+                    parser = create_multipart_parser(
+                        boundary,
+                        on_part_begin,
+                        on_header_field,
+                        on_header_value,
+                        on_header_end,
+                        on_headers_finished,
+                        on_part_data,
+                        on_part_end,
+                    )
+
+                    for chunk in resp.iter_bytes(64 * 1024):
+                        _ = parser.write(chunk)
+                        if file_chunks:
+                            emitted_chunks = file_chunks.copy()
+                            file_chunks.clear()
+                            received_file_data = True
+                            yield from emitted_chunks
+
+                    parser.finalize()
+                    if file_chunks:
+                        emitted_chunks = file_chunks.copy()
+                        file_chunks.clear()
+                        received_file_data = True
+                        yield from emitted_chunks
+
+            raise_if_stream_error(remote_path, error_text, error_details, received_file_data)
+
+        return stream_generator()
 
     @intercept_errors(message_prefix="Failed to download files: ")
     @with_instrumentation()

--- a/libs/sdk-python/src/daytona/common/file_transfer.py
+++ b/libs/sdk-python/src/daytona/common/file_transfer.py
@@ -1,0 +1,55 @@
+# Copyright Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from python_multipart.multipart import MultipartParser, parse_options_header
+
+from daytona_toolbox_api_client import FilesDownloadRequest
+
+from .errors import DaytonaError
+
+
+def serialize_download_request(api_client: Any, remote_path: str) -> tuple[str, str, dict[str, str], Any]:
+    method, url, headers, body, *_ = api_client._download_files_serialize(
+        download_files=FilesDownloadRequest(paths=[remote_path]),
+        _request_auth=None,
+        _content_type=None,
+        _headers=None,
+        _host_index=None,
+    )
+    return method, url, headers, body
+
+
+def parse_content_type_boundary(headers: Mapping[str, str]) -> bytes:
+    content_type_raw, options = parse_options_header(headers.get("Content-Type", ""))
+    if not (content_type_raw == b"multipart/form-data" and b"boundary" in options):
+        raise DaytonaError(f"Unexpected Content-Type: {content_type_raw!r}")
+    return options[b"boundary"]
+
+
+def create_multipart_parser(
+    boundary: bytes,
+    on_part_begin: Callable[[], None],
+    on_header_field: Callable[[bytes, int, int], None],
+    on_header_value: Callable[[bytes, int, int], None],
+    on_header_end: Callable[[], None],
+    on_headers_finished: Callable[[], None],
+    on_part_data: Callable[[bytes, int, int], None],
+    on_part_end: Callable[[], None],
+) -> MultipartParser:
+    return MultipartParser(
+        boundary,
+        callbacks={
+            "on_part_begin": on_part_begin,
+            "on_header_field": on_header_field,
+            "on_header_value": on_header_value,
+            "on_header_end": on_header_end,
+            "on_headers_finished": on_headers_finished,
+            "on_part_data": on_part_data,
+            "on_part_end": on_part_end,
+        },
+    )

--- a/libs/sdk-python/src/daytona/common/filesystem.py
+++ b/libs/sdk-python/src/daytona/common/filesystem.py
@@ -84,6 +84,25 @@ def create_file_download_error(response: FileDownloadResponse) -> DaytonaError:
     )
 
 
+def raise_if_stream_error(
+    remote_path: str,
+    error_text: str | None,
+    error_details: FileDownloadErrorDetails | None,
+    received_file_data: bool,
+) -> None:
+    """Raise the appropriate error after streaming a single-file multipart download."""
+    if error_text is not None:
+        raise create_file_download_error(
+            FileDownloadResponse(
+                source=remote_path,
+                error=error_text,
+                error_details=error_details,
+            )
+        )
+    if not received_file_data:
+        raise DaytonaError(f"No file data received for: {remote_path}")
+
+
 def parse_file_download_error_payload(
     payload: bytes,
     content_type: str | None,

--- a/libs/sdk-python/tests/test_e2e.py
+++ b/libs/sdk-python/tests/test_e2e.py
@@ -22,6 +22,7 @@ from daytona import (
     Resources,
     SessionExecuteRequest,
 )
+from daytona.common.errors import DaytonaError
 
 if not os.getenv("DAYTONA_API_KEY"):
     raise RuntimeError("DAYTONA_API_KEY environment variable is required for E2E tests")
@@ -222,6 +223,21 @@ def test_download_files_batch(sandbox):
     assert len(results) == 2, f"Expected 2 results, got {len(results)}"
     assert results[0].result == b"file one"
     assert results[1].result == b"file two"
+
+
+def test_download_file_stream_returns_exact_content(sandbox):
+    expected = b"streamed content\nsecond line\n"
+    path = f"{FS_TEST_DIR}/streamed.txt"
+    sandbox.fs.upload_file(expected, path)
+
+    content = b"".join(sandbox.fs.download_file_stream(path))
+
+    assert content == expected
+
+
+def test_download_file_stream_nonexistent_file_raises(sandbox):
+    with pytest.raises(DaytonaError):
+        b"".join(sandbox.fs.download_file_stream(f"{FS_TEST_DIR}/stream-does-not-exist.txt"))
 
 
 def test_find_files_finds_text_content(sandbox):
@@ -592,6 +608,7 @@ def test_lsp_did_open(sandbox):
 
 
 def test_lsp_document_symbols(sandbox):
+    assert lsp_server is not None, "LSP server should be started first"
     symbols = lsp_server.document_symbols(LSP_FILE_PATH)
     assert len(symbols) > 0, "Expected document symbols"
     names = [symbol.name for symbol in symbols]
@@ -599,17 +616,20 @@ def test_lsp_document_symbols(sandbox):
 
 
 def test_lsp_workspace_symbols(sandbox):
+    assert lsp_server is not None, "LSP server should be started first"
     symbols = lsp_server.sandbox_symbols("Greeter")
     assert len(symbols) > 0, "Expected workspace symbols"
 
 
 def test_lsp_did_close(sandbox):
+    assert lsp_server is not None, "LSP server should be started first"
     lsp_server.did_close(LSP_FILE_PATH)
 
 
 def test_lsp_stop_server(sandbox):
     global lsp_server
 
+    assert lsp_server is not None, "LSP server should be started first"
     lsp_server.stop()
     lsp_server = None
 

--- a/libs/sdk-python/tests/test_filesystem.py
+++ b/libs/sdk-python/tests/test_filesystem.py
@@ -3,11 +3,103 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from daytona.common.errors import DaytonaError
+
+
+def _build_multipart_body(
+    boundary: bytes,
+    *,
+    name: str,
+    filename: str,
+    payload: bytes,
+    content_type: str = "application/octet-stream",
+) -> bytes:
+    return b"".join(
+        [
+            b"--" + boundary + b"\r\n",
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode("utf-8"),
+            f"Content-Type: {content_type}\r\n\r\n".encode("utf-8"),
+            payload,
+            b"\r\n--" + boundary + b"--\r\n",
+        ]
+    )
+
+
+class _SyncStreamResponse:
+    def __init__(self, chunks: list[bytes], boundary: bytes):
+        self._chunks = chunks
+        self.headers = {"Content-Type": f'multipart/form-data; boundary={boundary.decode("utf-8")}'}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_bytes(self, _chunk_size):
+        return iter(self._chunks)
+
+
+class _SyncStreamClient:
+    def __init__(self, response: _SyncStreamResponse):
+        self._response = response
+        self.stream_args: tuple[object, ...] | None = None
+        self.stream_kwargs: dict[str, object] | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def stream(self, *args, **kwargs):
+        self.stream_args = args
+        self.stream_kwargs = kwargs
+        return self._response
+
+
+class _AsyncStreamResponse:
+    def __init__(self, chunks: list[bytes], boundary: bytes):
+        self._chunks = chunks
+        self.headers = {"Content-Type": f'multipart/form-data; boundary={boundary.decode("utf-8")}'}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self, _chunk_size):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _AsyncStreamClient:
+    def __init__(self, response: _AsyncStreamResponse):
+        self._response = response
+        self.stream_args: tuple[object, ...] | None = None
+        self.stream_kwargs: dict[str, object] | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def stream(self, *args, **kwargs):
+        self.stream_args = args
+        self.stream_kwargs = kwargs
+        return self._response
 
 
 class TestSyncFileSystem:
@@ -110,6 +202,67 @@ class TestSyncFileSystem:
         with pytest.raises(DaytonaError, match="missing"):
             fs.download_file("workspace/file.txt")
 
+    def test_download_file_stream_yields_chunks(self):
+        fs, api = self._make_fs()
+        remote_path = "workspace/file.txt"
+        boundary = b"sync-boundary"
+        payload = b"hello world"
+        multipart_body = _build_multipart_body(boundary, name="file", filename=remote_path, payload=payload)
+        payload_start = multipart_body.index(payload)
+        chunks = [
+            multipart_body[: payload_start + 5],
+            multipart_body[payload_start + 5 : payload_start + 9],
+            multipart_body[payload_start + 9 :],
+        ]
+        client = _SyncStreamClient(_SyncStreamResponse(chunks, boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {"Authorization": "Bearer token"},
+                {"paths": [remote_path]},
+            )
+        )
+
+        with patch("daytona._sync.filesystem.httpx.Client", return_value=client):
+            streamed_chunks = list(fs.download_file_stream(remote_path))
+
+        assert streamed_chunks == [b"hello", b" wor", b"ld"]
+        assert client.stream_args == ("POST", "https://download")
+        assert client.stream_kwargs == {
+            "json": {"paths": [remote_path]},
+            "headers": {"Authorization": "Bearer token"},
+        }
+
+    def test_download_file_stream_raises_on_error_part(self):
+        fs, api = self._make_fs()
+        remote_path = "workspace/missing.txt"
+        boundary = b"sync-boundary"
+        error_payload = b'{"message":"missing","statusCode":404,"code":"not_found"}'
+        multipart_body = _build_multipart_body(
+            boundary,
+            name="error",
+            filename=remote_path,
+            payload=error_payload,
+            content_type="application/json",
+        )
+        client = _SyncStreamClient(_SyncStreamResponse([multipart_body], boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {"Authorization": "Bearer token"},
+                {"paths": [remote_path]},
+            )
+        )
+
+        with patch("daytona._sync.filesystem.httpx.Client", return_value=client):
+            with pytest.raises(DaytonaError, match="missing") as exc_info:
+                list(fs.download_file_stream(remote_path))
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.error_code == "not_found"
+
 
 class TestAsyncFileSystem:
     def _make_fs(self):
@@ -188,3 +341,66 @@ class TestAsyncFileSystem:
 
         with pytest.raises(DaytonaError, match="missing"):
             await fs.download_file("workspace/file.txt")
+
+    @pytest.mark.asyncio
+    async def test_download_file_stream_yields_chunks(self):
+        fs, api = self._make_fs()
+        remote_path = "workspace/file.txt"
+        boundary = b"async-boundary"
+        payload = b"hello world"
+        multipart_body = _build_multipart_body(boundary, name="file", filename=remote_path, payload=payload)
+        payload_start = multipart_body.index(payload)
+        chunks = [
+            multipart_body[: payload_start + 5],
+            multipart_body[payload_start + 5 : payload_start + 9],
+            multipart_body[payload_start + 9 :],
+        ]
+        client = _AsyncStreamClient(_AsyncStreamResponse(chunks, boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {"Authorization": "Bearer token"},
+                {"paths": [remote_path]},
+            )
+        )
+
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            streamed_chunks = [chunk async for chunk in await fs.download_file_stream(remote_path)]
+
+        assert streamed_chunks == [b"hello", b" wor", b"ld"]
+        assert client.stream_args == ("POST", "https://download")
+        assert client.stream_kwargs == {
+            "json": {"paths": [remote_path]},
+            "headers": {"Authorization": "Bearer token"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_download_file_stream_raises_on_error_part(self):
+        fs, api = self._make_fs()
+        remote_path = "workspace/missing.txt"
+        boundary = b"async-boundary"
+        error_payload = b'{"message":"missing","statusCode":404,"code":"not_found"}'
+        multipart_body = _build_multipart_body(
+            boundary,
+            name="error",
+            filename=remote_path,
+            payload=error_payload,
+            content_type="application/json",
+        )
+        client = _AsyncStreamClient(_AsyncStreamResponse([multipart_body], boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {"Authorization": "Bearer token"},
+                {"paths": [remote_path]},
+            )
+        )
+
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            with pytest.raises(DaytonaError, match="missing") as exc_info:
+                [chunk async for chunk in await fs.download_file_stream(remote_path)]
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.error_code == "not_found"

--- a/libs/sdk-ruby/lib/daytona/file_system.rb
+++ b/libs/sdk-ruby/lib/daytona/file_system.rb
@@ -5,9 +5,10 @@
 
 require 'tempfile'
 require 'fileutils'
+require_relative 'file_transfer'
 
 module Daytona
-  class FileSystem
+  class FileSystem # rubocop:disable Metrics/ClassLength
     include Instrumentation
 
     # @return [String] The Sandbox ID
@@ -149,6 +150,37 @@ module Daytona
       else
         file
       end
+    rescue StandardError => e
+      raise Sdk::Error, "Failed to download file: #{e.message}"
+    end
+
+    # Downloads a single file from the Sandbox as a stream without buffering the entire
+    # file into memory. Yields file content in chunks to the given block, or returns an
+    # Enumerator if no block is given.
+    #
+    # @param remote_path [String] Path to the file in the Sandbox. Relative paths are resolved
+    #   based on the sandbox working directory.
+    # @param timeout [Integer] Timeout for the download operation in seconds. 0 means no timeout.
+    #   Default is 30 minutes.
+    # @yield [chunk] Yields each chunk of file content as it arrives
+    # @yieldparam chunk [String] A binary string chunk of file content
+    # @return [Enumerator, nil] An Enumerator yielding chunks if no block given, nil otherwise
+    # @raise [Daytona::Sdk::Error] If the file does not exist or the operation fails
+    #
+    # @example Stream to a local file without loading into memory
+    #   File.open("local_copy.bin", "wb") do |f|
+    #     sandbox.fs.download_file_stream("workspace/large-file.bin") { |chunk| f.write(chunk) }
+    #   end
+    #
+    # @example Collect chunks with an Enumerator
+    #   content = sandbox.fs.download_file_stream("workspace/data.json").reduce(:+)
+    #   puts content
+    def download_file_stream(remote_path, timeout: 30 * 60, &)
+      return enum_for(__method__, remote_path, timeout:) unless block_given?
+
+      FileTransfer.stream_download(api_client: toolbox_api.api_client, remote_path: remote_path,
+                                   timeout: timeout, &)
+      nil
     rescue StandardError => e
       raise Sdk::Error, "Failed to download file: #{e.message}"
     end
@@ -364,8 +396,8 @@ module Daytona
     end
 
     instrument :create_folder, :delete_file, :get_file_info, :list_files, :download_file,
-               :upload_file, :upload_files, :find_files, :search_files, :move_files,
-               :replace_in_files, :set_file_permissions,
+               :download_file_stream, :upload_file, :upload_files, :find_files,
+               :search_files, :move_files, :replace_in_files, :set_file_permissions,
                component: 'FileSystem'
 
     private

--- a/libs/sdk-ruby/lib/daytona/file_transfer.rb
+++ b/libs/sdk-ruby/lib/daytona/file_transfer.rb
@@ -1,0 +1,184 @@
+# Copyright Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# frozen_string_literal: true
+
+require 'json'
+require 'typhoeus'
+
+module Daytona
+  class MultipartDownloadStreamParser
+    attr_reader :error_message
+    attr_writer :boundary_token
+
+    def initialize(&on_file_chunk)
+      @on_file_chunk = on_file_chunk
+      @boundary_token = nil
+      @buffer = String.new.b
+      @state = :preamble
+      @part_name = nil
+      @error_buffer = String.new.b
+    end
+
+    def <<(chunk)
+      @buffer << chunk.b
+      process!
+    end
+
+    def finish!
+      process!
+
+      return if @state == :done || @buffer.empty?
+
+      emit(@buffer)
+      finalize_part!
+      @buffer = String.new.b
+      @state = :done
+    end
+
+    private
+
+    def process!
+      loop do
+        advanced = case @state
+                   when :preamble then consume_preamble?
+                   when :headers then consume_headers?
+                   when :body then consume_body?
+                   else false
+                   end
+
+        break unless advanced
+      end
+    end
+
+    def consume_preamble?
+      start_marker = "#{boundary}\r\n".b
+      index = @buffer.index(start_marker)
+      return retain_tail?(start_marker.bytesize - 1) unless index
+
+      @buffer = remaining_bytes(index + start_marker.bytesize)
+      @state = :headers
+      true
+    end
+
+    def consume_headers?
+      separator = "\r\n\r\n".b
+      index = @buffer.index(separator)
+      return false unless index
+
+      headers = @buffer.byteslice(0, index)
+      @buffer = remaining_bytes(index + separator.bytesize)
+      @part_name = headers[/Content-Disposition:\s*[^\r\n]*\bname="([^"]+)"/i, 1]
+      raise Sdk::Error, 'Invalid multipart response' if @part_name.nil?
+
+      @state = :body
+      true
+    end
+
+    def consume_body? # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      marker = "\r\n#{boundary}".b
+      index = @buffer.index(marker)
+
+      if index
+        emit(@buffer.byteslice(0, index))
+        @buffer = remaining_bytes(index + marker.bytesize)
+        finalize_part!
+        @state = :done
+        return true
+      end
+
+      flushable = @buffer.bytesize - marker.bytesize + 1
+      return false if flushable <= 0
+
+      emit(@buffer.byteslice(0, flushable))
+      @buffer = remaining_bytes(flushable)
+      false
+    end
+
+    def emit(data)
+      return if data.nil? || data.empty?
+
+      case @part_name
+      when 'file'
+        @on_file_chunk.call(data)
+      when 'error'
+        @error_buffer << data
+      end
+    end
+
+    def finalize_part!
+      return unless @part_name == 'error'
+
+      @error_message = extract_error_message(@error_buffer)
+    end
+
+    def extract_error_message(payload)
+      parsed = JSON.parse(payload)
+      parsed['message'] || parsed['error'] || payload
+    rescue JSON::ParserError
+      payload
+    end
+
+    def retain_tail?(size)
+      @buffer = @buffer.byteslice(-size, size) || String.new.b if size.positive? && @buffer.bytesize > size
+      false
+    end
+
+    def remaining_bytes(offset)
+      @buffer.byteslice(offset, @buffer.bytesize - offset) || String.new.b
+    end
+
+    def boundary
+      "--#{@boundary_token}".b
+    end
+  end
+
+  module FileTransfer
+    def self.extract_multipart_boundary(content_type)
+      match = content_type&.match(/boundary=(?:"([^"]+)"|([^;]+))/i)
+      return unless match
+
+      match.captures.compact.first
+    end
+
+    def self.stream_download(api_client:, remote_path:, timeout:, &) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      config = api_client.config
+      parser = MultipartDownloadStreamParser.new(&)
+      response = nil
+
+      request = Typhoeus::Request.new(
+        "#{config.base_url}/files/bulk-download",
+        method: :post,
+        headers: api_client.default_headers.dup.merge(
+          'Accept' => 'multipart/form-data',
+          'Content-Type' => 'application/json'
+        ),
+        body: JSON.generate(paths: [remote_path]),
+        timeout: timeout * 1000,
+        ssl_verifypeer: config.verify_ssl,
+        ssl_verifyhost: config.verify_ssl_host ? 2 : 0
+      )
+
+      request.on_headers do |stream_response|
+        boundary = extract_multipart_boundary(stream_response.headers['Content-Type'])
+        raise Sdk::Error, 'Missing multipart boundary in download response' unless boundary
+
+        parser.boundary_token = boundary
+      end
+
+      request.on_body do |chunk|
+        parser << chunk
+      end
+
+      request.on_complete do |completed_response|
+        response = completed_response
+        parser.finish!
+      end
+
+      request.run
+
+      raise Sdk::Error, parser.error_message if parser.error_message
+      raise Sdk::Error, "HTTP #{response.code}" if response && !response.success?
+    end
+  end
+end

--- a/libs/sdk-ruby/lib/daytona/file_transfer.rb
+++ b/libs/sdk-ruby/lib/daytona/file_transfer.rb
@@ -154,7 +154,7 @@ module Daytona
           'Content-Type' => 'application/json'
         ),
         body: JSON.generate(paths: [remote_path]),
-        timeout: timeout * 1000,
+        timeout: timeout,
         ssl_verifypeer: config.verify_ssl,
         ssl_verifyhost: config.verify_ssl_host ? 2 : 0
       )

--- a/libs/sdk-ruby/spec/daytona/file_system_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/file_system_spec.rb
@@ -4,8 +4,50 @@
 # frozen_string_literal: true
 
 RSpec.describe Daytona::FileSystem do
+  def multipart_response(parts, boundary: 'DAYTONA-FILE-BOUNDARY')
+    body = String.new.b
+
+    parts.each do |part|
+      body << "--#{boundary}\r\n"
+      body << %(Content-Disposition: form-data; name="#{part.fetch(:name)}")
+      body << %(; filename="#{part[:filename]}") if part[:filename]
+      body << "\r\n"
+      body << "Content-Type: #{part.fetch(:content_type, 'application/octet-stream')}\r\n\r\n"
+      body << part.fetch(:body)
+      body << "\r\n"
+    end
+
+    body << "--#{boundary}--\r\n"
+  end
+
+  def stub_streaming_request(chunks:, headers: { 'Content-Type' => 'multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY' },
+                             success: true, code: 200, body: nil)
+    request = instance_double(Typhoeus::Request)
+    callbacks = {}
+
+    allow(Typhoeus::Request).to receive(:new).and_return(request)
+    allow(request).to receive(:on_headers) { |&block| callbacks[:headers] = block }
+    allow(request).to receive(:on_body) { |&block| callbacks[:body] = block }
+    allow(request).to receive(:on_complete) { |&block| callbacks[:complete] = block }
+    allow(request).to receive(:run) do
+      callbacks[:headers]&.call(double('headers_response', headers: headers))
+      chunks.each { |chunk| callbacks[:body]&.call(chunk) }
+      callbacks[:complete]&.call(double('complete_response', success?: success, code: code, body: body))
+    end
+
+    request
+  end
+
   let(:toolbox_api) { instance_double(DaytonaToolboxApiClient::FileSystemApi) }
+  let(:toolbox_api_config) { double('ToolboxConfig', base_url: 'https://toolbox.example.com', verify_ssl: true, verify_ssl_host: true) }
+  let(:toolbox_api_client) do
+    double('ToolboxApiClient', config: toolbox_api_config, default_headers: { 'Authorization' => 'Bearer token' })
+  end
   let(:fs) { described_class.new(sandbox_id: 'sandbox-123', toolbox_api: toolbox_api) }
+
+  before do
+    allow(toolbox_api).to receive(:api_client).and_return(toolbox_api_client)
+  end
 
   describe '#create_folder' do
     it 'delegates to toolbox_api' do
@@ -103,6 +145,57 @@ RSpec.describe Daytona::FileSystem do
       allow(toolbox_api).to receive(:download_file).and_raise(StandardError, 'err')
 
       expect { fs.download_file('/x') }.to raise_error(Daytona::Sdk::Error, /Failed to download file: err/)
+    end
+  end
+
+  describe '#download_file_stream' do
+    it 'yields file content chunks when block given' do
+      body = multipart_response([
+                                  { name: 'file', filename: 'remote.txt', body: 'stream test content' }
+                                ])
+      stub_streaming_request(chunks: [body.byteslice(0, 96), body.byteslice(96, 8),
+                                      body.byteslice(104, body.bytesize - 104)])
+
+      chunks = []
+      fs.download_file_stream('/remote.txt', timeout: 45) { |chunk| chunks << chunk }
+
+      expect(chunks.join).to eq('stream test content')
+      expect(Typhoeus::Request).to have_received(:new).with(
+        'https://toolbox.example.com/files/bulk-download',
+        hash_including(
+          method: :post,
+          timeout: 45_000,
+          body: '{"paths":["/remote.txt"]}',
+          headers: hash_including(
+            'Authorization' => 'Bearer token',
+            'Accept' => 'multipart/form-data',
+            'Content-Type' => 'application/json'
+          )
+        )
+      )
+    end
+
+    it 'returns enumerator when no block given' do
+      body = multipart_response([
+                                  { name: 'file', filename: 'remote.txt', body: 'enumerated content' }
+                                ])
+      stub_streaming_request(chunks: [body.byteslice(0, 70), body.byteslice(70, body.bytesize - 70)])
+
+      enumerator = fs.download_file_stream('/remote.txt')
+
+      expect(enumerator).to be_a(Enumerator)
+      expect(enumerator.to_a.join).to eq('enumerated content')
+    end
+
+    it 'raises error when file not found' do
+      body = multipart_response([
+                                  { name: 'error', content_type: 'application/json',
+                                    body: '{"message":"file not found"}' }
+                                ])
+      stub_streaming_request(chunks: [body.byteslice(0, 82), body.byteslice(82, body.bytesize - 82)])
+
+      expect { fs.download_file_stream('/missing.txt') { |_chunk| nil } }
+        .to raise_error(Daytona::Sdk::Error, /Failed to download file: file not found/)
     end
   end
 

--- a/libs/sdk-ruby/spec/daytona/file_system_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/file_system_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Daytona::FileSystem do
         'https://toolbox.example.com/files/bulk-download',
         hash_including(
           method: :post,
-          timeout: 45_000,
+          timeout: 45,
           body: '{"paths":["/remote.txt"]}',
           headers: hash_including(
             'Authorization' => 'Bearer token',

--- a/libs/sdk-ruby/spec/e2e_spec.rb
+++ b/libs/sdk-ruby/spec/e2e_spec.rb
@@ -214,6 +214,15 @@ RSpec.describe 'Daytona SDK E2E', :e2e do
       expect(content).to include('hello world')
     end
 
+    it 'streams file download' do
+      @sandbox.fs.upload_file('stream test content'.b, "#{@fs_dir}/stream.txt")
+
+      chunks = []
+      @sandbox.fs.download_file_stream("#{@fs_dir}/stream.txt") { |chunk| chunks << chunk }
+
+      expect(chunks.join).to eq('stream test content')
+    end
+
     it 'finds text content in files' do
       matches = @sandbox.fs.find_files(@fs_dir, 'hello')
       expect(matches).not_to be_nil

--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -16,6 +16,7 @@ import { FileSystemApi } from '@daytona/toolbox-api-client'
 import { dynamicImport } from './utils/Import'
 import { RUNTIME, Runtime } from './utils/Runtime'
 import { createDaytonaError, DaytonaError } from './errors/DaytonaError'
+import type { Readable } from 'stream'
 import {
   normalizeResponseStream,
   processDownloadFilesResponseWithBusboy,
@@ -228,6 +229,83 @@ export class FileSystem {
     if (response[0].error) {
       throw createFileDownloadError(response[0].error, response[0].errorDetails)
     }
+  }
+
+  /**
+   * Downloads a single file from the Sandbox as a readable stream without buffering
+   * the entire file into memory. The returned stream can be piped directly to an HTTP
+   * response, a file write stream, or any other writable destination.
+   *
+   * This method is only supported in Node.js-compatible runtimes (Node.js, Bun).
+   * Browser and serverless environments should use {@link downloadFile} instead.
+   *
+   * @param {string} remotePath - Path to the file in the Sandbox. Relative paths are
+   *   resolved based on the sandbox working directory.
+   * @param {number} [timeout] - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+   * @returns {Promise<Readable>} A Node.js Readable stream of the file content.
+   *
+   * @example
+   * // Pipe directly to an HTTP response
+   * const stream = await sandbox.fs.downloadFileStream('outputs/report.pdf');
+   * stream.pipe(res);
+   *
+   * @example
+   * // Pipe to a local file
+   * import { createWriteStream } from 'fs';
+   * const stream = await sandbox.fs.downloadFileStream('outputs/data.csv');
+   * stream.pipe(createWriteStream('local-data.csv'));
+   */
+  @WithInstrumentation()
+  public async downloadFileStream(remotePath: string, timeout: number = 30 * 60): Promise<Readable> {
+    const isNonStreamingRuntime = RUNTIME === Runtime.BROWSER || RUNTIME === Runtime.SERVERLESS
+    if (isNonStreamingRuntime) {
+      throw new DaytonaError(
+        'downloadFileStream is not supported in browser or serverless environments. Use downloadFile instead.',
+      )
+    }
+
+    const response = await this.apiClient.downloadFiles(
+      { paths: [remotePath] },
+      {
+        responseType: 'stream',
+        timeout: timeout * 1000,
+      },
+    )
+
+    const responseStream = normalizeResponseStream(response.data)
+    const metadataMap = new Map<string, DownloadMetadata>()
+    metadataMap.set(remotePath, {})
+
+    return new Promise<Readable>((resolve, reject) => {
+      let resolvedStream: Readable | null = null
+
+      processDownloadFilesResponseWithBusboy(
+        responseStream,
+        response.headers as Record<string, string>,
+        metadataMap,
+        (_source, fileStream) => {
+          resolvedStream = fileStream as Readable
+          resolve(resolvedStream)
+        },
+      )
+        .then(() => {
+          if (!resolvedStream) {
+            const metadata = metadataMap.get(remotePath)
+            if (metadata?.error) {
+              reject(createFileDownloadError(metadata.error, metadata.errorDetails))
+            } else {
+              reject(new DaytonaError(`No file data received for: ${remotePath}`))
+            }
+          }
+        })
+        .catch((err) => {
+          if (!resolvedStream) {
+            reject(err)
+          } else if (!resolvedStream.destroyed) {
+            resolvedStream.destroy(err instanceof Error ? err : new Error(String(err)))
+          }
+        })
+    })
   }
 
   /**

--- a/libs/sdk-typescript/src/__tests__/e2e.test.ts
+++ b/libs/sdk-typescript/src/__tests__/e2e.test.ts
@@ -207,6 +207,26 @@ describe('TypeScript SDK E2E (real Daytona API)', () => {
       expect(content.toString()).toBe('hello world')
     })
 
+    test('stream download a file', async () => {
+      const content = 'hello from stream download'
+      await sandbox.fs.uploadFile(Buffer.from(content), 'fs-test/stream-test.txt')
+
+      const stream = await sandbox.fs.downloadFileStream('fs-test/stream-test.txt')
+      const chunks: Buffer[] = []
+
+      await new Promise<void>((resolve, reject) => {
+        stream.on('data', (chunk: Buffer) => chunks.push(chunk))
+        stream.on('end', resolve)
+        stream.on('error', reject)
+      })
+
+      expect(Buffer.concat(chunks).toString()).toBe(content)
+    })
+
+    test('rejects stream download for non-existent file', async () => {
+      await expect(sandbox.fs.downloadFileStream('fs-test/does-not-exist.txt')).rejects.toThrow()
+    })
+
     test('downloadFiles batch returns multiple files', async () => {
       console.log('[E2E][FS] Batch downloading files...')
       const results = await sandbox.fs.downloadFiles([{ source: 'fs-test/a.txt' }, { source: 'fs-test/b.txt' }])

--- a/libs/sdk-typescript/src/utils/FileTransfer.ts
+++ b/libs/sdk-typescript/src/utils/FileTransfer.ts
@@ -102,6 +102,7 @@ export async function processDownloadFilesResponseWithBusboy(
   stream: any,
   headers: Record<string, string>,
   metadataMap: Map<string, DownloadMetadata>,
+  onFileStream?: (source: string, fileStream: any) => void,
 ): Promise<void> {
   const fileTasks: Promise<void>[] = []
 
@@ -137,7 +138,9 @@ export async function processDownloadFilesResponseWithBusboy(
           metadata.error = `Stream error: ${err.message}`
         })
       } else if (fieldName === 'file') {
-        if (metadata.destination) {
+        if (onFileStream) {
+          onFileStream(source, fileStream)
+        } else if (metadata.destination) {
           // Stream to file
           fileTasks.push(
             new Promise((resolveTask) => {


### PR DESCRIPTION
## Summary

Add `downloadFileStream` method to all SDKs (TypeScript, Python, Go, Ruby, Java) that returns a streaming response for single-file downloads, avoiding buffering the entire file into memory. This addresses server memory spikes when proxying large file downloads to clients.

## Motivation

The existing `downloadFile` method buffers the entire file into memory before returning it. When a server proxies downloads to clients, this causes memory spikes proportional to file size. The new streaming method lets callers pipe data directly to an HTTP response or file without holding the full content in memory.

## Changes

### New method: `downloadFileStream`

| SDK | Method | Return Type |
|-----|--------|-------------|
| TypeScript | `downloadFileStream(remotePath, timeout?)` | `Promise<Readable>` |
| Python (sync) | `download_file_stream(remote_path, timeout)` | `Iterator[bytes]` |
| Python (async) | `download_file_stream(remote_path, timeout)` | `AsyncIterator[bytes]` |
| Go | `DownloadFileStream(ctx, remotePath)` | `io.ReadCloser, error` |
| Ruby | `download_file_stream(remote_path, timeout:, &block)` | Yields chunks / `Enumerator` |
| Java | `downloadFileStream(remotePath)` / `downloadFileStream(remotePath, timeoutSeconds)` | `InputStream` |

All implementations use the existing `POST /files/bulk-download` multipart endpoint with a single path, parse the multipart framing, and expose the raw file stream without buffering. Backpressure propagates end-to-end.

### Architecture

Multipart streaming logic is extracted into dedicated utility files, keeping `FileSystem` classes thin:

| SDK | FileSystem (public API) | FileTransfer (utility) |
|-----|------------------------|----------------------|
| TypeScript | `FileSystem.ts` | `FileTransfer.ts` (`onFileStream` callback) |
| Python | `_sync/filesystem.py`, `_async/filesystem.py` | `common/file_transfer.py` |
| Go | `filesystem.go` | `file_transfer.go` |
| Ruby | `file_system.rb` | `file_transfer.rb` |
| Java | `FileSystem.java` | `FileTransfer.java` |

### Shared error handling improvements

- **Go**: Added `errors.NewDaytonaErrorFromBody()` to the shared errors package — reusable JSON body → typed error mapping
- **Java**: Made `ExceptionMapper.map()` package-private for direct reuse, removed duplicated `trimTrailingSlash` and throw-and-catch `mapToolboxException` workaround
- **Python**: Extracted `raise_if_stream_error()` into `common/filesystem.py` for sync/async reuse

### Tests

- **Unit tests** added for all 5 SDKs covering: success, error part handling, not-found errors
- **E2E tests** added for all 5 SDKs, verified against production environment

### Examples & docs

- Updated `examples/*/file-operations/` for all 5 languages + Python async
- Added standalone `examples/typescript/stream-download/` example
- SDK reference docstrings added for all languages (JSDoc, Google-style, godoc, YARD, Javadoc)

## Files changed

```
37 files changed, ~2200 insertions(+), ~7 deletions(-)
```

**New files (5):** `file_transfer.{go,java,py,rb}`, `examples/typescript/stream-download/index.ts`
**Modified (32):** SDK implementations, tests, examples, docs across all 5 languages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `downloadFileStream` to all SDKs to stream single-file downloads without buffering, reducing memory usage and enabling direct piping to HTTP responses or files. Clarifies timeout behavior (0 = no timeout), improves Java streaming with buffered bulk reads, fixes Ruby timeout units, and updates docs/examples.

- **New Features**
  - TypeScript (Node/Bun only): `downloadFileStream(remotePath, timeout?) -> Promise<Readable>`
  - Python: `download_file_stream(remote_path, timeout) -> Iterator[bytes]` and async `AsyncIterator[bytes]`
  - Go: `DownloadFileStream(ctx, remotePath) -> io.ReadCloser`
  - Ruby: `download_file_stream(remote_path, timeout:, &block)` (yields chunks / returns Enumerator)
  - Java: `downloadFileStream(remotePath[, timeoutSeconds]) -> InputStream`
  - Reuses `POST /files/bulk-download` with a single path, parses multipart, and exposes the raw stream with backpressure.

- **Bug Fixes**
  - All SDKs: `timeout=0` disables timeouts.
  - Ruby: Typhoeus request timeout uses correct units.
  - Java: Buffered bulk reads in the multipart stream parser for better throughput.
  - Docs/examples: Added streaming usage across languages; TS notes non-browser/serverless support.

<sup>Written for commit 779ae8491b37fb0b8fa69c1c6b54cdea86cac957. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4590?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

