### PR TITLE
fix(dashboard): sandboxes table pagination reset fix

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
+++ b/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
@@ -16,11 +16,13 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  PaginationState,
   SortingState,
+  Updater,
   useReactTable,
   VisibilityState,
 } from '@tanstack/react-table'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { getColumns } from './columns'
 import { FacetedFilterOption } from './types'
 
@@ -92,6 +94,38 @@ export function useSandboxTable({
   ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [globalFilter, setGlobalFilter] = useState('')
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  })
+
+  const resetPageIndex = useCallback(() => {
+    setPagination((current) => (current.pageIndex === 0 ? current : { ...current, pageIndex: 0 }))
+  }, [])
+
+  const handleSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      setSorting(updater)
+      resetPageIndex()
+    },
+    [resetPageIndex],
+  )
+
+  const handleColumnFiltersChange = useCallback(
+    (updater: Updater<ColumnFiltersState>) => {
+      setColumnFilters(updater)
+      resetPageIndex()
+    },
+    [resetPageIndex],
+  )
+
+  const handleGlobalFilterChange = useCallback(
+    (updater: Updater<string>) => {
+      setGlobalFilter(updater)
+      resetPageIndex()
+    },
+    [resetPageIndex],
+  )
 
   const labelOptions: FacetedFilterOption[] = useMemo(() => {
     const labels = new Set<string>()
@@ -155,11 +189,12 @@ export function useSandboxTable({
   const table = useReactTable({
     data,
     columns,
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
+    autoResetPageIndex: false,
+    onColumnFiltersChange: handleColumnFiltersChange,
+    onGlobalFilterChange: handleGlobalFilterChange,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     getSortedRowModel: getSortedRowModel(),
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
@@ -186,23 +221,30 @@ export function useSandboxTable({
       sorting,
       columnFilters,
       columnVisibility,
+      pagination,
       columnPinning: {
         left: ['select', 'name'],
         right: ['actions'],
       },
     },
+    onPaginationChange: setPagination,
     onColumnVisibilityChange: setColumnVisibility,
     defaultColumn: {
       minSize: 0,
     },
     enableRowSelection: deletePermitted,
     getRowId: (row) => row.id,
-    initialState: {
-      pagination: {
-        pageSize: DEFAULT_PAGE_SIZE,
-      },
-    },
   })
+
+  const filteredPageCount = Math.max(Math.ceil(table.getFilteredRowModel().rows.length / pagination.pageSize), 1)
+
+  useEffect(() => {
+    setPagination((current) => {
+      const maxPageIndex = filteredPageCount - 1
+
+      return current.pageIndex > maxPageIndex ? { ...current, pageIndex: maxPageIndex } : current
+    })
+  }, [filteredPageCount])
 
   return {
     table,


### PR DESCRIPTION
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sandboxes table pagination so it resets to the first page on sort/search/filter changes and never shows empty pages after filtering. Improves UX and avoids confusion when results shrink.

- **Bug Fixes**
  - Added local `pagination` state (`pageIndex`, `pageSize`) with `onPaginationChange`.
  - Reset page index to 0 on sorting, column filter, and global search updates.
  - Set `autoResetPageIndex: false` in `@tanstack/react-table` to control pagination manually.
  - Clamp `pageIndex` when filtered results reduce total pages.

<sup>Written for commit ad6994f5eda6230eaa7de8e1562ea1460aca00bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

