### PR TITLE
feat(api): add tags property to runner entity

### DIFF
--- a/apps/api/src/admin/controllers/runner.controller.ts
+++ b/apps/api/src/admin/controllers/runner.controller.ts
@@ -90,6 +90,7 @@ export class AdminRunnerController {
       cpu: createRunnerDto.cpu,
       memoryGiB: createRunnerDto.memoryGiB,
       diskGiB: createRunnerDto.diskGiB,
+      tags: createRunnerDto.tags,
     })
 
     return CreateRunnerResponseDto.fromRunner(runner, apiKey)

--- a/apps/api/src/admin/controllers/runner.controller.ts
+++ b/apps/api/src/admin/controllers/runner.controller.ts
@@ -69,6 +69,7 @@ export class AdminRunnerController {
         name: req.body?.name,
         apiKey: MASKED_AUDIT_VALUE,
         apiVersion: req.body?.apiVersion,
+        tags: req.body?.tags,
       }),
     },
   })

--- a/apps/api/src/migrations/pre-deploy/1778494331904-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1778494331904-migration.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1778494331904 implements MigrationInterface {
+  name = 'Migration1778494331904'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "runner" ADD "tags" text array NOT NULL DEFAULT '{}'`)
+    await queryRunner.query(`CREATE INDEX "runner_tags_gin_idx" ON "runner" USING GIN ("tags")`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "runner_tags_gin_idx"`)
+    await queryRunner.query(`ALTER TABLE "runner" DROP COLUMN "tags"`)
+  }
+}

--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -116,6 +116,7 @@ export class RunnerController {
       regionId: createRunnerDto.regionId,
       name: createRunnerDto.name,
       apiVersion: '2',
+      tags: createRunnerDto.tags,
     })
 
     return CreateRunnerResponseDto.fromRunner(runner, apiKey)

--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -93,6 +93,7 @@ export class RunnerController {
       body: (req: TypedRequest<CreateRunnerDto>) => ({
         regionId: req.body?.regionId,
         name: req.body?.name,
+        tags: req.body?.tags,
       }),
     },
   })

