### PR TITLE
feat: add generic S3-compatible storage support (RustFS) and STS bypass logic

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -85,6 +85,7 @@ const configuration = {
     defaultBucket: process.env.S3_DEFAULT_BUCKET,
     accountId: process.env.S3_ACCOUNT_ID,
     roleName: process.env.S3_ROLE_NAME,
+    provider: process.env.S3_PROVIDER,
   },
   notificationGatewayDisabled: process.env.NOTIFICATION_GATEWAY_DISABLED === 'true',
   skipConnections: process.env.SKIP_CONNECTIONS === 'true',

--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -13,13 +13,14 @@ import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts'
 
 interface S3Config {
   endpoint: string
-  stsEndpoint: string
+  stsEndpoint?: string
   accessKey: string
   secretKey: string
   bucket: string
   region: string
   accountId?: string
   roleName?: string
+  provider?: string
   organizationId: string
   policy: any
 }
@@ -37,15 +38,19 @@ export class ObjectStorageService {
 
     try {
       const bucket = this.configService.getOrThrow('s3.defaultBucket')
+      const provider =
+        this.configService.get('s3.provider') ||
+        (this.configService.get('s3.endpoint').includes('minio') ? 'minio' : 'aws')
+
       const s3Config: S3Config = {
         endpoint: this.configService.getOrThrow('s3.endpoint'),
-        stsEndpoint: this.configService.getOrThrow('s3.stsEndpoint'),
         accessKey: this.configService.getOrThrow('s3.accessKey'),
         secretKey: this.configService.getOrThrow('s3.secretKey'),
         bucket,
         region: this.configService.getOrThrow('s3.region'),
         accountId: this.configService.getOrThrow('s3.accountId'),
         roleName: this.configService.getOrThrow('s3.roleName'),
+        provider: provider,
         organizationId,
         policy: {
           Version: '2012-10-17',
@@ -65,9 +70,21 @@ export class ObjectStorageService {
         },
       }
 
-      const isMinioServer = s3Config.endpoint.includes('minio')
+      if (provider === 'rustfs') {
+        return {
+          accessKey: s3Config.accessKey,
+          secret: s3Config.secretKey,
+          sessionToken: '',
+          storageUrl: s3Config.endpoint,
+          organizationId,
+          bucket: s3Config.bucket,
+        }
+      }
 
-      if (isMinioServer) {
+      // STS Endpoint is required for MinIO and AWS
+      s3Config.stsEndpoint = this.configService.getOrThrow('s3.stsEndpoint')
+
+      if (provider === 'minio') {
         return this.getMinioCredentials(s3Config)
       } else {
         return this.getAwsCredentials(s3Config)
@@ -102,7 +119,7 @@ export class ObjectStorageService {
       secretAccessKey: config.secretKey,
     })
 
-    const response = await axios.post(config.stsEndpoint, body.toString(), {
+    const response = await axios.post(config.stsEndpoint as string, body.toString(), {
       headers: requestOptions.headers,
     })
 


### PR DESCRIPTION
This PR introduces support for integrating Daytona with generic S3-compatible object storages, specifically targeting **RustFS**. 
Previously, Daytona strictly required the presence of an STS (AssumeRole) endpoint and only differentiated between AWS and MinIO based on a string-match against the endpoint URL. This PR:
1. Adds a dedicated `S3_PROVIDER` configuration variable.
2. Implements a conditional bypass for STS when the provider is `rustfs`, falling back to standard static credential authentication since RustFS does not expose an STS endpoint.
3. Maintains strict STS configuration checks (`getOrThrow`) for `aws` and `minio` providers to preserve existing security guarantees.
## Documentation
- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation
## Related Issue(s)
closes https://github.com/daytonaio/daytona/issues/4617
## Screenshots
*(N/A)*
## Notes
- The S3 fallback correctly passes an empty string (`sessionToken: ''`) to the Go CLI and Runner clients. This seamlessly triggers standard AWS Signature V4 authentication using just the provided static access and secret keys, which is natively supported by the MinIO Go SDK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for generic S3-compatible storage with a new provider flag and RustFS support. Skips STS for `rustfs` while keeping strict STS for `aws` and `minio`.

- New Features
  - Added `S3_PROVIDER` config/env to select `aws`, `minio`, or `rustfs`.
  - If not set, provider is inferred: `minio` if endpoint contains "minio", else `aws`.
  - `rustfs`: bypasses STS and uses static access/secret keys with an empty `sessionToken`; returns `storageUrl` as the endpoint.
  - `aws`/`minio`: STS endpoint is required and enforced.

- Migration
  - For RustFS: set `S3_PROVIDER=rustfs` and omit `S3_STS_ENDPOINT`.
  - For AWS/MinIO: ensure `S3_STS_ENDPOINT` is set; behavior unchanged.
  - Optional: set `S3_PROVIDER` explicitly to avoid inference; other S3 env vars remain required.

<sup>Written for commit bad70a50e6bb3e7f85fa0d19a7247cd118a852ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

