### PR TITLE
feat(api): end usage period on destroying state

### DIFF
--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -61,6 +61,7 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
         case SandboxState.ERROR:
         case SandboxState.BUILD_FAILED:
         case SandboxState.ARCHIVED:
+        case SandboxState.DESTROYING:
         case SandboxState.DESTROYED: {
           await this.closeUsagePeriod(event.sandbox.id)
           break


### PR DESCRIPTION
## Description

End the usage period as soon as the sandbox enters the "destroying" state instead of after it finishes

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
End usage charges as soon as a sandbox enters the DESTROYING state by closing the usage period immediately, instead of waiting for DESTROYED. This prevents extra billing during teardown.

<sup>Written for commit 60218165b467bb7cc9ba93163c7a4566c9974d09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

