### PR TITLE
fix(api): enabled v2 recover path and v0 race patched

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -521,18 +521,19 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
           return
         }
 
-        // ERROR → STOPPED activates disk usage; reserve so the v2 job-completion handler's
-        // decrement on failure is balanced. v0 path doesn't use the handler but keep parity.
-        const { diskIncremented } = await this.organizationUsageService.incrementPendingSandboxUsage(
-          sandbox.organizationId,
-          sandbox.region,
-          0,
-          0,
-          sandbox.disk,
-          sandbox.id,
-        )
-
+        let diskIncremented = false
         try {
+          // Reserve disk for the ERROR → STOPPED transition.
+          const result = await this.organizationUsageService.incrementPendingSandboxUsage(
+            sandbox.organizationId,
+            sandbox.region,
+            0,
+            0,
+            sandbox.disk,
+            sandbox.id,
+          )
+          diskIncremented = result.diskIncremented
+
           await runnerAdapter.recoverSandbox(sandbox, true)
 
           if (runner.apiVersion !== '2') {
@@ -547,6 +548,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
               whereCondition: { pending: false, state: sandbox.state },
             })
           }
+
+          // Skip this sandbox on subsequent polls until the v2 job resolves.
+          await this.redis.set(redisKey, '1', 'EX', SandboxManager.DRAINING_RECOVER_TTL_SECONDS)
 
           this.logger.log(`Recovered sandbox ${sandbox.id} on draining runner ${runnerId}`)
         } catch (e) {

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -481,6 +481,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       where: {
         runnerId,
         recoverable: true,
+        pending: false,
         desiredState: Not(In([SandboxDesiredState.DESTROYED])),
         backupSnapshot: Not(IsNull()),
       },

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -534,6 +534,14 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
           )
           diskIncremented = result.diskIncremented
 
