### PR TITLE
chore(security): escape redirect URL on proxy preview warning page

### DIFF
--- a/apps/proxy/pkg/proxy/warning_page.go
+++ b/apps/proxy/pkg/proxy/warning_page.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"slices"
@@ -297,8 +298,19 @@ func serveWarningPage(c *gin.Context, https bool) {
 	redirectPath := protocol + c.Request.Host + c.Request.URL.String()
 	redirectUrl := ACCEPT_PREVIEW_PAGE_WARNING_PATH + "?redirect=" + url.QueryEscape(redirectPath)
 
+	// Defense-in-depth: this page has no inline scripts and loads no external
+	// resources, so deny everything by default. style-src 'unsafe-inline' keeps
+	// the embedded <style> block working; form-action 'self' pins the consent POST.
+	// Any future contributor adding scripts/images/fonts/external CSS to this page
+	// must extend this policy.
+	c.Header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'")
+	c.Header("X-Content-Type-Options", "nosniff")
 	c.Header("Content-Type", "text/html; charset=utf-8")
-	c.String(http.StatusOK, fmt.Sprintf(htmlContent, redirectPath, redirectUrl))
+	// redirectPath is escaped because it is interpolated into HTML body context.
+	// redirectUrl is safe in action="..." because url.QueryEscape percent-encodes
+	// quotes and HTML-special characters; the constant prefix contains none of them.
+	// Any future interpolation should re-evaluate the contextual escaping requirement.
+	c.String(http.StatusOK, fmt.Sprintf(htmlContent, html.EscapeString(redirectPath), redirectUrl))
 }
 
 // isBrowser checks if the request is coming from a web browser

--- a/apps/proxy/pkg/proxy/warning_page_test.go
+++ b/apps/proxy/pkg/proxy/warning_page_test.go
@@ -1,0 +1,97 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestServeWarningPage_EscapesXSSPayloadInBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/?><ScRiPt>alert(1)</ScRiPt>", nil)
+	c.Request.Host = "daytonaproxy01.net"
+
+	serveWarningPage(c, false)
+
+	body := w.Body.String()
+	if strings.Contains(body, "<ScRiPt>") || strings.Contains(body, "<script>") {
+		t.Fatalf("XSS payload was rendered raw in warning page body:\n%s", body)
+	}
+	if !strings.Contains(body, "&lt;ScRiPt&gt;alert(1)&lt;/ScRiPt&gt;") {
+		t.Fatalf("expected the script tag to be HTML-escaped; body did not contain the escaped form:\n%s", body)
+	}
+}
+
+func TestServeWarningPage_EscapesHostHeader(t *testing.T) {
+	// Host header is technically attacker-controllable on forged requests. Even
+	// though browsers won't normally let an attacker forge it through a victim,
+	// escape defensively.
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+	c.Request.Host = "evil\"<img src=x>.example.com"
+
+	serveWarningPage(c, false)
+
+	body := w.Body.String()
+	if strings.Contains(body, "<img src=x>") {
+		t.Fatalf("Host header was rendered raw in warning page body:\n%s", body)
+	}
+}
+
+func TestServeWarningPage_RendersBenignURLReadably(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/dashboard/index.html", nil)
+	c.Request.Host = "3000-abc.daytonaproxy01.net"
+
+	serveWarningPage(c, true)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "https://3000-abc.daytonaproxy01.net/dashboard/index.html") {
+		t.Fatalf("expected benign redirect path to be rendered as readable text; got:\n%s", body)
+	}
+}
+
+func TestServeWarningPage_SetsCSPAndNosniffHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+	c.Request.Host = "daytonaproxy01.net"
+
+	serveWarningPage(c, false)
+
+	csp := w.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "default-src 'none'") {
+		t.Fatalf("expected restrictive CSP on warning page; got %q", csp)
+	}
+	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("expected X-Content-Type-Options: nosniff; got %q", got)
+	}
+}
+
+func TestServeWarningPage_FormActionUrlEncodesPayload(t *testing.T) {
+	// The redirectUrl is built via url.QueryEscape; confirm dangerous chars do
+	// not reach the action attribute as a literal '"' or '<'.
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/?\"><script>x</script>", nil)
+	c.Request.Host = "daytonaproxy01.net"
+
+	serveWarningPage(c, false)
+
+	body := w.Body.String()
+	if strings.Contains(body, `action="`) && strings.Contains(body, `"><script>`) {
+		t.Fatalf("form action attribute appears to allow attribute breakout:\n%s", body)
+	}
+}


### PR DESCRIPTION
HTML-escapes the user-controlled URL before interpolation into the proxy preview warning page. Adds `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; form-action 'self'` and `X-Content-Type-Options: nosniff` to the warning response as defense-in-depth. Bootstraps the `apps/proxy` Go test package with stdlib `testing` + `httptest` regression tests.

## Why `html.EscapeString` and not `html/template`

The template is a single static literal with one unsafe interpolation. `html.EscapeString` is the precise fix. The other `%s` already passes through `url.QueryEscape`, which encodes attribute-context-unsafe characters.

## Why CSP scoped to this response

The warning page has no inline `<script>` and loads zero external resources, so `default-src 'none'; style-src 'unsafe-inline'` causes no regression. Blanket proxy CSP would risk breaking sandbox content on `{port}-{id}.<proxy-domain>`. The page remains framable (no `X-Frame-Options`, no `frame-ancestors`) per the existing dashboard preview iframe UX.

## Surfaces verified

- `rg 'enableCors|cors\(|fmt\.Sprintf|c\.String\(.*<|c\.HTML\('` shows exactly one HTML emission in `apps/proxy/`.
- The page loads no scripts, images, fonts, iframes, or external CSS.
- Non-browser clients are skipped by `isBrowser` before reaching the warning page.

## Test plan

- [x] `go test ./apps/proxy/pkg/proxy/...` — 5 tests pass
- [x] `go vet ./apps/proxy/...` clean, `gofmt -l` clean
- [ ] Post-deploy: header presence + escaped body across the four proxy apex domains
- [ ] Post-deploy: consent flow (browser navigate, "I Understand, Continue", redirect) still works

## Rollback

`git revert <sha>`.
