### PR TITLE
feat(dashboard): show ids for volumes and snapshots

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -12,7 +12,7 @@ import { SandboxState as SandboxStateComponent } from '@/components/sandboxes/Sa
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { getRelativeTimeString } from '@/lib/utils'
+import { getRelativeTimeString, truncateUUID } from '@/lib/utils'
 import { SandboxDesiredState, SandboxListItem } from '@daytona/api-client'
 import { Column, ColumnDef, RowData, Table } from '@tanstack/react-table'
 import { Loader2 } from 'lucide-react'
@@ -176,10 +176,9 @@ const columns: ColumnDef<SandboxListItem>[] = [
     accessorKey: 'id',
     cell: ({ row }) => {
       const id = row.original.id
-      const truncated = id.length > 12 ? `${id.slice(0, 8)}...${id.slice(-4)}` : id
       return (
-        <div className="group/copy-button flex w-full items-center gap-1 truncate">
-          <span className="block truncate text-muted-foreground">{truncated}</span>
+        <div className="w-full truncate flex items-center gap-1 group/copy-button">
+          <span className="truncate block text-muted-foreground">{truncateUUID(id)}</span>
           <CopyButton value={id} size="icon-xs" autoHide tooltipText="Copy UUID" />
         </div>
       )

--- a/apps/dashboard/src/components/VolumeTable.tsx
+++ b/apps/dashboard/src/components/VolumeTable.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useCommandPaletteActions } from '@/components/CommandPalette'
+import { CopyButton } from '@/components/CopyButton'
 import { PageFooterPortal } from '@/components/PageLayout'
 import { Pagination } from '@/components/Pagination'
 import { SearchInput } from '@/components/SearchInput'
@@ -28,7 +29,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
-import { cn, getRelativeTimeString } from '@/lib/utils'
+import { cn, getRelativeTimeString, truncateUUID } from '@/lib/utils'
 import { getColumnSizeStyles } from '@/lib/utils/table'
 import { OrganizationRolePermissionsEnum, VolumeDto, VolumeState } from '@daytona/api-client'
 import {
@@ -432,6 +433,23 @@ const columns: ColumnDef<VolumeDto>[] = [
     },
     cell: ({ row }) => {
       return <div className="w-40">{row.original.name}</div>
+    },
+  },
+  {
+    accessorKey: 'id',
+    size: 180,
+    maxSize: 180,
+    header: 'ID',
+    enableSorting: false,
+    cell: ({ row }) => {
+      const id = row.original.id
+
+      return (
+        <div className="w-full truncate flex items-center gap-1 group/copy-button">
+          <span className="truncate block text-muted-foreground">{truncateUUID(id)}</span>
+          <CopyButton value={id} size="icon-xs" autoHide tooltipText="Copy ID" />
+        </div>
+      )
     },
   },
   {

--- a/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
@@ -16,7 +16,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { getSnapshotQueryErrorStatus, useSnapshotQuery } from '@/hooks/queries/useSnapshotsQuery'
-import { cn, getRelativeTimeString } from '@/lib/utils'
+import { cn, getRelativeTimeString, truncateUUID } from '@/lib/utils'
 import { SnapshotDto, SnapshotState } from '@daytona/api-client'
 import { MagnifyingGlassIcon } from '@phosphor-icons/react'
 import { ChevronDown, ChevronUp, CircleAlert, Pause, Play, Trash2, X } from 'lucide-react'
@@ -79,16 +79,18 @@ function InfoRow({
 
 function CopyValue({
   value,
+  displayValue = value,
   tooltipText = 'Copy',
   className,
 }: {
   value: string
+  displayValue?: string
   tooltipText?: string
   className?: string
 }) {
   return (
     <div className="flex items-center gap-1 min-w-0">
-      <span className={cn('truncate', className)}>{value}</span>
+      <span className={cn('truncate', className)}>{displayValue}</span>
       <CopyButton value={value} tooltipText={tooltipText} size="icon-xs" />
     </div>
   )
@@ -152,7 +154,7 @@ function TimestampRow({ label, value }: { label: string; value: Date | null | un
 }
 
 function SnapshotSheetSkeleton() {
-  const overviewRows = ['name', 'image', 'size', 'entrypoint', 'state']
+  const overviewRows = ['name', 'id', 'image', 'size', 'entrypoint', 'state']
   const timestampRows = ['created', 'updated', 'last-used']
 
   return (
@@ -300,6 +302,14 @@ export function SnapshotSheet({
               <InfoSection>
                 <InfoRow label="Name" className="-mr-2">
                   <CopyValue value={activeSnapshot.name} tooltipText="Copy name" />
+                </InfoRow>
+                <InfoRow label="ID" className="-mr-2">
+                  <CopyValue
+                    value={activeSnapshot.id}
+                    displayValue={truncateUUID(activeSnapshot.id)}
+                    tooltipText="Copy ID"
+                    className="font-mono text-muted-foreground"
+                  />
                 </InfoRow>
                 <InfoRow label="Image" className="-mr-2">
                   {activeSnapshot.imageName ? (

--- a/apps/dashboard/src/lib/utils/index.ts
+++ b/apps/dashboard/src/lib/utils/index.ts
@@ -59,7 +59,7 @@ export function getRelativeTimeString(
       date,
       relativeTimeString: isFuture ? `in ${years}y` : `${years}y ago`,
     }
-  } catch (e) {
+  } catch {
     return { date: new Date(), relativeTimeString: fallback }
   }
 }
@@ -104,6 +104,10 @@ export function pluralize(count: number, singular: string, plural: string): stri
 export function isValidUUID(str: string): boolean {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
   return uuidRegex.test(str)
+}
+
+export function truncateUUID(uuid: string): string {
+  return uuid.length > 12 ? `${uuid.slice(0, 8)}…${uuid.slice(-4)}` : uuid
 }
 
 export function formatTimestamp(timestamp: string | Date | undefined | null): string {


### PR DESCRIPTION
## Description

Shows ids for snapshots/volumes.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows IDs for volumes and snapshots with copy buttons and a consistent truncated display. Unifies UUID truncation across Sandbox, Volume, and Snapshot views; the UI shows a truncated value but copies the full ID.

- **New Features**
  - Volumes table: added ID column with truncated display and copy button.
  - Snapshot sheet: added ID row with truncated display and copy; skeleton updated to include ID.
  - Added `truncateUUID` util (8…4) and applied to Sandbox, Volume, and Snapshot IDs.

<sup>Written for commit 361cf9ea954825dcfe07a2a293b38ed48534beb5. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4764?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

