### PR TITLE
fix(daemon): return JSON error body for empty exec commands

### DIFF
--- a/apps/daemon/pkg/toolbox/process/execute.go
+++ b/apps/daemon/pkg/toolbox/process/execute.go
@@ -5,6 +5,7 @@ package process
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os/exec"
@@ -35,12 +36,12 @@ func ExecuteCommand(logger *slog.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var request ExecuteRequest
 		if err := c.ShouldBindJSON(&request); err != nil {
-			c.AbortWithError(http.StatusBadRequest, errors.New("command is required"))
+			c.Error(common_errors.NewBadRequestError(fmt.Errorf("invalid request body: %w", err)))
 			return
 		}
 
 		if strings.TrimSpace(request.Command) == "" {
-			c.AbortWithError(http.StatusBadRequest, errors.New("empty command"))
+			c.Error(common_errors.NewBadRequestError(errors.New("command cannot be empty or whitespace-only")))
 			return
 		}
 


### PR DESCRIPTION
## Problem

`sandbox.process.exec("")` (and any whitespace-only command — `"\n"`, `"\t"`, `"\u00a0"`, etc.) caused SDKs to raise an error with an **empty message**:

```
DaytonaValidationError: Failed to execute command: 
```

The empty message left users with no signal as to what was wrong.

## Root cause

The `/process/execute` handler in `apps/daemon/pkg/toolbox/process/execute.go` was using gin's `c.AbortWithError(http.StatusBadRequest, ...)` for two validation failures:

1. `c.ShouldBindJSON` failure (malformed body / missing required `command` field)
2. `strings.TrimSpace(request.Command) == ""` (empty / whitespace-only command)

`AbortWithError` internally calls `AbortWithStatus(code)` which writes the response header to the wire immediately. By the time the daemon's `ErrorMiddleware` ([`libs/common-go/pkg/errors/middleware.go`](../libs/common-go/pkg/errors/middleware.go)) runs, `ctx.Writer.Written()` returns `true` and the middleware short-circuits at its first check:

```go
if ctx.Writer.Written() {
    return
}
```

So the JSON error body is never serialized. Clients receive **HTTP 400 with an empty body**, and the SDK's `_get_open_api_exception_message` returns `""`.

## Fix

Replace both `c.AbortWithError(http.StatusBadRequest, ...)` calls with `c.Error(common_errors.NewBadRequestError(...))`, matching the pattern already used a few lines below for env validation:

```go
if err := common.ValidateEnvKeys(request.Envs); err != nil {
    c.Error(common_errors.NewBadRequestError(err))
    return
}
```

The middleware matches `*BadRequestError`, sets status 400, and writes a structured body `{statusCode, message, code: "BAD_REQUEST", timestamp, path, method}` that **all** SDKs (Python, TypeScript, Go, Java, Ruby) parse and surface as `exc.message`.

Also refined the empty-command message from `"empty command"` to `"command cannot be empty or whitespace-only"` so users understand that pure-whitespace strings count.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return JSON error bodies from `/process/execute` for invalid exec requests so clients get clear messages instead of empty 400 responses.

- **Bug Fixes**
  - Daemon: replaced `c.AbortWithError(...)` with `c.Error(common_errors.NewBadRequestError(...))` so middleware returns JSON; messages now read "command cannot be empty or whitespace-only" and "invalid request body: <err>".

<sup>Written for commit 9b78a0cbf002d3509ace024d5b543c8da9524cbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



