### PR TITLE
feat(docs): add cli installation commands

### DIFF
--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -32,7 +32,7 @@ To interact with Daytona Sandboxes from the command line, install the Daytona CL
 </TabItem>
 <TabItem label="Linux">
 
-On Linux, the GitHub release command downloads the latest binary and replaces the existing `daytona` binary in `/usr/local/bin`.
+On Linux, the command below downloads the latest binary from GitHub releases and installs it to `/usr/local/bin`, overwriting any existing version.
 
   ```bash
   sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
@@ -48,7 +48,7 @@ On Linux, the GitHub release command downloads the latest binary and replaces th
 </TabItem>
 </Tabs>
 
-After installing the Daytona CLI, use the `daytona` command to interact with Daytona Sandboxes from the command line.
+After installing the Daytona CLI, use the `daytona` command to interact with Daytona sandboxes from the command line.
 
 To upgrade the Daytona CLI to the latest version:
 

--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -23,10 +23,19 @@ Daytona provides command-line access to core features for interacting with Dayto
 To interact with Daytona Sandboxes from the command line, install the Daytona CLI:
 
 <Tabs syncKey="language">
-<TabItem label="Mac/Linux">
+<TabItem label="Mac">
 
   ```bash
   brew install daytonaio/cli/daytona
+  ```
+
+</TabItem>
+<TabItem label="Linux">
+
+On Linux, the GitHub release command downloads the latest binary and replaces the existing `daytona` binary in `/usr/local/bin`.
+
+  ```bash
+  sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
   ```
 
 </TabItem>
@@ -44,10 +53,17 @@ After installing the Daytona CLI, use the `daytona` command to interact with Day
 To upgrade the Daytona CLI to the latest version:
 
 <Tabs syncKey="language">
-<TabItem label="Mac/Linux">
+<TabItem label="Mac">
 
 ```bash
 brew upgrade daytonaio/cli/daytona
+```
+
+</TabItem>
+<TabItem label="Linux">
+
+```bash
+sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 ```
 
 </TabItem>

--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -32,10 +32,18 @@ To interact with Daytona Sandboxes from the command line, install the Daytona CL
 </TabItem>
 <TabItem label="Linux">
 
-On Linux, the command below downloads the latest binary from GitHub releases and installs it to `/usr/local/bin`, overwriting any existing version.
+Choose the command for your Linux architecture. Both commands download the latest binary from GitHub releases and install it to `/usr/local/bin`, overwriting any existing version.
+
+For `amd64` (`x86_64`):
 
   ```bash
-  sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  ```
+
+For `arm64` (`aarch64`):
+
+  ```bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
   ```
 
 </TabItem>
@@ -62,8 +70,16 @@ brew upgrade daytonaio/cli/daytona
 </TabItem>
 <TabItem label="Linux">
 
+For `amd64` (`x86_64`):
+
 ```bash
-sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+```
+
+For `arm64` (`aarch64`):
+
+```bash
+sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 ```
 
 </TabItem>

--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -18,16 +18,20 @@ Daytona provides [Python](/docs/en/python-sdk), [TypeScript](/docs/en/typescript
 
 ## CLI
 
-Daytona provides command-line access to core features for interacting with Daytona Sandboxes, including managing their lifecycle, snapshots, and more.
-
-To interact with Daytona Sandboxes from the command line, install the Daytona CLI:
+Daytona provides command-line access to core features for interacting with Daytona Sandboxes, including managing their lifecycle, snapshots, and more. To interact with Daytona Sandboxes from the command line, install the Daytona CLI:
 
 <Tabs syncKey="language">
 <TabItem label="Mac">
 
-  ```bash
-  brew install daytonaio/cli/daytona
-  ```
+```bash
+brew install daytonaio/cli/daytona
+```
+
+To upgrade the Daytona CLI to the latest version:
+
+```bash
+brew upgrade daytonaio/cli/daytona
+```
 
 </TabItem>
 <TabItem label="Linux">
@@ -49,48 +53,14 @@ For `arm64` (`aarch64`):
 </TabItem>
 <TabItem label="Windows">
 
-  ```bash
-  powershell -Command "irm https://get.daytona.io/windows | iex"
-  ```
-
-</TabItem>
-</Tabs>
-
-After installing the Daytona CLI, use the `daytona` command to interact with Daytona sandboxes from the command line.
-
-To upgrade the Daytona CLI to the latest version:
-
-<Tabs syncKey="language">
-<TabItem label="Mac">
-
-```bash
-brew upgrade daytonaio/cli/daytona
-```
-
-</TabItem>
-<TabItem label="Linux">
-
-For `amd64` (`x86_64`):
-
-```bash
-sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
-```
-
-For `arm64` (`aarch64`):
-
-```bash
-sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
-```
-
-</TabItem>
-<TabItem label="Windows">
-
 ```bash
 powershell -Command "irm https://get.daytona.io/windows | iex"
 ```
 
 </TabItem>
 </Tabs>
+
+After installing the Daytona CLI, use the `daytona` command to interact with Daytona sandboxes from the command line.
 
 To view all available commands and flags, see the [CLI reference](/docs/en/tools/cli).
 

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -67,6 +67,8 @@ brew upgrade daytonaio/cli/daytona
 </TabItem>
 <TabItem label="Linux">
 
+For `amd64` (`x86_64`):
+
 ```bash
 sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 ```

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -20,9 +20,15 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 <Tabs syncKey="language">
 <TabItem label="Mac">
 
-  ```bash
-  brew install daytonaio/cli/daytona
-  ```
+```bash
+brew install daytonaio/cli/daytona
+```
+
+To upgrade the Daytona CLI to the latest version:
+
+```bash
+brew upgrade daytonaio/cli/daytona
+```
 
 </TabItem>
 <TabItem label="Linux">
@@ -44,44 +50,6 @@ For `arm64` (`aarch64`):
 </TabItem>
 <TabItem label="Windows">
 
-  ```bash
-  powershell -Command "irm https://get.daytona.io/windows | iex"
-  ```
-
-</TabItem>
-</Tabs>
-
-After installing the Daytona CLI, use the `daytona` command to interact with Daytona Sandboxes from the command line.
-
-## Update
-
-To update the Daytona CLI to the latest version:
-
-<Tabs syncKey="language">
-<TabItem label="Mac">
-
-```bash
-brew upgrade daytonaio/cli/daytona
-```
-
-</TabItem>
-<TabItem label="Linux">
-
-For `amd64` (`x86_64`):
-
-```bash
-sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
-```
-
-For `arm64` (`aarch64`):
-
-```bash
-sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
-```
-
-</TabItem>
-<TabItem label="Windows">
-
 ```bash
 powershell -Command "irm https://get.daytona.io/windows | iex"
 ```
@@ -89,7 +57,7 @@ powershell -Command "irm https://get.daytona.io/windows | iex"
 </TabItem>
 </Tabs>
 
-On Linux, the GitHub release command downloads the latest binary and replaces the existing `daytona` binary in `/usr/local/bin`.
+After installing the Daytona CLI, use the `daytona` command to interact with Daytona sandboxes from the command line.
 
 ## daytona
 Daytona CLI

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -27,7 +27,7 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 </TabItem>
 <TabItem label="Linux">
 
-On Linux, the GitHub release command downloads the latest binary and replaces the existing `daytona` binary in `/usr/local/bin`.
+On Linux, the command below downloads the latest binary from GitHub releases and installs it to `/usr/local/bin`, overwriting any existing version.
 
   ```bash
   sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -18,10 +18,19 @@ You can access this documentation on a per-command basis by appending the `--hel
 Install the Daytona CLI to interact with Daytona sandboxes from the command line.
 
 <Tabs syncKey="language">
-<TabItem label="Mac/Linux">
+<TabItem label="Mac">
 
   ```bash
   brew install daytonaio/cli/daytona
