### PR TITLE
fix(dashboard): api-keys full access label check

### DIFF
--- a/apps/dashboard/src/components/ApiKeyTable.tsx
+++ b/apps/dashboard/src/components/ApiKeyTable.tsx
@@ -275,7 +275,7 @@ const columns: ColumnDef<ApiKeyList>[] = [
     cell: ({ row }) => {
       return (
         <div className="flex min-w-0">
-          <PermissionsTooltip permissions={row.original.permissions} availablePermissions={allPermissions} />
+          <PermissionsTooltip permissions={row.original.permissions} availablePermissions={allKnownPermissions} />
         </div>
       )
     },
@@ -369,7 +369,9 @@ const columns: ColumnDef<ApiKeyList>[] = [
   },
 ]
 
-const allPermissions = Object.values(CreateApiKeyPermissionsEnum)
+const allKnownPermissions = Object.values(CreateApiKeyPermissionsEnum).filter(
+  (permission) => permission !== CreateApiKeyPermissionsEnum.UNKNOWN_DEFAULT_OPEN_API,
+)
 
 const IMPLICIT_READ_RESOURCES = ['Sandboxes', 'Snapshots', 'Registries', 'Regions']
 
@@ -380,10 +382,14 @@ function PermissionsTooltip({
   permissions: ApiKeyListPermissionsEnum[]
   availablePermissions: CreateApiKeyPermissionsEnum[]
 }) {
-  const isFullAccess = allPermissions.length === permissions.length
+  const knownPermissions = permissions.filter(
+    (permission) => permission !== ApiKeyListPermissionsEnum.UNKNOWN_DEFAULT_OPEN_API,
+  )
+  const knownPermissionSet = new Set<string>(knownPermissions)
+  const isFullAccess = allKnownPermissions.length === knownPermissions.length
   const isSingleResourceAccess = CREATE_API_KEY_PERMISSIONS_GROUPS.find(
     (group) =>
-      group.permissions.length === permissions.length && group.permissions.every((p) => permissions.includes(p)),
+      group.permissions.length === knownPermissions.length && group.permissions.every((p) => knownPermissionSet.has(p)),
   )
 
   const availableGroups = useMemo(() => {


### PR DESCRIPTION
## Description

Fixes api key scope labels.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API key scope labels in the dashboard by correctly detecting Full access and single-resource scopes, ignoring unknown OpenAPI enum values. Prevents mislabeling in the permissions tooltip and table.

- **Bug Fixes**
  - Exclude `UNKNOWN_DEFAULT_OPEN_API` when computing Full access and group matches.
  - Use `allKnownPermissions` in `PermissionsTooltip` and a Set for faster, accurate comparisons.

<sup>Written for commit 7b41a000b00f490302d90d1eaeef43e118698b0d. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4599?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

