### PR TITLE
feat(dashboard): sandboxes terminal action

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/SandboxTableActions.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableActions.tsx
@@ -6,8 +6,9 @@
 import { FeatureFlags } from '@/enums/FeatureFlags'
 import { useRegions } from '@/hooks/useRegions'
 import { SandboxState } from '@daytona/api-client'
+import { Loader2, MoreHorizontal, Play, Square, Terminal, Wrench } from 'lucide-react'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
-import { MoreHorizontal, Play, Square, Loader2, Wrench } from 'lucide-react'
+import { useMemo } from 'react'
 import { Button } from '../ui/button'
 import {
   DropdownMenu,
@@ -17,7 +18,6 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu'
 import { SandboxTableActionsProps } from './types'
-import { useMemo } from 'react'
 
 export function SandboxTableActions({
   sandbox,
@@ -37,6 +37,7 @@ export function SandboxTableActions({
   onScreenRecordings,
   onFork,
   onViewForks,
+  onOpenTerminal,
 }: SandboxTableActionsProps) {
   const linuxVmEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_LINUX_VM)
   const { getRegionName } = useRegions()
@@ -190,7 +191,6 @@ export function SandboxTableActions({
       <Button
         variant="ghost"
         size="icon-sm"
-        className="text-muted-foreground"
         aria-label={
           sandbox.state === SandboxState.STARTED
             ? 'Stop sandbox'
@@ -220,9 +220,21 @@ export function SandboxTableActions({
         )}
       </Button>
 
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Open terminal"
+        onClick={(e) => {
+          e.stopPropagation()
+          onOpenTerminal?.()
+        }}
+      >
+        <Terminal className="w-4 h-4" />
+      </Button>
+
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon-sm" className="text-muted-foreground" aria-label="Open menu">
+          <Button variant="ghost" size="icon-sm" aria-label="Open menu">
             <MoreHorizontal className="w-4 h-4" />
           </Button>
         </DropdownMenuTrigger>

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -72,6 +72,7 @@ interface GetColumnsProps {
   handleCreateSnapshot: (id: string) => void
   handleFork: (id: string) => void
   handleViewForks: (id: string) => void
+  handleOpenTerminal: (sandbox: Sandbox) => void
 }
 
 export function getColumns({
@@ -91,6 +92,7 @@ export function getColumns({
   handleCreateSnapshot,
   handleFork,
   handleViewForks,
+  handleOpenTerminal,
 }: GetColumnsProps): ColumnDef<Sandbox>[] {
   const columns: ColumnDef<Sandbox>[] = [
     {
@@ -371,6 +373,7 @@ export function getColumns({
             onCreateSnapshot={() => handleCreateSnapshot(row.original.id)}
             onFork={() => handleFork(row.original.id)}
             onViewForks={() => handleViewForks(row.original.id)}
+            onOpenTerminal={() => handleOpenTerminal(row.original)}
           />
         </div>
       ),

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -350,9 +350,9 @@ export function getColumns({
     },
     {
       id: 'actions',
-      size: 88,
-      minSize: 88,
-      maxSize: 88,
+      size: 136,
+      maxSize: 136,
+      minSize: 136,
       enableHiding: false,
       cell: ({ row }) => (
         <div className="w-full flex justify-end">

--- a/apps/dashboard/src/components/SandboxTable/index.tsx
+++ b/apps/dashboard/src/components/SandboxTable/index.tsx
@@ -20,7 +20,7 @@ import { OrganizationRolePermissionsEnum, Sandbox, SandboxState } from '@daytona
 import { flexRender } from '@tanstack/react-table'
 import { Container } from 'lucide-react'
 import { AnimatePresence } from 'motion/react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useImperativeHandle, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCommandPaletteActions } from '../CommandPalette'
 import { PageFooterPortal } from '../PageLayout'
@@ -40,11 +40,12 @@ import {
 } from '../ui/table'
 import { BulkAction, BulkActionAlertDialog } from './BulkActionAlertDialog'
 import { SandboxTableHeader } from './SandboxTableHeader'
-import { SandboxTableProps } from './types'
+import type { SandboxTableProps, SandboxTableRef } from './types'
 import { useSandboxCommands } from './useSandboxCommands'
 import { useSandboxTable } from './useSandboxTable'
 
 export function SandboxTable({
+  ref,
   data,
   sandboxIsLoading,
   sandboxStateIsTransitioning,
@@ -100,6 +101,14 @@ export function SandboxTable({
     handleViewForks,
     handleOpenTerminal,
   })
+
+  useImperativeHandle(
+    ref,
+    (): SandboxTableRef => ({
+      table,
+    }),
+    [table],
+  )
 
   const [pendingBulkAction, setPendingBulkAction] = useState<BulkAction | null>(null)
 
@@ -267,12 +276,7 @@ export function SandboxTable({
                     'bg-muted animate-pulse': sandboxStateIsTransitioning[row.original.id],
                     'cursor-pointer': onRowClick,
                   })}
-                  onClick={() =>
-                    onRowClick?.(
-                      row.original,
-                      table.getPrePaginationRowModel().rows.map((row) => row.original),
-                    )
-                  }
+                  onClick={() => onRowClick?.(row.original)}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell

--- a/apps/dashboard/src/components/SandboxTable/index.tsx
+++ b/apps/dashboard/src/components/SandboxTable/index.tsx
@@ -72,6 +72,7 @@ export function SandboxTable({
   handleCreateSnapshot,
   handleFork,
   handleViewForks,
+  handleOpenTerminal,
 }: SandboxTableProps) {
   const navigate = useNavigate()
   const { authenticatedUserHasPermission } = useSelectedOrganization()
@@ -97,6 +98,7 @@ export function SandboxTable({
     handleCreateSnapshot,
     handleFork,
     handleViewForks,
+    handleOpenTerminal,
   })
 
   const [pendingBulkAction, setPendingBulkAction] = useState<BulkAction | null>(null)

--- a/apps/dashboard/src/components/SandboxTable/types.ts
+++ b/apps/dashboard/src/components/SandboxTable/types.ts
@@ -5,8 +5,14 @@
 
 import { Region, Sandbox, SandboxState, SnapshotDto } from '@daytona/api-client'
 import { Table } from '@tanstack/react-table'
+import type { Ref } from 'react'
+
+export interface SandboxTableRef {
+  table: Table<Sandbox>
+}
 
 export interface SandboxTableProps {
+  ref?: Ref<SandboxTableRef>
   data: Sandbox[]
   sandboxIsLoading: Record<string, boolean>
   sandboxStateIsTransitioning: Record<string, boolean>
@@ -28,7 +34,7 @@ export interface SandboxTableProps {
   handleVnc: (id: string) => void
   handleCreateSshAccess: (id: string) => void
   handleRevokeSshAccess: (id: string) => void
-  onRowClick?: (sandbox: Sandbox, orderedSandboxes: Sandbox[]) => void
+  onRowClick?: (sandbox: Sandbox) => void
   handleRecover: (id: string) => void
   handleScreenRecordings: (id: string) => void
   handleCreateSnapshot: (id: string) => void

--- a/apps/dashboard/src/components/SandboxTable/types.ts
+++ b/apps/dashboard/src/components/SandboxTable/types.ts
@@ -34,6 +34,7 @@ export interface SandboxTableProps {
   handleCreateSnapshot: (id: string) => void
   handleFork: (id: string) => void
   handleViewForks: (id: string) => void
+  handleOpenTerminal: (sandbox: Sandbox) => void
 }
 
 export interface SandboxTableActionsProps {
@@ -52,6 +53,7 @@ export interface SandboxTableActionsProps {
   onFork?: () => void
   onCreateSnapshot?: () => void
   onViewForks?: () => void
+  onOpenTerminal?: () => void
   onRecover: (id: string) => void
   onScreenRecordings: (id: string) => void
 }

--- a/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
+++ b/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
@@ -43,6 +43,7 @@ interface UseSandboxTableProps {
   handleCreateSnapshot: (id: string) => void
   handleFork: (id: string) => void
   handleViewForks: (id: string) => void
+  handleOpenTerminal: (sandbox: Sandbox) => void
 }
 
 export function useSandboxTable({
@@ -64,6 +65,7 @@ export function useSandboxTable({
   handleCreateSnapshot,
   handleFork,
   handleViewForks,
+  handleOpenTerminal,
 }: UseSandboxTableProps) {
   // Column visibility state management with persistence
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => {
@@ -127,6 +129,7 @@ export function useSandboxTable({
         handleCreateSnapshot,
         handleFork,
         handleViewForks,
+        handleOpenTerminal,
       }),
     [
       handleStart,
@@ -145,6 +148,7 @@ export function useSandboxTable({
       handleCreateSnapshot,
       handleFork,
       handleViewForks,
+      handleOpenTerminal,
     ],
   )
 

--- a/apps/dashboard/src/components/sandboxes/SandboxTerminalTab.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxTerminalTab.tsx
@@ -12,7 +12,7 @@ import { useSandboxSessionContext } from '@/hooks/useSandboxSessionContext'
 import { isStoppable } from '@/lib/utils/sandbox'
 import { Sandbox } from '@daytona/api-client'
 import { Spinner } from '@/components/ui/spinner'
-import { Play, RefreshCw, TerminalSquare } from 'lucide-react'
+import { ArrowUpRight, RefreshCw, TerminalSquare } from 'lucide-react'
 
 export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
   const running = isStoppable(sandbox)
@@ -29,6 +29,13 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
     reset,
   } = useTerminalSessionQuery(sandbox.id, running && activated)
 
+  useEffect(() => {
+    if (!running || activated) return
+
+    activateTerminal(sandbox.id)
+    setActivated(true)
+  }, [activateTerminal, activated, running, sandbox.id])
+
   // Auto-reconnect: if activated and session is expired, refetch
   useEffect(() => {
     if (!activated || !existingSession) return
@@ -36,11 +43,6 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
       reset()
     }
   }, [activated, existingSession, reset])
-
-  const handleConnect = () => {
-    activateTerminal(sandbox.id)
-    setActivated(true)
-  }
 
   if (!running) {
     return (
@@ -66,37 +68,7 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
     )
   }
 
-  // Not yet activated — show connect button
-  if (!activated) {
-    return (
-      <div className="flex-1 flex flex-col p-4">
-        <div className="flex-1 min-h-0 rounded-md border border-border flex">
-          <Empty className="border-0">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <TerminalSquare className="size-4" />
-              </EmptyMedia>
-              <EmptyTitle>Terminal</EmptyTitle>
-              <EmptyDescription>
-                Connect to an interactive terminal session in your sandbox.{' '}
-                <a href={`${DAYTONA_DOCS_URL}/en/web-terminal`} target="_blank" rel="noopener noreferrer">
-                  Learn more
-                </a>
-                .
-              </EmptyDescription>
-            </EmptyHeader>
-            <Button onClick={handleConnect}>
-              <Play className="size-4" />
-              Connect
-            </Button>
-          </Empty>
-        </div>
-      </div>
-    )
-  }
-
-  // Loading / fetching
-  if (isLoading || isFetching) {
+  if (!activated || isLoading || isFetching) {
     return (
       <div className="flex-1 flex flex-col p-4">
         <div className="flex-1 min-h-0 rounded-md border border-border flex items-center justify-center gap-2 text-muted-foreground">
@@ -130,6 +102,14 @@ export function SandboxTerminalTab({ sandbox }: { sandbox: Sandbox }) {
   // Active session
   return (
     <div className="flex-1 flex flex-col p-4">
+      <div className="mb-2 flex shrink-0 justify-end">
+        <Button variant="link" size="sm" className="h-auto px-0 py-0" asChild>
+          <a href={session.url} target="_blank" rel="noopener noreferrer">
+            Open in new tab
+            <ArrowUpRight className="size-4" />
+          </a>
+        </Button>
+      </div>
       <div className="flex-1 min-h-0 rounded-md border border-border bg-black overflow-hidden p-1">
         <iframe title="Sandbox terminal" src={session.url} className="w-full h-full border-0" />
       </div>

--- a/apps/dashboard/src/components/sandboxes/SandboxVncTab.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxVncTab.tsx
@@ -13,7 +13,7 @@ import { useVncSessionQuery } from '@/hooks/queries/useVncSessionQuery'
 import { isStoppable } from '@/lib/utils/sandbox'
 import { Sandbox } from '@daytona/api-client'
 import { Spinner } from '@/components/ui/spinner'
-import { Monitor, Play, RefreshCw } from 'lucide-react'
+import { ArrowUpRight, Monitor, Play, RefreshCw } from 'lucide-react'
 
 const VNC_MISSING_DEPS_MSG = 'Computer-use functionality is not available'
 
@@ -191,14 +191,20 @@ export function SandboxVncTab({ sandbox }: { sandbox: Sandbox }) {
 
   // Active session
   if (session) {
+    const vncUrl = `${session.url}/vnc.html?autoconnect=true&resize=scale`
+
     return (
       <div className="flex-1 flex flex-col p-4">
+        <div className="mb-2 flex shrink-0 justify-end">
+          <Button variant="link" size="sm" className="h-auto px-0 py-0" asChild>
+            <a href={vncUrl} target="_blank" rel="noopener noreferrer">
+              Open in new tab
+              <ArrowUpRight className="size-4" />
+            </a>
+          </Button>
+        </div>
         <div className="flex-1 min-h-0 rounded-md border border-border bg-neutral-950 overflow-hidden">
-          <iframe
-            title="VNC desktop"
-            src={`${session.url}/vnc.html?autoconnect=true&resize=scale`}
-            className="w-full h-full border-0"
-          />
+          <iframe title="VNC desktop" src={vncUrl} className="w-full h-full border-0" />
         </div>
       </div>
     )

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -14,6 +14,7 @@ import { CreateSshAccessSheet } from '@/components/sandboxes/CreateSshAccessShee
 import { RevokeSshAccessDialog } from '@/components/sandboxes/RevokeSshAccessDialog'
 import SandboxDetailsSheet, { type SandboxDetailsSheetTabValue } from '@/components/sandboxes/SandboxDetailsSheet'
 import { SandboxTable } from '@/components/SandboxTable'
+import type { SandboxTableRef } from '@/components/SandboxTable/types'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -123,6 +124,7 @@ const Sandboxes: React.FC = () => {
   const [showRevokeSshDialog, setShowRevokeSshDialog] = useState(false)
   const [sshSandboxId, setSshSandboxId] = useState<string>('')
   const createSandboxSheetRef = useRef<{ open: () => void }>(null)
+  const sandboxTableRef = useRef<SandboxTableRef>(null)
 
   // Region Filter
 
@@ -750,12 +752,10 @@ const Sandboxes: React.FC = () => {
     }
   }
 
-  const openSandboxDetails = (
-    sandbox: Sandbox,
-    orderedSandboxes: Sandbox[] | null,
-    initialTab: SandboxDetailsSheetTabValue = 'overview',
-  ) => {
-    setOrderedSandboxItems(orderedSandboxes)
+  const openSandboxDetails = (sandbox: Sandbox, initialTab: SandboxDetailsSheetTabValue = 'overview') => {
+    const orderedSandboxes =
+      sandboxTableRef.current?.table.getPrePaginationRowModel().rows.map((row) => row.original) ?? []
+    setOrderedSandboxItems(orderedSandboxes.some((item) => item.id === sandbox.id) ? orderedSandboxes : null)
     setSelectedSandbox(sandbox)
     setSandboxDetailsInitialTab(initialTab)
     setSandboxIdParam(sandbox.id)
@@ -763,12 +763,12 @@ const Sandboxes: React.FC = () => {
     setShowSandboxDetails(true)
   }
 
-  const handleSandboxRowClick = (sandbox: Sandbox, orderedSandboxes: Sandbox[]) => {
-    openSandboxDetails(sandbox, orderedSandboxes)
+  const handleSandboxRowClick = (sandbox: Sandbox) => {
+    openSandboxDetails(sandbox)
   }
 
   const handleOpenTerminal = (sandbox: Sandbox) => {
-    openSandboxDetails(sandbox, null, 'terminal')
+    openSandboxDetails(sandbox, 'terminal')
   }
 
   const handleSandboxCreated = (sandbox: CreatedSandbox) => {
@@ -779,7 +779,7 @@ const Sandboxes: React.FC = () => {
         ? prev.map((existingSandbox) => (existingSandbox.id === createdSandbox.id ? createdSandbox : existingSandbox))
         : [createdSandbox, ...prev],
     )
-    openSandboxDetails(createdSandbox, null)
+    openSandboxDetails(createdSandbox)
   }
 
   const writePermitted = useMemo(
@@ -860,6 +860,7 @@ const Sandboxes: React.FC = () => {
       </PageHeader>
       <PageContent size="full" className="overflow-hidden">
         <SandboxTable
+          ref={sandboxTableRef}
           sandboxIsLoading={loadingSandboxes}
           sandboxStateIsTransitioning={transitioningSandboxes}
           activeSandboxId={showSandboxDetails ? selectedSandbox?.id : undefined}

--- a/apps/dashboard/src/pages/Sandboxes.tsx
+++ b/apps/dashboard/src/pages/Sandboxes.tsx
@@ -750,17 +750,25 @@ const Sandboxes: React.FC = () => {
     }
   }
 
-  const openSandboxDetails = (sandbox: Sandbox, orderedSandboxes: Sandbox[] | null) => {
+  const openSandboxDetails = (
+    sandbox: Sandbox,
+    orderedSandboxes: Sandbox[] | null,
+    initialTab: SandboxDetailsSheetTabValue = 'overview',
+  ) => {
     setOrderedSandboxItems(orderedSandboxes)
     setSelectedSandbox(sandbox)
-    setSandboxDetailsInitialTab('overview')
+    setSandboxDetailsInitialTab(initialTab)
     setSandboxIdParam(sandbox.id)
-    setSandboxTabParam('overview')
+    setSandboxTabParam(initialTab)
     setShowSandboxDetails(true)
   }
 
   const handleSandboxRowClick = (sandbox: Sandbox, orderedSandboxes: Sandbox[]) => {
     openSandboxDetails(sandbox, orderedSandboxes)
+  }
+
+  const handleOpenTerminal = (sandbox: Sandbox) => {
+    openSandboxDetails(sandbox, null, 'terminal')
   }
 
   const handleSandboxCreated = (sandbox: CreatedSandbox) => {
@@ -879,6 +887,7 @@ const Sandboxes: React.FC = () => {
           handleCreateSnapshot={handleCreateSnapshot}
           handleFork={handleFork}
           handleViewForks={handleViewForks}
+          handleOpenTerminal={handleOpenTerminal}
         />
 
         {sandboxToDelete && (


### PR DESCRIPTION
## Description

Brings back the open terminal action in sandbox table.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-click “Open terminal” action for sandboxes and auto-connect the session to reduce steps to an interactive shell. Also adds “Open in new tab” links for Terminal and VNC views.

- New Features
  - Sandbox table: Terminal button opens the details sheet on the Terminal tab and syncs the URL.
  - Terminal tab: auto-activates for running sandboxes, shows a loading state, and adds an “Open in new tab” link.
  - VNC tab: adds an “Open in new tab” link.

- Refactors
  - Expose `SandboxTable` ref and simplify row click to pass only the sandbox.
  - Widen the actions column to fit the new button and minor UI cleanup.

<sup>Written for commit c11dd18a0408620d0227c0bd509a8abdbcaa51c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

