### PR TITLE
chore(dashboard): clean up unused FFs

### DIFF
--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -21,7 +21,6 @@ import {
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { FeatureFlags } from '@/enums/FeatureFlags'
 import { useCreateSandboxMutation } from '@/hooks/mutations/useCreateSandboxMutation'
 import { useSetOrganizationDefaultRegionMutation } from '@/hooks/mutations/useSetOrganizationDefaultRegionMutation'
 import { useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
@@ -37,7 +36,6 @@ import { Sandbox } from '@daytona/sdk'
 import { useForm } from '@tanstack/react-form'
 import { isAxiosError } from 'axios'
 import { Info, Minus, Plus, Upload } from 'lucide-react'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { ComponentProps, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { NumericFormat } from 'react-number-format'
 import { toast } from 'sonner'
@@ -157,7 +155,6 @@ export const CreateSandboxSheet = ({
   ref?: Ref<{ open: () => void }>
   onSandboxCreated?: (sandbox: Sandbox) => void
 }) => {
-  const createSandboxEnabled = useFeatureFlagEnabled(FeatureFlags.DASHBOARD_CREATE_SANDBOX)
   const [open, setOpen] = useState(false)
 
   const config = useConfig()
@@ -360,10 +357,6 @@ export const CreateSandboxSheet = ({
     if (form.getFieldValue('regionId')) return
     form.setFieldValue('regionId', regions[0].id)
   }, [open, loadingRegions, regions, selectedOrganization?.defaultRegionId, form])
-
-  if (!createSandboxEnabled) {
-    return null
-  }
 
   return (
     <Sheet

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -24,8 +24,6 @@ import { DAYTONA_DOCS_URL, DAYTONA_SLACK_URL } from '@/constants/ExternalLinks'
 import { useTheme } from '@/contexts/ThemeContext'
 import { FeatureFlags } from '@/enums/FeatureFlags'
 import { RoutePath } from '@/enums/RoutePath'
-import { useWebhookAppPortalAccessQuery } from '@/hooks/queries/useWebhookAppPortalAccessQuery'
-import { useConfig } from '@/hooks/useConfig'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { useUserOrganizationInvitations } from '@/hooks/useUserOrganizationInvitations'
 import { useWebhooks } from '@/hooks/useWebhooks'
@@ -110,7 +108,6 @@ const useNavCommands = (items: { label: string; path: RoutePath | string; onClic
 
 export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarProps) {
   const posthog = usePostHog()
-  const config = useConfig()
   const { theme, setTheme } = useTheme()
   const { user, signoutRedirect } = useAuth()
   const { pathname } = useLocation()
@@ -119,10 +116,7 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
     useSelectedOrganization()
   const { count: organizationInvitationsCount } = useUserOrganizationInvitations()
   const { isInitialized: webhooksInitialized } = useWebhooks()
-  const webhooksAccess = useWebhookAppPortalAccessQuery(selectedOrganization?.id)
   const orgInfraEnabled = useFeatureFlagEnabled(FeatureFlags.ORGANIZATION_INFRASTRUCTURE)
-  const playgroundEnabled = useFeatureFlagEnabled(FeatureFlags.DASHBOARD_PLAYGROUND)
-  const webhooksEnabled = useFeatureFlagEnabled(FeatureFlags.DASHBOARD_WEBHOOKS)
 
   const sidebarItems = useMemo(() => {
     const arr: SidebarItem[] = [
@@ -171,24 +165,12 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
       { icon: <KeyRound size={16} strokeWidth={1.5} />, label: 'API Keys', path: RoutePath.KEYS },
     ]
 
-    // Add Webhooks link if webhooks are initialized
     if (webhooksInitialized) {
-      if (webhooksEnabled) {
-        arr.push({
-          icon: <Mail size={16} strokeWidth={1.5} />,
-          label: 'Webhooks',
-          path: RoutePath.WEBHOOKS,
-        })
-      } else {
-        arr.push({
-          icon: <Mail size={16} strokeWidth={1.5} />,
-          label: 'Webhooks',
-          path: '#webhooks' as any, // This will be handled by onClick
-          onClick: () => {
-            window.open(webhooksAccess.data?.url, '_blank', 'noopener,noreferrer')
-          },
-        })
-      }
+      arr.push({
+        icon: <Mail size={16} strokeWidth={1.5} />,
+        label: 'Webhooks',
+        path: RoutePath.WEBHOOKS,
+      })
     }
 
     if (authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER) {
@@ -211,13 +193,7 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
     }
 
     return arr
-  }, [
-    authenticatedUserOrganizationMember?.role,
-    selectedOrganization?.personal,
-    webhooksInitialized,
-    webhooksAccess.data?.url,
-    webhooksEnabled,
-  ])
+  }, [authenticatedUserOrganizationMember?.role, selectedOrganization?.personal, webhooksInitialized])
 
   const billingItems = useMemo(() => {
     if (!billingEnabled || authenticatedUserOrganizationMember?.role !== OrganizationUserRoleEnum.OWNER) {
@@ -268,18 +244,14 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
   }
 
   const miscItems = useMemo(() => {
-    if (!playgroundEnabled) {
-      return []
-    }
-
     return [
-      playgroundEnabled && {
+      {
         icon: <Joystick size={16} strokeWidth={1.5} />,
         label: 'Playground',
         path: RoutePath.PLAYGROUND,
       },
     ]
-  }, [playgroundEnabled])
+  }, [])
 
   const sidebarGroups: { label: string; items: SidebarItem[] }[] = useMemo(() => {
     return [

--- a/apps/dashboard/src/components/sandboxes/SandboxContentTabs.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxContentTabs.tsx
@@ -23,7 +23,6 @@ interface SandboxContentTabsProps {
   sandbox: Sandbox | undefined
   isLoading: boolean
   spendingTabAvailable: boolean
-  filesystemEnabled: boolean | undefined
   tab: TabValue
   onTabChange: (tab: TabValue) => void
 }
@@ -32,7 +31,6 @@ export function SandboxContentTabs({
   sandbox,
   isLoading,
   spendingTabAvailable,
-  filesystemEnabled,
   tab,
   onTabChange,
 }: SandboxContentTabsProps) {
@@ -76,7 +74,7 @@ export function SandboxContentTabs({
           <TabsTrigger value="metrics">Metrics</TabsTrigger>
           {spendingTabAvailable && <TabsTrigger value="spending">Spending</TabsTrigger>}
           <TabsTrigger value="terminal">Terminal</TabsTrigger>
-          {filesystemEnabled && <TabsTrigger value="filesystem">Filesystem</TabsTrigger>}
+          <TabsTrigger value="filesystem">Filesystem</TabsTrigger>
           <TabsTrigger value="vnc">VNC</TabsTrigger>
         </TabsList>
       </ScrollArea>
@@ -101,14 +99,9 @@ export function SandboxContentTabs({
       <TabsContent value="terminal" className="flex-1 min-h-0 m-0 data-[state=active]:flex flex-col overflow-hidden">
         <SandboxTerminalTab sandbox={sandbox} />
       </TabsContent>
-      {filesystemEnabled && (
-        <TabsContent
-          value="filesystem"
-          className="flex-1 min-h-0 m-0 data-[state=active]:flex flex-col overflow-hidden"
-        >
-          <SandboxFileSystemTab sandbox={sandbox} />
-        </TabsContent>
-      )}
+      <TabsContent value="filesystem" className="flex-1 min-h-0 m-0 data-[state=active]:flex flex-col overflow-hidden">
+        <SandboxFileSystemTab sandbox={sandbox} />
+      </TabsContent>
       <TabsContent value="vnc" className="flex-1 min-h-0 m-0 data-[state=active]:flex flex-col overflow-hidden">
         <SandboxVncTab sandbox={sandbox} />
       </TabsContent>

--- a/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
@@ -60,7 +60,6 @@ export default function SandboxDetails() {
     useSelectedOrganization()
   const { getRegionName } = useRegions()
 
-  const filesystemEnabled = useFeatureFlagEnabled(FeatureFlags.DASHBOARD_FILESYSTEM)
   const spendingEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_SPENDING)
   const spendingTabAvailable = spendingEnabled && !!config.analyticsApiUrl
 
@@ -82,12 +81,6 @@ export default function SandboxDetails() {
       setTab('terminal')
     }
   }, [spendingTabAvailable, tab, setTab])
-
-  useEffect(() => {
-    if (filesystemEnabled === false && tab === 'filesystem') {
-      setTab('terminal')
-    }
-  }, [filesystemEnabled, tab, setTab])
 
   const { data: sandbox, isLoading, isError, error, refetch, isFetching } = useSandboxQuery(sandboxId ?? '')
   const isNotFound = isError && isAxiosError(error.cause) && error.cause?.status === 404
@@ -273,7 +266,6 @@ export default function SandboxDetails() {
                 sandbox={sandbox}
                 isLoading={isLoading}
                 spendingTabAvailable={!!spendingTabAvailable}
-                filesystemEnabled={filesystemEnabled}
                 tab={tab}
                 onTabChange={setTab}
               />

--- a/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsSheet.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsSheet.tsx
@@ -125,7 +125,6 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
   const [internalActiveTab, setInternalActiveTab] = useState<SandboxDetailsSheetTabValue>('overview')
   const activeTab = activeTabProp ?? internalActiveTab
   const [viewportWidth, setViewportWidth] = useState(() => getViewportWidth())
-  const filesystemEnabled = useFeatureFlagEnabled(FeatureFlags.DASHBOARD_FILESYSTEM)
   const spendingEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_SPENDING)
   const config = useConfig()
   const spendingTabAvailable = spendingEnabled && !!config.analyticsApiUrl
@@ -231,11 +230,7 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
     if (!spendingTabAvailable && activeTab === 'spending') {
       handleTabChange('logs')
     }
-
-    if (filesystemEnabled === false && activeTab === 'filesystem') {
-      handleTabChange('terminal')
-    }
-  }, [activeTab, filesystemEnabled, handleTabChange, resetToOverview, spendingTabAvailable])
+  }, [activeTab, handleTabChange, spendingTabAvailable])
 
   if (!sandbox) return null
 
@@ -334,11 +329,7 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
             {isDesktop ? (
               activeTab === 'overview' ? (
                 <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-                  <SandboxDetailsTabsList
-                    filesystemEnabled={filesystemEnabled}
-                    spendingTabAvailable={spendingTabAvailable}
-                    showOverview
-                  />
+                  <SandboxDetailsTabsList spendingTabAvailable={spendingTabAvailable} showOverview />
                   <div className="flex min-h-0 flex-1 max-w-[450px] flex-col">
                     <SandboxDetailsHeader sandbox={sandbox} actions={sandboxHeaderActions} />
                     {sandboxInfoPanel}
@@ -354,7 +345,6 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
                   <div className="flex min-w-0 min-h-0 flex-1 flex-col overflow-hidden">
                     <div className="animate-in fade-in slide-in-from-left-3 duration-500 ease-out">
                       <SandboxDetailsTabsList
-                        filesystemEnabled={filesystemEnabled}
                         spendingTabAvailable={spendingTabAvailable}
                         showOverview={false}
                         leadingContent={
@@ -377,11 +367,7 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
                     </div>
                     <div className="flex min-w-0 min-h-0 flex-1 flex-col overflow-hidden">
                       <div className="flex min-h-0 flex-1 flex-col animate-in fade-in slide-in-from-right-20 duration-300 ease-out">
-                        <SandboxDetailsTabContent
-                          sandbox={sandbox}
-                          filesystemEnabled={filesystemEnabled}
-                          spendingTabAvailable={spendingTabAvailable}
-                        />
+                        <SandboxDetailsTabContent sandbox={sandbox} spendingTabAvailable={spendingTabAvailable} />
                       </div>
                     </div>
                   </div>
@@ -391,22 +377,14 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
               <>
                 <div className="flex min-h-0 shrink-0 flex-col">
                   <SandboxDetailsHeader sandbox={sandbox} actions={sandboxHeaderActions} />
-                  <SandboxDetailsTabsList
-                    filesystemEnabled={filesystemEnabled}
-                    spendingTabAvailable={spendingTabAvailable}
-                    showOverview
-                  />
+                  <SandboxDetailsTabsList spendingTabAvailable={spendingTabAvailable} showOverview />
                 </div>
 
                 <TabsContent value="overview" className="m-0 min-h-0 flex-1 data-[state=active]:flex flex-col">
                   {sandboxInfoPanel}
                 </TabsContent>
 
-                <SandboxDetailsTabContent
-                  sandbox={sandbox}
-                  filesystemEnabled={filesystemEnabled}
-                  spendingTabAvailable={spendingTabAvailable}
-                />
+                <SandboxDetailsTabContent sandbox={sandbox} spendingTabAvailable={spendingTabAvailable} />
               </>
             )}
           </Tabs>

--- a/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsTabContent.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsTabContent.tsx
@@ -15,11 +15,9 @@ import { SandboxVncTab } from '../SandboxVncTab'
 
 export function SandboxDetailsTabContent({
   sandbox,
-  filesystemEnabled,
   spendingTabAvailable,
 }: {
   sandbox: Sandbox
-  filesystemEnabled: boolean | undefined
   spendingTabAvailable: boolean | undefined
 }) {
   return (
@@ -42,14 +40,9 @@ export function SandboxDetailsTabContent({
       <TabsContent value="terminal" className="m-0 min-h-0 flex-1 data-[state=active]:flex flex-col overflow-hidden">
         <SandboxTerminalTab sandbox={sandbox} />
       </TabsContent>
-      {filesystemEnabled && (
-        <TabsContent
-          value="filesystem"
-          className="m-0 min-h-0 flex-1 data-[state=active]:flex flex-col overflow-hidden"
-        >
-          <SandboxFileSystemTab sandbox={sandbox} />
-        </TabsContent>
-      )}
+      <TabsContent value="filesystem" className="m-0 min-h-0 flex-1 data-[state=active]:flex flex-col overflow-hidden">
+        <SandboxFileSystemTab sandbox={sandbox} />
+      </TabsContent>
       <TabsContent value="vnc" className="m-0 min-h-0 flex-1 data-[state=active]:flex flex-col overflow-hidden">
         <SandboxVncTab sandbox={sandbox} />
       </TabsContent>

--- a/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsTabsList.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsTabsList.tsx
@@ -8,12 +8,10 @@ import React from 'react'
 import { FadeTabList } from './FadeTabList'
 
 export function SandboxDetailsTabsList({
-  filesystemEnabled,
   spendingTabAvailable,
   showOverview,
   leadingContent,
 }: {
-  filesystemEnabled: boolean | undefined
   spendingTabAvailable: boolean | undefined
   showOverview: boolean
   leadingContent?: React.ReactNode
@@ -42,11 +40,9 @@ export function SandboxDetailsTabsList({
       <TabsTrigger value="terminal" className="h-[41px] border-b py-0">
         Terminal
       </TabsTrigger>
-      {filesystemEnabled && (
-        <TabsTrigger value="filesystem" className="h-[41px] border-b py-0">
-          Filesystem
-        </TabsTrigger>
-      )}
+      <TabsTrigger value="filesystem" className="h-[41px] border-b py-0">
+        Filesystem
+      </TabsTrigger>
       <TabsTrigger value="vnc" className="h-[41px] border-b py-0">
         VNC
       </TabsTrigger>

--- a/apps/dashboard/src/enums/FeatureFlags.ts
+++ b/apps/dashboard/src/enums/FeatureFlags.ts
@@ -6,10 +6,6 @@
 export enum FeatureFlags {
   ORGANIZATION_INFRASTRUCTURE = 'organization_infrastructure',
   ORGANIZATION_EXPERIMENTS = 'organization_experiments',
-  DASHBOARD_PLAYGROUND = 'dashboard_playground',
-  DASHBOARD_FILESYSTEM = 'dashboard_filesystem',
-  DASHBOARD_WEBHOOKS = 'dashboard_webhooks',
   SANDBOX_SPENDING = 'sandbox_spending',
-  DASHBOARD_CREATE_SANDBOX = 'dashboard_create-sandbox',
   SANDBOX_LINUX_VM = 'sandbox_linux_vm',
 }


### PR DESCRIPTION
## Description

Cleans up unused dashboard feature flags.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused dashboard feature flags and their gating code. Filesystem, Webhooks, Playground, and Create Sandbox are now always available (Webhooks still depend on initialization; Spending still depends on `SANDBOX_SPENDING` and analytics config).

- **Refactors**
  - Deleted unused flags from `FeatureFlags`: `DASHBOARD_PLAYGROUND`, `DASHBOARD_FILESYSTEM`, `DASHBOARD_WEBHOOKS`, `DASHBOARD_CREATE_SANDBOX`.
  - Always show the Filesystem tab in sandbox views; removed related redirects and checks.
  - Always render the Create Sandbox sheet.
  - Webhooks link now always routes to `RoutePath.WEBHOOKS` when webhooks are initialized (removed external portal fallback).
  - Always show the Playground link in the sidebar.
  - Kept Spending tab behind `SANDBOX_SPENDING` and `analyticsApiUrl` presence.

<sup>Written for commit be73ba451a27c98236b0c61854168f5de6a7507a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

