### PR TITLE
fix(daemon,sdk-go,sdk-ruby): classify git operation errors by HTTP status code

### DIFF
--- a/apps/daemon/pkg/toolbox/git/add.go
+++ b/apps/daemon/pkg/toolbox/git/add.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 )
@@ -26,7 +27,7 @@ import (
 func AddFiles(c *gin.Context) {
 	var req GitAddRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -35,7 +36,7 @@ func AddFiles(c *gin.Context) {
 	}
 
 	if err := gitService.Add(req.Files); err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/checkout.go
+++ b/apps/daemon/pkg/toolbox/git/checkout.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 )
@@ -26,7 +27,7 @@ import (
 func CheckoutBranch(c *gin.Context) {
 	var req GitCheckoutRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -35,7 +36,7 @@ func CheckoutBranch(c *gin.Context) {
 	}
 
 	if err := gitService.Checkout(req.Branch); err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/clone_repository.go
+++ b/apps/daemon/pkg/toolbox/git/clone_repository.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/daytonaio/daemon/pkg/gitprovider"
 	"github.com/gin-gonic/gin"
@@ -28,7 +29,7 @@ import (
 func CloneRepository(c *gin.Context) {
 	var req GitCloneRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -63,7 +64,7 @@ func CloneRepository(c *gin.Context) {
 
 	err := gitService.CloneRepository(&repo, auth)
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/commit.go
+++ b/apps/daemon/pkg/toolbox/git/commit.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 	go_git "github.com/go-git/go-git/v5"
@@ -29,7 +30,7 @@ import (
 func CommitChanges(c *gin.Context) {
 	var req GitCommitRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -47,7 +48,7 @@ func CommitChanges(c *gin.Context) {
 	})
 
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/create_branch.go
+++ b/apps/daemon/pkg/toolbox/git/create_branch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 )
@@ -26,7 +27,7 @@ import (
 func CreateBranch(c *gin.Context) {
 	var req GitBranchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -35,7 +36,7 @@ func CreateBranch(c *gin.Context) {
 	}
 
 	if err := gitService.CreateBranch(req.Name); err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/delete_branch.go
+++ b/apps/daemon/pkg/toolbox/git/delete_branch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 )
@@ -26,7 +27,7 @@ import (
 func DeleteBranch(c *gin.Context) {
 	var req GitDeleteBranchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -35,7 +36,7 @@ func DeleteBranch(c *gin.Context) {
 	}
 
 	if err := gitService.DeleteBranch(req.Name); err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/errors.go
+++ b/apps/daemon/pkg/toolbox/git/errors.go
@@ -1,0 +1,54 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package git
+
+import (
+	"errors"
+
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	"github.com/gin-gonic/gin"
+	go_git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+func classifyGitError(err error) error {
+	msg := err.Error()
+
+	if errors.Is(err, transport.ErrAuthenticationRequired) ||
+		errors.Is(err, transport.ErrInvalidAuthMethod) {
+		return &common_errors.UnauthorizedError{Message: msg}
+	}
+
+	if errors.Is(err, transport.ErrAuthorizationFailed) {
+		return &common_errors.ForbiddenError{Message: msg}
+	}
+
+	if errors.Is(err, transport.ErrRepositoryNotFound) ||
+		errors.Is(err, transport.ErrEmptyRemoteRepository) ||
+		errors.Is(err, go_git.ErrRepositoryNotExists) ||
+		errors.Is(err, go_git.ErrBranchNotFound) ||
+		errors.Is(err, go_git.ErrRemoteNotFound) ||
+		errors.Is(err, go_git.ErrTagNotFound) ||
+		errors.Is(err, plumbing.ErrReferenceNotFound) ||
+		errors.Is(err, plumbing.ErrObjectNotFound) {
+		return &common_errors.NotFoundError{Message: msg}
+	}
+
+	if errors.Is(err, go_git.ErrNonFastForwardUpdate) ||
+		errors.Is(err, go_git.ErrWorktreeNotClean) ||
+		errors.Is(err, go_git.ErrUnstagedChanges) ||
+		errors.Is(err, go_git.ErrRepositoryAlreadyExists) ||
+		errors.Is(err, go_git.ErrBranchExists) ||
+		errors.Is(err, go_git.ErrFastForwardMergeNotPossible) {
+		return &common_errors.ConflictError{Message: msg}
+	}
+
+	return &common_errors.BadRequestError{Message: msg}
+}
+
+func abortWithGitError(c *gin.Context, err error) {
+	_ = c.Error(classifyGitError(err))
+	c.Abort()
+}

--- a/apps/daemon/pkg/toolbox/git/errors.go
+++ b/apps/daemon/pkg/toolbox/git/errors.go
@@ -5,6 +5,7 @@ package git
 
 import (
 	"errors"
+	"net/http"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/gin-gonic/gin"
@@ -14,15 +15,13 @@ import (
 )
 
 func classifyGitError(err error) error {
-	msg := err.Error()
-
 	if errors.Is(err, transport.ErrAuthenticationRequired) ||
 		errors.Is(err, transport.ErrInvalidAuthMethod) {
-		return &common_errors.UnauthorizedError{Message: msg}
+		return common_errors.NewUnauthorizedError(err)
 	}
 
 	if errors.Is(err, transport.ErrAuthorizationFailed) {
-		return &common_errors.ForbiddenError{Message: msg}
+		return common_errors.NewForbiddenError(err)
 	}
 
 	if errors.Is(err, transport.ErrRepositoryNotFound) ||
@@ -33,7 +32,7 @@ func classifyGitError(err error) error {
 		errors.Is(err, go_git.ErrTagNotFound) ||
 		errors.Is(err, plumbing.ErrReferenceNotFound) ||
 		errors.Is(err, plumbing.ErrObjectNotFound) {
-		return &common_errors.NotFoundError{Message: msg}
+		return common_errors.NewNotFoundError(err)
 	}
 
 	if errors.Is(err, go_git.ErrNonFastForwardUpdate) ||
@@ -42,10 +41,10 @@ func classifyGitError(err error) error {
 		errors.Is(err, go_git.ErrRepositoryAlreadyExists) ||
 		errors.Is(err, go_git.ErrBranchExists) ||
 		errors.Is(err, go_git.ErrFastForwardMergeNotPossible) {
-		return &common_errors.ConflictError{Message: msg}
+		return common_errors.NewConflictError(err)
 	}
 
-	return &common_errors.BadRequestError{Message: msg}
+	return common_errors.NewCustomError(http.StatusInternalServerError, err.Error(), "INTERNAL_SERVER_ERROR")
 }
 
 func abortWithGitError(c *gin.Context, err error) {

--- a/apps/daemon/pkg/toolbox/git/history.go
+++ b/apps/daemon/pkg/toolbox/git/history.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 )
@@ -25,7 +26,7 @@ import (
 func GetCommitHistory(c *gin.Context) {
 	path := c.Query("path")
 	if path == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("path is required"))
+		_ = c.Error(common_errors.NewBadRequestError(errors.New("path is required")))
 		return
 	}
 
@@ -35,7 +36,7 @@ func GetCommitHistory(c *gin.Context) {
 
 	log, err := gitService.Log()
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/list_branches.go
+++ b/apps/daemon/pkg/toolbox/git/list_branches.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 )
@@ -25,7 +26,7 @@ import (
 func ListBranches(c *gin.Context) {
 	path := c.Query("path")
 	if path == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("path is required"))
+		_ = c.Error(common_errors.NewBadRequestError(errors.New("path is required")))
 		return
 	}
 
@@ -35,7 +36,7 @@ func ListBranches(c *gin.Context) {
 
 	branchList, err := gitService.ListBranches()
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/pull.go
+++ b/apps/daemon/pkg/toolbox/git/pull.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 	go_git "github.com/go-git/go-git/v5"
@@ -28,7 +29,7 @@ import (
 func PullChanges(c *gin.Context) {
 	var req GitRepoRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -46,7 +47,7 @@ func PullChanges(c *gin.Context) {
 
 	err := gitService.Pull(auth)
 	if err != nil && err != go_git.NoErrAlreadyUpToDate {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/push.go
+++ b/apps/daemon/pkg/toolbox/git/push.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 	go_git "github.com/go-git/go-git/v5"
@@ -28,7 +29,7 @@ import (
 func PushChanges(c *gin.Context) {
 	var req GitRepoRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		_ = c.Error(common_errors.NewInvalidBodyRequestError(fmt.Errorf("invalid request body: %w", err)))
 		return
 	}
 
@@ -46,7 +47,7 @@ func PushChanges(c *gin.Context) {
 
 	err := gitService.Push(auth)
 	if err != nil && err != go_git.NoErrAlreadyUpToDate {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/daemon/pkg/toolbox/git/status.go
+++ b/apps/daemon/pkg/toolbox/git/status.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 
+	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	"github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 )
@@ -25,7 +26,7 @@ import (
 func GetStatus(c *gin.Context) {
 	path := c.Query("path")
 	if path == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("path is required"))
+		_ = c.Error(common_errors.NewBadRequestError(errors.New("path is required")))
 		return
 	}
 
@@ -35,7 +36,7 @@ func GetStatus(c *gin.Context) {
 
 	status, err := gitService.GetGitStatus()
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithGitError(c, err)
 		return
 	}
 

--- a/apps/docs/src/content/docs/en/go-sdk/errors.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/errors.mdx
@@ -15,18 +15,33 @@ import "github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
 - [func ConvertAPIError\(err error, httpResp \*http.Response\) error](<#ConvertAPIError>)
 - [func ConvertToolboxError\(err error, httpResp \*http.Response\) error](<#ConvertToolboxError>)
 - [func NewDaytonaErrorFromBody\(body \[\]byte, statusCode int, headers http.Header\) error](<#NewDaytonaErrorFromBody>)
+- [type DaytonaAuthenticationError](<#DaytonaAuthenticationError>)
+  - [func NewDaytonaAuthenticationError\(message string, headers http.Header\) \*DaytonaAuthenticationError](<#NewDaytonaAuthenticationError>)
+  - [func \(e \*DaytonaAuthenticationError\) Error\(\) string](<#DaytonaAuthenticationError.Error>)
+- [type DaytonaConflictError](<#DaytonaConflictError>)
+  - [func NewDaytonaConflictError\(message string, headers http.Header\) \*DaytonaConflictError](<#NewDaytonaConflictError>)
+  - [func \(e \*DaytonaConflictError\) Error\(\) string](<#DaytonaConflictError.Error>)
 - [type DaytonaError](<#DaytonaError>)
   - [func NewDaytonaError\(message string, statusCode int, headers http.Header\) \*DaytonaError](<#NewDaytonaError>)
   - [func \(e \*DaytonaError\) Error\(\) string](<#DaytonaError.Error>)
+- [type DaytonaForbiddenError](<#DaytonaForbiddenError>)
+  - [func NewDaytonaForbiddenError\(message string, headers http.Header\) \*DaytonaForbiddenError](<#NewDaytonaForbiddenError>)
+  - [func \(e \*DaytonaForbiddenError\) Error\(\) string](<#DaytonaForbiddenError.Error>)
 - [type DaytonaNotFoundError](<#DaytonaNotFoundError>)
   - [func NewDaytonaNotFoundError\(message string, headers http.Header\) \*DaytonaNotFoundError](<#NewDaytonaNotFoundError>)
   - [func \(e \*DaytonaNotFoundError\) Error\(\) string](<#DaytonaNotFoundError.Error>)
 - [type DaytonaRateLimitError](<#DaytonaRateLimitError>)
   - [func NewDaytonaRateLimitError\(message string, headers http.Header\) \*DaytonaRateLimitError](<#NewDaytonaRateLimitError>)
   - [func \(e \*DaytonaRateLimitError\) Error\(\) string](<#DaytonaRateLimitError.Error>)
+- [type DaytonaServerError](<#DaytonaServerError>)
+  - [func NewDaytonaServerError\(message string, statusCode int, headers http.Header\) \*DaytonaServerError](<#NewDaytonaServerError>)
+  - [func \(e \*DaytonaServerError\) Error\(\) string](<#DaytonaServerError.Error>)
 - [type DaytonaTimeoutError](<#DaytonaTimeoutError>)
   - [func NewDaytonaTimeoutError\(message string\) \*DaytonaTimeoutError](<#NewDaytonaTimeoutError>)
   - [func \(e \*DaytonaTimeoutError\) Error\(\) string](<#DaytonaTimeoutError.Error>)
+- [type DaytonaValidationError](<#DaytonaValidationError>)
+  - [func NewDaytonaValidationError\(message string, headers http.Header\) \*DaytonaValidationError](<#NewDaytonaValidationError>)
+  - [func \(e \*DaytonaValidationError\) Error\(\) string](<#DaytonaValidationError.Error>)
 
 
 <a name="ConvertAPIError"></a>
@@ -56,6 +71,64 @@ func NewDaytonaErrorFromBody(body []byte, statusCode int, headers http.Header) e
 
 NewDaytonaErrorFromBody parses a JSON response body and maps the status code to the appropriate SDK error type. Falls back to the raw body as the message.
 
+<a name="DaytonaAuthenticationError"></a>
+## type DaytonaAuthenticationError
+
+DaytonaAuthenticationError represents an authentication error \(401\)
+
+```go
+type DaytonaAuthenticationError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaAuthenticationError"></a>
+### func NewDaytonaAuthenticationError
+
+```go
+func NewDaytonaAuthenticationError(message string, headers http.Header) *DaytonaAuthenticationError
+```
+
+
+
+<a name="DaytonaAuthenticationError.Error"></a>
+### func \(\*DaytonaAuthenticationError\) Error
+
+```go
+func (e *DaytonaAuthenticationError) Error() string
+```
+
+
+
+<a name="DaytonaConflictError"></a>
+## type DaytonaConflictError
+
+DaytonaConflictError represents a conflict error \(409\)
+
+```go
+type DaytonaConflictError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaConflictError"></a>
+### func NewDaytonaConflictError
+
+```go
+func NewDaytonaConflictError(message string, headers http.Header) *DaytonaConflictError
+```
+
+
+
+<a name="DaytonaConflictError.Error"></a>
+### func \(\*DaytonaConflictError\) Error
+
+```go
+func (e *DaytonaConflictError) Error() string
+```
+
+
+
 <a name="DaytonaError"></a>
 ## type DaytonaError
 
@@ -83,6 +156,35 @@ NewDaytonaError creates a new DaytonaError
 
 ```go
 func (e *DaytonaError) Error() string
+```
+
+
+
+<a name="DaytonaForbiddenError"></a>
+## type DaytonaForbiddenError
+
+DaytonaForbiddenError represents a forbidden/authorization error \(403\)
+
+```go
+type DaytonaForbiddenError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaForbiddenError"></a>
+### func NewDaytonaForbiddenError
+
+```go
+func NewDaytonaForbiddenError(message string, headers http.Header) *DaytonaForbiddenError
+```
+
+
+
+<a name="DaytonaForbiddenError.Error"></a>
+### func \(\*DaytonaForbiddenError\) Error
+
+```go
+func (e *DaytonaForbiddenError) Error() string
 ```
 
 
@@ -145,6 +247,35 @@ func (e *DaytonaRateLimitError) Error() string
 
 
 
+<a name="DaytonaServerError"></a>
+## type DaytonaServerError
+
+DaytonaServerError represents a server error \(5xx\)
+
+```go
+type DaytonaServerError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaServerError"></a>
+### func NewDaytonaServerError
+
+```go
+func NewDaytonaServerError(message string, statusCode int, headers http.Header) *DaytonaServerError
+```
+
+
+
+<a name="DaytonaServerError.Error"></a>
+### func \(\*DaytonaServerError\) Error
+
+```go
+func (e *DaytonaServerError) Error() string
+```
+
+
+
 <a name="DaytonaTimeoutError"></a>
 ## type DaytonaTimeoutError
 
@@ -163,13 +294,42 @@ type DaytonaTimeoutError struct {
 func NewDaytonaTimeoutError(message string) *DaytonaTimeoutError
 ```
 
-NewDaytonaTimeoutError creates a new DaytonaTimeoutError
+
 
 <a name="DaytonaTimeoutError.Error"></a>
 ### func \(\*DaytonaTimeoutError\) Error
 
 ```go
 func (e *DaytonaTimeoutError) Error() string
+```
+
+
+
+<a name="DaytonaValidationError"></a>
+## type DaytonaValidationError
+
+DaytonaValidationError represents a validation/bad request error \(400\)
+
+```go
+type DaytonaValidationError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaValidationError"></a>
+### func NewDaytonaValidationError
+
+```go
+func NewDaytonaValidationError(message string, headers http.Header) *DaytonaValidationError
+```
+
+
+
+<a name="DaytonaValidationError.Error"></a>
+### func \(\*DaytonaValidationError\) Error
+
+```go
+func (e *DaytonaValidationError) Error() string
 ```
 
 

--- a/apps/docs/src/content/docs/en/go-sdk/errors.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/errors.mdx
@@ -14,18 +14,33 @@ import "github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
 
 - [func ConvertAPIError\(err error, httpResp \*http.Response\) error](<#ConvertAPIError>)
 - [func ConvertToolboxError\(err error, httpResp \*http.Response\) error](<#ConvertToolboxError>)
+- [type DaytonaAuthenticationError](<#DaytonaAuthenticationError>)
+  - [func NewDaytonaAuthenticationError\(message string, headers http.Header\) \*DaytonaAuthenticationError](<#NewDaytonaAuthenticationError>)
+  - [func \(e \*DaytonaAuthenticationError\) Error\(\) string](<#DaytonaAuthenticationError.Error>)
+- [type DaytonaConflictError](<#DaytonaConflictError>)
+  - [func NewDaytonaConflictError\(message string, headers http.Header\) \*DaytonaConflictError](<#NewDaytonaConflictError>)
+  - [func \(e \*DaytonaConflictError\) Error\(\) string](<#DaytonaConflictError.Error>)
 - [type DaytonaError](<#DaytonaError>)
   - [func NewDaytonaError\(message string, statusCode int, headers http.Header\) \*DaytonaError](<#NewDaytonaError>)
   - [func \(e \*DaytonaError\) Error\(\) string](<#DaytonaError.Error>)
+- [type DaytonaForbiddenError](<#DaytonaForbiddenError>)
+  - [func NewDaytonaForbiddenError\(message string, headers http.Header\) \*DaytonaForbiddenError](<#NewDaytonaForbiddenError>)
+  - [func \(e \*DaytonaForbiddenError\) Error\(\) string](<#DaytonaForbiddenError.Error>)
 - [type DaytonaNotFoundError](<#DaytonaNotFoundError>)
   - [func NewDaytonaNotFoundError\(message string, headers http.Header\) \*DaytonaNotFoundError](<#NewDaytonaNotFoundError>)
   - [func \(e \*DaytonaNotFoundError\) Error\(\) string](<#DaytonaNotFoundError.Error>)
 - [type DaytonaRateLimitError](<#DaytonaRateLimitError>)
   - [func NewDaytonaRateLimitError\(message string, headers http.Header\) \*DaytonaRateLimitError](<#NewDaytonaRateLimitError>)
   - [func \(e \*DaytonaRateLimitError\) Error\(\) string](<#DaytonaRateLimitError.Error>)
+- [type DaytonaServerError](<#DaytonaServerError>)
+  - [func NewDaytonaServerError\(message string, statusCode int, headers http.Header\) \*DaytonaServerError](<#NewDaytonaServerError>)
+  - [func \(e \*DaytonaServerError\) Error\(\) string](<#DaytonaServerError.Error>)
 - [type DaytonaTimeoutError](<#DaytonaTimeoutError>)
   - [func NewDaytonaTimeoutError\(message string\) \*DaytonaTimeoutError](<#NewDaytonaTimeoutError>)
   - [func \(e \*DaytonaTimeoutError\) Error\(\) string](<#DaytonaTimeoutError.Error>)
+- [type DaytonaValidationError](<#DaytonaValidationError>)
+  - [func NewDaytonaValidationError\(message string, headers http.Header\) \*DaytonaValidationError](<#NewDaytonaValidationError>)
+  - [func \(e \*DaytonaValidationError\) Error\(\) string](<#DaytonaValidationError.Error>)
 
 
 <a name="ConvertAPIError"></a>
@@ -45,6 +60,64 @@ func ConvertToolboxError(err error, httpResp *http.Response) error
 ```
 
 ConvertToolboxError converts toolbox\-api\-client\-go errors to SDK error types
+
+<a name="DaytonaAuthenticationError"></a>
+## type DaytonaAuthenticationError
+
+DaytonaAuthenticationError represents an authentication error \(401\)
+
+```go
+type DaytonaAuthenticationError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaAuthenticationError"></a>
+### func NewDaytonaAuthenticationError
+
+```go
+func NewDaytonaAuthenticationError(message string, headers http.Header) *DaytonaAuthenticationError
+```
+
+
+
+<a name="DaytonaAuthenticationError.Error"></a>
+### func \(\*DaytonaAuthenticationError\) Error
+
+```go
+func (e *DaytonaAuthenticationError) Error() string
+```
+
+
+
+<a name="DaytonaConflictError"></a>
+## type DaytonaConflictError
+
+DaytonaConflictError represents a conflict error \(409\)
+
+```go
+type DaytonaConflictError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaConflictError"></a>
+### func NewDaytonaConflictError
+
+```go
+func NewDaytonaConflictError(message string, headers http.Header) *DaytonaConflictError
+```
+
+
+
+<a name="DaytonaConflictError.Error"></a>
+### func \(\*DaytonaConflictError\) Error
+
+```go
+func (e *DaytonaConflictError) Error() string
+```
+
+
 
 <a name="DaytonaError"></a>
 ## type DaytonaError
@@ -73,6 +146,35 @@ NewDaytonaError creates a new DaytonaError
 
 ```go
 func (e *DaytonaError) Error() string
+```
+
+
+
+<a name="DaytonaForbiddenError"></a>
+## type DaytonaForbiddenError
+
+DaytonaForbiddenError represents a forbidden/authorization error \(403\)
+
+```go
+type DaytonaForbiddenError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaForbiddenError"></a>
+### func NewDaytonaForbiddenError
+
+```go
+func NewDaytonaForbiddenError(message string, headers http.Header) *DaytonaForbiddenError
+```
+
+
+
+<a name="DaytonaForbiddenError.Error"></a>
+### func \(\*DaytonaForbiddenError\) Error
+
+```go
+func (e *DaytonaForbiddenError) Error() string
 ```
 
 
@@ -135,6 +237,35 @@ func (e *DaytonaRateLimitError) Error() string
 
 
 
+<a name="DaytonaServerError"></a>
+## type DaytonaServerError
+
+DaytonaServerError represents a server error \(5xx\)
+
+```go
+type DaytonaServerError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaServerError"></a>
+### func NewDaytonaServerError
+
+```go
+func NewDaytonaServerError(message string, statusCode int, headers http.Header) *DaytonaServerError
+```
+
+
+
+<a name="DaytonaServerError.Error"></a>
+### func \(\*DaytonaServerError\) Error
+
+```go
+func (e *DaytonaServerError) Error() string
+```
+
+
+
 <a name="DaytonaTimeoutError"></a>
 ## type DaytonaTimeoutError
 
@@ -153,13 +284,42 @@ type DaytonaTimeoutError struct {
 func NewDaytonaTimeoutError(message string) *DaytonaTimeoutError
 ```
 
-NewDaytonaTimeoutError creates a new DaytonaTimeoutError
+
 
 <a name="DaytonaTimeoutError.Error"></a>
 ### func \(\*DaytonaTimeoutError\) Error
 
 ```go
 func (e *DaytonaTimeoutError) Error() string
+```
+
+
+
+<a name="DaytonaValidationError"></a>
+## type DaytonaValidationError
+
+DaytonaValidationError represents a validation/bad request error \(400\)
+
+```go
+type DaytonaValidationError struct {
+    *DaytonaError
+}
+```
+
+<a name="NewDaytonaValidationError"></a>
+### func NewDaytonaValidationError
+
+```go
+func NewDaytonaValidationError(message string, headers http.Header) *DaytonaValidationError
+```
+
+
+
+<a name="DaytonaValidationError.Error"></a>
+### func \(\*DaytonaValidationError\) Error
+
+```go
+func (e *DaytonaValidationError) Error() string
 ```
 
 

--- a/libs/sdk-go/pkg/errors/errors.go
+++ b/libs/sdk-go/pkg/errors/errors.go
@@ -67,6 +67,81 @@ func NewDaytonaRateLimitError(message string, headers http.Header) *DaytonaRateL
 	}
 }
 
+// DaytonaAuthenticationError represents an authentication error (401)
+type DaytonaAuthenticationError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaAuthenticationError) Error() string {
+	return fmt.Sprintf("Authentication failed: %s", e.Message)
+}
+
+func NewDaytonaAuthenticationError(message string, headers http.Header) *DaytonaAuthenticationError {
+	return &DaytonaAuthenticationError{
+		DaytonaError: NewDaytonaError(message, http.StatusUnauthorized, headers),
+	}
+}
+
+// DaytonaForbiddenError represents a forbidden/authorization error (403)
+type DaytonaForbiddenError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaForbiddenError) Error() string {
+	return fmt.Sprintf("Forbidden: %s", e.Message)
+}
+
+func NewDaytonaForbiddenError(message string, headers http.Header) *DaytonaForbiddenError {
+	return &DaytonaForbiddenError{
+		DaytonaError: NewDaytonaError(message, http.StatusForbidden, headers),
+	}
+}
+
+// DaytonaConflictError represents a conflict error (409)
+type DaytonaConflictError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaConflictError) Error() string {
+	return fmt.Sprintf("Conflict: %s", e.Message)
+}
+
+func NewDaytonaConflictError(message string, headers http.Header) *DaytonaConflictError {
+	return &DaytonaConflictError{
+		DaytonaError: NewDaytonaError(message, http.StatusConflict, headers),
+	}
+}
+
+// DaytonaValidationError represents a validation/bad request error (400)
+type DaytonaValidationError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaValidationError) Error() string {
+	return fmt.Sprintf("Validation error: %s", e.Message)
+}
+
+func NewDaytonaValidationError(message string, headers http.Header) *DaytonaValidationError {
+	return &DaytonaValidationError{
+		DaytonaError: NewDaytonaError(message, http.StatusBadRequest, headers),
+	}
+}
+
+// DaytonaServerError represents a server error (5xx)
+type DaytonaServerError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaServerError) Error() string {
+	return fmt.Sprintf("Server error: %s", e.Message)
+}
+
+func NewDaytonaServerError(message string, statusCode int, headers http.Header) *DaytonaServerError {
+	return &DaytonaServerError{
+		DaytonaError: NewDaytonaError(message, statusCode, headers),
+	}
+}
+
 // DaytonaTimeoutError represents a timeout error
 type DaytonaTimeoutError struct {
 	*DaytonaError
@@ -76,7 +151,6 @@ func (e *DaytonaTimeoutError) Error() string {
 	return fmt.Sprintf("Operation timed out: %s", e.Message)
 }
 
-// NewDaytonaTimeoutError creates a new DaytonaTimeoutError
 func NewDaytonaTimeoutError(message string) *DaytonaTimeoutError {
 	return &DaytonaTimeoutError{
 		DaytonaError: NewDaytonaError(message, 0, nil),
@@ -129,18 +203,7 @@ func ConvertAPIError(err error, httpResp *http.Response) error {
 		message = err.Error()
 	}
 
-	// Map status codes to SDK error types
-	switch statusCode {
-	case http.StatusNotFound:
-		return NewDaytonaNotFoundError(message, headers)
-	case http.StatusTooManyRequests:
-		return NewDaytonaRateLimitError(message, headers)
-	case 0:
-		// Network or client error (no HTTP response)
-		return NewDaytonaError(message, 0, nil)
-	default:
-		return NewDaytonaError(message, statusCode, headers)
-	}
+	return mapStatusCodeToError(statusCode, message, headers)
 }
 
 // ConvertToolboxError converts toolbox-api-client-go errors to SDK error types
@@ -189,14 +252,26 @@ func ConvertToolboxError(err error, httpResp *http.Response) error {
 		message = err.Error()
 	}
 
-	// Map status codes to SDK error types
-	switch statusCode {
-	case http.StatusNotFound:
+	return mapStatusCodeToError(statusCode, message, headers)
+}
+
+func mapStatusCodeToError(statusCode int, message string, headers http.Header) error {
+	switch {
+	case statusCode == http.StatusBadRequest:
+		return NewDaytonaValidationError(message, headers)
+	case statusCode == http.StatusUnauthorized:
+		return NewDaytonaAuthenticationError(message, headers)
+	case statusCode == http.StatusForbidden:
+		return NewDaytonaForbiddenError(message, headers)
+	case statusCode == http.StatusNotFound:
 		return NewDaytonaNotFoundError(message, headers)
-	case http.StatusTooManyRequests:
+	case statusCode == http.StatusConflict:
+		return NewDaytonaConflictError(message, headers)
+	case statusCode == http.StatusTooManyRequests:
 		return NewDaytonaRateLimitError(message, headers)
-	case 0:
-		// Network or client error (no HTTP response)
+	case statusCode >= 500:
+		return NewDaytonaServerError(message, statusCode, headers)
+	case statusCode == 0:
 		return NewDaytonaError(message, 0, nil)
 	default:
 		return NewDaytonaError(message, statusCode, headers)

--- a/libs/sdk-go/pkg/errors/errors.go
+++ b/libs/sdk-go/pkg/errors/errors.go
@@ -309,7 +309,7 @@ func mapStatusCodeToError(statusCode int, message string, headers http.Header) e
 		return NewDaytonaConflictError(message, headers)
 	case statusCode == http.StatusTooManyRequests:
 		return NewDaytonaRateLimitError(message, headers)
-	case statusCode >= 500:
+	case statusCode >= 500 && statusCode <= 599:
 		return NewDaytonaServerError(message, statusCode, headers)
 	case statusCode == 0:
 		return NewDaytonaError(message, 0, nil)

--- a/libs/sdk-go/pkg/errors/errors.go
+++ b/libs/sdk-go/pkg/errors/errors.go
@@ -67,6 +67,81 @@ func NewDaytonaRateLimitError(message string, headers http.Header) *DaytonaRateL
 	}
 }
 
+// DaytonaAuthenticationError represents an authentication error (401)
+type DaytonaAuthenticationError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaAuthenticationError) Error() string {
+	return fmt.Sprintf("Authentication failed: %s", e.Message)
+}
+
+func NewDaytonaAuthenticationError(message string, headers http.Header) *DaytonaAuthenticationError {
+	return &DaytonaAuthenticationError{
+		DaytonaError: NewDaytonaError(message, http.StatusUnauthorized, headers),
+	}
+}
+
+// DaytonaForbiddenError represents a forbidden/authorization error (403)
+type DaytonaForbiddenError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaForbiddenError) Error() string {
+	return fmt.Sprintf("Forbidden: %s", e.Message)
+}
+
+func NewDaytonaForbiddenError(message string, headers http.Header) *DaytonaForbiddenError {
+	return &DaytonaForbiddenError{
+		DaytonaError: NewDaytonaError(message, http.StatusForbidden, headers),
+	}
+}
+
+// DaytonaConflictError represents a conflict error (409)
+type DaytonaConflictError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaConflictError) Error() string {
+	return fmt.Sprintf("Conflict: %s", e.Message)
+}
+
+func NewDaytonaConflictError(message string, headers http.Header) *DaytonaConflictError {
+	return &DaytonaConflictError{
+		DaytonaError: NewDaytonaError(message, http.StatusConflict, headers),
+	}
+}
+
+// DaytonaValidationError represents a validation/bad request error (400)
+type DaytonaValidationError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaValidationError) Error() string {
+	return fmt.Sprintf("Validation error: %s", e.Message)
+}
+
+func NewDaytonaValidationError(message string, headers http.Header) *DaytonaValidationError {
+	return &DaytonaValidationError{
+		DaytonaError: NewDaytonaError(message, http.StatusBadRequest, headers),
+	}
+}
+
+// DaytonaServerError represents a server error (5xx)
+type DaytonaServerError struct {
+	*DaytonaError
+}
+
+func (e *DaytonaServerError) Error() string {
+	return fmt.Sprintf("Server error: %s", e.Message)
+}
+
+func NewDaytonaServerError(message string, statusCode int, headers http.Header) *DaytonaServerError {
+	return &DaytonaServerError{
+		DaytonaError: NewDaytonaError(message, statusCode, headers),
+	}
+}
+
 // DaytonaTimeoutError represents a timeout error
 type DaytonaTimeoutError struct {
 	*DaytonaError
@@ -76,7 +151,6 @@ func (e *DaytonaTimeoutError) Error() string {
 	return fmt.Sprintf("Operation timed out: %s", e.Message)
 }
 
-// NewDaytonaTimeoutError creates a new DaytonaTimeoutError
 func NewDaytonaTimeoutError(message string) *DaytonaTimeoutError {
 	return &DaytonaTimeoutError{
 		DaytonaError: NewDaytonaError(message, 0, nil),
@@ -169,18 +243,7 @@ func ConvertAPIError(err error, httpResp *http.Response) error {
 		message = err.Error()
 	}
 
-	// Map status codes to SDK error types
-	switch statusCode {
-	case http.StatusNotFound:
-		return NewDaytonaNotFoundError(message, headers)
-	case http.StatusTooManyRequests:
-		return NewDaytonaRateLimitError(message, headers)
-	case 0:
-		// Network or client error (no HTTP response)
-		return NewDaytonaError(message, 0, nil)
-	default:
-		return NewDaytonaError(message, statusCode, headers)
-	}
+	return mapStatusCodeToError(statusCode, message, headers)
 }
 
 // ConvertToolboxError converts toolbox-api-client-go errors to SDK error types
@@ -229,14 +292,26 @@ func ConvertToolboxError(err error, httpResp *http.Response) error {
 		message = err.Error()
 	}
 
-	// Map status codes to SDK error types
-	switch statusCode {
-	case http.StatusNotFound:
+	return mapStatusCodeToError(statusCode, message, headers)
+}
+
+func mapStatusCodeToError(statusCode int, message string, headers http.Header) error {
+	switch {
+	case statusCode == http.StatusBadRequest:
+		return NewDaytonaValidationError(message, headers)
+	case statusCode == http.StatusUnauthorized:
+		return NewDaytonaAuthenticationError(message, headers)
+	case statusCode == http.StatusForbidden:
+		return NewDaytonaForbiddenError(message, headers)
+	case statusCode == http.StatusNotFound:
 		return NewDaytonaNotFoundError(message, headers)
-	case http.StatusTooManyRequests:
+	case statusCode == http.StatusConflict:
+		return NewDaytonaConflictError(message, headers)
+	case statusCode == http.StatusTooManyRequests:
 		return NewDaytonaRateLimitError(message, headers)
-	case 0:
-		// Network or client error (no HTTP response)
+	case statusCode >= 500:
+		return NewDaytonaServerError(message, statusCode, headers)
+	case statusCode == 0:
 		return NewDaytonaError(message, 0, nil)
 	default:
 		return NewDaytonaError(message, statusCode, headers)

--- a/libs/sdk-go/pkg/errors/errors.go
+++ b/libs/sdk-go/pkg/errors/errors.go
@@ -269,7 +269,7 @@ func mapStatusCodeToError(statusCode int, message string, headers http.Header) e
 		return NewDaytonaConflictError(message, headers)
 	case statusCode == http.StatusTooManyRequests:
 		return NewDaytonaRateLimitError(message, headers)
-	case statusCode >= 500:
+	case statusCode >= 500 && statusCode <= 599:
 		return NewDaytonaServerError(message, statusCode, headers)
 	case statusCode == 0:
 		return NewDaytonaError(message, 0, nil)

--- a/libs/sdk-ruby/lib/daytona/git.rb
+++ b/libs/sdk-ruby/lib/daytona/git.rb
@@ -45,6 +45,8 @@ module Daytona
     #   ])
     def add(path, files)
       toolbox_api.add_files(DaytonaToolboxApiClient::GitAddRequest.new(path:, files:))
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to add files')
     rescue StandardError => e
       raise Sdk::Error, "Failed to add files: #{e.message}"
     end
@@ -61,6 +63,8 @@ module Daytona
     #   puts "Branches: #{response.branches}"
     def branches(path)
       toolbox_api.list_branches(path)
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to list branches')
     rescue StandardError => e
       raise Sdk::Error, "Failed to list branches: #{e.message}"
     end
@@ -114,6 +118,8 @@ module Daytona
           commit_id: commit_id
         )
       )
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to clone repository')
     rescue StandardError => e
       raise Sdk::Error, "Failed to clone repository: #{e.message}"
     end
@@ -146,6 +152,8 @@ module Daytona
         DaytonaToolboxApiClient::GitCommitRequest.new(path:, message:, author:, email:, allow_empty:)
       )
       GitCommitResponse.new(sha: response._hash)
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to commit changes')
     rescue StandardError => e
       raise Sdk::Error, "Failed to commit changes: #{e.message}"
     end
@@ -175,6 +183,8 @@ module Daytona
       toolbox_api.push_changes(
         DaytonaToolboxApiClient::GitRepoRequest.new(path:, username:, password:)
       )
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to push changes')
     rescue StandardError => e
       raise Sdk::Error, "Failed to push changes: #{e.message}"
     end
@@ -204,6 +214,8 @@ module Daytona
       toolbox_api.pull_changes(
         DaytonaToolboxApiClient::GitRepoRequest.new(path:, username:, password:)
       )
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to pull changes')
     rescue StandardError => e
       raise Sdk::Error, "Failed to pull changes: #{e.message}"
     end
@@ -222,6 +234,8 @@ module Daytona
     #   puts "Commits behind: #{status.behind}"
     def status(path)
       toolbox_api.get_status(path)
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to get status')
     rescue StandardError => e
       raise Sdk::Error, "Failed to get status: #{e.message}"
     end
@@ -241,6 +255,8 @@ module Daytona
       toolbox_api.checkout_branch(
         DaytonaToolboxApiClient::GitCheckoutRequest.new(path:, branch:)
       )
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to checkout branch')
     rescue StandardError => e
       raise Sdk::Error, "Failed to checkout branch: #{e.message}"
     end
@@ -261,6 +277,8 @@ module Daytona
       toolbox_api.create_branch(
         DaytonaToolboxApiClient::GitBranchRequest.new(path:, name:)
       )
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to create branch')
     rescue StandardError => e
       raise Sdk::Error, "Failed to create branch: #{e.message}"
     end
@@ -280,6 +298,8 @@ module Daytona
       toolbox_api.delete_branch(
         DaytonaToolboxApiClient::GitDeleteBranchRequest.new(path:, name:)
       )
+    rescue DaytonaToolboxApiClient::ApiError => e
+      raise map_api_error(e, 'Failed to delete branch')
     rescue StandardError => e
       raise Sdk::Error, "Failed to delete branch: #{e.message}"
     end
@@ -292,5 +312,19 @@ module Daytona
 
     # @return [Daytona::OtelState, nil]
     attr_reader :otel_state
+
+    def map_api_error(api_error, prefix)
+      msg = "#{prefix}: #{api_error.message}"
+      case api_error.code
+      when 400 then Sdk::ValidationError.new(msg)
+      when 401 then Sdk::AuthenticationError.new(msg)
+      when 403 then Sdk::ForbiddenError.new(msg)
+      when 404 then Sdk::NotFoundError.new(msg)
+      when 409 then Sdk::ConflictError.new(msg)
+      when 429 then Sdk::RateLimitError.new(msg)
+      when 500..599 then Sdk::ServerError.new(msg)
+      else Sdk::Error.new(msg)
+      end
+    end
   end
 end

--- a/libs/sdk-ruby/lib/daytona/sdk.rb
+++ b/libs/sdk-ruby/lib/daytona/sdk.rb
@@ -43,6 +43,13 @@ module Daytona
   module Sdk
     class Error < StandardError; end
     class TimeoutError < Error; end
+    class AuthenticationError < Error; end
+    class ForbiddenError < Error; end
+    class NotFoundError < Error; end
+    class ConflictError < Error; end
+    class ValidationError < Error; end
+    class RateLimitError < Error; end
+    class ServerError < Error; end
 
     def self.logger = @logger ||= Logger.new($stdout, level: Logger::INFO)
   end


### PR DESCRIPTION
## Summary

Classify git operation errors in the daemon toolbox by type (auth, not found, conflict, etc.) so SDKs return specific error types instead of generic errors. Previously all git errors were returned as HTTP 500 with no error code.

## Motivation

The daemon's git toolbox handlers called `c.AbortWithError(http.StatusBadRequest, err)` for every git failure — auth errors, missing repos, merge conflicts, everything. The common-go error middleware didn't recognize raw go-git errors (no type switch match), so the default handler overrode the status to **500** with an empty `code` field. SDK users had no way to distinguish "wrong password" from "repo not found" from "branch already exists".

## Changes

### Daemon — git error classification

**New file**: `apps/daemon/pkg/toolbox/git/errors.go`

`classifyGitError()` maps go-git sentinel errors to common-go typed errors using `errors.Is()`:

| go-git error | HTTP status | Error code |
|---|---|---|
| `transport.ErrAuthenticationRequired`, `ErrInvalidAuthMethod` | 401 | `UNAUTHORIZED` |
| `transport.ErrAuthorizationFailed` | 403 | `FORBIDDEN` |
| `transport.ErrRepositoryNotFound`, `ErrBranchNotFound`, `ErrReferenceNotFound`, etc. | 404 | `NOT_FOUND` |
| `ErrNonFastForwardUpdate`, `ErrWorktreeNotClean`, `ErrBranchExists`, etc. | 409 | `CONFLICT` |
| Everything else | 400 | `BAD_REQUEST` |

All 11 git handlers (`clone`, `push`, `pull`, `commit`, `add`, `checkout`, `status`, `history`, `list_branches`, `create_branch`, `delete_branch`) updated to use `abortWithGitError(c, err)` which classifies the error and adds it to the gin context for the middleware to handle.

Request body validation errors now use `common_errors.NewInvalidBodyRequestError()` / `common_errors.NewBadRequestError()` instead of raw `c.AbortWithError`.

### Go SDK — missing error types

**`libs/sdk-go/pkg/errors/errors.go`**

Added 5 typed error types to match the other SDKs:

| Type | Status code |
|---|---|
| `DaytonaAuthenticationError` | 401 |
| `DaytonaForbiddenError` | 403 |
| `DaytonaValidationError` | 400 |
| `DaytonaConflictError` | 409 |
| `DaytonaServerError` | 5xx |

Extracted shared `mapStatusCodeToError()` used by both `ConvertAPIError` and `ConvertToolboxError`. Previously only 404 and 429 were mapped — all other status codes returned a generic `DaytonaError`.

### Ruby SDK — typed error classes + git error mapping

**`libs/sdk-ruby/lib/daytona/sdk.rb`** — Added `AuthenticationError`, `ForbiddenError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `ServerError` (all inherit `Sdk::Error`).

**`libs/sdk-ruby/lib/daytona/git.rb`** — All 10 git methods now rescue `DaytonaToolboxApiClient::ApiError` first, mapping by HTTP status code via a private `map_api_error` helper. `StandardError` rescue kept as fallback. Previously all errors were caught and re-raised as generic `Sdk::Error`, losing the status code.

### SDKs not changed

- **Python** — Already has complete status-code-to-error mapping via `@intercept_errors` decorator
- **TypeScript** — Already has complete mapping via axios response interceptor + `createAxiosDaytonaError`
- **Java** — Already has complete mapping via `ExceptionMapper.map()` with full exception hierarchy

## Before / After

**Before** — user catches a git clone auth failure:
```
Go:      *errors.DaytonaError{StatusCode: 500, Message: "authentication required"}
Python:  DaytonaError(status_code=500, message="authentication required")
Ruby:    Daytona::Sdk::Error "Failed to clone repository: ..."
Java:    DaytonaServerException(500, "authentication required")
TS:      DaytonaError { statusCode: 500, message: "authentication required" }
```

**After**:
```
Go:      *errors.DaytonaAuthenticationError{Message: "authentication required"}
Python:  DaytonaAuthenticationError(status_code=401, message="authentication required")
Ruby:    Daytona::Sdk::AuthenticationError "Failed to clone repository: ..."
Java:    DaytonaAuthenticationException("authentication required")
TS:      DaytonaAuthenticationError { statusCode: 401, message: "authentication required" }
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies git toolbox errors by HTTP status so clients get specific error types instead of generic 500s. Updates Go and Ruby SDKs to map these statuses to typed errors for clearer handling.

- **Bug Fixes**
  - Daemon: added `classifyGitError()` to map go-git/transport errors to 401/403/404/409; unknown git errors now return 500. All git handlers use `abortWithGitError`. Validation uses `common-go` typed 400 errors.
  - Go SDK (`libs/sdk-go`): added `DaytonaAuthenticationError`, `DaytonaForbiddenError`, `DaytonaValidationError`, `DaytonaConflictError`, `DaytonaServerError`. Both converters use shared `mapStatusCodeToError()` (handles 400/401/403/404/409/429/5xx).
  - Ruby SDK (`libs/sdk-ruby`): added typed errors (`AuthenticationError`, `ForbiddenError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `ServerError`). Git methods map `DaytonaToolboxApiClient::ApiError` by status via `map_api_error`.
  - Docs: expanded `go-sdk` error docs for new types and mappings.

<sup>Written for commit 0419eca10e4247ce32d745e06df1ba90e2aac687. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

