### PR TITLE
fix(daemon): don't reap idle commands

### DIFF
--- a/apps/daemon/pkg/childreap/childreap.go
+++ b/apps/daemon/pkg/childreap/childreap.go
@@ -247,6 +247,9 @@ func Reap(cmd *exec.Cmd) (int, error) {
 
 	waitCh := startCmdWaitGoroutine(cmd)
 
+	// Phase 1: wait for exit status. No timeout — long-running children
+	// (e.g. an interactive PTY shell) are legitimate. Returns when EITHER
+	// cmd.Wait or the reaper resolves.
 	select {
 	case r := <-waitCh:
 		if r.resolved {
@@ -263,11 +266,6 @@ func Reap(cmd *exec.Cmd) (int, error) {
 		}
 	case ws := <-reg.ch:
 		return ws.ExitStatus(), nil
-	case <-time.After(hangTimeout):
-		if ws, ok := claimPending(pid, reg.registeredAt); ok {
-			return ws.ExitStatus(), nil
-		}
-		return -1, fmt.Errorf("childreap.Reap: timed out waiting for pid %d", pid)
 	}
 }
 
@@ -298,9 +296,11 @@ func startCmdWaitGoroutine(cmd *exec.Cmd) chan cmdWaitResult {
 	return waitCh
 }
 
-// hangTimeout caps how long Wait/Reap will block AFTER the exit status
-// is known (Phase 2) waiting for cmd.Wait to drain. Phase 1 (waiting for
-// status itself) has no timeout — long-running children are legitimate.
+// hangTimeout caps how long Wait will block AFTER the exit status is
+// known (Phase 2) waiting for cmd.Wait to drain its internal I/O copy
+// goroutines. Phase 1 (waiting for status itself) has no timeout —
+// long-running children are legitimate. Reap doesn't drain I/O, so it
+// doesn't use this at all.
 var hangTimeout = 30 * time.Second
 
 // Run starts cmd and waits for it to finish. The reaper-safe analog of

--- a/apps/daemon/pkg/childreap/childreap_test.go
+++ b/apps/daemon/pkg/childreap/childreap_test.go
@@ -311,15 +311,21 @@ func TestReap_LongRunningProcess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Reap returned unexpected error: %v", err)
 	}
-	// SIGKILL surfaces as either 137 (128+9) via WaitStatus.ExitStatus
-	// being -1 mapped... actually ExitStatus returns -1 for signaled
-	// processes, which our switch upstream interprets. Just assert Reap
-	// did not return until at least the kill delay elapsed — that proves
-	// Phase 1 didn't time out.
+	// Wall-time check: Reap must not return until the kill lands. If
+	// Phase 1 had a (buggy) timeout shorter than the kill delay, Reap
+	// would return early — that's the regression we're guarding against.
 	if elapsed < 250*time.Millisecond {
 		t.Errorf("Reap returned before the kill landed (%s) — Phase 1 timed out", elapsed)
 	}
-	_ = code
+	// Exit-code check: SIGKILL surfaces as ExitStatus()/ExitCode() == -1
+	// on Linux for signaled processes (Go's syscall package returns -1
+	// when !WaitStatus.Exited()). A buggy Reap that completed at the
+	// right wall time but mapped the status wrong (e.g. returned 0 via
+	// a default branch) would slip past the elapsed check above — this
+	// assertion is what catches that.
+	if code != -1 {
+		t.Errorf("expected SIGKILL exit code -1, got %d", code)
+	}
 }
 
 // TestWait_StalePendingRejected guards the PID-reuse hardening: a status

--- a/apps/daemon/pkg/childreap/childreap_test.go
+++ b/apps/daemon/pkg/childreap/childreap_test.go
@@ -273,6 +273,55 @@ func TestOutput(t *testing.T) {
 	})
 }
 
+// TestReap_LongRunningProcess guards the PTY-session bug: Reap must NOT
+// impose a wall-clock timeout on Phase 1 (waiting for exit status). The
+// PTY session goroutine calls Reap on an interactive shell that stays
+// alive indefinitely; a Phase-1 timeout would kill the session.
+//
+// We start a process that runs longer than any realistic hangTimeout
+// shrinkage, kill it after a short delay, and assert that Reap returns
+// the signal-derived exit code rather than a timeout error.
+func TestReap_LongRunningProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running reap test in short mode")
+	}
+
+	// Shrink hangTimeout to a value that would trip a buggy Reap quickly.
+	// The real cmd doesn't exit on its own; we kill it after a delay that
+	// is strictly greater than hangTimeout. If Reap honors the (buggy)
+	// hangTimeout in Phase 1, it returns an error before the kill lands.
+	orig := hangTimeout
+	hangTimeout = 100 * time.Millisecond
+	defer func() { hangTimeout = orig }()
+
+	cmd := exec.Command("sh", "-c", "sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = cmd.Process.Kill()
+	}()
+
+	start := time.Now()
+	code, err := Reap(cmd)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Reap returned unexpected error: %v", err)
+	}
+	// SIGKILL surfaces as either 137 (128+9) via WaitStatus.ExitStatus
+	// being -1 mapped... actually ExitStatus returns -1 for signaled
+	// processes, which our switch upstream interprets. Just assert Reap
+	// did not return until at least the kill delay elapsed — that proves
+	// Phase 1 didn't time out.
+	if elapsed < 250*time.Millisecond {
+		t.Errorf("Reap returned before the kill landed (%s) — Phase 1 timed out", elapsed)
+	}
+	_ = code
+}
+
 // TestWait_StalePendingRejected guards the PID-reuse hardening: a status
 // stored in pending more than pendingMaxAge before the caller's register
 // must NOT be claimed as the caller's exit status, because it almost


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the child process reaper so idle or interactive commands aren’t killed by a timeout. Reap no longer times out while waiting for exit status, keeping PTY sessions alive.

- **Bug Fixes**
  - Removed Phase 1 timeout in Reap; it now waits for exit status or the reaper with no wall-clock limit.
  - Clarified that `hangTimeout` only applies to Wait’s Phase 2 I/O drain; Reap doesn’t use it.
  - Added TestReap_LongRunningProcess to ensure no premature timeout.

<sup>Written for commit 4fce99d92bd8b7077b11f043293b6f3b8c5b5387. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4741?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

