### PR TITLE
fix(dashboard): chart y axis cut off

### DIFF
--- a/apps/dashboard/src/components/spending/UsageTimelineChart.tsx
+++ b/apps/dashboard/src/components/spending/UsageTimelineChart.tsx
@@ -106,6 +106,17 @@ function formatTooltipLabel(value: string) {
   })
 }
 
+function formatCompactMoney(value: number) {
+  return Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    notation: 'compact',
+    compactDisplay: 'short',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
 export function UsageTimelineChart({
   data,
   isLoading,
@@ -202,7 +213,7 @@ export function UsageTimelineChart({
   }, [isResourceMode, resourceFilter, limits])
 
   const yAxisFormatter = useMemo(() => {
-    if (!isResourceMode) return (value: number) => formatMoney(value)
+    if (!isResourceMode) return (value: number) => formatCompactMoney(value)
     if (resourceFilter === 'all') return (value: number) => `${value}%`
     return (value: number) => value.toLocaleString()
   }, [isResourceMode, resourceFilter])
@@ -291,7 +302,7 @@ export function UsageTimelineChart({
               axisLine={false}
               tickMargin={4}
               tickCount={5}
-              width={50}
+              width={isResourceMode ? 50 : 56}
               domain={yAxisDomain}
               tickFormatter={yAxisFormatter}
             />


### PR DESCRIPTION
## Description

Fixes usage chart y axis values being cut off.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes y-axis labels getting cut off in the Usage Timeline chart by using compact USD formatting and slightly widening the axis in cost mode. This improves readability for larger values.

- **Bug Fixes**
  - Added compact USD formatter for cost mode to shorten y-axis labels.
  - Increased y-axis width in cost mode from 50 to 56 to prevent clipping (resource modes unchanged).

<sup>Written for commit 38295e37968c8072273837df7631fad7efd4b231. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

