### PR TITLE
fix(daemon,proxy,sdk): fix flaky E2E tests

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/download_files.go
+++ b/apps/daemon/pkg/toolbox/fs/download_files.go
@@ -70,7 +70,8 @@ func DownloadFiles(c *gin.Context) {
 		})
 		return
 	}
-	defer mw.Close() // ensure final boundary is written
+	// Do not `defer mw.Close()`: deferring the closing boundary races with
+	// net/http's response finalization and can silently truncate the response.
 
 	for _, path := range req.Paths {
 		f, info, downloadErr := openDownloadFile(c, path)
@@ -82,12 +83,23 @@ func DownloadFiles(c *gin.Context) {
 		if err := writeFilePart(c.Request.Context(), mw, path, f, info.Size()); err != nil {
 			f.Close()
 
-			// If streaming fails after the multipart file part has started, emitting a
-			// second error part for the same path breaks the response contract.
-			c.Error(err)
+			// Mid-part failure: end the response now so the client's truncation
+			// guard surfaces this loudly instead of as a successful short file.
+			_ = c.Error(err)
 			return
 		}
 		f.Close()
+	}
+
+	if err := mw.Close(); err != nil {
+		_ = c.Error(fmt.Errorf("close multipart writer: %w", err))
+	}
+	flushResponse(c)
+}
+
+func flushResponse(c *gin.Context) {
+	if flusher, ok := c.Writer.(http.Flusher); ok {
+		flusher.Flush()
 	}
 }
 

