### PR TITLE
docs: removing stale wording around dashboard bug from oss-domain-dep…

### DIFF
--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -209,14 +209,6 @@ The script installs Caddy with your DNS provider's module (needed for wildcard T
 
 Caddy handles certificate renewal automatically — no cron jobs are needed.
 
-### Dashboard Frontend Patch
-
-:::caution
-The Daytona OSS Docker images ship with `http://localhost:3000` hardcoded in the compiled frontend JavaScript bundle. Without patching this, the dashboard will load but **sandbox creation will fail** because the browser tries to reach `localhost:3000` on the user's machine.
-:::
-
-The script extracts the dashboard assets from the API container, replaces `http://localhost:3000` with `https://YOUR_DOMAIN`, and mounts the patched assets back via a Docker volume. If the Daytona API image is updated (e.g., via `docker compose pull`), this patch step must be re-run.
-
 ### Firewall Configuration
 
 The script opens ports 22, 80, 443, and 2222 on Linux (via ufw or firewalld). If your cloud provider has an external firewall (DigitalOcean Cloud Firewalls, AWS Security Groups, etc.), you must create matching inbound rules there as well — the host firewall and cloud firewall are independent. On macOS, firewall configuration is skipped.
@@ -250,10 +242,6 @@ The script opens ports 22, 80, 443, and 2222 on Linux (via ufw or firewalld). If
 **Caddy module**: `github.com/caddy-dns/hetzner`
 
 ## Domain Deployment Troubleshooting
-
-### Sandbox creation fails with "Network Error" / `localhost:3000` in browser console
-
-The compiled dashboard JavaScript has `http://localhost:3000` hardcoded. Follow the [Dashboard Frontend Patch](#dashboard-frontend-patch) section. After patching, do a hard refresh (Cmd+Shift+R or Ctrl+Shift+R) in the browser.
 
 ### Browser redirects to `localhost:5556` during login
 
@@ -289,7 +277,6 @@ If Caddy logs show `HTTP 429 rateLimited`, you have hit Let's Encrypt's rate lim
 - Database and storage data is persisted in Docker volumes
 - The registry is configured to allow image deletion for testing
 - Sandbox resource limits are disabled due to inability to partition cgroups in DinD environment where the sock is not mounted
-- The dashboard frontend patch (domain deployments only) is a workaround for a build-time bug in the Daytona Docker images and should be removed once the upstream project makes the SDK base URL configurable at runtime
 
 ## Security Considerations
 


### PR DESCRIPTION
## Description

This removes the documentation about the frontend dashboard patch, which is no longer needed because this was resolved in the original PR. The few lines of documentation lines are stale.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

There is no open Issue relevant to this issue

## Screenshots

No screenshots

## Notes

Removing irrelevant documentation lines only, not adding anything
