### PR TITLE
fix(daemon): memory optimized git CLI option for clone, push & pull

### DIFF
--- a/apps/daemon/pkg/git/cli_errors.go
+++ b/apps/daemon/pkg/git/cli_errors.go
@@ -1,0 +1,178 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/daytonaio/daemon/pkg/childreap"
+	go_git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+// gitCLIRun is the shared driver for clone, push, and pull on the git-CLI
+// codepath. It looks up `git`, writes a one-shot GIT_ASKPASS helper, runs
+// the supplied args with creds in env (never on argv / never in URL), and
+// classifies the resulting error through wrapCLIError so the toolbox handler
+// can map it to a sensible HTTP status.
+//
+// Params:
+//   - op        human-readable label for error messages ("git clone", ...).
+//   - args      git arguments — must NOT contain credentials.
+//   - auth      basic auth; pass nil for local-only ops (askpass is still
+//     written but never consulted — keeps the call sites symmetric).
+//   - tailSize  bytes of stderr+stdout retained for the error message.
+//
+// Memory: the askpass dir is cleaned up via defer on every exit path,
+// including panics. tailBuffer is bounded to tailSize regardless of how
+// chatty git is.
+func (s *Service) gitCLIRun(op string, args []string, auth *http.BasicAuth, tailSize int) error {
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		return fmt.Errorf("git binary not found in PATH: %w", err)
+	}
+
+	askDir, err := os.MkdirTemp("", "daytona-git-*")
+	if err != nil {
+		return fmt.Errorf("create askpass temp dir: %w", err)
+	}
+	defer os.RemoveAll(askDir)
+
+	askPath := filepath.Join(askDir, "askpass.sh")
+	if err := os.WriteFile(askPath, []byte(askpassScript), 0o700); err != nil {
+		return fmt.Errorf("write askpass helper: %w", err)
+	}
+
+	cmd := exec.Command(gitBin, args...)
+	cmd.Env = buildCloneEnv(os.Environ(), askPath, auth)
+	tail := s.attachCmdOutput(cmd, tailSize)
+
+	// childreap.Run instead of cmd.Run so the reaper claiming the zombie
+	// first doesn't surface as a spurious "wait: no child processes".
+	exitCode, err := childreap.Run(cmd)
+	if err != nil {
+		return wrapCLIError(op, err, exitCode, tail.String(), auth)
+	}
+	if exitCode != 0 {
+		return wrapCLIError(op, nil, exitCode, tail.String(), auth)
+	}
+	return nil
+}
+
+// classifyCLIError inspects captured `git` CLI stderr/stdout and returns the
+// matching go-git sentinel error, or nil when no pattern matches. CLI paths
+// wrap the returned sentinel via `%w` so the toolbox handler's
+// `classifyGitError` (which uses `errors.Is` against go-git sentinels) maps
+// CLI failures to the same HTTP status codes as the go-git default path
+// (401/403/404/409) instead of an opaque 500.
+//
+// Patterns are matched against the lowercased output to be robust against
+// minor casing differences between git versions.
+func classifyCLIError(output string) error {
+	s := strings.ToLower(output)
+
+	switch {
+	// 401 Unauthorized
+	case contains(s, "authentication failed"),
+		contains(s, "invalid username or password"),
+		contains(s, "could not read username"),
+		contains(s, "could not read password"),
+		contains(s, "terminal prompts disabled"):
+		return transport.ErrAuthenticationRequired
+
+	// 403 Forbidden — distinct enough HTTP-403 markers; raw "forbidden"
+	// alone is intentionally not matched because git surfaces it for both
+	// auth-failures and authz-failures depending on the host.
+	case contains(s, "the requested url returned error: 403"),
+		contains(s, "remote: permission") && contains(s, "denied"):
+		return transport.ErrAuthorizationFailed
+
+	// 404 Not Found
+	case contains(s, "repository not found"),
+		contains(s, "the requested url returned error: 404"),
+		contains(s, "remote: not found"),
+		contains(s, "does not appear to be a git repository"):
+		return transport.ErrRepositoryNotFound
+
+	// 404 — local ref/branch resolution problems (e.g. detached HEAD push)
+	case contains(s, "src refspec") && contains(s, "does not match any"),
+		contains(s, "you are not currently on a branch"),
+		contains(s, "unknown revision or path not in the working tree"):
+		return plumbing.ErrReferenceNotFound
+
+	// 409 Conflict — non-fast-forward / rejected updates.
+	// Note: "failed to push some refs" is intentionally NOT matched — git
+	// emits it for every push failure (including auth) and would shadow the
+	// more-specific cases above.
+	case contains(s, "non-fast-forward"),
+		contains(s, "fetch first"),
+		contains(s, "updates were rejected"),
+		contains(s, "stale info"):
+		return go_git.ErrNonFastForwardUpdate
+
+	// 409 Conflict — pull with dirty worktree
+	case contains(s, "your local changes to the following files would be overwritten"),
+		contains(s, "please commit your changes or stash them"),
+		contains(s, "needs merge"):
+		return go_git.ErrWorktreeNotClean
+	}
+
+	return nil
+}
+
+// contains is a tiny wrapper so the switch cases above stay readable.
+func contains(haystack, needle string) bool {
+	return strings.Contains(haystack, needle)
+}
+
+// redactCredentials replaces the basic-auth username and password with `***`
+// in the given string. Used to scrub captured git output before it surfaces
+// in error messages (where it would otherwise leak into logs / API responses).
+func redactCredentials(s string, auth *http.BasicAuth) string {
+	if auth == nil {
+		return s
+	}
+	if auth.Username != "" {
+		s = strings.ReplaceAll(s, auth.Username, "***")
+	}
+	if auth.Password != "" {
+		s = strings.ReplaceAll(s, auth.Password, "***")
+	}
+	return s
+}
+
+// wrapCLIError builds the final error returned from CLI codepaths. When
+// `classifyCLIError` matches a known stderr pattern, the returned error wraps
+// the corresponding go-git sentinel so the toolbox handler's
+// `classifyGitError` can map it to the same HTTP status as the go-git path.
+// Otherwise it falls back to the generic message (handled as 500 upstream).
+//
+// `op` is the human-readable operation name ("git push", "git clone", ...).
+// `runErr` is non-nil when childreap.Run itself failed (couldn't start /
+// reap the process). `exitCode` is 0 in that case.
+//
+// The captured git output is redacted of credentials before being included.
+func wrapCLIError(op string, runErr error, exitCode int, output string, auth *http.BasicAuth) error {
+	redacted := redactCredentials(output, auth)
+	sentinel := classifyCLIError(output)
+
+	var base error
+	switch {
+	case runErr != nil && sentinel != nil:
+		base = fmt.Errorf("%s failed: %w\n--- git output (tail) ---\n%s\n--- cause: %v", op, sentinel, redacted, runErr)
+	case runErr != nil:
+		base = fmt.Errorf("%s failed: %w\n--- git output (tail) ---\n%s", op, runErr, redacted)
+	case sentinel != nil:
+		base = fmt.Errorf("%s exited with status %d: %w\n--- git output (tail) ---\n%s", op, exitCode, sentinel, redacted)
+	default:
+		base = fmt.Errorf("%s exited with status %d\n--- git output (tail) ---\n%s", op, exitCode, redacted)
+	}
+	return base
+}

