### PR TITLE
feat: add openai dependencies to default image for codex functionality

### DIFF
--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -292,7 +292,7 @@ Use the flags `--cpu`, `--memory` and `--disk` to specify the [resources](/docs/
 <br />
 ```bash
 daytona snapshot push custom-alpine:3.21 --name alpine-minimal --cpu 2 --memory 4 --disk 8
-``` 
+```
 :::
 
 Alternatively, use the `--dockerfile` flag under `create` to pass the path to the Dockerfile you want to use and Daytona will build the snapshot for you. The `COPY`/`ADD` commands will be automatically parsed and added to the context. To manually add files to the context, use the `--context` flag.
@@ -1091,6 +1091,7 @@ All default snapshots are based on the `daytonaio/sandbox:<version>` image. For 
 - `anthropic` (v0.76.0)
 - `beautifulsoup4` (v4.14.3)
 - `claude-agent-sdk` (v0.1.22)
+- `openai-agents` (v0.15.1)
 - `daytona` (v0.134.0)
 - `django` (v6.0.1)
 - `flask` (v3.1.2)
@@ -1102,7 +1103,7 @@ All default snapshots are based on the `daytonaio/sandbox:<version>` image. For 
 - `matplotlib` (v3.10.8)
 - `numpy` (v2.4.1)
 - `ollama` (v0.6.1)
-- `openai` (v2.15.0)
+- `openai` (v2.33.0)
 - `opencv-python` (v4.13.0.90)
 - `pandas` (v2.3.3)
 - `pillow` (v12.1.0)
@@ -1118,6 +1119,7 @@ All default snapshots are based on the `daytonaio/sandbox:<version>` image. For 
 ### Node.js packages (npm)
 
 - `@anthropic-ai/claude-code` (v2.1.19)
+- `@openai/codex` (0.128.0)
 - `bun` (v1.3.6)
 - `openclaw` (v2026.2.1)
 - `opencode-ai` (v1.1.35)

--- a/images/sandbox/Dockerfile
+++ b/images/sandbox/Dockerfile
@@ -62,13 +62,14 @@ RUN python3 -m pip install --no-cache-dir \
     pydantic-ai==1.47.0 \
     langchain==1.2.7 \
     transformers==4.57.6 \
-    openai==2.15.0 \
+    openai==2.33.0 \
     anthropic==0.76.0 \
     llama-index==0.14.13 \
     instructor==1.14.4 \
     huggingface-hub==0.36.0 \
     ollama==0.6.1 \
-    claude-agent-sdk==0.1.22
+    claude-agent-sdk==0.1.22 \
+    openai-agents==0.15.1
 
 # Create the Daytona user and configure sudo access
 RUN useradd -m daytona && echo "daytona ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/91-daytona
@@ -77,7 +78,7 @@ RUN useradd -m daytona && echo "daytona ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d
 RUN bash -c "source /usr/local/share/nvm/nvm.sh && nvm install 25 && nvm use 25 && nvm alias default 25" \
   && chown -R daytona:daytona /usr/local/share/nvm
 
-RUN npm install -g ts-node@10.9.2 typescript@5.9.3 typescript-language-server@5.1.3 bun@1.3.6 @anthropic-ai/claude-code@2.1.19 openclaw@2026.2.1 opencode-ai@1.1.35
+RUN npm install -g ts-node@10.9.2 typescript@5.9.3 typescript-language-server@5.1.3 bun@1.3.6 @anthropic-ai/claude-code@2.1.19 @openai/codex@0.128.0 openclaw@2026.2.1 opencode-ai@1.1.35
 
 # Create directory for computer use plugin
 RUN mkdir -p /usr/local/lib && chown daytona:daytona /usr/local/lib

--- a/images/sandbox/README.md
+++ b/images/sandbox/README.md
@@ -33,11 +33,13 @@ The default sandbox image contains Python, Node and their most popular dependenc
 - huggingface
 - ollama
 - claude-agent-sdk
+- openai-agents
 
 - ts-node
 - typescript
 - typescript-language-server
 - bun
 - @anthropic-ai/claude-code
+- @openai/codex
 - openclaw
 - opencode-ai


### PR DESCRIPTION
## Description

This adds the the openai dependencies for codex functionality and bumps the openai dependency itself to a compatible version (with no conflicts across existing dependency requirements)

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

## Related Issue(s)

Related to a customer request

## Screenshots

No screenshot

## Notes


