### PR TITLE
chore(dashboard): cleanup spending FF

### DIFF
--- a/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetails.tsx
@@ -18,7 +18,6 @@ import {
 import { Button } from '@/components/ui/button'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { FeatureFlags } from '@/enums/FeatureFlags'
 import { RoutePath } from '@/enums/RoutePath'
 import { useArchiveSandboxMutation } from '@/hooks/mutations/useArchiveSandboxMutation'
 import { useDeleteSandboxMutation } from '@/hooks/mutations/useDeleteSandboxMutation'
@@ -39,7 +38,6 @@ import { OrganizationRolePermissionsEnum, OrganizationUserRoleEnum } from '@dayt
 import { isAxiosError } from 'axios'
 import { Container, GripVertical, RefreshCw } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { Group, Panel, Separator } from 'react-resizable-panels'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -60,8 +58,7 @@ export default function SandboxDetails() {
     useSelectedOrganization()
   const { getRegionName } = useRegions()
 
-  const spendingEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_SPENDING)
-  const spendingTabAvailable = spendingEnabled && !!config.analyticsApiUrl
+  const spendingTabAvailable = !!config.analyticsApiUrl
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [createSshDialogOpen, setCreateSshDialogOpen] = useState(false)

--- a/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsSheet.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxDetailsSheet/SandboxDetailsSheet.tsx
@@ -15,12 +15,10 @@ import {
 import { useSidebar } from '@/components/ui/sidebar'
 import { Tabs, TabsContent } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { FeatureFlags } from '@/enums/FeatureFlags'
 import { useConfig } from '@/hooks/useConfig'
 import { SandboxSessionProvider } from '@/providers/SandboxSessionProvider'
 import type { Sandbox } from '@daytona/api-client'
 import { ChevronDown, ChevronUp, ChevronsRight, X } from 'lucide-react'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import React, { useCallback, useEffect, useState } from 'react'
 import { SandboxActionsSegmented } from '../SandboxActionsSegmented'
 import { SandboxInfoPanel } from '../SandboxInfoPanel'
@@ -125,9 +123,8 @@ const SandboxDetailsSheet: React.FC<SandboxDetailsSheetProps> = ({
   const [internalActiveTab, setInternalActiveTab] = useState<SandboxDetailsSheetTabValue>('overview')
   const activeTab = activeTabProp ?? internalActiveTab
   const [viewportWidth, setViewportWidth] = useState(() => getViewportWidth())
-  const spendingEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_SPENDING)
   const config = useConfig()
-  const spendingTabAvailable = spendingEnabled && !!config.analyticsApiUrl
+  const spendingTabAvailable = !!config.analyticsApiUrl
   const isDesktop = viewportWidth >= MOBILE_BREAKPOINT
 
   useEffect(() => {

--- a/apps/dashboard/src/enums/FeatureFlags.ts
+++ b/apps/dashboard/src/enums/FeatureFlags.ts
@@ -6,6 +6,5 @@
 export enum FeatureFlags {
   ORGANIZATION_INFRASTRUCTURE = 'organization_infrastructure',
   ORGANIZATION_EXPERIMENTS = 'organization_experiments',
-  SANDBOX_SPENDING = 'sandbox_spending',
   SANDBOX_LINUX_VM = 'sandbox_linux_vm',
 }

--- a/apps/dashboard/src/pages/Spending.tsx
+++ b/apps/dashboard/src/pages/Spending.tsx
@@ -9,13 +9,12 @@ import { AggregatedUsageChart, ResourceUsageBreakdown, UsageSummary } from '@/co
 import { CostBreakdown } from '@/components/spending/CostBreakdown'
 import { UsageChartData } from '@/components/spending/ResourceUsageChart'
 import { SandboxUsageTable } from '@/components/spending/SandboxUsageTable'
+import { UsageTimelineChart } from '@/components/spending/UsageTimelineChart'
 import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle } from '@/components/ui/card'
 import { DateRangePicker, QuickRangesConfig } from '@/components/ui/date-range-picker'
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { Separator } from '@/components/ui/separator'
-import { FeatureFlags } from '@/enums/FeatureFlags'
-import { UsageTimelineChart } from '@/components/spending/UsageTimelineChart'
 import { useAggregatedUsage, useSandboxesUsage, useUsageChart } from '@/hooks/queries/useAnalyticsUsage'
 import { useOrganizationUsageOverviewQuery } from '@/hooks/queries/useOrganizationUsageOverviewQuery'
 import { useOrganizationUsageQuery } from '@/hooks/queries/useOrganizationUsageQuery'
@@ -24,7 +23,6 @@ import { useConfig } from '@/hooks/useConfig'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { addDays, differenceInCalendarDays, subDays } from 'date-fns'
 import { AlertCircle, BarChart3, RefreshCw } from 'lucide-react'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { DateRange } from 'react-day-picker'
 
@@ -36,8 +34,7 @@ const analyticsQuickRanges: QuickRangesConfig = {
 const Spending = () => {
   const { selectedOrganization } = useSelectedOrganization()
   const config = useConfig()
-  const spendingEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_SPENDING)
-  const analyticsAvailable = spendingEnabled && !!config.analyticsApiUrl
+  const analyticsAvailable = !!config.analyticsApiUrl
 
   const [analyticsDateRange, setAnalyticsDateRange] = useState<DateRange>(() => {
     const now = new Date()


### PR DESCRIPTION
## Description

Cleans up spending FF.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `SANDBOX_SPENDING` feature flag and now show Spending features based solely on `config.analyticsApiUrl`. This simplifies the UI logic and makes Spending available whenever analytics is configured.

- **Refactors**
  - Removed `FeatureFlags.SANDBOX_SPENDING` and all `useFeatureFlagEnabled` checks in Spending, SandboxDetails, and SandboxDetailsSheet.
  - Dropped imports from `posthog-js/react` and `FeatureFlags`; availability now uses `!!config.analyticsApiUrl`.

<sup>Written for commit 767a5bda07a0923495acc3cc28931832c00dee66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

