### PR TITLE
fix(daemon): direct-write upload to fix FUSE volume regression

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/upload_files.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files.go
@@ -46,8 +46,11 @@ func UploadFiles(c *gin.Context) {
 			break
 		}
 		if err != nil {
+			// The multipart reader is unrecoverable after a non-EOF error
+			// (subsequent calls return the same error forever), so we must
+			// stop iterating to avoid an infinite loop / OOM.
 			errs = append(errs, fmt.Sprintf("reading part: %v", err))
-			continue
+			break
 		}
 
 		name := part.FormName()
@@ -90,11 +93,20 @@ func UploadFiles(c *gin.Context) {
 				continue
 			}
 
-			n, err := io.Copy(f, part)
-			if err != nil {
-				errs = append(errs, fmt.Sprintf("%s: write: %v", dest, err))
+			n, copyErr := io.Copy(f, part)
+			if copyErr != nil {
+				errs = append(errs, fmt.Sprintf("%s: write: %v", dest, copyErr))
 			}
-			f.Close()
+			// Inspect Close() — on FUSE-backed filesystems (e.g. mount-s3 for
+			// volume mounts) the actual remote write/CompleteMultipartUpload
+			// happens here, so a swallowed close error means silent data loss.
+			if closeErr := f.Close(); closeErr != nil && copyErr == nil {
+				errs = append(errs, fmt.Sprintf("%s: close: %v", dest, closeErr))
+				continue
+			}
+			if copyErr != nil {
+				continue
+			}
 			files = append(files, fileResult{Path: dest, Bytes: n})
 			continue
 		}

--- a/apps/daemon/pkg/toolbox/fs/upload_files.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files.go
@@ -6,7 +6,6 @@ package fs
 import (
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ func UploadFiles(c *gin.Context) {
 		}
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("reading part: %v", err))
-			break
+			continue
 		}
 
 		name := part.FormName()
@@ -78,11 +77,24 @@ func UploadFiles(c *gin.Context) {
 				continue
 			}
 
-			n, writeErr := writeUploadedPart(part, dest)
-			if writeErr != nil {
-				errs = append(errs, fmt.Sprintf("%s: %v", dest, writeErr))
+			if d := filepath.Dir(dest); d != "" {
+				if err := os.MkdirAll(d, 0o755); err != nil {
+					errs = append(errs, fmt.Sprintf("%s: mkdir %s: %v", dest, d, err))
+					continue
+				}
+			}
+
+			f, err := os.Create(dest)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: create: %v", dest, err))
 				continue
 			}
+
+			n, err := io.Copy(f, part)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: write: %v", dest, err))
+			}
+			f.Close()
 			files = append(files, fileResult{Path: dest, Bytes: n})
 			continue
 		}
@@ -94,103 +106,6 @@ func UploadFiles(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"files": files})
-}
-
-func writeUploadedPart(part *multipart.Part, dest string) (int64, error) {
-	dir := filepath.Dir(dest)
-	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return 0, fmt.Errorf("mkdir %s: %w", dir, err)
-		}
-	}
-
-	tmp, err := os.CreateTemp(dir, ".daytona-upload-*")
-	if err != nil {
-		return 0, fmt.Errorf("create temp: %w", err)
-	}
-	tmpPath := tmp.Name()
-	committed := false
-	defer func() {
-		if !committed {
-			tmp.Close()
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	n, err := io.Copy(tmp, part)
-	if err != nil {
-		tmp.Close()
-		return 0, fmt.Errorf("write: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return 0, fmt.Errorf("close: %w", err)
-	}
-	resolvedDest, err := resolveSymlink(dest)
-	if err != nil {
-		return 0, fmt.Errorf("resolve dest: %w", err)
-	}
-	// Best-effort: some FUSE-backed filesystems (e.g. S3 volume mounts) reject
-	// chmod(2). If it fails we still attempt the rename; the copyAndRemove
-	// fallback creates the destination with 0644 via OpenFile, so permissions
-	// are correct on both code paths regardless.
-	_ = os.Chmod(tmpPath, 0o644)
-	if err := os.Rename(tmpPath, resolvedDest); err != nil {
-		if cpErr := copyAndRemove(tmpPath, resolvedDest); cpErr != nil {
-			return 0, fmt.Errorf("rename: %w; fallback: %v", err, cpErr)
-		}
-	}
-	committed = true
-	return n, nil
-}
-
-func resolveSymlink(path string) (string, error) {
-	fi, err := os.Lstat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return path, nil
-		}
-		return "", err
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		return path, nil
-	}
-	resolved, err := filepath.EvalSymlinks(path)
-	if err == nil {
-		return resolved, nil
-	}
-	if !os.IsNotExist(err) {
-		return "", err
-	}
-	target, err := os.Readlink(path)
-	if err != nil {
-		return "", err
-	}
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(filepath.Dir(path), target)
-	}
-	return target, nil
-}
-
-func copyAndRemove(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		return err
-	}
-	if err := out.Close(); err != nil {
-		return err
-	}
-	_ = os.Remove(src)
-	return nil
 }
 
 func extractIndex(fieldName string) string {

--- a/apps/daemon/pkg/toolbox/fs/upload_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files_test.go
@@ -88,45 +88,6 @@ func TestUploadFilesStreamsToDisk(t *testing.T) {
 	}
 }
 
-func TestUploadFilesTruncatedBodyLeavesNoFiles(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	tempDir := t.TempDir()
-	dest := filepath.Join(tempDir, "partial.bin")
-
-	boundary := "DaytonaTestBoundary"
-	body := &bytes.Buffer{}
-	body.WriteString("--" + boundary + "\r\n")
-	body.WriteString("Content-Disposition: form-data; name=\"files[0].path\"\r\n\r\n")
-	body.WriteString(dest)
-	body.WriteString("\r\n--" + boundary + "\r\n")
-	body.WriteString("Content-Disposition: form-data; name=\"files[0].file\"; filename=\"partial.bin\"\r\n")
-	body.WriteString("Content-Type: application/octet-stream\r\n\r\n")
-	body.WriteString("partial-data-no-trailing-boundary")
-
-	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
-	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
-	rec := httptest.NewRecorder()
-
-	_, engine := gin.CreateTestContext(rec)
-	engine.POST("/files/bulk-upload", UploadFiles)
-	engine.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d (body: %s)", rec.Code, rec.Body.String())
-	}
-	if _, err := os.Stat(dest); !os.IsNotExist(err) {
-		t.Fatalf("expected destination not to exist after truncated upload, got err=%v", err)
-	}
-	entries, err := os.ReadDir(tempDir)
-	if err != nil {
-		t.Fatalf("readdir: %v", err)
-	}
-	for _, e := range entries {
-		t.Fatalf("expected empty directory, found leftover: %s", e.Name())
-	}
-}
-
 // Empty path values are rejected with a per-index error; later parts are still
 // processed, mirroring the existing bulk-upload contract of best-effort batching.
 func TestUploadFilesRejectsEmptyPath(t *testing.T) {

--- a/apps/daemon/pkg/toolbox/fs/upload_files_test.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -85,6 +86,53 @@ func TestUploadFilesStreamsToDisk(t *testing.T) {
 				t.Fatalf("leftover temp file: %s", filepath.Join(filepath.Dir(w.path), e.Name()))
 			}
 		}
+	}
+}
+
+// A multipart body that ends before the final boundary causes NextPart to
+// return io.ErrUnexpectedEOF. The handler must break out of the read loop
+// (the multipart reader is unrecoverable after a non-EOF error) and return
+// 400 with the error captured. This prevents an infinite loop / OOM if the
+// caller hangs up mid-upload.
+func TestUploadFilesTruncatedBodyReturnsErrorWithoutHanging(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tempDir := t.TempDir()
+	dest := filepath.Join(tempDir, "partial.bin")
+
+	boundary := "DaytonaTestBoundary"
+	body := &bytes.Buffer{}
+	body.WriteString("--" + boundary + "\r\n")
+	body.WriteString("Content-Disposition: form-data; name=\"files[0].path\"\r\n\r\n")
+	body.WriteString(dest)
+	body.WriteString("\r\n--" + boundary + "\r\n")
+	body.WriteString("Content-Disposition: form-data; name=\"files[0].file\"; filename=\"partial.bin\"\r\n")
+	body.WriteString("Content-Type: application/octet-stream\r\n\r\n")
+	body.WriteString("partial-data-no-trailing-boundary")
+
+	req := httptest.NewRequest(http.MethodPost, "/files/bulk-upload", body)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	rec := httptest.NewRecorder()
+
+	_, engine := gin.CreateTestContext(rec)
+	engine.POST("/files/bulk-upload", UploadFiles)
+
+	done := make(chan struct{})
+	go func() {
+		engine.ServeHTTP(rec, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("handler did not return within 5s — likely infinite loop on multipart read error")
+	}
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "reading part") {
+		t.Fatalf("expected 'reading part' error, got %s", rec.Body.String())
 	}
 }
 

--- a/libs/sdk-go/pkg/daytona/e2e_test.go
+++ b/libs/sdk-go/pkg/daytona/e2e_test.go
@@ -304,28 +304,6 @@ func TestE2E(t *testing.T) {
 		assert.Equal(t, "neighbor ok", string(neighbor))
 	})
 
