### PR TITLE
feat(webhook): skip svix message create when org has no endpoints

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1778588023059-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1778588023059-migration.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1778588023059 implements MigrationInterface {
+  name = 'Migration1778588023059'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "webhook_initialization" ADD "hasEndpoints" boolean NOT NULL DEFAULT false`)
+    await queryRunner.query(`ALTER TABLE "webhook_initialization" ADD "endpointsCheckedAt" TIMESTAMP WITH TIME ZONE`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "webhook_initialization" DROP COLUMN "endpointsCheckedAt"`)
+    await queryRunner.query(`ALTER TABLE "webhook_initialization" DROP COLUMN "hasEndpoints"`)
+  }
+}

--- a/apps/api/src/webhook/controllers/webhook.controller.auth.spec.ts
+++ b/apps/api/src/webhook/controllers/webhook.controller.auth.spec.ts
@@ -36,4 +36,14 @@ describe('[AUTH] WebhookController', () => {
     ])
     expectArrayMatch(getAuthContextGuards(WebhookController, methodName), [OrganizationAuthContextGuard])
   })
+
+  it('refreshEndpoints', () => {
+    const methodName = trackMethod('refreshEndpoints')
+    expect(isPublicEndpoint(WebhookController, methodName)).toBe(false)
+    expectArrayMatch(getAllowedAuthStrategies(WebhookController, methodName), [
+      AuthStrategyType.API_KEY,
+      AuthStrategyType.JWT,
+    ])
+    expectArrayMatch(getAuthContextGuards(WebhookController, methodName), [OrganizationAuthContextGuard])
+  })
 })

--- a/apps/api/src/webhook/controllers/webhook.controller.ts
+++ b/apps/api/src/webhook/controllers/webhook.controller.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Controller, Post, Get, Param, UseGuards, HttpStatus, NotFoundException } from '@nestjs/common'
+import { Controller, Post, Get, Param, UseGuards, HttpCode, HttpStatus, NotFoundException } from '@nestjs/common'
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiOAuth2, ApiHeader } from '@nestjs/swagger'
 import { WebhookService } from '../services/webhook.service'
 import { OrganizationAuthContextGuard } from '../../organization/guards/organization-auth-context.guard'
@@ -55,5 +55,20 @@ export class WebhookController {
       throw new NotFoundException('Webhook initialization status not found')
     }
     return WebhookInitializationStatusDto.fromWebhookInitialization(status)
+  }
+
+  @Post('organizations/:organizationId/refresh-endpoints')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Refresh cached endpoint presence flag for an organization' })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Endpoint flag refreshed',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Webhook initialization status not found',
+  })
+  async refreshEndpoints(@Param('organizationId') organizationId: string): Promise<void> {
+    await this.webhookService.refreshEndpointFlagByOrg(organizationId)
   }
 }

--- a/apps/api/src/webhook/entities/webhook-initialization.entity.ts
+++ b/apps/api/src/webhook/entities/webhook-initialization.entity.ts
@@ -27,6 +27,18 @@ export class WebhookInitialization {
   })
   retryCount: number
 
+  @Column({
+    type: 'boolean',
+    default: false,
+  })
+  hasEndpoints: boolean
+
+  @Column({
+    type: 'timestamp with time zone',
+    nullable: true,
+  })
+  endpointsCheckedAt?: Date
+
   @CreateDateColumn({
     type: 'timestamp with time zone',
   })

--- a/apps/api/src/webhook/services/webhook.service.ts
+++ b/apps/api/src/webhook/services/webhook.service.ts
@@ -108,6 +108,39 @@ export class WebhookService implements OnModuleInit {
     }
   }
 
