### PR TITLE
fix(daemon): restore upload_files.go pre-regression behavior with progress tracking

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/upload_files.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files.go
@@ -151,10 +151,24 @@ func resolveSymlink(path string) (string, error) {
 		}
 		return "", err
 	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		return filepath.EvalSymlinks(path)
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return path, nil
 	}
-	return path, nil
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(path), target)
+	}
+	return target, nil
 }
 
 func copyAndRemove(src, dst string) error {

--- a/apps/daemon/pkg/toolbox/fs/upload_files.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files.go
@@ -4,7 +4,6 @@
 package fs
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -16,6 +15,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+type fileResult struct {
+	Path  string `json:"path"`
+	Bytes int64  `json:"bytes"`
+}
+
 // UploadFiles godoc
 //
 //	@Summary		Upload multiple files
@@ -26,19 +30,6 @@ import (
 //	@Router			/files/bulk-upload [post]
 //
 //	@id				UploadFiles
-//
-// UploadFiles streams multipart parts directly to disk without buffering. Each file body
-// is io.Copy'd into a sibling temp file in the destination's directory, then renamed
-// atomically onto the destination on success — readers never see a partial file. Any
-// error mid-upload (including client disconnect via context cancellation) removes the
-// temp file before returning.
-//
-// Wire format: a sequence of multipart parts alternating between
-//   - text part named "files[<idx>].path" carrying the destination path, and
-//   - file part named "files[<idx>].file" carrying the file body.
-//
-// The .path part for a given index MUST arrive before the corresponding .file part —
-// the server does not buffer file bodies waiting for late metadata.
 func UploadFiles(c *gin.Context) {
 	reader, err := c.Request.MultipartReader()
 	if err != nil {
@@ -48,6 +39,7 @@ func UploadFiles(c *gin.Context) {
 
 	dests := make(map[string]string)
 	var errs []string
+	var files []fileResult
 
 	for {
 		part, err := reader.NextPart()
@@ -55,64 +47,66 @@ func UploadFiles(c *gin.Context) {
 			break
 		}
 		if err != nil {
-			// A non-EOF error means the multipart stream is no longer parseable
-			// (truncated body, malformed boundary, etc.) — keep iterating would
-			// loop forever, so record and stop.
 			errs = append(errs, fmt.Sprintf("reading part: %v", err))
 			break
 		}
 
 		name := part.FormName()
-		idx := extractIndex(name)
 
-		switch {
-		case strings.HasSuffix(name, ".path"):
-			data, readErr := io.ReadAll(part)
-			if readErr != nil {
-				errs = append(errs, fmt.Sprintf("path[%s]: %v", idx, readErr))
+		if strings.HasSuffix(name, ".path") {
+			data, err := io.ReadAll(part)
+			if err != nil {
+				idx := extractIndex(name)
+				errs = append(errs, fmt.Sprintf("path[%s]: %v", idx, err))
 				continue
 			}
+			idx := extractIndex(name)
 			dest := strings.TrimSpace(string(data))
 			if dest == "" {
 				errs = append(errs, fmt.Sprintf("path[%s]: empty path", idx))
 				continue
 			}
 			dests[idx] = dest
+			continue
+		}
 
-		case strings.HasSuffix(name, ".file"):
+		if strings.HasSuffix(name, ".file") {
+			idx := extractIndex(name)
 			dest, ok := dests[idx]
 			if !ok {
 				errs = append(errs, fmt.Sprintf("file[%s]: missing .path metadata", idx))
 				continue
 			}
-			if err := writeUploadedPart(c.Request.Context(), part, dest); err != nil {
-				errs = append(errs, fmt.Sprintf("%s: %v", dest, err))
+
+			n, writeErr := writeUploadedPart(part, dest)
+			if writeErr != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", dest, writeErr))
+				continue
 			}
+			files = append(files, fileResult{Path: dest, Bytes: n})
+			continue
 		}
 	}
 
 	if len(errs) > 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"errors": errs})
+		c.JSON(http.StatusBadRequest, gin.H{"errors": errs, "files": files})
 		return
 	}
 
-	c.Status(http.StatusOK)
+	c.JSON(http.StatusOK, gin.H{"files": files})
 }
 
-// writeUploadedPart atomically writes a single multipart file body to dest. Bytes are
-// streamed into a temp file in the destination directory (so os.Rename is atomic on
-// the same filesystem), then renamed over dest on success. Any failure — including
-// context cancellation surfaced by ctxWriter — removes the temp file.
-func writeUploadedPart(ctx context.Context, part *multipart.Part, dest string) error {
-	if dir := filepath.Dir(dest); dir != "" && dir != "." {
+func writeUploadedPart(part *multipart.Part, dest string) (int64, error) {
+	dir := filepath.Dir(dest)
+	if dir != "" && dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("mkdir %s: %w", dir, err)
+			return 0, fmt.Errorf("mkdir %s: %w", dir, err)
 		}
 	}
 
-	tmp, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".daytona-upload-*")
+	tmp, err := os.CreateTemp(dir, ".daytona-upload-*")
 	if err != nil {
-		return fmt.Errorf("create temp: %w", err)
+		return 0, fmt.Errorf("create temp: %w", err)
 	}
 	tmpPath := tmp.Name()
 	committed := false
@@ -123,17 +117,65 @@ func writeUploadedPart(ctx context.Context, part *multipart.Part, dest string) e
 		}
 	}()
 
-	cw := &ctxWriter{ctx: ctx, w: tmp}
-	if _, err := io.Copy(cw, part); err != nil {
-		return fmt.Errorf("write: %w", err)
+	n, err := io.Copy(tmp, part)
+	if err != nil {
+		tmp.Close()
+		return 0, fmt.Errorf("write: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp: %w", err)
+		return 0, fmt.Errorf("close: %w", err)
 	}
-	if err := os.Rename(tmpPath, dest); err != nil {
-		return fmt.Errorf("rename: %w", err)
+	resolvedDest, err := resolveSymlink(dest)
+	if err != nil {
+		return 0, fmt.Errorf("resolve dest: %w", err)
+	}
+	// Best-effort: some FUSE-backed filesystems (e.g. S3 volume mounts) reject
+	// chmod(2). If it fails we still attempt the rename; the copyAndRemove
+	// fallback creates the destination with 0644 via OpenFile, so permissions
+	// are correct on both code paths regardless.
+	_ = os.Chmod(tmpPath, 0o644)
+	if err := os.Rename(tmpPath, resolvedDest); err != nil {
+		if cpErr := copyAndRemove(tmpPath, resolvedDest); cpErr != nil {
+			return 0, fmt.Errorf("rename: %w; fallback: %v", err, cpErr)
+		}
 	}
 	committed = true
+	return n, nil
+}
+
+func resolveSymlink(path string) (string, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
+		return "", err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return filepath.EvalSymlinks(path)
+	}
+	return path, nil
+}
+
+func copyAndRemove(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	_ = os.Remove(src)
 	return nil
 }
 

--- a/apps/daemon/pkg/toolbox/fs/upload_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files_test.go
@@ -411,6 +411,62 @@ func TestUploadFilesWritesThroughSymlink(t *testing.T) {
 	}
 }
 
