### PR TITLE
fix: correctly evaluate useSSL before trimming https prefix in runner minio client

### DIFF
--- a/apps/runner/pkg/storage/minio_client.go
+++ b/apps/runner/pkg/storage/minio_client.go
@@ -39,10 +39,10 @@ func GetObjectStorageClient() (ObjectStorageClient, error) {
 	bucketName := runnerConfig.AWSDefaultBucket
 	region := runnerConfig.AWSRegion
 
+	useSSL := strings.HasPrefix(endpoint, "https://")
+
 	endpoint = strings.TrimPrefix(endpoint, "http://")
 	endpoint = strings.TrimPrefix(endpoint, "https://")
-
-	useSSL := strings.Contains(endpoint, "https")
 
 	if endpoint == "" || accessKeyId == "" || secretKey == "" || bucketName == "" || region == "" {
 		return nil, fmt.Errorf("missing S3 configuration - endpoint, access key, secret key, region, or bucket name not provided")


### PR DESCRIPTION
This PR fixes a critical bug in the Runner's MinIO client initialization where S3 connections over HTTPS were incorrectly falling back to HTTP.
Previously, `AWSEndpointUrl` was having its `https://` and `http://` prefixes trimmed *before* evaluating whether the endpoint contained `https`. This resulted in `useSSL` always evaluating to `false` for standard S3 endpoints (e.g. `https://minio.example.com:9000`), forcing the MinIO client to connect over HTTP and causing connection failures on strictly secure S3 buckets.
The logic has been updated to evaluate the `https://` prefix *before* stripping it out, correctly enabling SSL for the connection.
## Documentation
- [ ] This change requires a documentation update
- [x] I have made corresponding changes to the documentation
## Related Issue(s)
*(Add related issue # if applicable)*
## Screenshots
*(N/A)*
## Notes
- This bug was isolated strictly to the Runner (`apps/runner/pkg/storage/minio_client.go`). The CLI implementation already correctly parses the URL scheme using the `net/url` package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Runner MinIO client to correctly detect HTTPS endpoints and enable SSL, preventing fallback to HTTP and failures on secure S3 buckets. `useSSL` is now set based on the original `https://` prefix before trimming the scheme.

<sup>Written for commit d7cb25fda97228fc0eb941907ad4e23677bae1dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