+          // Normalize desiredState upfront so the v2 job handler can detect mid-job intent changes.
+          if (runner.apiVersion === '2') {
+            await this.sandboxRepository.updateWhere(sandbox.id, {
+              updateData: { desiredState: SandboxDesiredState.STOPPED },
+              whereCondition: { state: SandboxState.ERROR },
+            })
+          }
+
           await runnerAdapter.recoverSandbox(sandbox, true)
 
           if (runner.apiVersion !== '2') {

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -47,6 +47,7 @@ import { Sandbox } from '../entities/sandbox.entity'
 import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { OrganizationService } from '../../organization/services/organization.service'
+import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { BackupManager } from './backup.manager'
 import { InjectRedis } from '@nestjs-modules/ioredis'
@@ -73,6 +74,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     private readonly configService: TypedConfigService,
     private readonly dockerRegistryService: DockerRegistryService,
     private readonly organizationService: OrganizationService,
+    private readonly organizationUsageService: OrganizationUsageService,
     private readonly runnerAdapterFactory: RunnerAdapterFactory,
     private readonly backupManager: BackupManager,
     @InjectRedis() private readonly redis: Redis,
@@ -481,6 +483,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       where: {
         runnerId,
         recoverable: true,
+        // ERROR forces pending=false via Sandbox invariants, but filter both explicitly to
+        // document the intended target set (recoverable errored sandboxes only).
+        state: SandboxState.ERROR,
         pending: false,
         desiredState: Not(In([SandboxDesiredState.DESTROYED])),
         backupSnapshot: Not(IsNull()),
@@ -495,14 +500,6 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     this.logger.debug(`Found ${recoverableSandboxes.length} recoverable sandboxes on draining runner ${runnerId}`)
 
     const runner = await this.runnerService.findOneOrFail(runnerId)
-
-    if (runner.apiVersion === '2') {
-      this.logger.debug(
-        `Skipping recovery for sandboxes on draining runner ${runnerId} — not supported for runner API v2`,
-      )
-      return
-    }
-
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
     await Promise.allSettled(
@@ -524,24 +521,40 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
           return
         }
 
+        // ERROR → STOPPED activates disk usage; reserve so the v2 job-completion handler's
+        // decrement on failure is balanced. v0 path doesn't use the handler but keep parity.
+        const { diskIncremented } = await this.organizationUsageService.incrementPendingSandboxUsage(
+          sandbox.organizationId,
+          sandbox.region,
+          0,
+          0,
+          sandbox.disk,
+          sandbox.id,
+        )
+
         try {
-          await runnerAdapter.recoverSandbox(sandbox)
+          await runnerAdapter.recoverSandbox(sandbox, true)
 
-          const updateData: Partial<Sandbox> = {
-            state: SandboxState.STOPPED,
-            desiredState: SandboxDesiredState.STOPPED,
-            errorReason: null,
-            recoverable: false,
-            backupState: BackupState.NONE,
+          if (runner.apiVersion !== '2') {
+            await this.sandboxRepository.updateWhere(sandbox.id, {
+              updateData: {
+                state: SandboxState.STOPPED,
+                desiredState: SandboxDesiredState.STOPPED,
+                errorReason: null,
+                recoverable: false,
+                backupState: BackupState.NONE,
+              },
+              whereCondition: { pending: false, state: sandbox.state },
+            })
           }
-
-          await this.sandboxRepository.updateWhere(sandbox.id, {
-            updateData,
-            whereCondition: { pending: false, state: sandbox.state },
-          })
 
           this.logger.log(`Recovered sandbox ${sandbox.id} on draining runner ${runnerId}`)
         } catch (e) {
+          if (diskIncremented) {
+            await this.organizationUsageService
+              .decrementPendingSandboxUsage(sandbox.organizationId, sandbox.region, undefined, undefined, sandbox.disk)
+              .catch(() => undefined)
+          }
           await this.redis.set(redisKey, '1', 'EX', SandboxManager.DRAINING_RECOVER_TTL_SECONDS)
           this.logger.error(`Failed to recover sandbox ${sandbox.id} on draining runner ${runnerId}`, e)
         } finally {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -119,7 +119,7 @@ export interface RunnerAdapter {
     registry?: DockerRegistry,
   ): Promise<void>
 
-  recoverSandbox(sandbox: Sandbox): Promise<void>
+  recoverSandbox(sandbox: Sandbox, skipStart?: boolean): Promise<void>
 
   resizeSandbox(sandboxId: string, cpu?: number, memory?: number, disk?: number): Promise<void>
 }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -429,7 +429,8 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     throw new Error('createSnapshotFromSandbox is not supported for V0 runners')
   }
 
-  async recoverSandbox(sandbox: Sandbox): Promise<void> {
+  // skipStart is a v2-only signal (carried in the job payload); v0's sync API has no equivalent.
+  async recoverSandbox(sandbox: Sandbox, _skipStart?: boolean): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -223,7 +223,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created DESTROY_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async recoverSandbox(sandbox: Sandbox): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, skipStart = false): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -243,14 +243,11 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
     }
-    await this.jobService.createJob(
-      null,
-      JobType.RECOVER_SANDBOX,
-      this.runner.id,
-      ResourceType.SANDBOX,
-      sandbox.id,
-      recoverSandboxDTO,
-    )
+    // skipStart is API-side metadata for the job-completion handler; the runner ignores extra fields.
+    await this.jobService.createJob(null, JobType.RECOVER_SANDBOX, this.runner.id, ResourceType.SANDBOX, sandbox.id, {
+      ...recoverSandboxDTO,
+      skipStart,
+    })
 
     this.logger.debug(`Created RECOVER_SANDBOX job for sandbox ${sandbox.id} on runner ${this.runner.id}`)
   }

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -502,6 +502,15 @@ export class JobStateHandlerService {
 
       const skipStart = job.getPayload<{ skipStart?: boolean }>()?.skipStart ?? true
 
+      // Bail if the user changed intent mid-job (e.g. /destroy, /archive).
+      const expectedDesiredState = skipStart ? SandboxDesiredState.STOPPED : SandboxDesiredState.STARTED
+      if (sandbox.desiredState !== expectedDesiredState) {
+        this.logger.warn(
+          `Sandbox ${sandboxId} desiredState ${sandbox.desiredState} no longer matches RECOVER_SANDBOX job ${job.id} intent (expected ${expectedDesiredState}); skipping state update`,
+        )
+        return
+      }
+
       const updateData: Partial<Sandbox> = {}
 
       if (job.status === JobStatus.COMPLETED) {

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -502,11 +502,18 @@ export class JobStateHandlerService {
 
       const skipStart = job.getPayload<{ skipStart?: boolean }>()?.skipStart ?? true
 
-      // Bail if the user changed intent mid-job (e.g. /destroy, /archive).
+      // Intent changed mid-job (e.g. /destroy); state stays ERROR so pending won't auto-drain.
       const expectedDesiredState = skipStart ? SandboxDesiredState.STOPPED : SandboxDesiredState.STARTED
       if (sandbox.desiredState !== expectedDesiredState) {
         this.logger.warn(
-          `Sandbox ${sandboxId} desiredState ${sandbox.desiredState} no longer matches RECOVER_SANDBOX job ${job.id} intent (expected ${expectedDesiredState}); skipping state update`,
+          `Sandbox ${sandboxId} desiredState ${sandbox.desiredState} no longer matches RECOVER_SANDBOX job ${job.id} intent (${expectedDesiredState}); rolling back pending reservation and skipping state update`,
+        )
+        await this.organizationUsageService.decrementPendingSandboxUsage(
+          sandbox.organizationId,
+          sandbox.region,
+          skipStart ? undefined : sandbox.cpu,
+          skipStart ? undefined : sandbox.mem,
+          sandbox.disk,
         )
         return
       }
@@ -514,11 +521,9 @@ export class JobStateHandlerService {
       const updateData: Partial<Sandbox> = {}
 
       if (job.status === JobStatus.COMPLETED) {
-        // Runner only expanded disk; container is left STOPPED. The chained start (if requested)
-        // is kicked off via SandboxStartedEvent below.
+        // Container left STOPPED; chained start (if requested) fires via SandboxStartedEvent below.
         this.logger.debug(`RECOVER_SANDBOX job ${job.id} completed successfully for sandbox ${sandboxId}`)
         updateData.state = SandboxState.STOPPED
-        updateData.desiredState = skipStart ? SandboxDesiredState.STOPPED : SandboxDesiredState.STARTED
         updateData.errorReason = null
         updateData.recoverable = false
         if ([BackupState.ERROR, BackupState.COMPLETED].includes(sandbox.backupState)) {
@@ -531,8 +536,7 @@ export class JobStateHandlerService {
         updateData.errorReason = errorReason || 'Failed to recover sandbox'
         updateData.recoverable = recoverable
 
-        // Roll back the reservation made upstream (SandboxService.recover or the draining
-        // manager): disk always, cpu/mem only when start was requested.
+        // Roll back upstream reservation: disk always, cpu/mem only when start was requested.
         await this.organizationUsageService.decrementPendingSandboxUsage(
           sandbox.organizationId,
           sandbox.region,
@@ -545,8 +549,7 @@ export class JobStateHandlerService {
       const updatedSandbox = await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })
 
       if (job.status === JobStatus.COMPLETED && !skipStart) {
-        // Pending was reserved by SandboxService.recover and authToken was already refreshed;
-        // sandboxStartAction does not re-validate.
+        // Pending and authToken were prepped in recover(); sandboxStartAction does not re-validate.
         this.eventEmitter.emit(SandboxEvents.STARTED, new SandboxStartedEvent(updatedSandbox))
       }
     } catch (error) {

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -28,6 +28,8 @@ import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { v4 as uuidv4 } from 'uuid'
 import { SnapshotEvents } from '../constants/snapshot-events'
 import { SnapshotCreatedEvent } from '../events/snapshot-created.event'
+import { SandboxEvents } from '../constants/sandbox-events.constants'
+import { SandboxStartedEvent } from '../events/sandbox-started.event'
 
 /**
  * Service for handling entity state updates based on job completion (v2 runners only).
@@ -498,31 +500,46 @@ export class JobStateHandlerService {
         return
       }
 
-      if (sandbox.desiredState !== SandboxDesiredState.STARTED) {
-        this.logger.error(
-          `Sandbox ${sandboxId} is not in desired state STARTED for RECOVER_SANDBOX job ${job.id}. Desired state: ${sandbox.desiredState}`,
-        )
-        return
-      }
+      const skipStart = job.getPayload<{ skipStart?: boolean }>()?.skipStart ?? true
 
       const updateData: Partial<Sandbox> = {}
 
       if (job.status === JobStatus.COMPLETED) {
-        this.logger.debug(
-          `RECOVER_SANDBOX job ${job.id} completed successfully, marking sandbox ${sandboxId} as STARTED`,
-        )
-        updateData.state = SandboxState.STARTED
+        // Runner only expanded disk; container is left STOPPED. The chained start (if requested)
+        // is kicked off via SandboxStartedEvent below.
+        this.logger.debug(`RECOVER_SANDBOX job ${job.id} completed successfully for sandbox ${sandboxId}`)
+        updateData.state = SandboxState.STOPPED
+        updateData.desiredState = skipStart ? SandboxDesiredState.STOPPED : SandboxDesiredState.STARTED
         updateData.errorReason = null
+        updateData.recoverable = false
         if ([BackupState.ERROR, BackupState.COMPLETED].includes(sandbox.backupState)) {
           Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.NONE))
         }
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`RECOVER_SANDBOX job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
         updateData.state = SandboxState.ERROR
-        updateData.errorReason = job.errorMessage || 'Failed to recover sandbox'
+        const { recoverable, errorReason } = sanitizeSandboxError(job.errorMessage)
+        updateData.errorReason = errorReason || 'Failed to recover sandbox'
+        updateData.recoverable = recoverable
+
+        // Roll back the reservation made upstream (SandboxService.recover or the draining
+        // manager): disk always, cpu/mem only when start was requested.
+        await this.organizationUsageService.decrementPendingSandboxUsage(
+          sandbox.organizationId,
+          sandbox.region,
+          skipStart ? undefined : sandbox.cpu,
+          skipStart ? undefined : sandbox.mem,
+          sandbox.disk,
+        )
       }
 
-      await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })
+      const updatedSandbox = await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })
+
+      if (job.status === JobStatus.COMPLETED && !skipStart) {
+        // Pending was reserved by SandboxService.recover and authToken was already refreshed;
+        // sandboxStartAction does not re-validate.
+        this.eventEmitter.emit(SandboxEvents.STARTED, new SandboxStartedEvent(updatedSandbox))
+      }
     } catch (error) {
       this.logger.error(`Error handling RECOVER_SANDBOX job completion for sandbox ${sandboxId}:`, error)
     }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -76,6 +76,7 @@ import {
   PER_SANDBOX_LIMIT_MESSAGE,
 } from '../../common/constants/error-messages'
 import { RedisLockProvider } from '../common/redis-lock.provider'
+import { getStateChangeLockKey } from '../utils/lock-key.util'
 import { customAlphabet as customNanoid, nanoid, urlAlphabet } from 'nanoid'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { validateMountPaths, validateSubpaths } from '../utils/volume-mount-path-validation.util'
@@ -1733,6 +1734,8 @@ export class SandboxService {
   }
 
   async recover(sandboxIdOrName: string, organization: Organization, skipStart = false): Promise<Sandbox> {
+    let pendingCpuIncrement: number | undefined
+    let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
@@ -1742,57 +1745,67 @@ export class SandboxService {
       throw new NotFoundException(`Region with ID ${sandbox.region} not found`)
     }
 
+    // Serialize against concurrent recover calls and the draining-runner manager (which takes
+    // the same lock). The pending flag can't be used here: enforceInvariants forces pending=false
+    // when state=ERROR (sandbox.entity.ts:390-395), so updateWhere claims don't stick.
+    const lockKey = getStateChangeLockKey(sandbox.id)
+    if (!(await this.redisLockProvider.lock(lockKey, 60))) {
+      throw new StateChangeInProgressError()
+    }
+
     try {
       if (sandbox.state !== SandboxState.ERROR) {
         throw new BadRequestError('Sandbox must be in error state to recover')
-      }
-
-      if (sandbox.pending) {
-        throw new StateChangeInProgressError()
       }
 
       if (!sandbox.runnerId) {
         throw new NotFoundException(`Sandbox with ID ${sandbox.id} does not have a runner`)
       }
       const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
+      const willStartOnV2 = runner.apiVersion === '2' && !skipStart
 
-      if (runner.apiVersion === '2') {
-        // TODO: we need "recovering" state that can be set after calling recover
-        // Once in recovering, we abort further processing and let the manager/job handler take care of it
-        // (Also, since desiredState would be STARTED, we need to check the quota)
-        throw new ForbiddenException('Recovering sandboxes with runner API version 2 is not supported')
+      // The chained start on v2 is queued by the job-completion handler via SandboxStartedEvent
+      // and bypasses SandboxService.start(); replicate the suspended-org check here.
+      if (willStartOnV2) {
+        this.organizationService.assertOrganizationIsNotSuspended(organization)
       }
 
-      // ERROR doesn't consume disk, STOPPED does — reserve before the runner round-trip
-      // so an over-quota org is rejected before disk is expanded on the runner.
-      const { pendingDiskIncremented } = await this.validateOrganizationQuotas(
-        organization,
-        region,
-        0,
-        0,
-        sandbox.disk,
-        isEphemeral(sandbox),
-        sandbox.id,
-      )
+      // ERROR → STOPPED activates disk usage; v2 + !skipStart additionally activates cpu/mem
+      // because there is no trailing start() call to validate them.
+      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
+        await this.validateOrganizationQuotas(
+          organization,
+          region,
+          willStartOnV2 ? sandbox.cpu : 0,
+          willStartOnV2 ? sandbox.mem : 0,
+          sandbox.disk,
+          isEphemeral(sandbox),
+          sandbox.id,
+        )
+      if (pendingCpuIncremented) {
+        pendingCpuIncrement = sandbox.cpu
+      }
+      if (pendingMemoryIncremented) {
+        pendingMemoryIncrement = sandbox.mem
+      }
       if (pendingDiskIncremented) {
         pendingDiskIncrement = sandbox.disk
       }
 
-      // Atomic claim — matches start()/stop(); throws SandboxConflictError on race.
-      await this.sandboxRepository.updateWhere(sandbox.id, {
-        updateData: { pending: true },
-        whereCondition: { state: SandboxState.ERROR, pending: false },
-      })
+      // For v2 + !skipStart, refresh authToken now: sandboxStartAction reads the current token
+      // when queueing START_SANDBOX, and we're skipping start() which normally refreshes it.
+      if (willStartOnV2) {
+        await this.sandboxRepository.updateWhere(sandbox.id, {
+          updateData: { authToken: nanoid(32).toLocaleLowerCase() },
+          whereCondition: { state: SandboxState.ERROR },
+        })
+      }
 
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
       try {
-        await runnerAdapter.recoverSandbox(sandbox)
+        await runnerAdapter.recoverSandbox(sandbox, skipStart)
       } catch (error) {
-        await this.sandboxRepository.updateWhere(sandbox.id, {
-          updateData: { pending: false },
-          whereCondition: { state: SandboxState.ERROR, pending: true },
-        })
         if (error instanceof Error && error.message.includes('storage cannot be further expanded')) {
           throw new ForbiddenException(
             `Sandbox storage cannot be further expanded. Maximum expansion of ${(sandbox.disk * 0.1).toFixed(2)}GB (10% of original ${sandbox.disk.toFixed(2)}GB) has been reached. Please contact support for further assistance.`,
@@ -1801,13 +1814,17 @@ export class SandboxService {
         throw error
       }
 
+      // v2: job-completion handler writes the terminal state and chains START_SANDBOX if needed.
+      if (runner.apiVersion === '2') {
+        return sandbox
+      }
+
       const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
         updateData: {
           state: SandboxState.STOPPED,
           desiredState: SandboxDesiredState.STOPPED,
           errorReason: null,
           recoverable: false,
-          pending: false,
         },
         whereCondition: { state: SandboxState.ERROR },
       })
@@ -1816,12 +1833,19 @@ export class SandboxService {
         return updatedSandbox
       }
 
-      // Sandbox is now STOPPED — normal start flow handles cpu/mem quota + pending usage.
-      // Disk is now in current usage; start()'s self-excluded validation skips re-incrementing it.
+      // start() validates cpu/mem with self-excluded so disk doesn't double-count.
       return await this.start(sandbox.id, organization)
     } catch (error) {
-      await this.rollbackPendingUsage(organization.id, sandbox.region, undefined, undefined, pendingDiskIncrement)
+      await this.rollbackPendingUsage(
+        organization.id,
+        sandbox.region,
+        pendingCpuIncrement,
+        pendingMemoryIncrement,
+        pendingDiskIncrement,
+      )
       throw error
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
     }
   }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1792,11 +1792,14 @@ export class SandboxService {
         pendingDiskIncrement = sandbox.disk
       }
 
-      // For v2 + !skipStart, refresh authToken now: sandboxStartAction reads the current token
-      // when queueing START_SANDBOX, and we're skipping start() which normally refreshes it.
-      if (willStartOnV2) {
+      // Normalize desiredState upfront so the job handler can detect mid-job intent changes
+      // (e.g. /destroy). For v2 + !skipStart, also refresh authToken since we're bypassing start().
+      if (runner.apiVersion === '2') {
         await this.sandboxRepository.updateWhere(sandbox.id, {
-          updateData: { authToken: nanoid(32).toLocaleLowerCase() },
+          updateData: {
+            desiredState: skipStart ? SandboxDesiredState.STOPPED : SandboxDesiredState.STARTED,
+            ...(willStartOnV2 && { authToken: nanoid(32).toLocaleLowerCase() }),
+          },
           whereCondition: { state: SandboxState.ERROR },
         })
       }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1733,60 +1733,96 @@ export class SandboxService {
   }
 
   async recover(sandboxIdOrName: string, organization: Organization, skipStart = false): Promise<Sandbox> {
+    let pendingDiskIncrement: number | undefined
+
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
-    if (sandbox.state !== SandboxState.ERROR) {
-      throw new BadRequestError('Sandbox must be in error state to recover')
+    const region = await this.regionService.findOne(sandbox.region)
+    if (!region) {
+      throw new NotFoundException(`Region with ID ${sandbox.region} not found`)
     }
-
-    if (sandbox.pending) {
-      throw new StateChangeInProgressError()
-    }
-
-    // Validate runner exists
-    if (!sandbox.runnerId) {
-      throw new NotFoundException(`Sandbox with ID ${sandbox.id} does not have a runner`)
-    }
-    const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
-
-    if (runner.apiVersion === '2') {
-      // TODO: we need "recovering" state that can be set after calling recover
-      // Once in recovering, we abort further processing and let the manager/job handler take care of it
-      // (Also, since desiredState would be STARTED, we need to check the quota)
-      throw new ForbiddenException('Recovering sandboxes with runner API version 2 is not supported')
-    }
-
-    const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
     try {
-      await runnerAdapter.recoverSandbox(sandbox)
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('storage cannot be further expanded')) {
-        const errorMsg = `Sandbox storage cannot be further expanded. Maximum expansion of ${(sandbox.disk * 0.1).toFixed(2)}GB (10% of original ${sandbox.disk.toFixed(2)}GB) has been reached. Please contact support for further assistance.`
-        throw new ForbiddenException(errorMsg)
+      if (sandbox.state !== SandboxState.ERROR) {
+        throw new BadRequestError('Sandbox must be in error state to recover')
       }
+
+      if (sandbox.pending) {
+        throw new StateChangeInProgressError()
+      }
+
+      if (!sandbox.runnerId) {
+        throw new NotFoundException(`Sandbox with ID ${sandbox.id} does not have a runner`)
+      }
+      const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
+
+      if (runner.apiVersion === '2') {
+        // TODO: we need "recovering" state that can be set after calling recover
+        // Once in recovering, we abort further processing and let the manager/job handler take care of it
+        // (Also, since desiredState would be STARTED, we need to check the quota)
+        throw new ForbiddenException('Recovering sandboxes with runner API version 2 is not supported')
+      }
+
+      // ERROR doesn't consume disk, STOPPED does — reserve before the runner round-trip
+      // so an over-quota org is rejected before disk is expanded on the runner.
+      const { pendingDiskIncremented } = await this.validateOrganizationQuotas(
+        organization,
+        region,
+        0,
+        0,
+        sandbox.disk,
+        isEphemeral(sandbox),
+        sandbox.id,
+      )
+      if (pendingDiskIncremented) {
+        pendingDiskIncrement = sandbox.disk
+      }
+
+      // Atomic claim — matches start()/stop(); throws SandboxConflictError on race.
+      await this.sandboxRepository.updateWhere(sandbox.id, {
+        updateData: { pending: true },
+        whereCondition: { state: SandboxState.ERROR, pending: false },
+      })
+
+      const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+
+      try {
+        await runnerAdapter.recoverSandbox(sandbox)
+      } catch (error) {
+        await this.sandboxRepository.updateWhere(sandbox.id, {
+          updateData: { pending: false },
+          whereCondition: { state: SandboxState.ERROR, pending: true },
+        })
+        if (error instanceof Error && error.message.includes('storage cannot be further expanded')) {
+          throw new ForbiddenException(
+            `Sandbox storage cannot be further expanded. Maximum expansion of ${(sandbox.disk * 0.1).toFixed(2)}GB (10% of original ${sandbox.disk.toFixed(2)}GB) has been reached. Please contact support for further assistance.`,
+          )
+        }
+        throw error
+      }
+
+      const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
+        updateData: {
+          state: SandboxState.STOPPED,
+          desiredState: SandboxDesiredState.STOPPED,
+          errorReason: null,
+          recoverable: false,
+          pending: false,
+        },
+        whereCondition: { state: SandboxState.ERROR },
+      })
+
+      if (skipStart) {
+        return updatedSandbox
+      }
+
+      // Sandbox is now STOPPED — normal start flow handles cpu/mem quota + pending usage.
+      // Disk is now in current usage; start()'s self-excluded validation skips re-incrementing it.
+      return await this.start(sandbox.id, organization)
+    } catch (error) {
+      await this.rollbackPendingUsage(organization.id, sandbox.region, undefined, undefined, pendingDiskIncrement)
       throw error
     }
-
-    const updateData: Partial<Sandbox> = {
-      state: SandboxState.STOPPED,
-      desiredState: SandboxDesiredState.STOPPED,
-      errorReason: null,
-      recoverable: false,
-    }
-
-    const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
-      updateData,
-      whereCondition: { state: SandboxState.ERROR },
-    })
-
-    if (skipStart) {
-      return updatedSandbox
-    }
-
-    // Now that sandbox is in STOPPED state, use the normal start flow
-    // This handles quota validation, pending usage, event emission, etc.
-    return await this.start(sandbox.id, organization)
   }
 
   async resize(sandboxIdOrName: string, resizeDto: ResizeSandboxDto, organization: Organization): Promise<Sandbox> {


### PR DESCRIPTION
## Description

The v0 sandbox recover endpoint was racy (two concurrent calls both hit the runner) and skipped disk quota entirely, so
an over-quota org could silently re-add disk to current usage. 
v2 was forbidden outright and had a few latent bugs that would have surfaced if it were unblocked. This PR adds a per-sandbox redis lock plus disk validation on v0, and enables v2 end-to-end: recover validates the right quota dimensions upfront, the job handler writes STOPPED (matching what the runner actually does) and chains START_SANDBOX when needed, recoverable errors are now extracted on failure, and the draining-runner manager handles v2 the same way.  

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation