### PR TITLE
feat(docs): add declarative builder image configuration examples

### DIFF
--- a/apps/docs/src/content/docs/en/declarative-builder.mdx
+++ b/apps/docs/src/content/docs/en/declarative-builder.mdx
@@ -10,7 +10,7 @@ Declarative Builder provides a powerful, code-first approach to defining depende
 The declarative builder system supports two primary workflows:
 
 - [**Declarative images**](#build-declarative-images): build images on demand when creating sandboxes
-- [**Pre-built snapshots**](#create-pre-built-snapshots): create and register ready-to-use reusable [snapshots](/docs/snapshots)
+- [**Pre-built snapshots**](#create-pre-built-snapshots): create and register ready-to-use [snapshots](/docs/snapshots)
 
 ## Build declarative images
 

--- a/apps/docs/src/content/docs/en/declarative-builder.mdx
+++ b/apps/docs/src/content/docs/en/declarative-builder.mdx
@@ -717,15 +717,18 @@ image := daytona.FromDockerfile(string(content)).
 
 ### System package installation
 
-Daytona provides an option to install OS-level packages during the image build. Combine commands and cleanup in a single layer to keep the resulting image small. Use this pattern when your sandbox needs CLI tools or system libraries that are not available through `pip`.
+Daytona provides an option to install OS-level packages during the image build. Use this pattern when your sandbox needs CLI tools or system libraries that are not available through `pip`.
+
+Each string passed to `run_commands` becomes a separate Dockerfile `RUN` instruction, and every `RUN` produces an immutable layer. To keep the image small, chain the package install and the apt cache cleanup together with `&&` inside a single string so the cache is never persisted in any layer.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
 ```python
 image = Image.debian_slim("3.12").run_commands(
-  "apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq",
-  "rm -rf /var/lib/apt/lists/*",
+  "apt-get update "
+  "&& apt-get install -y --no-install-recommends git curl ffmpeg jq "
+  "&& rm -rf /var/lib/apt/lists/*"
 )
 ```
 
@@ -734,8 +737,9 @@ image = Image.debian_slim("3.12").run_commands(
 
 ```typescript
 const image = Image.debianSlim('3.12').runCommands(
-  'apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq',
-  'rm -rf /var/lib/apt/lists/*',
+  'apt-get update ' +
+    '&& apt-get install -y --no-install-recommends git curl ffmpeg jq ' +
+    '&& rm -rf /var/lib/apt/lists/*',
 )
 ```
 
@@ -746,8 +750,9 @@ const image = Image.debianSlim('3.12').runCommands(
 image = Daytona::Image
   .debian_slim('3.12')
   .run_commands(
-    'apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq',
-    'rm -rf /var/lib/apt/lists/*'
+    'apt-get update ' \
+    '&& apt-get install -y --no-install-recommends git curl ffmpeg jq ' \
+    '&& rm -rf /var/lib/apt/lists/*'
   )
 ```
 
@@ -755,7 +760,6 @@ image = Daytona::Image
 <TabItem label="Go" icon="seti:go">
 
 ```go
-// AptGet handles update, install, and cleanup in a single layer
 version := "3.12"
 image := daytona.DebianSlim(&version).
   AptGet([]string{"git", "curl", "ffmpeg", "jq"})
@@ -766,8 +770,9 @@ image := daytona.DebianSlim(&version).
 
 ```java
 Image image = Image.debianSlim("3.12").runCommands(
-    "apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq",
-    "rm -rf /var/lib/apt/lists/*"
+    "apt-get update "
+        + "&& apt-get install -y --no-install-recommends git curl ffmpeg jq "
+        + "&& rm -rf /var/lib/apt/lists/*"
 );
 ```
 
@@ -778,9 +783,7 @@ Image image = Image.debianSlim("3.12").runCommands(
 
 Daytona provides an option to define a non-root user for application workloads. Run all installation steps as `root` first, then create the user, fix ownership of the working directory, and switch to the new user with the `USER` directive. Subsequent commands and the sandbox runtime then operate without root privileges.
 
-:::note
 Place all installation steps before the `USER` directive. After switching to the non-root user, commands that write to system locations (such as `apt-get install` or `pip install` without `--user`) will fail with permission errors.
-:::
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -847,6 +850,8 @@ image := daytona.DebianSlim(&version).
 
 Daytona provides an option to combine multiple language runtimes in a single image. The following pattern adds Node.js 20 to a Python base image by installing it from the NodeSource repository. The same approach works for adding Go, Ruby, Java, or any other runtime that distributes a Linux installer.
 
+Chain the apt operations, the NodeSource installer, and the cache cleanup into a single `RUN` instruction. If the cache cleanup runs in a separate `RUN`, the apt cache is already persisted in the earlier layers and the final image keeps those bytes.
+
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
@@ -854,10 +859,11 @@ Daytona provides an option to combine multiple language runtimes in a single ima
 image = (
   Image.debian_slim("3.12")
   .run_commands(
-    "apt-get update && apt-get install -y --no-install-recommends curl ca-certificates",
-    "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
-    "apt-get install -y nodejs",
-    "rm -rf /var/lib/apt/lists/*",
+    "apt-get update "
+    "&& apt-get install -y --no-install-recommends curl ca-certificates "
+    "&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - "
+    "&& apt-get install -y nodejs "
+    "&& rm -rf /var/lib/apt/lists/*"
   )
   .pip_install(["fastapi", "uvicorn"])
 )
@@ -869,10 +875,11 @@ image = (
 ```typescript
 const image = Image.debianSlim('3.12')
   .runCommands(
-    'apt-get update && apt-get install -y --no-install-recommends curl ca-certificates',
-    'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -',
-    'apt-get install -y nodejs',
-    'rm -rf /var/lib/apt/lists/*',
+    'apt-get update ' +
+      '&& apt-get install -y --no-install-recommends curl ca-certificates ' +
+      '&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - ' +
+      '&& apt-get install -y nodejs ' +
+      '&& rm -rf /var/lib/apt/lists/*',
   )
   .pipInstall(['fastapi', 'uvicorn'])
 ```
@@ -884,10 +891,11 @@ const image = Image.debianSlim('3.12')
 image = Daytona::Image
   .debian_slim('3.12')
   .run_commands(
-    'apt-get update && apt-get install -y --no-install-recommends curl ca-certificates',
-    'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -',
-    'apt-get install -y nodejs',
-    'rm -rf /var/lib/apt/lists/*'
+    'apt-get update ' \
+    '&& apt-get install -y --no-install-recommends curl ca-certificates ' \
+    '&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - ' \
+    '&& apt-get install -y nodejs ' \
+    '&& rm -rf /var/lib/apt/lists/*'
   )
   .pip_install(['fastapi', 'uvicorn'])
 ```
@@ -898,9 +906,11 @@ image = Daytona::Image
 ```go
 version := "3.12"
 image := daytona.DebianSlim(&version).
-  Run("apt-get update && apt-get install -y --no-install-recommends curl ca-certificates").
-  Run("curl -fsSL https://deb.nodesource.com/setup_20.x | bash -").
-  Run("apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*").
+  Run("apt-get update " +
+    "&& apt-get install -y --no-install-recommends curl ca-certificates " +
+    "&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - " +
+    "&& apt-get install -y nodejs " +
+    "&& rm -rf /var/lib/apt/lists/*").
   PipInstall([]string{"fastapi", "uvicorn"})
 ```
 
@@ -910,10 +920,11 @@ image := daytona.DebianSlim(&version).
 ```java
 Image image = Image.debianSlim("3.12")
     .runCommands(
-        "apt-get update && apt-get install -y --no-install-recommends curl ca-certificates",
-        "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
-        "apt-get install -y nodejs",
-        "rm -rf /var/lib/apt/lists/*"
+        "apt-get update "
+            + "&& apt-get install -y --no-install-recommends curl ca-certificates "
+            + "&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - "
+            + "&& apt-get install -y nodejs "
+            + "&& rm -rf /var/lib/apt/lists/*"
     )
     .pipInstall("fastapi", "uvicorn");
 ```

--- a/apps/docs/src/content/docs/en/declarative-builder.mdx
+++ b/apps/docs/src/content/docs/en/declarative-builder.mdx
@@ -9,8 +9,8 @@ Declarative Builder provides a powerful, code-first approach to defining depende
 
 The declarative builder system supports two primary workflows:
 
-1. [**Declarative images**](#build-declarative-images): build images with varying dependencies _on demand_ when creating sandboxes
-2. [**Pre-built Snapshots**](#create-pre-built-snapshots): create and register _ready-to-use_ [Snapshots](/docs/snapshots) that can be shared across multiple sandboxes
+- [**Declarative images**](#build-declarative-images): build images on demand when creating sandboxes
+- [**Pre-built snapshots**](#create-pre-built-snapshots): create and register ready-to-use reusable [snapshots](/docs/snapshots)
 
 ## Build declarative images
 
@@ -710,6 +710,212 @@ if err != nil {
 }
 image := daytona.FromDockerfile(string(content)).
   PipInstall([]string{"numpy"})
+```
+
+</TabItem>
+</Tabs>
+
+### System package installation
+
+Daytona provides an option to install OS-level packages during the image build. Combine commands and cleanup in a single layer to keep the resulting image small. Use this pattern when your sandbox needs CLI tools or system libraries that are not available through `pip`.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+image = Image.debian_slim("3.12").run_commands(
+  "apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq",
+  "rm -rf /var/lib/apt/lists/*",
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+const image = Image.debianSlim('3.12').runCommands(
+  'apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq',
+  'rm -rf /var/lib/apt/lists/*',
+)
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+image = Daytona::Image
+  .debian_slim('3.12')
+  .run_commands(
+    'apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq',
+    'rm -rf /var/lib/apt/lists/*'
+  )
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+// AptGet handles update, install, and cleanup in a single layer
+version := "3.12"
+image := daytona.DebianSlim(&version).
+  AptGet([]string{"git", "curl", "ffmpeg", "jq"})
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+Image image = Image.debianSlim("3.12").runCommands(
+    "apt-get update && apt-get install -y --no-install-recommends git curl ffmpeg jq",
+    "rm -rf /var/lib/apt/lists/*"
+);
+```
+
+</TabItem>
+</Tabs>
+
+### Non-root user setup
+
+Daytona provides an option to define a non-root user for application workloads. Run all installation steps as `root` first, then create the user, fix ownership of the working directory, and switch to the new user with the `USER` directive. Subsequent commands and the sandbox runtime then operate without root privileges.
+
+:::note
+Place all installation steps before the `USER` directive. After switching to the non-root user, commands that write to system locations (such as `apt-get install` or `pip install` without `--user`) will fail with permission errors.
+:::
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+image = (
+  Image.debian_slim("3.12")
+  .pip_install(["fastapi", "uvicorn"])
+  .run_commands(
+    "groupadd -r daytona && useradd -r -g daytona -m -d /home/daytona daytona",
+    "chown -R daytona:daytona /home/daytona",
+  )
+  .workdir("/home/daytona")
+  .dockerfile_commands(["USER daytona"])
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+const image = Image.debianSlim('3.12')
+  .pipInstall(['fastapi', 'uvicorn'])
+  .runCommands(
+    'groupadd -r daytona && useradd -r -g daytona -m -d /home/daytona daytona',
+    'chown -R daytona:daytona /home/daytona',
+  )
+  .workdir('/home/daytona')
+  .dockerfileCommands(['USER daytona'])
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+image = Daytona::Image
+  .debian_slim('3.12')
+  .pip_install(['fastapi', 'uvicorn'])
+  .run_commands(
+    'groupadd -r daytona && useradd -r -g daytona -m -d /home/daytona daytona',
+    'chown -R daytona:daytona /home/daytona'
+  )
+  .workdir('/home/daytona')
+  .dockerfile_commands(['USER daytona'])
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+version := "3.12"
+image := daytona.DebianSlim(&version).
+  PipInstall([]string{"fastapi", "uvicorn"}).
+  Run("groupadd -r daytona && useradd -r -g daytona -m -d /home/daytona daytona").
+  Run("chown -R daytona:daytona /home/daytona").
+  Workdir("/home/daytona").
+  User("daytona")
+```
+
+</TabItem>
+</Tabs>
+
+### Multi-language runtimes
+
+Daytona provides an option to combine multiple language runtimes in a single image. The following pattern adds Node.js 20 to a Python base image by installing it from the NodeSource repository. The same approach works for adding Go, Ruby, Java, or any other runtime that distributes a Linux installer.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+image = (
+  Image.debian_slim("3.12")
+  .run_commands(
+    "apt-get update && apt-get install -y --no-install-recommends curl ca-certificates",
+    "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
+    "apt-get install -y nodejs",
+    "rm -rf /var/lib/apt/lists/*",
+  )
+  .pip_install(["fastapi", "uvicorn"])
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+const image = Image.debianSlim('3.12')
+  .runCommands(
+    'apt-get update && apt-get install -y --no-install-recommends curl ca-certificates',
+    'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -',
+    'apt-get install -y nodejs',
+    'rm -rf /var/lib/apt/lists/*',
+  )
+  .pipInstall(['fastapi', 'uvicorn'])
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+image = Daytona::Image
+  .debian_slim('3.12')
+  .run_commands(
+    'apt-get update && apt-get install -y --no-install-recommends curl ca-certificates',
+    'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -',
+    'apt-get install -y nodejs',
+    'rm -rf /var/lib/apt/lists/*'
+  )
+  .pip_install(['fastapi', 'uvicorn'])
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+version := "3.12"
+image := daytona.DebianSlim(&version).
+  Run("apt-get update && apt-get install -y --no-install-recommends curl ca-certificates").
+  Run("curl -fsSL https://deb.nodesource.com/setup_20.x | bash -").
+  Run("apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*").
+  PipInstall([]string{"fastapi", "uvicorn"})
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+Image image = Image.debianSlim("3.12")
+    .runCommands(
+        "apt-get update && apt-get install -y --no-install-recommends curl ca-certificates",
+        "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
+        "apt-get install -y nodejs",
+        "rm -rf /var/lib/apt/lists/*"
+    )
+    .pipInstall("fastapi", "uvicorn");
 ```
 
 </TabItem>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added practical image configuration examples to the Declarative Builder docs for Python, TypeScript, Ruby, Go, and Java. Simplified the intro/workflow links and tightened prose to clarify layering and non-root usage.

- **New Features**
  - Added “System package installation” examples using single-layer `apt-get` install + cleanup.
  - Added “Non-root user setup” examples: create user, fix ownership, set workdir, switch via `USER`.
  - Added “Multi-language runtimes” examples showing Node.js 20 on a Python base; applies to other runtimes.

<sup>Written for commit 834e12472a9559a2faaa820e4272c173ea100a52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

