### PR TITLE
fix(docs): bump GPU snapshot example NVIDIA driver to 595.58.03

### DIFF
--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -584,15 +584,15 @@ curl https://app.daytona.io/api/snapshots \
 Building a custom image for a GPU snapshot requires Ubuntu 24.04 and compatible NVIDIA userspace packages. Include the following in your snapshot Dockerfile:
 
 ```dockerfile
-ARG NVIDIA_DRIVER_VERSION=580.126.20
-ARG UBUNTU_PKG_SUFFIX=0ubuntu0.24.04.2
+ARG NVIDIA_DRIVER_VERSION=595.58.03
+ARG UBUNTU_PKG_SUFFIX=0ubuntu0.24.04.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq \
  && apt-get install -y -qq --no-install-recommends \
-      nvidia-utils-580-server=${NVIDIA_DRIVER_VERSION}-${UBUNTU_PKG_SUFFIX} \
-      libnvidia-compute-580-server=${NVIDIA_DRIVER_VERSION}-${UBUNTU_PKG_SUFFIX} \
+      nvidia-utils-595-server=${NVIDIA_DRIVER_VERSION}-${UBUNTU_PKG_SUFFIX} \
+      libnvidia-compute-595-server=${NVIDIA_DRIVER_VERSION}-${UBUNTU_PKG_SUFFIX} \
       python3 \
       ca-certificates \
  && apt-get clean \


### PR DESCRIPTION
## What

Bumps the NVIDIA driver/userland version pinned in the GPU snapshot Dockerfile docs from `580.126.20` to `595.58.03` (and matching Ubuntu package suffix `0ubuntu0.24.04.1`).

## Why

The current snippet is broken against the GPU hosts currently deployed in the `gpu-experimental` region. The host kernel module is `595.58.03`:

```
$ cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX x86_64 Kernel Module  595.58.03  …
```

…while the doc tells users to install `nvidia-utils-580-server=580.126.20-…`. Userland must match the kernel module exactly, so any user who copy-pastes the current snippet today gets an immediately-broken `nvidia-smi`:

```
Failed to initialize NVML: Driver/library version mismatch
NVML library version: 580.126
```

## Verified

Built two snapshots from identical Dockerfiles modulo this diff, spun a sandbox from each, ran `nvidia-smi`:

| Snapshot | Result |
|---|---|
| current docs (`580.126.20`) | `Failed to initialize NVML: Driver/library version mismatch` (exit 18) |
| this PR (`595.58.03`) | `Driver Version: 595.58.03  CUDA Version: 13.2` on H100 PCIe (exit 0) |

## Scope / not in this PR

This is the **immediate fix** so the published snippet works today. The version pin will rot again the next time GPU hosts are bumped. The structural fix - relying on the `nvidia-container-runtime` hook to inject host userland libs at startup, so user Dockerfiles don't need to pin a driver version at all - is a separate, larger discussion that I'd like to raise as a follow-up issue.
