### PR TITLE
feat(dashboard): optimize fs search & tweak skeleton

### DIFF
--- a/apps/dashboard/src/components/sandboxes/SandboxFileSystemTab/FileSearchHeader.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxFileSystemTab/FileSearchHeader.tsx
@@ -70,7 +70,7 @@ export function FileSearchHeader({
       <div
         aria-hidden={isOpen}
         inert={isOpen}
-        className={cn('absolute inset-0 flex items-center px-2 transition-all duration-200', {
+        className={cn('absolute inset-0 flex items-center px-2 pl-3 transition-all duration-200', {
           'z-10 translate-x-0 opacity-100': !isOpen,
           'z-0 -translate-x-6 opacity-0': isOpen,
         })}

--- a/apps/dashboard/src/components/sandboxes/SandboxFileSystemTab/FileTreePane.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxFileSystemTab/FileTreePane.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Buffer } from 'buffer'
-import {
+import React, {
   memo,
   useCallback,
   useEffect,
@@ -16,6 +16,7 @@ import {
   type KeyboardEvent,
 } from 'react'
 
+import TooltipButton from '@/components/TooltipButton'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -27,7 +28,6 @@ import {
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Skeleton } from '@/components/ui/skeleton'
-import TooltipButton from '@/components/TooltipButton'
 import { cn } from '@/lib/utils'
 import {
   asyncDataLoaderFeature,
@@ -40,20 +40,21 @@ import { useTree } from '@headless-tree/react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronsUpDownIcon, EllipsisIcon, RefreshCwIcon } from 'lucide-react'
 
+import { AnimatePresence, motion, Variants } from 'motion/react'
 import { toast } from 'sonner'
 import { FILE_SEARCH_MIN_CHARS, ROOT_NODE, ROOT_PATH } from './constants'
 import { FileSearchHeader, type FileSearchHeaderHandle } from './FileSearchHeader'
-import { FileTreeRow } from './FileTreeRow'
 import { useFileSystemStore } from './fileSystemStore'
+import { FileTreeRow } from './FileTreeRow'
 import { useMoveNodeMutation } from './mutations'
 import {
-  useFileDetailsCache,
-  useFileDetailsQueries,
   useFetchDirectoryChildrenQuery,
   useFetchFileDetailsQuery,
+  useFileDetailsCache,
+  useFileDetailsQueries,
   useFileSearchQuery,
-  useIsDirectoryRefreshing,
   useInvalidateDirectoryQuery,
+  useIsDirectoryRefreshing,
 } from './queries'
 import type { SandboxFileSystemNode } from './types'
 import { useSandboxInstance } from './useSandboxInstance'
@@ -63,11 +64,11 @@ import {
   getAncestorPaths,
   getCanvasFont,
   getImageMimeType,
-  isSameOrDescendantPath,
-  joinSandboxPath,
   getParentPath,
   handleFileSystemApiError,
   isProbablyBinary,
+  isSameOrDescendantPath,
+  joinSandboxPath,
 } from './utils'
 
 export type FileTreePaneRef = {
@@ -81,12 +82,42 @@ export type FileTreePaneRef = {
 const MemoizedFileSearchHeader = memo(FileSearchHeader)
 const FILE_TREE_EDGE_PADDING = 8
 const FILE_SEARCH_RESULT_LABEL_RESERVED_WIDTH = 40
+type FileTreeInstance = ReturnType<typeof useTree<SandboxFileSystemNode | null>>
+type FileTreeItem = ReturnType<FileTreeInstance['getItems']>[number]
 
-function FileTreeSkeleton() {
+type FileTreeVirtualListRef = {
+  scrollToIndex: (index: number, options?: { align?: 'auto' | 'center' | 'end' | 'start' }) => unknown
+}
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, filter: 'blur(4px)', scale: 0.96 },
+  visible: (i) => ({
+    opacity: 1,
+    filter: 'blur(0px)',
+    scale: 1,
+    transition: {
+      delay: i * 0.02,
+      duration: 0.2,
+    },
+  }),
+}
+
+function FileTreeSkeleton({ count = 20 }: { count?: number }) {
   return (
-    <div className="space-y-1 p-2">
-      {Array.from({ length: 20 }).map((_, index) => (
-        <div key={index} className="flex items-center gap-2 rounded-md px-2 py-1">
+    <div
+      className="grid grid-cols-1 px-2 -mt-16 [mask-image:linear-gradient(180deg,black,transparent)]"
+      style={{ '--count': count } as React.CSSProperties}
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <motion.div
+          key={index}
+          custom={index}
+          variants={itemVariants}
+          initial="hidden"
+          animate="visible"
+          className="marquee-scroll-y flex items-center gap-2 rounded-md px-2 py-2 skeleton-group"
+          style={{ '--index': index } as React.CSSProperties}
+        >
           <Skeleton className="size-4 shrink-0 rounded-sm" />
           <Skeleton
             className={cn('h-4 rounded-sm', {
@@ -96,13 +127,215 @@ function FileTreeSkeleton() {
             })}
           />
           <Skeleton className="ml-auto h-3 w-12 rounded-sm" />
-        </div>
+        </motion.div>
       ))}
     </div>
   )
 }
 
 const defaultSearchResults: string[] = []
+
+function FileTreeVirtualList({
+  fileTreeViewportRef,
+  handleCopyNode,
+  handleDownloadNode,
+  handleItemKeyDown,
+  isTreeRefreshing,
+  observedNodesByPath,
+  onRequestCreateFolder,
+  onRequestDelete,
+  openNode,
+  previewLoadingPath,
+  ref,
+  refreshPath,
+  searchEnabled,
+  searchLabelAvailableWidth,
+  searchLabelFont,
+  searchQuery,
+  searchResultsDimmed,
+  searchResultPaths,
+  selectedPath,
+  tree,
+  visibleItems,
+}: {
+  fileTreeViewportRef: React.RefObject<HTMLDivElement | null>
+  handleCopyNode: (node: SandboxFileSystemNode) => Promise<unknown>
+  handleDownloadNode: (node: SandboxFileSystemNode) => Promise<unknown>
+  handleItemKeyDown: (item: FileTreeItem, event: KeyboardEvent<HTMLDivElement>) => unknown
+  isTreeRefreshing: boolean
+  observedNodesByPath: Map<string, SandboxFileSystemNode>
+  onRequestCreateFolder: (parentPath: string) => unknown
+  onRequestDelete: (node: SandboxFileSystemNode) => unknown
+  openNode: (path: string) => unknown
+  previewLoadingPath?: string
+  ref?: React.Ref<FileTreeVirtualListRef>
+  refreshPath: (path: string) => Promise<unknown>
+  searchEnabled: boolean
+  searchLabelAvailableWidth: number
+  searchLabelFont: string
+  searchQuery: string
+  searchResultsDimmed: boolean
+  searchResultPaths: string[]
+  selectedPath: string
+  tree: FileTreeInstance
+  visibleItems: FileTreeItem[]
+}) {
+  const fileTreeVirtualizer = useVirtualizer({
+    count: searchEnabled ? searchResultPaths.length : visibleItems.length,
+    getScrollElement: () => fileTreeViewportRef.current,
+    estimateSize: () => 32,
+    overscan: 12,
+  })
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToIndex: (index, options) => fileTreeVirtualizer.scrollToIndex(index, options),
+    }),
+    [fileTreeVirtualizer],
+  )
+
+  return (
+    <div
+      {...(!searchEnabled ? tree.getContainerProps('Sandbox filesystem') : {})}
+      className={cn('relative min-h-full px-2 transition-opacity', {
+        'opacity-60': isTreeRefreshing || searchResultsDimmed,
+      })}
+      style={{ height: `${fileTreeVirtualizer.getTotalSize() + FILE_TREE_EDGE_PADDING * 2}px` }}
+    >
+      {fileTreeVirtualizer.getVirtualItems().map((virtualItem) => {
+        const item = searchEnabled ? null : visibleItems[virtualItem.index]
+        const searchResultPath = searchEnabled ? searchResultPaths[virtualItem.index] : null
+        const node = searchEnabled
+          ? searchResultPath
+            ? createFallbackNode(searchResultPath)
+            : null
+          : (observedNodesByPath.get(item?.getId() ?? '') ?? item?.getItemData() ?? ROOT_NODE)
+
+        if (!node) {
+          return null
+        }
+
+        const isDirectory = searchEnabled ? node.isDir : (item?.isFolder() ?? node.isDir)
+        const isSelected = selectedPath === node.path
+        const isPreviewLoading = previewLoadingPath === node.path
+        const isFocused = searchEnabled ? false : (item?.isFocused() ?? false)
+        const isLoading = (item?.isLoading() ?? false) || isPreviewLoading
+        const itemProps = searchEnabled ? { tabIndex: -1 } : (item?.getProps() ?? {})
+
+        return (
+          <FileTreeRow
+            key={searchEnabled ? node.path : item?.getId()}
+            actions={
+              !searchEnabled ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    asChild
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) => event.stopPropagation()}
+                  >
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      tabIndex={isFocused || isSelected ? 0 : -1}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                    >
+                      <EllipsisIcon className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="end"
+                    side="right"
+                    className={cn({
+                      'w-44': node.isDir,
+                      'w-48': !node.isDir,
+                    })}
+                    onCloseAutoFocus={(event) => event.preventDefault()}
+                  >
+                    <DropdownMenuItem
+                      onClick={() => refreshPath(node.isDir ? node.path : getParentPath(node.path))}
+                      disabled={item?.isLoading() || (!node.isDir && selectedPath === node.path && isPreviewLoading)}
+                    >
+                      Refresh
+                    </DropdownMenuItem>
+                    {!node.isDir ? (
+                      <DropdownMenuItem onClick={() => handleDownloadNode(node)}>Download</DropdownMenuItem>
+                    ) : null}
+                    {!node.isDir && !getImageMimeType(node.path) ? (
+                      <DropdownMenuItem onClick={() => handleCopyNode(node)}>Copy contents</DropdownMenuItem>
+                    ) : null}
+                    {node.isDir ? (
+                      <DropdownMenuItem onSelect={() => onRequestCreateFolder(node.path)}>
+                        Create Folder
+                      </DropdownMenuItem>
+                    ) : null}
+                    {node.path !== ROOT_PATH ? <DropdownMenuSeparator /> : null}
+                    {node.path !== ROOT_PATH ? (
+                      <DropdownMenuItem variant="destructive" onClick={() => onRequestDelete(node)}>
+                        Delete
+                      </DropdownMenuItem>
+                    ) : null}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : undefined
+            }
+            itemProps={itemProps}
+            depth={item?.getItemMeta().level ?? 0}
+            dragHandleProps={!searchEnabled ? (item?.getDragHandleProps() ?? undefined) : undefined}
+            isExpanded={item?.isExpanded() ?? false}
+            isDragTarget={item?.isDragTarget() ?? false}
+            isDragTargetAbove={item?.isDragTargetAbove() ?? false}
+            isDragTargetBelow={item?.isDragTargetBelow() ?? false}
+            isDraggingOver={item?.isDraggingOver() ?? false}
+            isFocused={isFocused}
+            isLoading={isLoading}
+            isSearchResult={searchEnabled}
+            isSelected={isSelected}
+            node={node}
+            onActivate={(event) => {
+              itemProps.onClick?.(event)
+
+              if (event.defaultPrevented) {
+                return
+              }
+
+              if (!searchEnabled && item && node.isDir && !item.isExpanded()) {
+                item.expand()
+              }
+
+              openNode(node.path)
+            }}
+            onItemKeyDown={!searchEnabled && item ? (event) => handleItemKeyDown(item, event) : undefined}
+            onToggleExpand={
+              !searchEnabled && isDirectory && item
+                ? () => {
+                    if (item.isExpanded()) {
+                      item.collapse()
+                    } else {
+                      item.expand()
+                    }
+                  }
+                : undefined
+            }
+            searchLabel={
+              searchEnabled
+                ? {
+                    availableWidth: searchLabelAvailableWidth,
+                    font: searchLabelFont,
+                    query: searchQuery,
+                  }
+                : undefined
+            }
+            top={virtualItem.start + FILE_TREE_EDGE_PADDING}
+          />
+        )
+      })}
+      {!searchEnabled ? (
+        <div className="pointer-events-none border-t-2 border-primary" style={tree.getDragLineStyle()} />
+      ) : null}
+    </div>
+  )
+}
 
 function isFallbackNode(node: SandboxFileSystemNode) {
   return (
@@ -136,6 +369,7 @@ export function FileTreePane({
   const didSetInitialFocusRef = useRef(false)
   const fileTreeScrollAreaRef = useRef<HTMLDivElement>(null)
   const fileTreeViewportRef = useRef<HTMLDivElement>(null)
+  const fileTreeVirtualListRef = useRef<FileTreeVirtualListRef>(null)
   const searchHeaderRef = useRef<FileSearchHeaderHandle>(null)
   const sandboxInstanceQuery = useSandboxInstance(sandboxId)
   const sandboxInstance = sandboxInstanceQuery.data
@@ -206,16 +440,26 @@ export function FileTreePane({
     query: searchQuery,
     sandboxInstance,
   })
-  const searchResultPaths = searchQueryResult.data ?? defaultSearchResults
-  const searchResultNodesByPath = useFileDetailsQueries({
-    paths: searchEnabled ? searchResultPaths : defaultSearchResults,
-    sandboxInstance,
-  })
-  const searchResults = useMemo(() => {
-    return searchResultPaths.map((path) => searchResultNodesByPath.get(path) ?? createFallbackNode(path))
-  }, [searchResultNodesByPath, searchResultPaths])
+  const [shouldIgnorePreviousSearchResults, setShouldIgnorePreviousSearchResults] = useState(false)
+  const shouldShowSearchSkeleton =
+    searchEnabled && searchQueryResult.isPlaceholderData && shouldIgnorePreviousSearchResults
+  const searchResultPaths = shouldShowSearchSkeleton
+    ? defaultSearchResults
+    : (searchQueryResult.data ?? defaultSearchResults)
   const isSearchLoading = searchQueryResult.isFetching
+  const areSearchResultsDimmed = searchEnabled && searchQueryResult.isPlaceholderData && !shouldShowSearchSkeleton
   const searchFailed = searchQueryResult.isError
+
+  useEffect(() => {
+    if (!searchEnabled) {
+      setShouldIgnorePreviousSearchResults(true)
+      return
+    }
+
+    if (!searchQueryResult.isPlaceholderData) {
+      setShouldIgnorePreviousSearchResults(false)
+    }
+  }, [searchEnabled, searchQueryResult.isPlaceholderData])
 
   const tree = useTree<SandboxFileSystemNode | null>({
     rootItemId: ROOT_PATH,
@@ -339,11 +583,6 @@ export function FileTreePane({
     paths: observedDetailPaths,
     sandboxInstance,
   })
-  const selectedNode = selectedPath
-    ? (observedNodesByPath.get(selectedPath) ??
-      getCachedNode(selectedPath) ??
-      (selectedPath === ROOT_PATH ? ROOT_NODE : createFallbackNode(selectedPath)))
-    : null
   const rootItem = tree.getItemInstance(ROOT_PATH)
   const isRootDirectoryRefreshing = useIsDirectoryRefreshing({
     path: ROOT_PATH,
@@ -351,47 +590,38 @@ export function FileTreePane({
   })
   const isInitialTreeLoading = (!sandboxInstance || rootItem.isLoading()) && visibleItems.length <= 1 && !rootLoadFailed
   const isTreeRefreshing = !isInitialTreeLoading && (rootItem.isLoading() || isRootDirectoryRefreshing)
-  const visibleFileItems = useMemo(() => {
-    return visibleItems.filter((item) => {
+  const visibleFilePaths = useMemo(() => {
+    return visibleItems.flatMap((item) => {
       const node = observedNodesByPath.get(item.getId()) ?? item.getItemData() ?? createFallbackNode(item.getId())
-      return !node.isDir
+      return node.isDir ? [] : [node.path]
     })
   }, [observedNodesByPath, visibleItems])
 
-  const activeFileNodes = useMemo(() => {
+  const activeFilePaths = useMemo(() => {
     if (searchEnabled) {
-      return searchResults.filter((node) => !node.isDir)
+      return searchResultPaths
     }
 
-    return visibleFileItems.map(
-      (item) => observedNodesByPath.get(item.getId()) ?? item.getItemData() ?? createFallbackNode(item.getId()),
-    )
-  }, [observedNodesByPath, searchEnabled, searchResults, visibleFileItems])
+    return visibleFilePaths
+  }, [searchEnabled, searchResultPaths, visibleFilePaths])
 
   const selectedFileIndex = useMemo(() => {
-    if (!selectedNode || selectedNode.isDir) {
+    if (!selectedPath) {
       return -1
     }
 
-    return activeFileNodes.findIndex((node) => node.path === selectedPath)
-  }, [activeFileNodes, selectedNode, selectedPath])
+    return activeFilePaths.findIndex((path) => path === selectedPath)
+  }, [activeFilePaths, selectedPath])
 
   useEffect(() => {
     setAdjacentFilePaths({
-      previousFilePath: selectedFileIndex > 0 ? (activeFileNodes[selectedFileIndex - 1]?.path ?? null) : null,
+      previousFilePath: selectedFileIndex > 0 ? (activeFilePaths[selectedFileIndex - 1] ?? null) : null,
       nextFilePath:
-        selectedFileIndex >= 0 && selectedFileIndex < activeFileNodes.length - 1
-          ? (activeFileNodes[selectedFileIndex + 1]?.path ?? null)
+        selectedFileIndex >= 0 && selectedFileIndex < activeFilePaths.length - 1
+          ? (activeFilePaths[selectedFileIndex + 1] ?? null)
           : null,
     })
-  }, [activeFileNodes, selectedFileIndex, setAdjacentFilePaths])
-
-  const fileTreeVirtualizer = useVirtualizer({
-    count: searchEnabled ? searchResults.length : visibleItems.length,
-    getScrollElement: () => fileTreeViewportRef.current,
-    estimateSize: () => 32,
-    overscan: 12,
-  })
+  }, [activeFilePaths, selectedFileIndex, setAdjacentFilePaths])
 
   const focusedItemIndex = visibleItems.findIndex((item) => item.isFocused())
 
@@ -400,8 +630,8 @@ export function FileTreePane({
       return
     }
 
-    fileTreeVirtualizer.scrollToIndex(focusedItemIndex, { align: 'auto' })
-  }, [fileTreeVirtualizer, focusedItemIndex, searchEnabled])
+    fileTreeVirtualListRef.current?.scrollToIndex(focusedItemIndex, { align: 'auto' })
+  }, [focusedItemIndex, searchEnabled])
 
   useEffect(() => {
     const viewport = fileTreeViewportRef.current
@@ -483,18 +713,18 @@ export function FileTreePane({
   const revealPath = useCallback(
     (path: string) => {
       if (searchEnabled) {
-        const itemIndex = activeFileNodes.findIndex((node) => node.path === path)
+        const itemIndex = activeFilePaths.findIndex((activePath) => activePath === path)
         if (itemIndex >= 0) {
-          fileTreeVirtualizer.scrollToIndex(itemIndex, { align: 'auto' })
+          fileTreeVirtualListRef.current?.scrollToIndex(itemIndex, { align: 'auto' })
         }
         return
       }
 
-      const item = visibleFileItems.find((visibleItem) => visibleItem.getId() === path)
+      const item = visibleItems.find((visibleItem) => visibleItem.getId() === path)
       item?.setFocused()
       tree.updateDomFocus()
     },
-    [activeFileNodes, fileTreeVirtualizer, searchEnabled, tree, visibleFileItems],
+    [activeFilePaths, searchEnabled, tree, visibleItems],
   )
 
   const getNode = useCallback((path: string) => getCachedNode(path) ?? createFallbackNode(path), [getCachedNode])
@@ -637,7 +867,7 @@ export function FileTreePane({
   if (rootLoadFailed) {
     return (
       <div className="flex flex-1 min-h-0">
-        <Empty className="border-0">
+        <Empty className="border-0 rounded-none">
           <EmptyHeader>
             <EmptyTitle>Failed to load filesystem</EmptyTitle>
             <EmptyDescription>Something went wrong while listing the sandbox root directory.</EmptyDescription>
@@ -684,9 +914,9 @@ export function FileTreePane({
       />
       <div role="status" aria-live="polite" className="sr-only">
         {searchEnabled && !isSearchLoading && !searchFailed
-          ? searchResults.length === 0
+          ? searchResultPaths.length === 0
             ? 'No files found'
-            : `${searchResults.length} files found`
+            : `${searchResultPaths.length} files found`
           : null}
       </div>
 
@@ -698,159 +928,76 @@ export function FileTreePane({
         onFocusCapture={handleTreeFocusCapture}
       >
         <ScrollArea fade="mask" className="min-h-0 h-full" viewportRef={fileTreeViewportRef}>
-          {isInitialTreeLoading || (searchEnabled && isSearchLoading && searchResults.length === 0) ? (
-            <FileTreeSkeleton />
-          ) : searchEnabled && searchResults.length === 0 && !isSearchLoading && !searchFailed ? (
-            <Empty className="border-0">
-              <EmptyHeader>
-                <EmptyTitle>0 results</EmptyTitle>
-                <EmptyDescription>
-                  No files matched "{searchQuery}". Try another search or clear search.
-                </EmptyDescription>
-              </EmptyHeader>
-              <Button variant="outline" size="sm" onClick={resetSearch}>
-                Clear search
-              </Button>
-            </Empty>
-          ) : (
-            <div
-              {...(!searchEnabled ? tree.getContainerProps('Sandbox filesystem') : {})}
-              className={cn('relative min-h-full px-2 transition-opacity', {
-                'opacity-60': isTreeRefreshing,
-              })}
-              style={{ height: `${fileTreeVirtualizer.getTotalSize() + FILE_TREE_EDGE_PADDING * 2}px` }}
-            >
-              {fileTreeVirtualizer.getVirtualItems().map((virtualItem) => {
-                const item = searchEnabled ? null : visibleItems[virtualItem.index]
-                const node = searchEnabled
-                  ? searchResults[virtualItem.index]
-                  : (observedNodesByPath.get(item?.getId() ?? '') ?? item?.getItemData() ?? ROOT_NODE)
-
-                if (!node) {
-                  return null
-                }
-
-                const isDirectory = searchEnabled ? node.isDir : (item?.isFolder() ?? node.isDir)
-                const isSelected = selectedPath === node.path
-                const isPreviewLoading = previewLoadingPath === node.path
-                const isFocused = searchEnabled ? false : (item?.isFocused() ?? false)
-                const isLoading = (item?.isLoading() ?? false) || isPreviewLoading
-                const itemProps = searchEnabled ? { tabIndex: -1 } : (item?.getProps() ?? {})
-                return (
-                  <FileTreeRow
-                    key={searchEnabled ? node.path : item?.getId()}
-                    actions={
-                      !searchEnabled ? (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger
-                            asChild
-                            onClick={(event) => event.stopPropagation()}
-                            onPointerDown={(event) => event.stopPropagation()}
-                          >
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              tabIndex={isFocused || isSelected ? 0 : -1}
-                              className="inline-flex h-8 w-8 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
-                            >
-                              <EllipsisIcon className="size-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            align="end"
-                            side="right"
-                            className={cn({
-                              'w-44': node.isDir,
-                              'w-48': !node.isDir,
-                            })}
-                            onCloseAutoFocus={(event) => event.preventDefault()}
-                          >
-                            <DropdownMenuItem
-                              onClick={() => refreshPath(node.isDir ? node.path : getParentPath(node.path))}
-                              disabled={
-                                item?.isLoading() || (!node.isDir && selectedPath === node.path && isPreviewLoading)
-                              }
-                            >
-                              Refresh
-                            </DropdownMenuItem>
-                            {!node.isDir ? (
-                              <DropdownMenuItem onClick={() => handleDownloadNode(node)}>Download</DropdownMenuItem>
-                            ) : null}
-                            {!node.isDir && !getImageMimeType(node.path) ? (
-                              <DropdownMenuItem onClick={() => handleCopyNode(node)}>Copy contents</DropdownMenuItem>
-                            ) : null}
-                            {node.isDir ? (
-                              <DropdownMenuItem onSelect={() => onRequestCreateFolder(node.path)}>
-                                Create Folder
-                              </DropdownMenuItem>
-                            ) : null}
-                            {node.path !== ROOT_PATH ? <DropdownMenuSeparator /> : null}
-                            {node.path !== ROOT_PATH ? (
-                              <DropdownMenuItem variant="destructive" onClick={() => onRequestDelete(node)}>
-                                Delete
-                              </DropdownMenuItem>
-                            ) : null}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      ) : undefined
-                    }
-                    itemProps={itemProps}
-                    depth={item?.getItemMeta().level ?? 0}
-                    dragHandleProps={!searchEnabled ? (item?.getDragHandleProps() ?? undefined) : undefined}
-                    isExpanded={item?.isExpanded() ?? false}
-                    isDragTarget={item?.isDragTarget() ?? false}
-                    isDragTargetAbove={item?.isDragTargetAbove() ?? false}
-                    isDragTargetBelow={item?.isDragTargetBelow() ?? false}
-                    isDraggingOver={item?.isDraggingOver() ?? false}
-                    isFocused={isFocused}
-                    isLoading={isLoading}
-                    isSearchResult={searchEnabled}
-                    isSelected={isSelected}
-                    node={node}
-                    onActivate={async (event) => {
-                      itemProps.onClick?.(event)
-
-                      if (event.defaultPrevented) {
-                        return
-                      }
-
-                      if (!searchEnabled && item && node.isDir && !item.isExpanded()) {
-                        item.expand()
-                      }
-
-                      const resolvedNode = searchEnabled ? await resolveNode(node.path) : node
-                      openNode(resolvedNode.path)
-                    }}
-                    onItemKeyDown={!searchEnabled && item ? (event) => handleItemKeyDown(item, event) : undefined}
-                    onToggleExpand={
-                      !searchEnabled && isDirectory && item
-                        ? () => {
-                            if (item.isExpanded()) {
-                              item.collapse()
-                            } else {
-                              item.expand()
-                            }
-                          }
-                        : undefined
-                    }
-                    searchLabel={
-                      searchEnabled
-                        ? {
-                            availableWidth: searchLabelAvailableWidth,
-                            font: searchLabelFont,
-                            query: searchQuery,
-                          }
-                        : undefined
-                    }
-                    top={virtualItem.start + FILE_TREE_EDGE_PADDING}
-                  />
-                )
-              })}
-              {!searchEnabled ? (
-                <div className="pointer-events-none border-t-2 border-primary" style={tree.getDragLineStyle()} />
-              ) : null}
-            </div>
-          )}
+          <AnimatePresence mode="popLayout">
+            {isInitialTreeLoading || (searchEnabled && isSearchLoading && searchResultPaths.length === 0) ? (
+              <motion.div
+                key="skeleton"
+                initial={{ opacity: 1 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.15 }}
+                className="h-full w-full"
+              >
+                <FileTreeSkeleton />
+              </motion.div>
+            ) : searchEnabled && searchResultPaths.length === 0 && !isSearchLoading && !searchFailed ? (
+              <motion.div
+                key="empty"
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 10 }}
+                transition={{ duration: 0.15 }}
+                className="h-full w-full"
+              >
+                <div className="p-2 h-full">
+                  <Empty className="border-0 h-full bg-transparent">
+                    <EmptyHeader>
+                      <EmptyTitle>0 results</EmptyTitle>
+                      <EmptyDescription>
+                        No files matched "{searchQuery}". Try another search or clear search.
+                      </EmptyDescription>
+                    </EmptyHeader>
+                    <Button variant="outline" size="sm" onClick={resetSearch}>
+                      Clear search
+                    </Button>
+                  </Empty>
+                </div>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="content"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.15 }}
+                className="h-full w-full"
+              >
+                <FileTreeVirtualList
+                  fileTreeViewportRef={fileTreeViewportRef}
+                  handleCopyNode={handleCopyNode}
+                  handleDownloadNode={handleDownloadNode}
+                  handleItemKeyDown={handleItemKeyDown}
+                  isTreeRefreshing={isTreeRefreshing}
+                  observedNodesByPath={observedNodesByPath}
+                  onRequestCreateFolder={onRequestCreateFolder}
+                  onRequestDelete={onRequestDelete}
+                  openNode={openNode}
+                  previewLoadingPath={previewLoadingPath}
+                  ref={fileTreeVirtualListRef}
+                  refreshPath={refreshPath}
+                  searchEnabled={searchEnabled}
+                  searchLabelAvailableWidth={searchLabelAvailableWidth}
+                  searchLabelFont={searchLabelFont}
+                  searchQuery={searchQuery}
+                  searchResultsDimmed={areSearchResultsDimmed}
+                  searchResultPaths={searchResultPaths}
+                  selectedPath={selectedPath}
+                  tree={tree}
+                  visibleItems={visibleItems}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
         </ScrollArea>
       </div>
     </div>

--- a/apps/dashboard/src/components/sandboxes/SandboxFileSystemTab/queries.ts
+++ b/apps/dashboard/src/components/sandboxes/SandboxFileSystemTab/queries.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Buffer } from 'buffer'
-import { useCallback, useMemo } from 'react'
 import {
   keepPreviousData,
   useIsFetching,
@@ -14,9 +12,11 @@ import {
   type QueryClient,
   type UseQueryOptions,
 } from '@tanstack/react-query'
+import { Buffer } from 'buffer'
+import { useCallback, useMemo } from 'react'
 
-import type { PreviewKind, SandboxFileSystemNode, SandboxInstance } from './types'
 import { ROOT_NODE, ROOT_PATH } from './constants'
+import type { PreviewKind, SandboxFileSystemNode, SandboxInstance } from './types'
 import {
   getImageMimeType,
   getParentPath,

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -243,3 +243,37 @@ body {
     background-position: 200% top;
   }
 }
+
+.marquee-scroll-y {
+  --duration: 10s;
+  --delay: calc((var(--duration) / var(--count)) * (var(--index) - var(--count)));
+  animation: marquee-scroll-y-anim var(--duration) var(--delay) infinite linear;
+  translate: 0 calc((var(--count) - var(--index)) * 100%);
+}
+
+@keyframes marquee-scroll-y-anim {
+  100% {
+    translate: 0 calc(var(--index) * -100%);
+  }
+}
+
+.marquee-scroll-x {
+  --duration: 10s;
+  --delay: calc((var(--duration) / var(--count)) * (var(--index) - var(--count)));
+  animation: marquee-scroll-x-anim var(--duration) var(--delay) infinite linear;
+  translate: calc((var(--count) - var(--index)) * 100%) 0;
+}
+
+@keyframes marquee-scroll-x-anim {
+  100% {
+    translate: calc(var(--index) * -100%) 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marquee-scroll-y,
+  .marquee-scroll-x {
+    animation: none;
+    translate: none;
+  }
+}


### PR DESCRIPTION
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized filesystem search and file tree rendering to cut flicker and stale flashes, with smoother loading and transitions. Extracted a virtualized list with an imperative scroll API to keep focus and scroll stable during navigation and search.

- New Features
  - Animated skeletons using `motion/react` with subtle stagger/blur and marquee motion (x/y) respecting reduced motion.
  - Smooth transitions between skeleton, empty, and content via `AnimatePresence`.
  - Dim results while background fetching placeholder data; show a fresh skeleton on new queries to prevent stale flashes.

- Refactors
  - Extracted `FileTreeVirtualList` with `scrollToIndex`; decoupled keyboard/focus from the virtualizer and handled scrolling via a ref.
  - Improved search performance by listing result paths and rendering lightweight fallback nodes, deferring detail fetches.
  - UI tweaks: added `pl-3` to the search header, refined empty state, rounded pane edges, and added marquee CSS utilities.

<sup>Written for commit a637c5920795817a8f9a84499a915233448a4353. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4729?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

