### PR TITLE
NVIDIA GPU experimental runner

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -297,7 +297,7 @@ export class RunnerService {
     // GPU sandboxes get exclusive ownership of a runner: skip any runner that
     // already hosts an active sandbox, regardless of whether that sandbox uses GPU.
     if (params.gpu) {
-      const occupiedRunnerIds = await this.getRunnersWithActiveSandbox()
+      const occupiedRunnerIds = await this.getRunnersWithActiveGpuSandbox()
       for (const id of occupiedRunnerIds) {
         excludedRunnerIds.add(id)
       }
@@ -875,7 +875,7 @@ export class RunnerService {
    * non-terminal state. Used by the GPU scheduler to enforce
    * one-gpu-sandbox-per-runner exclusivity.
    */
-  async getRunnersWithActiveSandbox(): Promise<string[]> {
+  async getRunnersWithActiveGpuSandbox(): Promise<string[]> {
     const rows = await this.sandboxRepository
       .createQueryBuilder('sandbox')
       .select('DISTINCT sandbox.runnerId', 'runnerId')

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -278,6 +278,8 @@ export class RunnerService {
   }
 
   async findAvailableRunners(params: GetRunnerParams): Promise<Runner[]> {
+    const isGpuRequest = (params.gpu ?? 0) > 0
+
     const runnerFilter: FindOptionsWhere<Runner> = {
       state: RunnerState.READY,
       unschedulable: Not(true),
@@ -287,9 +289,20 @@ export class RunnerService {
         : MoreThanOrEqual(this.configService.getOrThrow('runnerScore.thresholds.availability')),
     }
 
-    const excludedRunnerIds = params.excludedRunnerIds?.length
-      ? params.excludedRunnerIds.filter((id) => !!id)
-      : undefined
+    if (isGpuRequest) {
+      runnerFilter.gpu = MoreThanOrEqual(params.gpu)
+    }
+
+    const excludedRunnerIds = new Set((params.excludedRunnerIds ?? []).filter((id): id is string => !!id))
+
+    // GPU sandboxes get exclusive ownership of a runner: skip any runner that
+    // already hosts an active sandbox, regardless of whether that sandbox uses GPU.
+    if (isGpuRequest) {
+      const occupiedRunnerIds = await this.getRunnersWithActiveSandbox()
+      for (const id of occupiedRunnerIds) {
+        excludedRunnerIds.add(id)
+      }
+    }
 
     if (params.snapshotRef !== undefined) {
       const snapshotRunners = await this.snapshotRunnerRepository.find({
@@ -299,19 +312,17 @@ export class RunnerService {
         },
       })
 
-      let runnerIds = snapshotRunners.map((snapshotRunner) => snapshotRunner.runnerId)
-
-      if (excludedRunnerIds?.length) {
-        runnerIds = runnerIds.filter((id) => !excludedRunnerIds.includes(id))
-      }
+      const runnerIds = snapshotRunners
+        .map((snapshotRunner) => snapshotRunner.runnerId)
+        .filter((id) => !excludedRunnerIds.has(id))
 
       if (!runnerIds.length) {
         return []
       }
 
       runnerFilter.id = In(runnerIds)
-    } else if (excludedRunnerIds?.length) {
-      runnerFilter.id = Not(In(excludedRunnerIds))
+    } else if (excludedRunnerIds.size) {
+      runnerFilter.id = Not(In(Array.from(excludedRunnerIds)))
     }
 
     if (params.regions?.length) {
@@ -860,6 +871,37 @@ export class RunnerService {
     return runners.map((item) => item.runnerId).filter((id): id is string => !!id)
   }
 
+  /**
+   * Returns runner IDs that currently host at least one sandbox in a
+   * non-terminal state. Used by the GPU scheduler to enforce
+   * one-sandbox-per-runner exclusivity.
+   */
+  async getRunnersWithActiveSandbox(): Promise<string[]> {
+    const activeStates: SandboxState[] = [
+      SandboxState.CREATING,
+      SandboxState.RESTORING,
+      SandboxState.STARTED,
+      SandboxState.STARTING,
+      SandboxState.STOPPING,
+      SandboxState.STOPPED,
+      SandboxState.BUILDING_SNAPSHOT,
+      SandboxState.PULLING_SNAPSHOT,
+      SandboxState.UNKNOWN,
+      SandboxState.RESIZING,
+      SandboxState.SNAPSHOTTING,
+      SandboxState.FORKING,
+    ]
+
+    const rows = await this.sandboxRepository
+      .createQueryBuilder('sandbox')
+      .select('DISTINCT sandbox.runnerId', 'runnerId')
+      .where('sandbox.runnerId IS NOT NULL')
+      .andWhere('sandbox.state IN (:...states)', { states: activeStates })
+      .getRawMany()
+
+    return rows.map((r) => r.runnerId).filter((id): id is string => !!id)
+  }
+
   async getRunnersBySnapshotRef(ref: string): Promise<RunnerSnapshotDto[]> {
     const snapshotRunners = await this.snapshotRunnerRepository.find({
       where: {
@@ -1079,6 +1121,9 @@ export class GetRunnerParams {
   snapshotRef?: string
   excludedRunnerIds?: string[]
   availabilityScoreThreshold?: number
+  // When > 0, only consider runners that have at least this much GPU capacity
+  // and do not currently host any active sandbox (one-GPU-sandbox-per-runner rule).
+  gpu?: number
 }
 
 interface AvailabilityScoreParams {

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -38,6 +38,7 @@ import { runnerLookupCacheKeyById, RUNNER_LOOKUP_CACHE_TTL_MS } from '../utils/r
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
+import { SANDBOX_STATES_CONSUMING_COMPUTE } from '../../organization/constants/sandbox-states-consuming-compute.constant'
 
 @Injectable()
 export class RunnerService {
@@ -278,8 +279,6 @@ export class RunnerService {
   }
 
   async findAvailableRunners(params: GetRunnerParams): Promise<Runner[]> {
-    const isGpuRequest = (params.gpu ?? 0) > 0
-
     const runnerFilter: FindOptionsWhere<Runner> = {
       state: RunnerState.READY,
       unschedulable: Not(true),
@@ -289,7 +288,7 @@ export class RunnerService {
         : MoreThanOrEqual(this.configService.getOrThrow('runnerScore.thresholds.availability')),
     }
 
-    if (isGpuRequest) {
+    if (params.gpu) {
       runnerFilter.gpu = MoreThanOrEqual(params.gpu)
     }
 
@@ -297,7 +296,7 @@ export class RunnerService {
 
     // GPU sandboxes get exclusive ownership of a runner: skip any runner that
     // already hosts an active sandbox, regardless of whether that sandbox uses GPU.
-    if (isGpuRequest) {
+    if (params.gpu) {
       const occupiedRunnerIds = await this.getRunnersWithActiveSandbox()
       for (const id of occupiedRunnerIds) {
         excludedRunnerIds.add(id)
@@ -872,31 +871,17 @@ export class RunnerService {
   }
 
   /**
-   * Returns runner IDs that currently host at least one sandbox in a
+   * Returns runner IDs that currently host at least one GPU sandbox in a
    * non-terminal state. Used by the GPU scheduler to enforce
-   * one-sandbox-per-runner exclusivity.
+   * one-gpu-sandbox-per-runner exclusivity.
    */
   async getRunnersWithActiveSandbox(): Promise<string[]> {
-    const activeStates: SandboxState[] = [
-      SandboxState.CREATING,
-      SandboxState.RESTORING,
-      SandboxState.STARTED,
-      SandboxState.STARTING,
-      SandboxState.STOPPING,
-      SandboxState.STOPPED,
-      SandboxState.BUILDING_SNAPSHOT,
-      SandboxState.PULLING_SNAPSHOT,
-      SandboxState.UNKNOWN,
-      SandboxState.RESIZING,
-      SandboxState.SNAPSHOTTING,
-      SandboxState.FORKING,
-    ]
-
     const rows = await this.sandboxRepository
       .createQueryBuilder('sandbox')
       .select('DISTINCT sandbox.runnerId', 'runnerId')
       .where('sandbox.runnerId IS NOT NULL')
-      .andWhere('sandbox.state IN (:...states)', { states: activeStates })
+      .andWhere('sandbox.gpu > 0')
+      .andWhere('sandbox.state IN (:...states)', { states: SANDBOX_STATES_CONSUMING_COMPUTE })
       .getRawMany()
 
     return rows.map((r) => r.runnerId).filter((id): id is string => !!id)

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -445,6 +445,11 @@ export class SandboxService {
       let disk = snapshot.disk
       let gpu = snapshot.gpu
 
+      // GPU sandboxes are always ephemeral - delete on first stop.
+      if (gpu > 0 && createSandboxDto.autoDeleteInterval !== 0) {
+        throw new BadRequestError('GPU sandboxes must be ephemeral - set autoDeleteInterval to 0')
+      }
+
       // Remove the deprecated behavior in a future release
       if (useSandboxResourceParams_deprecated) {
         if (createSandboxDto.cpu) {
@@ -556,11 +561,6 @@ export class SandboxService {
 
       if (createSandboxDto.autoDeleteInterval !== undefined) {
         sandbox.autoDeleteInterval = createSandboxDto.autoDeleteInterval
-      }
-
-      // GPU sandboxes are always ephemeral - delete on first stop.
-      if (gpu > 0) {
-        sandbox.autoDeleteInterval = 0
       }
 
       if (createSandboxDto.volumes !== undefined) {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -446,7 +446,7 @@ export class SandboxService {
       let gpu = snapshot.gpu
 
       // GPU sandboxes are always ephemeral - delete on first stop.
-      if (gpu > 0 && createSandboxDto.autoDeleteInterval !== 0) {
+      if (gpu > 0 && !isEphemeral(createSandboxDto)) {
         throw new BadRequestError('GPU sandboxes must be ephemeral - set autoDeleteInterval to 0')
       }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -476,7 +476,16 @@ export class SandboxService {
         pendingDiskIncrement = disk
       }
 
-      if (!createSandboxDto.volumes || createSandboxDto.volumes.length === 0) {
+      // GPU sandboxes are always ephemeral: they get exclusive ownership of a
+      // runner for their lifetime and are auto-deleted on first stop. Skip the
+      // warm-pool path entirely so we always provision a fresh container on a
+      // currently-unoccupied GPU runner.
+      if (gpu > 0) {
+        const volumeIdOrNames = (createSandboxDto.volumes ?? []).map((v) => v.volumeId)
+        if (volumeIdOrNames.length > 0) {
+          await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
+        }
+      } else if (!createSandboxDto.volumes || createSandboxDto.volumes.length === 0) {
         const skipWarmPool = (await this.redis.exists(`warm-pool:skip:${snapshot.id}`)) === 1
 
         if (!skipWarmPool) {
@@ -507,6 +516,7 @@ export class SandboxService {
         regions: [region.id],
         sandboxClass,
         snapshotRef: snapshot.ref,
+        gpu: gpu > 0 ? gpu : undefined,
       })
 
       const sandbox = new Sandbox(region.id, createSandboxDto.name)
@@ -546,6 +556,11 @@ export class SandboxService {
 
       if (createSandboxDto.autoDeleteInterval !== undefined) {
         sandbox.autoDeleteInterval = createSandboxDto.autoDeleteInterval
+      }
+
+      // GPU sandboxes are always ephemeral - delete on first stop.
+      if (gpu > 0) {
+        sandbox.autoDeleteInterval = 0
       }
 
       if (createSandboxDto.volumes !== undefined) {

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	ContainerRuntime                   string        `envconfig:"CONTAINER_RUNTIME"`
 	ContainerNetwork                   string        `envconfig:"CONTAINER_NETWORK"`
 	InterSandboxNetworkEnabled         bool          `envconfig:"INTER_SANDBOX_NETWORK_ENABLED" default:"true"`
+	GpuEnabled                         bool          `envconfig:"GPU_ENABLED" default:"false"`
 	LogFilePath                        string        `envconfig:"LOG_FILE_PATH"`
 	AWSRegion                          string        `envconfig:"AWS_REGION"`
 	AWSEndpointUrl                     string        `envconfig:"AWS_ENDPOINT_URL"`

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -164,6 +164,7 @@ func run() int {
 		BuildMemoryGB:                cfg.BuildMemoryGB,
 		InitializeDaemonTelemetry:    cfg.InitializeDaemonTelemetry,
 		InterSandboxNetworkEnabled:   cfg.InterSandboxNetworkEnabled,
+		GpuEnabled:                   cfg.GpuEnabled,
 	})
 	if err != nil {
 		logger.Error("Error creating Docker client wrapper", "error", err)

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -44,6 +44,7 @@ type DockerClientConfig struct {
 	BuildMemoryGB                int64
 	InitializeDaemonTelemetry    bool
 	InterSandboxNetworkEnabled   bool
+	GpuEnabled                   bool
 }
 
 func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerClient, error) {
@@ -141,6 +142,7 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 		buildMemoryGB:                config.BuildMemoryGB,
 		initializeDaemonTelemetry:    config.InitializeDaemonTelemetry,
 		interSandboxNetworkEnabled:   config.InterSandboxNetworkEnabled,
+		gpuEnabled:                   config.GpuEnabled,
 		filesystem:                   filesystem,
 	}, nil
 }
@@ -182,4 +184,5 @@ type DockerClient struct {
 	initializeDaemonTelemetry    bool
 	filesystem                   string
 	interSandboxNetworkEnabled   bool
+	gpuEnabled                   bool
 }

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -161,6 +161,23 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 		}
 	}
 
+	if d.gpuEnabled {
+		nvidiaDevices := []string{
+			"/dev/nvidia0",
+			"/dev/nvidiactl",
+			"/dev/nvidia-uvm",
+			"/dev/nvidia-uvm-tools",
+			"/dev/nvidia-modeset",
+		}
+		for _, dev := range nvidiaDevices {
+			hostConfig.Devices = append(hostConfig.Devices, container.DeviceMapping{
+				PathOnHost:        dev,
+				PathInContainer:   dev,
+				CgroupPermissions: "rwm",
+			})
+		}
+	}
+
 	return hostConfig, nil
 }
 


### PR DESCRIPTION
## Description

Adds first-class support for sandboxes with NVIDIA GPU devices.

### Runner (`apps/runner`)

- New `GPU_ENABLED` env-var on the runner (defaults to `false`).
- When enabled, every sandbox container gets the five NVIDIA character
  devices passed through via `HostConfig.Devices`:
  `/dev/nvidia0`, `/dev/nvidiactl`, `/dev/nvidia-uvm`,
  `/dev/nvidia-uvm-tools`, `/dev/nvidia-modeset` (`rwm` cgroup perms).
- Intended to be paired with `CONTAINER_RUNTIME=sysbox-runc` and a
  sandbox image that ships a matching `libnvidia-compute` userspace.
- No behavior change when `GPU_ENABLED=false` (the default).

### API (`apps/api`)

GPU-aware scheduling in `RunnerService.findAvailableRunners` and a new
branch in `SandboxService.createFromSnapshot`:

- `GetRunnerParams` gains an optional `gpu` field. When `gpu > 0`:
  - Only runners with `runner.gpu >= gpu` are considered.
  - Runners that already host any sandbox in a non-terminal state
    (`creating`, `restoring`, `started`, `starting`, `stopping`,
    `stopped`, `building_snapshot`, `pulling_snapshot`, `unknown`,
    `resizing`, `snapshotting`, `forking`) are excluded — enforces the
    one-sandbox-per-GPU-runner rule.
- New `RunnerService.getRunnersWithActiveSandbox()` helper backs the
  exclusivity check.
- In `SandboxService.createFromSnapshot`, when the resolved snapshot
  has `gpu > 0`:
  - Warm-pool lookup is skipped (always provision fresh).
  - `sandbox.gpu` is forwarded to the scheduler.
  - `sandbox.autoDeleteInterval` is forced to `0` so the sandbox is
    auto-deleted on first stop.

Scope is intentionally limited:
- Only `createFromSnapshot` is GPU-aware; `createFromBuildInfo`,
  `createForWarmPool` and fork paths are unchanged.
- Start/stop/restore actions are not modified — ephemeral semantics
  mean a stopped GPU sandbox is destroyed before any restore can run.

## Documentation

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

Docs (runner GPU prerequisites, image guidance, region/runner
registration) will be added in a follow-up PR.

## Related Issue(s)

N/A

## Screenshots

N/A — backend feature.

## Notes