--- a/apps/daemon/pkg/toolbox/fs/upload_file.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_file.go
@@ -23,6 +23,9 @@ import (
 //
 //	@id				UploadFile
 func UploadFile(c *gin.Context) {
+	enableFullDuplex(c)
+	defer drainBody(c)
+
 	path := c.Query("path")
 	if path == "" {
 		c.AbortWithError(http.StatusBadRequest, errors.New("path is required"))

--- a/apps/daemon/pkg/toolbox/fs/upload_files.go
+++ b/apps/daemon/pkg/toolbox/fs/upload_files.go
@@ -30,8 +30,11 @@ type fileResult struct {
 //
 //	@id				UploadFiles
 func UploadFiles(c *gin.Context) {
+	enableFullDuplex(c)
+
 	reader, err := c.Request.MultipartReader()
 	if err != nil {
+		drainBody(c)
 		c.JSON(http.StatusBadRequest, gin.H{"errors": []string{"invalid multipart form"}})
 		return
 	}
@@ -46,9 +49,6 @@ func UploadFiles(c *gin.Context) {
 			break
 		}
 		if err != nil {
-			// The multipart reader is unrecoverable after a non-EOF error
-			// (subsequent calls return the same error forever), so we must
-			// stop iterating to avoid an infinite loop / OOM.
 			errs = append(errs, fmt.Sprintf("reading part: %v", err))
 			break
 		}
@@ -112,12 +112,30 @@ func UploadFiles(c *gin.Context) {
 		}
 	}
 
+	drainBody(c)
+
 	if len(errs) > 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"errors": errs, "files": files})
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{"files": files})
+}
+
+// drainBody consumes remaining request body bytes before a response is sent.
+// Go's net/http server only auto-drains up to 256KB; anything beyond that
+// causes it to close the connection before the reverse proxy finishes reading
+// the response, producing 'unexpected EOF' on the proxy side.
+func drainBody(c *gin.Context) {
+	_, _ = io.Copy(io.Discard, c.Request.Body)
+}
+
+// enableFullDuplex allows the handler to write a response while the client is
+// still sending the request body. Without this, Go's HTTP/1.1 server may RST
+// the connection before the reverse proxy finishes reading the response.
+func enableFullDuplex(c *gin.Context) {
+	rc := http.NewResponseController(c.Writer)
+	_ = rc.EnableFullDuplex()
 }
 
 func extractIndex(fieldName string) string {

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// proxyTransport wraps *http.Transport with retryTransport for stale-connection
+// handling. If direct *http.Transport access is needed, split into two variables.
 var proxyTransport http.RoundTripper = &retryTransport{
 	base: &http.Transport{
 		MaxIdleConns:        100,

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -13,12 +13,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-var proxyTransport = &http.Transport{
-	MaxIdleConns:        100,
-	MaxIdleConnsPerHost: 100,
-	DialContext: (&net.Dialer{
-		KeepAlive: 30 * time.Second,
-	}).DialContext,
+var proxyTransport http.RoundTripper = &retryTransport{
+	base: &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+		DialContext: (&net.Dialer{
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	},
 }
 
 // ProxyRequest handles proxying requests to a sandbox's container

--- a/libs/common-go/pkg/proxy/retry_transport.go
+++ b/libs/common-go/pkg/proxy/retry_transport.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package proxy

--- a/libs/common-go/pkg/proxy/retry_transport.go
+++ b/libs/common-go/pkg/proxy/retry_transport.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+const maxRetryBodySize = 256 << 10 // max body size buffered for retry
+
+// retryTransport retries once on stale-connection errors (EOF/RST) and on
+// multipart responses with empty bodies (stale conn returned headers only).
+type retryTransport struct {
+	base http.RoundTripper
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	bufferSmallBody(req)
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		if canReplay(req) && isStaleConnError(err) {
+			slog.Warn("proxy: retrying after stale connection error",
+				"method", req.Method, "path", req.URL.Path, "error", err)
+			rewindBody(req)
+			return t.base.RoundTrip(req)
+		}
+		return nil, err
+	}
+
+	if canReplay(req) && isMultipart(resp) {
+		var peek [1]byte
+		n, readErr := resp.Body.Read(peek[:])
+		if n == 0 && readErr != nil {
+			slog.Warn("proxy: retrying after empty multipart body",
+				"method", req.Method, "path", req.URL.Path)
+			resp.Body.Close()
+			rewindBody(req)
+			return t.base.RoundTrip(req)
+		}
+		if n > 0 {
+			resp.Body = &prefixedBody{prefix: peek[:n], rest: resp.Body}
+		}
+	}
+
+	return resp, nil
+}
+
+// bufferSmallBody captures small request bodies for replay; large uploads are skipped.
+func bufferSmallBody(req *http.Request) {
+	if req.GetBody != nil || req.Body == nil {
+		return
+	}
+	if req.ContentLength < 0 || req.ContentLength > int64(maxRetryBodySize) {
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		req.Body = io.NopCloser(bytes.NewReader(nil))
+		return
+	}
+	req.ContentLength = int64(len(data))
+	req.Body = io.NopCloser(bytes.NewReader(data))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+}
+
+func canReplay(req *http.Request) bool { return req.GetBody != nil }
+
+func rewindBody(req *http.Request) {
+	if req.GetBody != nil {
+		req.Body, _ = req.GetBody()
+	}
+}
+
+func isStaleConnError(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	s := err.Error()
+	return strings.Contains(s, "connection reset by peer") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "use of closed network connection")
+}
+
+func isMultipart(resp *http.Response) bool {
+	return strings.HasPrefix(resp.Header.Get("Content-Type"), "multipart/")
+}
+
+// prefixedBody prepends already-read bytes back onto a ReadCloser.
+type prefixedBody struct {
+	prefix []byte
+	off    int
+	rest   io.ReadCloser
+}
+
+func (r *prefixedBody) Read(p []byte) (int, error) {
+	if r.off < len(r.prefix) {
+		n := copy(p, r.prefix[r.off:])
+		r.off += n
+		return n, nil
+	}
+	return r.rest.Read(p)
+}
+
+func (r *prefixedBody) Close() error { return r.rest.Close() }

--- a/libs/sdk-python/src/daytona/_async/filesystem.py
+++ b/libs/sdk-python/src/daytona/_async/filesystem.py
@@ -31,7 +31,12 @@ from daytona_toolbox_api_client_async import (
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from ..common.errors import DaytonaError
-from ..common.file_transfer import create_multipart_parser, parse_content_type_boundary, serialize_download_request
+from ..common.file_transfer import (
+    create_multipart_parser,
+    parse_content_type_boundary,
+    raise_if_multipart_truncated,
+    serialize_download_request,
+)
 from ..common.filesystem import (
     CancelEvent,
     DownloadProgress,
@@ -352,6 +357,7 @@ class AsyncFileSystem:
                 parser.finalize()
                 async for piece in drain():
                     yield piece
+                raise_if_multipart_truncated(parser, remote_path)
 
             raise_if_stream_error(remote_path, error_text, error_details, received_file_data)
 
@@ -560,6 +566,7 @@ class AsyncFileSystem:
                 events.clear()
                 parser.finalize()
                 await _process_events()
+                raise_if_multipart_truncated(parser, "bulk-download")
         finally:
             for writer in file_writers:
                 await writer.close()

--- a/libs/sdk-python/src/daytona/_sync/filesystem.py
+++ b/libs/sdk-python/src/daytona/_sync/filesystem.py
@@ -26,7 +26,12 @@ from daytona_toolbox_api_client import (
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
 from ..common.errors import DaytonaError
-from ..common.file_transfer import create_multipart_parser, parse_content_type_boundary, serialize_download_request
+from ..common.file_transfer import (
+    create_multipart_parser,
+    parse_content_type_boundary,
+    raise_if_multipart_truncated,
+    serialize_download_request,
+)
 from ..common.filesystem import (
     CancelEvent,
     DownloadProgress,
@@ -338,6 +343,7 @@ class FileSystem:
 
                 parser.finalize()
                 yield from drain()
+                raise_if_multipart_truncated(parser, remote_path)
 
             raise_if_stream_error(remote_path, error_text, error_details, received_file_data)
 
@@ -522,6 +528,7 @@ class FileSystem:
                 for chunk in resp.iter_bytes(64 * 1024):
                     _ = parser.write(chunk)
                 parser.finalize()
+                raise_if_multipart_truncated(parser, "bulk-download")
         finally:
             for writer in file_writers:
                 writer.close()

--- a/libs/sdk-python/src/daytona/common/file_transfer.py
+++ b/libs/sdk-python/src/daytona/common/file_transfer.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any
 
-from python_multipart.multipart import MultipartParser, parse_options_header
+from python_multipart.multipart import MultipartParser, MultipartState, parse_options_header
 
 from daytona_toolbox_api_client import FilesDownloadRequest
 
@@ -53,3 +53,17 @@ def create_multipart_parser(
             "on_part_end": on_part_end,
         },
     )
+
+
+def raise_if_multipart_truncated(parser: MultipartParser, remote_path: str) -> None:
+    """Raise if the multipart stream ended before the closing boundary.
+
+    python_multipart can silently drop boundary look-ahead bytes at finalize().
+    Call after parser.finalize() so short downloads become retryable errors.
+    """
+    if parser.state != MultipartState.END:
+        msg = (
+            f"Truncated multipart response for {remote_path!r}: "
+            f"closing boundary not received (parser state={parser.state.name})"
+        )
+        raise DaytonaError(msg)

--- a/libs/sdk-python/tests/test_filesystem.py
+++ b/libs/sdk-python/tests/test_filesystem.py
@@ -379,6 +379,28 @@ class TestSyncFileSystem:
         with pytest.raises(DaytonaError, match="cancelled"):
             next(stream)
 
+    def test_download_file_stream_raises_on_truncated_response(self):
+        """Response ends before the closing boundary; SDK must raise."""
+        from daytona._sync.filesystem import FileSystem
+
+        mock_api = MagicMock()
+        remote_path = "workspace/file.txt"
+        boundary = b"sync-boundary"
+        payload = b"hello world" * 32  # multi-chunk content
+        multipart_body = _build_multipart_body(
+            boundary, name="file", filename=remote_path, payload=payload, content_length=len(payload)
+        )
+        # Drop the final boundary bytes; parser would otherwise finalize silently.
+        truncated = multipart_body[:-10]
+        client = _SyncStreamClient(_SyncStreamResponse([truncated], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [remote_path]})
+        )
+        fs = FileSystem(mock_api, http_client=client)
+
+        with pytest.raises(DaytonaError, match=r"[Tt]runcated"):
+            list(fs.download_file_stream(remote_path))
+
 
 class TestAsyncFileSystem:
     def _make_fs(self):
@@ -604,6 +626,31 @@ class TestAsyncFileSystem:
         cancel.set()
         with pytest.raises(DaytonaError, match="cancelled"):
             await stream.__anext__()
+
+    @pytest.mark.asyncio
+    async def test_download_file_stream_raises_on_truncated_response(self):
+        """Async equivalent of the sync truncation guard. See sync test for context."""
+        from daytona._async.filesystem import AsyncFileSystem
+
+        mock_api = AsyncMock()
+        remote_path = "workspace/file.txt"
+        boundary = b"async-boundary"
+        payload = b"hello world" * 32
+        multipart_body = _build_multipart_body(
+            boundary, name="file", filename=remote_path, payload=payload, content_length=len(payload)
+        )
+        truncated = multipart_body[:-10]
+        client = _AsyncStreamClient(_AsyncStreamResponse([truncated], boundary))
+        mock_api._download_files_serialize = MagicMock(
+            return_value=("POST", "https://download", {}, {"paths": [remote_path]})
+        )
+        mock_api.api_client.http_session = client
+        fs = AsyncFileSystem(mock_api)
+
+        stream = await fs.download_file_stream(remote_path)
+        with pytest.raises(DaytonaError, match=r"[Tt]runcated"):
+            async for _ in stream:
+                pass
 
     @pytest.mark.asyncio
     async def test_upload_file_stream_accepts_async_iterable(self):

--- a/libs/sdk-ruby/lib/daytona/code_interpreter.rb
+++ b/libs/sdk-ruby/lib/daytona/code_interpreter.rb
@@ -108,40 +108,40 @@ module Daytona
 
       puts "[DEBUG] Connecting to WebSocket: #{ws_url}" if ENV['DEBUG']
 
-      ws = WebSocket::Client::Simple.connect(ws_url, headers:)
-
-      ws.on :open do
-        puts '[DEBUG] WebSocket opened, sending request' if ENV['DEBUG']
-        ws.send(JSON.dump(request))
-      end
-
-      ws.on :message do |msg|
-        puts "[DEBUG] Received message (length=#{msg.data.length}): #{msg.data.inspect[0..200]}" if ENV['DEBUG']
-
-        interpreter.send(:handle_message, msg.data, result, on_stdout, on_stderr, on_error, completion_queue)
-      end
-
-      ws.on :error do |e|
-        puts "[DEBUG] WebSocket error: #{e.message}" if ENV['DEBUG']
-        completion_queue.push({ type: :error, error: e })
-      end
-
-      ws.on :close do |e|
-        if ENV['DEBUG']
-          code = e&.code || 'nil'
-          reason = e&.reason || 'nil'
-          puts "[DEBUG] WebSocket closed: code=#{code}, reason=#{reason}"
+      ws = WebSocket::Client::Simple.connect(ws_url, headers:) do |client|
+        client.on :open do
+          puts '[DEBUG] WebSocket opened, sending request' if ENV['DEBUG']
+          client.send(JSON.dump(request))
         end
-        error_info = interpreter.send(:handle_close, e)
-        if error_info
-          completion_queue.push({ type: :error_from_close, error: error_info })
-        else
-          completion_queue.push({ type: :close })
+
+        client.on :message do |msg|
+          puts "[DEBUG] Received message (length=#{msg.data.length}): #{msg.data.inspect[0..200]}" if ENV['DEBUG']
+
+          interpreter.send(:handle_message, msg.data, result, on_stdout, on_stderr, on_error, completion_queue)
+        end
+
+        client.on :error do |e|
+          puts "[DEBUG] WebSocket error: #{e.message}" if ENV['DEBUG']
+          completion_queue.push({ type: :error, error: e })
+        end
+
+        client.on :close do |e|
+          if ENV['DEBUG']
+            code = e&.code || 'nil'
+            reason = e&.reason || 'nil'
+            puts "[DEBUG] WebSocket closed: code=#{code}, reason=#{reason}"
+          end
+          error_info = interpreter.send(:handle_close, e)
+          if error_info
+            completion_queue.push({ type: :error_from_close, error: error_info })
+          else
+            completion_queue.push({ type: :close })
+          end
         end
       end
 
       no_timeout = timeout.is_a?(Numeric) && timeout <= 0
-      max_wait = no_timeout ? nil : (timeout || 600) + 3
+      max_wait = no_timeout ? nil : (timeout || 600) + 30
       start_time = Time.now
       completion_reason = nil
 

--- a/libs/sdk-ruby/lib/daytona/file_system.rb
+++ b/libs/sdk-ruby/lib/daytona/file_system.rb
@@ -213,7 +213,7 @@ module Daytona
     #   # Upload binary data
     #   data = { key: "value" }.to_json
     #   sandbox.fs.upload_file(data, "tmp/config.json")
-    def upload_file(source, remote_path) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def upload_file(source, remote_path)
       if source.is_a?(String) && File.exist?(source)
         # Source is a file path
         File.open(source, 'rb') { |file| toolbox_api.upload_file(remote_path, file) }
@@ -221,12 +221,17 @@ module Daytona
         # Source is an IO object
         toolbox_api.upload_file(remote_path, source)
       else
-        # Source is string content - create a temporary file
-        Tempfile.create('daytona_upload') do |file|
-          file.binmode
-          file.write(source)
-          file.rewind
-          toolbox_api.upload_file(remote_path, file)
+        # Tempfile.create yields a ::File (works with Typhoeus) but deletes
+        # on block exit — too early if curl reads asynchronously. Write via
+        # Tempfile, close it, then reopen as ::File for the upload.
+        tmp = Tempfile.new('daytona_upload')
+        begin
+          tmp.binmode
+          tmp.write(source.to_s.b)
+          tmp.close
+          File.open(tmp.path, 'rb') { |file| toolbox_api.upload_file(remote_path, file) }
+        ensure
+          tmp.unlink
         end
       end
     rescue StandardError => e

--- a/libs/sdk-ruby/lib/daytona/file_transfer.rb
+++ b/libs/sdk-ruby/lib/daytona/file_transfer.rb
@@ -18,6 +18,7 @@ module Daytona
   class MultipartDownloadStreamParser
     attr_reader :error_message
     attr_reader :part_total_bytes
+    attr_reader :part_bytes_emitted
     attr_writer :boundary_token
 
     def initialize(&on_file_chunk)
@@ -27,6 +28,7 @@ module Daytona
       @state = :preamble
       @part_name = nil
       @part_total_bytes = nil
+      @part_bytes_emitted = 0
       @error_buffer = String.new.b
     end
 
@@ -35,15 +37,13 @@ module Daytona
       process!
     end
 
+    # Raises if the response ended before the closing multipart boundary, so
+    # truncations surface as typed errors instead of silently short downloads.
     def finish!
       process!
+      return if @state == :done
 
-      return if @state == :done || @buffer.empty?
-
-      emit(@buffer)
-      finalize_part!
-      @buffer = String.new.b
-      @state = :done
+      raise Sdk::Error, "Truncated multipart response: closing boundary not received (state=#{@state})"
     end
 
     private
@@ -110,6 +110,7 @@ module Daytona
 
       case @part_name
       when 'file'
+        @part_bytes_emitted += data.bytesize
         @on_file_chunk.call(data)
       when 'error'
         @error_buffer << data
@@ -201,7 +202,7 @@ module Daytona
 
       request.on_complete do |completed_response|
         response = completed_response
-        parser.finish!
+        parser.finish! unless cancel_event&.set?
       end
 
       request.run
@@ -209,6 +210,16 @@ module Daytona
       raise Sdk::Error, "Download cancelled: #{remote_path}" if cancel_event&.set?
       raise Sdk::Error, parser.error_message if parser.error_message
       raise Sdk::Error, "HTTP #{response.code}" if response && !response.success?
+
+      assert_download_length!(parser, remote_path)
+    end
+
+    def self.assert_download_length!(parser, remote_path)
+      return unless parser.part_total_bytes && parser.part_bytes_emitted != parser.part_total_bytes
+
+      raise Sdk::Error,
+            "Multipart response length mismatch for #{remote_path}: " \
+            "got #{parser.part_bytes_emitted} bytes, expected #{parser.part_total_bytes}"
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
@@ -232,6 +243,7 @@ module Daytona
     def self.stream_upload(api_client:, remote_path:, source:, timeout:, on_progress: nil, cancel_event: nil)
       with_upload_file(source, cancel_event, remote_path) do |upload_path|
         config = api_client.config
+        expected_bytes = File.size(upload_path)
         progress_callback = upload_progress_callback(on_progress, cancel_event)
         response = with_open_upload_file(upload_path) do |file|
           upload_request(
@@ -244,6 +256,7 @@ module Daytona
           ).run
         end
         raise_upload_error(response, cancel_event, remote_path)
+        verify_upload_response(response, remote_path, expected_bytes)
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/ParameterLists
@@ -336,6 +349,28 @@ module Daytona
       raise Sdk::Error, "Upload timed out: #{remote_path}" if response.timed_out?
       raise Sdk::Error, "Upload cancelled: #{remote_path}" if response.return_code == :aborted_by_callback
       raise Sdk::Error, "HTTP #{response.code}: #{response.body}" unless response.success?
+    end
+
+    # Compares the daemon's reported bytes-written against what the SDK sent.
+    # Catches server-side miscounts (or extra-byte injection) at the upload
+    # call site instead of surfacing later as a download mismatch.
+    def self.verify_upload_response(response, remote_path, expected_bytes)
+      recorded = recorded_upload_bytes(response.body, remote_path)
+      return if recorded.nil? || recorded == expected_bytes
+
+      raise Sdk::Error,
+            "Upload size mismatch for #{remote_path}: sent #{expected_bytes} bytes, " \
+            "daemon recorded #{recorded}"
+    end
+
+    def self.recorded_upload_bytes(body, remote_path)
+      parsed = JSON.parse(body) rescue nil # rubocop:disable Style/RescueModifier
+      return nil unless parsed.is_a?(Hash)
+
+      files = Array(parsed['files'])
+      match = files.find { |f| f.is_a?(Hash) && f['path'] == remote_path }
+      bytes = match&.dig('bytes')
+      bytes.is_a?(Integer) ? bytes : nil
     end
 
     def self.open_drain_source(source)

--- a/libs/sdk-ruby/lib/daytona/process.rb
+++ b/libs/sdk-ruby/lib/daytona/process.rb
@@ -235,34 +235,34 @@ module Daytona
 
       completion_queue = Queue.new
 
-      ws = WebSocket::Client::Simple.connect(
+      WebSocket::Client::Simple.connect(
         url.to_s,
         headers: toolbox_api.api_client.default_headers.dup.merge(
           'X-Daytona-Preview-Token' => preview_link.token,
           'Content-Type' => 'text/plain',
           'Accept' => 'text/plain'
         )
-      )
+      ) do |client|
+        client.on(:message) do |message|
+          if message.type == :close
+            client.close
+            completion_queue.push(:close)
+          else
+            stdout, stderr = Util.demux(message.data.to_s)
 
-      ws.on(:message) do |message|
-        if message.type == :close
-          ws.close
-          completion_queue.push(:close)
-        else
-          stdout, stderr = Util.demux(message.data.to_s)
-
-          on_stdout.call(stdout) unless stdout.empty?
-          on_stderr.call(stderr) unless stderr.empty?
+            on_stdout.call(stdout) unless stdout.empty?
+            on_stderr.call(stderr) unless stderr.empty?
+          end
         end
-      end
 
-      ws.on(:close) do
-        completion_queue.push(:close)
-      end
+        client.on(:close) do
+          completion_queue.push(:close)
+        end
 
-      ws.on(:error) do |e|
-        completion_queue.push(:error)
-        raise Sdk::Error, "WebSocket error: #{e.message}"
+        client.on(:error) do |e|
+          completion_queue.push(:error)
+          raise Sdk::Error, "WebSocket error: #{e.message}"
+        end
       end
 
       # Wait for completion
@@ -302,34 +302,34 @@ module Daytona
 
       completion_queue = Queue.new
 
-      ws = WebSocket::Client::Simple.connect(
+      WebSocket::Client::Simple.connect(
         url.to_s,
         headers: toolbox_api.api_client.default_headers.dup.merge(
           'X-Daytona-Preview-Token' => preview_link.token,
           'Content-Type' => 'text/plain',
           'Accept' => 'text/plain'
         )
-      )
+      ) do |client|
+        client.on(:message) do |message|
+          if message.type == :close
+            client.close
+            completion_queue.push(:close)
+          else
+            stdout, stderr = Util.demux(message.data.to_s)
 
-      ws.on(:message) do |message|
-        if message.type == :close
-          ws.close
-          completion_queue.push(:close)
-        else
-          stdout, stderr = Util.demux(message.data.to_s)
-
-          on_stdout.call(stdout) unless stdout.empty?
-          on_stderr.call(stderr) unless stderr.empty?
+            on_stdout.call(stdout) unless stdout.empty?
+            on_stderr.call(stderr) unless stderr.empty?
+          end
         end
-      end
 
-      ws.on(:close) do
-        completion_queue.push(:close)
-      end
+        client.on(:close) do
+          completion_queue.push(:close)
+        end
 
-      ws.on(:error) do |e|
-        completion_queue.push(:error)
-        raise Sdk::Error, "WebSocket error: #{e.message}"
+        client.on(:error) do |e|
+          completion_queue.push(:error)
+          raise Sdk::Error, "WebSocket error: #{e.message}"
+        end
       end
 
       # Wait for completion
@@ -448,18 +448,21 @@ module Daytona
       url.scheme = url.scheme == 'https' ? 'wss' : 'ws'
       url.path = "/process/pty/#{session_id}/connect"
 
-      PtyHandle.new(
-        WebSocket::Client::Simple.connect(
-          url.to_s,
-          headers: toolbox_api.api_client.default_headers.dup.merge(
-            'X-Daytona-Preview-Token' => preview_link.token
-          )
-        ),
-        session_id:,
-
-        handle_resize: ->(pty_size) { resize_pty_session(session_id, pty_size) },
-        handle_kill: -> { delete_pty_session(session_id) }
-      ).tap(&:wait_for_connection)
+      handle = nil
+      WebSocket::Client::Simple.connect(
+        url.to_s,
+        headers: toolbox_api.api_client.default_headers.dup.merge(
+          'X-Daytona-Preview-Token' => preview_link.token
+        )
+      ) do |client|
+        handle = PtyHandle.new(
+          client,
+          session_id:,
+          handle_resize: ->(pty_size) { resize_pty_session(session_id, pty_size) },
+          handle_kill: -> { delete_pty_session(session_id) }
+        )
+      end
+      handle.tap(&:wait_for_connection)
     end
 
     # Resizes a PTY session to the specified dimensions

--- a/libs/sdk-ruby/spec/daytona/code_interpreter_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/code_interpreter_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Daytona::CodeInterpreter do
       stdout = []
       stderr = []
       errors = []
-      allow(WebSocket::Client::Simple).to receive(:connect).and_return(socket)
+      allow(WebSocket::Client::Simple).to receive(:connect).and_yield(socket).and_return(socket)
 
       result = interpreter.run_code(
         'print("hello")',
@@ -103,7 +103,7 @@ RSpec.describe Daytona::CodeInterpreter do
     it 'raises TimeoutError when the websocket closes with the timeout code' do
       socket = InterpreterWebSocket.new([[:close,
                                           double(code: described_class::WEBSOCKET_TIMEOUT_CODE, reason: 'timeout')]])
-      allow(WebSocket::Client::Simple).to receive(:connect).and_return(socket)
+      allow(WebSocket::Client::Simple).to receive(:connect).and_yield(socket).and_return(socket)
 
       expect { interpreter.run_code('sleep(10)', timeout: 1) }
         .to raise_error(Daytona::Sdk::TimeoutError, /Execution timed out/)
@@ -111,7 +111,7 @@ RSpec.describe Daytona::CodeInterpreter do
 
     it 'wraps websocket errors as SDK errors' do
       socket = InterpreterWebSocket.new([[:error, StandardError.new('socket boom')]])
-      allow(WebSocket::Client::Simple).to receive(:connect).and_return(socket)
+      allow(WebSocket::Client::Simple).to receive(:connect).and_yield(socket).and_return(socket)
       allow(interpreter).to receive(:sleep)
       allow(Time).to receive(:now).and_return(Time.now, Time.now + 10)
 

--- a/libs/sdk-ruby/spec/daytona/process_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/process_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Daytona::Process do
   describe '#get_session_command_logs_async' do
     it 'streams stdout and stderr chunks until close' do
       socket = PassiveWebSocket.new
-      allow(WebSocket::Client::Simple).to receive(:connect).and_return(socket)
+      allow(WebSocket::Client::Simple).to receive(:connect).and_yield(socket).and_return(socket)
       stdout_chunks = []
       stderr_chunks = []
 
@@ -323,7 +323,7 @@ RSpec.describe Daytona::Process do
   describe '#get_entrypoint_logs_async' do
     it 'streams entrypoint logs until close' do
       socket = PassiveWebSocket.new
-      allow(WebSocket::Client::Simple).to receive(:connect).and_return(socket)
+      allow(WebSocket::Client::Simple).to receive(:connect).and_yield(socket).and_return(socket)
       stdout_chunks = []
 
       thread = Thread.new do
@@ -376,7 +376,7 @@ RSpec.describe Daytona::Process do
     it 'connects via websocket and waits for the PTY connection' do
       socket = double('PtySocket')
       handle = instance_double(Daytona::PtyHandle)
-      allow(WebSocket::Client::Simple).to receive(:connect).and_return(socket)
+      allow(WebSocket::Client::Simple).to receive(:connect).and_yield(socket).and_return(socket)
       allow(Daytona::PtyHandle).to receive(:new).and_return(handle)
       allow(handle).to receive(:wait_for_connection)
 

--- a/libs/sdk-ruby/spec/e2e_spec.rb
+++ b/libs/sdk-ruby/spec/e2e_spec.rb
@@ -570,7 +570,7 @@ RSpec.describe 'Daytona SDK E2E', :e2e do
     end
   end
 
-  context 'Code Interpreter', order: :defined do
+  context 'Code Interpreter', order: :defined, timeout: 120 do
     it 'runs simple Python code' do
       result = @sandbox.code_interpreter.run_code('print("interpreter hello")')
       expect(result).to be_a(Daytona::ExecutionResult)

--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -340,6 +340,16 @@ export class FileSystem {
       return Boolean(axios.isCancel?.(err) || error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED')
     }
 
+    let returnedStreamForAbort: Readable | null = null
+    const forwardAbortToReturnedStream = () => {
+      const stream = returnedStreamForAbort
+      if (stream && !stream.destroyed && !stream.readableEnded) {
+        stream.destroy(toDownloadCancelledError())
+      }
+    }
+    const removeAbortForwarder = () => options.signal?.removeEventListener('abort', forwardAbortToReturnedStream)
+    options.signal?.addEventListener('abort', forwardAbortToReturnedStream, { once: true })
+
     let response
     try {
       response = await this.apiClient.downloadFiles(
@@ -351,6 +361,7 @@ export class FileSystem {
         },
       )
     } catch (err) {
+      removeAbortForwarder()
       if (options.signal?.aborted || isCanceledError(err)) {
         throw toDownloadCancelledError()
       }
@@ -389,15 +400,30 @@ export class FileSystem {
               if (fileStreamEnded) return
               if (!progress.destroyed) progress.destroy(err)
             })
+            // pipe() does not forward 'close'. If the upstream connection
+            // drops, busboy may close the fileStream without 'end', leaving
+            // the progress Transform dangling. Propagate close → end so the
+            // caller's stream always terminates.
+            fileStream.once('close', () => {
+              if (!progress.writableFinished && !progress.destroyed) {
+                progress.end()
+              }
+            })
             resolvedStream = progress
           } else {
             resolvedStream = fileStream as Readable
           }
+          returnedStreamForAbort = resolvedStream
+          resolvedStream.once('end', removeAbortForwarder)
+          resolvedStream.once('error', removeAbortForwarder)
+          resolvedStream.once('close', removeAbortForwarder)
+          if (options.signal?.aborted) queueMicrotask(forwardAbortToReturnedStream)
           resolve(resolvedStream)
         },
       )
         .then(() => {
           if (!resolvedStream) {
+            removeAbortForwarder()
             const metadata = metadataMap.get(remotePath)
             if (metadata?.error) {
               reject(createFileDownloadError(metadata.error, metadata.errorDetails))
@@ -409,6 +435,7 @@ export class FileSystem {
         .catch((err) => {
           const normalizedError = options.signal?.aborted || isCanceledError(err) ? toDownloadCancelledError() : err
           if (!resolvedStream) {
+            removeAbortForwarder()
             reject(normalizedError)
             return
           }

--- a/libs/sdk-typescript/src/__tests__/e2e.test.ts
+++ b/libs/sdk-typescript/src/__tests__/e2e.test.ts
@@ -267,20 +267,26 @@ describe('TypeScript SDK E2E (real Daytona API)', () => {
     })
 
     test('download abort surfaces DaytonaError', async () => {
-      // Large enough to require multiple network chunks so abort fires mid-stream.
-      const content = Buffer.from(('download-abort-' + randomUUID()).repeat(1024 * 16))
-      await sandbox.fs.uploadFile(content, 'fs-test/download-abort.bin')
+      const remotePath = `fs-test/download-abort-${randomUUID()}.bin`
+      await sandbox.fs.uploadFile(Buffer.from('download-abort-' + randomUUID()), remotePath)
 
       const controller = new AbortController()
-      const stream = await sandbox.fs.downloadFileStream('fs-test/download-abort.bin', { signal: controller.signal })
+      const stream = await sandbox.fs.downloadFileStream(remotePath, { signal: controller.signal })
 
-      const error = await new Promise<unknown>((resolve, reject) => {
-        stream.once('data', () => controller.abort())
+      // The SDK returns the file stream paused. Aborting BEFORE attaching
+      // listeners and resuming lets the SDK's abort forwarder destroy the
+      // returned stream with DaytonaError before any bytes flow, so this is
+      // independent of network/CI speed and never races on small payloads.
+      controller.abort()
+
+      const outcome = new Promise<unknown>((resolve, reject) => {
         stream.once('error', resolve)
-        stream.once('end', () => reject(new Error('Expected download to be aborted')))
+        stream.once('end', () => reject(new Error('Expected aborted download to error, got clean end')))
+        stream.once('close', () => reject(new Error('Expected aborted download to error, got close')))
         stream.resume()
       })
 
+      const error = await outcome
       expect(error).toBeInstanceOf(DaytonaError)
       expect((error as Error).message).toMatch(/cancel/i)
     })


### PR DESCRIPTION
## Summary

This PR fixes **five independent root causes** of flaky SDK E2E test failures across Go daemon, proxy, Python, Ruby, and TypeScript SDKs. Each change targets a specific, reproducible failure mode. Total: 18 files, +419/-118 lines.

---

## Layer 1: Go Daemon — Upload/Download Handler Fixes

### `apps/daemon/pkg/toolbox/fs/upload_file.go` (+3 lines)
### `apps/daemon/pkg/toolbox/fs/upload_files.go` (+24/-6 lines)

**What**: Added `enableFullDuplex(c)` and `drainBody(c)` to both upload handlers.

**Why**: Go's HTTP/1.1 server sends RST when a handler writes a response while the client is still sending the request body. Behind `httputil.ReverseProxy`, this manifests as `unexpected EOF` on the proxy side. `enableFullDuplex` allows simultaneous read/write. `drainBody` consumes remaining bytes beyond Go's 256KB auto-drain limit, preventing premature connection closure.

**Side effects**: None. These only affect the upload request/response lifecycle. `enableFullDuplex` is a no-op for HTTP/2. `drainBody` reads to `/dev/null` — no memory allocation.

**Why not just proxy-level retry?** Upload bodies are multi-MB files — too large to buffer for retry (the retry transport's 256KB limit correctly skips them).

---

### `apps/daemon/pkg/toolbox/fs/download_files.go` (+20/-4 lines)

**What**: Replaced `defer mw.Close()` with explicit `mw.Close()` + `flushResponse(c)` after the file loop.

**Why**: `defer mw.Close()` races with `net/http`'s response finalization. When the handler returns, Go's server may start tearing down the response before the deferred `Close()` writes the multipart closing boundary. This silently truncates the response — the client receives a 200 with an incomplete multipart body.

**Side effects**: None. The explicit close writes the same bytes, just at a deterministic point before the handler returns. The `flushResponse` helper is a standard Gin pattern.

**Mid-part failure path**: If `writeFilePart` fails, the handler returns WITHOUT closing `mw` — intentionally. The missing closing boundary triggers the SDK's truncation guard, surfacing the error loudly instead of delivering a silently short file.

---

## Layer 2: Proxy — Retry Transport for Stale Connections

### `libs/common-go/pkg/proxy/proxy.go` (+15/-6 lines)
### `libs/common-go/pkg/proxy/retry_transport.go` (+114 lines, new)

**What**: Wrapped the shared `proxyTransport` with a `retryTransport` that retries once on stale-connection errors. Added `IdleConnTimeout: 90s` to the base transport.

**Why**: The proxy's `http.Transport` had `IdleConnTimeout: 0` (infinite — unlike `http.DefaultTransport`'s 90s default). Daemon-closed connections stayed in the pool indefinitely. Two failure modes:
1. **Transport error**: `RoundTrip` returns EOF/RST → default error handler sends 502
2. **Empty body**: TCP buffer holds status+headers from dying connection → `RoundTrip` returns `*Response{200}` but body immediately EOFs → client gets 200 with empty multipart body → "parser state=START"

The retry transport handles both:
- On transport error (EOF, connection reset, broken pipe): retry once
- On multipart response with empty body: peek 1 byte; if immediate EOF → retry once

**Side effects**:
- **Performance**: `bufferSmallBody` replaces (not duplicates) the existing body reader — net ~0 additional memory. Only bodies with known `ContentLength ≤ 256KB` are buffered (JSON payloads). Large uploads, chunked bodies, and GET requests are skipped.
- **Latency**: 1-byte peek on multipart responses adds negligible latency (first boundary bytes are in the TCP buffer).
- **GET requests**: Not affected — Go's transport natively retries GET on stale connections.
- **WebSocket upgrades**: Not affected — no body, non-multipart response.

**Why not just `DisableKeepAlives`?** Performance — every request would create a new TCP connection to the daemon. The retry transport preserves connection pooling while handling the stale-connection edge case.

---

## Layer 3: Python SDK — Multipart Truncation Guard

### `libs/sdk-python/src/daytona/common/file_transfer.py` (+16 lines)
### `libs/sdk-python/src/daytona/_async/filesystem.py` (+9 lines)
### `libs/sdk-python/src/daytona/_sync/filesystem.py` (+9 lines)
### `libs/sdk-python/tests/test_filesystem.py` (+47 lines)

**What**: Added `raise_if_multipart_truncated(parser, path)` after `parser.finalize()` in all download paths (sync/async, single-file/bulk).

**Why**: `python_multipart` silently drops look-ahead bytes at `finalize()`. If the multipart closing boundary is missing (truncated response), the parser stays in a non-`END` state but doesn't raise. Downloads would silently return partial data.

**Side effects**: None for well-formed responses — the check passes in O(1). Only raises on genuinely truncated responses that previously would have silently succeeded with incomplete data.

**Tests**: Added sync and async unit tests that truncate a multipart body by 10 bytes and verify `DaytonaError` is raised.

---

## Layer 4: Ruby SDK — WebSocket Race Conditions + Upload Fix

### `libs/sdk-ruby/lib/daytona/code_interpreter.rb` (+52/-52 lines)

**What**: Changed `WebSocket::Client::Simple.connect` from post-connect handler registration to block form.

**Why**: `connect()` starts a background thread immediately. If the TCP handshake completes before the `:open` handler is registered (very likely on localhost in CI), the handler fires with no listener — the request is never sent, `completion_queue.pop` blocks forever, and the 60s test timeout kills it.

The block form (`connect(url) { |client| client.on(:open) { ... } }`) registers handlers BEFORE the connection thread starts. This is the gem's intended API for this exact scenario.

**Also**: Bumped internal timeout buffer from `+3s` to `+30s` for CI headroom.

---

### `libs/sdk-ruby/lib/daytona/process.rb` (+99/-99 lines)

**What**: Same block-form WebSocket fix applied to all three WebSocket consumers: `get_session_command_logs_async`, `get_entrypoint_logs_async`, and `connect_pty_session`.

**Why**: Same race condition as code interpreter. The PTY timeout failure ("PTY connection timeout") was the `:open` event firing before `PtyHandle#subscribe` registered the handler.

**Side effects**: None. The block form is functionally identical — same handlers, same events — just registered at a safe point in the lifecycle.

---

### `libs/sdk-ruby/lib/daytona/file_system.rb` (+19/-12 lines)

**What**: Replaced `Tempfile.create` (block form) with `Tempfile.new` + explicit `File.open` + `ensure` unlink.

**Why**: Two issues with the original code:
1. `Tempfile.create` with a block deletes the file when the block exits. If Typhoeus/curl reads the file asynchronously, the file may be gone → "Failed to open/read local data from file/application" (HTTP 0).
2. The auto-generated API client checks `when ::File` in `build_request_body`. `Tempfile` is NOT a `::File` (it uses `DelegateClass`), so it falls to `.to_s` → garbage string → daemon 400.

The fix writes via `Tempfile.new`, closes it, then reopens as `::File` for the upload. The tempfile persists until `ensure` unlinks it — no GC race, no type mismatch.

---

### `libs/sdk-ruby/lib/daytona/file_transfer.rb` (+49/-12 lines)

**What**: 
- `finish!` now raises on non-`done` state instead of silently accepting
- Added `part_bytes_emitted` tracking + `assert_download_length!`
- Added `verify_upload_response` to check daemon-reported bytes

**Why**: The old `finish!` would emit partial buffer data and force `@state = :done` on truncation — silently accepting incomplete downloads. The new behavior raises `Sdk::Error`, matching the Python truncation guard.

The length checks are defense-in-depth: `assert_download_length!` catches Content-Length vs actual-bytes mismatches; `verify_upload_response` catches daemon-side byte count discrepancies at the upload call site.

**Side effects**: `verify_upload_response` parses the daemon's JSON response — if the format changes, it returns `nil` and skips (fail-open).

---

### `libs/sdk-ruby/spec/e2e_spec.rb` (+2/-2 lines)

**What**: Set `timeout: 120` on the Code Interpreter test context.

**Why**: Each `run_code` call opens a new WebSocket through the proxy chain. In CI, a single WebSocket roundtrip can take 30-60s. The default 60s per-test timeout wasn't enough for tests with 2+ `run_code` calls. The block-form fix eliminates the indefinite hang, but 120s provides headroom for slow CI environments.

---

## Layer 5: TypeScript SDK — Download Abort + Stream Propagation

### `libs/sdk-typescript/src/FileSystem.ts` (+27 lines)

**What**: 
- Added `AbortSignal` forwarding from the download request to the returned stream
- Added `close → end` propagation on the progress Transform

**Why**: After `downloadFileStream()` returns a stream, aborting the signal only tore down the internal axios/busboy pipeline. The returned stream dangled — no `error` event, no `end`, the caller hung until Jest timeout.

The abort forwarder destroys the returned stream with `DaytonaError("Download cancelled")` when the signal fires. The `close → end` propagation handles a busboy edge case where upstream connection drops emit `close` but not `end` on the file stream, leaving the progress Transform open.

**Side effects**: The abort forwarder is cleaned up on `end`/`error`/`close` — no leaks. The `queueMicrotask` handles the edge case where the signal is already aborted at resolve time.

---

### `libs/sdk-typescript/src/__tests__/e2e.test.ts` (+20/-12 lines)

**What**: Made the abort test deterministic — abort BEFORE resuming the stream, not mid-stream.

**Why**: The old test uploaded a 256KB file and aborted on first `data` event. In fast CI, all data arrived in one chunk — abort never fired. The new test aborts while the stream is paused, which is CI-speed-independent.

---

## Test Spec Updates

### `libs/sdk-ruby/spec/daytona/code_interpreter_spec.rb` (+6/-6 lines)
### `libs/sdk-ruby/spec/daytona/process_spec.rb` (+6/-6 lines)

**What**: Updated mock WebSocket stubs to use `.and_yield(socket).and_return(socket)`.

**Why**: The production code now uses the block form of `connect`. The mock stubs must yield the socket to the block so handlers are registered during the test.

