### PR TITLE
feat(docs): add examples section with config, localization, and sampl…

### DIFF
--- a/apps/docs/src/content.config.ts
+++ b/apps/docs/src/content.config.ts
@@ -16,6 +16,13 @@ export const collections = {
       }),
     }),
   }),
+  examples: defineCollection({
+    type: 'content',
+    schema: z.object({
+      title: z.string(),
+      description: z.string().optional(),
+    }),
+  }),
   i18n: defineCollection({
     loader: i18nLoader(),
     schema: i18nSchema({

--- a/apps/docs/src/content/docs/en/examples/advanced_examples.md
+++ b/apps/docs/src/content/docs/en/examples/advanced_examples.md
@@ -1,0 +1,289 @@
+---
+title: Advanced Examples
+description: Real-world Daytona SDK usage examples
+---
+
+This section demonstrates real-world usage of the Daytona SDK for executing AI-generated code securely inside isolated sandboxes. These examples go beyond basic usage and show how developers can build AI-powered systems using Daytona.
+
+---
+
+## 🤖 Example 1: AI-Generated Code Execution
+
+This example shows how to take a natural language prompt, generate code using an AI model, and execute it securely in a Daytona sandbox.
+
+### 🔹 Workflow
+
+```
+apps/docs/src/content/docs/en/examples/daytona_ai_workflow_diagram.png
+```
+
+---
+
+### 🔹 Input Prompt
+
+```
+"Write Python code to sort a list of numbers"
+```
+
+---
+
+### 🔹 Generated Code (from AI)
+
+```python
+numbers = [5, 2, 9, 1]
+print(sorted(numbers))
+```
+
+---
+
+### 🔹 Python Implementation
+
+```python
+from daytona import Daytona
+
+# Step 1: User input prompt
+prompt = "Write Python code to sort a list of numbers"
+
+# Step 2: Simulated AI-generated code
+generated_code = """
+numbers = [5, 2, 9, 1]
+print(sorted(numbers))
+"""
+
+# Step 3: Initialize Daytona
+daytona = Daytona()
+
+# Step 4: Create sandbox
+sandbox = daytona.create()
+
+# Step 5: Execute generated code
+response = sandbox.execute(
+    command="python3",
+    code=generated_code
+)
+
+# Step 6: Print output
+print("Execution Output:", response.output)
+```
+
+---
+
+### 🔹 Output
+
+```
+[1, 2, 5, 9]
+```
+
+---
+
+### 🔹 Explanation
+
+* The user provides a natural language prompt
+* An AI model converts the prompt into executable Python code
+* The code is executed securely inside a Daytona sandbox
+* The output is returned without affecting the host system
+
+---
+
+## ⚙️ Example 2: Using File, Git, and Execute APIs
+
+This example demonstrates how to combine multiple Daytona APIs in a single workflow.
+
+### 🔹 Use Case
+
+Clone a repository, modify a file, and execute a script.
+
+---
+
+### 🔹 Python Example
+
+```python
+from daytona import Daytona
+
+daytona = Daytona()
+sandbox = daytona.create()
+
+# Clone repository
+sandbox.git.clone("https://github.com/example/repo.git")
+
+# Write to a file
+sandbox.fs.write_file("repo/test.py", "print('Hello from Daytona')")
+
+# Execute the file
+result = sandbox.execute(
+    command="python3 repo/test.py"
+)
+
+print(result.output)
+```
+
+---
+
+### 🔹 Explanation
+
+* Git API is used to clone a repository
+* File API is used to modify files inside the sandbox
+* Execute API runs the script inside the isolated environment
+
+---
+
+## 🔄 Example 3: Persistent Sandbox Workflow
+
+This example shows how to reuse the same sandbox across multiple operations.
+
+---
+
+### 🔹 Python Example
+
+```python
+from daytona import Daytona
+
+daytona = Daytona()
+sandbox = daytona.create()
+
+# Step 1: Install dependency
+sandbox.execute(command="pip install numpy")
+
+# Step 2: Run computation
+result = sandbox.execute(
+    command="python3",
+    code="import numpy as np; print(np.array([1,2,3]))"
+)
+
+print(result.output)
+```
+
+---
+
+### 🔹 Explanation
+
+* The sandbox persists across multiple commands
+* Dependencies installed remain available
+* Useful for long-running workflows and AI agents
+
+---
+
+## ⚡ Example 4: Parallel Sandbox Execution
+
+This example demonstrates running multiple sandboxes concurrently.
+
+---
+
+### 🔹 Python Example
+
+```python
+from daytona import Daytona
+import concurrent.futures
+
+daytona = Daytona()
+
+def run_code(code):
+    sandbox = daytona.create()
+    return sandbox.execute(command="python3", code=code).output
+
+codes = [
+    "print(1+1)",
+    "print(2+2)",
+    "print(3+3)"
+]
+
+with concurrent.futures.ThreadPoolExecutor() as executor:
+    results = list(executor.map(run_code, codes))
+
+print(results)
+```
+
+---
+
+### 🔹 Explanation
+
+* Multiple sandboxes run independently
+* Enables parallel execution of AI-generated tasks
+* Useful for scaling workloads
+
+---
+
+## ❌ Error Handling and Retry Logic
+
+Robust applications must handle failures gracefully.
+
+---
+
+### 🔹 Python Example
+
+```python
+from daytona import Daytona
+
+daytona = Daytona()
+sandbox = daytona.create()
+
+code = "print(unknown_variable)"  # This will fail
+
+for attempt in range(3):
+    try:
+        result = sandbox.execute(command="python3", code=code)
+        print(result.output)
+        break
+    except Exception as e:
+        print(f"Attempt {attempt+1} failed:", e)
+```
+
+---
+
+### 🔹 Explanation
+
+* Errors during execution are caught
+* Retry logic improves reliability
+* Essential for production-grade AI workflows
+
+---
+
+## 🤖 Optional: Agentic Workflow (Advanced)
+
+This example shows how Daytona can be used inside an AI agent loop for self-correcting code execution.
+
+---
+
+### 🔹 Python Example
+
+```python
+while True:
+    code = llm.generate(prompt)
+    
+    result = sandbox.execute(command="python3", code=code)
+    
+    if "error" not in result.output:
+        break
+    
+    prompt = f"Fix this error: {result.output}"
+```
+
+---
+
+### 🔹 Explanation
+
+* The agent generates code
+* Executes it using Daytona
+* Fixes errors iteratively
+* Demonstrates autonomous AI workflows
+
+---
+
+## 📊 Architecture Overview
+
+```
+Client → AI Model → Daytona → Sandbox → Execution → Response
+```
+
+---
+
+## 📚 Additional Resources
+
+* Python Notebook: `examples/python/advanced_usage.ipynb`
+* TypeScript Example: `examples/typescript/advanced_usage.ts`
+
+---
+
+## 🧠 Summary
+
+These examples demonstrate how Daytona can be used as a secure execution layer for AI-generated code, enabling developers to build scalable, reliable, and safe AI-powered applications.

--- a/apps/docs/src/content/docs/en/examples/python/advanced_usage.ipynb
+++ b/apps/docs/src/content/docs/en/examples/python/advanced_usage.ipynb
@@ -1,0 +1,419 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bb91c390",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Advanced Usage: AI-Generated Code Execution & Sandbox Workflows\\n\\nThis notebook demonstrates how AI-generated code can be:\\n- Generated dynamically\\n- Executed safely in a sandbox\\n- Validated automatically\\n- Improved via feedback loops\\n\\n---\\n\\n### Why this matters\\nExecuting AI-generated code directly is risky. This notebook shows a controlled approach to make it safe and reliable.'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"Advanced Usage: AI-Generated Code Execution & Sandbox Workflows\n",
+    "\n",
+    "This notebook demonstrates how AI-generated code can be:\n",
+    "- Generated dynamically\n",
+    "- Executed safely in a sandbox\n",
+    "- Validated automatically\n",
+    "- Improved via feedback loops\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Why this matters\n",
+    "Executing AI-generated code directly is risky. This notebook shows a controlled approach to make it safe and reliable.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "047f40fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "import tempfile\n",
+    "import time\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "480369ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_code(prompt: str) -> str:\n",
+    "    \"\"\"\n",
+    "    Simulated AI code generation.\n",
+    "    Replace with LLM API in real use.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if \"factorial\" in prompt:\n",
+    "        return \"\"\"\n",
+    "def factorial(n):\n",
+    "    if n == 0:\n",
+    "        return 1\n",
+    "    return n * factorial(n-1)\n",
+    "\n",
+    "print(factorial(5))\n",
+    "\"\"\"\n",
+    "\n",
+    "    elif \"fibonacci\" in prompt:\n",
+    "        return \"\"\"\n",
+    "def fib(n):\n",
+    "    if n <= 1:\n",
+    "        return n\n",
+    "    return fib(n-1) + fib(n-2)\n",
+    "\n",
+    "print(fib(6))\n",
+    "\"\"\"\n",
+    "\n",
+    "    elif \"bug\" in prompt:\n",
+    "        return \"print(10/0)\"  # intentional error\n",
+    "\n",
+    "    return \"print('Unsupported task')\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "87e11c7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_in_sandbox(code: str, timeout: int = 5):\n",
+    "    \"\"\"\n",
+    "    Executes code safely using a temporary file.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    try:\n",
+    "        with tempfile.NamedTemporaryFile(delete=False, suffix=\".py\") as tmp:\n",
+    "            tmp.write(code.encode())\n",
+    "            file_path = tmp.name\n",
+    "\n",
+    "        start = time.time()\n",
+    "\n",
+    "        result = subprocess.run(\n",
+    "            [\"python\", file_path],\n",
+    "            capture_output=True,\n",
+    "            text=True,\n",
+    "            timeout=timeout\n",
+    "        )\n",
+    "\n",
+    "        end = time.time()\n",
+    "\n",
+    "        return {\n",
+    "            \"output\": result.stdout.strip(),\n",
+    "            \"error\": result.stderr.strip(),\n",
+    "            \"time\": round(end - start, 4)\n",
+    "        }\n",
+    "\n",
+    "    except subprocess.TimeoutExpired:\n",
+    "        return {\"output\": \"\", \"error\": \"Execution timed out\", \"time\": timeout}\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        return {\"output\": \"\", \"error\": str(e), \"time\": 0}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "53e4a983",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def validate(prompt: str, output: str) -> bool:\n",
+    "    \"\"\"\n",
+    "    Simple correctness check.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    expected = {\n",
+    "        \"factorial\": \"120\",\n",
+    "        \"fibonacci\": \"8\"\n",
+    "    }\n",
+    "\n",
+    "    for key in expected:\n",
+    "        if key in prompt:\n",
+    "            return output == expected[key]\n",
+    "\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "99620fdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def execute_pipeline(prompt: str):\n",
+    "    print(f\"\\n🔹 Prompt: {prompt}\")\n",
+    "\n",
+    "    # Step 1: Generate\n",
+    "    code = generate_code(prompt)\n",
+    "    print(\"\\nGenerated Code:\\n\", code)\n",
+    "\n",
+    "    # Step 2: Execute\n",
+    "    result = run_in_sandbox(code)\n",
+    "\n",
+    "    print(\"\\nOutput:\", result[\"output\"])\n",
+    "    print(\"Error:\", result[\"error\"])\n",
+    "    print(\"Execution Time:\", result[\"time\"], \"sec\")\n",
+    "\n",
+    "    # Step 3: Validate\n",
+    "    if result[\"output\"]:\n",
+    "        if validate(prompt, result[\"output\"]):\n",
+    "            print(\"✅ Validation Passed\")\n",
+    "        else:\n",
+    "            print(\"❌ Validation Failed\")\n",
+    "\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c34a93c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "🔹 Prompt: factorial\n",
+      "\n",
+      "Generated Code:\n",
+      " \n",
+      "def factorial(n):\n",
+      "    if n == 0:\n",
+      "        return 1\n",
+      "    return n * factorial(n-1)\n",
+      "\n",
+      "print(factorial(5))\n",
+      "\n",
+      "\n",
+      "Output: 120\n",
+      "Error: \n",
+      "Execution Time: 0.1431 sec\n",
+      "✅ Validation Passed\n",
+      "\n",
+      "🔹 Prompt: fibonacci\n",
+      "\n",
+      "Generated Code:\n",
+      " \n",
+      "def fib(n):\n",
+      "    if n <= 1:\n",
+      "        return n\n",
+      "    return fib(n-1) + fib(n-2)\n",
+      "\n",
+      "print(fib(6))\n",
+      "\n",
+      "\n",
+      "Output: 8\n",
+      "Error: \n",
+      "Execution Time: 0.0745 sec\n",
+      "✅ Validation Passed\n",
+      "\n",
+      "🔹 Prompt: bug\n",
+      "\n",
+      "Generated Code:\n",
+      " print(10/0)\n",
+      "\n",
+      "Output: \n",
+      "Error: Traceback (most recent call last):\n",
+      "  File \"C:\\Users\\Vansh\\AppData\\Local\\Temp\\tmpbpxyghun.py\", line 1, in <module>\n",
+      "    print(10/0)\n",
+      "          ~~^~\n",
+      "ZeroDivisionError: division by zero\n",
+      "Execution Time: 0.0618 sec\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'output': '',\n",
+       " 'error': 'Traceback (most recent call last):\\n  File \"C:\\\\Users\\\\Vansh\\\\AppData\\\\Local\\\\Temp\\\\tmpbpxyghun.py\", line 1, in <module>\\n    print(10/0)\\n          ~~^~\\nZeroDivisionError: division by zero',\n",
+       " 'time': 0.0618}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Successful case\n",
+    "execute_pipeline(\"factorial\")\n",
+    "\n",
+    "# Another valid case\n",
+    "execute_pipeline(\"fibonacci\")\n",
+    "\n",
+    "# Error case\n",
+    "execute_pipeline(\"bug\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "27943916",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def retry_execution(prompt: str, retries: int = 2):\n",
+    "    for i in range(retries):\n",
+    "        print(f\"\\nAttempt {i+1}\")\n",
+    "\n",
+    "        result = execute_pipeline(prompt)\n",
+    "\n",
+    "        if not result[\"error\"]:\n",
+    "            print(\"✅ Success achieved\")\n",
+    "            return result\n",
+    "\n",
+    "        print(\"⚠️ Retrying with fallback...\")\n",
+    "\n",
+    "    print(\"❌ Failed after retries\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7c87283e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Attempt 1\n",
+      "\n",
+      "🔹 Prompt: bug\n",
+      "\n",
+      "Generated Code:\n",
+      " print(10/0)\n",
+      "\n",
+      "Output: \n",
+      "Error: Traceback (most recent call last):\n",
+      "  File \"C:\\Users\\Vansh\\AppData\\Local\\Temp\\tmp53f1bbgs.py\", line 1, in <module>\n",
+      "    print(10/0)\n",
+      "          ~~^~\n",
+      "ZeroDivisionError: division by zero\n",
+      "Execution Time: 0.1716 sec\n",
+      "⚠️ Retrying with fallback...\n",
+      "\n",
+      "Attempt 2\n",
+      "\n",
+      "🔹 Prompt: bug\n",
+      "\n",
+      "Generated Code:\n",
+      " print(10/0)\n",
+      "\n",
+      "Output: \n",
+      "Error: Traceback (most recent call last):\n",
+      "  File \"C:\\Users\\Vansh\\AppData\\Local\\Temp\\tmp3uxx7n0d.py\", line 1, in <module>\n",
+      "    print(10/0)\n",
+      "          ~~^~\n",
+      "ZeroDivisionError: division by zero\n",
+      "Execution Time: 0.1364 sec\n",
+      "⚠️ Retrying with fallback...\n",
+      "❌ Failed after retries\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test retry logic\n",
+    "retry_execution(\"bug\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "355e9f65",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "' Security Considerations\\n\\nThis notebook uses basic safeguards:\\n- Timeout to prevent infinite loops\\n- Temporary files for isolation\\n- No direct shell/system access\\n\\n### Production-Level Improvements\\n- Docker or container sandboxing\\n- Resource limits (CPU, memory)\\n- File system restrictions\\n- Static code analysis before execution'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\" Security Considerations\n",
+    "\n",
+    "This notebook uses basic safeguards:\n",
+    "- Timeout to prevent infinite loops\n",
+    "- Temporary files for isolation\n",
+    "- No direct shell/system access\n",
+    "\n",
+    "### Production-Level Improvements\n",
+    "- Docker or container sandboxing\n",
+    "- Resource limits (CPU, memory)\n",
+    "- File system restrictions\n",
+    "- Static code analysis before execution\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7ea18e05",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "' Real-World Applications\\n\\n- AI coding assistants (like Copilot)\\n- Auto-grading systems\\n- Secure execution engines\\n- Hackathon prototypes'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\" Real-World Applications\n",
+    "\n",
+    "- AI coding assistants (like Copilot)\n",
+    "- Auto-grading systems\n",
+    "- Secure execution engines\n",
+    "- Hackathon prototypes\"\"\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/apps/docs/src/content/docs/en/examples/typescript/advanced_usage.ts
+++ b/apps/docs/src/content/docs/en/examples/typescript/advanced_usage.ts
@@ -1,0 +1,116 @@
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+/**
+ * 1. Simulated AI Code Generator
+ */
+function generateCode(prompt: string): string {
+  if (prompt.includes("factorial")) {
+    return `
+    function factorial(n) {
+      if (n === 0) return 1;
+      return n * factorial(n - 1);
+    }
+    return factorial(5);
+    `;
+  }
+
+  if (prompt.includes("fibonacci")) {
+    return `
+    function fib(n) {
+      if (n <= 1) return n;
+      return fib(n - 1) + fib(n - 2);
+    }
+    return fib(6);
+    `;
+  }
+
+  if (prompt.includes("error")) {
+    return `return x + 1;`; // intentional error
+  }
+
+  return `return "Unsupported prompt";`;
+}
+
+/**
+ * 2. Sandbox Execution
+ * ⚠️ Demo only — not production-safe
+ */
+function runSandbox(code: string) {
+  try {
+    const fn = new Function(code);
+    const result = fn();
+
+    return {
+      output: String(result),
+      error: null,
+    };
+  } catch (err: any) {
+    return {
+      output: null,
+      error: err.message,
+    };
+  }
+}
+
+/**
+ * 3. Output Validation
+ */
+function validate(prompt: string, output: string | null): boolean {
+  const expected: Record<string, string> = {
+    factorial: "120",
+    fibonacci: "8",
+  };
+
+  if (!output) return false;
+
+  for (const key in expected) {
+    if (prompt.includes(key)) {
+      return output === expected[key];
+    }
+  }
+
+  return false;
+}
+
+/**
+ * 4. API Endpoint (Full Pipeline)
+ */
+app.post("/execute", (req, res) => {
+  const { prompt } = req.body;
+
+  if (!prompt) {
+    return res.status(400).json({
+      success: false,
+      error: "Prompt is required",
+    });
+  }
+
+  // Step 1: Generate code
+  const code = generateCode(prompt);
+
+  // Step 2: Execute
+  const result = runSandbox(code);
+
+  // Step 3: Validate
+  const isValid = validate(prompt, result.output);
+
+  // Step 4: Response
+  res.json({
+    prompt,
+    generatedCode: code,
+    output: result.output,
+    error: result.error,
+    valid: isValid,
+  });
+});
+
+/**
+ * 5. Start Server
+ */
+const PORT = 3000;
+app.listen(PORT, () => {
+  console.log(`🚀 Server running on http://localhost:${PORT}`);
+});

--- a/apps/docs/src/content/i18n/en.json
+++ b/apps/docs/src/content/i18n/en.json
@@ -42,6 +42,7 @@
   "sidebarconfig.reference": "Reference",
   "sidebarconfig.documentation": "Docs",
   "sidebarconfig.guides": "Guides",
+  "sidebarconfig.examples": "Examples",
   "sidebarconfig.tsSdkReference": "TypeScript SDK",
   "sidebarconfig.pythonSdkReference": "Python SDK",
   "sidebarconfig.rubySdkReference": "Ruby SDK",


### PR DESCRIPTION
## Description
Adds a new `examples` section to the documentation, following the structure of the existing guides.

## Changes
- Created `/examples` directory under docs
- Added README and workflow diagram
- Included Python notebook and TypeScript example
- Registered `examples` in content.config.ts
- Added localization entry in i18n/en.json

## Notes
- Structure mirrors the existing `guides` section
- Ensures consistency in documentation layout

## Related Issue(s)

This PR addresses issue #2782


