### PR TITLE
perf: optimize daemon size

### DIFF
--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -22,7 +22,6 @@ import (
 	common_errors "github.com/daytonaio/common-go/pkg/errors"
 	common_proxy "github.com/daytonaio/common-go/pkg/proxy"
 	"github.com/daytonaio/common-go/pkg/telemetry"
-	"github.com/daytonaio/daemon/internal"
 	"github.com/daytonaio/daemon/pkg/recording"
 	session_svc "github.com/daytonaio/daemon/pkg/session"
 	"github.com/daytonaio/daemon/pkg/toolbox/computeruse"
@@ -45,11 +44,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
-	"github.com/daytonaio/daemon/pkg/toolbox/docs"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-	swaggerfiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 type ServerConfig struct {
@@ -115,11 +111,6 @@ func (s *server) Start() error {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	defer s.cancel()
 
-	docs.SwaggerInfo.Description = "Daytona Toolbox API"
-	docs.SwaggerInfo.Title = "Daytona Toolbox API"
-	docs.SwaggerInfo.BasePath = "/"
-	docs.SwaggerInfo.Version = internal.Version
-
 	// Set Gin to release mode in production
 	if os.Getenv("ENVIRONMENT") == "production" {
 		gin.SetMode(gin.ReleaseMode)
@@ -152,10 +143,7 @@ func (s *server) Start() error {
 	noTelemetryRouter.Use(errMiddleware)
 	binding.Validator = new(DefaultValidator)
 
-	// Add swagger UI in development mode
-	if os.Getenv("ENVIRONMENT") != "production" {
-		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
-	}
+	registerSwagger(r)
 
 	r.POST("/init", s.Initialize(otelServiceName, s.entrypointLogFilePath, s.organizationId, s.regionId, s.snapshot))
 

--- a/apps/daemon/pkg/toolbox/swagger.go
+++ b/apps/daemon/pkg/toolbox/swagger.go
@@ -1,0 +1,27 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build !noswagger
+
+package toolbox
+
+import (
+	"os"
+
+	"github.com/daytonaio/daemon/internal"
+	"github.com/daytonaio/daemon/pkg/toolbox/docs"
+	"github.com/gin-gonic/gin"
+	swaggerfiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+)
+
+func registerSwagger(r *gin.Engine) {
+	docs.SwaggerInfo.Description = "Daytona Toolbox API"
+	docs.SwaggerInfo.Title = "Daytona Toolbox API"
+	docs.SwaggerInfo.BasePath = "/"
+	docs.SwaggerInfo.Version = internal.Version
+
+	if os.Getenv("ENVIRONMENT") != "production" {
+		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+	}
+}

--- a/apps/daemon/pkg/toolbox/swagger_disabled.go
+++ b/apps/daemon/pkg/toolbox/swagger_disabled.go
@@ -1,0 +1,10 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build noswagger
+
+package toolbox
+
+import "github.com/gin-gonic/gin"
+
+func registerSwagger(_ *gin.Engine) {}

--- a/apps/daemon/project.json
+++ b/apps/daemon/project.json
@@ -32,7 +32,11 @@
       },
       "configurations": {
         "production": {
-          "flags": ["-ldflags \"-X 'github.com/daytonaio/daemon/internal.Version=$VERSION'\""]
+          "flags": [
+            "-tags=nomsgpack,noswagger",
+            "-trimpath",
+            "-ldflags \"-s -w -X 'github.com/daytonaio/daemon/internal.Version=$VERSION'\""
+          ]
         }
       },
       "dependsOn": ["build-amd64"]
@@ -47,7 +51,11 @@
           "GOOS": "linux",
           "CGO_ENABLED": "0"
         },
-        "flags": ["-ldflags \"-X 'github.com/daytonaio/daemon/internal.Version=$VERSION'\""]
+        "flags": [
+          "-tags=nomsgpack,noswagger",
+          "-trimpath",
+          "-ldflags \"-s -w -X 'github.com/daytonaio/daemon/internal.Version=$VERSION'\""
+        ]
       },
       "dependsOn": ["prepare"],
       "inputs": [


### PR DESCRIPTION
## Description

Reduces the daemon production binary size from **55MB to 24MB (−56%)** by addressing three categories of waste identified via `go tool nm -size` analysis:

1. **Debug symbols & DWARF info (14MB):** Added `-s -w` linker flags to strip symbol tables and debug information from production builds.

2. **Embedded Swagger UI assets (8.2MB):** The `swaggo/files` package embeds the entire Swagger UI single-page application (HTML/JS/CSS) into the binary. Previously, the runtime check `ENVIRONMENT != "production"` prevented *serving* it, but the blob was always *linked*. Introduced a `noswagger` build tag that excludes the Swagger UI, its dependencies (`swaggo/files`, `gin-swagger`, `docs`), and the OpenAPI spec from production builds entirely. Dev builds remain unaffected.

3. **Unused codec library (3.2MB):** Gin unconditionally pulls in `ugorji/go/codec`, a multi-format serialization library supporting MsgPack, CBOR, Binc, and JSON. The daemon exclusively uses JSON (`ShouldBindJSON`/`ctx.JSON`). Added Gin's supported `nomsgpack` build tag to exclude this dead weight.

Additionally added `-trimpath` to remove local filesystem paths from the binary for reproducibility and security.

### Build size progression

| Build configuration | Size |
|---|---|
| Before (no flags) | 55 MB |
| + `-s -w` | 40 MB |
| + `-tags=nomsgpack` | 35 MB |
| + `-tags=noswagger` | **24 MB** |

### Changes

- **`project.json`** — Added `-tags=nomsgpack,noswagger`, `-trimpath`, `-s -w` to `build` and `build-amd64` target flags
- **`pkg/toolbox/swagger.go`** *(new)* — `//go:build !noswagger` — Registers Swagger UI routes and configures SwaggerInfo metadata (extracted from `server.go`)
- **`pkg/toolbox/swagger_disabled.go`** *(new)* — `//go:build noswagger` — No-op stub for production builds
- **`pkg/toolbox/server.go`** — Replaced inline Swagger setup with `registerSwagger(r)` call; removed `swaggo/files`, `gin-swagger`, `docs`, and `internal` imports

### What's preserved

- Dev builds (`go build` / `gow` without tags) include Swagger UI exactly as before — **zero behavioral change** in development
- All existing tests pass with both build configurations
- `go vet` clean for both tagged and untagged builds

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

No user-facing documentation changes required. The build tag behavior is internal to the build system.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink daemon production binary from 55MB to 24MB (−56%) by stripping debug info, trimming paths, and excluding Swagger assets and the MsgPack codec in production. Dev builds behave the same.

- **Performance**
  - Add `-ldflags "-s -w"` and `-trimpath` in `project.json`.
  - Add `noswagger` build tag to exclude Swagger UI and related packages (`swaggo/files`, `gin-swagger`, `docs`); move setup to build-tagged files (`swagger.go`, `swagger_disabled.go`).
  - Use Gin’s `nomsgpack` tag to drop unused `ugorji/go/codec`.

<sup>Written for commit 9bc90a0dd7fda4bb77ac300f0845638ddb8f0d27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

