### PR TITLE
fix(cli): snapshot create no longer hangs after fast builds

### DIFF
--- a/apps/cli/cmd/common/logs.go
+++ b/apps/cli/cmd/common/logs.go
@@ -91,10 +91,16 @@ func ReadBuildLogs(ctx context.Context, params ReadLogParams) {
 					}
 					return
 				}
-				// Don't log context.Canceled as it's an expected case when streaming is stopped
-				if err != context.Canceled {
-					log.Errorf("Error reading from stream: %v", err)
+				if err == context.Canceled {
+					return
 				}
+				// In follow mode the upstream proxy can reset long-lived streams; the
+				// build itself is unaffected and the caller still polls for completion.
+				if params.Follow != nil && *params.Follow {
+					log.Warnf("Build log stream interrupted (%v); the build is still running, waiting for it to complete...", err)
+					return
+				}
+				log.Errorf("Error reading from stream: %v", err)
 				return
 			}
 		}

--- a/apps/cli/cmd/common/state.go
+++ b/apps/cli/cmd/common/state.go
@@ -12,16 +12,20 @@ import (
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 )
 
-func AwaitSnapshotState(ctx context.Context, apiClient *apiclient.APIClient, name string, state apiclient.SnapshotState) error {
+func AwaitSnapshotState(ctx context.Context, apiClient *apiclient.APIClient, name string, states ...apiclient.SnapshotState) error {
 	for {
 		snapshot, res, err := apiClient.SnapshotsAPI.GetSnapshot(ctx, name).Execute()
 		if err != nil {
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
+		for _, s := range states {
+			if snapshot.State == s {
+				return nil
+			}
+		}
+
 		switch snapshot.State {
-		case state:
-			return nil
 		case apiclient.SNAPSHOTSTATE_ERROR, apiclient.SNAPSHOTSTATE_BUILD_FAILED:
 			if !snapshot.ErrorReason.IsSet() {
 				return fmt.Errorf("snapshot processing failed")
@@ -33,20 +37,25 @@ func AwaitSnapshotState(ctx context.Context, apiClient *apiclient.APIClient, nam
 	}
 }
 
-func AwaitSandboxState(ctx context.Context, apiClient *apiclient.APIClient, targetSandbox string, state apiclient.SandboxState) error {
+func AwaitSandboxState(ctx context.Context, apiClient *apiclient.APIClient, targetSandbox string, states ...apiclient.SandboxState) error {
 	for {
 		sandbox, res, err := apiClient.SandboxAPI.GetSandbox(ctx, targetSandbox).Execute()
 		if err != nil {
 			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
-		if sandbox.State != nil && *sandbox.State == state {
-			return nil
-		} else if sandbox.State != nil && (*sandbox.State == apiclient.SANDBOXSTATE_ERROR || *sandbox.State == apiclient.SANDBOXSTATE_BUILD_FAILED) {
-			if sandbox.ErrorReason == nil {
-				return fmt.Errorf("sandbox processing failed")
+		if sandbox.State != nil {
+			for _, s := range states {
+				if *sandbox.State == s {
+					return nil
+				}
 			}
-			return fmt.Errorf("sandbox processing failed: %s", *sandbox.ErrorReason)
+			if *sandbox.State == apiclient.SANDBOXSTATE_ERROR || *sandbox.State == apiclient.SANDBOXSTATE_BUILD_FAILED {
+				if sandbox.ErrorReason == nil {
+					return fmt.Errorf("sandbox processing failed")
+				}
+				return fmt.Errorf("sandbox processing failed: %s", *sandbox.ErrorReason)
+			}
 		}
 
 		time.Sleep(time.Second)

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -145,7 +145,13 @@ var CreateCmd = &cobra.Command{
 				return err
 			}
 
-			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id, apiclient.SANDBOXSTATE_BUILDING_SNAPSHOT)
+			// Accept any post-pending state — transient states can be skipped between polls.
+			err = common.AwaitSandboxState(ctx, apiClient, sandbox.Id,
+				apiclient.SANDBOXSTATE_BUILDING_SNAPSHOT,
+				apiclient.SANDBOXSTATE_PULLING_SNAPSHOT,
+				apiclient.SANDBOXSTATE_STARTING,
+				apiclient.SANDBOXSTATE_STARTED,
+			)
 			if err != nil {
 				return err
 			}

--- a/apps/cli/cmd/snapshot/create.go
+++ b/apps/cli/cmd/snapshot/create.go
@@ -104,7 +104,13 @@ var CreateCmd = &cobra.Command{
 				ResourceType:         common.ResourceTypeSnapshot,
 			})
 
-			err = common.AwaitSnapshotState(ctx, apiClient, snapshotName, apiclient.SNAPSHOTSTATE_PENDING)
+			// Accept any post-build state — transient states can be skipped between polls.
+			err = common.AwaitSnapshotState(ctx, apiClient, snapshotName,
+				apiclient.SNAPSHOTSTATE_PENDING,
+				apiclient.SNAPSHOTSTATE_PULLING,
+				apiclient.SNAPSHOTSTATE_ACTIVE,
+				apiclient.SNAPSHOTSTATE_INACTIVE,
+			)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

`daytona snapshot create --dockerfile ...` could hang indefinitely after a successful
build, eventually surfacing a misleading `Error reading from stream: ... INTERNAL_ERROR`
while the snapshot was already `active` in the dashboard. Root cause: a polling-state
race in the CLI. Fixed by accepting any post-build state and improving log-stream
behaviour for long-lived builds.

## Root cause

After kicking off the build, the CLI polled `AwaitSnapshotState(ctx, ..., SNAPSHOTSTATE_PENDING)`
([apps/cli/cmd/snapshot/create.go:107](apps/cli/cmd/snapshot/create.go#L107)) to know when
to stop streaming build logs. The helper matched a single state with `==` and polled
once per second. The snapshot state machine progresses
`building → pending → pulling → active`, and `pending` is short-lived — easily skipped
between polls — so the loop never matched and never terminated.

The `ERRO[0145] Error reading from stream` message users saw was a side effect: the
upstream proxy reset the long-lived build-log HTTP/2 stream after ~145s of
build/streaming, the goroutine logged an error and exited, and the main thread kept
spinning in the dead poll loop until the user killed the process.

## Changes

- **[apps/cli/cmd/common/state.go](apps/cli/cmd/common/state.go)** — `AwaitSnapshotState`
  and `AwaitSandboxState` are now variadic. They return as soon as the resource hits
  any of the supplied states, so callers can accept whole "phases" of the state
  machine instead of betting on a single transient state. Existing single-state
  callers (`AwaitSnapshotState(... ACTIVE)`) keep working unchanged. `ERROR` /
  `BUILD_FAILED` short-circuiting is preserved.

- **[apps/cli/cmd/snapshot/create.go](apps/cli/cmd/snapshot/create.go)** — post-build
  wait now accepts `{PENDING, PULLING, ACTIVE, INACTIVE}`. Returns as soon as the
  snapshot leaves `BUILDING`, regardless of how fast it transitions afterwards.

- **[apps/cli/cmd/sandbox/create.go](apps/cli/cmd/sandbox/create.go)** — analogous race
  before log streaming starts (waited for `BUILDING_SNAPSHOT` only). Now accepts
  `{BUILDING_SNAPSHOT, PULLING_SNAPSHOT, STARTING, STARTED}` so cached/fast builds
  don't hang either.

- **[apps/cli/cmd/common/logs.go](apps/cli/cmd/common/logs.go)** — in follow mode, a
  mid-stream HTTP/2 reset is no longer a red `Error`. It's a `Warn` with a clear
  message ("Build log stream interrupted (...); the build is still running, waiting
  for it to complete..."). The main flow keeps polling state and surfaces the real
  outcome. Non-follow callers still get `Error` since for them a stream cut is a real
  fetch failure.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang in `daytona snapshot create` after fast builds by accepting any post-build state and making log follow resilient to stream resets. CLI commands now exit promptly once builds finish.

- **Bug Fixes**
  - `daytona snapshot create --dockerfile` no longer stalls; waits for any of `PENDING`, `PULLING`, `ACTIVE`, or `INACTIVE` after `BUILDING`.
  - `daytona sandbox create` uses the same approach to avoid hangs on cached/fast builds.
  - Log follow treats mid-stream HTTP/2 resets as warnings and keeps polling; `context.Canceled` is ignored; non-follow still errors.

- **Refactors**
  - `AwaitSnapshotState` and `AwaitSandboxState` now accept multiple target states and return on the first match. Error/build-failure short-circuiting is unchanged.

<sup>Written for commit f3ceb674f0798e3edc059c55a88026f47fb7c684. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

