### PR TITLE
feat(docs): add runtime features and specs

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -46,19 +46,20 @@ The diagram below demonstrates the states and possible transitions between them.
 
 ## Runtime features
 
-| **Runtime features**  | **Linux <br /> (VM)**                             | **Linux (Container)**                               | **Windows <br /> (VM)**                       | **MacOS <br /> (VM)**                    | **Android <br /> (VM)**                       |
-| :-------------------- | :------------------------------------------------ | :-------------------------------------------------- | :-------------------------------------------- | :--------------------------------------- | :-------------------------------------------- |
-| Description           | <small>Full virtual machine running Linux</small> | <small>Lightweight isolated Linux container</small> | <small>Windows OS runtime environment</small> | <small>macOS runtime environment</small> | <small>Android OS runtime environment</small> |
-| GPU                   | ✓                                                 | ✗                                                   | ✓                                             | ✓                                        | ✗                                             |
-| Filesystem operations | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✗                                             |
-| Process and code exec | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✗                                             |
-| Pause sandboxes       | ✓                                                 | ✗                                                   | ✓                                             | ✗                                        | ✗                                             |
-| Fork sandboxes        | ✓                                                 | ✗                                                   | ✓                                             | ✗                                        | ✗                                             |
-| Resize sandboxes      | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✓                                             |
-| Create snapshot       | ✓                                                 | <small>Coming soon</small>                                         | ✓                                             | ✓                                        | ✗                                             |
-| Declarative builder   | ✗                                                 | ✓                                                   | ✗                                             | ✗                                        | ✗                                             |
-| SSH access            | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✗                                             |
-| ADB access            | ✗                                                 | ✗                                                   | ✗                                             | ✗                                        | ✓                                             |
+| **Runtime**           | **Linux <br />Container**               | **Linux <br /> VM**                  | **Windows <br /> VM**             | **MacOS <br /> VM**          | **Android <br /> VM**             |
+| :-------------------- | :--------------------------------------- | :------------------------------------ | :--------------------------------- | :---------------------------- | :--------------------------------- |
+| Description           | <small>Isolated Linux container</small> | <small>Linux virtual machine</small> | <small>Windows OS runtime</small> | <small>macOS runtime</small> | <small>Android OS runtime</small> |
+| GPU                   | ✗                                       | ✓                                    | ✓                                 | ✓                            | ✗                                 |
+| **Features**              |                                         |                                      |                                   |                              |                                   |
+| Filesystem operations | ✓                                       | ✓                                    | ✓                                 | ✓                            | ✗                                 |
+| Process and code exec | ✓                                       | ✓                                    | ✓                                 | ✓                            | ✗                                 |
+| Pause sandboxes       | ✗                                       | ✓                                    | ✓                                 | ✗                            | ✗                                 |
+| Fork sandboxes        | ✗                                       | ✓                                    | ✓                                 | ✗                            | ✗                                 |
+| Resize sandboxes      | ✓                                       | ✓                                    | ✓                                 | ✓                            | ✓                                 |
+| Create snapshots      | <small>*Coming soon*</small>            | ✓                                    | ✓                                 | ✓                            | ✗                                 |
+| Declarative builder   | ✓                                       | ✗                                    | ✗                                 | ✗                            | ✗                                 |
+| SSH access            | ✓                                       | ✓                                    | ✓                                 | ✓                            | ✗                                 |
+| ADB access            | ✗                                       | ✗                                    | ✗                                 | ✗                            | ✓                                 |
 
 ## Multiple runtime support
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -44,6 +44,22 @@ The diagram below demonstrates the states and possible transitions between them.
 
 <SandboxDiagram />
 
