### PR TITLE
feat(dashboard): otel config zod validation

### DIFF
--- a/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
+++ b/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
@@ -3,19 +3,64 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import TooltipButton from '@/components/TooltipButton'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Field, FieldContent, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { useApi } from '@/hooks/useApi'
-import { useOrganizations } from '@/hooks/useOrganizations'
+import { Spinner } from '@/components/ui/spinner'
+import { useDeleteOrganizationOtelConfigMutation } from '@/hooks/mutations/useDeleteOrganizationOtelConfigMutation'
+import { useUpdateOrganizationOtelConfigMutation } from '@/hooks/mutations/useUpdateOrganizationOtelConfigMutation'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import type { Organization } from '@daytona/api-client'
-import React, { useState } from 'react'
+import { useForm } from '@tanstack/react-form'
+import { Minus, Plus } from 'lucide-react'
+import React, { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
+import { z } from 'zod'
 
 type HeaderEntry = { key: string; value: string }
+
+const emptyHeader = (): HeaderEntry => ({ key: '', value: '' })
+
+const headerRowIsComplete = (headers: HeaderEntry[]) =>
+  headers.every(({ key, value }) => {
+    const hasKey = !!key.trim()
+    const hasValue = !!value.trim()
+    return hasKey === hasValue
+  })
+
+const noDuplicateHeaderKeys = (headers: HeaderEntry[]) => {
+  const keys = headers.map(({ key }) => key.trim().toLowerCase()).filter(Boolean)
+
+  return new Set(keys).size === keys.length
+}
+
+const formSchema = z.object({
+  endpoint: z
+    .string()
+    .trim()
+    .refine((value) => {
+      try {
+        new URL(value)
+        return true
+      } catch {
+        return false
+      }
+    }, 'A valid OTLP endpoint URL is required'),
+  headers: z
+    .array(
+      z.object({
+        key: z.string().trim(),
+        value: z.string().trim(),
+      }),
+    )
+    .refine(headerRowIsComplete, 'Header rows need both a key and a value')
+    .refine(noDuplicateHeaderKeys, 'Header keys must be unique'),
+})
+
+type FormValues = z.infer<typeof formSchema>
 
 const headersFromOrganization = (organization: Organization | null | undefined): HeaderEntry[] => {
   const headers = organization?.otelConfig?.headers
@@ -28,168 +73,265 @@ const headersFromOrganization = (organization: Organization | null | undefined):
 const endpointFromOrganization = (organization: Organization | null | undefined): string =>
   organization?.otelConfig?.endpoint ?? ''
 
-export const OtelConfigCard: React.FC = () => {
-  const { organizationsApi } = useApi()
-  const { selectedOrganization } = useSelectedOrganization()
-  const { refreshOrganizations } = useOrganizations()
+const valuesFromOrganization = (organization: Organization | null | undefined): FormValues => ({
+  endpoint: endpointFromOrganization(organization),
+  headers: headersFromOrganization(organization).length ? headersFromOrganization(organization) : [emptyHeader()],
+})
 
-  const [endpoint, setEndpoint] = useState(() => endpointFromOrganization(selectedOrganization))
-  const [headers, setHeaders] = useState<HeaderEntry[]>(() => headersFromOrganization(selectedOrganization))
-  const [newHeader, setNewHeader] = useState<HeaderEntry>({ key: '', value: '' })
-  const [saving, setSaving] = useState(false)
+const getHeaderRowErrors = (headers: HeaderEntry[]) => {
+  const errors: Record<number, { key?: string; value?: string }> = {}
+  const keys = new Map<string, number>()
 
-  const hasOtelEnabled = !!selectedOrganization?.otelConfig
+  headers.forEach(({ key, value }, index) => {
+    const trimmedKey = key.trim()
+    const normalizedKey = trimmedKey.toLowerCase()
+    const trimmedValue = value.trim()
 
-  const handleSave = async () => {
-    if (!selectedOrganization) {
+    if (!trimmedKey && !trimmedValue) {
       return
     }
 
-    setSaving(true)
-    try {
-      const allHeaders = [...headers, newHeader]
-        .filter(({ key, value }) => key.trim() && value.trim())
-        .reduce(
-          (acc, { key, value }) => {
-            acc[key] = value
-            return acc
-          },
-          {} as Record<string, string>,
-        )
-
-      await organizationsApi.updateOrganizationOtelConfig(selectedOrganization.id, {
-        endpoint,
-        headers: allHeaders,
-      })
-      await refreshOrganizations(selectedOrganization.id)
-      setNewHeader({ key: '', value: '' })
-      toast.success('OpenTelemetry configuration saved')
-    } catch (error) {
-      handleApiError(error, 'Failed to save OpenTelemetry configuration')
-    } finally {
-      setSaving(false)
+    if (!trimmedKey) {
+      errors[index] = { ...errors[index], key: 'Header key is required' }
     }
-  }
+
+    if (!trimmedValue) {
+      errors[index] = { ...errors[index], value: 'Header value is required' }
+    }
+
+    if (!trimmedKey || !trimmedValue) {
+      return
+    }
+
+    const duplicateIndex = keys.get(normalizedKey)
+    if (duplicateIndex != null) {
+      errors[index] = { ...errors[index], key: 'Header keys must be unique' }
+      errors[duplicateIndex] = { ...errors[duplicateIndex], key: 'Header keys must be unique' }
+      return
+    }
+
+    keys.set(normalizedKey, index)
+  })
+
+  return errors
+}
+
+export const OtelConfigCard: React.FC = () => {
+  const { selectedOrganization } = useSelectedOrganization()
+  const updateOtelConfigMutation = useUpdateOrganizationOtelConfigMutation()
+  const deleteOtelConfigMutation = useDeleteOrganizationOtelConfigMutation()
+
+  const formRef = useRef<HTMLFormElement>(null)
+  const headerKeyInputRefs = useRef<Array<HTMLInputElement | null>>([])
+
+  const hasOtelEnabled = !!selectedOrganization?.otelConfig
+  const saving = updateOtelConfigMutation.isPending
+  const disabling = deleteOtelConfigMutation.isPending
+
+  const form = useForm({
+    defaultValues: valuesFromOrganization(selectedOrganization),
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmitInvalid: () => {
+      const formEl = formRef.current
+      if (!formEl) return
+      const invalidInput = formEl.querySelector('[aria-invalid="true"]') as HTMLInputElement | null
+      if (invalidInput) {
+        invalidInput.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        invalidInput.focus()
+      }
+    },
+    onSubmit: async ({ value }) => {
+      if (!selectedOrganization) {
+        return
+      }
+
+      try {
+        const headers = value.headers
+          .filter(({ key, value }) => key.trim() || value.trim())
+          .reduce(
+            (acc, { key, value }) => {
+              acc[key.trim()] = value.trim()
+              return acc
+            },
+            {} as Record<string, string>,
+          )
+
+        await updateOtelConfigMutation.mutateAsync({
+          organizationId: selectedOrganization.id,
+          otelConfig: {
+            endpoint: value.endpoint.trim(),
+            headers,
+          },
+        })
+        toast.success('OpenTelemetry configuration saved')
+      } catch (error) {
+        handleApiError(error, 'Failed to save OpenTelemetry configuration')
+      }
+    },
+  })
 
   const handleDisable = async () => {
     if (!selectedOrganization) {
       return
     }
 
-    setSaving(true)
     try {
-      await organizationsApi.deleteOrganizationOtelConfig(selectedOrganization.id)
-      await refreshOrganizations(selectedOrganization.id)
-      setEndpoint('')
-      setHeaders([])
-      setNewHeader({ key: '', value: '' })
+      await deleteOtelConfigMutation.mutateAsync({ organizationId: selectedOrganization.id })
+      form.reset({ endpoint: '', headers: [emptyHeader()] })
       toast.success('OpenTelemetry configuration disabled')
     } catch (error) {
       handleApiError(error, 'Failed to disable OpenTelemetry configuration')
-    } finally {
-      setSaving(false)
     }
   }
+
+  const selectedOrganizationId = selectedOrganization?.id
+  const selectedOtelEndpoint = selectedOrganization?.otelConfig?.endpoint
+  const selectedOtelHeaders = selectedOrganization?.otelConfig?.headers
+
+  useEffect(() => {
+    form.reset(valuesFromOrganization(selectedOrganization))
+  }, [selectedOrganizationId, selectedOtelEndpoint, selectedOtelHeaders])
 
   return (
     <Card>
       <CardHeader className="p-4">
         <CardTitle>OpenTelemetry</CardTitle>
       </CardHeader>
-      <CardContent className="border-t border-border">
+      <CardContent className="border-t border-border p-0">
         <form
+          ref={formRef}
           id="otel-config-form"
-          className="space-y-6"
           onSubmit={async (e) => {
             e.preventDefault()
-            await handleSave()
+            e.stopPropagation()
+            form.handleSubmit()
           }}
         >
-          <div className="space-y-2">
-            <Label htmlFor="otel-endpoint">OTLP Endpoint</Label>
-            <Input
-              id="otel-endpoint"
-              placeholder="https://otel-collector.example.com:4318"
-              value={endpoint}
-              onChange={(e) => setEndpoint(e.target.value)}
-            />
-            <p className="text-sm text-muted-foreground">The OpenTelemetry collector endpoint URL.</p>
+          <div className="border-b border-border p-4 last:border-b-0">
+            <form.Field name="endpoint">
+              {(field) => {
+                const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
+
+                return (
+                  <Field data-invalid={isInvalid} className="grid gap-3 sm:grid-cols-2 sm:items-center">
+                    <FieldContent>
+                      <FieldLabel htmlFor={field.name}>OTLP Endpoint</FieldLabel>
+                      <FieldDescription>The OpenTelemetry collector endpoint URL.</FieldDescription>
+                    </FieldContent>
+                    <div className="space-y-1">
+                      <Input
+                        aria-invalid={isInvalid}
+                        id={field.name}
+                        name={field.name}
+                        placeholder="https://otel-collector.example.com:4318"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                      />
+                      {field.state.meta.errors.length > 0 && field.state.meta.isTouched && (
+                        <FieldError errors={field.state.meta.errors} />
+                      )}
+                    </div>
+                  </Field>
+                )
+              }}
+            </form.Field>
           </div>
 
-          <div className="space-y-2">
-            <Label>Headers</Label>
-            <div className="space-y-2">
-              {headers.map(({ key, value }, index) => (
-                <div key={index} className="flex items-center gap-2">
-                  <HeaderInput
-                    headerKey={key}
-                    headerValue={value}
-                    onChangeKey={(e) => {
-                      const next = [...headers]
-                      next[index].key = e.target.value
-                      setHeaders(next)
-                    }}
-                    onChangeValue={(e) => {
-                      const next = [...headers]
-                      next[index].value = e.target.value
-                      setHeaders(next)
+          <div className="border-b border-border p-4 last:border-b-0">
+            <form.Field name="headers">
+              {(field) => {
+                return (
+                  <form.Subscribe
+                    selector={(state) => state.submissionAttempts}
+                    children={(submissionAttempts) => {
+                      const headerErrors = getHeaderRowErrors(field.state.value)
+                      const showErrors = submissionAttempts > 0 && Object.keys(headerErrors).length > 0
+
+                      return (
+                        <Field data-invalid={showErrors} className="gap-3">
+                          <FieldContent>
+                            <FieldLabel>Headers</FieldLabel>
+                            <FieldDescription>
+                              Optional headers to send with OTLP requests. Existing values are stored encrypted and
+                              shown as <code>******</code>.
+                            </FieldDescription>
+                          </FieldContent>
+                          <div className="space-y-2">
+                            {field.state.value.map((header, index) => (
+                              <HeaderInput
+                                key={index}
+                                keyInputRef={(element) => {
+                                  headerKeyInputRefs.current[index] = element
+                                }}
+                                headerKey={header.key}
+                                headerValue={header.value}
+                                errors={showErrors ? headerErrors[index] : undefined}
+                                onChangeKey={(key) => {
+                                  const next = [...field.state.value]
+                                  next[index] = { ...next[index], key }
+                                  field.handleChange(next)
+                                }}
+                                onChangeValue={(value) => {
+                                  const next = [...field.state.value]
+                                  next[index] = { ...next[index], value }
+                                  field.handleChange(next)
+                                }}
+                                onRemove={() => field.handleChange(field.state.value.filter((_, i) => i !== index))}
+                              />
+                            ))}
+                            <div className="flex justify-start">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                  const nextIndex = field.state.value.length
+                                  field.handleChange([...field.state.value, emptyHeader()])
+                                  setTimeout(() => headerKeyInputRefs.current[nextIndex]?.focus())
+                                }}
+                              >
+                                <Plus className="size-4" />
+                                Add Header
+                              </Button>
+                            </div>
+                          </div>
+                        </Field>
+                      )
                     }}
                   />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setHeaders(headers.filter((_, i) => i !== index))}
-                  >
-                    Remove
-                  </Button>
-                </div>
-              ))}
-
-              <div className="flex items-center gap-2">
-                <HeaderInput
-                  headerKey={newHeader.key}
-                  headerValue={newHeader.value}
-                  onChangeKey={(e) => setNewHeader({ ...newHeader, key: e.target.value })}
-                  onChangeValue={(e) => setNewHeader({ ...newHeader, value: e.target.value })}
-                  onAdd={() => {
-                    if (newHeader.key.trim() && newHeader.value.trim()) {
-                      setHeaders([...headers, newHeader])
-                      setNewHeader({ key: '', value: '' })
-                    }
-                  }}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    if (newHeader.key.trim() && newHeader.value.trim()) {
-                      setHeaders([...headers, newHeader])
-                      setNewHeader({ key: '', value: '' })
-                    }
-                  }}
-                  disabled={!newHeader.key.trim() || !newHeader.value.trim()}
-                >
-                  +
-                </Button>
-              </div>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Optional headers to send with OTLP requests (e.g., authentication tokens). Existing values are stored
-              encrypted and shown as <code>******</code>.
-            </p>
+                )
+              }}
+            </form.Field>
           </div>
 
-          <div className="flex items-center gap-2">
-            <Button type="submit" form="otel-config-form" disabled={saving || !endpoint.trim()}>
-              {saving ? 'Saving...' : 'Save'}
-            </Button>
+          <div className="flex justify-end gap-2 p-4">
             {hasOtelEnabled && (
-              <Button type="button" variant="outline" onClick={handleDisable} disabled={saving}>
-                Disable
-              </Button>
+              <form.Subscribe
+                selector={(state) => state.isSubmitting}
+                children={(isSubmitting) => (
+                  <Button type="button" variant="outline" onClick={handleDisable} disabled={isSubmitting || disabling}>
+                    {disabling && <Spinner />}
+                    Disable
+                  </Button>
+                )}
+              />
             )}
+            <form.Subscribe
+              selector={(state) => [state.canSubmit, state.isSubmitting]}
+              children={([canSubmit, isSubmitting]) => (
+                <Button
+                  type="submit"
+                  form="otel-config-form"
+                  disabled={!canSubmit || isSubmitting || saving || disabling}
+                >
+                  {(isSubmitting || saving) && <Spinner />}
+                  Save
+                </Button>
+              )}
+            />
           </div>
         </form>
       </CardContent>
@@ -198,31 +340,48 @@ export const OtelConfigCard: React.FC = () => {
 }
 
 const HeaderInput = ({
+  keyInputRef,
   headerKey,
   headerValue,
+  errors,
   onChangeKey,
   onChangeValue,
-  onAdd,
+  onRemove,
 }: {
+  keyInputRef: (element: HTMLInputElement | null) => void
   headerKey: string
   headerValue: string
-  onChangeKey: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onChangeValue: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onAdd?: () => void
+  errors?: { key?: string; value?: string }
+  onChangeKey: (value: string) => void
+  onChangeValue: (value: string) => void
+  onRemove: () => void
 }) => (
-  <>
-    <Input placeholder="Header key" className="flex-1" value={headerKey} onChange={onChangeKey} />
-    <Input
-      placeholder="Header value"
-      className="flex-1"
-      value={headerValue}
-      onChange={onChangeValue}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' && headerKey.trim() && headerValue.trim()) {
-          e.preventDefault()
-          onAdd?.()
-        }
-      }}
-    />
-  </>
+  <div className="space-y-1">
+    <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2rem] gap-2">
+      <Input
+        ref={keyInputRef}
+        aria-invalid={!!errors?.key}
+        placeholder="Header key"
+        value={headerKey}
+        onChange={(e) => onChangeKey(e.target.value)}
+      />
+      <Input
+        aria-invalid={!!errors?.value}
+        placeholder="Header value"
+        value={headerValue}
+        onChange={(e) => onChangeValue(e.target.value)}
+      />
+      <TooltipButton
+        type="button"
+        tooltipText="Remove header"
+        variant="ghost"
+        size="icon"
+        className="flex-shrink-0 h-8 w-8"
+        onClick={onRemove}
+      >
+        <Minus className="size-4" />
+      </TooltipButton>
+    </div>
+    {(errors?.key || errors?.value) && <FieldError>{[errors.key, errors.value].filter(Boolean).join('. ')}</FieldError>}
+  </div>
 )

--- a/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
+++ b/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
@@ -24,18 +24,20 @@ type HeaderEntry = { key: string; value: string }
 
 const emptyHeader = (): HeaderEntry => ({ key: '', value: '' })
 
-const headerRowIsComplete = (headers: HeaderEntry[]) =>
-  headers.every(({ key, value }) => {
-    const hasKey = !!key.trim()
-    const hasValue = !!value.trim()
-    return hasKey === hasValue
-  })
-
 const noDuplicateHeaderKeys = (headers: HeaderEntry[]) => {
   const keys = headers.map(({ key }) => key.trim().toLowerCase()).filter(Boolean)
 
   return new Set(keys).size === keys.length
 }
+
+const headersSchema = z
+  .array(
+    z.object({
+      key: z.string().trim().min(1, 'Header key is required'),
+      value: z.string().trim(),
+    }),
+  )
+  .refine(noDuplicateHeaderKeys, 'Header keys must be unique')
 
 const formSchema = z.object({
   endpoint: z
@@ -49,16 +51,12 @@ const formSchema = z.object({
         return false
       }
     }, 'A valid OTLP endpoint URL is required'),
-  headers: z
-    .array(
-      z.object({
-        key: z.string().trim(),
-        value: z.string().trim(),
-      }),
-    )
-    .refine(headerRowIsComplete, 'Header rows need both a key and a value')
-    .refine(noDuplicateHeaderKeys, 'Header keys must be unique'),
+  headers: headersSchema,
 })
+
+const headersValidators = {
+  onSubmit: headersSchema,
+}
 
 type FormValues = z.infer<typeof formSchema>
 
@@ -75,46 +73,8 @@ const endpointFromOrganization = (organization: Organization | null | undefined)
 
 const valuesFromOrganization = (organization: Organization | null | undefined): FormValues => ({
   endpoint: endpointFromOrganization(organization),
-  headers: headersFromOrganization(organization).length ? headersFromOrganization(organization) : [emptyHeader()],
+  headers: headersFromOrganization(organization),
 })
-
-const getHeaderRowErrors = (headers: HeaderEntry[]) => {
-  const errors: Record<number, { key?: string; value?: string }> = {}
-  const keys = new Map<string, number>()
-
-  headers.forEach(({ key, value }, index) => {
-    const trimmedKey = key.trim()
-    const normalizedKey = trimmedKey.toLowerCase()
-    const trimmedValue = value.trim()
-
-    if (!trimmedKey && !trimmedValue) {
-      return
-    }
-
-    if (!trimmedKey) {
-      errors[index] = { ...errors[index], key: 'Header key is required' }
-    }
-
-    if (!trimmedValue) {
-      errors[index] = { ...errors[index], value: 'Header value is required' }
-    }
-
-    if (!trimmedKey || !trimmedValue) {
-      return
-    }
-
-    const duplicateIndex = keys.get(normalizedKey)
-    if (duplicateIndex != null) {
-      errors[index] = { ...errors[index], key: 'Header keys must be unique' }
-      errors[duplicateIndex] = { ...errors[duplicateIndex], key: 'Header keys must be unique' }
-      return
-    }
-
-    keys.set(normalizedKey, index)
-  })
-
-  return errors
-}
 
 export const OtelConfigCard: React.FC = () => {
   const { selectedOrganization } = useSelectedOrganization()
@@ -179,7 +139,7 @@ export const OtelConfigCard: React.FC = () => {
 
     try {
       await deleteOtelConfigMutation.mutateAsync({ organizationId: selectedOrganization.id })
-      form.reset({ endpoint: '', headers: [emptyHeader()] })
+      form.reset({ endpoint: '', headers: [] })
       toast.success('OpenTelemetry configuration disabled')
     } catch (error) {
       handleApiError(error, 'Failed to disable OpenTelemetry configuration')
@@ -241,67 +201,59 @@ export const OtelConfigCard: React.FC = () => {
           </div>
 
           <div className="border-b border-border p-4 last:border-b-0">
-            <form.Field name="headers">
+            <form.Field name="headers" validators={headersValidators}>
               {(field) => {
-                return (
-                  <form.Subscribe
-                    selector={(state) => state.submissionAttempts}
-                    children={(submissionAttempts) => {
-                      const headerErrors = getHeaderRowErrors(field.state.value)
-                      const showErrors = submissionAttempts > 0 && Object.keys(headerErrors).length > 0
+                const hasErrors = field.state.meta.errors.length > 0
 
-                      return (
-                        <Field data-invalid={showErrors} className="gap-3">
-                          <FieldContent>
-                            <FieldLabel>Headers</FieldLabel>
-                            <FieldDescription>
-                              Optional headers to send with OTLP requests. Existing values are stored encrypted and
-                              shown as <code>******</code>.
-                            </FieldDescription>
-                          </FieldContent>
-                          <div className="space-y-2">
-                            {field.state.value.map((header, index) => (
-                              <HeaderInput
-                                key={index}
-                                keyInputRef={(element) => {
-                                  headerKeyInputRefs.current[index] = element
-                                }}
-                                headerKey={header.key}
-                                headerValue={header.value}
-                                errors={showErrors ? headerErrors[index] : undefined}
-                                onChangeKey={(key) => {
-                                  const next = [...field.state.value]
-                                  next[index] = { ...next[index], key }
-                                  field.handleChange(next)
-                                }}
-                                onChangeValue={(value) => {
-                                  const next = [...field.state.value]
-                                  next[index] = { ...next[index], value }
-                                  field.handleChange(next)
-                                }}
-                                onRemove={() => field.handleChange(field.state.value.filter((_, i) => i !== index))}
-                              />
-                            ))}
-                            <div className="flex justify-start">
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                onClick={() => {
-                                  const nextIndex = field.state.value.length
-                                  field.handleChange([...field.state.value, emptyHeader()])
-                                  setTimeout(() => headerKeyInputRefs.current[nextIndex]?.focus())
-                                }}
-                              >
-                                <Plus className="size-4" />
-                                Add Header
-                              </Button>
-                            </div>
-                          </div>
-                        </Field>
-                      )
-                    }}
-                  />
+                return (
+                  <Field data-invalid={hasErrors} className="gap-3">
+                    <FieldContent>
+                      <FieldLabel>Headers</FieldLabel>
+                      <FieldDescription>
+                        Optional headers to send with OTLP requests. Existing values are stored encrypted and shown as{' '}
+                        <code>******</code>.
+                      </FieldDescription>
+                    </FieldContent>
+                    <div className="space-y-2">
+                      {field.state.value.map((header, index) => (
+                        <HeaderInput
+                          key={index}
+                          keyInputRef={(element) => {
+                            headerKeyInputRefs.current[index] = element
+                          }}
+                          headerKey={header.key}
+                          headerValue={header.value}
+                          onChangeKey={(key) => {
+                            const next = [...field.state.value]
+                            next[index] = { ...next[index], key }
+                            field.handleChange(next)
+                          }}
+                          onChangeValue={(value) => {
+                            const next = [...field.state.value]
+                            next[index] = { ...next[index], value }
+                            field.handleChange(next)
+                          }}
+                          onRemove={() => field.handleChange(field.state.value.filter((_, i) => i !== index))}
+                        />
+                      ))}
+                      <div className="flex justify-start">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            const nextIndex = field.state.value.length
+                            field.handleChange([...field.state.value, emptyHeader()])
+                            setTimeout(() => headerKeyInputRefs.current[nextIndex]?.focus())
+                          }}
+                        >
+                          <Plus className="size-4" />
+                          Add Header
+                        </Button>
+                      </div>
+                    </div>
+                    {hasErrors && <FieldError errors={field.state.meta.errors} />}
+                  </Field>
                 )
               }}
             </form.Field>
@@ -343,7 +295,6 @@ const HeaderInput = ({
   keyInputRef,
   headerKey,
   headerValue,
-  errors,
   onChangeKey,
   onChangeValue,
   onRemove,
@@ -351,7 +302,6 @@ const HeaderInput = ({
   keyInputRef: (element: HTMLInputElement | null) => void
   headerKey: string
   headerValue: string
-  errors?: { key?: string; value?: string }
   onChangeKey: (value: string) => void
   onChangeValue: (value: string) => void
   onRemove: () => void
@@ -360,17 +310,11 @@ const HeaderInput = ({
     <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2rem] gap-2">
       <Input
         ref={keyInputRef}
-        aria-invalid={!!errors?.key}
         placeholder="Header key"
         value={headerKey}
         onChange={(e) => onChangeKey(e.target.value)}
       />
-      <Input
-        aria-invalid={!!errors?.value}
-        placeholder="Header value"
-        value={headerValue}
-        onChange={(e) => onChangeValue(e.target.value)}
-      />
+      <Input placeholder="Header value" value={headerValue} onChange={(e) => onChangeValue(e.target.value)} />
       <TooltipButton
         type="button"
         tooltipText="Remove header"
@@ -382,6 +326,5 @@ const HeaderInput = ({
         <Minus className="size-4" />
       </TooltipButton>
     </div>
-    {(errors?.key || errors?.value) && <FieldError>{[errors.key, errors.value].filter(Boolean).join('. ')}</FieldError>}
   </div>
 )

--- a/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
+++ b/apps/dashboard/src/components/Organizations/OtelConfigCard.tsx
@@ -222,6 +222,7 @@ export const OtelConfigCard: React.FC = () => {
                             headerKeyInputRefs.current[index] = element
                           }}
                           headerKey={header.key}
+                          invalid={hasErrors}
                           headerValue={header.value}
                           onChangeKey={(key) => {
                             const next = [...field.state.value]
@@ -294,6 +295,7 @@ export const OtelConfigCard: React.FC = () => {
 const HeaderInput = ({
   keyInputRef,
   headerKey,
+  invalid,
   headerValue,
   onChangeKey,
   onChangeValue,
@@ -301,6 +303,7 @@ const HeaderInput = ({
 }: {
   keyInputRef: (element: HTMLInputElement | null) => void
   headerKey: string
+  invalid: boolean
   headerValue: string
   onChangeKey: (value: string) => void
   onChangeValue: (value: string) => void
@@ -310,6 +313,7 @@ const HeaderInput = ({
     <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2rem] gap-2">
       <Input
         ref={keyInputRef}
+        aria-invalid={invalid}
         placeholder="Header key"
         value={headerKey}
         onChange={(e) => onChangeKey(e.target.value)}

--- a/apps/dashboard/src/hooks/mutations/useDeleteOrganizationOtelConfigMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useDeleteOrganizationOtelConfigMutation.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { queryKeys } from '../queries/queryKeys'
+import { useApi } from '../useApi'
+
+interface DeleteOrganizationOtelConfigVariables {
+  organizationId: string
+}
+
+export const useDeleteOrganizationOtelConfigMutation = () => {
+  const { organizationsApi } = useApi()
+  const queryClient = useQueryClient()
+
+  return useMutation<void, unknown, DeleteOrganizationOtelConfigVariables>({
+    mutationFn: async ({ organizationId }) => {
+      await organizationsApi.deleteOrganizationOtelConfig(organizationId)
+    },
+    onSuccess: async (_data, { organizationId }) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.organization.list() })
+      await queryClient.invalidateQueries({ queryKey: queryKeys.organization.detail(organizationId) })
+    },
+  })
+}

--- a/apps/dashboard/src/hooks/mutations/useUpdateOrganizationOtelConfigMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useUpdateOrganizationOtelConfigMutation.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { OtelConfig } from '@daytona/api-client'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { queryKeys } from '../queries/queryKeys'
+import { useApi } from '../useApi'
+
+interface UpdateOrganizationOtelConfigVariables {
+  organizationId: string
+  otelConfig: OtelConfig
+}
+
+export const useUpdateOrganizationOtelConfigMutation = () => {
+  const { organizationsApi } = useApi()
+  const queryClient = useQueryClient()
+
+  return useMutation<void, unknown, UpdateOrganizationOtelConfigVariables>({
+    mutationFn: async ({ organizationId, otelConfig }) => {
+      await organizationsApi.updateOrganizationOtelConfig(organizationId, otelConfig)
+    },
+    onSuccess: async (_data, { organizationId }) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.organization.list() })
+      await queryClient.invalidateQueries({ queryKey: queryKeys.organization.detail(organizationId) })
+    },
+  })
+}

--- a/apps/dashboard/src/pages/OrganizationSettings.tsx
+++ b/apps/dashboard/src/pages/OrganizationSettings.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+import { CopyButton } from '@/components/CopyButton'
 import { DeleteOrganizationDialog } from '@/components/Organizations/DeleteOrganizationDialog'
 import { LeaveOrganizationDialog } from '@/components/Organizations/LeaveOrganizationDialog'
 import { OtelConfigCard } from '@/components/Organizations/OtelConfigCard'
@@ -15,7 +16,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Field, FieldContent, FieldDescription, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
-import { InputGroup, InputGroupButton, InputGroupInput } from '@/components/ui/input-group'
+import { InputGroup, InputGroupInput } from '@/components/ui/input-group'
 import { useDeleteOrganizationMutation } from '@/hooks/mutations/useDeleteOrganizationMutation'
 import { useLeaveOrganizationMutation } from '@/hooks/mutations/useLeaveOrganizationMutation'
 import { useOrganizations } from '@/hooks/useOrganizations'
@@ -23,10 +24,8 @@ import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import { OrganizationUserRoleEnum } from '@daytona/api-client'
-import { CheckIcon, CopyIcon } from 'lucide-react'
 import React, { useRef } from 'react'
 import { toast } from 'sonner'
-import { useCopyToClipboard } from 'usehooks-ts'
 
 const OrganizationSettings: React.FC = () => {
   const { refreshOrganizations } = useOrganizations()
@@ -36,7 +35,6 @@ const OrganizationSettings: React.FC = () => {
   const deleteOrganizationMutation = useDeleteOrganizationMutation()
   const leaveOrganizationMutation = useLeaveOrganizationMutation()
   const setDefaultRegionDialogRef = useRef<SetDefaultRegionDialogRef>(null)
-  const [copied, copyToClipboard] = useCopyToClipboard()
 
   if (!selectedOrganization) {
     return null
@@ -101,16 +99,13 @@ const OrganizationSettings: React.FC = () => {
                 </FieldDescription>
               </FieldContent>
               <InputGroup className="pr-1 flex-1">
-                <InputGroupInput id="organization-id" value={selectedOrganization.id} readOnly />
-                <InputGroupButton
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() =>
-                    copyToClipboard(selectedOrganization.id).then(() => toast.success('Copied to clipboard'))
-                  }
-                >
-                  {copied ? <CheckIcon className="h-4 w-4" /> : <CopyIcon className="h-4 w-4" />}
-                </InputGroupButton>
+                <InputGroupInput
+                  id="organization-id"
+                  value={selectedOrganization.id}
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <CopyButton value={selectedOrganization.id} size="icon-xs" tooltipText="Copy Organization ID" />
               </InputGroup>
             </Field>
           </CardContent>


### PR DESCRIPTION
## Description

Otel config consistency pass - zod, tanstack form, layout tweaks.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `zod` validation and `@tanstack/react-form` to the OpenTelemetry settings for stricter endpoint/header rules, clearer inline errors, and smoother saves. Also fixes validation edge cases and adds proper loading states when saving or disabling via `@tanstack/react-query`.

- New Features
  - Validate endpoint as a URL; header keys are required and must be unique. Show row-level errors and a headers-level error for duplicates; focus/scroll to the first invalid field.
  - Add/remove header rows with auto-focus on new keys; existing header values are masked. Only non-empty entries are saved.
  - Save and disable OTEL config via dedicated mutations with spinners and cache invalidation.

- Refactors
  - Migrated to `@tanstack/react-form` and mutation hooks; removed ad‑hoc state and direct API calls.
  - Replaced custom clipboard logic with `CopyButton` in Organization Settings; the form resets when the selected organization or its OTEL config changes.

<sup>Written for commit 5ff7d2b52135166ed10b38ea98fac83cc7444c81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

