### PR TITLE
fix(sdk-typescript): suppress busboy late teardown errors in downloadFileStream

### DIFF
--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -384,7 +384,14 @@ export class FileSystem {
               },
             })
             fileStream.pipe(progress)
+            // busboy's teardown can emit 'error' on the file stream after 'end',
+            // even when every byte was delivered — ignore those late errors.
+            let fileStreamEnded = false
+            fileStream.once('end', () => {
+              fileStreamEnded = true
+            })
             fileStream.on('error', (err: Error) => {
+              if (fileStreamEnded) return
               if (!progress.destroyed) progress.destroy(err)
             })
             resolvedStream = progress


### PR DESCRIPTION
## Summary

Fixes the only failing SDK E2E test in CI — `stream download with onProgress tracks bytes` — which fails with `Unexpected end of form` even though every byte of the file is delivered successfully.

The fix is a 7-line guard inside `downloadFileStream`'s `onProgress` branch.

## Failing scenario

```
✕ stream download with onProgress tracks bytes (31 ms)
   → Unexpected end of form
   at Multipart._final (node_modules/busboy/lib/types/multipart.js:588:17)
```

All other download/upload streaming tests in the same suite pass, including:

- `stream download a file`
- `download abort surfaces DaytonaError`
- `uploadFileStream from a Readable source streams with progress`
- `uploadFileStream rejects with a pre-aborted signal`

## Root cause

When `downloadFileStream` is called with an `onProgress` callback, the code wraps busboy's file stream in a `Transform`:

```typescript
fileStream.pipe(progress)
fileStream.on('error', (err) => progress.destroy(err))  // forwards errors
```

`pipe()` does not forward errors, so the explicit forwarder was added previously (commit `e35a8bd`) for the abort case. That's correct on its own, but it's unconditional — it forwards ANY error, including late teardown errors.

Busboy's `_final()` runs during stream teardown and emits `cb(new Error('Unexpected end of form'))` when its internal `_complete` flag isn't set. Node's writable destroy logic then calls busboy's `_destroy(err)`, which cascades the error into `_fileStream.destroy(err)`. The file stream re-emits `'error'` even though it has already emitted `'end'` and delivered every byte.

Sequence in the failing scenario:

1. busboy parses the file part fully → emits `'end'` on `fileStream`
2. `pipe()` ends `progress` → `progress` emits `'end'` → consumer's test promise is about to resolve
3. busboy continues, can't find the outer multipart terminator `--BOUNDARY--\r\n` → `_final` errors
4. busboy's `_destroy(err)` cascades → `fileStream.destroy(err)` → `fileStream` re-emits `'error'`
5. The unconditional forwarder calls `progress.destroy(err)` on an already-ended progress stream
6. `progress` emits `'error'` → consumer's `stream.on('error', reject)` fires → **test fails with `Unexpected end of form`**

By Node stream convention, once a stream emits `'end'`, subsequent events are teardown noise — they don't represent a real delivery failure. The forwarder must respect that.

## The fix

In `libs/sdk-typescript/src/FileSystem.ts`, inside `downloadFileStream`'s `onFileStream` callback (the `options.onProgress` branch):

```typescript
fileStream.pipe(progress)
// busboy's teardown can emit 'error' on the file stream after 'end',
// even when every byte was delivered — ignore those late errors.
let fileStreamEnded = false
fileStream.once('end', () => {
  fileStreamEnded = true
})
fileStream.on('error', (err: Error) => {
  if (fileStreamEnded) return
  if (!progress.destroyed) progress.destroy(err)
})
```

## Why this is correct

- Standard Node stream semantics: `'end'` means "all data delivered successfully". Anything after that is by definition teardown.
- The abort path still works: when `fileStream` is destroyed mid-stream **before** `'end'`, `fileStreamEnded` stays `false` → the error forwards to `progress` → consumer's `stream.on('error')` fires with the proper `DaytonaError`.
- No magic-string matching on busboy's error messages — survives busboy version upgrades.
- The 2-line comment documents the non-obvious library behavior so a future maintainer doesn't "clean up" the `fileStreamEnded` check and reintroduce the bug.

## What this PR does NOT change

The original draft of this PR also rewrote `wrapWithUploadProgress` in `libs/sdk-typescript/src/utils/FileTransfer.ts` (replacing a `Transform` + `pipeline()` chain with a hand-rolled push-through `Readable`). That change has been reverted because:

- The PR's stated purpose was fixing the failing CI test — but no upload tests fail in CI; only the download progress test fails.
- The rewrite is 47 lines of bespoke stream code, which is significantly more surface area than the idiomatic Transform/pipeline approach it replaces.
- The "deadlock" the author observed locally was never reproduced in CI. If a real upload-side flake exists, it should land in a separate PR with a regression test that fails without the change.

The upload-side hardening can be revisited in a focused follow-up PR.

## Files changed

```
libs/sdk-typescript/src/FileSystem.ts  | 7 +++++++
1 file changed, 7 insertions(+), 0 deletions(-)
```
