### PR TITLE
fix(sdk-java): preserve exception cause chain and classify transport failures

### DIFF
--- a/apps/docs/src/content/docs/en/java-sdk/errors.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/errors.mdx
@@ -60,6 +60,19 @@ Creates a Daytona exception with explicit HTTP status code.
 
 #### new DaytonaException()
 ```java
+public DaytonaException(int statusCode, String message, Throwable cause)
+```
+
+Creates a Daytona exception with explicit HTTP status code and a cause.
+
+**Parameters**:
+
+- `statusCode` _int_ - HTTP status code
+- `message` _String_ - error description
+- `cause` _Throwable_ - root cause
+
+#### new DaytonaException()
+```java
 public DaytonaException(int statusCode, String message, Map<String, String> headers)
 ```
 
@@ -119,6 +132,16 @@ Creates an authentication exception.
 
 - `message` _String_ - error description from the API
 
+#### new DaytonaAuthenticationException()
+```java
+public DaytonaAuthenticationException(String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause
+
 ## DaytonaBadRequestException
 
 Raised when the request is malformed or contains invalid parameters (HTTP 400).
@@ -142,6 +165,16 @@ Creates a bad-request exception.
 **Parameters**:
 
 - `message` _String_ - error description from the API
+
+#### new DaytonaBadRequestException()
+```java
+public DaytonaBadRequestException(String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause
 
 ## DaytonaConflictException
 
@@ -169,6 +202,16 @@ Creates a conflict exception.
 **Parameters**:
 
 - `message` _String_ - error description from the API
+
+#### new DaytonaConflictException()
+```java
+public DaytonaConflictException(String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause
 
 ## DaytonaConnectionException
 
@@ -233,6 +276,16 @@ Creates a forbidden exception.
 
 - `message` _String_ - error description from the API
 
+#### new DaytonaForbiddenException()
+```java
+public DaytonaForbiddenException(String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause
+
 ## DaytonaNotFoundException
 
 Raised when a requested resource does not exist (HTTP 404).
@@ -250,6 +303,16 @@ Creates a not-found exception.
 
 - `message` _String_ - error description from the API
 
+#### new DaytonaNotFoundException()
+```java
+public DaytonaNotFoundException(String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause
+
 ## DaytonaRateLimitException
 
 Raised when API rate limits are exceeded (HTTP 429).
@@ -266,6 +329,16 @@ Creates a rate-limit exception.
 **Parameters**:
 
 - `message` _String_ - error description from the API
+
+#### new DaytonaRateLimitException()
+```java
+public DaytonaRateLimitException(String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause
 
 ## DaytonaServerException
 
@@ -293,6 +366,17 @@ Creates a server exception.
 
 - `statusCode` _int_ - HTTP status code (typically 5xx)
 - `message` _String_ - error description from the API
+
+#### new DaytonaServerException()
+```java
+public DaytonaServerException(int statusCode, String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `statusCode` _int_ - HTTP status code (typically 5xx)
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause
 
 ## DaytonaTimeoutException
 
@@ -351,3 +435,13 @@ Creates a validation exception.
 **Parameters**:
 
 - `message` _String_ - error description from the API
+
+#### new DaytonaValidationException()
+```java
+public DaytonaValidationException(String message, Throwable cause)
+```
+
+**Parameters**:
+
+- `message` _String_ - error description from the API
+- `cause` _Throwable_ - root cause

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/CodeInterpreter.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/CodeInterpreter.java
@@ -153,8 +153,9 @@ public class CodeInterpreter {
 
             @Override
             public void onFailure(WebSocket webSocket, Throwable t, Response response) {
-                String message = t == null ? "Interpreter WebSocket failure" : t.getMessage();
-                failure.compareAndSet(null, new DaytonaException("Failed to execute code: " + message));
+                String msg = (t == null || t.getMessage() == null || t.getMessage().isEmpty())
+                        ? "WebSocket failure" : t.getMessage();
+                failure.compareAndSet(null, new DaytonaException("Failed to execute code: " + msg, t));
                 complete();
             }
 

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/ExceptionMapper.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/ExceptionMapper.java
@@ -6,13 +6,16 @@ package io.daytona.sdk;
 import io.daytona.sdk.exception.DaytonaAuthenticationException;
 import io.daytona.sdk.exception.DaytonaBadRequestException;
 import io.daytona.sdk.exception.DaytonaConflictException;
+import io.daytona.sdk.exception.DaytonaConnectionException;
 import io.daytona.sdk.exception.DaytonaException;
 import io.daytona.sdk.exception.DaytonaForbiddenException;
 import io.daytona.sdk.exception.DaytonaNotFoundException;
 import io.daytona.sdk.exception.DaytonaRateLimitException;
 import io.daytona.sdk.exception.DaytonaServerException;
+import io.daytona.sdk.exception.DaytonaTimeoutException;
 import io.daytona.sdk.exception.DaytonaValidationException;
 
+import java.net.SocketTimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,7 +27,7 @@ final class ExceptionMapper {
         try {
             return supplier.get();
         } catch (io.daytona.api.client.ApiException e) {
-            throw map(e.getCode(), e.getResponseBody());
+            throw map(e.getCode(), e.getResponseBody(), e);
         }
     }
 
@@ -32,7 +35,7 @@ final class ExceptionMapper {
         try {
             runnable.run();
         } catch (io.daytona.api.client.ApiException e) {
-            throw map(e.getCode(), e.getResponseBody());
+            throw map(e.getCode(), e.getResponseBody(), e);
         }
     }
 
@@ -40,7 +43,7 @@ final class ExceptionMapper {
         try {
             return supplier.get();
         } catch (io.daytona.toolbox.client.ApiException e) {
-            throw map(e.getCode(), e.getResponseBody());
+            throw map(e.getCode(), e.getResponseBody(), e);
         }
     }
 
@@ -48,33 +51,69 @@ final class ExceptionMapper {
         try {
             runnable.run();
         } catch (io.daytona.toolbox.client.ApiException e) {
-            throw map(e.getCode(), e.getResponseBody());
+            throw map(e.getCode(), e.getResponseBody(), e);
         }
     }
 
-    static DaytonaException map(int statusCode, String responseBody) {
+    static DaytonaException map(int statusCode, String responseBody, Throwable cause) {
+        // Only treat status==0 as a transport failure when the ApiException
+        // wraps an underlying Throwable; client-side ApiExceptions thrown for
+        // parameter validation also have status==0 but no wrapped cause.
+        if (statusCode == 0 && (responseBody == null || responseBody.isEmpty())
+                && cause != null && cause.getCause() != null) {
+            return mapTransportFailure(cause);
+        }
         String message = extractMessage(responseBody, statusCode);
+        if (statusCode == 0 && (responseBody == null || responseBody.isEmpty())
+                && cause != null && cause.getMessage() != null && !cause.getMessage().isEmpty()) {
+            message = cause.getMessage();
+        }
         switch (statusCode) {
             case 400:
-                return new DaytonaBadRequestException(message);
+                return new DaytonaBadRequestException(message, cause);
             case 401:
-                return new DaytonaAuthenticationException(message);
+                return new DaytonaAuthenticationException(message, cause);
             case 403:
-                return new DaytonaForbiddenException(message);
+                return new DaytonaForbiddenException(message, cause);
             case 404:
-                return new DaytonaNotFoundException(message);
+                return new DaytonaNotFoundException(message, cause);
             case 409:
-                return new DaytonaConflictException(message);
+                return new DaytonaConflictException(message, cause);
             case 422:
-                return new DaytonaValidationException(message);
+                return new DaytonaValidationException(message, cause);
             case 429:
-                return new DaytonaRateLimitException(message);
+                return new DaytonaRateLimitException(message, cause);
             default:
                 if (statusCode >= 500) {
-                    return new DaytonaServerException(statusCode, message);
+                    return new DaytonaServerException(statusCode, message, cause);
                 }
-                return new DaytonaException(statusCode, message);
+                return new DaytonaException(statusCode, message, cause);
         }
+    }
+
+    private static DaytonaException mapTransportFailure(Throwable cause) {
+        Throwable root = rootCause(cause);
+        String message = rootMessage(root);
+        if (root instanceof SocketTimeoutException) {
+            return new DaytonaTimeoutException("Request timed out: " + message, cause);
+        }
+        return new DaytonaConnectionException("Connection failed: " + message, cause);
+    }
+
+    private static Throwable rootCause(Throwable t) {
+        Throwable current = t;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private static String rootMessage(Throwable t) {
+        String msg = t.getMessage();
+        if (msg != null && !msg.isEmpty()) {
+            return msg;
+        }
+        return t.getClass().getSimpleName();
     }
 
     /**

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/FileTransfer.java
@@ -130,7 +130,7 @@ final class FileTransfer {
             apiClient.processCookieParams(new HashMap<String, String>(), requestBuilder);
             return requestBuilder.build();
         } catch (io.daytona.toolbox.client.ApiException e) {
-            throw ExceptionMapper.map(e.getCode(), e.getResponseBody());
+            throw ExceptionMapper.map(e.getCode(), e.getResponseBody(), e);
         }
     }
 
@@ -286,7 +286,7 @@ final class FileTransfer {
             responseBody = "{\"message\":\"Download failed\"}";
         }
 
-        return ExceptionMapper.map(statusCode, responseBody);
+        return ExceptionMapper.map(statusCode, responseBody, null);
     }
 
     private static long parsePartContentLength(String contentLengthHeader) {

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/Process.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/Process.java
@@ -442,7 +442,9 @@ public class Process {
             @Override
             public void onFailure(WebSocket webSocket, Throwable t, Response response) {
                 flush();
-                failure.compareAndSet(null, new DaytonaException("Log streaming failed: " + t.getMessage()));
+                String msg = (t == null || t.getMessage() == null || t.getMessage().isEmpty())
+                        ? "WebSocket failure" : t.getMessage();
+                failure.compareAndSet(null, new DaytonaException("Log streaming failed: " + msg, t));
                 doneLatch.countDown();
             }
 

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/PtyHandle.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/PtyHandle.java
@@ -30,6 +30,7 @@ public class PtyHandle {
     private final String sessionId;
     private volatile Integer exitCode;
     private volatile String error;
+    private volatile Throwable failure;
     private volatile boolean connected = false;
     private volatile boolean connectionEstablished = false;
     private final CountDownLatch connectionLatch = new CountDownLatch(1);
@@ -75,7 +76,7 @@ public class PtyHandle {
         }
 
         if (error != null && !error.isEmpty()) {
-            throw new DaytonaException("PTY connection failed: " + error);
+            throw new DaytonaException("PTY connection failed: " + error, failure);
         }
         if (!connectionEstablished) {
             throw new DaytonaException("PTY connection was not established");
@@ -260,7 +261,9 @@ public class PtyHandle {
 
         @Override
         public void onFailure(WebSocket ws, Throwable t, Response response) {
-            error = t == null ? "PTY websocket failure" : t.getMessage();
+            String msg = t == null ? "PTY websocket failure" : t.getMessage();
+            error = (msg != null && !msg.isEmpty()) ? msg : "PTY websocket failure";
+            failure = t;
             connected = false;
             connectionLatch.countDown();
             exitLatch.countDown();

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaAuthenticationException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaAuthenticationException.java
@@ -23,4 +23,12 @@ public class DaytonaAuthenticationException extends DaytonaException {
     public DaytonaAuthenticationException(String message) {
         super(401, message);
     }
+
+    /**
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaAuthenticationException(String message, Throwable cause) {
+        super(401, message, cause);
+    }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaBadRequestException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaBadRequestException.java
@@ -23,4 +23,12 @@ public class DaytonaBadRequestException extends DaytonaException {
     public DaytonaBadRequestException(String message) {
         super(400, message);
     }
+
+    /**
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaBadRequestException(String message, Throwable cause) {
+        super(400, message, cause);
+    }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaConflictException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaConflictException.java
@@ -26,4 +26,12 @@ public class DaytonaConflictException extends DaytonaException {
     public DaytonaConflictException(String message) {
         super(409, message);
     }
+
+    /**
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaConflictException(String message, Throwable cause) {
+        super(409, message, cause);
+    }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaException.java
@@ -64,6 +64,19 @@ public class DaytonaException extends RuntimeException {
     }
 
     /**
+     * Creates a Daytona exception with explicit HTTP status code and a cause.
+     *
+     * @param statusCode HTTP status code
+     * @param message error description
+     * @param cause root cause
+     */
+    public DaytonaException(int statusCode, String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+        this.headers = Collections.emptyMap();
+    }
+
+    /**
      * Creates a Daytona exception with HTTP status code and headers.
      *
      * @param statusCode HTTP status code

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaForbiddenException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaForbiddenException.java
@@ -23,4 +23,12 @@ public class DaytonaForbiddenException extends DaytonaException {
     public DaytonaForbiddenException(String message) {
         super(403, message);
     }
+
+    /**
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaForbiddenException(String message, Throwable cause) {
+        super(403, message, cause);
+    }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaNotFoundException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaNotFoundException.java
@@ -15,4 +15,12 @@ public class DaytonaNotFoundException extends DaytonaException {
     public DaytonaNotFoundException(String message) {
         super(404, message);
     }
+
+    /**
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaNotFoundException(String message, Throwable cause) {
+        super(404, message, cause);
+    }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaRateLimitException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaRateLimitException.java
@@ -15,4 +15,12 @@ public class DaytonaRateLimitException extends DaytonaException {
     public DaytonaRateLimitException(String message) {
         super(429, message);
     }
+
+    /**
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaRateLimitException(String message, Throwable cause) {
+        super(429, message, cause);
+    }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaServerException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaServerException.java
@@ -26,4 +26,13 @@ public class DaytonaServerException extends DaytonaException {
     public DaytonaServerException(int statusCode, String message) {
         super(statusCode, message);
     }
+
+    /**
+     * @param statusCode HTTP status code (typically 5xx)
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaServerException(int statusCode, String message, Throwable cause) {
+        super(statusCode, message, cause);
+    }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaValidationException.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/exception/DaytonaValidationException.java
@@ -26,4 +26,12 @@ public class DaytonaValidationException extends DaytonaException {
     public DaytonaValidationException(String message) {
         super(422, message);
     }
+
+    /**
+     * @param message error description from the API
+     * @param cause root cause
+     */
+    public DaytonaValidationException(String message, Throwable cause) {
+        super(422, message, cause);
+    }
 }

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/ExceptionMapperTest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/ExceptionMapperTest.java
@@ -6,13 +6,19 @@ package io.daytona.sdk;
 import io.daytona.sdk.exception.DaytonaAuthenticationException;
 import io.daytona.sdk.exception.DaytonaBadRequestException;
 import io.daytona.sdk.exception.DaytonaConflictException;
+import io.daytona.sdk.exception.DaytonaConnectionException;
 import io.daytona.sdk.exception.DaytonaException;
 import io.daytona.sdk.exception.DaytonaForbiddenException;
 import io.daytona.sdk.exception.DaytonaNotFoundException;
 import io.daytona.sdk.exception.DaytonaRateLimitException;
 import io.daytona.sdk.exception.DaytonaServerException;
+import io.daytona.sdk.exception.DaytonaTimeoutException;
 import io.daytona.sdk.exception.DaytonaValidationException;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -117,5 +123,79 @@ class ExceptionMapperTest {
         ExceptionMapper.runToolbox(() -> { });
 
         assertThat(value).isEqualTo("ok");
+    }
+
+    @Test
+    void preservesApiExceptionAsCause() {
+        io.daytona.api.client.ApiException apiException =
+                new io.daytona.api.client.ApiException(404, "not found", null, "{\"message\":\"gone\"}");
+
+        assertThatThrownBy(() -> ExceptionMapper.callMain(() -> { throw apiException; }))
+                .isInstanceOf(DaytonaNotFoundException.class)
+                .hasCause(apiException);
+    }
+
+    @Test
+    void preservesNestedIoExceptionCauseChain() {
+        IOException ioException = new IOException("connection reset");
+        io.daytona.api.client.ApiException apiException = new io.daytona.api.client.ApiException(ioException);
+
+        assertThatThrownBy(() -> ExceptionMapper.callMain(() -> { throw apiException; }))
+                .hasCause(apiException)
+                .hasRootCause(ioException);
+    }
+
+    @Test
+    void mapsSocketTimeoutToTimeoutException() {
+        SocketTimeoutException timeout = new SocketTimeoutException("Read timed out");
+        io.daytona.api.client.ApiException apiException = new io.daytona.api.client.ApiException(timeout);
+
+        assertThatThrownBy(() -> ExceptionMapper.callMain(() -> { throw apiException; }))
+                .isInstanceOf(DaytonaTimeoutException.class)
+                .hasMessageContaining("Read timed out")
+                .hasCause(apiException);
+    }
+
+    @Test
+    void mapsConnectExceptionToConnectionException() {
+        ConnectException connectException = new ConnectException("Connection refused");
+        io.daytona.api.client.ApiException apiException = new io.daytona.api.client.ApiException(connectException);
+
+        assertThatThrownBy(() -> ExceptionMapper.callMain(() -> { throw apiException; }))
+                .isInstanceOf(DaytonaConnectionException.class)
+                .hasMessageContaining("Connection refused")
+                .hasCause(apiException);
+    }
+
+    @Test
+    void mapsGenericIoExceptionToConnectionException() {
+        IOException ioException = new IOException("DNS resolution failed");
+        io.daytona.api.client.ApiException apiException = new io.daytona.api.client.ApiException(ioException);
+
+        assertThatThrownBy(() -> ExceptionMapper.callMain(() -> { throw apiException; }))
+                .isInstanceOf(DaytonaConnectionException.class)
+                .hasMessageContaining("DNS resolution failed")
+                .hasCause(apiException);
+    }
+
+    @Test
+    void nullCauseDoesNotThrow() {
+        DaytonaException exception = ExceptionMapper.map(400, "{\"message\":\"bad\"}", null);
+        assertThat(exception).isInstanceOf(DaytonaBadRequestException.class);
+        assertThat(exception.getCause()).isNull();
+        assertThat(exception.getMessage()).isEqualTo("bad");
+    }
+
+    @Test
+    void clientSideValidationApiExceptionIsNotMisclassifiedAsTransportFailure() {
+        io.daytona.api.client.ApiException apiException = new io.daytona.api.client.ApiException(
+                "Missing the required parameter 'id' when calling getSandbox(Async)");
+
+        assertThatThrownBy(() -> ExceptionMapper.callMain(() -> { throw apiException; }))
+                .isInstanceOf(DaytonaException.class)
+                .isNotInstanceOf(DaytonaConnectionException.class)
+                .isNotInstanceOf(DaytonaTimeoutException.class)
+                .hasMessageContaining("Missing the required parameter 'id'")
+                .hasCause(apiException);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a long-standing issue in the Java SDK where the original cause of
a failed API call was silently discarded by `ExceptionMapper`. Users
hitting network-level failures (e.g. connection refused, DNS failure,
socket timeout) saw only:

```
io.daytona.sdk.exception.DaytonaException: Request failed with status 0
    at io.daytona.sdk.ExceptionMapper.map(ExceptionMapper.java:76)
    at io.daytona.sdk.ExceptionMapper.callMain(ExceptionMapper.java:27)
    at io.daytona.sdk.Daytona.create(Daytona.java:127)
```

…with no `Caused by`, no transport-level detail, and no actionable
information for diagnosis or retry decisions.

## Root cause

`ExceptionMapper.map(int, String)` only accepted a status code and a
response body string. The caught `ApiException` (and any wrapped
`IOException` / `SocketTimeoutException`) was dropped on the floor. WebSocket `onFailure` handlers did the same — extracting
`t.getMessage()` into a string and discarding the `Throwable`.

When the underlying transport fails before a response is received,
`ApiException.getCode()` is `0` and `getResponseBody()` is `null`, so
the mapper produced a generic `DaytonaException` with the unhelpful
"Request failed with status 0" message.

## Changes

### Core mapping (`ExceptionMapper`)

- `map(int statusCode, String responseBody, Throwable cause)` —
  signature now takes the caught exception; all four catch sites
  (`callMain`, `runMain`, `callToolbox`, `runToolbox`) pass `e`.
- `mapTransportFailure(Throwable)` — new helper invoked when
  `statusCode == 0` and the body is empty. It walks the cause chain
  and classifies:
    - `SocketTimeoutException` → `DaytonaTimeoutException`
    - any other root cause → `DaytonaConnectionException`
  The thrown exception includes the root cause's message
  (e.g. `"Connection refused"`, `"Name or service not known"`) and
  keeps the full chain via `initCause`.

### Exception subclasses

All status-code-specific exceptions gained a `(message, cause)`
constructor so the cause can be threaded through without losing type
information:

- `DaytonaBadRequestException` (400)
- `DaytonaAuthenticationException` (401)
- `DaytonaForbiddenException` (403)
- `DaytonaNotFoundException` (404)
- `DaytonaConflictException` (409)
- `DaytonaValidationException` (422)
- `DaytonaRateLimitException` (429)
- `DaytonaServerException` (5xx)
- `DaytonaException` (base, fallback)

### WebSocket `onFailure` handlers

`Process`, `CodeInterpreter`, and `PtyHandle` all had handlers that
extracted `t.getMessage()` and discarded the `Throwable`. They now:

- Null-check the incoming `Throwable` (defensive NPE fix).
- Fall back to a descriptive label when `t.getMessage()` is
  `null`/empty.
- Pass `t` as the cause when constructing the SDK exception.

For `PtyHandle`, a new `volatile Throwable failure` field stores the
WebSocket-failure throwable so `waitForConnection()` can attach it as
the cause of the SDK exception it surfaces to the caller.

### `FileTransfer`

Both `ExceptionMapper.map` call sites updated — the catch site passes
the caught `ApiException`; the one path that synthesizes an
exception from a raw response body without a Java-side caught
exception passes `null` (which is handled safely by the mapper).

### Tests

Six new unit tests in `ExceptionMapperTest`:

- `preservesApiExceptionAsCause`
- `preservesNestedIoExceptionCauseChain`
- `mapsSocketTimeoutToTimeoutException`
- `mapsConnectExceptionToConnectionException`
- `mapsGenericIoExceptionToConnectionException`
- `nullCauseDoesNotThrow`

All pre-existing tests (status-code mapping, JSON-body extraction,
escape handling, run/call helper variants) continue to pass.

## Behavior comparison

**Before** (any transport failure):

```
io.daytona.sdk.exception.DaytonaException: Request failed with status 0
    at io.daytona.sdk.ExceptionMapper.map(...)
    at io.daytona.sdk.ExceptionMapper.callMain(...)
```

**After — connection refused:**

```
io.daytona.sdk.exception.DaytonaConnectionException: Connection failed: Connection refused
    ...
Caused by: io.daytona.api.client.ApiException: java.net.ConnectException: Failed to connect to /...
HTTP response code: 0
HTTP response body: null
    ...
Caused by: java.net.ConnectException: Failed to connect to /...
Caused by: java.net.ConnectException: Connection refused
```

**After — DNS failure:**

```
io.daytona.sdk.exception.DaytonaConnectionException: Connection failed: <host>: Name or service not known
    ...
Caused by: io.daytona.api.client.ApiException: java.net.UnknownHostException: <host>: ...
Caused by: java.net.UnknownHostException: <host>: Name or service not known
```

**After — socket timeout:**

```
io.daytona.sdk.exception.DaytonaTimeoutException: Request timed out: Read timed out
    ...
Caused by: io.daytona.api.client.ApiException: java.net.SocketTimeoutException: Read timed out
Caused by: java.net.SocketTimeoutException: Read timed out
```

**After — 401 from real API:**

```
io.daytona.sdk.exception.DaytonaAuthenticationException: Invalid credentials
    ...
Caused by: io.daytona.api.client.ApiException
HTTP response code: 401
HTTP response body: {"path":"/api/sandbox","statusCode":401,"error":"Unauthorized","message":"Invalid credentials"}
```

## Verification

- `./gradlew build` in `libs/sdk-java` — passes (15 tests in
  `ExceptionMapperTest`, all green; Javadoc clean).
- Manually verified against the production API by repurposing
  `examples/java/lifecycle` to exercise:
    1. Happy-path sandbox create + delete — works.
    2. DNS-failure URL → `DaytonaConnectionException` with full
       cause chain ending in `UnknownHostException`.
    3. Connection-refused URL → `DaytonaConnectionException` with
       full cause chain ending in `ConnectException: Connection refused`.
    4. Invalid API key → `DaytonaAuthenticationException` with
       `ApiException` cause (code=401, body, headers).

## Compatibility

- **Source compatible** — every change to existing constructors and
  method signatures is additive. `ExceptionMapper` is package-private,
  so its signature change is internal.
- **Binary compatible** — no removed or modified public/protected
  signatures on the exception classes; new constructors only.
- **Behavioral**: callers that previously caught the generic
  `DaytonaException` for transport failures will now see a more
  specific `DaytonaConnectionException` or `DaytonaTimeoutException`.
  Both extend `DaytonaException`, so existing `catch (DaytonaException)`
  handlers continue to work.

## Out of scope (intentionally not addressed)

- Mutable collections returned by some getters
  (`Sandbox.getEnv()`, `Process.listSessions()`, etc.).
- Best-effort `catch (Exception ignored)` cleanup blocks in
  `Daytona.shutdownHttpClient`, `CodeInterpreter.onMessage`,
  `PtyHandle.parseCloseReason`.
- `DaytonaException.getHeaders()` is still empty for mapped exceptions
  — populating headers from `ApiException` is a separate, larger
  change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the original exception cause chain in the Java SDK and classifies transport failures into timeouts vs connection errors for clearer, actionable errors. WebSocket failures now propagate the throwable, HTTP mapping attaches causes, and docs/tests were updated.

- **Bug Fixes**
  - Updated `ExceptionMapper.map` to take a `Throwable`, keep the full cause chain, and only treat status `0` as a transport failure when an underlying cause exists; timeouts map to `DaytonaTimeoutException`, other transport errors to `DaytonaConnectionException`, with message fallback to the cause when the body is empty.
  - Added `(message, cause)` constructors to all status-specific exceptions and the base exception so callers get precise types with full causes.
  - Fixed WebSocket `onFailure` in `Process`, `CodeInterpreter`, and `PtyHandle` to handle null messages and attach the throwable; `PtyHandle.waitForConnection` now surfaces the stored cause.
  - Updated `FileTransfer` to pass the caught `ApiException` to `ExceptionMapper`; synthetic responses pass `null` safely.
  - Expanded tests, including a guard to avoid misclassifying client-side `ApiException` (status `0` without a cause); updated Java SDK error docs to include the new constructors.

<sup>Written for commit 4ee980ae8496cd1dbb3e6227fc740000d1b27cb8. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4749?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

