### PR TITLE
feat(dashboard): snapshot details sheet

### DIFF
--- a/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
@@ -4,6 +4,10 @@
  */
 
 import { Button } from '@/components/ui/button'
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   Sheet,
   SheetContent,
@@ -13,21 +17,18 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet'
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Spinner } from '@/components/ui/spinner'
 import { useCreateSnapshotMutation } from '@/hooks/mutations/useCreateSnapshotMutation'
 import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
+import { imageNameSchema } from '@/lib/schema'
 import { getRegionFullDisplayName } from '@/lib/utils'
+import type { SnapshotDto } from '@daytona/api-client'
 import { useForm } from '@tanstack/react-form'
 import { Plus } from 'lucide-react'
-import { Ref, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { imageNameSchema } from '@/lib/schema'
 import { z } from 'zod'
 import { ScrollArea } from '../ui/scroll-area'
 
@@ -60,20 +61,35 @@ const defaultValues: FormValues = {
   regionId: undefined,
 }
 
-export const CreateSnapshotSheet = ({ className, ref }: { className?: string; ref?: Ref<{ open: () => void }> }) => {
+export const CreateSnapshotSheet = ({
+  className,
+  onSnapshotCreated,
+  ref,
+}: {
+  className?: string
+  onSnapshotCreated?: (snapshot: SnapshotDto) => void
+  ref?: Ref<{ open: () => void }>
+}) => {
   const [open, setOpen] = useState(false)
 
   const { availableRegions: regions, loadingAvailableRegions: loadingRegions } = useRegions()
   const { selectedOrganization } = useSelectedOrganization()
   const { reset: resetCreateSnapshotMutation, ...createSnapshotMutation } = useCreateSnapshotMutation()
   const formRef = useRef<HTMLFormElement>(null)
+  const formDefaultValues = useMemo<FormValues>(
+    () => ({
+      ...defaultValues,
+      regionId: selectedOrganization?.defaultRegionId,
+    }),
+    [selectedOrganization?.defaultRegionId],
+  )
 
   useImperativeHandle(ref, () => ({
     open: () => setOpen(true),
   }))
 
   const form = useForm({
-    defaultValues,
+    defaultValues: formDefaultValues,
     validators: {
       onSubmit: formSchema,
     },
@@ -95,7 +111,7 @@ export const CreateSnapshotSheet = ({ className, ref }: { className?: string; re
       const trimmedEntrypoint = value.entrypoint?.trim()
 
       try {
-        await createSnapshotMutation.mutateAsync({
+        const snapshot = await createSnapshotMutation.mutateAsync({
           snapshot: {
             name: value.name.trim(),
             imageName: value.imageName.trim(),
@@ -109,6 +125,7 @@ export const CreateSnapshotSheet = ({ className, ref }: { className?: string; re
         })
 
         toast.success(`Creating snapshot ${value.name.trim()}`)
+        onSnapshotCreated?.(snapshot)
         setOpen(false)
       } catch (error) {
         handleApiError(error, 'Failed to create snapshot')
@@ -118,9 +135,9 @@ export const CreateSnapshotSheet = ({ className, ref }: { className?: string; re
   const { reset: resetForm } = form
 
   const resetState = useCallback(() => {
-    resetForm(defaultValues)
+    resetForm(formDefaultValues)
     resetCreateSnapshotMutation()
-  }, [resetForm, resetCreateSnapshotMutation])
+  }, [formDefaultValues, resetForm, resetCreateSnapshotMutation])
 
   useEffect(() => {
     if (open) {
@@ -222,10 +239,7 @@ export const CreateSnapshotSheet = ({ className, ref }: { className?: string; re
                       ))}
                     </SelectContent>
                   </Select>
-                  <FieldDescription>
-                    The region where the snapshot will be available. If not specified, your organization's default
-                    region will be used.
-                  </FieldDescription>
+                  <FieldDescription>The region where the snapshot will be available.</FieldDescription>
                 </Field>
               )}
             </form.Field>

--- a/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
@@ -1,0 +1,421 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { CopyButton } from '@/components/CopyButton'
+import { ResourceChip } from '@/components/ResourceChip'
+import { TimestampTooltip } from '@/components/TimestampTooltip'
+import { Badge, type BadgeProps } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { ButtonGroup } from '@/components/ui/button-group'
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { getSnapshotQueryErrorStatus, useSnapshotQuery } from '@/hooks/queries/useSnapshotsQuery'
+import { cn, getRelativeTimeString } from '@/lib/utils'
+import { SnapshotDto, SnapshotState } from '@daytona/api-client'
+import { MagnifyingGlassIcon } from '@phosphor-icons/react'
+import { ChevronDown, ChevronUp, CircleAlert, Pause, Play, Trash2, X } from 'lucide-react'
+import React from 'react'
+
+export interface SnapshotSheetProps {
+  snapshotId?: string | null
+  snapshot: SnapshotDto | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  getRegionName: (regionId: string) => string | undefined
+  onNavigate: (direction: 'prev' | 'next') => void
+  hasPrev: boolean
+  hasNext: boolean
+  actionsDisabled?: boolean
+  writePermitted: boolean
+  deletePermitted: boolean
+  onActivate: (snapshot: SnapshotDto) => void
+  onDeactivate: (snapshot: SnapshotDto) => void
+  onDelete: (snapshot: SnapshotDto) => void
+}
+
+function InfoSection({
+  title,
+  children,
+  className,
+}: {
+  title?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('px-5 py-4 border-b border-border last:border-b-0', className)}>
+      {title && <div className="text-xs uppercase tracking-widest text-muted-foreground mb-2">{title}</div>}
+      {children}
+    </div>
+  )
+}
+
+function InfoRow({
+  label,
+  children,
+  className,
+}: {
+  label: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('flex items-center justify-between gap-3 py-1', className)}>
+      <span className="text-sm text-muted-foreground shrink-0">{label}</span>
+      <div className="min-w-0 text-sm text-right">{children}</div>
+    </div>
+  )
+}
+
+function CopyValue({
+  value,
+  tooltipText = 'Copy',
+  className,
+}: {
+  value: string
+  tooltipText?: string
+  className?: string
+}) {
+  return (
+    <div className="flex items-center gap-1 min-w-0">
+      <span className={cn('truncate', className)}>{value}</span>
+      <CopyButton value={value} tooltipText={tooltipText} size="icon-xs" />
+    </div>
+  )
+}
+
+function EmptyValue() {
+  return <span className="text-muted-foreground">-</span>
+}
+
+function getStateBadgeVariant(state: SnapshotState): BadgeProps['variant'] {
+  switch (state) {
+    case SnapshotState.ACTIVE:
+      return 'success'
+    case SnapshotState.ERROR:
+    case SnapshotState.BUILD_FAILED:
+      return 'destructive'
+    default:
+      return 'secondary'
+  }
+}
+
+function getStateLabel(state: SnapshotState) {
+  if (state === SnapshotState.REMOVING) {
+    return 'Deleting'
+  }
+
+  return state
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}
+
+function SnapshotStateBadge({ snapshot }: { snapshot: SnapshotDto }) {
+  return <Badge variant={getStateBadgeVariant(snapshot.state)}>{getStateLabel(snapshot.state)}</Badge>
+}
+
+function TimestampRow({ label, value }: { label: string; value: Date | null | undefined }) {
+  if (!value) {
+    return (
+      <InfoRow label={label}>
+        <span className="text-muted-foreground">-</span>
+      </InfoRow>
+    )
+  }
+
+  const timestamp = getRelativeTimeString(value)
+
+  return (
+    <InfoRow label={label}>
+      <TimestampTooltip timestamp={value.toString()}>{timestamp.relativeTimeString}</TimestampTooltip>
+    </InfoRow>
+  )
+}
+
+function SnapshotSheetSkeleton() {
+  const overviewRows = ['name', 'image', 'entrypoint', 'state']
+  const timestampRows = ['created', 'updated', 'last-used']
+
+  return (
+    <>
+      <InfoSection>
+        {overviewRows.map((row) => (
+          <div key={row} className="flex items-center justify-between gap-3 py-1">
+            <Skeleton className="h-4 w-20 shrink-0" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        ))}
+      </InfoSection>
+      <InfoSection title="Resources">
+        <div className="flex flex-wrap gap-2 py-1">
+          <Skeleton className="h-7 w-16" />
+          <Skeleton className="h-7 w-20" />
+          <Skeleton className="h-7 w-16" />
+        </div>
+      </InfoSection>
+      <InfoSection title="Regions">
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-6 w-20" />
+        </div>
+      </InfoSection>
+      <InfoSection title="Timestamps">
+        {timestampRows.map((row) => (
+          <div key={row} className="flex items-center justify-between gap-3 py-1">
+            <Skeleton className="h-4 w-20 shrink-0" />
+            <Skeleton className="h-4 w-28" />
+          </div>
+        ))}
+      </InfoSection>
+    </>
+  )
+}
+
+function SnapshotSheetEmptyState({ error }: { error: boolean }) {
+  const Icon = error ? CircleAlert : MagnifyingGlassIcon
+
+  return (
+    <Empty variant={error ? 'destructive' : 'neutral'} className="min-h-64 border-0 bg-transparent px-5 py-6">
+      <EmptyHeader>
+        <EmptyMedia
+          variant="icon"
+          className={cn('[&_svg]:size-4', {
+            'bg-destructive-background text-destructive': error,
+          })}
+        >
+          <Icon className="size-4" />
+        </EmptyMedia>
+        <EmptyTitle>{error ? 'Failed to load snapshot' : 'Snapshot not found'}</EmptyTitle>
+        <EmptyDescription>
+          {error
+            ? 'Something went wrong while fetching this snapshot.'
+            : 'This snapshot may have been deleted or you may not have access to it.'}
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  )
+}
+
+export function SnapshotSheet({
+  snapshotId,
+  snapshot,
+  open,
+  onOpenChange,
+  getRegionName,
+  onNavigate,
+  hasPrev,
+  hasNext,
+  actionsDisabled = false,
+  writePermitted,
+  deletePermitted,
+  onActivate,
+  onDeactivate,
+  onDelete,
+}: SnapshotSheetProps) {
+  const {
+    data: fetchedSnapshot,
+    isLoading: snapshotIsLoading,
+    isFetching: snapshotIsFetching,
+    isError: snapshotIsError,
+    error: snapshotError,
+  } = useSnapshotQuery(snapshotId, {
+    enabled: open && !snapshot && !!snapshotId,
+  })
+
+  const activeSnapshot = snapshot ?? fetchedSnapshot
+  const loadingSnapshot = !activeSnapshot && (snapshotIsLoading || snapshotIsFetching)
+  const snapshotNotFound = snapshotIsError && getSnapshotQueryErrorStatus(snapshotError) === 404
+  const regionNames = activeSnapshot?.regionIds?.map((id) => getRegionName(id) ?? id) ?? []
+  const showActions = !!activeSnapshot && !activeSnapshot.general && (writePermitted || deletePermitted)
+  const showActivate = !!activeSnapshot && writePermitted && activeSnapshot.state === SnapshotState.INACTIVE
+  const showDeactivate = !!activeSnapshot && writePermitted && activeSnapshot.state === SnapshotState.ACTIVE
+  const showDelete = !!activeSnapshot && deletePermitted && activeSnapshot.state !== SnapshotState.REMOVING
+
+  if (!snapshotId && !activeSnapshot) return null
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        showCloseButton={false}
+        className="w-dvw p-0 flex flex-col gap-0 sm:w-[450px] [&>button]:hidden"
+      >
+        <SheetHeader className="flex flex-row items-center justify-between p-4 px-5 space-y-0">
+          <div className="min-w-0">
+            <SheetTitle className="text-lg font-medium">Snapshot Details</SheetTitle>
+          </div>
+          <div className="flex items-center justify-end shrink-0">
+            <Button variant="ghost" size="icon-sm" disabled={!hasPrev} onClick={() => onNavigate('prev')}>
+              <ChevronUp className="size-4" />
+              <span className="sr-only">Previous snapshot</span>
+            </Button>
+            <Button variant="ghost" size="icon-sm" disabled={!hasNext} onClick={() => onNavigate('next')}>
+              <ChevronDown className="size-4" />
+              <span className="sr-only">Next snapshot</span>
+            </Button>
+            <Button variant="ghost" size="icon-sm" onClick={() => onOpenChange(false)}>
+              <X className="size-4" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </div>
+        </SheetHeader>
+
+        <Separator />
+
+        <ScrollArea fade="mask" className="min-h-0 flex-1">
+          {loadingSnapshot ? (
+            <SnapshotSheetSkeleton />
+          ) : !activeSnapshot ? (
+            <SnapshotSheetEmptyState error={snapshotIsError && !snapshotNotFound} />
+          ) : (
+            <>
+              <InfoSection>
+                <InfoRow label="Name" className="-mr-2">
+                  <CopyValue value={activeSnapshot.name} tooltipText="Copy name" />
+                </InfoRow>
+                <InfoRow label="Image" className="-mr-2">
+                  {activeSnapshot.imageName ? (
+                    <CopyValue value={activeSnapshot.imageName} tooltipText="Copy image" className="font-mono" />
+                  ) : activeSnapshot.buildInfo ? (
+                    <Badge variant="secondary" className="rounded-sm px-1 font-medium">
+                      DECLARATIVE BUILD
+                    </Badge>
+                  ) : (
+                    <EmptyValue />
+                  )}
+                </InfoRow>
+                {activeSnapshot.entrypoint?.length ? (
+                  <InfoRow label="Entrypoint" className="items-start -mr-2">
+                    <CopyValue
+                      value={activeSnapshot.entrypoint.join(' ')}
+                      tooltipText="Copy entrypoint"
+                      className="font-mono"
+                    />
+                  </InfoRow>
+                ) : null}
+                <InfoRow label="State">
+                  <SnapshotStateBadge snapshot={activeSnapshot} />
+                </InfoRow>
+                {activeSnapshot.general && (
+                  <InfoRow label="Type">
+                    <Badge variant="secondary">System</Badge>
+                  </InfoRow>
+                )}
+                {showActions && (
+                  <div className="flex items-center justify-end pt-3">
+                    <ButtonGroup>
+                      {showActivate && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={actionsDisabled}
+                          onClick={() => onActivate(activeSnapshot)}
+                        >
+                          <Play className="size-4" />
+                          Activate
+                        </Button>
+                      )}
+                      {showDeactivate && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={actionsDisabled}
+                          onClick={() => onDeactivate(activeSnapshot)}
+                        >
+                          <Pause className="size-4" />
+                          Deactivate
+                        </Button>
+                      )}
+                      {showDelete && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon-sm"
+                              disabled={actionsDisabled}
+                              onClick={() => onDelete(activeSnapshot)}
+                              aria-label="Delete snapshot"
+                              className="text-destructive-foreground hover:bg-destructive/10 hover:text-destructive-foreground"
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Delete</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </ButtonGroup>
+                  </div>
+                )}
+              </InfoSection>
+
+              {activeSnapshot.errorReason && (
+                <InfoSection title="Error">
+                  <p className="text-sm text-destructive-foreground break-words">{activeSnapshot.errorReason}</p>
+                </InfoSection>
+              )}
+
+              <InfoSection title="Resources">
+                <div className="flex flex-wrap gap-2 py-1">
+                  <ResourceChip resource="cpu" value={activeSnapshot.cpu} />
+                  <ResourceChip resource="memory" value={activeSnapshot.mem} />
+                  <ResourceChip resource="disk" value={activeSnapshot.disk} />
+                </div>
+              </InfoSection>
+
+              <InfoSection title="Regions">
+                {regionNames.length ? (
+                  <div className="flex flex-wrap gap-2">
+                    {regionNames.map((regionName) => (
+                      <Badge key={regionName} variant="secondary">
+                        {regionName}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : (
+                  <span className="text-sm text-muted-foreground">-</span>
+                )}
+              </InfoSection>
+
+              {activeSnapshot.buildInfo && (
+                <InfoSection title="Build">
+                  <TimestampRow label="Created" value={activeSnapshot.buildInfo.createdAt} />
+                  <TimestampRow label="Updated" value={activeSnapshot.buildInfo.updatedAt} />
+                  {!!activeSnapshot.buildInfo.contextHashes?.length && (
+                    <InfoRow label="Context hashes" className="items-start -mr-2">
+                      <div className="flex min-w-0 flex-col items-end gap-1">
+                        {activeSnapshot.buildInfo.contextHashes.map((hash) => (
+                          <CopyValue key={hash} value={hash} tooltipText="Copy hash" className="font-mono" />
+                        ))}
+                      </div>
+                    </InfoRow>
+                  )}
+                  {activeSnapshot.buildInfo.dockerfileContent && (
+                    <div className="mt-3">
+                      <div className="mb-1 text-sm text-muted-foreground">Dockerfile</div>
+                      <pre className="max-h-64 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-left text-xs">
+                        <code>{activeSnapshot.buildInfo.dockerfileContent}</code>
+                      </pre>
+                    </div>
+                  )}
+                </InfoSection>
+              )}
+
+              <InfoSection title="Timestamps">
+                <TimestampRow label="Created" value={activeSnapshot.createdAt} />
+                <TimestampRow label="Updated" value={activeSnapshot.updatedAt} />
+                <TimestampRow label="Last used" value={activeSnapshot.lastUsedAt} />
+              </InfoSection>
+            </>
+          )}
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/SnapshotTable.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { SnapshotSorting } from '@/hooks/queries/useSnapshotsQuery'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { cn } from '@/lib/utils'
 import { getColumnSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
@@ -54,6 +55,8 @@ interface DataTableProps {
   onActivate?: (snapshot: SnapshotDto) => void
   onDeactivate?: (snapshot: SnapshotDto) => void
   onCreateSnapshot?: () => void
+  onRowClick?: (snapshot: SnapshotDto, orderedSnapshots: SnapshotDto[]) => void
+  activeSnapshotId?: string
   pagination: {
     pageIndex: number
     pageSize: number
@@ -88,6 +91,8 @@ export function SnapshotTable({
   onActivate,
   onDeactivate,
   onCreateSnapshot,
+  onRowClick,
+  activeSnapshotId,
   pagination,
   pageCount,
   totalItems,
@@ -341,16 +346,28 @@ export function SnapshotTable({
               table.getRowModel().rows.map((row) => (
                 <TableRow
                   key={row.id}
-                  data-state={row.getIsSelected() ? 'selected' : undefined}
-                  className={`${
-                    loadingSnapshots[row.original.id] || row.original.state === SnapshotState.REMOVING
-                      ? 'opacity-50 pointer-events-none'
-                      : ''
-                  } ${row.original.general ? 'pointer-events-none' : ''}`}
+                  data-selected={row.getIsSelected() || row.original.id === activeSnapshotId ? true : undefined}
+                  className={cn('group/table-row transition-all', {
+                    'opacity-50 pointer-events-none':
+                      loadingSnapshots[row.original.id] || row.original.state === SnapshotState.REMOVING,
+                    'cursor-pointer': onRowClick,
+                  })}
+                  onClick={() =>
+                    onRowClick?.(
+                      row.original,
+                      table.getRowModel().rows.map((row) => row.original),
+                    )
+                  }
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell
                       key={cell.id}
+                      onClick={(event) => {
+                        if (cell.column.id === 'select' || cell.column.id === 'actions') {
+                          event.stopPropagation()
+                        }
+                      }}
+                      className={cn({ 'group-hover/table-row:underline': cell.column.id === 'name' })}
                       sticky={cell.column.getIsPinned()}
                       style={getColumnSizeStyles(cell.column)}
                     >

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { CopyButton } from '@/components/CopyButton'
+import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { getRelativeTimeString } from '@/lib/utils'
 import { SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { ColumnDef, RowData, Table } from '@tanstack/react-table'
@@ -146,12 +146,12 @@ const columns: ColumnDef<SnapshotDto>[] = [
       return (
         <div className="flex items-center gap-1 min-w-0 group/copy-button">
           <span className="truncate">{snapshot.name}</span>
-          <CopyButton value={snapshot.name} size="icon-xs" autoHide tooltipText="Copy name" />
           {snapshot.general && (
             <Badge variant="secondary" className="ml-1 shrink-0">
               System
             </Badge>
           )}
+          <CopyButton value={snapshot.name} size="icon-xs" autoHide tooltipText="Copy name" />
         </div>
       )
     },

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
@@ -4,6 +4,7 @@
  */
 
 import { TimestampTooltip } from '@/components/TimestampTooltip'
+import { CopyButton } from '@/components/CopyButton'
 import { getRelativeTimeString } from '@/lib/utils'
 import { SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { ColumnDef, RowData, Table } from '@tanstack/react-table'
@@ -143,10 +144,11 @@ const columns: ColumnDef<SnapshotDto>[] = [
     cell: ({ row }) => {
       const snapshot = row.original
       return (
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-1 min-w-0 group/copy-button">
           <span className="truncate">{snapshot.name}</span>
+          <CopyButton value={snapshot.name} size="icon-xs" autoHide tooltipText="Copy name" />
           {snapshot.general && (
-            <Badge variant="secondary" className="shrink-0">
+            <Badge variant="secondary" className="ml-1 shrink-0">
               System
             </Badge>
           )}
@@ -168,7 +170,14 @@ const columns: ColumnDef<SnapshotDto>[] = [
           </Badge>
         )
       }
-      return <div className="truncate">{snapshot.imageName}</div>
+      return snapshot.imageName ? (
+        <div className="flex items-center gap-1 min-w-0 group/copy-button">
+          <span className="truncate">{snapshot.imageName}</span>
+          <CopyButton value={snapshot.imageName} size="icon-xs" autoHide tooltipText="Copy image" />
+        </div>
+      ) : (
+        <div className="truncate text-muted-foreground/50">-</div>
+      )
     },
   },
   {

--- a/apps/dashboard/src/hooks/queries/queryKeys.ts
+++ b/apps/dashboard/src/hooks/queries/queryKeys.ts
@@ -60,6 +60,8 @@ export const queryKeys = {
   },
   snapshots: {
     all: ['snapshots'] as const,
+    detail: (organizationId: string, snapshotId: string) =>
+      [...queryKeys.snapshots.all, organizationId, snapshotId, 'detail'] as const,
     list: (organizationId: string, params?: SnapshotQueryParams) => {
       const base = [...queryKeys.snapshots.all, organizationId, 'list'] as const
       if (!params) return base

--- a/apps/dashboard/src/hooks/queries/useSnapshotsQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useSnapshotsQuery.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { GetAllSnapshotsOrderEnum, GetAllSnapshotsSortEnum, PaginatedSnapshots } from '@daytona/api-client'
+import { GetAllSnapshotsOrderEnum, GetAllSnapshotsSortEnum, PaginatedSnapshots, SnapshotDto } from '@daytona/api-client'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
 import { useApi } from '../useApi'
 import { useSelectedOrganization } from '../useSelectedOrganization'
 import { queryKeys } from './queryKeys'
@@ -28,6 +29,55 @@ export interface SnapshotQueryParams {
   pageSize: number
   filters?: SnapshotFilters
   sorting?: SnapshotSorting
+}
+
+export function getSnapshotQueryErrorStatus(error: unknown) {
+  const cause = error instanceof Error ? error.cause : undefined
+
+  if (!isAxiosError(cause)) {
+    return undefined
+  }
+
+  return cause.response?.status ?? cause.status
+}
+
+export function useSnapshotQuery(
+  snapshotId: string | null | undefined,
+  { enabled = true }: { enabled?: boolean } = {},
+) {
+  const { snapshotApi } = useApi()
+  const { selectedOrganization } = useSelectedOrganization()
+
+  return useQuery<SnapshotDto>({
+    queryKey: queryKeys.snapshots.detail(selectedOrganization?.id ?? '', snapshotId ?? ''),
+    queryFn: async () => {
+      if (!selectedOrganization) {
+        throw new Error('No organization selected')
+      }
+
+      if (!snapshotId) {
+        throw new Error('No snapshot selected')
+      }
+
+      const response = await snapshotApi.getSnapshot(snapshotId, selectedOrganization.id)
+      return response.data
+    },
+    enabled: enabled && !!snapshotId && !!selectedOrganization,
+    staleTime: 1000 * 10,
+    retry: (failureCount, error) => {
+      const status = getSnapshotQueryErrorStatus(error)
+
+      if (status === 404) {
+        return failureCount < 1
+      }
+
+      if (status && status >= 400 && status < 500) {
+        return false
+      }
+
+      return failureCount < 3
+    },
+  })
 }
 
 export function useSnapshotsQuery(params: SnapshotQueryParams) {

--- a/apps/dashboard/src/hooks/useSnapshotWsSync.ts
+++ b/apps/dashboard/src/hooks/useSnapshotWsSync.ts
@@ -21,6 +21,8 @@ export function useSnapshotWsSync() {
     const queryKey = queryKeys.snapshots.list(selectedOrganization.id)
 
     const updateSnapshotInCacheIfPresent = (snapshot: SnapshotDto) => {
+      queryClient.setQueryData<SnapshotDto>(queryKeys.snapshots.detail(selectedOrganization.id, snapshot.id), snapshot)
+
       queryClient.setQueriesData<PaginatedSnapshots>({ queryKey }, (previousSnapshots) => {
         if (!previousSnapshots) return previousSnapshots
         if (!previousSnapshots.items.some((existingSnapshot) => existingSnapshot.id === snapshot.id))

--- a/apps/dashboard/src/pages/Snapshots.tsx
+++ b/apps/dashboard/src/pages/Snapshots.tsx
@@ -200,6 +200,12 @@ const Snapshots: React.FC = () => {
       await markAllSnapshotQueriesAsStale(true)
       setSnapshotToDelete(null)
       setShowDeleteDialog(false)
+      if (snapshotIdParam === snapshot.id || selectedSnapshot?.id === snapshot.id) {
+        setSelectedSnapshot(null)
+        setOrderedSnapshotItems(null)
+        setShowSnapshotSheet(false)
+        setSnapshotIdParam(null)
+      }
       toast.success(`Deleting snapshot ${snapshot.name}`)
     } catch (error) {
       handleApiError(error, 'Failed to delete snapshot')

--- a/apps/dashboard/src/pages/Snapshots.tsx
+++ b/apps/dashboard/src/pages/Snapshots.tsx
@@ -5,6 +5,7 @@
 
 import { PageContent, PageFooter, PageHeader, PageLayout, PageTitle } from '@/components/PageLayout'
 import { CreateSnapshotSheet } from '@/components/snapshots/CreateSnapshotSheet'
+import { SnapshotSheet } from '@/components/snapshots/SnapshotSheet'
 import { SnapshotTable } from '@/components/snapshots/SnapshotTable'
 import { Button } from '@/components/ui/button'
 import {
@@ -36,6 +37,7 @@ import { handleApiError } from '@/lib/error-handling'
 import { pluralize } from '@/lib/utils'
 import { OrganizationRolePermissionsEnum, PaginatedSnapshots, SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { useQueryClient } from '@tanstack/react-query'
+import { parseAsString, useQueryState } from 'nuqs'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -47,6 +49,10 @@ const Snapshots: React.FC = () => {
   const [loadingSnapshots, setLoadingSnapshots] = useState<Record<string, boolean>>({})
   const [snapshotToDelete, setSnapshotToDelete] = useState<SnapshotDto | null>(null)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [selectedSnapshot, setSelectedSnapshot] = useState<SnapshotDto | null>(null)
+  const [orderedSnapshotItems, setOrderedSnapshotItems] = useState<SnapshotDto[] | null>(null)
+  const [showSnapshotSheet, setShowSnapshotSheet] = useState(false)
+  const [snapshotIdParam, setSnapshotIdParam] = useQueryState('snapshotId', parseAsString)
 
   const { selectedOrganization, authenticatedUserHasPermission } = useSelectedOrganization()
   const deleteSnapshotMutation = useDeleteSnapshotMutation({ invalidateOnSuccess: false })
@@ -88,6 +94,11 @@ const Snapshots: React.FC = () => {
     error: snapshotsDataError,
   } = useSnapshotsQuery(queryParams)
 
+  const snapshotFromLoadedResults = useMemo(
+    () => snapshotsData?.items.find((snapshot) => snapshot.id === snapshotIdParam),
+    [snapshotIdParam, snapshotsData?.items],
+  )
+
   const filteredItems = useMemo(() => {
     const items = snapshotsData?.items ?? []
     if (stateFilter.size === 0) {
@@ -102,8 +113,37 @@ const Snapshots: React.FC = () => {
     }
   }, [snapshotsDataError])
 
+  useEffect(() => {
+    if (!snapshotIdParam) {
+      setSelectedSnapshot(null)
+      setOrderedSnapshotItems(null)
+      setShowSnapshotSheet(false)
+      return
+    }
+
+    setShowSnapshotSheet(true)
+
+    if (!snapshotFromLoadedResults) {
+      if (selectedSnapshot?.id === snapshotIdParam) return
+      setSelectedSnapshot(null)
+      setOrderedSnapshotItems(null)
+      return
+    }
+
+    setSelectedSnapshot(snapshotFromLoadedResults)
+    setOrderedSnapshotItems(snapshotsData?.items ?? null)
+  }, [selectedSnapshot?.id, snapshotIdParam, snapshotFromLoadedResults, snapshotsData?.items])
+
   const updateSnapshotInCache = useCallback(
     (snapshotId: string, updates: Partial<SnapshotDto>) => {
+      queryClient.setQueryData<SnapshotDto>(
+        queryKeys.snapshots.detail(selectedOrganization?.id ?? '', snapshotId),
+        (oldData) => {
+          if (!oldData) return oldData
+          return { ...oldData, ...updates }
+        },
+      )
+
       queryClient.setQueryData(queryKey, (oldData: PaginatedSnapshots | undefined) => {
         if (!oldData) return oldData
         return {
@@ -112,7 +152,7 @@ const Snapshots: React.FC = () => {
         }
       })
     },
-    [queryClient, queryKey],
+    [queryClient, queryKey, selectedOrganization?.id],
   )
 
   const markAllSnapshotQueriesAsStale = useCallback(
@@ -209,6 +249,11 @@ const Snapshots: React.FC = () => {
 
   const writePermitted = useMemo(
     () => authenticatedUserHasPermission(OrganizationRolePermissionsEnum.WRITE_SNAPSHOTS),
+    [authenticatedUserHasPermission],
+  )
+
+  const deletePermitted = useMemo(
+    () => authenticatedUserHasPermission(OrganizationRolePermissionsEnum.DELETE_SNAPSHOTS),
     [authenticatedUserHasPermission],
   )
 
@@ -343,6 +388,42 @@ const Snapshots: React.FC = () => {
     dialogRef.current?.open()
   }
 
+  const snapshotItems = orderedSnapshotItems ?? filteredItems
+  const selectedSnapshotIndex = useMemo(
+    () => snapshotItems.findIndex((snapshot) => snapshot.id === selectedSnapshot?.id),
+    [snapshotItems, selectedSnapshot?.id],
+  )
+
+  const handleSnapshotRowClick = (snapshot: SnapshotDto, orderedSnapshots: SnapshotDto[]) => {
+    setOrderedSnapshotItems(orderedSnapshots)
+    setSelectedSnapshot(snapshot)
+    setSnapshotIdParam(snapshot.id)
+    setShowSnapshotSheet(true)
+  }
+
+  const handleSnapshotSheetOpenChange = (isOpen: boolean) => {
+    setShowSnapshotSheet(isOpen)
+
+    if (!isOpen) {
+      setSelectedSnapshot(null)
+      setOrderedSnapshotItems(null)
+      setSnapshotIdParam(null)
+    }
+  }
+
+  const handleSnapshotSheetNavigate = (direction: 'prev' | 'next') => {
+    if (selectedSnapshotIndex < 0) {
+      return
+    }
+
+    const nextIndex = direction === 'prev' ? selectedSnapshotIndex - 1 : selectedSnapshotIndex + 1
+    const nextSnapshot = snapshotItems[nextIndex]
+    if (nextSnapshot) {
+      setSelectedSnapshot(nextSnapshot)
+      setSnapshotIdParam(nextSnapshot.id)
+    }
+  }
+
   return (
     <PageLayout contained>
       <PageHeader>
@@ -366,6 +447,8 @@ const Snapshots: React.FC = () => {
           onActivate={handleActivate}
           onDeactivate={handleDeactivate}
           onCreateSnapshot={handleCreateSnapshot}
+          onRowClick={handleSnapshotRowClick}
+          activeSnapshotId={showSnapshotSheet ? selectedSnapshot?.id : undefined}
           pageCount={snapshotsData?.totalPages ?? 0}
           totalItems={snapshotsData?.total ?? 0}
           onPaginationChange={handlePaginationChange}
@@ -381,6 +464,26 @@ const Snapshots: React.FC = () => {
           onStateFilterChange={(values) => {
             setStateFilter(values)
             setPaginationParams((prev) => ({ ...prev, pageIndex: 0 }))
+          }}
+        />
+
+        <SnapshotSheet
+          snapshotId={snapshotIdParam}
+          snapshot={selectedSnapshot}
+          open={showSnapshotSheet}
+          onOpenChange={handleSnapshotSheetOpenChange}
+          getRegionName={getRegionName}
+          onNavigate={handleSnapshotSheetNavigate}
+          hasPrev={selectedSnapshotIndex > 0}
+          hasNext={selectedSnapshotIndex >= 0 && selectedSnapshotIndex < snapshotItems.length - 1}
+          actionsDisabled={selectedSnapshot ? loadingSnapshots[selectedSnapshot.id] : false}
+          writePermitted={writePermitted}
+          deletePermitted={deletePermitted}
+          onActivate={handleActivate}
+          onDeactivate={handleDeactivate}
+          onDelete={(snapshot) => {
+            setSnapshotToDelete(snapshot)
+            setShowDeleteDialog(true)
           }}
         />
 

--- a/apps/dashboard/src/pages/Snapshots.tsx
+++ b/apps/dashboard/src/pages/Snapshots.tsx
@@ -394,6 +394,13 @@ const Snapshots: React.FC = () => {
     dialogRef.current?.open()
   }
 
+  const handleSnapshotCreated = (snapshot: SnapshotDto) => {
+    setSelectedSnapshot(snapshot)
+    setOrderedSnapshotItems(null)
+    setSnapshotIdParam(snapshot.id)
+    setShowSnapshotSheet(true)
+  }
+
   const snapshotItems = orderedSnapshotItems ?? filteredItems
   const selectedSnapshotIndex = useMemo(
     () => snapshotItems.findIndex((snapshot) => snapshot.id === selectedSnapshot?.id),
@@ -434,7 +441,9 @@ const Snapshots: React.FC = () => {
     <PageLayout contained>
       <PageHeader>
         <PageTitle>Snapshots</PageTitle>
-        {writePermitted && <CreateSnapshotSheet className="ml-auto" ref={dialogRef} />}
+        {writePermitted && (
+          <CreateSnapshotSheet className="ml-auto" onSnapshotCreated={handleSnapshotCreated} ref={dialogRef} />
+        )}
       </PageHeader>
 
       <PageContent size="full" className="flex-1 overflow-hidden">


### PR DESCRIPTION
## Description

Implements a linkable snapshot details sheet.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a linkable Snapshot Details sheet to the dashboard. Open it from the table, via the `snapshotId` URL param, or automatically after creating a snapshot. It also closes if the selected snapshot is deleted.

- New Features
  - Right-side `SnapshotSheet` with state badge, actions (Activate, Deactivate, Delete), and copy for name/image/entrypoint.
  - Shows resources, regions, build info (context hashes, Dockerfile), error reason, timestamps, and clear skeleton/empty/error states.
  - Deep-linking via `snapshotId` using `nuqs`, plus prev/next navigation across the current ordered list, and auto-open after create.
  - Table rows are clickable to open the sheet and highlight the active row.

- Refactors
  - Introduced `snapshots.detail` query key and `useSnapshotQuery` with targeted retry rules and short stale time.
  - WebSocket sync now updates the detail cache alongside the list.
  - Table UX: inline, auto-hide copy buttons in name/image, hover underline on name, better click handling for action/select cells, and disabled state for removing rows.
  - Creation form preselects the org’s default region.
  - Close the sheet and clear `snapshotId` when deleting the selected snapshot.

<sup>Written for commit 982b1c88e43cd41a714127357725cef2ed31e8a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

