### PR TITLE
fix(docker): bump Go toolchain to 1.25.7 and patch openssl/pcre2 in runner and proxy

### DIFF
--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.7-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -42,7 +42,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM alpine:3.22 AS proxy
 
-RUN apk add --no-cache curl
+RUN apk update && apk upgrade --no-cache openssl pcre2 \
+  && apk add --no-cache curl
 
 WORKDIR /usr/local/bin
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.7-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -57,7 +57,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM docker:28.2.2-dind-alpine3.22 AS runner
 
-RUN apk add --no-cache curl rsync
+RUN apk update && apk upgrade --no-cache openssl pcre2 \
+  && apk add --no-cache curl rsync
 
 WORKDIR /usr/local/bin
 


### PR DESCRIPTION
## Description

Two targeted hardening changes across `apps/runner/Dockerfile` and
`apps/proxy/Dockerfile`.

**Go toolchain bump (`golang:1.25.4-alpine` → `golang:1.25.7-alpine`)**

Both build stages copy the Go compiler directly from the official `golang`
image via `COPY --from=golang:...`. Bumping from 1.25.4 to 1.25.7 picks up
all compiler-level and stdlib CVE fixes shipped in the three patch releases.

**Alpine OS package patch (openssl, pcre2)**

The runtime stages (`docker:28.2.2-dind-alpine3.22` for runner,
`alpine:3.22` for proxy) carry the Alpine base versions of `openssl` and
`pcre2`. The existing `apk add` calls have been extended to run
`apk upgrade --no-cache openssl pcre2` first, ensuring the CI build
fetches `openssl >= 3.5.5-r0` and `pcre2 >= 10.46-r0` from the Alpine
mirror at image build time regardless of what the base tag was pinned against.

| File | Change |
|---|---|
| `apps/runner/Dockerfile` | `golang:1.25.4-alpine` → `1.25.7-alpine`; upgrade `openssl pcre2` in `runner` stage |
| `apps/proxy/Dockerfile` | `golang:1.25.4-alpine` → `1.25.7-alpine`; upgrade `openssl pcre2` in `proxy` stage |

No application logic, environment variables, or entrypoints were changed.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

N/A

## Notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the runner and proxy Docker images by bumping the Go toolchain to `golang:1.25.7-alpine` and upgrading `openssl` and `pcre2` at build time to pick up security fixes. No application logic changes.

- **Dependencies**
  - Build: copy Go from `golang:1.25.7-alpine` (was `1.25.4-alpine`) in `apps/runner` and `apps/proxy`.
  - Runtime: on `docker:28.2.2-dind-alpine3.22` and `alpine:3.22`, run `apk update && apk upgrade --no-cache openssl pcre2` before installs to ensure patched `openssl` and `pcre2` are used.

<sup>Written for commit c6e9386ccc9bbf5dc98a709f31b2a290179971f0. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4770?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

