### PR TITLE
Refactor computer-use startup readiness and FD cleanup

### DIFF
--- a/libs/computer-use/pkg/computeruse/computeruse.go
+++ b/libs/computer-use/pkg/computeruse/computeruse.go
@@ -6,6 +6,7 @@ package computeruse
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,8 +31,8 @@ type Process struct {
 	ErrFile     string
 	AutoRestart bool
 	cmd         *exec.Cmd
-	ctx         context.Context
 	cancel      context.CancelFunc
+	done        chan struct{}
 	mu          sync.Mutex
 	running     bool
 }
@@ -49,12 +50,21 @@ type ComputerUse struct {
 	a11yHealth func() bool
 	waitDBus   func(string, time.Duration) error
 
+	// Test-only hooks. Production leaves these unset so child stdout/stderr use
+	// real *os.File handles from os.OpenFile.
+	openProcessFile     func(string, int, os.FileMode) (io.WriteCloser, error)
+	processRestartDelay time.Duration
+
 	a11yStatusMu        sync.Mutex
 	a11yStatusRunning   bool
 	a11yStatusCheckedAt time.Time
 }
 
 var _ computeruse.IComputerUse = &ComputerUse{}
+
+// Keep the existing restart delay as a named default so tests can use a short
+// per-instance delay without changing production behavior.
+const defaultProcessRestartDelay = 5 * time.Second
 
 func (c *ComputerUse) Initialize() (*computeruse.Empty, error) {
 	c.processes = make(map[string]*Process)
@@ -353,80 +363,132 @@ func (c *ComputerUse) startProcess(process *Process) {
 		process.mu.Unlock()
 		return
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	process.cancel = cancel
+	process.done = done
 	process.running = true
 	process.mu.Unlock()
 
+	defer func() {
+		process.mu.Lock()
+		process.cancel = nil
+		process.done = nil
+		process.cmd = nil
+		process.running = false
+		process.mu.Unlock()
+		close(done)
+	}()
+
 	for {
-		log.Infof("Starting process: %s", process.Name)
-
-		// Create context for the process
-		process.ctx, process.cancel = context.WithCancel(context.Background())
-
-		// Create command
-		process.cmd = exec.CommandContext(process.ctx, process.Command, process.Args...)
-
-		// Set environment variables
-		if len(process.Env) > 0 {
-			process.cmd.Env = os.Environ()
-			for key, value := range process.Env {
-				process.cmd.Env = append(process.cmd.Env, fmt.Sprintf("%s=%s", key, value))
-			}
+		if ctx.Err() != nil {
+			return
 		}
 
-		// Set up logging
-		if process.LogFile != "" {
-			logFile, err := os.OpenFile(process.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-			if err != nil {
-				log.Errorf("Failed to open log file for %s: %v", process.Name, err)
-			} else {
-				process.cmd.Stdout = logFile
-				defer logFile.Close()
-			}
-		}
-
-		if process.ErrFile != "" {
-			errFile, err := os.OpenFile(process.ErrFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-			if err != nil {
-				log.Errorf("Failed to open error file for %s: %v", process.Name, err)
-			} else {
-				process.cmd.Stderr = errFile
-				defer errFile.Close()
-			}
-		}
-
-		// Start the process
-		err := process.cmd.Start()
-		if err != nil {
-			log.Errorf("Failed to start process %s: %v", process.Name, err)
-			if !process.AutoRestart {
-				break
-			}
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
-		log.Infof("Process %s started with PID: %d", process.Name, process.cmd.Process.Pid)
-
-		// Wait for the process to finish
-		err = process.cmd.Wait()
+		err := c.runProcessOnce(ctx, process)
 		if err != nil {
 			log.Errorf("Process %s exited with error: %v", process.Name, err)
 		} else {
 			log.Infof("Process %s exited normally", process.Name)
 		}
 
-		// Check if we should restart
 		if !process.AutoRestart {
-			break
+			return
 		}
 
-		log.Infof("Restarting process %s in 5 seconds...", process.Name)
-		time.Sleep(5 * time.Second)
+		restartDelay := c.getProcessRestartDelay()
+		log.Infof("Restarting process %s in %s...", process.Name, restartDelay)
+		timer := time.NewTimer(restartDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (c *ComputerUse) getProcessRestartDelay() time.Duration {
+	if c.processRestartDelay > 0 {
+		return c.processRestartDelay
+	}
+	return defaultProcessRestartDelay
+}
+
+func (c *ComputerUse) openProcessOutputFile(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	if c.openProcessFile != nil {
+		return c.openProcessFile(name, flag, perm)
+	}
+	return os.OpenFile(name, flag, perm)
+}
+
+func (c *ComputerUse) runProcessOnce(ctx context.Context, process *Process) error {
+	log.Infof("Starting process: %s", process.Name)
+
+	cmd := exec.CommandContext(ctx, process.Command, process.Args...)
+
+	if len(process.Env) > 0 {
+		cmd.Env = os.Environ()
+		for key, value := range process.Env {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
+	if process.LogFile != "" {
+		logFile, err := c.openProcessOutputFile(process.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			log.Errorf("Failed to open log file for %s: %v", process.Name, err)
+		} else {
+			cmd.Stdout = logFile
+			defer closeProcessFile(process.Name, "log", logFile)
+		}
+	}
+
+	if process.ErrFile != "" {
+		errFile, err := c.openProcessOutputFile(process.ErrFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			log.Errorf("Failed to open error file for %s: %v", process.Name, err)
+		} else {
+			cmd.Stderr = errFile
+			defer closeProcessFile(process.Name, "error", errFile)
+		}
 	}
 
 	process.mu.Lock()
-	process.running = false
+	if ctx.Err() != nil {
+		process.mu.Unlock()
+		return ctx.Err()
+	}
+	process.cmd = cmd
 	process.mu.Unlock()
+
+	err := cmd.Start()
+	if err != nil {
+		process.mu.Lock()
+		if process.cmd == cmd {
+			process.cmd = nil
+		}
+		process.mu.Unlock()
+		return fmt.Errorf("failed to start process %s: %w", process.Name, err)
+	}
+
+	log.Infof("Process %s started with PID: %d", process.Name, cmd.Process.Pid)
+
+	err = cmd.Wait()
+	process.mu.Lock()
+	if process.cmd == cmd {
+		process.cmd = nil
+	}
+	process.mu.Unlock()
+	return err
+}
+
+func closeProcessFile(processName, fileKind string, file io.Closer) {
+	if err := file.Close(); err != nil {
+		log.Errorf("Failed to close %s file for %s: %v", fileKind, processName, err)
+	}
 }
 
 func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
@@ -442,7 +504,9 @@ func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
 	// Stop processes in reverse priority order
 	for i := len(processes) - 1; i >= 0; i-- {
 		process := processes[i]
-		c.stopProcess(process)
+		if err := c.stopProcess(process); err != nil {
+			log.Errorf("Failed to stop process %s: %v", process.Name, err)
+		}
 	}
 
 	// Release the cached AT-SPI bus connection so a later Start() dials a
@@ -458,30 +522,30 @@ func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
 	return new(computeruse.Empty), nil
 }
 
-func (c *ComputerUse) stopProcess(process *Process) {
+func (c *ComputerUse) stopProcess(process *Process) error {
 	process.mu.Lock()
-	defer process.mu.Unlock()
 
 	if !process.running {
-		return
+		process.mu.Unlock()
+		return nil
 	}
 
 	log.Infof("Stopping process: %s", process.Name)
-
-	// Cancel the context to stop the process
-	if process.cancel != nil {
-		process.cancel()
+	cancel := process.cancel
+	done := process.done
+	if cancel != nil {
+		cancel()
 	}
+	process.mu.Unlock()
 
-	// Kill the process if it's still running
-	if process.cmd != nil && process.cmd.Process != nil {
-		err := process.cmd.Process.Kill()
-		if err != nil {
-			log.Errorf("Failed to kill process %s: %v", process.Name, err)
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			return fmt.Errorf("timed out waiting for process %s supervisor to stop", process.Name)
 		}
 	}
-
-	process.running = false
+	return nil
 }
 
 func (c *ComputerUse) GetProcessStatus() (map[string]computeruse.ProcessStatus, error) {
@@ -553,13 +617,10 @@ func (c *ComputerUse) RestartProcess(req *computeruse.ProcessRequest) (*computer
 		return nil, fmt.Errorf("process %s not found", req.ProcessName)
 	}
 
-	// Stop the process first
-	c.stopProcess(process)
+	if err := c.stopProcess(process); err != nil {
+		return nil, err
+	}
 
-	// Wait a moment for cleanup
-	time.Sleep(1 * time.Second)
-
-	// Start the process again
 	go c.startProcess(process)
 
 	return new(computeruse.Empty), nil

--- a/libs/computer-use/pkg/computeruse/computeruse.go
+++ b/libs/computer-use/pkg/computeruse/computeruse.go
@@ -21,20 +21,22 @@ import (
 )
 
 type Process struct {
-	Name        string
-	Command     string
-	Args        []string
-	User        string
-	Priority    int
-	Env         map[string]string
-	LogFile     string
-	ErrFile     string
-	AutoRestart bool
-	cmd         *exec.Cmd
-	cancel      context.CancelFunc
-	done        chan struct{}
-	mu          sync.Mutex
-	running     bool
+	Name             string
+	Command          string
+	Args             []string
+	User             string
+	Priority         int
+	Env              map[string]string
+	LogFile          string
+	ErrFile          string
+	AutoRestart      bool
+	readinessProbe   func(context.Context) error
+	readinessTimeout time.Duration
+	cmd              *exec.Cmd
+	cancel           context.CancelFunc
+	done             chan struct{}
+	mu               sync.Mutex
+	running          bool
 }
 
 type ComputerUse struct {
@@ -64,7 +66,12 @@ var _ computeruse.IComputerUse = &ComputerUse{}
 
 // Keep the existing restart delay as a named default so tests can use a short
 // per-instance delay without changing production behavior.
-const defaultProcessRestartDelay = 5 * time.Second
+const (
+	defaultProcessRestartDelay = 5 * time.Second
+	defaultReadinessTimeout    = 10 * time.Second
+	xfce4ReadinessTimeout      = 20 * time.Second
+	readinessPollInterval      = 100 * time.Millisecond
+)
 
 func (c *ComputerUse) Initialize() (*computeruse.Empty, error) {
 	c.processes = make(map[string]*Process)
@@ -111,14 +118,18 @@ func (c *ComputerUse) Start() (*computeruse.Empty, error) {
 	}
 	os.Setenv("DISPLAY", display)
 	log.Infof("Set DISPLAY environment variable to: %s", display)
+	defer c.invalidateA11yStatus()
 
-	// Start all processes in order of priority
-	c.startAllProcesses()
-	c.invalidateA11yStatus()
+	// Start all processes in order of priority, waiting for the required
+	// desktop services to become usable before starting their dependents.
+	if err := c.startAllProcesses(); err != nil {
+		return nil, err
+	}
 
 	// Check process status after starting
 	status, err := c.GetProcessStatus()
 	if err != nil {
+		c.stopProcessesReverse(c.getProcessesByPriority(), "after status check failure")
 		return nil, fmt.Errorf("failed to get process status after start: %v", err)
 	}
 
@@ -134,6 +145,7 @@ func (c *ComputerUse) Start() (*computeruse.Empty, error) {
 	}
 
 	if len(failed) > 0 {
+		c.stopProcessesReverse(c.getProcessesByPriority(), "after required process check failure")
 		return nil, fmt.Errorf("failed to start: %v", failed)
 	}
 
@@ -185,8 +197,10 @@ func (c *ComputerUse) initializeProcesses(homeDir string) {
 		Env: map[string]string{
 			"DISPLAY": display,
 		},
-		LogFile: filepath.Join(c.configDir, "xvfb.log"),
-		ErrFile: filepath.Join(c.configDir, "xvfb.err"),
+		LogFile:          filepath.Join(c.configDir, "xvfb.log"),
+		ErrFile:          filepath.Join(c.configDir, "xvfb.err"),
+		readinessProbe:   xDisplayReadinessProbe(display),
+		readinessTimeout: defaultReadinessTimeout,
 	}
 
 	// Process 2: xfce4 (Desktop Environment)
@@ -203,8 +217,10 @@ func (c *ComputerUse) initializeProcesses(homeDir string) {
 			"USER":                     user,
 			"DBUS_SESSION_BUS_ADDRESS": dbusAddress,
 		},
-		LogFile: filepath.Join(c.configDir, "xfce4.log"),
-		ErrFile: filepath.Join(c.configDir, "xfce4.err"),
+		LogFile:          filepath.Join(c.configDir, "xfce4.log"),
+		ErrFile:          filepath.Join(c.configDir, "xfce4.err"),
+		readinessProbe:   xfce4ReadinessProbe(display),
+		readinessTimeout: xfce4ReadinessTimeout,
 	}
 
 	// Process 2.5: at-spi-bus-launcher (AT-SPI daemon for the accessibility API)
@@ -264,8 +280,10 @@ func (c *ComputerUse) initializeProcesses(homeDir string) {
 		Env: map[string]string{
 			"DISPLAY": display,
 		},
-		LogFile: filepath.Join(c.configDir, "x11vnc.log"),
-		ErrFile: filepath.Join(c.configDir, "x11vnc.err"),
+		LogFile:          filepath.Join(c.configDir, "x11vnc.log"),
+		ErrFile:          filepath.Join(c.configDir, "x11vnc.err"),
+		readinessProbe:   tcpReadinessProbe("127.0.0.1", vncPort),
+		readinessTimeout: defaultReadinessTimeout,
 	}
 	// Determine the best available NoVNC command with fallback options
 	var novncCommand string
@@ -298,8 +316,10 @@ func (c *ComputerUse) initializeProcesses(homeDir string) {
 		Env: map[string]string{
 			"DISPLAY": display,
 		},
-		LogFile: filepath.Join(c.configDir, "novnc.log"),
-		ErrFile: filepath.Join(c.configDir, "novnc.err"),
+		LogFile:          filepath.Join(c.configDir, "novnc.log"),
+		ErrFile:          filepath.Join(c.configDir, "novnc.err"),
+		readinessProbe:   tcpReadinessProbe("127.0.0.1", noVncPort),
+		readinessTimeout: defaultReadinessTimeout,
 	}
 }
 
@@ -325,15 +345,29 @@ func waitForSessionBus(address string, timeout time.Duration) error {
 	}
 }
 
-func (c *ComputerUse) startAllProcesses() {
-	// Sort processes by priority and start them
+func (c *ComputerUse) startAllProcesses() error {
 	processes := c.getProcessesByPriority()
+	started := make([]*Process, 0, len(processes))
 
 	for _, process := range processes {
 		go c.startProcess(process)
-		// Wait a bit between starting processes to ensure proper initialization
-		time.Sleep(2 * time.Second)
+		started = append(started, process)
+
+		if process.readinessProbe == nil {
+			continue
+		}
+
+		err := c.waitForProcessReadiness(process)
+		if err == nil {
+			log.Infof("Process %s is ready", process.Name)
+			continue
+		}
+
+		c.stopProcessesReverse(started, "after startup failure")
+		return err
 	}
+
+	return nil
 }
 
 func (c *ComputerUse) getProcessesByPriority() []*Process {
@@ -428,13 +462,7 @@ func (c *ComputerUse) runProcessOnce(ctx context.Context, process *Process) erro
 	log.Infof("Starting process: %s", process.Name)
 
 	cmd := exec.CommandContext(ctx, process.Command, process.Args...)
-
-	if len(process.Env) > 0 {
-		cmd.Env = os.Environ()
-		for key, value := range process.Env {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
-		}
-	}
+	cmd.Env = mergedEnv(process.Env)
 
 	if process.LogFile != "" {
 		logFile, err := c.openProcessOutputFile(process.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
@@ -494,20 +522,7 @@ func closeProcessFile(processName, fileKind string, file io.Closer) {
 func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
 	log.Info("Stopping all computer use processes...")
 
-	c.mu.RLock()
-	processes := make([]*Process, 0, len(c.processes))
-	for _, p := range c.processes {
-		processes = append(processes, p)
-	}
-	c.mu.RUnlock()
-
-	// Stop processes in reverse priority order
-	for i := len(processes) - 1; i >= 0; i-- {
-		process := processes[i]
-		if err := c.stopProcess(process); err != nil {
-			log.Errorf("Failed to stop process %s: %v", process.Name, err)
-		}
-	}
+	c.stopProcessesReverse(c.getProcessesByPriority(), "during stop")
 
 	// Release the cached AT-SPI bus connection so a later Start() dials a
 	// fresh one — the bus address can change across launcher restarts.
@@ -520,6 +535,15 @@ func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
 	c.setA11yStatus(false)
 
 	return new(computeruse.Empty), nil
+}
+
+func (c *ComputerUse) stopProcessesReverse(processes []*Process, reason string) {
+	for i := len(processes) - 1; i >= 0; i-- {
+		process := processes[i]
+		if err := c.stopProcess(process); err != nil {
+			log.Errorf("Failed to stop process %s %s: %v", process.Name, reason, err)
+		}
+	}
 }
 
 func (c *ComputerUse) stopProcess(process *Process) error {
@@ -622,6 +646,14 @@ func (c *ComputerUse) RestartProcess(req *computeruse.ProcessRequest) (*computer
 	}
 
 	go c.startProcess(process)
+	if process.readinessProbe != nil {
+		if err := c.waitForProcessReadiness(process); err != nil {
+			if stopErr := c.stopProcess(process); stopErr != nil {
+				log.Errorf("Failed to stop process %s after restart readiness failure: %v", process.Name, stopErr)
+			}
+			return nil, err
+		}
+	}
 
 	return new(computeruse.Empty), nil
 }

--- a/libs/computer-use/pkg/computeruse/process_readiness.go
+++ b/libs/computer-use/pkg/computeruse/process_readiness.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package computeruse
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func (c *ComputerUse) waitForProcessReadiness(process *Process) error {
+	timeout := process.readinessTimeout
+	if timeout <= 0 {
+		timeout = defaultReadinessTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := waitForReadiness(ctx, process.readinessProbe); err != nil {
+		return fmt.Errorf("process %s did not become ready within %s: %w", process.Name, timeout, err)
+	}
+	return nil
+}
+
+func waitForReadiness(ctx context.Context, probe func(context.Context) error) error {
+	var lastErr error
+	for {
+		if ctx.Err() != nil {
+			if lastErr != nil {
+				return lastErr
+			}
+			return ctx.Err()
+		}
+
+		if err := probe(ctx); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+		case <-time.After(readinessPollInterval):
+		}
+	}
+}
+
+func xDisplayReadinessProbe(display string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		if socketPath, ok := xDisplaySocketPath(display); ok {
+			var dialer net.Dialer
+			conn, err := dialer.DialContext(ctx, "unix", socketPath)
+			if err != nil {
+				return fmt.Errorf("X display socket %s is not ready: %w", socketPath, err)
+			}
+			return conn.Close()
+		}
+
+		return runReadinessCommand(ctx, map[string]string{"DISPLAY": display}, "xdpyinfo", "-display", display)
+	}
+}
+
+func xDisplaySocketPath(display string) (string, bool) {
+	if !strings.HasPrefix(display, ":") {
+		return "", false
+	}
+
+	number := strings.TrimPrefix(display, ":")
+	if dot := strings.IndexByte(number, '.'); dot >= 0 {
+		number = number[:dot]
+	}
+	if number == "" {
+		return "", false
+	}
+	for _, r := range number {
+		if r < '0' || r > '9' {
+			return "", false
+		}
+	}
+	return filepath.Join("/tmp/.X11-unix", "X"+number), true
+}
+
+func xfce4ReadinessProbe(display string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		output, err := runReadinessCommandOutput(ctx, map[string]string{"DISPLAY": display}, "xprop", "-root", "_NET_SUPPORTING_WM_CHECK")
+		if err != nil {
+			return err
+		}
+
+		return xfce4WindowManagerReady(strings.TrimSpace(string(output)))
+	}
+}
+
+func xfce4WindowManagerReady(xpropOutput string) error {
+	if strings.Contains(xpropOutput, "not found") || !strings.Contains(xpropOutput, "_NET_SUPPORTING_WM_CHECK(WINDOW): window id #") {
+		return fmt.Errorf("xfce4 window manager is not ready: %s", xpropOutput)
+	}
+	return nil
+}
+
+func tcpReadinessProbe(host, port string) func(context.Context) error {
+	address := net.JoinHostPort(host, port)
+	return func(ctx context.Context) error {
+		var dialer net.Dialer
+		conn, err := dialer.DialContext(ctx, "tcp", address)
+		if err != nil {
+			return fmt.Errorf("tcp %s is not ready: %w", address, err)
+		}
+		return conn.Close()
+	}
+}
+
+func runReadinessCommand(ctx context.Context, env map[string]string, command string, args ...string) error {
+	_, err := runReadinessCommandOutput(ctx, env, command, args...)
+	return err
+}
+
+func runReadinessCommandOutput(ctx context.Context, env map[string]string, command string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Env = mergedEnv(env)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		text := strings.TrimSpace(string(output))
+		if text != "" {
+			return output, fmt.Errorf("%s %s failed: %w: %s", command, strings.Join(args, " "), err, text)
+		}
+		return output, fmt.Errorf("%s %s failed: %w", command, strings.Join(args, " "), err)
+	}
+	return output, nil
+}
+
+func mergedEnv(extra map[string]string) []string {
+	if len(extra) == 0 {
+		return nil
+	}
+	env := os.Environ()
+	for key, value := range extra {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+	return env
+}

--- a/libs/computer-use/pkg/computeruse/process_supervisor_test.go
+++ b/libs/computer-use/pkg/computeruse/process_supervisor_test.go
@@ -4,9 +4,13 @@
 package computeruse
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -102,9 +106,234 @@ func TestRestartProcessWaitsForOldSupervisor(t *testing.T) {
 	}
 }
 
+func TestRestartProcessWaitsForReadiness(t *testing.T) {
+	computerUse := &ComputerUse{processes: make(map[string]*Process)}
+	process := blockingHelperProcess("x11vnc", 300)
+	release := make(chan struct{})
+	events := make(chan string, 1)
+	process.readinessProbe = gatedReadinessProbe(process.Name, process, events, release)
+	process.readinessTimeout = 5 * time.Second
+	computerUse.processes[process.Name] = process
+	t.Cleanup(func() { _, _ = computerUse.Stop() })
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := computerUse.RestartProcess(&toolbox.ProcessRequest{ProcessName: process.Name})
+		errCh <- err
+	}()
+
+	expectReadinessEvent(t, events, process.Name)
+	assertNoRestartResult(t, errCh, 100*time.Millisecond)
+	close(release)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("RestartProcess() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RestartProcess() did not return")
+	}
+}
+
+func TestRestartProcessStopsProcessOnReadinessFailure(t *testing.T) {
+	sentinel := errors.New("vnc not ready")
+	computerUse := &ComputerUse{processes: make(map[string]*Process)}
+	process := blockingHelperProcess("x11vnc", 300)
+	failReadiness := make(chan struct{})
+	events := make(chan string, 1)
+	process.readinessProbe = gatedFailingReadinessProbe(process.Name, process, events, failReadiness, sentinel)
+	process.readinessTimeout = 300 * time.Millisecond
+	computerUse.processes[process.Name] = process
+	t.Cleanup(func() { _, _ = computerUse.Stop() })
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := computerUse.RestartProcess(&toolbox.ProcessRequest{ProcessName: process.Name})
+		errCh <- err
+	}()
+
+	expectReadinessEvent(t, events, process.Name)
+	assertNoRestartResult(t, errCh, 20*time.Millisecond)
+	close(failReadiness)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("RestartProcess() error = %v, want %v", err, sentinel)
+		}
+		if err == nil || !strings.Contains(err.Error(), process.Name) {
+			t.Fatalf("error = %v, want process name", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RestartProcess() did not return")
+	}
+	eventuallyProcessStopped(t, process)
+}
+
+func TestStartAllProcessesWaitsForReadinessInPriorityOrder(t *testing.T) {
+	computerUse, releases, events := readinessOrderedComputerUse()
+	t.Cleanup(func() { _, _ = computerUse.Stop() })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- computerUse.startAllProcesses() }()
+
+	expectReadinessEvent(t, events, "xvfb")
+	assertNoReadinessEvent(t, events, 100*time.Millisecond)
+	close(releases["xvfb"])
+
+	expectReadinessEvent(t, events, "xfce4")
+	assertNoReadinessEvent(t, events, 100*time.Millisecond)
+	close(releases["xfce4"])
+
+	expectReadinessEvent(t, events, "x11vnc")
+	assertNoReadinessEvent(t, events, 100*time.Millisecond)
+	close(releases["x11vnc"])
+
+	expectReadinessEvent(t, events, "novnc")
+	close(releases["novnc"])
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("startAllProcesses() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("startAllProcesses() did not return")
+	}
+}
+
+func TestStartAllProcessesStopsStartedProcessesOnReadinessFailure(t *testing.T) {
+	sentinel := errors.New("desktop not ready")
+	computerUse, releases, events := readinessOrderedComputerUse()
+	failReadiness := make(chan struct{})
+	computerUse.processes["xfce4"].readinessProbe = gatedFailingReadinessProbe("xfce4", computerUse.processes["xfce4"], events, failReadiness, sentinel)
+	computerUse.processes["xfce4"].readinessTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { _, _ = computerUse.Stop() })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- computerUse.startAllProcesses() }()
+
+	expectReadinessEvent(t, events, "xvfb")
+	close(releases["xvfb"])
+	expectReadinessEvent(t, events, "xfce4")
+	assertNoReadinessEvent(t, events, 20*time.Millisecond)
+	close(failReadiness)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("startAllProcesses() error = %v, want %v", err, sentinel)
+		}
+		if err == nil || !strings.Contains(err.Error(), "xfce4") {
+			t.Fatalf("error = %v, want process name", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("startAllProcesses() did not return")
+	}
+
+	if processMarkedRunning(computerUse.processes["x11vnc"]) {
+		t.Fatal("x11vnc should not start after xfce4 failure")
+	}
+	if processMarkedRunning(computerUse.processes["novnc"]) {
+		t.Fatal("novnc should not start after xfce4 failure")
+	}
+	eventuallyProcessStopped(t, computerUse.processes["xvfb"])
+	eventuallyProcessStopped(t, computerUse.processes["xfce4"])
+}
+
+func TestStartAllProcessesDoesNotUseFixedStartupSleepWhenReadinessSucceeds(t *testing.T) {
+	computerUse, _ := immediateReadinessComputerUseWithCalls()
+	t.Cleanup(func() { _, _ = computerUse.Stop() })
+
+	startedAt := time.Now()
+	if err := computerUse.startAllProcesses(); err != nil {
+		t.Fatalf("startAllProcesses() error = %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 1500*time.Millisecond {
+		t.Fatalf("startAllProcesses() took %s, fixed startup sleeps likely remain", elapsed)
+	}
+}
+
+func TestWaitForReadinessReportsLastError(t *testing.T) {
+	sentinel := errors.New("still not ready")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := waitForReadiness(ctx, func(ctx context.Context) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("waitForReadiness() error = %v, want %v", err, sentinel)
+	}
+}
+
+func TestXDisplaySocketPath(t *testing.T) {
+	tests := []struct {
+		display string
+		path    string
+		ok      bool
+	}{
+		{display: ":0", path: "/tmp/.X11-unix/X0", ok: true},
+		{display: ":12.0", path: "/tmp/.X11-unix/X12", ok: true},
+		{display: "localhost:10.0", ok: false},
+		{display: ":bad", ok: false},
+	}
+
+	for _, tt := range tests {
+		path, ok := xDisplaySocketPath(tt.display)
+		if ok != tt.ok || path != tt.path {
+			t.Fatalf("xDisplaySocketPath(%q) = %q, %v; want %q, %v", tt.display, path, ok, tt.path, tt.ok)
+		}
+	}
+}
+
+func TestXfce4WindowManagerReady(t *testing.T) {
+	if err := xfce4WindowManagerReady("_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x200003"); err != nil {
+		t.Fatalf("xfce4WindowManagerReady() error = %v", err)
+	}
+	if err := xfce4WindowManagerReady("_NET_SUPPORTING_WM_CHECK:  not found."); err == nil {
+		t.Fatal("xfce4WindowManagerReady() should reject missing window manager property")
+	}
+}
+
+func TestTCPReadinessProbe(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			_ = conn.Close()
+		}
+		close(accepted)
+	}()
+
+	tcpAddr := listener.Addr().(*net.TCPAddr)
+	if err := tcpReadinessProbe("127.0.0.1", fmt.Sprint(tcpAddr.Port))(context.Background()); err != nil {
+		t.Fatalf("tcpReadinessProbe() error = %v", err)
+	}
+
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("listener did not accept readiness connection")
+	}
+}
+
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_COMPUTER_USE_HELPER_PROCESS") != "1" {
 		return
+	}
+	if os.Getenv("GO_COMPUTER_USE_HELPER_MODE") == "block" {
+		select {}
 	}
 	fmt.Fprintln(os.Stdout, "stdout")
 	fmt.Fprintln(os.Stderr, "stderr")
@@ -140,6 +369,163 @@ func helperProcess() *Process {
 		},
 		LogFile: "helper.log",
 		ErrFile: "helper.err",
+	}
+}
+
+type desktopProcessSpec struct {
+	name     string
+	priority int
+}
+
+var desktopProcessSpecs = []desktopProcessSpec{
+	{name: "xvfb", priority: 100},
+	{name: "xfce4", priority: 200},
+	{name: "x11vnc", priority: 300},
+	{name: "novnc", priority: 400},
+}
+
+func readinessOrderedComputerUse() (*ComputerUse, map[string]chan struct{}, chan string) {
+	computerUse := &ComputerUse{processes: make(map[string]*Process)}
+	releases := make(map[string]chan struct{})
+	events := make(chan string, 4)
+	for _, spec := range desktopProcessSpecs {
+		process := blockingHelperProcess(spec.name, spec.priority)
+		release := make(chan struct{})
+		process.readinessProbe = gatedReadinessProbe(spec.name, process, events, release)
+		process.readinessTimeout = 5 * time.Second
+		computerUse.processes[spec.name] = process
+		releases[spec.name] = release
+	}
+	return computerUse, releases, events
+}
+
+func immediateReadinessComputerUseWithCalls() (*ComputerUse, map[string]*atomic.Bool) {
+	calls := make(map[string]*atomic.Bool)
+	computerUse := &ComputerUse{processes: make(map[string]*Process)}
+	for _, spec := range desktopProcessSpecs {
+		process := blockingHelperProcess(spec.name, spec.priority)
+		called := &atomic.Bool{}
+		process.readinessProbe = trackedImmediateReadinessProbe(process, called)
+		process.readinessTimeout = time.Second
+		calls[spec.name] = called
+		computerUse.processes[spec.name] = process
+	}
+	return computerUse, calls
+}
+
+func blockingHelperProcess(name string, priority int) *Process {
+	return &Process{
+		Name:        name,
+		Command:     os.Args[0],
+		Args:        []string{"-test.run=TestHelperProcess"},
+		Priority:    priority,
+		AutoRestart: false,
+		Env: map[string]string{
+			"GO_WANT_COMPUTER_USE_HELPER_PROCESS": "1",
+			"GO_COMPUTER_USE_HELPER_MODE":         "block",
+		},
+	}
+}
+
+func gatedReadinessProbe(name string, process *Process, events chan<- string, release <-chan struct{}) func(context.Context) error {
+	var sent atomic.Bool
+	return func(ctx context.Context) error {
+		if !processMarkedRunning(process) {
+			return fmt.Errorf("process %s is not running", name)
+		}
+		if sent.CompareAndSwap(false, true) {
+			select {
+			case events <- name:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func gatedFailingReadinessProbe(name string, process *Process, events chan<- string, fail <-chan struct{}, err error) func(context.Context) error {
+	var sent atomic.Bool
+	return func(ctx context.Context) error {
+		if !processMarkedRunning(process) {
+			return fmt.Errorf("process %s is not running", name)
+		}
+		if sent.CompareAndSwap(false, true) {
+			select {
+			case events <- name:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		select {
+		case <-fail:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func trackedImmediateReadinessProbe(process *Process, called *atomic.Bool) func(context.Context) error {
+	return func(context.Context) error {
+		if !processMarkedRunning(process) {
+			return fmt.Errorf("process %s is not running", process.Name)
+		}
+		called.Store(true)
+		return nil
+	}
+}
+
+func processMarkedRunning(process *Process) bool {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	return process.running
+}
+
+func eventuallyProcessStopped(t *testing.T, process *Process) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processMarkedRunning(process) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("process %s is still running", process.Name)
+}
+
+func expectReadinessEvent(t *testing.T, events <-chan string, want string) {
+	t.Helper()
+	select {
+	case got := <-events:
+		if got != want {
+			t.Fatalf("readiness event = %s, want %s", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for readiness event %s", want)
+	}
+}
+
+func assertNoReadinessEvent(t *testing.T, events <-chan string, wait time.Duration) {
+	t.Helper()
+	select {
+	case got := <-events:
+		t.Fatalf("unexpected readiness event %s", got)
+	case <-time.After(wait):
+	}
+}
+
+func assertNoRestartResult(t *testing.T, results <-chan error, wait time.Duration) {
+	t.Helper()
+	select {
+	case err := <-results:
+		t.Fatalf("RestartProcess() returned before readiness completed: %v", err)
+	case <-time.After(wait):
 	}
 }
 

--- a/libs/computer-use/pkg/computeruse/process_supervisor_test.go
+++ b/libs/computer-use/pkg/computeruse/process_supervisor_test.go
@@ -1,0 +1,156 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package computeruse
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	toolbox "github.com/daytonaio/daemon/pkg/toolbox/computeruse"
+)
+
+type processFileCounts struct {
+	opens    atomic.Int32
+	closes   atomic.Int32
+	logOpens atomic.Int32
+	errOpens atomic.Int32
+}
+
+type countingWriteCloser struct {
+	closes *atomic.Int32
+}
+
+func (c countingWriteCloser) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c countingWriteCloser) Close() error {
+	c.closes.Add(1)
+	return nil
+}
+
+func TestStartProcessClosesLogFilesEachRestart(t *testing.T) {
+	computerUse, process, counts := supervisedHelperProcess(10 * time.Millisecond)
+
+	go computerUse.startProcess(process)
+	t.Cleanup(func() { _ = computerUse.stopProcess(process) })
+
+	waitForAtomicAtLeast(t, &counts.closes, 4, 5*time.Second)
+	if err := computerUse.stopProcess(process); err != nil {
+		t.Fatalf("stopProcess() error = %v", err)
+	}
+
+	if counts.opens.Load() != counts.closes.Load() {
+		t.Fatalf("opened process files = %d, closed = %d", counts.opens.Load(), counts.closes.Load())
+	}
+	if counts.logOpens.Load() == 0 {
+		t.Fatal("helper log file was not opened")
+	}
+	if counts.errOpens.Load() == 0 {
+		t.Fatal("helper error file was not opened")
+	}
+}
+
+func TestStopProcessPreventsAutoRestart(t *testing.T) {
+	computerUse, process, counts := supervisedHelperProcess(25 * time.Millisecond)
+
+	go computerUse.startProcess(process)
+	t.Cleanup(func() { _ = computerUse.stopProcess(process) })
+
+	waitForAtomicAtLeast(t, &counts.closes, 2, 5*time.Second)
+	if err := computerUse.stopProcess(process); err != nil {
+		t.Fatalf("stopProcess() error = %v", err)
+	}
+
+	closedAfterStop := counts.closes.Load()
+	openedAfterStop := counts.opens.Load()
+	time.Sleep(3 * computerUse.getProcessRestartDelay())
+
+	if counts.closes.Load() != closedAfterStop {
+		t.Fatalf("process files closed after stop = %d, want %d", counts.closes.Load(), closedAfterStop)
+	}
+	if counts.opens.Load() != openedAfterStop {
+		t.Fatalf("process files opened after stop = %d, want %d", counts.opens.Load(), openedAfterStop)
+	}
+}
+
+func TestRestartProcessWaitsForOldSupervisor(t *testing.T) {
+	computerUse, process, counts := supervisedHelperProcess(time.Hour)
+	computerUse.processes = map[string]*Process{process.Name: process}
+
+	go computerUse.startProcess(process)
+	t.Cleanup(func() { _ = computerUse.stopProcess(process) })
+	waitForAtomicAtLeast(t, &counts.closes, 2, 5*time.Second)
+
+	_, err := computerUse.RestartProcess(&toolbox.ProcessRequest{ProcessName: process.Name})
+	if err != nil {
+		t.Fatalf("RestartProcess() error = %v", err)
+	}
+
+	waitForAtomicAtLeast(t, &counts.closes, 4, 5*time.Second)
+
+	process.mu.Lock()
+	running := process.running
+	process.mu.Unlock()
+	if !running {
+		t.Fatal("process supervisor should be running after restart")
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_COMPUTER_USE_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stdout, "stdout")
+	fmt.Fprintln(os.Stderr, "stderr")
+	os.Exit(0)
+}
+
+func supervisedHelperProcess(restartDelay time.Duration) (*ComputerUse, *Process, *processFileCounts) {
+	counts := &processFileCounts{}
+	computerUse := &ComputerUse{
+		openProcessFile: func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+			counts.opens.Add(1)
+			switch name {
+			case "helper.log":
+				counts.logOpens.Add(1)
+			case "helper.err":
+				counts.errOpens.Add(1)
+			}
+			return countingWriteCloser{closes: &counts.closes}, nil
+		},
+		processRestartDelay: restartDelay,
+	}
+	return computerUse, helperProcess(), counts
+}
+
+func helperProcess() *Process {
+	return &Process{
+		Name:        "helper",
+		Command:     os.Args[0],
+		Args:        []string{"-test.run=TestHelperProcess"},
+		AutoRestart: true,
+		Env: map[string]string{
+			"GO_WANT_COMPUTER_USE_HELPER_PROCESS": "1",
+		},
+		LogFile: "helper.log",
+		ErrFile: "helper.err",
+	}
+}
+
+func waitForAtomicAtLeast(t *testing.T, value *atomic.Int32, want int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if value.Load() >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("value = %d, want at least %d", value.Load(), want)
+}


### PR DESCRIPTION
## Description

Refactors computer-use process startup so desktop services start in priority order and readiness is confirmed before the next required process starts. Adds readiness probes for Xvfb, XFCE, X11VNC, and noVNC, keeps AT-SPI non-blocking, and closes process log/error files per restart iteration to prevent FD leaks.

This also tightens the noVNC lifecycle invariant: noVNC is served by the directly supervised `websockify` process instead of a wrapper script, so process status, restart behavior, and the listener on `NO_VNC_PORT` all refer to the same child process. The sandbox/devcontainer dependency list and computer-use docs now include `websockify` explicitly.

This PR is stacked on #4485 / `feat/a11y-api`.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #4457

## Screenshots

Not applicable.

## Notes

Validation:

- Added unit coverage for readiness ordering, required readiness failures, optional readiness behavior, restart-loop file closure, concurrent status/stop during readiness, XFCE stale WM detection, and direct noVNC `websockify` supervision
- `go test ./libs/computer-use/pkg/computeruse/... ./apps/daemon/pkg/toolbox/computeruse/...`
- `go test -race ./libs/computer-use/pkg/computeruse`
- `go vet ./libs/computer-use/pkg/computeruse/... ./apps/daemon/pkg/toolbox/computeruse/...`
- `go test ./libs/computer-use/...`
- Validated locally in Docker with the daemon and plugin loaded together
- Validated end to end in Daytona experimental with a branch-built image snapshot: `/computeruse/start`, `/computeruse/status`, `/computeruse/process-status`, per-process status, logs, errors, restart, display info, and screenshot all succeeded
- Ran a real Codex CLI agent against a real Daytona sandbox using `gpt-5.5` with reasoning low; the agent started the desktop, typed and saved a note in Mousepad through the GUI, restarted `x11vnc`, and verified status stayed `active` with all required processes running