### PR TITLE
fix(sdk-typescript): resolve Buffer in browser without require()

### DIFF
--- a/libs/sdk-typescript/runtime-tests/vite-browser/src/main.ts
+++ b/libs/sdk-typescript/runtime-tests/vite-browser/src/main.ts
@@ -1,12 +1,16 @@
 // Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Buffer } from 'buffer'
 import { Daytona, Image } from '@daytona/sdk'
 
-const result = {
+const result: Record<string, unknown> = {
   imageOk: false,
   daytonaConstructorOk: false,
   fsThrowsOk: false,
+  bufferOk: false,
+  listOk: false,
+  downloadFileOk: false,
 }
 
 try {
@@ -29,6 +33,48 @@ try {
 } catch (e: unknown) {
   const msg = e instanceof Error ? e.message : String(e)
   result.fsThrowsOk = /not available|require.*unavailable|fs/.test(msg)
+}
+
+// Verify the Buffer polyfill (vite-plugin-node-polyfills with globals.Buffer:true)
+// works correctly — same import pattern used by the dashboard's FileTreePane.tsx.
+try {
+  const buf = Buffer.from('hello buffer')
+  result.bufferOk = buf instanceof Uint8Array && buf.toString('utf-8') === 'hello buffer'
+} catch (e: unknown) {
+  result.bufferError = e instanceof Error ? e.message : String(e)
+  result.bufferOk = false
+}
+
+// Real API tests — require DAYTONA_API_KEY / DAYTONA_API_URL injected by the
+// Node.js orchestrator and a pre-created sandbox with a test file uploaded.
+const apiKey = (window as any).__DAYTONA_API_KEY__ as string | undefined
+const apiUrl = (window as any).__DAYTONA_API_URL__ as string | undefined
+const sandboxId = (window as any).__TEST_SANDBOX_ID__ as string | undefined
+const fileContent = (window as any).__TEST_FILE_CONTENT__ as string | undefined
+
+if (apiKey && apiUrl) {
+  const daytona = new Daytona({ apiKey, apiUrl })
+
+  try {
+    const r = await daytona.list()
+    result.listOk = Array.isArray(r.items)
+  } catch (e: unknown) {
+    result.listError = e instanceof Error ? e.message : String(e)
+    result.listOk = false
+  }
+
+  // downloadFile exercises the exact regression path fixed in Binary.ts:
+  // processDownloadFilesResponseWithBuffered → toBuffer → getBufferCtor.
+  if (sandboxId && fileContent) {
+    try {
+      const sandbox = await daytona.get(sandboxId)
+      const buf = await sandbox.fs.downloadFile('test.txt')
+      result.downloadFileOk = buf.toString('utf-8') === fileContent
+    } catch (e: unknown) {
+      result.downloadFileError = e instanceof Error ? e.message : String(e)
+      result.downloadFileOk = false
+    }
+  }
 }
 
 ;(window as any).__runtimeTestResult = result

--- a/libs/sdk-typescript/runtime-tests/vite-browser/test-browser.mjs
+++ b/libs/sdk-typescript/runtime-tests/vite-browser/test-browser.mjs
@@ -1,71 +1,132 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { chromium } from 'playwright'
 import { createServer } from 'http'
 import { readFileSync, existsSync } from 'fs'
 import { extname, join, resolve } from 'path'
+import { Daytona } from '@daytona/sdk'
 
 const DIST = resolve('dist')
-
 const mime = { '.js': 'application/javascript', '.html': 'text/html', '.css': 'text/css', '.json': 'application/json' }
 
-const server = createServer((req, res) => {
-  let p = req.url.split('?')[0]
-  if (p === '/') p = '/index.html'
-  const fp = resolve(join(DIST, p))
-  if (!fp.startsWith(DIST + '/') && fp !== DIST) {
-    res.writeHead(403)
-    res.end()
-    return
-  }
-  if (existsSync(fp)) {
-    res.writeHead(200, { 'content-type': mime[extname(fp)] || 'text/plain' })
-    res.end(readFileSync(fp))
-  } else {
-    res.writeHead(404)
-    res.end()
-  }
-})
-
-await new Promise((r) => server.listen(0, r))
-const PORT = server.address().port
-
-const cleanup = () => {
-  try { server.close() } catch { /* noop */ }
+const API_KEY = process.env.DAYTONA_API_KEY
+const API_URL = process.env.DAYTONA_API_URL
+if (!API_KEY || !API_URL) {
+  console.error('FAIL: DAYTONA_API_KEY and DAYTONA_API_URL must be set')
+  process.exit(1)
 }
-process.on('exit', cleanup)
 
-const browser = await chromium.launch({ headless: true })
+const FILE_CONTENT = 'hello buffer'
+const FILE_PATH = 'test.txt'
+
+// ---------------------------------------------------------------------------
+// Create sandbox + upload test file (Node.js SDK, runs before browser launch)
+// ---------------------------------------------------------------------------
+
+console.log('Creating sandbox...')
+const daytona = new Daytona({ apiKey: API_KEY, apiUrl: API_URL })
+const sandbox = await daytona.create({ timeout: 120, labels: { purpose: 'runtime-test-vite-browser' } })
+console.log('Sandbox created:', sandbox.id)
+
+let exitCode = 0
+
 try {
-  const page = await browser.newPage()
-  const errors = []
-  page.on('pageerror', (e) => errors.push('pageerror: ' + e.message))
-  page.on('console', (msg) => { if (msg.type() === 'error') errors.push('console.error: ' + msg.text()) })
+  await sandbox.fs.uploadFile(Buffer.from(FILE_CONTENT), FILE_PATH)
+  console.log('Uploaded test file:', FILE_PATH)
 
-  const allConsole = []
-  page.on('console', (msg) => allConsole.push(`[${msg.type()}] ${msg.text()}`))
-  page.on('pageerror', (e) => allConsole.push(`[pageerror] ${e.message}`))
-
-  await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'networkidle' })
-  await page.waitForFunction(() => document.body.hasAttribute('data-result'), { timeout: 5000 }).catch(() => {})
-
-  const body = await page.locator('body').first()
-  const attr = await body.getAttribute('data-result')
-  if (!attr) {
-    console.error('FAIL: no data-result attribute')
-    console.error('HTML:', await page.content())
-    console.error('Browser console:', allConsole)
-    process.exit(1)
-  }
-  const result = JSON.parse(attr)
-
-  console.log('Result:', JSON.stringify(result))
-  if (errors.length) console.log('Browser errors:', errors)
-
-  if (!result.imageOk) { console.error('FAIL: Image API broken'); process.exit(1) }
-  if (!result.daytonaConstructorOk) { console.error('FAIL: Daytona constructor broken'); process.exit(1) }
-  if (!result.fsThrowsOk) { console.error('FAIL: fs methods did not throw clear error'); process.exit(1) }
-
-  console.log('PASS')
+  exitCode = await runBrowserTest(sandbox.id)
 } finally {
-  await browser.close()
-  cleanup()
+  console.log('Deleting sandbox:', sandbox.id)
+  await daytona.delete(sandbox).catch((e) => console.warn('Sandbox delete warning:', e.message))
+}
+
+process.exit(exitCode)
+
+// ---------------------------------------------------------------------------
+// Browser test — isolated in a function so we can use early returns cleanly
+// ---------------------------------------------------------------------------
+
+async function runBrowserTest(sandboxId) {
+  // Injects Daytona config into index.html at serve time so the browser bundle
+  // can reach the real API and sandbox toolbox.
+  // Both http://localhost:3001/api and http://proxy.localhost:4000/toolbox
+  // support CORS with reflected origins, so no proxy is needed.
+  const injectedScript = `<script>
+    window.__DAYTONA_API_KEY__ = ${JSON.stringify(API_KEY)};
+    window.__DAYTONA_API_URL__ = ${JSON.stringify(API_URL)};
+    window.__TEST_SANDBOX_ID__ = ${JSON.stringify(sandboxId)};
+    window.__TEST_FILE_CONTENT__ = ${JSON.stringify(FILE_CONTENT)};
+  </script>`
+
+  const server = createServer((req, res) => {
+    let p = req.url.split('?')[0]
+    if (p === '/') p = '/index.html'
+    const fp = resolve(join(DIST, p))
+    if (!fp.startsWith(DIST + '/') && fp !== DIST) {
+      res.writeHead(403); res.end(); return
+    }
+    if (existsSync(fp)) {
+      if (extname(fp) === '.html') {
+        const html = readFileSync(fp, 'utf-8').replace('<head>', `<head>${injectedScript}`)
+        res.writeHead(200, { 'content-type': 'text/html' })
+        res.end(html)
+      } else {
+        res.writeHead(200, { 'content-type': mime[extname(fp)] || 'text/plain' })
+        res.end(readFileSync(fp))
+      }
+    } else {
+      res.writeHead(404); res.end()
+    }
+  })
+
+  await new Promise((r) => server.listen(0, r))
+  const PORT = server.address().port
+  const closeServer = () => { try { server.close() } catch { /* noop */ } }
+
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    const errors = []
+    const allConsole = []
+    page.on('pageerror', (e) => { errors.push('pageerror: ' + e.message); allConsole.push(`[pageerror] ${e.message}`) })
+    page.on('console', (msg) => {
+      allConsole.push(`[${msg.type()}] ${msg.text()}`)
+      if (msg.type() === 'error') errors.push('console.error: ' + msg.text())
+    })
+
+    await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'networkidle' })
+    await page.waitForFunction(() => document.body.hasAttribute('data-result'), { timeout: 15000 }).catch(() => {})
+
+    const attr = await page.locator('body').first().getAttribute('data-result')
+    if (!attr) {
+      console.error('FAIL: no data-result attribute set')
+      console.error('HTML:', await page.content())
+      console.error('Browser console:', allConsole)
+      return 1
+    }
+
+    const result = JSON.parse(attr)
+    console.log('Result:', JSON.stringify(result))
+    if (errors.length) console.log('Browser errors:', errors)
+
+    const checks = [
+      ['imageOk', 'Image API broken'],
+      ['daytonaConstructorOk', 'Daytona constructor broken'],
+      ['fsThrowsOk', 'fs methods did not throw clear error'],
+      ['bufferOk', 'globalThis.Buffer polyfill not available or broken'],
+      ['listOk', 'daytona.list() failed in browser'],
+      ['downloadFileOk', 'FileSystem.downloadFile Buffer handling broken in browser (Binary.ts regression)'],
+    ]
+
+    let code = 0
+    for (const [key, msg] of checks) {
+      if (!result[key]) { console.error(`FAIL: ${msg}`); code = 1 }
+    }
+    if (code === 0) console.log('PASS')
+    return code
+  } finally {
+    await browser.close()
+    closeServer()
+  }
 }

--- a/libs/sdk-typescript/runtime-tests/vite-browser/tsconfig.json
+++ b/libs/sdk-typescript/runtime-tests/vite-browser/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@daytona/sdk": ["../../src"],
+      "@daytona/sdk/*": ["../../src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/sdk-typescript/runtime-tests/vite-browser/vite.config.js
+++ b/libs/sdk-typescript/runtime-tests/vite-browser/vite.config.js
@@ -5,5 +5,10 @@ import { defineConfig } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 export default defineConfig({
+  build: {
+    // es2022 target is required for top-level await in the browser bundle.
+    // Playwright installs a recent Chromium (Chrome 94+) that supports ES2022.
+    target: 'es2022',
+  },
   plugins: [nodePolyfills({ globals: { Buffer: true, process: true, global: true } })],
 })

--- a/libs/sdk-typescript/src/utils/Binary.ts
+++ b/libs/sdk-typescript/src/utils/Binary.ts
@@ -8,7 +8,18 @@ import { dynamicRequire } from './Import'
 
 let _BufferCtor: typeof Buffer | null = null
 function getBufferCtor(): typeof Buffer {
-  if (!_BufferCtor) _BufferCtor = (dynamicRequire('buffer', '"Buffer" is not supported: ') as any).Buffer
+  if (!_BufferCtor) {
+    // Priority: (1) globalThis.Buffer — Node.js native or polyfills that assign
+    // to globalThis; (2) bare Buffer — esbuild/Vite inject it as a module-scoped
+    // variable without touching globalThis; (3) dynamicRequire as last resort.
+    if (typeof (globalThis as any).Buffer !== 'undefined') {
+      _BufferCtor = (globalThis as any).Buffer as typeof Buffer
+    } else if (typeof Buffer !== 'undefined') {
+      _BufferCtor = Buffer
+    } else {
+      _BufferCtor = (dynamicRequire('buffer', '"Buffer" is not supported: ') as any).Buffer
+    }
+  }
   return _BufferCtor
 }
 


### PR DESCRIPTION
## Problem

After the dual CJS/ESM build landed (#4607), `FileSystem.downloadFile` started throwing in browser environments (including the dashboard's file system tab):

```
"Buffer" is not supported: Module "buffer" is not available in the "browser" runtime: require is not defined
```

`Binary.ts:getBufferCtor` was calling `dynamicRequire('buffer')` to get the `Buffer` constructor, which internally calls `require()` — not available in browsers.

## Fix

`getBufferCtor` now resolves `Buffer` in priority order, without touching `require`:

1. **`globalThis.Buffer`** — available natively in Node.js and in browsers where the polyfill assigns to `globalThis`.
2. **bare `typeof Buffer`** — esbuild/Vite bundlers inject `Buffer` as a module-scoped variable without assigning it to `globalThis`; the `typeof` guard is safe even when `Buffer` is not defined at all.
3. **`dynamicRequire('buffer')`** — unchanged last resort for unknown/non-standard runtimes.

## Tests

The `vite-browser` runtime compatibility test was refactored from a mock-server approach to using the **real Daytona API**:

- Creates a real sandbox (Node.js SDK in the Playwright orchestrator)
- Uploads a `test.txt` file
- Launches headless Chromium via Playwright; the browser:
  - verifies `Buffer` polyfill availability (`bufferOk`)
  - calls `daytona.list()` (`listOk`)
  - calls `sandbox.fs.downloadFile('test.txt')` and asserts the returned `Buffer` content matches (`downloadFileOk`) — this is the exact `processDownloadFilesResponseWithBuffered → toBuffer → getBufferCtor` regression path
- Deletes the sandbox in `finally`

No mock servers. Both `http://localhost:3001/api` and `http://proxy.localhost:4000/toolbox` support CORS with reflected origins, so the browser reaches the real stack directly.

## Files changed

| File | Change |
|---|---|
| `libs/sdk-typescript/src/utils/Binary.ts` | Core fix — `getBufferCtor` 3-level fallback |
| `libs/sdk-typescript/runtime-tests/vite-browser/src/main.ts` | Real API tests: `bufferOk`, `listOk`, `downloadFileOk` |
| `libs/sdk-typescript/runtime-tests/vite-browser/test-browser.mjs` | Orchestrator creates/cleans real sandbox; no mock server |
| `libs/sdk-typescript/runtime-tests/vite-browser/vite.config.js` | `build.target: 'es2022'` for top-level await support |
| `libs/sdk-typescript/runtime-tests/vite-browser/tsconfig.json` | New — `ESNext` module + SDK path alias for IDE |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `FileSystem.downloadFile` in browsers by resolving `Buffer` without `require()`. Adds a real-browser runtime test against the Daytona API to verify the end-to-end path.

- **Bug Fixes**
  - Update `getBufferCtor()` to resolve `Buffer` in order: `globalThis.Buffer`, module `Buffer`, then `dynamicRequire('buffer')` as a last resort.
  - Removes `require()` usage in browser paths; `downloadFile` now works in Vite/esbuild bundles and Node.

- **Refactors**
  - Reworked `vite-browser` runtime test to use the real API: creates a sandbox, uploads `test.txt`, checks `Buffer` polyfill, runs `daytona.list()`, and verifies `fs.downloadFile`.
  - Set Vite target to `es2022` and added a local `tsconfig.json` with `@daytona/sdk` path alias.

<sup>Written for commit ca31834c12426ed19e6143655b09685232e189f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