+func TestUploadFilesWritesThroughDanglingSymlink(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	target := filepath.Join(tempDir, "not-yet.txt")
+	link := filepath.Join(tempDir, "dangling.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	content := "created via dangling symlink"
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if err := mw.WriteField("files[0].path", link); err != nil {
+		t.Fatalf("write path: %v", err)
+	}
+	part, err := mw.CreateFormFile("files[0].file", "dangling.txt")
+	if err != nil {
+		t.Fatalf("form file: %v", err)
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink was replaced instead of written through")
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("target should have been created: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("expected %q at target, got %q", content, string(got))
+	}
+}
+
 func formField(idx int, suffix string) string {
 	switch idx {
 	case 0:

--- a/apps/daemon/pkg/toolbox/fs/upload_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files_test.go
@@ -5,6 +5,7 @@ package fs
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -75,7 +76,6 @@ func TestUploadFilesStreamsToDisk(t *testing.T) {
 		if string(got) != w.body {
 			t.Fatalf("%s: expected %q, got %q", w.path, w.body, string(got))
 		}
-		// Atomic write should have left no temp file behind.
 		entries, err := os.ReadDir(filepath.Dir(w.path))
 		if err != nil {
 			t.Fatalf("readdir %s: %v", filepath.Dir(w.path), err)
@@ -88,17 +88,12 @@ func TestUploadFilesStreamsToDisk(t *testing.T) {
 	}
 }
 
-// Asserts that errors during the file-body copy do not leave a partial file on disk
-// at the destination — atomic-rename means we either commit a complete file or none.
-func TestUploadFilesAtomicCleanupOnTruncatedBody(t *testing.T) {
+func TestUploadFilesTruncatedBodyLeavesNoFiles(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tempDir := t.TempDir()
 	dest := filepath.Join(tempDir, "partial.bin")
 
-	// Hand-craft a multipart body that opens a file part but truncates mid-stream.
-	// The reader will see an unexpected EOF inside io.Copy, surfacing as an error
-	// for that part. The destination must NOT exist after the request.
 	boundary := "DaytonaTestBoundary"
 	body := &bytes.Buffer{}
 	body.WriteString("--" + boundary + "\r\n")
@@ -108,7 +103,6 @@ func TestUploadFilesAtomicCleanupOnTruncatedBody(t *testing.T) {
 	body.WriteString("Content-Disposition: form-data; name=\"files[0].file\"; filename=\"partial.bin\"\r\n")
 	body.WriteString("Content-Type: application/octet-stream\r\n\r\n")
 	body.WriteString("partial-data-no-trailing-boundary")
-	// Note: intentionally missing the closing "\r\n--BOUNDARY--\r\n".
 
 	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
 	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
@@ -211,6 +205,209 @@ func TestUploadFilesUsesStreamingMultipartReader(t *testing.T) {
 	}
 	if string(got) != payload {
 		t.Fatalf("payload mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+// Verifies that uploaded files have 0644 permissions and the JSON response
+// contains accurate byte counts per file.
+func TestUploadFilesResponseBytesAndMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	content := "hello, progress tracking!"
+	dest := filepath.Join(tempDir, "progress.txt")
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if err := mw.WriteField("files[0].path", dest); err != nil {
+		t.Fatalf("write path: %v", err)
+	}
+	part, err := mw.CreateFormFile("files[0].file", "progress.txt")
+	if err != nil {
+		t.Fatalf("form file: %v", err)
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Files []struct {
+			Path  string `json:"path"`
+			Bytes int64  `json:"bytes"`
+		} `json:"files"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Files) != 1 {
+		t.Fatalf("expected 1 file result, got %d", len(resp.Files))
+	}
+	if resp.Files[0].Path != dest {
+		t.Fatalf("expected path %q, got %q", dest, resp.Files[0].Path)
+	}
+	if resp.Files[0].Bytes != int64(len(content)) {
+		t.Fatalf("expected %d bytes, got %d", len(content), resp.Files[0].Bytes)
+	}
+
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Fatalf("expected mode 0644, got %04o", perm)
+	}
+}
+
+// Verifies that a multi-file upload returns correct byte counts for each file
+// and that all files have 0644 permissions.
+func TestUploadFilesMultiFileBytesAndMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+
+	type entry struct {
+		dest    string
+		content string
+	}
+	entries := []entry{
+		{dest: filepath.Join(tempDir, "a.txt"), content: "short"},
+		{dest: filepath.Join(tempDir, "b.bin"), content: strings.Repeat("B", 128*1024)},
+		{dest: filepath.Join(tempDir, "c.txt"), content: ""},
+	}
+
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	for i, e := range entries {
+		if err := mw.WriteField(formField(i, "path"), e.dest); err != nil {
+			t.Fatalf("write path: %v", err)
+		}
+		part, err := mw.CreateFormFile(formField(i, "file"), filepath.Base(e.dest))
+		if err != nil {
+			t.Fatalf("form file: %v", err)
+		}
+		if _, err := part.Write([]byte(e.content)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Files []struct {
+			Path  string `json:"path"`
+			Bytes int64  `json:"bytes"`
+		} `json:"files"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Files) != len(entries) {
+		t.Fatalf("expected %d file results, got %d", len(entries), len(resp.Files))
+	}
+
+	for i, e := range entries {
+		r := resp.Files[i]
+		if r.Path != e.dest {
+			t.Fatalf("file[%d]: expected path %q, got %q", i, e.dest, r.Path)
+		}
+		if r.Bytes != int64(len(e.content)) {
+			t.Fatalf("file[%d]: expected %d bytes, got %d", i, len(e.content), r.Bytes)
+		}
+
+		info, err := os.Stat(e.dest)
+		if err != nil {
+			t.Fatalf("stat %s: %v", e.dest, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o644 {
+			t.Fatalf("file[%d]: expected mode 0644, got %04o", i, perm)
+		}
+	}
+}
+
+func TestUploadFilesWritesThroughSymlink(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	realFile := filepath.Join(tempDir, "real.txt")
+	if err := os.WriteFile(realFile, []byte("old content"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	link := filepath.Join(tempDir, "link.txt")
+	if err := os.Symlink(realFile, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	content := "new content via symlink"
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if err := mw.WriteField("files[0].path", link); err != nil {
+		t.Fatalf("write path: %v", err)
+	}
+	part, err := mw.CreateFormFile("files[0].file", "link.txt")
+	if err != nil {
+		t.Fatalf("form file: %v", err)
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink was replaced instead of written through")
+	}
+
+	got, err := os.ReadFile(realFile)
+	if err != nil {
+		t.Fatalf("read real file: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("expected %q at real path, got %q", content, string(got))
 	}
 }
 

--- a/libs/sdk-go/pkg/daytona/e2e_test.go
+++ b/libs/sdk-go/pkg/daytona/e2e_test.go
@@ -6,6 +6,7 @@
 package daytona
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -200,19 +201,19 @@ func TestE2E(t *testing.T) {
 		assert.Equal(t, binary, downloaded)
 	})
 
-	t.Run("FileSystem/UploadFilePermissions", func(t *testing.T) {
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("perm check"), permTestPath))
+	t.Run("FileSystem/UploadStreamPermissions", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("perm check")), permTestPath))
 		res, execErr := sandbox.Process.ExecuteCommand(ctx, "stat -c '%a' "+permTestPath)
 		require.NoError(t, execErr)
 		assert.Contains(t, strings.TrimSpace(res.Result), "644")
 	})
 
-	t.Run("FileSystem/UploadFileSymlinkWriteThrough", func(t *testing.T) {
+	t.Run("FileSystem/UploadStreamSymlinkWriteThrough", func(t *testing.T) {
 		_, execErr := sandbox.Process.ExecuteCommand(ctx,
 			fmt.Sprintf("echo 'original' > %s && ln -s %s %s", symlinkRealPath, symlinkRealPath, symlinkPath))
 		require.NoError(t, execErr)
 
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("via symlink"), symlinkPath))
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("via symlink")), symlinkPath))
 
 		isSymlink, execErr := sandbox.Process.ExecuteCommand(ctx,
 			"test -L "+symlinkPath+" && echo SYMLINK_OK || echo NOT_SYMLINK")
@@ -224,9 +225,28 @@ func TestE2E(t *testing.T) {
 		assert.Equal(t, "via symlink", string(content))
 	})
 
-	t.Run("FileSystem/UploadFileOverwritePreservesContent", func(t *testing.T) {
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("version1"), overwritePath))
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("version2"), overwritePath))
+	t.Run("FileSystem/UploadStreamDanglingSymlink", func(t *testing.T) {
+		danglingTarget := textDir + "/dangling-target.txt"
+		danglingLink := textDir + "/dangling-link.txt"
+		_, execErr := sandbox.Process.ExecuteCommand(ctx,
+			fmt.Sprintf("ln -s %s %s", danglingTarget, danglingLink))
+		require.NoError(t, execErr)
+
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("created via dangling")), danglingLink))
+
+		isSymlink, execErr := sandbox.Process.ExecuteCommand(ctx,
+			"test -L "+danglingLink+" && echo SYMLINK_OK || echo NOT_SYMLINK")
+		require.NoError(t, execErr)
+		assert.Contains(t, isSymlink.Result, "SYMLINK_OK")
+
+		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, danglingTarget, nil)
+		require.NoError(t, downloadErr)
+		assert.Equal(t, "created via dangling", string(content))
+	})
+
+	t.Run("FileSystem/UploadStreamOverwritePreservesContent", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("version1")), overwritePath))
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("version2")), overwritePath))
 
 		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, overwritePath, nil)
 		require.NoError(t, downloadErr)