-	t.Run("FileSystem/UploadFileMidUploadAbortPreservesOriginal", func(t *testing.T) {
-		// Use UploadFileStream with a reader that errors on the second read.
-		// The first read succeeds and data is already in-flight to the server
-		// when the goroutine's io.Copy returns an error, causing the pipe to
-		// close with an error. The HTTP client drops the connection, the
-		// server's io.Copy returns an error, the temp file is removed, and
-		// the original content must be unchanged.
-		abortPath := textDir + "/abort-test.txt"
-		require.NoError(t, sandbox.FileSystem.UploadFile(ctx, []byte("original content"), abortPath))
-
-		_ = sandbox.FileSystem.UploadFileStream(ctx, &errorAfterFirstChunkReader{}, abortPath)
-
-		content, downloadErr := sandbox.FileSystem.DownloadFile(ctx, abortPath, nil)
-		require.NoError(t, downloadErr)
-		assert.Equal(t, "original content", string(content))
-
-		leftovers, execErr := sandbox.Process.ExecuteCommand(ctx,
-			"ls "+textDir+"/ | grep daytona-upload || echo NO_LEFTOVERS")
-		require.NoError(t, execErr)
-		assert.Contains(t, leftovers.Result, "NO_LEFTOVERS")
-	})
-
 	t.Run("FileSystem/ListFiles", func(t *testing.T) {
 		files, listErr := sandbox.FileSystem.ListFiles(ctx, textDir)
 		require.NoError(t, listErr)
@@ -1023,24 +1001,6 @@ PY`, options.WithExecuteTimeout(10*time.Second))
 	_ = sandbox.FileSystem.DeleteFile(ctx, baseDir, true)
 	_ = sandbox.Process.DeleteSession(ctx, sessionID)
 	_ = sandbox.StartWithTimeout(ctx, 60*time.Second)
-}
-
-// errorAfterFirstChunkReader returns one full chunk then errors on subsequent
-// reads, simulating a connection abort mid-upload. The first chunk is large
-// enough to be in-flight before the error is returned.
-type errorAfterFirstChunkReader struct {
-	fired bool
-}
-
-func (r *errorAfterFirstChunkReader) Read(p []byte) (int, error) {
-	if r.fired {
-		return 0, fmt.Errorf("simulated mid-upload abort")
-	}
-	for i := range p {
-		p[i] = 'X'
-	}
-	r.fired = true
-	return len(p), nil
 }
 
 func extractContextIDs(contexts []map[string]any) []string {


### PR DESCRIPTION
## Summary

Revert `UploadFiles` (the daemon's bulk-upload handler) to the pre-regression
direct-write pattern from commit `ee1ba4a62`, on top of the progress-tracking
response added in #4665. Uploads to volume mount paths now work; uploads to
regular FS are unchanged.

## Problem

Volumes back their FUSE mount with **AWS Mountpoint for S3 (`mount-s3`)**.
Two syscalls used by the temp-file + rename upload pattern are not supported
by `mount-s3`:

| Syscall | mount-s3 behavior |
|---|---|
| `rename(2)` | `ENOSYS` (function not implemented) |
| `chmod(2)`  | `EPERM` (operation not permitted) |
| `open(2)` on a just-written object | transiently `EPERM` until the multipart upload metadata propagates |

The handler introduced in #4665 always took this path for every upload, so
**every** upload to a volume failed. The user-visible error:

```
daytona.common.errors.DaytonaError: Failed to upload files: 400:
/mnt/skills/public/pptx/scripts/__init__.py: rename:
rename .../.daytona-upload-1921890494 .../__init__.py: function not implemented;
fallback: open .../.daytona-upload-1921890494: operation not permitted
```

Even when the `copyAndRemove` fallback worked, it forced **3× S3 traffic per
upload** (original write + read-back + re-write through FUSE) because the
local "temp" file on the FUSE mount lives in S3.

## Fix

Drop the temp-file + rename + chmod machinery and write directly to the
destination, exactly like commit `ee1ba4a62` did. Streaming, permissions,
symlink-following, and parent-directory creation are all delegated to
`os.MkdirAll` + `os.Create` + `io.Copy`, which already worked correctly on
both regular FS and `mount-s3`.

The only delta from `ee1ba4a62` is keeping the progress-tracking response
(`{"files":[{"path":"...","bytes":N}]}`) that downstream SDKs rely on for
upload progress events, plus a per-index empty-path guard.

## Trade-off (intentional)

The temp+rename pattern was supposed to provide atomicity: readers never
see a partial file, and a mid-upload abort preserves the original content.
This guarantee was **already broken on FUSE mounts** (rename returns ENOSYS;
the `copyAndRemove` fallback also leaves partial files on failure), so we
drop it everywhere for consistency:

- Mid-upload cancel leaves a partial file at the destination on regular FS.
- On mount-s3 the partial object may be temporarily unreadable (EPERM)
  until the next write completes — fully recoverable by retrying the upload.

This matches the behavior of `ee1ba4a62`, the contract that existed before
#4665, and is acceptable given:

1. The feature was 5 days old, no users built workflows around atomicity.
2. Eliminates 3× S3 cost on every volume upload.
3. Fixes the only known production failure mode for volume uploads.

## Streaming guarantee preserved

The handler still streams part-by-part using `request.MultipartReader()` and
`io.Copy(*os.File, *multipart.Part)`. No request body, no file content, and
no temp staging is buffered in RAM at any point. `TestUploadFilesUsesStreamingMultipartReader`
remains in place as a regression guard.

## Verification

### Daemon unit tests
7/7 pass:

- `TestUploadFilesStreamsToDisk`
- `TestUploadFilesRejectsEmptyPath`
- `TestUploadFilesUsesStreamingMultipartReader`
- `TestUploadFilesResponseBytesAndMode`
- `TestUploadFilesMultiFileBytesAndMode`
- `TestUploadFilesWritesThroughSymlink`
- `TestUploadFilesWritesThroughDanglingSymlink`

### Local environment (no volumes)
- Python SDK e2e: 11/11 upload+download tests pass
- TypeScript SDK e2e: 15/15 upload+download tests pass
- Ruby SDK e2e: 5/5 upload tests pass
- Java SDK e2e: 6/6 filesystem tests pass
- Go SDK e2e: all filesystem tests pass after removing the atomicity-only
  test (see below)

### Preprod environment **with mount-s3 volume**
- Regular FS: new, overwrite (smaller + larger), batch, batch overwrite,
  empty file via batch, stream upload, stream overwrite, progress events
- Volume mount: new, overwrite, batch with nested dirs, **25 MiB stream
  upload** (400 progress events, 2.5 s @ 9.8 MiB/s), overwrite of large
  file with small content
- Cancellation mid-upload (regular FS + volume): error raised, partial
  state observed, subsequent uploads heal the file
- Progress callback: strictly monotonic, final `bytes_sent` == total,
  consistent 64 KiB chunks on the wire

## Files changed

| File | Change |
|---|---|
| `apps/daemon/pkg/toolbox/fs/upload_files.go` | Drop temp-file + rename + chmod + `copyAndRemove`. Inline `os.MkdirAll` → `os.Create` → `io.Copy`. Keep `fileResult` + JSON response for progress. |
| `apps/daemon/pkg/toolbox/fs/upload_files_test.go` | Drop `TestUploadFilesTruncatedBodyLeavesNoFiles` (atomicity guarantee no longer offered). |
| `libs/sdk-go/pkg/daytona/e2e_test.go` | Drop `FileSystem/UploadFileMidUploadAbortPreservesOriginal` and its `errorAfterFirstChunkReader` helper. |

Net: **+23 / −186 lines.**

## Behavior parity with `ee1ba4a62`

`diff` against `ee1ba4a62:apps/daemon/pkg/toolbox/fs/upload_files.go` shows
only additive changes:

- `fileResult` struct (response body for progress).
- `n, err := io.Copy(...)` capturing the byte count.
- `files = append(files, fileResult{Path: dest, Bytes: n})`.
- `gin.H{"files": files}` response shape on both success and error.
- `strings.TrimSpace` + empty-path check (per-index error).

No file-system call shape was changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed uploads to FUSE-backed volumes by switching the daemon’s bulk upload to direct writes and tightening error handling. Streaming and progress events stay the same; regular filesystem uploads are unchanged.

- **Bug Fixes**
  - Write files directly (`os.MkdirAll` → `os.Create` → `io.Copy`). Works on `mount-s3`, avoids ENOSYS/EPERM, and cuts S3 traffic from 3× to 1×.
  - Break on multipart read errors (e.g., truncated body) and return 400 to prevent infinite loops/OOM.
  - Surface `Close()` errors after `io.Copy` to catch FUSE remote write failures and avoid silent data loss.
  - Preserve streaming with the multipart reader and the JSON progress response: {"files":[{"path":"...","bytes":N}]}.

- **Migration**
  - Atomic writes are removed. Mid-upload cancel can leave a partial file; retrying the upload overwrites it.

<sup>Written for commit bb9755a60c1621667e67856ba180976912799605. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4745?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

