### PR TITLE
fix(runner): disable storage limits when limits are off

### DIFF
--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -155,7 +155,7 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 		hostConfig.Runtime = containerRuntime
 	}
 
-	if d.filesystem == "xfs" {
+	if !d.resourceLimitsDisabled && d.filesystem == "xfs" {
 		hostConfig.StorageOpt = map[string]string{
 			"size": fmt.Sprintf("%dG", sandboxDto.StorageQuota),
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable per-container storage limits in the runner when resource limits are turned off. We now set Docker `HostConfig.StorageOpt` only if limits are enabled and the filesystem is xfs, preventing unintended quotas.

<sup>Written for commit d7f020bdcd98b53e2b7e1bae96b7b186189ba398. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