@@ -237,8 +257,8 @@ func TestE2E(t *testing.T) {
 		assert.Contains(t, strings.TrimSpace(res.Result), "644")
 	})
 
-	t.Run("FileSystem/UploadFileNestedDirCreation", func(t *testing.T) {
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("deep"), deepPath))
+	t.Run("FileSystem/UploadStreamNestedDirCreation", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("deep")), deepPath))
 
 		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, deepPath, nil)
 		require.NoError(t, downloadErr)
@@ -249,8 +269,8 @@ func TestE2E(t *testing.T) {
 		assert.Contains(t, res.Result, "DIR_OK")
 	})
 
-	t.Run("FileSystem/UploadFileNoTempFileLeftovers", func(t *testing.T) {
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("clean"), cleanPath))
+	t.Run("FileSystem/UploadStreamNoTempFileLeftovers", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("clean")), cleanPath))
 
 		res, execErr := sandbox.Process.ExecuteCommand(ctx,
 			"ls -la "+textDir+"/ | grep daytona-upload || echo NO_LEFTOVERS")
@@ -258,18 +278,15 @@ func TestE2E(t *testing.T) {
 		assert.Contains(t, res.Result, "NO_LEFTOVERS")
 	})
 
-	t.Run("FileSystem/UploadFileRenameFailureNoLeftovers", func(t *testing.T) {
-		// Place a directory at the destination path so rename(file, dir) fails
-		// with EISDIR (even for root). Verifies the temp file is cleaned up and
-		// a neighbouring file is unaffected.
+	t.Run("FileSystem/UploadStreamRenameFailureNoLeftovers", func(t *testing.T) {
 		dirDest := textDir + "/dir-as-dest"
 		neighborPath := textDir + "/failure-neighbor.txt"
 
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("neighbor ok"), neighborPath))
+		require.NoError(t, sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("neighbor ok")), neighborPath))
 		_, execErr := sandbox.Process.ExecuteCommand(ctx, "mkdir "+dirDest)
 		require.NoError(t, execErr)
 
