### PR TITLE
feat(sdk): add upload streaming + progress and cancellation across SDKs

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/download_files.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files.go
@@ -15,6 +15,7 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,19 +73,13 @@ func DownloadFiles(c *gin.Context) {
 	defer mw.Close() // ensure final boundary is written
 
 	for _, path := range req.Paths {
-		downloadErr := classifyDownloadPathError(c, path)
+		f, info, downloadErr := openDownloadFile(c, path)
 		if downloadErr != nil {
 			writeErrorPart(c, mw, path, *downloadErr)
 			continue
 		}
 
-		f, err := os.Open(path)
-		if err != nil {
-			writeErrorPart(c, mw, path, classifyOpenFileError(c, path, err))
-			continue
-		}
-
-		if err := writeFilePart(c.Request.Context(), mw, path, f); err != nil {
+		if err := writeFilePart(c.Request.Context(), mw, path, f, info.Size()); err != nil {
 			f.Close()
 
 			// If streaming fails after the multipart file part has started, emitting a
@@ -97,7 +92,7 @@ func DownloadFiles(c *gin.Context) {
 }
 
 // Streams a file part using io.Copy and respects context cancellation.
-func writeFilePart(ctx context.Context, mw *multipart.Writer, path string, r io.Reader) error {
+func writeFilePart(ctx context.Context, mw *multipart.Writer, path string, r io.Reader, size int64) error {
 	ctype := mime.TypeByExtension(filepath.Ext(path))
 	if ctype == "" {
 		ctype = "application/octet-stream"
@@ -106,6 +101,7 @@ func writeFilePart(ctx context.Context, mw *multipart.Writer, path string, r io.
 	hdr := textproto.MIMEHeader{}
 	hdr.Set("Content-Type", ctype)
 	hdr.Set("Content-Disposition", multipartContentDisposition("file", path))
+	hdr.Set("Content-Length", strconv.FormatInt(size, 10))
 
 	part, err := mw.CreatePart(hdr)
 	if err != nil {
@@ -141,8 +137,13 @@ func writeErrorPart(ctx *gin.Context, mw *multipart.Writer, path string, errorRe
 	}
 }
 
-func classifyDownloadPathError(ctx *gin.Context, path string) *common.ErrorResponse {
-	// Validate the input path before touching the filesystem.
+// openDownloadFile opens path for reading and validates it is a downloadable
+// regular file. On success, the caller owns closing the returned file.
+//
+// Stat is performed against the open file descriptor rather than the path, so
+// the size used for Content-Length and the bytes streamed afterwards reference
+// the same inode and cannot diverge under a concurrent rename or replace.
+func openDownloadFile(ctx *gin.Context, path string) (*os.File, os.FileInfo, *common.ErrorResponse) {
 	if path == "" {
 		errorResponse := newFileDownloadErrorResponse(
 			ctx,
@@ -151,17 +152,25 @@ func classifyDownloadPathError(ctx *gin.Context, path string) *common.ErrorRespo
 			"INVALID_FILE_PATH",
 			"invalid file path: path is empty",
 		)
-		return &errorResponse
+		return nil, nil, &errorResponse
 	}
 
-	info, err := os.Stat(path)
+	f, err := os.Open(path)
 	if err != nil {
+		errorResponse := classifyOpenFileError(ctx, path, err)
+		return nil, nil, &errorResponse
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
 		statusCode, errorCode, message := classifyPathStatError(path, err)
 		errorResponse := newFileDownloadErrorResponse(ctx, path, statusCode, errorCode, message)
-		return &errorResponse
+		return nil, nil, &errorResponse
 	}
 
 	if info.IsDir() {
+		f.Close()
 		errorResponse := newFileDownloadErrorResponse(
 			ctx,
 			path,
@@ -169,10 +178,10 @@ func classifyDownloadPathError(ctx *gin.Context, path string) *common.ErrorRespo
 			"INVALID_FILE_PATH",
 			fmt.Sprintf("invalid file path: path points to a directory: %s", path),
 		)
-		return &errorResponse
+		return nil, nil, &errorResponse
 	}
 
-	return nil
+	return f, info, nil
 }
 
 func multipartContentDisposition(formName string, path string) string {

--- a/apps/daemon/pkg/toolbox/fs/download_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files_test.go
@@ -6,11 +6,14 @@ package fs
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -24,13 +27,17 @@ func newTestContext(method string) *gin.Context {
 	return ctx
 }
 
-func TestClassifyDownloadPathError(t *testing.T) {
+func TestOpenDownloadFile(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("rejects empty paths as validation errors", func(t *testing.T) {
 		ctx := newTestContext(http.MethodPost)
 
-		errorResponse := classifyDownloadPathError(ctx, "")
+		f, _, errorResponse := openDownloadFile(ctx, "")
+		if f != nil {
+			f.Close()
+			t.Fatal("expected no file handle for empty path")
+		}
 
 		if errorResponse == nil {
 			t.Fatal("expected an error response")
@@ -53,7 +60,11 @@ func TestClassifyDownloadPathError(t *testing.T) {
 		ctx := newTestContext(http.MethodPost)
 		tempDir := t.TempDir()
 
-		errorResponse := classifyDownloadPathError(ctx, tempDir)
+		f, _, errorResponse := openDownloadFile(ctx, tempDir)
+		if f != nil {
+			f.Close()
+			t.Fatal("expected no file handle for directory")
+		}
 
 		if errorResponse == nil {
 			t.Fatal("expected an error response")
@@ -73,6 +84,32 @@ func TestClassifyDownloadPathError(t *testing.T) {
 
 		if errorResponse.Path != tempDir {
 			t.Fatalf("expected path %q, got %q", tempDir, errorResponse.Path)
+		}
+	})
+
+	t.Run("returns file handle and info for a regular file", func(t *testing.T) {
+		ctx := newTestContext(http.MethodPost)
+		tempDir := t.TempDir()
+		path := filepath.Join(tempDir, "regular.txt")
+		const payload = "abcdef"
+		if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		f, info, errorResponse := openDownloadFile(ctx, path)
+		if errorResponse != nil {
+			t.Fatalf("expected no error, got %+v", errorResponse)
+		}
+		if f == nil {
+			t.Fatal("expected an open file handle")
+		}
+		defer f.Close()
+
+		if info == nil {
+			t.Fatal("expected file info")
+		}
+		if got := info.Size(); got != int64(len(payload)) {
+			t.Fatalf("expected size %d, got %d", len(payload), got)
 		}
 	})
 }
@@ -243,5 +280,110 @@ func TestWriteErrorPart(t *testing.T) {
 
 	if errorResponse.Path != sourcePath {
 		t.Fatalf("expected path %q, got %q", sourcePath, errorResponse.Path)
+	}
+}
+
+// Exercises DownloadFiles end-to-end and asserts that successful file parts
+// carry an accurate Content-Length header (the load-bearing claim downstream
+// SDKs depend on for progress totalBytes), including for empty files. Mixed
+// in a directory path to verify the error part is still emitted correctly
+// alongside the file parts.
+func TestDownloadFilesEmitsContentLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+
+	smallPath := filepath.Join(tempDir, "small.txt")
+	const smallBody = "hello, world"
+	if err := os.WriteFile(smallPath, []byte(smallBody), 0o644); err != nil {
+		t.Fatalf("write small file: %v", err)
+	}
+
+	emptyPath := filepath.Join(tempDir, "empty.bin")
+	if err := os.WriteFile(emptyPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+
+	dirPath := filepath.Join(tempDir, "subdir")
+	if err := os.Mkdir(dirPath, 0o755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+
+	body, err := json.Marshal(FilesDownloadRequest{Paths: []string{smallPath, emptyPath, dirPath}})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-download", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-download", DownloadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d (body: %s)", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	mediaType, params, err := mime.ParseMediaType(rec.Header().Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse content type: %v", err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("expected multipart/form-data, got %q", mediaType)
+	}
+
+	type wantPart struct {
+		formName   string
+		path       string
+		hasLength  bool
+		wantLength int
+		wantBody   string
+	}
+	wants := []wantPart{
+		{formName: "file", path: smallPath, hasLength: true, wantLength: len(smallBody), wantBody: smallBody},
+		{formName: "file", path: emptyPath, hasLength: true, wantLength: 0, wantBody: ""},
+		{formName: "error", path: dirPath, hasLength: false},
+	}
+
+	reader := multipart.NewReader(rec.Body, params["boundary"])
+	for i, want := range wants {
+		part, err := reader.NextPart()
+		if err != nil {
+			t.Fatalf("part %d (%s): read: %v", i, want.path, err)
+		}
+
+		if got := part.FormName(); got != want.formName {
+			t.Fatalf("part %d (%s): expected form name %q, got %q", i, want.path, want.formName, got)
+		}
+
+		gotLength := part.Header.Get("Content-Length")
+		if want.hasLength {
+			if gotLength == "" {
+				t.Fatalf("part %d (%s): expected Content-Length header, got none", i, want.path)
+			}
+			parsed, parseErr := strconv.Atoi(gotLength)
+			if parseErr != nil {
+				t.Fatalf("part %d (%s): Content-Length %q is not numeric: %v", i, want.path, gotLength, parseErr)
+			}
+			if parsed != want.wantLength {
+				t.Fatalf("part %d (%s): expected Content-Length %d, got %d", i, want.path, want.wantLength, parsed)
+			}
+		} else if gotLength != "" {
+			t.Fatalf("part %d (%s): expected no Content-Length on error part, got %q", i, want.path, gotLength)
+		}
+
+		gotBody, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("part %d (%s): read body: %v", i, want.path, err)
+		}
+		if want.formName == "file" && string(gotBody) != want.wantBody {
+			t.Fatalf("part %d (%s): expected body %q, got %q", i, want.path, want.wantBody, string(gotBody))
+		}
+	}
+
+	if _, err := reader.NextPart(); err != io.EOF {
+		t.Fatalf("expected io.EOF after final part, got %v", err)
 	}
 }

--- a/apps/daemon/pkg/toolbox/fs/upload_files.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files.go
@@ -4,8 +4,10 @@
 package fs
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -24,6 +26,19 @@ import (
 //	@Router			/files/bulk-upload [post]
 //
 //	@id				UploadFiles
+//
+// UploadFiles streams multipart parts directly to disk without buffering. Each file body
+// is io.Copy'd into a sibling temp file in the destination's directory, then renamed
+// atomically onto the destination on success — readers never see a partial file. Any
+// error mid-upload (including client disconnect via context cancellation) removes the
+// temp file before returning.
+//
+// Wire format: a sequence of multipart parts alternating between
+//   - text part named "files[<idx>].path" carrying the destination path, and
+//   - file part named "files[<idx>].file" carrying the file body.
+//
+// The .path part for a given index MUST arrive before the corresponding .file part —
+// the server does not buffer file bodies waiting for late metadata.
 func UploadFiles(c *gin.Context) {
 	reader, err := c.Request.MultipartReader()
 	if err != nil {
@@ -40,50 +55,39 @@ func UploadFiles(c *gin.Context) {
 			break
 		}
 		if err != nil {
+			// A non-EOF error means the multipart stream is no longer parseable
+			// (truncated body, malformed boundary, etc.) — keep iterating would
+			// loop forever, so record and stop.
 			errs = append(errs, fmt.Sprintf("reading part: %v", err))
-			continue
+			break
 		}
 
 		name := part.FormName()
+		idx := extractIndex(name)
 
-		if strings.HasSuffix(name, ".path") {
-			data, err := io.ReadAll(part)
-			if err != nil {
-				idx := extractIndex(name)
-				errs = append(errs, fmt.Sprintf("path[%s]: %v", idx, err))
+		switch {
+		case strings.HasSuffix(name, ".path"):
+			data, readErr := io.ReadAll(part)
+			if readErr != nil {
+				errs = append(errs, fmt.Sprintf("path[%s]: %v", idx, readErr))
 				continue
 			}
-			idx := extractIndex(name)
-			dests[idx] = string(data)
-			continue
-		}
+			dest := strings.TrimSpace(string(data))
+			if dest == "" {
+				errs = append(errs, fmt.Sprintf("path[%s]: empty path", idx))
+				continue
+			}
+			dests[idx] = dest
 
-		if strings.HasSuffix(name, ".file") {
-			idx := extractIndex(name)
+		case strings.HasSuffix(name, ".file"):
 			dest, ok := dests[idx]
 			if !ok {
 				errs = append(errs, fmt.Sprintf("file[%s]: missing .path metadata", idx))
 				continue
 			}
-
-			if d := filepath.Dir(dest); d != "" {
-				if err := os.MkdirAll(d, 0o755); err != nil {
-					errs = append(errs, fmt.Sprintf("%s: mkdir %s: %v", dest, d, err))
-					continue
-				}
+			if err := writeUploadedPart(c.Request.Context(), part, dest); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", dest, err))
 			}
-
-			f, err := os.Create(dest)
-			if err != nil {
-				errs = append(errs, fmt.Sprintf("%s: create: %v", dest, err))
-				continue
-			}
-
-			if _, err := io.Copy(f, part); err != nil {
-				errs = append(errs, fmt.Sprintf("%s: write: %v", dest, err))
-			}
-			f.Close()
-			continue
 		}
 	}
 
@@ -93,6 +97,44 @@ func UploadFiles(c *gin.Context) {
 	}
 
 	c.Status(http.StatusOK)
+}
+
+// writeUploadedPart atomically writes a single multipart file body to dest. Bytes are
+// streamed into a temp file in the destination directory (so os.Rename is atomic on
+// the same filesystem), then renamed over dest on success. Any failure — including
+// context cancellation surfaced by ctxWriter — removes the temp file.
+func writeUploadedPart(ctx context.Context, part *multipart.Part, dest string) error {
+	if dir := filepath.Dir(dest); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".daytona-upload-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	cw := &ctxWriter{ctx: ctx, w: tmp}
+	if _, err := io.Copy(cw, part); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, dest); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func extractIndex(fieldName string) string {

--- a/apps/daemon/pkg/toolbox/fs/upload_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files_test.go
@@ -1,0 +1,227 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package fs
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Drives /files/bulk-upload end-to-end through the gin router and verifies the
+// load-bearing behaviours: bytes land at the destination, the parent directory is
+// created on demand, and (negatively) no leftover temp files are left behind.
+func TestUploadFilesStreamsToDisk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+
+	type want struct {
+		path     string
+		body     string
+		mkParent bool
+	}
+	wants := []want{
+		{path: filepath.Join(tempDir, "small.txt"), body: "hello, world"},
+		{path: filepath.Join(tempDir, "empty.bin"), body: ""},
+		// Ensure the parent dir is created on the fly.
+		{path: filepath.Join(tempDir, "nested", "deep", "file.bin"), body: strings.Repeat("X", 64*1024), mkParent: true},
+	}
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	for i, w := range wants {
+		if err := mw.WriteField(formField(i, "path"), w.path); err != nil {
+			t.Fatalf("write path field: %v", err)
+		}
+		part, err := mw.CreateFormFile(formField(i, "file"), filepath.Base(w.path))
+		if err != nil {
+			t.Fatalf("create form file: %v", err)
+		}
+		if _, err := part.Write([]byte(w.body)); err != nil {
+			t.Fatalf("write file body: %v", err)
+		}
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	for _, w := range wants {
+		got, err := os.ReadFile(w.path)
+		if err != nil {
+			t.Fatalf("read %s: %v", w.path, err)
+		}
+		if string(got) != w.body {
+			t.Fatalf("%s: expected %q, got %q", w.path, w.body, string(got))
+		}
+		// Atomic write should have left no temp file behind.
+		entries, err := os.ReadDir(filepath.Dir(w.path))
+		if err != nil {
+			t.Fatalf("readdir %s: %v", filepath.Dir(w.path), err)
+		}
+		for _, e := range entries {
+			if strings.Contains(e.Name(), ".daytona-upload-") {
+				t.Fatalf("leftover temp file: %s", filepath.Join(filepath.Dir(w.path), e.Name()))
+			}
+		}
+	}
+}
+
+// Asserts that errors during the file-body copy do not leave a partial file on disk
+// at the destination — atomic-rename means we either commit a complete file or none.
+func TestUploadFilesAtomicCleanupOnTruncatedBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	dest := filepath.Join(tempDir, "partial.bin")
+
+	// Hand-craft a multipart body that opens a file part but truncates mid-stream.
+	// The reader will see an unexpected EOF inside io.Copy, surfacing as an error
+	// for that part. The destination must NOT exist after the request.
+	boundary := "DaytonaTestBoundary"
+	body := &bytes.Buffer{}
+	body.WriteString("--" + boundary + "\r\n")
+	body.WriteString("Content-Disposition: form-data; name=\"files[0].path\"\r\n\r\n")
+	body.WriteString(dest)
+	body.WriteString("\r\n--" + boundary + "\r\n")
+	body.WriteString("Content-Disposition: form-data; name=\"files[0].file\"; filename=\"partial.bin\"\r\n")
+	body.WriteString("Content-Type: application/octet-stream\r\n\r\n")
+	body.WriteString("partial-data-no-trailing-boundary")
+	// Note: intentionally missing the closing "\r\n--BOUNDARY--\r\n".
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("expected destination not to exist after truncated upload, got err=%v", err)
+	}
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		t.Fatalf("expected empty directory, found leftover: %s", e.Name())
+	}
+}
+
+// Empty path values are rejected with a per-index error; later parts are still
+// processed, mirroring the existing bulk-upload contract of best-effort batching.
+func TestUploadFilesRejectsEmptyPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if err := mw.WriteField("files[0].path", "  "); err != nil {
+		t.Fatalf("write empty path: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "empty path") {
+		t.Fatalf("expected empty-path error, got %s", rec.Body.String())
+	}
+	if _, err := os.ReadDir(tempDir); err != nil {
+		t.Fatalf("tempdir gone: %v", err)
+	}
+}
+
+// Reading the request body via Request.Body proves the daemon doesn't depend on Gin
+// having buffered the form into MaxMultipartMemory — we read the multipart envelope
+// part-by-part. If anything ever switches it back to FormFile, this test will fail
+// because the buffered parser would have consumed the body before our reader runs.
+func TestUploadFilesUsesStreamingMultipartReader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	dest := filepath.Join(tempDir, "stream-only.bin")
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if err := mw.WriteField("files[0].path", dest); err != nil {
+		t.Fatalf("write field: %v", err)
+	}
+	part, err := mw.CreateFormFile("files[0].file", "stream-only.bin")
+	if err != nil {
+		t.Fatalf("form file: %v", err)
+	}
+	payload := strings.Repeat("y", 1024*1024) // 1 MiB — well under MaxMultipartMemory
+	if _, err := io.Copy(part, strings.NewReader(payload)); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("payload mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func formField(idx int, suffix string) string {
+	switch idx {
+	case 0:
+		return "files[0]." + suffix
+	case 1:
+		return "files[1]." + suffix
+	case 2:
+		return "files[2]." + suffix
+	}
+	return ""
+}

--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -126,12 +126,15 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(img \*DockerImage\) Volume\(paths \[\]string\) \*DockerImage](<#DockerImage.Volume>)
   - [func \(img \*DockerImage\) Workdir\(path string\) \*DockerImage](<#DockerImage.Workdir>)
 - [type DockerImageContext](<#DockerImageContext>)
+- [type DownloadProgress](<#DownloadProgress>)
+- [type DownloadStreamOption](<#DownloadStreamOption>)
+  - [func WithDownloadProgress\(fn func\(DownloadProgress\)\) DownloadStreamOption](<#WithDownloadProgress>)
 - [type FileSystemService](<#FileSystemService>)
   - [func NewFileSystemService\(toolboxClient \*toolbox.APIClient, otel \*otelState\) \*FileSystemService](<#NewFileSystemService>)
   - [func \(f \*FileSystemService\) CreateFolder\(ctx context.Context, path string, opts ...func\(\*options.CreateFolder\)\) error](<#FileSystemService.CreateFolder>)
   - [func \(f \*FileSystemService\) DeleteFile\(ctx context.Context, path string, recursive bool\) error](<#FileSystemService.DeleteFile>)
   - [func \(f \*FileSystemService\) DownloadFile\(ctx context.Context, remotePath string, localPath \*string\) \(\[\]byte, error\)](<#FileSystemService.DownloadFile>)
-  - [func \(f \*FileSystemService\) DownloadFileStream\(ctx context.Context, remotePath string\) \(io.ReadCloser, error\)](<#FileSystemService.DownloadFileStream>)
+  - [func \(f \*FileSystemService\) DownloadFileStream\(ctx context.Context, remotePath string, opts ...DownloadStreamOption\) \(io.ReadCloser, error\)](<#FileSystemService.DownloadFileStream>)
   - [func \(f \*FileSystemService\) FindFiles\(ctx context.Context, path, pattern string\) \(any, error\)](<#FileSystemService.FindFiles>)
   - [func \(f \*FileSystemService\) GetFileInfo\(ctx context.Context, path string\) \(\*types.FileInfo, error\)](<#FileSystemService.GetFileInfo>)
   - [func \(f \*FileSystemService\) ListFiles\(ctx context.Context, path string\) \(\[\]\*types.FileInfo, error\)](<#FileSystemService.ListFiles>)
@@ -140,6 +143,7 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(f \*FileSystemService\) SearchFiles\(ctx context.Context, path, pattern string\) \(any, error\)](<#FileSystemService.SearchFiles>)
   - [func \(f \*FileSystemService\) SetFilePermissions\(ctx context.Context, path string, opts ...func\(\*options.SetFilePermissions\)\) error](<#FileSystemService.SetFilePermissions>)
   - [func \(f \*FileSystemService\) UploadFile\(ctx context.Context, source any, destination string\) error](<#FileSystemService.UploadFile>)
+  - [func \(f \*FileSystemService\) UploadFileStream\(ctx context.Context, source io.Reader, remotePath string, opts ...UploadStreamOption\) error](<#FileSystemService.UploadFileStream>)
 - [type GitService](<#GitService>)
   - [func NewGitService\(toolboxClient \*toolbox.APIClient, otel \*otelState\) \*GitService](<#NewGitService>)
   - [func \(g \*GitService\) Add\(ctx context.Context, path string, files \[\]string\) error](<#GitService.Add>)
@@ -258,6 +262,9 @@ result, err := sandbox.Process.ExecuteCommand(ctx, "ls -la")
   - [func \(s \*SnapshotService\) Delete\(ctx context.Context, snapshot \*types.Snapshot\) error](<#SnapshotService.Delete>)
   - [func \(s \*SnapshotService\) Get\(ctx context.Context, nameOrID string\) \(\*types.Snapshot, error\)](<#SnapshotService.Get>)
   - [func \(s \*SnapshotService\) List\(ctx context.Context, page \*int, limit \*int\) \(\*types.PaginatedSnapshots, error\)](<#SnapshotService.List>)
+- [type UploadProgress](<#UploadProgress>)
+- [type UploadStreamOption](<#UploadStreamOption>)
+  - [func WithUploadProgress\(fn func\(UploadProgress\)\) UploadStreamOption](<#WithUploadProgress>)
 - [type VolumeService](<#VolumeService>)
   - [func NewVolumeService\(client \*Client\) \*VolumeService](<#NewVolumeService>)
   - [func \(v \*VolumeService\) Create\(ctx context.Context, name string\) \(\*types.Volume, error\)](<#VolumeService.Create>)
@@ -1289,6 +1296,39 @@ type DockerImageContext struct {
 }
 ```
 
+<a name="DownloadProgress"></a>
+## type DownloadProgress
+
+DownloadProgress contains progress information for a streaming download.
+
+```go
+type DownloadProgress struct {
+    // BytesReceived is the cumulative number of bytes read so far.
+    BytesReceived int64
+    // TotalBytes is the total number of bytes expected, if known.
+    // Zero means unknown.
+    TotalBytes int64
+}
+```
+
+<a name="DownloadStreamOption"></a>
+## type DownloadStreamOption
+
+DownloadStreamOption configures the behavior of DownloadFileStream.
+
+```go
+type DownloadStreamOption func(*downloadStreamConfig)
+```
+
+<a name="WithDownloadProgress"></a>
+### func WithDownloadProgress
+
+```go
+func WithDownloadProgress(fn func(DownloadProgress)) DownloadStreamOption
+```
+
+WithDownloadProgress returns an option that enables progress tracking for streaming downloads. The callback receives the cumulative bytes read and, when available, the total bytes expected.
+
 <a name="FileSystemService"></a>
 ## type FileSystemService
 
@@ -1418,7 +1458,7 @@ Returns an error if the file doesn't exist or cannot be read.
 ### func \(\*FileSystemService\) DownloadFileStream
 
 ```go
-func (f *FileSystemService) DownloadFileStream(ctx context.Context, remotePath string) (io.ReadCloser, error)
+func (f *FileSystemService) DownloadFileStream(ctx context.Context, remotePath string, opts ...DownloadStreamOption) (io.ReadCloser, error)
 ```
 
 DownloadFileStream downloads a single file from the sandbox as a stream without buffering the entire file into memory. The returned [io.ReadCloser](<https://pkg.go.dev/io/#ReadCloser>) can be piped directly to an HTTP response, written to a file, or processed on the fly.
@@ -1706,6 +1746,27 @@ err := sandbox.FileSystem.UploadFile(ctx, content, "/home/user/hello.txt")
 ```
 
 Returns an error if the upload fails.
+
+<a name="FileSystemService.UploadFileStream"></a>
+### func \(\*FileSystemService\) UploadFileStream
+
+```go
+func (f *FileSystemService) UploadFileStream(ctx context.Context, source io.Reader, remotePath string, opts ...UploadStreamOption) error
+```
+
+UploadFileStream streams a file to the sandbox without buffering it in memory. The reader is piped directly into a multipart request, so heap usage stays flat regardless of source size. The HTTP layer uses chunked transfer encoding, so the source's natural EOF terminates the upload — no advance size is needed. Cancellation flows through the context: cancelling ctx aborts the in\-flight HTTP request.
+
+Example:
+
+```
+f, _ := os.Open("/local/big.bin")
+defer f.Close()
+err := sandbox.FileSystem.UploadFileStream(ctx, f, "/home/user/big.bin",
+    WithUploadProgress(func(p UploadProgress) {
+        log.Printf("%d bytes sent", p.BytesSent)
+    }),
+)
+```
 
 <a name="GitService"></a>
 ## type GitService
@@ -4561,6 +4622,36 @@ fmt.Printf("Page %d of %d, total: %d\n", result.Page, result.TotalPages, result.
 ```
 
 Returns \[types.PaginatedSnapshots\] containing the snapshots and pagination info.
+
+<a name="UploadProgress"></a>
+## type UploadProgress
+
+UploadProgress contains progress information for a streaming upload.
+
+```go
+type UploadProgress struct {
+    // BytesSent is the cumulative number of bytes written to the wire so far.
+    BytesSent int64
+}
+```
+
+<a name="UploadStreamOption"></a>
+## type UploadStreamOption
+
+UploadStreamOption configures the behavior of UploadFileStream.
+
+```go
+type UploadStreamOption func(*uploadStreamConfig)
+```
+
+<a name="WithUploadProgress"></a>
+### func WithUploadProgress
+
+```go
+func WithUploadProgress(fn func(UploadProgress)) UploadStreamOption
+```
+
+WithUploadProgress returns an option that enables progress tracking for streaming uploads. The callback fires once per chunk written to the wire with the cumulative byte count.
 
 <a name="VolumeService"></a>
 ## type VolumeService

--- a/apps/docs/src/content/docs/en/java-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/file-system.mdx
@@ -108,6 +108,26 @@ The caller is responsible for closing the returned stream.
 
 - `io.daytona.sdk.exception.DaytonaException` - if the file does not exist or access is denied
 
+#### downloadFileStream()
+```java
+public InputStream downloadFileStream(String remotePath, DownloadStreamOptions options) throws io.daytona.sdk.exception.DaytonaException
+```
+
+Downloads a single file from the Sandbox as a stream with configurable options.
+
+**Parameters**:
+
+- `remotePath` _String_ - source file path in the Sandbox
+- `options` _DownloadStreamOptions_ - download options including timeout and progress callback
+
+**Returns**:
+
+- `InputStream` - an InputStream streaming the file content
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if download fails
+
 #### uploadFile()
 ```java
 public void uploadFile(byte[] content, String remotePath)
@@ -123,6 +143,37 @@ Uploads in-memory file content to a Sandbox path.
 **Throws**:
 
 - `io.daytona.sdk.exception.DaytonaException` - if upload fails
+
+#### uploadFileStream()
+```java
+public void uploadFileStream(InputStream source, String remotePath, UploadStreamOptions options)
+```
+
+Streams an upload to a Sandbox path without buffering the source. The bytes are
+piped through a progress-counting wrapper directly into a streaming multipart
+request, so heap usage stays flat regardless of source size.
+
+**Parameters**:
+
+- `source` _InputStream_ - the data source; the caller retains ownership and is responsible for closing it
+- `remotePath` _String_ - destination file path in the Sandbox
+- `options` _UploadStreamOptions_ - upload options including timeout, cancellation, and progress callback
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if upload fails
+
+#### uploadFileStream()
+```java
+public void uploadFileStream(InputStream source, String remotePath)
+```
+
+Convenience overload using default options.
+
+**Parameters**:
+
+- `source` _InputStream_ -
+- `remotePath` _String_ -
 
 #### listFiles()
 ```java

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-file-system.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-file-system.mdx
@@ -147,8 +147,12 @@ print(f"Size of the downloaded file {local_path}: {size_mb} MB")
 ```python
 @intercept_errors(message_prefix="Failed to download file: ")
 @with_instrumentation()
-async def download_file_stream(remote_path: str,
-                               timeout: int = 30 * 60) -> AsyncIterator[bytes]
+async def download_file_stream(
+        remote_path: str,
+        timeout: int = 30 * 60,
+        on_progress: Callable[[DownloadProgress], Awaitable[None] | None]
+    | None = None,
+        cancel_event: CancelEvent | None = None) -> AsyncIterator[bytes]
 ```
 
 Downloads a single file from the Sandbox as a stream without buffering the entire file
@@ -161,6 +165,15 @@ directly to an HTTP response, written to a file incrementally, or processed on t
   on the sandbox working directory.
 - `timeout` _int_ - Timeout for the download operation in seconds. 0 means no timeout.
   Default is 30 minutes.
+- `on_progress` _Callable[[DownloadProgress], Awaitable[None] | None] | None_ - Optional
+  callback invoked with cumulative bytes received and total bytes, when known, as
+  the download progresses. May be either a regular function or an ``async def``
+  coroutine — coroutine returns are awaited before the next chunk is yielded.
+  Default is None.
+- `cancel_event` _CancelEvent | None_ - Optional ``asyncio.Event``-compatible token. When
+  set during streaming, the next chunk raises ``DaytonaError`` and the underlying
+  HTTP connection is closed. Standard ``asyncio.CancelledError`` from task
+  cancellation is also honoured automatically by the generator.
   
 
 **Returns**:
@@ -170,7 +183,8 @@ directly to an HTTP response, written to a file incrementally, or processed on t
 
 **Raises**:
 
-- `DaytonaError` - If the file does not exist or access is denied.
+- `DaytonaError` - If the file does not exist, access is denied, or the download is
+  cancelled via ``cancel_event``.
   
 
 **Example**:
@@ -181,9 +195,12 @@ async with aiofiles.open("local_copy.bin", "wb") as f:
     async for chunk in await sandbox.fs.download_file_stream("workspace/large-file.bin"):
         await f.write(chunk)
 
-# Stream to an HTTP response (FastAPI)
-return StreamingResponse(await sandbox.fs.download_file_stream("workspace/report.pdf"),
-                         media_type="application/pdf")
+# Cancel a download from another coroutine
+import asyncio
+cancel = asyncio.Event()
+asyncio.get_running_loop().call_later(5.0, cancel.set)
+async for chunk in await sandbox.fs.download_file_stream("workspace/big.bin", cancel_event=cancel):
+    process(chunk)
 ```
 
 #### AsyncFileSystem.download\_files
@@ -620,6 +637,82 @@ files = [
 await sandbox.fs.upload_files(files)
 ```
 
+#### AsyncFileSystem.upload\_file\_stream
+
+```python
+@intercept_errors(message_prefix="Failed to upload file: ")
+@with_instrumentation()
+async def upload_file_stream(source: bytes | bytearray | str | io.IOBase
+                             | AsyncIterable[bytes] | object,
+                             remote_path: str,
+                             timeout: int = 30 * 60,
+                             on_progress: Callable[[UploadProgress],
+                                                   Awaitable[None] | None]
+                             | None = None,
+                             cancel_event: CancelEvent | None = None) -> None
+```
+
+Uploads a single file to the Sandbox using true streaming, with optional progress
+tracking and cancellation. Memory usage stays flat regardless of source size. The
+HTTP layer uses chunked transfer encoding, so the source's natural EOF terminates
+the upload — no advance size is needed.
+
+**Arguments**:
+
+- `source` - Data to upload. Accepts:
+  
+  * ``bytes`` / ``bytearray`` — uploaded from memory.
+  * ``str`` — treated as a local file path and read in chunks.
+  * sync file-like (anything with ``.read(n) -> bytes``) — streamed as-is.
+  * **async file-like** (anything with ``async def read(n) -> bytes``,
+  e.g. an ``aiofiles`` handle) — streamed without ever blocking the loop.
+  * ``AsyncIterable[bytes]`` — yielded chunks are forwarded to the wire.
+- `remote_path` _str_ - Destination path in the Sandbox.
+- `timeout` _int_ - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+- `on_progress` _Callable[[UploadProgress], Awaitable[None] | None] | None_ - Optional
+  callback invoked with cumulative bytes sent. May be sync or ``async def``
+  **when paired with an async source** (async file-like or ``AsyncIterable[bytes]``).
+  Sync sources (``bytes``, ``str`` path, sync file-like) require a sync callback
+  because the underlying httpx multipart serializer pulls bytes through a
+  synchronous ``.read()``; passing an async callback alongside a sync source
+  raises ``DaytonaError``.
+- `cancel_event` _CancelEvent | None_ - Optional ``asyncio.Event``-compatible token.
+  When set during streaming, the next chunk raises ``DaytonaError`` and
+  tears down the request. Standard ``asyncio.CancelledError`` from task
+  cancellation is also honoured automatically.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the upload fails or is cancelled via ``cancel_event``.
+  
+
+**Example**:
+
+```python
+import aiofiles, asyncio
+cancel = asyncio.Event()
+async with aiofiles.open("large_dataset.csv", "rb") as f:
+    await sandbox.fs.upload_file_stream(
+        f,
+        "tmp/dataset.csv",
+        on_progress=lambda p: print(f"{p.bytes_sent} bytes sent"),
+        cancel_event=cancel,
+    )
+```
+
+
+## CancelEvent
+
+```python
+@runtime_checkable
+class CancelEvent(Protocol)
+```
+
+Duck-typed cancellation token. Compatible with ``threading.Event`` and
+``asyncio.Event`` (both expose ``is_set()``). When supplied to a streaming
+download, the next chunk read after the event becomes set raises
+``DaytonaError``, closing the underlying HTTP connection.
 
 ## FileUpload
 
@@ -636,6 +729,33 @@ Represents a file to be uploaded to the Sandbox.
   make sure it fits into memory, otherwise use the local file path which content will be streamed to the Sandbox.
 - `destination` _str_ - Absolute destination path in the Sandbox. Relative paths are resolved based on
   the sandbox working directory.
+
+## DownloadProgress
+
+```python
+@dataclass
+class DownloadProgress()
+```
+
+Progress information for a streaming download.
+
+**Attributes**:
+
+- `bytes_received` _int_ - Cumulative bytes received so far.
+- `total_bytes` _int | None_ - Total bytes expected, if known.
+
+## UploadProgress
+
+```python
+@dataclass
+class UploadProgress()
+```
+
+Progress information for a streaming upload.
+
+**Attributes**:
+
+- `bytes_sent` _int_ - Cumulative bytes sent so far.
 
 ## FileDownloadRequest
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/file-system.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/file-system.mdx
@@ -147,8 +147,11 @@ print(f"Size of the downloaded file {local_path}: {size_mb} MB")
 ```python
 @intercept_errors(message_prefix="Failed to download file: ")
 @with_instrumentation()
-def download_file_stream(remote_path: str,
-                         timeout: int = 30 * 60) -> Iterator[bytes]
+def download_file_stream(
+        remote_path: str,
+        timeout: int = 30 * 60,
+        on_progress: Callable[[DownloadProgress], None] | None = None,
+        cancel_event: CancelEvent | None = None) -> Iterator[bytes]
 ```
 
 Downloads a single file from the Sandbox as a stream without buffering the entire file
@@ -161,6 +164,12 @@ directly to an HTTP response, written to a file incrementally, or processed on t
   on the sandbox working directory.
 - `timeout` _int_ - Timeout for the download operation in seconds. 0 means no timeout.
   Default is 30 minutes.
+- `on_progress` _Callable[[DownloadProgress], None] | None_ - Optional callback invoked with
+  cumulative bytes received and total bytes, when known, as the download progresses.
+  Default is None.
+- `cancel_event` _CancelEvent | None_ - Optional ``threading.Event``-compatible token. When
+  set during streaming, the next chunk raises ``DaytonaError`` and the underlying
+  HTTP connection is closed.
   
 
 **Returns**:
@@ -170,7 +179,8 @@ directly to an HTTP response, written to a file incrementally, or processed on t
 
 **Raises**:
 
-- `DaytonaError` - If the file does not exist or access is denied.
+- `DaytonaError` - If the file does not exist, access is denied, or the download is
+  cancelled via ``cancel_event``.
   
 
 **Example**:
@@ -181,9 +191,12 @@ with open("local_copy.bin", "wb") as f:
     for chunk in sandbox.fs.download_file_stream("workspace/large-file.bin"):
         f.write(chunk)
 
-# Stream to an HTTP response (Flask)
-return Response(sandbox.fs.download_file_stream("workspace/report.pdf"),
-                mimetype="application/pdf")
+# Cancel an in-progress download from another thread
+import threading
+cancel = threading.Event()
+threading.Timer(5.0, cancel.set).start()
+for chunk in sandbox.fs.download_file_stream("workspace/big.bin", cancel_event=cancel):
+    process(chunk)
 ```
 
 #### FileSystem.download\_files
@@ -617,6 +630,69 @@ files = [
 sandbox.fs.upload_files(files)
 ```
 
+#### FileSystem.upload\_file\_stream
+
+```python
+@intercept_errors(message_prefix="Failed to upload file: ")
+@with_instrumentation()
+def upload_file_stream(source: bytes | bytearray | str | io.IOBase,
+                       remote_path: str,
+                       timeout: int = 30 * 60,
+                       on_progress: Callable[[UploadProgress], None]
+                       | None = None,
+                       cancel_event: CancelEvent | None = None) -> None
+```
+
+Uploads a single file to the Sandbox using true streaming, with optional progress
+tracking and cancellation. Memory usage stays flat regardless of source size. The
+HTTP layer uses chunked transfer encoding, so the source's natural EOF terminates
+the upload — no advance size is needed.
+
+**Arguments**:
+
+- `source` _bytes | bytearray | str | IOBase_ - Data to upload. ``bytes`` is uploaded
+  from memory; ``str`` is treated as a local file path and read in chunks; a
+  file-like object (anything implementing ``.read()``) is streamed as-is.
+- `remote_path` _str_ - Destination path in the Sandbox.
+- `timeout` _int_ - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+- `on_progress` _Callable[[UploadProgress], None] | None_ - Optional callback invoked
+  with cumulative bytes sent.
+- `cancel_event` _CancelEvent | None_ - Optional ``threading.Event``-compatible token.
+  When set during streaming, the next chunk read raises ``DaytonaError`` and
+  tears down the request.
+  
+
+**Raises**:
+
+- `DaytonaError` - If the upload fails or is cancelled via ``cancel_event``.
+  
+
+**Example**:
+
+```python
+import threading
+cancel = threading.Event()
+with open("large_dataset.csv", "rb") as f:
+    sandbox.fs.upload_file_stream(
+        f,
+        "tmp/dataset.csv",
+        on_progress=lambda p: print(f"{p.bytes_sent} bytes sent"),
+        cancel_event=cancel,
+    )
+```
+
+
+## CancelEvent
+
+```python
+@runtime_checkable
+class CancelEvent(Protocol)
+```
+
+Duck-typed cancellation token. Compatible with ``threading.Event`` and
+``asyncio.Event`` (both expose ``is_set()``). When supplied to a streaming
+download, the next chunk read after the event becomes set raises
+``DaytonaError``, closing the underlying HTTP connection.
 
 ## FileUpload
 
@@ -633,6 +709,33 @@ Represents a file to be uploaded to the Sandbox.
   make sure it fits into memory, otherwise use the local file path which content will be streamed to the Sandbox.
 - `destination` _str_ - Absolute destination path in the Sandbox. Relative paths are resolved based on
   the sandbox working directory.
+
+## DownloadProgress
+
+```python
+@dataclass
+class DownloadProgress()
+```
+
+Progress information for a streaming download.
+
+**Attributes**:
+
+- `bytes_received` _int_ - Cumulative bytes received so far.
+- `total_bytes` _int | None_ - Total bytes expected, if known.
+
+## UploadProgress
+
+```python
+@dataclass
+class UploadProgress()
+```
+
+Progress information for a streaming upload.
+
+**Attributes**:
+
+- `bytes_sent` _int_ - Cumulative bytes sent so far.
 
 ## FileDownloadRequest
 

--- a/apps/docs/src/content/docs/en/ruby-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/file-system.mdx
@@ -239,7 +239,7 @@ puts "Size of the downloaded file: #{size_mb} MB"
 #### download_file_stream()
 
 ```ruby
-def download_file_stream(remote_path, timeout:)
+def download_file_stream(remote_path, timeout:, on_progress:, cancel_event:)
 
 ```
 
@@ -253,6 +253,12 @@ Enumerator if no block is given.
 based on the sandbox working directory.
 - `timeout` _Integer_ - Timeout for the download operation in seconds. 0 means no timeout.
 Default is 30 minutes.
+- `on_progress` _Proc, nil_ - Optional callback invoked with a Daytona::DownloadProgress
+struct containing bytes_received (Integer) and total_bytes (Integer or nil).
+- `cancel_event` _#set?, nil_ - Optional cancellation token (anything responding to +set?+;
+the standard library's +Concurrent::Event+ or a small ad-hoc object both work). When set
+during streaming, the next chunk raises Daytona::Sdk::Error and the underlying HTTP
+connection is torn down.
 
 **Returns**:
 
@@ -260,7 +266,8 @@ Default is 30 minutes.
 
 **Raises**:
 
-- `Daytona:Sdk:Error` - If the file does not exist or the operation fails
+- `Daytona:Sdk:Error` - If the file does not exist, the operation fails, or
++cancel_event+ is set during streaming
 
 **Examples:**
 
@@ -314,6 +321,48 @@ sandbox.fs.upload_file("local_file.txt", "tmp/file.txt")
 # Upload binary data
 data = { key: "value" }.to_json
 sandbox.fs.upload_file(data, "tmp/config.json")
+
+```
+
+#### upload_file_stream()
+
+```ruby
+def upload_file_stream(source, remote_path, timeout:, on_progress:, cancel_event:)
+
+```
+
+Streams +source+ to the Sandbox without buffering its contents in memory, with
+optional progress reporting.
+
+**Parameters**:
+
+- `source` _String, IO_ - A local file path or any IO-like object responding to
++read(n)+. Strings that don't reference an existing file are uploaded as their
+raw bytes (still streamed, just from memory).
+- `remote_path` _String_ - Destination path in the Sandbox.
+- `timeout` _Integer_ - Timeout in seconds. 0 means no timeout. Default 30 minutes.
+- `on_progress` _Proc, nil_ - Optional callback invoked with a
++Daytona::UploadProgress+ struct as libcurl reports bytes actually uploaded.
+- `cancel_event` _#set?, nil_ - Optional cancellation token. When set while
+staging a non-file source or during the libcurl upload, the operation raises
+Daytona::Sdk::Error and the in-progress upload is aborted (no destination file
+is left on the sandbox thanks to the daemon's atomic-rename behaviour).
+
+**Returns**:
+
+- `void`
+
+**Raises**:
+
+- `Daytona:Sdk:Error` - If the operation fails or +cancel_event+ is set.
+
+**Examples:**
+
+```ruby
+File.open("large.bin", "rb") do |f|
+  sandbox.fs.upload_file_stream(f, "tmp/large.bin",
+    on_progress: ->(p) { puts "#{p.bytes_sent} bytes sent" })
+end
 
 ```
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/file-system.mdx
@@ -189,6 +189,8 @@ results.forEach(result => {
 
 #### downloadFileStream()
 
+##### Call Signature
+
 ```ts
 downloadFileStream(remotePath: string, timeout?: number): Promise<Readable>
 ```
@@ -204,8 +206,7 @@ Browser and serverless environments should use downloadFile instead.
 
 - `remotePath` _string_ - Path to the file in the Sandbox. Relative paths are
     resolved based on the sandbox working directory.
-- `timeout?` _number = ..._ - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
-
+- `timeout?` _number_
 
 **Returns**:
 
@@ -220,10 +221,54 @@ stream.pipe(res);
 ```
 
 ```ts
-// Pipe to a local file
-import { createWriteStream } from 'fs';
-const stream = await sandbox.fs.downloadFileStream('outputs/data.csv');
-stream.pipe(createWriteStream('local-data.csv'));
+// Download with progress tracking and cancellation
+const controller = new AbortController();
+const stream = await sandbox.fs.downloadFileStream('outputs/large-file.bin', {
+  signal: controller.signal,
+  onProgress: ({ bytesReceived, totalBytes }) => console.log(bytesReceived, totalBytes),
+});
+stream.pipe(createWriteStream('local-file.bin'));
+```
+
+##### Call Signature
+
+```ts
+downloadFileStream(remotePath: string, options?: DownloadStreamOptions): Promise<Readable>
+```
+
+Downloads a single file from the Sandbox as a readable stream without buffering
+the entire file into memory. The returned stream can be piped directly to an HTTP
+response, a file write stream, or any other writable destination.
+
+This method is only supported in Node.js-compatible runtimes (Node.js, Bun).
+Browser and serverless environments should use downloadFile instead.
+
+**Parameters**:
+
+- `remotePath` _string_ - Path to the file in the Sandbox. Relative paths are
+    resolved based on the sandbox working directory.
+- `options?` _DownloadStreamOptions_
+
+**Returns**:
+
+- `Promise<Readable>` - A Node.js Readable stream of the file content.
+
+**Examples:**
+
+```ts
+// Pipe directly to an HTTP response
+const stream = await sandbox.fs.downloadFileStream('outputs/report.pdf');
+stream.pipe(res);
+```
+
+```ts
+// Download with progress tracking and cancellation
+const controller = new AbortController();
+const stream = await sandbox.fs.downloadFileStream('outputs/large-file.bin', {
+  signal: controller.signal,
+  onProgress: ({ bytesReceived, totalBytes }) => console.log(bytesReceived, totalBytes),
+});
+stream.pipe(createWriteStream('local-file.bin'));
 ```
 
 ***
@@ -542,6 +587,52 @@ await fs.uploadFiles(files);
 
 ***
 
+#### uploadFileStream()
+
+```ts
+uploadFileStream(
+   source: UploadSource, 
+   remotePath: string, 
+options?: UploadStreamOptions): Promise<void>
+```
+
+Uploads a single file to the Sandbox using true streaming, with optional progress
+tracking and cancellation. Memory usage stays flat regardless of source size: the
+SDK pipes the source through a transform that counts bytes and forwards to the
+underlying multipart upload without buffering the whole payload. The HTTP layer
+uses chunked transfer encoding, so the source's natural EOF terminates the upload —
+no advance size is needed.
+
+**Parameters**:
+
+- `source` _UploadSource_ - The data to upload. Accepts the same `Buffer | string`
+    inputs as FileSystem.uploadFile, plus Node `Readable` streams and Web
+    `ReadableStream` instances. When a string is passed, it is treated as a local
+    file path and read in streaming chunks.
+- `remotePath` _string_ - Destination path in the Sandbox. Relative paths are
+    resolved against the sandbox working directory.
+- `options?` _UploadStreamOptions = {}_ - Streaming options: AbortSignal, onProgress
+    callback, timeout.
+
+
+**Returns**:
+
+- `Promise<void>`
+
+**Example:**
+
+```ts
+// Upload a 2 GB file with progress tracking and the ability to cancel
+import { createReadStream } from 'fs';
+const controller = new AbortController();
+await sandbox.fs.uploadFileStream(createReadStream('big.bin'), 'tmp/big.bin', {
+  signal: controller.signal,
+  onProgress: ({ bytesSent }) => console.log(`${bytesSent} bytes sent`),
+});
+```
+
+***
+
 
 ## DownloadMetadata
 
@@ -554,6 +645,24 @@ Represents metadata for a file download operation.
 - `errorDetails?` _FileDownloadErrorDetails_ - Structured error metadata for a failed download item.
 - `result?` _string \| Buffer\<ArrayBufferLike\> \| Uint8Array\<ArrayBufferLike\>_ - The download result - file path (if destination provided in the request)
     or bytes content (if no destination in the request), undefined if failed or no data received.
+## DownloadStreamOptions
+
+Options for streaming file downloads.
+
+**Properties**:
+
+- `onProgress()?` _\(progress: DownloadProgress\) =\> void_ - Callback invoked with cumulative progress information.
+    
+    **Parameters**:
+    
+    - `progress` _DownloadProgress_
+    
+    
+    **Returns**:
+    
+    - `void`
+- `signal?` _AbortSignal_ - AbortSignal for cancelling the download.
+- `timeout?` _number_ - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
 ## FileDownloadErrorDetails
 
 Structured error metadata for a failed bulk file download item.
@@ -616,3 +725,60 @@ Represents a file to be uploaded to the Sandbox.
 - `destination` _string_ - Absolute destination path in the Sandbox. Relative paths are resolved based on the sandbox working directory.
 - `source` _string \| Buffer\<ArrayBufferLike\>_ - File to upload. If a Buffer, it is interpreted as the file content which is loaded into memory.
     Make sure it fits into memory, otherwise use the local file path which content will be streamed to the Sandbox.
+## UploadStreamOptions
+
+Options for streaming file uploads.
+
+**Properties**:
+
+- `onProgress()?` _\(progress: UploadProgress\) =\> void_ - Callback invoked with cumulative progress information.
+    
+    **Parameters**:
+    
+    - `progress` _UploadProgress_
+    
+    
+    **Returns**:
+    
+    - `void`
+- `signal?` _AbortSignal_ - AbortSignal for cancelling the upload.
+- `timeout?` _number_ - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+## DownloadProgress
+
+```ts
+type DownloadProgress = {
+  bytesReceived: number;
+  totalBytes: number;
+};
+```
+
+**Type declaration**:
+
+- `bytesReceived` _number_ - Cumulative bytes received so far.
+- `totalBytes?` _number_ - Total bytes expected, if known. Undefined if unavailable.
+    
+
+
+## UploadProgress
+
+```ts
+type UploadProgress = {
+  bytesSent: number;
+};
+```
+
+**Type declaration**:
+
+- `bytesSent` _number_ - Cumulative bytes sent so far.
+    
+
+
+## UploadSource
+
+```ts
+type UploadSource = Buffer | Uint8Array | string | Readable | ReadableStream<Uint8Array>;
+```
+
+Source for a streaming file upload. The same input shapes accepted by
+FileSystem.uploadFile are also valid here, plus Node `Readable`
+streams and Web `ReadableStream` instances.

--- a/examples/go/filesystem/main.go
+++ b/examples/go/filesystem/main.go
@@ -4,9 +4,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
@@ -66,8 +68,32 @@ func main() {
 	}
 	log.Printf("✓ Downloaded file content: %s\n", string(downloadedContent))
 
-	// Stream download — process file content as chunks arrive
-	stream, err := sandbox.FileSystem.DownloadFileStream(ctx, testPath)
+	// Stream upload — push any io.Reader straight to the sandbox without
+	// buffering the whole payload, with live progress reporting.
+	streamedPath := "/tmp/streamed.bin"
+	generatedPayload := []byte(strings.Repeat("streamed-upload-content-", 2048)) // ~48 KB
+	uploadErr := sandbox.FileSystem.UploadFileStream(
+		ctx,
+		bytes.NewReader(generatedPayload),
+		streamedPath,
+		daytona.WithUploadProgress(func(p daytona.UploadProgress) {
+			log.Printf("  uploaded %d / %d bytes\n", p.BytesSent, len(generatedPayload))
+		}),
+	)
+	if uploadErr != nil {
+		log.Fatalf("Failed to stream upload: %v", uploadErr)
+	}
+	log.Printf("✓ Streamed upload to %s (%d bytes)\n", streamedPath, len(generatedPayload))
+
+	// Stream download — process file content as chunks arrive, with progress.
+	// Cancel a long-running transfer by cancelling the context.
+	stream, err := sandbox.FileSystem.DownloadFileStream(
+		ctx,
+		testPath,
+		daytona.WithDownloadProgress(func(p daytona.DownloadProgress) {
+			log.Printf("  downloaded %d / %d bytes\n", p.BytesReceived, p.TotalBytes)
+		}),
+	)
 	if err != nil {
 		log.Fatalf("Failed to stream download file: %v", err)
 	}

--- a/examples/java/file-operations/src/main/java/io/daytona/examples/FileOperations.java
+++ b/examples/java/file-operations/src/main/java/io/daytona/examples/FileOperations.java
@@ -4,9 +4,12 @@
 package io.daytona.examples;
 
 import io.daytona.sdk.Daytona;
+import io.daytona.sdk.DownloadStreamOptions;
 import io.daytona.sdk.Sandbox;
+import io.daytona.sdk.UploadStreamOptions;
 import io.daytona.sdk.model.FileInfo;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -33,9 +36,27 @@ public class FileOperations {
                 byte[] downloaded = sandbox.getFs().downloadFile("test-dir/hello.txt");
                 System.out.println("Content: " + new String(downloaded, StandardCharsets.UTF_8));
 
-                // Stream download — process file content as chunks arrive
-                System.out.println("Streaming download hello.txt");
-                try (java.io.InputStream stream = sandbox.getFs().downloadFileStream("test-dir/hello.txt")) {
+                // Stream upload — push an InputStream to the Sandbox with live
+                // progress reporting. (This example builds the payload in a byte[]
+                // for brevity; real-world code should pass a FileInputStream or
+                // similar to avoid loading the whole file into memory.)
+                System.out.println("Streaming upload streamed.bin with progress");
+                byte[] generatedPayload = ("streamed-upload-content-").repeat(2048)
+                        .getBytes(StandardCharsets.UTF_8);
+                sandbox.getFs().uploadFileStream(
+                        new ByteArrayInputStream(generatedPayload),
+                        "test-dir/streamed.bin",
+                        new UploadStreamOptions().setOnProgress(p -> System.out.println(
+                                "  uploaded " + p.getBytesSent() + " / " + generatedPayload.length + " bytes")));
+
+                // Stream download — process file content as chunks arrive, with progress.
+                System.out.println("Streaming download hello.txt with progress");
+                try (java.io.InputStream stream = sandbox.getFs().downloadFileStream(
+                        "test-dir/hello.txt",
+                        new DownloadStreamOptions().setOnProgress(p -> System.out.println(
+                                "  downloaded " + p.getBytesReceived() + " / "
+                                        + p.getTotalBytes().stream().boxed().findFirst().map(String::valueOf).orElse("?")
+                                        + " bytes")))) {
                     byte[] streamed = stream.readAllBytes();
                     System.out.println("Streamed content: " + new String(streamed, StandardCharsets.UTF_8));
                 } catch (java.io.IOException e) {

--- a/examples/python/file-operations/_async/main.py
+++ b/examples/python/file-operations/_async/main.py
@@ -91,9 +91,28 @@ async def main():
         config_content = await sandbox.fs.download_file(os.path.join(new_dir, "config.json"))
         print("Config content:", config_content.decode("utf-8"))
 
-        # Stream download — process file content as chunks arrive
-        print("\nStreaming download example:")
-        stream = await sandbox.fs.download_file_stream(os.path.join(new_dir, "config.json"))
+        # Stream upload — accepts bytes, sync IOBase, async file-likes (e.g. aiofiles),
+        # or AsyncIterable[bytes]. Progress fires once per chunk pulled from the source.
+        print("\nStreaming upload with progress:")
+        generated_payload = b"streamed-upload-content-" * 2048  # ~48 KB
+
+        async def chunked_source():
+            for i in range(0, len(generated_payload), 8192):
+                yield generated_payload[i : i + 8192]
+
+        await sandbox.fs.upload_file_stream(
+            chunked_source(),
+            os.path.join(new_dir, "streamed.bin"),
+            on_progress=lambda p: print(f"  uploaded {p.bytes_sent} / {len(generated_payload)} bytes"),
+        )
+
+        # Stream download — process file content as chunks arrive, with progress.
+        # Pass an asyncio.Event as cancel_event to abort a long-running transfer.
+        print("\nStreaming download with progress:")
+        stream = await sandbox.fs.download_file_stream(
+            os.path.join(new_dir, "config.json"),
+            on_progress=lambda p: print(f"  downloaded {p.bytes_received} / {p.total_bytes} bytes"),
+        )
         streamed_chunks = [chunk async for chunk in stream]
         print("Streamed content:", b"".join(streamed_chunks).decode("utf-8"))
 

--- a/examples/python/file-operations/main.py
+++ b/examples/python/file-operations/main.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 from datetime import datetime
@@ -89,9 +90,25 @@ def main():
     config_content = sandbox.fs.download_file(os.path.join(new_dir, "config.json"))
     print("Config content:", config_content.decode("utf-8"))
 
-    # Stream download — process file content as chunks arrive
-    print("\nStreaming download example:")
-    streamed_chunks = list(sandbox.fs.download_file_stream(os.path.join(new_dir, "config.json")))
+    # Stream upload — push bytes straight to the Sandbox without buffering the
+    # whole payload, with live progress reporting.
+    print("\nStreaming upload with progress:")
+    generated_payload = b"streamed-upload-content-" * 2048  # ~48 KB
+    sandbox.fs.upload_file_stream(
+        io.BytesIO(generated_payload),
+        os.path.join(new_dir, "streamed.bin"),
+        on_progress=lambda p: print(f"  uploaded {p.bytes_sent} / {len(generated_payload)} bytes"),
+    )
+
+    # Stream download — process file content as chunks arrive, with progress.
+    # Pass a threading.Event as cancel_event to abort a long-running transfer.
+    print("\nStreaming download with progress:")
+    streamed_chunks = list(
+        sandbox.fs.download_file_stream(
+            os.path.join(new_dir, "config.json"),
+            on_progress=lambda p: print(f"  downloaded {p.bytes_received} / {p.total_bytes} bytes"),
+        )
+    )
     print("Streamed content:", b"".join(streamed_chunks).decode("utf-8"))
 
     # Create a report of all operations

--- a/examples/ruby/file-operations/main.rb
+++ b/examples/ruby/file-operations/main.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'json'
 require 'daytona'
 
@@ -63,13 +64,29 @@ file = sandbox.fs.download_file(File.join(project_files, 'example.txt'))
 puts "Content of example.txt: #{file.open.read}"
 puts "Size of the downloaded file: #{file.size} bytes"
 
-# Stream download — process file content as chunks arrive
-puts "\nStreaming download example:"
+# Stream upload — push an IO straight to the Sandbox without buffering the whole
+# payload in memory, with live progress reporting.
+require 'stringio'
+
+puts "\nStreaming upload with progress:"
+generated_payload = ('streamed-upload-content-' * 2048).b # ~48 KB
+sandbox.fs.upload_file_stream(
+  StringIO.new(generated_payload),
+  File.join(project_files, 'streamed.bin'),
+  on_progress: ->(p) { puts "  uploaded #{p.bytes_sent} / #{generated_payload.bytesize} bytes" }
+)
+
+# Stream download — process file content as chunks arrive, with progress.
+# Pass any object responding to `set?` as cancel_event to abort a long-running transfer.
+puts "\nStreaming download with progress:"
 chunks = []
-sandbox.fs.download_file_stream(File.join(project_files, 'config.json')) { |chunk| chunks << chunk }
+sandbox.fs.download_file_stream(
+  File.join(project_files, 'config.json'),
+  on_progress: ->(p) { puts "  downloaded #{p.bytes_received} / #{p.total_bytes} bytes" }
+) { |chunk| chunks << chunk }
 puts "Streamed content: #{chunks.join}"
 
 # Cleanup
-File.delete('local-config.json') if File.exist?('local-config.json')
-File.delete('example.txt') if File.exist?('example.txt')
+FileUtils.rm_f('local-config.json')
+FileUtils.rm_f('example.txt')
 daytona.delete(sandbox)

--- a/examples/typescript/file-operations/index.ts
+++ b/examples/typescript/file-operations/index.ts
@@ -104,9 +104,24 @@ async function main() {
     const reportBuffer = await sandbox.fs.downloadFile(path.join(newDir, 'config.json'))
     console.log('Config content:', reportBuffer.toString())
 
-    //  stream download — process file content as chunks arrive
-    console.log('\nStreaming download example:')
-    const stream = await sandbox.fs.downloadFileStream(path.join(newDir, 'config.json'))
+    //  stream upload — push a Readable straight to the Sandbox without
+    //  buffering the whole payload in memory, with live progress.
+    console.log('\nStreaming upload with progress:')
+    const { Readable } = await import('stream')
+    const generatedPayload = Buffer.from('streamed-upload-content-'.repeat(2048)) // ~48 KB
+    await sandbox.fs.uploadFileStream(Readable.from(generatedPayload), path.join(newDir, 'streamed.bin'), {
+      onProgress: ({ bytesSent }) => console.log(`  uploaded ${bytesSent} / ${generatedPayload.length} bytes`),
+    })
+
+    //  stream download — process file content as chunks arrive, with progress.
+    //  Use an AbortController if you need to cancel a long-running transfer.
+    console.log('\nStreaming download with progress:')
+    const downloadController = new AbortController()
+    const stream = await sandbox.fs.downloadFileStream(path.join(newDir, 'config.json'), {
+      signal: downloadController.signal,
+      onProgress: ({ bytesReceived, totalBytes }) =>
+        console.log(`  downloaded ${bytesReceived} / ${totalBytes ?? '?'} bytes`),
+    })
     const chunks: Buffer[] = []
     await new Promise<void>((resolve, reject) => {
       stream.on('data', (chunk: Buffer) => chunks.push(chunk))

--- a/libs/sdk-go/pkg/daytona/e2e_test.go
+++ b/libs/sdk-go/pkg/daytona/e2e_test.go
@@ -230,6 +230,49 @@ func TestE2E(t *testing.T) {
 		assert.Equal(t, "hello world", string(data))
 	})
 
+	t.Run("FileSystem/DownloadFileStreamProgress", func(t *testing.T) {
+		var lastProgress DownloadProgress
+		stream, err := sandbox.FileSystem.DownloadFileStream(ctx, helloPath, WithDownloadProgress(func(progress DownloadProgress) {
+			lastProgress = progress
+		}))
+		require.NoError(t, err)
+		defer stream.Close()
+
+		data, err := io.ReadAll(stream)
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", string(data))
+		assert.Equal(t, int64(len(data)), lastProgress.BytesReceived)
+		assert.Equal(t, int64(len(data)), lastProgress.TotalBytes)
+	})
+
+	t.Run("FileSystem/UploadFileStream", func(t *testing.T) {
+		streamPath := textDir + "/upload-stream.bin"
+		payload := strings.Repeat("upload-stream-content-", 1024)
+		var lastProgress UploadProgress
+
+		err := sandbox.FileSystem.UploadFileStream(
+			ctx,
+			strings.NewReader(payload),
+			streamPath,
+			WithUploadProgress(func(p UploadProgress) { lastProgress = p }),
+		)
+		require.NoError(t, err)
+
+		data, err := sandbox.FileSystem.DownloadFile(ctx, streamPath, nil)
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(data))
+		assert.Equal(t, int64(len(payload)), lastProgress.BytesSent)
+	})
+
+	t.Run("FileSystem/UploadFileStreamCancellation", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		time.AfterFunc(100*time.Millisecond, cancel)
+
+		err := sandbox.FileSystem.UploadFileStream(cancelCtx, endlessReader{}, textDir+"/upload-stream-cancel.bin")
+		require.Error(t, err)
+		assert.True(t, containsAny(strings.ToLower(err.Error()), "context canceled", "context deadline exceeded"))
+	})
+
 	t.Run("FileSystem/FindFiles", func(t *testing.T) {
 		findResult, findErr := sandbox.FileSystem.FindFiles(ctx, textDir, "hello")
 		require.NoError(t, findErr)

--- a/libs/sdk-go/pkg/daytona/file_transfer.go
+++ b/libs/sdk-go/pkg/daytona/file_transfer.go
@@ -12,6 +12,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
@@ -23,8 +24,27 @@ type downloadStreamCloser struct {
 	response   *http.Response
 }
 
+type progressReader struct {
+	inner      io.Reader
+	onProgress func(DownloadProgress)
+	total      int64
+	expected   int64
+}
+
 func (d *downloadStreamCloser) Read(p []byte) (int, error) {
 	return d.partReader.Read(p)
+}
+
+func (p *progressReader) Read(buf []byte) (int, error) {
+	n, err := p.inner.Read(buf)
+	if n > 0 {
+		p.total += int64(n)
+		p.onProgress(DownloadProgress{
+			BytesReceived: p.total,
+			TotalBytes:    p.expected,
+		})
+	}
+	return n, err
 }
 
 func (d *downloadStreamCloser) Close() error {
@@ -34,7 +54,7 @@ func (d *downloadStreamCloser) Close() error {
 	return d.response.Body.Close()
 }
 
-func streamDownloadFile(cfg *toolbox.Configuration, remotePath string, ctx context.Context) (io.ReadCloser, error) {
+func streamDownloadFile(cfg *toolbox.Configuration, remotePath string, ctx context.Context, onProgress func(DownloadProgress)) (io.ReadCloser, error) {
 	if len(cfg.Servers) == 0 {
 		return nil, errors.NewDaytonaError("Toolbox client is not configured", 0, nil)
 	}
@@ -103,7 +123,18 @@ func streamDownloadFile(cfg *toolbox.Configuration, remotePath string, ctx conte
 
 		switch part.FormName() {
 		case "file":
-			return &downloadStreamCloser{partReader: part, response: resp}, nil
+			expected := int64(0)
+			if cl := part.Header.Get("Content-Length"); cl != "" {
+				if n, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
+					expected = n
+				}
+			}
+
+			var reader io.Reader = part
+			if onProgress != nil {
+				reader = &progressReader{inner: part, onProgress: onProgress, expected: expected}
+			}
+			return &downloadStreamCloser{partReader: reader, response: resp}, nil
 		case "error":
 			body, readErr := io.ReadAll(part)
 			_ = resp.Body.Close()
@@ -113,4 +144,103 @@ func streamDownloadFile(cfg *toolbox.Configuration, remotePath string, ctx conte
 			return nil, errors.NewDaytonaErrorFromBody(body, resp.StatusCode, resp.Header)
 		}
 	}
+}
+
+type uploadProgressReader struct {
+	inner      io.Reader
+	onProgress func(UploadProgress)
+	total      int64
+}
+
+func (p *uploadProgressReader) Read(buf []byte) (int, error) {
+	n, err := p.inner.Read(buf)
+	if n > 0 {
+		p.total += int64(n)
+		if p.onProgress != nil {
+			p.onProgress(UploadProgress{BytesSent: p.total})
+		}
+	}
+	return n, err
+}
+
+// streamUploadFile builds a multipart/form-data request body via io.Pipe and feeds the
+// caller's io.Reader directly through it, so neither the SDK nor net/http buffer the
+// payload. Context cancellation aborts both the multipart writer goroutine and the
+// in-flight HTTP request.
+func streamUploadFile(cfg *toolbox.Configuration, remotePath string, source io.Reader, opts *uploadStreamConfig, ctx context.Context) error {
+	if len(cfg.Servers) == 0 {
+		return errors.NewDaytonaError("Toolbox client is not configured", 0, nil)
+	}
+
+	wrapped := io.Reader(source)
+	if opts.onProgress != nil {
+		wrapped = &uploadProgressReader{inner: source, onProgress: opts.onProgress}
+	}
+
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(errCh)
+
+		writeErr := func() error {
+			if err := mw.WriteField("files[0].path", remotePath); err != nil {
+				return err
+			}
+			part, err := mw.CreateFormFile("files[0].file", remotePath)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(part, wrapped); err != nil {
+				return err
+			}
+			if err := mw.Close(); err != nil {
+				return err
+			}
+			return nil
+		}()
+
+		_ = pw.CloseWithError(writeErr)
+		errCh <- writeErr
+	}()
+
+	endpoint := strings.TrimRight(cfg.Servers[0].URL, "/") + "/files/bulk-upload"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, pr)
+	if err != nil {
+		_ = pw.CloseWithError(err)
+		<-errCh
+		return errors.NewDaytonaError(fmt.Sprintf("Failed to create upload request: %v", err), 0, nil)
+	}
+	for key, value := range cfg.DefaultHeader {
+		req.Header.Set(key, value)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		_ = pw.CloseWithError(err)
+		<-errCh
+		return errors.NewDaytonaError(fmt.Sprintf("Failed to upload file: %v", err), 0, nil)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		returnErr := errors.NewDaytonaErrorFromBody(body, resp.StatusCode, resp.Header)
+		_ = pw.CloseWithError(returnErr)
+		<-errCh
+		return returnErr
+	}
+
+	if writeErr := <-errCh; writeErr != nil {
+		return writeErr
+	}
+
+	return nil
 }

--- a/libs/sdk-go/pkg/daytona/filesystem.go
+++ b/libs/sdk-go/pkg/daytona/filesystem.go
@@ -241,6 +241,31 @@ func (f *FileSystemService) DownloadFile(ctx context.Context, remotePath string,
 	})
 }
 
+// DownloadStreamOption configures the behavior of DownloadFileStream.
+type DownloadStreamOption func(*downloadStreamConfig)
+
+// DownloadProgress contains progress information for a streaming download.
+type DownloadProgress struct {
+	// BytesReceived is the cumulative number of bytes read so far.
+	BytesReceived int64
+	// TotalBytes is the total number of bytes expected, if known.
+	// Zero means unknown.
+	TotalBytes int64
+}
+
+type downloadStreamConfig struct {
+	onProgress func(DownloadProgress)
+}
+
+// WithDownloadProgress returns an option that enables progress tracking for streaming
+// downloads. The callback receives the cumulative bytes read and, when available, the
+// total bytes expected.
+func WithDownloadProgress(fn func(DownloadProgress)) DownloadStreamOption {
+	return func(c *downloadStreamConfig) {
+		c.onProgress = fn
+	}
+}
+
 // DownloadFileStream downloads a single file from the sandbox as a stream without
 // buffering the entire file into memory. The returned [io.ReadCloser] can be piped
 // directly to an HTTP response, written to a file, or processed on the fly.
@@ -272,9 +297,64 @@ func (f *FileSystemService) DownloadFile(ctx context.Context, remotePath string,
 //	out, _ := os.Create("local-copy.bin")
 //	defer out.Close()
 //	io.Copy(out, stream)
-func (f *FileSystemService) DownloadFileStream(ctx context.Context, remotePath string) (io.ReadCloser, error) {
+func (f *FileSystemService) DownloadFileStream(ctx context.Context, remotePath string, opts ...DownloadStreamOption) (io.ReadCloser, error) {
+	cfg := &downloadStreamConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	return withInstrumentation(ctx, f.otel, "FileSystem", "DownloadFileStream", func(ctx context.Context) (io.ReadCloser, error) {
-		return streamDownloadFile(f.toolboxClient.GetConfig(), remotePath, ctx)
+		return streamDownloadFile(f.toolboxClient.GetConfig(), remotePath, ctx, cfg.onProgress)
+	})
+}
+
+// UploadStreamOption configures the behavior of UploadFileStream.
+type UploadStreamOption func(*uploadStreamConfig)
+
+// UploadProgress contains progress information for a streaming upload.
+type UploadProgress struct {
+	// BytesSent is the cumulative number of bytes written to the wire so far.
+	BytesSent int64
+}
+
+type uploadStreamConfig struct {
+	onProgress func(UploadProgress)
+}
+
+// WithUploadProgress returns an option that enables progress tracking for streaming uploads.
+// The callback fires once per chunk written to the wire with the cumulative byte count.
+func WithUploadProgress(fn func(UploadProgress)) UploadStreamOption {
+	return func(c *uploadStreamConfig) {
+		c.onProgress = fn
+	}
+}
+
+// UploadFileStream streams a file to the sandbox without buffering it in memory. The
+// reader is piped directly into a multipart request, so heap usage stays flat regardless
+// of source size. The HTTP layer uses chunked transfer encoding, so the source's natural
+// EOF terminates the upload — no advance size is needed. Cancellation flows through the
+// context: cancelling ctx aborts the in-flight HTTP request.
+//
+// Example:
+//
+//	f, _ := os.Open("/local/big.bin")
+//	defer f.Close()
+//	err := sandbox.FileSystem.UploadFileStream(ctx, f, "/home/user/big.bin",
+//	    WithUploadProgress(func(p UploadProgress) {
+//	        log.Printf("%d bytes sent", p.BytesSent)
+//	    }),
+//	)
+func (f *FileSystemService) UploadFileStream(ctx context.Context, source io.Reader, remotePath string, opts ...UploadStreamOption) error {
+	if source == nil {
+		return errors.NewDaytonaError("source must not be nil", 0, nil)
+	}
+	cfg := &uploadStreamConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return withInstrumentationVoid(ctx, f.otel, "FileSystem", "UploadFileStream", func(ctx context.Context) error {
+		return streamUploadFile(f.toolboxClient.GetConfig(), remotePath, source, cfg, ctx)
 	})
 }
 

--- a/libs/sdk-go/pkg/daytona/filesystem_test.go
+++ b/libs/sdk-go/pkg/daytona/filesystem_test.go
@@ -13,6 +13,8 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -179,6 +181,59 @@ func TestDownloadFileStream(t *testing.T) {
 	assert.Equal(t, "streamed file content", string(data))
 }
 
+func TestDownloadFileStreamProgress(t *testing.T) {
+	remotePath := "/home/user/file.txt"
+	content := "streamed file content"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mw := multipart.NewWriter(w)
+		w.Header().Set("Content-Type", mw.FormDataContentType())
+		hdr := textproto.MIMEHeader{}
+		hdr.Set("Content-Disposition", `form-data; name="file"; filename="test.txt"`)
+		hdr.Set("Content-Length", strconv.Itoa(len(content)))
+		part, err := mw.CreatePart(hdr)
+		require.NoError(t, err)
+		_, err = part.Write([]byte(content))
+		require.NoError(t, err)
+		require.NoError(t, mw.Close())
+	}))
+	defer server.Close()
+
+	fs := NewFileSystemService(createTestToolboxClient(server), nil)
+
+	var progress []DownloadProgress
+	stream, err := fs.DownloadFileStream(context.Background(), remotePath, WithDownloadProgress(func(progressUpdate DownloadProgress) {
+		progress = append(progress, progressUpdate)
+	}))
+	require.NoError(t, err)
+	defer stream.Close()
+
+	buf := make([]byte, 5)
+	var data []byte
+	for {
+		n, readErr := stream.Read(buf)
+		if n > 0 {
+			data = append(data, buf[:n]...)
+		}
+		if readErr == io.EOF {
+			break
+		}
+		require.NoError(t, readErr)
+	}
+
+	assert.Equal(t, content, string(data))
+	// Validate monotonic progress with correct totals — do not assert exact intermediate
+	// byte boundaries, which depend on OS read chunk sizes and can be flaky in CI.
+	require.NotEmpty(t, progress)
+	expectedTotal := int64(len(content))
+	for i, p := range progress {
+		assert.Equal(t, expectedTotal, p.TotalBytes, "TotalBytes should always equal content length")
+		if i > 0 {
+			assert.Greater(t, p.BytesReceived, progress[i-1].BytesReceived, "progress should be strictly increasing")
+		}
+	}
+	assert.Equal(t, expectedTotal, progress[len(progress)-1].BytesReceived, "final BytesReceived should equal content length")
+}
+
 func TestDownloadFileStreamError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mw := multipart.NewWriter(w)
@@ -343,6 +398,52 @@ func TestUploadFileInvalidSource(t *testing.T) {
 	assert.Contains(t, err.Error(), "Invalid source type")
 }
 
+func TestUploadFileStreamCancellation(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	cfg := toolbox.NewConfiguration()
+	cfg.Servers = toolbox.ServerConfigurations{{URL: "http://example.test"}}
+	cfg.HTTPClient = &http.Client{Transport: uploadRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})}
+
+	fs := NewFileSystemService(toolbox.NewAPIClient(cfg), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(20*time.Millisecond, cancel)
+
+	err := fs.UploadFileStream(ctx, endlessReader{}, "/home/user/cancel.bin")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "context canceled")
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= before+1
+	}, time.Second, 20*time.Millisecond)
+}
+
+func TestUploadFileStreamServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"upload failed"}`))
+	}))
+	defer server.Close()
+
+	fs := NewFileSystemService(createTestToolboxClient(server), nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- fs.UploadFileStream(context.Background(), endlessReader{}, "/home/user/error.bin")
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "upload failed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("UploadFileStream hung after server error")
+	}
+}
+
 func TestFileSystemErrorHandling(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -494,4 +595,19 @@ func TestFileSystemSearchAndReplaceSuccessMappings(t *testing.T) {
 	require.NoError(t, err)
 	results := replaced.([]map[string]any)
 	assert.Equal(t, "permission denied", results[1]["error"])
+}
+
+type uploadRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f uploadRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type endlessReader struct{}
+
+func (endlessReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/CancellationToken.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/CancellationToken.java
@@ -1,0 +1,56 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Cancellation token for streaming download/upload operations.
+ *
+ * <p>Calling {@link #cancel()} aborts an in-flight HTTP request and causes the
+ * SDK to throw a {@code DaytonaException} with a "cancelled" message.
+ *
+ * <p>A token is single-shot and can only be cancelled once. Tokens are not reusable
+ * across multiple requests.
+ */
+public final class CancellationToken {
+    private final AtomicReference<Runnable> handler = new AtomicReference<Runnable>();
+    private volatile boolean cancelled;
+
+    public void cancel() {
+        cancelled = true;
+        Runnable h = handler.getAndSet(null);
+        if (h != null) {
+            h.run();
+        }
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Internal: registers a handler that runs when cancel() fires.
+     * Returns a Runnable that callers must invoke (typically in a finally block)
+     * to deregister the handler after the operation completes successfully.
+     *
+     * <p>Uses double-checked compareAndSet to avoid losing a cancel signal that
+     * arrives between the cancelled-check and the handler-set.
+     */
+    Runnable onCancel(Runnable h) {
+        if (cancelled) {
+            h.run();
+            return () -> {};
+        }
+        handler.set(h);
+        if (cancelled) {
+            Runnable existing = handler.getAndSet(null);
+            if (existing != null) {
+                existing.run();
+            }
+            return () -> {};
+        }
+        return () -> handler.compareAndSet(h, null);
+    }
+}

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/DownloadProgress.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/DownloadProgress.java
@@ -1,0 +1,29 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import java.util.OptionalLong;
+
+/**
+ * Progress information for a streaming download.
+ */
+public final class DownloadProgress {
+    private final long bytesReceived;
+    private final OptionalLong totalBytes;
+
+    public DownloadProgress(long bytesReceived, OptionalLong totalBytes) {
+        this.bytesReceived = bytesReceived;
+        this.totalBytes = totalBytes;
+    }
+
+    /** Cumulative bytes received so far. */
+    public long getBytesReceived() {
+        return bytesReceived;
+    }
+
+    /** Total bytes expected, if known. */
+    public OptionalLong getTotalBytes() {
+        return totalBytes;
+    }
+}

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/DownloadStreamOptions.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/DownloadStreamOptions.java
@@ -1,0 +1,31 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import java.util.function.Consumer;
+
+public class DownloadStreamOptions {
+    private int timeoutSeconds = 30 * 60;
+    private Consumer<DownloadProgress> onProgress;
+    private CancellationToken cancellationToken;
+
+    public int getTimeoutSeconds() { return timeoutSeconds; }
+    public Consumer<DownloadProgress> getOnProgress() { return onProgress; }
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+
+    public DownloadStreamOptions setTimeout(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+        return this;
+    }
+
+    public DownloadStreamOptions setOnProgress(Consumer<DownloadProgress> onProgress) {
+        this.onProgress = onProgress;
+        return this;
+    }
+
+    public DownloadStreamOptions setCancellationToken(CancellationToken token) {
+        this.cancellationToken = token;
+        return this;
+    }
+}

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileSystem.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileSystem.java
@@ -83,7 +83,7 @@ public class FileSystem {
      * @throws io.daytona.sdk.exception.DaytonaException if the file does not exist or access is denied
      */
     public InputStream downloadFileStream(String remotePath) throws io.daytona.sdk.exception.DaytonaException {
-        return downloadFileStream(remotePath, FileTransfer.DEFAULT_DOWNLOAD_STREAM_TIMEOUT_SECONDS);
+        return downloadFileStream(remotePath, new DownloadStreamOptions());
     }
 
     /**
@@ -98,7 +98,19 @@ public class FileSystem {
      * @throws io.daytona.sdk.exception.DaytonaException if the file does not exist or access is denied
      */
     public InputStream downloadFileStream(String remotePath, int timeoutSeconds) throws io.daytona.sdk.exception.DaytonaException {
-        return FileTransfer.streamDownload(fileSystemApi, remotePath, timeoutSeconds);
+        return downloadFileStream(remotePath, new DownloadStreamOptions().setTimeout(timeoutSeconds));
+    }
+
+    /**
+     * Downloads a single file from the Sandbox as a stream with configurable options.
+     *
+     * @param remotePath source file path in the Sandbox
+     * @param options download options including timeout and progress callback
+     * @return an InputStream streaming the file content
+     * @throws io.daytona.sdk.exception.DaytonaException if download fails
+     */
+    public InputStream downloadFileStream(String remotePath, DownloadStreamOptions options) throws io.daytona.sdk.exception.DaytonaException {
+        return FileTransfer.streamDownload(fileSystemApi, remotePath, options != null ? options : new DownloadStreamOptions());
     }
 
     /**
@@ -117,6 +129,25 @@ public class FileSystem {
         } catch (IOException e) {
             throw new io.daytona.sdk.exception.DaytonaException("Failed to upload file", e);
         }
+    }
+
+    /**
+     * Streams an upload to a Sandbox path without buffering the source. The bytes are
+     * piped through a progress-counting wrapper directly into a streaming multipart
+     * request, so heap usage stays flat regardless of source size.
+     *
+     * @param source the data source; the caller retains ownership and is responsible for closing it
+     * @param remotePath destination file path in the Sandbox
+     * @param options upload options including timeout, cancellation, and progress callback
+     * @throws io.daytona.sdk.exception.DaytonaException if upload fails
+     */
+    public void uploadFileStream(InputStream source, String remotePath, UploadStreamOptions options) {
+        FileTransfer.streamUpload(fileSystemApi, source, remotePath, options != null ? options : new UploadStreamOptions());
+    }
+
+    /** Convenience overload using default options. */
+    public void uploadFileStream(InputStream source, String remotePath) {
+        uploadFileStream(source, remotePath, new UploadStreamOptions());
     }
 
     /**

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
@@ -8,14 +8,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.daytona.toolbox.client.ApiClient;
 import io.daytona.toolbox.client.api.FileSystemApi;
 import io.daytona.toolbox.client.model.FilesDownloadRequest;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okio.BufferedSink;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -23,7 +28,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,7 +43,8 @@ final class FileTransfer {
     private FileTransfer() {
     }
 
-    static InputStream streamDownload(FileSystemApi fileSystemApi, String remotePath, int timeoutSeconds) throws io.daytona.sdk.exception.DaytonaException {
+    static InputStream streamDownload(FileSystemApi fileSystemApi, String remotePath, DownloadStreamOptions options) throws io.daytona.sdk.exception.DaytonaException {
+        int timeoutSeconds = options.getTimeoutSeconds();
         if (timeoutSeconds < 0) {
             throw new io.daytona.sdk.exception.DaytonaException("Timeout must be non-negative");
         }
@@ -55,16 +63,51 @@ final class FileTransfer {
                 .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
                 .build();
 
+        Request request = buildDownloadFileStreamRequest(apiClient, remotePath);
+        Call call = streamingClient.newCall(request);
+        CancellationToken cancellationToken = options.getCancellationToken();
+        Runnable unregister = cancellationToken != null
+                ? cancellationToken.onCancel(call::cancel)
+                : () -> {};
+
         Response response = null;
+        boolean handedOff = false;
         try {
-            Request request = buildDownloadFileStreamRequest(apiClient, remotePath);
-            response = streamingClient.newCall(request).execute();
-            return extractDownloadFileStream(response);
+            response = call.execute();
+            InputStream stream = extractDownloadFileStream(response, options, call);
+            Runnable finalUnregister = unregister;
+            InputStream wrapped = new java.io.FilterInputStream(stream) {
+                private boolean closed = false;
+
+                @Override
+                public void close() throws IOException {
+                    if (closed) return;
+                    closed = true;
+                    try {
+                        super.close();
+                    } finally {
+                        finalUnregister.run();
+                    }
+                }
+            };
+            handedOff = true;
+            return wrapped;
         } catch (IOException e) {
-            if (response != null) {
-                response.close();
+            if (call.isCanceled()) {
+                throw new io.daytona.sdk.exception.DaytonaException("Download cancelled");
             }
             throw new io.daytona.sdk.exception.DaytonaException("Failed to download file stream", e);
+        } finally {
+            // On any failure path (IOException *or* RuntimeException / DaytonaException
+            // thrown by extractDownloadFileStream) we must deregister the cancel handler
+            // and close the response. On the success path handedOff=true skips this block
+            // because the FilterInputStream owns the cleanup.
+            if (!handedOff) {
+                unregister.run();
+                if (response != null) {
+                    response.close();
+                }
+            }
         }
     }
 
@@ -91,7 +134,7 @@ final class FileTransfer {
         }
     }
 
-    private static InputStream extractDownloadFileStream(Response response) throws IOException {
+    private static InputStream extractDownloadFileStream(Response response, DownloadStreamOptions options, Call call) throws IOException {
         ResponseBody responseBody = response.body();
         if (responseBody == null) {
             response.close();
@@ -115,19 +158,27 @@ final class FileTransfer {
             moveToFirstPart(bufferedStream, boundary);
             Map<String, String> partHeaders = readPartHeaders(bufferedStream);
             String partName = extractPartName(partHeaders.get("content-disposition"));
+            long totalBytes = parsePartContentLength(partHeaders.get("content-length"));
             if ("file".equals(partName)) {
-                return new MultipartPartInputStream(bufferedStream, response, boundary);
+                InputStream result = new MultipartPartInputStream(bufferedStream, response, boundary, call, "Download cancelled");
+                return withProgress(result, options, totalBytes);
             }
 
             if ("error".equals(partName)) {
-                try (InputStream errorStream = new MultipartPartInputStream(bufferedStream, response, boundary)) {
+                try (InputStream errorStream = new MultipartPartInputStream(bufferedStream, response, boundary, call, "Download cancelled")) {
                     throw parseDownloadError(errorStream.readAllBytes(), response.code());
                 }
             }
 
             response.close();
             throw new io.daytona.sdk.exception.DaytonaException("File stream not found in download response");
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException e) {
+            response.close();
+            if (call.isCanceled()) {
+                throw new io.daytona.sdk.exception.DaytonaException("Download cancelled");
+            }
+            throw e;
+        } catch (RuntimeException e) {
             response.close();
             throw e;
         }
@@ -238,12 +289,82 @@ final class FileTransfer {
         return ExceptionMapper.map(statusCode, responseBody);
     }
 
+    private static long parsePartContentLength(String contentLengthHeader) {
+        if (contentLengthHeader == null) {
+            return -1;
+        }
+        try {
+            long parsed = Long.parseLong(contentLengthHeader.trim());
+            return parsed >= 0 ? parsed : -1;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static InputStream withProgress(InputStream inputStream, DownloadStreamOptions options, long totalBytes) {
+        if (options.getOnProgress() == null) {
+            return inputStream;
+        }
+        return new ProgressInputStream(inputStream, options.getOnProgress(), totalBytes);
+    }
+
+    private static final class ProgressInputStream extends FilterInputStream {
+        // Coarse cadence for the byte-at-a-time read() overload: emit at most
+        // once per 8 KiB. Bulk reads still emit per call (chunks already coalesce
+        // bytes), so typical consumers see one event per network chunk.
+        private static final long SINGLE_BYTE_REPORT_INTERVAL = 8192;
+
+        private final Consumer<DownloadProgress> onProgress;
+        private final OptionalLong totalBytes;
+        private long total;
+        private long lastReported;
+
+        private ProgressInputStream(InputStream in, Consumer<DownloadProgress> onProgress, long totalBytesValue) {
+            super(in);
+            this.onProgress = onProgress;
+            this.totalBytes = totalBytesValue >= 0 ? OptionalLong.of(totalBytesValue) : OptionalLong.empty();
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = super.read();
+            if (b != -1) {
+                total++;
+                if (total - lastReported >= SINGLE_BYTE_REPORT_INTERVAL) {
+                    emit();
+                }
+            } else if (total > lastReported) {
+                emit();
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int n = super.read(b, off, len);
+            if (n > 0) {
+                total += n;
+                emit();
+            } else if (n < 0 && total > lastReported) {
+                emit();
+            }
+            return n;
+        }
+
+        private void emit() {
+            onProgress.accept(new DownloadProgress(total, totalBytes));
+            lastReported = total;
+        }
+    }
+
     private static final class MultipartPartInputStream extends InputStream {
         private static final int BUF_SIZE = 8192;
 
         private final InputStream source;
         private final Response response;
         private final byte[] delimiter;
+        private final Call call;
+        private final String cancelledMessage;
 
         private byte[] buf = new byte[BUF_SIZE];
         private int pos;
@@ -253,10 +374,12 @@ final class FileTransfer {
         private boolean finished;
         private boolean closed;
 
-        private MultipartPartInputStream(InputStream source, Response response, String boundary) {
+        private MultipartPartInputStream(InputStream source, Response response, String boundary, Call call, String cancelledMessage) {
             this.source = source;
             this.response = response;
             this.delimiter = ("\r\n--" + boundary).getBytes(StandardCharsets.ISO_8859_1);
+            this.call = call;
+            this.cancelledMessage = cancelledMessage;
         }
 
         @Override
@@ -331,7 +454,15 @@ final class FileTransfer {
             compact();
             if (sourceEnded) return limit > 0;
 
-            int read = source.read(buf, limit, buf.length - limit);
+            int read;
+            try {
+                read = source.read(buf, limit, buf.length - limit);
+            } catch (IOException e) {
+                if (call.isCanceled()) {
+                    throw new io.daytona.sdk.exception.DaytonaException(cancelledMessage);
+                }
+                throw e;
+            }
             if (read == -1) {
                 sourceEnded = true;
                 return limit > 0;
@@ -370,6 +501,134 @@ final class FileTransfer {
                 if (buf[offset + j] != delimiter[j]) return false;
             }
             return true;
+        }
+    }
+
+    /**
+     * Streams an upload to {@code /files/bulk-upload}. The body is constructed as a
+     * multipart envelope whose file part is a {@link StreamingRequestBody} — OkHttp
+     * pulls bytes from the user's {@link InputStream} via {@code BufferedSink} and
+     * writes them straight to the wire, with no intermediate buffering. The wrapper
+     * meters bytes as they flow and invokes the optional progress callback.
+     *
+     * <p>Cancellation flows through OkHttp's call timeout. The daemon owns atomicity
+     * (writes to a sibling temp file then renames), so a client-side abort just
+     * leaves no destination file at all — partial uploads are never visible.
+     */
+    static void streamUpload(FileSystemApi fileSystemApi, InputStream source, String remotePath, UploadStreamOptions options) {
+        int timeoutSeconds = options.getTimeoutSeconds();
+        if (timeoutSeconds < 0) {
+            throw new io.daytona.sdk.exception.DaytonaException("Timeout must be non-negative");
+        }
+        if (source == null) {
+            throw new io.daytona.sdk.exception.DaytonaException("Upload source must not be null");
+        }
+        if (remotePath == null || remotePath.isEmpty()) {
+            throw new io.daytona.sdk.exception.DaytonaException("remotePath must not be empty");
+        }
+
+        ApiClient apiClient = fileSystemApi.getApiClient();
+        if (apiClient == null || apiClient.getBasePath() == null || apiClient.getBasePath().isEmpty()) {
+            throw new io.daytona.sdk.exception.DaytonaException("Toolbox client is not configured");
+        }
+
+        OkHttpClient httpClient = apiClient.getHttpClient();
+        if (httpClient == null) {
+            throw new io.daytona.sdk.exception.DaytonaException("Toolbox client is not configured");
+        }
+
+        OkHttpClient streamingClient = httpClient.newBuilder()
+                .writeTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                .callTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                .build();
+
+        StreamingRequestBody fileBody = new StreamingRequestBody(source,
+                options.getOnProgress(), MediaType.parse("application/octet-stream"));
+
+        MultipartBody multipart = new MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("files[0].path", remotePath)
+                .addFormDataPart("files[0].file", remotePath, fileBody)
+                .build();
+
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(apiClient.getBasePath().replaceAll("/+$", "") + "/files/bulk-upload")
+                .post(multipart);
+        Map<String, String> headerParams = new HashMap<String, String>();
+        headerParams.put("Accept", "*/*");
+        apiClient.processHeaderParams(headerParams, requestBuilder);
+        apiClient.processCookieParams(new HashMap<String, String>(), requestBuilder);
+
+        Request request = requestBuilder.build();
+        Call call = streamingClient.newCall(request);
+        CancellationToken cancellationToken = options.getCancellationToken();
+        Runnable unregister = cancellationToken != null
+                ? cancellationToken.onCancel(call::cancel)
+                : () -> {};
+
+        try (Response response = call.execute()) {
+            if (!response.isSuccessful()) {
+                ResponseBody body = response.body();
+                byte[] bodyBytes = body == null ? new byte[0] : body.bytes();
+                throw parseDownloadError(bodyBytes, response.code());
+            }
+        } catch (IOException e) {
+            if (call.isCanceled()) {
+                throw new io.daytona.sdk.exception.DaytonaException("Upload cancelled");
+            }
+            throw new io.daytona.sdk.exception.DaytonaException("Failed to upload file stream", e);
+        } finally {
+            unregister.run();
+        }
+    }
+
+    /**
+     * RequestBody that streams from a caller-provided InputStream straight into OkHttp's
+     * BufferedSink. Bytes are forwarded a chunk at a time so heap usage is bounded by
+     * the buffer size, not the upload size. When supplied, the progress callback fires
+     * once per chunk written.
+     *
+     * <p>{@link #contentLength()} returns {@code -1} (unknown), which makes OkHttp use
+     * chunked transfer encoding. The source's natural EOF terminates the upload — no
+     * advance byte count is needed.
+     */
+    private static final class StreamingRequestBody extends RequestBody {
+        private static final int CHUNK_SIZE = 64 * 1024;
+
+        private final InputStream source;
+        private final Consumer<UploadProgress> onProgress;
+        private final MediaType mediaType;
+
+        private StreamingRequestBody(InputStream source,
+                                     Consumer<UploadProgress> onProgress,
+                                     MediaType mediaType) {
+            this.source = source;
+            this.onProgress = onProgress;
+            this.mediaType = mediaType;
+        }
+
+        @Override
+        public MediaType contentType() {
+            return mediaType;
+        }
+
+        @Override
+        public long contentLength() {
+            return -1L;
+        }
+
+        @Override
+        public void writeTo(BufferedSink sink) throws IOException {
+            byte[] buf = new byte[CHUNK_SIZE];
+            long sent = 0;
+            int n;
+            while ((n = source.read(buf)) != -1) {
+                sink.write(buf, 0, n);
+                sent += n;
+                if (onProgress != null) {
+                    onProgress.accept(new UploadProgress(sent));
+                }
+            }
         }
     }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/UploadProgress.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/UploadProgress.java
@@ -1,0 +1,20 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+/**
+ * Progress information for a streaming upload.
+ */
+public final class UploadProgress {
+    private final long bytesSent;
+
+    public UploadProgress(long bytesSent) {
+        this.bytesSent = bytesSent;
+    }
+
+    /** Cumulative bytes sent so far. */
+    public long getBytesSent() {
+        return bytesSent;
+    }
+}

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/UploadStreamOptions.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/UploadStreamOptions.java
@@ -1,0 +1,31 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import java.util.function.Consumer;
+
+public class UploadStreamOptions {
+    private int timeoutSeconds = 30 * 60;
+    private Consumer<UploadProgress> onProgress;
+    private CancellationToken cancellationToken;
+
+    public int getTimeoutSeconds() { return timeoutSeconds; }
+    public Consumer<UploadProgress> getOnProgress() { return onProgress; }
+    public CancellationToken getCancellationToken() { return cancellationToken; }
+
+    public UploadStreamOptions setTimeout(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+        return this;
+    }
+
+    public UploadStreamOptions setOnProgress(Consumer<UploadProgress> onProgress) {
+        this.onProgress = onProgress;
+        return this;
+    }
+
+    public UploadStreamOptions setCancellationToken(CancellationToken token) {
+        this.cancellationToken = token;
+        return this;
+    }
+}

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/E2ETest.java
@@ -47,6 +47,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -263,6 +265,87 @@ class E2ETest {
         try (InputStream stream = sandbox.getFs().downloadFileStream(fsDir + "/stream.txt")) {
             assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("stream content");
         }
+    }
+
+    @Test
+    @Order(16)
+    void downloadFileStreamWithProgress() throws Exception {
+        sandbox.getFs().uploadFile("progress test".getBytes(StandardCharsets.UTF_8), fsDir + "/progress.txt");
+        AtomicReference<DownloadProgress> lastProgress = new AtomicReference<DownloadProgress>();
+
+        try (InputStream stream = sandbox.getFs().downloadFileStream(
+                fsDir + "/progress.txt",
+                new DownloadStreamOptions().setOnProgress(lastProgress::set))) {
+            byte[] content = stream.readAllBytes();
+            assertThat(new String(content, StandardCharsets.UTF_8)).isEqualTo("progress test");
+            assertThat(lastProgress.get().getBytesReceived()).isEqualTo(content.length);
+            assertThat(lastProgress.get().getTotalBytes()).satisfies(totalBytes -> {
+                if (totalBytes.isPresent()) {
+                    assertThat(totalBytes.getAsLong()).isEqualTo(content.length);
+                }
+            });
+        }
+    }
+
+    @Test
+    @Order(17)
+    void downloadFileStreamCancellationCancelsRequest() {
+        String remotePath = fsDir + "/cancel-stream.bin";
+        ExecuteResponse createFile = sandbox.getProcess().executeCommand(
+                "python - <<'PY'\n"
+                        + "with open('" + remotePath + "', 'wb') as f:\n"
+                        + "    chunk = b'x' * (1024 * 1024)\n"
+                        + "    for _ in range(16):\n"
+                        + "        f.write(chunk)\n"
+                        + "PY"
+        );
+        assertThat(createFile.getExitCode()).isEqualTo(0);
+
+        CancellationToken token = new CancellationToken();
+        Thread canceller = cancelAfter(token, 50L);
+
+        try {
+            assertThatThrownBy(() -> {
+                try (InputStream stream = sandbox.getFs().downloadFileStream(
+                        remotePath,
+                        new DownloadStreamOptions().setCancellationToken(token))) {
+                    byte[] buffer = new byte[1024];
+                    while (stream.read(buffer) != -1) {
+                        Thread.sleep(10L);
+                    }
+                }
+            })
+                    .isInstanceOf(DaytonaException.class)
+                    .hasMessageContaining("cancel");
+        } finally {
+            try {
+                canceller.join(1000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Test
+    @Order(17)
+    void uploadFileStreamWithProgress() throws Exception {
+        byte[] payload = ("upload-stream-content-" + java.util.UUID.randomUUID()).repeat(512).getBytes(StandardCharsets.UTF_8);
+        java.util.List<UploadProgress> updates = new java.util.ArrayList<UploadProgress>();
+
+        sandbox.getFs().uploadFileStream(
+                new java.io.ByteArrayInputStream(payload),
+                fsDir + "/upload-stream.bin",
+                new UploadStreamOptions().setOnProgress(updates::add));
+
+        try (InputStream stream = sandbox.getFs().downloadFileStream(fsDir + "/upload-stream.bin")) {
+            byte[] roundTripped = stream.readAllBytes();
+            assertThat(roundTripped).isEqualTo(payload);
+        }
+
+        assertThat(updates).isNotEmpty();
+        UploadProgress last = updates.get(updates.size() - 1);
+        assertThat(last.getBytesSent()).isEqualTo(payload.length);
+        assertThat(updates).extracting(UploadProgress::getBytesSent).isSorted();
     }
 
     @Test
@@ -581,6 +664,19 @@ class E2ETest {
 
     private String messageOf(Throwable error) {
         return error == null ? "" : String.valueOf(error.getMessage());
+    }
+
+    private Thread cancelAfter(CancellationToken token, long delayMillis) {
+        Thread thread = new Thread(() -> {
+            try {
+                Thread.sleep(delayMillis);
+                token.cancel();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        thread.start();
+        return thread;
     }
 
     private String fileUri(String path) {

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/FileSystemTest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/FileSystemTest.java
@@ -17,6 +17,7 @@ import io.daytona.toolbox.client.api.FileSystemApi;
 import io.daytona.toolbox.client.model.Match;
 import io.daytona.toolbox.client.model.ReplaceRequest;
 import io.daytona.toolbox.client.model.SearchFilesResponse;
+import okio.Buffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,10 +33,13 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -166,6 +170,125 @@ class FileSystemTest {
     }
 
     @Test
+    void downloadFileStreamWithProgressCallsCallback() throws Exception {
+        byte[] content = "hello progress".getBytes(StandardCharsets.UTF_8);
+        String multipart = "--DAYTONA-FILE-BOUNDARY\r\n"
+                + "Content-Disposition: form-data; name=\"file\"; filename=\"remote.txt\"\r\n"
+                + "Content-Type: application/octet-stream\r\n"
+                + "Content-Length: " + content.length + "\r\n"
+                + "\r\n"
+                + new String(content, StandardCharsets.UTF_8)
+                + "\r\n--DAYTONA-FILE-BOUNDARY--\r\n";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setHeader("Content-Type", "multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY")
+                    .setBody(multipart));
+
+            io.daytona.toolbox.client.ApiClient apiClient = new io.daytona.toolbox.client.ApiClient();
+            apiClient.setBasePath(server.url("/").toString());
+            FileSystem streamingFileSystem = new FileSystem(new FileSystemApi(apiClient));
+            List<DownloadProgress> progressUpdates = new ArrayList<DownloadProgress>();
+
+            try (InputStream stream = streamingFileSystem.downloadFileStream(
+                    "/remote.txt",
+                    new DownloadStreamOptions().setOnProgress(progressUpdates::add))) {
+                byte[] buffer = new byte[4];
+                int read;
+                StringBuilder received = new StringBuilder();
+                while ((read = stream.read(buffer)) != -1) {
+                    received.append(new String(buffer, 0, read, StandardCharsets.UTF_8));
+                }
+
+                assertThat(received.toString()).isEqualTo(new String(content, StandardCharsets.UTF_8));
+            }
+
+            assertThat(progressUpdates)
+                    .extracting(DownloadProgress::getBytesReceived)
+                    .isEqualTo(Arrays.asList(4L, 8L, 12L, (long) content.length));
+            assertThat(progressUpdates)
+                    .extracting(DownloadProgress::getTotalBytes)
+                    .containsOnly(OptionalLong.of(content.length));
+        }
+    }
+
+    @Test
+    void downloadFileStreamSingleByteReadThrottlesProgressEvents() throws Exception {
+        // 9216 bytes -> with the 8 KiB throttle on single-byte read(), the
+        // callback should fire once when total crosses 8192 and once on EOF.
+        byte[] content = new byte[9216];
+        java.util.Arrays.fill(content, (byte) 'a');
+        String multipart = "--DAYTONA-FILE-BOUNDARY\r\n"
+                + "Content-Disposition: form-data; name=\"file\"; filename=\"remote.txt\"\r\n"
+                + "Content-Type: application/octet-stream\r\n"
+                + "Content-Length: " + content.length + "\r\n"
+                + "\r\n"
+                + new String(content, StandardCharsets.UTF_8)
+                + "\r\n--DAYTONA-FILE-BOUNDARY--\r\n";
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setHeader("Content-Type", "multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY")
+                    .setBody(multipart));
+
+            io.daytona.toolbox.client.ApiClient apiClient = new io.daytona.toolbox.client.ApiClient();
+            apiClient.setBasePath(server.url("/").toString());
+            FileSystem streamingFileSystem = new FileSystem(new FileSystemApi(apiClient));
+            List<DownloadProgress> progressUpdates = new ArrayList<DownloadProgress>();
+
+            try (InputStream stream = streamingFileSystem.downloadFileStream(
+                    "/remote.txt",
+                    new DownloadStreamOptions().setOnProgress(progressUpdates::add))) {
+                int totalRead = 0;
+                while (stream.read() != -1) {
+                    totalRead++;
+                }
+                assertThat(totalRead).isEqualTo(content.length);
+            }
+
+            assertThat(progressUpdates)
+                    .extracting(DownloadProgress::getBytesReceived)
+                    .isEqualTo(Arrays.asList(8192L, (long) content.length));
+        }
+    }
+
+    @Test
+    void downloadFileStreamCancellationCancelsRequest() throws Exception {
+        byte[] content = new byte[256 * 1024];
+        Arrays.fill(content, (byte) 'a');
+        Buffer multipart = new Buffer()
+                .writeUtf8("--DAYTONA-FILE-BOUNDARY\r\n")
+                .writeUtf8("Content-Disposition: form-data; name=\"file\"; filename=\"remote.txt\"\r\n")
+                .writeUtf8("Content-Type: application/octet-stream\r\n")
+                .writeUtf8("\r\n")
+                .write(content)
+                .writeUtf8("\r\n--DAYTONA-FILE-BOUNDARY--\r\n");
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse()
+                    .setHeader("Content-Type", "multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY")
+                    .setBody(multipart)
+                    .throttleBody(1024, 25, TimeUnit.MILLISECONDS));
+
+            io.daytona.toolbox.client.ApiClient apiClient = new io.daytona.toolbox.client.ApiClient();
+            apiClient.setBasePath(server.url("/").toString());
+            FileSystem streamingFileSystem = new FileSystem(new FileSystemApi(apiClient));
+            CancellationToken token = new CancellationToken();
+            Thread canceller = cancelAfter(token, 50L);
+
+            try (InputStream stream = streamingFileSystem.downloadFileStream(
+                    "/remote.txt",
+                    new DownloadStreamOptions().setCancellationToken(token))) {
+                assertThatThrownBy(stream::readAllBytes)
+                        .isInstanceOf(DaytonaException.class)
+                        .hasMessageContaining("cancel");
+            } finally {
+                canceller.join(1000L);
+            }
+        }
+    }
+
+    @Test
     void downloadFileStreamThrowsOnErrorPart() throws Exception {
         try (MockWebServer server = new MockWebServer()) {
             server.enqueue(new MockResponse()
@@ -185,6 +308,124 @@ class FileSystemTest {
                     .isInstanceOf(DaytonaNotFoundException.class)
                     .hasMessage("missing file");
         }
+    }
+
+    @Test
+    void uploadFileStreamSendsBytesAndFiresProgress() throws Exception {
+        byte[] payload = ("upload-stream-content-").repeat(8).getBytes(StandardCharsets.UTF_8);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200));
+
+            io.daytona.toolbox.client.ApiClient apiClient = new io.daytona.toolbox.client.ApiClient();
+            apiClient.setBasePath(server.url("/").toString());
+            FileSystem streamingFileSystem = new FileSystem(new FileSystemApi(apiClient));
+            List<UploadProgress> updates = new ArrayList<UploadProgress>();
+
+            streamingFileSystem.uploadFileStream(
+                    new java.io.ByteArrayInputStream(payload),
+                    "/remote.txt",
+                    new UploadStreamOptions().setOnProgress(updates::add));
+
+            // The recorded request body should contain both multipart parts and the
+            // file bytes verbatim — proves we actually streamed content to the server.
+            okhttp3.mockwebserver.RecordedRequest request = server.takeRequest();
+            assertThat(request.getMethod()).isEqualTo("POST");
+            assertThat(request.getPath()).endsWith("/files/bulk-upload");
+            String contentType = request.getHeader("Content-Type");
+            assertThat(contentType).startsWith("multipart/form-data");
+            byte[] bodyBytes = request.getBody().readByteArray();
+            assertThat(new String(bodyBytes, StandardCharsets.UTF_8)).contains("name=\"files[0].path\"");
+            assertThat(new String(bodyBytes, StandardCharsets.UTF_8)).contains("name=\"files[0].file\"");
+            assertThat(indexOfBytes(bodyBytes, payload)).isGreaterThanOrEqualTo(0);
+
+            assertThat(updates).isNotEmpty();
+            UploadProgress last = updates.get(updates.size() - 1);
+            assertThat(last.getBytesSent()).isEqualTo(payload.length);
+            assertThat(updates).extracting(UploadProgress::getBytesSent).isSorted();
+        }
+    }
+
+    @Test
+    void uploadFileStreamCancellationCancelsRequest() throws Exception {
+        byte[] payload = new byte[256 * 1024];
+        Arrays.fill(payload, (byte) 'b');
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200));
+
+            io.daytona.toolbox.client.ApiClient apiClient = new io.daytona.toolbox.client.ApiClient();
+            apiClient.setBasePath(server.url("/").toString());
+            FileSystem streamingFileSystem = new FileSystem(new FileSystemApi(apiClient));
+            CancellationToken token = new CancellationToken();
+            Thread canceller = cancelAfter(token, 50L);
+
+            try {
+                assertThatThrownBy(() -> streamingFileSystem.uploadFileStream(
+                        new SlowByteArrayInputStream(payload, 1024, 20L),
+                        "/remote.txt",
+                        new UploadStreamOptions().setCancellationToken(token)))
+                        .isInstanceOf(DaytonaException.class)
+                        .hasMessageContaining("cancel");
+            } finally {
+                canceller.join(1000L);
+            }
+        }
+    }
+
+    private static Thread cancelAfter(CancellationToken token, long delayMillis) {
+        Thread thread = new Thread(() -> {
+            try {
+                Thread.sleep(delayMillis);
+                token.cancel();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        thread.start();
+        return thread;
+    }
+
+    private static final class SlowByteArrayInputStream extends java.io.ByteArrayInputStream {
+        private final int maxChunkSize;
+        private final long delayMillis;
+
+        private SlowByteArrayInputStream(byte[] buf, int maxChunkSize, long delayMillis) {
+            super(buf);
+            this.maxChunkSize = maxChunkSize;
+            this.delayMillis = delayMillis;
+        }
+
+        @Override
+        public synchronized int read(byte[] b, int off, int len) {
+            sleepQuietly();
+            return super.read(b, off, Math.min(len, maxChunkSize));
+        }
+
+        @Override
+        public synchronized int read() {
+            sleepQuietly();
+            return super.read();
+        }
+
+        private void sleepQuietly() {
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static int indexOfBytes(byte[] haystack, byte[] needle) {
+        outer:
+        for (int i = 0; i <= haystack.length - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) continue outer;
+            }
+            return i;
+        }
+        return -1;
     }
 
     @Test

--- a/libs/sdk-python/src/daytona/__init__.py
+++ b/libs/sdk-python/src/daytona/__init__.py
@@ -45,7 +45,15 @@ if TYPE_CHECKING:
         DaytonaTimeoutError,
         DaytonaValidationError,
     )
-    from .common.filesystem import FileDownloadErrorDetails, FileDownloadRequest, FileDownloadResponse, FileUpload
+    from .common.filesystem import (
+        CancelEvent,
+        DownloadProgress,
+        FileDownloadErrorDetails,
+        FileDownloadRequest,
+        FileDownloadResponse,
+        FileUpload,
+        UploadProgress,
+    )
     from .common.image import Image
     from .common.lsp_server import LspCompletionPosition, LspLanguageId
     from .common.process import CodeRunParams, ExecuteResponse, ExecutionArtifacts, OutputHandler, SessionExecuteRequest
@@ -79,6 +87,9 @@ __all__ = [
     "FileDownloadRequest",
     "FileDownloadResponse",
     "FileDownloadErrorDetails",
+    "DownloadProgress",
+    "UploadProgress",
+    "CancelEvent",
     "FileUpload",
     "VolumeMount",
     "AsyncDaytona",
@@ -166,6 +177,9 @@ _DYNAMIC_IMPORTS: dict[str, str] = {
     "DaytonaConnectionError": "common.errors",
     # common.filesystem
     "FileDownloadErrorDetails": "common.filesystem",
+    "DownloadProgress": "common.filesystem",
+    "UploadProgress": "common.filesystem",
+    "CancelEvent": "common.filesystem",
     "FileDownloadRequest": "common.filesystem",
     "FileDownloadResponse": "common.filesystem",
     "FileUpload": "common.filesystem",

--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -2,17 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import inspect
 import io
 import os
-from collections.abc import AsyncIterator
+import secrets
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from contextlib import ExitStack
-from typing import Any, cast, overload
+from typing import Any, cast, final, overload
 
 import aiofiles
 import aiofiles.os
 import httpx
 from aiofiles.threadpool.binary import AsyncBufferedIOBase
 from python_multipart.multipart import MultipartParser, parse_options_header
+from typing_extensions import override
 
 from daytona_toolbox_api_client_async import (
     FileInfo,
@@ -29,10 +32,13 @@ from .._utils.otel_decorator import with_instrumentation
 from ..common.errors import DaytonaError
 from ..common.file_transfer import create_multipart_parser, parse_content_type_boundary, serialize_download_request
 from ..common.filesystem import (
+    CancelEvent,
+    DownloadProgress,
     FileDownloadErrorDetails,
     FileDownloadRequest,
     FileDownloadResponse,
     FileUpload,
+    UploadProgress,
     create_file_download_error,
     parse_file_download_error_payload,
     raise_if_stream_error,
@@ -174,7 +180,13 @@ class AsyncFileSystem:
 
     @intercept_errors(message_prefix="Failed to download file: ")
     @with_instrumentation()
-    async def download_file_stream(self, remote_path: str, timeout: int = 30 * 60) -> AsyncIterator[bytes]:
+    async def download_file_stream(
+        self,
+        remote_path: str,
+        timeout: int = 30 * 60,
+        on_progress: Callable[[DownloadProgress], Awaitable[None] | None] | None = None,
+        cancel_event: CancelEvent | None = None,
+    ) -> AsyncIterator[bytes]:
         """Downloads a single file from the Sandbox as a stream without buffering the entire file
         into memory. Returns an async iterator that yields file content in chunks, which can be piped
         directly to an HTTP response, written to a file incrementally, or processed on the fly.
@@ -184,12 +196,22 @@ class AsyncFileSystem:
                 on the sandbox working directory.
             timeout (int): Timeout for the download operation in seconds. 0 means no timeout.
                 Default is 30 minutes.
+            on_progress (Callable[[DownloadProgress], Awaitable[None] | None] | None): Optional
+                callback invoked with cumulative bytes received and total bytes, when known, as
+                the download progresses. May be either a regular function or an ``async def``
+                coroutine — coroutine returns are awaited before the next chunk is yielded.
+                Default is None.
+            cancel_event (CancelEvent | None): Optional ``asyncio.Event``-compatible token. When
+                set during streaming, the next chunk raises ``DaytonaError`` and the underlying
+                HTTP connection is closed. Standard ``asyncio.CancelledError`` from task
+                cancellation is also honoured automatically by the generator.
 
         Returns:
             AsyncIterator[bytes]: An async iterator yielding chunks of file content as bytes.
 
         Raises:
-            DaytonaError: If the file does not exist or access is denied.
+            DaytonaError: If the file does not exist, access is denied, or the download is
+                cancelled via ``cancel_event``.
 
         Example:
             ```python
@@ -198,9 +220,12 @@ class AsyncFileSystem:
                 async for chunk in await sandbox.fs.download_file_stream("workspace/large-file.bin"):
                     await f.write(chunk)
 
-            # Stream to an HTTP response (FastAPI)
-            return StreamingResponse(await sandbox.fs.download_file_stream("workspace/report.pdf"),
-                                     media_type="application/pdf")
+            # Cancel a download from another coroutine
+            import asyncio
+            cancel = asyncio.Event()
+            asyncio.get_running_loop().call_later(5.0, cancel.set)
+            async for chunk in await sandbox.fs.download_file_stream("workspace/big.bin", cancel_event=cancel):
+                process(chunk)
             ```
         """
 
@@ -209,22 +234,24 @@ class AsyncFileSystem:
 
             mode: str | None = None
             part_content_type: str | None = None
-            source: str | None = None
             header_field = bytearray()
             header_value = bytearray()
-            pending_headers: list[tuple[str, str]] = []
+            part_headers: dict[str, str] = {}
             error_buffer = bytearray()
-            events: list[tuple[str, Any]] = []
-            file_chunks: list[bytes] = []
+            pending_chunks: list[bytes] = []
             error_text: str | None = None
             error_details: FileDownloadErrorDetails | None = None
             received_file_data = False
+            bytes_received = 0
+            total_bytes: int | None = None
 
             def on_part_begin() -> None:
-                pending_headers.clear()
+                nonlocal total_bytes
+                part_headers.clear()
                 header_field.clear()
                 header_value.clear()
-                events.append(("begin", None))
+                error_buffer.clear()
+                total_bytes = None
 
             def on_header_field(data: bytes, start: int, end: int) -> None:
                 header_field.extend(data[start:end])
@@ -235,72 +262,67 @@ class AsyncFileSystem:
             def on_header_end() -> None:
                 field = bytes(header_field).decode("utf-8", errors="ignore").lower()
                 value = bytes(header_value).decode("utf-8", errors="ignore")
-                pending_headers.append((field, value))
+                part_headers[field] = value
                 header_field.clear()
                 header_value.clear()
 
             def on_headers_finished() -> None:
-                events.append(("headers_finished", dict(pending_headers)))
+                nonlocal mode, part_content_type, total_bytes
+                cd = part_headers.get("content-disposition", "")
+                _, cd_params = parse_options_header(cd)
+                name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
+                if not cd_params.get(b"filename"):
+                    raise DaytonaError("No source path found for this file")
+                part_content_type = part_headers.get("content-type")
+                cl = part_headers.get("content-length")
+                if cl is not None:
+                    try:
+                        total_bytes = int(cl)
+                    except (TypeError, ValueError):
+                        total_bytes = None
+                else:
+                    total_bytes = None
+                mode = name if name in ("file", "error") else None
 
             def on_part_data(data: bytes, start: int, end: int) -> None:
-                events.append(("data", bytes(data[start:end])))
+                if mode == "error":
+                    error_buffer.extend(data[start:end])
+                elif mode == "file":
+                    pending_chunks.append(bytes(data[start:end]))
 
             def on_part_end() -> None:
-                events.append(("end", None))
+                nonlocal mode, part_content_type, error_text, error_details
+                if mode == "error" and error_buffer:
+                    error_text, error_details = parse_file_download_error_payload(
+                        bytes(error_buffer),
+                        part_content_type,
+                    )
+                    error_buffer.clear()
+                mode = None
+                part_content_type = None
 
-            async def process_events() -> None:
-                nonlocal mode, part_content_type, source, error_text, error_details
-
-                for event_tag, event_payload in events:
-                    if event_tag == "begin":
-                        error_buffer.clear()
-                        mode = None
-                        part_content_type = None
-                        source = None
-
-                    elif event_tag == "headers_finished":
-                        hdrs = cast(dict[str, str], event_payload)
-                        cd = hdrs.get("content-disposition", "")
-                        _, cd_params = parse_options_header(cd)
-                        name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
-                        source = cd_params.get(b"filename", b"").decode("utf-8", errors="ignore") or None
-                        if not source:
-                            raise DaytonaError("No source path found for this file")
-                        part_content_type = hdrs.get("content-type")
-
-                        if name == "error":
-                            mode = "error"
-                        elif name == "file":
-                            mode = "file"
-
-                    elif event_tag == "data":
-                        part_data = event_payload
-                        if not isinstance(part_data, bytes):
-                            continue
-                        if mode == "error":
-                            error_buffer.extend(part_data)
-                        elif mode == "file":
-                            file_chunks.append(part_data)
-
-                    elif event_tag == "end":
-                        if mode == "error" and error_buffer:
-                            error_text, error_details = parse_file_download_error_payload(
-                                bytes(error_buffer),
-                                part_content_type,
-                            )
-                            error_buffer.clear()
-                        mode = None
-                        part_content_type = None
-                        source = None
+            async def drain() -> AsyncIterator[bytes]:
+                nonlocal received_file_data, bytes_received
+                if not pending_chunks:
+                    return
+                if cancel_event is not None and cancel_event.is_set():
+                    raise DaytonaError(f"Download cancelled: {remote_path}")
+                emitted = pending_chunks.copy()
+                pending_chunks.clear()
+                received_file_data = True
+                for piece in emitted:
+                    bytes_received += len(piece)
+                    if on_progress is not None:
+                        progress = DownloadProgress(bytes_received=bytes_received, total_bytes=total_bytes)
+                        if inspect.iscoroutinefunction(on_progress):
+                            await on_progress(progress)
+                        else:
+                            _ = on_progress(progress)
+                    yield piece
 
             httpx_timeout = None if timeout == 0 else timeout
             async with httpx.AsyncClient(timeout=httpx_timeout) as client:
-                async with client.stream(
-                    method,
-                    url,
-                    json=body,
-                    headers=headers,
-                ) as resp:
+                async with client.stream(method, url, json=body, headers=headers) as resp:
                     _ = resp.raise_for_status()
 
                     boundary = parse_content_type_boundary(resp.headers)
@@ -316,25 +338,13 @@ class AsyncFileSystem:
                     )
 
                     async for chunk in resp.aiter_bytes(64 * 1024):
-                        events.clear()
                         _ = parser.write(chunk)
-                        await process_events()
-                        if file_chunks:
-                            emitted_chunks = file_chunks.copy()
-                            file_chunks.clear()
-                            received_file_data = True
-                            for file_chunk in emitted_chunks:
-                                yield file_chunk
+                        async for piece in drain():
+                            yield piece
 
-                    events.clear()
                     parser.finalize()
-                    await process_events()
-                    if file_chunks:
-                        emitted_chunks = file_chunks.copy()
-                        file_chunks.clear()
-                        received_file_data = True
-                        for file_chunk in emitted_chunks:
-                            yield file_chunk
+                    async for piece in drain():
+                        yield piece
 
             raise_if_stream_error(remote_path, error_text, error_details, received_file_data)
 
@@ -419,7 +429,7 @@ class AsyncFileSystem:
                     header_value = bytearray()
                     pending_headers: list[tuple[str, str]] = []
                     error_buffer = bytearray()
-                    events: list[tuple[str, Any]] = []
+                    events: list[tuple[str, object]] = []
 
                     def on_part_begin() -> None:
                         # Keep callback-owned header state local and communicate via immutable
@@ -475,7 +485,7 @@ class AsyncFileSystem:
                                 source = None
 
                             elif event_tag == "headers_finished":
-                                hdrs: dict[str, str] = event_payload
+                                hdrs = cast(dict[str, str], event_payload)
                                 cd = hdrs.get("content-disposition", "")
                                 _, cd_params = parse_options_header(cd)
                                 name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
@@ -502,7 +512,7 @@ class AsyncFileSystem:
                                         meta.result = writer
 
                             elif event_tag == "data":
-                                part_data: bytes = event_payload
+                                part_data = cast(bytes, event_payload)
                                 if mode == "error":
                                     error_buffer.extend(part_data)
                                 elif mode == "file":
@@ -943,3 +953,270 @@ class AsyncFileSystem:
                         f"{response.status_code}: {detail}",
                         status_code=response.status_code,
                     )
+
+    @intercept_errors(message_prefix="Failed to upload file: ")
+    @with_instrumentation()
+    async def upload_file_stream(
+        self,
+        source: bytes | bytearray | str | io.IOBase | AsyncIterable[bytes] | object,
+        remote_path: str,
+        timeout: int = 30 * 60,
+        on_progress: Callable[[UploadProgress], Awaitable[None] | None] | None = None,
+        cancel_event: CancelEvent | None = None,
+    ) -> None:
+        """Uploads a single file to the Sandbox using true streaming, with optional progress
+        tracking and cancellation. Memory usage stays flat regardless of source size. The
+        HTTP layer uses chunked transfer encoding, so the source's natural EOF terminates
+        the upload — no advance size is needed.
+
+        Args:
+            source: Data to upload. Accepts:
+
+                * ``bytes`` / ``bytearray`` — uploaded from memory.
+                * ``str`` — treated as a local file path and read in chunks.
+                * sync file-like (anything with ``.read(n) -> bytes``) — streamed as-is.
+                * **async file-like** (anything with ``async def read(n) -> bytes``,
+                  e.g. an ``aiofiles`` handle) — streamed without ever blocking the loop.
+                * ``AsyncIterable[bytes]`` — yielded chunks are forwarded to the wire.
+            remote_path (str): Destination path in the Sandbox.
+            timeout (int): Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+            on_progress (Callable[[UploadProgress], Awaitable[None] | None] | None): Optional
+                callback invoked with cumulative bytes sent. May be sync or ``async def``
+                **when paired with an async source** (async file-like or ``AsyncIterable[bytes]``).
+                Sync sources (``bytes``, ``str`` path, sync file-like) require a sync callback
+                because the underlying httpx multipart serializer pulls bytes through a
+                synchronous ``.read()``; passing an async callback alongside a sync source
+                raises ``DaytonaError``.
+            cancel_event (CancelEvent | None): Optional ``asyncio.Event``-compatible token.
+                When set during streaming, the next chunk raises ``DaytonaError`` and
+                tears down the request. Standard ``asyncio.CancelledError`` from task
+                cancellation is also honoured automatically.
+
+        Raises:
+            DaytonaError: If the upload fails or is cancelled via ``cancel_event``.
+
+        Example:
+            ```python
+            import aiofiles, asyncio
+            cancel = asyncio.Event()
+            async with aiofiles.open("large_dataset.csv", "rb") as f:
+                await sandbox.fs.upload_file_stream(
+                    f,
+                    "tmp/dataset.csv",
+                    on_progress=lambda p: print(f"{p.bytes_sent} bytes sent"),
+                    cancel_event=cancel,
+                )
+            ```
+        """
+        if cancel_event is not None and cancel_event.is_set():
+            raise DaytonaError(f"Upload cancelled: {remote_path}")
+
+        _, url, headers, *_ = self._api_client._upload_files_serialize(None, None, None, None)
+        _ = headers.pop("Content-Type", None)
+
+        if _is_async_source(source):
+            # Async file-like / AsyncIterable need their own multipart body builder
+            # because httpx.files= demands a sync .read(). We build the multipart
+            # envelope as an async byte iterator and ship it via httpx.content=.
+            await self._upload_async_stream(
+                source,
+                remote_path,
+                url,
+                headers,
+                timeout,
+                on_progress,
+                cancel_event,
+            )
+            return
+
+        # Sync sources flow through httpx's native multipart serialiser. The
+        # _CountingUploadReader interleaves byte counting + cancel checks into
+        # each .read() call that httpx makes during serialisation. That .read()
+        # is necessarily synchronous, so an async on_progress can't be awaited
+        # there — fail loudly instead of silently dropping the coroutine.
+        if on_progress is not None and inspect.iscoroutinefunction(on_progress):
+            raise DaytonaError(
+                "An async on_progress callback is only supported with an async source"
+                + " (async file-like or AsyncIterable[bytes]). With a sync source pass a"
+                + " regular function, or convert the source to async."
+            )
+        # The iscoroutinefunction guard above ensures on_progress is a plain
+        # sync callable on this branch, so the cast to the narrower type the
+        # _CountingUploadReader constructor expects is safe.
+        sync_on_progress = cast(Callable[[UploadProgress], None] | None, on_progress)
+        with ExitStack() as stack:
+            stream = _open_upload_source(stack, source)
+            wrapped = _CountingUploadReader(stream, sync_on_progress, cancel_event, remote_path)
+
+            data_fields = {"files[0].path": remote_path}
+            # httpx accepts any IO[bytes]-shaped object as a multipart file; our
+            # _CountingUploadReader is RawIOBase but pyright can't see that the
+            # (filename, reader) tuple satisfies the structural FileTypes union,
+            # so we drop into Any for the call.
+            file_fields = cast(Any, {"files[0].file": (remote_path, wrapped)})
+
+            async with httpx.AsyncClient(timeout=timeout or None) as client:
+                response = await client.post(url, data=data_fields, files=file_fields, headers=headers)
+                _raise_for_upload_status(response)
+
+    async def _upload_async_stream(
+        self,
+        source: object,
+        remote_path: str,
+        url: str,
+        headers: dict[str, str],
+        timeout: int,
+        on_progress: Callable[[UploadProgress], Awaitable[None] | None] | None,
+        cancel_event: CancelEvent | None,
+    ) -> None:
+        boundary = "----DaytonaUpload" + secrets.token_hex(12)
+        envelope_header, envelope_trailer = _build_multipart_envelope(boundary, remote_path)
+
+        async def body_generator() -> AsyncIterator[bytes]:
+            yield envelope_header
+            sent = 0
+            async for chunk in _iter_async_source_chunks(source):
+                if cancel_event is not None and cancel_event.is_set():
+                    raise DaytonaError(f"Upload cancelled: {remote_path}")
+                if not chunk:
+                    continue
+                sent += len(chunk)
+                if on_progress is not None:
+                    progress = UploadProgress(bytes_sent=sent)
+                    if inspect.iscoroutinefunction(on_progress):
+                        await on_progress(progress)
+                    else:
+                        _ = on_progress(progress)
+                yield chunk
+            yield envelope_trailer
+
+        request_headers = dict(headers)
+        request_headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+
+        async with httpx.AsyncClient(timeout=timeout or None) as client:
+            response = await client.post(url, content=body_generator(), headers=request_headers)
+            _raise_for_upload_status(response)
+
+
+def _is_async_source(source: object) -> bool:
+    """A source is "async" if its ``read`` is a coroutine function (e.g. an aiofiles
+    file handle) or if it implements the ``__aiter__`` protocol. Sync ``IOBase`` and
+    bytes/str sources stay on the existing httpx-multipart path."""
+    if hasattr(source, "__aiter__"):
+        return True
+    read = getattr(source, "read", None)
+    return read is not None and inspect.iscoroutinefunction(read)
+
+
+async def _iter_async_source_chunks(source: object) -> AsyncIterator[bytes]:
+    """Yields bytes from either an async file-like (``async def read``) or an
+    ``AsyncIterable[bytes]``. Both variants are pulled in 64 KiB chunks; the async
+    iterable case forwards whatever sized chunks the producer emits."""
+    read = getattr(source, "read", None)
+    if read is not None and inspect.iscoroutinefunction(read):
+        while True:
+            chunk = cast(bytes, await read(64 * 1024))
+            if not chunk:
+                return
+            yield chunk
+
+    # The dispatch in upload_file_stream guarantees source has either an async
+    # `read` method (handled above) or implements `__aiter__`, so this branch
+    # is reached only with an AsyncIterable[bytes]. The cast lets pyright follow
+    # that invariant.
+    async for chunk in cast(AsyncIterable[bytes], source):
+        yield chunk
+
+
+_FILENAME_FORBIDDEN_CHARS = str.maketrans({'"': "_", "\\": "_", "\r": "_", "\n": "_"})
+
+
+def _build_multipart_envelope(boundary: str, remote_path: str) -> tuple[bytes, bytes]:
+    """Returns ``(header, trailer)`` byte strings for a single-file ``files[0]`` part
+    targeting the bulk-upload endpoint. The body of the file part goes between them.
+
+    The Content-Disposition filename is sanitized so a remote path containing quotes,
+    backslashes, or CR/LF can't break out of the header — the daemon doesn't actually
+    use this filename (the destination comes from the ``files[0].path`` text part), so
+    a lossy substitution is fine."""
+    filename = os.path.basename(remote_path).translate(_FILENAME_FORBIDDEN_CHARS) or "upload"
+    header = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="files[0].path"\r\n\r\n'
+        f"{remote_path}\r\n"
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="files[0].file"; filename="{filename}"\r\n'
+        "Content-Type: application/octet-stream\r\n\r\n"
+    ).encode("utf-8")
+    trailer = f"\r\n--{boundary}--\r\n".encode("utf-8")
+    return header, trailer
+
+
+def _raise_for_upload_status(response: httpx.Response) -> None:
+    if response.is_success:
+        return
+    try:
+        detail = ", ".join(response.json()["errors"])
+    except Exception:
+        detail = response.text
+    raise DaytonaError(
+        f"{response.status_code}: {detail}",
+        status_code=response.status_code,
+    )
+
+
+def _open_upload_source(stack: ExitStack, source: object) -> io.IOBase:
+    """Coerces ``upload_file_stream`` source variants into a uniform read-ready stream.
+
+    The stack owns closing any file we opened on the caller's behalf; file-like objects passed
+    in by the caller are returned untouched (caller retains ownership and lifecycle).
+    """
+    if isinstance(source, (bytes, bytearray)):
+        return io.BytesIO(bytes(source))
+    if isinstance(source, str):
+        return stack.enter_context(open(source, "rb"))
+    if hasattr(source, "read"):
+        # Caller-supplied IOBase (or duck-typed file-like). httpx will read
+        # from it via .read(); the cast is structural since pyright can't
+        # infer "anything with .read" implies io.IOBase.
+        return cast(io.IOBase, source)
+    raise DaytonaError(f"Unsupported upload source: {type(source).__name__}")
+
+
+@final
+class _CountingUploadReader(io.RawIOBase):
+    """File-like wrapper that meters bytes flowing into httpx and honours cancellation
+    between chunks."""
+
+    def __init__(
+        self,
+        source: io.IOBase,
+        on_progress: Callable[[UploadProgress], None] | None,
+        cancel_event: CancelEvent | None,
+        remote_path: str,
+    ) -> None:
+        super().__init__()
+        self._source = source
+        self._on_progress = on_progress
+        self._cancel_event = cancel_event
+        self._remote_path = remote_path
+        self._sent = 0
+
+    @override
+    def readable(self) -> bool:
+        return True
+
+    @override
+    def read(self, size: int = -1) -> bytes:
+        if self._cancel_event is not None and self._cancel_event.is_set():
+            raise DaytonaError(f"Upload cancelled: {self._remote_path}")
+        chunk = self._source.read(size)
+        if chunk:
+            self._sent += len(chunk)
+            if self._on_progress is not None:
+                self._on_progress(UploadProgress(bytes_sent=self._sent))
+        return chunk
+
+    @override
+    def readall(self) -> bytes:
+        return self.read(-1)

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 
 import io
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import ExitStack
-from typing import overload
+from typing import Any, cast, final, overload
 
 import httpx
 from python_multipart.multipart import MultipartParser, parse_options_header
+from typing_extensions import override
 
 from daytona_toolbox_api_client import (
     FileInfo,
@@ -27,10 +28,13 @@ from .._utils.otel_decorator import with_instrumentation
 from ..common.errors import DaytonaError
 from ..common.file_transfer import create_multipart_parser, parse_content_type_boundary, serialize_download_request
 from ..common.filesystem import (
+    CancelEvent,
+    DownloadProgress,
     FileDownloadErrorDetails,
     FileDownloadRequest,
     FileDownloadResponse,
     FileUpload,
+    UploadProgress,
     create_file_download_error,
     parse_file_download_error_payload,
     raise_if_stream_error,
@@ -170,7 +174,13 @@ class FileSystem:
 
     @intercept_errors(message_prefix="Failed to download file: ")
     @with_instrumentation()
-    def download_file_stream(self, remote_path: str, timeout: int = 30 * 60) -> Iterator[bytes]:
+    def download_file_stream(
+        self,
+        remote_path: str,
+        timeout: int = 30 * 60,
+        on_progress: Callable[[DownloadProgress], None] | None = None,
+        cancel_event: CancelEvent | None = None,
+    ) -> Iterator[bytes]:
         """Downloads a single file from the Sandbox as a stream without buffering the entire file
         into memory. Returns an iterator that yields file content in chunks, which can be piped
         directly to an HTTP response, written to a file incrementally, or processed on the fly.
@@ -180,12 +190,19 @@ class FileSystem:
                 on the sandbox working directory.
             timeout (int): Timeout for the download operation in seconds. 0 means no timeout.
                 Default is 30 minutes.
+            on_progress (Callable[[DownloadProgress], None] | None): Optional callback invoked with
+                cumulative bytes received and total bytes, when known, as the download progresses.
+                Default is None.
+            cancel_event (CancelEvent | None): Optional ``threading.Event``-compatible token. When
+                set during streaming, the next chunk raises ``DaytonaError`` and the underlying
+                HTTP connection is closed.
 
         Returns:
             Iterator[bytes]: An iterator yielding chunks of file content as bytes.
 
         Raises:
-            DaytonaError: If the file does not exist or access is denied.
+            DaytonaError: If the file does not exist, access is denied, or the download is
+                cancelled via ``cancel_event``.
 
         Example:
             ```python
@@ -194,9 +211,12 @@ class FileSystem:
                 for chunk in sandbox.fs.download_file_stream("workspace/large-file.bin"):
                     f.write(chunk)
 
-            # Stream to an HTTP response (Flask)
-            return Response(sandbox.fs.download_file_stream("workspace/report.pdf"),
-                            mimetype="application/pdf")
+            # Cancel an in-progress download from another thread
+            import threading
+            cancel = threading.Event()
+            threading.Timer(5.0, cancel.set).start()
+            for chunk in sandbox.fs.download_file_stream("workspace/big.bin", cancel_event=cancel):
+                process(chunk)
             ```
         """
 
@@ -205,21 +225,24 @@ class FileSystem:
 
             mode: str | None = None
             part_content_type: str | None = None
-            source: str | None = None
             header_field = bytearray()
             header_value = bytearray()
             part_headers: dict[str, str] = {}
             error_buffer = bytearray()
-            file_chunks: list[bytes] = []
+            pending_chunks: list[bytes] = []
             error_text: str | None = None
             error_details: FileDownloadErrorDetails | None = None
             received_file_data = False
+            bytes_received = 0
+            total_bytes: int | None = None
 
             def on_part_begin() -> None:
+                nonlocal total_bytes
                 part_headers.clear()
                 header_field.clear()
                 header_value.clear()
                 error_buffer.clear()
+                total_bytes = None
 
             def on_header_field(data: bytes, start: int, end: int) -> None:
                 header_field.extend(data[start:end])
@@ -235,29 +258,31 @@ class FileSystem:
                 header_value.clear()
 
             def on_headers_finished() -> None:
-                nonlocal mode, part_content_type, source
+                nonlocal mode, part_content_type, total_bytes
                 cd = part_headers.get("content-disposition", "")
                 _, cd_params = parse_options_header(cd)
                 name = cd_params.get(b"name", b"").decode("utf-8", errors="ignore")
-                source = cd_params.get(b"filename", b"").decode("utf-8", errors="ignore") or None
-                if not source:
+                if not cd_params.get(b"filename"):
                     raise DaytonaError("No source path found for this file")
                 part_content_type = part_headers.get("content-type")
-
-                if name == "error":
-                    mode = "error"
-                elif name == "file":
-                    mode = "file"
+                cl = part_headers.get("content-length")
+                if cl is not None:
+                    try:
+                        total_bytes = int(cl)
+                    except (TypeError, ValueError):
+                        total_bytes = None
+                else:
+                    total_bytes = None
+                mode = name if name in ("file", "error") else None
 
             def on_part_data(data: bytes, start: int, end: int) -> None:
-                part_data = data[start:end]
                 if mode == "error":
-                    error_buffer.extend(part_data)
+                    error_buffer.extend(data[start:end])
                 elif mode == "file":
-                    file_chunks.append(part_data)
+                    pending_chunks.append(bytes(data[start:end]))
 
             def on_part_end() -> None:
-                nonlocal mode, part_content_type, source, error_text, error_details
+                nonlocal mode, part_content_type, error_text, error_details
                 if mode == "error" and error_buffer:
                     error_text, error_details = parse_file_download_error_payload(
                         bytes(error_buffer),
@@ -266,16 +291,25 @@ class FileSystem:
                     error_buffer.clear()
                 mode = None
                 part_content_type = None
-                source = None
+
+            def drain() -> Iterator[bytes]:
+                nonlocal received_file_data, bytes_received
+                if not pending_chunks:
+                    return
+                if cancel_event is not None and cancel_event.is_set():
+                    raise DaytonaError(f"Download cancelled: {remote_path}")
+                emitted = pending_chunks.copy()
+                pending_chunks.clear()
+                received_file_data = True
+                for piece in emitted:
+                    bytes_received += len(piece)
+                    if on_progress is not None:
+                        on_progress(DownloadProgress(bytes_received=bytes_received, total_bytes=total_bytes))
+                    yield piece
 
             httpx_timeout = None if timeout == 0 else timeout
             with httpx.Client(timeout=httpx_timeout) as client:
-                with client.stream(
-                    method,
-                    url,
-                    json=body,
-                    headers=headers,
-                ) as resp:
+                with client.stream(method, url, json=body, headers=headers) as resp:
                     _ = resp.raise_for_status()
 
                     boundary = parse_content_type_boundary(resp.headers)
@@ -292,18 +326,10 @@ class FileSystem:
 
                     for chunk in resp.iter_bytes(64 * 1024):
                         _ = parser.write(chunk)
-                        if file_chunks:
-                            emitted_chunks = file_chunks.copy()
-                            file_chunks.clear()
-                            received_file_data = True
-                            yield from emitted_chunks
+                        yield from drain()
 
                     parser.finalize()
-                    if file_chunks:
-                        emitted_chunks = file_chunks.copy()
-                        file_chunks.clear()
-                        received_file_data = True
-                        yield from emitted_chunks
+                    yield from drain()
 
             raise_if_stream_error(remote_path, error_text, error_details, received_file_data)
 
@@ -886,3 +912,134 @@ class FileSystem:
                         f"{response.status_code}: {detail}",
                         status_code=response.status_code,
                     )
+
+    @intercept_errors(message_prefix="Failed to upload file: ")
+    @with_instrumentation()
+    def upload_file_stream(
+        self,
+        source: bytes | bytearray | str | io.IOBase,
+        remote_path: str,
+        timeout: int = 30 * 60,
+        on_progress: Callable[[UploadProgress], None] | None = None,
+        cancel_event: CancelEvent | None = None,
+    ) -> None:
+        """Uploads a single file to the Sandbox using true streaming, with optional progress
+        tracking and cancellation. Memory usage stays flat regardless of source size. The
+        HTTP layer uses chunked transfer encoding, so the source's natural EOF terminates
+        the upload — no advance size is needed.
+
+        Args:
+            source (bytes | bytearray | str | IOBase): Data to upload. ``bytes`` is uploaded
+                from memory; ``str`` is treated as a local file path and read in chunks; a
+                file-like object (anything implementing ``.read()``) is streamed as-is.
+            remote_path (str): Destination path in the Sandbox.
+            timeout (int): Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+            on_progress (Callable[[UploadProgress], None] | None): Optional callback invoked
+                with cumulative bytes sent.
+            cancel_event (CancelEvent | None): Optional ``threading.Event``-compatible token.
+                When set during streaming, the next chunk read raises ``DaytonaError`` and
+                tears down the request.
+
+        Raises:
+            DaytonaError: If the upload fails or is cancelled via ``cancel_event``.
+
+        Example:
+            ```python
+            import threading
+            cancel = threading.Event()
+            with open("large_dataset.csv", "rb") as f:
+                sandbox.fs.upload_file_stream(
+                    f,
+                    "tmp/dataset.csv",
+                    on_progress=lambda p: print(f"{p.bytes_sent} bytes sent"),
+                    cancel_event=cancel,
+                )
+            ```
+        """
+        if cancel_event is not None and cancel_event.is_set():
+            raise DaytonaError(f"Upload cancelled: {remote_path}")
+
+        with ExitStack() as stack:
+            stream = _open_upload_source(stack, source)
+            wrapped = _CountingUploadReader(stream, on_progress, cancel_event, remote_path)
+
+            data_fields = {"files[0].path": remote_path}
+            # httpx accepts any IO[bytes]-shaped object as a multipart file; our
+            # _CountingUploadReader is RawIOBase but pyright can't see that the
+            # (filename, reader) tuple satisfies the structural FileTypes union,
+            # so we drop into Any for the call.
+            file_fields = cast(Any, {"files[0].file": (remote_path, wrapped)})
+
+            _, url, headers, *_ = self._api_client._upload_files_serialize(None, None, None, None)
+            _ = headers.pop("Content-Type", None)
+
+            with httpx.Client(timeout=timeout or None) as client:
+                response = client.post(url, data=data_fields, files=file_fields, headers=headers)
+
+                if not response.is_success:
+                    try:
+                        detail = ", ".join(response.json()["errors"])
+                    except Exception:
+                        detail = response.text
+                    raise DaytonaError(
+                        f"{response.status_code}: {detail}",
+                        status_code=response.status_code,
+                    )
+
+
+def _open_upload_source(stack: ExitStack, source: object) -> io.IOBase:
+    """Coerces ``upload_file_stream`` source variants into a uniform read-ready stream.
+
+    The stack owns closing any file we opened on the caller's behalf; file-like objects passed
+    in by the caller are returned untouched (caller retains ownership and lifecycle).
+    """
+    if isinstance(source, (bytes, bytearray)):
+        return io.BytesIO(bytes(source))
+    if isinstance(source, str):
+        return stack.enter_context(open(source, "rb"))
+    if hasattr(source, "read"):
+        # Caller-supplied IOBase (or duck-typed file-like). httpx will read
+        # from it via .read(); the cast is structural since pyright can't
+        # infer "anything with .read" implies io.IOBase.
+        return cast(io.IOBase, source)
+    raise DaytonaError(f"Unsupported upload source: {type(source).__name__}")
+
+
+@final
+class _CountingUploadReader(io.RawIOBase):
+    """File-like wrapper that meters bytes flowing into httpx and honours cancellation
+    between chunks. ``read()`` is what httpx calls during multipart streaming, so the
+    cancellation check naturally interleaves with network progress."""
+
+    def __init__(
+        self,
+        source: io.IOBase,
+        on_progress: Callable[[UploadProgress], None] | None,
+        cancel_event: CancelEvent | None,
+        remote_path: str,
+    ) -> None:
+        super().__init__()
+        self._source = source
+        self._on_progress = on_progress
+        self._cancel_event = cancel_event
+        self._remote_path = remote_path
+        self._sent = 0
+
+    @override
+    def readable(self) -> bool:
+        return True
+
+    @override
+    def read(self, size: int = -1) -> bytes:
+        if self._cancel_event is not None and self._cancel_event.is_set():
+            raise DaytonaError(f"Upload cancelled: {self._remote_path}")
+        chunk = self._source.read(size)
+        if chunk:
+            self._sent += len(chunk)
+            if self._on_progress is not None:
+                self._on_progress(UploadProgress(bytes_sent=self._sent))
+        return chunk
+
+    @override
+    def readall(self) -> bytes:
+        return self.read(-1)

--- a/libs/sdk-python/src/daytona/common/filesystem.py
+++ b/libs/sdk-python/src/daytona/common/filesystem.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from .errors import DaytonaError, DaytonaValidationError, create_daytona_error
+
+
+@runtime_checkable
+class CancelEvent(Protocol):
+    """Duck-typed cancellation token. Compatible with ``threading.Event`` and
+    ``asyncio.Event`` (both expose ``is_set()``). When supplied to a streaming
+    download, the next chunk read after the event becomes set raises
+    ``DaytonaError``, closing the underlying HTTP connection."""
+
+    def is_set(self) -> bool:
+        ...
 
 
 @dataclass
@@ -23,6 +34,30 @@ class FileUpload:
 
     source: bytes | str
     destination: str
+
+
+@dataclass
+class DownloadProgress:
+    """Progress information for a streaming download.
+
+    Attributes:
+        bytes_received (int): Cumulative bytes received so far.
+        total_bytes (int | None): Total bytes expected, if known.
+    """
+
+    bytes_received: int
+    total_bytes: int | None = None
+
+
+@dataclass
+class UploadProgress:
+    """Progress information for a streaming upload.
+
+    Attributes:
+        bytes_sent (int): Cumulative bytes sent so far.
+    """
+
+    bytes_sent: int
 
 
 @dataclass

--- a/libs/sdk-python/tests/test_e2e.py
+++ b/libs/sdk-python/tests/test_e2e.py
@@ -15,12 +15,14 @@ from daytona import (
     CreateSandboxFromImageParams,
     CreateSandboxFromSnapshotParams,
     Daytona,
+    DownloadProgress,
     FileDownloadRequest,
     FileUpload,
     Image,
     PtySize,
-    Resources,
+    Sandbox,
     SessionExecuteRequest,
+    UploadProgress,
 )
 from daytona.common.errors import DaytonaError
 
@@ -227,7 +229,7 @@ def test_download_files_batch(sandbox):
 
 def test_download_file_stream_returns_exact_content(sandbox):
     expected = b"streamed content\nsecond line\n"
-    path = f"{FS_TEST_DIR}/streamed.txt"
+    path = f"{FS_TEST_DIR}/streamed-{uuid.uuid4().hex}.txt"
     sandbox.fs.upload_file(expected, path)
 
     content = b"".join(sandbox.fs.download_file_stream(path))
@@ -235,9 +237,51 @@ def test_download_file_stream_returns_exact_content(sandbox):
     assert content == expected
 
 
+def test_download_file_stream_on_progress(sandbox: Sandbox):
+    run_id = uuid.uuid4().hex
+    expected = ("progress-check-" + run_id).encode("utf-8") * 512
+    # Use a run-unique path to avoid interference when multiple E2E suites
+    # run concurrently against the same sandbox (e.g. nx run-many in CI).
+    path = f"{FS_TEST_DIR}/streamed-progress-{run_id}.txt"
+    sandbox.fs.upload_file(expected, path)
+    progress_updates: list[DownloadProgress] = []
+
+    content = b"".join(sandbox.fs.download_file_stream(path, on_progress=progress_updates.append))
+
+    assert content == expected
+    assert progress_updates
+    assert progress_updates[-1].bytes_received == len(expected)
+    assert progress_updates[-1].total_bytes == len(expected)
+    assert [progress.bytes_received for progress in progress_updates] == sorted(
+        progress.bytes_received for progress in progress_updates
+    )
+    assert all(progress.total_bytes == len(expected) for progress in progress_updates)
+
+
 def test_download_file_stream_nonexistent_file_raises(sandbox):
     with pytest.raises(DaytonaError):
         b"".join(sandbox.fs.download_file_stream(f"{FS_TEST_DIR}/stream-does-not-exist.txt"))
+
+
+def test_upload_file_stream_with_progress(sandbox: Sandbox):
+    import io as _io
+
+    run_id = uuid.uuid4().hex
+    payload = ("upload-stream-content-" + run_id).encode("utf-8") * 512
+    path = f"{FS_TEST_DIR}/upload-stream-{run_id}.bin"
+    progress: list[UploadProgress] = []
+
+    sandbox.fs.upload_file_stream(
+        _io.BytesIO(payload),
+        path,
+        on_progress=progress.append,
+    )
+
+    downloaded = b"".join(sandbox.fs.download_file_stream(path))
+    assert downloaded == payload
+    assert progress, "expected at least one progress event"
+    assert progress[-1].bytes_sent == len(payload)
+    assert [p.bytes_sent for p in progress] == sorted(p.bytes_sent for p in progress)
 
 
 def test_find_files_finds_text_content(sandbox):

--- a/libs/sdk-python/tests/test_filesystem.py
+++ b/libs/sdk-python/tests/test_filesystem.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from daytona.common.errors import DaytonaError
+from daytona.common.filesystem import DownloadProgress, UploadProgress
 
 
 def _build_multipart_body(
@@ -17,16 +19,38 @@ def _build_multipart_body(
     filename: str,
     payload: bytes,
     content_type: str = "application/octet-stream",
+    content_length: int | None = None,
 ) -> bytes:
+    headers = [
+        f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode("utf-8"),
+        f"Content-Type: {content_type}\r\n".encode("utf-8"),
+    ]
+    if content_length is not None:
+        headers.append(f"Content-Length: {content_length}\r\n".encode("utf-8"))
+
     return b"".join(
         [
             b"--" + boundary + b"\r\n",
-            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode("utf-8"),
-            f"Content-Type: {content_type}\r\n\r\n".encode("utf-8"),
+            *headers,
+            b"\r\n",
             payload,
             b"\r\n--" + boundary + b"--\r\n",
         ]
     )
+
+
+class _Response:
+    """Minimal stand-in for httpx.Response — only the bits the upload path checks."""
+
+    def __init__(self, status_code: int, text: str):
+        self.status_code = status_code
+        self.text = text
+        self.is_success = 200 <= status_code < 300
+
+    def json(self):
+        import json as _json
+
+        return _json.loads(self.text)
 
 
 class _SyncStreamResponse:
@@ -234,6 +258,45 @@ class TestSyncFileSystem:
             "headers": {"Authorization": "Bearer token"},
         }
 
+    def test_download_file_stream_calls_on_progress_with_total(self):
+        fs, api = self._make_fs()
+        remote_path = "workspace/file.txt"
+        boundary = b"sync-boundary"
+        payload = b"hello world"
+        multipart_body = _build_multipart_body(
+            boundary,
+            name="file",
+            filename=remote_path,
+            payload=payload,
+            content_length=len(payload),
+        )
+        payload_start = multipart_body.index(payload)
+        chunks = [
+            multipart_body[: payload_start + 5],
+            multipart_body[payload_start + 5 : payload_start + 9],
+            multipart_body[payload_start + 9 :],
+        ]
+        client = _SyncStreamClient(_SyncStreamResponse(chunks, boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {"Authorization": "Bearer token"},
+                {"paths": [remote_path]},
+            )
+        )
+        progress_updates: list[DownloadProgress] = []
+
+        with patch("daytona._sync.filesystem.httpx.Client", return_value=client):
+            streamed_chunks = list(fs.download_file_stream(remote_path, on_progress=progress_updates.append))
+
+        assert streamed_chunks == [b"hello", b" wor", b"ld"]
+        assert progress_updates == [
+            DownloadProgress(bytes_received=5, total_bytes=11),
+            DownloadProgress(bytes_received=9, total_bytes=11),
+            DownloadProgress(bytes_received=11, total_bytes=11),
+        ]
+
     def test_download_file_stream_raises_on_error_part(self):
         fs, api = self._make_fs()
         remote_path = "workspace/missing.txt"
@@ -262,6 +325,32 @@ class TestSyncFileSystem:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.error_code == "not_found"
+
+    def test_download_file_stream_cancel_event_aborts(self):
+        import threading
+
+        fs, api = self._make_fs()
+        remote_path = "workspace/file.txt"
+        boundary = b"sync-boundary"
+        payload = b"hello world"
+        multipart_body = _build_multipart_body(
+            boundary, name="file", filename=remote_path, payload=payload, content_length=len(payload)
+        )
+        payload_start = multipart_body.index(payload)
+        chunks = [multipart_body[: payload_start + 5], multipart_body[payload_start + 5 :]]
+        client = _SyncStreamClient(_SyncStreamResponse(chunks, boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [remote_path]})
+        )
+        cancel = threading.Event()
+
+        with patch("daytona._sync.filesystem.httpx.Client", return_value=client):
+            stream = fs.download_file_stream(remote_path, cancel_event=cancel)
+            first = next(stream)
+            assert first == b"hello"
+            cancel.set()
+            with pytest.raises(DaytonaError, match="cancelled"):
+                next(stream)
 
 
 class TestAsyncFileSystem:
@@ -376,6 +465,48 @@ class TestAsyncFileSystem:
         }
 
     @pytest.mark.asyncio
+    async def test_download_file_stream_calls_on_progress_with_total_async(self):
+        fs, api = self._make_fs()
+        remote_path = "workspace/file.txt"
+        boundary = b"async-boundary"
+        payload = b"hello world"
+        multipart_body = _build_multipart_body(
+            boundary,
+            name="file",
+            filename=remote_path,
+            payload=payload,
+            content_length=len(payload),
+        )
+        payload_start = multipart_body.index(payload)
+        chunks = [
+            multipart_body[: payload_start + 5],
+            multipart_body[payload_start + 5 : payload_start + 9],
+            multipart_body[payload_start + 9 :],
+        ]
+        client = _AsyncStreamClient(_AsyncStreamResponse(chunks, boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=(
+                "POST",
+                "https://download",
+                {"Authorization": "Bearer token"},
+                {"paths": [remote_path]},
+            )
+        )
+        progress_updates: list[DownloadProgress] = []
+
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            streamed_chunks = [
+                chunk async for chunk in await fs.download_file_stream(remote_path, on_progress=progress_updates.append)
+            ]
+
+        assert streamed_chunks == [b"hello", b" wor", b"ld"]
+        assert progress_updates == [
+            DownloadProgress(bytes_received=5, total_bytes=11),
+            DownloadProgress(bytes_received=9, total_bytes=11),
+            DownloadProgress(bytes_received=11, total_bytes=11),
+        ]
+
+    @pytest.mark.asyncio
     async def test_download_file_stream_raises_on_error_part(self):
         fs, api = self._make_fs()
         remote_path = "workspace/missing.txt"
@@ -404,3 +535,210 @@ class TestAsyncFileSystem:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.error_code == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_download_file_stream_cancel_event_aborts(self):
+        import asyncio
+
+        fs, api = self._make_fs()
+        remote_path = "workspace/file.txt"
+        boundary = b"async-boundary"
+        payload = b"hello world"
+        multipart_body = _build_multipart_body(
+            boundary, name="file", filename=remote_path, payload=payload, content_length=len(payload)
+        )
+        payload_start = multipart_body.index(payload)
+        chunks = [multipart_body[: payload_start + 5], multipart_body[payload_start + 5 :]]
+        client = _AsyncStreamClient(_AsyncStreamResponse(chunks, boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [remote_path]})
+        )
+        cancel = asyncio.Event()
+
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            stream = await fs.download_file_stream(remote_path, cancel_event=cancel)
+            first = await stream.__anext__()
+            assert first == b"hello"
+            cancel.set()
+            with pytest.raises(DaytonaError, match="cancelled"):
+                await stream.__anext__()
+
+    @pytest.mark.asyncio
+    async def test_upload_file_stream_accepts_async_iterable(self):
+        # AsyncIterable[bytes] sources go through the manual multipart path; we
+        # capture the request body and assert the chunks land verbatim between
+        # the multipart envelope, with progress firing once per source chunk.
+        fs, api = self._make_fs()
+        api._upload_files_serialize = MagicMock(return_value=(None, "https://upload", {}, None, None))
+
+        chunks_in = [b"chunk-one-", b"chunk-two-", b"chunk-three"]
+
+        async def source():
+            for chunk in chunks_in:
+                yield chunk
+
+        captured = {}
+
+        async def fake_post(url, content=None, headers=None, **kwargs):
+            collected = bytearray()
+            async for piece in content:
+                collected.extend(piece)
+            captured["body"] = bytes(collected)
+            captured["headers"] = headers
+            return _Response(200, "")
+
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.post = fake_post
+
+        progress: list[UploadProgress] = []
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            await fs.upload_file_stream(
+                source(),
+                "/remote/path.bin",
+                on_progress=progress.append,
+            )
+
+        body = captured["body"]
+        assert b'name="files[0].path"' in body
+        assert b'name="files[0].file"' in body
+        assert b"".join(chunks_in) in body
+        assert captured["headers"]["Content-Type"].startswith("multipart/form-data; boundary=")
+        assert [p.bytes_sent for p in progress] == [10, 20, 31]
+
+    @pytest.mark.asyncio
+    async def test_upload_file_stream_accepts_async_filelike(self):
+        # An object whose .read is a coroutine (mirrors aiofiles) is detected
+        # via inspect.iscoroutinefunction and pulled in 64 KiB chunks.
+        fs, api = self._make_fs()
+        api._upload_files_serialize = MagicMock(return_value=(None, "https://upload", {}, None, None))
+
+        payload = b"async-filelike-payload-" * 8
+
+        class FakeAioFile:
+            def __init__(self, data: bytes) -> None:
+                self._buf = data
+                self._pos = 0
+
+            async def read(self, n: int) -> bytes:
+                chunk = self._buf[self._pos : self._pos + n]
+                self._pos += len(chunk)
+                return chunk
+
+        captured = {}
+
+        async def fake_post(url, content=None, headers=None, **kwargs):
+            collected = bytearray()
+            async for piece in content:
+                collected.extend(piece)
+            captured["body"] = bytes(collected)
+            return _Response(200, "")
+
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.post = fake_post
+
+        progress: list[UploadProgress] = []
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            await fs.upload_file_stream(
+                FakeAioFile(payload),
+                "/remote/aiof.bin",
+                on_progress=progress.append,
+            )
+
+        assert payload in captured["body"]
+        assert progress
+        assert progress[-1].bytes_sent == len(payload)
+
+    @pytest.mark.asyncio
+    async def test_upload_file_stream_awaits_async_on_progress(self):
+        # Async on_progress is awaited so async work (e.g. DB writes) actually
+        # runs before the next chunk is yielded — passing an async callback
+        # should never silently drop a coroutine.
+        fs, api = self._make_fs()
+        api._upload_files_serialize = MagicMock(return_value=(None, "https://upload", {}, None, None))
+
+        observed: list[UploadProgress] = []
+
+        async def on_progress(p: UploadProgress) -> None:
+            # Real async work — yields control to the loop, proving the await
+            # is actually happening rather than the callback being a coroutine
+            # function that we synchronously called and abandoned.
+            await asyncio.sleep(0)
+            observed.append(p)
+
+        async def source():
+            yield b"async-callback-chunk-one"
+            yield b"async-callback-chunk-two"
+
+        async def fake_post(url, content=None, headers=None, **kwargs):
+            collected = bytearray()
+            async for piece in content:
+                collected.extend(piece)
+            return _Response(200, "")
+
+        client = MagicMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client.post = fake_post
+
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            await fs.upload_file_stream(
+                source(),
+                "/remote/awaited.bin",
+                on_progress=on_progress,
+            )
+
+        assert [p.bytes_sent for p in observed] == [24, 48]
+
+    @pytest.mark.asyncio
+    async def test_upload_file_stream_rejects_async_on_progress_with_sync_source(self):
+        # Sync sources flow through httpx's sync .read() pull, so an async
+        # on_progress can't be awaited. Fail loudly rather than silently
+        # dropping the coroutine the user passed.
+        fs, api = self._make_fs()
+        api._upload_files_serialize = MagicMock(return_value=(None, "https://upload", {}, None, None))
+
+        async def on_progress(p: UploadProgress) -> None:
+            pass
+
+        with pytest.raises(DaytonaError, match="async source"):
+            await fs.upload_file_stream(
+                b"sync-bytes",
+                "/remote/sync.bin",
+                on_progress=on_progress,
+            )
+
+    @pytest.mark.asyncio
+    async def test_download_file_stream_awaits_async_on_progress(self):
+        fs, api = self._make_fs()
+        remote_path = "workspace/file.txt"
+        boundary = b"async-boundary"
+        payload = b"hello async progress"
+        multipart_body = _build_multipart_body(
+            boundary,
+            name="file",
+            filename=remote_path,
+            payload=payload,
+            content_length=len(payload),
+        )
+        client = _AsyncStreamClient(_AsyncStreamResponse([multipart_body], boundary))
+        api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [remote_path]})
+        )
+
+        observed: list[DownloadProgress] = []
+
+        async def on_progress(p: DownloadProgress) -> None:
+            await asyncio.sleep(0)
+            observed.append(p)
+
+        with patch("daytona._async.filesystem.httpx.AsyncClient", return_value=client):
+            chunks = [c async for c in await fs.download_file_stream(remote_path, on_progress=on_progress)]
+
+        assert b"".join(chunks) == payload
+        assert observed
+        assert observed[-1].bytes_received == len(payload)
+        assert observed[-1].total_bytes == len(payload)

--- a/libs/sdk-ruby/.rubocop.yml
+++ b/libs/sdk-ruby/.rubocop.yml
@@ -14,3 +14,9 @@ Style/Documentation:
 
 Style/AccessorGrouping:
   EnforcedStyle: separated
+
+# RSpec describe / context blocks naturally span the whole file; the
+# stock 25-line cap forces noise instead of catching real complexity.
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/libs/sdk-ruby/lib/daytona/file_system.rb
+++ b/libs/sdk-ruby/lib/daytona/file_system.rb
@@ -162,10 +162,17 @@ module Daytona
     #   based on the sandbox working directory.
     # @param timeout [Integer] Timeout for the download operation in seconds. 0 means no timeout.
     #   Default is 30 minutes.
+    # @param on_progress [Proc, nil] Optional callback invoked with a Daytona::DownloadProgress
+    #   struct containing bytes_received (Integer) and total_bytes (Integer or nil).
+    # @param cancel_event [#set?, nil] Optional cancellation token (anything responding to +set?+;
+    #   the standard library's +Concurrent::Event+ or a small ad-hoc object both work). When set
+    #   during streaming, the next chunk raises Daytona::Sdk::Error and the underlying HTTP
+    #   connection is torn down.
     # @yield [chunk] Yields each chunk of file content as it arrives
     # @yieldparam chunk [String] A binary string chunk of file content
     # @return [Enumerator, nil] An Enumerator yielding chunks if no block given, nil otherwise
-    # @raise [Daytona::Sdk::Error] If the file does not exist or the operation fails
+    # @raise [Daytona::Sdk::Error] If the file does not exist, the operation fails, or
+    #   +cancel_event+ is set during streaming
     #
     # @example Stream to a local file without loading into memory
     #   File.open("local_copy.bin", "wb") do |f|
@@ -175,11 +182,12 @@ module Daytona
     # @example Collect chunks with an Enumerator
     #   content = sandbox.fs.download_file_stream("workspace/data.json").reduce(:+)
     #   puts content
-    def download_file_stream(remote_path, timeout: 30 * 60, &)
-      return enum_for(__method__, remote_path, timeout:) unless block_given?
+    def download_file_stream(remote_path, timeout: 30 * 60, on_progress: nil, cancel_event: nil, &)
+      return enum_for(__method__, remote_path, timeout:, on_progress:, cancel_event:) unless block_given?
 
       FileTransfer.stream_download(api_client: toolbox_api.api_client, remote_path: remote_path,
-                                   timeout: timeout, &)
+                                   timeout: timeout, on_progress: on_progress,
+                                   cancel_event: cancel_event, &)
       nil
     rescue StandardError => e
       raise Sdk::Error, "Failed to download file: #{e.message}"
@@ -221,6 +229,36 @@ module Daytona
           toolbox_api.upload_file(remote_path, file)
         end
       end
+    rescue StandardError => e
+      raise Sdk::Error, "Failed to upload file: #{e.message}"
+    end
+
+    # Streams +source+ to the Sandbox without buffering its contents in memory, with
+    # optional progress reporting.
+    #
+    # @param source [String, IO] A local file path or any IO-like object responding to
+    #   +read(n)+. Strings that don't reference an existing file are uploaded as their
+    #   raw bytes (still streamed, just from memory).
+    # @param remote_path [String] Destination path in the Sandbox.
+    # @param timeout [Integer] Timeout in seconds. 0 means no timeout. Default 30 minutes.
+    # @param on_progress [Proc, nil] Optional callback invoked with a
+    #   +Daytona::UploadProgress+ struct as libcurl reports bytes actually uploaded.
+    # @param cancel_event [#set?, nil] Optional cancellation token. When set while
+    #   staging a non-file source or during the libcurl upload, the operation raises
+    #   Daytona::Sdk::Error and the in-progress upload is aborted (no destination file
+    #   is left on the sandbox thanks to the daemon's atomic-rename behaviour).
+    # @return [void]
+    # @raise [Daytona::Sdk::Error] If the operation fails or +cancel_event+ is set.
+    #
+    # @example
+    #   File.open("large.bin", "rb") do |f|
+    #     sandbox.fs.upload_file_stream(f, "tmp/large.bin",
+    #       on_progress: ->(p) { puts "#{p.bytes_sent} bytes sent" })
+    #   end
+    def upload_file_stream(source, remote_path, timeout: 30 * 60, on_progress: nil, cancel_event: nil)
+      FileTransfer.stream_upload(api_client: toolbox_api.api_client, remote_path: remote_path,
+                                 source: source, timeout: timeout, on_progress: on_progress,
+                                 cancel_event: cancel_event)
     rescue StandardError => e
       raise Sdk::Error, "Failed to upload file: #{e.message}"
     end

--- a/libs/sdk-ruby/lib/daytona/file_transfer.rb
+++ b/libs/sdk-ruby/lib/daytona/file_transfer.rb
@@ -4,11 +4,20 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'stringio'
+require 'tempfile'
 require 'typhoeus'
 
 module Daytona
+  # Progress information for a streaming download.
+  DownloadProgress = Struct.new(:bytes_received, :total_bytes, keyword_init: true)
+
+  # Progress information for a streaming upload.
+  UploadProgress = Struct.new(:bytes_sent, keyword_init: true)
+
   class MultipartDownloadStreamParser
     attr_reader :error_message
+    attr_reader :part_total_bytes
     attr_writer :boundary_token
 
     def initialize(&on_file_chunk)
@@ -17,6 +26,7 @@ module Daytona
       @buffer = String.new.b
       @state = :preamble
       @part_name = nil
+      @part_total_bytes = nil
       @error_buffer = String.new.b
     end
 
@@ -62,14 +72,14 @@ module Daytona
     end
 
     def consume_headers?
-      separator = "\r\n\r\n".b
-      index = @buffer.index(separator)
+      index = @buffer.index("\r\n\r\n".b)
       return false unless index
 
       headers = @buffer.byteslice(0, index)
-      @buffer = remaining_bytes(index + separator.bytesize)
-      @part_name = headers[/Content-Disposition:\s*[^\r\n]*\bname="([^"]+)"/i, 1]
-      raise Sdk::Error, 'Invalid multipart response' if @part_name.nil?
+      @buffer = remaining_bytes(index + 4)
+      @part_name = headers[/Content-Disposition:\s*[^\r\n]*\bname="([^"]+)"/i, 1] ||
+                   raise(Sdk::Error, 'Invalid multipart response')
+      @part_total_bytes = headers[/Content-Length:\s*(\d+)/i, 1]&.to_i
 
       @state = :body
       true
@@ -124,16 +134,11 @@ module Daytona
       false
     end
 
-    def remaining_bytes(offset)
-      @buffer.byteslice(offset, @buffer.bytesize - offset) || String.new.b
-    end
-
-    def boundary
-      "--#{@boundary_token}".b
-    end
+    def remaining_bytes(offset) = @buffer.byteslice(offset, @buffer.bytesize - offset) || String.new.b
+    def boundary = "--#{@boundary_token}".b
   end
 
-  module FileTransfer
+  module FileTransfer # rubocop:disable Metrics/ModuleLength
     def self.extract_multipart_boundary(content_type)
       match = content_type&.match(/boundary=(?:"([^"]+)"|([^;]+))/i)
       return unless match
@@ -141,9 +146,31 @@ module Daytona
       match.captures.compact.first
     end
 
-    def self.stream_download(api_client:, remote_path:, timeout:, &) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def self.assign_download_boundary(parser, content_type)
+      boundary = extract_multipart_boundary(content_type)
+      raise Sdk::Error, 'Missing multipart boundary in download response' unless boundary
+
+      parser.boundary_token = boundary
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def self.stream_download(api_client:, remote_path:, timeout:, on_progress: nil, cancel_event: nil, &block)
       config = api_client.config
-      parser = MultipartDownloadStreamParser.new(&)
+      bytes_received = 0
+      parser = nil
+      wrapped_block = proc do |chunk|
+        raise Sdk::Error, "Download cancelled: #{remote_path}" if cancel_event&.set?
+
+        if on_progress
+          bytes_received += chunk.bytesize
+          on_progress.call(DownloadProgress.new(
+                             bytes_received: bytes_received,
+                             total_bytes: parser&.part_total_bytes
+                           ))
+        end
+        block.call(chunk)
+      end
+      parser = MultipartDownloadStreamParser.new(&wrapped_block)
       response = nil
 
       request = Typhoeus::Request.new(
@@ -160,13 +187,15 @@ module Daytona
       )
 
       request.on_headers do |stream_response|
-        boundary = extract_multipart_boundary(stream_response.headers['Content-Type'])
-        raise Sdk::Error, 'Missing multipart boundary in download response' unless boundary
-
-        parser.boundary_token = boundary
+        assign_download_boundary(parser, stream_response.headers['Content-Type'])
       end
 
+      # Returning +:abort+ from the on_body callback tells libcurl to tear down the
+      # connection immediately, which is how cancellation actually severs the
+      # transfer rather than just stopping our own bookkeeping.
       request.on_body do |chunk|
+        next :abort if cancel_event&.set?
+
         parser << chunk
       end
 
@@ -177,8 +206,143 @@ module Daytona
 
       request.run
 
+      raise Sdk::Error, "Download cancelled: #{remote_path}" if cancel_event&.set?
       raise Sdk::Error, parser.error_message if parser.error_message
       raise Sdk::Error, "HTTP #{response.code}" if response && !response.success?
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    # Uploads +source+ to /files/bulk-upload via Typhoeus (libcurl), which streams the
+    # request body straight from disk without buffering it in memory. Local file paths
+    # are uploaded directly; in-memory IOs/bytes are first drained to a tempfile so we
+    # have a stable file handle for libcurl.
+    #
+    # The daemon owns atomicity (writes to a sibling tempfile then renames), so a
+    # client-side abort just leaves no destination file at all.
+    #
+    # @param api_client The OpenAPI-generated toolbox API client (auth/base-url only).
+    # @param remote_path [String] Destination path in the sandbox.
+    # @param source [String, IO] Local file path or any IO-like object responding to +read(n)+.
+    # @param timeout [Integer] Typhoeus timeout in seconds (0 disables).
+    # @param on_progress [Proc, nil] Optional callback invoked with +Daytona::UploadProgress+
+    #   as libcurl reports real network upload progress.
+    # @param cancel_event [#set?, nil] Optional cancellation token. Checked while staging
+    #   non-file sources and during the libcurl transfer itself.
+    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+    def self.stream_upload(api_client:, remote_path:, source:, timeout:, on_progress: nil, cancel_event: nil)
+      with_upload_file(source, cancel_event, remote_path) do |upload_path|
+        config = api_client.config
+        progress_callback = upload_progress_callback(on_progress, cancel_event)
+        response = with_open_upload_file(upload_path) do |file|
+          upload_request(
+            api_client: api_client,
+            config: config,
+            remote_path: remote_path,
+            file: file,
+            timeout: timeout,
+            progress_callback: progress_callback
+          ).run
+        end
+        raise_upload_error(response, cancel_event, remote_path)
+      end
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
+
+    # Yields a path on disk that holds the source's bytes, ready for libcurl to stream.
+    # Local files are passed through unchanged; everything else is drained into a
+    # tempfile that gets unlinked when we return.
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def self.with_upload_file(source, cancel_event, remote_path)
+      raise Sdk::Error, "Upload cancelled: #{remote_path}" if cancel_event&.set?
+
+      return yield(source) if source.is_a?(String) && File.exist?(source)
+
+      tmp = Tempfile.new(['daytona-upload-', File.extname(remote_path).to_s])
+      tmp.binmode
+      begin
+        drain_source_to(source, tmp, cancel_event, remote_path)
+        tmp.flush
+        tmp.close
+        yield(tmp.path)
+      ensure
+        tmp.close unless tmp.closed?
+        begin
+          tmp.unlink
+        rescue StandardError
+          # tempfile already gone, nothing to do
+        end
+      end
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def self.drain_source_to(source, sink, cancel_event, remote_path)
+      io, owns_io = open_drain_source(source)
+      begin
+        while (chunk = io.read(64 * 1024))
+          break if chunk.empty?
+          raise Sdk::Error, "Upload cancelled: #{remote_path}" if cancel_event&.set?
+
+          sink.write(chunk)
+        end
+      ensure
+        io.close if owns_io && io.respond_to?(:close)
+      end
+    end
+
+    def self.with_open_upload_file(upload_path)
+      file = File.open(upload_path, 'rb')
+      yield(file)
+    ensure
+      file.close if file && !file.closed?
+    end
+
+    # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+    def self.upload_request(api_client:, config:, remote_path:, file:, timeout:, progress_callback:)
+      Typhoeus::Request.new(
+        "#{config.base_url}/files/bulk-upload",
+        method: :post,
+        headers: api_client.default_headers.dup.tap { |h| h.delete('Content-Type') },
+        body: {
+          'files[0].path' => remote_path,
+          'files[0].file' => file
+        },
+        timeout: timeout,
+        ssl_verifypeer: config.verify_ssl,
+        ssl_verifyhost: config.verify_ssl_host ? 2 : 0,
+        noprogress: false,
+        progressfunction: progress_callback,
+        xferinfofunction: progress_callback
+      )
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
+
+    def self.upload_progress_callback(on_progress, cancel_event)
+      last_bytes_sent = -1
+
+      proc do |_clientp, _dltotal, _dlnow, _ultotal, ulnow|
+        next 1 if cancel_event&.set?
+
+        bytes_sent = ulnow.to_i
+        if on_progress && bytes_sent > last_bytes_sent
+          last_bytes_sent = bytes_sent
+          on_progress.call(UploadProgress.new(bytes_sent: bytes_sent))
+        end
+
+        0
+      end
+    end
+
+    def self.raise_upload_error(response, _cancel_event, remote_path)
+      raise Sdk::Error, "Upload timed out: #{remote_path}" if response.timed_out?
+      raise Sdk::Error, "Upload cancelled: #{remote_path}" if response.return_code == :aborted_by_callback
+      raise Sdk::Error, "HTTP #{response.code}: #{response.body}" unless response.success?
+    end
+
+    def self.open_drain_source(source)
+      return [source, false] if source.respond_to?(:read)
+      return [StringIO.new(source.b), true] if source.is_a?(String)
+
+      raise Sdk::Error, "Unsupported upload source: #{source.class}"
     end
   end
 end

--- a/libs/sdk-ruby/spec/daytona/config_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/config_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Daytona::Config do
       expect(config.api_key).to eq('explicit-key')
     end
 
-    it 'reads .env and .env.local without mutating ENV and prefers .env.local' do
+    it 'reads .env and .env.local without mutating ENV and prefers .env.local', :real_dotenv do
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, '.env'), <<~ENVFILE)
           DAYTONA_API_KEY=env-file-key

--- a/libs/sdk-ruby/spec/daytona/file_system_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/file_system_spec.rb
@@ -4,6 +4,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Daytona::FileSystem do
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def multipart_response(parts, boundary: 'DAYTONA-FILE-BOUNDARY')
     body = String.new.b
 
@@ -12,16 +13,18 @@ RSpec.describe Daytona::FileSystem do
       body << %(Content-Disposition: form-data; name="#{part.fetch(:name)}")
       body << %(; filename="#{part[:filename]}") if part[:filename]
       body << "\r\n"
-      body << "Content-Type: #{part.fetch(:content_type, 'application/octet-stream')}\r\n\r\n"
-      body << part.fetch(:body)
+      part_body = part.fetch(:body)
+      body << "Content-Type: #{part.fetch(:content_type, 'application/octet-stream')}\r\n"
+      body << "Content-Length: #{part_body.bytesize}\r\n\r\n"
+      body << part_body
       body << "\r\n"
     end
 
     body << "--#{boundary}--\r\n"
   end
 
-  def stub_streaming_request(chunks:, headers: { 'Content-Type' => 'multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY' },
-                             success: true, code: 200, body: nil)
+  def stub_streaming_request(chunks:, headers: nil, success: true, code: 200, body: nil)
+    headers ||= { 'Content-Type' => 'multipart/form-data; boundary=DAYTONA-FILE-BOUNDARY' }
     request = instance_double(Typhoeus::Request)
     callbacks = {}
 
@@ -37,6 +40,47 @@ RSpec.describe Daytona::FileSystem do
 
     request
   end
+
+  def build_cancel_event
+    Class.new do
+      def initialize
+        @set = false
+      end
+
+      def set!
+        @set = true
+      end
+
+      def set?
+        @set
+      end
+    end.new
+  end
+
+  def stub_upload_request(success: true, code: 200, body: '', return_code: :ok, timed_out: false, &block)
+    request = instance_double(Typhoeus::Request)
+    request_options = nil
+    response = instance_double(
+      Typhoeus::Response,
+      success?: success,
+      code: code,
+      body: body,
+      return_code: return_code,
+      timed_out?: timed_out
+    )
+
+    allow(Typhoeus::Request).to receive(:new) do |_url, options|
+      request_options = options
+      request
+    end
+    allow(request).to receive(:run) do
+      block&.call(request_options)
+      response
+    end
+
+    [request, response, -> { request_options }]
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   let(:toolbox_api) { instance_double(DaytonaToolboxApiClient::FileSystemApi) }
   let(:toolbox_api_config) { double('ToolboxConfig', base_url: 'https://toolbox.example.com', verify_ssl: true, verify_ssl_host: true) }
@@ -187,6 +231,18 @@ RSpec.describe Daytona::FileSystem do
       expect(enumerator.to_a.join).to eq('enumerated content')
     end
 
+    it 'calls on_progress with bytes_received and total_bytes' do
+      body = multipart_response([{ name: 'file', filename: 'remote.txt', body: 'hello world' }])
+      stub_streaming_request(chunks: [body])
+
+      progress_calls = []
+      fs.download_file_stream('/remote.txt', on_progress: ->(progress) { progress_calls << progress }) { |_chunk| nil }
+
+      expect(progress_calls).not_to be_empty
+      expect(progress_calls.last.bytes_received).to eq('hello world'.bytesize)
+      expect(progress_calls.last.total_bytes).to eq('hello world'.bytesize)
+    end
+
     it 'raises error when file not found' do
       body = multipart_response([
                                   { name: 'error', content_type: 'application/json',
@@ -196,6 +252,15 @@ RSpec.describe Daytona::FileSystem do
 
       expect { fs.download_file_stream('/missing.txt') { |_chunk| nil } }
         .to raise_error(Daytona::Sdk::Error, /Failed to download file: file not found/)
+    end
+
+    it 'aborts when cancel_event is set before the first chunk' do
+      body = multipart_response([{ name: 'file', filename: 'remote.txt', body: 'hello world' }])
+      stub_streaming_request(chunks: [body])
+      cancel = double('CancelEvent', set?: true)
+
+      expect { fs.download_file_stream('/remote.txt', cancel_event: cancel) { |_chunk| nil } }
+        .to raise_error(Daytona::Sdk::Error, /Failed to download file: Download cancelled/)
     end
   end
 
@@ -234,6 +299,57 @@ RSpec.describe Daytona::FileSystem do
       allow(toolbox_api).to receive(:upload_file).and_raise(StandardError, 'err')
 
       expect { fs.upload_file('data', '/x') }.to raise_error(Daytona::Sdk::Error, /Failed to upload file: err/)
+    end
+  end
+
+  describe '#upload_file_stream' do
+    it 'aborts when cancel_event is set before the upload starts' do
+      cancel = double('CancelEvent', set?: true)
+      io = StringIO.new('streamed-bytes')
+
+      expect { fs.upload_file_stream(io, '/remote.bin', cancel_event: cancel) }
+        .to raise_error(Daytona::Sdk::Error, /Failed to upload file: Upload cancelled/)
+    end
+
+    it 'cancels mid-upload from the libcurl progress callback' do
+      cancel = build_cancel_event
+      progress_calls = []
+      stub_upload_request(success: false, code: 0, return_code: :aborted_by_callback) do |options|
+        progress = options.fetch(:xferinfofunction)
+
+        expect(progress.call(nil, 0, 0, 128, 32)).to eq(0)
+        cancel.set!
+        expect(progress.call(nil, 0, 0, 128, 64)).to eq(1)
+      end
+
+      expect do
+        fs.upload_file_stream(
+          StringIO.new('streamed-bytes'),
+          '/remote.bin',
+          cancel_event: cancel,
+          on_progress: ->(p) { progress_calls << p }
+        )
+      end.to raise_error(Daytona::Sdk::Error, /Failed to upload file: Upload cancelled/)
+
+      expect(progress_calls.map(&:bytes_sent)).to eq([32])
+    end
+
+    it 'closes the upload file handle after the request completes' do
+      uploaded_file = nil
+      stub_upload_request do |options|
+        uploaded_file = options.dig(:body, 'files[0].file')
+        expect(uploaded_file).to be_a(File)
+        expect(uploaded_file.closed?).to be(false)
+      end
+
+      Dir.mktmpdir do |dir|
+        source_path = File.join(dir, 'upload.bin')
+        File.binwrite(source_path, 'payload')
+
+        fs.upload_file_stream(source_path, '/remote.bin')
+      end
+
+      expect(uploaded_file.closed?).to be(true)
     end
   end
 

--- a/libs/sdk-ruby/spec/e2e_spec.rb
+++ b/libs/sdk-ruby/spec/e2e_spec.rb
@@ -55,6 +55,31 @@ RSpec.describe 'Daytona SDK E2E', :e2e do
     error.is_a?(StandardError) ? error.message : error.to_s
   end
 
+  def build_cancel_event
+    Class.new do
+      def initialize
+        @set = false
+      end
+
+      def set!
+        @set = true
+      end
+
+      def set?
+        @set
+      end
+    end.new
+  end
+
+  def with_large_upload_file(size_mb)
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "upload-#{size_mb}mb.bin")
+      File.open(path, 'wb') { |file| file.truncate(size_mb * 1024 * 1024) }
+
+      yield path
+    end
+  end
+
   context 'Sandbox Lifecycle', order: :defined do
     it 'has a valid non-empty id' do
       expect(@sandbox.id).to be_a(String)
@@ -221,6 +246,86 @@ RSpec.describe 'Daytona SDK E2E', :e2e do
       @sandbox.fs.download_file_stream("#{@fs_dir}/stream.txt") { |chunk| chunks << chunk }
 
       expect(chunks.join).to eq('stream test content')
+    end
+
+    it 'calls on_progress during stream download' do
+      content = 'progress test content'
+      @sandbox.fs.upload_file(content.b, "#{@fs_dir}/progress.txt")
+
+      progress_calls = []
+      @sandbox.fs.download_file_stream(
+        "#{@fs_dir}/progress.txt",
+        on_progress: ->(progress) { progress_calls << progress }
+      ) { |_chunk| nil }
+
+      expect(progress_calls).not_to be_empty
+      expect(progress_calls.last.bytes_received).to eq(content.bytesize)
+      expect(progress_calls.last.total_bytes).to eq(content.bytesize)
+    end
+
+    it 'streams upload from an IO with progress' do
+      content = ('upload-stream-content-' * 512).b
+      progress_calls = []
+
+      io = StringIO.new(content)
+      @sandbox.fs.upload_file_stream(
+        io,
+        "#{@fs_dir}/upload-stream.bin",
+        on_progress: ->(p) { progress_calls << p }
+      )
+
+      chunks = []
+      @sandbox.fs.download_file_stream("#{@fs_dir}/upload-stream.bin") { |chunk| chunks << chunk }
+      expect(chunks.join.b).to eq(content)
+      expect(progress_calls).not_to be_empty
+      expect(progress_calls.last.bytes_sent).to be >= content.bytesize
+    end
+
+    it 'reports upload progress multiple times with increasing bytes_sent', timeout: 300 do
+      progress_values = []
+
+      with_large_upload_file(256) do |local_path|
+        @sandbox.fs.upload_file_stream(
+          local_path,
+          "#{@fs_dir}/upload-progress-large.bin",
+          timeout: 180,
+          on_progress: ->(progress) { progress_values << progress.bytes_sent }
+        )
+
+        unique_progress = progress_values.each_with_object([]) do |bytes_sent, memo|
+          memo << bytes_sent if bytes_sent.positive? && memo.last != bytes_sent
+        end
+
+        expect(unique_progress.length).to be > 1
+        expect(unique_progress).to eq(unique_progress.sort)
+        expect(unique_progress.last).to be >= File.size(local_path)
+      end
+    end
+
+    it 'cancels upload mid-transfer', timeout: 300 do
+      cancel_event = build_cancel_event
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      with_large_upload_file(512) do |local_path|
+        cancel_thread = Thread.new do
+          sleep 0.1
+          cancel_event.set!
+        end
+
+        expect do
+          @sandbox.fs.upload_file_stream(
+            local_path,
+            "#{@fs_dir}/upload-cancelled.bin",
+            timeout: 180,
+            cancel_event: cancel_event
+          )
+        end.to raise_error(Daytona::Sdk::Error, /Failed to upload file: Upload cancelled/)
+
+        cancel_thread.join
+      end
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      expect(elapsed).to be >= 0.1
     end
 
     it 'finds text content in files' do

--- a/libs/sdk-ruby/spec/spec_helper.rb
+++ b/libs/sdk-ruby/spec/spec_helper.rb
@@ -26,6 +26,34 @@ RSpec.configure do |config|
   config.before(:suite) do
     Daytona::Sdk.logger.level = Logger::FATAL
   end
+
+  # Auth/url resolution must be deterministic in tests, so:
+  #   1. Stub Dotenv.parse so .env / .env.local files are never consulted.
+  #   2. Snapshot and clear DAYTONA_* ENV vars around each example, so the
+  #      developer's shell or local-service env can't leak into a unit test
+  #      that asserts on the absence of credentials.
+  # E2E specs read DAYTONA_API_KEY / DAYTONA_API_URL up front (in before(:all)
+  # / before(:suite) hooks that run prior to each example's around block, or
+  # via a manually re-set ENV inside the spec) and so remain unaffected.
+  daytona_env_keys = %w[
+    DAYTONA_API_KEY
+    DAYTONA_JWT_TOKEN
+    DAYTONA_API_URL
+    DAYTONA_SERVER_URL
+    DAYTONA_TARGET
+    DAYTONA_ORGANIZATION_ID
+  ].freeze
+
+  config.before do |example|
+    allow(Dotenv).to receive(:parse).and_return({}) unless example.metadata[:real_dotenv]
+  end
+
+  config.around do |example|
+    saved = daytona_env_keys.to_h { |key| [key, ENV.delete(key)] }
+    example.run
+  ensure
+    saved.each { |key, value| value ? ENV[key] = value : ENV.delete(key) }
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -4,6 +4,7 @@
  */
 
 import * as pathe from 'pathe'
+import axios from 'axios'
 import {
   Configuration,
   FileInfo,
@@ -18,9 +19,12 @@ import { RUNTIME, Runtime } from './utils/Runtime'
 import { createDaytonaError, DaytonaError } from './errors/DaytonaError'
 import type { Readable } from 'stream'
 import {
+  coerceUploadSource,
+  createAbortError,
   normalizeResponseStream,
   processDownloadFilesResponseWithBusboy,
   processDownloadFilesResponseWithBuffered,
+  wrapWithUploadProgress,
 } from './utils/FileTransfer'
 import { WithInstrumentation } from './utils/otel.decorator'
 
@@ -121,6 +125,59 @@ export interface DownloadMetadata {
   error?: string
   errorDetails?: FileDownloadErrorDetails
   result?: Buffer | string | Uint8Array
+}
+
+export type DownloadProgress = {
+  /** Cumulative bytes received so far. */
+  bytesReceived: number
+  /** Total bytes expected, if known. Undefined if unavailable. */
+  totalBytes?: number
+}
+
+export type UploadProgress = {
+  /** Cumulative bytes sent so far. */
+  bytesSent: number
+}
+
+/**
+ * Options for streaming file downloads.
+ *
+ * @interface
+ * @property {number} [timeout] - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+ * @property {AbortSignal} [signal] - AbortSignal for cancelling the download.
+ * @property {(progress: DownloadProgress) => void} [onProgress] - Callback invoked with cumulative progress information.
+ */
+export type DownloadStreamOptions = {
+  /** Callback invoked with cumulative progress information as the download progresses. */
+  onProgress?: (progress: DownloadProgress) => void
+  /** AbortSignal for cancelling the download. */
+  signal?: AbortSignal
+  /** Timeout in seconds. 0 means no timeout. Default is 30 minutes. */
+  timeout?: number
+}
+
+/**
+ * Source for a streaming file upload. The same input shapes accepted by
+ * {@link FileSystem.uploadFile} are also valid here, plus Node `Readable`
+ * streams and Web `ReadableStream` instances.
+ */
+export type UploadSource = Buffer | Uint8Array | string | Readable | ReadableStream<Uint8Array>
+
+/**
+ * Options for streaming file uploads.
+ *
+ * @interface
+ * @property {number} [timeout] - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+ * @property {AbortSignal} [signal] - AbortSignal for cancelling the upload.
+ * @property {(progress: UploadProgress) => void} [onProgress] - Callback invoked with cumulative progress information.
+ */
+export type UploadStreamOptions = {
+  /** Callback invoked with cumulative progress information as the upload progresses. */
+  onProgress?: (progress: UploadProgress) => void
+  /** AbortSignal for cancelling the upload. */
+  signal?: AbortSignal
+  /** Timeout in seconds. 0 means no timeout. Default is 30 minutes. */
+  timeout?: number
 }
 
 function createFileDownloadError(error: string, errorDetails?: FileDownloadErrorDetails): DaytonaError {
@@ -241,7 +298,9 @@ export class FileSystem {
    *
    * @param {string} remotePath - Path to the file in the Sandbox. Relative paths are
    *   resolved based on the sandbox working directory.
-   * @param {number} [timeout] - Timeout in seconds. 0 means no timeout. Default is 30 minutes.
+   * @param {number | DownloadStreamOptions} [timeoutOrOptions] - Timeout in seconds, or an options
+   *   object with timeout, AbortSignal for cancellation, and/or onProgress callback.
+   *   Default timeout is 30 minutes.
    * @returns {Promise<Readable>} A Node.js Readable stream of the file content.
    *
    * @example
@@ -250,13 +309,24 @@ export class FileSystem {
    * stream.pipe(res);
    *
    * @example
-   * // Pipe to a local file
-   * import { createWriteStream } from 'fs';
-   * const stream = await sandbox.fs.downloadFileStream('outputs/data.csv');
-   * stream.pipe(createWriteStream('local-data.csv'));
+   * // Download with progress tracking and cancellation
+   * const controller = new AbortController();
+   * const stream = await sandbox.fs.downloadFileStream('outputs/large-file.bin', {
+   *   signal: controller.signal,
+   *   onProgress: ({ bytesReceived, totalBytes }) => console.log(bytesReceived, totalBytes),
+   * });
+   * stream.pipe(createWriteStream('local-file.bin'));
    */
+  public async downloadFileStream(remotePath: string, timeout?: number): Promise<Readable>
+  public async downloadFileStream(remotePath: string, options?: DownloadStreamOptions): Promise<Readable>
   @WithInstrumentation()
-  public async downloadFileStream(remotePath: string, timeout: number = 30 * 60): Promise<Readable> {
+  public async downloadFileStream(
+    remotePath: string,
+    timeoutOrOptions?: number | DownloadStreamOptions,
+  ): Promise<Readable> {
+    const options: DownloadStreamOptions =
+      typeof timeoutOrOptions === 'number' ? { timeout: timeoutOrOptions } : (timeoutOrOptions ?? {})
+    const timeout = options.timeout ?? 30 * 60
     const isNonStreamingRuntime = RUNTIME === Runtime.BROWSER || RUNTIME === Runtime.SERVERLESS
     if (isNonStreamingRuntime) {
       throw new DaytonaError(
@@ -264,13 +334,32 @@ export class FileSystem {
       )
     }
 
-    const response = await this.apiClient.downloadFiles(
-      { paths: [remotePath] },
-      {
-        responseType: 'stream',
-        timeout: timeout * 1000,
-      },
-    )
+    if (options.signal?.aborted) {
+      throw new DaytonaError('Download cancelled')
+    }
+
+    const toDownloadCancelledError = () => new DaytonaError('Download cancelled')
+    const isCanceledError = (err: unknown) => {
+      const error = err as { code?: string; name?: string }
+      return Boolean(axios.isCancel?.(err) || error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED')
+    }
+
+    let response
+    try {
+      response = await this.apiClient.downloadFiles(
+        { paths: [remotePath] },
+        {
+          responseType: 'stream',
+          timeout: timeout * 1000,
+          signal: options.signal,
+        },
+      )
+    } catch (err) {
+      if (options.signal?.aborted || isCanceledError(err)) {
+        throw toDownloadCancelledError()
+      }
+      throw err
+    }
 
     const responseStream = normalizeResponseStream(response.data)
     const metadataMap = new Map<string, DownloadMetadata>()
@@ -283,8 +372,22 @@ export class FileSystem {
         responseStream,
         response.headers as Record<string, string>,
         metadataMap,
-        (_source, fileStream) => {
-          resolvedStream = fileStream as Readable
+        (_source, fileStream, totalBytes) => {
+          if (options.onProgress) {
+            const { Transform } = require('stream') as typeof import('stream')
+            let bytesReceived = 0
+            const progress = new Transform({
+              transform(chunk, _encoding, callback) {
+                bytesReceived += chunk.length
+                options.onProgress!({ bytesReceived, totalBytes })
+                callback(null, chunk)
+              },
+            })
+            fileStream.pipe(progress)
+            resolvedStream = progress
+          } else {
+            resolvedStream = fileStream as Readable
+          }
           resolve(resolvedStream)
         },
       )
@@ -299,10 +402,13 @@ export class FileSystem {
           }
         })
         .catch((err) => {
+          const normalizedError = options.signal?.aborted || isCanceledError(err) ? toDownloadCancelledError() : err
           if (!resolvedStream) {
-            reject(err)
+            reject(normalizedError)
           } else if (!resolvedStream.destroyed) {
-            resolvedStream.destroy(err instanceof Error ? err : new Error(String(err)))
+            resolvedStream.destroy(
+              normalizedError instanceof Error ? normalizedError : new Error(String(normalizedError)),
+            )
           }
         })
     })
@@ -562,6 +668,78 @@ export class FileSystem {
   @WithInstrumentation()
   public async uploadFile(src: string | Buffer, dst: string, timeout: number = 30 * 60): Promise<void> {
     await this.uploadFiles([{ source: src, destination: dst }], timeout)
+  }
+
+  /**
+   * Uploads a single file to the Sandbox using true streaming, with optional progress
+   * tracking and cancellation. Memory usage stays flat regardless of source size: the
+   * SDK pipes the source through a transform that counts bytes and forwards to the
+   * underlying multipart upload without buffering the whole payload. The HTTP layer
+   * uses chunked transfer encoding, so the source's natural EOF terminates the upload —
+   * no advance size is needed.
+   *
+   * @param {UploadSource} source - The data to upload. Accepts the same `Buffer | string`
+   *   inputs as {@link FileSystem.uploadFile}, plus Node `Readable` streams and Web
+   *   `ReadableStream` instances. When a string is passed, it is treated as a local
+   *   file path and read in streaming chunks.
+   * @param {string} remotePath - Destination path in the Sandbox. Relative paths are
+   *   resolved against the sandbox working directory.
+   * @param {UploadStreamOptions} [options] - Streaming options: AbortSignal, onProgress
+   *   callback, timeout.
+   * @returns {Promise<void>}
+   *
+   * @example
+   * // Upload a 2 GB file with progress tracking and the ability to cancel
+   * import { createReadStream } from 'fs';
+   * const controller = new AbortController();
+   * await sandbox.fs.uploadFileStream(createReadStream('big.bin'), 'tmp/big.bin', {
+   *   signal: controller.signal,
+   *   onProgress: ({ bytesSent }) => console.log(`${bytesSent} bytes sent`),
+   * });
+   */
+  @WithInstrumentation()
+  public async uploadFileStream(
+    source: UploadSource,
+    remotePath: string,
+    options: UploadStreamOptions = {},
+  ): Promise<void> {
+    const isNonStreamingRuntime =
+      RUNTIME === Runtime.DENO || RUNTIME === Runtime.BROWSER || RUNTIME === Runtime.SERVERLESS
+    if (isNonStreamingRuntime) {
+      throw new DaytonaError(
+        'uploadFileStream is not supported in browser, Deno, or serverless runtimes. Use uploadFile instead.',
+      )
+    }
+
+    if (options.signal?.aborted) {
+      throw createAbortError(remotePath)
+    }
+
+    const timeout = options.timeout ?? 30 * 60
+    const sourceStream = await coerceUploadSource(source)
+    const tracked = wrapWithUploadProgress(sourceStream, options.onProgress, options.signal)
+
+    const FormDataClass = (await dynamicImport('form-data', 'Uploading files is not supported: ')) as any
+    const form = new FormDataClass()
+    form.append('files[0].path', remotePath)
+    // No knownLength: form-data falls back to chunked transfer encoding, which the
+    // daemon's MultipartReader handles transparently. The source's EOF terminates
+    // the upload — no advance byte count needed.
+    form.append('files[0].file', tracked, { filename: remotePath })
+
+    try {
+      await this.apiClient.uploadFiles({
+        data: form,
+        maxRedirects: 0,
+        timeout: timeout * 1000,
+        signal: options.signal,
+      })
+    } catch (err) {
+      if (options.signal?.aborted) {
+        throw createAbortError(remotePath)
+      }
+      throw err
+    }
   }
 
   /**

--- a/libs/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -59,6 +59,22 @@ jest.mock(
   { virtual: true },
 )
 
+// Constructor-time auth/url resolution must be deterministic in tests, so
+// short-circuit DaytonaEnvReader to read process.env only — never the
+// developer's .env / .env.local files.
+jest.mock('../utils/Runtime', () => {
+  const actual = jest.requireActual('../utils/Runtime')
+  class TestEnvReader {
+    get(name: string): string | undefined {
+      if (!name.startsWith('DAYTONA_')) {
+        throw new Error(`DaytonaEnvReader: variable name must start with 'DAYTONA_', got '${name}'`)
+      }
+      return process.env[name]
+    }
+  }
+  return { ...actual, DaytonaEnvReader: TestEnvReader }
+})
+
 jest.mock('../Snapshot', () => {
   const SnapshotService = jest.fn().mockImplementation((...args: unknown[]) => {
     mockSnapshotServiceCtor(...args)

--- a/libs/sdk-typescript/src/__tests__/e2e.test.ts
+++ b/libs/sdk-typescript/src/__tests__/e2e.test.ts
@@ -1,7 +1,10 @@
 // Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { randomUUID } from 'node:crypto'
+
 import { Daytona } from '../Daytona'
+import { DaytonaError } from '../errors/DaytonaError'
 import { Image } from '../Image'
 import { Sandbox } from '../Sandbox'
 import { PtyHandle } from '../PtyHandle'
@@ -225,6 +228,100 @@ describe('TypeScript SDK E2E (real Daytona API)', () => {
 
     test('rejects stream download for non-existent file', async () => {
       await expect(sandbox.fs.downloadFileStream('fs-test/does-not-exist.txt')).rejects.toThrow()
+    })
+
+    test('stream download with onProgress tracks bytes', async () => {
+      const content = ('progress-tracking-content-' + randomUUID()).repeat(512)
+      await sandbox.fs.uploadFile(Buffer.from(content), 'fs-test/progress-test.txt')
+
+      const progressUpdates: { bytesReceived: number }[] = []
+      const stream = await sandbox.fs.downloadFileStream('fs-test/progress-test.txt', {
+        onProgress: (progress) => {
+          progressUpdates.push(progress)
+        },
+      })
+      const chunks: Buffer[] = []
+      await new Promise<void>((resolve, reject) => {
+        stream.on('data', (chunk: Buffer) => chunks.push(chunk))
+        stream.on('end', resolve)
+        stream.on('error', reject)
+      })
+
+      expect(Buffer.concat(chunks).toString()).toBe(content)
+      expect(progressUpdates.length).toBeGreaterThan(0)
+      const last = progressUpdates[progressUpdates.length - 1]
+      expect(last.bytesReceived).toBe(content.length)
+      const bytesReceivedValues = progressUpdates.map((p) => p.bytesReceived)
+      expect(bytesReceivedValues).toEqual([...bytesReceivedValues].sort((a, b) => a - b))
+    })
+
+    test('stream download with aborted signal rejects with DaytonaError', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      const error = await sandbox.fs
+        .downloadFileStream('fs-test/stream-test.txt', { signal: controller.signal })
+        .catch((err) => err)
+
+      expect(error).toBeInstanceOf(DaytonaError)
+      expect((error as Error).message).toMatch(/cancel/i)
+    })
+
+    test('download abort surfaces DaytonaError', async () => {
+      // Large enough to require multiple network chunks so abort fires mid-stream.
+      const content = Buffer.from(('download-abort-' + randomUUID()).repeat(1024 * 16))
+      await sandbox.fs.uploadFile(content, 'fs-test/download-abort.bin')
+
+      const controller = new AbortController()
+      const stream = await sandbox.fs.downloadFileStream('fs-test/download-abort.bin', { signal: controller.signal })
+
+      const error = await new Promise<unknown>((resolve, reject) => {
+        stream.once('data', () => controller.abort())
+        stream.once('error', resolve)
+        stream.once('end', () => reject(new Error('Expected download to be aborted')))
+        stream.resume()
+      })
+
+      expect(error).toBeInstanceOf(DaytonaError)
+      expect((error as Error).message).toMatch(/cancel/i)
+    })
+
+    test('uploadFileStream from a Readable source streams with progress', async () => {
+      const { Readable } = require('stream') as typeof import('stream')
+      const content = ('streamed-upload-' + randomUUID()).repeat(512)
+      const source = Readable.from(Buffer.from(content))
+      const progressUpdates: { bytesSent: number }[] = []
+
+      await sandbox.fs.uploadFileStream(source, 'fs-test/upload-stream.txt', {
+        onProgress: (p) => progressUpdates.push(p),
+      })
+
+      const downloaded = await sandbox.fs.downloadFile('fs-test/upload-stream.txt')
+      expect(downloaded.toString()).toBe(content)
+      expect(progressUpdates.length).toBeGreaterThan(0)
+      const last = progressUpdates[progressUpdates.length - 1]
+      expect(last.bytesSent).toBe(Buffer.byteLength(content))
+      const sent = progressUpdates.map((p) => p.bytesSent)
+      expect(sent).toEqual([...sent].sort((a, b) => a - b))
+    })
+
+    test('uploadFileStream with Buffer source reports bytesSent in progress', async () => {
+      const content = Buffer.from(('buffer-upload-progress-' + randomUUID()).repeat(1024))
+      const progressUpdates: { bytesSent: number }[] = []
+
+      await sandbox.fs.uploadFileStream(content, 'fs-test/upload-buffer-progress.txt', {
+        onProgress: (progress) => progressUpdates.push(progress),
+      })
+
+      expect(progressUpdates.length).toBeGreaterThan(0)
+      expect(progressUpdates[progressUpdates.length - 1]).toEqual({ bytesSent: content.length })
+    })
+
+    test('uploadFileStream rejects with a pre-aborted signal', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      await expect(
+        sandbox.fs.uploadFileStream(Buffer.from('x'), 'fs-test/upload-aborted.txt', { signal: controller.signal }),
+      ).rejects.toThrow(/cancelled/i)
     })
 
     test('downloadFiles batch returns multiple files', async () => {

--- a/libs/sdk-typescript/src/index.ts
+++ b/libs/sdk-typescript/src/index.ts
@@ -14,7 +14,12 @@ export type {
 } from './Daytona'
 export { FileSystem } from './FileSystem'
 export type {
+  DownloadProgress,
   DownloadMetadata,
+  DownloadStreamOptions,
+  UploadProgress,
+  UploadStreamOptions,
+  UploadSource,
   FileDownloadErrorDetails,
   FileDownloadRequest,
   FileDownloadResponse,

--- a/libs/sdk-typescript/src/utils/FileTransfer.ts
+++ b/libs/sdk-typescript/src/utils/FileTransfer.ts
@@ -5,12 +5,13 @@
 
 import { Buffer } from 'buffer'
 import busboy from 'busboy'
+import { pipeline, Readable, Transform } from 'stream'
 import { DaytonaError } from '../errors/DaytonaError'
 import { dynamicImport } from './Import'
 import { collectStreamBytes, toBuffer, toUint8Array } from './Binary'
 import { extractBoundary, getHeader, parseMultipartWithFormData } from './Multipart'
 import { parseMultipart } from './Multipart'
-import type { DownloadMetadata, FileDownloadErrorDetails } from '../FileSystem'
+import type { DownloadMetadata, FileDownloadErrorDetails, UploadProgress, UploadSource } from '../FileSystem'
 
 type DownloadErrorPartResult = {
   message: string
@@ -96,15 +97,135 @@ export function normalizeResponseStream(responseData: any): any {
 }
 
 /**
+ * Side-channel parser that runs alongside busboy. Busboy 1.x only exposes
+ * `{ filename, encoding, mimeType }` for each file part and discards the
+ * remaining headers, so it cannot surface `Content-Length` for progress
+ * reporting. This observer scans the raw byte stream — fed in lockstep via a
+ * `Transform` tap — and queues each part's `Content-Length`. The `'file'`
+ * event handler pops one value per emitted part, keeping the queue aligned
+ * with busboy's event order.
+ */
+class MultipartHeaderObserver {
+  private readonly boundary: Buffer
+  private readonly closingBoundary: Buffer
+  private buffer: Buffer = Buffer.alloc(0)
+  private state: 'preamble' | 'headers' | 'body' | 'done' = 'preamble'
+  private readonly queue: (number | undefined)[] = []
+
+  constructor(boundary: string) {
+    this.boundary = Buffer.from(`--${boundary}`)
+    this.closingBoundary = Buffer.concat([Buffer.from('\r\n'), this.boundary])
+  }
+
+  observe(chunk: Buffer): void {
+    if (this.state === 'done') return
+    this.buffer = Buffer.concat([this.buffer, chunk])
+    while (this.advance()) {
+      /* drive the state machine until it stalls awaiting more bytes */
+    }
+  }
+
+  /** Returns and removes the next part's Content-Length value (undefined when header was absent). */
+  next(): number | undefined {
+    return this.queue.shift()
+  }
+
+  private advance(): boolean {
+    switch (this.state) {
+      case 'preamble':
+        return this.consumeBoundary(0)
+      case 'headers':
+        return this.consumeHeaders()
+      case 'body':
+        return this.consumeBodyToBoundary()
+      default:
+        return false
+    }
+  }
+
+  private consumeHeaders(): boolean {
+    const sepIdx = this.buffer.indexOf(HEADER_SEPARATOR)
+    if (sepIdx < 0) {
+      this.retainTail(HEADER_SEPARATOR.length - 1)
+      return false
+    }
+    this.queue.push(parseContentLength(this.buffer.subarray(0, sepIdx)))
+    this.buffer = this.buffer.subarray(sepIdx + HEADER_SEPARATOR.length)
+    this.state = 'body'
+    return true
+  }
+
+  private consumeBodyToBoundary(): boolean {
+    const idx = this.buffer.indexOf(this.closingBoundary)
+    if (idx < 0) {
+      this.retainTail(this.closingBoundary.length - 1)
+      return false
+    }
+    // Skip the leading CRLF; the rest is a regular boundary line.
+    return this.consumeBoundary(idx + 2)
+  }
+
+  // Given a buffer position at-or-after "--boundary", advance past the boundary
+  // and its trailing CRLF (next part follows) or "--" (multipart terminator).
+  // Returns true to drive the outer loop, false when more bytes are needed.
+  private consumeBoundary(searchFrom: number): boolean {
+    const idx = this.buffer.indexOf(this.boundary, searchFrom)
+    if (idx < 0) {
+      this.retainTail(this.boundary.length - 1)
+      return false
+    }
+    const after = idx + this.boundary.length
+    if (this.buffer.length < after + 2) {
+      this.buffer = this.buffer.subarray(idx)
+      return false
+    }
+    if (this.buffer[after] === 0x2d /* '-' */ && this.buffer[after + 1] === 0x2d /* '-' */) {
+      this.state = 'done'
+      return false
+    }
+    if (this.buffer[after] === 0x0d /* CR */ && this.buffer[after + 1] === 0x0a /* LF */) {
+      this.buffer = this.buffer.subarray(after + 2)
+      this.state = 'headers'
+      return true
+    }
+    // The matched substring was not a real boundary delimiter — skip it.
+    return this.consumeBoundary(after)
+  }
+
+  private retainTail(keep: number): void {
+    if (keep > 0 && this.buffer.length > keep) {
+      this.buffer = this.buffer.subarray(this.buffer.length - keep)
+    }
+  }
+}
+
+const HEADER_SEPARATOR = Buffer.from('\r\n\r\n')
+
+function parseContentLength(headersBlock: Buffer): number | undefined {
+  const text = headersBlock.toString('latin1')
+  for (const line of text.split('\r\n')) {
+    const colon = line.indexOf(':')
+    if (colon <= 0) continue
+    if (line.slice(0, colon).trim().toLowerCase() !== 'content-length') continue
+    const value = Number.parseInt(line.slice(colon + 1).trim(), 10)
+    return Number.isFinite(value) && value >= 0 ? value : undefined
+  }
+  return undefined
+}
+
+/**
  * Processes multipart response using busboy (Node.js path)
  */
 export async function processDownloadFilesResponseWithBusboy(
   stream: any,
   headers: Record<string, string>,
   metadataMap: Map<string, DownloadMetadata>,
-  onFileStream?: (source: string, fileStream: any) => void,
+  onFileStream?: (source: string, fileStream: any, totalBytes?: number) => void,
 ): Promise<void> {
   const fileTasks: Promise<void>[] = []
+
+  const boundary = extractBoundary(getHeader(headers, 'content-type') || '')
+  const observer = boundary ? new MultipartHeaderObserver(boundary) : null
 
   await new Promise<void>((resolve, reject) => {
     const bb = busboy({
@@ -113,6 +234,10 @@ export async function processDownloadFilesResponseWithBusboy(
     })
 
     bb.on('file', (fieldName: string, fileStream: any, fileInfo: { filename?: string; mimeType?: string }) => {
+      // Pop one queued Content-Length for every emitted part to keep the
+      // observer's queue aligned with busboy's event order.
+      const totalBytes = observer?.next()
+
       const source = fileInfo?.filename
       if (!source) {
         abortStream(stream)
@@ -139,7 +264,7 @@ export async function processDownloadFilesResponseWithBusboy(
         })
       } else if (fieldName === 'file') {
         if (onFileStream) {
-          onFileStream(source, fileStream)
+          onFileStream(source, fileStream, totalBytes)
         } else if (metadata.destination) {
           // Stream to file
           fileTasks.push(
@@ -188,26 +313,63 @@ export async function processDownloadFilesResponseWithBusboy(
     bb.on('finish', resolve)
 
     // Feed stream into busboy
-    feedStreamToBusboy(stream, bb).catch((err) => bb.destroy(err as Error))
+    feedStreamToBusboy(stream, bb, observer).catch((err) => bb.destroy(err as Error))
   })
 
   await Promise.all(fileTasks)
 }
 
 /**
- * Feeds various stream types into busboy
+ * Feeds various stream types into busboy. When an observer is supplied, every
+ * chunk is also handed to the observer before being forwarded to busboy so
+ * per-part Content-Length can be queued in lockstep with busboy events.
  */
-async function feedStreamToBusboy(stream: any, bb: any): Promise<void> {
-  // Node.js stream (piping)
+async function feedStreamToBusboy(stream: any, bb: any, observer: MultipartHeaderObserver | null): Promise<void> {
+  const tap = (chunk: Buffer): Buffer => {
+    if (observer) observer.observe(chunk)
+    return chunk
+  }
+
+  // Node.js stream (piping). pipe() does NOT propagate errors from source to
+  // downstream, so we manually forward them so that mid-stream cancellations
+  // (e.g. AbortSignal firing after the response has started streaming) reach
+  // busboy and cause the outer Promise to reject correctly.
+  //
+  // Errors are normalized at the forwarding site so that axios "CanceledError"
+  // is already wrapped as DaytonaError by the time busboy's internal cleanup
+  // destroys the file stream — ensuring the stream returned to the caller
+  // always emits DaytonaError, not a raw library error.
   if (typeof stream?.pipe === 'function') {
-    stream.pipe(bb)
+    if (observer) {
+      const { Transform } = require('stream') as typeof import('stream')
+      const tapStream = new Transform({
+        transform(chunk: any, _encoding: BufferEncoding, callback: (err?: Error | null, data?: any) => void) {
+          const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+          observer.observe(buf)
+          callback(null, buf)
+        },
+      })
+      stream.on('error', (err: Error) => {
+        if (!tapStream.destroyed) tapStream.destroy(normalizeDownloadStreamError(err))
+      })
+      tapStream.on('error', (err: Error) => {
+        if (!bb.destroyed) bb.destroy(err)
+      })
+      stream.pipe(tapStream).pipe(bb)
+    } else {
+      stream.on('error', (err: Error) => {
+        if (!bb.destroyed) bb.destroy(normalizeDownloadStreamError(err))
+      })
+      stream.pipe(bb)
+    }
     return
   }
 
   // Direct buffer-like data
   if (typeof stream === 'string' || stream instanceof ArrayBuffer || ArrayBuffer.isView(stream)) {
     const data = toUint8Array(stream)
-    bb.write(Buffer.from(data))
+    const buf = tap(Buffer.from(data))
+    bb.write(buf)
     bb.end()
     return
   }
@@ -218,7 +380,7 @@ async function feedStreamToBusboy(stream: any, bb: any): Promise<void> {
     while (true) {
       const { done, value } = await reader.read()
       if (done) break
-      bb.write(Buffer.from(value))
+      bb.write(tap(Buffer.from(value)))
     }
     bb.end()
     return
@@ -228,7 +390,7 @@ async function feedStreamToBusboy(stream: any, bb: any): Promise<void> {
   if (stream?.[Symbol.asyncIterator]) {
     for await (const chunk of stream) {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(toUint8Array(chunk))
-      bb.write(buffer)
+      bb.write(tap(buffer))
     }
     bb.end()
     return
@@ -290,4 +452,94 @@ export async function processDownloadFilesResponseWithBuffered(
   }
 
   return
+}
+
+/**
+ * Normalizes errors that arrive from the HTTP transport layer to ensure
+ * callers always see a consistent error type. Axios emits "CanceledError"
+ * when an AbortSignal fires; we normalize it here (at the source stream's
+ * error boundary) so that DaytonaError propagates through all downstream
+ * pipe stages rather than the raw library error.
+ */
+function normalizeDownloadStreamError(err: Error): Error {
+  const e = err as { code?: string; name?: string }
+  if (e.code === 'ERR_CANCELED' || e.name === 'CanceledError' || e.name === 'AbortError') {
+    return new DaytonaError('Download cancelled')
+  }
+  return err
+}
+
+/** Construct the cancellation error thrown when an upload is aborted. */
+export function createAbortError(remotePath: string): DaytonaError {
+  return new DaytonaError(`Upload cancelled: ${remotePath}`)
+}
+
+/**
+ * Coerces every accepted upload source shape into a Node ``Readable`` so the
+ * downstream multipart writer has a uniform input type. Web ``ReadableStream``
+ * is bridged via ``Readable.fromWeb``; in-memory bytes via ``Readable.from``;
+ * local paths via ``fs.createReadStream``; existing ``Readable`` is passed
+ * through unchanged.
+ */
+export async function coerceUploadSource(source: UploadSource): Promise<Readable> {
+  if (Buffer.isBuffer(source) || source instanceof Uint8Array) {
+    return Readable.from(Buffer.from(source))
+  }
+  if (typeof source === 'string') {
+    const fs = await dynamicImport('fs', 'Uploading file from local file system is not supported: ')
+    return fs.createReadStream(source)
+  }
+  if (source instanceof Readable) return source
+  if (typeof (source as ReadableStream).getReader === 'function') {
+    return Readable.fromWeb(source as any)
+  }
+  throw new DaytonaError(
+    `Unsupported upload source: ${(source as { constructor?: { name?: string } }).constructor?.name ?? typeof source}`,
+  )
+}
+
+/**
+ * Wraps an upload source in a pass-through that counts bytes and invokes
+ * ``onProgress`` per chunk. When ``onProgress`` is omitted the source is
+ * returned unchanged so there is zero overhead in the no-progress path.
+ */
+export function wrapWithUploadProgress(
+  source: Readable,
+  onProgress: ((progress: UploadProgress) => void) | undefined,
+  signal?: AbortSignal,
+): Readable {
+  if (!onProgress && !signal) return source
+
+  let bytesSent = 0
+  const tracker = new Transform({
+    transform(chunk: Buffer | string, _encoding: BufferEncoding, callback: (err?: Error | null, data?: any) => void) {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      bytesSent += buf.length
+      onProgress?.({ bytesSent })
+      callback(null, buf)
+    },
+  })
+
+  pipeline(source, tracker, (err) => {
+    if (!err) return
+    if (!source.destroyed) source.destroy(err)
+    if (!tracker.destroyed) tracker.destroy(err)
+  })
+
+  if (signal) {
+    const onAbort = () => {
+      const abortError = new Error('aborted')
+      if (!source.destroyed) source.destroy(abortError)
+      if (!tracker.destroyed) tracker.destroy(abortError)
+    }
+
+    if (signal.aborted) {
+      queueMicrotask(onAbort)
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true })
+      tracker.on('close', () => signal.removeEventListener('abort', onAbort))
+    }
+  }
+
+  return tracker
 }


### PR DESCRIPTION
Closes #3216
Closes #3217

## Summary

Adds `uploadFileStream` and enhances `downloadFileStream` across all five SDKs (TypeScript, Python sync/async, Go, Ruby, Java) with **true streaming** (heap-flat for any file size), **progress callbacks**, and **cancellation** — backed by daemon-side improvements that make both endpoints properly atomic.

---

## Daemon changes (`apps/daemon/pkg/toolbox/fs`)

### `/files/bulk-upload` — true atomic streaming
- Replaced buffered `FormFile` / disk-spill with `MultipartReader` streaming: bytes go straight from the wire to a sibling temp file, then `os.Rename` onto the destination. Readers never see a partial file.
- Empty path validation, structured error responses, and a bug fix: non-EOF `NextPart()` errors (truncated body, malformed boundary) now `break` instead of `continue`, preventing an infinite parse loop.

### `/files/bulk-download` — Content-Length per part
- `classifyDownloadPathError` → `openDownloadFile`: open-then-stat (single inode, no TOCTOU) so the `Content-Length` in the response matches the bytes actually streamed.
- `writeFilePart` emits `Content-Length: <size>` per multipart part — SDKs use this to populate `DownloadProgress.totalBytes` without a separate `getFileDetails` round trip.

Both endpoints have new integration tests (`upload_files_test.go`, `download_files_test.go`).

---

## SDK changes

### API surface

#### Download streaming (existing method, enhanced)

| SDK | Signature | Cancellation |
|---|---|---|
| TypeScript | `downloadFileStream(path, { signal?, onProgress?, timeout? })` | `AbortSignal` |
| Python | `download_file_stream(path, timeout, on_progress=fn, cancel_event=event)` | `threading.Event` / `asyncio.Event` |
| Go | `DownloadFileStream(ctx, path, WithDownloadProgress(fn))` | `context.Context` |
| Ruby | `download_file_stream(path, on_progress: proc, cancel_event: event) { \|chunk\| }` | duck-typed `#set?` |
| Java | `downloadFileStream(path, new DownloadStreamOptions().setOnProgress(fn).setCancellationToken(token))` | `CancellationToken` |

#### Upload streaming (new method)

| SDK | Signature | Source types | Cancellation |
|---|---|---|---|
| TypeScript | `uploadFileStream(source, path, { signal?, onProgress?, timeout? })` | `Buffer \| string \| Readable \| ReadableStream` | `AbortSignal` |
| Python | `upload_file_stream(source, path, *, on_progress=fn, cancel_event=event)` | `bytes \| str \| IOBase \| AsyncIterable[bytes] \| async file-like` | `CancelEvent` |
| Go | `UploadFileStream(ctx, io.Reader, path, WithUploadProgress(fn))` | `io.Reader` | `context.Context` |
| Ruby | `upload_file_stream(source, path, on_progress: proc, cancel_event: event)` | `String` (path) / `IO` | duck-typed `#set?` |
| Java | `uploadFileStream(InputStream, path, new UploadStreamOptions().setOnProgress(fn).setCancellationToken(token))` | `InputStream` | `CancellationToken` |

#### Progress types

```
DownloadProgress  { bytesReceived, totalBytes? }   ← totalBytes from daemon Content-Length
UploadProgress    { bytesSent }                     ← no totalBytes; caller already knows it
```

#### Cancellation error

All non-Go SDKs throw the SDK-native error (`DaytonaError` / `DaytonaException` / `Sdk::Error`) with message `"Download cancelled"` or `"Upload cancelled: <path>"`. Go propagates `context.Canceled`.

---

### Per-SDK highlights

**TypeScript**
- `MultipartHeaderObserver`: busboy 1.x discards per-part headers; a side-channel Transform tap queues each part's `Content-Length` before busboy can discard it — the only way to get `totalBytes` without replacing busboy.
- `wrapWithUploadProgress` uses `stream.pipeline()` + `Transform` for proper backpressure (previous `'data'` listener forced flowing mode and could buffer entire files).
- Mid-stream abort: `pipe()` doesn't propagate source-stream errors to busboy; explicit `stream.on('error', ...)` forwarding now ensures AbortSignal fires reach the caller as `DaytonaError`.

**Python**
- Async `on_progress` callbacks may be `async def` — coroutine returns are awaited before the next chunk yields.
- Async `upload_file_stream` accepts `AsyncIterable[bytes]` and async file-like objects (e.g. `aiofiles`), routed through a manual multipart body builder via `httpx.content=`.
- `CancelEvent` Protocol: duck-typed `is_set()` — compatible with both `threading.Event` and `asyncio.Event`.
- `@final` + `@override` on `_CountingUploadReader`; `cast(Any, ...)` at the httpx `files=` call site (structural subtype gap in httpx stubs).

**Go**
- `UploadFileStream` uses `io.Pipe` + goroutine; buffered `errCh` ensures the writer goroutine is always joined, even on early HTTP errors or context cancellation — no goroutine leak.
- Renamed `WithProgress` → `WithDownloadProgress` for symmetry with `WithUploadProgress`.

**Ruby**
- Upload progress uses libcurl's `xferinfofunction` (real wire bytes, not source-read bytes). The progress callback returns `1` to abort the libcurl transfer when `cancel_event.set?`.
- `raise_upload_error` only treats `:aborted_by_callback` as cancellation — ignores `cancel_event` state post-request to avoid false-cancel when the event is set after a successful transfer.
- `File.open` for upload wrapped in `with_open_upload_file` `ensure` block.

**Java**
- `CancellationToken` uses a double-checked CAS pattern to prevent the lost-cancel race (T1 cancels between T2's `cancelled` read and `handler.set`) — after `handler.set(h)`, the token re-reads `cancelled` and runs the handler immediately if true.
- `onCancel(h)` returns a `Runnable` unregister handle. Download wraps the returned `InputStream` in a `FilterInputStream` that runs unregister on `close()`. Upload uses `try/finally`. Both prevent token retention (holding the OkHttp `Call` reference) after the operation ends.
- `downloadFileStream` uses `handedOff` flag + `finally` block so unregister fires on every failure path, including `DaytonaException` (RuntimeException) throws from `extractDownloadFileStream`.

---

## Test coverage

Every SDK has unit tests (mock-based) and E2E tests run against a local daemon for the new streaming + progress + cancellation surface. Highlights:

- Go: `TestUploadFileStreamCancellation` checks goroutine count returns to baseline after cancel (leak detector).
- Ruby: spec_helper gains a global `around` + `before` hook that clears `DAYTONA_*` ENV keys and stubs Dotenv per example, preventing `.env.local` from leaking into unit tests that assert on credential absence.
- TS: `Daytona.test.ts` now mocks `DaytonaEnvReader` to prevent `.env.local` from leaking into credential-absence assertions.
- Java: `downloadFileStreamCancellationCancelsRequest` uses `throttleBody` (1 KB/25 ms) to exercise mid-stream cancel; `uploadFileStreamCancellationCancelsRequest` uses `SlowByteArrayInputStream`.

---

## Examples

All six file-operations examples (`TypeScript`, `Python sync`, `Python async`, `Go`, `Ruby`, `Java`) updated to demonstrate streaming upload with `onProgress` and streaming download with `onProgress`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds true streaming uploads and enhanced streaming downloads across all SDKs with progress and cancellation. The daemon streams directly to temp files and sets per-part Content-Length for accurate progress and atomic writes, with new tests covering both paths.

- **New Features**
  - Added `uploadFileStream` and upgraded `downloadFileStream` in `typescript`, `python` (sync/async), `go`, `ruby`, and `java`, with progress callbacks and cancellation (`AbortSignal`, `CancelEvent`/`asyncio.Event`, `context.Context`, `#set?`, `CancellationToken`).
  - Daemon: multipart uploads stream to sibling temp files and atomically rename on success; downloads open-then-stat each file and emit per-part `Content-Length`. Enforces `.path` before `.file` and removes temp files on cancel/disconnect. New integration tests verify on-disk writes, header correctness, and temp-file cleanup.
  - Go: `WithDownloadProgress`/`WithUploadProgress`. Java: `DownloadStreamOptions`/`UploadStreamOptions`, `DownloadProgress`/`UploadProgress`, `CancellationToken`. TypeScript: exports `DownloadStreamOptions`/`UploadStreamOptions`, `UploadSource`, and progress types. Docs/examples updated to show progress and cancellation.

- **Bug Fixes**
  - Daemon: upload parser stops on malformed boundaries; rejects empty paths; download uses open-then-stat to avoid TOCTOU and ensures `Content-Length` matches bytes streamed.
  - SDKs: Ruby requires `stringio` for IO uploads; Java guards options against null and unregisters cancel handlers; Go rejects nil upload readers and stabilizes progress tests; TypeScript marks `DownloadProgress.totalBytes` optional and fixes missing imports. Tests in TS/Ruby stub env readers and use run-unique paths to prevent cross-suite interference.
  - Docs: fixes in Ruby SDK pages to resolve MDX build issues.

<sup>Written for commit 68f669c8e38bbc9bc86fc49ef54223a4e58f1aad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

