### PR TITLE
fix(sdk-python,sdk-java): fix publish job failures

### DIFF
--- a/libs/sdk-java/project.json
+++ b/libs/sdk-java/project.json
@@ -35,7 +35,7 @@
       "outputs": ["{projectRoot}/build"],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "./gradlew build -x test"
+        "command": "./gradlew --stop; ./gradlew build -x test"
       },
       "dependsOn": [
         "set-version",

--- a/libs/sdk-python/pyproject.toml
+++ b/libs/sdk-python/pyproject.toml
@@ -43,5 +43,5 @@ keywords = ["daytona", "sdk"]
 license = {text = "Apache-2.0"}
 
 [tool.deptry]
-exclude = ["scripts"]
+exclude = ["scripts", "tests"]
 extend_exclude = [".venv", "dist", "build", ".pytest_cache", "__pycache__"]


### PR DESCRIPTION
## Summary

Fixes two failures in the [SDK and CLI Publish](https://github.com/daytonaio/daytona/actions/runs/25099144221/job/73543428456) workflow.

### sdk-python:deps-check — deptry scanning test files

`poetry run deptry .` was scanning `libs/sdk-python/tests/` and flagging 105 DEP003 errors for `pytest` and `daytona` imports — these are test-only/transitive dependencies that aren't in sdk-python's direct `[project.dependencies]`.

**Fix**: Added `"tests"` to the `[tool.deptry] exclude` list in `libs/sdk-python/pyproject.toml`. The other four Python libs already pass `deps-check` since they don't have test directories with such imports.

### sdk-java:build — Gradle composite build file lock conflict

`api-client-java:build` and `sdk-java:build` both write to `libs/api-client-java/build/classes/java/main/`:
1. Nx runs `api-client-java:build` → Gradle daemon compiles into that directory
2. Nx runs `sdk-java:build` → its `settings.gradle.kts` uses `includeBuild("../api-client-java")`, so a second Gradle daemon tries to recompile into the **same directory**
3. The first Gradle daemon is still alive and holds file handles → `Unable to delete directory` error

**Fix**: Added `./gradlew --stop` before the sdk-java build command to kill lingering daemons from prior steps.

## Changed files

- `libs/sdk-python/pyproject.toml` — exclude `tests` from deptry
- `libs/sdk-java/project.json` — stop Gradle daemons before build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SDK publish workflow failures by excluding `sdk-python` tests from `deptry` and stopping Gradle daemons before `sdk-java` builds. This stabilizes the SDK and CLI Publish job.

- **Bug Fixes**
  - `sdk-python`: Exclude `tests` in `deptry` to avoid false DEP003 errors on test-only imports.
  - `sdk-java`: Run `./gradlew --stop; ./gradlew build -x test` to prevent composite build directory lock errors.

<sup>Written for commit 3b41f01fd5c245b27b808e9022e055668aad7be3. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4596?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

