### PR TITLE
fix(api,runner): forward candidate source and backup registries on resize/recover

### DIFF
--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -141,8 +141,10 @@ export class DockerRegistryService {
 
   /**
    * Returns candidate registries a runner may need to pull the container's current image
-   * from during resize/recover: the sandbox's backup registry plus the internal registry
-   * holding its source snapshot. Either side may be missing; rows are deduplicated by id.
+   * from during resize/recover: the internal registry holding the source snapshot plus
+   * the sandbox's backup registry. Source comes first so same-host matches prefer the
+   * pull-scoped creds over backup creds that may be push-only. Either side may be
+   * missing; rows are deduplicated by id.
    */
   async findCandidateRegistriesForSandbox(
     backupRegistryId: string | null | undefined,
@@ -151,17 +153,17 @@ export class DockerRegistryService {
   ): Promise<DockerRegistry[]> {
     const candidates: DockerRegistry[] = []
 
-    if (backupRegistryId) {
-      const backup = await this.findOne(backupRegistryId)
-      if (backup) {
-        candidates.push(backup)
+    if (snapshotRef) {
+      const internal = await this.findInternalRegistryBySnapshotRef(snapshotRef, regionId)
+      if (internal) {
+        candidates.push(internal)
       }
     }
 
-    if (snapshotRef) {
-      const internal = await this.findInternalRegistryBySnapshotRef(snapshotRef, regionId)
-      if (internal && !candidates.some((r) => r.id === internal.id)) {
-        candidates.push(internal)
+    if (backupRegistryId) {
+      const backup = await this.findOne(backupRegistryId)
+      if (backup && !candidates.some((r) => r.id === backup.id)) {
+        candidates.push(backup)
       }
     }
 

--- a/apps/api/src/docker-registry/services/docker-registry.service.ts
+++ b/apps/api/src/docker-registry/services/docker-registry.service.ts
@@ -139,6 +139,35 @@ export class DockerRegistryService {
     })
   }
 
+  /**
+   * Returns candidate registries a runner may need to pull the container's current image
+   * from during resize/recover: the sandbox's backup registry plus the internal registry
+   * holding its source snapshot. Either side may be missing; rows are deduplicated by id.
+   */
+  async findCandidateRegistriesForSandbox(
+    backupRegistryId: string | null | undefined,
+    snapshotRef: string | null | undefined,
+    regionId: string,
+  ): Promise<DockerRegistry[]> {
+    const candidates: DockerRegistry[] = []
+
+    if (backupRegistryId) {
+      const backup = await this.findOne(backupRegistryId)
+      if (backup) {
+        candidates.push(backup)
+      }
+    }
+
+    if (snapshotRef) {
+      const internal = await this.findInternalRegistryBySnapshotRef(snapshotRef, regionId)
+      if (internal && !candidates.some((r) => r.id === internal.id)) {
+        candidates.push(internal)
+      }
+    }
+
+    return candidates
+  }
+
   async update(registryId: string, updateDto: UpdateDockerRegistryDto): Promise<DockerRegistry> {
     const registry = await this.dockerRegistryRepository.findOne({
       where: { id: registryId },

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -47,6 +47,8 @@ import { Sandbox } from '../entities/sandbox.entity'
 import { Runner } from '../entities/runner.entity'
 import { RunnerAdapterFactory } from '../runner-adapter/runnerAdapter'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
+import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
+import { SnapshotService } from '../services/snapshot.service'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
 import { TypedConfigService } from '../../config/typed-config.service'
@@ -74,6 +76,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
     private readonly sandboxArchiveAction: SandboxArchiveAction,
     private readonly configService: TypedConfigService,
     private readonly dockerRegistryService: DockerRegistryService,
+    private readonly snapshotService: SnapshotService,
     private readonly organizationService: OrganizationService,
     private readonly organizationUsageService: OrganizationUsageService,
     private readonly runnerAdapterFactory: RunnerAdapterFactory,
@@ -662,11 +665,9 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             })
           }
 
-          const backupRegistry = sandbox.backupRegistryId
-            ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
-            : undefined
+          const candidateRegistries = await this.resolveCandidateRegistriesForSandbox(sandbox)
 
-          await runnerAdapter.recoverSandbox(sandbox, backupRegistry, true)
+          await runnerAdapter.recoverSandbox(sandbox, candidateRegistries, true)
 
           if (runner.apiVersion !== '2') {
             await this.sandboxRepository.updateWhere(sandbox.id, {
@@ -704,6 +705,30 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
           await this.redisLockProvider.unlock(sandboxLockKey)
         }
       }),
+    )
+  }
+
+  // Mirror of SandboxService.resolveCandidateRegistriesForSandbox for the drain-recover path,
+  // which can't reach SandboxService without a circular module dependency.
+  private async resolveCandidateRegistriesForSandbox(sandbox: Sandbox): Promise<DockerRegistry[]> {
+    let snapshotRef: string | null = null
+    if (sandbox.buildInfo) {
+      snapshotRef = sandbox.buildInfo.snapshotRef
+    } else if (sandbox.snapshot) {
+      try {
+        const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
+        snapshotRef = snapshot.ref
+      } catch (err) {
+        this.logger.warn(
+          `Could not resolve snapshot ref for sandbox ${sandbox.id} (snapshot=${sandbox.snapshot}): ${err instanceof Error ? err.message : err}`,
+        )
+      }
+    }
+
+    return this.dockerRegistryService.findCandidateRegistriesForSandbox(
+      sandbox.backupRegistryId,
+      snapshotRef,
+      sandbox.region,
     )
   }
 

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -725,11 +725,19 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       }
     }
 
-    return this.dockerRegistryService.findCandidateRegistriesForSandbox(
+    const candidates = await this.dockerRegistryService.findCandidateRegistriesForSandbox(
       sandbox.backupRegistryId,
       snapshotRef,
       sandbox.region,
     )
+
+    if (sandbox.backupRegistryId && !candidates.some((r) => r.id === sandbox.backupRegistryId)) {
+      this.logger.warn(
+        `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without backup registry credentials`,
+      )
+    }
+
+    return candidates
   }
 
   private async migrateSandbox(sandbox: Sandbox, oldRunnerId: string, newRunnerId: string): Promise<void> {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -134,14 +134,14 @@ export interface RunnerAdapter {
     includeMemory?: boolean,
   ): Promise<CreateSandboxSnapshotResult | undefined>
 
-  recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry, skipStart?: boolean): Promise<void>
+  recoverSandbox(sandbox: Sandbox, registries?: DockerRegistry[], skipStart?: boolean): Promise<void>
 
   resizeSandbox(
     sandboxId: string,
     cpu?: number,
     memory?: number,
     disk?: number,
-    registry?: DockerRegistry,
+    registries?: DockerRegistry[],
   ): Promise<void>
 }
 

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -462,7 +462,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
   }
 
   // skipStart is a v2-only signal (carried in the job payload); v0's sync API has no equivalent.
-  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry, _skipStart?: boolean): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registries?: DockerRegistry[], _skipStart?: boolean): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -481,14 +481,12 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
-      registry: registry
-        ? {
-            project: registry.project,
-            url: registry.url.replace(/^(https?:\/\/)/, ''),
-            username: registry.username,
-            password: registry.password,
-          }
-        : undefined,
+      registries: registries?.map((registry) => ({
+        project: registry.project,
+        url: registry.url.replace(/^(https?:\/\/)/, ''),
+        username: registry.username,
+        password: registry.password,
+      })),
     }
     await this.sandboxApiClient.recover(sandbox.id, recoverSandboxDTO)
   }
@@ -498,20 +496,18 @@ export class RunnerAdapterV0 implements RunnerAdapter {
     cpu?: number,
     memory?: number,
     disk?: number,
-    registry?: DockerRegistry,
+    registries?: DockerRegistry[],
   ): Promise<void> {
     await this.sandboxApiClient.resize(sandboxId, {
       cpu,
       memory,
       disk,
-      registry: registry
-        ? {
-            project: registry.project,
-            url: registry.url.replace(/^(https?:\/\/)/, ''),
-            username: registry.username,
-            password: registry.password,
-          }
-        : undefined,
+      registries: registries?.map((registry) => ({
+        project: registry.project,
+        url: registry.url.replace(/^(https?:\/\/)/, ''),
+        username: registry.username,
+        password: registry.password,
+      })),
     })
   }
 }

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -234,7 +234,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     this.logger.debug(`Created DESTROY_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)
   }
 
-  async recoverSandbox(sandbox: Sandbox, registry?: DockerRegistry, skipStart = false): Promise<void> {
+  async recoverSandbox(sandbox: Sandbox, registries?: DockerRegistry[], skipStart = false): Promise<void> {
     const recoverSandboxDTO: RecoverSandboxDTO = {
       userId: sandbox.organizationId,
       snapshot: sandbox.snapshot,
@@ -253,14 +253,12 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       networkAllowList: sandbox.networkAllowList,
       errorReason: sandbox.errorReason,
       backupErrorReason: sandbox.backupErrorReason,
-      registry: registry
-        ? {
-            project: registry.project,
-            url: registry.url.replace(/^(https?:\/\/)/, ''),
-            username: registry.username,
-            password: registry.password,
-          }
-        : undefined,
+      registries: registries?.map((registry) => ({
+        project: registry.project,
+        url: registry.url.replace(/^(https?:\/\/)/, ''),
+        username: registry.username,
+        password: registry.password,
+      })),
     }
     // skipStart is API-side metadata for the job-completion handler; the runner ignores extra fields.
     await this.jobService.createJob(null, JobType.RECOVER_SANDBOX, this.runner.id, ResourceType.SANDBOX, sandbox.id, {
@@ -615,20 +613,18 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     cpu?: number,
     memory?: number,
     disk?: number,
-    registry?: DockerRegistry,
+    registries?: DockerRegistry[],
   ): Promise<void> {
     await this.jobService.createJob(null, JobType.RESIZE_SANDBOX, this.runner.id, ResourceType.SANDBOX, sandboxId, {
       cpu,
       memory,
       disk,
-      registry: registry
-        ? {
-            project: registry.project,
-            url: registry.url.replace(/^(https?:\/\/)/, ''),
-            username: registry.username,
-            password: registry.password,
-          }
-        : undefined,
+      registries: registries?.map((registry) => ({
+        project: registry.project,
+        url: registry.url.replace(/^(https?:\/\/)/, ''),
+        username: registry.username,
+        password: registry.password,
+      })),
     })
 
     this.logger.debug(`Created RESIZE_SANDBOX job for sandbox ${sandboxId} on runner ${this.runner.id}`)

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -2300,18 +2300,10 @@ export class SandboxService {
 
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
-      const backupRegistry = sandbox.backupRegistryId
-        ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
-        : undefined
-
-      if (sandbox.backupRegistryId && !backupRegistry) {
-        this.logger.warn(
-          `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
-        )
-      }
+      const candidateRegistries = await this.resolveCandidateRegistriesForSandbox(sandbox)
 
       try {
-        await runnerAdapter.recoverSandbox(sandbox, backupRegistry, skipStart)
+        await runnerAdapter.recoverSandbox(sandbox, candidateRegistries, skipStart)
       } catch (error) {
         if (error instanceof Error && error.message.includes('storage cannot be further expanded')) {
           throw new ForbiddenException(
@@ -2533,17 +2525,15 @@ export class SandboxService {
       try {
         const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
-        const backupRegistry = sandbox.backupRegistryId
-          ? ((await this.dockerRegistryService.findOne(sandbox.backupRegistryId)) ?? undefined)
-          : undefined
+        const candidateRegistries = await this.resolveCandidateRegistriesForSandbox(sandbox)
 
-        if (sandbox.backupRegistryId && !backupRegistry) {
-          this.logger.warn(
-            `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without registry credentials`,
-          )
-        }
-
-        await runnerAdapter.resizeSandbox(sandbox.id, resizeDto.cpu, resizeDto.memory, resizeDto.disk, backupRegistry)
+        await runnerAdapter.resizeSandbox(
+          sandbox.id,
+          resizeDto.cpu,
+          resizeDto.memory,
+          resizeDto.disk,
+          candidateRegistries,
+        )
 
         // For V0 runners, update resources immediately (subscriber emits STATE_UPDATED)
         // For V2 runners, job handler will update resources on completion
@@ -2722,6 +2712,39 @@ export class SandboxService {
     }
 
     return region.proxyUrl + '/sandboxes/' + sandbox.id + '/build-logs'
+  }
+
+  // Returns the registries a runner may need to pull the sandbox's current container image
+  // during resize/recover. The runner doesn't tell us which image its container is currently
+  // on (snapshot vs. backup), so we forward both candidates and let it pick by host match.
+  private async resolveCandidateRegistriesForSandbox(sandbox: Sandbox): Promise<DockerRegistry[]> {
+    let snapshotRef: string | null = null
+    if (sandbox.buildInfo) {
+      snapshotRef = sandbox.buildInfo.snapshotRef
+    } else if (sandbox.snapshot) {
+      try {
+        const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
+        snapshotRef = snapshot.ref
+      } catch (err) {
+        this.logger.warn(
+          `Could not resolve snapshot ref for sandbox ${sandbox.id} (snapshot=${sandbox.snapshot}): ${err instanceof Error ? err.message : err}`,
+        )
+      }
+    }
+
+    const candidates = await this.dockerRegistryService.findCandidateRegistriesForSandbox(
+      sandbox.backupRegistryId,
+      snapshotRef,
+      sandbox.region,
+    )
+
+    if (sandbox.backupRegistryId && !candidates.some((r) => r.id === sandbox.backupRegistryId)) {
+      this.logger.warn(
+        `Backup registry ${sandbox.backupRegistryId} not found for sandbox ${sandbox.id}; proceeding without backup registry credentials`,
+      )
+    }
+
+    return candidates
   }
 
   private async getValidatedOrDefaultRegion(organization: Organization, regionIdOrName?: string): Promise<Region> {

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1802,8 +1802,11 @@ const docTemplate = `{
                 "osUser": {
                     "type": "string"
                 },
-                "registry": {
-                    "$ref": "#/definitions/RegistryDTO"
+                "registries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/RegistryDTO"
+                    }
                 },
                 "snapshot": {
                     "type": "string"
@@ -1862,8 +1865,11 @@ const docTemplate = `{
                     "type": "integer",
                     "minimum": 1
                 },
-                "registry": {
-                    "$ref": "#/definitions/RegistryDTO"
+                "registries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/RegistryDTO"
+                    }
                 }
             }
         },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1680,8 +1680,11 @@
         "osUser": {
           "type": "string"
         },
-        "registry": {
-          "$ref": "#/definitions/RegistryDTO"
+        "registries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RegistryDTO"
+          }
         },
         "snapshot": {
           "type": "string"
@@ -1738,8 +1741,11 @@
           "type": "integer",
           "minimum": 1
         },
-        "registry": {
-          "$ref": "#/definitions/RegistryDTO"
+        "registries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RegistryDTO"
+          }
         }
       }
     },

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -220,8 +220,10 @@ definitions:
         type: boolean
       osUser:
         type: string
-      registry:
-        $ref: '#/definitions/RegistryDTO'
+      registries:
+        items:
+          $ref: '#/definitions/RegistryDTO'
+        type: array
       snapshot:
         type: string
       storageQuota:
@@ -264,8 +266,10 @@ definitions:
       memory:
         minimum: 1
         type: integer
-      registry:
-        $ref: '#/definitions/RegistryDTO'
+      registries:
+        items:
+          $ref: '#/definitions/RegistryDTO'
+        type: array
     type: object
   RunnerInfoResponseDTO:
     properties:

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -48,11 +48,11 @@ func (c *CreateSandboxDTO) IsAndroidSandbox() bool {
 }
 
 type ResizeSandboxDTO struct {
-	Cpu      int64        `json:"cpu,omitempty" validate:"omitempty,min=1"`
-	Gpu      int64        `json:"gpu,omitempty" validate:"omitempty,min=0"`
-	Memory   int64        `json:"memory,omitempty" validate:"omitempty,min=1"`
-	Disk     int64        `json:"disk,omitempty" validate:"omitempty,min=1"`
-	Registry *RegistryDTO `json:"registry,omitempty"`
+	Cpu        int64         `json:"cpu,omitempty" validate:"omitempty,min=1"`
+	Gpu        int64         `json:"gpu,omitempty" validate:"omitempty,min=0"`
+	Memory     int64         `json:"memory,omitempty" validate:"omitempty,min=1"`
+	Disk       int64         `json:"disk,omitempty" validate:"omitempty,min=1"`
+	Registries []RegistryDTO `json:"registries,omitempty"`
 } //	@name	ResizeSandboxDTO
 
 type UpdateNetworkSettingsDTO struct {
@@ -75,9 +75,9 @@ type RecoverSandboxDTO struct {
 	NetworkBlockAll  *bool             `json:"networkBlockAll,omitempty"`
 	NetworkAllowList *string           `json:"networkAllowList,omitempty"`
 	// At least one of ErrorReason or BackupErrorReason must yield a recovery type; both are optional.
-	ErrorReason       string       `json:"errorReason,omitempty"`
-	BackupErrorReason string       `json:"backupErrorReason,omitempty"`
-	Registry          *RegistryDTO `json:"registry,omitempty"`
+	ErrorReason       string        `json:"errorReason,omitempty"`
+	BackupErrorReason string        `json:"backupErrorReason,omitempty"`
+	Registries        []RegistryDTO `json:"registries,omitempty"`
 } //	@name	RecoverSandboxDTO
 
 type IsRecoverableDTO struct {

--- a/apps/runner/pkg/docker/recover.go
+++ b/apps/runner/pkg/docker/recover.go
@@ -24,7 +24,7 @@ func (d *DockerClient) RecoverSandbox(ctx context.Context, sandboxId string, rec
 
 	switch recoveryType {
 	case models.RecoveryTypeStorageExpansion:
-		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota), recoverDto.Registry)
+		return d.RecoverFromStorageLimit(ctx, sandboxId, float64(recoverDto.StorageQuota), recoverDto.Registries)
 	default:
 		return fmt.Errorf("unsupported recovery type: %s", recoveryType)
 	}

--- a/apps/runner/pkg/docker/recover_from_storage_limit.go
+++ b/apps/runner/pkg/docker/recover_from_storage_limit.go
@@ -13,7 +13,7 @@ import (
 
 // RecoverFromStorageLimit attempts to recover a sandbox from storage limit issues
 // by expanding its storage quota by 5% of the original quota per attempt, up to 10% total.
-func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, registry *dto.RegistryDTO) error {
+func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId string, originalStorageQuota float64, registries []dto.RegistryDTO) error {
 	originalContainer, err := d.ContainerInspect(ctx, sandboxId)
 	if err != nil {
 		return fmt.Errorf("failed to inspect container: %w", err)
@@ -60,5 +60,5 @@ func (d *DockerClient) RecoverFromStorageLimit(ctx context.Context, sandboxId st
 		}
 	}
 
-	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", registry)
+	return d.ContainerDiskResize(ctx, sandboxId, newStorageQuota, 0, 0, "recovery", registries)
 }

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -6,9 +6,9 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
-	"github.com/containerd/errdefs"
 	"github.com/daytonaio/common-go/pkg/utils"
 	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
@@ -30,7 +30,7 @@ func (d *DockerClient) Resize(ctx context.Context, sandboxId string, sandboxDto 
 			return fmt.Errorf("disk resize requires stopped container")
 		}
 
-		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize", sandboxDto.Registry)
+		err = d.ContainerDiskResize(ctx, sandboxId, float64(sandboxDto.Disk), sandboxDto.Cpu, sandboxDto.Memory, "resize", sandboxDto.Registries)
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func (d *DockerClient) Resize(ctx context.Context, sandboxId string, sandboxDto 
 // Optionally updates CPU/memory at the same time (0 = don't change).
 // Used by both storage recovery and disk resize.
 // Container must be stopped before calling this function.
-func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string, newStorageGB float64, cpu int64, memory int64, operationName string, registry *dto.RegistryDTO) error {
+func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string, newStorageGB float64, cpu int64, memory int64, operationName string, registries []dto.RegistryDTO) error {
 	if d.filesystem != "xfs" {
 		return fmt.Errorf("%s requires XFS filesystem, current filesystem: %s", operationName, d.filesystem)
 	}
@@ -89,11 +89,7 @@ func (d *DockerClient) ContainerDiskResize(ctx context.Context, sandboxId string
 		}
 	}
 
-	resolvedImage, err := d.resolveContainerImage(ctx, sandboxId, originalContainer, registry)
-	if err != nil {
-		return err
-	}
-	originalContainer.Config.Image = resolvedImage
+	originalContainer.Config.Image = d.resolveContainerImage(ctx, sandboxId, originalContainer, registries)
 
 	// Rename container after validation checks to reduce error handling complexity
 	timestamp := time.Now().Unix()
@@ -210,34 +206,56 @@ func (d *DockerClient) copyContainerOverlayData(ctx context.Context, oldContaine
 	return common.RsyncCopy(copyCtx, d.logger, oldContainerOverlayPath, newUpperDir)
 }
 
-func (d *DockerClient) resolveContainerImage(ctx context.Context, sandboxId string, originalContainer *container.InspectResponse, registry *dto.RegistryDTO) (string, error) {
+// resolveContainerImage picks the image reference to use when recreating the container.
+// Preference order: original tag → image ID → pull from a host-matching registry.
+// On any failure it falls through to the image ID and lets ContainerCreate make the final
+// call, so a doomed pull (e.g. wrong-host registry creds) doesn't block resize when the
+// image layers are actually still present locally.
+func (d *DockerClient) resolveContainerImage(ctx context.Context, sandboxId string, originalContainer *container.InspectResponse, registries []dto.RegistryDTO) string {
 	imageRef := originalContainer.Config.Image
 
-	_, err := d.apiClient.ImageInspect(ctx, imageRef)
-	if err == nil {
-		return imageRef, nil
-	}
-	if !errdefs.IsNotFound(err) {
-		return "", fmt.Errorf("failed to inspect image %s: %w", imageRef, err)
+	if _, err := d.apiClient.ImageInspect(ctx, imageRef); err == nil {
+		return imageRef
 	}
 
-	_, idErr := d.apiClient.ImageInspect(ctx, originalContainer.Image)
-	if idErr == nil {
+	if _, err := d.apiClient.ImageInspect(ctx, originalContainer.Image); err == nil {
 		d.logger.WarnContext(ctx, "Image not found by tag, falling back to image ID",
 			"imageRef", imageRef, "imageID", originalContainer.Image)
-		return originalContainer.Image, nil
-	}
-	if !errdefs.IsNotFound(idErr) {
-		return "", fmt.Errorf("failed to inspect image by ID %s: %w", originalContainer.Image, idErr)
+		return originalContainer.Image
 	}
 
-	if registry == nil {
-		return "", fmt.Errorf("image %s is not available locally", imageRef)
+	matched := pickRegistryForImage(imageRef, registries)
+	if matched == nil {
+		d.logger.WarnContext(ctx, "Image not found locally and no registry matches its host; falling back to image ID",
+			"imageRef", imageRef, "imageID", originalContainer.Image)
+		return originalContainer.Image
 	}
-	d.logger.WarnContext(ctx, "Image not found locally, pulling from registry before resize",
-		"containerName", originalContainer.Name, "imageRef", imageRef)
-	if _, pullErr := d.PullImage(ctx, imageRef, registry, &sandboxId); pullErr != nil {
-		return "", fmt.Errorf("image %s not available locally and pull from registry failed: %w", imageRef, pullErr)
+
+	d.logger.InfoContext(ctx, "Image not found locally, pulling from matching registry",
+		"imageRef", imageRef, "registryUrl", matched.Url)
+	if _, err := d.PullImage(ctx, imageRef, matched, &sandboxId); err != nil {
+		d.logger.WarnContext(ctx, "Pull failed; falling back to image ID and letting ContainerCreate decide",
+			"imageRef", imageRef, "registryUrl", matched.Url, "error", err)
+		return originalContainer.Image
 	}
-	return imageRef, nil
+	return imageRef
+}
+
+// pickRegistryForImage returns the first registry whose URL is a host-prefix of imageRef.
+// The match must end at a boundary (/, :, or end-of-string) to prevent shadowing
+// (e.g. "cr.app.daytona.io" must not match "cr.app.daytona.io.evil.com").
+func pickRegistryForImage(imageRef string, registries []dto.RegistryDTO) *dto.RegistryDTO {
+	for i := range registries {
+		reg := &registries[i]
+		stripped := strings.TrimPrefix(reg.Url, "https://")
+		stripped = strings.TrimPrefix(stripped, "http://")
+		if stripped == "" || !strings.HasPrefix(imageRef, stripped) {
+			continue
+		}
+		rest := imageRef[len(stripped):]
+		if rest == "" || rest[0] == '/' || rest[0] == ':' {
+			return reg
+		}
+	}
+	return nil
 }

--- a/apps/runner/pkg/docker/resize.go
+++ b/apps/runner/pkg/docker/resize.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/daytonaio/common-go/pkg/utils"
 	"github.com/daytonaio/runner/pkg/api/dto"
 	"github.com/daytonaio/runner/pkg/common"
@@ -216,12 +217,18 @@ func (d *DockerClient) resolveContainerImage(ctx context.Context, sandboxId stri
 
 	if _, err := d.apiClient.ImageInspect(ctx, imageRef); err == nil {
 		return imageRef
+	} else if !errdefs.IsNotFound(err) {
+		d.logger.WarnContext(ctx, "ImageInspect by tag failed with non-NotFound error; treating as missing",
+			"imageRef", imageRef, "error", err)
 	}
 
 	if _, err := d.apiClient.ImageInspect(ctx, originalContainer.Image); err == nil {
 		d.logger.WarnContext(ctx, "Image not found by tag, falling back to image ID",
 			"imageRef", imageRef, "imageID", originalContainer.Image)
 		return originalContainer.Image
+	} else if !errdefs.IsNotFound(err) {
+		d.logger.WarnContext(ctx, "ImageInspect by ID failed with non-NotFound error; treating as missing",
+			"imageID", originalContainer.Image, "error", err)
 	}
 
 	matched := pickRegistryForImage(imageRef, registries)
@@ -247,8 +254,10 @@ func (d *DockerClient) resolveContainerImage(ctx context.Context, sandboxId stri
 func pickRegistryForImage(imageRef string, registries []dto.RegistryDTO) *dto.RegistryDTO {
 	for i := range registries {
 		reg := &registries[i]
-		stripped := strings.TrimPrefix(reg.Url, "https://")
+		stripped := strings.TrimSpace(reg.Url)
+		stripped = strings.TrimPrefix(stripped, "https://")
 		stripped = strings.TrimPrefix(stripped, "http://")
+		stripped = strings.TrimSuffix(stripped, "/")
 		if stripped == "" || !strings.HasPrefix(imageRef, stripped) {
 			continue
 		}

--- a/libs/runner-api-client/src/models/recover-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/recover-sandbox-dto.ts
@@ -34,7 +34,7 @@ export interface RecoverSandboxDTO {
     'networkAllowList'?: string;
     'networkBlockAll'?: boolean;
     'osUser': string;
-    'registry'?: RegistryDTO;
+    'registries'?: Array<RegistryDTO>;
     'snapshot'?: string;
     'storageQuota'?: number;
     'userId': string;

--- a/libs/runner-api-client/src/models/resize-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/resize-sandbox-dto.ts
@@ -22,6 +22,6 @@ export interface ResizeSandboxDTO {
     'disk'?: number;
     'gpu'?: number;
     'memory'?: number;
-    'registry'?: RegistryDTO;
+    'registries'?: Array<RegistryDTO>;
 }
 


### PR DESCRIPTION
## Description

[4491](https://github.com/daytonaio/daytona/pull/4491) started forwarding sandbox.backupRegistryId so resize/recover could pull a missing image, but the container's image often lives in the source registry (cr.app...) not the backup (cr3.app...). Sandboxes hit this: backup creds were used against cr.app.daytona.io/sbox/daytona-<hash>:daytona and Harbor returned unauthorized. API now forwards both backup and source registries, and the runner picks by host-prefix match against the imageRef. on pull failure it falls back to the image ID so ContainerCreate can still succeed when layers are still local.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation