### PR TITLE
feat(docs): add netbird vpn connection setup

### DIFF
--- a/apps/docs/src/content/docs/en/vpn-connections.mdx
+++ b/apps/docs/src/content/docs/en/vpn-connections.mdx
@@ -5,7 +5,7 @@ description: Connect your sandboxes to private networks.
 
 import { TabItem, Tabs } from '@astrojs/starlight/components'
 
-VPN connections are a way to connect your Daytona Sandboxes to private networks. By establishing a VPN connection, your sandbox can access network resources using private IP addresses and can be accessed by other devices on the same VPN network.
+VPN connections are a way to connect your Daytona sandboxes to private networks. By establishing a VPN connection, your sandbox can access network resources using private IP addresses and can be accessed by other devices on the same VPN network.
 
 This integration enables communication between your development environment and existing infrastructure, allowing you to test applications against services within the private network, access shared development resources, and collaborate with team members.
 
@@ -13,26 +13,27 @@ Daytona supports the following VPN network providers:
 
 - [Tailscale](#tailscale)
 - [OpenVPN](#openvpn)
+- [Netbird](#netbird)
 
 :::note
-For connecting to a VPN network, you need to [create or access your Daytona Sandbox](/docs/en/sandboxes), **have access to your VPN network provider credentials**, and be on [**Tier 3** or higher](/docs/en/limits#resources).
+For connecting to a VPN network, you need to [create or access your Daytona sandbox](/docs/en/sandboxes), **have access to your VPN network provider credentials**, and be on [**Tier 3** or higher](/docs/en/limits#resources).
 :::
 
 ## Tailscale
 
-Daytona provides multiple ways to connect to a Daytona Sandbox with a Tailscale network:
+Daytona provides multiple ways to connect to a Daytona sandbox with a Tailscale network:
 
 - [Connect with browser login](#connect-with-browser-login)
 - [Connect with auth key](#connect-with-auth-key)
 - [Connect with web terminal](#connect-with-web-terminal)
 
-When you connect a Daytona Sandbox to a Tailscale network, the sandbox becomes part of your private Tailscale network, allowing you to access resources that are available within the network and enabling other devices on the network to access the sandbox.
+When you connect a Daytona sandbox to a Tailscale network, the sandbox becomes part of your private Tailscale network, allowing you to access resources that are available within the network and enabling other devices on the network to access the sandbox.
 
 This integration makes your sandbox appear as a device within your Tailscale network, with its own Tailscale IP address and access to other devices and services on the network.
 
 ### Connect with browser login
 
-The browser login method initiates an interactive authentication flow where Tailscale generates a unique login URL that you visit in your web browser to authenticate the Dayona Sandbox.
+The browser login method initiates an interactive authentication flow where Tailscale generates a unique login URL that you visit in your web browser to authenticate the Dayona sandbox.
 
 The process involves installing Tailscale, starting the daemon, initiating the login process, and then polling for the authentication status until the connection is established.
 
@@ -319,7 +320,7 @@ Once the connection is established and authentication is complete, the sandbox w
 
 ### Connect with auth key
 
-Using an auth key provides a non-interactive way to connect your Daytona Sandbox to Tailscale, making it suitable for automated scripts, CI/CD pipelines, or any scenario where manual browser interaction is not available.
+Using an auth key provides a non-interactive way to connect your Daytona sandbox to Tailscale, making it suitable for automated scripts, CI/CD pipelines, or any scenario where manual browser interaction is not available.
 
 1. Access your [Tailscale admin console ↗](https://login.tailscale.com/admin/machines)
 2. Click **Add device** and select **Linux server**
@@ -331,7 +332,7 @@ This will generate a script that you can use to install Tailscale and connect to
 curl -fsSL https://tailscale.com/install.sh | sh && sudo tailscale up --auth-key=tskey-auth-<AUTH_KEY>
 ```
 
-Copy the auth key from the generated script and use it to connect your Daytona Sandbox to Tailscale:
+Copy the auth key from the generated script and use it to connect your Daytona sandbox to Tailscale:
 
 <Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">
@@ -547,15 +548,15 @@ You've now successfully connected your Daytona sandbox to your Tailscale network
 
 ## OpenVPN
 
-Daytona provides multiple ways to connect to a Daytona Sandbox with an OpenVPN network:
+Daytona provides multiple ways to connect to a Daytona sandbox with an OpenVPN network:
 
 - [Connect with client configuration](#connect-with-client-configuration)
 - [Connect with web terminal](#connect-with-web-terminal)
 
-OpenVPN uses a client-server model where your Daytona Sandbox acts as a client connecting to an OpenVPN server. This approach is suitable for connecting to existing corporate VPNs, accessing resources behind firewalls, or integrating with infrastructure that already uses OpenVPN.
+OpenVPN uses a client-server model where your Daytona sandbox acts as a client connecting to an OpenVPN server. This approach is suitable for connecting to existing corporate VPNs, accessing resources behind firewalls, or integrating with infrastructure that already uses OpenVPN.
 
 :::note
-Connecting a Daytona Sandbox to OpenVPN network requires a [client configuration file](#client-configuration-file).
+Connecting a Daytona sandbox to OpenVPN network requires a [client configuration file](#client-configuration-file).
 :::
 
 ### Client configuration file
@@ -858,3 +859,443 @@ curl ifconfig.me
 This will return the IP address of the sandbox connected to the OpenVPN network.
 
 You've now successfully connected your Daytona sandbox to your OpenVPN network.
+
+## Netbird
+
+Daytona provides multiple ways to connect to a Daytona sandbox with a Netbird network:
+
+- [Connect with setup key](#connect-with-setup-key)
+- [Connect with browser login](#connect-with-browser-login)
+
+When you connect a Daytona sandbox to a Netbird network, the sandbox becomes part of your private Netbird network, allowing you to access resources that are available within the network and enabling other devices on the network to access the sandbox.
+
+This integration makes your sandbox appear as a device within your Netbird network, with its own Netbird IP address and access to other devices and services on the network.
+
+### Connect with setup key
+
+Using a Netbird setup key provides a non-interactive way to connect your Daytona sandbox to Netbird, making it suitable for automated scripts, CI/CD pipelines, or any scenario where manual browser interaction is not available.
+
+For more information about Netbird setup keys, see the [Netbird documentation ↗](https://docs.netbird.io/manage/peers/access-infrastructure/setup-keys-add-servers-to-network).
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import Daytona, DaytonaConfig
+
+# Configuration
+DAYTONA_API_KEY = "YOUR_API_KEY" # Replace with your API key
+NETBIRD_SETUP_KEY = "YOUR_SETUP_KEY" # Replace with your setup key
+
+# Initialize the Daytona client
+config = DaytonaConfig(api_key=DAYTONA_API_KEY)
+daytona = Daytona(config)
+
+
+def setup_netbird_vpn_with_setup_key():
+    """
+    Connect a Daytona sandbox to a NetBird network using the Python SDK.
+    Uses a NetBird Setup Key for non-interactive authentication.
+    See: https://docs.netbird.io/manage/peers/access-infrastructure/setup-keys-add-servers-to-network
+    """
+    if NETBIRD_SETUP_KEY == "YOUR_SETUP_KEY":
+        print("Error: please set NETBIRD_SETUP_KEY to a valid setup key.")
+        return None
+
+    # Create the sandbox
+    print("Creating sandbox...")
+    sandbox = daytona.create()
+    print(f"Sandbox created: {sandbox.id}")
+
+    # Install NetBird (manual repo setup since the bundled installer can fail
+    # on the broken Yarn repo present in the base image).
+    print("\nInstalling NetBird (this may take a few minutes)...")
+    install_cmd = (
+        "sudo rm -f /etc/apt/sources.list.d/yarn.list && "
+        "sudo apt-get update && "
+        "sudo apt-get install -y ca-certificates curl gnupg && "
+        "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg && "
+        "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list && "
+        "sudo apt-get update && "
+        "sudo apt-get install -y netbird"
+    )
+    response = sandbox.process.exec(install_cmd, timeout=300)
+    if response.exit_code != 0:
+        print(f"Error installing NetBird: {response.result}")
+        return sandbox
+    print("NetBird installed successfully.")
+
+    # Connect to the NetBird network using the setup key.
+    # The setup key authenticates this peer without any interactive browser flow.
+    print("\nConnecting to NetBird network with setup key...")
+    up_cmd = f"sudo netbird up --setup-key {NETBIRD_SETUP_KEY}"
+    response = sandbox.process.exec(up_cmd, timeout=120)
+    if response.exit_code != 0:
+        print(f"Error running 'netbird up': {response.result}")
+        return sandbox
+    print(response.result)
+
+    # Final status check
+    print("\nFinal NetBird status:")
+    response = sandbox.process.exec("netbird status", timeout=30)
+    print(response.result)
+
+    return sandbox
+
+
+if __name__ == "__main__":
+    sandbox = setup_netbird_vpn_with_setup_key()
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona } from '@daytonaio/sdk';
+
+// Configuration
+const DAYTONA_API_KEY = "YOUR_API_KEY"; // Replace with your API key
+const NETBIRD_SETUP_KEY = "YOUR_SETUP_KEY"; // Replace with your setup key
+
+// Initialize the Daytona client
+const daytona = new Daytona({
+  apiKey: DAYTONA_API_KEY,
+});
+
+async function setupNetbirdVpnWithSetupKey(): Promise<void> {
+  /**
+   * Connect a Daytona sandbox to a NetBird network using the TypeScript SDK.
+   * Uses a NetBird Setup Key for non-interactive authentication.
+   * See: https://docs.netbird.io/manage/peers/access-infrastructure/setup-keys-add-servers-to-network
+   */
+
+  if (NETBIRD_SETUP_KEY === "YOUR_SETUP_KEY") {
+    console.log("Error: please set NETBIRD_SETUP_KEY to a valid setup key.");
+    return;
+  }
+
+  // Create the sandbox
+  console.log("Creating sandbox...");
+  const sandbox = await daytona.create();
+  console.log(`Sandbox created: ${sandbox.id}`);
+
+  // Install NetBird (manual repo setup since the bundled installer can fail
+  // on the broken Yarn repo present in the base image).
+  console.log("\nInstalling NetBird (this may take a few minutes)...");
+  const installCmd = [
+    "sudo rm -f /etc/apt/sources.list.d/yarn.list",
+    "sudo apt-get update",
+    "sudo apt-get install -y ca-certificates curl gnupg",
+    "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg",
+    "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list",
+    "sudo apt-get update",
+    "sudo apt-get install -y netbird",
+  ].join(" && ");
+  let response = await sandbox.process.executeCommand(
+    installCmd,
+    undefined,  // cwd
+    undefined,  // env
+    300         // timeout
+  );
+  if (response.exitCode !== 0) {
+    console.log(`Error installing NetBird: ${response.result}`);
+    return;
+  }
+  console.log("NetBird installed successfully.");
+
+  // Connect to the NetBird network using the setup key.
+  // The setup key authenticates this peer without any interactive browser flow.
+  console.log("\nConnecting to NetBird network with setup key...");
+  const upCmd = `sudo netbird up --setup-key ${NETBIRD_SETUP_KEY}`;
+  response = await sandbox.process.executeCommand(
+    upCmd,
+    undefined,  // cwd
+    undefined,  // env
+    120         // timeout
+  );
+  if (response.exitCode !== 0) {
+    console.log(`Error running 'netbird up': ${response.result}`);
+    return;
+  }
+  console.log(response.result);
+
+  // Final status check
+  console.log("\nFinal NetBird status:");
+  response = await sandbox.process.executeCommand(
+    "netbird status",
+    undefined,  // cwd
+    undefined,  // env
+    30          // timeout
+  );
+  console.log(response.result);
+}
+
+// Run the main function
+setupNetbirdVpnWithSetupKey().catch(console.error);
+```
+
+</TabItem>
+</Tabs>
+
+### Connect with browser login
+
+The browser login method initiates an interactive authentication flow where Netbird generates a unique login URL that you visit in your web browser to authenticate the Daytona sandbox.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import Daytona, DaytonaConfig
+import time
+import re
+
+# Configuration
+DAYTONA_API_KEY = "YOUR_API_KEY" # Replace with your API key
+
+# Initialize the Daytona client
+config = DaytonaConfig(api_key=DAYTONA_API_KEY)
+daytona = Daytona(config)
+
+
+def setup_netbird_vpn_interactive():
+    """
+    Connect a Daytona sandbox to a NetBird network using the Python SDK.
+    Uses interactive login via browser URL.
+    """
+    # Create the sandbox
+    print("Creating sandbox...")
+    sandbox = daytona.create()
+    print(f"Sandbox created: {sandbox.id}")
+
+    # Step 1: Remove problematic Yarn repo that breaks apt update, then install NetBird manually
+    print("\nInstalling NetBird (this may take a few minutes)...")
+    install_cmd = (
+        "sudo rm -f /etc/apt/sources.list.d/yarn.list && "
+        "sudo apt-get update && "
+        "sudo apt-get install -y ca-certificates curl gnupg && "
+        "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg && "
+        "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list && "
+        "sudo apt-get update && "
+        "sudo apt-get install -y netbird"
+    )
+    response = sandbox.process.exec(install_cmd, timeout=300)
+    if response.exit_code != 0:
+        print(f"Error installing NetBird: {response.result}")
+        return sandbox
+    print("NetBird installed successfully.")
+
+    # Step 3: Run netbird up in background and capture output to a file
+    print("\nInitiating NetBird login...")
+    sandbox.process.exec(
+        "netbird up > /tmp/netbird-login.txt 2>&1 &",
+        timeout=10
+    )
+
+    # Wait for the login URL to be written to the file
+    time.sleep(5)
+
+    # Read the login URL from the output file
+    response = sandbox.process.exec("cat /tmp/netbird-login.txt", timeout=10)
+    output = response.result
+    url_match = re.search(r'https?://[^\s]+', output)
+
+    if url_match:
+        login_url = url_match.group(0)
+        print(f"\n{'='*60}")
+        print("To authenticate, visit this URL in your browser:")
+        print(f"\n  {login_url}")
+        print(f"\n{'='*60}")
+        print("\nWaiting for authentication...")
+
+        # Poll for connection status
+        max_wait = 300  # 5 minutes max wait
+        poll_interval = 5
+        waited = 0
+
+        while waited < max_wait:
+            time.sleep(poll_interval)
+            waited += poll_interval
+
+            status_response = sandbox.process.exec("netbird status 2>&1", timeout=30)
+            status_output = status_response.result
+
+            # Check if we're connected
+            if status_response.exit_code == 0 and "connected" in status_output.lower():
+                print(f"\nConnected to NetBird network!")
+                print(f"NetBird status:\n{status_output}")
+                break
+
+            print(f"  Still waiting... ({waited}s)")
+        else:
+            print("\nTimeout waiting for authentication. Please try again.")
+            return sandbox
+    else:
+        # Maybe already connected or different output
+        print(f"Output from netbird up:\n{output}")
+
+        # Check if already connected
+        status_response = sandbox.process.exec("netbird status", timeout=30)
+        if status_response.exit_code == 0:
+            print("\nNetBird status:")
+            print(status_response.result)
+
+    # Final status check
+    print("\nFinal NetBird status:")
+    response = sandbox.process.exec("netbird status", timeout=30)
+    print(response.result)
+
+    return sandbox
+
+
+if __name__ == "__main__":
+    sandbox = setup_netbird_vpn_interactive()
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona } from '@daytonaio/sdk';
+
+// Configuration
+const DAYTONA_API_KEY = "YOUR_API_KEY"; // Replace with your API key
+
+// Initialize the Daytona client
+const daytona = new Daytona({
+  apiKey: DAYTONA_API_KEY,
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function setupNetbirdVpnInteractive(): Promise<void> {
+  /**
+   * Connect a Daytona sandbox to a NetBird network using the TypeScript SDK.
+   * Uses interactive login via browser URL.
+   */
+
+  // Create the sandbox
+  console.log("Creating sandbox...");
+  const sandbox = await daytona.create();
+  console.log(`Sandbox created: ${sandbox.id}`);
+
+  // Step 1: Remove problematic Yarn repo that breaks apt update, then install NetBird manually
+  console.log("\nInstalling NetBird (this may take a few minutes)...");
+  const installCmd = [
+    "sudo rm -f /etc/apt/sources.list.d/yarn.list",
+    "sudo apt-get update",
+    "sudo apt-get install -y ca-certificates curl gnupg",
+    "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg",
+    "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list",
+    "sudo apt-get update",
+    "sudo apt-get install -y netbird",
+  ].join(" && ");
+  let response = await sandbox.process.executeCommand(
+    installCmd,
+    undefined,  // cwd
+    undefined,  // env
+    300         // timeout
+  );
+  if (response.exitCode !== 0) {
+    console.log(`Error installing NetBird: ${response.result}`);
+    return;
+  }
+  console.log("NetBird installed successfully.");
+
+  // Step 3: Run netbird up in background and capture output to a file
+  console.log("\nInitiating NetBird login...");
+  await sandbox.process.executeCommand(
+    "netbird up > /tmp/netbird-login.txt 2>&1 &",
+    undefined,  // cwd
+    undefined,  // env
+    10          // timeout
+  );
+
+  // Wait for the login URL to be written to the file
+  await sleep(5000);
+
+  // Read the login URL from the output file
+  response = await sandbox.process.executeCommand(
+    "cat /tmp/netbird-login.txt",
+    undefined,  // cwd
+    undefined,  // env
+    10          // timeout
+  );
+  const output = response.result || "";
+  const urlMatch = output.match(/https?:\/\/[^\s]+/);
+
+  if (urlMatch) {
+    const loginUrl = urlMatch[0];
+    console.log("\n" + "=".repeat(60));
+    console.log("To authenticate, visit this URL in your browser:");
+    console.log(`\n  ${loginUrl}`);
+    console.log("\n" + "=".repeat(60));
+    console.log("\nWaiting for authentication...");
+
+    // Poll for connection status
+    const maxWait = 300; // 5 minutes max wait
+    const pollInterval = 5;
+    let waited = 0;
+
+    while (waited < maxWait) {
+      await sleep(pollInterval * 1000);
+      waited += pollInterval;
+
+      const statusResponse = await sandbox.process.executeCommand(
+        "netbird status 2>&1",
+        undefined,  // cwd
+        undefined,  // env
+        30          // timeout
+      );
+      const statusOutput = statusResponse.result || "";
+
+      // Check if we're connected
+      if (statusResponse.exitCode === 0 && statusOutput.toLowerCase().includes("connected")) {
+        console.log("\nConnected to NetBird network!");
+        console.log(`NetBird status:\n${statusOutput}`);
+        break;
+      }
+
+      console.log(`  Still waiting... (${waited}s)`);
+    }
+
+    if (waited >= maxWait) {
+      console.log("\nTimeout waiting for authentication. Please try again.");
+      return;
+    }
+  } else {
+    // Maybe already connected or different output
+    console.log(`Output from netbird up:\n${output}`);
+
+    // Check if already connected
+    const statusResponse = await sandbox.process.executeCommand(
+      "netbird status",
+      undefined,  // cwd
+      undefined,  // env
+      30          // timeout
+    );
+    if (statusResponse.exitCode === 0) {
+      console.log("\nNetBird status:");
+      console.log(statusResponse.result);
+    }
+  }
+
+  // Final status check
+  console.log("\nFinal NetBird status:");
+  response = await sandbox.process.executeCommand(
+    "netbird status",
+    undefined,  // cwd
+    undefined,  // env
+    30          // timeout
+  );
+  console.log(response.result);
+}
+
+// Run the main function
+setupNetbirdVpnInteractive().catch(console.error);
+```
+
+</TabItem>
+</Tabs>
+

--- a/apps/docs/src/content/docs/en/vpn-connections.mdx
+++ b/apps/docs/src/content/docs/en/vpn-connections.mdx
@@ -23,9 +23,9 @@ For connecting to a VPN network, you need to [create or access your Daytona sand
 
 Daytona provides multiple ways to connect to a Daytona sandbox with a Tailscale network:
 
-- [Connect with browser login](#connect-with-browser-login)
-- [Connect with auth key](#connect-with-auth-key)
-- [Connect with web terminal](#connect-with-web-terminal)
+- [Connect with browser login](#tailscale-browser-login)
+- [Connect with auth key](#tailscale-auth-key)
+- [Connect with web terminal](#tailscale-web-terminal)
 
 When you connect a Daytona sandbox to a Tailscale network, the sandbox becomes part of your private Tailscale network, allowing you to access resources that are available within the network and enabling other devices on the network to access the sandbox.
 
@@ -551,7 +551,7 @@ You've now successfully connected your Daytona sandbox to your Tailscale network
 Daytona provides multiple ways to connect to a Daytona sandbox with an OpenVPN network:
 
 - [OpenVPN client configuration](#openvpn-client-configuration)
-- [OpenVPN web terminal](#openvpn-web-terminal)
+- [Connect with web terminal](#openvpn-web-terminal)
 
 OpenVPN uses a client-server model where your Daytona sandbox acts as a client connecting to an OpenVPN server. This approach is suitable for connecting to existing corporate VPNs, accessing resources behind firewalls, or integrating with infrastructure that already uses OpenVPN.
 
@@ -615,6 +615,8 @@ verb 3
 ```
 
 ### OpenVPN client configuration
+
+The following snippets demonstrate connecting to an OpenVPN network using a client configuration file.
 
 <Tabs>
   <TabItem label="Python" icon="seti:python">
@@ -864,8 +866,8 @@ You've now successfully connected your Daytona sandbox to your OpenVPN network.
 
 Daytona provides multiple ways to connect to a Daytona sandbox with a Netbird network:
 
-- [Netbird setup key](#netbird-setup-key)
-- [Netbird browser login](#netbird-browser-login)
+- [Connect with setup key](#netbird-setup-key)
+- [Connect with browser login](#netbird-browser-login)
 
 When you connect a Daytona sandbox to a Netbird network, the sandbox becomes part of your private Netbird network, allowing you to access resources that are available within the network and enabling other devices on the network to access the sandbox.
 
@@ -875,7 +877,11 @@ This integration makes your sandbox appear as a device within your Netbird netwo
 
 Using a Netbird setup key provides a non-interactive way to connect your Daytona sandbox to Netbird, making it suitable for automated scripts, CI/CD pipelines, or any scenario where manual browser interaction is not available.
 
-For more information about Netbird setup keys, see the [Netbird documentation ↗](https://docs.netbird.io/manage/peers/access-infrastructure/setup-keys-add-servers-to-network).
+1. Access your [Netbird dashboard ↗](https://app.netbird.io/)
+2. Click **Setup Keys**
+3. Create a new setup key or use an existing one
+
+The following snippets demonstrate connecting to a Netbird network using a setup key.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -884,17 +890,18 @@ For more information about Netbird setup keys, see the [Netbird documentation �
 from daytona import Daytona, DaytonaConfig
 
 # Configuration
-DAYTONA_API_KEY = "YOUR_API_KEY" # Replace with your API key
-NETBIRD_SETUP_KEY = "YOUR_SETUP_KEY" # Replace with your setup key
+DAYTONA_API_KEY = "YOUR_API_KEY"
+NETBIRD_SETUP_KEY = "YOUR_SETUP_KEY"
 
 # Initialize the Daytona client
 config = DaytonaConfig(api_key=DAYTONA_API_KEY)
 daytona = Daytona(config)
 
-def setup_netbird_vpn_with_setup_key():
+
+def setup_netbird():
     """
     Connect a Daytona sandbox to a NetBird network using the Python SDK.
-    Uses a NetBird Setup Key for non-interactive authentication.
+    Uses the official NetBird install script and a Setup Key for non-interactive auth.
     See: https://docs.netbird.io/manage/peers/access-infrastructure/setup-keys-add-servers-to-network
     """
     if NETBIRD_SETUP_KEY == "YOUR_SETUP_KEY":
@@ -905,18 +912,10 @@ def setup_netbird_vpn_with_setup_key():
     print("Creating sandbox...")
     sandbox = daytona.create()
     print(f"Sandbox created: {sandbox.id}")
-
-    # Install NetBird (manual repo setup since the bundled installer can fail
-    # on the broken Yarn repo present in the base image).
-    print("\nInstalling NetBird (this may take a few minutes)...")
+    print("\nInstalling NetBird via the official install script...")
     install_cmd = (
         "sudo rm -f /etc/apt/sources.list.d/yarn.list && "
-        "sudo apt-get update && "
-        "sudo apt-get install -y ca-certificates curl gnupg && "
-        "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg && "
-        "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list && "
-        "sudo apt-get update && "
-        "sudo apt-get install -y netbird"
+        "curl -fsSL https://pkgs.netbird.io/install.sh | sudo sh"
     )
     response = sandbox.process.exec(install_cmd, timeout=300)
     if response.exit_code != 0:
@@ -924,8 +923,7 @@ def setup_netbird_vpn_with_setup_key():
         return sandbox
     print("NetBird installed successfully.")
 
-    # Connect to the NetBird network using the setup key.
-    # The setup key authenticates this peer without any interactive browser flow.
+    # Connect to the NetBird network using the setup key
     print("\nConnecting to NetBird network with setup key...")
     up_cmd = f"sudo netbird up --setup-key {NETBIRD_SETUP_KEY}"
     response = sandbox.process.exec(up_cmd, timeout=120)
@@ -943,7 +941,7 @@ def setup_netbird_vpn_with_setup_key():
 
 
 if __name__ == "__main__":
-    sandbox = setup_netbird_vpn_with_setup_key()
+    sandbox = setup_netbird()
 ```
 
 </TabItem>
@@ -953,18 +951,18 @@ if __name__ == "__main__":
 import { Daytona } from '@daytonaio/sdk';
 
 // Configuration
-const DAYTONA_API_KEY = "YOUR_API_KEY"; // Replace with your API key
-const NETBIRD_SETUP_KEY = "YOUR_SETUP_KEY"; // Replace with your setup key
+const DAYTONA_API_KEY = "YOUR_API_KEY";
+const NETBIRD_SETUP_KEY = "YOUR_SETUP_KEY";
 
 // Initialize the Daytona client
 const daytona = new Daytona({
   apiKey: DAYTONA_API_KEY,
 });
 
-async function setupNetbirdVpnWithSetupKey(): Promise<void> {
+async function setupNetbird(): Promise<void> {
   /**
    * Connect a Daytona sandbox to a NetBird network using the TypeScript SDK.
-   * Uses a NetBird Setup Key for non-interactive authentication.
+   * Uses the official NetBird install script and a Setup Key for non-interactive auth.
    * See: https://docs.netbird.io/manage/peers/access-infrastructure/setup-keys-add-servers-to-network
    */
 
@@ -973,17 +971,11 @@ async function setupNetbirdVpnWithSetupKey(): Promise<void> {
   const sandbox = await daytona.create();
   console.log(`Sandbox created: ${sandbox.id}`);
 
-  // Install NetBird (manual repo setup since the bundled installer can fail
-  // on the broken Yarn repo present in the base image).
-  console.log("\nInstalling NetBird (this may take a few minutes)...");
+  // Install NetBird via the official install script
+  console.log("\nInstalling NetBird via the official install script...");
   const installCmd = [
     "sudo rm -f /etc/apt/sources.list.d/yarn.list",
-    "sudo apt-get update",
-    "sudo apt-get install -y ca-certificates curl gnupg",
-    "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg",
-    "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list",
-    "sudo apt-get update",
-    "sudo apt-get install -y netbird",
+    "curl -fsSL https://pkgs.netbird.io/install.sh | sudo sh",
   ].join(" && ");
   let response = await sandbox.process.executeCommand(
     installCmd,
@@ -997,8 +989,7 @@ async function setupNetbirdVpnWithSetupKey(): Promise<void> {
   }
   console.log("NetBird installed successfully.");
 
-  // Connect to the NetBird network using the setup key.
-  // The setup key authenticates this peer without any interactive browser flow.
+  // Connect to the NetBird network using the setup key
   console.log("\nConnecting to NetBird network with setup key...");
   const upCmd = `sudo netbird up --setup-key ${NETBIRD_SETUP_KEY}`;
   response = await sandbox.process.executeCommand(
@@ -1025,7 +1016,7 @@ async function setupNetbirdVpnWithSetupKey(): Promise<void> {
 }
 
 // Run the main function
-setupNetbirdVpnWithSetupKey().catch(console.error);
+setupNetbird().catch(console.error);
 ```
 
 </TabItem>
@@ -1034,6 +1025,8 @@ setupNetbirdVpnWithSetupKey().catch(console.error);
 ### Netbird browser login
 
 The browser login method initiates an interactive authentication flow where Netbird generates a unique login URL that you visit in your web browser to authenticate the Daytona sandbox.
+
+The following snippets demonstrate connecting to a Netbird network using a browser login.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -1044,33 +1037,27 @@ import time
 import re
 
 # Configuration
-DAYTONA_API_KEY = "YOUR_API_KEY" # Replace with your API key
+DAYTONA_API_KEY = "YOUR_API_KEY"
 
 # Initialize the Daytona client
 config = DaytonaConfig(api_key=DAYTONA_API_KEY)
 daytona = Daytona(config)
 
 
-def setup_netbird_vpn_interactive():
+def setup_netbird():
     """
     Connect a Daytona sandbox to a NetBird network using the Python SDK.
-    Uses interactive login via browser URL.
+    Uses the official NetBird install script and interactive browser login.
     """
     # Create the sandbox
     print("Creating sandbox...")
     sandbox = daytona.create()
     print(f"Sandbox created: {sandbox.id}")
-
-    # Step 1: Remove problematic Yarn repo that breaks apt update, then install NetBird manually
-    print("\nInstalling NetBird (this may take a few minutes)...")
+    # Install NetBird via the official install script
+    print("\nInstalling NetBird via the official install script...")
     install_cmd = (
         "sudo rm -f /etc/apt/sources.list.d/yarn.list && "
-        "sudo apt-get update && "
-        "sudo apt-get install -y ca-certificates curl gnupg && "
-        "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg && "
-        "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list && "
-        "sudo apt-get update && "
-        "sudo apt-get install -y netbird"
+        "curl -fsSL https://pkgs.netbird.io/install.sh | sudo sh"
     )
     response = sandbox.process.exec(install_cmd, timeout=300)
     if response.exit_code != 0:
@@ -1078,7 +1065,7 @@ def setup_netbird_vpn_interactive():
         return sandbox
     print("NetBird installed successfully.")
 
-    # Step 3: Run netbird up in background and capture output to a file
+    # Run netbird up in background and capture output to a file
     print("\nInitiating NetBird login...")
     sandbox.process.exec(
         "netbird up > /tmp/netbird-login.txt 2>&1 &",
@@ -1142,7 +1129,7 @@ def setup_netbird_vpn_interactive():
 
 
 if __name__ == "__main__":
-    sandbox = setup_netbird_vpn_interactive()
+    sandbox = setup_netbird()
 ```
 
 </TabItem>
@@ -1152,7 +1139,7 @@ if __name__ == "__main__":
 import { Daytona } from '@daytonaio/sdk';
 
 // Configuration
-const DAYTONA_API_KEY = "YOUR_API_KEY"; // Replace with your API key
+const DAYTONA_API_KEY = "YOUR_API_KEY";
 
 // Initialize the Daytona client
 const daytona = new Daytona({
@@ -1166,7 +1153,7 @@ function sleep(ms: number): Promise<void> {
 async function setupNetbirdVpnInteractive(): Promise<void> {
   /**
    * Connect a Daytona sandbox to a NetBird network using the TypeScript SDK.
-   * Uses interactive login via browser URL.
+   * Uses the official NetBird install script and interactive browser login.
    */
 
   // Create the sandbox
@@ -1174,16 +1161,14 @@ async function setupNetbirdVpnInteractive(): Promise<void> {
   const sandbox = await daytona.create();
   console.log(`Sandbox created: ${sandbox.id}`);
 
-  // Step 1: Remove problematic Yarn repo that breaks apt update, then install NetBird manually
-  console.log("\nInstalling NetBird (this may take a few minutes)...");
+  // Remove the broken Yarn list so apt-get update inside the installer succeeds,
+  // then run the official NetBird install script. The script adds the NetBird
+  // APT repo, imports the signing key, installs the package, and registers the
+  // systemd service.
+  console.log("\nInstalling NetBird via the official install script...");
   const installCmd = [
     "sudo rm -f /etc/apt/sources.list.d/yarn.list",
-    "sudo apt-get update",
-    "sudo apt-get install -y ca-certificates curl gnupg",
-    "curl -sSL https://pkgs.netbird.io/debian/public.key | sudo gpg --dearmor --output /usr/share/keyrings/netbird-archive-keyring.gpg",
-    "echo 'deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main' | sudo tee /etc/apt/sources.list.d/netbird.list",
-    "sudo apt-get update",
-    "sudo apt-get install -y netbird",
+    "curl -fsSL https://pkgs.netbird.io/install.sh | sudo sh",
   ].join(" && ");
   let response = await sandbox.process.executeCommand(
     installCmd,
@@ -1197,7 +1182,7 @@ async function setupNetbirdVpnInteractive(): Promise<void> {
   }
   console.log("NetBird installed successfully.");
 
-  // Step 3: Run netbird up in background and capture output to a file
+  // Run netbird up in background and capture output to a file
   console.log("\nInitiating NetBird login...");
   await sandbox.process.executeCommand(
     "netbird up > /tmp/netbird-login.txt 2>&1 &",

--- a/apps/docs/src/content/docs/en/vpn-connections.mdx
+++ b/apps/docs/src/content/docs/en/vpn-connections.mdx
@@ -556,7 +556,7 @@ Daytona provides multiple ways to connect to a Daytona sandbox with an OpenVPN n
 OpenVPN uses a client-server model where your Daytona sandbox acts as a client connecting to an OpenVPN server. This approach is suitable for connecting to existing corporate VPNs, accessing resources behind firewalls, or integrating with infrastructure that already uses OpenVPN.
 
 :::note
-Connecting a Daytona sandbox to OpenVPN network requires a [client configuration file](#client-configuration-file).
+Connecting a Daytona sandbox to OpenVPN network requires a [client configuration file](#openvpn-client-configuration-file).
 :::
 
 ### OpenVPN client configuration file
@@ -834,7 +834,7 @@ Daytona provides a [web terminal](/docs/en/web-terminal) for interacting with yo
 sudo apt update && sudo apt install -y openvpn tmux
 ```
 
-3. Create the OpenVPN [client configuration file](#client-configuration-file) for your Daytona sandbox
+3. Create the OpenVPN [client configuration file](#openvpn-client-configuration-file) for your Daytona sandbox
 
 ```bash
 sudo nano client.ovpn

--- a/apps/docs/src/content/docs/en/vpn-connections.mdx
+++ b/apps/docs/src/content/docs/en/vpn-connections.mdx
@@ -31,7 +31,7 @@ When you connect a Daytona sandbox to a Tailscale network, the sandbox becomes p
 
 This integration makes your sandbox appear as a device within your Tailscale network, with its own Tailscale IP address and access to other devices and services on the network.
 
-### Connect with browser login
+### Tailscale browser login
 
 The browser login method initiates an interactive authentication flow where Tailscale generates a unique login URL that you visit in your web browser to authenticate the Dayona sandbox.
 
@@ -318,7 +318,7 @@ setupTailscaleVpnInteractive().catch(console.error)
 
 Once the connection is established and authentication is complete, the sandbox will maintain its connection as long as the service is running.
 
-### Connect with auth key
+### Tailscale auth key
 
 Using an auth key provides a non-interactive way to connect your Daytona sandbox to Tailscale, making it suitable for automated scripts, CI/CD pipelines, or any scenario where manual browser interaction is not available.
 
@@ -496,7 +496,7 @@ setupTailscaleVpn(TAILSCALE_AUTH_KEY).catch(console.error)
 
 Once the connection is established and authentication is complete, the sandbox will maintain its connection as long as the service is running.
 
-### Connect with web terminal
+### Tailscale web terminal
 
 For working directly in the terminal or for more control over the Tailscale connection process, you can set up Tailscale manually through the Daytona [web terminal](/docs/en/web-terminal) or [SSH](/docs/en/ssh-access).
 
@@ -550,8 +550,8 @@ You've now successfully connected your Daytona sandbox to your Tailscale network
 
 Daytona provides multiple ways to connect to a Daytona sandbox with an OpenVPN network:
 
-- [Connect with client configuration](#connect-with-client-configuration)
-- [Connect with web terminal](#connect-with-web-terminal)
+- [OpenVPN client configuration](#openvpn-client-configuration)
+- [OpenVPN web terminal](#openvpn-web-terminal)
 
 OpenVPN uses a client-server model where your Daytona sandbox acts as a client connecting to an OpenVPN server. This approach is suitable for connecting to existing corporate VPNs, accessing resources behind firewalls, or integrating with infrastructure that already uses OpenVPN.
 
@@ -559,7 +559,7 @@ OpenVPN uses a client-server model where your Daytona sandbox acts as a client c
 Connecting a Daytona sandbox to OpenVPN network requires a [client configuration file](#client-configuration-file).
 :::
 
-### Client configuration file
+### OpenVPN client configuration file
 
 Client configuration file contains the connection parameters, certificates, and keys required to establish a secure connection to your OpenVPN server. This file is typically provided by your network administrator or generated from your OpenVPN server setup.
 
@@ -614,7 +614,7 @@ verb 3
 </tls-crypt-v2>
 ```
 
-### Connect with client configuration
+### OpenVPN client configuration
 
 <Tabs>
   <TabItem label="Python" icon="seti:python">
@@ -820,7 +820,7 @@ setupOpenvpn(OPENVPN_CONFIG).catch(console.error);
   </TabItem>
 </Tabs>
 
-### Connect with web terminal
+### OpenVPN web terminal
 
 Daytona provides a [web terminal](/docs/en/web-terminal) for interacting with your sandboxes, allowing you to install OpenVPN and connect to your OpenVPN network.
 
@@ -864,14 +864,14 @@ You've now successfully connected your Daytona sandbox to your OpenVPN network.
 
 Daytona provides multiple ways to connect to a Daytona sandbox with a Netbird network:
 
-- [Connect with setup key](#connect-with-setup-key)
-- [Connect with browser login](#connect-with-browser-login)
+- [Netbird setup key](#netbird-setup-key)
+- [Netbird browser login](#netbird-browser-login)
 
 When you connect a Daytona sandbox to a Netbird network, the sandbox becomes part of your private Netbird network, allowing you to access resources that are available within the network and enabling other devices on the network to access the sandbox.
 
 This integration makes your sandbox appear as a device within your Netbird network, with its own Netbird IP address and access to other devices and services on the network.
 
-### Connect with setup key
+### Netbird setup key
 
 Using a Netbird setup key provides a non-interactive way to connect your Daytona sandbox to Netbird, making it suitable for automated scripts, CI/CD pipelines, or any scenario where manual browser interaction is not available.
 
@@ -890,7 +890,6 @@ NETBIRD_SETUP_KEY = "YOUR_SETUP_KEY" # Replace with your setup key
 # Initialize the Daytona client
 config = DaytonaConfig(api_key=DAYTONA_API_KEY)
 daytona = Daytona(config)
-
 
 def setup_netbird_vpn_with_setup_key():
     """
@@ -969,11 +968,6 @@ async function setupNetbirdVpnWithSetupKey(): Promise<void> {
    * See: https://docs.netbird.io/manage/peers/access-infrastructure/setup-keys-add-servers-to-network
    */
 
-  if (NETBIRD_SETUP_KEY === "YOUR_SETUP_KEY") {
-    console.log("Error: please set NETBIRD_SETUP_KEY to a valid setup key.");
-    return;
-  }
-
   // Create the sandbox
   console.log("Creating sandbox...");
   const sandbox = await daytona.create();
@@ -1037,7 +1031,7 @@ setupNetbirdVpnWithSetupKey().catch(console.error);
 </TabItem>
 </Tabs>
 
-### Connect with browser login
+### Netbird browser login
 
 The browser login method initiates an interactive authentication flow where Netbird generates a unique login URL that you visit in your web browser to authenticate the Daytona sandbox.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Netbird VPN setup with setup key and browser login, and fixes OpenVPN anchor links. Standardizes Tailscale/OpenVPN headings and improves Netbird examples for more reliable installs and auth.

- **New Features**
  - Added Netbird provider with setup key and browser login guides, plus Python/TypeScript examples using `@daytonaio/sdk` to create a sandbox, connect, and check status.

- **Refactors**
  - Consistent “Daytona sandbox” naming; updated Tailscale/OpenVPN headings; fixed OpenVPN section anchor links.
  - Improved Netbird examples: official install script, background login, status polling, and timeouts.

<sup>Written for commit a9b6566e0b699e9bc077502f354da374f70022a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

