### PR TITLE
feat(api): delete sandbox jobs on removal

### DIFF
--- a/apps/api/src/sandbox/services/job.service.ts
+++ b/apps/api/src/sandbox/services/job.service.ts
@@ -6,7 +6,7 @@
 import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { JobConflictError } from '../errors/job-conflict.error'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository, LessThan, In, EntityManager } from 'typeorm'
+import { Repository, LessThan, In, EntityManager, DeleteResult } from 'typeorm'
 import { Job } from '../entities/job.entity'
 import { JobDto, JobStatus, JobType, ResourceType } from '../dto/job.dto'
 import { ResourceTypeForJobType } from '../dto/job-type-map.dto'
@@ -328,6 +328,17 @@ export class JobService {
       order: {
         createdAt: 'DESC',
       },
+    })
+  }
+
+  async deleteByResourceIds(resourceType: ResourceType, resourceIds: string[]): Promise<DeleteResult> {
+    if (resourceIds.length === 0) {
+      return { affected: 0, raw: [] }
+    }
+
+    return this.jobRepository.delete({
+      resourceType,
+      resourceId: In(resourceIds),
     })
   }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -108,6 +108,8 @@ import {
 import { SandboxLookupCacheInvalidationService } from './sandbox-lookup-cache-invalidation.service'
 import { Region } from '../../region/entities/region.entity'
 import { SandboxActivityService } from './sandbox-activity.service'
+import { JobService } from './job.service'
+import { ResourceType } from '../enums/resource-type.enum'
 
 const DEFAULT_CPU = 1
 const DEFAULT_MEMORY = 1
@@ -144,6 +146,7 @@ export class SandboxService {
     private readonly dockerRegistryService: DockerRegistryService,
     @InjectRepository(SandboxFork)
     private readonly sandboxForkRepository: Repository<SandboxFork>,
+    private readonly jobService: JobService,
   ) {}
 
   protected getLockKey(id: string): string {
@@ -2386,6 +2389,18 @@ export class SandboxService {
     return await this.sandboxRepository.update(sandbox.id, { updateData, entity: sandbox })
   }
 
+  private async cleanupSandboxesMatching(criteria: FindOptionsWhere<Sandbox>, label: string): Promise<void> {
+    const sandboxes = await this.sandboxRepository.find({ where: criteria, select: ['id'] })
+    if (sandboxes.length === 0) {
+      return
+    }
+
+    const sandboxIds = sandboxes.map((s) => s.id)
+    await this.jobService.deleteByResourceIds(ResourceType.SANDBOX, sandboxIds)
+    const result = await this.sandboxRepository.delete(criteria)
+    this.logger.debug(`Cleaned up ${result.affected} ${label}`)
+  }
+
   @Cron(CronExpression.EVERY_SECOND, { name: 'cleanup-destroyed-sandboxes' })
   @LogExecution('cleanup-destroyed-sandboxes')
   @WithInstrumentation()
@@ -2400,14 +2415,13 @@ export class SandboxService {
       const twentyFourHoursAgo = new Date()
       twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24)
 
-      const destroyedSandboxs = await this.sandboxRepository.delete({
-        state: SandboxState.DESTROYED,
-        updatedAt: LessThan(twentyFourHoursAgo),
-      })
-
-      if (destroyedSandboxs.affected > 0) {
-        this.logger.debug(`Cleaned up ${destroyedSandboxs.affected} destroyed sandboxes`)
-      }
+      await this.cleanupSandboxesMatching(
+        {
+          state: SandboxState.DESTROYED,
+          updatedAt: LessThan(twentyFourHoursAgo),
+        },
+        'destroyed sandboxes',
+      )
     } finally {
       await this.redisLockProvider.unlock(lockKey)
     }
@@ -2427,15 +2441,14 @@ export class SandboxService {
       const twentyFourHoursAgo = new Date()
       twentyFourHoursAgo.setHours(twentyFourHoursAgo.getHours() - 24)
 
-      const destroyedSandboxs = await this.sandboxRepository.delete({
-        state: SandboxState.BUILD_FAILED,
-        desiredState: SandboxDesiredState.DESTROYED,
-        updatedAt: LessThan(twentyFourHoursAgo),
-      })
-
-      if (destroyedSandboxs.affected > 0) {
-        this.logger.debug(`Cleaned up ${destroyedSandboxs.affected} build failed sandboxes`)
-      }
+      await this.cleanupSandboxesMatching(
+        {
+          state: SandboxState.BUILD_FAILED,
+          desiredState: SandboxDesiredState.DESTROYED,
+          updatedAt: LessThan(twentyFourHoursAgo),
+        },
+        'build failed sandboxes',
+      )
     } finally {
       await this.redisLockProvider.unlock(lockKey)
     }
@@ -2455,15 +2468,14 @@ export class SandboxService {
       const sevenDaysAgo = new Date()
       sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
 
-      const result = await this.sandboxRepository.delete({
-        state: SandboxState.BUILD_FAILED,
-        desiredState: SandboxDesiredState.STARTED,
-        updatedAt: LessThan(sevenDaysAgo),
-      })
-
-      if (result.affected > 0) {
-        this.logger.debug(`Cleaned up ${result.affected} stale build failed sandboxes`)
-      }
+      await this.cleanupSandboxesMatching(
+        {
+          state: SandboxState.BUILD_FAILED,
+          desiredState: SandboxDesiredState.STARTED,
+          updatedAt: LessThan(sevenDaysAgo),
+        },
+        'stale build failed sandboxes',
+      )
     } finally {
       await this.redisLockProvider.unlock(lockKey)
     }
@@ -2483,15 +2495,14 @@ export class SandboxService {
       const sevenDaysAgo = new Date()
       sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
 
-      const result = await this.sandboxRepository.delete({
-        state: SandboxState.ERROR,
-        desiredState: SandboxDesiredState.DESTROYED,
-        updatedAt: LessThan(sevenDaysAgo),
-      })
-
-      if (result.affected > 0) {
-        this.logger.debug(`Cleaned up ${result.affected} stale error sandboxes`)
-      }
+      await this.cleanupSandboxesMatching(
+        {
+          state: SandboxState.ERROR,
+          desiredState: SandboxDesiredState.DESTROYED,
+          updatedAt: LessThan(sevenDaysAgo),
+        },
+        'stale error sandboxes',
+      )
     } finally {
       await this.redisLockProvider.unlock(lockKey)
     }


### PR DESCRIPTION
## Description

Delete all associated jobs on sandbox delete. Cascading isn't possible because the resource ID for a job doesn't have to be a sandbox ID

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete sandbox jobs on removal to prevent orphaned jobs and cleanup failures. Adds a job deletion method and uses it across all sandbox cleanup paths.

- **Bug Fixes**
  - Delete jobs with resource type SANDBOX before removing matching sandboxes.
  - Unified cron cleanup paths via a shared helper to delete jobs and then sandboxes (destroyed, build-failed, stale error).

<sup>Written for commit 2ac56140701e0ae22a1ff7f1eefff3b3e4f59590. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