--- a/apps/daemon/pkg/git/cli_errors.go
+++ b/apps/daemon/pkg/git/cli_errors.go
@@ -135,15 +135,22 @@ func contains(haystack, needle string) bool {
 // redactCredentials replaces the basic-auth username and password with `***`
 // in the given string. Used to scrub captured git output before it surfaces
 // in error messages (where it would otherwise leak into logs / API responses).
+//
+// Order matters: replace the password first. If the username happens to be a
+// substring of the password (e.g. username="foo", password="foopassword"),
+// redacting the username first turns "foopassword" into "***password" and
+// the remaining "password" tail leaks. Replacing the password first avoids
+// this. We can't sort by length generically because the strings are short
+// enough that an explicit ordering is clearer than a sort.
 func redactCredentials(s string, auth *http.BasicAuth) string {
 	if auth == nil {
 		return s
 	}
-	if auth.Username != "" {
-		s = strings.ReplaceAll(s, auth.Username, "***")
-	}
 	if auth.Password != "" {
 		s = strings.ReplaceAll(s, auth.Password, "***")
+	}
+	if auth.Username != "" {
+		s = strings.ReplaceAll(s, auth.Username, "***")
 	}
 	return s
 }

--- a/apps/daemon/pkg/git/cli_errors_internal_test.go
+++ b/apps/daemon/pkg/git/cli_errors_internal_test.go
@@ -181,4 +181,19 @@ func TestRedactCredentials(t *testing.T) {
 		got := redactCredentials(raw, &http.BasicAuth{})
 		require.Equal(t, raw, got)
 	})
+
+	t.Run("username substring of password does not leak password tail", func(t *testing.T) {
+		// Regression: when username is a substring of password (e.g.
+		// username="foo", password="foopassword"), redacting the username
+		// first would turn "foopassword" into "***password" and leak the
+		// "password" suffix. Password must be redacted first.
+		overlapping := &http.BasicAuth{
+			Username: "foo",
+			Password: "foopassword",
+		}
+		raw := "leaked: foopassword and foo"
+		got := redactCredentials(raw, overlapping)
+		require.NotContains(t, got, "password", "password tail leaked: %q", got)
+		require.NotContains(t, got, "foopassword")
+	})
 }

