### PR TITLE
chore: prevent concurrent npm version git conflicts during publish

### DIFF
--- a/libs/analytics-api-client/project.json
+++ b/libs/analytics-api-client/project.json
@@ -31,7 +31,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
+        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version --no-git-tag-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
       },
       "cache": true,
       "inputs": ["{projectRoot}/package.json", { "env": "NPM_PKG_VERSION" }, { "env": "DEFAULT_PACKAGE_VERSION" }],

--- a/libs/api-client/project.json
+++ b/libs/api-client/project.json
@@ -38,7 +38,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
+        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version --no-git-tag-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
       },
       "cache": true,
       "inputs": ["{projectRoot}/package.json", { "env": "NPM_PKG_VERSION" }, { "env": "DEFAULT_PACKAGE_VERSION" }],

--- a/libs/opencode-plugin/project.json
+++ b/libs/opencode-plugin/project.json
@@ -40,7 +40,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
+        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version --no-git-tag-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
       },
       "cache": true,
       "inputs": ["{projectRoot}/package.json", { "env": "NPM_PKG_VERSION" }, { "env": "DEFAULT_PACKAGE_VERSION" }],

--- a/libs/sdk-typescript/project.json
+++ b/libs/sdk-typescript/project.json
@@ -107,7 +107,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
+        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version --no-git-tag-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
       },
       "cache": true,
       "inputs": ["{projectRoot}/package.json", { "env": "NPM_PKG_VERSION" }, { "env": "DEFAULT_PACKAGE_VERSION" }],

--- a/libs/toolbox-api-client/project.json
+++ b/libs/toolbox-api-client/project.json
@@ -38,7 +38,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
+        "command": "if [ -n \"$NPM_PKG_VERSION\" ] || [ -n \"$DEFAULT_PACKAGE_VERSION\" ]; then VER=${NPM_PKG_VERSION:-$DEFAULT_PACKAGE_VERSION}; npm version \"$VER\" --allow-same-version --no-git-tag-version && echo \"Changed version to $VER\"; else echo \"Using version from package.json\"; fi"
       },
       "cache": true,
       "inputs": ["{projectRoot}/package.json", { "env": "NPM_PKG_VERSION" }, { "env": "DEFAULT_PACKAGE_VERSION" }],


### PR DESCRIPTION
## Summary

- Add `--no-git-tag-version` to `npm version` in all `set-version` Nx targets (`sdk-typescript`, `api-client`, `toolbox-api-client`, `analytics-api-client`, `opencode-plugin`)

## Problem

`nx run-many --target=publish --all` runs all `set-version` tasks concurrently. Each one calls `npm version`, which — without `--no-git-tag-version` — attempts to `git add` + `git commit` + `git tag` after writing to `package.json`. Multiple concurrent git commits on the same repo cause a race condition: the losers exit non-zero, leaving their `package.json` unchanged at `0.0.0-dev`.

When `sdk-typescript:set-version` loses the race, Nx finds an NX Cloud cache hit for `sdk-typescript:build` from a previous local developer build (also at `0.0.0-dev`), restores the stale dist, and `publish` releases `0.0.0-dev` instead of the intended version.

## Fix

`--no-git-tag-version` makes `npm version` a pure file write with no git side effects. All concurrent `set-version` tasks succeed independently, cache keys are properly invalidated, and the correct version flows through to the published package.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `npm version` in all `set-version` targets write-only by adding `--no-git-tag-version`, so parallel publishes don’t fail and the correct version is released.

- **Bug Fixes**
  - Added `--no-git-tag-version` to `npm version` for `sdk-typescript`, `api-client`, `toolbox-api-client`, `analytics-api-client`, `opencode-plugin`.
  - Removes git side effects from version bumps to avoid commit/tag races under `nx run-many --target=publish --all`.
  - Prevents stale cache restores that could publish `0.0.0-dev`.

<sup>Written for commit d86aa71ab1797c40097822b3e1fbe49827f533e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

