### PR TITLE
feat(api): add draining mode and force flags for self-hosted drains

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -335,18 +335,11 @@ const configuration = {
   sandboxSnapshottingTimeoutMin: parseInt(process.env.SANDBOX_SNAPSHOTTING_TIMEOUT_MIN || '60', 10),
   failedSnapshotRunnerRetentionHours: parseInt(process.env.FAILED_SNAPSHOT_RUNNER_RETENTION_HOURS || '3', 10),
   buildInfoSnapshotRunnerStalenessDays: parseInt(process.env.BUILDINFO_SNAPSHOT_RUNNER_STALENESS_DAYS || '7', 10),
-  // Runner draining behavior:
-  //   DRAINING_MODE selects what happens to STOPPED sandboxes on a draining runner.
-  //     - 'migrate' (default): relocate to another ready runner (suitable for SaaS).
-  //     - 'archive': archive in place (clears runnerId). No target capacity required —
-  //       suitable for k8s self-hosted clusters where a full cluster drain leaves no
-  //       schedulable target runners.
-  //   DRAINING_FORCE controls whether running sandboxes are force-stopped to make the
-  //   drain converge. Off by default — preserves user work until the user (or auto-stop)
-  //   stops the sandbox naturally. Turn on for operator-initiated aggressive drains (SaaS)
-  //   or k8s full drains where nodes must empty quickly.
+  // DRAINING_MODE: 'migrate' (default) relocates stopped sandboxes to another runner;
+  // 'archive' archives in place (no target capacity needed — for k8s full drains).
+  // DRAINING_FORCE: when true, force-stops running sandboxes so the drain converges.
   draining: {
-    mode: (process.env.DRAINING_MODE || 'migrate') as 'migrate' | 'archive',
+    mode: (process.env.DRAINING_MODE === 'archive' ? 'archive' : 'migrate') as 'migrate' | 'archive',
     force: process.env.DRAINING_FORCE === 'true',
   },
 }

--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -335,6 +335,20 @@ const configuration = {
   sandboxSnapshottingTimeoutMin: parseInt(process.env.SANDBOX_SNAPSHOTTING_TIMEOUT_MIN || '60', 10),
   failedSnapshotRunnerRetentionHours: parseInt(process.env.FAILED_SNAPSHOT_RUNNER_RETENTION_HOURS || '3', 10),
   buildInfoSnapshotRunnerStalenessDays: parseInt(process.env.BUILDINFO_SNAPSHOT_RUNNER_STALENESS_DAYS || '7', 10),
+  // Runner draining behavior:
+  //   DRAINING_MODE selects what happens to STOPPED sandboxes on a draining runner.
+  //     - 'migrate' (default): relocate to another ready runner (suitable for SaaS).
+  //     - 'archive': archive in place (clears runnerId). No target capacity required —
+  //       suitable for k8s self-hosted clusters where a full cluster drain leaves no
+  //       schedulable target runners.
+  //   DRAINING_FORCE controls whether running sandboxes are force-stopped to make the
+  //   drain converge. Off by default — preserves user work until the user (or auto-stop)
+  //   stops the sandbox naturally. Turn on for operator-initiated aggressive drains (SaaS)
+  //   or k8s full drains where nodes must empty quickly.
+  draining: {
+    mode: (process.env.DRAINING_MODE || 'migrate') as 'migrate' | 'archive',
+    force: process.env.DRAINING_FORCE === 'true',
+  },
 }
 
 export { configuration }

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -44,6 +44,7 @@ import { OnAsyncEvent } from '../../common/decorators/on-async-event.decorator'
 import { sanitizeSandboxError } from '../utils/sanitize-error.util'
 import { isEphemeral } from '../utils/ephemeral.util'
 import { Sandbox } from '../entities/sandbox.entity'
+import { Runner } from '../entities/runner.entity'
 import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { OrganizationService } from '../../organization/services/organization.service'
@@ -79,7 +80,11 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     private readonly backupManager: BackupManager,
     @InjectRedis() private readonly redis: Redis,
     @InjectDataSource() private readonly dataSource: DataSource,
