### PR TITLE
fix(api): apply soft-delete rename on ephemeral stop and state sync

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -281,6 +281,13 @@ export class Sandbox {
   }
 
   /**
+   * Helper method that returns the name of a soft deleted sandbox.
+   */
+  static getSoftDeleteName(originalName: string): string {
+    return 'DESTROYED_' + originalName + '_' + Date.now()
+  }
+
+  /**
    * Helper method that returns the update data needed for a soft delete operation.
    */
   static getSoftDeleteUpdate(sandbox: Sandbox): Partial<Sandbox> {
@@ -288,7 +295,7 @@ export class Sandbox {
       pending: true,
       desiredState: SandboxDesiredState.DESTROYED,
       backupState: BackupState.NONE,
-      name: 'DESTROYED_' + sandbox.name + '_' + Date.now(),
+      name: Sandbox.getSoftDeleteName(sandbox.name),
     }
   }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -2723,7 +2723,7 @@ export class SandboxService {
     }
 
     if (newState === SandboxState.DESTROYED) {
-      Object.assign(updateData, Sandbox.getSoftDeleteUpdate(sandbox))
+      updateData.name = Sandbox.getSoftDeleteName(sandbox.name)
     }
 
     await this.sandboxRepository.updateWhere(sandbox.id, {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1838,9 +1838,12 @@ export class SandboxService {
       throw new StateChangeInProgressError()
     }
 
-    const updateData: Partial<Sandbox> = {
-      pending: true,
-      desiredState: isEphemeral(sandbox) ? SandboxDesiredState.DESTROYED : SandboxDesiredState.STOPPED,
+    let updateData: Partial<Sandbox> = {}
+    if (isEphemeral(sandbox)) {
+      updateData = Sandbox.getSoftDeleteUpdate(sandbox)
+    } else {
+      updateData.pending = true
+      updateData.desiredState = SandboxDesiredState.STOPPED
     }
 
     const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
@@ -2717,6 +2720,10 @@ export class SandboxService {
     const desiredState = this.getExpectedDesiredStateForState(newState)
     if (desiredState) {
       updateData.desiredState = desiredState
+    }
+
+    if (newState === SandboxState.DESTROYED) {
+      Object.assign(updateData, Sandbox.getSoftDeleteUpdate(sandbox))
     }
 
     await this.sandboxRepository.updateWhere(sandbox.id, {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure ephemeral sandboxes get soft-delete renaming on stop and when state sync marks them DESTROYED. Introduces `Sandbox.getSoftDeleteName` to standardize the rename format.

- **Bug Fixes**
  - Stop: ephemeral sandboxes now use `Sandbox.getSoftDeleteUpdate(sandbox)`; non-ephemeral still set `pending: true` and `desiredState: STOPPED`.
  - State sync: on transition to DESTROYED, set `name` via `Sandbox.getSoftDeleteName(sandbox.name)` to apply the soft-delete rename.

<sup>Written for commit 8c51713267e20a0f62c6da7947d8828e249fdac4. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4758?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

