### PR TITLE
 fix(runner): escape quotes in env values for import/export commit falback

### DIFF
--- a/apps/runner/pkg/docker/container_commit.go
+++ b/apps/runner/pkg/docker/container_commit.go
@@ -95,11 +95,11 @@ func (d *DockerClient) exportImportContainer(ctx context.Context, containerId, i
 			if len(splitEnv) != 2 {
 				continue
 			}
-			// Escape backslashes and double quotes so Docker's Dockerfile parser
-			// doesn't misinterpret values containing them (e.g. embedded JSON) as
-			// additional key=value tokens.
+			// Escape Dockerfile double-quoted specials so embedded JSON parses
+			// and $VAR isn't expanded to "". Backslash first to avoid re-escaping.
 			escapedValue := strings.ReplaceAll(splitEnv[1], `\`, `\\`)
 			escapedValue = strings.ReplaceAll(escapedValue, `"`, `\"`)
+			escapedValue = strings.ReplaceAll(escapedValue, `$`, `\$`)
 			env = fmt.Sprintf(`%s="%s"`, splitEnv[0], escapedValue)
 			changes = append(changes, fmt.Sprintf(`ENV %s`, env))
 		}

--- a/apps/runner/pkg/docker/container_commit.go
+++ b/apps/runner/pkg/docker/container_commit.go
@@ -95,8 +95,12 @@ func (d *DockerClient) exportImportContainer(ctx context.Context, containerId, i
 			if len(splitEnv) != 2 {
 				continue
 			}
-			// Quote the value to handle spaces and special characters
-			env = fmt.Sprintf(`%s="%s"`, splitEnv[0], splitEnv[1])
+			// Escape backslashes and double quotes so Docker's Dockerfile parser
+			// doesn't misinterpret values containing them (e.g. embedded JSON) as
+			// additional key=value tokens.
+			escapedValue := strings.ReplaceAll(splitEnv[1], `\`, `\\`)
+			escapedValue = strings.ReplaceAll(escapedValue, `"`, `\"`)
+			env = fmt.Sprintf(`%s="%s"`, splitEnv[0], escapedValue)
 			changes = append(changes, fmt.Sprintf(`ENV %s`, env))
 		}
 	}


### PR DESCRIPTION
## Description

On the export+import fallback in commitContainer, env values were quoted but inner quotes weren't escaped. an env with JSON like {"*":"deny",...} produced a malformed ENV directive: Docker errored with Syntax error - can't find = in "*":"deny","apt. 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation