### PR TITLE
feat(docs): add sandbox get, labels, and last activity

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1113,6 +1113,81 @@ Daytona provides methods to view forks. You can view the fork tree for a sandbox
 
 The fork tree displays each sandbox in the hierarchy along with its current state and creation time, allowing you to trace the lineage of any fork back to its origin.
 
+## Label Sandboxes
+
+Daytona provides methods to set sandbox labels using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), and [Java](/docs/en/java-sdk/sandbox) **SDKs** and [API](/docs/en/tools/api/#daytona). Labels are key-value metadata associated with a sandbox that you can use for grouping, filtering, ownership, environment tagging, and automation.
+
+Setting labels replaces the full label set for the sandbox. Include all labels you want to keep in the request. If you omit an existing label, it will be removed.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+sandbox.set_labels({
+    "team": "platform",
+    "env": "staging",
+})
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+await sandbox.setLabels({
+  team: "platform",
+  env: "staging",
+});
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+sandbox.labels = {
+  team: 'platform',
+  env: 'staging'
+}
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+err := sandbox.SetLabels(ctx, map[string]string{
+	"team": "platform",
+	"env":  "staging",
+})
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+Map<String, String> labels = new HashMap<>();
+labels.put("team", "platform");
+labels.put("env", "staging");
+sandbox.setLabels(labels);
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/labels' \
+  --request PUT \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --data '{
+  "labels": {
+    "team": "platform",
+    "env": "staging"
+  }
+}'
+```
+
+</TabItem>
+</Tabs>
+
 ## Create Snapshot from Sandbox
 
 :::caution[Experimental]
@@ -1246,82 +1321,15 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}' \
 </TabItem>
 </Tabs>
 
-## Sandbox Labels
+## Automated lifecycle management
 
-Daytona provides methods to replace sandbox labels using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), and [Java](/docs/en/java-sdk/sandbox) **SDKs** and [API](/docs/en/tools/api/#daytona). Setting labels replaces the full label set for the sandbox. Include all labels you want to keep.
+Daytona sandboxes can be automatically stopped, archived, and deleted based on user-defined intervals. You can also refresh the last activity timestamp to explicitly signal activity when lifecycle behavior depends on inactivity windows.
 
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
+### Update sandbox last activity
 
-```python
-sandbox.set_labels({
-    "team": "platform",
-    "env": "staging",
-})
-```
+Daytona provides methods to update a sandbox's last activity timestamp programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), and [Ruby](/docs/en/ruby-sdk/) **SDKs** and [API](/docs/en/tools/api/#daytona). Use this operation to explicitly signal activity when lifecycle behavior depends on inactivity windows.
 
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-
-```typescript
-await sandbox.setLabels({
-  team: "platform",
-  env: "staging",
-});
-```
-
-</TabItem>
-<TabItem label="Ruby" icon="seti:ruby">
-
-```ruby
-sandbox.labels = {
-  team: 'platform',
-  env: 'staging'
-}
-```
-
-</TabItem>
-<TabItem label="Go" icon="seti:go">
-
-```go
-err := sandbox.SetLabels(ctx, map[string]string{
-	"team": "platform",
-	"env":  "staging",
-})
-```
-
-</TabItem>
-<TabItem label="Java" icon="seti:java">
-
-```java
-Map<String, String> labels = new HashMap<>();
-labels.put("team", "platform");
-labels.put("env", "staging");
-sandbox.setLabels(labels);
-```
-
-</TabItem>
-<TabItem label="API" icon="seti:json">
-
-```bash
-curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/labels' \
-  --request PUT \
-  --header 'Content-Type: application/json' \
-  --header 'Authorization: Bearer YOUR_API_KEY' \
-  --data '{
-  "labels": {
-    "team": "platform",
-    "env": "staging"
-  }
-}'
-```
-
-</TabItem>
-</Tabs>
-
-## Sandbox Last Activity
-
-Daytona provides methods to update the sandbox last activity timestamp using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), and [Ruby](/docs/en/ruby-sdk/) **SDKs** and [API](/docs/en/tools/api/#daytona). Use this to signal external activity and keep the sandbox active when lifecycle policies depend on activity.
+This updates the sandbox's recorded activity time without changing its runtime state. It is useful when your workflow is driven by external systems or background orchestration that may not reset inactivity tracking. For example, if you run long-lived automation around a sandbox and want to avoid unintended auto-stop behavior, call this operation periodically to indicate that the sandbox is still actively used.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -1355,10 +1363,6 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxId}/last-activity' \
 
 </TabItem>
 </Tabs>
-
-## Automated lifecycle management
-
-Daytona sandboxes can be automatically stopped, archived, and deleted based on user-defined intervals.
 
 ### Auto-stop interval
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -586,6 +586,63 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/start' \
 </TabItem>
 </Tabs>
 
+## Get Sandbox
+
+Daytona provides methods to get a sandbox by ID or name using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), [Java](/docs/en/java-sdk/daytona) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona).
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+sandbox = daytona.get("my-sandbox-id-or-name")
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+const sandbox = await daytona.get("my-sandbox-id-or-name");
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+sandbox = daytona.get('my-sandbox-id-or-name')
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+sandbox, err := client.Get(ctx, "my-sandbox-id-or-name")
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+Sandbox sandbox = daytona.get("my-sandbox-id-or-name");
+```
+
+</TabItem>
+<TabItem label="CLI" icon="seti:shell">
+
+```bash
+daytona info [SANDBOX_ID] | [SANDBOX_NAME] [flags]
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}' \
+  --header 'Authorization: Bearer YOUR_API_KEY'
+```
+
+</TabItem>
+</Tabs>
+
 ## List Sandboxes
 
 Daytona provides methods to list sandboxes and view their details in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) via the [sandbox details page](#sandbox-details-page) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), [Java](/docs/en/java-sdk/daytona) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona).
@@ -1183,6 +1240,116 @@ daytona delete [SANDBOX_ID] | [SANDBOX_NAME] [flags]
 ```bash
 curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}' \
   --request DELETE \
+  --header 'Authorization: Bearer YOUR_API_KEY'
+```
+
+</TabItem>
+</Tabs>
+
+## Sandbox Labels
+
+Daytona provides methods to replace sandbox labels using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), and [Java](/docs/en/java-sdk/sandbox) **SDKs** and [API](/docs/en/tools/api/#daytona). Setting labels replaces the full label set for the sandbox. Include all labels you want to keep.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+sandbox.set_labels({
+    "team": "platform",
+    "env": "staging",
+})
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+await sandbox.setLabels({
+  team: "platform",
+  env: "staging",
+});
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+sandbox.labels = {
+  team: 'platform',
+  env: 'staging'
+}
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+err := sandbox.SetLabels(ctx, map[string]string{
+	"team": "platform",
+	"env":  "staging",
+})
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+Map<String, String> labels = new HashMap<>();
+labels.put("team", "platform");
+labels.put("env", "staging");
+sandbox.setLabels(labels);
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/labels' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --data '{
+  "labels": {
+    "team": "platform",
+    "env": "staging"
+  }
+}'
+```
+
+</TabItem>
+</Tabs>
+
+## Sandbox Last Activity
+
+Daytona provides methods to update the sandbox last activity timestamp using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), and [Ruby](/docs/en/ruby-sdk/) **SDKs** and [API](/docs/en/tools/api/#daytona). Use this to signal external activity and keep the sandbox active when lifecycle policies depend on activity.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+sandbox.refresh_activity()
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+await sandbox.refreshActivity();
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+sandbox.refresh_activity
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox/{sandboxId}/last-activity' \
+  --request POST \
   --header 'Authorization: Bearer YOUR_API_KEY'
 ```
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1305,7 +1305,7 @@ sandbox.setLabels(labels);
 
 ```bash
 curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/labels' \
-  --request POST \
+  --request PUT \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_API_KEY' \
   --data '{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds docs for getting a sandbox, replacing labels, and refreshing last activity, with examples across SDKs, CLI, and API. Also improves formatting for clarity.

- **New Features**
  - Added “Get Sandbox” with examples for `Python`, `TypeScript`, `Ruby`, `Go`, `Java`, CLI, and API.
  - Added “Label Sandboxes” explaining full label replacement; uses PUT `/sandbox/{idOrName}/labels` with examples for `Python`, `TypeScript`, `Ruby`, `Go`, `Java`, and API.
  - Added “Sandbox Last Activity” with examples for `Python`, `TypeScript`, `Ruby`, and API; uses POST `/sandbox/{id}/last-activity`.

<sup>Written for commit ad48fe8906c1a749783f88774cffe1ee0ac17024. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4732?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

