### PR TITLE
fix(deps): pin vulnerable transitive dependencies (handlebars, protobufjs, fast-xml-parser)

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,6 +326,13 @@
   "nx": {
     "includedScripts": []
   },
+  "resolutions": {
+    "handlebars": "4.7.9",
+    "fast-xml-parser@5.2.5": "5.3.5",
+    "protobufjs@^7.2.5": "7.5.5",
+    "protobufjs@^7.3.2": "7.5.5",
+    "protobufjs@^7.5.3": "7.5.5"
+  },
   "lint-staged": {
     "apps/api/src/migrations/**/*-migration.ts": [
       "bash apps/api/scripts/validate-migration-paths.sh"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24120,14 +24120,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.2.5":
-  version: 5.2.5
-  resolution: "fast-xml-parser@npm:5.2.5"
+"fast-xml-parser@npm:5.3.5":
+  version: 5.3.5
+  resolution: "fast-xml-parser@npm:5.3.5"
   dependencies:
-    strnum: "npm:^2.1.0"
+    strnum: "npm:^2.1.2"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/d1057d2e790c327ccfc42b872b91786a4912a152d44f9507bf053f800102dfb07ece3da0a86b33ff6a0caa5a5cad86da3326744f6ae5efb0c6c571d754fe48cd
+  checksum: 10c0/ac6232de821c8292436c53a58fc583f073cc5a73d14310b956391512e325e1ef65b950a1d41f5f2715b0d4d363fac2e483d7df1748b344647ea7c7f219a5d2f4
   languageName: node
   linkType: hard
 
@@ -25435,9 +25435,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.8, handlebars@npm:^4.7.8":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+"handlebars@npm:4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -25449,7 +25449,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -34431,6 +34431,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
+  languageName: node
+  linkType: hard
+
 "protobufjs@npm:8.0.1":
   version: 8.0.1
   resolution: "protobufjs@npm:8.0.1"
@@ -34448,26 +34468,6 @@ __metadata:
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
   checksum: 10c0/04c8c1b5b1b6355230534aaf01915f1d46cbf1ca14799628097997163d0c6611931fd9971c3eef9b2428703dc81464ef27c7f1f41f3cbb885a567ea942401454
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
-  dependencies:
-    "@protobufjs/aspromise": "npm:^1.1.2"
-    "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
-    "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
-    "@protobufjs/path": "npm:^1.1.2"
-    "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
-    "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
   languageName: node
   linkType: hard
 
@@ -38237,10 +38237,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "strnum@npm:2.1.1"
-  checksum: 10c0/1f9bd1f9b4c68333f25c2b1f498ea529189f060cd50aa59f1876139c994d817056de3ce57c12c970f80568d75df2289725e218bd9e3cdf73cd1a876c9c102733
+"strnum@npm:^2.1.2":
+  version: 2.3.0
+  resolution: "strnum@npm:2.3.0"
+  checksum: 10c0/8d29ea0789df22dfa6101153573c76ce12fb065ed0807eb99cc64624cd7f3d67a5aa0db507e75ab985ca23908cc4f02c65f3359ad762cb3659e3d6456e76e143
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Pins three vulnerable transitive Node.js dependencies to their minimum secure versions using Yarn 4's `resolutions` field in the root `package.json`.

All three packages are reachable only as transitive dependencies — no workspace manifest lists them directly — so `resolutions` is the correct Yarn mechanism to enforce a version floor without modifying every upstream consumer.

| Package | Before | After | Severity | CVE |
|---|---|---|---|---|
| `handlebars` | 4.7.8 | 4.7.9 | Critical (RCE) | CVE-2026-33937 |
| `fast-xml-parser` | 5.2.5 | 5.3.5 | High (XSS) | CVE-2026-25896 |
| `protobufjs` (^7.x) | 7.5.4 | 7.5.5 | Critical (RCE) | CVE-2026-41242 |

**Resolution scoping decisions:**
  - `handlebars` — global override; all consumers (`nestjs-pino`, `ts-jest`, `@nx-tools/nx-container`) request `^4.7.8`, which accepts 4.7.9.
  - `fast-xml-parser@5.2.5` — descriptor-scoped to the exact `5.2.5` pin used by `@aws-sdk` packages; the separately-locked `5.5.8` version used by other aws-sdk packages is left untouched.
  - `protobufjs@^7.2.5 / ^7.3.2 / ^7.5.3` — three range-scoped entries covering `dockerode`, `@grpc/proto-loader@0.7.x`, and `@grpc/proto-loader@0.8.x`; the separately-pinned `8.0.1` used by `@opentelemetry/otlp-proto-exporter-base` is intentionally excluded — a blanket override would be a breaking downgrade for that package.

`yarn.lock` will be regenerated on the next `yarn install` run in CI.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins vulnerable transitive dependencies via Yarn 4 `resolutions` to enforce minimum secure versions. No code or API changes; `yarn.lock` regenerated.

- **Dependencies**
  - `handlebars`: 4.7.8 → 4.7.9 (CVE-2026-33937, RCE) — global override
  - `fast-xml-parser@5.2.5`: 5.2.5 → 5.3.5 (CVE-2026-25896, XSS) — scoped to `5.2.5`; leaves `5.5.8` untouched
  - `protobufjs@^7.2.5|^7.3.2|^7.5.3`: → 7.5.5 (CVE-2026-41242, RCE) — range-scoped; excludes pinned `8.0.1`

- **Migration**
  - Run `yarn install` to sync local installs.

<sup>Written for commit c6c1e6ddcdb121e19a50897fd9e5be59b902b7de. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4768?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

