### PR TITLE
feat(docs): add volumes data sharing examples

### DIFF
--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -6,7 +6,9 @@ description: Shared file access across sandboxes.
 import { TabItem, Tabs } from '@astrojs/starlight/components'
 import Label from '@components/Label.astro'
 
-Volumes are FUSE-based mounts that provide shared file access across Daytona Sandboxes. They enable sandboxes to read from large files instantly - no need to upload files manually to each sandbox. Volume data is stored in an S3-compatible object store.
+Volumes are FUSE-based mounts that provide shared file access across Daytona sandboxes. They enable sandboxes to read from large files instantly - no need to upload files manually to each sandbox. Volume data is stored in an S3-compatible object store.
+
+A sandbox reads and writes a mounted volume like any local directory, and the contents persist independently of the sandbox lifecycle. Use volumes to share datasets, model weights, build caches, or application state between sandboxes, scope per-user or per-tenant data with a `subpath`, and combine multiple volumes in the same sandbox at different mount paths.
 
 - multiple volumes can be mounted to a single sandbox
 - a single volume can be mounted to multiple sandboxes
@@ -606,6 +608,505 @@ daytona volume delete <VOLUME_ID>
 curl 'https://app.daytona.io/api/volumes/<VOLUME_ID>' \
   --request DELETE \
   --header 'Authorization: Bearer <API_KEY>'
