### PR TITLE
feat(api): backup retry cron

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -158,6 +158,7 @@ const configuration = {
   },
   cronTimeZone: process.env.CRON_TIMEZONE,
   maxConcurrentBackupsPerRunner: parseInt(process.env.MAX_CONCURRENT_BACKUPS_PER_RUNNER || '6', 10),
+  backupRetryIntervalHours: parseInt(process.env.BACKUP_RETRY_INTERVAL_HOURS || '6', 10),
   webhook: {
     authToken: process.env.SVIX_AUTH_TOKEN,
     serverUrl: process.env.SVIX_SERVER_URL,

--- a/apps/api/src/sandbox/constants/errors-for-backup-retry.ts
+++ b/apps/api/src/sandbox/constants/errors-for-backup-retry.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+// Substrings in a backup error reason that indicate a transient failure eligible for automatic retry
+export const BACKUP_RETRY_ERROR_SUBSTRINGS: string[] = [
+  'connect ECONNREFUSED',
+  'received unexpected HTTP status',
+  'read: connection reset by peer',
+  'Backup timed out after 2 hours',
+]

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -5,7 +5,7 @@
 
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { In, IsNull, LessThan, Not, Or, Repository } from 'typeorm'
+import { Brackets, In, IsNull, LessThan, Not, Or, Repository } from 'typeorm'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxState } from '../enums/sandbox-state.enum'
@@ -18,6 +18,7 @@ import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { InjectRedis } from '@nestjs-modules/ioredis'
 import { Redis } from 'ioredis'
 import { SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION } from '../constants/sandbox.constants'
+import { BACKUP_RETRY_ERROR_SUBSTRINGS } from '../constants/errors-for-backup-retry'
 import { fromAxiosError } from '../../common/utils/from-axios-error'
 import { sanitizeSandboxError } from '../utils/sanitize-error.util'
 import { RedisLockProvider } from '../common/redis-lock.provider'
@@ -854,6 +855,86 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
       )
       await this.markErroredIfDraining(sandbox, errorReason, recoverable, isOnDrainingRunner)
       throw error
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES, { name: 'retry-errored-backups', waitForCompletion: true })
+  @TrackJobExecution()
+  @LogExecution('retry-errored-backups')
+  @WithInstrumentation()
+  async retryErroredBackups(): Promise<void> {
+    const retryIntervalHours = this.configService.getOrThrow('backupRetryIntervalHours')
+    if (retryIntervalHours <= 0) {
+      return
+    }
+
+    const lockKey = 'retry-errored-backups'
+    const hasLock = await this.redisLockProvider.lock(lockKey, 5 * 60)
+    if (!hasLock) {
+      return
+    }
+
+    try {
+      const cutoff = new Date(Date.now() - retryIntervalHours * 60 * 60 * 1000)
+
+      // Filter eligible (transient) errors in SQL so each run only selects retryable sandboxes
+      // instead of pulling a random batch that might be mostly non-retryable.
+      const sandboxes = await this.sandboxRepository
+        .createQueryBuilder('sandbox')
+        .addSelect('RANDOM()', 'rand')
+        .where('sandbox.backupState = :error', { error: BackupState.ERROR })
+        .andWhere('sandbox.desiredState != :destroyed', { destroyed: SandboxDesiredState.DESTROYED })
+        .andWhere('sandbox.updatedAt < :cutoff', { cutoff })
+        .andWhere(
+          new Brackets((qb) => {
+            BACKUP_RETRY_ERROR_SUBSTRINGS.forEach((substring, index) => {
+              const param = `retrySubstring${index}`
+              qb.orWhere(`sandbox.backupErrorReason ILIKE :${param}`, { [param]: `%${substring}%` })
+            })
+          }),
+        )
+        // Random ordering avoids head-of-line blocking on the same sandboxes that keep failing.
+        .orderBy('rand')
+        .take(100)
+        .getMany()
+
+      const results = await Promise.allSettled(
+        sandboxes.map(async (s) => {
+          // Take the same per-sandbox lock used by the rest of the backup workflows to avoid
+          // racing with in-flight backup processing and causing state flapping.
+          const sandboxLockKey = `sandbox-backup-${s.id}`
+          const hasSandboxLock = await this.redisLockProvider.lock(sandboxLockKey, 60)
+          if (!hasSandboxLock) {
+            return
+          }
+
+          try {
+            // Re-fetch the latest state inside the lock; only reset if it is still errored.
+            const sandbox = await this.sandboxRepository.findOneByOrFail({ id: s.id })
+            if (sandbox.backupState !== BackupState.ERROR) {
+              return
+            }
+
+            this.logger.log(`Retrying backup for sandbox ${sandbox.id} (error: ${sandbox.backupErrorReason})`)
+            await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.NONE)
+          } finally {
+            await this.redisLockProvider.unlock(sandboxLockKey)
+          }
+        }),
+      )
+
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          this.logger.error(
+            `Failed to reset backup state for sandbox ${sandboxes[index].id}:`,
+            fromAxiosError(result.reason),
+          )
+        }
+      })
+    } catch (error) {
+      this.logger.error('Error retrying errored backups:', error)
     } finally {
       await this.redisLockProvider.unlock(lockKey)
     }

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -461,6 +461,7 @@ Below is a full list of environment variables with their default values:
 | `FAILED_SNAPSHOT_RUNNER_RETENTION_HOURS`   | number  | `3`                                                  | Hours to retain failed snapshot runner records before cleanup                                                                                             |
 | `BUILDINFO_SNAPSHOT_RUNNER_STALENESS_DAYS` | number  | `7`                                                  | Days of inactivity before a snapshot runner is considered stale and eligible for cleanup                                                                  |
 | `DONT_SERVE_DASHBOARD`                     | boolean | `false`                                              | Disable serving dashboard static files from API service                                                                                                   |
+| `BACKUP_RETRY_INTERVAL_HOURS`              | number  | `6`                                                  | Hours to wait before automatically retrying backups that failed due to transient errors (e.g. connection refused, connection reset). Set to `0` to disable automatic backup retries |
 
 ### Runner
 


### PR DESCRIPTION
## Description

Adds a cron that will retry certain kinds of backups after they have been in an errored state for a period of time

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a cron that automatically retries transiently failed backups after a cooldown. Runs every 10 minutes to improve reliability and reduce manual work.

- **New Features**
  - Runs every 10 minutes; retries errored backups older than `BACKUP_RETRY_INTERVAL_HOURS` (default `6`; set `0` to disable). Docs updated.
  - Retries only transient failures (e.g., `connect ECONNREFUSED`, `received unexpected HTTP status`, `read: connection reset by peer`, `Backup timed out after 2 hours`), filtered in SQL.
  - Uses a global lock and per-sandbox locks; selects up to 100 random eligible sandboxes; resets backup state to `NONE` to trigger a new attempt.

<sup>Written for commit c82896ba27de85abc85fe4118890e51ac2181425. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

