### PR TITLE
fix(api): handle buildSnapshot errors

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -268,14 +268,14 @@ export class SandboxStartAction extends SandboxAction {
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
       const sourceRegistries = await this.dockerRegistryService.getSourceRegistriesForDockerfile(
-        buildInfo.dockerfileContent,
-        organizationId,
+        sandbox.buildInfo.dockerfileContent,
+        sandbox.organizationId,
       )
 
       // Fire build request - resolves immediately
       await runnerAdapter.buildSnapshot(
-        buildInfo,
-        organizationId,
+        sandbox.buildInfo,
+        sandbox.organizationId,
         sourceRegistries.length > 0 ? sourceRegistries : undefined,
       )
 
@@ -330,7 +330,7 @@ export class SandboxStartAction extends SandboxAction {
     }
   }
 
-  // Initiates the snapshot build on the runner and creates an SnapshotRunner depending on the result
+  // Polls the snapshot build status on the runner and creates the SnapshotRunner entry based on the result
   async pollBuildStatus(buildInfo: BuildInfo, runner: Runner) {
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -265,7 +265,21 @@ export class SandboxStartAction extends SandboxAction {
     }
 
     if (isBuild) {
-      this.buildOnRunner(sandbox.buildInfo, runner, sandbox.organizationId)
+      const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+
+      const sourceRegistries = await this.dockerRegistryService.getSourceRegistriesForDockerfile(
+        buildInfo.dockerfileContent,
+        organizationId,
+      )
+
+      // Fire build request - resolves immediately
+      await runnerAdapter.buildSnapshot(
+        buildInfo,
+        organizationId,
+        sourceRegistries.length > 0 ? sourceRegistries : undefined,
+      )
+
+      this.pollBuildStatus(sandbox.buildInfo, runner).catch(this.logger.error)
       await this.updateSandboxState(sandbox, SandboxState.BUILDING_SNAPSHOT, lockCode, runner.id)
     } else {
       const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
@@ -317,20 +331,8 @@ export class SandboxStartAction extends SandboxAction {
   }
 
   // Initiates the snapshot build on the runner and creates an SnapshotRunner depending on the result
-  async buildOnRunner(buildInfo: BuildInfo, runner: Runner, organizationId: string) {
+  async pollBuildStatus(buildInfo: BuildInfo, runner: Runner) {
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
-
-    const sourceRegistries = await this.dockerRegistryService.getSourceRegistriesForDockerfile(
-      buildInfo.dockerfileContent,
-      organizationId,
-    )
-
-    // Fire build request (runner returns 202 immediately)
-    await runnerAdapter.buildSnapshot(
-      buildInfo,
-      organizationId,
-      sourceRegistries.length > 0 ? sourceRegistries : undefined,
-    )
 
     const pollTimeoutMs = 60 * 60 * 1_000 // 1 hour
     const pollIntervalMs = 5 * 1_000 // 5 seconds


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes unhandled errors when starting a snapshot build by awaiting the build trigger and polling build status in the background to avoid unhandled promise rejections.

- **Bug Fixes**
  - Await `runnerAdapter.buildSnapshot(...)` to surface runner errors during start.
  - Introduce `pollBuildStatus` for background polling; run without awaiting and attach `.catch(this.logger.error)`.
  - Resolve and pass Dockerfile source registries before triggering the build.

<sup>Written for commit 5f10692b17b90cb3959de753d637eb68a201d49f. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4603?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