--- a/apps/daemon/pkg/git/cli_errors_internal_test.go
+++ b/apps/daemon/pkg/git/cli_errors_internal_test.go
@@ -1,0 +1,184 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package git
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	go_git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyCLIError(t *testing.T) {
+	cases := []struct {
+		name     string
+		output   string
+		expected error
+	}{
+		// 401
+		{
+			name:     "authentication failed",
+			output:   "remote: Invalid username or password.\nfatal: Authentication failed for 'https://github.com/foo/bar.git/'",
+			expected: transport.ErrAuthenticationRequired,
+		},
+		{
+			name:     "terminal prompts disabled",
+			output:   "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+			expected: transport.ErrAuthenticationRequired,
+		},
+		// 403
+		{
+			name:     "http 403",
+			output:   "fatal: unable to access 'https://example.com/foo.git/': The requested URL returned error: 403",
+			expected: transport.ErrAuthorizationFailed,
+		},
+		{
+			name:     "permission denied",
+			output:   "remote: Permission to foo/bar.git denied to user.",
+			expected: transport.ErrAuthorizationFailed,
+		},
+		// 404 — remote
+		{
+			name:     "repository not found",
+			output:   "remote: Repository not found.\nfatal: repository 'https://github.com/foo/missing.git/' not found",
+			expected: transport.ErrRepositoryNotFound,
+		},
+		{
+			name:     "http 404",
+			output:   "fatal: unable to access 'https://example.com/foo.git/': The requested URL returned error: 404",
+			expected: transport.ErrRepositoryNotFound,
+		},
+		// 404 — local ref (detached HEAD push, etc.)
+		{
+			name:     "src refspec does not match",
+			output:   "error: src refspec HEAD does not match any.\nerror: failed to push some refs to 'origin'",
+			expected: plumbing.ErrReferenceNotFound,
+		},
+		// 409 — non-fast-forward
+		{
+			name:     "non-fast-forward",
+			output:   "! [rejected]        main -> main (non-fast-forward)\nerror: failed to push some refs to 'origin'",
+			expected: go_git.ErrNonFastForwardUpdate,
+		},
+		{
+			name:     "fetch first",
+			output:   "! [rejected]        main -> main (fetch first)\nerror: failed to push some refs to 'origin'\nhint: Updates were rejected because the remote contains work that you do not have locally.",
+			expected: go_git.ErrNonFastForwardUpdate,
+		},
+		// 409 — pull onto dirty worktree
+		{
+			name:     "local changes would be overwritten",
+			output:   "error: Your local changes to the following files would be overwritten by merge:\n\tREADME.md\nPlease commit your changes or stash them before you merge.",
+			expected: go_git.ErrWorktreeNotClean,
+		},
+		// No match
+		{
+			name:     "unknown error",
+			output:   "fatal: something completely unexpected happened",
+			expected: nil,
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			expected: nil,
+		},
+		// Auth-failure shadow check: "failed to push some refs" alone must
+		// not be classified as non-fast-forward.
+		{
+			name:     "generic push failure is not classified as conflict",
+			output:   "error: failed to push some refs to 'origin'",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyCLIError(tc.output)
+			if tc.expected == nil {
+				require.Nil(t, got, "expected no match, got %v", got)
+				return
+			}
+			require.ErrorIs(t, got, tc.expected)
+		})
+	}
+}
+
+func TestWrapCLIError_AttachesSentinelForKnownPatterns(t *testing.T) {
+	auth := &http.BasicAuth{Username: "u", Password: "secret-token"}
+
+	// runErr nil, exitCode != 0, output matches auth-failure pattern → wraps sentinel
+	err := wrapCLIError("git push", nil, 128,
+		"fatal: Authentication failed for 'https://github.com/foo/bar.git/'", auth)
+	require.Error(t, err)
+	require.ErrorIs(t, err, transport.ErrAuthenticationRequired)
+}
+
+func TestWrapCLIError_FallsBackWhenUnknownPattern(t *testing.T) {
+	auth := &http.BasicAuth{Username: "u", Password: "secret-token"}
+
+	err := wrapCLIError("git push", nil, 1, "fatal: kaboom", auth)
+	require.Error(t, err)
+	// Should NOT match any go-git sentinel (will map to 500 upstream).
+	require.False(t, errors.Is(err, transport.ErrAuthenticationRequired))
+	require.False(t, errors.Is(err, transport.ErrRepositoryNotFound))
+	require.False(t, errors.Is(err, go_git.ErrNonFastForwardUpdate))
+}
+
+func TestWrapCLIError_RedactsCredentialsInOutput(t *testing.T) {
+	auth := &http.BasicAuth{Username: "leaky-user", Password: "leaky-token-zzz"}
+
+	output := "fatal: Authentication failed for 'https://leaky-user:leaky-token-zzz@example.com/foo.git/'"
+	err := wrapCLIError("git push", nil, 128, output, auth)
+	require.Error(t, err)
+
+	msg := err.Error()
+	require.NotContains(t, msg, "leaky-user")
+	require.NotContains(t, msg, "leaky-token-zzz")
+	require.Contains(t, msg, "***")
+}
+
+func TestWrapCLIError_IncludesRunErrCause(t *testing.T) {
+	auth := &http.BasicAuth{Username: "u", Password: "p"}
+
+	runErr := errors.New("exec: signal killed")
+	err := wrapCLIError("git pull", runErr, 0, "(no output)", auth)
+	require.Error(t, err)
+	// runErr should be surfaced (either as the wrapped error or in the message).
+	require.True(t,
+		errors.Is(err, runErr) || strings.Contains(err.Error(), runErr.Error()),
+		"expected runErr to be referenced; got: %v", err)
+}
+
+func TestRedactCredentials(t *testing.T) {
+	auth := &http.BasicAuth{
+		Username: "secret-user",
+		Password: "secret-token-xyz",
+	}
+
+	t.Run("redacts username and password", func(t *testing.T) {
+		raw := "fatal: Authentication failed for 'https://secret-user@github.com/repo.git'\nPassword was secret-token-xyz"
+		got := redactCredentials(raw, auth)
+		require.NotContains(t, got, "secret-user")
+		require.NotContains(t, got, "secret-token-xyz")
+		require.Contains(t, got, "***")
+	})
+
+	t.Run("nil auth returns input unchanged", func(t *testing.T) {
+		raw := "some output with no secrets"
+		got := redactCredentials(raw, nil)
+		require.Equal(t, raw, got)
+	})
+
+	t.Run("empty creds are no-ops", func(t *testing.T) {
+		raw := "some output"
+		got := redactCredentials(raw, &http.BasicAuth{})
+		require.Equal(t, raw, got)
+	})
+}

