### PR TITLE
fix(api): stopped sandbox usage period guards

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1779199836948-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1779199836948-migration.ts
@@ -9,6 +9,7 @@ export class Migration1779199836948 implements MigrationInterface {
   name = 'Migration1779199836948'
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Note: not using CONCURRENTLY + skipping transactions because of reverting issue: https://github.com/typeorm/typeorm/issues/9981
     await queryRunner.query(
       `CREATE UNIQUE INDEX "sandbox_usage_periods_one_open_period_per_sandbox_idx" ON "sandbox_usage_periods" ("sandboxId") WHERE "endAt" IS NULL`,
     )

--- a/apps/api/src/migrations/pre-deploy/1779199836948-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1779199836948-migration.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1779199836948 implements MigrationInterface {
+  name = 'Migration1779199836948'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX CONCURRENTLY "sandbox_usage_periods_one_open_period_per_sandbox_idx" ON "sandbox_usage_periods" ("sandboxId") WHERE "endAt" IS NULL`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX CONCURRENTLY "public"."sandbox_usage_periods_one_open_period_per_sandbox_idx"`)
+  }
+}

--- a/apps/api/src/migrations/pre-deploy/1779199836948-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1779199836948-migration.ts
@@ -10,11 +10,11 @@ export class Migration1779199836948 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE UNIQUE INDEX CONCURRENTLY "sandbox_usage_periods_one_open_period_per_sandbox_idx" ON "sandbox_usage_periods" ("sandboxId") WHERE "endAt" IS NULL`,
+      `CREATE UNIQUE INDEX "sandbox_usage_periods_one_open_period_per_sandbox_idx" ON "sandbox_usage_periods" ("sandboxId") WHERE "endAt" IS NULL`,
     )
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX CONCURRENTLY "public"."sandbox_usage_periods_one_open_period_per_sandbox_idx"`)
+    await queryRunner.query(`DROP INDEX "public"."sandbox_usage_periods_one_open_period_per_sandbox_idx"`)
   }
 }

--- a/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
+++ b/apps/api/src/usage/entities/sandbox-usage-period.entity.ts
@@ -7,6 +7,10 @@ import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm'
 
 @Entity('sandbox_usage_periods')
 @Index('idx_sandbox_usage_periods_sandbox_end', ['sandboxId', 'endAt'])
+@Index('sandbox_usage_periods_one_open_period_per_sandbox_idx', ['sandboxId'], {
+  unique: true,
+  where: '"endAt" IS NULL',
+})
 export class SandboxUsagePeriod {
   @PrimaryGeneratedColumn('uuid')
   id: string

--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -58,6 +58,21 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           await this.closeUsagePeriod(event.sandbox.id)
           await this.createUsagePeriod(event, true)
           break
+        // Safeguard if STOPPING state is skipped
+        case SandboxState.STOPPED: {
+          const cpuUsagePeriod = await this.sandboxUsagePeriodRepository.findOne({
+            where: {
+              sandboxId: event.sandbox.id,
+              endAt: IsNull(),
+              cpu: Not(0),
+            },
+          })
+          if (cpuUsagePeriod) {
+            await this.closeUsagePeriod(event.sandbox.id)
+            await this.createUsagePeriod(event, true)
+          }
+          break
+        }
         case SandboxState.ERROR:
         case SandboxState.BUILD_FAILED:
         case SandboxState.ARCHIVED:
@@ -160,6 +175,11 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
             const newUsagePeriod = SandboxUsagePeriod.fromUsagePeriod(usagePeriod)
             newUsagePeriod.startAt = closeTime
             newUsagePeriod.endAt = null
+            if (sandbox.state === SandboxState.STOPPED) {
+              newUsagePeriod.cpu = 0
+              newUsagePeriod.gpu = 0
+              newUsagePeriod.mem = 0
+            }
             await transactionalEntityManager.save(newUsagePeriod)
           }
         })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure only one open usage period per sandbox and correctly handle STOPPED sandboxes so usage doesn’t linger. Adds a partial unique index and service guards to close/reopen periods and zero resource metrics when stopped.

- **Bug Fixes**
  - Add STOPPED-state safeguard: if STOPPING is skipped but an open CPU-using period exists, close it and start a new period with zeroed `cpu/gpu/mem`.
  - When rolling periods, set usage to zero if the sandbox is STOPPED.

- **Migration**
  - Create partial unique index `sandbox_usage_periods_one_open_period_per_sandbox_idx` on `sandboxId` where `endAt IS NULL` to prevent multiple open periods.
  - Mirror the index in the entity with a `@Index` decorator in `typeorm`.

<sup>Written for commit aa2819b3accdf35eca089c76087068710f65857c. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4754?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

