### PR TITLE
feat(api): check stale in progress backups

### DIFF
--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -532,7 +532,7 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
   }
 
-  @Cron(CronExpression.EVERY_MINUTE, { name: 'check-stale-in-progress-backups' })
+  @Cron(CronExpression.EVERY_10_MINUTES, { name: 'check-stale-in-progress-backups' })
   @TrackJobExecution()
   @LogExecution('check-stale-in-progress-backups')
   @WithInstrumentation()

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -532,6 +532,54 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
   }
 
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'check-stale-in-progress-backups' })
+  @TrackJobExecution()
+  @LogExecution('check-stale-in-progress-backups')
+  @WithInstrumentation()
+  async checkStaleInProgressBackups(): Promise<void> {
+    const lockKey = 'check-stale-in-progress-backups'
+    const lockTtlSeconds = 5 * 60
+    const hasLock = await this.redisLockProvider.lock(lockKey, lockTtlSeconds)
+    if (!hasLock) {
+      return
+    }
+
+    try {
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+
+      const staleSandboxes = await this.sandboxRepository.find({
+        where: {
+          backupState: BackupState.IN_PROGRESS,
+          desiredState: Not(SandboxDesiredState.DESTROYED),
+          updatedAt: LessThan(twoHoursAgo),
+        },
+        order: {
+          updatedAt: 'ASC',
+        },
+        take: 100,
+      })
+
+      for (const sandbox of staleSandboxes) {
+        try {
+          await this.sandboxService.updateSandboxBackupState(
+            sandbox.id,
+            BackupState.ERROR,
+            undefined,
+            undefined,
+            'Backup timed out after 2 hours',
+          )
+          this.logger.warn(`Backup for sandbox ${sandbox.id} timed out after 2 hours`)
+        } catch (error) {
+          this.logger.error(`Failed to mark stale backup as errored for sandbox ${sandbox.id}:`, error)
+        }
+      }
+    } catch (error) {
+      this.logger.error('Error checking for stale in-progress backups:', error)
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
+  }
+
   async setBackupPending(sandbox: Sandbox): Promise<void> {
     if (sandbox.backupState === BackupState.COMPLETED) {
       return

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -561,13 +561,17 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
 
       for (const sandbox of staleSandboxes) {
         try {
-          await this.sandboxService.updateSandboxBackupState(
-            sandbox.id,
-            BackupState.ERROR,
-            undefined,
-            undefined,
-            'Backup timed out after 2 hours',
-          )
+          await this.sandboxRepository.updateWhere(sandbox.id, {
+            updateData: {
+              backupState: BackupState.ERROR,
+              backupErrorReason: 'Backup timed out after 2 hours',
+            },
+            whereCondition: {
+              backupState: BackupState.IN_PROGRESS,
+              desiredState: Not(SandboxDesiredState.DESTROYED),
+              updatedAt: LessThan(twoHoursAgo),
+            },
+          })
           this.logger.warn(`Backup for sandbox ${sandbox.id} timed out after 2 hours`)
         } catch (error) {
           this.logger.error(`Failed to mark stale backup as errored for sandbox ${sandbox.id}:`, error)


### PR DESCRIPTION
## Description

Adds a cron that marks sandboxes that have been backing up for more than two hours as timed out

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cron job to mark backups stuck over 2 hours as timed out (`BackupState.ERROR`). This prevents long-running backups from staying stuck and surfaces failures sooner.

- **New Features**
  - Runs every 10 minutes with a Redis lock (5‑min TTL) to avoid concurrent runs.
  - Scans up to 100 sandboxes with `backupState: IN_PROGRESS` and `updatedAt < 2h`, oldest first; skips `desiredState: DESTROYED`.
  - Marks as `BackupState.ERROR` with a timeout message via conditional update; adds execution tracking, logging, and instrumentation for `check-stale-in-progress-backups`.

<sup>Written for commit ac9d45666e529a0c709c384b312b9d04c5be1979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