+## Runtime features
+
+| **Runtime features**  | **Linux <br /> (VM)**                             | **Linux (Container)**                               | **Windows <br /> (VM)**                       | **MacOS <br /> (VM)**                    | **Android <br /> (VM)**                       |
+| :-------------------- | :------------------------------------------------ | :-------------------------------------------------- | :-------------------------------------------- | :--------------------------------------- | :-------------------------------------------- |
+| Description           | <small>Full virtual machine running Linux</small> | <small>Lightweight isolated Linux container</small> | <small>Windows OS runtime environment</small> | <small>macOS runtime environment</small> | <small>Android OS runtime environment</small> |
+| GPU                   | ✓                                                 | ✗                                                   | ✓                                             | ✓                                        | ✗                                             |
+| Filesystem operations | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✗                                             |
+| Process and code exec | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✗                                             |
+| Pause sandboxes       | ✓                                                 | ✗                                                   | ✓                                             | ✗                                        | ✗                                             |
+| Fork sandboxes        | ✓                                                 | ✗                                                   | ✓                                             | ✗                                        | ✗                                             |
+| Resize sandboxes      | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✓                                             |
+| Create snapshot       | ✓                                                 | <small>Coming soon</small>                                         | ✓                                             | ✓                                        | ✗                                             |
+| Declarative builder   | ✗                                                 | ✓                                                   | ✗                                             | ✗                                        | ✗                                             |
+| SSH access            | ✓                                                 | ✓                                                   | ✓                                             | ✓                                        | ✗                                             |
+| ADB access            | ✗                                                 | ✗                                                   | ✗                                             | ✗                                        | ✓                                             |
+
 ## Multiple runtime support
 
 Daytona sandboxes support Python, TypeScript, and JavaScript programming language runtimes for direct code execution inside the sandbox. The `language` parameter controls which programming language runtime is used for the sandbox:

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -46,11 +46,11 @@ The diagram below demonstrates the states and possible transitions between them.
 
 ## Runtime features
 
-| **Runtime**           | **Linux <br />Container**               | **Linux <br /> VM**                  | **Windows <br /> VM**             | **MacOS <br /> VM**          | **Android <br /> VM**             |
-| :-------------------- | :--------------------------------------- | :------------------------------------ | :--------------------------------- | :---------------------------- | :--------------------------------- |
-| Description           | <small>Isolated Linux container</small> | <small>Linux virtual machine</small> | <small>Windows OS runtime</small> | <small>macOS runtime</small> | <small>Android OS runtime</small> |
+| **Runtime**           | **Linux Container**                     | **Linux VM**                         | **Windows VM**                    | **MacOS VM**                 | **Android VM**                    |
+| :-------------------- | :------------------------------------- | :----------------------------------- | :-------------------------------- | :--------------------------- | :-------------------------------- |
+| Description           | <small>Isolated Linux container</small> | <small>Linux virtual machine</small> | <small>Windows OS runtime</small> | <small>MacOS runtime</small> | <small>Android OS runtime</small> |
 | GPU                   | ✗                                       | ✓                                    | ✓                                 | ✓                            | ✗                                 |
-| **Features**              |                                         |                                      |                                   |                              |                                   |
+| **Features**          |                                         |                                      |                                   |                              |                                   |
 | Filesystem operations | ✓                                       | ✓                                    | ✓                                 | ✓                            | ✗                                 |
 | Process and code exec | ✓                                       | ✓                                    | ✓                                 | ✓                            | ✗                                 |
 | Pause sandboxes       | ✗                                       | ✓                                    | ✓                                 | ✗                            | ✗                                 |


### PR DESCRIPTION

<img width="793" height="775" alt="Screenshot 2026-05-04 at 14 45 37" src="https://github.com/user-attachments/assets/dbcf8a4d-bb6b-44d3-8d3e-0837f689232a" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime features matrix to Sandboxes docs for Linux containers/VMs, Windows, macOS, and Android. Lists GPU, filesystem/exec, pause/fork, resize, snapshots (containers coming soon), declarative builder (containers only), SSH, and ADB, plus minor prose and table formatting fixes.

<sup>Written for commit 0a66ba44abad6cb5a913cafd39c734320d41feed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



