### PR TITLE
fix(sdk-typescript): use import type for type-only imports

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -170,6 +170,32 @@ jobs:
           GONOSUMDB=github.com/daytonaio/daytona go work sync
           git diff --exit-code || (echo "Code not formatted or linting errors! Hint: 'yarn generate:api-client', 'yarn lint:fix', 'yarn docs' and commit" && exit 1)
 
+  typecheck-sdk-typescript:
+    name: TypeScript SDK type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - run: corepack enable
+      - name: Get yarn cache directory
+        id: yarn-cache
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-${{ runner.arch }}-
+      - run: yarn install --immutable
+      - name: Check type-only imports (verbatimModuleSyntax)
+        run: |
+          npx tsc -p ./libs/sdk-typescript/tsconfig.json \
+            --noEmit --verbatimModuleSyntax \
+            --module preserve --moduleResolution bundler
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/libs/sdk-typescript/src/CodeInterpreter.ts
+++ b/libs/sdk-typescript/src/CodeInterpreter.ts
@@ -8,7 +8,8 @@
  */
 
 import WebSocket from 'isomorphic-ws'
-import { InterpreterApi, InterpreterContext } from '@daytona/toolbox-api-client'
+import { InterpreterApi } from '@daytona/toolbox-api-client'
+import type { InterpreterContext } from '@daytona/toolbox-api-client'
 import { Configuration } from '@daytona/api-client'
 import {
   DaytonaConnectionError,
@@ -16,7 +17,7 @@ import {
   DaytonaTimeoutError,
   DaytonaValidationError,
 } from './errors/DaytonaError'
-import { ExecutionError, ExecutionResult, RunCodeOptions } from './types/CodeInterpreter'
+import type { ExecutionError, ExecutionResult, RunCodeOptions } from './types/CodeInterpreter'
 import { createSandboxWebSocket } from './utils/WebSocket'
 
 type CloseEvent = {

--- a/libs/sdk-typescript/src/ComputerUse.ts
+++ b/libs/sdk-typescript/src/ComputerUse.ts
@@ -4,8 +4,8 @@
  */
 
 import * as pathe from 'pathe'
-import {
-  ComputerUseApi,
+import { ComputerUseApi } from '@daytona/toolbox-api-client'
+import type {
   MousePositionResponse,
   MouseMoveRequest,
   MouseClickRequest,

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -10,10 +10,11 @@ import {
   SandboxApi,
   SandboxState,
   VolumesApi,
-  SandboxVolume,
   ConfigApi,
 } from '@daytona/api-client'
-import axios, { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import type { SandboxVolume } from '@daytona/api-client'
+import axios, { AxiosError } from 'axios'
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
 import {
   DaytonaAuthenticationError,
   createAxiosDaytonaError,
@@ -22,7 +23,8 @@ import {
   DaytonaValidationError,
 } from './errors/DaytonaError'
 import { Image } from './Image'
-import { Sandbox, PaginatedSandboxes } from './Sandbox'
+import { Sandbox } from './Sandbox'
+import type { PaginatedSandboxes } from './Sandbox'
 import { SnapshotService } from './Snapshot'
 import { VolumeService } from './Volume'
 import { getPackageInfo, dynamicRequire } from './utils/Import'

--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -5,15 +5,8 @@
 
 import * as pathe from 'pathe'
 import axios from 'axios'
-import {
-  Configuration,
-  FileInfo,
-  Match,
-  ReplaceRequest,
-  ReplaceResult,
-  SearchFilesResponse,
-} from '@daytona/toolbox-api-client'
-import { FileSystemApi } from '@daytona/toolbox-api-client'
+import { Configuration, FileSystemApi } from '@daytona/toolbox-api-client'
+import type { FileInfo, Match, ReplaceRequest, ReplaceResult, SearchFilesResponse } from '@daytona/toolbox-api-client'
 import { dynamicImport } from './utils/Import'
 import { RUNTIME, Runtime } from './utils/Runtime'
 import { createDaytonaError, DaytonaError } from './errors/DaytonaError'

--- a/libs/sdk-typescript/src/Git.ts
+++ b/libs/sdk-typescript/src/Git.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GitApi, ListBranchResponse, GitStatus } from '@daytona/toolbox-api-client'
+import { GitApi } from '@daytona/toolbox-api-client'
+import type { ListBranchResponse, GitStatus } from '@daytona/toolbox-api-client'
 import { WithInstrumentation } from './utils/otel.decorator'
 
 /**

--- a/libs/sdk-typescript/src/LspServer.ts
+++ b/libs/sdk-typescript/src/LspServer.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CompletionList, LspSymbol, LspApi } from '@daytona/toolbox-api-client'
+import { LspApi } from '@daytona/toolbox-api-client'
+import type { CompletionList, LspSymbol } from '@daytona/toolbox-api-client'
 import { DaytonaValidationError } from './errors/DaytonaError'
 import { WithInstrumentation } from './utils/otel.decorator'
 

--- a/libs/sdk-typescript/src/Process.ts
+++ b/libs/sdk-typescript/src/Process.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  Configuration,
-  ProcessApi,
+import { Configuration, ProcessApi } from '@daytona/toolbox-api-client'
+import type {
   Command,
   Session,
   SessionExecuteRequest,
@@ -14,11 +13,11 @@ import {
   PtyCreateRequest,
   PtySessionInfo,
 } from '@daytona/toolbox-api-client'
-import { ExecuteResponse } from './types/ExecuteResponse'
+import type { ExecuteResponse } from './types/ExecuteResponse'
 import { parseChart } from './types/Charts'
 import { stdDemuxStream } from './utils/Stream'
 import { PtyHandle } from './PtyHandle'
-import { PtyCreateOptions, PtyConnectOptions } from './types/Pty'
+import type { PtyCreateOptions, PtyConnectOptions } from './types/Pty'
 import { createSandboxWebSocket } from './utils/WebSocket'
 import { WithInstrumentation } from './utils/otel.decorator'
 

--- a/libs/sdk-typescript/src/PtyHandle.ts
+++ b/libs/sdk-typescript/src/PtyHandle.ts
@@ -4,9 +4,9 @@
  */
 
 import WebSocket from 'isomorphic-ws'
-import { PtyResult } from './types/Pty'
+import type { PtyResult } from './types/Pty'
 import { DaytonaConnectionError, DaytonaError, DaytonaTimeoutError } from './errors/DaytonaError'
-import { PtySessionInfo } from '@daytona/toolbox-api-client'
+import type { PtySessionInfo } from '@daytona/toolbox-api-client'
 import { WithInstrumentation } from './utils/otel.decorator'
 
 /**

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -3,16 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  SandboxState,
-  SandboxApi,
+import { SandboxState, SandboxApi, SandboxBackupStateEnum, Configuration } from '@daytona/api-client'
+import type {
   Sandbox as SandboxDto,
   PaginatedSandboxes as PaginatedSandboxesDto,
   PortPreviewUrl,
   SandboxVolume,
   BuildInfo,
-  SandboxBackupStateEnum,
-  Configuration,
   SshAccessDto,
   SshAccessValidationDto,
   SignedPortPreviewUrl,
@@ -20,7 +17,8 @@ import {
   CreateSandboxSnapshot,
   UpdateSandboxNetworkSettings,
 } from '@daytona/api-client'
-import { Resources, Daytona } from './Daytona'
+import { Daytona } from './Daytona'
+import type { Resources } from './Daytona'
 import type { CodeLanguage } from './Daytona'
 import {
   FileSystemApi,

--- a/libs/sdk-typescript/src/Sandbox.ts
+++ b/libs/sdk-typescript/src/Sandbox.ts
@@ -36,7 +36,7 @@ import { LspLanguageId, LspServer } from './LspServer'
 import { DaytonaError, DaytonaNotFoundError, DaytonaTimeoutError, DaytonaValidationError } from './errors/DaytonaError'
 import { CODE_TOOLBOX_LANGUAGE_LABEL } from './Daytona'
 import { ComputerUse } from './ComputerUse'
-import { AxiosInstance } from 'axios'
+import type { AxiosInstance } from 'axios'
 import { CodeInterpreter } from './CodeInterpreter'
 import { WithInstrumentation } from './utils/otel.decorator'
 

--- a/libs/sdk-typescript/src/Snapshot.ts
+++ b/libs/sdk-typescript/src/Snapshot.ts
@@ -3,18 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  ObjectStorageApi,
-  SnapshotDto,
-  SnapshotsApi,
-  SnapshotState,
-  CreateSnapshot,
-  Configuration,
-  PaginatedSnapshots as PaginatedSnapshotsDto,
-} from '@daytona/api-client'
+import { ObjectStorageApi, SnapshotsApi, SnapshotState, Configuration } from '@daytona/api-client'
+import type { SnapshotDto, CreateSnapshot, PaginatedSnapshots as PaginatedSnapshotsDto } from '@daytona/api-client'
 import { DaytonaError } from './errors/DaytonaError'
 import { Image } from './Image'
-import { Resources } from './Daytona'
+import type { Resources } from './Daytona'
 import { processStreamingResponse } from './utils/Stream'
 import { dynamicImport } from './utils/Import'
 import { WithInstrumentation } from './utils/otel.decorator'

--- a/libs/sdk-typescript/src/Volume.ts
+++ b/libs/sdk-typescript/src/Volume.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { VolumeDto, VolumesApi } from '@daytona/api-client'
+import { VolumesApi } from '@daytona/api-client'
+import type { VolumeDto } from '@daytona/api-client'
 import { DaytonaNotFoundError } from './errors/DaytonaError'
 import { WithInstrumentation } from './utils/otel.decorator'
 

--- a/libs/sdk-typescript/src/errors/DaytonaError.ts
+++ b/libs/sdk-typescript/src/errors/DaytonaError.ts
@@ -7,7 +7,8 @@
  * @module Errors
  */
 
-import { AxiosError, AxiosHeaders } from 'axios'
+import { AxiosHeaders } from 'axios'
+import type { AxiosError } from 'axios'
 
 export type ResponseHeaders = InstanceType<typeof AxiosHeaders>
 
@@ -58,8 +59,7 @@ export class DaytonaError extends Error {
  * }
  * ```
  */
-export class DaytonaNotFoundError extends DaytonaError {
-}
+export class DaytonaNotFoundError extends DaytonaError {}
 
 /**
  * Error thrown when rate limit is exceeded.
@@ -75,8 +75,7 @@ export class DaytonaNotFoundError extends DaytonaError {
  * }
  * ```
  */
-export class DaytonaRateLimitError extends DaytonaError {
-}
+export class DaytonaRateLimitError extends DaytonaError {}
 
 /**
  * Error thrown when authentication fails (HTTP 401).
@@ -92,8 +91,7 @@ export class DaytonaRateLimitError extends DaytonaError {
  * }
  * ```
  */
-export class DaytonaAuthenticationError extends DaytonaError {
-}
+export class DaytonaAuthenticationError extends DaytonaError {}
 
 /**
  * Error thrown when the request is forbidden (HTTP 403).
@@ -109,8 +107,7 @@ export class DaytonaAuthenticationError extends DaytonaError {
  * }
  * ```
  */
-export class DaytonaAuthorizationError extends DaytonaError {
-}
+export class DaytonaAuthorizationError extends DaytonaError {}
 
 /**
  * Error thrown when a resource conflict occurs (HTTP 409).
@@ -126,8 +123,7 @@ export class DaytonaAuthorizationError extends DaytonaError {
  * }
  * ```
  */
-export class DaytonaConflictError extends DaytonaError {
-}
+export class DaytonaConflictError extends DaytonaError {}
 
 /**
  * Error thrown when input validation fails (HTTP 400 or client-side validation).
@@ -143,8 +139,7 @@ export class DaytonaConflictError extends DaytonaError {
  * }
  * ```
  */
-export class DaytonaValidationError extends DaytonaError {
-}
+export class DaytonaValidationError extends DaytonaError {}
 
 /**
  * Error thrown when a timeout occurs.
@@ -160,8 +155,7 @@ export class DaytonaValidationError extends DaytonaError {
  * }
  * ```
  */
-export class DaytonaTimeoutError extends DaytonaError {
-}
+export class DaytonaTimeoutError extends DaytonaError {}
 
 /**
  * Error thrown when a network connection fails.
@@ -177,8 +171,7 @@ export class DaytonaTimeoutError extends DaytonaError {
  * }
  * ```
  */
-export class DaytonaConnectionError extends DaytonaError {
-}
+export class DaytonaConnectionError extends DaytonaError {}
 
 const STATUS_CODE_TO_ERROR: Record<number, typeof DaytonaError> = {
   400: DaytonaValidationError,

--- a/libs/sdk-typescript/src/types/CodeInterpreter.ts
+++ b/libs/sdk-typescript/src/types/CodeInterpreter.ts
@@ -7,7 +7,7 @@
  * @module code-interpreter
  */
 
-import { InterpreterContext } from '@daytona/toolbox-api-client'
+import type { InterpreterContext } from '@daytona/toolbox-api-client'
 
 /**
  * Represents stdout or stderr output from code execution.

--- a/libs/sdk-typescript/src/utils/otel.decorator.ts
+++ b/libs/sdk-typescript/src/utils/otel.decorator.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { trace, context as otelContext, metrics, SpanStatusCode, Histogram } from '@opentelemetry/api'
+import { trace, context as otelContext, metrics, SpanStatusCode } from '@opentelemetry/api'
+import type { Histogram } from '@opentelemetry/api'
 
 // Lazy initialization to ensure SDK is started before getting tracer/meter
 const getTracer = () => trace.getTracer('')


### PR DESCRIPTION
## Description

Splits each mixed import statement into `import type { ... }` for types and `import { ... }` for runtime values. This is the recommended pattern under `isolatedModules` (default in modern TS configs): per-file transpilers like bun, esbuild, and swc can only reliably erase a symbol when it's marked with `import type`. Without it, the type name leaks into the emitted JS and ESM linking fails at runtime when the SDK is consumed from source. `tsc`-compiled consumers of the published npm artifact are unaffected because whole-program type erasure hides the issue.

Changes
  - Splits mixed imports across the SDK source into import type { … } for
  type-only symbols and plain import { … } for runtime values.
  - Affects imports from @daytona/api-client, @daytona/toolbox-api-client,
  axios, and intra-SDK cross-file imports.

Verification
  - `tsc -p libs/sdk-typescript/tsconfig.esm.json --noEmit` passes.
 
## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ESM runtime errors by converting mixed imports to `import type` for type-only imports across the TypeScript SDK and adds a CI type check to prevent regressions. Works with `isolatedModules` and `verbatimModuleSyntax` so per-file transpilers erase types and ESM linking succeeds.

- **Bug Fixes**
  - Split mixed imports from `@daytona/api-client`, `@daytona/toolbox-api-client`, `axios`, `@opentelemetry/api`, and internal modules; explicitly fixed `AxiosInstance`, `InternalAxiosRequestConfig`, and `Histogram`. No API or runtime changes.

- **New Features**
  - Added `typecheck-sdk-typescript` PR job that runs `tsc --verbatimModuleSyntax` (module preserve + bundler resolution) to enforce type-only imports.

<sup>Written for commit 49b8ee5bffbc083c7e0bb3d256266418bfd6eb1a. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4703?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