+```
+
+</TabItem>
+</Tabs>
+
+## Share data between sandboxes
+
+Daytona provides an option to share data across sandboxes by mounting the same volume in each one. A producer sandbox writes to the volume and is then deleted; a separately created consumer sandbox mounts the same volume by ID and reads the data. Volume contents persist independently of any individual sandbox.
+
+Sandboxes that mount the same volume see writes immediately, but FUSE-backed volumes are not transactional. If two sandboxes write to the same path concurrently, the last write wins. Coordinate access in your application when ordering matters.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import CreateSandboxFromSnapshotParams, Daytona, VolumeMount
+
+daytona = Daytona()
+volume = daytona.volume.get("shared-data", create=True)
+mount_dir = "/home/daytona/volume"
+
+# Producer: write data into the volume, then delete the sandbox
+producer = daytona.create(CreateSandboxFromSnapshotParams(
+    language="python",
+    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir)],
+))
+producer.fs.upload_file(b"shared payload", f"{mount_dir}/payload.bin")
+producer.delete()
+
+# Consumer: a separate sandbox mounts the same volume by ID and reads the data
+consumer = daytona.create(CreateSandboxFromSnapshotParams(
+    language="python",
+    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir)],
+))
+data = consumer.fs.download_file(f"{mount_dir}/payload.bin")
+print(data.decode())
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona } from '@daytona/sdk'
+
+const daytona = new Daytona()
+const volume = await daytona.volume.get('shared-data', true)
+const mountDir = '/home/daytona/volume'
+
+// Producer: write data into the volume, then delete the sandbox
+const producer = await daytona.create({
+  language: 'typescript',
+  volumes: [{ volumeId: volume.id, mountPath: mountDir }],
+})
+await producer.fs.uploadFile(Buffer.from('shared payload'), `${mountDir}/payload.bin`)
+await daytona.delete(producer)
+
+// Consumer: a separate sandbox mounts the same volume by ID and reads the data
+const consumer = await daytona.create({
+  language: 'typescript',
+  volumes: [{ volumeId: volume.id, mountPath: mountDir }],
+})
+const data = await consumer.fs.downloadFile(`${mountDir}/payload.bin`)
+console.log(data.toString())
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+require 'daytona'
+
+daytona = Daytona::Daytona.new
+volume = daytona.volume.get('shared-data', create: true)
+mount_dir = '/home/daytona/volume'
+
+mount = DaytonaApiClient::SandboxVolume.new(volume_id: volume.id, mount_path: mount_dir)
+
+# Producer: write data into the volume, then delete the sandbox
+producer = daytona.create(Daytona::CreateSandboxFromSnapshotParams.new(
+  language: Daytona::CodeLanguage::PYTHON,
+  volumes: [mount]
+))
+producer.fs.upload_file('shared payload', "#{mount_dir}/payload.bin")
+daytona.delete(producer)
+
+# Consumer: a separate sandbox mounts the same volume by ID and reads the data
+consumer = daytona.create(Daytona::CreateSandboxFromSnapshotParams.new(
+  language: Daytona::CodeLanguage::PYTHON,
+  volumes: [mount]
+))
+data = consumer.fs.download_file("#{mount_dir}/payload.bin")
+puts data
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+ctx := context.Background()
+client, err := daytona.NewClient()
+if err != nil {
+	log.Fatal(err)
+}
+
+volume, err := client.Volume.Get(ctx, "shared-data")
+if err != nil {
+	volume, err = client.Volume.Create(ctx, "shared-data")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+mountDir := "/home/daytona/volume"
+mount := types.VolumeMount{VolumeID: volume.ID, MountPath: mountDir}
+
+// Producer: write data into the volume, then delete the sandbox
+producer, err := client.Create(ctx, types.SnapshotParams{
+	SandboxBaseParams: types.SandboxBaseParams{
+		Language: types.CodeLanguagePython,
+		Volumes:  []types.VolumeMount{mount},
+	},
+})
+if err != nil {
+	log.Fatal(err)
+}
+if err := producer.FileSystem.UploadFile(ctx, []byte("shared payload"), mountDir+"/payload.bin"); err != nil {
+	log.Fatal(err)
+}
+producer.Delete(ctx)
+
+// Consumer: a separate sandbox mounts the same volume by ID and reads the data
+consumer, err := client.Create(ctx, types.SnapshotParams{
+	SandboxBaseParams: types.SandboxBaseParams{
+		Language: types.CodeLanguagePython,
+		Volumes:  []types.VolumeMount{mount},
+	},
+})
+if err != nil {
+	log.Fatal(err)
+}
+data, err := consumer.FileSystem.DownloadFile(ctx, mountDir+"/payload.bin", nil)
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(string(data))
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+import io.daytona.sdk.Daytona;
+import io.daytona.sdk.Sandbox;
+import io.daytona.sdk.exception.DaytonaNotFoundException;
+import io.daytona.sdk.model.CreateSandboxFromSnapshotParams;
+import io.daytona.sdk.model.Volume;
+import io.daytona.sdk.model.VolumeMount;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class App {
+    public static void main(String[] args) {
+        try (Daytona daytona = new Daytona()) {
+            Volume volume;
+            try {
+                volume = daytona.volume().getByName("shared-data");
+            } catch (DaytonaNotFoundException e) {
+                volume = daytona.volume().create("shared-data");
+            }
+
+            String mountDir = "/home/daytona/volume";
+
+            VolumeMount mount = new VolumeMount();
+            mount.setVolumeId(volume.getId());
+            mount.setMountPath(mountDir);
+
+            // Producer: write data into the volume, then delete the sandbox
+            CreateSandboxFromSnapshotParams producerParams = new CreateSandboxFromSnapshotParams();
+            producerParams.setLanguage("python");
+            producerParams.setVolumes(Collections.singletonList(mount));
+            Sandbox producer = daytona.create(producerParams);
+            producer.fs.uploadFile(
+                "shared payload".getBytes(StandardCharsets.UTF_8),
+                mountDir + "/payload.bin");
+            producer.delete();
+
+            // Consumer: a separate sandbox mounts the same volume by ID and reads the data
+            CreateSandboxFromSnapshotParams consumerParams = new CreateSandboxFromSnapshotParams();
+            consumerParams.setLanguage("python");
+            consumerParams.setVolumes(Collections.singletonList(mount));
+            Sandbox consumer = daytona.create(consumerParams);
+            byte[] data = consumer.fs.downloadFile(mountDir + "/payload.bin");
+            System.out.println(new String(data, StandardCharsets.UTF_8));
+        }
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Mount multiple volumes to one sandbox
+
+Daytona provides an option to mount more than one volume to a single sandbox by passing multiple entries in the `volumes` list. Use this pattern to combine shared assets, models, or datasets in one volume with separate per-application or per-user state in another, exposed at distinct mount paths.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import CreateSandboxFromSnapshotParams, Daytona, VolumeMount
+
+daytona = Daytona()
+shared_assets = daytona.volume.get("shared-assets", create=True)
+logs = daytona.volume.get("logs", create=True)
+
+sandbox = daytona.create(CreateSandboxFromSnapshotParams(
+    language="python",
+    volumes=[
+        VolumeMount(volume_id=shared_assets.id, mount_path="/home/daytona/assets"),
+        VolumeMount(volume_id=logs.id, mount_path="/home/daytona/logs"),
+    ],
+))
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+const sharedAssets = await daytona.volume.get('shared-assets', true)
+const logs = await daytona.volume.get('logs', true)
+
+const sandbox = await daytona.create({
+  language: 'typescript',
+  volumes: [
+    { volumeId: sharedAssets.id, mountPath: '/home/daytona/assets' },
+    { volumeId: logs.id, mountPath: '/home/daytona/logs' },
+  ],
+})
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+shared_assets = daytona.volume.get('shared-assets', create: true)
+logs = daytona.volume.get('logs', create: true)
+
+params = Daytona::CreateSandboxFromSnapshotParams.new(
+  language: Daytona::CodeLanguage::PYTHON,
+  volumes: [
+    DaytonaApiClient::SandboxVolume.new(volume_id: shared_assets.id, mount_path: '/home/daytona/assets'),
+    DaytonaApiClient::SandboxVolume.new(volume_id: logs.id, mount_path: '/home/daytona/logs')
+  ]
+)
+sandbox = daytona.create(params)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+sharedAssets, err := client.Volume.Get(ctx, "shared-assets")
+if err != nil {
+	sharedAssets, err = client.Volume.Create(ctx, "shared-assets")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+logs, err := client.Volume.Get(ctx, "logs")
+if err != nil {
+	logs, err = client.Volume.Create(ctx, "logs")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+sandbox, err := client.Create(ctx, types.SnapshotParams{
+	SandboxBaseParams: types.SandboxBaseParams{
+		Language: types.CodeLanguagePython,
+		Volumes: []types.VolumeMount{
+			{VolumeID: sharedAssets.ID, MountPath: "/home/daytona/assets"},
+			{VolumeID: logs.ID, MountPath: "/home/daytona/logs"},
+		},
+	},
+})
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+Volume sharedAssets;
+try {
+    sharedAssets = daytona.volume().getByName("shared-assets");
+} catch (DaytonaNotFoundException e) {
+    sharedAssets = daytona.volume().create("shared-assets");
+}
+
+Volume logs;
+try {
+    logs = daytona.volume().getByName("logs");
+} catch (DaytonaNotFoundException e) {
+    logs = daytona.volume().create("logs");
+}
+
+VolumeMount assetsMount = new VolumeMount();
+assetsMount.setVolumeId(sharedAssets.getId());
+assetsMount.setMountPath("/home/daytona/assets");
+
+VolumeMount logsMount = new VolumeMount();
+logsMount.setVolumeId(logs.getId());
+logsMount.setMountPath("/home/daytona/logs");
+
+CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
+params.setLanguage("python");
+params.setVolumes(java.util.Arrays.asList(assetsMount, logsMount));
+Sandbox sandbox = daytona.create(params);
+```
+
+</TabItem>
+</Tabs>
+
+## Multi-tenant isolation with subpaths
+
+Daytona provides an option to isolate per-tenant or per-user data inside a single shared volume by setting a unique `subpath` on each sandbox's volume mount. Each sandbox sees only files under its assigned subpath at `mount_path` and cannot read or write sibling subpaths within the same volume. This is the recommended pattern for multi-tenant workloads because it stays within the [per-organization volume limit](#pricing--limits) instead of creating one volume per tenant.
+
+Isolation is enforced at the FUSE mount boundary. Each sandbox sees its assigned subpath as the volume root, so a sandbox mounted at `users/alice` cannot reach `users/bob` through relative paths such as `../bob`.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import CreateSandboxFromSnapshotParams, Daytona, VolumeMount
+
+daytona = Daytona()
+volume = daytona.volume.get("tenants", create=True)
+mount_dir = "/home/daytona/data"
+
+# Tenant A
+alice_sandbox = daytona.create(CreateSandboxFromSnapshotParams(
+    language="python",
+    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir, subpath="users/alice")],
+))
+alice_sandbox.fs.upload_file(b"alice's data", f"{mount_dir}/notes.txt")
+
+# Tenant B sees only its own subpath; alice's notes.txt is invisible
+bob_sandbox = daytona.create(CreateSandboxFromSnapshotParams(
+    language="python",
+    volumes=[VolumeMount(volume_id=volume.id, mount_path=mount_dir, subpath="users/bob")],
+))
+bob_sandbox.fs.upload_file(b"bob's data", f"{mount_dir}/notes.txt")
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+const volume = await daytona.volume.get('tenants', true)
+const mountDir = '/home/daytona/data'
+
+// Tenant A
+const aliceSandbox = await daytona.create({
+  language: 'typescript',
+  volumes: [{ volumeId: volume.id, mountPath: mountDir, subpath: 'users/alice' }],
+})
+await aliceSandbox.fs.uploadFile(Buffer.from("alice's data"), `${mountDir}/notes.txt`)
+
+// Tenant B sees only its own subpath; alice's notes.txt is invisible
+const bobSandbox = await daytona.create({
+  language: 'typescript',
+  volumes: [{ volumeId: volume.id, mountPath: mountDir, subpath: 'users/bob' }],
+})
+await bobSandbox.fs.uploadFile(Buffer.from("bob's data"), `${mountDir}/notes.txt`)
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+volume = daytona.volume.get('tenants', create: true)
+mount_dir = '/home/daytona/data'
+
+# Tenant A
+alice_params = Daytona::CreateSandboxFromSnapshotParams.new(
+  language: Daytona::CodeLanguage::PYTHON,
+  volumes: [DaytonaApiClient::SandboxVolume.new(
+    volume_id: volume.id, mount_path: mount_dir, subpath: 'users/alice'
+  )]
+)
+alice_sandbox = daytona.create(alice_params)
+alice_sandbox.fs.upload_file("alice's data", "#{mount_dir}/notes.txt")
+
+# Tenant B sees only its own subpath; alice's notes.txt is invisible
+bob_params = Daytona::CreateSandboxFromSnapshotParams.new(
+  language: Daytona::CodeLanguage::PYTHON,
+  volumes: [DaytonaApiClient::SandboxVolume.new(
+    volume_id: volume.id, mount_path: mount_dir, subpath: 'users/bob'
+  )]
+)
+bob_sandbox = daytona.create(bob_params)
+bob_sandbox.fs.upload_file("bob's data", "#{mount_dir}/notes.txt")
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+volume, err := client.Volume.Get(ctx, "tenants")
+if err != nil {
+	volume, err = client.Volume.Create(ctx, "tenants")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+mountDir := "/home/daytona/data"
+
+// Tenant A
+aliceSubpath := "users/alice"
+aliceSandbox, err := client.Create(ctx, types.SnapshotParams{
+	SandboxBaseParams: types.SandboxBaseParams{
+		Language: types.CodeLanguagePython,
+		Volumes: []types.VolumeMount{
+			{VolumeID: volume.ID, MountPath: mountDir, Subpath: &aliceSubpath},
+		},
+	},
+})
+if err != nil {
+	log.Fatal(err)
+}
+if err := aliceSandbox.FileSystem.UploadFile(ctx, []byte("alice's data"), mountDir+"/notes.txt"); err != nil {
+	log.Fatal(err)
+}
+
+// Tenant B sees only its own subpath; alice's notes.txt is invisible
+bobSubpath := "users/bob"
+bobSandbox, err := client.Create(ctx, types.SnapshotParams{
+	SandboxBaseParams: types.SandboxBaseParams{
+		Language: types.CodeLanguagePython,
+		Volumes: []types.VolumeMount{
+			{VolumeID: volume.ID, MountPath: mountDir, Subpath: &bobSubpath},
+		},
+	},
+})
+if err != nil {
+	log.Fatal(err)
+}
+if err := bobSandbox.FileSystem.UploadFile(ctx, []byte("bob's data"), mountDir+"/notes.txt"); err != nil {
+	log.Fatal(err)
+}
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+The Java SDK and CLI do not currently expose `subpath`. Use the REST API directly when you need subpath mounts from those clients.
+
+```bash
+# Tenant A
+curl 'https://app.daytona.io/api/sandbox' \
+  --request POST \
+  --header 'Authorization: Bearer <API_KEY>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "volumes": [
+    {
+      "volumeId": "<VOLUME_ID>",
+      "mountPath": "/home/daytona/data",
+      "subpath": "users/alice"
+    }
+  ]
+}'
+
+# Tenant B
+curl 'https://app.daytona.io/api/sandbox' \
+  --request POST \
+  --header 'Authorization: Bearer <API_KEY>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "volumes": [
+    {
+      "volumeId": "<VOLUME_ID>",
+      "mountPath": "/home/daytona/data",
+      "subpath": "users/bob"
+    }
+  ]
+}'
 ```
 
 </TabItem>

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -745,7 +745,9 @@ if err != nil {
 if err := producer.FileSystem.UploadFile(ctx, []byte("shared payload"), mountDir+"/payload.bin"); err != nil {
 	log.Fatal(err)
 }
-producer.Delete(ctx)
+if err := producer.Delete(ctx); err != nil {
+	log.Fatal(err)
+}
 
 // Consumer: a separate sandbox mounts the same volume by ID and reads the data
 consumer, err := client.Create(ctx, types.SnapshotParams{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add examples for Daytona volumes: share data across sandboxes, mount multiple volumes, and multi-tenant isolation with `subpath`. Snippets for Python, TypeScript, Ruby, Go, and Java; clarifies persistence and non-transactional writes.

- **New Features**
  - Share data between sandboxes by mounting the same volume; writes are immediate but not transactional.
  - Mount multiple volumes in one sandbox with distinct `mountPath`s.
  - Isolate tenant/user data using `subpath`; includes REST example and notes that Java SDK/CLI don’t expose `subpath` yet.

<sup>Written for commit 3be7ca9fb10acbd023c102cec9af60ea8aa64444. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

