### PR TITLE
chore(security): redact sandbox authToken in cache invalidation logs

### DIFF
--- a/apps/api/src/sandbox/services/sandbox-lookup-cache-invalidation.service.ts
+++ b/apps/api/src/sandbox/services/sandbox-lookup-cache-invalidation.service.ts
@@ -38,12 +38,13 @@ export class SandboxLookupCacheInvalidationService {
     }
 
     if ('authToken' in args) {
+      const tokenPrefix = `${args.authToken.slice(0, 6)}...`
       cache
         .remove([sandboxLookupCacheKeyByAuthToken({ authToken: args.authToken })])
-        .then(() => this.logger.debug(`Invalidated sandbox lookup cache for authToken ${args.authToken}`))
+        .then(() => this.logger.debug(`Invalidated sandbox lookup cache for authToken ${tokenPrefix}`))
         .catch((error) =>
           this.logger.warn(
-            `Failed to invalidate sandbox lookup cache for authToken ${args.authToken}: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to invalidate sandbox lookup cache for authToken ${tokenPrefix}: ${error instanceof Error ? error.message : String(error)}`,
           ),
         )
       return


### PR DESCRIPTION
Log only the first 6 characters of the sandbox authToken in the sandbox lookup cache invalidation service so the log line retains correlation value without exposing the full secret to log aggregators.

The full token has ~168 bits of entropy (`nanoid(32).toLowerCase()`); the 6-char prefix reveals ~31 bits — enough to grep, useless for guessing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redact the sandbox `authToken` in cache invalidation logs by logging only the first 6 characters (e.g., abcdef...). This keeps logs useful for correlation while preventing the full secret from reaching log aggregators.

<sup>Written for commit e53812ba9b78f9ccf9b770f0146d6916761a2e9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

