### PR TITLE
chore(security): enable Dependabot for Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,33 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: docker
+    directories:
+      - "/apps/api"
+      - "/apps/proxy"
+      - "/apps/runner"
+      - "/apps/snapshot-manager"
+      - "/apps/ssh-gateway"
+      - "/apps/otel-collector"
+      - "/apps/docs"
+      - "/images/sandbox"
+      - "/images/sandbox-slim"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "docker"
+      docker-engine:
+        patterns:
+          - "docker"
+    ignore:
+      - dependency-name: "docker"
+        update-types:
+          - "version-update:semver-major"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## What

Adds the `docker` ecosystem to `.github/dependabot.yml` for nine production Dockerfile directories under `/apps` and `/images`. Routine Alpine / Node / Python base bumps group into `docker-base-images`; the runner's dind engine groups into `docker-engine` and ignores major-version updates pending Sysbox compatibility review.

## Why

Container base images are currently not covered by any automated bot. `apps/runner/Dockerfile` has been pinned to `docker:28.2.2-dind-alpine3.22` for ~11 months. Adding the `docker` ecosystem brings these into the same weekly cadence as github-actions and closes the gap that produces recurring base-image SCA findings.

## Scope

- Covered: `apps/{api,proxy,runner,snapshot-manager,ssh-gateway,otel-collector,docs}`, `images/{sandbox,sandbox-slim}`
- Not covered (intentional): `apps/cli`, `apps/daemon`, `apps/dashboard`, `apps/daytona-e2e` (no Dockerfile), `hack/`, `guides/`, `.devcontainer`
- Not covered (limitation): `COPY --from=<image>` references — Dependabot only scans `FROM` directives. Go toolchain bump is a separate manual PR.

## Test plan

- [x] YAML parses cleanly (`uv run --no-project --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`)
- [ ] After merge, Dependabot Insights lists `docker` ecosystem against the nine directories
- [ ] First Monday run produces grouped PRs labelled `docker-base-images` and/or `docker-engine`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Dependabot’s `docker` ecosystem to track base images across production Dockerfiles, keeping images fresh and reducing recurring SCA findings. Routine base bumps are grouped, and `docker` engine updates are isolated with major versions held for Sysbox review.

- **Dependencies**
  - Runs weekly on Monday.
  - Coverage: nine production Dockerfiles under `/apps` and `/images`; excludes `apps/cli`, `apps/daemon`, `apps/dashboard`, `apps/daytona-e2e`, `hack/`, `guides/`, `.devcontainer`.
  - Grouping: `docker-base-images` for all except `docker`; `docker-engine` for `docker`, with major versions ignored pending Sysbox compatibility.
  - Limitation: only `FROM` lines are scanned; `COPY --from=` refs (e.g., Go toolchain) require manual bumps.

<sup>Written for commit 51ef8edc6dd10274ea1ffa2dd8694ccfb7720598. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4752?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

