### PR TITLE
fix(sdk-typescript): handle late busboy errors and forward abort to progress stream

### DIFF
--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -384,6 +384,9 @@ export class FileSystem {
               },
             })
             fileStream.pipe(progress)
+            fileStream.on('error', (err: Error) => {
+              if (!progress.destroyed) progress.destroy(err)
+            })
             resolvedStream = progress
           } else {
             resolvedStream = fileStream as Readable
@@ -405,11 +408,13 @@ export class FileSystem {
           const normalizedError = options.signal?.aborted || isCanceledError(err) ? toDownloadCancelledError() : err
           if (!resolvedStream) {
             reject(normalizedError)
-          } else if (!resolvedStream.destroyed) {
-            resolvedStream.destroy(
-              normalizedError instanceof Error ? normalizedError : new Error(String(normalizedError)),
-            )
+            return
           }
+          const stream = resolvedStream as Readable & { readableEnded?: boolean }
+          if (stream.destroyed || stream.readableEnded) {
+            return
+          }
+          stream.destroy(normalizedError instanceof Error ? normalizedError : new Error(String(normalizedError)))
         })
     })
   }

--- a/libs/sdk-typescript/src/utils/FileTransfer.ts
+++ b/libs/sdk-typescript/src/utils/FileTransfer.ts
@@ -214,7 +214,13 @@ function parseContentLength(headersBlock: Buffer): number | undefined {
 }
 
 /**
- * Processes multipart response using busboy (Node.js path)
+ * Processes multipart response using busboy (Node.js path).
+ *
+ * Once the file stream has been handed off via `onFileStream`, errors from the
+ * busboy stream are the consumer's concern — they arrive via the file stream's
+ * own 'error' event. The inner Promise resolves cleanly in that case to avoid
+ * surfacing late teardown errors (busboy's `_final`, premature pipe close)
+ * after the caller has already started consuming the file.
  */
 export async function processDownloadFilesResponseWithBusboy(
   stream: any,
@@ -232,6 +238,8 @@ export async function processDownloadFilesResponseWithBusboy(
       headers,
       preservePath: true,
     })
+
+    let consumerHandedOff = false
 
     bb.on('file', (fieldName: string, fileStream: any, fileInfo: { filename?: string; mimeType?: string }) => {
       // Pop one queued Content-Length for every emitted part to keep the
@@ -264,6 +272,10 @@ export async function processDownloadFilesResponseWithBusboy(
         })
       } else if (fieldName === 'file') {
         if (onFileStream) {
+          consumerHandedOff = true
+          fileStream.on('error', () => {
+            return
+          })
           onFileStream(source, fileStream, totalBytes)
         } else if (metadata.destination) {
           // Stream to file
@@ -306,6 +318,10 @@ export async function processDownloadFilesResponseWithBusboy(
     })
 
     bb.on('error', (err: any) => {
+      if (consumerHandedOff) {
+        resolve()
+        return
+      }
       abortStream(stream)
       reject(err)
     })


### PR DESCRIPTION
## Summary

Fixes two CI-breaking failures in the TypeScript SDK's `downloadFileStream` that appeared after the upload/download streaming + progress + cancellation feature landed on `main`:

1. `Unhandled error. (Error: Unexpected end of form at Multipart._final ...)` — Jest unhandled-error report on the `stream download with onProgress tracks bytes` E2E test.
2. `Exceeded timeout of 120000 ms for a test` — the `download abort surfaces DaytonaError` E2E test hung for 120s instead of receiving the abort error.

Both regressions are confined to `downloadFileStream` and only surface in CI; unit tests still pass.

## Root cause

### Bug 1 — late busboy `_final` error
After `processDownloadFilesResponseWithBusboy` hands the file stream to the caller via the `onFileStream` callback (resolving the outer SDK Promise with the consumer's stream), the busboy parser is still doing its own teardown. If the upstream HTTP stream is destroyed mid-parse — or even on a normal completion where the consumer finishes reading before busboy sees the closing boundary — busboy's `_final()` emits an `"Unexpected end of form"` error. That error has nothing to do with the user's operation at that point, but the inner Promise's `bb.on('error', reject)` was still rejecting, which cascaded into `FileSystem.ts` `.catch()` and eventually surfaced as an unhandled error in Jest.

### Bug 2 — abort never reaches the consumer's progress stream
When `onProgress` is supplied, `downloadFileStream` wraps the busboy file stream in a `Transform` (the progress tracker) via `fileStream.pipe(progress)` and returns `progress` to the caller. Node's `pipe()` **does not forward errors** from source to destination. So when an abort (or any other upstream failure) destroys `fileStream` with a `DaytonaError`, the error is dropped on the floor as far as the `progress` stream is concerned. The consumer's `stream.on('error')` listener never fires, and the test waits for an error/end event that will never arrive — until Jest's 120s timeout kills it.

## Fix

### `libs/sdk-typescript/src/utils/FileTransfer.ts`
- Track `consumerHandedOff` once `onFileStream` is invoked.
- In `bb.on('error', ...)`: if the consumer already owns the file stream, resolve the inner Promise cleanly and stop propagating. Errors from this point onward arrive at the consumer via the file stream's own `'error'` event — they're not the inner Promise's concern anymore.
- Attach a no-op `fileStream.on('error', () => {})` listener on handoff so a destroy event between `onFileStream` returning and the caller attaching their own listener doesn't become an unhandled error.
- No magic-string matching on busboy's error messages — the handoff-state contract is what determines who owns errors.

### `libs/sdk-typescript/src/FileSystem.ts`
- When wrapping the file stream in a progress `Transform`, also attach `fileStream.on('error', err => progress.destroy(err))` so that errors propagate through the wrapper to the caller.
- Keep the `.catch()` guard that avoids re-destroying already-ended/destroyed streams.

## Why this fix is robust

- **No magic strings.** A previous draft matched `err.message === 'Unexpected end of form'`. That breaks the moment busboy renames the error or wraps it. The handoff flag captures the actual architectural boundary: post-handoff, errors travel through the consumer's file stream, not through our inner Promise.
- **Symmetric error semantics for both paths.** Whether the caller takes the raw file stream or the wrapped progress stream, an abort or upstream error reaches `stream.on('error')` exactly once with a normalized `DaytonaError`.
- **No suppression of real errors.** Pre-handoff errors (network failure before any data arrives, malformed multipart envelope, etc.) still reject the outer Promise as before.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes late busboy errors and missing abort/error propagation in `downloadFileStream` so downloads complete cleanly and aborts reach consumers. Prevents CI hangs and unhandled “Unexpected end of form” errors.

- **Bug Fixes**
  - After handing off the file stream (`onFileStream`), resolve on busboy errors and stop propagating them; attach a no-op `fileStream.on('error')` to avoid unhandled gaps.
  - Forward source errors to the progress `Transform` by calling `progress.destroy(err)`; ensures aborts and upstream failures reach `stream.on('error')`.
  - Guard destruction logic to avoid re-destroying streams that already ended or were destroyed; still reject early when no stream was produced.

<sup>Written for commit 1daaf1a87cc4807e5ce6ac51bf1cfbe7c2de1909. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