-		err := sandbox.FileSystem.UploadFile(ctx, []byte("must not win"), dirDest)
+		err := sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader([]byte("must not win")), dirDest)
 		require.Error(t, err)
 
 		leftovers, execErr := sandbox.Process.ExecuteCommand(ctx,

--- a/libs/sdk-go/pkg/daytona/e2e_test.go
+++ b/libs/sdk-go/pkg/daytona/e2e_test.go
@@ -60,6 +60,12 @@ func TestE2E(t *testing.T) {
 	helloPath := textDir + "/hello.txt"
 	binaryPath := textDir + "/binary.bin"
 	movedPath := textDir + "/moved.txt"
+	permTestPath := textDir + "/perm-test.txt"
+	symlinkRealPath := textDir + "/real-target.txt"
+	symlinkPath := textDir + "/sym-link.txt"
+	overwritePath := textDir + "/overwrite.txt"
+	deepPath := textDir + "/a/b/c/deep.txt"
+	cleanPath := textDir + "/clean.txt"
 	repoPath := baseDir + "/repo-default"
 	cloneBranchPath := baseDir + "/repo-branch"
 	sessionID := "test-session-" + suffix
@@ -192,6 +198,115 @@ func TestE2E(t *testing.T) {
 		downloaded, downloadErr := sandbox.FileSystem.DownloadFile(ctx, binaryPath, nil)
 		require.NoError(t, downloadErr)
 		assert.Equal(t, binary, downloaded)
+	})
+
+	t.Run("FileSystem/UploadFilePermissions", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("perm check"), permTestPath))
+		res, execErr := sandbox.Process.ExecuteCommand(ctx, "stat -c '%a' "+permTestPath)
+		require.NoError(t, execErr)
+		assert.Contains(t, strings.TrimSpace(res.Result), "644")
+	})
+
+	t.Run("FileSystem/UploadFileSymlinkWriteThrough", func(t *testing.T) {
+		_, execErr := sandbox.Process.ExecuteCommand(ctx,
+			fmt.Sprintf("echo 'original' > %s && ln -s %s %s", symlinkRealPath, symlinkRealPath, symlinkPath))
+		require.NoError(t, execErr)
+
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("via symlink"), symlinkPath))
+
+		isSymlink, execErr := sandbox.Process.ExecuteCommand(ctx,
+			"test -L "+symlinkPath+" && echo SYMLINK_OK || echo NOT_SYMLINK")
+		require.NoError(t, execErr)
+		assert.Contains(t, isSymlink.Result, "SYMLINK_OK")
+
+		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, symlinkRealPath, nil)
+		require.NoError(t, downloadErr)
+		assert.Equal(t, "via symlink", string(content))
+	})
+
+	t.Run("FileSystem/UploadFileOverwritePreservesContent", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("version1"), overwritePath))
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("version2"), overwritePath))
+
+		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, overwritePath, nil)
+		require.NoError(t, downloadErr)
+		assert.Equal(t, "version2", string(content))
+
+		res, execErr := sandbox.Process.ExecuteCommand(ctx, "stat -c '%a' "+overwritePath)
+		require.NoError(t, execErr)
+		assert.Contains(t, strings.TrimSpace(res.Result), "644")
+	})
+
+	t.Run("FileSystem/UploadFileNestedDirCreation", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("deep"), deepPath))
+
+		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, deepPath, nil)
+		require.NoError(t, downloadErr)
+		assert.Equal(t, "deep", string(content))
+
+		res, execErr := sandbox.Process.ExecuteCommand(ctx, "test -d "+textDir+"/a/b/c && echo DIR_OK")
+		require.NoError(t, execErr)
+		assert.Contains(t, res.Result, "DIR_OK")
+	})
+
+	t.Run("FileSystem/UploadFileNoTempFileLeftovers", func(t *testing.T) {
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("clean"), cleanPath))
+
+		res, execErr := sandbox.Process.ExecuteCommand(ctx,
+			"ls -la "+textDir+"/ | grep daytona-upload || echo NO_LEFTOVERS")
+		require.NoError(t, execErr)
+		assert.Contains(t, res.Result, "NO_LEFTOVERS")
+	})
+
+	t.Run("FileSystem/UploadFileRenameFailureNoLeftovers", func(t *testing.T) {
+		// Place a directory at the destination path so rename(file, dir) fails
+		// with EISDIR (even for root). Verifies the temp file is cleaned up and
+		// a neighbouring file is unaffected.
+		dirDest := textDir + "/dir-as-dest"
+		neighborPath := textDir + "/failure-neighbor.txt"
+
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("neighbor ok"), neighborPath))
+		_, execErr := sandbox.Process.ExecuteCommand(ctx, "mkdir "+dirDest)
+		require.NoError(t, execErr)
+
+		err := sandbox.FileSystem.UploadFile(ctx, []byte("must not win"), dirDest)
+		require.Error(t, err)
+
+		leftovers, execErr := sandbox.Process.ExecuteCommand(ctx,
+			"ls "+textDir+"/ | grep daytona-upload || echo NO_LEFTOVERS")
+		require.NoError(t, execErr)
+		assert.Contains(t, leftovers.Result, "NO_LEFTOVERS")
+
+		dirCheck, execErr := sandbox.Process.ExecuteCommand(ctx,
+			"test -d "+dirDest+" && echo DIR_OK")
+		require.NoError(t, execErr)
+		assert.Contains(t, dirCheck.Result, "DIR_OK")
+
+		neighbor, downloadErr := sandbox.FileSystem.DownloadFile(ctx, neighborPath, nil)
+		require.NoError(t, downloadErr)
+		assert.Equal(t, "neighbor ok", string(neighbor))
+	})
+
+	t.Run("FileSystem/UploadFileMidUploadAbortPreservesOriginal", func(t *testing.T) {
+		// Use UploadFileStream with a reader that errors on the second read.
+		// The first read succeeds and data is already in-flight to the server
+		// when the goroutine's io.Copy returns an error, causing the pipe to
+		// close with an error. The HTTP client drops the connection, the
+		// server's io.Copy returns an error, the temp file is removed, and
+		// the original content must be unchanged.
+		abortPath := textDir + "/abort-test.txt"
+		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("original content"), abortPath))
+
+		_ = sandbox.FileSystem.UploadFileStream(ctx, &errorAfterFirstChunkReader{}, abortPath)
+
+		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, abortPath, nil)
+		require.NoError(t, downloadErr)
+		assert.Equal(t, "original content", string(content))
+
+		leftovers, execErr := sandbox.Process.ExecuteCommand(ctx,
+			"ls "+textDir+"/ | grep daytona-upload || echo NO_LEFTOVERS")
+		require.NoError(t, execErr)
+		assert.Contains(t, leftovers.Result, "NO_LEFTOVERS")
 	})
 
 	t.Run("FileSystem/ListFiles", func(t *testing.T) {
@@ -891,6 +1006,24 @@ PY`, options.WithExecuteTimeout(10*time.Second))
 	_ = sandbox.FileSystem.DeleteFile(ctx, baseDir, true)
 	_ = sandbox.Process.DeleteSession(ctx, sessionID)
 	_ = sandbox.StartWithTimeout(ctx, 60*time.Second)
+}
+
+// errorAfterFirstChunkReader returns one full chunk then errors on subsequent
+// reads, simulating a connection abort mid-upload. The first chunk is large
+// enough to be in-flight before the error is returned.
+type errorAfterFirstChunkReader struct {
+	fired bool
+}
+
+func (r *errorAfterFirstChunkReader) Read(p []byte) (int, error) {
+	if r.fired {
+		return 0, fmt.Errorf("simulated mid-upload abort")
+	}
+	for i := range p {
+		p[i] = 'X'
+	}
+	r.fired = true
+	return len(p), nil
 }
 
 func extractContextIDs(contexts []map[string]any) []string {


### PR DESCRIPTION
### Problem

PR #4665 (`3736be3`) introduced an atomic-rename refactor to `upload_files.go` that caused two regressions:

1. **Broken volume mount uploads** — `os.Rename` fails with `ENOSYS` on S3-backed FUSE mounts and some overlay filesystems, making file uploads impossible on volume-mounted paths.
2. **Wrong file permissions** — `os.CreateTemp` hardcodes mode `0600`, changing uploaded file permissions from the expected `0644`.

Additional issues introduced by that commit:
- `ctxWriter` wrapper added unnecessary complexity for the daemon's use case.
- Verbose multi-paragraph doc comments on internal functions.
- `switch/case` replaced the original `if/continue` flow for no functional benefit.

### Solution

Rewrites `upload_files.go` to restore the original streaming structure while adding targeted improvements:

**Restored from pre-regression:**
- `if/continue` multipart parsing flow (matches original structure)
- `break` on malformed multipart stream (prevents infinite loop on truncated bodies)
- Works on all filesystem types including volume mounts

**New — atomic writes via temp + rename:**
- Each file body is streamed into a `CreateTemp` file in the destination directory
- `os.Chmod(tmpPath, 0644)` sets permissions before rename — file arrives at dest with correct mode, no visibility window with `0600`
- `os.Rename(tmp, dest)` provides atomic replacement — existing files are protected if the upload fails midway
- On any error, the deferred cleanup removes the temp file; dest is untouched

**New — volume mount fallback:**
- If `rename(2)` fails (FUSE/S3/overlay mounts), `copyAndRemove` streams tmp → dest via `os.OpenFile(..., 0644)` then removes the temp
- The fallback reports both the rename error and any copy error for debuggability

**New — symlink write-through:**
- `resolveSymlink(dest)` uses `os.Lstat` + `filepath.EvalSymlinks` to detect symlink targets before rename
- Rename targets the resolved real path, preserving the symlink (matches `os.Create` behavior from before #4665)

**New — progress tracking:**
- Success response changed from bare `200` to `200` with `{"files": [{"path": "...", "bytes": N}]}`
- Both Go and TypeScript SDKs ignore the response body on success — non-breaking
- On partial failure, `400` now returns `{"errors": [...], "files": [...]}` so callers know which files succeeded

**New — input validation:**
- `strings.TrimSpace` on destination paths
- Empty path rejection with per-index error reporting

### Files changed

| File | What changed |
|---|---|
| `apps/daemon/pkg/toolbox/fs/upload_files.go` | Full rewrite: temp+rename, chmod, symlink resolution, copy fallback, progress response |
| `apps/daemon/pkg/toolbox/fs/upload_files_test.go` | 4 new unit tests (permissions + byte count, multi-file, truncated body cleanup, symlink write-through); updated existing tests |
| `libs/sdk-go/pkg/daytona/e2e_test.go` | 7 new E2E tests validating permissions, symlinks, overwrites, nested dirs, temp cleanup, rename failure, and mid-upload abort |

### Test coverage

**Unit tests (7 total, all pass):**
- `TestUploadFilesStreamsToDisk` — multi-file upload, content verification, no temp file leftovers
- `TestUploadFilesTruncatedBodyLeavesNoFiles` — truncated body leaves no dest or temp files
- `TestUploadFilesRejectsEmptyPath` — whitespace-only path returns 400
- `TestUploadFilesUsesStreamingMultipartReader` — 1 MiB streaming upload
- `TestUploadFilesResponseBytesAndMode` — JSON response byte count + 0644 permissions
- `TestUploadFilesMultiFileBytesAndMode` — 3-file upload, per-file byte count + 0644
- `TestUploadFilesWritesThroughSymlink` — symlink preserved, content written to real target

**E2E tests (7 new):**
- `FileSystem/UploadFilePermissions` — `stat` confirms 0644 inside sandbox
- `FileSystem/UploadFileSymlinkWriteThrough` — symlink survives upload, real target updated
- `FileSystem/UploadFileOverwritePreservesContent` — second upload replaces first, permissions retained
- `FileSystem/UploadFileNestedDirCreation` — deep parent directories created on the fly
- `FileSystem/UploadFileNoTempFileLeftovers` — no `.daytona-upload-*` files after success
- `FileSystem/UploadFileRenameFailureNoLeftovers` — rename to a directory fails cleanly, no temp leaks
- `FileSystem/UploadFileMidUploadAbortPreservesOriginal` — cancelled upload preserves original file content

### Intentional behavior changes from #4665

| Behavior | #4665 | This PR |
|---|---|---|
| `ctxWriter` for context cancellation during writes | Yes | Removed — multipart reader already respects request context on reads; kernel-blocked writes to FUSE can't be interrupted anyway |
| Response on success | Bare `200` | `200` with `{"files": [...]}` |
| Response on partial failure | `400` with errors only | `400` with both `errors` and `files` |
| Symlink targets | `rename` replaces symlink | `resolveSymlink` + rename to real path (matches pre-#4665 `os.Create`) |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores pre-#4665 upload behavior in `apps/daemon/pkg/toolbox/fs/upload_files.go` so uploads work on volume mounts, files keep 0644 permissions, and the API returns per-file progress. Adds symlink write-through, including dangling symlinks.

- **New Features**
  - Atomic temp-write then rename with copy fallback for FUSE/overlay; sets 0644 before commit and writes through symlinks (including dangling).
  - Progress response: 200 returns `{"files":[{path,bytes}]}`; partial failure (400) returns `{"errors":[...],"files":[...]}`.
  - Input validation: trims paths and rejects empty values.

- **Bug Fixes**
  - Restores streaming multipart flow and exits cleanly on malformed bodies.
  - Uploads on volume-mounted paths work again; no temp file leftovers on errors.
  - Simplifies code by removing `ctxWriter` and unnecessary `switch/case`.

<sup>Written for commit 0428fb9a0b25252d809f4b1f74a97058135cf4c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

