### PR TITLE
chore(security): disable Access-Control-Allow-Credentials on /api

### DIFF
--- a/apps/api/src/cors-options.spec.ts
+++ b/apps/api/src/cors-options.spec.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { corsOptions } from './cors-options'
+
+describe('corsOptions', () => {
+  it('does not enable credentials with reflected origins', () => {
+    expect(corsOptions.credentials).toBe(false)
+  })
+})

--- a/apps/api/src/cors-options.ts
+++ b/apps/api/src/cors-options.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface'
+
+export const corsOptions: CorsOptions = {
+  origin: true,
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+  credentials: false,
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -24,6 +24,7 @@ import { getOpenApiConfig } from './openapi.config'
 import { AuditInterceptor } from './audit/interceptors/audit.interceptor'
 import { join } from 'node:path'
 import { ApiKeyService } from './api-key/api-key.service'
+import { corsOptions } from './cors-options'
 import { DAYTONA_ADMIN_USER_ID } from './app.service'
 import { OrganizationService } from './organization/services/organization.service'
 import { OrganizationResourcePermission } from './organization/enums/organization-resource-permission.enum'
@@ -56,11 +57,7 @@ async function bootstrap() {
   })
   app.useLogger(app.get(PinoLogger))
   app.flushLogs()
-  app.enableCors({
-    origin: true,
-    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
-    credentials: true,
-  })
+  app.enableCors(corsOptions)
 
   const configService = app.get(TypedConfigService)
   const failedAuthTracker = app.get(FailedAuthTrackerService)


### PR DESCRIPTION
Sets `Access-Control-Allow-Credentials: false` on `/api`.

The API is Bearer-token authenticated (`jwt.strategy.ts` uses `ExtractJwt.fromAuthHeaderAsBearerToken()`); no endpoint authorizes via cookies. Disabling the credentials flag has no functional effect on:

- Dashboard SPA (same-origin)
- SDKs in browser contexts (use `Authorization: Bearer ...`; custom headers are not subject to the credentials flag)
- CLI / server-side SDK / webhooks (non-browser)
- socket.io gateway (independent CORS surface, token-only auth in handshake)

## Test plan

- [x] `yarn nx test api --testPathPatterns=cors-options.spec.ts` passes
- [x] ESLint + Prettier clean on changed files
- [ ] Post-deploy: dashboard logs in, lists/creates/deletes API keys
- [ ] Post-deploy: at least one SDK consumer (TS SDK in a browser app) confirms cross-origin requests still succeed

## Rollback

`git revert <sha>`.
