### PR TITLE
feat(api): extend backup job timeout

### DIFF
--- a/apps/api/src/sandbox/services/job.service.ts
+++ b/apps/api/src/sandbox/services/job.service.ts
@@ -28,6 +28,7 @@ const DEFAULT_STALE_TIMEOUT_MINUTES = 10
  */
 const JOB_STALE_TIMEOUT_MINUTES: Partial<Record<JobType, number>> = {
   [JobType.BUILD_SNAPSHOT]: 120,
+  [JobType.CREATE_BACKUP]: 120,
   [JobType.PULL_SNAPSHOT]: 120,
   [JobType.SNAPSHOT_SANDBOX]: 120,
 }


### PR DESCRIPTION
## Description

Extends the timeout of v2 backups from 10 to 120 minutes

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended v2 backup job timeout from 10 to 120 minutes to prevent long backups from being marked stale. Adds a 120-minute stale timeout for `JobType.CREATE_BACKUP` in the job service; no other behavior changed.

<sup>Written for commit 78dabc36fb69d2b544ac44923c5cb2a9d8b17936. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