+  ```
+
+</TabItem>
+<TabItem label="Linux">
+
+On Linux, the GitHub release command downloads the latest binary and replaces the existing `daytona` binary in `/usr/local/bin`.
+
+  ```bash
+  sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
   ```
 
 </TabItem>
@@ -41,10 +50,17 @@ After installing the Daytona CLI, use the `daytona` command to interact with Day
 To update the Daytona CLI to the latest version:
 
 <Tabs syncKey="language">
-<TabItem label="Mac/Linux">
+<TabItem label="Mac">
 
 ```bash
 brew upgrade daytonaio/cli/daytona
+```
+
+</TabItem>
+<TabItem label="Linux">
+
+```bash
+sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 ```
 
 </TabItem>
@@ -56,6 +72,8 @@ powershell -Command "irm https://get.daytona.io/windows | iex"
 
 </TabItem>
 </Tabs>
+
+On Linux, the GitHub release command downloads the latest binary and replaces the existing `daytona` binary in `/usr/local/bin`.
 
 ## daytona
 Daytona CLI

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -27,10 +27,18 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 </TabItem>
 <TabItem label="Linux">
 
-On Linux, the command below downloads the latest binary from GitHub releases and installs it to `/usr/local/bin`, overwriting any existing version.
+Choose the command for your Linux architecture. Both commands download the latest binary from GitHub releases and install it to `/usr/local/bin`, overwriting any existing version.
+
+For `amd64` (`x86_64`):
 
   ```bash
-  sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  ```
+
+For `arm64` (`aarch64`):
+
+  ```bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
   ```
 
 </TabItem>
@@ -60,7 +68,13 @@ brew upgrade daytonaio/cli/daytona
 <TabItem label="Linux">
 
 ```bash
-sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+```
+
+For `arm64` (`aarch64`):
+
+```bash
+sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 ```
 
 </TabItem>

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -33,9 +33,15 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 <Tabs syncKey="language">
 <TabItem label="Mac">
 
-  \`\`\`bash
-  brew install daytonaio/cli/daytona
-  \`\`\`
+\`\`\`bash
+brew install daytonaio/cli/daytona
+\`\`\`
+
+To upgrade the Daytona CLI to the latest version:
+
+\`\`\`bash
+brew upgrade daytonaio/cli/daytona
+\`\`\`
 
 </TabItem>
 <TabItem label="Linux">
@@ -57,44 +63,6 @@ For \`arm64\` (\`aarch64\`):
 </TabItem>
 <TabItem label="Windows">
 
-  \`\`\`bash
-  powershell -Command "irm https://get.daytona.io/windows | iex"
-  \`\`\`
-
-</TabItem>
-</Tabs>
-
-After installing the Daytona CLI, use the \`daytona\` command to interact with Daytona Sandboxes from the command line.
-
-## Update
-
-To update the Daytona CLI to the latest version:
-
-<Tabs syncKey="language">
-<TabItem label="Mac">
-
-\`\`\`bash
-brew upgrade daytonaio/cli/daytona
-\`\`\`
-
-</TabItem>
-<TabItem label="Linux">
-
-For \`amd64\` (\`x86_64\`):
-
-\`\`\`bash
-sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
-\`\`\`
-
-For \`arm64\` (\`aarch64\`):
-
-\`\`\`bash
-sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
-\`\`\`
-
-</TabItem>
-<TabItem label="Windows">
-
 \`\`\`bash
 powershell -Command "irm https://get.daytona.io/windows | iex"
 \`\`\`
@@ -102,7 +70,7 @@ powershell -Command "irm https://get.daytona.io/windows | iex"
 </TabItem>
 </Tabs>
 
-On Linux, the GitHub release command downloads the latest binary and replaces the existing \`daytona\` binary in \`/usr/local/bin\`.
+After installing the Daytona CLI, use the \`daytona\` command to interact with Daytona sandboxes from the command line.
 `
 
 // content to appear below the commands outline

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -40,10 +40,18 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 </TabItem>
 <TabItem label="Linux">
 
-On Linux, the command below downloads the latest binary from GitHub releases and installs it to \`/usr/local/bin\`, overwriting any existing version.
+Choose the command for your Linux architecture. Both commands download the latest binary from GitHub releases and install it to \`/usr/local/bin\`, overwriting any existing version.
+
+For \`amd64\` (\`x86_64\`):
 
   \`\`\`bash
-  sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+  \`\`\`
+
+For \`arm64\` (\`aarch64\`):
+
+  \`\`\`bash
+  sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
   \`\`\`
 
 </TabItem>
@@ -73,7 +81,13 @@ brew upgrade daytonaio/cli/daytona
 <TabItem label="Linux">
 
 \`\`\`bash
-sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
+\`\`\`
+
+For \`arm64\` (\`aarch64\`):
+
+\`\`\`bash
+sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-arm64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 \`\`\`
 
 </TabItem>

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -31,10 +31,19 @@ You can access this documentation on a per-command basis by appending the \`--he
 Install the Daytona CLI to interact with Daytona sandboxes from the command line.
 
 <Tabs syncKey="language">
-<TabItem label="Mac/Linux">
+<TabItem label="Mac">
 
   \`\`\`bash
   brew install daytonaio/cli/daytona
+  \`\`\`
+
+</TabItem>
+<TabItem label="Linux">
+
+On Linux, the GitHub release command downloads the latest binary and replaces the existing \`daytona\` binary in \`/usr/local/bin\`.
+
+  \`\`\`bash
+  sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
   \`\`\`
 
 </TabItem>
@@ -54,10 +63,17 @@ After installing the Daytona CLI, use the \`daytona\` command to interact with D
 To update the Daytona CLI to the latest version:
 
 <Tabs syncKey="language">
-<TabItem label="Mac/Linux">
+<TabItem label="Mac">
 
 \`\`\`bash
 brew upgrade daytonaio/cli/daytona
+\`\`\`
+
+</TabItem>
+<TabItem label="Linux">
+
+\`\`\`bash
+sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 \`\`\`
 
 </TabItem>
@@ -69,6 +85,8 @@ powershell -Command "irm https://get.daytona.io/windows | iex"
 
 </TabItem>
 </Tabs>
+
+On Linux, the GitHub release command downloads the latest binary and replaces the existing \`daytona\` binary in \`/usr/local/bin\`.
 `
 
 // content to appear below the commands outline

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -80,6 +80,8 @@ brew upgrade daytonaio/cli/daytona
 </TabItem>
 <TabItem label="Linux">
 
+For \`amd64\` (\`x86_64\`):
+
 \`\`\`bash
 sudo curl -fL https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona
 \`\`\`

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -40,7 +40,7 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 </TabItem>
 <TabItem label="Linux">
 
-On Linux, the GitHub release command downloads the latest binary and replaces the existing \`daytona\` binary in \`/usr/local/bin\`.
+On Linux, the command below downloads the latest binary from GitHub releases and installs it to \`/usr/local/bin\`, overwriting any existing version.
 
   \`\`\`bash
   sudo curl -L https://github.com/daytonaio/daytona/releases/latest/download/daytona-linux-amd64 -o /usr/local/bin/daytona && sudo chmod +x /usr/local/bin/daytona


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added architecture-specific Linux install commands and inlined Mac upgrade steps in the CLI docs. Split Mac and Linux into separate tabs and clarified that Linux installs write to `/usr/local/bin/daytona` and overwrite existing binaries.

- **New Features**
  - Linux `amd64` and `arm64` install commands via GitHub releases.
  - Mac tab now shows `brew install` and `brew upgrade`; Windows unchanged.

- **Refactors**
  - Merged the separate “Update” section into the Mac tab and moved the post-install note below the tabs.
  - Updated `apps/docs/tools/update-cli-reference.js` and page prose/formatting to generate the new tabs and wording.

<sup>Written for commit 60cf8b59bf9072666ab0d590616dfef36489925a. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4751?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