--- a/apps/api/src/sandbox/dto/create-runner-internal.dto.ts
+++ b/apps/api/src/sandbox/dto/create-runner-internal.dto.ts
@@ -15,6 +15,7 @@ export type CreateRunnerV0InternalDto = {
   apiKey?: string
   apiVersion: '0'
   appVersion?: string
+  tags?: string[]
 }
 
 export type CreateRunnerV2InternalDto = {
@@ -23,6 +24,7 @@ export type CreateRunnerV2InternalDto = {
   name: string
   apiVersion: '2'
   appVersion?: string
+  tags?: string[]
 }
 
 export type CreateRunnerInternalDto = CreateRunnerV0InternalDto | CreateRunnerV2InternalDto

--- a/apps/api/src/sandbox/dto/create-runner.dto.ts
+++ b/apps/api/src/sandbox/dto/create-runner.dto.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { IsString } from 'class-validator'
-import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { IsArray, IsOptional, IsString } from 'class-validator'
+import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { IsSafeDisplayString } from '../../common/validators'
 
 @ApiSchema({ name: 'CreateRunner' })
@@ -17,4 +17,14 @@ export class CreateRunnerDto {
   @IsSafeDisplayString()
   @ApiProperty()
   name: string
+
+  @ApiPropertyOptional({
+    description: 'Tags to associate with the runner',
+    example: ['gpu', 'us-east'],
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[]
 }

--- a/apps/api/src/sandbox/dto/runner.dto.ts
+++ b/apps/api/src/sandbox/dto/runner.dto.ts
@@ -174,6 +174,13 @@ export class RunnerDto {
   unschedulable: boolean
 
   @ApiProperty({
+    description: 'Tags associated with the runner',
+    example: ['gpu', 'us-east'],
+    type: [String],
+  })
+  tags: string[]
+
+  @ApiProperty({
     description: 'The creation timestamp of the runner',
     example: '2023-10-01T12:00:00Z',
   })
@@ -243,6 +250,7 @@ export class RunnerDto {
       state: runner.state,
       lastChecked: runner.lastChecked?.toISOString(),
       unschedulable: runner.unschedulable,
+      tags: runner.tags ?? [],
       createdAt: runner.createdAt.toISOString(),
       updatedAt: runner.updatedAt.toISOString(),
       version: runner.apiVersion,

--- a/apps/api/src/sandbox/entities/runner.entity.ts
+++ b/apps/api/src/sandbox/entities/runner.entity.ts
@@ -12,6 +12,7 @@ import { RunnerServiceInfo } from '../common/runner-service-info'
 @Entity()
 @Unique(['region', 'name'])
 @Index(['state', 'unschedulable', 'region'])
+@Index('runner_tags_gin_idx', { synchronize: false })
 export class Runner {
   @PrimaryGeneratedColumn('uuid')
   id: string
@@ -174,6 +175,13 @@ export class Runner {
   draining: boolean
 
   @Column({
+    type: 'text',
+    array: true,
+    default: () => "'{}'",
+  })
+  tags: string[]
+
+  @Column({
     type: 'jsonb',
     nullable: true,
     default: null,
@@ -202,6 +210,7 @@ export class Runner {
     apiUrl?: string
     proxyUrl?: string
     appVersion?: string | null
+    tags?: string[]
   }) {
     this.region = params.region
     this.name = params.name
@@ -217,6 +226,7 @@ export class Runner {
     this.appVersion = params.appVersion ?? null
     this.gpu = null
     this.gpuType = null
+    this.tags = params.tags ?? []
 
     if (this.apiVersion === '0') {
       if (!this.apiUrl) {

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -100,6 +100,7 @@ export class RunnerService {
           apiUrl: createRunnerDto.apiUrl,
           proxyUrl: createRunnerDto.proxyUrl,
           appVersion: createRunnerDto.appVersion,
+          tags: createRunnerDto.tags,
         })
         break
       case '2':
@@ -109,6 +110,7 @@ export class RunnerService {
           apiVersion: createRunnerDto.apiVersion,
           apiKey: apiKey,
           appVersion: createRunnerDto.appVersion,
+          tags: createRunnerDto.tags,
         })
         break
       default:

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -11497,11 +11497,22 @@ components:
       example:
         regionId: regionId
         name: name
+        tags:
+        - gpu
+        - us-east
       properties:
         regionId:
           type: string
         name:
           type: string
+        tags:
+          description: Tags to associate with the runner
+          example:
+          - gpu
+          - us-east
+          items:
+            type: string
+          type: array
       required:
       - name
       - regionId
@@ -11573,6 +11584,9 @@ components:
         gpu: 1
         currentSnapshotCount: 12
         version: "0"
+        tags:
+        - gpu
+        - us-east
         disk: 100
         domain: runner1.example.com
         name: runner1
@@ -11677,6 +11691,14 @@ components:
           description: Whether the runner is unschedulable
           example: false
           type: boolean
+        tags:
+          description: Tags associated with the runner
+          example:
+          - gpu
+          - us-east
+          items:
+            type: string
+          type: array
         createdAt:
           description: The creation timestamp of the runner
           example: 2023-10-01T12:00:00Z
@@ -11727,6 +11749,7 @@ components:
       - region
       - runnerClass
       - state
+      - tags
       - unschedulable
       - updatedAt
       - version
@@ -11779,6 +11802,9 @@ components:
         gpu: 1
         currentSnapshotCount: 12
         version: "0"
+        tags:
+        - gpu
+        - us-east
         disk: 100
         domain: runner1.example.com
         name: runner1
@@ -11883,6 +11909,14 @@ components:
           description: Whether the runner is unschedulable
           example: false
           type: boolean
+        tags:
+          description: Tags associated with the runner
+          example:
+          - gpu
+          - us-east
+          items:
+            type: string
+          type: array
         createdAt:
           description: The creation timestamp of the runner
           example: 2023-10-01T12:00:00Z
@@ -11923,6 +11957,7 @@ components:
       - region
       - runnerClass
       - state
+      - tags
       - unschedulable
       - updatedAt
       - version
@@ -14548,11 +14583,22 @@ components:
         domain: runner1.example.com
         name: name
         cpu: 8
+        tags:
+        - gpu
+        - us-east
       properties:
         regionId:
           type: string
         name:
           type: string
+        tags:
+          description: Tags to associate with the runner
+          example:
+          - gpu
+          - us-east
+          items:
+            type: string
+          type: array
         apiKey:
           type: string
         apiVersion:

--- a/libs/api-client-go/model_admin_create_runner.go
+++ b/libs/api-client-go/model_admin_create_runner.go
@@ -23,6 +23,8 @@ var _ MappedNullable = &AdminCreateRunner{}
 type AdminCreateRunner struct {
 	RegionId string `json:"regionId"`
 	Name string `json:"name"`
+	// Tags to associate with the runner
+	Tags []string `json:"tags,omitempty"`
 	ApiKey string `json:"apiKey"`
 	// The api version of the runner to create
 	ApiVersion string `json:"apiVersion" validate:"regexp=^(0|2)$"`
@@ -110,6 +112,38 @@ func (o *AdminCreateRunner) GetNameOk() (*string, bool) {
 // SetName sets field value
 func (o *AdminCreateRunner) SetName(v string) {
 	o.Name = v
+}
+
+// GetTags returns the Tags field value if set, zero value otherwise.
+func (o *AdminCreateRunner) GetTags() []string {
+	if o == nil || IsNil(o.Tags) {
+		var ret []string
+		return ret
+	}
+	return o.Tags
+}
+
+// GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AdminCreateRunner) GetTagsOk() ([]string, bool) {
+	if o == nil || IsNil(o.Tags) {
+		return nil, false
+	}
+	return o.Tags, true
+}
+
+// HasTags returns a boolean if a field has been set.
+func (o *AdminCreateRunner) HasTags() bool {
+	if o != nil && !IsNil(o.Tags) {
+		return true
+	}
+
+	return false
+}
+
+// SetTags gets a reference to the given []string and assigns it to the Tags field.
+func (o *AdminCreateRunner) SetTags(v []string) {
+	o.Tags = v
 }
 
 // GetApiKey returns the ApiKey field value
@@ -364,6 +398,9 @@ func (o AdminCreateRunner) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["regionId"] = o.RegionId
 	toSerialize["name"] = o.Name
+	if !IsNil(o.Tags) {
+		toSerialize["tags"] = o.Tags
+	}
 	toSerialize["apiKey"] = o.ApiKey
 	toSerialize["apiVersion"] = o.ApiVersion
 	if !IsNil(o.Domain) {
@@ -432,6 +469,7 @@ func (o *AdminCreateRunner) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "regionId")
 		delete(additionalProperties, "name")
+		delete(additionalProperties, "tags")
 		delete(additionalProperties, "apiKey")
 		delete(additionalProperties, "apiVersion")
 		delete(additionalProperties, "domain")

--- a/libs/api-client-go/model_create_runner.go
+++ b/libs/api-client-go/model_create_runner.go
@@ -23,6 +23,8 @@ var _ MappedNullable = &CreateRunner{}
 type CreateRunner struct {
 	RegionId string `json:"regionId"`
 	Name string `json:"name"`
+	// Tags to associate with the runner
+	Tags []string `json:"tags,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -95,6 +97,38 @@ func (o *CreateRunner) SetName(v string) {
 	o.Name = v
 }
 
+// GetTags returns the Tags field value if set, zero value otherwise.
+func (o *CreateRunner) GetTags() []string {
+	if o == nil || IsNil(o.Tags) {
+		var ret []string
+		return ret
+	}
+	return o.Tags
+}
+
+// GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateRunner) GetTagsOk() ([]string, bool) {
+	if o == nil || IsNil(o.Tags) {
+		return nil, false
+	}
+	return o.Tags, true
+}
+
+// HasTags returns a boolean if a field has been set.
+func (o *CreateRunner) HasTags() bool {
+	if o != nil && !IsNil(o.Tags) {
+		return true
+	}
+
+	return false
+}
+
+// SetTags gets a reference to the given []string and assigns it to the Tags field.
+func (o *CreateRunner) SetTags(v []string) {
+	o.Tags = v
+}
+
 func (o CreateRunner) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -107,6 +141,9 @@ func (o CreateRunner) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["regionId"] = o.RegionId
 	toSerialize["name"] = o.Name
+	if !IsNil(o.Tags) {
+		toSerialize["tags"] = o.Tags
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -153,6 +190,7 @@ func (o *CreateRunner) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "regionId")
 		delete(additionalProperties, "name")
+		delete(additionalProperties, "tags")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-go/model_runner.go
+++ b/libs/api-client-go/model_runner.go
@@ -69,6 +69,8 @@ type Runner struct {
 	LastChecked *string `json:"lastChecked,omitempty"`
 	// Whether the runner is unschedulable
 	Unschedulable bool `json:"unschedulable"`
+	// Tags associated with the runner
+	Tags []string `json:"tags"`
 	// The creation timestamp of the runner
 	CreatedAt string `json:"createdAt"`
 	// The last update timestamp of the runner
@@ -93,7 +95,7 @@ type _Runner Runner
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRunner(id string, cpu float32, memory float32, disk float32, class SandboxClass, region string, name string, state RunnerState, unschedulable bool, createdAt string, updatedAt string, version string, apiVersion string, runnerClass RunnerClass) *Runner {
+func NewRunner(id string, cpu float32, memory float32, disk float32, class SandboxClass, region string, name string, state RunnerState, unschedulable bool, tags []string, createdAt string, updatedAt string, version string, apiVersion string, runnerClass RunnerClass) *Runner {
 	this := Runner{}
 	this.Id = id
 	this.Cpu = cpu
@@ -104,6 +106,7 @@ func NewRunner(id string, cpu float32, memory float32, disk float32, class Sandb
 	this.Name = name
 	this.State = state
 	this.Unschedulable = unschedulable
+	this.Tags = tags
 	this.CreatedAt = createdAt
 	this.UpdatedAt = updatedAt
 	this.Version = version
@@ -816,6 +819,30 @@ func (o *Runner) SetUnschedulable(v bool) {
 	o.Unschedulable = v
 }
 
+// GetTags returns the Tags field value
+func (o *Runner) GetTags() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+
+	return o.Tags
+}
+
+// GetTagsOk returns a tuple with the Tags field value
+// and a boolean to check if the value has been set.
+func (o *Runner) GetTagsOk() ([]string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Tags, true
+}
+
+// SetTags sets field value
+func (o *Runner) SetTags(v []string) {
+	o.Tags = v
+}
+
 // GetCreatedAt returns the CreatedAt field value
 func (o *Runner) GetCreatedAt() string {
 	if o == nil {
@@ -1041,6 +1068,7 @@ func (o Runner) ToMap() (map[string]interface{}, error) {
 		toSerialize["lastChecked"] = o.LastChecked
 	}
 	toSerialize["unschedulable"] = o.Unschedulable
+	toSerialize["tags"] = o.Tags
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
 	toSerialize["version"] = o.Version
@@ -1071,6 +1099,7 @@ func (o *Runner) UnmarshalJSON(data []byte) (err error) {
 		"name",
 		"state",
 		"unschedulable",
+		"tags",
 		"createdAt",
 		"updatedAt",
 		"version",
@@ -1129,6 +1158,7 @@ func (o *Runner) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "state")
 		delete(additionalProperties, "lastChecked")
 		delete(additionalProperties, "unschedulable")
+		delete(additionalProperties, "tags")
 		delete(additionalProperties, "createdAt")
 		delete(additionalProperties, "updatedAt")
 		delete(additionalProperties, "version")

--- a/libs/api-client-go/model_runner_full.go
+++ b/libs/api-client-go/model_runner_full.go
@@ -69,6 +69,8 @@ type RunnerFull struct {
 	LastChecked *string `json:"lastChecked,omitempty"`
 	// Whether the runner is unschedulable
 	Unschedulable bool `json:"unschedulable"`
+	// Tags associated with the runner
+	Tags []string `json:"tags"`
 	// The creation timestamp of the runner
 	CreatedAt string `json:"createdAt"`
 	// The last update timestamp of the runner
@@ -97,7 +99,7 @@ type _RunnerFull RunnerFull
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRunnerFull(id string, cpu float32, memory float32, disk float32, class SandboxClass, region string, name string, state RunnerState, unschedulable bool, createdAt string, updatedAt string, version string, apiVersion string, runnerClass RunnerClass, apiKey string) *RunnerFull {
+func NewRunnerFull(id string, cpu float32, memory float32, disk float32, class SandboxClass, region string, name string, state RunnerState, unschedulable bool, tags []string, createdAt string, updatedAt string, version string, apiVersion string, runnerClass RunnerClass, apiKey string) *RunnerFull {
 	this := RunnerFull{}
 	this.Id = id
 	this.Cpu = cpu
@@ -108,6 +110,7 @@ func NewRunnerFull(id string, cpu float32, memory float32, disk float32, class S
 	this.Name = name
 	this.State = state
 	this.Unschedulable = unschedulable
+	this.Tags = tags
 	this.CreatedAt = createdAt
 	this.UpdatedAt = updatedAt
 	this.Version = version
@@ -821,6 +824,30 @@ func (o *RunnerFull) SetUnschedulable(v bool) {
 	o.Unschedulable = v
 }
 
+// GetTags returns the Tags field value
+func (o *RunnerFull) GetTags() []string {
+	if o == nil {
+		var ret []string
+		return ret
+	}
+
+	return o.Tags
+}
+
+// GetTagsOk returns a tuple with the Tags field value
+// and a boolean to check if the value has been set.
+func (o *RunnerFull) GetTagsOk() ([]string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Tags, true
+}
+
+// SetTags sets field value
+func (o *RunnerFull) SetTags(v []string) {
+	o.Tags = v
+}
+
 // GetCreatedAt returns the CreatedAt field value
 func (o *RunnerFull) GetCreatedAt() string {
 	if o == nil {
@@ -1102,6 +1129,7 @@ func (o RunnerFull) ToMap() (map[string]interface{}, error) {
 		toSerialize["lastChecked"] = o.LastChecked
 	}
 	toSerialize["unschedulable"] = o.Unschedulable
+	toSerialize["tags"] = o.Tags
 	toSerialize["createdAt"] = o.CreatedAt
 	toSerialize["updatedAt"] = o.UpdatedAt
 	toSerialize["version"] = o.Version
@@ -1136,6 +1164,7 @@ func (o *RunnerFull) UnmarshalJSON(data []byte) (err error) {
 		"name",
 		"state",
 		"unschedulable",
+		"tags",
 		"createdAt",
 		"updatedAt",
 		"version",
@@ -1195,6 +1224,7 @@ func (o *RunnerFull) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "state")
 		delete(additionalProperties, "lastChecked")
 		delete(additionalProperties, "unschedulable")
+		delete(additionalProperties, "tags")
 		delete(additionalProperties, "createdAt")
 		delete(additionalProperties, "updatedAt")
 		delete(additionalProperties, "version")

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/AdminCreateRunner.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/AdminCreateRunner.java
@@ -21,7 +21,9 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -60,6 +62,11 @@ public class AdminCreateRunner {
   @SerializedName(SERIALIZED_NAME_NAME)
   @javax.annotation.Nonnull
   private String name;
+
+  public static final String SERIALIZED_NAME_TAGS = "tags";
+  @SerializedName(SERIALIZED_NAME_TAGS)
+  @javax.annotation.Nullable
+  private List<String> tags = new ArrayList<>();
 
   public static final String SERIALIZED_NAME_API_KEY = "apiKey";
   @SerializedName(SERIALIZED_NAME_API_KEY)
@@ -139,6 +146,33 @@ public class AdminCreateRunner {
 
   public void setName(@javax.annotation.Nonnull String name) {
     this.name = name;
+  }
+
+
+  public AdminCreateRunner tags(@javax.annotation.Nullable List<String> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  public AdminCreateRunner addTagsItem(String tagsItem) {
+    if (this.tags == null) {
+      this.tags = new ArrayList<>();
+    }
+    this.tags.add(tagsItem);
+    return this;
+  }
+
+  /**
+   * Tags to associate with the runner
+   * @return tags
+   */
+  @javax.annotation.Nullable
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(@javax.annotation.Nullable List<String> tags) {
+    this.tags = tags;
   }
 
 
@@ -350,6 +384,7 @@ public class AdminCreateRunner {
     AdminCreateRunner adminCreateRunner = (AdminCreateRunner) o;
     return Objects.equals(this.regionId, adminCreateRunner.regionId) &&
         Objects.equals(this.name, adminCreateRunner.name) &&
+        Objects.equals(this.tags, adminCreateRunner.tags) &&
         Objects.equals(this.apiKey, adminCreateRunner.apiKey) &&
         Objects.equals(this.apiVersion, adminCreateRunner.apiVersion) &&
         Objects.equals(this.domain, adminCreateRunner.domain) &&
@@ -363,7 +398,7 @@ public class AdminCreateRunner {
 
   @Override
   public int hashCode() {
-    return Objects.hash(regionId, name, apiKey, apiVersion, domain, apiUrl, proxyUrl, cpu, memoryGiB, diskGiB, additionalProperties);
+    return Objects.hash(regionId, name, tags, apiKey, apiVersion, domain, apiUrl, proxyUrl, cpu, memoryGiB, diskGiB, additionalProperties);
   }
 
   @Override
@@ -372,6 +407,7 @@ public class AdminCreateRunner {
     sb.append("class AdminCreateRunner {\n");
     sb.append("    regionId: ").append(toIndentedString(regionId)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    apiKey: ").append(toIndentedString(apiKey)).append("\n");
     sb.append("    apiVersion: ").append(toIndentedString(apiVersion)).append("\n");
     sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
@@ -399,7 +435,7 @@ public class AdminCreateRunner {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("regionId", "name", "apiKey", "apiVersion", "domain", "apiUrl", "proxyUrl", "cpu", "memoryGiB", "diskGiB"));
+    openapiFields = new HashSet<String>(Arrays.asList("regionId", "name", "tags", "apiKey", "apiVersion", "domain", "apiUrl", "proxyUrl", "cpu", "memoryGiB", "diskGiB"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("regionId", "name", "apiKey", "apiVersion"));
@@ -430,6 +466,10 @@ public class AdminCreateRunner {
       }
       if (!jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
+      }
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       if (!jsonObj.get("apiKey").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `apiKey` to be a primitive type in the JSON string but got `%s`", jsonObj.get("apiKey").toString()));

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/CreateRunner.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/CreateRunner.java
@@ -20,7 +20,9 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -60,6 +62,11 @@ public class CreateRunner {
   @javax.annotation.Nonnull
   private String name;
 
+  public static final String SERIALIZED_NAME_TAGS = "tags";
+  @SerializedName(SERIALIZED_NAME_TAGS)
+  @javax.annotation.Nullable
+  private List<String> tags = new ArrayList<>();
+
   public CreateRunner() {
   }
 
@@ -98,6 +105,33 @@ public class CreateRunner {
 
   public void setName(@javax.annotation.Nonnull String name) {
     this.name = name;
+  }
+
+
+  public CreateRunner tags(@javax.annotation.Nullable List<String> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  public CreateRunner addTagsItem(String tagsItem) {
+    if (this.tags == null) {
+      this.tags = new ArrayList<>();
+    }
+    this.tags.add(tagsItem);
+    return this;
+  }
+
+  /**
+   * Tags to associate with the runner
+   * @return tags
+   */
+  @javax.annotation.Nullable
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(@javax.annotation.Nullable List<String> tags) {
+    this.tags = tags;
   }
 
   /**
@@ -156,13 +190,14 @@ public class CreateRunner {
     }
     CreateRunner createRunner = (CreateRunner) o;
     return Objects.equals(this.regionId, createRunner.regionId) &&
-        Objects.equals(this.name, createRunner.name)&&
+        Objects.equals(this.name, createRunner.name) &&
+        Objects.equals(this.tags, createRunner.tags)&&
         Objects.equals(this.additionalProperties, createRunner.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(regionId, name, additionalProperties);
+    return Objects.hash(regionId, name, tags, additionalProperties);
   }
 
   @Override
@@ -171,6 +206,7 @@ public class CreateRunner {
     sb.append("class CreateRunner {\n");
     sb.append("    regionId: ").append(toIndentedString(regionId)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -190,7 +226,7 @@ public class CreateRunner {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("regionId", "name"));
+    openapiFields = new HashSet<String>(Arrays.asList("regionId", "name", "tags"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("regionId", "name"));
@@ -221,6 +257,10 @@ public class CreateRunner {
       }
       if (!jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
+      }
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull() && !jsonObj.get("tags").isJsonArray()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
   }
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Runner.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Runner.java
@@ -24,7 +24,9 @@ import io.daytona.api.client.model.RunnerState;
 import io.daytona.api.client.model.SandboxClass;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -173,6 +175,11 @@ public class Runner {
   @SerializedName(SERIALIZED_NAME_UNSCHEDULABLE)
   @javax.annotation.Nonnull
   private Boolean unschedulable;
+
+  public static final String SERIALIZED_NAME_TAGS = "tags";
+  @SerializedName(SERIALIZED_NAME_TAGS)
+  @javax.annotation.Nonnull
+  private List<String> tags = new ArrayList<>();
 
   public static final String SERIALIZED_NAME_CREATED_AT = "createdAt";
   @SerializedName(SERIALIZED_NAME_CREATED_AT)
@@ -666,6 +673,33 @@ public class Runner {
   }
 
 
+  public Runner tags(@javax.annotation.Nonnull List<String> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  public Runner addTagsItem(String tagsItem) {
+    if (this.tags == null) {
+      this.tags = new ArrayList<>();
+    }
+    this.tags.add(tagsItem);
+    return this;
+  }
+
+  /**
+   * Tags associated with the runner
+   * @return tags
+   */
+  @javax.annotation.Nonnull
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(@javax.annotation.Nonnull List<String> tags) {
+    this.tags = tags;
+  }
+
+
   public Runner createdAt(@javax.annotation.Nonnull String createdAt) {
     this.createdAt = createdAt;
     return this;
@@ -870,6 +904,7 @@ public class Runner {
         Objects.equals(this.state, runner.state) &&
         Objects.equals(this.lastChecked, runner.lastChecked) &&
         Objects.equals(this.unschedulable, runner.unschedulable) &&
+        Objects.equals(this.tags, runner.tags) &&
         Objects.equals(this.createdAt, runner.createdAt) &&
         Objects.equals(this.updatedAt, runner.updatedAt) &&
         Objects.equals(this.version, runner.version) &&
@@ -881,7 +916,7 @@ public class Runner {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, domain, apiUrl, proxyUrl, cpu, memory, disk, gpu, gpuType, propertyClass, currentCpuUsagePercentage, currentMemoryUsagePercentage, currentDiskUsagePercentage, currentAllocatedCpu, currentAllocatedMemoryGiB, currentAllocatedDiskGiB, currentSnapshotCount, currentStartedSandboxes, availabilityScore, region, name, state, lastChecked, unschedulable, createdAt, updatedAt, version, apiVersion, runnerClass, appVersion, additionalProperties);
+    return Objects.hash(id, domain, apiUrl, proxyUrl, cpu, memory, disk, gpu, gpuType, propertyClass, currentCpuUsagePercentage, currentMemoryUsagePercentage, currentDiskUsagePercentage, currentAllocatedCpu, currentAllocatedMemoryGiB, currentAllocatedDiskGiB, currentSnapshotCount, currentStartedSandboxes, availabilityScore, region, name, state, lastChecked, unschedulable, tags, createdAt, updatedAt, version, apiVersion, runnerClass, appVersion, additionalProperties);
   }
 
   @Override
@@ -912,6 +947,7 @@ public class Runner {
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    lastChecked: ").append(toIndentedString(lastChecked)).append("\n");
     sb.append("    unschedulable: ").append(toIndentedString(unschedulable)).append("\n");
+    sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
@@ -937,10 +973,10 @@ public class Runner {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "cpu", "memory", "disk", "class", "region", "name", "state", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "cpu", "memory", "disk", "class", "region", "name", "state", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass"));
   }
 
   /**
@@ -990,6 +1026,12 @@ public class Runner {
       RunnerState.validateJsonElement(jsonObj.get("state"));
       if ((jsonObj.get("lastChecked") != null && !jsonObj.get("lastChecked").isJsonNull()) && !jsonObj.get("lastChecked").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `lastChecked` to be a primitive type in the JSON string but got `%s`", jsonObj.get("lastChecked").toString()));
+      }
+      // ensure the required json array is present
+      if (jsonObj.get("tags") == null) {
+        throw new IllegalArgumentException("Expected the field `linkedContent` to be an array in the JSON string but got `null`");
+      } else if (!jsonObj.get("tags").isJsonArray()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       if (!jsonObj.get("createdAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `createdAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("createdAt").toString()));

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerFull.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerFull.java
@@ -25,7 +25,9 @@ import io.daytona.api.client.model.RunnerState;
 import io.daytona.api.client.model.SandboxClass;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -174,6 +176,11 @@ public class RunnerFull {
   @SerializedName(SERIALIZED_NAME_UNSCHEDULABLE)
   @javax.annotation.Nonnull
   private Boolean unschedulable;
+
+  public static final String SERIALIZED_NAME_TAGS = "tags";
+  @SerializedName(SERIALIZED_NAME_TAGS)
+  @javax.annotation.Nonnull
+  private List<String> tags = new ArrayList<>();
 
   public static final String SERIALIZED_NAME_CREATED_AT = "createdAt";
   @SerializedName(SERIALIZED_NAME_CREATED_AT)
@@ -677,6 +684,33 @@ public class RunnerFull {
   }
 
 
+  public RunnerFull tags(@javax.annotation.Nonnull List<String> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  public RunnerFull addTagsItem(String tagsItem) {
+    if (this.tags == null) {
+      this.tags = new ArrayList<>();
+    }
+    this.tags.add(tagsItem);
+    return this;
+  }
+
+  /**
+   * Tags associated with the runner
+   * @return tags
+   */
+  @javax.annotation.Nonnull
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(@javax.annotation.Nonnull List<String> tags) {
+    this.tags = tags;
+  }
+
+
   public RunnerFull createdAt(@javax.annotation.Nonnull String createdAt) {
     this.createdAt = createdAt;
     return this;
@@ -919,6 +953,7 @@ public class RunnerFull {
         Objects.equals(this.state, runnerFull.state) &&
         Objects.equals(this.lastChecked, runnerFull.lastChecked) &&
         Objects.equals(this.unschedulable, runnerFull.unschedulable) &&
+        Objects.equals(this.tags, runnerFull.tags) &&
         Objects.equals(this.createdAt, runnerFull.createdAt) &&
         Objects.equals(this.updatedAt, runnerFull.updatedAt) &&
         Objects.equals(this.version, runnerFull.version) &&
@@ -932,7 +967,7 @@ public class RunnerFull {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, domain, apiUrl, proxyUrl, cpu, memory, disk, gpu, gpuType, propertyClass, currentCpuUsagePercentage, currentMemoryUsagePercentage, currentDiskUsagePercentage, currentAllocatedCpu, currentAllocatedMemoryGiB, currentAllocatedDiskGiB, currentSnapshotCount, currentStartedSandboxes, availabilityScore, region, name, state, lastChecked, unschedulable, createdAt, updatedAt, version, apiVersion, runnerClass, appVersion, apiKey, regionType, additionalProperties);
+    return Objects.hash(id, domain, apiUrl, proxyUrl, cpu, memory, disk, gpu, gpuType, propertyClass, currentCpuUsagePercentage, currentMemoryUsagePercentage, currentDiskUsagePercentage, currentAllocatedCpu, currentAllocatedMemoryGiB, currentAllocatedDiskGiB, currentSnapshotCount, currentStartedSandboxes, availabilityScore, region, name, state, lastChecked, unschedulable, tags, createdAt, updatedAt, version, apiVersion, runnerClass, appVersion, apiKey, regionType, additionalProperties);
   }
 
   @Override
@@ -963,6 +998,7 @@ public class RunnerFull {
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    lastChecked: ").append(toIndentedString(lastChecked)).append("\n");
     sb.append("    unschedulable: ").append(toIndentedString(unschedulable)).append("\n");
+    sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
@@ -990,10 +1026,10 @@ public class RunnerFull {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion", "apiKey", "regionType"));
+    openapiFields = new HashSet<String>(Arrays.asList("id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion", "apiKey", "regionType"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "cpu", "memory", "disk", "class", "region", "name", "state", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "apiKey"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("id", "cpu", "memory", "disk", "class", "region", "name", "state", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "apiKey"));
   }
 
   /**
@@ -1043,6 +1079,12 @@ public class RunnerFull {
       RunnerState.validateJsonElement(jsonObj.get("state"));
       if ((jsonObj.get("lastChecked") != null && !jsonObj.get("lastChecked").isJsonNull()) && !jsonObj.get("lastChecked").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `lastChecked` to be a primitive type in the JSON string but got `%s`", jsonObj.get("lastChecked").toString()));
+      }
+      // ensure the required json array is present
+      if (jsonObj.get("tags") == null) {
+        throw new IllegalArgumentException("Expected the field `linkedContent` to be an array in the JSON string but got `null`");
+      } else if (!jsonObj.get("tags").isJsonArray()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
       }
       if (!jsonObj.get("createdAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `createdAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("createdAt").toString()));

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/AdminCreateRunnerTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/AdminCreateRunnerTest.java
@@ -20,7 +20,9 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +54,14 @@ public class AdminCreateRunnerTest {
     @Test
     public void nameTest() {
         // TODO: test name
+    }
+
+    /**
+     * Test the property 'tags'
+     */
+    @Test
+    public void tagsTest() {
+        // TODO: test tags
     }
 
     /**

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/CreateRunnerTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/CreateRunnerTest.java
@@ -19,7 +19,9 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +53,14 @@ public class CreateRunnerTest {
     @Test
     public void nameTest() {
         // TODO: test name
+    }
+
+    /**
+     * Test the property 'tags'
+     */
+    @Test
+    public void tagsTest() {
+        // TODO: test tags
     }
 
 }

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RunnerFullTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RunnerFullTest.java
@@ -24,7 +24,9 @@ import io.daytona.api.client.model.RunnerState;
 import io.daytona.api.client.model.SandboxClass;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -232,6 +234,14 @@ public class RunnerFullTest {
     @Test
     public void unschedulableTest() {
         // TODO: test unschedulable
+    }
+
+    /**
+     * Test the property 'tags'
+     */
+    @Test
+    public void tagsTest() {
+        // TODO: test tags
     }
 
     /**

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RunnerTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RunnerTest.java
@@ -23,7 +23,9 @@ import io.daytona.api.client.model.RunnerState;
 import io.daytona.api.client.model.SandboxClass;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -231,6 +233,14 @@ public class RunnerTest {
     @Test
     public void unschedulableTest() {
         // TODO: test unschedulable
+    }
+
+    /**
+     * Test the property 'tags'
+     */
+    @Test
+    public void tagsTest() {
+        // TODO: test tags
     }
 
     /**

--- a/libs/api-client-python-async/daytona_api_client_async/models/admin_create_runner.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/admin_create_runner.py
@@ -33,6 +33,7 @@ class AdminCreateRunner(BaseModel):
     """ # noqa: E501
     region_id: StrictStr = Field(serialization_alias="regionId")
     name: StrictStr
+    tags: Optional[List[StrictStr]] = Field(default=None, description="Tags to associate with the runner")
     api_key: StrictStr = Field(serialization_alias="apiKey")
     api_version: Annotated[str, Field(strict=True)] = Field(description="The api version of the runner to create", serialization_alias="apiVersion")
     domain: Optional[StrictStr] = Field(default=None, description="The domain of the runner")
@@ -42,7 +43,7 @@ class AdminCreateRunner(BaseModel):
     memory_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="The memory capacity of the runner in GiB", serialization_alias="memoryGiB")
     disk_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="The disk capacity of the runner in GiB", serialization_alias="diskGiB")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "name", "apiKey", "apiVersion", "domain", "apiUrl", "proxyUrl", "cpu", "memoryGiB", "diskGiB"]
+    __properties: ClassVar[List[str]] = ["regionId", "name", "tags", "apiKey", "apiVersion", "domain", "apiUrl", "proxyUrl", "cpu", "memoryGiB", "diskGiB"]
 
     @field_validator('api_version')
     def api_version_validate_regular_expression(cls, value):
@@ -110,6 +111,7 @@ class AdminCreateRunner(BaseModel):
         _obj = cls.model_validate({
             "region_id": obj.get("regionId"),
             "name": obj.get("name"),
+            "tags": obj.get("tags"),
             "api_key": obj.get("apiKey"),
             "api_version": obj.get("apiVersion"),
             "domain": obj.get("domain"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/create_runner.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/create_runner.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -32,8 +32,9 @@ class CreateRunner(BaseModel):
     """ # noqa: E501
     region_id: StrictStr = Field(serialization_alias="regionId")
     name: StrictStr
+    tags: Optional[List[StrictStr]] = Field(default=None, description="Tags to associate with the runner")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "name"]
+    __properties: ClassVar[List[str]] = ["regionId", "name", "tags"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -93,7 +94,8 @@ class CreateRunner(BaseModel):
 
         _obj = cls.model_validate({
             "region_id": obj.get("regionId"),
-            "name": obj.get("name")
+            "name": obj.get("name"),
+            "tags": obj.get("tags")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/runner.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/runner.py
@@ -57,6 +57,7 @@ class Runner(BaseModel):
     state: RunnerState = Field(description="The state of the runner")
     last_checked: Optional[StrictStr] = Field(default=None, description="The last time the runner was checked", serialization_alias="lastChecked")
     unschedulable: StrictBool = Field(description="Whether the runner is unschedulable")
+    tags: List[StrictStr] = Field(description="Tags associated with the runner")
     created_at: StrictStr = Field(description="The creation timestamp of the runner", serialization_alias="createdAt")
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
@@ -64,7 +65,7 @@ class Runner(BaseModel):
     runner_class: RunnerClass = Field(description="The class of the runner", serialization_alias="runnerClass")
     app_version: Optional[StrictStr] = Field(default=None, description="The app version of the runner", serialization_alias="appVersion")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"]
+    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -147,6 +148,7 @@ class Runner(BaseModel):
             "state": obj.get("state"),
             "last_checked": obj.get("lastChecked"),
             "unschedulable": obj.get("unschedulable"),
+            "tags": obj.get("tags"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "version": obj.get("version"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/runner_full.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/runner_full.py
@@ -58,6 +58,7 @@ class RunnerFull(BaseModel):
     state: RunnerState = Field(description="The state of the runner")
     last_checked: Optional[StrictStr] = Field(default=None, description="The last time the runner was checked", serialization_alias="lastChecked")
     unschedulable: StrictBool = Field(description="Whether the runner is unschedulable")
+    tags: List[StrictStr] = Field(description="Tags associated with the runner")
     created_at: StrictStr = Field(description="The creation timestamp of the runner", serialization_alias="createdAt")
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
@@ -67,7 +68,7 @@ class RunnerFull(BaseModel):
     api_key: StrictStr = Field(description="The API key for the runner", serialization_alias="apiKey")
     region_type: Optional[RegionType] = Field(default=None, description="The region type of the runner", serialization_alias="regionType")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion", "apiKey", "regionType"]
+    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion", "apiKey", "regionType"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -150,6 +151,7 @@ class RunnerFull(BaseModel):
             "state": obj.get("state"),
             "last_checked": obj.get("lastChecked"),
             "unschedulable": obj.get("unschedulable"),
+            "tags": obj.get("tags"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "version": obj.get("version"),

--- a/libs/api-client-python/daytona_api_client/models/admin_create_runner.py
+++ b/libs/api-client-python/daytona_api_client/models/admin_create_runner.py
@@ -33,6 +33,7 @@ class AdminCreateRunner(BaseModel):
     """ # noqa: E501
     region_id: StrictStr = Field(serialization_alias="regionId")
     name: StrictStr
+    tags: Optional[List[StrictStr]] = Field(default=None, description="Tags to associate with the runner")
     api_key: StrictStr = Field(serialization_alias="apiKey")
     api_version: Annotated[str, Field(strict=True)] = Field(description="The api version of the runner to create", serialization_alias="apiVersion")
     domain: Optional[StrictStr] = Field(default=None, description="The domain of the runner")
@@ -42,7 +43,7 @@ class AdminCreateRunner(BaseModel):
     memory_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="The memory capacity of the runner in GiB", serialization_alias="memoryGiB")
     disk_gi_b: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="The disk capacity of the runner in GiB", serialization_alias="diskGiB")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "name", "apiKey", "apiVersion", "domain", "apiUrl", "proxyUrl", "cpu", "memoryGiB", "diskGiB"]
+    __properties: ClassVar[List[str]] = ["regionId", "name", "tags", "apiKey", "apiVersion", "domain", "apiUrl", "proxyUrl", "cpu", "memoryGiB", "diskGiB"]
 
     @field_validator('api_version')
     def api_version_validate_regular_expression(cls, value):
@@ -110,6 +111,7 @@ class AdminCreateRunner(BaseModel):
         _obj = cls.model_validate({
             "region_id": obj.get("regionId"),
             "name": obj.get("name"),
+            "tags": obj.get("tags"),
             "api_key": obj.get("apiKey"),
             "api_version": obj.get("apiVersion"),
             "domain": obj.get("domain"),

--- a/libs/api-client-python/daytona_api_client/models/create_runner.py
+++ b/libs/api-client-python/daytona_api_client/models/create_runner.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -32,8 +32,9 @@ class CreateRunner(BaseModel):
     """ # noqa: E501
     region_id: StrictStr = Field(serialization_alias="regionId")
     name: StrictStr
+    tags: Optional[List[StrictStr]] = Field(default=None, description="Tags to associate with the runner")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "name"]
+    __properties: ClassVar[List[str]] = ["regionId", "name", "tags"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -93,7 +94,8 @@ class CreateRunner(BaseModel):
 
         _obj = cls.model_validate({
             "region_id": obj.get("regionId"),
-            "name": obj.get("name")
+            "name": obj.get("name"),
+            "tags": obj.get("tags")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/runner.py
+++ b/libs/api-client-python/daytona_api_client/models/runner.py
@@ -57,6 +57,7 @@ class Runner(BaseModel):
     state: RunnerState = Field(description="The state of the runner")
     last_checked: Optional[StrictStr] = Field(default=None, description="The last time the runner was checked", serialization_alias="lastChecked")
     unschedulable: StrictBool = Field(description="Whether the runner is unschedulable")
+    tags: List[StrictStr] = Field(description="Tags associated with the runner")
     created_at: StrictStr = Field(description="The creation timestamp of the runner", serialization_alias="createdAt")
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
@@ -64,7 +65,7 @@ class Runner(BaseModel):
     runner_class: RunnerClass = Field(description="The class of the runner", serialization_alias="runnerClass")
     app_version: Optional[StrictStr] = Field(default=None, description="The app version of the runner", serialization_alias="appVersion")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"]
+    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -147,6 +148,7 @@ class Runner(BaseModel):
             "state": obj.get("state"),
             "last_checked": obj.get("lastChecked"),
             "unschedulable": obj.get("unschedulable"),
+            "tags": obj.get("tags"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "version": obj.get("version"),

--- a/libs/api-client-python/daytona_api_client/models/runner_full.py
+++ b/libs/api-client-python/daytona_api_client/models/runner_full.py
@@ -58,6 +58,7 @@ class RunnerFull(BaseModel):
     state: RunnerState = Field(description="The state of the runner")
     last_checked: Optional[StrictStr] = Field(default=None, description="The last time the runner was checked", serialization_alias="lastChecked")
     unschedulable: StrictBool = Field(description="Whether the runner is unschedulable")
+    tags: List[StrictStr] = Field(description="Tags associated with the runner")
     created_at: StrictStr = Field(description="The creation timestamp of the runner", serialization_alias="createdAt")
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
@@ -67,7 +68,7 @@ class RunnerFull(BaseModel):
     api_key: StrictStr = Field(description="The API key for the runner", serialization_alias="apiKey")
     region_type: Optional[RegionType] = Field(default=None, description="The region type of the runner", serialization_alias="regionType")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion", "apiKey", "regionType"]
+    __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "class", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion", "apiKey", "regionType"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -150,6 +151,7 @@ class RunnerFull(BaseModel):
             "state": obj.get("state"),
             "last_checked": obj.get("lastChecked"),
             "unschedulable": obj.get("unschedulable"),
+            "tags": obj.get("tags"),
             "created_at": obj.get("createdAt"),
             "updated_at": obj.get("updatedAt"),
             "version": obj.get("version"),

--- a/libs/api-client-ruby/lib/daytona_api_client/models/admin_create_runner.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/admin_create_runner.rb
@@ -19,6 +19,9 @@ module DaytonaApiClient
 
     attr_accessor :name
 
+    # Tags to associate with the runner
+    attr_accessor :tags
+
     attr_accessor :api_key
 
     # The api version of the runner to create
@@ -47,6 +50,7 @@ module DaytonaApiClient
       {
         :'region_id' => :'regionId',
         :'name' => :'name',
+        :'tags' => :'tags',
         :'api_key' => :'apiKey',
         :'api_version' => :'apiVersion',
         :'domain' => :'domain',
@@ -73,6 +77,7 @@ module DaytonaApiClient
       {
         :'region_id' => :'String',
         :'name' => :'String',
+        :'tags' => :'Array<String>',
         :'api_key' => :'String',
         :'api_version' => :'String',
         :'domain' => :'String',
@@ -116,6 +121,12 @@ module DaytonaApiClient
         self.name = attributes[:'name']
       else
         self.name = nil
+      end
+
+      if attributes.key?(:'tags')
+        if (value = attributes[:'tags']).is_a?(Array)
+          self.tags = value
+        end
       end
 
       if attributes.key?(:'api_key')
@@ -248,6 +259,7 @@ module DaytonaApiClient
       self.class == o.class &&
           region_id == o.region_id &&
           name == o.name &&
+          tags == o.tags &&
           api_key == o.api_key &&
           api_version == o.api_version &&
           domain == o.domain &&
@@ -267,7 +279,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [region_id, name, api_key, api_version, domain, api_url, proxy_url, cpu, memory_gi_b, disk_gi_b].hash
+      [region_id, name, tags, api_key, api_version, domain, api_url, proxy_url, cpu, memory_gi_b, disk_gi_b].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/create_runner.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/create_runner.rb
@@ -19,11 +19,15 @@ module DaytonaApiClient
 
     attr_accessor :name
 
+    # Tags to associate with the runner
+    attr_accessor :tags
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'region_id' => :'regionId',
-        :'name' => :'name'
+        :'name' => :'name',
+        :'tags' => :'tags'
       }
     end
 
@@ -41,7 +45,8 @@ module DaytonaApiClient
     def self.openapi_types
       {
         :'region_id' => :'String',
-        :'name' => :'String'
+        :'name' => :'String',
+        :'tags' => :'Array<String>'
       }
     end
 
@@ -77,6 +82,12 @@ module DaytonaApiClient
         self.name = attributes[:'name']
       else
         self.name = nil
+      end
+
+      if attributes.key?(:'tags')
+        if (value = attributes[:'tags']).is_a?(Array)
+          self.tags = value
+        end
       end
     end
 
@@ -131,7 +142,8 @@ module DaytonaApiClient
       return true if self.equal?(o)
       self.class == o.class &&
           region_id == o.region_id &&
-          name == o.name
+          name == o.name &&
+          tags == o.tags
     end
 
     # @see the `==` method
@@ -143,7 +155,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [region_id, name].hash
+      [region_id, name, tags].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/runner.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/runner.rb
@@ -87,6 +87,9 @@ module DaytonaApiClient
     # Whether the runner is unschedulable
     attr_accessor :unschedulable
 
+    # Tags associated with the runner
+    attr_accessor :tags
+
     # The creation timestamp of the runner
     attr_accessor :created_at
 
@@ -154,6 +157,7 @@ module DaytonaApiClient
         :'state' => :'state',
         :'last_checked' => :'lastChecked',
         :'unschedulable' => :'unschedulable',
+        :'tags' => :'tags',
         :'created_at' => :'createdAt',
         :'updated_at' => :'updatedAt',
         :'version' => :'version',
@@ -200,6 +204,7 @@ module DaytonaApiClient
         :'state' => :'RunnerState',
         :'last_checked' => :'String',
         :'unschedulable' => :'Boolean',
+        :'tags' => :'Array<String>',
         :'created_at' => :'String',
         :'updated_at' => :'String',
         :'version' => :'String',
@@ -345,6 +350,14 @@ module DaytonaApiClient
         self.unschedulable = nil
       end
 
+      if attributes.key?(:'tags')
+        if (value = attributes[:'tags']).is_a?(Array)
+          self.tags = value
+        end
+      else
+        self.tags = nil
+      end
+
       if attributes.key?(:'created_at')
         self.created_at = attributes[:'created_at']
       else
@@ -421,6 +434,10 @@ module DaytonaApiClient
         invalid_properties.push('invalid value for "unschedulable", unschedulable cannot be nil.')
       end
 
+      if @tags.nil?
+        invalid_properties.push('invalid value for "tags", tags cannot be nil.')
+      end
+
       if @created_at.nil?
         invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
       end
@@ -457,6 +474,7 @@ module DaytonaApiClient
       return false if @name.nil?
       return false if @state.nil?
       return false if @unschedulable.nil?
+      return false if @tags.nil?
       return false if @created_at.nil?
       return false if @updated_at.nil?
       return false if @version.nil?
@@ -556,6 +574,16 @@ module DaytonaApiClient
     end
 
     # Custom attribute writer method with validation
+    # @param [Object] tags Value to be assigned
+    def tags=(tags)
+      if tags.nil?
+        fail ArgumentError, 'tags cannot be nil'
+      end
+
+      @tags = tags
+    end
+
+    # Custom attribute writer method with validation
     # @param [Object] created_at Value to be assigned
     def created_at=(created_at)
       if created_at.nil?
@@ -634,6 +662,7 @@ module DaytonaApiClient
           state == o.state &&
           last_checked == o.last_checked &&
           unschedulable == o.unschedulable &&
+          tags == o.tags &&
           created_at == o.created_at &&
           updated_at == o.updated_at &&
           version == o.version &&
@@ -651,7 +680,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, domain, api_url, proxy_url, cpu, memory, disk, gpu, gpu_type, _class, current_cpu_usage_percentage, current_memory_usage_percentage, current_disk_usage_percentage, current_allocated_cpu, current_allocated_memory_gi_b, current_allocated_disk_gi_b, current_snapshot_count, current_started_sandboxes, availability_score, region, name, state, last_checked, unschedulable, created_at, updated_at, version, api_version, runner_class, app_version].hash
+      [id, domain, api_url, proxy_url, cpu, memory, disk, gpu, gpu_type, _class, current_cpu_usage_percentage, current_memory_usage_percentage, current_disk_usage_percentage, current_allocated_cpu, current_allocated_memory_gi_b, current_allocated_disk_gi_b, current_snapshot_count, current_started_sandboxes, availability_score, region, name, state, last_checked, unschedulable, tags, created_at, updated_at, version, api_version, runner_class, app_version].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/runner_full.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/runner_full.rb
@@ -87,6 +87,9 @@ module DaytonaApiClient
     # Whether the runner is unschedulable
     attr_accessor :unschedulable
 
+    # Tags associated with the runner
+    attr_accessor :tags
+
     # The creation timestamp of the runner
     attr_accessor :created_at
 
@@ -160,6 +163,7 @@ module DaytonaApiClient
         :'state' => :'state',
         :'last_checked' => :'lastChecked',
         :'unschedulable' => :'unschedulable',
+        :'tags' => :'tags',
         :'created_at' => :'createdAt',
         :'updated_at' => :'updatedAt',
         :'version' => :'version',
@@ -208,6 +212,7 @@ module DaytonaApiClient
         :'state' => :'RunnerState',
         :'last_checked' => :'String',
         :'unschedulable' => :'Boolean',
+        :'tags' => :'Array<String>',
         :'created_at' => :'String',
         :'updated_at' => :'String',
         :'version' => :'String',
@@ -355,6 +360,14 @@ module DaytonaApiClient
         self.unschedulable = nil
       end
 
+      if attributes.key?(:'tags')
+        if (value = attributes[:'tags']).is_a?(Array)
+          self.tags = value
+        end
+      else
+        self.tags = nil
+      end
+
       if attributes.key?(:'created_at')
         self.created_at = attributes[:'created_at']
       else
@@ -441,6 +454,10 @@ module DaytonaApiClient
         invalid_properties.push('invalid value for "unschedulable", unschedulable cannot be nil.')
       end
 
+      if @tags.nil?
+        invalid_properties.push('invalid value for "tags", tags cannot be nil.')
+      end
+
       if @created_at.nil?
         invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
       end
@@ -481,6 +498,7 @@ module DaytonaApiClient
       return false if @name.nil?
       return false if @state.nil?
       return false if @unschedulable.nil?
+      return false if @tags.nil?
       return false if @created_at.nil?
       return false if @updated_at.nil?
       return false if @version.nil?
@@ -581,6 +599,16 @@ module DaytonaApiClient
     end
 
     # Custom attribute writer method with validation
+    # @param [Object] tags Value to be assigned
+    def tags=(tags)
+      if tags.nil?
+        fail ArgumentError, 'tags cannot be nil'
+      end
+
+      @tags = tags
+    end
+
+    # Custom attribute writer method with validation
     # @param [Object] created_at Value to be assigned
     def created_at=(created_at)
       if created_at.nil?
@@ -669,6 +697,7 @@ module DaytonaApiClient
           state == o.state &&
           last_checked == o.last_checked &&
           unschedulable == o.unschedulable &&
+          tags == o.tags &&
           created_at == o.created_at &&
           updated_at == o.updated_at &&
           version == o.version &&
@@ -688,7 +717,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, domain, api_url, proxy_url, cpu, memory, disk, gpu, gpu_type, _class, current_cpu_usage_percentage, current_memory_usage_percentage, current_disk_usage_percentage, current_allocated_cpu, current_allocated_memory_gi_b, current_allocated_disk_gi_b, current_snapshot_count, current_started_sandboxes, availability_score, region, name, state, last_checked, unschedulable, created_at, updated_at, version, api_version, runner_class, app_version, api_key, region_type].hash
+      [id, domain, api_url, proxy_url, cpu, memory, disk, gpu, gpu_type, _class, current_cpu_usage_percentage, current_memory_usage_percentage, current_disk_usage_percentage, current_allocated_cpu, current_allocated_memory_gi_b, current_allocated_disk_gi_b, current_snapshot_count, current_started_sandboxes, availability_score, region, name, state, last_checked, unschedulable, tags, created_at, updated_at, version, api_version, runner_class, app_version, api_key, region_type].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/models/admin-create-runner.ts
+++ b/libs/api-client/src/models/admin-create-runner.ts
@@ -17,6 +17,10 @@
 export interface AdminCreateRunner {
     'regionId': string;
     'name': string;
+    /**
+     * Tags to associate with the runner
+     */
+    'tags'?: Array<string>;
     'apiKey': string;
     /**
      * The api version of the runner to create

--- a/libs/api-client/src/models/create-runner.ts
+++ b/libs/api-client/src/models/create-runner.ts
@@ -17,5 +17,9 @@
 export interface CreateRunner {
     'regionId': string;
     'name': string;
+    /**
+     * Tags to associate with the runner
+     */
+    'tags'?: Array<string>;
 }
 

--- a/libs/api-client/src/models/runner-full.ts
+++ b/libs/api-client/src/models/runner-full.ts
@@ -124,6 +124,10 @@ export interface RunnerFull {
      */
     'unschedulable': boolean;
     /**
+     * Tags associated with the runner
+     */
+    'tags': Array<string>;
+    /**
      * The creation timestamp of the runner
      */
     'createdAt': string;

--- a/libs/api-client/src/models/runner.ts
+++ b/libs/api-client/src/models/runner.ts
@@ -121,6 +121,10 @@ export interface Runner {
      */
     'unschedulable': boolean;
     /**
+     * Tags associated with the runner
+     */
+    'tags': Array<string>;
+    /**
      * The creation timestamp of the runner
      */
     'createdAt': string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tags to runners for lightweight labeling and retrieval in API responses. Tags are optional on create, stored as a `text[]` with a GIN index, always included in runner payloads, and captured in audit metadata on create.

- **New Features**
  - Added `tags` `text[]` column with default `[]` and GIN index `runner_tags_gin_idx`.
  - Create Runner (sandbox/admin) accepts optional `tags: string[]`.
  - Runner responses include `tags` (always an array).
  - Audit request metadata now includes `tags` for create runner calls.
  - Updated OpenAPI and all API clients (`go`, `java`, `python`, `python-async`, `ruby`, `ts`) to support tags.

- **Migration**
  - Run the pre-deploy DB migration to add the tags column and index.
  - No breaking changes; existing clients continue to work.

<sup>Written for commit 99003bcbcf713bb054f9ef41cf3736f3e3e9c336. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