-  ) {}
+  ) {
+    this.logger.log(
+      `Drain mode: ${this.configService.get('draining.mode')} (force=${this.configService.get('draining.force')})`,
+    )
+  }
 
   async onApplicationShutdown() {
     //  wait for all active jobs to finish
@@ -311,48 +316,28 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
 
       await this.redis.set('draining-runner-sandboxes-skip', Number(skip) + drainingRunners.length)
 
+      const drainMode = this.configService.get('draining.mode')
+      const drainForce = this.configService.get('draining.force')
+
       await Promise.allSettled(
         drainingRunners.map(async (runner) => {
           try {
-            const sandboxes = await this.sandboxRepository.find({
-              where: {
-                runnerId: runner.id,
-                state: SandboxState.STOPPED,
-                desiredState: SandboxDesiredState.STOPPED,
-                backupState: BackupState.COMPLETED,
-                backupSnapshot: Not(IsNull()),
-              },
-              take: 100,
-            })
+            // Force-stop running sandboxes regardless of disposition strategy.
+            // Required for drain to converge in k8s full-drain or operator-initiated
+            // aggressive drains; off by default to preserve current SaaS behavior.
+            if (drainForce) {
+              await this.forceStopStartedSandboxesOnDrainingRunner(runner.id)
+            }
 
-            this.logger.debug(
-              `Found ${sandboxes.length} eligible sandboxes on draining runner ${runner.id} for migration`,
-            )
-
-            await Promise.allSettled(
-              sandboxes.map(async (sandbox) => {
-                const sandboxLockKey = getStateChangeLockKey(sandbox.id)
-                const hasSandboxLock = await this.redisLockProvider.lock(sandboxLockKey, 60)
-                if (!hasSandboxLock) {
-                  return
-                }
-
-                try {
-                  const startScoreThreshold = this.configService.get('runnerScore.thresholds.start') || 0
-                  const targetRunner = await this.runnerService.getRandomAvailableRunner({
-                    snapshotRef: sandbox.backupSnapshot,
-                    excludedRunnerIds: [runner.id],
-                    availabilityScoreThreshold: startScoreThreshold,
-                  })
-
-                  await this.reassignSandbox(sandbox, runner.id, targetRunner.id)
-                } catch (e) {
-                  this.logger.error(`Error migrating sandbox ${sandbox.id} from draining runner ${runner.id}`, e)
-                } finally {
-                  await this.redisLockProvider.unlock(sandboxLockKey)
-                }
-              }),
-            )
+            // Disposition for STOPPED + backup=COMPLETED sandboxes. Transient-state
+            // sandboxes (PULLING_SNAPSHOT, BUILDING_SNAPSHOT, ARCHIVING, RESIZING,
+            // FORKING, SNAPSHOTTING) are skipped by both branches and picked up on a
+            // subsequent tick once they settle.
+            if (drainMode === 'archive') {
+              await this.archiveStoppedSandboxesOnDrainingRunner(runner.id)
+            } else {
+              await this.migrateStoppedSandboxesOnDrainingRunner(runner)
+            }
 
             // Archive ERROR sandboxes that have completed backups on this draining runner
             await this.archiveErroredSandboxesOnDrainingRunner(runner.id)
@@ -370,6 +355,140 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     } finally {
       await this.redisLockProvider.unlock(lockKey)
     }
+  }
+
+  private async migrateStoppedSandboxesOnDrainingRunner(runner: Runner): Promise<void> {
+    const sandboxes = await this.sandboxRepository.find({
+      where: {
+        // STOPPED sandboxes without a completed backup are picked up by the backup
+        // manager and become eligible on a subsequent tick.
+        runnerId: runner.id,
+        state: SandboxState.STOPPED,
+        desiredState: SandboxDesiredState.STOPPED,
+        backupState: BackupState.COMPLETED,
+        backupSnapshot: Not(IsNull()),
+      },
+      take: 100,
+    })
+
+    this.logger.debug(`Found ${sandboxes.length} eligible sandboxes on draining runner ${runner.id} for migration`)
+
+    await Promise.allSettled(
+      sandboxes.map(async (sandbox) => {
+        const sandboxLockKey = getStateChangeLockKey(sandbox.id)
+        const hasSandboxLock = await this.redisLockProvider.lock(sandboxLockKey, 60)
+        if (!hasSandboxLock) {
+          return
+        }
+
+        try {
+          const startScoreThreshold = this.configService.get('runnerScore.thresholds.start') || 0
+          const targetRunner = await this.runnerService.getRandomAvailableRunner({
+            snapshotRef: sandbox.backupSnapshot,
+            excludedRunnerIds: [runner.id],
+            availabilityScoreThreshold: startScoreThreshold,
+          })
+
+          await this.migrateSandbox(sandbox, runner.id, targetRunner.id)
+        } catch (e) {
+          this.logger.error(`Error migrating sandbox ${sandbox.id} from draining runner ${runner.id}`, e)
+        } finally {
+          await this.redisLockProvider.unlock(sandboxLockKey)
+        }
+      }),
+    )
+  }
+
+  private async forceStopStartedSandboxesOnDrainingRunner(runnerId: string): Promise<void> {
+    const sandboxes = await this.sandboxRepository.find({
+      where: {
+        runnerId,
+        state: SandboxState.STARTED,
+        desiredState: SandboxDesiredState.STARTED,
+        pending: false,
+      },
+      take: 100,
+    })
+
+    if (sandboxes.length === 0) {
+      return
+    }
+
+    this.logger.debug(`Found ${sandboxes.length} started sandboxes on draining runner ${runnerId} to stop`)
+
+    await Promise.allSettled(
+      sandboxes.map(async (sandbox) => {
+        const sandboxLockKey = getStateChangeLockKey(sandbox.id)
+        const acquired = await this.redisLockProvider.lock(sandboxLockKey, 30)
+        if (!acquired) {
+          return
+        }
+
+        try {
+          let updateData: Partial<Sandbox> = {}
+          if (isEphemeral(sandbox)) {
+            updateData = Sandbox.getSoftDeleteUpdate(sandbox)
+          } else {
+            updateData.pending = true
+            updateData.desiredState = SandboxDesiredState.STOPPED
+          }
+
+          await this.sandboxRepository.updateWhere(sandbox.id, {
+            updateData,
+            whereCondition: { pending: false, state: SandboxState.STARTED },
+          })
+
+          this.syncInstanceState(sandbox.id).catch(this.logger.error)
+        } catch (e) {
+          this.logger.error(`Failed to request stop for sandbox ${sandbox.id} on draining runner ${runnerId}`, e)
+        } finally {
+          await this.redisLockProvider.unlock(sandboxLockKey)
+        }
+      }),
+    )
+  }
+
+  private async archiveStoppedSandboxesOnDrainingRunner(runnerId: string): Promise<void> {
+    const sandboxes = await this.sandboxRepository.find({
+      where: {
+        // STOPPED sandboxes without a completed backup are picked up by the backup
+        // manager and become eligible on a subsequent tick.
+        runnerId,
+        state: SandboxState.STOPPED,
+        desiredState: SandboxDesiredState.STOPPED,
+        backupState: BackupState.COMPLETED,
+        backupSnapshot: Not(IsNull()),
+        pending: false,
+      },
+      take: 100,
+    })
+
+    if (sandboxes.length === 0) {
+      return
+    }
+
+    this.logger.debug(`Found ${sandboxes.length} stopped sandboxes on draining runner ${runnerId} to archive`)
+
+    await Promise.allSettled(
+      sandboxes.map(async (sandbox) => {
+        const sandboxLockKey = getStateChangeLockKey(sandbox.id)
+        const acquired = await this.redisLockProvider.lock(sandboxLockKey, 30)
+        if (!acquired) {
+          return
+        }
+
+        try {
+          await this.sandboxRepository.updateWhere(sandbox.id, {
+            updateData: { desiredState: SandboxDesiredState.ARCHIVED },
+            whereCondition: { pending: false, state: SandboxState.STOPPED },
+          })
+        } catch (e) {
+          this.logger.error(`Failed to request archive for sandbox ${sandbox.id} on draining runner ${runnerId}`, e)
+        } finally {
+          await this.redisLockProvider.unlock(sandboxLockKey)
+        }
+      }),
+    )
   }
 
   private async archiveErroredSandboxesOnDrainingRunner(runnerId: string): Promise<void> {
@@ -580,15 +699,15 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     )
   }
 
-  private async reassignSandbox(sandbox: Sandbox, oldRunnerId: string, newRunnerId: string): Promise<void> {
+  private async migrateSandbox(sandbox: Sandbox, oldRunnerId: string, newRunnerId: string): Promise<void> {
     this.logger.debug(
-      `Starting sandbox reassignment for ${sandbox.id} from runner ${oldRunnerId} to runner ${newRunnerId}`,
+      `Starting sandbox migration for ${sandbox.id} from runner ${oldRunnerId} to runner ${newRunnerId}`,
     )
 
     // Safety check: ensure sandbox is not pending
     if (sandbox.pending) {
       this.logger.warn(
-        `Sandbox ${sandbox.id} is pending, skipping reassignment from runner ${oldRunnerId} to runner ${newRunnerId}`,
+        `Sandbox ${sandbox.id} is pending, skipping migration from runner ${oldRunnerId} to runner ${newRunnerId}`,
       )
       return
     }
@@ -633,7 +752,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     const freshSandbox = await this.sandboxRepository.findOne({ where: { id: sandbox.id } })
     if (!freshSandbox || freshSandbox.pending) {
       this.logger.warn(
-        `Sandbox ${sandbox.id} is pending or missing, aborting reassignment from runner ${oldRunnerId} to runner ${newRunnerId}`,
+        `Sandbox ${sandbox.id} is pending or missing, aborting migration from runner ${oldRunnerId} to runner ${newRunnerId}`,
       )
 
       // Roll back: remove the sandbox from the new runner since we won't complete the migration

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -322,17 +322,13 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       await Promise.allSettled(
         drainingRunners.map(async (runner) => {
           try {
-            // Force-stop running sandboxes regardless of disposition strategy.
-            // Required for drain to converge in k8s full-drain or operator-initiated
-            // aggressive drains; off by default to preserve current SaaS behavior.
+            // Stop running sandboxes so drain can converge. Off by default.
             if (drainForce) {
               await this.forceStopStartedSandboxesOnDrainingRunner(runner.id)
             }
 
-            // Disposition for STOPPED + backup=COMPLETED sandboxes. Transient-state
-            // sandboxes (PULLING_SNAPSHOT, BUILDING_SNAPSHOT, ARCHIVING, RESIZING,
-            // FORKING, SNAPSHOTTING) are skipped by both branches and picked up on a
-            // subsequent tick once they settle.
+            // Dispose STOPPED+backed-up sandboxes. Transient states are skipped here
+            // and picked up on a subsequent tick.
             if (drainMode === 'archive') {
               await this.archiveStoppedSandboxesOnDrainingRunner(runner.id)
             } else {
@@ -360,8 +356,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
   private async migrateStoppedSandboxesOnDrainingRunner(runner: Runner): Promise<void> {
     const sandboxes = await this.sandboxRepository.find({
       where: {
-        // STOPPED sandboxes without a completed backup are picked up by the backup
-        // manager and become eligible on a subsequent tick.
+        // Sandboxes without a completed backup are handled by the backup manager.
         runnerId: runner.id,
         state: SandboxState.STOPPED,
         desiredState: SandboxDesiredState.STOPPED,
@@ -451,8 +446,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
   private async archiveStoppedSandboxesOnDrainingRunner(runnerId: string): Promise<void> {
     const sandboxes = await this.sandboxRepository.find({
       where: {
-        // STOPPED sandboxes without a completed backup are picked up by the backup
-        // manager and become eligible on a subsequent tick.
+        // Sandboxes without a completed backup are handled by the backup manager.
         runnerId,
         state: SandboxState.STOPPED,
         desiredState: SandboxDesiredState.STOPPED,

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -600,8 +600,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
-  // Pulls stopped sandboxes' backup snapshots to another runner to prepare for migration during draining.
-  // Only meaningful when DRAIN_MODE=migrate; in 'archive' mode no relocation happens, so no pre-pull is needed.
+  // Pre-pulls backup snapshots to other runners to speed migration during draining.
+  // No-op when DRAINING_MODE != migrate (nothing to migrate to).
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'migrate-draining-runner-snapshots', waitForCompletion: true })
   @TrackJobExecution()
   @LogExecution('migrate-draining-runner-snapshots')

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -600,12 +600,17 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
-  // Pulls stopped sandboxes' backup snapshots to another runner to prepare for reassignment during draining
+  // Pulls stopped sandboxes' backup snapshots to another runner to prepare for migration during draining.
+  // Only meaningful when DRAIN_MODE=migrate; in 'archive' mode no relocation happens, so no pre-pull is needed.
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'migrate-draining-runner-snapshots', waitForCompletion: true })
   @TrackJobExecution()
   @LogExecution('migrate-draining-runner-snapshots')
   @WithInstrumentation()
   private async handleMigrateDrainingRunnerSnapshots() {
+    if (this.configService.get('draining.mode') !== 'migrate') {
+      return
+    }
+
     const lockKey = 'migrate-draining-runner-snapshots'
     const hasLock = await this.redisLockProvider.lock(lockKey, 60)
     if (!hasLock) {


### PR DESCRIPTION
## Description

On k8s self-hosted clusters, operators cordon every node at once for maintenance, leaving no schedulable target for relocating draining sandboxes — the drain blocks forever. This adds two orthogonal env flags: DRAINING_MODE (`migrate` default, or `archive`) chooses the disposition for stopped sandboxes on a draining runner, and DRAINING_FORCE (default false) controls whether running sandboxes get force-stopped to make the drain converge. Default behavior is byte-for-byte unchanged. Set `DRAINING_MODE=archive` with `DRAINING_FORCE=true` for full-cluster k8s drains; archived sandboxes are restored on the next user-initiated start onto whichever runner is healthy.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation