### PR TITLE
feat: add optimized git clone options

### DIFF
--- a/apps/api/src/sandbox/dto/toolbox.deprecated.dto.ts
+++ b/apps/api/src/sandbox/dto/toolbox.deprecated.dto.ts
@@ -124,6 +124,42 @@ export class GitCloneRequestDto {
 
   @ApiPropertyOptional()
   commit_id?: string
+
+  @ApiPropertyOptional()
+  depth?: number
+
+  @ApiPropertyOptional()
+  single_branch?: boolean
+
+  @ApiPropertyOptional()
+  shallow_since?: string
+
+  @ApiPropertyOptional()
+  no_tags?: boolean
+
+  @ApiPropertyOptional()
+  filter?: string
+
+  @ApiPropertyOptional()
+  sparse?: boolean
+
+  @ApiPropertyOptional({ type: [String] })
+  sparse_paths?: string[]
+
+  @ApiPropertyOptional()
+  reference_path?: string
+
+  @ApiPropertyOptional()
+  dissociate?: boolean
+
+  @ApiPropertyOptional()
+  recurse_submodules?: boolean
+
+  @ApiPropertyOptional()
+  shallow_submodules?: boolean
+
+  @ApiPropertyOptional()
+  filter_submodules?: boolean
 }
 
 @ApiSchema({ name: 'GitCommitRequest' })

--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/daytonaio/daemon/pkg/gitprovider"
@@ -24,7 +25,12 @@ import (
 const experimentalUseGitCloneCLIEnv = "DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI"
 
 func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.BasicAuth) error {
-	if os.Getenv(experimentalUseGitCloneCLIEnv) == "true" {
+	useCLI := os.Getenv(experimentalUseGitCloneCLIEnv) == "true"
+	if err := validateCloneOptions(repo, useCLI); err != nil {
+		return err
+	}
+
+	if useCLI {
 		return s.CloneRepositoryCLI(repo, auth)
 	}
 
@@ -125,6 +131,103 @@ func (s *Service) CloneRepositoryCLI(repo *gitprovider.GitRepository, auth *http
 		}
 	}
 
+	if len(repo.SparsePaths) > 0 {
+		sparseCheckout := exec.Command(gitBin, buildSparseCheckoutArgs(s.WorkDir, repo.SparsePaths)...)
+		sparseCheckout.Env = buildCloneEnv(os.Environ(), askPath, nil)
+		sparseCheckoutTail := s.attachCmdOutput(sparseCheckout, 16*1024)
+		if err := sparseCheckout.Run(); err != nil {
+			return fmt.Errorf("git sparse-checkout set failed: %w\n--- git output (tail) ---\n%s", err, sparseCheckoutTail.String())
+		}
+	}
+
+	return nil
+}
+
+type InvalidCloneOptionsError struct {
+	Message string
+}
+
+func (e *InvalidCloneOptionsError) Error() string {
+	return e.Message
+}
+
+func validateCloneOptions(repo *gitprovider.GitRepository, useCLI bool) error {
+	if repo == nil {
+		return nil
+	}
+
+	if repo.Depth != nil && *repo.Depth < 1 {
+		return &InvalidCloneOptionsError{Message: "depth must be greater than or equal to 1"}
+	}
+	if strings.ContainsAny(repo.Filter, "\x00\r\n") {
+		return &InvalidCloneOptionsError{Message: "filter contains invalid characters"}
+	}
+	if strings.ContainsAny(repo.ReferencePath, "\x00\r\n") {
+		return &InvalidCloneOptionsError{Message: "reference_path contains invalid characters"}
+	}
+	for _, sparsePath := range repo.SparsePaths {
+		if err := validateSparsePath(sparsePath); err != nil {
+			return err
+		}
+	}
+
+	if hasOptimizedCloneOptions(repo) && !useCLI {
+		return &InvalidCloneOptionsError{Message: "optimized clone options require DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true"}
+	}
+	if repo.Target == gitprovider.CloneTargetCommit && repo.Branch == "" && (repo.Depth != nil || repo.ShallowSince != "") {
+		return &InvalidCloneOptionsError{Message: "commit_id with depth or shallow_since requires branch to be set"}
+	}
+	if repo.Dissociate != nil && *repo.Dissociate && repo.ReferencePath == "" {
+		return &InvalidCloneOptionsError{Message: "dissociate requires reference_path"}
+	}
+	if repo.ShallowSubmodules != nil && *repo.ShallowSubmodules && !boolValue(repo.RecurseSubmodules) {
+		return &InvalidCloneOptionsError{Message: "shallow_submodules requires recurse_submodules"}
+	}
+	if repo.FilterSubmodules != nil && *repo.FilterSubmodules {
+		if !boolValue(repo.RecurseSubmodules) {
+			return &InvalidCloneOptionsError{Message: "filter_submodules requires recurse_submodules"}
+		}
+		if repo.Filter == "" {
+			return &InvalidCloneOptionsError{Message: "filter_submodules requires filter"}
+		}
+	}
+
+	return nil
+}
+
+func hasOptimizedCloneOptions(repo *gitprovider.GitRepository) bool {
+	return repo.Depth != nil ||
+		repo.SingleBranch != nil ||
+		repo.ShallowSince != "" ||
+		repo.NoTags != nil ||
+		repo.Filter != "" ||
+		repo.Sparse != nil ||
+		len(repo.SparsePaths) > 0 ||
+		repo.ReferencePath != "" ||
+		repo.Dissociate != nil ||
+		repo.RecurseSubmodules != nil ||
+		repo.ShallowSubmodules != nil ||
+		repo.FilterSubmodules != nil
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
+}
+
+func validateSparsePath(sparsePath string) error {
+	if sparsePath == "" {
+		return &InvalidCloneOptionsError{Message: "sparse_paths must not contain empty paths"}
+	}
+	if strings.ContainsAny(sparsePath, "\x00\r\n") {
+		return &InvalidCloneOptionsError{Message: "sparse_paths contains invalid characters"}
+	}
+	if filepath.IsAbs(sparsePath) {
+		return &InvalidCloneOptionsError{Message: "sparse_paths must contain relative paths"}
+	}
+	clean := filepath.Clean(sparsePath)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return &InvalidCloneOptionsError{Message: "sparse_paths must contain relative paths"}
+	}
 	return nil
 }
 
@@ -157,8 +260,42 @@ func buildCloneArgs(repo *gitprovider.GitRepository, workDir string) []string {
 		"-c", "credential.helper=", // prevent any inherited helper from persisting the token
 		"-c", "http.sslVerify=false", // parity with go-git InsecureSkipTLS
 		"clone",
-		"--single-branch",
-		"--progress",
+	}
+	if repo.SingleBranch == nil || *repo.SingleBranch {
+		args = append(args, "--single-branch")
+	} else {
+		args = append(args, "--no-single-branch")
+	}
+	args = append(args, "--progress")
+	if repo.Depth != nil {
+		args = append(args, "--depth="+strconv.Itoa(*repo.Depth))
+	}
+	if repo.ShallowSince != "" {
+		args = append(args, "--shallow-since="+repo.ShallowSince)
+	}
+	if repo.NoTags != nil && *repo.NoTags {
+		args = append(args, "--no-tags")
+	}
+	if repo.Filter != "" {
+		args = append(args, "--filter="+repo.Filter)
+	}
+	if (repo.Sparse != nil && *repo.Sparse) || len(repo.SparsePaths) > 0 {
+		args = append(args, "--sparse")
+	}
+	if repo.ReferencePath != "" {
+		args = append(args, "--reference-if-able="+repo.ReferencePath)
+	}
+	if repo.Dissociate != nil && *repo.Dissociate {
+		args = append(args, "--dissociate")
+	}
+	if repo.RecurseSubmodules != nil && *repo.RecurseSubmodules {
+		args = append(args, "--recurse-submodules")
+	}
+	if repo.ShallowSubmodules != nil && *repo.ShallowSubmodules {
+		args = append(args, "--shallow-submodules")
+	}
+	if repo.FilterSubmodules != nil && *repo.FilterSubmodules {
+		args = append(args, "--also-filter-submodules")
 	}
 	if repo.Branch != "" {
 		args = append(args, "--branch", repo.Branch)
@@ -199,6 +336,12 @@ func buildCloneEnv(baseEnv []string, askPath string, auth *http.BasicAuth) []str
 func buildCheckoutArgs(workDir, sha string) []string {
 	// No `--` separator: that would make git treat the SHA as a pathspec.
 	return []string{"-C", workDir, "checkout", sha}
+}
+
+func buildSparseCheckoutArgs(workDir string, sparsePaths []string) []string {
+	args := []string{"-C", workDir, "sparse-checkout", "set", "--cone", "--"}
+	args = append(args, sparsePaths...)
+	return args
 }
 
 // tailBuffer keeps only the last N bytes — lets us include git's final error

--- a/apps/daemon/pkg/git/clone_internal_test.go
+++ b/apps/daemon/pkg/git/clone_internal_test.go
@@ -112,6 +112,121 @@ func TestBuildCloneArgs_NeverEmbedsCredsInURL(t *testing.T) {
 	}
 }
 
+func TestBuildCloneArgs_WithShallowAndAdvancedOptions(t *testing.T) {
+	depth := 1
+	singleBranch := false
+	noTags := true
+	sparse := true
+	repo := &gitprovider.GitRepository{
+		Url:          "https://github.com/daytonaio/daytona",
+		Branch:       "main",
+		Depth:        &depth,
+		SingleBranch: &singleBranch,
+		ShallowSince: "2025-01-01",
+		NoTags:       &noTags,
+		Filter:       "blob:none",
+		Sparse:       &sparse,
+	}
+
+	got := buildCloneArgs(repo, "/work-dir")
+
+	require.Equal(t, []string{
+		"-c", "credential.helper=",
+		"-c", "http.sslVerify=false",
+		"clone",
+		"--no-single-branch",
+		"--progress",
+		"--depth=1",
+		"--shallow-since=2025-01-01",
+		"--no-tags",
+		"--filter=blob:none",
+		"--sparse",
+		"--branch", "main",
+		"--", "https://github.com/daytonaio/daytona", "/work-dir",
+	}, got)
+}
+
+func TestBuildCloneArgs_WithReferenceAndSubmoduleOptions(t *testing.T) {
+	recurseSubmodules := true
+	shallowSubmodules := true
+	filterSubmodules := true
+	dissociate := true
+	repo := &gitprovider.GitRepository{
+		Url:               "https://github.com/daytonaio/daytona",
+		ReferencePath:     "/cache/daytona.git",
+		Dissociate:        &dissociate,
+		Filter:            "blob:none",
+		RecurseSubmodules: &recurseSubmodules,
+		ShallowSubmodules: &shallowSubmodules,
+		FilterSubmodules:  &filterSubmodules,
+	}
+
+	got := buildCloneArgs(repo, "/work-dir")
+
+	require.Equal(t, []string{
+		"-c", "credential.helper=",
+		"-c", "http.sslVerify=false",
+		"clone",
+		"--single-branch",
+		"--progress",
+		"--filter=blob:none",
+		"--reference-if-able=/cache/daytona.git",
+		"--dissociate",
+		"--recurse-submodules",
+		"--shallow-submodules",
+		"--also-filter-submodules",
+		"--", "https://github.com/daytonaio/daytona", "/work-dir",
+	}, got)
+}
+
+func TestValidateCloneOptions(t *testing.T) {
+	depth := 0
+	repo := &gitprovider.GitRepository{Depth: &depth}
+	require.ErrorContains(t, validateCloneOptions(repo, true), "depth must be greater than or equal to 1")
+
+	depth = 1
+	repo = &gitprovider.GitRepository{Depth: &depth}
+	require.ErrorContains(t, validateCloneOptions(repo, false), "DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true")
+
+	repo = &gitprovider.GitRepository{
+		Depth:  &depth,
+		Target: gitprovider.CloneTargetCommit,
+		Sha:    "abc123",
+	}
+	require.ErrorContains(t, validateCloneOptions(repo, true), "requires branch to be set")
+
+	repo = &gitprovider.GitRepository{Filter: "blob:none\n--upload-pack=evil"}
+	require.ErrorContains(t, validateCloneOptions(repo, true), "filter contains invalid characters")
+
+	repo = &gitprovider.GitRepository{SparsePaths: []string{"../outside"}}
+	require.ErrorContains(t, validateCloneOptions(repo, true), "sparse_paths must contain relative paths")
+
+	dissociate := true
+	repo = &gitprovider.GitRepository{Dissociate: &dissociate}
+	require.ErrorContains(t, validateCloneOptions(repo, true), "dissociate requires reference_path")
+
+	shallowSubmodules := true
+	repo = &gitprovider.GitRepository{ShallowSubmodules: &shallowSubmodules}
+	require.ErrorContains(t, validateCloneOptions(repo, true), "shallow_submodules requires recurse_submodules")
+
+	filterSubmodules := true
+	recurseSubmodules := true
+	repo = &gitprovider.GitRepository{FilterSubmodules: &filterSubmodules, RecurseSubmodules: &recurseSubmodules}
+	require.ErrorContains(t, validateCloneOptions(repo, true), "filter_submodules requires filter")
+}
+
+func TestBuildSparseCheckoutArgs(t *testing.T) {
+	got := buildSparseCheckoutArgs("/work-dir", []string{"src", "docs/guides"})
+
+	require.Equal(t, []string{
+		"-C", "/work-dir",
+		"sparse-checkout", "set",
+		"--cone",
+		"--",
+		"src", "docs/guides",
+	}, got)
+}
+
 func TestBuildCloneEnv_WithCreds(t *testing.T) {
 	env := buildCloneEnv(nil, "/tmp/askpass.sh", testCreds)
 

--- a/apps/daemon/pkg/gitprovider/types.go
+++ b/apps/daemon/pkg/gitprovider/types.go
@@ -36,16 +36,28 @@ const (
 )
 
 type GitRepository struct {
-	Id       string      `json:"id" validate:"required"`
-	Url      string      `json:"url" validate:"required"`
-	Name     string      `json:"name" validate:"required"`
-	Branch   string      `json:"branch" validate:"required"`
-	Sha      string      `json:"sha" validate:"required"`
-	Owner    string      `json:"owner" validate:"required"`
-	PrNumber *uint32     `json:"prNumber,omitempty" validate:"optional"`
-	Source   string      `json:"source" validate:"required"`
-	Path     *string     `json:"path,omitempty" validate:"optional"`
-	Target   CloneTarget `json:"cloneTarget,omitempty" validate:"optional"`
+	Id                string      `json:"id" validate:"required"`
+	Url               string      `json:"url" validate:"required"`
+	Name              string      `json:"name" validate:"required"`
+	Branch            string      `json:"branch" validate:"required"`
+	Sha               string      `json:"sha" validate:"required"`
+	Owner             string      `json:"owner" validate:"required"`
+	PrNumber          *uint32     `json:"prNumber,omitempty" validate:"optional"`
+	Source            string      `json:"source" validate:"required"`
+	Path              *string     `json:"path,omitempty" validate:"optional"`
+	Target            CloneTarget `json:"cloneTarget,omitempty" validate:"optional"`
+	Depth             *int        `json:"depth,omitempty" validate:"optional"`
+	SingleBranch      *bool       `json:"single_branch,omitempty" validate:"optional"`
+	ShallowSince      string      `json:"shallow_since,omitempty" validate:"optional"`
+	NoTags            *bool       `json:"no_tags,omitempty" validate:"optional"`
+	Filter            string      `json:"filter,omitempty" validate:"optional"`
+	Sparse            *bool       `json:"sparse,omitempty" validate:"optional"`
+	SparsePaths       []string    `json:"sparse_paths,omitempty" validate:"optional"`
+	ReferencePath     string      `json:"reference_path,omitempty" validate:"optional"`
+	Dissociate        *bool       `json:"dissociate,omitempty" validate:"optional"`
+	RecurseSubmodules *bool       `json:"recurse_submodules,omitempty" validate:"optional"`
+	ShallowSubmodules *bool       `json:"shallow_submodules,omitempty" validate:"optional"`
+	FilterSubmodules  *bool       `json:"filter_submodules,omitempty" validate:"optional"`
 } // @name GitRepository
 
 type GitNamespace struct {

--- a/apps/daemon/pkg/toolbox/docs/docs.go
+++ b/apps/daemon/pkg/toolbox/docs/docs.go
@@ -3471,11 +3471,50 @@ const docTemplate = `{
                 "commit_id": {
                     "type": "string"
                 },
+                "depth": {
+                    "type": "integer"
+                },
+                "dissociate": {
+                    "type": "boolean"
+                },
+                "filter": {
+                    "type": "string"
+                },
+                "filter_submodules": {
+                    "type": "boolean"
+                },
+                "no_tags": {
+                    "type": "boolean"
+                },
                 "password": {
                     "type": "string"
                 },
                 "path": {
                     "type": "string"
+                },
+                "recurse_submodules": {
+                    "type": "boolean"
+                },
+                "reference_path": {
+                    "type": "string"
+                },
+                "shallow_since": {
+                    "type": "string"
+                },
+                "shallow_submodules": {
+                    "type": "boolean"
+                },
+                "single_branch": {
+                    "type": "boolean"
+                },
+                "sparse": {
+                    "type": "boolean"
+                },
+                "sparse_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "url": {
                     "type": "string"

--- a/apps/daemon/pkg/toolbox/docs/swagger.json
+++ b/apps/daemon/pkg/toolbox/docs/swagger.json
@@ -3014,11 +3014,50 @@
         "commit_id": {
           "type": "string"
         },
+        "depth": {
+          "type": "integer"
+        },
+        "dissociate": {
+          "type": "boolean"
+        },
+        "filter": {
+          "type": "string"
+        },
+        "filter_submodules": {
+          "type": "boolean"
+        },
+        "no_tags": {
+          "type": "boolean"
+        },
         "password": {
           "type": "string"
         },
         "path": {
           "type": "string"
+        },
+        "recurse_submodules": {
+          "type": "boolean"
+        },
+        "reference_path": {
+          "type": "string"
+        },
+        "shallow_since": {
+          "type": "string"
+        },
+        "shallow_submodules": {
+          "type": "boolean"
+        },
+        "single_branch": {
+          "type": "boolean"
+        },
+        "sparse": {
+          "type": "boolean"
+        },
+        "sparse_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "url": {
           "type": "string"

--- a/apps/daemon/pkg/toolbox/docs/swagger.yaml
+++ b/apps/daemon/pkg/toolbox/docs/swagger.yaml
@@ -347,10 +347,36 @@ definitions:
         type: string
       commit_id:
         type: string
+      depth:
+        type: integer
+      dissociate:
+        type: boolean
+      filter:
+        type: string
+      filter_submodules:
+        type: boolean
+      no_tags:
+        type: boolean
       password:
         type: string
       path:
         type: string
+      recurse_submodules:
+        type: boolean
+      reference_path:
+        type: string
+      shallow_since:
+        type: string
+      shallow_submodules:
+        type: boolean
+      single_branch:
+        type: boolean
+      sparse:
+        type: boolean
+      sparse_paths:
+        items:
+          type: string
+        type: array
       url:
         type: string
       username:

--- a/apps/daemon/pkg/toolbox/git/clone_repository.go
+++ b/apps/daemon/pkg/toolbox/git/clone_repository.go
@@ -39,8 +39,27 @@ func CloneRepository(c *gin.Context) {
 	}
 
 	repo := gitprovider.GitRepository{
-		Url:    req.URL,
-		Branch: branch,
+		Url:               req.URL,
+		Branch:            branch,
+		Depth:             req.Depth,
+		SingleBranch:      req.SingleBranch,
+		NoTags:            req.NoTags,
+		Sparse:            req.Sparse,
+		SparsePaths:       req.SparsePaths,
+		Dissociate:        req.Dissociate,
+		RecurseSubmodules: req.RecurseSubmodules,
+		ShallowSubmodules: req.ShallowSubmodules,
+		FilterSubmodules:  req.FilterSubmodules,
+	}
+
+	if req.ShallowSince != nil {
+		repo.ShallowSince = *req.ShallowSince
+	}
+	if req.Filter != nil {
+		repo.Filter = *req.Filter
+	}
+	if req.ReferencePath != nil {
+		repo.ReferencePath = *req.ReferencePath
 	}
 
 	if req.CommitID != nil {

--- a/apps/daemon/pkg/toolbox/git/errors.go
+++ b/apps/daemon/pkg/toolbox/git/errors.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
+	daemon_git "github.com/daytonaio/daemon/pkg/git"
 	"github.com/gin-gonic/gin"
 	go_git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -15,6 +16,11 @@ import (
 )
 
 func classifyGitError(err error) error {
+	var invalidCloneOptions *daemon_git.InvalidCloneOptionsError
+	if errors.As(err, &invalidCloneOptions) {
+		return common_errors.NewBadRequestError(err)
+	}
+
 	if errors.Is(err, transport.ErrAuthenticationRequired) ||
 		errors.Is(err, transport.ErrInvalidAuthMethod) {
 		return common_errors.NewUnauthorizedError(err)

--- a/apps/daemon/pkg/toolbox/git/types.go
+++ b/apps/daemon/pkg/toolbox/git/types.go
@@ -10,12 +10,24 @@ type GitAddRequest struct {
 } //	@name	GitAddRequest
 
 type GitCloneRequest struct {
-	URL      string  `json:"url" validate:"required"`
-	Path     string  `json:"path" validate:"required"`
-	Username *string `json:"username,omitempty" validate:"optional"`
-	Password *string `json:"password,omitempty" validate:"optional"`
-	Branch   *string `json:"branch,omitempty" validate:"optional"`
-	CommitID *string `json:"commit_id,omitempty" validate:"optional"`
+	URL               string   `json:"url" validate:"required"`
+	Path              string   `json:"path" validate:"required"`
+	Username          *string  `json:"username,omitempty" validate:"optional"`
+	Password          *string  `json:"password,omitempty" validate:"optional"`
+	Branch            *string  `json:"branch,omitempty" validate:"optional"`
+	CommitID          *string  `json:"commit_id,omitempty" validate:"optional"`
+	Depth             *int     `json:"depth,omitempty" validate:"optional"`
+	SingleBranch      *bool    `json:"single_branch,omitempty" validate:"optional"`
+	ShallowSince      *string  `json:"shallow_since,omitempty" validate:"optional"`
+	NoTags            *bool    `json:"no_tags,omitempty" validate:"optional"`
+	Filter            *string  `json:"filter,omitempty" validate:"optional"`
+	Sparse            *bool    `json:"sparse,omitempty" validate:"optional"`
+	SparsePaths       []string `json:"sparse_paths,omitempty" validate:"optional"`
+	ReferencePath     *string  `json:"reference_path,omitempty" validate:"optional"`
+	Dissociate        *bool    `json:"dissociate,omitempty" validate:"optional"`
+	RecurseSubmodules *bool    `json:"recurse_submodules,omitempty" validate:"optional"`
+	ShallowSubmodules *bool    `json:"shallow_submodules,omitempty" validate:"optional"`
+	FilterSubmodules  *bool    `json:"filter_submodules,omitempty" validate:"optional"`
 } //	@name	GitCloneRequest
 
 type GitCommitRequest struct {

--- a/apps/docs/src/content/docs/en/git-operations.mdx
+++ b/apps/docs/src/content/docs/en/git-operations.mdx
@@ -15,7 +15,7 @@ Similar to [file system operations](/docs/en/file-system-operations), the starti
 
 ### Clone repositories
 
-Daytona provides methods to clone Git repositories into sandboxes. You can clone public or private repositories, specific branches, and authenticate using personal access tokens.
+Daytona provides methods to clone Git repositories into sandboxes. You can clone public or private repositories, specific branches, authenticate using personal access tokens, and use shallow, partial, or sparse clone options for large repositories.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -41,6 +41,17 @@ sandbox.git.clone(
     path="workspace/repo",
     branch="develop"
 )
+
+# Faster clone for large repositories
+sandbox.git.clone(
+    url="https://github.com/user/repo.git",
+    path="workspace/repo",
+    branch="main",
+    depth=1,
+    no_tags=True,
+    filter="blob:none",
+    sparse_paths=["src", "README.md"]
+)
 ```
 
 </TabItem>
@@ -48,27 +59,33 @@ sandbox.git.clone(
 
 ```typescript
 // Basic clone
-await sandbox.git.clone(
-    "https://github.com/user/repo.git",
-    "workspace/repo"
-);
+await sandbox.git.clone('https://github.com/user/repo.git', 'workspace/repo')
 
 // Clone with authentication
 await sandbox.git.clone(
-    "https://github.com/user/repo.git",
-    "workspace/repo",
-    undefined,
-    undefined,
-    "git",
-    "personal_access_token"
-);
+  'https://github.com/user/repo.git',
+  'workspace/repo',
+  undefined,
+  undefined,
+  'git',
+  'personal_access_token'
+)
 
 // Clone specific branch
 await sandbox.git.clone(
-    "https://github.com/user/repo.git",
-    "workspace/repo",
-    "develop"
-);
+  'https://github.com/user/repo.git',
+  'workspace/repo',
+  'develop'
+)
+
+// Faster clone for large repositories
+await sandbox.git.clone('https://github.com/user/repo.git', 'workspace/repo', {
+  branch: 'main',
+  depth: 1,
+  noTags: true,
+  filter: 'blob:none',
+  sparsePaths: ['src', 'README.md'],
+})
 ```
 
 </TabItem>
@@ -95,6 +112,17 @@ sandbox.git.clone(
   path: 'workspace/repo',
   branch: 'develop'
 )
+
+# Faster clone for large repositories
+sandbox.git.clone(
+  url: 'https://github.com/user/repo.git',
+  path: 'workspace/repo',
+  branch: 'main',
+  depth: 1,
+  no_tags: true,
+  filter: 'blob:none',
+  sparse_paths: ['src', 'README.md']
+)
 ```
 
 </TabItem>
@@ -119,6 +147,18 @@ if err != nil {
 // Clone specific branch
 err = sandbox.Git.Clone(ctx, "https://github.com/user/repo.git", "workspace/repo",
 	options.WithBranch("develop"),
+)
+if err != nil {
+	log.Fatal(err)
+}
+
+// Faster clone for large repositories
+err = sandbox.Git.Clone(ctx, "https://github.com/user/repo.git", "workspace/repo",
+	options.WithBranch("main"),
+	options.WithDepth(1),
+	options.WithNoTags(true),
+	options.WithFilter("blob:none"),
+	options.WithSparsePaths([]string{"src", "README.md"}),
 )
 if err != nil {
 	log.Fatal(err)
@@ -151,6 +191,18 @@ sandbox.git.clone(
     null,
     null
 );
+
+// Faster clone for large repositories
+sandbox.git.clone(
+    "https://github.com/user/repo.git",
+    "workspace/repo",
+    new GitCloneOptions()
+        .branch("main")
+        .depth(1)
+        .noTags(true)
+        .filter("blob:none")
+        .sparsePaths(List.of("src", "README.md"))
+);
 ```
 
 </TabItem>
@@ -163,10 +215,287 @@ curl 'https://proxy.app.daytona.io/toolbox/{sandboxId}/git/clone' \
   --data '{
   "branch": "",
   "commit_id": "",
+  "depth": 1,
+  "filter": "blob:none",
+  "no_tags": true,
   "password": "",
   "path": "",
+  "shallow_since": "",
+  "single_branch": true,
+  "sparse": true,
+  "sparse_paths": ["src", "README.md"],
   "url": "",
   "username": ""
+}'
+```
+
+</TabItem>
+</Tabs>
+
+### Shallow clone large repositories
+
+Use `depth` and `single_branch` when you only need the current working tree of a repository with a large history. These options require `DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true` in the sandbox environment.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+sandbox.git.clone(
+    url="https://github.com/torvalds/linux.git",
+    path="/home/daytona/linux",
+    depth=1,
+    single_branch=True
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+await sandbox.git.clone(
+  'https://github.com/torvalds/linux.git',
+  '/home/daytona/linux',
+  {
+    depth: 1,
+    singleBranch: true,
+  }
+)
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+sandbox.git.clone(
+  url: 'https://github.com/torvalds/linux.git',
+  path: '/home/daytona/linux',
+  depth: 1,
+  single_branch: true
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+err := sandbox.Git.Clone(ctx, "https://github.com/torvalds/linux.git", "/home/daytona/linux",
+	options.WithDepth(1),
+	options.WithSingleBranch(true),
+)
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+sandbox.git.clone(
+    "https://github.com/torvalds/linux.git",
+    "/home/daytona/linux",
+    new GitCloneOptions()
+        .depth(1)
+        .singleBranch(true)
+);
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://proxy.app.daytona.io/toolbox/{sandboxId}/git/clone' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "url": "https://github.com/torvalds/linux.git",
+  "path": "/home/daytona/linux",
+  "depth": 1,
+  "single_branch": true
+}'
+```
+
+</TabItem>
+</Tabs>
+
+### Reuse local Git object caches
+
+Use `reference_path` when the sandbox already has a bare mirror or previous checkout that can act as a local object cache. Daytona passes this to Git as `--reference-if-able`, so a missing cache does not fail the clone. Add `dissociate` when you want the resulting repository to copy borrowed objects and stay independent of the cache after clone completion.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+sandbox.git.clone(
+    url="https://github.com/daytonaio/daytona.git",
+    path="/home/daytona/daytona",
+    reference_path="/var/cache/git/daytona.git",
+    dissociate=True
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+await sandbox.git.clone(
+  'https://github.com/daytonaio/daytona.git',
+  '/home/daytona/daytona',
+  {
+    referencePath: '/var/cache/git/daytona.git',
+    dissociate: true,
+  }
+)
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+sandbox.git.clone(
+  url: 'https://github.com/daytonaio/daytona.git',
+  path: '/home/daytona/daytona',
+  reference_path: '/var/cache/git/daytona.git',
+  dissociate: true
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+err := sandbox.Git.Clone(ctx, "https://github.com/daytonaio/daytona.git", "/home/daytona/daytona",
+	options.WithReferencePath("/var/cache/git/daytona.git"),
+	options.WithDissociate(true),
+)
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+sandbox.git.clone(
+    "https://github.com/daytonaio/daytona.git",
+    "/home/daytona/daytona",
+    new GitCloneOptions()
+        .referencePath("/var/cache/git/daytona.git")
+        .dissociate(true)
+);
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://proxy.app.daytona.io/toolbox/{sandboxId}/git/clone' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "url": "https://github.com/daytonaio/daytona.git",
+  "path": "/home/daytona/daytona",
+  "reference_path": "/var/cache/git/daytona.git",
+  "dissociate": true
+}'
+```
+
+</TabItem>
+</Tabs>
+
+### Optimize submodule clones
+
+Use `recurse_submodules` when a repository needs submodules. Combine it with `shallow_submodules` to avoid fetching full submodule histories. When using a partial clone filter such as `blob:none`, add `filter_submodules` to apply the same filter to submodules.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+sandbox.git.clone(
+    url="https://github.com/user/repo-with-submodules.git",
+    path="/home/daytona/repo",
+    filter="blob:none",
+    recurse_submodules=True,
+    shallow_submodules=True,
+    filter_submodules=True
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+await sandbox.git.clone(
+  'https://github.com/user/repo-with-submodules.git',
+  '/home/daytona/repo',
+  {
+    filter: 'blob:none',
+    recurseSubmodules: true,
+    shallowSubmodules: true,
+    filterSubmodules: true,
+  }
+)
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+sandbox.git.clone(
+  url: 'https://github.com/user/repo-with-submodules.git',
+  path: '/home/daytona/repo',
+  filter: 'blob:none',
+  recurse_submodules: true,
+  shallow_submodules: true,
+  filter_submodules: true
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+err := sandbox.Git.Clone(ctx, "https://github.com/user/repo-with-submodules.git", "/home/daytona/repo",
+	options.WithFilter("blob:none"),
+	options.WithRecurseSubmodules(true),
+	options.WithShallowSubmodules(true),
+	options.WithFilterSubmodules(true),
+)
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+sandbox.git.clone(
+    "https://github.com/user/repo-with-submodules.git",
+    "/home/daytona/repo",
+    new GitCloneOptions()
+        .filter("blob:none")
+        .recurseSubmodules(true)
+        .shallowSubmodules(true)
+        .filterSubmodules(true)
+);
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://proxy.app.daytona.io/toolbox/{sandboxId}/git/clone' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "url": "https://github.com/user/repo-with-submodules.git",
+  "path": "/home/daytona/repo",
+  "filter": "blob:none",
+  "recurse_submodules": true,
+  "shallow_submodules": true,
+  "filter_submodules": true
 }'
 ```
 
@@ -200,19 +529,19 @@ for branch in response.branches:
 
 ```typescript
 // Get repository status
-const status = await sandbox.git.status("workspace/repo");
-console.log(`Current branch: ${status.currentBranch}`);
-console.log(`Commits ahead: ${status.ahead}`);
-console.log(`Commits behind: ${status.behind}`);
+const status = await sandbox.git.status('workspace/repo')
+console.log(`Current branch: ${status.currentBranch}`)
+console.log(`Commits ahead: ${status.ahead}`)
+console.log(`Commits behind: ${status.behind}`)
 status.fileStatus.forEach(file => {
-    console.log(`File: ${file.name}`);
-});
+  console.log(`File: ${file.name}`)
+})
 
 // List branches
-const response = await sandbox.git.branches("workspace/repo");
+const response = await sandbox.git.branches('workspace/repo')
 response.branches.forEach(branch => {
-    console.log(`Branch: ${branch}`);
-});
+  console.log(`Branch: ${branch}`)
+})
 ```
 
 </TabItem>
@@ -317,7 +646,7 @@ sandbox.git.create_branch("workspace/repo", "new-feature")
 
 ```typescript
 // Create new branch
-await git.createBranch('workspace/repo', 'new-feature');
+await git.createBranch('workspace/repo', 'new-feature')
 ```
 
 </TabItem>
@@ -372,7 +701,7 @@ sandbox.git.checkout_branch("workspace/repo", "feature-branch")
 
 ```typescript
 // Checkout a branch
-await git.checkoutBranch('workspace/repo', 'feature-branch');
+await git.checkoutBranch('workspace/repo', 'feature-branch')
 ```
 
 </TabItem>
@@ -427,7 +756,7 @@ sandbox.git.delete_branch("workspace/repo", "old-feature")
 
 ```typescript
 // Delete a branch
-await git.deleteBranch('workspace/repo', 'old-feature');
+await git.deleteBranch('workspace/repo', 'old-feature')
 ```
 
 </TabItem>
@@ -489,9 +818,9 @@ sandbox.git.add("workspace/repo", [
 
 ```typescript
 // Stage a single file
-await git.add('workspace/repo', ['file.txt']);
+await git.add('workspace/repo', ['file.txt'])
 // Stage whole repository
-await git.add('workspace/repo', ['.']);
+await git.add('workspace/repo', ['.'])
 ```
 
 </TabItem>
@@ -590,14 +919,14 @@ sandbox.git.commit(
 
 ```typescript
 // Stage and commit changes
-await git.add('workspace/repo', ['README.md']);
+await git.add('workspace/repo', ['README.md'])
 await git.commit(
   'workspace/repo',
   'Update documentation',
   'John Doe',
   'john@example.com',
   true
-);
+)
 ```
 
 </TabItem>
@@ -696,14 +1025,10 @@ sandbox.git.push(
 
 ```typescript
 // Push to a public repository
-await git.push('workspace/repo');
+await git.push('workspace/repo')
 
 // Push to a private repository
-await git.push(
-  'workspace/repo',
-  'user',
-  'token'
-);
+await git.push('workspace/repo', 'user', 'token')
 ```
 
 </TabItem>
@@ -781,14 +1106,10 @@ sandbox.git.pull(
 
 ```typescript
 // Pull from a public repository
-await git.pull('workspace/repo');
+await git.pull('workspace/repo')
 
 // Pull from a private repository
-await git.pull(
-  'workspace/repo',
-  'user',
-  'token'
-);
+await git.pull('workspace/repo', 'user', 'token')
 ```
 
 </TabItem>
@@ -798,6 +1119,7 @@ await git.pull(
 # Pull changes
 sandbox.git.pull('workspace/repo')
 ```
+
 </TabItem>
 <TabItem label="Go" icon="seti:go">
 
@@ -842,4 +1164,3 @@ curl 'https://proxy.app.daytona.io/toolbox/{sandboxId}/git/pull' \
 
 </TabItem>
 </Tabs>
-

--- a/libs/sdk-go/pkg/daytona/git.go
+++ b/libs/sdk-go/pkg/daytona/git.go
@@ -59,6 +59,18 @@ func NewGitService(toolboxClient *toolbox.APIClient, otel *otelState) *GitServic
 //   - [options.WithCommitId]: Checkout a specific commit after cloning
 //   - [options.WithUsername]: Username for authentication (HTTPS)
 //   - [options.WithPassword]: Password or token for authentication (HTTPS)
+//   - [options.WithDepth]: Use a shallow clone with the specified depth
+//   - [options.WithSingleBranch]: Control whether clone history is restricted to one branch
+//   - [options.WithShallowSince]: Fetch history newer than the supplied date
+//   - [options.WithNoTags]: Skip fetching tags
+//   - [options.WithFilter]: Use a partial clone filter, such as "blob:none"
+//   - [options.WithSparse]: Initialize sparse checkout
+//   - [options.WithSparsePaths]: Restrict sparse checkout to the supplied paths
+//   - [options.WithReferencePath]: Borrow objects from a local Git repository or mirror
+//   - [options.WithDissociate]: Copy borrowed reference objects into the clone
+//   - [options.WithRecurseSubmodules]: Clone submodules recursively
+//   - [options.WithShallowSubmodules]: Use shallow clones for submodules
+//   - [options.WithFilterSubmodules]: Apply the partial clone filter to submodules
 //
 // Example:
 //
@@ -94,6 +106,42 @@ func (g *GitService) Clone(ctx context.Context, url, path string, opts ...func(*
 		}
 		if cloneOpts.Password != nil {
 			req.SetPassword(*cloneOpts.Password)
+		}
+		if cloneOpts.Depth != nil {
+			req.SetDepth(int32(*cloneOpts.Depth))
+		}
+		if cloneOpts.SingleBranch != nil {
+			req.SetSingleBranch(*cloneOpts.SingleBranch)
+		}
+		if cloneOpts.ShallowSince != nil {
+			req.SetShallowSince(*cloneOpts.ShallowSince)
+		}
+		if cloneOpts.NoTags != nil {
+			req.SetNoTags(*cloneOpts.NoTags)
+		}
+		if cloneOpts.Filter != nil {
+			req.SetFilter(*cloneOpts.Filter)
+		}
+		if cloneOpts.Sparse != nil {
+			req.SetSparse(*cloneOpts.Sparse)
+		}
+		if len(cloneOpts.SparsePaths) > 0 {
+			req.SetSparsePaths(cloneOpts.SparsePaths)
+		}
+		if cloneOpts.ReferencePath != nil {
+			req.SetReferencePath(*cloneOpts.ReferencePath)
+		}
+		if cloneOpts.Dissociate != nil {
+			req.SetDissociate(*cloneOpts.Dissociate)
+		}
+		if cloneOpts.RecurseSubmodules != nil {
+			req.SetRecurseSubmodules(*cloneOpts.RecurseSubmodules)
+		}
+		if cloneOpts.ShallowSubmodules != nil {
+			req.SetShallowSubmodules(*cloneOpts.ShallowSubmodules)
+		}
+		if cloneOpts.FilterSubmodules != nil {
+			req.SetFilterSubmodules(*cloneOpts.FilterSubmodules)
 		}
 
 		httpResp, err := g.toolboxClient.GitAPI.CloneRepository(ctx).Request(*req).Execute()

--- a/libs/sdk-go/pkg/daytona/git_test.go
+++ b/libs/sdk-go/pkg/daytona/git_test.go
@@ -37,6 +37,23 @@ func TestGitClone(t *testing.T) {
 
 func TestGitCloneWithOptions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req toolbox.GitCloneRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.Equal(t, "develop", req.GetBranch())
+		require.Equal(t, "user", req.GetUsername())
+		require.Equal(t, "token", req.GetPassword())
+		require.Equal(t, int32(1), req.GetDepth())
+		require.False(t, req.GetSingleBranch())
+		require.Equal(t, "2025-01-01", req.GetShallowSince())
+		require.True(t, req.GetNoTags())
+		require.Equal(t, "blob:none", req.GetFilter())
+		require.True(t, req.GetSparse())
+		require.Equal(t, []string{"src", "README.md"}, req.GetSparsePaths())
+		require.Equal(t, "/cache/repo.git", req.GetReferencePath())
+		require.True(t, req.GetDissociate())
+		require.True(t, req.GetRecurseSubmodules())
+		require.True(t, req.GetShallowSubmodules())
+		require.True(t, req.GetFilterSubmodules())
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -49,6 +66,18 @@ func TestGitCloneWithOptions(t *testing.T) {
 		options.WithBranch("develop"),
 		options.WithUsername("user"),
 		options.WithPassword("token"),
+		options.WithDepth(1),
+		options.WithSingleBranch(false),
+		options.WithShallowSince("2025-01-01"),
+		options.WithNoTags(true),
+		options.WithFilter("blob:none"),
+		options.WithSparse(true),
+		options.WithSparsePaths([]string{"src", "README.md"}),
+		options.WithReferencePath("/cache/repo.git"),
+		options.WithDissociate(true),
+		options.WithRecurseSubmodules(true),
+		options.WithShallowSubmodules(true),
+		options.WithFilterSubmodules(true),
 	)
 	assert.NoError(t, err)
 }

--- a/libs/sdk-go/pkg/options/git.go
+++ b/libs/sdk-go/pkg/options/git.go
@@ -54,10 +54,22 @@ func Apply[T any](opts ...func(*T)) *T {
 // Fields are pointers to distinguish between unset values and zero values.
 // Use the corresponding With* functions to set these options.
 type GitClone struct {
-	Branch   *string // Branch to clone (defaults to repository's default branch)
-	CommitId *string // Specific commit SHA to checkout after cloning
-	Username *string // Username for HTTPS authentication
-	Password *string // Password or token for HTTPS authentication
+	Branch            *string  // Branch to clone (defaults to repository's default branch)
+	CommitId          *string  // Specific commit SHA to checkout after cloning
+	Username          *string  // Username for HTTPS authentication
+	Password          *string  // Password or token for HTTPS authentication
+	Depth             *int     // Number of commits to fetch for a shallow clone
+	SingleBranch      *bool    // Restrict clone history to one branch
+	ShallowSince      *string  // Fetch commits newer than this date
+	NoTags            *bool    // Skip fetching tags
+	Filter            *string  // Partial clone filter, such as blob:none
+	Sparse            *bool    // Initialize sparse checkout
+	SparsePaths       []string // Sparse checkout paths to include
+	ReferencePath     *string  // Local Git object store to borrow with --reference-if-able
+	Dissociate        *bool    // Copy borrowed objects so the clone is self-contained
+	RecurseSubmodules *bool    // Clone submodules recursively
+	ShallowSubmodules *bool    // Use shallow clones for submodules
+	FilterSubmodules  *bool    // Apply the partial clone filter to submodules
 }
 
 // WithBranch sets the branch to clone instead of the repository's default branch.
@@ -116,6 +128,94 @@ func WithUsername(username string) func(*GitClone) {
 func WithPassword(password string) func(*GitClone) {
 	return func(opts *GitClone) {
 		opts.Password = &password
+	}
+}
+
+// WithDepth sets the shallow clone depth.
+//
+// Example:
+//
+//	err := sandbox.Git.Clone(ctx, url, path, options.WithDepth(1))
+func WithDepth(depth int) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.Depth = &depth
+	}
+}
+
+// WithSingleBranch controls whether clone history is restricted to one branch.
+func WithSingleBranch(singleBranch bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.SingleBranch = &singleBranch
+	}
+}
+
+// WithShallowSince fetches only history newer than the supplied date.
+func WithShallowSince(shallowSince string) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.ShallowSince = &shallowSince
+	}
+}
+
+// WithNoTags skips fetching tags during clone.
+func WithNoTags(noTags bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.NoTags = &noTags
+	}
+}
+
+// WithFilter sets a partial clone filter, such as "blob:none".
+func WithFilter(filter string) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.Filter = &filter
+	}
+}
+
+// WithSparse initializes sparse checkout for the clone.
+func WithSparse(sparse bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.Sparse = &sparse
+	}
+}
+
+// WithSparsePaths sets the sparse checkout paths to include.
+func WithSparsePaths(paths []string) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.SparsePaths = paths
+	}
+}
+
+// WithReferencePath borrows objects from a local Git repository or mirror if it exists.
+func WithReferencePath(path string) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.ReferencePath = &path
+	}
+}
+
+// WithDissociate copies borrowed reference objects into the clone before finishing.
+func WithDissociate(dissociate bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.Dissociate = &dissociate
+	}
+}
+
+// WithRecurseSubmodules clones submodules recursively.
+func WithRecurseSubmodules(recurseSubmodules bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.RecurseSubmodules = &recurseSubmodules
+	}
+}
+
+// WithShallowSubmodules uses shallow clones for submodules.
+func WithShallowSubmodules(shallowSubmodules bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.ShallowSubmodules = &shallowSubmodules
+	}
+}
+
+// WithFilterSubmodules applies the partial clone filter to submodules.
+func WithFilterSubmodules(filterSubmodules bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.FilterSubmodules = &filterSubmodules
 	}
 }
 

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/Git.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/Git.java
@@ -38,7 +38,7 @@ public class Git {
      * @throws io.daytona.sdk.exception.DaytonaException if cloning fails
      */
     public void clone(String url, String path) {
-        clone(url, path, null, null, null, null);
+        clone(url, path, (GitCloneOptions) null);
     }
 
     /**
@@ -53,11 +53,41 @@ public class Git {
      * @throws io.daytona.sdk.exception.DaytonaException if cloning fails
      */
     public void clone(String url, String path, String branch, String commitId, String username, String password) {
+        clone(url, path, new GitCloneOptions()
+                .branch(branch)
+                .commitId(commitId)
+                .username(username)
+                .password(password));
+    }
+
+    /**
+     * Clones a repository with advanced clone options.
+     *
+     * @param url repository URL
+     * @param path destination path in the Sandbox
+     * @param options clone options; {@code null} uses defaults
+     * @throws io.daytona.sdk.exception.DaytonaException if cloning fails
+     */
+    public void clone(String url, String path, GitCloneOptions options) {
         GitCloneRequest request = new GitCloneRequest().url(url).path(path);
-        if (branch != null) request.branch(branch);
-        if (commitId != null) request.commitId(commitId);
-        if (username != null) request.username(username);
-        if (password != null) request.password(password);
+        if (options != null) {
+            if (options.getBranch() != null) request.branch(options.getBranch());
+            if (options.getCommitId() != null) request.commitId(options.getCommitId());
+            if (options.getUsername() != null) request.username(options.getUsername());
+            if (options.getPassword() != null) request.password(options.getPassword());
+            if (options.getDepth() != null) request.depth(options.getDepth());
+            if (options.getSingleBranch() != null) request.singleBranch(options.getSingleBranch());
+            if (options.getShallowSince() != null) request.shallowSince(options.getShallowSince());
+            if (options.getNoTags() != null) request.noTags(options.getNoTags());
+            if (options.getFilter() != null) request.filter(options.getFilter());
+            if (options.getSparse() != null) request.sparse(options.getSparse());
+            if (options.getSparsePaths() != null) request.sparsePaths(options.getSparsePaths());
+            if (options.getReferencePath() != null) request.referencePath(options.getReferencePath());
+            if (options.getDissociate() != null) request.dissociate(options.getDissociate());
+            if (options.getRecurseSubmodules() != null) request.recurseSubmodules(options.getRecurseSubmodules());
+            if (options.getShallowSubmodules() != null) request.shallowSubmodules(options.getShallowSubmodules());
+            if (options.getFilterSubmodules() != null) request.filterSubmodules(options.getFilterSubmodules());
+        }
         ExceptionMapper.runToolbox(() -> gitApi.cloneRepository(request));
     }
 

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/GitCloneOptions.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/GitCloneOptions.java
@@ -1,0 +1,172 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package io.daytona.sdk;
+
+import java.util.List;
+
+/**
+ * Optional parameters for cloning a Git repository.
+ */
+public class GitCloneOptions {
+    private String branch;
+    private String commitId;
+    private String username;
+    private String password;
+    private Integer depth;
+    private Boolean singleBranch;
+    private String shallowSince;
+    private Boolean noTags;
+    private String filter;
+    private Boolean sparse;
+    private List<String> sparsePaths;
+    private String referencePath;
+    private Boolean dissociate;
+    private Boolean recurseSubmodules;
+    private Boolean shallowSubmodules;
+    private Boolean filterSubmodules;
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public GitCloneOptions branch(String branch) {
+        this.branch = branch;
+        return this;
+    }
+
+    public String getCommitId() {
+        return commitId;
+    }
+
+    public GitCloneOptions commitId(String commitId) {
+        this.commitId = commitId;
+        return this;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public GitCloneOptions username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public GitCloneOptions password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public Integer getDepth() {
+        return depth;
+    }
+
+    public GitCloneOptions depth(Integer depth) {
+        this.depth = depth;
+        return this;
+    }
+
+    public Boolean getSingleBranch() {
+        return singleBranch;
+    }
+
+    public GitCloneOptions singleBranch(Boolean singleBranch) {
+        this.singleBranch = singleBranch;
+        return this;
+    }
+
+    public String getShallowSince() {
+        return shallowSince;
+    }
+
+    public GitCloneOptions shallowSince(String shallowSince) {
+        this.shallowSince = shallowSince;
+        return this;
+    }
+
+    public Boolean getNoTags() {
+        return noTags;
+    }
+
+    public GitCloneOptions noTags(Boolean noTags) {
+        this.noTags = noTags;
+        return this;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    public GitCloneOptions filter(String filter) {
+        this.filter = filter;
+        return this;
+    }
+
+    public Boolean getSparse() {
+        return sparse;
+    }
+
+    public GitCloneOptions sparse(Boolean sparse) {
+        this.sparse = sparse;
+        return this;
+    }
+
+    public List<String> getSparsePaths() {
+        return sparsePaths;
+    }
+
+    public GitCloneOptions sparsePaths(List<String> sparsePaths) {
+        this.sparsePaths = sparsePaths;
+        return this;
+    }
+
+    public String getReferencePath() {
+        return referencePath;
+    }
+
+    public GitCloneOptions referencePath(String referencePath) {
+        this.referencePath = referencePath;
+        return this;
+    }
+
+    public Boolean getDissociate() {
+        return dissociate;
+    }
+
+    public GitCloneOptions dissociate(Boolean dissociate) {
+        this.dissociate = dissociate;
+        return this;
+    }
+
+    public Boolean getRecurseSubmodules() {
+        return recurseSubmodules;
+    }
+
+    public GitCloneOptions recurseSubmodules(Boolean recurseSubmodules) {
+        this.recurseSubmodules = recurseSubmodules;
+        return this;
+    }
+
+    public Boolean getShallowSubmodules() {
+        return shallowSubmodules;
+    }
+
+    public GitCloneOptions shallowSubmodules(Boolean shallowSubmodules) {
+        this.shallowSubmodules = shallowSubmodules;
+        return this;
+    }
+
+    public Boolean getFilterSubmodules() {
+        return filterSubmodules;
+    }
+
+    public GitCloneOptions filterSubmodules(Boolean filterSubmodules) {
+        this.filterSubmodules = filterSubmodules;
+        return this;
+    }
+}

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/GitTest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/GitTest.java
@@ -73,6 +73,46 @@ class GitTest {
     }
 
     @Test
+    void cloneBuildsAdvancedRequest() {
+        git.clone("https://example.com/repo.git", "/workspace/repo", new GitCloneOptions()
+                .branch("main")
+                .commitId("abc123")
+                .username("user")
+                .password("pass")
+                .depth(1)
+                .singleBranch(false)
+                .shallowSince("2025-01-01")
+                .noTags(true)
+                .filter("blob:none")
+                .sparse(true)
+                .sparsePaths(Arrays.asList("src", "README.md"))
+                .referencePath("/cache/repo.git")
+                .dissociate(true)
+                .recurseSubmodules(true)
+                .shallowSubmodules(true)
+                .filterSubmodules(true));
+
+        ArgumentCaptor<io.daytona.toolbox.client.model.GitCloneRequest> captor = ArgumentCaptor.forClass(io.daytona.toolbox.client.model.GitCloneRequest.class);
+        verify(gitApi).cloneRepository(captor.capture());
+        assertThat(captor.getValue().getBranch()).isEqualTo("main");
+        assertThat(captor.getValue().getCommitId()).isEqualTo("abc123");
+        assertThat(captor.getValue().getUsername()).isEqualTo("user");
+        assertThat(captor.getValue().getPassword()).isEqualTo("pass");
+        assertThat(captor.getValue().getDepth()).isEqualTo(1);
+        assertThat(captor.getValue().getSingleBranch()).isFalse();
+        assertThat(captor.getValue().getShallowSince()).isEqualTo("2025-01-01");
+        assertThat(captor.getValue().getNoTags()).isTrue();
+        assertThat(captor.getValue().getFilter()).isEqualTo("blob:none");
+        assertThat(captor.getValue().getSparse()).isTrue();
+        assertThat(captor.getValue().getSparsePaths()).containsExactly("src", "README.md");
+        assertThat(captor.getValue().getReferencePath()).isEqualTo("/cache/repo.git");
+        assertThat(captor.getValue().getDissociate()).isTrue();
+        assertThat(captor.getValue().getRecurseSubmodules()).isTrue();
+        assertThat(captor.getValue().getShallowSubmodules()).isTrue();
+        assertThat(captor.getValue().getFilterSubmodules()).isTrue();
+    }
+
+    @Test
     void branchesReturnsResponseData() {
         when(gitApi.listBranches("/repo")).thenReturn(new ListBranchResponse().branches(Arrays.asList("main", "feature")));
 

--- a/libs/sdk-python/src/daytona/_async/git.py
+++ b/libs/sdk-python/src/daytona/_async/git.py
@@ -118,6 +118,18 @@ class AsyncGit:
         commit_id: str | None = None,
         username: str | None = None,
         password: str | None = None,
+        depth: int | None = None,
+        single_branch: bool | None = None,
+        shallow_since: str | None = None,
+        no_tags: bool | None = None,
+        filter: str | None = None,
+        sparse: bool | None = None,
+        sparse_paths: list[str] | None = None,
+        reference_path: str | None = None,
+        dissociate: bool | None = None,
+        recurse_submodules: bool | None = None,
+        shallow_submodules: bool | None = None,
+        filter_submodules: bool | None = None,
     ) -> None:
         """Clones a Git repository into the specified path. It supports
         cloning specific branches or commits, and can authenticate with the remote
@@ -133,6 +145,18 @@ class AsyncGit:
                 the repository will be left in a detached HEAD state at this commit.
             username (str | None): Git username for authentication.
             password (str | None): Git password or token for authentication.
+            depth (int | None): Number of commits to fetch for a shallow clone.
+            single_branch (bool | None): Whether to restrict history to one branch.
+            shallow_since (str | None): Fetch only history newer than this date.
+            no_tags (bool | None): Skip fetching tags.
+            filter (str | None): Partial clone filter, such as "blob:none".
+            sparse (bool | None): Initialize sparse checkout.
+            sparse_paths (list[str] | None): Sparse checkout paths to include.
+            reference_path (str | None): Local Git object store to borrow from if available.
+            dissociate (bool | None): Copy borrowed reference objects into the clone.
+            recurse_submodules (bool | None): Clone submodules recursively.
+            shallow_submodules (bool | None): Use shallow clones for submodules.
+            filter_submodules (bool | None): Apply the partial clone filter to submodules.
 
         Example:
             ```python
@@ -167,6 +191,18 @@ class AsyncGit:
                 username=username,
                 password=password,
                 commit_id=commit_id,
+                depth=depth,
+                single_branch=single_branch,
+                shallow_since=shallow_since,
+                no_tags=no_tags,
+                filter=filter,
+                sparse=sparse,
+                sparse_paths=sparse_paths,
+                reference_path=reference_path,
+                dissociate=dissociate,
+                recurse_submodules=recurse_submodules,
+                shallow_submodules=shallow_submodules,
+                filter_submodules=filter_submodules,
             ),
         )
 

--- a/libs/sdk-python/src/daytona/_sync/git.py
+++ b/libs/sdk-python/src/daytona/_sync/git.py
@@ -118,6 +118,18 @@ class Git:
         commit_id: str | None = None,
         username: str | None = None,
         password: str | None = None,
+        depth: int | None = None,
+        single_branch: bool | None = None,
+        shallow_since: str | None = None,
+        no_tags: bool | None = None,
+        filter: str | None = None,
+        sparse: bool | None = None,
+        sparse_paths: list[str] | None = None,
+        reference_path: str | None = None,
+        dissociate: bool | None = None,
+        recurse_submodules: bool | None = None,
+        shallow_submodules: bool | None = None,
+        filter_submodules: bool | None = None,
     ) -> None:
         """Clones a Git repository into the specified path. It supports
         cloning specific branches or commits, and can authenticate with the remote
@@ -133,6 +145,18 @@ class Git:
                 the repository will be left in a detached HEAD state at this commit.
             username (str | None): Git username for authentication.
             password (str | None): Git password or token for authentication.
+            depth (int | None): Number of commits to fetch for a shallow clone.
+            single_branch (bool | None): Whether to restrict history to one branch.
+            shallow_since (str | None): Fetch only history newer than this date.
+            no_tags (bool | None): Skip fetching tags.
+            filter (str | None): Partial clone filter, such as "blob:none".
+            sparse (bool | None): Initialize sparse checkout.
+            sparse_paths (list[str] | None): Sparse checkout paths to include.
+            reference_path (str | None): Local Git object store to borrow from if available.
+            dissociate (bool | None): Copy borrowed reference objects into the clone.
+            recurse_submodules (bool | None): Clone submodules recursively.
+            shallow_submodules (bool | None): Use shallow clones for submodules.
+            filter_submodules (bool | None): Apply the partial clone filter to submodules.
 
         Example:
             ```python
@@ -167,6 +191,18 @@ class Git:
                 username=username,
                 password=password,
                 commit_id=commit_id,
+                depth=depth,
+                single_branch=single_branch,
+                shallow_since=shallow_since,
+                no_tags=no_tags,
+                filter=filter,
+                sparse=sparse,
+                sparse_paths=sparse_paths,
+                reference_path=reference_path,
+                dissociate=dissociate,
+                recurse_submodules=recurse_submodules,
+                shallow_submodules=shallow_submodules,
+                filter_submodules=filter_submodules,
             ),
         )
 

--- a/libs/sdk-python/tests/test_git.py
+++ b/libs/sdk-python/tests/test_git.py
@@ -63,6 +63,45 @@ class TestSyncGit:
         assert call_args.kwargs["request"].username == "user"
         assert call_args.kwargs["request"].password == "token"
 
+    def test_clone_with_advanced_options(self):
+        git, api = self._make_git()
+        api.clone_repository.return_value = None
+        git.clone(
+            "https://github.com/user/repo.git",
+            "workspace/repo",
+            branch="main",
+            commit_id="abc123",
+            username="user",
+            password="token",
+            depth=1,
+            single_branch=False,
+            shallow_since="2025-01-01",
+            no_tags=True,
+            filter="blob:none",
+            sparse=True,
+            sparse_paths=["src", "README.md"],
+            reference_path="/cache/repo.git",
+            dissociate=True,
+            recurse_submodules=True,
+            shallow_submodules=True,
+            filter_submodules=True,
+        )
+        request = api.clone_repository.call_args.kwargs["request"]
+        assert request.branch == "main"
+        assert request.commit_id == "abc123"
+        assert request.depth == 1
+        assert request.single_branch is False
+        assert request.shallow_since == "2025-01-01"
+        assert request.no_tags is True
+        assert request.filter == "blob:none"
+        assert request.sparse is True
+        assert request.sparse_paths == ["src", "README.md"]
+        assert request.reference_path == "/cache/repo.git"
+        assert request.dissociate is True
+        assert request.recurse_submodules is True
+        assert request.shallow_submodules is True
+        assert request.filter_submodules is True
+
     def test_commit(self):
         git, api = self._make_git()
         mock_response = MagicMock()
@@ -149,6 +188,45 @@ class TestAsyncGit:
         git, api = self._make_git()
         await git.clone("https://github.com/user/repo.git", "workspace/repo")
         api.clone_repository.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_clone_with_advanced_options(self):
+        git, api = self._make_git()
+        await git.clone(
+            "https://github.com/user/repo.git",
+            "workspace/repo",
+            branch="main",
+            commit_id="abc123",
+            username="user",
+            password="token",
+            depth=1,
+            single_branch=False,
+            shallow_since="2025-01-01",
+            no_tags=True,
+            filter="blob:none",
+            sparse=True,
+            sparse_paths=["src", "README.md"],
+            reference_path="/cache/repo.git",
+            dissociate=True,
+            recurse_submodules=True,
+            shallow_submodules=True,
+            filter_submodules=True,
+        )
+        request = api.clone_repository.call_args.kwargs["request"]
+        assert request.branch == "main"
+        assert request.commit_id == "abc123"
+        assert request.depth == 1
+        assert request.single_branch is False
+        assert request.shallow_since == "2025-01-01"
+        assert request.no_tags is True
+        assert request.filter == "blob:none"
+        assert request.sparse is True
+        assert request.sparse_paths == ["src", "README.md"]
+        assert request.reference_path == "/cache/repo.git"
+        assert request.dissociate is True
+        assert request.recurse_submodules is True
+        assert request.shallow_submodules is True
+        assert request.filter_submodules is True
 
     @pytest.mark.asyncio
     async def test_commit(self):

--- a/libs/sdk-ruby/lib/daytona/git.rb
+++ b/libs/sdk-ruby/lib/daytona/git.rb
@@ -82,6 +82,18 @@ module Daytona
     #   the repository will be left in a detached HEAD state at this commit.
     # @param username [String, nil] Git username for authentication.
     # @param password [String, nil] Git password or token for authentication.
+    # @param depth [Integer, nil] Number of commits to fetch for a shallow clone.
+    # @param single_branch [Boolean, nil] Whether to restrict history to one branch.
+    # @param shallow_since [String, nil] Fetch only history newer than this date.
+    # @param no_tags [Boolean, nil] Skip fetching tags.
+    # @param filter [String, nil] Partial clone filter, such as "blob:none".
+    # @param sparse [Boolean, nil] Initialize sparse checkout.
+    # @param sparse_paths [Array<String>, nil] Sparse checkout paths to include.
+    # @param reference_path [String, nil] Local Git object store to borrow from if available.
+    # @param dissociate [Boolean, nil] Copy borrowed reference objects into the clone.
+    # @param recurse_submodules [Boolean, nil] Clone submodules recursively.
+    # @param shallow_submodules [Boolean, nil] Use shallow clones for submodules.
+    # @param filter_submodules [Boolean, nil] Apply the partial clone filter to submodules.
     # @return [void]
     # @raise [Daytona::Sdk::Error] if cloning repository fails
     #
@@ -107,7 +119,26 @@ module Daytona
     #     path: "workspace/repo-old",
     #     commit_id: "abc123"
     #   )
-    def clone(url:, path:, branch: nil, commit_id: nil, username: nil, password: nil) # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+    def clone( # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+      url:,
+      path:,
+      branch: nil,
+      commit_id: nil,
+      username: nil,
+      password: nil,
+      depth: nil,
+      single_branch: nil,
+      shallow_since: nil,
+      no_tags: nil,
+      filter: nil,
+      sparse: nil,
+      sparse_paths: nil,
+      reference_path: nil,
+      dissociate: nil,
+      recurse_submodules: nil,
+      shallow_submodules: nil,
+      filter_submodules: nil
+    )
       toolbox_api.clone_repository(
         DaytonaToolboxApiClient::GitCloneRequest.new(
           url: url,
@@ -115,7 +146,19 @@ module Daytona
           path: path,
           username: username,
           password: password,
-          commit_id: commit_id
+          commit_id: commit_id,
+          depth: depth,
+          single_branch: single_branch,
+          shallow_since: shallow_since,
+          no_tags: no_tags,
+          filter: filter,
+          sparse: sparse,
+          sparse_paths: sparse_paths,
+          reference_path: reference_path,
+          dissociate: dissociate,
+          recurse_submodules: recurse_submodules,
+          shallow_submodules: shallow_submodules,
+          filter_submodules: filter_submodules
         )
       )
     rescue DaytonaToolboxApiClient::ApiError => e

--- a/libs/sdk-ruby/spec/daytona/git_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/git_spec.rb
@@ -75,6 +75,48 @@ RSpec.describe Daytona::Git do
       end
     end
 
+    it 'passes advanced clone options' do
+      allow(toolbox_api).to receive(:clone_repository)
+
+      git.clone(
+        url: 'https://github.com/user/repo.git',
+        path: '/repo',
+        branch: 'main',
+        commit_id: 'abc123',
+        username: 'user',
+        password: 'token',
+        depth: 1,
+        single_branch: false,
+        shallow_since: '2025-01-01',
+        no_tags: true,
+        filter: 'blob:none',
+        sparse: true,
+        sparse_paths: ['src', 'README.md'],
+        reference_path: '/cache/repo.git',
+        dissociate: true,
+        recurse_submodules: true,
+        shallow_submodules: true,
+        filter_submodules: true
+      )
+
+      expect(toolbox_api).to have_received(:clone_repository) do |req|
+        expect(req.branch).to eq('main')
+        expect(req.commit_id).to eq('abc123')
+        expect(req.depth).to eq(1)
+        expect(req.single_branch).to be(false)
+        expect(req.shallow_since).to eq('2025-01-01')
+        expect(req.no_tags).to be(true)
+        expect(req.filter).to eq('blob:none')
+        expect(req.sparse).to be(true)
+        expect(req.sparse_paths).to eq(['src', 'README.md'])
+        expect(req.reference_path).to eq('/cache/repo.git')
+        expect(req.dissociate).to be(true)
+        expect(req.recurse_submodules).to be(true)
+        expect(req.shallow_submodules).to be(true)
+        expect(req.filter_submodules).to be(true)
+      end
+    end
+
     it 'wraps errors' do
       allow(toolbox_api).to receive(:clone_repository).and_raise(StandardError, 'err')
 

--- a/libs/sdk-typescript/src/Git.ts
+++ b/libs/sdk-typescript/src/Git.ts
@@ -17,6 +17,28 @@ export interface GitCommitResponse {
 }
 
 /**
+ * Optional parameters for cloning a Git repository.
+ */
+export interface GitCloneOptions {
+  branch?: string
+  commitId?: string
+  username?: string
+  password?: string
+  depth?: number
+  singleBranch?: boolean
+  shallowSince?: string
+  noTags?: boolean
+  filter?: string
+  sparse?: boolean
+  sparsePaths?: string[]
+  referencePath?: string
+  dissociate?: boolean
+  recurseSubmodules?: boolean
+  shallowSubmodules?: boolean
+  filterSubmodules?: boolean
+}
+
+/**
  * Provides Git operations within a Sandbox.
  *
  * @class
@@ -128,10 +150,10 @@ export class Git {
    *
    * @param {string} url - Repository URL to clone from
    * @param {string} path - Path where the repository should be cloned. Relative paths are resolved based on the sandbox working directory.
-   * @param {string} [branch] - Specific branch to clone. If not specified, clones the default branch
-   * @param {string} [commitId] - Specific commit to clone. If specified, the repository will be left in a detached HEAD state at this commit
-   * @param {string} [username] - Git username for authentication
-   * @param {string} [password] - Git password or token for authentication
+   * @param {GitCloneOptions|string} [options] - Clone options or, for backward compatibility, a branch name
+   * @param {string} [commitId] - Specific commit to clone when using positional arguments
+   * @param {string} [username] - Git username for authentication when using positional arguments
+   * @param {string} [password] - Git password or token for authentication when using positional arguments
    * @returns {Promise<void>}
    *
    * @example
@@ -159,7 +181,7 @@ export class Git {
    *   commitId='abc123'
    * );
    */
-  @WithInstrumentation()
+  public async clone(url: string, path: string, options?: GitCloneOptions): Promise<void>
   public async clone(
     url: string,
     path: string,
@@ -167,14 +189,45 @@ export class Git {
     commitId?: string,
     username?: string,
     password?: string,
+  ): Promise<void>
+  @WithInstrumentation()
+  public async clone(
+    url: string,
+    path: string,
+    optionsOrBranch?: GitCloneOptions | string,
+    commitId?: string,
+    username?: string,
+    password?: string,
   ): Promise<void> {
+    const options: GitCloneOptions =
+      typeof optionsOrBranch === 'object' && optionsOrBranch !== null
+        ? optionsOrBranch
+        : {
+            branch: optionsOrBranch as string | undefined,
+            commitId,
+            username,
+            password,
+          }
+
     await this.apiClient.cloneRepository({
       url: url,
-      branch: branch,
+      branch: options.branch,
       path,
-      username,
-      password,
-      commit_id: commitId,
+      username: options.username,
+      password: options.password,
+      commit_id: options.commitId,
+      depth: options.depth,
+      single_branch: options.singleBranch,
+      shallow_since: options.shallowSince,
+      no_tags: options.noTags,
+      filter: options.filter,
+      sparse: options.sparse,
+      sparse_paths: options.sparsePaths,
+      reference_path: options.referencePath,
+      dissociate: options.dissociate,
+      recurse_submodules: options.recurseSubmodules,
+      shallow_submodules: options.shallowSubmodules,
+      filter_submodules: options.filterSubmodules,
     })
   }
 

--- a/libs/sdk-typescript/src/__tests__/Git.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Git.test.ts
@@ -59,6 +59,60 @@ describe('Git', () => {
       username: 'alice',
       password: 'secret',
       commit_id: 'deadbeef',
+      depth: undefined,
+      single_branch: undefined,
+      shallow_since: undefined,
+      no_tags: undefined,
+      filter: undefined,
+      sparse: undefined,
+      sparse_paths: undefined,
+      reference_path: undefined,
+      dissociate: undefined,
+      recurse_submodules: undefined,
+      shallow_submodules: undefined,
+      filter_submodules: undefined,
+    })
+  })
+
+  it('passes advanced clone options', async () => {
+    await git.clone('https://github.com/org/repo.git', '/repo', {
+      branch: 'main',
+      commitId: 'abc123',
+      username: 'alice',
+      password: 'secret',
+      depth: 1,
+      singleBranch: false,
+      shallowSince: '2025-01-01',
+      noTags: true,
+      filter: 'blob:none',
+      sparse: true,
+      sparsePaths: ['src', 'README.md'],
+      referencePath: '/cache/repo.git',
+      dissociate: true,
+      recurseSubmodules: true,
+      shallowSubmodules: true,
+      filterSubmodules: true,
+    })
+
+    expect(apiClient.cloneRepository).toHaveBeenCalledWith({
+      url: 'https://github.com/org/repo.git',
+      branch: 'main',
+      path: '/repo',
+      username: 'alice',
+      password: 'secret',
+      commit_id: 'abc123',
+      depth: 1,
+      single_branch: false,
+      shallow_since: '2025-01-01',
+      no_tags: true,
+      filter: 'blob:none',
+      sparse: true,
+      sparse_paths: ['src', 'README.md'],
+      reference_path: '/cache/repo.git',
+      dissociate: true,
+      recurse_submodules: true,
+      shallow_submodules: true,
+      filter_submodules: true,
     })
   })
 
@@ -72,6 +126,18 @@ describe('Git', () => {
       username: undefined,
       password: undefined,
       commit_id: undefined,
+      depth: undefined,
+      single_branch: undefined,
+      shallow_since: undefined,
+      no_tags: undefined,
+      filter: undefined,
+      sparse: undefined,
+      sparse_paths: undefined,
+      reference_path: undefined,
+      dissociate: undefined,
+      recurse_submodules: undefined,
+      shallow_submodules: undefined,
+      filter_submodules: undefined,
     })
   })
 

--- a/libs/toolbox-api-client-go/api/openapi.yaml
+++ b/libs/toolbox-api-client-go/api/openapi.yaml
@@ -2878,21 +2878,61 @@ components:
       type: object
     GitCloneRequest:
       example:
+        dissociate: true
+        shallow_submodules: true
+        recurse_submodules: true
+        reference_path: reference_path
+        single_branch: true
+        branch: branch
+        url: url
+        filter: filter
+        filter_submodules: true
         path: path
         password: password
-        branch: branch
+        depth: 0
+        sparse: true
+        sparse_paths:
+        - sparse_paths
+        - sparse_paths
+        shallow_since: shallow_since
         commit_id: commit_id
-        url: url
+        no_tags: true
         username: username
       properties:
         branch:
           type: string
         commit_id:
           type: string
+        depth:
+          type: integer
+        dissociate:
+          type: boolean
+        filter:
+          type: string
+        filter_submodules:
+          type: boolean
+        no_tags:
+          type: boolean
         password:
           type: string
         path:
           type: string
+        recurse_submodules:
+          type: boolean
+        reference_path:
+          type: string
+        shallow_since:
+          type: string
+        shallow_submodules:
+          type: boolean
+        single_branch:
+          type: boolean
+        sparse:
+          type: boolean
+        sparse_paths:
+          items:
+            type: string
+          type: array
         url:
           type: string
         username:

--- a/libs/toolbox-api-client-go/model_git_clone_request.go
+++ b/libs/toolbox-api-client-go/model_git_clone_request.go
@@ -11,8 +11,8 @@ API version: v0.0.0-dev
 package toolbox
 
 import (
-	"encoding/json"
 	"bytes"
+	"encoding/json"
 	"fmt"
 )
 
@@ -21,12 +21,24 @@ var _ MappedNullable = &GitCloneRequest{}
 
 // GitCloneRequest struct for GitCloneRequest
 type GitCloneRequest struct {
-	Branch *string `json:"branch,omitempty"`
-	CommitId *string `json:"commit_id,omitempty"`
-	Password *string `json:"password,omitempty"`
-	Path string `json:"path"`
-	Url string `json:"url"`
-	Username *string `json:"username,omitempty"`
+	Branch            *string  `json:"branch,omitempty"`
+	CommitId          *string  `json:"commit_id,omitempty"`
+	Depth             *int32   `json:"depth,omitempty"`
+	Dissociate        *bool    `json:"dissociate,omitempty"`
+	Filter            *string  `json:"filter,omitempty"`
+	FilterSubmodules  *bool    `json:"filter_submodules,omitempty"`
+	NoTags            *bool    `json:"no_tags,omitempty"`
+	Password          *string  `json:"password,omitempty"`
+	Path              string   `json:"path"`
+	RecurseSubmodules *bool    `json:"recurse_submodules,omitempty"`
+	ReferencePath     *string  `json:"reference_path,omitempty"`
+	ShallowSince      *string  `json:"shallow_since,omitempty"`
+	ShallowSubmodules *bool    `json:"shallow_submodules,omitempty"`
+	SingleBranch      *bool    `json:"single_branch,omitempty"`
+	Sparse            *bool    `json:"sparse,omitempty"`
+	SparsePaths       []string `json:"sparse_paths,omitempty"`
+	Url               string   `json:"url"`
+	Username          *string  `json:"username,omitempty"`
 }
 
 type _GitCloneRequest GitCloneRequest
@@ -114,6 +126,166 @@ func (o *GitCloneRequest) SetCommitId(v string) {
 	o.CommitId = &v
 }
 
+// GetDepth returns the Depth field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetDepth() int32 {
+	if o == nil || IsNil(o.Depth) {
+		var ret int32
+		return ret
+	}
+	return *o.Depth
+}
+
+// GetDepthOk returns a tuple with the Depth field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetDepthOk() (*int32, bool) {
+	if o == nil || IsNil(o.Depth) {
+		return nil, false
+	}
+	return o.Depth, true
+}
+
+// HasDepth returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasDepth() bool {
+	if o != nil && !IsNil(o.Depth) {
+		return true
+	}
+
+	return false
+}
+
+// SetDepth gets a reference to the given int32 and assigns it to the Depth field.
+func (o *GitCloneRequest) SetDepth(v int32) {
+	o.Depth = &v
+}
+
+// GetDissociate returns the Dissociate field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetDissociate() bool {
+	if o == nil || IsNil(o.Dissociate) {
+		var ret bool
+		return ret
+	}
+	return *o.Dissociate
+}
+
+// GetDissociateOk returns a tuple with the Dissociate field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetDissociateOk() (*bool, bool) {
+	if o == nil || IsNil(o.Dissociate) {
+		return nil, false
+	}
+	return o.Dissociate, true
+}
+
+// HasDissociate returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasDissociate() bool {
+	if o != nil && !IsNil(o.Dissociate) {
+		return true
+	}
+
+	return false
+}
+
+// SetDissociate gets a reference to the given bool and assigns it to the Dissociate field.
+func (o *GitCloneRequest) SetDissociate(v bool) {
+	o.Dissociate = &v
+}
+
+// GetFilter returns the Filter field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetFilter() string {
+	if o == nil || IsNil(o.Filter) {
+		var ret string
+		return ret
+	}
+	return *o.Filter
+}
+
+// GetFilterOk returns a tuple with the Filter field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetFilterOk() (*string, bool) {
+	if o == nil || IsNil(o.Filter) {
+		return nil, false
+	}
+	return o.Filter, true
+}
+
+// HasFilter returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasFilter() bool {
+	if o != nil && !IsNil(o.Filter) {
+		return true
+	}
+
+	return false
+}
+
+// SetFilter gets a reference to the given string and assigns it to the Filter field.
+func (o *GitCloneRequest) SetFilter(v string) {
+	o.Filter = &v
+}
+
+// GetFilterSubmodules returns the FilterSubmodules field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetFilterSubmodules() bool {
+	if o == nil || IsNil(o.FilterSubmodules) {
+		var ret bool
+		return ret
+	}
+	return *o.FilterSubmodules
+}
+
+// GetFilterSubmodulesOk returns a tuple with the FilterSubmodules field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetFilterSubmodulesOk() (*bool, bool) {
+	if o == nil || IsNil(o.FilterSubmodules) {
+		return nil, false
+	}
+	return o.FilterSubmodules, true
+}
+
+// HasFilterSubmodules returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasFilterSubmodules() bool {
+	if o != nil && !IsNil(o.FilterSubmodules) {
+		return true
+	}
+
+	return false
+}
+
+// SetFilterSubmodules gets a reference to the given bool and assigns it to the FilterSubmodules field.
+func (o *GitCloneRequest) SetFilterSubmodules(v bool) {
+	o.FilterSubmodules = &v
+}
+
+// GetNoTags returns the NoTags field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetNoTags() bool {
+	if o == nil || IsNil(o.NoTags) {
+		var ret bool
+		return ret
+	}
+	return *o.NoTags
+}
+
+// GetNoTagsOk returns a tuple with the NoTags field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetNoTagsOk() (*bool, bool) {
+	if o == nil || IsNil(o.NoTags) {
+		return nil, false
+	}
+	return o.NoTags, true
+}
+
+// HasNoTags returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasNoTags() bool {
+	if o != nil && !IsNil(o.NoTags) {
+		return true
+	}
+
+	return false
+}
+
+// SetNoTags gets a reference to the given bool and assigns it to the NoTags field.
+func (o *GitCloneRequest) SetNoTags(v bool) {
+	o.NoTags = &v
+}
+
 // GetPassword returns the Password field value if set, zero value otherwise.
 func (o *GitCloneRequest) GetPassword() string {
 	if o == nil || IsNil(o.Password) {
@@ -168,6 +340,230 @@ func (o *GitCloneRequest) GetPathOk() (*string, bool) {
 // SetPath sets field value
 func (o *GitCloneRequest) SetPath(v string) {
 	o.Path = v
+}
+
+// GetRecurseSubmodules returns the RecurseSubmodules field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetRecurseSubmodules() bool {
+	if o == nil || IsNil(o.RecurseSubmodules) {
+		var ret bool
+		return ret
+	}
+	return *o.RecurseSubmodules
+}
+
+// GetRecurseSubmodulesOk returns a tuple with the RecurseSubmodules field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetRecurseSubmodulesOk() (*bool, bool) {
+	if o == nil || IsNil(o.RecurseSubmodules) {
+		return nil, false
+	}
+	return o.RecurseSubmodules, true
+}
+
+// HasRecurseSubmodules returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasRecurseSubmodules() bool {
+	if o != nil && !IsNil(o.RecurseSubmodules) {
+		return true
+	}
+
+	return false
+}
+
+// SetRecurseSubmodules gets a reference to the given bool and assigns it to the RecurseSubmodules field.
+func (o *GitCloneRequest) SetRecurseSubmodules(v bool) {
+	o.RecurseSubmodules = &v
+}
+
+// GetReferencePath returns the ReferencePath field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetReferencePath() string {
+	if o == nil || IsNil(o.ReferencePath) {
+		var ret string
+		return ret
+	}
+	return *o.ReferencePath
+}
+
+// GetReferencePathOk returns a tuple with the ReferencePath field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetReferencePathOk() (*string, bool) {
+	if o == nil || IsNil(o.ReferencePath) {
+		return nil, false
+	}
+	return o.ReferencePath, true
+}
+
+// HasReferencePath returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasReferencePath() bool {
+	if o != nil && !IsNil(o.ReferencePath) {
+		return true
+	}
+
+	return false
+}
+
+// SetReferencePath gets a reference to the given string and assigns it to the ReferencePath field.
+func (o *GitCloneRequest) SetReferencePath(v string) {
+	o.ReferencePath = &v
+}
+
+// GetShallowSince returns the ShallowSince field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetShallowSince() string {
+	if o == nil || IsNil(o.ShallowSince) {
+		var ret string
+		return ret
+	}
+	return *o.ShallowSince
+}
+
+// GetShallowSinceOk returns a tuple with the ShallowSince field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetShallowSinceOk() (*string, bool) {
+	if o == nil || IsNil(o.ShallowSince) {
+		return nil, false
+	}
+	return o.ShallowSince, true
+}
+
+// HasShallowSince returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasShallowSince() bool {
+	if o != nil && !IsNil(o.ShallowSince) {
+		return true
+	}
+
+	return false
+}
+
+// SetShallowSince gets a reference to the given string and assigns it to the ShallowSince field.
+func (o *GitCloneRequest) SetShallowSince(v string) {
+	o.ShallowSince = &v
+}
+
+// GetShallowSubmodules returns the ShallowSubmodules field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetShallowSubmodules() bool {
+	if o == nil || IsNil(o.ShallowSubmodules) {
+		var ret bool
+		return ret
+	}
+	return *o.ShallowSubmodules
+}
+
+// GetShallowSubmodulesOk returns a tuple with the ShallowSubmodules field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetShallowSubmodulesOk() (*bool, bool) {
+	if o == nil || IsNil(o.ShallowSubmodules) {
+		return nil, false
+	}
+	return o.ShallowSubmodules, true
+}
+
+// HasShallowSubmodules returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasShallowSubmodules() bool {
+	if o != nil && !IsNil(o.ShallowSubmodules) {
+		return true
+	}
+
+	return false
+}
+
+// SetShallowSubmodules gets a reference to the given bool and assigns it to the ShallowSubmodules field.
+func (o *GitCloneRequest) SetShallowSubmodules(v bool) {
+	o.ShallowSubmodules = &v
+}
+
+// GetSingleBranch returns the SingleBranch field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetSingleBranch() bool {
+	if o == nil || IsNil(o.SingleBranch) {
+		var ret bool
+		return ret
+	}
+	return *o.SingleBranch
+}
+
+// GetSingleBranchOk returns a tuple with the SingleBranch field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetSingleBranchOk() (*bool, bool) {
+	if o == nil || IsNil(o.SingleBranch) {
+		return nil, false
+	}
+	return o.SingleBranch, true
+}
+
+// HasSingleBranch returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasSingleBranch() bool {
+	if o != nil && !IsNil(o.SingleBranch) {
+		return true
+	}
+
+	return false
+}
+
+// SetSingleBranch gets a reference to the given bool and assigns it to the SingleBranch field.
+func (o *GitCloneRequest) SetSingleBranch(v bool) {
+	o.SingleBranch = &v
+}
+
+// GetSparse returns the Sparse field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetSparse() bool {
+	if o == nil || IsNil(o.Sparse) {
+		var ret bool
+		return ret
+	}
+	return *o.Sparse
+}
+
+// GetSparseOk returns a tuple with the Sparse field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetSparseOk() (*bool, bool) {
+	if o == nil || IsNil(o.Sparse) {
+		return nil, false
+	}
+	return o.Sparse, true
+}
+
+// HasSparse returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasSparse() bool {
+	if o != nil && !IsNil(o.Sparse) {
+		return true
+	}
+
+	return false
+}
+
+// SetSparse gets a reference to the given bool and assigns it to the Sparse field.
+func (o *GitCloneRequest) SetSparse(v bool) {
+	o.Sparse = &v
+}
+
+// GetSparsePaths returns the SparsePaths field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetSparsePaths() []string {
+	if o == nil || IsNil(o.SparsePaths) {
+		var ret []string
+		return ret
+	}
+	return o.SparsePaths
+}
+
+// GetSparsePathsOk returns a tuple with the SparsePaths field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetSparsePathsOk() ([]string, bool) {
+	if o == nil || IsNil(o.SparsePaths) {
+		return nil, false
+	}
+	return o.SparsePaths, true
+}
+
+// HasSparsePaths returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasSparsePaths() bool {
+	if o != nil && !IsNil(o.SparsePaths) {
+		return true
+	}
+
+	return false
+}
+
+// SetSparsePaths gets a reference to the given []string and assigns it to the SparsePaths field.
+func (o *GitCloneRequest) SetSparsePaths(v []string) {
+	o.SparsePaths = v
 }
 
 // GetUrl returns the Url field value
@@ -227,7 +623,7 @@ func (o *GitCloneRequest) SetUsername(v string) {
 }
 
 func (o GitCloneRequest) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -242,10 +638,46 @@ func (o GitCloneRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CommitId) {
 		toSerialize["commit_id"] = o.CommitId
 	}
+	if !IsNil(o.Depth) {
+		toSerialize["depth"] = o.Depth
+	}
+	if !IsNil(o.Dissociate) {
+		toSerialize["dissociate"] = o.Dissociate
+	}
+	if !IsNil(o.Filter) {
+		toSerialize["filter"] = o.Filter
+	}
+	if !IsNil(o.FilterSubmodules) {
+		toSerialize["filter_submodules"] = o.FilterSubmodules
+	}
+	if !IsNil(o.NoTags) {
+		toSerialize["no_tags"] = o.NoTags
+	}
 	if !IsNil(o.Password) {
 		toSerialize["password"] = o.Password
 	}
 	toSerialize["path"] = o.Path
+	if !IsNil(o.RecurseSubmodules) {
+		toSerialize["recurse_submodules"] = o.RecurseSubmodules
+	}
+	if !IsNil(o.ReferencePath) {
+		toSerialize["reference_path"] = o.ReferencePath
+	}
+	if !IsNil(o.ShallowSince) {
+		toSerialize["shallow_since"] = o.ShallowSince
+	}
+	if !IsNil(o.ShallowSubmodules) {
+		toSerialize["shallow_submodules"] = o.ShallowSubmodules
+	}
+	if !IsNil(o.SingleBranch) {
+		toSerialize["single_branch"] = o.SingleBranch
+	}
+	if !IsNil(o.Sparse) {
+		toSerialize["sparse"] = o.Sparse
+	}
+	if !IsNil(o.SparsePaths) {
+		toSerialize["sparse_paths"] = o.SparsePaths
+	}
 	toSerialize["url"] = o.Url
 	if !IsNil(o.Username) {
 		toSerialize["username"] = o.Username
@@ -267,10 +699,10 @@ func (o *GitCloneRequest) UnmarshalJSON(data []byte) (err error) {
 	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
-		return err;
+		return err
 	}
 
-	for _, requiredProperty := range(requiredProperties) {
+	for _, requiredProperty := range requiredProperties {
 		if _, exists := allProperties[requiredProperty]; !exists {
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
@@ -326,5 +758,3 @@ func (v *NullableGitCloneRequest) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/GitCloneRequest.java
+++ b/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/GitCloneRequest.java
@@ -20,7 +20,9 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -60,6 +62,31 @@ public class GitCloneRequest {
   @javax.annotation.Nullable
   private String commitId;
 
+  public static final String SERIALIZED_NAME_DEPTH = "depth";
+  @SerializedName(SERIALIZED_NAME_DEPTH)
+  @javax.annotation.Nullable
+  private Integer depth;
+
+  public static final String SERIALIZED_NAME_DISSOCIATE = "dissociate";
+  @SerializedName(SERIALIZED_NAME_DISSOCIATE)
+  @javax.annotation.Nullable
+  private Boolean dissociate;
+
+  public static final String SERIALIZED_NAME_FILTER = "filter";
+  @SerializedName(SERIALIZED_NAME_FILTER)
+  @javax.annotation.Nullable
+  private String filter;
+
+  public static final String SERIALIZED_NAME_FILTER_SUBMODULES = "filter_submodules";
+  @SerializedName(SERIALIZED_NAME_FILTER_SUBMODULES)
+  @javax.annotation.Nullable
+  private Boolean filterSubmodules;
+
+  public static final String SERIALIZED_NAME_NO_TAGS = "no_tags";
+  @SerializedName(SERIALIZED_NAME_NO_TAGS)
+  @javax.annotation.Nullable
+  private Boolean noTags;
+
   public static final String SERIALIZED_NAME_PASSWORD = "password";
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   @javax.annotation.Nullable
@@ -69,6 +96,41 @@ public class GitCloneRequest {
   @SerializedName(SERIALIZED_NAME_PATH)
   @javax.annotation.Nonnull
   private String path;
+
+  public static final String SERIALIZED_NAME_RECURSE_SUBMODULES = "recurse_submodules";
+  @SerializedName(SERIALIZED_NAME_RECURSE_SUBMODULES)
+  @javax.annotation.Nullable
+  private Boolean recurseSubmodules;
+
+  public static final String SERIALIZED_NAME_REFERENCE_PATH = "reference_path";
+  @SerializedName(SERIALIZED_NAME_REFERENCE_PATH)
+  @javax.annotation.Nullable
+  private String referencePath;
+
+  public static final String SERIALIZED_NAME_SHALLOW_SINCE = "shallow_since";
+  @SerializedName(SERIALIZED_NAME_SHALLOW_SINCE)
+  @javax.annotation.Nullable
+  private String shallowSince;
+
+  public static final String SERIALIZED_NAME_SHALLOW_SUBMODULES = "shallow_submodules";
+  @SerializedName(SERIALIZED_NAME_SHALLOW_SUBMODULES)
+  @javax.annotation.Nullable
+  private Boolean shallowSubmodules;
+
+  public static final String SERIALIZED_NAME_SINGLE_BRANCH = "single_branch";
+  @SerializedName(SERIALIZED_NAME_SINGLE_BRANCH)
+  @javax.annotation.Nullable
+  private Boolean singleBranch;
+
+  public static final String SERIALIZED_NAME_SPARSE = "sparse";
+  @SerializedName(SERIALIZED_NAME_SPARSE)
+  @javax.annotation.Nullable
+  private Boolean sparse;
+
+  public static final String SERIALIZED_NAME_SPARSE_PATHS = "sparse_paths";
+  @SerializedName(SERIALIZED_NAME_SPARSE_PATHS)
+  @javax.annotation.Nullable
+  private List<String> sparsePaths = new ArrayList<>();
 
   public static final String SERIALIZED_NAME_URL = "url";
   @SerializedName(SERIALIZED_NAME_URL)
@@ -121,6 +183,101 @@ public class GitCloneRequest {
   }
 
 
+  public GitCloneRequest depth(@javax.annotation.Nullable Integer depth) {
+    this.depth = depth;
+    return this;
+  }
+
+  /**
+   * Get depth
+   * @return depth
+   */
+  @javax.annotation.Nullable
+  public Integer getDepth() {
+    return depth;
+  }
+
+  public void setDepth(@javax.annotation.Nullable Integer depth) {
+    this.depth = depth;
+  }
+
+
+  public GitCloneRequest dissociate(@javax.annotation.Nullable Boolean dissociate) {
+    this.dissociate = dissociate;
+    return this;
+  }
+
+  /**
+   * Get dissociate
+   * @return dissociate
+   */
+  @javax.annotation.Nullable
+  public Boolean getDissociate() {
+    return dissociate;
+  }
+
+  public void setDissociate(@javax.annotation.Nullable Boolean dissociate) {
+    this.dissociate = dissociate;
+  }
+
+
+  public GitCloneRequest filter(@javax.annotation.Nullable String filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  /**
+   * Get filter
+   * @return filter
+   */
+  @javax.annotation.Nullable
+  public String getFilter() {
+    return filter;
+  }
+
+  public void setFilter(@javax.annotation.Nullable String filter) {
+    this.filter = filter;
+  }
+
+
+  public GitCloneRequest filterSubmodules(@javax.annotation.Nullable Boolean filterSubmodules) {
+    this.filterSubmodules = filterSubmodules;
+    return this;
+  }
+
+  /**
+   * Get filterSubmodules
+   * @return filterSubmodules
+   */
+  @javax.annotation.Nullable
+  public Boolean getFilterSubmodules() {
+    return filterSubmodules;
+  }
+
+  public void setFilterSubmodules(@javax.annotation.Nullable Boolean filterSubmodules) {
+    this.filterSubmodules = filterSubmodules;
+  }
+
+
+  public GitCloneRequest noTags(@javax.annotation.Nullable Boolean noTags) {
+    this.noTags = noTags;
+    return this;
+  }
+
+  /**
+   * Get noTags
+   * @return noTags
+   */
+  @javax.annotation.Nullable
+  public Boolean getNoTags() {
+    return noTags;
+  }
+
+  public void setNoTags(@javax.annotation.Nullable Boolean noTags) {
+    this.noTags = noTags;
+  }
+
+
   public GitCloneRequest password(@javax.annotation.Nullable String password) {
     this.password = password;
     return this;
@@ -156,6 +313,147 @@ public class GitCloneRequest {
 
   public void setPath(@javax.annotation.Nonnull String path) {
     this.path = path;
+  }
+
+
+  public GitCloneRequest recurseSubmodules(@javax.annotation.Nullable Boolean recurseSubmodules) {
+    this.recurseSubmodules = recurseSubmodules;
+    return this;
+  }
+
+  /**
+   * Get recurseSubmodules
+   * @return recurseSubmodules
+   */
+  @javax.annotation.Nullable
+  public Boolean getRecurseSubmodules() {
+    return recurseSubmodules;
+  }
+
+  public void setRecurseSubmodules(@javax.annotation.Nullable Boolean recurseSubmodules) {
+    this.recurseSubmodules = recurseSubmodules;
+  }
+
+
+  public GitCloneRequest referencePath(@javax.annotation.Nullable String referencePath) {
+    this.referencePath = referencePath;
+    return this;
+  }
+
+  /**
+   * Get referencePath
+   * @return referencePath
+   */
+  @javax.annotation.Nullable
+  public String getReferencePath() {
+    return referencePath;
+  }
+
+  public void setReferencePath(@javax.annotation.Nullable String referencePath) {
+    this.referencePath = referencePath;
+  }
+
+
+  public GitCloneRequest shallowSince(@javax.annotation.Nullable String shallowSince) {
+    this.shallowSince = shallowSince;
+    return this;
+  }
+
+  /**
+   * Get shallowSince
+   * @return shallowSince
+   */
+  @javax.annotation.Nullable
+  public String getShallowSince() {
+    return shallowSince;
+  }
+
+  public void setShallowSince(@javax.annotation.Nullable String shallowSince) {
+    this.shallowSince = shallowSince;
+  }
+
+
+  public GitCloneRequest shallowSubmodules(@javax.annotation.Nullable Boolean shallowSubmodules) {
+    this.shallowSubmodules = shallowSubmodules;
+    return this;
+  }
+
+  /**
+   * Get shallowSubmodules
+   * @return shallowSubmodules
+   */
+  @javax.annotation.Nullable
+  public Boolean getShallowSubmodules() {
+    return shallowSubmodules;
+  }
+
+  public void setShallowSubmodules(@javax.annotation.Nullable Boolean shallowSubmodules) {
+    this.shallowSubmodules = shallowSubmodules;
+  }
+
+
+  public GitCloneRequest singleBranch(@javax.annotation.Nullable Boolean singleBranch) {
+    this.singleBranch = singleBranch;
+    return this;
+  }
+
+  /**
+   * Get singleBranch
+   * @return singleBranch
+   */
+  @javax.annotation.Nullable
+  public Boolean getSingleBranch() {
+    return singleBranch;
+  }
+
+  public void setSingleBranch(@javax.annotation.Nullable Boolean singleBranch) {
+    this.singleBranch = singleBranch;
+  }
+
+
+  public GitCloneRequest sparse(@javax.annotation.Nullable Boolean sparse) {
+    this.sparse = sparse;
+    return this;
+  }
+
+  /**
+   * Get sparse
+   * @return sparse
+   */
+  @javax.annotation.Nullable
+  public Boolean getSparse() {
+    return sparse;
+  }
+
+  public void setSparse(@javax.annotation.Nullable Boolean sparse) {
+    this.sparse = sparse;
+  }
+
+
+  public GitCloneRequest sparsePaths(@javax.annotation.Nullable List<String> sparsePaths) {
+    this.sparsePaths = sparsePaths;
+    return this;
+  }
+
+  public GitCloneRequest addSparsePathsItem(String sparsePathsItem) {
+    if (this.sparsePaths == null) {
+      this.sparsePaths = new ArrayList<>();
+    }
+    this.sparsePaths.add(sparsePathsItem);
+    return this;
+  }
+
+  /**
+   * Get sparsePaths
+   * @return sparsePaths
+   */
+  @javax.annotation.Nullable
+  public List<String> getSparsePaths() {
+    return sparsePaths;
+  }
+
+  public void setSparsePaths(@javax.annotation.Nullable List<String> sparsePaths) {
+    this.sparsePaths = sparsePaths;
   }
 
 
@@ -253,8 +551,20 @@ public class GitCloneRequest {
     GitCloneRequest gitCloneRequest = (GitCloneRequest) o;
     return Objects.equals(this.branch, gitCloneRequest.branch) &&
         Objects.equals(this.commitId, gitCloneRequest.commitId) &&
+        Objects.equals(this.depth, gitCloneRequest.depth) &&
+        Objects.equals(this.dissociate, gitCloneRequest.dissociate) &&
+        Objects.equals(this.filter, gitCloneRequest.filter) &&
+        Objects.equals(this.filterSubmodules, gitCloneRequest.filterSubmodules) &&
+        Objects.equals(this.noTags, gitCloneRequest.noTags) &&
         Objects.equals(this.password, gitCloneRequest.password) &&
         Objects.equals(this.path, gitCloneRequest.path) &&
+        Objects.equals(this.recurseSubmodules, gitCloneRequest.recurseSubmodules) &&
+        Objects.equals(this.referencePath, gitCloneRequest.referencePath) &&
+        Objects.equals(this.shallowSince, gitCloneRequest.shallowSince) &&
+        Objects.equals(this.shallowSubmodules, gitCloneRequest.shallowSubmodules) &&
+        Objects.equals(this.singleBranch, gitCloneRequest.singleBranch) &&
+        Objects.equals(this.sparse, gitCloneRequest.sparse) &&
+        Objects.equals(this.sparsePaths, gitCloneRequest.sparsePaths) &&
         Objects.equals(this.url, gitCloneRequest.url) &&
         Objects.equals(this.username, gitCloneRequest.username)&&
         Objects.equals(this.additionalProperties, gitCloneRequest.additionalProperties);
@@ -262,7 +572,7 @@ public class GitCloneRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(branch, commitId, password, path, url, username, additionalProperties);
+    return Objects.hash(branch, commitId, depth, dissociate, filter, filterSubmodules, noTags, password, path, recurseSubmodules, referencePath, shallowSince, shallowSubmodules, singleBranch, sparse, sparsePaths, url, username, additionalProperties);
   }
 
   @Override
@@ -271,8 +581,20 @@ public class GitCloneRequest {
     sb.append("class GitCloneRequest {\n");
     sb.append("    branch: ").append(toIndentedString(branch)).append("\n");
     sb.append("    commitId: ").append(toIndentedString(commitId)).append("\n");
+    sb.append("    depth: ").append(toIndentedString(depth)).append("\n");
+    sb.append("    dissociate: ").append(toIndentedString(dissociate)).append("\n");
+    sb.append("    filter: ").append(toIndentedString(filter)).append("\n");
+    sb.append("    filterSubmodules: ").append(toIndentedString(filterSubmodules)).append("\n");
+    sb.append("    noTags: ").append(toIndentedString(noTags)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    path: ").append(toIndentedString(path)).append("\n");
+    sb.append("    recurseSubmodules: ").append(toIndentedString(recurseSubmodules)).append("\n");
+    sb.append("    referencePath: ").append(toIndentedString(referencePath)).append("\n");
+    sb.append("    shallowSince: ").append(toIndentedString(shallowSince)).append("\n");
+    sb.append("    shallowSubmodules: ").append(toIndentedString(shallowSubmodules)).append("\n");
+    sb.append("    singleBranch: ").append(toIndentedString(singleBranch)).append("\n");
+    sb.append("    sparse: ").append(toIndentedString(sparse)).append("\n");
+    sb.append("    sparsePaths: ").append(toIndentedString(sparsePaths)).append("\n");
     sb.append("    url: ").append(toIndentedString(url)).append("\n");
     sb.append("    username: ").append(toIndentedString(username)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
@@ -294,7 +616,7 @@ public class GitCloneRequest {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("branch", "commit_id", "password", "path", "url", "username"));
+    openapiFields = new HashSet<String>(Arrays.asList("branch", "commit_id", "depth", "dissociate", "filter", "filter_submodules", "no_tags", "password", "path", "recurse_submodules", "reference_path", "shallow_since", "shallow_submodules", "single_branch", "sparse", "sparse_paths", "url", "username"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("path", "url"));
@@ -326,11 +648,24 @@ public class GitCloneRequest {
       if ((jsonObj.get("commit_id") != null && !jsonObj.get("commit_id").isJsonNull()) && !jsonObj.get("commit_id").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `commit_id` to be a primitive type in the JSON string but got `%s`", jsonObj.get("commit_id").toString()));
       }
+      if ((jsonObj.get("filter") != null && !jsonObj.get("filter").isJsonNull()) && !jsonObj.get("filter").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `filter` to be a primitive type in the JSON string but got `%s`", jsonObj.get("filter").toString()));
+      }
       if ((jsonObj.get("password") != null && !jsonObj.get("password").isJsonNull()) && !jsonObj.get("password").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `password` to be a primitive type in the JSON string but got `%s`", jsonObj.get("password").toString()));
       }
       if (!jsonObj.get("path").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `path` to be a primitive type in the JSON string but got `%s`", jsonObj.get("path").toString()));
+      }
+      if ((jsonObj.get("reference_path") != null && !jsonObj.get("reference_path").isJsonNull()) && !jsonObj.get("reference_path").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `reference_path` to be a primitive type in the JSON string but got `%s`", jsonObj.get("reference_path").toString()));
+      }
+      if ((jsonObj.get("shallow_since") != null && !jsonObj.get("shallow_since").isJsonNull()) && !jsonObj.get("shallow_since").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `shallow_since` to be a primitive type in the JSON string but got `%s`", jsonObj.get("shallow_since").toString()));
+      }
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("sparse_paths") != null && !jsonObj.get("sparse_paths").isJsonNull() && !jsonObj.get("sparse_paths").isJsonArray()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `sparse_paths` to be an array in the JSON string but got `%s`", jsonObj.get("sparse_paths").toString()));
       }
       if (!jsonObj.get("url").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `url` to be a primitive type in the JSON string but got `%s`", jsonObj.get("url").toString()));

--- a/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/GitCloneRequestTest.java
+++ b/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/GitCloneRequestTest.java
@@ -19,7 +19,9 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +56,46 @@ public class GitCloneRequestTest {
     }
 
     /**
+     * Test the property 'depth'
+     */
+    @Test
+    public void depthTest() {
+        // TODO: test depth
+    }
+
+    /**
+     * Test the property 'dissociate'
+     */
+    @Test
+    public void dissociateTest() {
+        // TODO: test dissociate
+    }
+
+    /**
+     * Test the property 'filter'
+     */
+    @Test
+    public void filterTest() {
+        // TODO: test filter
+    }
+
+    /**
+     * Test the property 'filterSubmodules'
+     */
+    @Test
+    public void filterSubmodulesTest() {
+        // TODO: test filterSubmodules
+    }
+
+    /**
+     * Test the property 'noTags'
+     */
+    @Test
+    public void noTagsTest() {
+        // TODO: test noTags
+    }
+
+    /**
      * Test the property 'password'
      */
     @Test
@@ -67,6 +109,62 @@ public class GitCloneRequestTest {
     @Test
     public void pathTest() {
         // TODO: test path
+    }
+
+    /**
+     * Test the property 'recurseSubmodules'
+     */
+    @Test
+    public void recurseSubmodulesTest() {
+        // TODO: test recurseSubmodules
+    }
+
+    /**
+     * Test the property 'referencePath'
+     */
+    @Test
+    public void referencePathTest() {
+        // TODO: test referencePath
+    }
+
+    /**
+     * Test the property 'shallowSince'
+     */
+    @Test
+    public void shallowSinceTest() {
+        // TODO: test shallowSince
+    }
+
+    /**
+     * Test the property 'shallowSubmodules'
+     */
+    @Test
+    public void shallowSubmodulesTest() {
+        // TODO: test shallowSubmodules
+    }
+
+    /**
+     * Test the property 'singleBranch'
+     */
+    @Test
+    public void singleBranchTest() {
+        // TODO: test singleBranch
+    }
+
+    /**
+     * Test the property 'sparse'
+     */
+    @Test
+    public void sparseTest() {
+        // TODO: test sparse
+    }
+
+    /**
+     * Test the property 'sparsePaths'
+     */
+    @Test
+    public void sparsePathsTest() {
+        // TODO: test sparsePaths
     }
 
     /**

--- a/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/git_clone_request.py
+++ b/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/git_clone_request.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
@@ -31,12 +31,24 @@ class GitCloneRequest(BaseModel):
     """ # noqa: E501
     branch: Optional[StrictStr] = None
     commit_id: Optional[StrictStr] = None
+    depth: Optional[StrictInt] = None
+    dissociate: Optional[StrictBool] = None
+    filter: Optional[StrictStr] = None
+    filter_submodules: Optional[StrictBool] = None
+    no_tags: Optional[StrictBool] = None
     password: Optional[StrictStr] = None
     path: StrictStr
+    recurse_submodules: Optional[StrictBool] = None
+    reference_path: Optional[StrictStr] = None
+    shallow_since: Optional[StrictStr] = None
+    shallow_submodules: Optional[StrictBool] = None
+    single_branch: Optional[StrictBool] = None
+    sparse: Optional[StrictBool] = None
+    sparse_paths: Optional[List[StrictStr]] = None
     url: StrictStr
     username: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["branch", "commit_id", "password", "path", "url", "username"]
+    __properties: ClassVar[List[str]] = ["branch", "commit_id", "depth", "dissociate", "filter", "filter_submodules", "no_tags", "password", "path", "recurse_submodules", "reference_path", "shallow_since", "shallow_submodules", "single_branch", "sparse", "sparse_paths", "url", "username"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,8 +109,20 @@ class GitCloneRequest(BaseModel):
         _obj = cls.model_validate({
             "branch": obj.get("branch"),
             "commit_id": obj.get("commit_id"),
+            "depth": obj.get("depth"),
+            "dissociate": obj.get("dissociate"),
+            "filter": obj.get("filter"),
+            "filter_submodules": obj.get("filter_submodules"),
+            "no_tags": obj.get("no_tags"),
             "password": obj.get("password"),
             "path": obj.get("path"),
+            "recurse_submodules": obj.get("recurse_submodules"),
+            "reference_path": obj.get("reference_path"),
+            "shallow_since": obj.get("shallow_since"),
+            "shallow_submodules": obj.get("shallow_submodules"),
+            "single_branch": obj.get("single_branch"),
+            "sparse": obj.get("sparse"),
+            "sparse_paths": obj.get("sparse_paths"),
             "url": obj.get("url"),
             "username": obj.get("username")
         })

--- a/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/git_clone_request.py
+++ b/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/git_clone_request.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
@@ -31,12 +31,24 @@ class GitCloneRequest(BaseModel):
     """ # noqa: E501
     branch: Optional[StrictStr] = None
     commit_id: Optional[StrictStr] = None
+    depth: Optional[StrictInt] = None
+    dissociate: Optional[StrictBool] = None
+    filter: Optional[StrictStr] = None
+    filter_submodules: Optional[StrictBool] = None
+    no_tags: Optional[StrictBool] = None
     password: Optional[StrictStr] = None
     path: StrictStr
+    recurse_submodules: Optional[StrictBool] = None
+    reference_path: Optional[StrictStr] = None
+    shallow_since: Optional[StrictStr] = None
+    shallow_submodules: Optional[StrictBool] = None
+    single_branch: Optional[StrictBool] = None
+    sparse: Optional[StrictBool] = None
+    sparse_paths: Optional[List[StrictStr]] = None
     url: StrictStr
     username: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["branch", "commit_id", "password", "path", "url", "username"]
+    __properties: ClassVar[List[str]] = ["branch", "commit_id", "depth", "dissociate", "filter", "filter_submodules", "no_tags", "password", "path", "recurse_submodules", "reference_path", "shallow_since", "shallow_submodules", "single_branch", "sparse", "sparse_paths", "url", "username"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,8 +109,20 @@ class GitCloneRequest(BaseModel):
         _obj = cls.model_validate({
             "branch": obj.get("branch"),
             "commit_id": obj.get("commit_id"),
+            "depth": obj.get("depth"),
+            "dissociate": obj.get("dissociate"),
+            "filter": obj.get("filter"),
+            "filter_submodules": obj.get("filter_submodules"),
+            "no_tags": obj.get("no_tags"),
             "password": obj.get("password"),
             "path": obj.get("path"),
+            "recurse_submodules": obj.get("recurse_submodules"),
+            "reference_path": obj.get("reference_path"),
+            "shallow_since": obj.get("shallow_since"),
+            "shallow_submodules": obj.get("shallow_submodules"),
+            "single_branch": obj.get("single_branch"),
+            "sparse": obj.get("sparse"),
+            "sparse_paths": obj.get("sparse_paths"),
             "url": obj.get("url"),
             "username": obj.get("username")
         })

--- a/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/git_clone_request.rb
+++ b/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/git_clone_request.rb
@@ -19,9 +19,33 @@ module DaytonaToolboxApiClient
 
     attr_accessor :commit_id
 
+    attr_accessor :depth
+
+    attr_accessor :dissociate
+
+    attr_accessor :filter
+
+    attr_accessor :filter_submodules
+
+    attr_accessor :no_tags
+
     attr_accessor :password
 
     attr_accessor :path
+
+    attr_accessor :recurse_submodules
+
+    attr_accessor :reference_path
+
+    attr_accessor :shallow_since
+
+    attr_accessor :shallow_submodules
+
+    attr_accessor :single_branch
+
+    attr_accessor :sparse
+
+    attr_accessor :sparse_paths
 
     attr_accessor :url
 
@@ -32,8 +56,20 @@ module DaytonaToolboxApiClient
       {
         :'branch' => :'branch',
         :'commit_id' => :'commit_id',
+        :'depth' => :'depth',
+        :'dissociate' => :'dissociate',
+        :'filter' => :'filter',
+        :'filter_submodules' => :'filter_submodules',
+        :'no_tags' => :'no_tags',
         :'password' => :'password',
         :'path' => :'path',
+        :'recurse_submodules' => :'recurse_submodules',
+        :'reference_path' => :'reference_path',
+        :'shallow_since' => :'shallow_since',
+        :'shallow_submodules' => :'shallow_submodules',
+        :'single_branch' => :'single_branch',
+        :'sparse' => :'sparse',
+        :'sparse_paths' => :'sparse_paths',
         :'url' => :'url',
         :'username' => :'username'
       }
@@ -54,8 +90,20 @@ module DaytonaToolboxApiClient
       {
         :'branch' => :'String',
         :'commit_id' => :'String',
+        :'depth' => :'Integer',
+        :'dissociate' => :'Boolean',
+        :'filter' => :'String',
+        :'filter_submodules' => :'Boolean',
+        :'no_tags' => :'Boolean',
         :'password' => :'String',
         :'path' => :'String',
+        :'recurse_submodules' => :'Boolean',
+        :'reference_path' => :'String',
+        :'shallow_since' => :'String',
+        :'shallow_submodules' => :'Boolean',
+        :'single_branch' => :'Boolean',
+        :'sparse' => :'Boolean',
+        :'sparse_paths' => :'Array<String>',
         :'url' => :'String',
         :'username' => :'String'
       }
@@ -91,6 +139,26 @@ module DaytonaToolboxApiClient
         self.commit_id = attributes[:'commit_id']
       end
 
+      if attributes.key?(:'depth')
+        self.depth = attributes[:'depth']
+      end
+
+      if attributes.key?(:'dissociate')
+        self.dissociate = attributes[:'dissociate']
+      end
+
+      if attributes.key?(:'filter')
+        self.filter = attributes[:'filter']
+      end
+
+      if attributes.key?(:'filter_submodules')
+        self.filter_submodules = attributes[:'filter_submodules']
+      end
+
+      if attributes.key?(:'no_tags')
+        self.no_tags = attributes[:'no_tags']
+      end
+
       if attributes.key?(:'password')
         self.password = attributes[:'password']
       end
@@ -99,6 +167,36 @@ module DaytonaToolboxApiClient
         self.path = attributes[:'path']
       else
         self.path = nil
+      end
+
+      if attributes.key?(:'recurse_submodules')
+        self.recurse_submodules = attributes[:'recurse_submodules']
+      end
+
+      if attributes.key?(:'reference_path')
+        self.reference_path = attributes[:'reference_path']
+      end
+
+      if attributes.key?(:'shallow_since')
+        self.shallow_since = attributes[:'shallow_since']
+      end
+
+      if attributes.key?(:'shallow_submodules')
+        self.shallow_submodules = attributes[:'shallow_submodules']
+      end
+
+      if attributes.key?(:'single_branch')
+        self.single_branch = attributes[:'single_branch']
+      end
+
+      if attributes.key?(:'sparse')
+        self.sparse = attributes[:'sparse']
+      end
+
+      if attributes.key?(:'sparse_paths')
+        if (value = attributes[:'sparse_paths']).is_a?(Array)
+          self.sparse_paths = value
+        end
       end
 
       if attributes.key?(:'url')
@@ -164,8 +262,20 @@ module DaytonaToolboxApiClient
       self.class == o.class &&
           branch == o.branch &&
           commit_id == o.commit_id &&
+          depth == o.depth &&
+          dissociate == o.dissociate &&
+          filter == o.filter &&
+          filter_submodules == o.filter_submodules &&
+          no_tags == o.no_tags &&
           password == o.password &&
           path == o.path &&
+          recurse_submodules == o.recurse_submodules &&
+          reference_path == o.reference_path &&
+          shallow_since == o.shallow_since &&
+          shallow_submodules == o.shallow_submodules &&
+          single_branch == o.single_branch &&
+          sparse == o.sparse &&
+          sparse_paths == o.sparse_paths &&
           url == o.url &&
           username == o.username
     end
@@ -179,7 +289,7 @@ module DaytonaToolboxApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [branch, commit_id, password, path, url, username].hash
+      [branch, commit_id, depth, dissociate, filter, filter_submodules, no_tags, password, path, recurse_submodules, reference_path, shallow_since, shallow_submodules, single_branch, sparse, sparse_paths, url, username].hash
     end
 
     # Builds the object from hash

--- a/libs/toolbox-api-client/src/models/git-clone-request.ts
+++ b/libs/toolbox-api-client/src/models/git-clone-request.ts
@@ -17,8 +17,20 @@
 export interface GitCloneRequest {
     'branch'?: string;
     'commit_id'?: string;
+    'depth'?: number;
+    'dissociate'?: boolean;
+    'filter'?: string;
+    'filter_submodules'?: boolean;
+    'no_tags'?: boolean;
     'password'?: string;
     'path': string;
+    'recurse_submodules'?: boolean;
+    'reference_path'?: string;
+    'shallow_since'?: string;
+    'shallow_submodules'?: boolean;
+    'single_branch'?: boolean;
+    'sparse'?: boolean;
+    'sparse_paths'?: Array<string>;
     'url': string;
     'username'?: string;
 }


### PR DESCRIPTION
## Summary

- add optimized clone options to `/git/clone`: `depth`, `single_branch`, `shallow_since`, `no_tags`, plus partial/sparse/reference/submodule controls
- route optimized clone requests through the opt-in native Git CLI path with validation before spawning subprocesses
- expose the new clone options in the Python, TypeScript, Ruby, Go, and Java SDKs
- regenerate toolbox OpenAPI clients and update Git operation docs

## Validation

- `go test ./pkg/git ./pkg/toolbox/git` from `apps/daemon`
- `go test ./pkg/...` from `libs/sdk-go`
- TypeScript Git Jest test
- Python Git tests
- Ruby Git specs
- Java `GitTest`
- `nx build toolbox-api-client`
- `nx build sdk-typescript`
- `git diff --check`
- local daemon smoke in a 1 vCPU / 1 GiB Docker container:
  - `torvalds/linux` with `depth=1,single_branch=true` completed in 47s
  - `llvm/llvm-project` with `depth=1` completed in 52s
  - invalid shallow options returned 400 before clone directories were created

## Benchmarks

Environment for these measurements: local daemon running in Docker with `--cpus=1 --memory=1g`, `DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true`, and `alpine/git:2.49.1`.

### This PR

These are request-path clone times for the options implemented in this PR.

| Repo | Clone options | Time | Disk | Notes |
|---|---:|---:|---:|---|
| `daytonaio/daytona` | `depth=1,single_branch=true,no_tags=true,filter=blob:none` | 6s | 109.5M | shallow, promisor, `blob:none` |
| `microsoft/vscode` | `depth=1,single_branch=true,no_tags=true,filter=blob:none` | 17s | 806.8M | shallow, promisor, `blob:none` |
| `rust-lang/rust` | `depth=1,single_branch=true,no_tags=true,filter=blob:none` | 31s | 447.2M | shallow, promisor, `blob:none` |
| `llvm/llvm-project` | `depth=1,single_branch=true,no_tags=true,filter=blob:none` | 127s | 2.8G | shallow, promisor, `blob:none` |
| `torvalds/linux` | `depth=1,single_branch=true,no_tags=true,filter=blob:none` | 57s | 2.0G | shallow, promisor, `blob:none` |

Acceptance-criteria payloads without partial clone filtering:

| Repo | Clone options | Time | Disk | Result |
|---|---:|---:|---:|---|
| `torvalds/linux` | `depth=1,single_branch=true` | 47s | 2.0G | passes under-60s criterion |
| `llvm/llvm-project` | `depth=1` | 52s | 2.7G | succeeds under 1 GiB memory cap |

Treeless partial clone comparison:

| Repo | Clone options | Time | Disk | Notes |
|---|---:|---:|---:|---|
| `torvalds/linux` | `depth=1,single_branch=true,no_tags=true,filter=tree:0` | 67s | 2.0G | shallow, promisor, `tree:0` |
| `llvm/llvm-project` | `depth=1,single_branch=true,no_tags=true,filter=tree:0` | 108s | 2.8G | shallow, promisor, `tree:0` |

### Follow-up branch: background expansion prototype

I also benchmarked the follow-up branch `git-clone-background-expansion` to validate the proposed next direction. These numbers are not part of this PR, but they show why the next PR should split clone into a foreground usable clone and background expansion.

| Repo | Config | Foreground return | Disk at return | Background total | Final disk |
|---|---:|---:|---:|---:|---:|
| Linux | baseline `depth=1 + blob:none` | 51.31s | 2.0G | 52.71s | 2.0G |
| Linux | `no_checkout + blob:none + background_deepen=50` | 2.11s | 3.2M | 68.60s | 2.1G |
| Linux | sparse `README, Makefile + blob:none + background_deepen=50` | 2.29s | 14.5M | 66.77s | 2.1G |
| Linux | `no_checkout + tree:0 + background_deepen=50` | 0.60s | 124K | 57.14s | 2.0G |
| LLVM | baseline `depth=1 + blob:none` | 113.00s | 2.8G | 117.28s | 2.8G |
| LLVM | `no_checkout + blob:none + background_deepen=50` | 1.36s | 6.3M | 116.00s | 2.8G |
| LLVM | sparse `README.md + blob:none + background_deepen=50` | 3.57s | 27.1M | 120.30s | 2.8G |
| LLVM | `no_checkout + tree:0 + background_deepen=50` | 0.79s | 124K | 119.43s | 2.8G |

The follow-up branch also uncovered and fixed a sparse-checkout edge case for file paths in `initial_sparse_paths` by using `git sparse-checkout set --skip-checks`.

## Follow-up

I am also working on a separate branch for a two-phase/background expansion design: return quickly from a minimal shallow partial/sparse clone, then progressively widen sparse checkout, deepen history, run prefetch/maintenance, and hydrate common paths in the background. That follow-up is intentionally not bundled into this PR so this one can stay focused on the issue acceptance criteria.

Fixes #4667


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds advanced Git clone options to the `/git/clone` API and all SDKs, including shallow, sparse, partial, reference, and submodule controls. Enables an opt-in native Git CLI path with validation to speed up large repo clones and reduce network usage.

- **New Features**
  - API: Support `depth`, `single_branch`, `shallow_since`, `no_tags`, `filter`, `sparse`, `sparse_paths`, `reference_path`, `dissociate`, `recurse_submodules`, `shallow_submodules`, `filter_submodules`.
  - Daemon: Validate options before exec; route optimized clones via native Git when `DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true`; add sparse checkout and reference handling; never embed creds in URLs.
  - SDKs: Expose options in Go, TypeScript, Python, Ruby, and Java (`GitCloneOptions`), with tests in each language.
  - Docs/OpenAPI: Updated Git operations docs with examples; regenerated toolbox OpenAPI specs and clients.

<sup>Written for commit c212e0d1f36f51fffbbe6e142f569962a1a471c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