--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -132,6 +132,7 @@ func buildCloneArgs(repo *gitprovider.GitRepository, workDir string) []string {
 	args := []string{
 		"-c", "credential.helper=", // prevent any inherited helper from persisting the token
 		"-c", "http.sslVerify=false", // parity with go-git InsecureSkipTLS
+		"-c", "core.hooksPath=/dev/null", // disable post-checkout (and any inherited core.hooksPath) — defense-in-depth so hooks can't read GIT_USERNAME / GIT_PASSWORD
 		"clone",
 		"--single-branch",
 		"--progress",

--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -9,10 +9,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
-	"github.com/daytonaio/daemon/pkg/childreap"
 	"github.com/daytonaio/daemon/pkg/gitprovider"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -21,11 +19,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
-// Set to "true" to opt into the git-CLI clone path (bounded memory, needs `git` in PATH).
-const experimentalUseGitCloneCLIEnv = "DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI"
-
 func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.BasicAuth) error {
-	if os.Getenv(experimentalUseGitCloneCLIEnv) == "true" {
+	if isGitCLIModeEnabled() || os.Getenv(experimentalUseGitCloneCLIEnv) == "true" {
 		return s.CloneRepositoryCLI(repo, auth)
 	}
 
@@ -91,52 +86,21 @@ esac
 // CloneRepositoryCLI clones via the `git` CLI. Bounded memory (mmap pack handling).
 // Creds flow through GIT_ASKPASS + env — never via URL or argv.
 func (s *Service) CloneRepositoryCLI(repo *gitprovider.GitRepository, auth *http.BasicAuth) error {
-	gitBin, err := exec.LookPath("git")
-	if err != nil {
-		return fmt.Errorf("git binary not found in PATH: %w", err)
-	}
-
-	askDir, err := os.MkdirTemp("", "daytona-clone-*")
-	if err != nil {
-		return fmt.Errorf("create askpass temp dir: %w", err)
-	}
-	defer os.RemoveAll(askDir)
-
-	askPath := filepath.Join(askDir, "askpass.sh")
-	if err := os.WriteFile(askPath, []byte(askpassScript), 0o700); err != nil {
-		return fmt.Errorf("write askpass helper: %w", err)
-	}
-
-	cmd := exec.Command(gitBin, buildCloneArgs(repo, s.WorkDir)...)
-	cmd.Env = buildCloneEnv(os.Environ(), askPath, auth)
-	tail := s.attachCmdOutput(cmd, 64*1024)
-	// childreap.Run instead of cmd.Run so the reaper claiming the zombie
-	// first doesn't surface as a spurious "git clone failed: wait: no
-	// child processes" to API clients.
-	exitCode, err := childreap.Run(cmd)
-	if err != nil {
-		return fmt.Errorf("git clone failed: %w\n--- git output (tail) ---\n%s", err, tail.String())
-	}
-	if exitCode != 0 {
-		return fmt.Errorf("git clone exited with status %d\n--- git output (tail) ---\n%s", exitCode, tail.String())
+	if err := s.gitCLIRun("git clone", buildCloneArgs(repo, s.WorkDir), auth, 64*1024); err != nil {
+		return err
 	}
 
 	if repo.Target == gitprovider.CloneTargetCommit {
-		checkout := exec.Command(gitBin, buildCheckoutArgs(s.WorkDir, repo.Sha)...)
-		// Checkout is a purely local op and does not need network credentials.
-		// Pass a sanitized env with auth omitted so rogue checkout hooks cannot
-		// exfiltrate GIT_USERNAME / GIT_PASSWORD.
-		checkout.Env = buildCloneEnv(os.Environ(), askPath, nil)
-		checkoutTail := s.attachCmdOutput(checkout, 16*1024)
-		checkoutCode, err := childreap.Run(checkout)
-		if err != nil {
-			return fmt.Errorf("git checkout %s failed: %w\n--- git output (tail) ---\n%s", repo.Sha, err, checkoutTail.String())
-		}
-		if checkoutCode != 0 {
-			return fmt.Errorf("git checkout %s exited with status %d\n--- git output (tail) ---\n%s", repo.Sha, checkoutCode, checkoutTail.String())
-		}
+		// Checkout is a purely local op — no network creds needed. Pass
+		// auth=nil so rogue checkout hooks cannot exfiltrate the token via
+		// GIT_USERNAME / GIT_PASSWORD.
+		return s.gitCLIRun(
+			fmt.Sprintf("git checkout %s", repo.Sha),
+			buildCheckoutArgs(s.WorkDir, repo.Sha),
+			nil,
+			16*1024,
+		)
 	}
-
 	return nil
 }
 

--- a/apps/daemon/pkg/git/clone_internal_test.go
+++ b/apps/daemon/pkg/git/clone_internal_test.go
@@ -37,6 +37,7 @@ func TestBuildCloneArgs(t *testing.T) {
 			expected: []string{
 				"-c", "credential.helper=",
 				"-c", "http.sslVerify=false",
+				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--branch", "main",
 				"--", "https://github.com/daytonaio/daytona", "/work-dir",
@@ -52,6 +53,7 @@ func TestBuildCloneArgs(t *testing.T) {
 			expected: []string{
 				"-c", "credential.helper=",
 				"-c", "http.sslVerify=false",
+				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--branch", "main",
 				"--", "http://localhost:3000/daytonaio/daytona", "/work-dir",
@@ -67,6 +69,7 @@ func TestBuildCloneArgs(t *testing.T) {
 			expected: []string{
 				"-c", "credential.helper=",
 				"-c", "http.sslVerify=false",
+				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--branch", "main",
 				"--", "https://github.com/daytonaio/daytona", "/work-dir",
@@ -81,6 +84,7 @@ func TestBuildCloneArgs(t *testing.T) {
 			expected: []string{
 				"-c", "credential.helper=",
 				"-c", "http.sslVerify=false",
+				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--", "https://github.com/daytonaio/daytona", "/work-dir",
 			},

--- a/apps/daemon/pkg/git/pull.go
+++ b/apps/daemon/pkg/git/pull.go
@@ -37,13 +37,23 @@ func (s *Service) PullCLI(auth *http.BasicAuth) error {
 }
 
 func buildPullArgs(workDir string) []string {
+	// Note: no -c http.sslVerify=false here. go-git's default PullOptions
+	// does NOT skip TLS verification (unlike its CloneOptions, which we
+	// match with InsecureSkipTLS:true). Skipping verify on pull would be a
+	// behavior change and a MITM risk for the basic-auth token.
+	//
+	// --ff-only matches go-git's `w.Pull()` semantics, which fails with
+	// ErrNonFastForwardUpdate on divergent histories instead of producing
+	// a merge commit. Without --ff-only, plain `git pull` would honor the
+	// repo/user pull.rebase / merge.ff config and could diverge from the
+	// go-git path's behavior.
 	return []string{
 		"-C", workDir,
 		"-c", "credential.helper=",
-		"-c", "http.sslVerify=false",
 		"-c", "core.hooksPath=/dev/null",
 		"pull",
-		"origin",
+		"--ff-only",
 		"--progress",
+		"origin",
 	}
 }

--- a/apps/daemon/pkg/git/pull.go
+++ b/apps/daemon/pkg/git/pull.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (s *Service) Pull(auth *http.BasicAuth) error {
+	if isGitCLIModeEnabled() {
+		return s.PullCLI(auth)
+	}
+
 	repo, err := git.PlainOpen(s.WorkDir)
 	if err != nil {
 		return err
@@ -26,4 +30,20 @@ func (s *Service) Pull(auth *http.BasicAuth) error {
 	}
 
 	return w.Pull(options)
+}
+
+func (s *Service) PullCLI(auth *http.BasicAuth) error {
+	return s.gitCLIRun("git pull", buildPullArgs(s.WorkDir), auth, 64*1024)
+}
+
+func buildPullArgs(workDir string) []string {
+	return []string{
+		"-C", workDir,
+		"-c", "credential.helper=",
+		"-c", "http.sslVerify=false",
+		"-c", "core.hooksPath=/dev/null",
+		"pull",
+		"origin",
+		"--progress",
+	}
 }

--- a/apps/daemon/pkg/git/pull_internal_test.go
+++ b/apps/daemon/pkg/git/pull_internal_test.go
@@ -1,0 +1,76 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package git
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/require"
+)
+
+var pullTestCreds = &http.BasicAuth{
+	Username: "pull-test-user-xyz",
+	Password: "pull-test-token-abc123",
+}
+
+func TestBuildPullArgs(t *testing.T) {
+	got := buildPullArgs("/work-dir")
+	require.Equal(t, []string{
+		"-C", "/work-dir",
+		"-c", "credential.helper=",
+		"-c", "http.sslVerify=false",
+		"-c", "core.hooksPath=/dev/null",
+		"pull",
+		"origin",
+		"--progress",
+	}, got)
+}
+
+func TestBuildPullArgs_NeverEmbedsCredsInArgs(t *testing.T) {
+	args := buildPullArgs("/work-dir")
+
+	for _, arg := range args {
+		require.NotContains(t, arg, pullTestCreds.Username,
+			"username leaked into pull args: %q", arg)
+		require.NotContains(t, arg, pullTestCreds.Password,
+			"password leaked into pull args: %q", arg)
+	}
+}
+
+func TestBuildPullArgs_DisablesHooks(t *testing.T) {
+	args := buildPullArgs("/work-dir")
+
+	found := false
+	for i, arg := range args {
+		if arg == "core.hooksPath=/dev/null" && i > 0 && args[i-1] == "-c" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "pull args must disable hooks via core.hooksPath=/dev/null")
+}
+
+func TestPullCLI_EnvContainsAskpassAndCreds(t *testing.T) {
+	env := buildCloneEnv(nil, "/tmp/askpass.sh", pullTestCreds)
+
+	require.Contains(t, env, "GIT_ASKPASS=/tmp/askpass.sh")
+	require.Contains(t, env, "GIT_TERMINAL_PROMPT=0")
+	require.Contains(t, env, "GIT_USERNAME="+pullTestCreds.Username)
+	require.Contains(t, env, "GIT_PASSWORD="+pullTestCreds.Password)
+}
+
+func TestPullCLI_EnvOmitsCredsWhenNil(t *testing.T) {
+	env := buildCloneEnv(nil, "/tmp/askpass.sh", nil)
+
+	require.Contains(t, env, "GIT_ASKPASS=/tmp/askpass.sh")
+	require.Contains(t, env, "GIT_TERMINAL_PROMPT=0")
+
+	for _, kv := range env {
+		require.NotContains(t, kv, "GIT_USERNAME=",
+			"GIT_USERNAME must not appear when auth is nil")
+		require.NotContains(t, kv, "GIT_PASSWORD=",
+			"GIT_PASSWORD must not appear when auth is nil")
+	}
+}

--- a/apps/daemon/pkg/git/pull_internal_test.go
+++ b/apps/daemon/pkg/git/pull_internal_test.go
@@ -20,12 +20,38 @@ func TestBuildPullArgs(t *testing.T) {
 	require.Equal(t, []string{
 		"-C", "/work-dir",
 		"-c", "credential.helper=",
-		"-c", "http.sslVerify=false",
 		"-c", "core.hooksPath=/dev/null",
 		"pull",
-		"origin",
+		"--ff-only",
 		"--progress",
+		"origin",
 	}, got)
+}
+
+func TestBuildPullArgs_VerifiesTLS(t *testing.T) {
+	// Pull must NOT skip TLS verification (parity with go-git PullOptions,
+	// which does not set InsecureSkipTLS). Skipping verify would be a MITM
+	// risk for the basic-auth token.
+	args := buildPullArgs("/work-dir")
+	for _, arg := range args {
+		require.NotEqual(t, "http.sslVerify=false", arg,
+			"pull args must NOT disable TLS verification")
+	}
+}
+
+func TestBuildPullArgs_FastForwardOnly(t *testing.T) {
+	// Pull must be fast-forward-only to match go-git's w.Pull() behavior
+	// (which returns ErrNonFastForwardUpdate on divergent histories instead
+	// of producing a merge commit).
+	args := buildPullArgs("/work-dir")
+	found := false
+	for _, arg := range args {
+		if arg == "--ff-only" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "pull args must include --ff-only")
 }
 
 func TestBuildPullArgs_NeverEmbedsCredsInArgs(t *testing.T) {

--- a/apps/daemon/pkg/git/push.go
+++ b/apps/daemon/pkg/git/push.go
@@ -4,15 +4,23 @@
 package git
 
 import (
+	"bytes"
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/go-git/go-git/v5"
 )
 
 func (s *Service) Push(auth *http.BasicAuth) error {
+	if isGitCLIModeEnabled() {
+		return s.PushCLI(auth)
+	}
+
 	repo, err := git.PlainOpen(s.WorkDir)
 	if err != nil {
 		return err
@@ -31,4 +39,58 @@ func (s *Service) Push(auth *http.BasicAuth) error {
 	}
 
 	return repo.Push(options)
+}
+
+func (s *Service) PushCLI(auth *http.BasicAuth) error {
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		return fmt.Errorf("git binary not found in PATH: %w", err)
+	}
+
+	// Match go-git's `repo.Push` semantics, which pushes the resolved HEAD
+	// ref as `<full-ref>:<full-ref>`. Resolve via the CLI rather than
+	// re-opening the repo with go-git to keep this codepath dependency-free
+	// (the whole point of the CLI fallback is bounded memory).
+	branchRef, err := resolveSymbolicHEAD(gitBin, s.WorkDir)
+	if err != nil {
+		return err
+	}
+
+	return s.gitCLIRun("git push", buildPushArgs(s.WorkDir, branchRef), auth, 64*1024)
+}
+
+// resolveSymbolicHEAD returns the fully-qualified ref name of the current
+// branch (e.g. `refs/heads/main`). When HEAD is detached, it returns a
+// plumbing.ErrReferenceNotFound-wrapped error so the toolbox handler maps it
+// to HTTP 404 — same status the go-git path produces for an unresolvable ref.
+func resolveSymbolicHEAD(gitBin, workDir string) (string, error) {
+	cmd := exec.Command(gitBin, "-C", workDir, "symbolic-ref", "HEAD")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// `git symbolic-ref HEAD` exits non-zero in detached HEAD state. We
+		// can't push HEAD on detached state — go-git fails too in that case
+		// (different error, same outcome). Surface a 404-mappable error.
+		return "", fmt.Errorf("resolve HEAD: detached or unresolvable (%s): %w",
+			strings.TrimSpace(stderr.String()), plumbing.ErrReferenceNotFound)
+	}
+	ref := strings.TrimSpace(stdout.String())
+	if ref == "" {
+		return "", fmt.Errorf("resolve HEAD: empty symbolic ref: %w", plumbing.ErrReferenceNotFound)
+	}
+	return ref, nil
+}
+
+func buildPushArgs(workDir, branchRef string) []string {
+	return []string{
+		"-C", workDir,
+		"-c", "credential.helper=",
+		"-c", "http.sslVerify=false",
+		"-c", "core.hooksPath=/dev/null",
+		"push",
+		"origin",
+		fmt.Sprintf("%s:%s", branchRef, branchRef),
+		"--progress",
+	}
 }

--- a/apps/daemon/pkg/git/push.go
+++ b/apps/daemon/pkg/git/push.go
@@ -83,10 +83,13 @@ func resolveSymbolicHEAD(gitBin, workDir string) (string, error) {
 }
 
 func buildPushArgs(workDir, branchRef string) []string {
+	// Note: no -c http.sslVerify=false here. go-git's default PushOptions
+	// does NOT skip TLS verification (unlike CloneOptions, where we set
+	// InsecureSkipTLS:true). Skipping verify on push would be a behavior
+	// change and a MITM risk for the basic-auth token.
 	return []string{
 		"-C", workDir,
 		"-c", "credential.helper=",
-		"-c", "http.sslVerify=false",
 		"-c", "core.hooksPath=/dev/null",
 		"push",
 		"origin",

--- a/apps/daemon/pkg/git/push_internal_test.go
+++ b/apps/daemon/pkg/git/push_internal_test.go
@@ -24,7 +24,6 @@ func TestBuildPushArgs(t *testing.T) {
 	require.Equal(t, []string{
 		"-C", "/work-dir",
 		"-c", "credential.helper=",
-		"-c", "http.sslVerify=false",
 		"-c", "core.hooksPath=/dev/null",
 		"push",
 		"origin",
@@ -55,6 +54,17 @@ func TestBuildPushArgs_DisablesHooks(t *testing.T) {
 		}
 	}
 	require.True(t, found, "push args must disable hooks via core.hooksPath=/dev/null")
+}
+
+func TestBuildPushArgs_VerifiesTLS(t *testing.T) {
+	// Push must NOT skip TLS verification (parity with go-git PushOptions,
+	// which does not set InsecureSkipTLS). Skipping verify would be a MITM
+	// risk for the basic-auth token.
+	args := buildPushArgs("/work-dir", "refs/heads/main")
+	for _, arg := range args {
+		require.NotEqual(t, "http.sslVerify=false", arg,
+			"push args must NOT disable TLS verification")
+	}
 }
 
 func TestPushCLI_EnvContainsAskpassAndCreds(t *testing.T) {
@@ -91,7 +101,16 @@ func initTestRepoOnBranch(t *testing.T, branch string) string {
 
 	dir := t.TempDir()
 	run := func(args ...string) {
-		cmd := exec.Command(gitBin, append([]string{"-C", dir}, args...)...)
+		// Force-disable global git config that can break these tests on dev
+		// machines (commit hooks set in ~/.gitconfig, gpg signing requirements,
+		// commit signoff templates, etc.).
+		base := []string{
+			"-C", dir,
+			"-c", "core.hooksPath=/dev/null",
+			"-c", "commit.gpgSign=false",
+			"-c", "tag.gpgSign=false",
+		}
+		cmd := exec.Command(gitBin, append(base, args...)...)
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",

--- a/apps/daemon/pkg/git/push_internal_test.go
+++ b/apps/daemon/pkg/git/push_internal_test.go
@@ -1,0 +1,141 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/require"
+)
+
+var pushTestCreds = &http.BasicAuth{
+	Username: "push-test-user-xyz",
+	Password: "push-test-token-abc123",
+}
+
+func TestBuildPushArgs(t *testing.T) {
+	got := buildPushArgs("/work-dir", "refs/heads/main")
+	require.Equal(t, []string{
+		"-C", "/work-dir",
+		"-c", "credential.helper=",
+		"-c", "http.sslVerify=false",
+		"-c", "core.hooksPath=/dev/null",
+		"push",
+		"origin",
+		"refs/heads/main:refs/heads/main",
+		"--progress",
+	}, got)
+}
+
+func TestBuildPushArgs_NeverEmbedsCredsInArgs(t *testing.T) {
+	args := buildPushArgs("/work-dir", "refs/heads/main")
+
+	for _, arg := range args {
+		require.NotContains(t, arg, pushTestCreds.Username,
+			"username leaked into push args: %q", arg)
+		require.NotContains(t, arg, pushTestCreds.Password,
+			"password leaked into push args: %q", arg)
+	}
+}
+
+func TestBuildPushArgs_DisablesHooks(t *testing.T) {
+	args := buildPushArgs("/work-dir", "refs/heads/main")
+
+	found := false
+	for i, arg := range args {
+		if arg == "core.hooksPath=/dev/null" && i > 0 && args[i-1] == "-c" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "push args must disable hooks via core.hooksPath=/dev/null")
+}
+
+func TestPushCLI_EnvContainsAskpassAndCreds(t *testing.T) {
+	env := buildCloneEnv(nil, "/tmp/askpass.sh", pushTestCreds)
+
+	require.Contains(t, env, "GIT_ASKPASS=/tmp/askpass.sh")
+	require.Contains(t, env, "GIT_TERMINAL_PROMPT=0")
+	require.Contains(t, env, "GIT_USERNAME="+pushTestCreds.Username)
+	require.Contains(t, env, "GIT_PASSWORD="+pushTestCreds.Password)
+}
+
+func TestPushCLI_EnvOmitsCredsWhenNil(t *testing.T) {
+	env := buildCloneEnv(nil, "/tmp/askpass.sh", nil)
+
+	require.Contains(t, env, "GIT_ASKPASS=/tmp/askpass.sh")
+	require.Contains(t, env, "GIT_TERMINAL_PROMPT=0")
+
+	for _, kv := range env {
+		require.NotContains(t, kv, "GIT_USERNAME=",
+			"GIT_USERNAME must not appear when auth is nil")
+		require.NotContains(t, kv, "GIT_PASSWORD=",
+			"GIT_PASSWORD must not appear when auth is nil")
+	}
+}
+
+// initTestRepoOnBranch creates a fresh git repo on the given branch with one
+// commit. Skips the test if `git` is unavailable.
+func initTestRepoOnBranch(t *testing.T, branch string) string {
+	t.Helper()
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(gitBin, append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	run("init", "--initial-branch="+branch)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f"), []byte("hi"), 0o644))
+	run("add", "f")
+	run("commit", "-m", "init")
+	return dir
+}
+
+func TestResolveSymbolicHEAD_ReturnsFullRefOnBranch(t *testing.T) {
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	dir := initTestRepoOnBranch(t, "feature/xyz")
+
+	ref, err := resolveSymbolicHEAD(gitBin, dir)
+	require.NoError(t, err)
+	require.Equal(t, "refs/heads/feature/xyz", ref)
+}
+
+func TestResolveSymbolicHEAD_DetachedReturnsReferenceNotFound(t *testing.T) {
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	dir := initTestRepoOnBranch(t, "master")
+
+	// Detach HEAD by checking out the commit SHA directly.
+	rev := exec.Command(gitBin, "-C", dir, "rev-parse", "HEAD")
+	out, err := rev.Output()
+	require.NoError(t, err)
+	sha := string(out[:len(out)-1])
+
+	checkout := exec.Command(gitBin, "-C", dir, "-c", "advice.detachedHead=false", "checkout", sha)
+	checkoutOut, err := checkout.CombinedOutput()
+	require.NoError(t, err, "checkout: %s", checkoutOut)
+
+	_, err = resolveSymbolicHEAD(gitBin, dir)
+	require.Error(t, err)
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+}

--- a/apps/daemon/pkg/git/service.go
+++ b/apps/daemon/pkg/git/service.go
@@ -68,6 +68,21 @@ type Service struct {
 	OpenRepository    *git.Repository
 }
 
+// Set to "true" to opt into the git-CLI clone path (bounded memory, needs `git` in PATH).
+// Deprecated: prefer experimentalUseGitCLIEnv which covers all network git operations.
+const experimentalUseGitCloneCLIEnv = "DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI"
+
+// Set to "true" to opt into git-CLI paths for all network operations (clone, push, pull).
+// Bounded memory via native git's mmap-based pack handling.
+const experimentalUseGitCLIEnv = "DAYTONA_EXPERIMENTAL_USE_GIT_CLI"
+
+// isGitCLIModeEnabled reports whether the umbrella `DAYTONA_EXPERIMENTAL_USE_GIT_CLI`
+// env var is set. Push and pull only check this flag; clone additionally honors
+// the legacy `DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI` for backward compatibility.
+func isGitCLIModeEnabled() bool {
+	return os.Getenv(experimentalUseGitCLIEnv) == "true"
+}
+
 func (s *Service) RepositoryExists() (bool, error) {
 	_, err := os.Stat(filepath.Join(s.WorkDir, ".git"))
 	if os.IsNotExist(err) {


### PR DESCRIPTION
### Summary

Adds an opt-in git-CLI fallback for **push** and **pull** to complement the existing clone-CLI fallback (PR #4561). Both new and legacy env vars are supported:

| Env var | Scope |
|---|---|
| `DAYTONA_EXPERIMENTAL_USE_GIT_CLI=true` | **clone + push + pull** (new umbrella flag) |
| `DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true` | clone only (legacy, still works) |

Default (no flag) behavior is **unchanged** — verified end-to-end. Zero blast radius.

### Why

Users on the clone-CLI workaround (PR #4561) hit 502s on the very next `git push`. Root cause: go-git's `repo.Push()` / `w.Pull()` enumerate and pack all reachable objects in-process. On a large repo (~1 GB+) in a 1 GiB sandbox the daemon OOMs mid-push, taking the sandbox network namespace with it.

Same class of bug as the clone OOM that #4561 fixed — different codepath. Native `git` uses mmap'd packfile handling, so memory stays flat regardless of repo size.

### What's in the PR

#### New files
- **`apps/daemon/pkg/git/cli_errors.go`** — shared `gitCLIRun()` driver, `classifyCLIError()` (stderr → go-git sentinel), `wrapCLIError()` (final error builder), `redactCredentials()` (scrubs creds from captured output).
- **`apps/daemon/pkg/git/cli_errors_internal_test.go`** — 18 test cases covering every classifier branch, sentinel attachment, fallback, redaction, and `runErr` propagation.
- **`apps/daemon/pkg/git/push_internal_test.go`** — argv-leak checks, env-leak checks, hook-disable check, `resolveSymbolicHEAD` happy path + detached-HEAD-returns-404.
- **`apps/daemon/pkg/git/pull_internal_test.go`** — argv/env/hook checks mirroring push.

#### Changed files
- **`clone.go`** — `CloneRepositoryCLI` now delegates to `gitCLIRun()`; checkout follow-up also uses it (with `auth=nil` so rogue checkout hooks can't exfiltrate creds).
- **`push.go`** — new `PushCLI()` resolves current branch via `git symbolic-ref HEAD` and pushes `refs/heads/X:refs/heads/X` (parity with go-git's `repo.Push()`). Detached HEAD wraps `plumbing.ErrReferenceNotFound` → HTTP 404.
- **`pull.go`** — new `PullCLI()`. One-line dispatch through `gitCLIRun()`.
- **`service.go`** — moved env-var constants and `isGitCLIModeEnabled()` here since they're shared by clone/push/pull (not clone-specific).
- **`clone_internal_test.go`** — moved `TestRedactCredentials` into `cli_errors_internal_test.go` next to its caller.

### Security

Same posture as PR #4561, applied to push and pull:

| Concern | Mitigation |
|---|---|
| Creds in argv (`/proc/PID/cmdline`) | Flow via `GIT_ASKPASS` + `GIT_USERNAME` / `GIT_PASSWORD` env |
| Creds in clone URL | URL has no userinfo component |
| Creds in `.git/config` | `-c credential.helper=` overrides inherited helpers |
| Creds leaked in error messages | `redactCredentials()` strips username + password from captured output |
| Hooks exfiltrating creds | `-c core.hooksPath=/dev/null` disables hooks on push/pull as defense-in-depth (clone doesn't need it — fresh repos have no local hooks) |
| `GIT_TERMINAL_PROMPT` hangs | Set to `0` in env |

### Error classification

`classifyCLIError()` matches lowercased stderr against narrow patterns and attaches the matching go-git sentinel via `%w`. The toolbox handler's existing `classifyGitError()` (which uses `errors.Is`) maps CLI failures to the same HTTP status codes as the go-git path:

| Pattern | go-git sentinel | HTTP |
|---|---|---|
| `authentication failed`, `invalid username or password`, terminal-prompt errors | `transport.ErrAuthenticationRequired` | 401 |
| `the requested url returned error: 403`, `remote: permission … denied` | `transport.ErrAuthorizationFailed` | 403 |
| `repository not found`, `the requested url returned error: 404`, `remote: not found` | `transport.ErrRepositoryNotFound` | 404 |
| `src refspec … does not match any`, `you are not currently on a branch`, detached HEAD | `plumbing.ErrReferenceNotFound` | 404 |
| `non-fast-forward`, `fetch first`, `updates were rejected`, `stale info` | `go_git.ErrNonFastForwardUpdate` | 409 |
| `your local changes … would be overwritten`, `needs merge` | `go_git.ErrWorktreeNotClean` | 409 |

Generic `failed to push some refs` is intentionally NOT matched — git emits it for every push failure including auth — would shadow the more specific cases above.

### Tests

- **49 unit tests pass**, including:
  - 14 subtests in `TestClassifyCLIError` covering every pattern + negative cases + the auth/conflict shadow check
  - 4 `wrapCLIError` tests (sentinel attachment / fallback / redaction / runErr cause)
  - 3 `redactCredentials` subtests
  - Argv/env/hook leak checks for clone, push, pull
  - `resolveSymbolicHEAD` against a real git repo: returns full ref on branch, returns `plumbing.ErrReferenceNotFound`-wrapped error on detached HEAD

### End-to-end verification (stage)

| Scenario | Flag | Clone | Push | Pull |
|---|---|---|---|---|
| **Stage + new umbrella flag** | `USE_GIT_CLI=true` | ✅ 77s (1.2 GB) | ✅ 1.5s | ✅ 0.2s |
| **Stage + new flag (private repo)** | `USE_GIT_CLI=true` | ✅ 75s | ✅ 1.2s | ✅ 0.3s |
| Stage no flag (regression check) | (none) | 💥 OOM 52s | cascade | cascade |
| Stage clone-CLI-only (legacy workaround) | `USE_GIT_CLONE_CLI=true` | ✅ 74s | 💥 OOM 40s | cascade |
| Prod baseline (current state) | (none) | 💥 OOM 72s | cascade | cascade |

Sandbox memory with the new flag stays flat (~4-5 GiB / 128 GiB total) — no spike. Same workload OOM-kills the daemon on every codepath that still uses go-git for network ops.

### How to enable

After this lands, users currently on the legacy clone-only flag should swap:

```diff
- DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true
+ DAYTONA_EXPERIMENTAL_USE_GIT_CLI=true
```

The new flag is a superset — it covers clone too — so the legacy var becomes unnecessary.

### Known limitations

- **Error classification is pattern-based**: covers GitHub, GitLab, generic HTTP errors. Exotic provider stderr strings may fall through to HTTP 500. Patterns are narrow by design (e.g. "failed to push some refs" alone is NOT matched).
- **Hooks disabled on CLI network paths**: pre-push / pre-merge-commit hooks won't run on the CLI path. This matches the existing go-git path, which also does not run client-side hooks in `repo.Push()` / `w.Pull()` — so this is **not a regression**. Local-only hooks (pre-commit on `sandbox.git.commit`, etc.) are unaffected.
- **Detached HEAD push returns 404**: pushing in detached-HEAD state surfaces `plumbing.ErrReferenceNotFound`. Matches the spirit of go-git's failure mode (which also fails on detached push). Users must checkout a branch first.
- **LogWriter not redacted**: clone handler may set `Service.LogWriter` for progress streaming. Push/pull don't. If LogWriter redaction is needed for clone, a wrapping writer would be required (separate scope).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in, memory-safe `git` CLI path for push and pull (alongside clone) to prevent daemon OOMs on large repos. Default behavior is unchanged; enable with `DAYTONA_EXPERIMENTAL_USE_GIT_CLI=true`.

- **Bug Fixes**
  - Adds CLI fallback for push and pull behind `DAYTONA_EXPERIMENTAL_USE_GIT_CLI`; clone now uses the shared runner.
  - Matches go-git behavior on the CLI path: pull is `--ff-only`; push/pull keep TLS verification enabled; clone keeps `http.sslVerify=false`; detached-HEAD push returns `plumbing.ErrReferenceNotFound`.
  - Keeps HTTP error mapping consistent via stderr classification, routes creds through `GIT_ASKPASS`, disables hooks across clone/push/pull, and redacts output; includes tests for patterns and env/argv leaks.

- **Migration**
  - Replace `DAYTONA_EXPERIMENTAL_USE_GIT_CLONE_CLI=true` with `DAYTONA_EXPERIMENTAL_USE_GIT_CLI=true` to enable clone + push + pull.

<sup>Written for commit d94eba1cf2cf49b83ff6496ebe9ff7f2c08bb871. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4753?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

