### PR TITLE
cli: add --force option for snapshot create

### DIFF
--- a/apps/cli/cmd/snapshot/create.go
+++ b/apps/cli/cmd/snapshot/create.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var forceFlag bool
+
 var CreateCmd = &cobra.Command{
 	Use:     "create [SNAPSHOT]",
 	Short:   "Create a snapshot",
@@ -76,6 +78,19 @@ var CreateCmd = &cobra.Command{
 
 		// Send create request
 		snapshot, res, err := apiClient.SnapshotsAPI.CreateSnapshot(ctx).CreateSnapshot(*createSnapshot).Execute()
+		if err != nil && forceFlag {
+			existingSnapshot, _, getErr := apiClient.SnapshotsAPI.GetSnapshot(ctx, snapshotName).Execute()
+			if getErr != nil {
+				return apiclient_cli.HandleErrorResponse(res, err)
+			}
+
+			deleteRes, deleteErr := apiClient.SnapshotsAPI.RemoveSnapshot(ctx, existingSnapshot.Id).Execute()
+			if deleteErr != nil {
+				return apiclient_cli.HandleErrorResponse(deleteRes, deleteErr)
+			}
+
+			snapshot, res, err = apiClient.SnapshotsAPI.CreateSnapshot(ctx).CreateSnapshot(*createSnapshot).Execute()
+		}
 		if err != nil {
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
@@ -147,6 +162,7 @@ func init() {
 	CreateCmd.Flags().Int32Var(&memoryFlag, "memory", 0, "Memory that will be allocated to the underlying sandboxes in GB (default: 1)")
 	CreateCmd.Flags().Int32Var(&diskFlag, "disk", 0, "Disk space that will be allocated to the underlying sandboxes in GB (default: 3)")
 	CreateCmd.Flags().StringVar(&regionIdFlag, "region", "", "ID of the region where the snapshot will be available (defaults to organization default region)")
+	CreateCmd.Flags().BoolVar(&forceFlag, "force", false, "Replace an existing snapshot with the same name")
 
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "dockerfile")
 	CreateCmd.MarkFlagsMutuallyExclusive("image", "context")


### PR DESCRIPTION
## Summary
Adds a --force flag to  so CI workflows can converge a snapshot name in one command.

## What changes
- Adds  flag to .
- On create error with , CLI resolves existing snapshot by name, removes it, and retries create with the same payload.

## Why
Issue #2661 asks for a safer, idempotent way to update snapshot content without manual delete/recreate steps. This provides a practical CLI-level replacement path until a native atomic update endpoint exists.

## Testing
- go test ./apps/cli/cmd/snapshot/...

Closes #2661.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--force` flag to `snapshot create` to replace an existing snapshot with the same name in one step. This makes CI updates idempotent and addresses #2661.

- **New Features**
  - `--force`: on create error, fetches the snapshot by name, deletes it, then retries create with the same payload; returns API errors if fetch or delete fails.

<sup>Written for commit fb93160f61be9ac637b54895b5e48152b33d9c77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

