### PR TITLE
feat(api): default snapshot quota to 30

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -278,7 +278,7 @@ const configuration = {
     maxCpuPerSandbox: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_CPU_PER_SANDBOX || '4', 10),
     maxMemoryPerSandbox: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_MEMORY_PER_SANDBOX || '8', 10),
     maxDiskPerSandbox: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_DISK_PER_SANDBOX || '10', 10),
-    snapshotQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_SNAPSHOT_QUOTA || '100', 10),
+    snapshotQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_SNAPSHOT_QUOTA || '30', 10),
     maxSnapshotSize: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_SNAPSHOT_SIZE || '20', 10),
     volumeQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_VOLUME_QUOTA || '100', 10),
   },

--- a/apps/api/src/migrations/pre-deploy/1777973463276-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1777973463276-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1777973463276 implements MigrationInterface {
+  name = 'Migration1777973463276'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "organization" ALTER COLUMN "snapshot_quota" SET DEFAULT '30'`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "organization" ALTER COLUMN "snapshot_quota" SET DEFAULT '100'`)
+  }
+}

--- a/apps/api/src/organization/entities/organization.entity.ts
+++ b/apps/api/src/organization/entities/organization.entity.ts
@@ -63,7 +63,7 @@ export class Organization {
 
   @Column({
     type: 'int',
-    default: 100,
+    default: 30,
     name: 'snapshot_quota',
   })
   snapshotQuota: number


### PR DESCRIPTION
## Description

Reduces the default active snapshot quota for new organizations from 100 to 30

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the default active snapshot quota for new organizations from 100 to 30 to better match usage and reduce storage costs.

- **Migration**
  - Updates the DB default to 30 and applies only to new organizations; existing orgs are unchanged. `DEFAULT_ORG_QUOTA_SNAPSHOT_QUOTA` can still override.

<sup>Written for commit 94c308c5a970bc647f7f2425042cf1b4b32756a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

