### PR TITLE
fix(dashboard): use sdk dist for dev

### DIFF
--- a/apps/dashboard/project.json
+++ b/apps/dashboard/project.json
@@ -18,6 +18,14 @@
         }
       ]
     },
+    "serve": {
+      "dependsOn": [
+        {
+          "target": "build",
+          "projects": "sdk-typescript"
+        }
+      ]
+    },
     "storybook": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/dashboard/vite.config.mts
+++ b/apps/dashboard/vite.config.mts
@@ -71,10 +71,10 @@ export default defineConfig((mode) => ({
   ],
   resolve: {
     alias: [
-      // Resolve @daytona/sdk to the local source
+      // Resolve @daytona/sdk to the built ESM entry so browsers never receive raw SDK TypeScript decorators.
       {
         find: '@daytona/sdk',
-        replacement: path.resolve(__dirname, '../../libs/sdk-typescript/src'),
+        replacement: path.resolve(__dirname, '../../dist/libs/sdk-typescript'),
       },
       // Target @ but not @daytona,
       {


### PR DESCRIPTION
## Description

Fixes dashboard dev by using sdk dist instead of src.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the compiled SDK in dashboard dev by aliasing `@daytona/sdk` to the built dist and building it before `serve`. This prevents runtime errors from browsers receiving raw TypeScript decorators.

- **Bug Fixes**
  - Vite alias: `@daytona/sdk` now points to `../../dist/libs/sdk-typescript` (ESM) instead of `src`.
  - Nx: `serve` depends on building `sdk-typescript` to ensure the dist exists.

<sup>Written for commit 9814a6530158137263c2d0892d6618fbfd119d81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

