### PR TITLE
fix(dashboard): default region prompt on any page

### DIFF
--- a/apps/dashboard/src/components/Organizations/SetDefaultRegionDialog.tsx
+++ b/apps/dashboard/src/components/Organizations/SetDefaultRegionDialog.tsx
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { useState } from 'react'
-import { Region } from '@daytona/api-client'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -17,44 +15,60 @@ import {
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useSetOrganizationDefaultRegionMutation } from '@/hooks/mutations/useSetOrganizationDefaultRegionMutation'
+import { useOrganizations } from '@/hooks/useOrganizations'
+import { useRegions } from '@/hooks/useRegions'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { handleApiError } from '@/lib/error-handling'
+import { Ref, useId, useImperativeHandle, useState } from 'react'
+import { toast } from 'sonner'
+import { Spinner } from '../ui/spinner'
 
 interface SetDefaultRegionDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  regions: Region[]
-  loadingRegions: boolean
-  onSetDefaultRegion: (defaultRegionId: string) => Promise<boolean>
+  ref?: Ref<SetDefaultRegionDialogRef>
 }
 
-export const SetDefaultRegionDialog: React.FC<SetDefaultRegionDialogProps> = ({
-  open,
-  onOpenChange,
-  regions,
-  loadingRegions,
-  onSetDefaultRegion,
-}) => {
+export type SetDefaultRegionDialogRef = {
+  open: () => void
+}
+
+export const SetDefaultRegionDialog: React.FC<SetDefaultRegionDialogProps> = ({ ref }) => {
+  const { refreshOrganizations } = useOrganizations()
+  const { sharedRegions: regions, loadingSharedRegions: loadingRegions } = useRegions()
+  const { selectedOrganization } = useSelectedOrganization()
+  const setDefaultRegionMutation = useSetOrganizationDefaultRegionMutation()
+  const formId = useId()
+  const regionSelectId = useId()
+  const [open, setOpen] = useState(false)
   const [defaultRegionId, setDefaultRegionId] = useState<string | undefined>(undefined)
-  const [loading, setLoading] = useState(false)
+
+  useImperativeHandle(ref, () => ({
+    open: () => setOpen(true),
+  }))
 
   const handleSetDefaultRegion = async () => {
-    if (!defaultRegionId) {
+    if (!selectedOrganization || !defaultRegionId) {
       return
     }
 
-    setLoading(true)
-    const success = await onSetDefaultRegion(defaultRegionId)
-    // TODO: Return when we fix the selected org states
-    // if (success) {
-    //   onOpenChange(false)
-    // }
-    // setLoading(false)
+    try {
+      await setDefaultRegionMutation.mutateAsync({
+        organizationId: selectedOrganization.id,
+        defaultRegionId,
+      })
+      toast.success('Default region set successfully')
+      setOpen(false)
+      void refreshOrganizations(selectedOrganization.id)
+    } catch (error) {
+      handleApiError(error, 'Failed to set default region')
+    }
   }
 
   return (
     <Dialog
       open={open}
       onOpenChange={(isOpen) => {
-        onOpenChange(isOpen)
+        setOpen(isOpen)
         if (!isOpen) {
           setDefaultRegionId(undefined)
         }
@@ -74,7 +88,7 @@ export const SetDefaultRegionDialog: React.FC<SetDefaultRegionDialogProps> = ({
           </div>
         ) : (
           <form
-            id="set-default-region-form"
+            id={formId}
             className="space-y-6 overflow-y-auto px-1 pb-1"
             onSubmit={async (e) => {
               e.preventDefault()
@@ -82,9 +96,9 @@ export const SetDefaultRegionDialog: React.FC<SetDefaultRegionDialogProps> = ({
             }}
           >
             <div className="space-y-3">
-              <Label htmlFor="region-select">Region</Label>
+              <Label htmlFor={regionSelectId}>Region</Label>
               <Select value={defaultRegionId} onValueChange={setDefaultRegionId}>
-                <SelectTrigger className="h-8" id="region-select" disabled={loadingRegions} loading={loadingRegions}>
+                <SelectTrigger className="h-8" id={regionSelectId} disabled={loadingRegions} loading={loadingRegions}>
                   <SelectValue placeholder={loadingRegions ? 'Loading regions...' : 'Select a region'} />
                 </SelectTrigger>
                 <SelectContent>
@@ -100,19 +114,19 @@ export const SetDefaultRegionDialog: React.FC<SetDefaultRegionDialogProps> = ({
         )}
         <DialogFooter>
           <DialogClose asChild>
-            <Button type="button" variant="secondary" disabled={loading}>
+            <Button type="button" variant="secondary" disabled={setDefaultRegionMutation.isPending}>
               Cancel
             </Button>
           </DialogClose>
-          {loading ? (
-            <Button type="button" variant="default" disabled>
-              Saving...
-            </Button>
-          ) : (
-            <Button type="submit" form="set-default-region-form" variant="default" disabled={!defaultRegionId}>
-              Save
-            </Button>
-          )}
+          <Button
+            type="submit"
+            form={formId}
+            variant="default"
+            disabled={!defaultRegionId || setDefaultRegionMutation.isPending}
+          >
+            {setDefaultRegionMutation.isPending && <Spinner />}
+            Save
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -3,11 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { AnnouncementBanner } from '@/components/AnnouncementBanner'
 import { CommandPalette, useRegisterCommands, type CommandConfig } from '@/components/CommandPalette'
+import {
+  SetDefaultRegionDialog,
+  type SetDefaultRegionDialogRef,
+} from '@/components/Organizations/SetDefaultRegionDialog'
 import { Sidebar } from '@/components/Sidebar'
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { Toaster } from '@/components/ui/sonner'
@@ -15,7 +19,6 @@ import { VerifyEmailDialog } from '@/components/VerifyEmailDialog'
 import { DAYTONA_DOCS_URL, DAYTONA_SLACK_URL } from '@/constants/ExternalLinks'
 import { useTheme } from '@/contexts/ThemeContext'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
-import { RoutePath } from '@/enums/RoutePath'
 import { useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
 import { useConfig } from '@/hooks/useConfig'
 import { useDocsSearchCommands } from '@/hooks/useDocsSearchCommands'
@@ -23,7 +26,6 @@ import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { useSuspensionBanner } from '@/hooks/useSuspensionBanner'
 import { cn } from '@/lib/utils'
 import { BookOpen, BookSearchIcon, SlackIcon, SunMoon } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
 import { PrivacyBanner } from '@/components/PrivacyBanner'
 
 function useDashboardCommands() {
@@ -71,13 +73,12 @@ function useDashboardCommands() {
 const Dashboard: React.FC = () => {
   const { selectedOrganization } = useSelectedOrganization()
   const [showVerifyEmailDialog, setShowVerifyEmailDialog] = useState(false)
+  const setDefaultRegionDialogRef = useRef<SetDefaultRegionDialogRef>(null)
   const config = useConfig()
   useOwnerWalletQuery() // prefetch wallet
 
   useDashboardCommands()
   useDocsSearchCommands()
-
-  const navigate = useNavigate()
 
   useSuspensionBanner(selectedOrganization)
 
@@ -91,19 +92,10 @@ const Dashboard: React.FC = () => {
   }, [selectedOrganization])
 
   useEffect(() => {
-    if (!config.billingApiUrl) {
-      return
+    if (selectedOrganization?.id && !selectedOrganization.defaultRegionId) {
+      setDefaultRegionDialogRef.current?.open()
     }
-
-    if (!selectedOrganization) {
-      return
-    }
-
-    if (!selectedOrganization.defaultRegionId) {
-      navigate(RoutePath.SETTINGS)
-      return
-    }
-  }, [config.billingApiUrl, selectedOrganization]) // Do not depend on navigate to avoid infinite loops
+  }, [selectedOrganization?.id, selectedOrganization?.defaultRegionId])
 
   const [bannerText, bannerLearnMoreUrl] = useMemo(() => {
     if (!config.announcements || Object.entries(config.announcements).length === 0) {
@@ -150,6 +142,7 @@ const Dashboard: React.FC = () => {
         </SidebarInset>
         <Toaster />
         <VerifyEmailDialog open={showVerifyEmailDialog} onOpenChange={setShowVerifyEmailDialog} />
+        <SetDefaultRegionDialog ref={setDefaultRegionDialogRef} />
         <PrivacyBanner />
       </SidebarProvider>
     </div>

--- a/apps/dashboard/src/pages/OrganizationSettings.tsx
+++ b/apps/dashboard/src/pages/OrganizationSettings.tsx
@@ -5,7 +5,10 @@
 
 import { DeleteOrganizationDialog } from '@/components/Organizations/DeleteOrganizationDialog'
 import { LeaveOrganizationDialog } from '@/components/Organizations/LeaveOrganizationDialog'
-import { SetDefaultRegionDialog } from '@/components/Organizations/SetDefaultRegionDialog'
+import {
+  SetDefaultRegionDialog,
+  type SetDefaultRegionDialogRef,
+} from '@/components/Organizations/SetDefaultRegionDialog'
 import { PageContent, PageHeader, PageLayout, PageTitle } from '@/components/PageLayout'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -14,52 +17,28 @@ import { Input } from '@/components/ui/input'
 import { InputGroup, InputGroupButton, InputGroupInput } from '@/components/ui/input-group'
 import { useDeleteOrganizationMutation } from '@/hooks/mutations/useDeleteOrganizationMutation'
 import { useLeaveOrganizationMutation } from '@/hooks/mutations/useLeaveOrganizationMutation'
-import { useSetOrganizationDefaultRegionMutation } from '@/hooks/mutations/useSetOrganizationDefaultRegionMutation'
 import { useOrganizations } from '@/hooks/useOrganizations'
 import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import { OrganizationUserRoleEnum } from '@daytona/api-client'
 import { CheckIcon, CopyIcon } from 'lucide-react'
-import React, { useEffect, useState } from 'react'
+import React, { useRef } from 'react'
 import { toast } from 'sonner'
 import { useCopyToClipboard } from 'usehooks-ts'
 
 const OrganizationSettings: React.FC = () => {
   const { refreshOrganizations } = useOrganizations()
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
-  const { getRegionName, sharedRegions: regions, loadingSharedRegions: loadingRegions } = useRegions()
+  const { getRegionName } = useRegions()
 
   const deleteOrganizationMutation = useDeleteOrganizationMutation()
   const leaveOrganizationMutation = useLeaveOrganizationMutation()
-  const setDefaultRegionMutation = useSetOrganizationDefaultRegionMutation()
-  const [showSetDefaultRegionDialog, setSetDefaultRegionDialog] = useState(false)
+  const setDefaultRegionDialogRef = useRef<SetDefaultRegionDialogRef>(null)
   const [copied, copyToClipboard] = useCopyToClipboard()
-
-  useEffect(() => {
-    if (selectedOrganization && !selectedOrganization.defaultRegionId) {
-      setSetDefaultRegionDialog(true)
-    }
-  }, [selectedOrganization])
 
   if (!selectedOrganization) {
     return null
-  }
-
-  const handleSetDefaultRegion = async (defaultRegionId: string): Promise<boolean> => {
-    try {
-      await setDefaultRegionMutation.mutateAsync({
-        organizationId: selectedOrganization.id,
-        defaultRegionId,
-      })
-      toast.success('Default region set successfully')
-      await refreshOrganizations(selectedOrganization.id)
-      setSetDefaultRegionDialog(false)
-      return true
-    } catch (error) {
-      handleApiError(error, 'Failed to set default region')
-      return false
-    }
   }
 
   const handleDeleteOrganization = async () => {
@@ -149,7 +128,7 @@ const OrganizationSettings: React.FC = () => {
                 />
               ) : isOwner ? (
                 <div className="flex sm:justify-end">
-                  <Button onClick={() => setSetDefaultRegionDialog(true)} variant="secondary">
+                  <Button onClick={() => setDefaultRegionDialogRef.current?.open()} variant="secondary">
                     Set Region
                   </Button>
                 </div>
@@ -188,13 +167,7 @@ const OrganizationSettings: React.FC = () => {
             </CardContent>
           </Card>
         )}
-        <SetDefaultRegionDialog
-          open={showSetDefaultRegionDialog}
-          onOpenChange={setSetDefaultRegionDialog}
-          regions={regions}
-          loadingRegions={loadingRegions}
-          onSetDefaultRegion={handleSetDefaultRegion}
-        />
+        <SetDefaultRegionDialog ref={setDefaultRegionDialogRef} />
       </PageContent>
     </PageLayout>
   )


### PR DESCRIPTION
## Description

Prompt setting default region on any page.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the “Set default region” dialog automatically on any page when an organization has no default region. No redirects; the dialog is ref-driven, self-contained, and shows a saving spinner.

- **Bug Fixes**
  - Auto-open dialog from `Dashboard` when `selectedOrganization.defaultRegionId` is missing.
  - No redirect to Settings; users stay on the current page.
  - Show success/error toasts via `sonner` and refresh organizations after save.

- **Refactors**
  - Convert `SetDefaultRegionDialog` to a ref-driven API (`open()`), internal state, `useId` for form/select IDs, and mutation-based loading with a spinner.
  - Self-fetch data via `useRegions`, `useSelectedOrganization`, and `useSetOrganizationDefaultRegionMutation`; removed external props and local save handlers.
  - Update Organization Settings to open the dialog via a ref-backed button.

<sup>Written for commit 637004e66e51930e293dbbae609abbf2a5883a49. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4598?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