+  private static readonly ENDPOINT_FLAG_TTL_MS = 60_000
+
+  /**
+   * Refresh hasEndpoints by counting endpoints in Svix.
+   * On error, returns the row unchanged — we'd rather try to send than silently drop during a Svix transient issue.
+   */
+  private async refreshEndpointFlag(init: WebhookInitialization): Promise<WebhookInitialization> {
+    if (!this.svix) {
+      return init
+    }
+
+    try {
+      const result = await this.svix.endpoint.list(init.organizationId, { limit: 1 })
+      init.hasEndpoints = result.data.length > 0
+      init.endpointsCheckedAt = new Date()
+      return await this.webhookInitializationRepository.save(init)
+    } catch (error) {
+      this.logger.error(`Failed to refresh endpoint flag for organization ${init.organizationId}:`, error)
+      return init
+    }
+  }
+
+  /**
+   * Public wrapper for the refresh used by the controller ping route.
+   */
+  async refreshEndpointFlagByOrg(organizationId: string): Promise<void> {
+    const init = await this.getInitializationStatus(organizationId)
+    if (!init) {
+      throw new NotFoundException('Webhook initialization status not found')
+    }
+    await this.refreshEndpointFlag(init)
+  }
+
   /**
    * Send a webhook message to all endpoints of an organization
    */
