### PR TITLE
chore(docs): remove underline text decoration from code snippets

### DIFF
--- a/apps/docs/src/styles/components/markdown.scss
+++ b/apps/docs/src/styles/components/markdown.scss
@@ -686,6 +686,7 @@
           margin-right: 16px;
           font-weight: 400;
           letter-spacing: -0.0075rem;
+          text-decoration: none;
           border-bottom: 1px solid transparent;
           line-height: 28px;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove underline decoration from code snippets in the docs to avoid link-like styling and improve readability. Applies `text-decoration: none` in the Markdown snippet style.

<sup>Written for commit 7ef83e63b0918c0d685fc384563c14dfb5b6649c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

