### PR TITLE
chore(sdk-java): resolve intermittent publish failure caused by parallel Gradle builds on shared directory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,7 +74,7 @@
     },
     "ghcr.io/devcontainers/features/java:1.8.0": {
       "jdkDistro": "tem",
-      "version": "21.0.10",
+      "version": "21.0.11",
       "installMaven": true,
       "installGradle": true,
       "installAnt": true

--- a/libs/api-client-java/project.json
+++ b/libs/api-client-java/project.json
@@ -51,7 +51,7 @@
         "cwd": "{projectRoot}",
         "command": "chmod +x gradlew && test -n \"$MAVEN_PKG_VERSION\" || { echo 'ERROR: MAVEN_PKG_VERSION is required for publish'; exit 1; } && rm -rf build/staging-deploy build/central-bundle.zip && ./gradlew publishToMavenLocal && ./gradlew clean publishMavenPublicationToReleaseRepository && if ! echo \"$MAVEN_PKG_VERSION\" | grep -q SNAPSHOT; then find build/staging-deploy -name 'maven-metadata.xml*' -delete && cd build/staging-deploy && zip -r ../central-bundle.zip . && cd .. && curl -s -w '\\nHTTP %{http_code}\\n' --fail-with-body -X POST 'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC' -H \"Authorization: Bearer $(echo -n $MAVEN_USERNAME:$MAVEN_PASSWORD | base64 -w0)\" -F 'bundle=@central-bundle.zip'; fi"
       },
-      "dependsOn": ["build"]
+      "dependsOn": ["set-version"]
     }
   }
 }

--- a/libs/sdk-java/project.json
+++ b/libs/sdk-java/project.json
@@ -35,7 +35,7 @@
       "outputs": ["{projectRoot}/build"],
       "options": {
         "cwd": "{projectRoot}",
-        "command": "./gradlew --stop; ./gradlew build -x test"
+        "command": "./gradlew build -x test"
       },
       "dependsOn": [
         "set-version",
@@ -52,7 +52,7 @@
         "command": "test -n \"$MAVEN_PKG_VERSION\" || { echo 'ERROR: MAVEN_PKG_VERSION is required for publish'; exit 1; } && rm -rf build/staging-deploy build/central-bundle.zip && ./gradlew clean publishMavenJavaPublicationToReleaseRepository && if ! echo \"$MAVEN_PKG_VERSION\" | grep -q SNAPSHOT; then find build/staging-deploy -name 'maven-metadata.xml*' -delete && cd build/staging-deploy && zip -r ../central-bundle.zip . && cd .. && curl -s -w '\\nHTTP %{http_code}\\n' --fail-with-body -X POST 'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC' -H \"Authorization: Bearer $(echo -n $MAVEN_USERNAME:$MAVEN_PASSWORD | base64 -w0)\" -F 'bundle=@central-bundle.zip'; fi"
       },
       "dependsOn": [
-        "build",
+        "set-version",
         {
           "target": "publish",
           "projects": ["api-client-java", "toolbox-api-client-java"]

--- a/libs/toolbox-api-client-java/project.json
+++ b/libs/toolbox-api-client-java/project.json
@@ -51,7 +51,7 @@
         "cwd": "{projectRoot}",
         "command": "chmod +x gradlew && test -n \"$MAVEN_PKG_VERSION\" || { echo 'ERROR: MAVEN_PKG_VERSION is required for publish'; exit 1; } && rm -rf build/staging-deploy build/central-bundle.zip && ./gradlew publishToMavenLocal && ./gradlew clean publishMavenPublicationToReleaseRepository && if ! echo \"$MAVEN_PKG_VERSION\" | grep -q SNAPSHOT; then find build/staging-deploy -name 'maven-metadata.xml*' -delete && cd build/staging-deploy && zip -r ../central-bundle.zip . && cd .. && curl -s -w '\\nHTTP %{http_code}\\n' --fail-with-body -X POST 'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC' -H \"Authorization: Bearer $(echo -n $MAVEN_USERNAME:$MAVEN_PASSWORD | base64 -w0)\" -F 'bundle=@central-bundle.zip'; fi"
       },
-      "dependsOn": ["build"]
+      "dependsOn": ["set-version"]
     }
   }
 }


### PR DESCRIPTION
### Problem

The Java publish pipeline fails intermittently with:

```
Execution failed for task ':api-client:compileJava'.
> Unable to delete directory '.../libs/api-client-java/build/classes/java/main'
    Failed to delete some children. This might happen because a process has files
    open or has its working directory set in the target directory.
    New files were found. This might happen because a process is still writing to
    the target directory.
```

**Root cause:** After `api-client-java:build` completes, Nx schedules `sdk-java:build` and `api-client-java:publish` in parallel. Because `sdk-java/settings.gradle.kts` uses composite builds (`includeBuild("../api-client-java")`), the `sdk-java:build` Gradle process compiles `api-client-java` in-place — writing to `libs/api-client-java/build/`. At the same time, `api-client-java:publish` runs its own Gradle process in the same directory. Two Gradle processes writing to the same `build/` directory simultaneously causes the filesystem conflict.

Additionally, `sdk-java:build` ran `./gradlew --stop` which kills all Gradle daemons machine-wide, potentially terminating daemons used by the parallel publish tasks (exit code 130 = SIGINT).

### Fix

- **Decouple publish from build targets** — Gradle's `publish` tasks already compile everything as part of their task graph, so the explicit `build` dependency was redundant. Publish targets now depend only on `set-version`.
- **Remove `./gradlew --stop`** from `sdk-java:build` — no longer needed since publish and build don't run in parallel against the same directories.
- **sdk-java:publish depends on api-client publishes, not builds** — ensures api-client publish completes before sdk-java's Gradle touches the api-client directory via composite builds.

### Changes

| File | Change |
|---|---|
| `libs/sdk-java/project.json` | `build`: removed `./gradlew --stop`. `publish`: depends on `set-version` + api-client publishes instead of `build`. |
| `libs/api-client-java/project.json` | `publish`: depends on `set-version` instead of `build`. |
| `libs/toolbox-api-client-java/project.json` | `publish`: depends on `set-version` instead of `build`. |
| `.devcontainer/devcontainer.json` | JDK version bump 21.0.10 → 21.0.11. |

### Nx execution order (before → after)

**Before** (race condition):
```
api-client-java:build ──┬── sdk-java:build          (parallel, CONFLICT on api-client-java/build/)
                         └── api-client-java:publish  (parallel, CONFLICT on api-client-java/build/)
```

**After** (serialized):
```
api-client-java:set-version → api-client-java:publish ─┐
toolbox-api-client-java:set-version → toolbox-api-client-java:publish ─┤
sdk-java:set-version ──────────────────────────────────────────────────┴── sdk-java:publish
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent Java publish failures by preventing parallel Gradle processes from writing to the same `build/` directory. Publishing is now serialized via Nx dependencies and no longer kills shared daemons.

- **Bug Fixes**
  - Decoupled publish from build: `publish` depends on `set-version` for `api-client-java`, `toolbox-api-client-java`, and `sdk-java`.
  - `sdk-java:publish` now depends on `api-client-java:publish` and `toolbox-api-client-java:publish` to avoid composite build conflicts.
  - Removed `./gradlew --stop` from `sdk-java:build` to prevent terminating daemons used by parallel tasks.

- **Dependencies**
  - Devcontainer Java updated from 21.0.10 to 21.0.11.

<sup>Written for commit 33f0c4f407826e12c03c5c122cef51a18baaa7d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