@@ -119,15 +152,21 @@ export class WebhookService implements OnModuleInit {
 
     try {
       // Check if webhooks are initialized for this organization
-      const isInitialized = await this.getInitializationStatus(organizationId)
+      let init = await this.getInitializationStatus(organizationId)
 
-      if (!isInitialized) {
-        this.logger.log(`Webhooks not initialized for organization ${organizationId}, creating Svix application now...`)
-        // For now, we'll just log that initialization is needed
-        // The actual initialization should be done through the API or event handler
-        this.logger.warn(
-          `Organization ${organizationId} needs webhook initialization. Please use the initialization API endpoint.`,
-        )
+      if (!init) {
+        this.logger.debug(`Skipping webhook ${eventType} for organization ${organizationId}: webhooks not initialized`)
+        return
+      }
+
+      const stale =
+        !init.endpointsCheckedAt || Date.now() - init.endpointsCheckedAt.getTime() > WebhookService.ENDPOINT_FLAG_TTL_MS
+      if (stale) {
+        init = await this.refreshEndpointFlag(init)
+      }
+
+      if (!init.hasEndpoints) {
+        this.logger.debug(`Skipping webhook ${eventType} for organization ${organizationId}: no endpoints`)
         return
       }
 

--- a/apps/api/src/webhook/services/webhook.service.ts
+++ b/apps/api/src/webhook/services/webhook.service.ts
@@ -112,7 +112,9 @@ export class WebhookService implements OnModuleInit {
 
   /**
    * Refresh hasEndpoints by counting endpoints in Svix.
-   * On error, returns the row unchanged — we'd rather try to send than silently drop during a Svix transient issue.
+   * On error, returns the input row untouched. Callers distinguish a freshly-refreshed row
+   * from a stale one via endpointsCheckedAt and fall back to attempting delivery rather than
+   * treating a never-confirmed false as authoritative.
    */
   private async refreshEndpointFlag(init: WebhookInitialization): Promise<WebhookInitialization> {
     if (!this.svix) {
@@ -121,9 +123,11 @@ export class WebhookService implements OnModuleInit {
 
     try {
       const result = await this.svix.endpoint.list(init.organizationId, { limit: 1 })
-      init.hasEndpoints = result.data.length > 0
-      init.endpointsCheckedAt = new Date()
-      return await this.webhookInitializationRepository.save(init)
+      return await this.webhookInitializationRepository.save({
+        ...init,
+        hasEndpoints: result.data.length > 0,
+        endpointsCheckedAt: new Date(),
+      })
     } catch (error) {
       this.logger.error(`Failed to refresh endpoint flag for organization ${init.organizationId}:`, error)
       return init
@@ -159,13 +163,18 @@ export class WebhookService implements OnModuleInit {
         return
       }
 
-      const stale =
-        !init.endpointsCheckedAt || Date.now() - init.endpointsCheckedAt.getTime() > WebhookService.ENDPOINT_FLAG_TTL_MS
-      if (stale) {
+      const isFresh = (checkedAt?: Date) =>
+        checkedAt !== undefined &&
+        checkedAt !== null &&
+        Date.now() - checkedAt.getTime() <= WebhookService.ENDPOINT_FLAG_TTL_MS
+      if (!isFresh(init.endpointsCheckedAt)) {
         init = await this.refreshEndpointFlag(init)
       }
 
-      if (!init.hasEndpoints) {
+      // Only treat hasEndpoints=false as authoritative when we have a recent confirmation;
+      // if the refresh failed and the flag is stale, fall through to message.create rather
+      // than silently dropping (a Svix outage should surface as a send failure, not a quiet skip).
+      if (!init.hasEndpoints && isFresh(init.endpointsCheckedAt)) {
         this.logger.debug(`Skipping webhook ${eventType} for organization ${organizationId}: no endpoints`)
         return
       }

--- a/apps/dashboard/src/components/Webhooks/UpsertEndpointSheet.tsx
+++ b/apps/dashboard/src/components/Webhooks/UpsertEndpointSheet.tsx
@@ -28,7 +28,9 @@ import {
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { WEBHOOK_EVENT_CATEGORIES, WEBHOOK_EVENTS } from '@/constants/webhook-events'
+import { useRefreshWebhookEndpointFlagMutation } from '@/hooks/mutations/useRefreshWebhookEndpointFlagMutation'
 import { useUpdateWebhookEndpointMutation } from '@/hooks/mutations/useUpdateWebhookEndpointMutation'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import { cn } from '@/lib/utils'
 import { useForm } from '@tanstack/react-form'
@@ -88,6 +90,8 @@ export const UpsertEndpointSheet = ({
 
   const formRef = useRef<HTMLFormElement>(null)
   const { svix, appId } = useSvix()
+  const { selectedOrganization } = useSelectedOrganization()
+  const refreshEndpointFlag = useRefreshWebhookEndpointFlagMutation()
   const { reset: resetUpdateEndpointMutation, ...updateEndpointMutation } = useUpdateWebhookEndpointMutation()
   const { reset: resetCreateEndpointMutation, ...createEndpointMutation } = useMutation({
     mutationFn: async (value: FormValues) => {
@@ -96,6 +100,9 @@ export const UpsertEndpointSheet = ({
         description: value.description?.trim() || undefined,
         filterTypes: value.filterTypes.length > 0 ? value.filterTypes : undefined,
       })
+      if (selectedOrganization?.id) {
+        refreshEndpointFlag.mutate(selectedOrganization.id)
+      }
     },
   })
 

--- a/apps/dashboard/src/hooks/mutations/useDeleteWebhookEndpointMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useDeleteWebhookEndpointMutation.ts
@@ -5,6 +5,8 @@
 
 import { useMutation } from '@tanstack/react-query'
 import { useSvix } from 'svix-react'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { useRefreshWebhookEndpointFlagMutation } from './useRefreshWebhookEndpointFlagMutation'
 
 interface DeleteWebhookEndpointVariables {
   endpointId: string
@@ -12,10 +14,15 @@ interface DeleteWebhookEndpointVariables {
 
 export const useDeleteWebhookEndpointMutation = () => {
   const { svix, appId } = useSvix()
+  const { selectedOrganization } = useSelectedOrganization()
+  const refreshFlag = useRefreshWebhookEndpointFlagMutation()
 
   return useMutation({
     mutationFn: async ({ endpointId }: DeleteWebhookEndpointVariables) => {
       await svix.endpoint.delete(appId, endpointId)
+      if (selectedOrganization?.id) {
+        refreshFlag.mutate(selectedOrganization.id)
+      }
     },
   })
 }

--- a/apps/dashboard/src/hooks/mutations/useRefreshWebhookEndpointFlagMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useRefreshWebhookEndpointFlagMutation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Daytona Platforms Inc.
+ * Copyright Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
 

--- a/apps/dashboard/src/hooks/mutations/useRefreshWebhookEndpointFlagMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useRefreshWebhookEndpointFlagMutation.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { useMutation } from '@tanstack/react-query'
+import { useApi } from '../useApi'
+
+export const useRefreshWebhookEndpointFlagMutation = () => {
+  const { axiosInstance } = useApi()
+
+  return useMutation({
+    mutationFn: async (organizationId: string) => {
+      await axiosInstance.post(`/webhooks/organizations/${organizationId}/refresh-endpoints`)
+    },
+  })
+}

--- a/apps/dashboard/src/hooks/mutations/useUpdateWebhookEndpointMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useUpdateWebhookEndpointMutation.ts
@@ -6,8 +6,6 @@
 import { useMutation } from '@tanstack/react-query'
 import { EndpointPatch } from 'svix'
 import { useSvix } from 'svix-react'
-import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { useRefreshWebhookEndpointFlagMutation } from './useRefreshWebhookEndpointFlagMutation'
 
 interface UpdateWebhookEndpointVariables {
   endpointId: string
@@ -16,16 +14,10 @@ interface UpdateWebhookEndpointVariables {
 
 export const useUpdateWebhookEndpointMutation = () => {
   const { svix, appId } = useSvix()
-  const { selectedOrganization } = useSelectedOrganization()
-  const refreshFlag = useRefreshWebhookEndpointFlagMutation()
 
   return useMutation({
     mutationFn: async ({ endpointId, update }: UpdateWebhookEndpointVariables) => {
-      const result = await svix.endpoint.patch(appId, endpointId, update)
-      if (selectedOrganization?.id) {
-        refreshFlag.mutate(selectedOrganization.id)
-      }
-      return result
+      return svix.endpoint.patch(appId, endpointId, update)
     },
   })
 }

--- a/apps/dashboard/src/hooks/mutations/useUpdateWebhookEndpointMutation.ts
+++ b/apps/dashboard/src/hooks/mutations/useUpdateWebhookEndpointMutation.ts
@@ -6,6 +6,8 @@
 import { useMutation } from '@tanstack/react-query'
 import { EndpointPatch } from 'svix'
 import { useSvix } from 'svix-react'
+import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
+import { useRefreshWebhookEndpointFlagMutation } from './useRefreshWebhookEndpointFlagMutation'
 
 interface UpdateWebhookEndpointVariables {
   endpointId: string
@@ -14,10 +16,16 @@ interface UpdateWebhookEndpointVariables {
 
 export const useUpdateWebhookEndpointMutation = () => {
   const { svix, appId } = useSvix()
+  const { selectedOrganization } = useSelectedOrganization()
+  const refreshFlag = useRefreshWebhookEndpointFlagMutation()
 
   return useMutation({
     mutationFn: async ({ endpointId, update }: UpdateWebhookEndpointVariables) => {
-      return svix.endpoint.patch(appId, endpointId, update)
+      const result = await svix.endpoint.patch(appId, endpointId, update)
+      if (selectedOrganization?.id) {
+        refreshFlag.mutate(selectedOrganization.id)
+      }
+      return result
     },
   })
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -8775,6 +8775,39 @@ paths:
       summary: Get webhook initialization status for an organization
       tags:
       - webhooks
+  /webhooks/organizations/{organizationId}/refresh-endpoints:
+    post:
+      operationId: WebhookController_refreshEndpoints
+      parameters:
+      - description: Use with JWT to specify the organization ID
+        explode: false
+        in: header
+        name: X-Daytona-Organization-ID
+        required: false
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "204":
+          description: Endpoint flag refreshed
+        "404":
+          description: Webhook initialization status not found
+      security:
+      - bearer: []
+      - oauth2:
+        - openid
+        - profile
+        - email
+      summary: Refresh cached endpoint presence flag for an organization
+      tags:
+      - webhooks
   /audit/organizations/{organizationId}:
     get:
       operationId: getOrganizationAuditLogs

--- a/libs/api-client-go/api_webhooks.go
+++ b/libs/api-client-go/api_webhooks.go
@@ -48,6 +48,18 @@ type WebhooksAPI interface {
 	// WebhookControllerGetInitializationStatusExecute executes the request
 	//  @return WebhookInitializationStatus
 	WebhookControllerGetInitializationStatusExecute(r WebhooksAPIWebhookControllerGetInitializationStatusRequest) (*WebhookInitializationStatus, *http.Response, error)
+
+	/*
+	WebhookControllerRefreshEndpoints Refresh cached endpoint presence flag for an organization
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param organizationId
+	@return WebhooksAPIWebhookControllerRefreshEndpointsRequest
+	*/
+	WebhookControllerRefreshEndpoints(ctx context.Context, organizationId string) WebhooksAPIWebhookControllerRefreshEndpointsRequest
+
+	// WebhookControllerRefreshEndpointsExecute executes the request
+	WebhookControllerRefreshEndpointsExecute(r WebhooksAPIWebhookControllerRefreshEndpointsRequest) (*http.Response, error)
 }
 
 // WebhooksAPIService WebhooksAPI service
@@ -273,4 +285,104 @@ func (a *WebhooksAPIService) WebhookControllerGetInitializationStatusExecute(r W
 	}
 
 	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type WebhooksAPIWebhookControllerRefreshEndpointsRequest struct {
+	ctx context.Context
+	ApiService WebhooksAPI
+	organizationId string
+	xDaytonaOrganizationID *string
+}
+
+// Use with JWT to specify the organization ID
+func (r WebhooksAPIWebhookControllerRefreshEndpointsRequest) XDaytonaOrganizationID(xDaytonaOrganizationID string) WebhooksAPIWebhookControllerRefreshEndpointsRequest {
+	r.xDaytonaOrganizationID = &xDaytonaOrganizationID
+	return r
+}
+
+func (r WebhooksAPIWebhookControllerRefreshEndpointsRequest) Execute() (*http.Response, error) {
+	return r.ApiService.WebhookControllerRefreshEndpointsExecute(r)
+}
+
+/*
+WebhookControllerRefreshEndpoints Refresh cached endpoint presence flag for an organization
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param organizationId
+ @return WebhooksAPIWebhookControllerRefreshEndpointsRequest
+*/
+func (a *WebhooksAPIService) WebhookControllerRefreshEndpoints(ctx context.Context, organizationId string) WebhooksAPIWebhookControllerRefreshEndpointsRequest {
+	return WebhooksAPIWebhookControllerRefreshEndpointsRequest{
+		ApiService: a,
+		ctx: ctx,
+		organizationId: organizationId,
+	}
+}
+
+// Execute executes the request
+func (a *WebhooksAPIService) WebhookControllerRefreshEndpointsExecute(r WebhooksAPIWebhookControllerRefreshEndpointsRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodPost
+		localVarPostBody     interface{}
+		formFiles            []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WebhooksAPIService.WebhookControllerRefreshEndpoints")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/webhooks/organizations/{organizationId}/refresh-endpoints"
+	localVarPath = strings.Replace(localVarPath, "{"+"organizationId"+"}", url.PathEscape(parameterValueToString(r.organizationId, "organizationId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.xDaytonaOrganizationID != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "X-Daytona-Organization-ID", r.xDaytonaOrganizationID, "simple", "")
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
 }

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/api/WebhooksApi.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/api/WebhooksApi.java
@@ -349,4 +349,139 @@ public class WebhooksApi {
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+    /**
+     * Build call for webhookControllerRefreshEndpoints
+     * @param organizationId  (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> Endpoint flag refreshed </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Webhook initialization status not found </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call webhookControllerRefreshEndpointsCall(@javax.annotation.Nonnull String organizationId, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/webhooks/organizations/{organizationId}/refresh-endpoints"
+            .replace("{" + "organizationId" + "}", localVarApiClient.escapeString(organizationId.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        if (xDaytonaOrganizationID != null) {
+            localVarHeaderParams.put("X-Daytona-Organization-ID", localVarApiClient.parameterToString(xDaytonaOrganizationID));
+        }
+
+
+        String[] localVarAuthNames = new String[] { "bearer", "oauth2" };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call webhookControllerRefreshEndpointsValidateBeforeCall(@javax.annotation.Nonnull String organizationId, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback _callback) throws ApiException {
+        // verify the required parameter 'organizationId' is set
+        if (organizationId == null) {
+            throw new ApiException("Missing the required parameter 'organizationId' when calling webhookControllerRefreshEndpoints(Async)");
+        }
+
+        return webhookControllerRefreshEndpointsCall(organizationId, xDaytonaOrganizationID, _callback);
+
+    }
+
+    /**
+     * Refresh cached endpoint presence flag for an organization
+     * 
+     * @param organizationId  (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> Endpoint flag refreshed </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Webhook initialization status not found </td><td>  -  </td></tr>
+     </table>
+     */
+    public void webhookControllerRefreshEndpoints(@javax.annotation.Nonnull String organizationId, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+        webhookControllerRefreshEndpointsWithHttpInfo(organizationId, xDaytonaOrganizationID);
+    }
+
+    /**
+     * Refresh cached endpoint presence flag for an organization
+     * 
+     * @param organizationId  (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> Endpoint flag refreshed </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Webhook initialization status not found </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Void> webhookControllerRefreshEndpointsWithHttpInfo(@javax.annotation.Nonnull String organizationId, @javax.annotation.Nullable String xDaytonaOrganizationID) throws ApiException {
+        okhttp3.Call localVarCall = webhookControllerRefreshEndpointsValidateBeforeCall(organizationId, xDaytonaOrganizationID, null);
+        return localVarApiClient.execute(localVarCall);
+    }
+
+    /**
+     * Refresh cached endpoint presence flag for an organization (asynchronously)
+     * 
+     * @param organizationId  (required)
+     * @param xDaytonaOrganizationID Use with JWT to specify the organization ID (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> Endpoint flag refreshed </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Webhook initialization status not found </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call webhookControllerRefreshEndpointsAsync(@javax.annotation.Nonnull String organizationId, @javax.annotation.Nullable String xDaytonaOrganizationID, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = webhookControllerRefreshEndpointsValidateBeforeCall(organizationId, xDaytonaOrganizationID, _callback);
+        localVarApiClient.executeAsync(localVarCall, _callback);
+        return localVarCall;
+    }
 }

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/api/WebhooksApiTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/api/WebhooksApiTest.java
@@ -58,4 +58,17 @@ public class WebhooksApiTest {
         // TODO: test validations
     }
 
+    /**
+     * Refresh cached endpoint presence flag for an organization
+     *
+     * @throws ApiException if the Api call fails
+     */
+    @Test
+    public void webhookControllerRefreshEndpointsTest() throws ApiException {
+        String organizationId = null;
+        String xDaytonaOrganizationID = null;
+        api.webhookControllerRefreshEndpoints(organizationId, xDaytonaOrganizationID);
+        // TODO: test validations
+    }
+
 }

--- a/libs/api-client-python-async/daytona_api_client_async/api/webhooks_api.py
+++ b/libs/api-client-python-async/daytona_api_client_async/api/webhooks_api.py
@@ -589,3 +589,273 @@ class WebhooksApi:
         )
 
 
+
+
+    @validate_call
+    async def webhook_controller_refresh_endpoints(
+        self,
+        organization_id: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> None:
+        """Refresh cached endpoint presence flag for an organization
+
+
+        :param organization_id: (required)
+        :type organization_id: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._webhook_controller_refresh_endpoints_serialize(
+            organization_id=organization_id,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '404': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    async def webhook_controller_refresh_endpoints_with_http_info(
+        self,
+        organization_id: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[None]:
+        """Refresh cached endpoint presence flag for an organization
+
+
+        :param organization_id: (required)
+        :type organization_id: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._webhook_controller_refresh_endpoints_serialize(
+            organization_id=organization_id,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '404': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    async def webhook_controller_refresh_endpoints_without_preload_content(
+        self,
+        organization_id: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Refresh cached endpoint presence flag for an organization
+
+
+        :param organization_id: (required)
+        :type organization_id: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._webhook_controller_refresh_endpoints_serialize(
+            organization_id=organization_id,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '404': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _webhook_controller_refresh_endpoints_serialize(
+        self,
+        organization_id,
+        x_daytona_organization_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if organization_id is not None:
+            _path_params['organizationId'] = organization_id
+        # process the query parameters
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/webhooks/organizations/{organizationId}/refresh-endpoints',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+

--- a/libs/api-client-python/daytona_api_client/api/webhooks_api.py
+++ b/libs/api-client-python/daytona_api_client/api/webhooks_api.py
@@ -589,3 +589,273 @@ class WebhooksApi:
         )
 
 
+
+
+    @validate_call
+    def webhook_controller_refresh_endpoints(
+        self,
+        organization_id: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> None:
+        """Refresh cached endpoint presence flag for an organization
+
+
+        :param organization_id: (required)
+        :type organization_id: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._webhook_controller_refresh_endpoints_serialize(
+            organization_id=organization_id,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '404': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def webhook_controller_refresh_endpoints_with_http_info(
+        self,
+        organization_id: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[None]:
+        """Refresh cached endpoint presence flag for an organization
+
+
+        :param organization_id: (required)
+        :type organization_id: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._webhook_controller_refresh_endpoints_serialize(
+            organization_id=organization_id,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '404': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def webhook_controller_refresh_endpoints_without_preload_content(
+        self,
+        organization_id: StrictStr,
+        x_daytona_organization_id: Annotated[Optional[StrictStr], Field(description="Use with JWT to specify the organization ID")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Refresh cached endpoint presence flag for an organization
+
+
+        :param organization_id: (required)
+        :type organization_id: str
+        :param x_daytona_organization_id: Use with JWT to specify the organization ID
+        :type x_daytona_organization_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._webhook_controller_refresh_endpoints_serialize(
+            organization_id=organization_id,
+            x_daytona_organization_id=x_daytona_organization_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '404': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _webhook_controller_refresh_endpoints_serialize(
+        self,
+        organization_id,
+        x_daytona_organization_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if organization_id is not None:
+            _path_params['organizationId'] = organization_id
+        # process the query parameters
+        # process the header parameters
+        if x_daytona_organization_id is not None:
+            _header_params['X-Daytona-Organization-ID'] = x_daytona_organization_id
+        # process the form parameters
+        # process the body parameter
+
+
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'bearer', 
+            'oauth2'
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/webhooks/organizations/{organizationId}/refresh-endpoints',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+

--- a/libs/api-client-ruby/lib/daytona_api_client/api/webhooks_api.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/api/webhooks_api.rb
@@ -146,5 +146,67 @@ module DaytonaApiClient
       end
       return data, status_code, headers
     end
+
+    # Refresh cached endpoint presence flag for an organization
+    # @param organization_id [String] 
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
+    # @return [nil]
+    def webhook_controller_refresh_endpoints(organization_id, opts = {})
+      webhook_controller_refresh_endpoints_with_http_info(organization_id, opts)
+      nil
+    end
+
+    # Refresh cached endpoint presence flag for an organization
+    # @param organization_id [String] 
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :x_daytona_organization_id Use with JWT to specify the organization ID
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def webhook_controller_refresh_endpoints_with_http_info(organization_id, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: WebhooksApi.webhook_controller_refresh_endpoints ...'
+      end
+      # verify the required parameter 'organization_id' is set
+      if @api_client.config.client_side_validation && organization_id.nil?
+        fail ArgumentError, "Missing the required parameter 'organization_id' when calling WebhooksApi.webhook_controller_refresh_endpoints"
+      end
+      # resource path
+      local_var_path = '/webhooks/organizations/{organizationId}/refresh-endpoints'.sub('{' + 'organizationId' + '}', CGI.escape(organization_id.to_s))
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      header_params[:'X-Daytona-Organization-ID'] = opts[:'x_daytona_organization_id'] if !opts[:'x_daytona_organization_id'].nil?
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type]
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || ['bearer', 'oauth2']
+
+      new_options = opts.merge(
+        :operation => :"WebhooksApi.webhook_controller_refresh_endpoints",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: WebhooksApi#webhook_controller_refresh_endpoints\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/libs/api-client/src/api/webhooks-api.ts
+++ b/libs/api-client/src/api/webhooks-api.ts
@@ -118,6 +118,49 @@ export const WebhooksApiAxiosParamCreator = function (configuration?: Configurat
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Refresh cached endpoint presence flag for an organization
+         * @param {string} organizationId 
+         * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        webhookControllerRefreshEndpoints: async (organizationId: string, xDaytonaOrganizationID?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'organizationId' is not null or undefined
+            assertParamExists('webhookControllerRefreshEndpoints', 'organizationId', organizationId)
+            const localVarPath = `/webhooks/organizations/{organizationId}/refresh-endpoints`
+                .replace(`{${"organizationId"}}`, encodeURIComponent(String(organizationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication oauth2 required
+
+
+            if (xDaytonaOrganizationID != null) {
+                localVarHeaderParameter['X-Daytona-Organization-ID'] = String(xDaytonaOrganizationID);
+            }
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -155,6 +198,20 @@ export const WebhooksApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['WebhooksApi.webhookControllerGetInitializationStatus']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
+        /**
+         * 
+         * @summary Refresh cached endpoint presence flag for an organization
+         * @param {string} organizationId 
+         * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async webhookControllerRefreshEndpoints(organizationId: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.webhookControllerRefreshEndpoints(organizationId, xDaytonaOrganizationID, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['WebhooksApi.webhookControllerRefreshEndpoints']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
     }
 };
 
@@ -186,6 +243,17 @@ export const WebhooksApiFactory = function (configuration?: Configuration, baseP
         webhookControllerGetInitializationStatus(organizationId: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<WebhookInitializationStatus> {
             return localVarFp.webhookControllerGetInitializationStatus(organizationId, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
         },
+        /**
+         * 
+         * @summary Refresh cached endpoint presence flag for an organization
+         * @param {string} organizationId 
+         * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        webhookControllerRefreshEndpoints(organizationId: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.webhookControllerRefreshEndpoints(organizationId, xDaytonaOrganizationID, options).then((request) => request(axios, basePath));
+        },
     };
 };
 
@@ -215,6 +283,18 @@ export class WebhooksApi extends BaseAPI {
      */
     public webhookControllerGetInitializationStatus(organizationId: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
         return WebhooksApiFp(this.configuration).webhookControllerGetInitializationStatus(organizationId, xDaytonaOrganizationID, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Refresh cached endpoint presence flag for an organization
+     * @param {string} organizationId 
+     * @param {string} [xDaytonaOrganizationID] Use with JWT to specify the organization ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public webhookControllerRefreshEndpoints(organizationId: string, xDaytonaOrganizationID?: string, options?: RawAxiosRequestConfig) {
+        return WebhooksApiFp(this.configuration).webhookControllerRefreshEndpoints(organizationId, xDaytonaOrganizationID, options).then((request) => request(this.axios, this.basePath));
     }
 }
 


### PR DESCRIPTION
## Description

Adds a hasEndpoints flag to webhook_initialization so sendWebhook short-circuits when an organization has zero Svix endpoints registered, mirroring the existing "no consumer app" skip and avoiding wasted message.create calls. The flag is lazy-refreshed inside sendWebhook every 60 seconds via svix.endpoint.list, and updated immediately by a small POST /webhooks/organizations/:id/refresh-endpoints route that the dashboard pings after a successful endpoint create, update, or delete. The existing "not initialized" log lines were also downgraded to debug to match the new skip log and keep noise out of production output.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation