### PR TITLE
feat(api): throttle resizes per runner by projected availability score

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -197,6 +197,7 @@ const configuration = {
       availability: parseInt(process.env.RUNNER_AVAILABILITY_SCORE_THRESHOLD || '10', 10),
       start: parseInt(process.env.RUNNER_START_SCORE_THRESHOLD || '3', 10),
       initialRunnerScoreAddon: parseInt(process.env.RUNNER_INITIAL_RUNNER_SCORE_ADDON || '20', 10),
+      resize: parseInt(process.env.RUNNER_RESIZE_SCORE_THRESHOLD || '10', 10),
     },
     weights: {
       cpuUsage: parseFloat(process.env.RUNNER_CPU_USAGE_WEIGHT || '0.25'),

--- a/apps/api/src/sandbox/sandbox.module.ts
+++ b/apps/api/src/sandbox/sandbox.module.ts
@@ -11,6 +11,7 @@ import { TypeOrmModule } from '@nestjs/typeorm'
 import { Sandbox } from './entities/sandbox.entity'
 import { UserModule } from '../user/user.module'
 import { RunnerService } from './services/runner.service'
+import { RunnerUsageService } from './services/runner-usage.service'
 import { Runner } from './entities/runner.entity'
 import { RunnerController } from './controllers/runner.controller'
 import { ToolboxService } from './services/toolbox.deprecated.service'
@@ -107,6 +108,7 @@ import { SandboxSearchAdapterProvider } from './providers/sandbox-search.provide
     BackupManager,
     SandboxWarmPoolService,
     RunnerService,
+    RunnerUsageService,
     ToolboxService,
     SnapshotService,
     ProxyCacheInvalidationService,

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -20,7 +20,7 @@ import { BackupState } from '../enums/backup-state.enum'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { sanitizeSandboxError } from '../utils/sanitize-error.util'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
-import { RunnerService } from './runner.service'
+import { RunnerUsageService } from './runner-usage.service'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { Sandbox } from '../entities/sandbox.entity'
 import { RedisLockProvider } from '../common/redis-lock.provider'
@@ -47,7 +47,7 @@ export class JobStateHandlerService {
     private readonly organizationUsageService: OrganizationUsageService,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly eventEmitter: EventEmitter2,
-    private readonly runnerService: RunnerService,
+    private readonly runnerUsageService: RunnerUsageService,
     @InjectRepository(Runner)
     private readonly runnerRepository: Repository<Runner>,
   ) {}
@@ -646,6 +646,11 @@ export class JobStateHandlerService {
       const memDeltaForQuota = isHotResize ? (payload.memory ?? sandbox.mem) - sandbox.mem : 0
       const diskDeltaForQuota = (payload.disk ?? sandbox.disk) - sandbox.disk // Disk only increases
 
+      // Runner deltas — mirror what the admission gate reserved, to release the slot.
+      const cpuDeltaForRunner = Math.max(0, (payload.cpu ?? sandbox.cpu) - sandbox.cpu)
+      const memDeltaForRunner = Math.max(0, (payload.memory ?? sandbox.mem) - sandbox.mem)
+      const diskDeltaForRunner = Math.max(0, (payload.disk ?? sandbox.disk) - sandbox.disk)
+
       try {
         const updateData: Partial<Sandbox> = {}
 
@@ -689,14 +694,14 @@ export class JobStateHandlerService {
 
         await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })
       } finally {
-        // Release the per-runner pending allocation slot regardless of COMPLETED vs FAILED —
-        // either way the runner has finished with this resize. Safe-wrapped so a Redis blip
-        // doesn't shadow the original error; 60s TTL is the safety net for any swallow.
-        await this.runnerService.safeDecrementPendingRunnerAllocation(
+        // Release the per-runner pending usage slot on COMPLETED or FAILED — either way the
+        // runner is done resizing. Safe-wrapped so a Redis blip can't shadow the original
+        // error; the 2-minute TTL is the backstop.
+        await this.runnerUsageService.safeDecrementPendingRunnerUsage(
           job.runnerId,
-          cpuDeltaForQuota,
-          memDeltaForQuota,
-          diskDeltaForQuota,
+          cpuDeltaForRunner,
+          memDeltaForRunner,
+          diskDeltaForRunner,
         )
       }
     } catch (error) {

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -20,6 +20,7 @@ import { BackupState } from '../enums/backup-state.enum'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { sanitizeSandboxError } from '../utils/sanitize-error.util'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
+import { RunnerService } from './runner.service'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { Sandbox } from '../entities/sandbox.entity'
 import { RedisLockProvider } from '../common/redis-lock.provider'
@@ -46,6 +47,7 @@ export class JobStateHandlerService {
     private readonly organizationUsageService: OrganizationUsageService,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly eventEmitter: EventEmitter2,
+    private readonly runnerService: RunnerService,
     @InjectRepository(Runner)
     private readonly runnerRepository: Repository<Runner>,
   ) {}
@@ -644,47 +646,59 @@ export class JobStateHandlerService {
       const memDeltaForQuota = isHotResize ? (payload.memory ?? sandbox.mem) - sandbox.mem : 0
       const diskDeltaForQuota = (payload.disk ?? sandbox.disk) - sandbox.disk // Disk only increases
 
-      const updateData: Partial<Sandbox> = {}
+      try {
+        const updateData: Partial<Sandbox> = {}
 
-      if (job.status === JobStatus.COMPLETED) {
-        this.logger.debug(`RESIZE_SANDBOX job ${job.id} completed successfully for sandbox ${sandboxId}`)
+        if (job.status === JobStatus.COMPLETED) {
+          this.logger.debug(`RESIZE_SANDBOX job ${job.id} completed successfully for sandbox ${sandboxId}`)
 
-        // Update sandbox resources
-        updateData.cpu = payload.cpu ?? sandbox.cpu
-        updateData.mem = payload.memory ?? sandbox.mem
-        updateData.disk = payload.disk ?? sandbox.disk
-        updateData.state = previousState
+          // Update sandbox resources
+          updateData.cpu = payload.cpu ?? sandbox.cpu
+          updateData.mem = payload.memory ?? sandbox.mem
+          updateData.disk = payload.disk ?? sandbox.disk
+          updateData.state = previousState
 
-        // Apply usage change (handles both positive and negative deltas).
-        // Resize never changes GPU allocation — always pass 0.
-        await this.organizationUsageService.applyResizeUsageChange(
-          sandbox.organizationId,
-          sandbox.region,
-          sandbox.sandboxClass,
+          // Apply usage change (handles both positive and negative deltas).
+          // Resize never changes GPU allocation — always pass 0.
+          await this.organizationUsageService.applyResizeUsageChange(
+            sandbox.organizationId,
+            sandbox.region,
+            sandbox.sandboxClass,
+            cpuDeltaForQuota,
+            memDeltaForQuota,
+            diskDeltaForQuota,
+            0,
+          )
+        } else if (job.status === JobStatus.FAILED) {
+          this.logger.error(`RESIZE_SANDBOX job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
+
+          // Rollback pending usage (all deltas were tracked, including negative).
+          // Resize never changes GPU allocation — always pass undefined for gpu.
+          await this.organizationUsageService.decrementPendingSandboxUsage(
+            sandbox.organizationId,
+            sandbox.region,
+            sandbox.sandboxClass,
+            cpuDeltaForQuota !== 0 ? cpuDeltaForQuota : undefined,
+            memDeltaForQuota !== 0 ? memDeltaForQuota : undefined,
+            diskDeltaForQuota !== 0 ? diskDeltaForQuota : undefined,
+            undefined,
+          )
+
+          updateData.state = previousState
+        }
+
+        await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })
+      } finally {
+        // Release the per-runner pending allocation slot regardless of COMPLETED vs FAILED —
+        // either way the runner has finished with this resize. Safe-wrapped so a Redis blip
+        // doesn't shadow the original error; 60s TTL is the safety net for any swallow.
+        await this.runnerService.safeDecrementPendingRunnerAllocation(
+          job.runnerId,
           cpuDeltaForQuota,
           memDeltaForQuota,
           diskDeltaForQuota,
-          0,
         )
-      } else if (job.status === JobStatus.FAILED) {
-        this.logger.error(`RESIZE_SANDBOX job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
-
-        // Rollback pending usage (all deltas were tracked, including negative).
-        // Resize never changes GPU allocation — always pass undefined for gpu.
-        await this.organizationUsageService.decrementPendingSandboxUsage(
-          sandbox.organizationId,
-          sandbox.region,
-          sandbox.sandboxClass,
-          cpuDeltaForQuota !== 0 ? cpuDeltaForQuota : undefined,
-          memDeltaForQuota !== 0 ? memDeltaForQuota : undefined,
-          diskDeltaForQuota !== 0 ? diskDeltaForQuota : undefined,
-          undefined,
-        )
-
-        updateData.state = previousState
       }
-
-      await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })
     } catch (error) {
       this.logger.error(`Error handling RESIZE_SANDBOX job completion for sandbox ${sandboxId}:`, error)
     }

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -609,49 +609,44 @@ export class JobStateHandlerService {
     if (!sandboxId) return
 
     try {
-      const sandbox = await this.sandboxRepository.findOne({ where: { id: sandboxId } })
-      if (!sandbox) {
-        this.logger.warn(`Sandbox ${sandboxId} not found for RESIZE_SANDBOX job ${job.id}`)
-        return
-      }
-
-      if (sandbox.state !== SandboxState.RESIZING) {
-        this.logger.warn(
-          `Sandbox ${sandboxId} is not in RESIZING state for RESIZE_SANDBOX job ${job.id}. State: ${sandbox.state}`,
-        )
-        return
-      }
-
-      // Determine the previous state (STARTED or STOPPED based on desiredState)
-      const previousState =
-        sandbox.desiredState === SandboxDesiredState.STARTED
-          ? SandboxState.STARTED
-          : sandbox.desiredState === SandboxDesiredState.STOPPED
-            ? SandboxState.STOPPED
-            : null
-
-      if (!previousState) {
-        this.logger.error(
-          `Sandbox ${sandboxId} has unexpected desiredState ${sandbox.desiredState} for RESIZE_SANDBOX job ${job.id}`,
-        )
-        return
-      }
-
-      // Calculate deltas before updating sandbox
-      const payload = job.getPayload<{ cpu?: number; memory?: number; disk?: number }>() ?? {}
-
-      // For cold resize (previousState === STOPPED), cpu/memory don't affect org quota.
-      const isHotResize = previousState === SandboxState.STARTED
-      const cpuDeltaForQuota = isHotResize ? (payload.cpu ?? sandbox.cpu) - sandbox.cpu : 0
-      const memDeltaForQuota = isHotResize ? (payload.memory ?? sandbox.mem) - sandbox.mem : 0
-      const diskDeltaForQuota = (payload.disk ?? sandbox.disk) - sandbox.disk // Disk only increases
-
-      // Runner deltas — mirror what the admission gate reserved, to release the slot.
-      const cpuDeltaForRunner = Math.max(0, (payload.cpu ?? sandbox.cpu) - sandbox.cpu)
-      const memDeltaForRunner = Math.max(0, (payload.memory ?? sandbox.mem) - sandbox.mem)
-      const diskDeltaForRunner = Math.max(0, (payload.disk ?? sandbox.disk) - sandbox.disk)
-
       try {
+        const sandbox = await this.sandboxRepository.findOne({ where: { id: sandboxId } })
+        if (!sandbox) {
+          this.logger.warn(`Sandbox ${sandboxId} not found for RESIZE_SANDBOX job ${job.id}`)
+          return
+        }
+
+        if (sandbox.state !== SandboxState.RESIZING) {
+          this.logger.warn(
+            `Sandbox ${sandboxId} is not in RESIZING state for RESIZE_SANDBOX job ${job.id}. State: ${sandbox.state}`,
+          )
+          return
+        }
+
+        // Determine the previous state (STARTED or STOPPED based on desiredState)
+        const previousState =
+          sandbox.desiredState === SandboxDesiredState.STARTED
+            ? SandboxState.STARTED
+            : sandbox.desiredState === SandboxDesiredState.STOPPED
+              ? SandboxState.STOPPED
+              : null
+
+        if (!previousState) {
+          this.logger.error(
+            `Sandbox ${sandboxId} has unexpected desiredState ${sandbox.desiredState} for RESIZE_SANDBOX job ${job.id}`,
+          )
+          return
+        }
+
+        // Calculate deltas before updating sandbox
+        const payload = job.getPayload<{ cpu?: number; memory?: number; disk?: number }>() ?? {}
+
+        // For cold resize (previousState === STOPPED), cpu/memory don't affect org quota.
+        const isHotResize = previousState === SandboxState.STARTED
+        const cpuDeltaForQuota = isHotResize ? (payload.cpu ?? sandbox.cpu) - sandbox.cpu : 0
+        const memDeltaForQuota = isHotResize ? (payload.memory ?? sandbox.mem) - sandbox.mem : 0
+        const diskDeltaForQuota = (payload.disk ?? sandbox.disk) - sandbox.disk // Disk only increases
+
         const updateData: Partial<Sandbox> = {}
 
         if (job.status === JobStatus.COMPLETED) {
@@ -694,15 +689,9 @@ export class JobStateHandlerService {
 
         await this.sandboxRepository.update(sandboxId, { updateData, entity: sandbox })
       } finally {
-        // Release the per-runner pending usage slot on COMPLETED or FAILED — either way the
-        // runner is done resizing. Safe-wrapped so a Redis blip can't shadow the original
-        // error; the 2-minute TTL is the backstop.
-        await this.runnerUsageService.safeDecrementPendingRunnerUsage(
-          job.runnerId,
-          cpuDeltaForRunner,
-          memDeltaForRunner,
-          diskDeltaForRunner,
-        )
+        // Release runs on every exit path including the early returns above; the
+        // reservation amount is keyed by sandboxId in Redis, no sandbox row needed.
+        await this.runnerUsageService.safeReleasePendingRunnerUsageForResize(job.runnerId, sandboxId)
       }
     } catch (error) {
       this.logger.error(`Error handling RESIZE_SANDBOX job completion for sandbox ${sandboxId}:`, error)

--- a/apps/api/src/sandbox/services/runner-usage.service.ts
+++ b/apps/api/src/sandbox/services/runner-usage.service.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRedis } from '@nestjs-modules/ioredis'
+import Redis from 'ioredis'
+
+/**
+ * Owns the per-runner "pending usage" Redis hash — the in-flight resource reservations
+ * (cpu/memory/disk) used to throttle on-runner work (e.g. resizes) before the next
+ * healthcheck reflects them. The runner analog of OrganizationUsageService's pending usage.
+ *
+ * Extracted from RunnerService so JobStateHandlerService can release a slot without
+ * importing RunnerService, which would close a runner.service <-> job.service import cycle.
+ * This service deliberately depends on nothing but Redis.
+ */
+@Injectable()
+export class RunnerUsageService {
+  private readonly logger = new Logger(RunnerUsageService.name)
+
+  // Safety-net TTL only; the normal path releases each slot explicitly on completion.
+  private readonly PENDING_USAGE_TTL_S = 2 * 60
+
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  private getPendingUsageKey(runnerId: string): string {
+    return `runner:${runnerId}:usage:pending`
+  }
+
+  /**
+   * Atomically adjusts the per-runner pending usage hash and refreshes its TTL.
+   * Signed deltas; each field is clamped at 0 so a double-release can't go negative.
+   */
+  async incrementPendingRunnerUsage(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
+    const script = `
+      local function adjust(field, delta)
+        local value = redis.call("HINCRBY", KEYS[1], field, delta)
+        if value < 0 then
+          redis.call("HSET", KEYS[1], field, 0)
+        end
+      end
+      adjust("cpu",    ARGV[1])
+      adjust("memory", ARGV[2])
+      adjust("disk",   ARGV[3])
+      redis.call("EXPIRE", KEYS[1], ARGV[4])
+    `
+    await this.redis.eval(
+      script,
+      1,
+      this.getPendingUsageKey(runnerId),
+      cpu.toString(),
+      memory.toString(),
+      disk.toString(),
+      this.PENDING_USAGE_TTL_S.toString(),
+    )
+  }
+
+  /**
+   * Releases a pending usage slot. Symmetric with incrementPendingRunnerUsage — passes
+   * negatives through the same Lua so behavior (incl. TTL refresh) stays identical.
+   */
+  async decrementPendingRunnerUsage(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
+    return this.incrementPendingRunnerUsage(runnerId, -cpu, -memory, -disk)
+  }
+
+  /**
+   * decrementPendingRunnerUsage that swallows + warns on failure, so a Redis blip in a
+   * terminal hook never shadows the original error; the TTL is the safety net.
+   */
+  async safeDecrementPendingRunnerUsage(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
+    try {
+      await this.decrementPendingRunnerUsage(runnerId, cpu, memory, disk)
+    } catch (e) {
+      this.logger.warn(`Failed to decrement pending runner usage for ${runnerId}: ${e}`)
+    }
+  }
+
+  /**
+   * Reads the current pending usage counters (cpu/memory/disk) for a runner.
+   * Missing fields read as 0.
+   */
+  async getPendingRunnerUsage(runnerId: string): Promise<{ cpu: number; memory: number; disk: number }> {
+    const [cpu, memory, disk] = await this.redis.hmget(this.getPendingUsageKey(runnerId), 'cpu', 'memory', 'disk')
+    return {
+      cpu: Number(cpu ?? 0),
+      memory: Number(memory ?? 0),
+      disk: Number(disk ?? 0),
+    }
+  }
+}

--- a/apps/api/src/sandbox/services/runner-usage.service.ts
+++ b/apps/api/src/sandbox/services/runner-usage.service.ts
@@ -29,11 +29,20 @@ export class RunnerUsageService {
     return `runner:${runnerId}:usage:pending`
   }
 
-  /**
-   * Atomically adjusts the per-runner pending usage hash and refreshes its TTL.
-   * Signed deltas; each field is clamped at 0 so a double-release can't go negative.
-   */
-  async incrementPendingRunnerUsage(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
+  // Per-resize sidecar: stamps this resize's contribution to the runner hash so the
+  // release path can look it up by sandboxId without needing the sandbox row.
+  private getResizeReservationKey(runnerId: string, sandboxId: string): string {
+    return `runner:${runnerId}:resize:${sandboxId}`
+  }
+
+  // Atomic: bump the per-runner hash and write the matching sidecar in one EVAL.
+  async reservePendingRunnerUsageForResize(
+    runnerId: string,
+    sandboxId: string,
+    cpu: number,
+    memory: number,
+    disk: number,
+  ): Promise<void> {
     const script = `
       local function adjust(field, delta)
         local value = redis.call("HINCRBY", KEYS[1], field, delta)
@@ -45,11 +54,15 @@ export class RunnerUsageService {
       adjust("memory", ARGV[2])
       adjust("disk",   ARGV[3])
       redis.call("EXPIRE", KEYS[1], ARGV[4])
+
+      redis.call("HSET", KEYS[2], "cpu", ARGV[1], "memory", ARGV[2], "disk", ARGV[3])
+      redis.call("EXPIRE", KEYS[2], ARGV[4])
     `
     await this.redis.eval(
       script,
-      1,
+      2,
       this.getPendingUsageKey(runnerId),
+      this.getResizeReservationKey(runnerId, sandboxId),
       cpu.toString(),
       memory.toString(),
       disk.toString(),
@@ -57,23 +70,41 @@ export class RunnerUsageService {
     )
   }
 
-  /**
-   * Releases a pending usage slot. Symmetric with incrementPendingRunnerUsage — passes
-   * negatives through the same Lua so behavior (incl. TTL refresh) stays identical.
-   */
-  async decrementPendingRunnerUsage(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
-    return this.incrementPendingRunnerUsage(runnerId, -cpu, -memory, -disk)
-  }
-
-  /**
-   * decrementPendingRunnerUsage that swallows + warns on failure, so a Redis blip in a
-   * terminal hook never shadows the original error; the TTL is the safety net.
-   */
-  async safeDecrementPendingRunnerUsage(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
+  // Atomic: read sidecar → decrement runner hash by it → delete sidecar. Missing sidecar
+  // is a no-op, so double-release is safe. Swallows Redis errors; TTL is the backstop.
+  // HINCRBY rejects `-0` / float-stringified deltas — skip zero-deltas and format the
+  // negated integer explicitly so the script stays safe across field combinations.
+  async safeReleasePendingRunnerUsageForResize(runnerId: string, sandboxId: string): Promise<void> {
+    const script = `
+      local reserved = redis.call("HMGET", KEYS[2], "cpu", "memory", "disk")
+      if not reserved[1] and not reserved[2] and not reserved[3] then
+        return 0
+      end
+      local function adjust(field, delta_str)
+        local d = tonumber(delta_str)
+        if d == nil or d == 0 then return end
+        local value = redis.call("HINCRBY", KEYS[1], field, string.format("%d", -d))
+        if value < 0 then
+          redis.call("HSET", KEYS[1], field, 0)
+        end
+      end
+      adjust("cpu",    reserved[1])
+      adjust("memory", reserved[2])
+      adjust("disk",   reserved[3])
+      redis.call("EXPIRE", KEYS[1], ARGV[1])
+      redis.call("DEL", KEYS[2])
+      return 1
+    `
     try {
-      await this.decrementPendingRunnerUsage(runnerId, cpu, memory, disk)
+      await this.redis.eval(
+        script,
+        2,
+        this.getPendingUsageKey(runnerId),
+        this.getResizeReservationKey(runnerId, sandboxId),
+        this.PENDING_USAGE_TTL_S.toString(),
+      )
     } catch (e) {
-      this.logger.warn(`Failed to decrement pending runner usage for ${runnerId}: ${e}`)
+      this.logger.warn(`Failed to release pending runner usage for ${runnerId}/${sandboxId}: ${e}`)
     }
   }
 

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -51,14 +51,13 @@ import { normalizeGpuType } from '../utils/gpu-type-normalizer.util'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
+import { RunnerUsageService } from './runner-usage.service'
 
 @Injectable()
 export class RunnerService {
   private readonly logger = new Logger(RunnerService.name)
   private readonly serviceStartTime = new Date()
   private readonly scoreConfig: AvailabilityScoreConfig
-  // Safety-net TTL only; the normal path releases each slot explicitly on completion.
-  private readonly PENDING_ALLOCATION_TTL_S = 2 * 60
 
   constructor(
     @InjectRepository(Runner)
@@ -76,6 +75,7 @@ export class RunnerService {
     private readonly dataSource: DataSource,
     @InjectRedis()
     private readonly redis: Redis,
+    private readonly runnerUsageService: RunnerUsageService,
   ) {
     this.scoreConfig = this.getAvailabilityScoreConfig()
   }
@@ -1203,87 +1203,21 @@ export class RunnerService {
     }
   }
 
-  private getPendingAllocationKey(runnerId: string): string {
-    return `runner:${runnerId}:allocation:pending`
-  }
-
   /**
-   * Atomically adjusts the per-runner pending allocation hash and refreshes its TTL.
-   * Signed deltas; each field is clamped at 0 so a double-release can't go negative.
+   * Computes the runner's availabilityScore as it would be with the currently-reserved
+   * pending usage applied on top of its last reported metrics. The resize admission gate
+   * calls this *after* reserving its own usage, so the projection already includes it.
    */
-  async incrementPendingRunnerAllocation(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
-    const script = `
-      local function adjust(field, delta)
-        local value = redis.call("HINCRBY", KEYS[1], field, delta)
-        if value < 0 then
-          redis.call("HSET", KEYS[1], field, 0)
-        end
-      end
-      adjust("cpu",    ARGV[1])
-      adjust("memory", ARGV[2])
-      adjust("disk",   ARGV[3])
-      redis.call("EXPIRE", KEYS[1], ARGV[4])
-    `
-    await this.redis.eval(
-      script,
-      1,
-      this.getPendingAllocationKey(runnerId),
-      cpu.toString(),
-      memory.toString(),
-      disk.toString(),
-      this.PENDING_ALLOCATION_TTL_S.toString(),
-    )
-  }
-
-  /**
-   * Releases a pending allocation slot. Symmetric with incrementPendingRunnerAllocation —
-   * passes negatives through the same Lua so behavior (incl. TTL refresh) stays identical.
-   */
-  async decrementPendingRunnerAllocation(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
-    return this.incrementPendingRunnerAllocation(runnerId, -cpu, -memory, -disk)
-  }
-
-  /**
-   * decrementPendingRunnerAllocation that swallows + warns on failure, so a Redis blip
-   * in a terminal hook never shadows the original error; the TTL is the safety net.
-   */
-  async safeDecrementPendingRunnerAllocation(
-    runnerId: string,
-    cpu: number,
-    memory: number,
-    disk: number,
-  ): Promise<void> {
-    try {
-      await this.decrementPendingRunnerAllocation(runnerId, cpu, memory, disk)
-    } catch (e) {
-      this.logger.warn(`Failed to decrement pending runner allocation for ${runnerId}: ${e}`)
-    }
-  }
-
-  /**
-   * Computes the runner's availabilityScore as it would be after the currently-cached
-   * pending allocations *and* the caller-supplied extra deltas are applied on top of
-   * the runner's last reported metrics. Used as an admission gate before accepting
-   * new on-runner work.
-   */
-  async getProjectedAvailabilityScore(
-    runner: Runner,
-    extra: { cpu: number; memory: number; disk: number },
-  ): Promise<number> {
-    const [cpuPending, memoryPending, diskPending] = await this.redis.hmget(
-      this.getPendingAllocationKey(runner.id),
-      'cpu',
-      'memory',
-      'disk',
-    )
+  async getProjectedAvailabilityScore(runner: Runner): Promise<number> {
+    const pending = await this.runnerUsageService.getPendingRunnerUsage(runner.id)
     return this.calculateAvailabilityScore(runner.id, {
       cpuLoadAverage: runner.currentCpuLoadAverage,
       cpuUsage: runner.currentCpuUsagePercentage,
       memoryUsage: runner.currentMemoryUsagePercentage,
       diskUsage: runner.currentDiskUsagePercentage,
-      allocatedCpu: runner.currentAllocatedCpu + Number(cpuPending ?? 0) + extra.cpu,
-      allocatedMemoryGiB: runner.currentAllocatedMemoryGiB + Number(memoryPending ?? 0) + extra.memory,
-      allocatedDiskGiB: runner.currentAllocatedDiskGiB + Number(diskPending ?? 0) + extra.disk,
+      allocatedCpu: runner.currentAllocatedCpu + pending.cpu,
+      allocatedMemoryGiB: runner.currentAllocatedMemoryGiB + pending.memory,
+      allocatedDiskGiB: runner.currentAllocatedDiskGiB + pending.disk,
       runnerCpu: runner.cpu,
       runnerMemoryGiB: runner.memoryGiB,
       runnerDiskGiB: runner.diskGiB,

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -57,6 +57,8 @@ export class RunnerService {
   private readonly logger = new Logger(RunnerService.name)
   private readonly serviceStartTime = new Date()
   private readonly scoreConfig: AvailabilityScoreConfig
+  // Safety-net TTL only; the normal path releases each slot explicitly on completion.
+  private readonly PENDING_ALLOCATION_TTL_S = 2 * 60
 
   constructor(
     @InjectRepository(Runner)
@@ -1199,6 +1201,94 @@ export class RunnerService {
         ],
       },
     }
+  }
+
+  private getPendingAllocationKey(runnerId: string): string {
+    return `runner:${runnerId}:allocation:pending`
+  }
+
+  /**
+   * Atomically adjusts the per-runner pending allocation hash and refreshes its TTL.
+   * Signed deltas; each field is clamped at 0 so a double-release can't go negative.
+   */
+  async incrementPendingRunnerAllocation(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
+    const script = `
+      local function adjust(field, delta)
+        local value = redis.call("HINCRBY", KEYS[1], field, delta)
+        if value < 0 then
+          redis.call("HSET", KEYS[1], field, 0)
+        end
+      end
+      adjust("cpu",    ARGV[1])
+      adjust("memory", ARGV[2])
+      adjust("disk",   ARGV[3])
+      redis.call("EXPIRE", KEYS[1], ARGV[4])
+    `
+    await this.redis.eval(
+      script,
+      1,
+      this.getPendingAllocationKey(runnerId),
+      cpu.toString(),
+      memory.toString(),
+      disk.toString(),
+      this.PENDING_ALLOCATION_TTL_S.toString(),
+    )
+  }
+
+  /**
+   * Releases a pending allocation slot. Symmetric with incrementPendingRunnerAllocation —
+   * passes negatives through the same Lua so behavior (incl. TTL refresh) stays identical.
+   */
+  async decrementPendingRunnerAllocation(runnerId: string, cpu: number, memory: number, disk: number): Promise<void> {
+    return this.incrementPendingRunnerAllocation(runnerId, -cpu, -memory, -disk)
+  }
+
+  /**
+   * decrementPendingRunnerAllocation that swallows + warns on failure, so a Redis blip
+   * in a terminal hook never shadows the original error; the TTL is the safety net.
+   */
+  async safeDecrementPendingRunnerAllocation(
+    runnerId: string,
+    cpu: number,
+    memory: number,
+    disk: number,
+  ): Promise<void> {
+    try {
+      await this.decrementPendingRunnerAllocation(runnerId, cpu, memory, disk)
+    } catch (e) {
+      this.logger.warn(`Failed to decrement pending runner allocation for ${runnerId}: ${e}`)
+    }
+  }
+
+  /**
+   * Computes the runner's availabilityScore as it would be after the currently-cached
+   * pending allocations *and* the caller-supplied extra deltas are applied on top of
+   * the runner's last reported metrics. Used as an admission gate before accepting
+   * new on-runner work.
+   */
+  async getProjectedAvailabilityScore(
+    runner: Runner,
+    extra: { cpu: number; memory: number; disk: number },
+  ): Promise<number> {
+    const [cpuPending, memoryPending, diskPending] = await this.redis.hmget(
+      this.getPendingAllocationKey(runner.id),
+      'cpu',
+      'memory',
+      'disk',
+    )
+    return this.calculateAvailabilityScore(runner.id, {
+      cpuLoadAverage: runner.currentCpuLoadAverage,
+      cpuUsage: runner.currentCpuUsagePercentage,
+      memoryUsage: runner.currentMemoryUsagePercentage,
+      diskUsage: runner.currentDiskUsagePercentage,
+      allocatedCpu: runner.currentAllocatedCpu + Number(cpuPending ?? 0) + extra.cpu,
+      allocatedMemoryGiB: runner.currentAllocatedMemoryGiB + Number(memoryPending ?? 0) + extra.memory,
+      allocatedDiskGiB: runner.currentAllocatedDiskGiB + Number(diskPending ?? 0) + extra.disk,
+      runnerCpu: runner.cpu,
+      runnerMemoryGiB: runner.memoryGiB,
+      runnerDiskGiB: runner.diskGiB,
+      startedSandboxes: runner.currentStartedSandboxes,
+    })
   }
 }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -29,6 +29,7 @@ import { FeatureFlags } from '../../common/constants/feature-flags'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { resolveGpuTypePreferences } from '../utils/gpu-type-preferences.util'
 import { RunnerService } from './runner.service'
+import { RunnerUsageService } from './runner-usage.service'
 import { SandboxError } from '../../exceptions/sandbox-error.exception'
 import { StateChangeInProgressError } from '../../exceptions/state-change-in-progress.exception'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
@@ -137,6 +138,7 @@ export class SandboxService {
     @InjectRepository(SshAccess)
     private readonly sshAccessRepository: Repository<SshAccess>,
     private readonly runnerService: RunnerService,
+    private readonly runnerUsageService: RunnerUsageService,
     private readonly volumeService: VolumeService,
     private readonly configService: TypedConfigService,
     private readonly warmPoolService: SandboxWarmPoolService,
@@ -2370,7 +2372,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
-    let admittedRunnerAllocation: { runnerId: string; cpu: number; memory: number; disk: number } | undefined
+    let admittedRunnerUsage: { runnerId: string; cpu: number; memory: number; disk: number } | undefined
     let pendingGpuIncrement: number | undefined
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
@@ -2472,6 +2474,12 @@ export class SandboxService {
       const memDeltaForQuota = isHotResize ? newMem - sandbox.mem : 0
       const diskDeltaForQuota = newDisk - sandbox.disk // Disk only increases (validated at start of method)
 
+      // Runner admission deltas: actual increase (hot or cold), clamped at >= 0 so a
+      // downsize reserves nothing and admission/release stay symmetric.
+      const cpuDeltaForRunner = Math.max(0, newCpu - sandbox.cpu)
+      const memDeltaForRunner = Math.max(0, newMem - sandbox.mem)
+      const diskDeltaForRunner = Math.max(0, newDisk - sandbox.disk)
+
       // Validate and track pending for any non-zero quota changes.
       // Resize never changes GPU allocation — always pass 0 for the GPU delta, but pass
       // `gpuEnabled = sandbox.gpu > 0` so per-sandbox limit checks use the GPU-specific table.
@@ -2521,37 +2529,27 @@ export class SandboxService {
         throw new BadRequestError('Sandbox must be in started or stopped state to resize')
       }
 
-      // Per-runner admission gate: reject (409) if pending allocations + this resize would
-      // drop the runner's projected score below the threshold. Locked against stale-view
-      // races. Cold cpu/mem resizes are gated too, as a proxy until start is also gated.
-      const allocationLockKey = `runner-${runner.id}-pending-allocation-lock`
-      await this.redisLockProvider.waitForLock(allocationLockKey, 10)
-      try {
-        const projectedScore = await this.runnerService.getProjectedAvailabilityScore(runner, {
-          cpu: cpuDeltaForQuota,
-          memory: memDeltaForQuota,
-          disk: diskDeltaForQuota,
-        })
-        const resizeScoreThreshold = this.configService.getOrThrow('runnerScore.thresholds.resize')
-        if (projectedScore < resizeScoreThreshold) {
-          throw new ConflictException(
-            `Runner load would exceed resize threshold (projected score ${projectedScore} < ${resizeScoreThreshold}). Please retry shortly.`,
-          )
-        }
-        await this.runnerService.incrementPendingRunnerAllocation(
-          runner.id,
-          cpuDeltaForQuota,
-          memDeltaForQuota,
-          diskDeltaForQuota,
-        )
-        admittedRunnerAllocation = {
-          runnerId: runner.id,
-          cpu: cpuDeltaForQuota,
-          memory: memDeltaForQuota,
-          disk: diskDeltaForQuota,
-        }
-      } finally {
-        await this.redisLockProvider.unlock(allocationLockKey)
+      // Per-runner admission gate (lock-free, mirrors OrganizationUsageService): reserve the
+      // usage first via atomic HINCRBY, then project the score from the post-reservation
+      // hash — so concurrent resizes each see the others' reservations and none can
+      // over-admit. Below threshold → throw; the outer catch releases the reservation.
+      // Cold cpu/mem resizes are gated too, as a proxy until start is also gated.
+      await this.runnerUsageService.incrementPendingRunnerUsage(
+        runner.id,
+        cpuDeltaForRunner,
+        memDeltaForRunner,
+        diskDeltaForRunner,
+      )
+      admittedRunnerUsage = {
+        runnerId: runner.id,
+        cpu: cpuDeltaForRunner,
+        memory: memDeltaForRunner,
+        disk: diskDeltaForRunner,
+      }
+      const projectedScore = await this.runnerService.getProjectedAvailabilityScore(runner)
+      const resizeScoreThreshold = this.configService.getOrThrow('runnerScore.thresholds.resize')
+      if (projectedScore < resizeScoreThreshold) {
+        throw new ConflictException('Sandbox runner is temporarily at capacity. Please retry the resize shortly.')
       }
 
       // Now transition to RESIZING state
@@ -2607,20 +2605,19 @@ export class SandboxService {
             0,
           )
 
-          // Release the per-runner pending allocation slot — runner has applied the resize
-          // synchronously on the V0 path. (Brief under-counting until the next healthcheck
-          // refreshes runner.currentAllocatedCpu is documented and accepted.)
-          await this.runnerService.safeDecrementPendingRunnerAllocation(
+          // Release the slot — V0 applies the resize synchronously. (Brief under-counting
+          // until the next healthcheck refreshes currentAllocatedCpu is accepted.)
+          await this.runnerUsageService.safeDecrementPendingRunnerUsage(
             runner.id,
-            cpuDeltaForQuota,
-            memDeltaForQuota,
-            diskDeltaForQuota,
+            cpuDeltaForRunner,
+            memDeltaForRunner,
+            diskDeltaForRunner,
           )
-          admittedRunnerAllocation = undefined
+          admittedRunnerUsage = undefined
         } else {
           // V2: job enqueued — handler now owns state + slot release; clear to avoid a
           // double-release in the outer catch.
-          admittedRunnerAllocation = undefined
+          admittedRunnerUsage = undefined
         }
       } catch (error) {
         // resize failed — revert RESIZING. Excludes the findOneByIdOrName below, which
@@ -2648,12 +2645,12 @@ export class SandboxService {
         pendingDiskIncrement,
         pendingGpuIncrement,
       )
-      if (admittedRunnerAllocation) {
-        await this.runnerService.safeDecrementPendingRunnerAllocation(
-          admittedRunnerAllocation.runnerId,
-          admittedRunnerAllocation.cpu,
-          admittedRunnerAllocation.memory,
-          admittedRunnerAllocation.disk,
+      if (admittedRunnerUsage) {
+        await this.runnerUsageService.safeDecrementPendingRunnerUsage(
+          admittedRunnerUsage.runnerId,
+          admittedRunnerUsage.cpu,
+          admittedRunnerUsage.memory,
+          admittedRunnerUsage.disk,
         )
       }
       throw error

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -2372,7 +2372,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
-    let admittedRunnerUsage: { runnerId: string; cpu: number; memory: number; disk: number } | undefined
+    let admittedRunnerReservation: { runnerId: string; sandboxId: string } | undefined
     let pendingGpuIncrement: number | undefined
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
@@ -2529,27 +2529,24 @@ export class SandboxService {
         throw new BadRequestError('Sandbox must be in started or stopped state to resize')
       }
 
-      // Per-runner admission gate (lock-free, mirrors OrganizationUsageService): reserve the
-      // usage first via atomic HINCRBY, then project the score from the post-reservation
-      // hash — so concurrent resizes each see the others' reservations and none can
-      // over-admit. Below threshold → throw; the outer catch releases the reservation.
-      // Cold cpu/mem resizes are gated too, as a proxy until start is also gated.
-      await this.runnerUsageService.incrementPendingRunnerUsage(
-        runner.id,
-        cpuDeltaForRunner,
-        memDeltaForRunner,
-        diskDeltaForRunner,
-      )
-      admittedRunnerUsage = {
-        runnerId: runner.id,
-        cpu: cpuDeltaForRunner,
-        memory: memDeltaForRunner,
-        disk: diskDeltaForRunner,
-      }
-      const projectedScore = await this.runnerService.getProjectedAvailabilityScore(runner)
-      const resizeScoreThreshold = this.configService.getOrThrow('runnerScore.thresholds.resize')
-      if (projectedScore < resizeScoreThreshold) {
-        throw new ConflictException('Sandbox runner is temporarily at capacity. Please retry the resize shortly.')
+      // Lock-free admission: reserve first, then project the score from the post-reservation
+      // hash so concurrent resizes can't over-admit. Cold cpu/mem are gated as a proxy until
+      // start is also gated. Pure downsizes skip the gate — they only free resources, so a
+      // congested runner shouldn't 409 them.
+      if (cpuDeltaForRunner > 0 || memDeltaForRunner > 0 || diskDeltaForRunner > 0) {
+        await this.runnerUsageService.reservePendingRunnerUsageForResize(
+          runner.id,
+          sandbox.id,
+          cpuDeltaForRunner,
+          memDeltaForRunner,
+          diskDeltaForRunner,
+        )
+        admittedRunnerReservation = { runnerId: runner.id, sandboxId: sandbox.id }
+        const projectedScore = await this.runnerService.getProjectedAvailabilityScore(runner)
+        const resizeScoreThreshold = this.configService.getOrThrow('runnerScore.thresholds.resize')
+        if (projectedScore < resizeScoreThreshold) {
+          throw new ConflictException('Sandbox runner is temporarily at capacity. Please retry the resize shortly.')
+        }
       }
 
       // Now transition to RESIZING state
@@ -2605,19 +2602,13 @@ export class SandboxService {
             0,
           )
 
-          // Release the slot — V0 applies the resize synchronously. (Brief under-counting
-          // until the next healthcheck refreshes currentAllocatedCpu is accepted.)
-          await this.runnerUsageService.safeDecrementPendingRunnerUsage(
-            runner.id,
-            cpuDeltaForRunner,
-            memDeltaForRunner,
-            diskDeltaForRunner,
-          )
-          admittedRunnerUsage = undefined
+          // V0 applies the resize synchronously; release now. Brief under-counting until
+          // the next healthcheck refreshes currentAllocatedCpu is accepted.
+          await this.runnerUsageService.safeReleasePendingRunnerUsageForResize(runner.id, sandbox.id)
+          admittedRunnerReservation = undefined
         } else {
-          // V2: job enqueued — handler now owns state + slot release; clear to avoid a
-          // double-release in the outer catch.
-          admittedRunnerUsage = undefined
+          // V2: completion handler owns the release. Clear so the outer catch doesn't double-release.
+          admittedRunnerReservation = undefined
         }
       } catch (error) {
         // resize failed — revert RESIZING. Excludes the findOneByIdOrName below, which
@@ -2645,12 +2636,10 @@ export class SandboxService {
         pendingDiskIncrement,
         pendingGpuIncrement,
       )
-      if (admittedRunnerUsage) {
-        await this.runnerUsageService.safeDecrementPendingRunnerUsage(
-          admittedRunnerUsage.runnerId,
-          admittedRunnerUsage.cpu,
-          admittedRunnerUsage.memory,
-          admittedRunnerUsage.disk,
+      if (admittedRunnerReservation) {
+        await this.runnerUsageService.safeReleasePendingRunnerUsageForResize(
+          admittedRunnerReservation.runnerId,
+          admittedRunnerReservation.sandboxId,
         )
       }
       throw error

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -2370,6 +2370,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
+    let admittedRunnerAllocation: { runnerId: string; cpu: number; memory: number; disk: number } | undefined
     let pendingGpuIncrement: number | undefined
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
@@ -2520,6 +2521,39 @@ export class SandboxService {
         throw new BadRequestError('Sandbox must be in started or stopped state to resize')
       }
 
+      // Per-runner admission gate: reject (409) if pending allocations + this resize would
+      // drop the runner's projected score below the threshold. Locked against stale-view
+      // races. Cold cpu/mem resizes are gated too, as a proxy until start is also gated.
+      const allocationLockKey = `runner-${runner.id}-pending-allocation-lock`
+      await this.redisLockProvider.waitForLock(allocationLockKey, 10)
+      try {
+        const projectedScore = await this.runnerService.getProjectedAvailabilityScore(runner, {
+          cpu: cpuDeltaForQuota,
+          memory: memDeltaForQuota,
+          disk: diskDeltaForQuota,
+        })
+        const resizeScoreThreshold = this.configService.getOrThrow('runnerScore.thresholds.resize')
+        if (projectedScore < resizeScoreThreshold) {
+          throw new ConflictException(
+            `Runner load would exceed resize threshold (projected score ${projectedScore} < ${resizeScoreThreshold}). Please retry shortly.`,
+          )
+        }
+        await this.runnerService.incrementPendingRunnerAllocation(
+          runner.id,
+          cpuDeltaForQuota,
+          memDeltaForQuota,
+          diskDeltaForQuota,
+        )
+        admittedRunnerAllocation = {
+          runnerId: runner.id,
+          cpu: cpuDeltaForQuota,
+          memory: memDeltaForQuota,
+          disk: diskDeltaForQuota,
+        }
+      } finally {
+        await this.redisLockProvider.unlock(allocationLockKey)
+      }
+
       // Now transition to RESIZING state
       const updateData: Partial<Sandbox> = {
         state: SandboxState.RESIZING,
@@ -2572,11 +2606,25 @@ export class SandboxService {
             diskDeltaForQuota,
             0,
           )
-        }
 
-        return await this.findOneByIdOrName(sandbox.id, organization.id)
+          // Release the per-runner pending allocation slot — runner has applied the resize
+          // synchronously on the V0 path. (Brief under-counting until the next healthcheck
+          // refreshes runner.currentAllocatedCpu is documented and accepted.)
+          await this.runnerService.safeDecrementPendingRunnerAllocation(
+            runner.id,
+            cpuDeltaForQuota,
+            memDeltaForQuota,
+            diskDeltaForQuota,
+          )
+          admittedRunnerAllocation = undefined
+        } else {
+          // V2: job enqueued — handler now owns state + slot release; clear to avoid a
+          // double-release in the outer catch.
+          admittedRunnerAllocation = undefined
+        }
       } catch (error) {
-        // Return to previous state on error
+        // resize failed — revert RESIZING. Excludes the findOneByIdOrName below, which
+        // must not revert state for an in-flight V2 job.
         const updateData: Partial<Sandbox> = {
           state: previousState,
         }
@@ -2588,6 +2636,8 @@ export class SandboxService {
 
         throw error
       }
+
+      return await this.findOneByIdOrName(sandbox.id, organization.id)
     } catch (error) {
       await this.rollbackPendingUsage(
         organization.id,
@@ -2598,6 +2648,14 @@ export class SandboxService {
         pendingDiskIncrement,
         pendingGpuIncrement,
       )
+      if (admittedRunnerAllocation) {
+        await this.runnerService.safeDecrementPendingRunnerAllocation(
+          admittedRunnerAllocation.runnerId,
+          admittedRunnerAllocation.cpu,
+          admittedRunnerAllocation.memory,
+          admittedRunnerAllocation.disk,
+        )
+      }
       throw error
     }
   }


### PR DESCRIPTION
This adds a per-runner admission gate for sandbox resizes so one runner can't be overwhelmed by concurrent or oversized resize requests. Before a resize is accepted we project what the runner's availability score would be once every in-flight resize plus this one is applied, and reject with a 409 if that projection falls below RUNNER_RESIZE_SCORE_THRESHOLD. In-flight resizes are tracked in a per-runner Redis hash, mirroring how organization quotas track pending usage: the slot is reserved at admission under a per-runner lock — so concurrent requests are checked against an up-to-date view rather than all passing on a stale score — and released when the resize finishes, inline for V0 runners and in the RESIZE_SANDBOX job handler for V2. The pending counters are clamped at zero and carry a 2-minute safety-net TTL, so a lost release can't strand a runner or distort its score.

Examples:
- A runner is already near capacity: a resize that would push its projected score below the threshold is rejected with a 409 telling the caller to retry shortly, instead of landing on the runner and degrading every sandbox on it.
- Several resizes target the same runner at once: the per-runner lock serialises admission, so each is checked against the others' reservations and only as many as fit get accepted. 
- A resize finishes or fails: its slot is released and the runner's projected score recovers, so later resizes are admitted again.
- A cold cpu/mem resize is gated too — it adds no load until the next start, but the allocation is reserved up front.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation