### PR TITLE
feat(dashboard): add snapshot size

### DIFF
--- a/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
@@ -94,6 +94,14 @@ function EmptyValue() {
   return <span className="text-muted-foreground">-</span>
 }
 
+function formatSnapshotSize(size: number | null | undefined) {
+  if (size == null || !Number.isFinite(size)) {
+    return null
+  }
+
+  return `${size.toFixed(2)} GB`
+}
+
 function getStateBadgeVariant(state: SnapshotState): BadgeProps['variant'] {
   switch (state) {
     case SnapshotState.ACTIVE:
@@ -140,7 +148,7 @@ function TimestampRow({ label, value }: { label: string; value: Date | null | un
 }
 
 function SnapshotSheetSkeleton() {
-  const overviewRows = ['name', 'image', 'entrypoint', 'state']
+  const overviewRows = ['name', 'image', 'size', 'entrypoint', 'state']
   const timestampRows = ['created', 'updated', 'last-used']
 
   return (
@@ -291,6 +299,7 @@ export function SnapshotSheet({
                     <EmptyValue />
                   )}
                 </InfoRow>
+                <InfoRow label="Size">{formatSnapshotSize(activeSnapshot.size) ?? <EmptyValue />}</InfoRow>
                 {activeSnapshot.entrypoint?.length ? (
                   <InfoRow label="Entrypoint" className="items-start -mr-2">
                     <CopyValue


### PR DESCRIPTION
## Description

Adds snapshot size prop to snapshot sheet.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show snapshot size in the snapshot sheet. Size is formatted in GB with two decimals, falls back to “-” when missing, and the skeleton now includes a Size row.

<sup>Written for commit de190d0df584187ca91b63c7414bee01353bc39b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

