### PR TITLE
chore: include .nxignore in all app Docker build contexts

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,7 +14,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # Nx + TS config
-COPY nx.json tsconfig.base.json ./
+COPY nx.json tsconfig.base.json .nxignore ./
 
 # App source
 COPY apps/api/ apps/api/

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -11,7 +11,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # Nx + TS config
-COPY nx.json tsconfig.base.json ./
+COPY nx.json tsconfig.base.json .nxignore ./
 
 # App source (docs + api for openapi generation)
 COPY apps/docs/ apps/docs/

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -17,7 +17,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # Nx config
-COPY nx.json ./
+COPY nx.json .nxignore ./
 
 # Go dependency layer (cached unless go.mod/go.sum change)
 COPY go.work go.work.sum ./

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -17,7 +17,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # Nx config
-COPY nx.json ./
+COPY nx.json .nxignore ./
 
 # Go dependency layer (cached unless go.mod/go.sum change)
 COPY go.work go.work.sum ./

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -17,7 +17,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # Nx config
-COPY nx.json ./
+COPY nx.json .nxignore ./
 
 # Go dependency layer (cached unless go.mod/go.sum change)
 COPY go.work go.work.sum ./

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -17,7 +17,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # Nx config
-COPY nx.json ./
+COPY nx.json .nxignore ./
 
 # Go dependency layer (cached unless go.mod/go.sum change)
 COPY go.work go.work.sum ./

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -17,7 +17,7 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --immutable
 
 # Nx config
-COPY nx.json ./
+COPY nx.json .nxignore ./
 
 # Go dependency layer (cached unless go.mod/go.sum change)
 COPY go.work go.work.sum ./


### PR DESCRIPTION
## Summary

- Include `.nxignore` in the Docker build context for all apps that were missing it
- Extends commit `ed39e75` (which fixed `apps/api`) to `apps/docs`, `apps/proxy`, `apps/runner`, `apps/ssh-gateway`, `apps/otel-collector`, and `apps/snapshot-manager`
- Without `.nxignore` in the build context, Nx inside Docker picks up projects that are excluded locally (e.g. runtime test projects), attempts to build them, and fails because their dependencies are not installed in the Docker image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `.nxignore` in all app Docker build contexts so Nx respects ignored projects inside Docker and stops building excluded targets. This prevents build failures caused by missing deps for test/runtime-only projects.

- **Bug Fixes**
  - Copy `.nxignore` with `nx.json` in Dockerfiles for `apps/docs`, `apps/proxy`, `apps/runner`, `apps/ssh-gateway`, `apps/otel-collector`, and `apps/snapshot-manager` (extends prior `apps/api` fix).
  - Avoids Docker builds picking up excluded projects and failing due to uninstalled dependencies.

<sup>Written for commit 74e0d354f767c9bc8f43a77d976a93f499161249. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

