### PR TITLE
feat(api,dashboard): GPU region quota, per-sandbox limits, and dashboard surfacing

### DIFF
--- a/apps/api/src/migrations/pre-deploy/1779840000000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1779840000000-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1779840000000 implements MigrationInterface {
+  name = 'Migration1779840000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "total_gpu_quota" integer NOT NULL DEFAULT 0`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "total_gpu_quota"`)
+  }
+}

--- a/apps/api/src/migrations/pre-deploy/1779840000000-migration.ts
+++ b/apps/api/src/migrations/pre-deploy/1779840000000-migration.ts
@@ -10,9 +10,15 @@ export class Migration1779840000000 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "region_quota" ADD "total_gpu_quota" integer NOT NULL DEFAULT 0`)
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_cpu_per_gpu_sandbox" integer`)
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_memory_per_gpu_sandbox" integer`)
+    await queryRunner.query(`ALTER TABLE "region_quota" ADD "max_disk_per_gpu_sandbox" integer`)
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_disk_per_gpu_sandbox"`)
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_memory_per_gpu_sandbox"`)
+    await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "max_cpu_per_gpu_sandbox"`)
     await queryRunner.query(`ALTER TABLE "region_quota" DROP COLUMN "total_gpu_quota"`)
   }
 }

--- a/apps/api/src/organization/controllers/organization.controller.ts
+++ b/apps/api/src/organization/controllers/organization.controller.ts
@@ -406,6 +406,7 @@ export class OrganizationController {
         totalCpuQuota: req.body?.totalCpuQuota,
         totalMemoryQuota: req.body?.totalMemoryQuota,
         totalDiskQuota: req.body?.totalDiskQuota,
+        totalGpuQuota: req.body?.totalGpuQuota,
       }),
     },
   })

--- a/apps/api/src/organization/dto/organization-usage-overview.dto.ts
+++ b/apps/api/src/organization/dto/organization-usage-overview.dto.ts
@@ -41,6 +41,15 @@ export class RegionUsageOverviewDto {
 
   @ApiProperty({ nullable: true })
   maxDiskPerNonEphemeralSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxCpuPerGpuSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxMemoryPerGpuSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxDiskPerGpuSandbox: number | null
 }
 
 @ApiSchema({ name: 'OrganizationUsageOverview' })

--- a/apps/api/src/organization/dto/organization-usage-overview.dto.ts
+++ b/apps/api/src/organization/dto/organization-usage-overview.dto.ts
@@ -25,6 +25,11 @@ export class RegionUsageOverviewDto {
   @ApiProperty()
   currentDiskUsage: number
 
+  @ApiProperty()
+  totalGpuQuota: number
+  @ApiProperty()
+  currentGpuUsage: number
+
   @ApiProperty({ nullable: true })
   maxCpuPerSandbox: number | null
 

--- a/apps/api/src/organization/dto/region-quota.dto.ts
+++ b/apps/api/src/organization/dto/region-quota.dto.ts
@@ -38,6 +38,15 @@ export class RegionQuotaDto {
   @ApiProperty({ nullable: true })
   maxDiskPerNonEphemeralSandbox: number | null
 
+  @ApiProperty({ nullable: true })
+  maxCpuPerGpuSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxMemoryPerGpuSandbox: number | null
+
+  @ApiProperty({ nullable: true })
+  maxDiskPerGpuSandbox: number | null
+
   constructor(regionQuota: RegionQuota) {
     this.organizationId = regionQuota.organizationId
     this.regionId = regionQuota.regionId
@@ -49,5 +58,8 @@ export class RegionQuotaDto {
     this.maxMemoryPerSandbox = regionQuota.maxMemoryPerSandbox
     this.maxDiskPerSandbox = regionQuota.maxDiskPerSandbox
     this.maxDiskPerNonEphemeralSandbox = regionQuota.maxDiskPerNonEphemeralSandbox
+    this.maxCpuPerGpuSandbox = regionQuota.maxCpuPerGpuSandbox
+    this.maxMemoryPerGpuSandbox = regionQuota.maxMemoryPerGpuSandbox
+    this.maxDiskPerGpuSandbox = regionQuota.maxDiskPerGpuSandbox
   }
 }

--- a/apps/api/src/organization/dto/region-quota.dto.ts
+++ b/apps/api/src/organization/dto/region-quota.dto.ts
@@ -23,6 +23,9 @@ export class RegionQuotaDto {
   @ApiProperty()
   totalDiskQuota: number
 
+  @ApiProperty()
+  totalGpuQuota: number
+
   @ApiProperty({ nullable: true })
   maxCpuPerSandbox: number | null
 
@@ -41,6 +44,7 @@ export class RegionQuotaDto {
     this.totalCpuQuota = regionQuota.totalCpuQuota
     this.totalMemoryQuota = regionQuota.totalMemoryQuota
     this.totalDiskQuota = regionQuota.totalDiskQuota
+    this.totalGpuQuota = regionQuota.totalGpuQuota
     this.maxCpuPerSandbox = regionQuota.maxCpuPerSandbox
     this.maxMemoryPerSandbox = regionQuota.maxMemoryPerSandbox
     this.maxDiskPerSandbox = regionQuota.maxDiskPerSandbox

--- a/apps/api/src/organization/dto/sandbox-usage-overview-internal.dto.ts
+++ b/apps/api/src/organization/dto/sandbox-usage-overview-internal.dto.ts
@@ -7,12 +7,14 @@ export type SandboxUsageOverviewInternalDto = {
   currentCpuUsage: number
   currentMemoryUsage: number
   currentDiskUsage: number
+  currentGpuUsage: number
 }
 
 export type PendingSandboxUsageOverviewInternalDto = {
   pendingCpuUsage: number | null
   pendingMemoryUsage: number | null
   pendingDiskUsage: number | null
+  pendingGpuUsage: number | null
 }
 
 export type SandboxUsageOverviewWithPendingInternalDto = SandboxUsageOverviewInternalDto &

--- a/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
@@ -16,6 +16,9 @@ export class UpdateOrganizationRegionQuotaDto {
   @ApiProperty({ nullable: true })
   totalDiskQuota?: number
 
+  @ApiProperty({ nullable: true })
+  totalGpuQuota?: number
+
   @ApiPropertyOptional({ nullable: true })
   maxCpuPerSandbox?: number | null
 

--- a/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
@@ -30,4 +30,13 @@ export class UpdateOrganizationRegionQuotaDto {
 
   @ApiPropertyOptional({ nullable: true })
   maxDiskPerNonEphemeralSandbox?: number | null
+
+  @ApiPropertyOptional({ nullable: true })
+  maxCpuPerGpuSandbox?: number | null
+
+  @ApiPropertyOptional({ nullable: true })
+  maxMemoryPerGpuSandbox?: number | null
+
+  @ApiPropertyOptional({ nullable: true })
+  maxDiskPerGpuSandbox?: number | null
 }

--- a/apps/api/src/organization/entities/region-quota.entity.ts
+++ b/apps/api/src/organization/entities/region-quota.entity.ts
@@ -81,6 +81,39 @@ export class RegionQuota {
   })
   maxDiskPerNonEphemeralSandbox: number | null
 
+  /**
+   * If `null`, fallback to `maxCpuPerSandbox`.
+   * Typically larger than `maxCpuPerSandbox` since GPU sandboxes own the whole runner exclusively.
+   */
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: 'max_cpu_per_gpu_sandbox',
+  })
+  maxCpuPerGpuSandbox: number | null
+
+  /**
+   * If `null`, fallback to `maxMemoryPerSandbox`.
+   * Typically larger than `maxMemoryPerSandbox` since GPU sandboxes own the whole runner exclusively.
+   */
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: 'max_memory_per_gpu_sandbox',
+  })
+  maxMemoryPerGpuSandbox: number | null
+
+  /**
+   * If `null`, fallback to `maxDiskPerSandbox`.
+   * Typically larger than `maxDiskPerSandbox` since GPU sandboxes own the whole runner exclusively.
+   */
+  @Column({
+    type: 'int',
+    nullable: true,
+    name: 'max_disk_per_gpu_sandbox',
+  })
+  maxDiskPerGpuSandbox: number | null
+
   @CreateDateColumn({
     type: 'timestamp with time zone',
   })
@@ -102,6 +135,9 @@ export class RegionQuota {
     maxMemoryPerSandbox: number | null = null,
     maxDiskPerSandbox: number | null = null,
     maxDiskPerNonEphemeralSandbox: number | null = null,
+    maxCpuPerGpuSandbox: number | null = null,
+    maxMemoryPerGpuSandbox: number | null = null,
+    maxDiskPerGpuSandbox: number | null = null,
   ) {
     this.organizationId = organizationId
     this.regionId = regionId
@@ -113,5 +149,8 @@ export class RegionQuota {
     this.maxMemoryPerSandbox = maxMemoryPerSandbox
     this.maxDiskPerSandbox = maxDiskPerSandbox
     this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
+    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox
+    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox
+    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox
   }
 }

--- a/apps/api/src/organization/entities/region-quota.entity.ts
+++ b/apps/api/src/organization/entities/region-quota.entity.ts
@@ -43,6 +43,13 @@ export class RegionQuota {
 
   @Column({
     type: 'int',
+    default: 0,
+    name: 'total_gpu_quota',
+  })
+  totalGpuQuota: number
+
+  @Column({
+    type: 'int',
     nullable: true,
     name: 'max_cpu_per_sandbox',
   })
@@ -90,6 +97,7 @@ export class RegionQuota {
     totalCpuQuota: number,
     totalMemoryQuota: number,
     totalDiskQuota: number,
+    totalGpuQuota = 0,
     maxCpuPerSandbox: number | null = null,
     maxMemoryPerSandbox: number | null = null,
     maxDiskPerSandbox: number | null = null,
@@ -100,6 +108,7 @@ export class RegionQuota {
     this.totalCpuQuota = totalCpuQuota
     this.totalMemoryQuota = totalMemoryQuota
     this.totalDiskQuota = totalDiskQuota
+    this.totalGpuQuota = totalGpuQuota
     this.maxCpuPerSandbox = maxCpuPerSandbox
     this.maxMemoryPerSandbox = maxMemoryPerSandbox
     this.maxDiskPerSandbox = maxDiskPerSandbox

--- a/apps/api/src/organization/helpers/organization-usage.helper.ts
+++ b/apps/api/src/organization/helpers/organization-usage.helper.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-export type OrganizationUsageQuotaType = 'cpu' | 'memory' | 'disk' | 'snapshot_count' | 'volume_count'
+export type OrganizationUsageQuotaType = 'cpu' | 'memory' | 'disk' | 'gpu' | 'snapshot_count' | 'volume_count'
 export type OrganizationUsageResourceType = 'sandbox' | 'snapshot' | 'volume'
 
 const QUOTA_TO_RESOURCE_MAP: Record<OrganizationUsageQuotaType, OrganizationUsageResourceType> = {
   cpu: 'sandbox',
   memory: 'sandbox',
   disk: 'sandbox',
+  gpu: 'sandbox',
   snapshot_count: 'snapshot',
   volume_count: 'volume',
 } as const

--- a/apps/api/src/organization/services/org-metrics-exporter.service.ts
+++ b/apps/api/src/organization/services/org-metrics-exporter.service.ts
@@ -127,6 +127,9 @@ export class OrgMetricsExporterService {
       if (rq.totalDiskQuota > 0) {
         this.addDataPoint(metrics, 'daytona.sandbox.total_storage', regionAttrs, rq.totalDiskQuota, nowNano)
       }
+      if (rq.totalGpuQuota > 0) {
+        this.addDataPoint(metrics, 'daytona.sandbox.total_gpu', regionAttrs, rq.totalGpuQuota, nowNano)
+      }
     }
 
     const payload = {

--- a/apps/api/src/organization/services/org-metrics-exporter.service.ts
+++ b/apps/api/src/organization/services/org-metrics-exporter.service.ts
@@ -96,6 +96,7 @@ export class OrgMetricsExporterService {
         totalCpuQuota: -1,
         totalMemoryQuota: -1,
         totalDiskQuota: -1,
+        totalGpuQuota: -1,
         maxCpuPerSandbox: null,
         maxMemoryPerSandbox: null,
         maxDiskPerSandbox: null,

--- a/apps/api/src/organization/services/org-metrics-exporter.service.ts
+++ b/apps/api/src/organization/services/org-metrics-exporter.service.ts
@@ -101,6 +101,9 @@ export class OrgMetricsExporterService {
         maxMemoryPerSandbox: null,
         maxDiskPerSandbox: null,
         maxDiskPerNonEphemeralSandbox: null,
+        maxCpuPerGpuSandbox: null,
+        maxMemoryPerGpuSandbox: null,
+        maxDiskPerGpuSandbox: null,
       })
     }
 

--- a/apps/api/src/organization/services/organization-usage.service.ts
+++ b/apps/api/src/organization/services/organization-usage.service.ts
@@ -107,9 +107,11 @@ export class OrganizationUsageService {
           totalCpuQuota: rq.totalCpuQuota,
           totalMemoryQuota: rq.totalMemoryQuota,
           totalDiskQuota: rq.totalDiskQuota,
+          totalGpuQuota: rq.totalGpuQuota,
           currentCpuUsage: sandboxUsage.currentCpuUsage,
           currentMemoryUsage: sandboxUsage.currentMemoryUsage,
           currentDiskUsage: sandboxUsage.currentDiskUsage,
+          currentGpuUsage: sandboxUsage.currentGpuUsage,
           maxCpuPerSandbox: rq.maxCpuPerSandbox,
           maxMemoryPerSandbox: rq.maxMemoryPerSandbox,
           maxDiskPerSandbox: rq.maxDiskPerSandbox,
@@ -296,10 +298,12 @@ export class OrganizationUsageService {
     let cpuToSubtract = 0
     let memToSubtract = 0
     let diskToSubtract = 0
+    let gpuToSubtract = 0
 
     if (SANDBOX_STATES_CONSUMING_COMPUTE.includes(excludedSandbox.state)) {
       cpuToSubtract = excludedSandbox.cpu
       memToSubtract = excludedSandbox.mem
+      gpuToSubtract = excludedSandbox.gpu
     }
 
     if (SANDBOX_STATES_CONSUMING_DISK.includes(excludedSandbox.state)) {
@@ -311,6 +315,7 @@ export class OrganizationUsageService {
       currentCpuUsage: Math.max(0, usageOverview.currentCpuUsage - cpuToSubtract),
       currentMemoryUsage: Math.max(0, usageOverview.currentMemoryUsage - memToSubtract),
       currentDiskUsage: Math.max(0, usageOverview.currentDiskUsage - diskToSubtract),
+      currentGpuUsage: Math.max(0, usageOverview.currentGpuUsage - gpuToSubtract),
     }
   }
 
@@ -331,25 +336,38 @@ export class OrganizationUsageService {
         redis.call("GET", KEYS[3]),
         redis.call("GET", KEYS[4]),
         redis.call("GET", KEYS[5]),
-        redis.call("GET", KEYS[6])
+        redis.call("GET", KEYS[6]),
+        redis.call("GET", KEYS[7]),
+        redis.call("GET", KEYS[8])
       }
     `
 
     const result = (await this.redis.eval(
       script,
-      6,
+      8,
       this.getCurrentQuotaUsageCacheKey(organizationId, 'cpu', regionId),
       this.getCurrentQuotaUsageCacheKey(organizationId, 'memory', regionId),
       this.getCurrentQuotaUsageCacheKey(organizationId, 'disk', regionId),
+      this.getCurrentQuotaUsageCacheKey(organizationId, 'gpu', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'cpu', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'memory', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'disk', regionId),
+      this.getPendingQuotaUsageCacheKey(organizationId, 'gpu', regionId),
     )) as (string | null)[]
 
-    const [cpuUsage, memoryUsage, diskUsage, pendingCpuUsage, pendingMemoryUsage, pendingDiskUsage] = result
+    const [
+      cpuUsage,
+      memoryUsage,
+      diskUsage,
+      gpuUsage,
+      pendingCpuUsage,
+      pendingMemoryUsage,
+      pendingDiskUsage,
+      pendingGpuUsage,
+    ] = result
 
     // Cache miss
-    if (cpuUsage === null || memoryUsage === null || diskUsage === null) {
+    if (cpuUsage === null || memoryUsage === null || diskUsage === null || gpuUsage === null) {
       return null
     }
 
@@ -364,8 +382,9 @@ export class OrganizationUsageService {
     const parsedCpuUsage = this.parseNonNegativeCachedValue(cpuUsage)
     const parsedMemoryUsage = this.parseNonNegativeCachedValue(memoryUsage)
     const parsedDiskUsage = this.parseNonNegativeCachedValue(diskUsage)
+    const parsedGpuUsage = this.parseNonNegativeCachedValue(gpuUsage)
 
-    if (parsedCpuUsage === null || parsedMemoryUsage === null || parsedDiskUsage === null) {
+    if (parsedCpuUsage === null || parsedMemoryUsage === null || parsedDiskUsage === null || parsedGpuUsage === null) {
       return null
     }
 
@@ -373,14 +392,17 @@ export class OrganizationUsageService {
     const parsedPendingCpuUsage = this.parseNonNegativeCachedValue(pendingCpuUsage)
     const parsedPendingMemoryUsage = this.parseNonNegativeCachedValue(pendingMemoryUsage)
     const parsedPendingDiskUsage = this.parseNonNegativeCachedValue(pendingDiskUsage)
+    const parsedPendingGpuUsage = this.parseNonNegativeCachedValue(pendingGpuUsage)
 
     return {
       currentCpuUsage: parsedCpuUsage,
       currentMemoryUsage: parsedMemoryUsage,
       currentDiskUsage: parsedDiskUsage,
+      currentGpuUsage: parsedGpuUsage,
       pendingCpuUsage: parsedPendingCpuUsage,
       pendingMemoryUsage: parsedPendingMemoryUsage,
       pendingDiskUsage: parsedPendingDiskUsage,
+      pendingGpuUsage: parsedPendingGpuUsage,
     }
   }
 
@@ -398,27 +420,31 @@ export class OrganizationUsageService {
       return {
         redis.call("GET", KEYS[1]),
         redis.call("GET", KEYS[2]),
-        redis.call("GET", KEYS[3])
+        redis.call("GET", KEYS[3]),
+        redis.call("GET", KEYS[4])
       }
     `
     const result = (await this.redis.eval(
       script,
-      3,
+      4,
       this.getPendingQuotaUsageCacheKey(organizationId, 'cpu', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'memory', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'disk', regionId),
+      this.getPendingQuotaUsageCacheKey(organizationId, 'gpu', regionId),
     )) as (string | null)[]
 
-    const [pendingCpuUsage, pendingMemoryUsage, pendingDiskUsage] = result
+    const [pendingCpuUsage, pendingMemoryUsage, pendingDiskUsage, pendingGpuUsage] = result
 
     const parsedPendingCpuUsage = this.parseNonNegativeCachedValue(pendingCpuUsage)
     const parsedPendingMemoryUsage = this.parseNonNegativeCachedValue(pendingMemoryUsage)
     const parsedPendingDiskUsage = this.parseNonNegativeCachedValue(pendingDiskUsage)
+    const parsedPendingGpuUsage = this.parseNonNegativeCachedValue(pendingGpuUsage)
 
     return {
       pendingCpuUsage: parsedPendingCpuUsage,
       pendingMemoryUsage: parsedPendingMemoryUsage,
       pendingDiskUsage: parsedPendingDiskUsage,
+      pendingGpuUsage: parsedPendingGpuUsage,
     }
   }
 
@@ -611,18 +637,20 @@ export class OrganizationUsageService {
    */
   async fetchSandboxUsageFromDb(organizationId: string, regionId: string): Promise<SandboxUsageOverviewInternalDto> {
     // fetch from db
-    // For CPU/memory, we need to also count RESIZING sandboxes that were hot resizing (desiredState = 'started')
+    // For CPU/memory/GPU, we need to also count RESIZING sandboxes that were hot resizing (desiredState = 'started')
     // since they are still running and consuming compute resources
     const sandboxUsageMetrics: {
       used_cpu: number
       used_mem: number
       used_disk: number
+      used_gpu: number
     } = await this.sandboxRepository
       .createQueryBuilder('sandbox')
       .select([
         `SUM(CASE WHEN sandbox.state IN (:...statesConsumingCompute) OR (sandbox.state IN (:...statesConditionallyConsumingCompute) AND sandbox."desiredState" = :startedDesiredState) THEN sandbox.cpu ELSE 0 END) as used_cpu`,
         `SUM(CASE WHEN sandbox.state IN (:...statesConsumingCompute) OR (sandbox.state IN (:...statesConditionallyConsumingCompute) AND sandbox."desiredState" = :startedDesiredState) THEN sandbox.mem ELSE 0 END) as used_mem`,
         'SUM(CASE WHEN sandbox.state IN (:...statesConsumingDisk) THEN sandbox.disk ELSE 0 END) as used_disk',
+        `SUM(CASE WHEN sandbox.state IN (:...statesConsumingCompute) OR (sandbox.state IN (:...statesConditionallyConsumingCompute) AND sandbox."desiredState" = :startedDesiredState) THEN sandbox.gpu ELSE 0 END) as used_gpu`,
       ])
       .where('sandbox.organizationId = :organizationId', { organizationId })
       .andWhere('sandbox.region = :regionId', { regionId })
@@ -635,17 +663,20 @@ export class OrganizationUsageService {
     const cpuUsage = Number(sandboxUsageMetrics.used_cpu) || 0
     const memoryUsage = Number(sandboxUsageMetrics.used_mem) || 0
     const diskUsage = Number(sandboxUsageMetrics.used_disk) || 0
+    const gpuUsage = Number(sandboxUsageMetrics.used_gpu) || 0
 
     // cache the results
     const cpuCacheKey = this.getCurrentQuotaUsageCacheKey(organizationId, 'cpu', regionId)
     const memoryCacheKey = this.getCurrentQuotaUsageCacheKey(organizationId, 'memory', regionId)
     const diskCacheKey = this.getCurrentQuotaUsageCacheKey(organizationId, 'disk', regionId)
+    const gpuCacheKey = this.getCurrentQuotaUsageCacheKey(organizationId, 'gpu', regionId)
 
     await this.redis
       .multi()
       .setex(cpuCacheKey, this.CACHE_TTL_SECONDS, cpuUsage)
       .setex(memoryCacheKey, this.CACHE_TTL_SECONDS, memoryUsage)
       .setex(diskCacheKey, this.CACHE_TTL_SECONDS, diskUsage)
+      .setex(gpuCacheKey, this.CACHE_TTL_SECONDS, gpuUsage)
       .exec()
 
     await this.resetCacheStaleness(organizationId, 'sandbox', regionId)
@@ -654,6 +685,7 @@ export class OrganizationUsageService {
       currentCpuUsage: cpuUsage,
       currentMemoryUsage: memoryUsage,
       currentDiskUsage: diskUsage,
+      currentGpuUsage: gpuUsage,
     }
   }
 
@@ -712,7 +744,7 @@ export class OrganizationUsageService {
    */
   private getCurrentQuotaUsageCacheKey(
     organizationId: string,
-    quotaType: 'cpu' | 'memory' | 'disk',
+    quotaType: 'cpu' | 'memory' | 'disk' | 'gpu',
     regionId: string,
   ): string
   private getCurrentQuotaUsageCacheKey(organizationId: string, quotaType: 'snapshot_count' | 'volume_count'): string
@@ -729,7 +761,7 @@ export class OrganizationUsageService {
    */
   private getPendingQuotaUsageCacheKey(
     organizationId: string,
-    quotaType: 'cpu' | 'memory' | 'disk',
+    quotaType: 'cpu' | 'memory' | 'disk' | 'gpu',
     regionId: string,
   ): string
   private getPendingQuotaUsageCacheKey(organizationId: string, quotaType: 'snapshot_count' | 'volume_count'): string
@@ -748,7 +780,7 @@ export class OrganizationUsageService {
    */
   private async updateCurrentQuotaUsage(
     organizationId: string,
-    quotaType: 'cpu' | 'memory' | 'disk',
+    quotaType: 'cpu' | 'memory' | 'disk' | 'gpu',
     delta: number,
     regionId: string,
   ): Promise<void>
@@ -787,6 +819,7 @@ export class OrganizationUsageService {
       case 'cpu':
       case 'memory':
       case 'disk':
+      case 'gpu':
         currentQuotaUsageCacheKey = this.getCurrentQuotaUsageCacheKey(organizationId, quotaType, regionId)
         pendingQuotaUsageCacheKey = this.getPendingQuotaUsageCacheKey(organizationId, quotaType, regionId)
         break
@@ -832,16 +865,19 @@ export class OrganizationUsageService {
     cpu: number,
     memory: number,
     disk: number,
+    gpu: number,
     excludeSandboxId?: string,
   ): Promise<{
     cpuIncremented: boolean
     memoryIncremented: boolean
     diskIncremented: boolean
+    gpuIncremented: boolean
   }> {
     // determine for which quota types we should increment the pending usage
     let shouldIncrementCpu = true
     let shouldIncrementMemory = true
     let shouldIncrementDisk = true
+    let shouldIncrementGpu = true
 
     if (excludeSandboxId) {
       const excludedSandbox = await this.sandboxRepository.findOne({
@@ -852,6 +888,7 @@ export class OrganizationUsageService {
         if (SANDBOX_STATES_CONSUMING_COMPUTE.includes(excludedSandbox.state)) {
           shouldIncrementCpu = false
           shouldIncrementMemory = false
+          shouldIncrementGpu = false
         }
 
         if (SANDBOX_STATES_CONSUMING_DISK.includes(excludedSandbox.state)) {
@@ -865,16 +902,19 @@ export class OrganizationUsageService {
       local cpuKey = KEYS[1]
       local memoryKey = KEYS[2]
       local diskKey = KEYS[3]
+      local gpuKey = KEYS[4]
 
       local shouldIncrementCpu = ARGV[1] == "true"
       local shouldIncrementMemory = ARGV[2] == "true"
       local shouldIncrementDisk = ARGV[3] == "true"
+      local shouldIncrementGpu = ARGV[4] == "true"
 
-      local cpuIncrement = tonumber(ARGV[4])
-      local memoryIncrement = tonumber(ARGV[5])
-      local diskIncrement = tonumber(ARGV[6])
+      local cpuIncrement = tonumber(ARGV[5])
+      local memoryIncrement = tonumber(ARGV[6])
+      local diskIncrement = tonumber(ARGV[7])
+      local gpuIncrement = tonumber(ARGV[8])
 
-      local ttl = tonumber(ARGV[7])
+      local ttl = tonumber(ARGV[9])
     
       if shouldIncrementCpu then
         redis.call("INCRBY", cpuKey, cpuIncrement)
@@ -890,20 +930,28 @@ export class OrganizationUsageService {
         redis.call("INCRBY", diskKey, diskIncrement)
         redis.call("EXPIRE", diskKey, ttl)
       end
+
+      if shouldIncrementGpu then
+        redis.call("INCRBY", gpuKey, gpuIncrement)
+        redis.call("EXPIRE", gpuKey, ttl)
+      end
     `
 
     await this.redis.eval(
       script,
-      3,
+      4,
       this.getPendingQuotaUsageCacheKey(organizationId, 'cpu', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'memory', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'disk', regionId),
+      this.getPendingQuotaUsageCacheKey(organizationId, 'gpu', regionId),
       shouldIncrementCpu.toString(),
       shouldIncrementMemory.toString(),
       shouldIncrementDisk.toString(),
+      shouldIncrementGpu.toString(),
       cpu.toString(),
       memory.toString(),
       disk.toString(),
+      gpu.toString(),
       this.CACHE_TTL_SECONDS.toString(),
     )
 
@@ -911,6 +959,7 @@ export class OrganizationUsageService {
       cpuIncremented: shouldIncrementCpu,
       memoryIncremented: shouldIncrementMemory,
       diskIncremented: shouldIncrementDisk,
+      gpuIncremented: shouldIncrementGpu,
     }
   }
 
@@ -937,16 +986,19 @@ export class OrganizationUsageService {
     cpu?: number,
     memory?: number,
     disk?: number,
+    gpu?: number,
   ): Promise<void> {
     // decrement the pending usage for necessary quota types
     const script = `
       local cpuKey = KEYS[1]
       local memoryKey = KEYS[2] 
       local diskKey = KEYS[3]
+      local gpuKey = KEYS[4]
 
       local cpuDecrement = tonumber(ARGV[1])
       local memoryDecrement = tonumber(ARGV[2])
       local diskDecrement = tonumber(ARGV[3])
+      local gpuDecrement = tonumber(ARGV[4])
       
       if cpuDecrement then
         redis.call("DECRBY", cpuKey, cpuDecrement)
@@ -959,17 +1011,23 @@ export class OrganizationUsageService {
       if diskDecrement then
         redis.call("DECRBY", diskKey, diskDecrement)
       end
+
+      if gpuDecrement then
+        redis.call("DECRBY", gpuKey, gpuDecrement)
+      end
     `
 
     await this.redis.eval(
       script,
-      3,
+      4,
       this.getPendingQuotaUsageCacheKey(organizationId, 'cpu', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'memory', regionId),
       this.getPendingQuotaUsageCacheKey(organizationId, 'disk', regionId),
+      this.getPendingQuotaUsageCacheKey(organizationId, 'gpu', regionId),
       cpu?.toString() ?? '0',
       memory?.toString() ?? '0',
       disk?.toString() ?? '0',
+      gpu?.toString() ?? '0',
     )
   }
 
@@ -1125,6 +1183,7 @@ export class OrganizationUsageService {
     cpuDelta: number,
     memDelta: number,
     diskDelta: number,
+    gpuDelta: number,
   ): Promise<void> {
     if (cpuDelta !== 0) {
       await this.updateCurrentQuotaUsage(organizationId, 'cpu', cpuDelta, regionId)
@@ -1134,6 +1193,9 @@ export class OrganizationUsageService {
     }
     if (diskDelta !== 0) {
       await this.updateCurrentQuotaUsage(organizationId, 'disk', diskDelta, regionId)
+    }
+    if (gpuDelta !== 0) {
+      await this.updateCurrentQuotaUsage(organizationId, 'gpu', gpuDelta, regionId)
     }
   }
 
@@ -1207,6 +1269,7 @@ export class OrganizationUsageService {
         event.sandbox.region,
       )
       await this.updateCurrentQuotaUsage(event.sandbox.organizationId, 'disk', event.sandbox.disk, event.sandbox.region)
+      await this.updateCurrentQuotaUsage(event.sandbox.organizationId, 'gpu', event.sandbox.gpu, event.sandbox.region)
     } catch (error) {
       this.logger.warn(
         `Error updating cached sandbox quota usage for organization ${event.sandbox.organizationId} in region ${event.sandbox.region}`,
@@ -1245,6 +1308,7 @@ export class OrganizationUsageService {
           event.sandbox.disk,
           event.sandbox.region,
         )
+        await this.updateCurrentQuotaUsage(event.sandbox.organizationId, 'gpu', event.sandbox.gpu, event.sandbox.region)
         return
       } catch (error) {
         this.logger.warn(
@@ -1279,6 +1343,13 @@ export class OrganizationUsageService {
         SANDBOX_STATES_CONSUMING_DISK,
       )
 
+      const gpuDelta = this.calculateQuotaUsageDelta(
+        event.sandbox.gpu,
+        event.oldState,
+        event.newState,
+        SANDBOX_STATES_CONSUMING_COMPUTE,
+      )
+
       if (cpuDelta !== 0) {
         await this.updateCurrentQuotaUsage(event.sandbox.organizationId, 'cpu', cpuDelta, event.sandbox.region)
       }
@@ -1289,6 +1360,10 @@ export class OrganizationUsageService {
 
       if (diskDelta !== 0) {
         await this.updateCurrentQuotaUsage(event.sandbox.organizationId, 'disk', diskDelta, event.sandbox.region)
+      }
+
+      if (gpuDelta !== 0) {
+        await this.updateCurrentQuotaUsage(event.sandbox.organizationId, 'gpu', gpuDelta, event.sandbox.region)
       }
     } catch (error) {
       this.logger.warn(

--- a/apps/api/src/organization/services/organization-usage.service.ts
+++ b/apps/api/src/organization/services/organization-usage.service.ts
@@ -116,6 +116,9 @@ export class OrganizationUsageService {
           maxMemoryPerSandbox: rq.maxMemoryPerSandbox,
           maxDiskPerSandbox: rq.maxDiskPerSandbox,
           maxDiskPerNonEphemeralSandbox: rq.maxDiskPerNonEphemeralSandbox,
+          maxCpuPerGpuSandbox: rq.maxCpuPerGpuSandbox,
+          maxMemoryPerGpuSandbox: rq.maxMemoryPerGpuSandbox,
+          maxDiskPerGpuSandbox: rq.maxDiskPerGpuSandbox,
         }
 
         return usage

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -212,6 +212,7 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     regionQuota.totalCpuQuota = updateDto.totalCpuQuota ?? regionQuota.totalCpuQuota
     regionQuota.totalMemoryQuota = updateDto.totalMemoryQuota ?? regionQuota.totalMemoryQuota
     regionQuota.totalDiskQuota = updateDto.totalDiskQuota ?? regionQuota.totalDiskQuota
+    regionQuota.totalGpuQuota = updateDto.totalGpuQuota ?? regionQuota.totalGpuQuota
 
     if (updateDto.maxCpuPerSandbox !== undefined) {
       regionQuota.maxCpuPerSandbox = updateDto.maxCpuPerSandbox

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -226,6 +226,15 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     if (updateDto.maxDiskPerNonEphemeralSandbox !== undefined) {
       regionQuota.maxDiskPerNonEphemeralSandbox = updateDto.maxDiskPerNonEphemeralSandbox
     }
+    if (updateDto.maxCpuPerGpuSandbox !== undefined) {
+      regionQuota.maxCpuPerGpuSandbox = updateDto.maxCpuPerGpuSandbox
+    }
+    if (updateDto.maxMemoryPerGpuSandbox !== undefined) {
+      regionQuota.maxMemoryPerGpuSandbox = updateDto.maxMemoryPerGpuSandbox
+    }
+    if (updateDto.maxDiskPerGpuSandbox !== undefined) {
+      regionQuota.maxDiskPerGpuSandbox = updateDto.maxDiskPerGpuSandbox
+    }
 
     await this.regionQuotaRepository.save(regionQuota)
   }

--- a/apps/api/src/organization/utils/sandbox-limits.util.ts
+++ b/apps/api/src/organization/utils/sandbox-limits.util.ts
@@ -8,21 +8,34 @@ import { RegionQuotaDto } from '../dto/region-quota.dto'
 
 /**
  * Get the effective per-sandbox limits.
- * If the region quota limit is set, it overrides the organization limit.
  *
  * @param organization - The organization to get the limits for.
  * @param regionQuota - The region quota to get the limits for.
+ * @param gpuEnabled - Whether the sandbox uses GPU; selects GPU-aware overrides when true.
  * @returns The effective per-sandbox limits.
  */
 export function getEffectivePerSandboxLimits(
   organization: Organization,
   regionQuota: RegionQuotaDto | null | undefined,
+  gpuEnabled: boolean,
 ): {
   maxCpuPerSandbox: number
   maxMemoryPerSandbox: number
   maxDiskPerSandbox: number
   maxDiskPerNonEphemeralSandbox: number | null
 } {
+  if (gpuEnabled) {
+    return {
+      maxCpuPerSandbox:
+        regionQuota?.maxCpuPerGpuSandbox ?? regionQuota?.maxCpuPerSandbox ?? organization.maxCpuPerSandbox,
+      maxMemoryPerSandbox:
+        regionQuota?.maxMemoryPerGpuSandbox ?? regionQuota?.maxMemoryPerSandbox ?? organization.maxMemoryPerSandbox,
+      maxDiskPerSandbox:
+        regionQuota?.maxDiskPerGpuSandbox ?? regionQuota?.maxDiskPerSandbox ?? organization.maxDiskPerSandbox,
+      maxDiskPerNonEphemeralSandbox: null,
+    }
+  }
+
   return {
     maxCpuPerSandbox: regionQuota?.maxCpuPerSandbox ?? organization.maxCpuPerSandbox,
     maxMemoryPerSandbox: regionQuota?.maxMemoryPerSandbox ?? organization.maxMemoryPerSandbox,

--- a/apps/api/src/sandbox/dto/create-sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/create-sandbox.dto.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { IsEnum, IsObject, IsOptional, IsString, IsNumber, IsBoolean, IsArray } from 'class-validator'
+import { IsEnum, IsObject, IsOptional, IsString, IsNumber, IsBoolean, IsArray, Max, Min } from 'class-validator'
 import { ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { SandboxClass } from '../enums/sandbox-class.enum'
 import { SandboxVolume } from './sandbox.dto'
@@ -105,6 +105,7 @@ export class CreateSandboxDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
   cpu?: number
 
   @ApiPropertyOptional({
@@ -114,6 +115,8 @@ export class CreateSandboxDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
+  @Max(1)
   gpu?: number
 
   @ApiPropertyOptional({
@@ -123,6 +126,7 @@ export class CreateSandboxDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
   memory?: number
 
   @ApiPropertyOptional({
@@ -132,6 +136,7 @@ export class CreateSandboxDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
   disk?: number
 
   @ApiPropertyOptional({

--- a/apps/api/src/sandbox/dto/create-snapshot.dto.ts
+++ b/apps/api/src/sandbox/dto/create-snapshot.dto.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
-import { IsArray, IsObject, IsNumber, IsOptional, IsString } from 'class-validator'
+import { IsArray, IsObject, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator'
 import { CreateBuildInfoDto } from './create-build-info.dto'
 import { IsSafeDisplayString } from '../../common/validators'
 
@@ -44,6 +44,7 @@ export class CreateSnapshotDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
   cpu?: number
 
   @ApiPropertyOptional({
@@ -53,6 +54,8 @@ export class CreateSnapshotDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
+  @Max(1)
   gpu?: number
 
   @ApiPropertyOptional({
@@ -62,6 +65,7 @@ export class CreateSnapshotDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
   memory?: number
 
   @ApiPropertyOptional({
@@ -71,6 +75,7 @@ export class CreateSnapshotDto {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
   disk?: number
 
   @ApiPropertyOptional({

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -188,6 +188,7 @@ export class SandboxStartAction extends SandboxAction {
         regions: [sandbox.region],
         sandboxClass: sandbox.class,
         snapshotRef: snapshotRef,
+        gpu: sandbox.gpu,
         ...(buildInfoOverloadedRunnerIds.length > 0 && { excludedRunnerIds: buildInfoOverloadedRunnerIds }),
         ...(isBuild &&
           declarativeBuildScoreThreshold !== undefined && {
@@ -253,6 +254,7 @@ export class SandboxStartAction extends SandboxAction {
       runner = await this.runnerService.getRandomAvailableRunner({
         regions: [sandbox.region],
         sandboxClass: sandbox.class,
+        gpu: sandbox.gpu,
         excludedRunnerIds: excludedRunnerIds,
         ...(isBuild &&
           declarativeBuildScoreThreshold !== undefined && {
@@ -471,6 +473,7 @@ export class SandboxStartAction extends SandboxAction {
           const availableRunners = await this.runnerService.findAvailableRunners({
             regions: [sandbox.region],
             sandboxClass: sandbox.class,
+            gpu: sandbox.gpu,
           })
           const lessUsedRunners = availableRunners.filter((runner) => runner.id !== originalRunnerId)
 
@@ -750,6 +753,7 @@ export class SandboxStartAction extends SandboxAction {
           sandboxClass: sandbox.class,
           snapshotRef,
           excludedRunnerIds,
+          gpu: sandbox.gpu,
         })
       : []
     if (runnersWithBaseSnapshot.length > 0) {
@@ -759,6 +763,7 @@ export class SandboxStartAction extends SandboxAction {
       availableRunners = await this.runnerService.findAvailableRunners({
         regions: [sandbox.region],
         excludedRunnerIds,
+        gpu: sandbox.gpu,
       })
     }
 

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -637,13 +637,15 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
 
         let diskIncremented = false
         try {
-          // Reserve disk for the ERROR → STOPPED transition.
+          // Reserve disk for the ERROR → STOPPED transition. GPU is not reserved here:
+          // the recover path does not transition to STARTED, so no GPU is consumed.
           const result = await this.organizationUsageService.incrementPendingSandboxUsage(
             sandbox.organizationId,
             sandbox.region,
             0,
             0,
             sandbox.disk,
+            0,
             sandbox.id,
           )
           diskIncremented = result.diskIncremented
@@ -682,7 +684,14 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
         } catch (e) {
           if (diskIncremented) {
             await this.organizationUsageService
-              .decrementPendingSandboxUsage(sandbox.organizationId, sandbox.region, undefined, undefined, sandbox.disk)
+              .decrementPendingSandboxUsage(
+                sandbox.organizationId,
+                sandbox.region,
+                undefined,
+                undefined,
+                sandbox.disk,
+                undefined,
+              )
               .catch(() => undefined)
           }
           await this.redis.set(redisKey, '1', 'EX', SandboxManager.DRAINING_RECOVER_TTL_SECONDS)

--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -382,6 +382,7 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             snapshotRef: sandbox.backupSnapshot,
             excludedRunnerIds: [runner.id],
             availabilityScoreThreshold: startScoreThreshold,
+            gpu: sandbox.gpu,
           })
 
           await this.migrateSandbox(sandbox, runner.id, targetRunner.id)

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -659,6 +659,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
                     regions: [sandbox.region],
                     sandboxClass: sandbox.class,
                     excludedRunnerIds: [runner.id],
+                    gpu: sandbox.gpu,
                   })
 
                   // Check if snapshot runner entry already exists
@@ -1129,6 +1130,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
           regions: regions.map((region) => region.id),
           excludedRunnerIds: excludedRunnerIds,
           availabilityScoreThreshold: availabilityThreshold,
+          gpu: snapshot.gpu,
         })
       } catch (error) {
         this.logger.warn(`Failed to get initial runner: ${fromAxiosError(error)}`)

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -544,6 +544,7 @@ export class JobStateHandlerService {
           skipStart ? undefined : sandbox.cpu,
           skipStart ? undefined : sandbox.mem,
           sandbox.disk,
+          skipStart ? undefined : sandbox.gpu,
         )
         return
       }
@@ -566,13 +567,14 @@ export class JobStateHandlerService {
         updateData.errorReason = errorReason || 'Failed to recover sandbox'
         updateData.recoverable = recoverable
 
-        // Roll back upstream reservation: disk always, cpu/mem only when start was requested.
+        // Roll back upstream reservation: disk always, cpu/mem/gpu only when start was requested.
         await this.organizationUsageService.decrementPendingSandboxUsage(
           sandbox.organizationId,
           sandbox.region,
           skipStart ? undefined : sandbox.cpu,
           skipStart ? undefined : sandbox.mem,
           sandbox.disk,
+          skipStart ? undefined : sandbox.gpu,
         )
       }
 
@@ -640,24 +642,28 @@ export class JobStateHandlerService {
         updateData.disk = payload.disk ?? sandbox.disk
         updateData.state = previousState
 
-        // Apply usage change (handles both positive and negative deltas)
+        // Apply usage change (handles both positive and negative deltas).
+        // Resize never changes GPU allocation — always pass 0.
         await this.organizationUsageService.applyResizeUsageChange(
           sandbox.organizationId,
           sandbox.region,
           cpuDeltaForQuota,
           memDeltaForQuota,
           diskDeltaForQuota,
+          0,
         )
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`RESIZE_SANDBOX job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
 
-        // Rollback pending usage (all deltas were tracked, including negative)
+        // Rollback pending usage (all deltas were tracked, including negative).
+        // Resize never changes GPU allocation — always pass undefined for gpu.
         await this.organizationUsageService.decrementPendingSandboxUsage(
           sandbox.organizationId,
           sandbox.region,
           cpuDeltaForQuota !== 0 ? cpuDeltaForQuota : undefined,
           memDeltaForQuota !== 0 ? memDeltaForQuota : undefined,
           diskDeltaForQuota !== 0 ? diskDeltaForQuota : undefined,
+          undefined,
         )
 
         updateData.state = previousState

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -49,7 +49,10 @@ import { runnerLookupCacheKeyById, RUNNER_LOOKUP_CACHE_TTL_MS } from '../utils/r
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
-import { SANDBOX_STATES_CONSUMING_COMPUTE } from '../../organization/constants/sandbox-states-consuming-compute.constant'
+import {
+  SANDBOX_STATES_CONDITIONALLY_CONSUMING_COMPUTE,
+  SANDBOX_STATES_CONSUMING_COMPUTE,
+} from '../../organization/constants/sandbox-states-consuming-compute.constant'
 
 @Injectable()
 export class RunnerService {
@@ -900,6 +903,10 @@ export class RunnerService {
    * Returns runner IDs that currently host at least one GPU sandbox in a
    * non-terminal state. Used by the GPU scheduler to enforce
    * one-gpu-sandbox-per-runner exclusivity.
+   *
+   * Includes the conditionally-consuming states (RESIZING, SNAPSHOTTING) because a
+   * GPU sandbox in either of those states is still physically present on its runner,
+   * regardless of `desiredState`. The runner cannot host a second GPU sandbox.
    */
   async getRunnersWithActiveGpuSandbox(): Promise<string[]> {
     const rows = await this.sandboxRepository
@@ -907,7 +914,9 @@ export class RunnerService {
       .select('DISTINCT sandbox.runnerId', 'runnerId')
       .where('sandbox.runnerId IS NOT NULL')
       .andWhere('sandbox.gpu > 0')
-      .andWhere('sandbox.state IN (:...states)', { states: SANDBOX_STATES_CONSUMING_COMPUTE })
+      .andWhere('sandbox.state IN (:...states)', {
+        states: [...SANDBOX_STATES_CONSUMING_COMPUTE, ...SANDBOX_STATES_CONDITIONALLY_CONSUMING_COMPUTE],
+      })
       .getRawMany()
 
     return rows.map((r) => r.runnerId).filter((id): id is string => !!id)

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -6,7 +6,18 @@
 import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { DataSource, FindOptionsWhere, In, MoreThanOrEqual, Not, Repository, UpdateResult } from 'typeorm'
+import {
+  DataSource,
+  Equal,
+  FindOptionsWhere,
+  In,
+  IsNull,
+  MoreThanOrEqual,
+  Not,
+  Or,
+  Repository,
+  UpdateResult,
+} from 'typeorm'
 import { Runner } from '../entities/runner.entity'
 import { CreateRunnerInternalDto } from '../dto/create-runner-internal.dto'
 import { SandboxClass } from '../enums/sandbox-class.enum'
@@ -290,15 +301,18 @@ export class RunnerService {
         : MoreThanOrEqual(this.configService.getOrThrow('runnerScore.thresholds.availability')),
     }
 
-    if (params.gpu) {
+    if (params.gpu > 0) {
       runnerFilter.gpu = MoreThanOrEqual(params.gpu)
+    } else {
+      // GPU runners are exclusively reserved for GPU sandboxes.
+      runnerFilter.gpu = Or(IsNull(), Equal(0))
     }
 
     const excludedRunnerIds = new Set((params.excludedRunnerIds ?? []).filter((id): id is string => !!id))
 
     // GPU sandboxes get exclusive ownership of a runner: skip any runner that
     // already hosts an active sandbox, regardless of whether that sandbox uses GPU.
-    if (params.gpu) {
+    if (params.gpu > 0) {
       const occupiedRunnerIds = await this.getRunnersWithActiveGpuSandbox()
       for (const id of occupiedRunnerIds) {
         excludedRunnerIds.add(id)
@@ -1120,7 +1134,7 @@ export class GetRunnerParams {
   availabilityScoreThreshold?: number
   // When > 0, only consider runners that have at least this much GPU capacity
   // and do not currently host any active sandbox (one-GPU-sandbox-per-runner rule).
-  gpu?: number
+  gpu: number
 }
 
 interface AvailabilityScoreParams {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -621,6 +621,9 @@ export class SandboxService {
     }
 
     if (createSandboxDto.autoDeleteInterval !== undefined) {
+      if (warmPoolSandbox.gpu > 0 && createSandboxDto.autoDeleteInterval !== 0) {
+        throw new BadRequestError('GPU sandboxes must be ephemeral - autoDeleteInterval must be 0')
+      }
       updateData.autoDeleteInterval = createSandboxDto.autoDeleteInterval
     }
 
@@ -686,6 +689,11 @@ export class SandboxService {
       const mem = createSandboxDto.memory || DEFAULT_MEMORY
       const disk = createSandboxDto.disk || DEFAULT_DISK
       const gpu = createSandboxDto.gpu || DEFAULT_GPU
+
+      // GPU sandboxes are always ephemeral - delete on first stop.
+      if (gpu > 0 && !isEphemeral(createSandboxDto)) {
+        throw new BadRequestError('GPU sandboxes must be ephemeral - set autoDeleteInterval to 0')
+      }
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
@@ -2613,6 +2621,10 @@ export class SandboxService {
 
   async setAutoDeleteInterval(sandboxIdOrName: string, interval: number, organizationId?: string): Promise<Sandbox> {
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organizationId)
+
+    if (sandbox.gpu > 0) {
+      throw new BadRequestError('GPU sandboxes must remain ephemeral')
+    }
 
     const updateData: Partial<Sandbox> = {
       autoDeleteInterval: interval,

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -166,6 +166,11 @@ export class SandboxService {
     ephemeral: boolean,
     excludeSandboxId?: string,
     regionQuota?: RegionQuotaDto | null,
+    // Controls which per-sandbox limits table is used (GPU-specific vs non-GPU).
+    // Defaults to `gpu > 0`, which is correct for create/start/fork/archive paths where
+    // `gpu` is the absolute sandbox GPU allocation. Resize passes `gpu = 0` (no GPU delta)
+    // but still needs GPU-aware per-sandbox limits when the sandbox itself is a GPU sandbox.
+    gpuEnabled: boolean = gpu > 0,
   ): Promise<{
     pendingCpuIncremented: boolean
     pendingMemoryIncremented: boolean
@@ -178,7 +183,7 @@ export class SandboxService {
 
     // validate per-sandbox quotas
     const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox } =
-      getEffectivePerSandboxLimits(organization, regionQuota, gpu > 0)
+      getEffectivePerSandboxLimits(organization, regionQuota, gpuEnabled)
 
     if (cpu > maxCpuPerSandbox) {
       throw new BadRequestError(
@@ -645,10 +650,12 @@ export class SandboxService {
       updateData.autoArchiveInterval = this.resolveAutoArchiveInterval(createSandboxDto.autoArchiveInterval)
     }
 
-    if (createSandboxDto.autoDeleteInterval !== undefined) {
-      if (warmPoolSandbox.gpu > 0 && createSandboxDto.autoDeleteInterval !== 0) {
+    if (warmPoolSandbox.gpu > 0) {
+      if (createSandboxDto.autoDeleteInterval !== undefined && createSandboxDto.autoDeleteInterval !== 0) {
         throw new BadRequestError('GPU sandboxes must be ephemeral - autoDeleteInterval must be 0')
       }
+      updateData.autoDeleteInterval = 0
+    } else if (createSandboxDto.autoDeleteInterval !== undefined) {
       updateData.autoDeleteInterval = createSandboxDto.autoDeleteInterval
     }
 
@@ -2172,7 +2179,8 @@ export class SandboxService {
       const diskDeltaForQuota = newDisk - sandbox.disk // Disk only increases (validated at start of method)
 
       // Validate and track pending for any non-zero quota changes.
-      // Resize never changes GPU allocation — always pass 0.
+      // Resize never changes GPU allocation — always pass 0 for the GPU delta, but pass
+      // `gpuEnabled = sandbox.gpu > 0` so per-sandbox limit checks use the GPU-specific table.
       if (cpuDeltaForQuota !== 0 || memDeltaForQuota !== 0 || diskDeltaForQuota !== 0) {
         const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
           await this.validateOrganizationQuotas(
@@ -2185,6 +2193,7 @@ export class SandboxService {
             isEphemeral(sandbox),
             undefined,
             regionQuota,
+            sandbox.gpu > 0,
           )
 
         if (pendingCpuIncremented) {

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -162,6 +162,7 @@ export class SandboxService {
     cpu: number,
     memory: number,
     disk: number,
+    gpu: number,
     ephemeral: boolean,
     excludeSandboxId?: string,
     regionQuota?: RegionQuotaDto | null,
@@ -169,6 +170,7 @@ export class SandboxService {
     pendingCpuIncremented: boolean
     pendingMemoryIncremented: boolean
     pendingDiskIncremented: boolean
+    pendingGpuIncremented: boolean
   }> {
     if (!regionQuota && region.enforceQuotas) {
       regionQuota = await this.organizationService.getRegionQuota(organization.id, region.id)
@@ -211,6 +213,7 @@ export class SandboxService {
         pendingCpuIncremented: false,
         pendingMemoryIncremented: false,
         pendingDiskIncremented: false,
+        pendingGpuIncremented: false,
       }
     }
 
@@ -224,17 +227,24 @@ export class SandboxService {
       }
     }
 
+    // Fail fast: requesting GPU in a region with no GPU quota at all.
+    if (gpu > 0 && regionQuota.totalGpuQuota === 0) {
+      throw new BadRequestError(`Total GPU limit exceeded. Maximum allowed: ${regionQuota.totalGpuQuota}.`)
+    }
+
     // validate usage quotas
     const {
       cpuIncremented: pendingCpuIncremented,
       memoryIncremented: pendingMemoryIncremented,
       diskIncremented: pendingDiskIncremented,
+      gpuIncremented: pendingGpuIncremented,
     } = await this.organizationUsageService.incrementPendingSandboxUsage(
       organization.id,
       region.id,
       cpu,
       memory,
       disk,
+      gpu,
       excludeSandboxId,
     )
 
@@ -264,6 +274,12 @@ export class SandboxService {
           `Total disk limit exceeded. Maximum allowed: ${regionQuota.totalDiskQuota}GiB.\n${ARCHIVE_SANDBOXES_MESSAGE}\n${upgradeTierMessage}`,
         )
       }
+
+      if (usageOverview.currentGpuUsage + usageOverview.pendingGpuUsage > regionQuota.totalGpuQuota) {
+        throw new BadRequestError(
+          `Total GPU limit exceeded. Maximum allowed: ${regionQuota.totalGpuQuota}.\n${upgradeTierMessage}`,
+        )
+      }
     } catch (error) {
       await this.rollbackPendingUsage(
         organization.id,
@@ -271,6 +287,7 @@ export class SandboxService {
         pendingCpuIncremented ? cpu : undefined,
         pendingMemoryIncremented ? memory : undefined,
         pendingDiskIncremented ? disk : undefined,
+        pendingGpuIncremented ? gpu : undefined,
       )
       throw error
     }
@@ -279,6 +296,7 @@ export class SandboxService {
       pendingCpuIncremented,
       pendingMemoryIncremented,
       pendingDiskIncremented,
+      pendingGpuIncremented,
     }
   }
 
@@ -288,8 +306,9 @@ export class SandboxService {
     pendingCpuIncrement?: number,
     pendingMemoryIncrement?: number,
     pendingDiskIncrement?: number,
+    pendingGpuIncrement?: number,
   ): Promise<void> {
-    if (!pendingCpuIncrement && !pendingMemoryIncrement && !pendingDiskIncrement) {
+    if (!pendingCpuIncrement && !pendingMemoryIncrement && !pendingDiskIncrement && !pendingGpuIncrement) {
       return
     }
 
@@ -300,6 +319,7 @@ export class SandboxService {
         pendingCpuIncrement,
         pendingMemoryIncrement,
         pendingDiskIncrement,
+        pendingGpuIncrement,
       )
     } catch (error) {
       this.logger.error(`Error rolling back pending sandbox usage: ${error}`)
@@ -389,6 +409,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
+    let pendingGpuIncrement: number | undefined
 
     const region = await this.getValidatedOrDefaultRegion(organization, createSandboxDto.target)
 
@@ -469,8 +490,8 @@ export class SandboxService {
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
-      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
-        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk, isEphemeral(createSandboxDto))
+      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
+        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk, gpu, isEphemeral(createSandboxDto))
 
       if (pendingCpuIncremented) {
         pendingCpuIncrement = cpu
@@ -480,6 +501,9 @@ export class SandboxService {
       }
       if (pendingDiskIncremented) {
         pendingDiskIncrement = disk
+      }
+      if (pendingGpuIncremented) {
+        pendingGpuIncrement = gpu
       }
 
       // GPU sandboxes are always ephemeral: they get exclusive ownership of a
@@ -585,6 +609,7 @@ export class SandboxService {
         pendingCpuIncrement,
         pendingMemoryIncrement,
         pendingDiskIncrement,
+        pendingGpuIncrement,
       )
 
       if (error.code === '23505') {
@@ -679,6 +704,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
+    let pendingGpuIncrement: number | undefined
 
     const region = await this.getValidatedOrDefaultRegion(organization, createSandboxDto.target)
 
@@ -697,8 +723,8 @@ export class SandboxService {
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
-      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
-        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk, isEphemeral(createSandboxDto))
+      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
+        await this.validateOrganizationQuotas(organization, region, cpu, mem, disk, gpu, isEphemeral(createSandboxDto))
 
       if (pendingCpuIncremented) {
         pendingCpuIncrement = cpu
@@ -708,6 +734,9 @@ export class SandboxService {
       }
       if (pendingDiskIncremented) {
         pendingDiskIncrement = disk
+      }
+      if (pendingGpuIncremented) {
+        pendingGpuIncrement = gpu
       }
 
       if (createSandboxDto.volumes && createSandboxDto.volumes.length > 0) {
@@ -836,6 +865,7 @@ export class SandboxService {
         pendingCpuIncrement,
         pendingMemoryIncrement,
         pendingDiskIncrement,
+        pendingGpuIncrement,
       )
 
       if (error.code === '23505') {
@@ -866,6 +896,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
+    let pendingGpuIncrement: number | undefined
 
     const sourceSandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
@@ -923,13 +954,14 @@ export class SandboxService {
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
       // Validate organization usage quotas are not exceeded due to new sandbox created by forking
-      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
+      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
         await this.validateOrganizationQuotas(
           organization,
           region,
           forkedSandbox.cpu,
           forkedSandbox.mem,
           forkedSandbox.disk,
+          forkedSandbox.gpu,
           isEphemeral(forkedSandbox),
         )
 
@@ -941,6 +973,9 @@ export class SandboxService {
       }
       if (pendingDiskIncremented) {
         pendingDiskIncrement = forkedSandbox.disk
+      }
+      if (pendingGpuIncremented) {
+        pendingGpuIncrement = forkedSandbox.gpu
       }
 
       // Capture state of source sandbox before transitioning to FORKING
@@ -1001,6 +1036,7 @@ export class SandboxService {
         pendingCpuIncrement,
         pendingMemoryIncrement,
         pendingDiskIncrement,
+        pendingGpuIncrement,
       )
 
       if (error.code === '23505') {
@@ -1115,6 +1151,7 @@ export class SandboxService {
         sandbox.cpu,
         sandbox.mem,
         sandbox.disk,
+        sandbox.gpu,
       )
 
       if (pendingSnapshotCountIncremented) {
@@ -1753,6 +1790,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
+    let pendingGpuIncrement: number | undefined
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
@@ -1788,13 +1826,14 @@ export class SandboxService {
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
-      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
+      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
         await this.validateOrganizationQuotas(
           organization,
           region,
           sandbox.cpu,
           sandbox.mem,
           sandbox.disk,
+          sandbox.gpu,
           isEphemeral(sandbox),
           sandbox.id,
         )
@@ -1807,6 +1846,9 @@ export class SandboxService {
       }
       if (pendingDiskIncremented) {
         pendingDiskIncrement = sandbox.disk
+      }
+      if (pendingGpuIncremented) {
+        pendingGpuIncrement = sandbox.gpu
       }
 
       const updateData: Partial<Sandbox> = {
@@ -1830,6 +1872,7 @@ export class SandboxService {
         pendingCpuIncrement,
         pendingMemoryIncrement,
         pendingDiskIncrement,
+        pendingGpuIncrement,
       )
       throw error
     }
@@ -1878,6 +1921,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
+    let pendingGpuIncrement: number | undefined
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
@@ -1915,15 +1959,16 @@ export class SandboxService {
         this.organizationService.assertOrganizationIsNotSuspended(organization)
       }
 
-      // ERROR → STOPPED activates disk usage; v2 + !skipStart additionally activates cpu/mem
+      // ERROR → STOPPED activates disk usage; v2 + !skipStart additionally activates cpu/mem/gpu
       // because there is no trailing start() call to validate them.
-      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
+      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
         await this.validateOrganizationQuotas(
           organization,
           region,
           willStartOnV2 ? sandbox.cpu : 0,
           willStartOnV2 ? sandbox.mem : 0,
           sandbox.disk,
+          willStartOnV2 ? sandbox.gpu : 0,
           isEphemeral(sandbox),
           sandbox.id,
         )
@@ -1935,6 +1980,9 @@ export class SandboxService {
       }
       if (pendingDiskIncremented) {
         pendingDiskIncrement = sandbox.disk
+      }
+      if (pendingGpuIncremented) {
+        pendingGpuIncrement = sandbox.gpu
       }
 
       // Normalize desiredState upfront so the job handler can detect mid-job intent changes
@@ -2010,6 +2058,7 @@ export class SandboxService {
         pendingCpuIncrement,
         pendingMemoryIncrement,
         pendingDiskIncrement,
+        pendingGpuIncrement,
       )
       throw error
     } finally {
@@ -2021,6 +2070,7 @@ export class SandboxService {
     let pendingCpuIncrement: number | undefined
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
+    let pendingGpuIncrement: number | undefined
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
@@ -2121,7 +2171,8 @@ export class SandboxService {
       const memDeltaForQuota = isHotResize ? newMem - sandbox.mem : 0
       const diskDeltaForQuota = newDisk - sandbox.disk // Disk only increases (validated at start of method)
 
-      // Validate and track pending for any non-zero quota changes
+      // Validate and track pending for any non-zero quota changes.
+      // Resize never changes GPU allocation — always pass 0.
       if (cpuDeltaForQuota !== 0 || memDeltaForQuota !== 0 || diskDeltaForQuota !== 0) {
         const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented } =
           await this.validateOrganizationQuotas(
@@ -2130,6 +2181,7 @@ export class SandboxService {
             cpuDeltaForQuota,
             memDeltaForQuota,
             diskDeltaForQuota,
+            0,
             isEphemeral(sandbox),
             undefined,
             regionQuota,
@@ -2206,13 +2258,15 @@ export class SandboxService {
           })
 
           // Apply the usage change (increments current, decrements pending)
-          // Only apply deltas for quotas that were validated/pending-incremented
+          // Only apply deltas for quotas that were validated/pending-incremented.
+          // Resize never changes GPU allocation — always pass 0.
           await this.organizationUsageService.applyResizeUsageChange(
             organization.id,
             sandbox.region,
             cpuDeltaForQuota,
             memDeltaForQuota,
             diskDeltaForQuota,
+            0,
           )
         }
 
@@ -2237,6 +2291,7 @@ export class SandboxService {
         pendingCpuIncrement,
         pendingMemoryIncrement,
         pendingDiskIncrement,
+        pendingGpuIncrement,
       )
       throw error
     }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -472,11 +472,6 @@ export class SandboxService {
       let disk = snapshot.disk
       let gpu = snapshot.gpu
 
-      // GPU sandboxes are always ephemeral - delete on first stop.
-      if (gpu > 0 && !isEphemeral(createSandboxDto)) {
-        throw new BadRequestError('GPU sandboxes must be ephemeral - set autoDeleteInterval to 0')
-      }
-
       // Remove the deprecated behavior in a future release
       if (useSandboxResourceParams_deprecated) {
         if (createSandboxDto.cpu) {
@@ -491,6 +486,12 @@ export class SandboxService {
         if (createSandboxDto.gpu) {
           gpu = createSandboxDto.gpu
         }
+      }
+
+      // GPU sandboxes are always ephemeral. Must run after the deprecated-override block
+      // above so it sees the effective gpu value, not the initial snapshot.gpu.
+      if (gpu > 0 && !isEphemeral(createSandboxDto)) {
+        throw new BadRequestError('GPU sandboxes must be ephemeral - set autoDeleteInterval to 0')
       }
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -371,6 +371,7 @@ export class SandboxService {
       regions: [sandbox.region],
       sandboxClass: sandbox.class,
       snapshotRef: snapshot.ref,
+      gpu: sandbox.gpu,
     })
 
     sandbox.runnerId = runner.id
@@ -521,7 +522,7 @@ export class SandboxService {
         regions: [region.id],
         sandboxClass,
         snapshotRef: snapshot.ref,
-        gpu: gpu > 0 ? gpu : undefined,
+        gpu,
       })
 
       const sandbox = new Sandbox(region.id, createSandboxDto.name)
@@ -767,6 +768,7 @@ export class SandboxService {
           regions: [sandbox.region],
           sandboxClass: sandbox.class,
           snapshotRef: buildInfoSnapshotRef,
+          gpu: sandbox.gpu,
           ...(excludedRunnerIds.length > 0 && { excludedRunnerIds }),
           ...(declarativeBuildScoreThreshold !== undefined && {
             availabilityScoreThreshold: declarativeBuildScoreThreshold,
@@ -881,6 +883,10 @@ export class SandboxService {
 
       if (runner.runnerClass !== RunnerClass.VM) {
         throw new HttpException('Forking is not supported for this sandbox', HttpStatus.UNPROCESSABLE_ENTITY)
+      }
+
+      if (sourceSandbox.gpu > 0) {
+        throw new HttpException('Forking is not supported for GPU sandboxes', HttpStatus.UNPROCESSABLE_ENTITY)
       }
 
       // Copy all properties from source sandbox to forked sandbox

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -178,7 +178,7 @@ export class SandboxService {
 
     // validate per-sandbox quotas
     const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox } =
-      getEffectivePerSandboxLimits(organization, regionQuota)
+      getEffectivePerSandboxLimits(organization, regionQuota, gpu > 0)
 
     if (cpu > maxCpuPerSandbox) {
       throw new BadRequestError(
@@ -2136,7 +2136,7 @@ export class SandboxService {
         : null
 
       const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox } =
-        getEffectivePerSandboxLimits(organization, regionQuota)
+        getEffectivePerSandboxLimits(organization, regionQuota, sandbox.gpu > 0)
 
       if (newCpu > maxCpuPerSandbox) {
         throw new BadRequestError(

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -554,6 +554,7 @@ export class SnapshotService {
     const { maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox } = getEffectivePerSandboxLimits(
       organization,
       regionQuota,
+      (gpu ?? 0) > 0,
     )
 
     if (cpu && cpu > maxCpuPerSandbox) {

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -575,7 +575,7 @@ export class SnapshotService {
 
     // Do not allow creation of GPU snapshots if the region has no GPU quota at all.
     if (gpu && gpu > 0 && region.enforceQuotas && (!regionQuota || regionQuota.totalGpuQuota === 0)) {
-      throw new BadRequestError(`GPU quota exceeded. Maximum allowed: ${regionQuota.totalGpuQuota}`)
+      throw new BadRequestError(`GPU quota exceeded. Maximum allowed: ${regionQuota?.totalGpuQuota ?? 0}.`)
     }
 
     // validate usage quotas

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -184,6 +184,7 @@ export class SnapshotService {
         createSnapshotDto.cpu,
         createSnapshotDto.memory,
         createSnapshotDto.disk,
+        createSnapshotDto.gpu,
       )
 
       if (pendingSnapshotCountIncremented) {
@@ -252,6 +253,7 @@ export class SnapshotService {
         createSnapshotDto.cpu,
         createSnapshotDto.memory,
         createSnapshotDto.disk,
+        createSnapshotDto.gpu,
       )
 
       if (pendingSnapshotCountIncremented) {
@@ -540,6 +542,7 @@ export class SnapshotService {
     cpu?: number,
     memory?: number,
     disk?: number,
+    gpu?: number,
   ): Promise<{
     pendingSnapshotCountIncremented: boolean
   }> {
@@ -567,6 +570,11 @@ export class SnapshotService {
       throw new BadRequestError(
         `Disk request ${disk}GB exceeds maximum allowed per sandbox (${maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
+    }
+
+    // Do not allow creation of GPU snapshots if the region has no GPU quota at all.
+    if (gpu && gpu > 0 && region.enforceQuotas && (!regionQuota || regionQuota.totalGpuQuota === 0)) {
+      throw new BadRequestError(`GPU quota exceeded. Maximum allowed: ${regionQuota.totalGpuQuota}`)
     }
 
     // validate usage quotas
@@ -669,6 +677,7 @@ export class SnapshotService {
         snapshot.cpu,
         snapshot.mem,
         snapshot.disk,
+        snapshot.gpu,
       )
 
       if (pendingSnapshotCountIncremented) {

--- a/apps/dashboard/src/components/ResourceChip.tsx
+++ b/apps/dashboard/src/components/ResourceChip.tsx
@@ -3,25 +3,37 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { CpuIcon, HardDriveIcon, MemoryStickIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { CpuIcon, HardDriveIcon, MemoryStickIcon, SparklesIcon } from 'lucide-react'
+
+type Resource = 'cpu' | 'memory' | 'disk' | 'gpu'
 
 interface Props {
-  resource: 'cpu' | 'memory' | 'disk'
+  resource: Resource
   value: number
   unit?: string
   icon?: React.ReactNode
 }
 
-const resourceUnits = {
+const resourceUnits: Record<Resource, string> = {
   cpu: 'vCPU',
   memory: 'GiB',
   disk: 'GiB',
+  gpu: 'GPU',
 }
 
-const resourceIcons = {
+const resourceIcons: Record<Resource, React.ComponentType<{ className?: string; strokeWidth?: number }>> = {
   cpu: CpuIcon,
   memory: MemoryStickIcon,
   disk: HardDriveIcon,
+  gpu: SparklesIcon,
+}
+
+const resourceChipClassName: Record<Resource, string> = {
+  cpu: 'bg-muted/80 border border-border',
+  memory: 'bg-muted/80 border border-border',
+  disk: 'bg-muted/80 border border-border',
+  gpu: 'bg-purple-100 text-purple-600 dark:bg-purple-950 dark:text-purple-200',
 }
 
 export function ResourceChip({ resource, value, unit, icon }: Props) {
@@ -29,7 +41,12 @@ export function ResourceChip({ resource, value, unit, icon }: Props) {
   const ResourceIcon = resourceIcons[resource]
 
   return (
-    <div className="flex items-center gap-1 bg-muted/80 border border-border rounded-full px-2 py-[2px] text-sm whitespace-nowrap">
+    <div
+      className={cn(
+        'flex items-center gap-1 rounded-full px-2 py-[2px] text-sm whitespace-nowrap',
+        resourceChipClassName[resource],
+      )}
+    >
       {icon === null ? null : (icon ?? <ResourceIcon className="w-4 h-4 flex-shrink-0" strokeWidth={1.5} />)} {value}{' '}
       {resourceUnit}
     </div>

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -24,6 +24,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useCreateSandboxMutation } from '@/hooks/mutations/useCreateSandboxMutation'
 import { useSetOrganizationDefaultRegionMutation } from '@/hooks/mutations/useSetOrganizationDefaultRegionMutation'
+import { useOrganizationUsageOverviewQuery } from '@/hooks/queries/useOrganizationUsageOverviewQuery'
 import { useSnapshotsQuery } from '@/hooks/queries/useSnapshotsQuery'
 import { useConfig } from '@/hooks/useConfig'
 import { useRegions } from '@/hooks/useRegions'
@@ -95,6 +96,7 @@ const buildBaseFormSchema = (maxCpu?: number, maxMemory?: number, maxDisk?: numb
     networkBlockAll: z.boolean().optional(),
     ephemeral: z.boolean().optional(),
     setAsDefaultRegion: z.boolean().optional(),
+    gpu: z.boolean().optional(),
   })
 
 const buildFormSchema = (maxCpu?: number, maxMemory?: number, maxDisk?: number) => {
@@ -137,6 +139,7 @@ const defaultValues: FormValues = {
   networkBlockAll: false,
   ephemeral: false,
   setAsDefaultRegion: false,
+  gpu: false,
 }
 
 const InfoTooltipButton = ({ className, ...props }: ComponentProps<'button'>) => {
@@ -182,6 +185,10 @@ export const CreateSandboxSheet = ({
   const canSetDefaultRegion =
     !selectedOrganization?.defaultRegionId &&
     authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
+
+  const { data: usageOverview } = useOrganizationUsageOverviewQuery({
+    organizationId: selectedOrganization?.id || '',
+  })
 
   const formSchema = useMemo(() => buildFormSchema(maxCpu, maxMemory, maxDisk), [maxCpu, maxMemory, maxDisk])
 
@@ -261,8 +268,13 @@ export const CreateSandboxSheet = ({
             ...baseParams,
             image: value.image,
             resources:
-              value.cpu || value.memory || value.disk
-                ? { cpu: value.cpu, memory: value.memory, disk: value.disk }
+              value.cpu || value.memory || value.disk || value.gpu
+                ? {
+                    cpu: value.cpu,
+                    memory: value.memory,
+                    disk: value.disk,
+                    gpu: value.gpu ? 1 : undefined,
+                  }
                 : undefined,
           })
         } else {
@@ -590,6 +602,34 @@ export const CreateSandboxSheet = ({
                             )
                           }}
                         </form.Field>
+                        <form.Subscribe selector={(state) => state.values.regionId}>
+                          {(regionId) => {
+                            const region = usageOverview?.regionUsage.find((r) => r.regionId === regionId)
+                            if ((region?.totalGpuQuota ?? 0) <= 0) return null
+                            return (
+                              <form.Field name="gpu">
+                                {(field) => (
+                                  <div className="flex items-start gap-2 pt-1">
+                                    <Checkbox
+                                      id={field.name}
+                                      className="mt-0.5"
+                                      checked={field.state.value ?? false}
+                                      onCheckedChange={(checked) => field.handleChange(checked === true)}
+                                    />
+                                    <div className="flex flex-col gap-1">
+                                      <Label htmlFor={field.name} className="text-sm font-normal">
+                                        Allocate GPU
+                                      </Label>
+                                      <FieldDescription>
+                                        Sandbox will own a GPU runner exclusively and is auto-deleted on first stop.
+                                      </FieldDescription>
+                                    </div>
+                                  </div>
+                                )}
+                              </form.Field>
+                            )
+                          }}
+                        </form.Subscribe>
                       </div>
                       <FieldDescription>
                         {`Defaults: 1 vCPU, 1 GiB memory, 3 GiB storage.`}

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -306,6 +306,7 @@ export const CreateSandboxSheet = ({
         form.setFieldValue('cpu', undefined)
         form.setFieldValue('memory', undefined)
         form.setFieldValue('disk', undefined)
+        form.setFieldValue('gpu', false)
       } else {
         form.setFieldValue('snapshot', undefined)
       }
@@ -614,14 +615,21 @@ export const CreateSandboxSheet = ({
                                       id={field.name}
                                       className="mt-0.5"
                                       checked={field.state.value ?? false}
-                                      onCheckedChange={(checked) => field.handleChange(checked === true)}
+                                      onCheckedChange={(checked) => {
+                                        const isChecked = checked === true
+                                        field.handleChange(isChecked)
+                                        if (isChecked) {
+                                          form.setFieldValue('ephemeral', true)
+                                          form.setFieldValue('autoDeleteInterval', 0)
+                                        }
+                                      }}
                                     />
                                     <div className="flex flex-col gap-1">
                                       <Label htmlFor={field.name} className="text-sm font-normal">
                                         Allocate GPU
                                       </Label>
                                       <FieldDescription>
-                                        GPU sandboxes must be ephemeral - set autoDeleteInterval to 0.
+                                        GPU sandboxes are always ephemeral and auto-deleted when stopped.
                                       </FieldDescription>
                                     </div>
                                   </div>
@@ -797,26 +805,35 @@ export const CreateSandboxSheet = ({
                 </form.Field>
                 <form.Field name="ephemeral">
                   {(field) => (
-                    <div className="flex items-start gap-2">
-                      <Checkbox
-                        className="mt-0.5"
-                        id={field.name}
-                        checked={field.state.value ?? false}
-                        onCheckedChange={(checked) => {
-                          const isEphemeral = checked === true
-                          field.handleChange(isEphemeral)
-                          if (isEphemeral) {
-                            form.setFieldValue('autoDeleteInterval', 0)
-                          }
-                        }}
-                      />
-                      <div className="flex flex-col gap-1">
-                        <Label htmlFor={field.name} className="text-sm font-normal">
-                          Ephemeral
-                        </Label>
-                        <FieldDescription>Automatically delete the sandbox when it stops.</FieldDescription>
-                      </div>
-                    </div>
+                    <form.Subscribe selector={(state) => state.values.gpu}>
+                      {(gpu) => (
+                        <div className="flex items-start gap-2">
+                          <Checkbox
+                            className="mt-0.5"
+                            id={field.name}
+                            checked={field.state.value ?? false}
+                            disabled={gpu ?? false}
+                            onCheckedChange={(checked) => {
+                              const isEphemeral = checked === true
+                              field.handleChange(isEphemeral)
+                              if (isEphemeral) {
+                                form.setFieldValue('autoDeleteInterval', 0)
+                              }
+                            }}
+                          />
+                          <div className="flex flex-col gap-1">
+                            <Label htmlFor={field.name} className="text-sm font-normal">
+                              Ephemeral
+                            </Label>
+                            <FieldDescription>
+                              {gpu
+                                ? 'Required for GPU sandboxes - automatically deleted when stopped.'
+                                : 'Automatically delete the sandbox when it stops.'}
+                            </FieldDescription>
+                          </div>
+                        </div>
+                      )}
+                    </form.Subscribe>
                   )}
                 </form.Field>
               </div>

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -620,6 +620,9 @@ export const CreateSandboxSheet = ({
                                       <Label htmlFor={field.name} className="text-sm font-normal">
                                         Allocate GPU
                                       </Label>
+                                      <FieldDescription>
+                                        GPU sandboxes must be ephemeral - set autoDeleteInterval to 0.
+                                      </FieldDescription>
                                     </div>
                                   </div>
                                 )}

--- a/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
+++ b/apps/dashboard/src/components/Sandbox/CreateSandboxSheet.tsx
@@ -620,9 +620,6 @@ export const CreateSandboxSheet = ({
                                       <Label htmlFor={field.name} className="text-sm font-normal">
                                         Allocate GPU
                                       </Label>
-                                      <FieldDescription>
-                                        Sandbox will own a GPU runner exclusively and is auto-deleted on first stop.
-                                      </FieldDescription>
                                     </div>
                                   </div>
                                 )}
@@ -632,9 +629,7 @@ export const CreateSandboxSheet = ({
                         </form.Subscribe>
                       </div>
                       <FieldDescription>
-                        {`Defaults: 1 vCPU, 1 GiB memory, 3 GiB storage.`}
-                        <br />
-                        {maxCpu ? ` Limits: ${maxCpu} vCPU, ${maxMemory} GiB memory, ${maxDisk} GiB storage.` : ''}
+                        If not specified, default values will be used (1 vCPU, 1 GiB memory, 3 GiB storage).
                       </FieldDescription>
                     </div>
                   </TabsContent>

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -266,6 +266,14 @@ export function getColumns({
             <div className="whitespace-nowrap">
               {row.original.disk} <span className="text-muted-foreground">GiB</span>
             </div>
+            {row.original.gpu > 0 && (
+              <>
+                <div className="w-[1px] h-6 bg-muted-foreground/20 rounded-full inline-block"></div>
+                <div className="whitespace-nowrap">
+                  {row.original.gpu} <span className="text-muted-foreground">GPU</span>
+                </div>
+              </>
+            )}
           </div>
         )
       },

--- a/apps/dashboard/src/components/UsageOverview.tsx
+++ b/apps/dashboard/src/components/UsageOverview.tsx
@@ -38,6 +38,15 @@ export function UsageOverview({
         </div>
         <QuotaLine current={usageOverview.currentDiskUsage} total={usageOverview.totalDiskQuota} />
       </div>
+      {usageOverview.totalGpuQuota > 0 && (
+        <div className="flex flex-col gap-1">
+          <div className="w-full flex justify-between gap-2">
+            <div className="text-muted-foreground text-xs">GPU</div>
+            <UsageLabel current={usageOverview.currentGpuUsage} total={usageOverview.totalGpuQuota} unit="GPU" />
+          </div>
+          <QuotaLine current={usageOverview.currentGpuUsage} total={usageOverview.totalGpuQuota} />
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/components/sandboxes/SandboxInfoPanel.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxInfoPanel.tsx
@@ -114,6 +114,7 @@ export function SandboxInfoPanel({
           <ResourceChip resource="cpu" value={sandbox.cpu} />
           <ResourceChip resource="memory" value={sandbox.memory} />
           <ResourceChip resource="disk" value={sandbox.disk} />
+          {sandbox.gpu > 0 && <ResourceChip resource="gpu" value={sandbox.gpu} />}
         </div>
       </InfoSection>
 

--- a/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
@@ -324,6 +324,10 @@ export const CreateSnapshotSheet = ({
                               <Label htmlFor={field.name} className="text-sm font-normal">
                                 Allocate GPU
                               </Label>
+                              <FieldDescription>
+                                Sandboxes created from this snapshot must be ephemeral - set autoDeleteInterval to 0
+                                when creating the sandbox.
+                              </FieldDescription>
                             </div>
                           </div>
                         )}

--- a/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
@@ -5,6 +5,7 @@
 
 import { CreateResourceButton } from '@/components/CreateResourceButton'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -20,6 +21,7 @@ import {
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { useCreateSnapshotMutation } from '@/hooks/mutations/useCreateSnapshotMutation'
+import { useOrganizationUsageOverviewQuery } from '@/hooks/queries/useOrganizationUsageOverviewQuery'
 import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
@@ -46,6 +48,7 @@ const formSchema = z.object({
   cpu: z.number().min(1).optional(),
   memory: z.number().min(1).optional(),
   disk: z.number().min(1).optional(),
+  gpu: z.boolean().optional(),
   regionId: z.string().optional(),
 })
 
@@ -58,6 +61,7 @@ const defaultValues: FormValues = {
   cpu: undefined,
   memory: undefined,
   disk: undefined,
+  gpu: false,
   regionId: undefined,
 }
 
@@ -76,6 +80,9 @@ export const CreateSnapshotSheet = ({
   const { selectedOrganization } = useSelectedOrganization()
   const { reset: resetCreateSnapshotMutation, ...createSnapshotMutation } = useCreateSnapshotMutation()
   const formRef = useRef<HTMLFormElement>(null)
+  const { data: usageOverview } = useOrganizationUsageOverviewQuery({
+    organizationId: selectedOrganization?.id || '',
+  })
   const formDefaultValues = useMemo<FormValues>(
     () => ({
       ...defaultValues,
@@ -119,6 +126,7 @@ export const CreateSnapshotSheet = ({
             cpu: value.cpu,
             memory: value.memory,
             disk: value.disk,
+            gpu: value.gpu ? 1 : undefined,
             regionId: value.regionId,
           },
           organizationId: selectedOrganization.id,
@@ -298,6 +306,35 @@ export const CreateSnapshotSheet = ({
                     </div>
                   )}
                 </form.Field>
+                <form.Subscribe selector={(state) => state.values.regionId}>
+                  {(regionId) => {
+                    const region = usageOverview?.regionUsage.find((r) => r.regionId === regionId)
+                    if ((region?.totalGpuQuota ?? 0) <= 0) return null
+                    return (
+                      <form.Field name="gpu">
+                        {(field) => (
+                          <div className="flex items-start gap-2 pt-1">
+                            <Checkbox
+                              id={field.name}
+                              className="mt-0.5"
+                              checked={field.state.value ?? false}
+                              onCheckedChange={(checked) => field.handleChange(checked === true)}
+                            />
+                            <div className="flex flex-col gap-1">
+                              <Label htmlFor={field.name} className="text-sm font-normal">
+                                Allocate GPU
+                              </Label>
+                              <FieldDescription>
+                                Sandboxes created from this snapshot will own a GPU runner exclusively and are
+                                auto-deleted on first stop.
+                              </FieldDescription>
+                            </div>
+                          </div>
+                        )}
+                      </form.Field>
+                    )
+                  }}
+                </form.Subscribe>
               </div>
               <FieldDescription>
                 If not specified, default values will be used (1 vCPU, 1 GiB memory, 3 GiB storage).

--- a/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
@@ -324,10 +324,6 @@ export const CreateSnapshotSheet = ({
                               <Label htmlFor={field.name} className="text-sm font-normal">
                                 Allocate GPU
                               </Label>
-                              <FieldDescription>
-                                Sandboxes created from this snapshot will own a GPU runner exclusively and are
-                                auto-deleted on first stop.
-                              </FieldDescription>
                             </div>
                           </div>
                         )}

--- a/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotSheet.tsx
@@ -388,6 +388,7 @@ export function SnapshotSheet({
                   <ResourceChip resource="cpu" value={activeSnapshot.cpu} />
                   <ResourceChip resource="memory" value={activeSnapshot.mem} />
                   <ResourceChip resource="disk" value={activeSnapshot.disk} />
+                  {activeSnapshot.gpu > 0 && <ResourceChip resource="gpu" value={activeSnapshot.gpu} />}
                 </div>
               </InfoSection>
 

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
@@ -257,6 +257,14 @@ const columns: ColumnDef<SnapshotDto>[] = [
           <div className="whitespace-nowrap">
             {snapshot.disk} <span className="text-muted-foreground">GiB</span>
           </div>
+          {snapshot.gpu > 0 && (
+            <>
+              <div className="w-[1px] h-6 bg-muted-foreground/20 rounded-full inline-block"></div>
+              <div className="whitespace-nowrap">
+                {snapshot.gpu} <span className="text-muted-foreground">GPU</span>
+              </div>
+            </>
+          )}
         </div>
       )
     },

--- a/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
+++ b/apps/dashboard/src/components/snapshots/SnapshotTable/columns.tsx
@@ -238,7 +238,6 @@ const columns: ColumnDef<SnapshotDto>[] = [
   {
     id: 'resources',
     size: 190,
-    maxSize: 190,
     enableSorting: false,
     header: 'Resources',
     cell: ({ row }) => {

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -241,7 +241,7 @@ export default function Limits() {
   )
 }
 
-type ResourceType = 'compute' | 'memory' | 'storage' | 'gpu'
+type ResourceType = 'compute' | 'memory' | 'storage'
 
 interface LimitItem {
   value?: number | null
@@ -274,20 +274,21 @@ function buildSandboxLimitItems(region: RegionUsageOverview | null, org: Organiz
   const diskGpu = gpuEnabled ? region?.maxDiskPerGpuSandbox : null
 
   const showNonEphemSplit = diskNonEphem != null && diskNonEphem > 0 && diskNonEphem !== diskBase
+  const showStorageGpuVariant = diskGpu != null && diskGpu !== diskBase
 
-  if (showNonEphemSplit) {
-    items.push({ resourceType: 'storage', label: 'Storage (Ephemeral)', value: diskBase, unit: 'GiB' })
-    items.push({ resourceType: 'storage', label: 'Storage (Non-Ephemeral)', value: diskNonEphem, unit: 'GiB' })
-  } else {
-    items.push({ resourceType: 'storage', label: 'Storage', value: diskBase, unit: 'GiB' })
-  }
+  items.push({
+    resourceType: 'storage',
+    label: showNonEphemSplit ? 'Storage (Ephemeral)' : 'Storage',
+    value: diskBase,
+    unit: 'GiB',
+  })
 
-  if (diskGpu != null && diskGpu !== diskBase) {
+  if (showStorageGpuVariant) {
     items.push({ resourceType: 'storage', label: 'Storage (GPU)', value: diskGpu, unit: 'GiB' })
   }
 
-  if (gpuEnabled) {
-    items.push({ resourceType: 'gpu', label: 'GPU', value: 1, unit: 'GPU' })
+  if (showNonEphemSplit) {
+    items.push({ resourceType: 'storage', label: 'Storage (Non-Ephemeral)', value: diskNonEphem, unit: 'GiB' })
   }
 
   return items
@@ -319,9 +320,7 @@ function RateLimits({
         <div className="text-muted-foreground text-sm">{description}</div>
       </div>
       {grouped ? (
-        <div
-          className={cn('grid grid-cols-1 gap-2 sm:gap-4', grouped.length === 4 ? 'sm:grid-cols-4' : 'sm:grid-cols-3')}
-        >
+        <div className="grid grid-cols-1 gap-2 sm:gap-4 sm:grid-cols-3">
           {grouped.map((column) => (
             <div key={column[0].resourceType} className="flex flex-col gap-2 sm:gap-4">
               {column.map(

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -20,7 +20,7 @@ import { useConfig } from '@/hooks/useConfig'
 import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
-import type { RegionUsageOverview } from '@daytona/api-client'
+import type { Organization, RegionUsageOverview } from '@daytona/api-client'
 import { keepPreviousData } from '@tanstack/react-query'
 import { RefreshCcw } from 'lucide-react'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -171,27 +171,7 @@ export default function Limits() {
                   title="Sandbox Limits"
                   description="Resources limit per sandbox."
                   className="border-t border-border"
-                  rateLimits={[
-                    {
-                      label: 'Compute',
-                      value: currentRegionUsageOverview?.maxCpuPerSandbox ?? selectedOrganization?.maxCpuPerSandbox,
-                      unit: 'vCPU',
-                    },
-                    {
-                      label: 'Memory',
-                      value:
-                        currentRegionUsageOverview?.maxMemoryPerSandbox ?? selectedOrganization?.maxMemoryPerSandbox,
-                      unit: 'GiB',
-                    },
-                    {
-                      label: 'Storage',
-                      value: currentRegionUsageOverview?.maxDiskPerSandbox ?? selectedOrganization?.maxDiskPerSandbox,
-                      unit: 'GiB',
-                    },
-                    ...((currentRegionUsageOverview?.totalGpuQuota ?? 0) > 0
-                      ? [{ label: 'GPU', value: 1, unit: 'GPU' }]
-                      : []),
-                  ]}
+                  rateLimits={buildSandboxLimitItems(currentRegionUsageOverview, selectedOrganization)}
                 />
 
                 <RateLimits
@@ -261,11 +241,56 @@ export default function Limits() {
   )
 }
 
+type ResourceType = 'compute' | 'memory' | 'storage' | 'gpu'
+
 interface LimitItem {
   value?: number | null
   unit?: string
   label: string
   ttlSeconds?: number | null
+  resourceType?: ResourceType
+}
+
+function buildSandboxLimitItems(region: RegionUsageOverview | null, org: Organization | null | undefined): LimitItem[] {
+  const items: LimitItem[] = []
+  const gpuEnabled = (region?.totalGpuQuota ?? 0) > 0
+
+  const cpuBase = region?.maxCpuPerSandbox ?? org?.maxCpuPerSandbox
+  const cpuGpu = gpuEnabled ? region?.maxCpuPerGpuSandbox : null
+  items.push({ resourceType: 'compute', label: 'Compute', value: cpuBase, unit: 'vCPU' })
+  if (cpuGpu != null && cpuGpu !== cpuBase) {
+    items.push({ resourceType: 'compute', label: 'Compute (GPU)', value: cpuGpu, unit: 'vCPU' })
+  }
+
+  const memBase = region?.maxMemoryPerSandbox ?? org?.maxMemoryPerSandbox
+  const memGpu = gpuEnabled ? region?.maxMemoryPerGpuSandbox : null
+  items.push({ resourceType: 'memory', label: 'Memory', value: memBase, unit: 'GiB' })
+  if (memGpu != null && memGpu !== memBase) {
+    items.push({ resourceType: 'memory', label: 'Memory (GPU)', value: memGpu, unit: 'GiB' })
+  }
+
+  const diskBase = region?.maxDiskPerSandbox ?? org?.maxDiskPerSandbox
+  const diskNonEphem = region?.maxDiskPerNonEphemeralSandbox
+  const diskGpu = gpuEnabled ? region?.maxDiskPerGpuSandbox : null
+
+  const showNonEphemSplit = diskNonEphem != null && diskNonEphem > 0 && diskNonEphem !== diskBase
+
+  if (showNonEphemSplit) {
+    items.push({ resourceType: 'storage', label: 'Storage (Ephemeral)', value: diskBase, unit: 'GiB' })
+    items.push({ resourceType: 'storage', label: 'Storage (Non-Ephemeral)', value: diskNonEphem, unit: 'GiB' })
+  } else {
+    items.push({ resourceType: 'storage', label: 'Storage', value: diskBase, unit: 'GiB' })
+  }
+
+  if (diskGpu != null && diskGpu !== diskBase) {
+    items.push({ resourceType: 'storage', label: 'Storage (GPU)', value: diskGpu, unit: 'GiB' })
+  }
+
+  if (gpuEnabled) {
+    items.push({ resourceType: 'gpu', label: 'GPU', value: 1, unit: 'GPU' })
+  }
+
+  return items
 }
 
 function RateLimits({
@@ -280,9 +305,12 @@ function RateLimits({
   description: ReactNode
 }) {
   const isEmpty = rateLimits.every(({ value }) => !value)
-  if (isEmpty) {
-    return null
-  }
+  if (isEmpty) return null
+
+  // When items carry resourceType, render each type as its own desktop column
+  // (variants stack vertically within the column). Otherwise fall back to the
+  // flat grid used by sections like "Rate Limits".
+  const grouped = groupByResourceType(rateLimits)
 
   return (
     <div className={cn('p-4 border-t border-border flex flex-col gap-4', className)}>
@@ -290,14 +318,48 @@ function RateLimits({
         <div className="text-foreground text-sm font-medium">{title}</div>
         <div className="text-muted-foreground text-sm">{description}</div>
       </div>
-      <div className="grid grid-cols-1 gap-2 sm:gap-4 sm:grid-cols-3">
-        {rateLimits.map(
-          ({ label, value, unit, ttlSeconds }) =>
-            value && <RateLimitItem key={label} label={label} value={value} unit={unit} ttlSeconds={ttlSeconds} />,
-        )}
-      </div>
+      {grouped ? (
+        <div
+          className={cn('grid grid-cols-1 gap-2 sm:gap-4', grouped.length === 4 ? 'sm:grid-cols-4' : 'sm:grid-cols-3')}
+        >
+          {grouped.map((column) => (
+            <div key={column[0].resourceType} className="flex flex-col gap-2 sm:gap-4">
+              {column.map(
+                ({ label, value, unit, ttlSeconds }) =>
+                  value && (
+                    <RateLimitItem key={label} label={label} value={value} unit={unit} ttlSeconds={ttlSeconds} />
+                  ),
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-2 sm:gap-4 sm:grid-cols-3">
+          {rateLimits.map(
+            ({ label, value, unit, ttlSeconds }) =>
+              value && <RateLimitItem key={label} label={label} value={value} unit={unit} ttlSeconds={ttlSeconds} />,
+          )}
+        </div>
+      )}
     </div>
   )
+}
+
+function groupByResourceType(items: LimitItem[]): LimitItem[][] | null {
+  if (!items.some((item) => item.resourceType !== undefined)) {
+    return null
+  }
+  const groups = new Map<ResourceType, LimitItem[]>()
+  for (const item of items) {
+    if (!item.resourceType) continue
+    const existing = groups.get(item.resourceType)
+    if (existing) {
+      existing.push(item)
+    } else {
+      groups.set(item.resourceType, [item])
+    }
+  }
+  return Array.from(groups.values())
 }
 
 function formatTtl(ttlSeconds?: number | null): string {

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -188,6 +188,9 @@ export default function Limits() {
                       value: currentRegionUsageOverview?.maxDiskPerSandbox ?? selectedOrganization?.maxDiskPerSandbox,
                       unit: 'GiB',
                     },
+                    ...((currentRegionUsageOverview?.totalGpuQuota ?? 0) > 0
+                      ? [{ label: 'GPU', value: 1, unit: 'GPU' }]
+                      : []),
                   ]}
                 />
 

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9930,14 +9930,16 @@ components:
     RegionUsageOverview:
       example:
         totalCpuQuota: 0.8008281904610115
-        maxCpuPerSandbox: 7.061401241503109
-        maxDiskPerSandbox: 3.616076749251911
-        maxDiskPerNonEphemeralSandbox: 2.027123023002322
+        currentGpuUsage: 9.301444243932576
+        totalGpuQuota: 7.061401241503109
+        maxCpuPerSandbox: 3.616076749251911
+        maxDiskPerSandbox: 4.145608029883936
+        maxDiskPerNonEphemeralSandbox: 7.386281948385884
         regionId: regionId
         currentDiskUsage: 2.3021358869347655
         currentMemoryUsage: 5.962133916683182
         currentCpuUsage: 6.027456183070403
-        maxMemoryPerSandbox: 9.301444243932576
+        maxMemoryPerSandbox: 2.027123023002322
         totalMemoryQuota: 1.4658129805029452
         totalDiskQuota: 5.637376656633329
       properties:
@@ -9955,6 +9957,10 @@ components:
           type: number
         currentDiskUsage:
           type: number
+        totalGpuQuota:
+          type: number
+        currentGpuUsage:
+          type: number
         maxCpuPerSandbox:
           nullable: true
           type: number
@@ -9970,6 +9976,7 @@ components:
       required:
       - currentCpuUsage
       - currentDiskUsage
+      - currentGpuUsage
       - currentMemoryUsage
       - maxCpuPerSandbox
       - maxDiskPerNonEphemeralSandbox
@@ -9978,35 +9985,40 @@ components:
       - regionId
       - totalCpuQuota
       - totalDiskQuota
+      - totalGpuQuota
       - totalMemoryQuota
       type: object
     OrganizationUsageOverview:
       example:
-        totalSnapshotQuota: 4.145608029883936
-        currentVolumeUsage: 1.0246457001441578
-        totalVolumeQuota: 1.2315135367772556
-        currentSnapshotUsage: 7.386281948385884
+        totalSnapshotQuota: 1.2315135367772556
+        currentVolumeUsage: 6.84685269835264
+        totalVolumeQuota: 1.4894159098541704
+        currentSnapshotUsage: 1.0246457001441578
         regionUsage:
         - totalCpuQuota: 0.8008281904610115
-          maxCpuPerSandbox: 7.061401241503109
-          maxDiskPerSandbox: 3.616076749251911
-          maxDiskPerNonEphemeralSandbox: 2.027123023002322
+          currentGpuUsage: 9.301444243932576
+          totalGpuQuota: 7.061401241503109
+          maxCpuPerSandbox: 3.616076749251911
+          maxDiskPerSandbox: 4.145608029883936
+          maxDiskPerNonEphemeralSandbox: 7.386281948385884
           regionId: regionId
           currentDiskUsage: 2.3021358869347655
           currentMemoryUsage: 5.962133916683182
           currentCpuUsage: 6.027456183070403
-          maxMemoryPerSandbox: 9.301444243932576
+          maxMemoryPerSandbox: 2.027123023002322
           totalMemoryQuota: 1.4658129805029452
           totalDiskQuota: 5.637376656633329
         - totalCpuQuota: 0.8008281904610115
-          maxCpuPerSandbox: 7.061401241503109
-          maxDiskPerSandbox: 3.616076749251911
-          maxDiskPerNonEphemeralSandbox: 2.027123023002322
+          currentGpuUsage: 9.301444243932576
+          totalGpuQuota: 7.061401241503109
+          maxCpuPerSandbox: 3.616076749251911
+          maxDiskPerSandbox: 4.145608029883936
+          maxDiskPerNonEphemeralSandbox: 7.386281948385884
           regionId: regionId
           currentDiskUsage: 2.3021358869347655
           currentMemoryUsage: 5.962133916683182
           currentCpuUsage: 6.027456183070403
-          maxMemoryPerSandbox: 9.301444243932576
+          maxMemoryPerSandbox: 2.027123023002322
           totalMemoryQuota: 1.4658129805029452
           totalDiskQuota: 5.637376656633329
       properties:
@@ -10103,10 +10115,11 @@ components:
     UpdateOrganizationRegionQuota:
       example:
         totalCpuQuota: 0.8008281904610115
-        maxCpuPerSandbox: 5.962133916683182
-        maxDiskPerSandbox: 2.3021358869347655
-        maxDiskPerNonEphemeralSandbox: 7.061401241503109
-        maxMemoryPerSandbox: 5.637376656633329
+        maxCpuPerSandbox: 5.637376656633329
+        maxDiskPerSandbox: 7.061401241503109
+        maxDiskPerNonEphemeralSandbox: 9.301444243932576
+        maxMemoryPerSandbox: 2.3021358869347655
+        totalGpuQuota: 5.962133916683182
         totalMemoryQuota: 6.027456183070403
         totalDiskQuota: 1.4658129805029452
       properties:
@@ -10117,6 +10130,9 @@ components:
           nullable: true
           type: number
         totalDiskQuota:
+          nullable: true
+          type: number
+        totalGpuQuota:
           nullable: true
           type: number
         maxCpuPerSandbox:
@@ -10134,6 +10150,7 @@ components:
       required:
       - totalCpuQuota
       - totalDiskQuota
+      - totalGpuQuota
       - totalMemoryQuota
       type: object
     OrganizationSuspension:
@@ -11485,11 +11502,12 @@ components:
       example:
         organizationId: organizationId
         totalCpuQuota: 0.8008281904610115
-        maxCpuPerSandbox: 5.962133916683182
-        maxDiskPerSandbox: 2.3021358869347655
-        maxDiskPerNonEphemeralSandbox: 7.061401241503109
+        maxCpuPerSandbox: 5.637376656633329
+        maxDiskPerSandbox: 7.061401241503109
+        maxDiskPerNonEphemeralSandbox: 9.301444243932576
         regionId: regionId
-        maxMemoryPerSandbox: 5.637376656633329
+        maxMemoryPerSandbox: 2.3021358869347655
+        totalGpuQuota: 5.962133916683182
         totalMemoryQuota: 6.027456183070403
         totalDiskQuota: 1.4658129805029452
       properties:
@@ -11502,6 +11520,8 @@ components:
         totalMemoryQuota:
           type: number
         totalDiskQuota:
+          type: number
+        totalGpuQuota:
           type: number
         maxCpuPerSandbox:
           nullable: true
@@ -11524,6 +11544,7 @@ components:
       - regionId
       - totalCpuQuota
       - totalDiskQuota
+      - totalGpuQuota
       - totalMemoryQuota
       type: object
     CreateRunner:

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9931,7 +9931,9 @@ components:
       example:
         totalCpuQuota: 0.8008281904610115
         currentGpuUsage: 9.301444243932576
+        maxDiskPerGpuSandbox: 1.4894159098541704
         totalGpuQuota: 7.061401241503109
+        maxCpuPerGpuSandbox: 1.2315135367772556
         maxCpuPerSandbox: 3.616076749251911
         maxDiskPerSandbox: 4.145608029883936
         maxDiskPerNonEphemeralSandbox: 7.386281948385884
@@ -9942,6 +9944,7 @@ components:
         maxMemoryPerSandbox: 2.027123023002322
         totalMemoryQuota: 1.4658129805029452
         totalDiskQuota: 5.637376656633329
+        maxMemoryPerGpuSandbox: 1.0246457001441578
       properties:
         regionId:
           type: string
@@ -9973,14 +9976,26 @@ components:
         maxDiskPerNonEphemeralSandbox:
           nullable: true
           type: number
+        maxCpuPerGpuSandbox:
+          nullable: true
+          type: number
+        maxMemoryPerGpuSandbox:
+          nullable: true
+          type: number
+        maxDiskPerGpuSandbox:
+          nullable: true
+          type: number
       required:
       - currentCpuUsage
       - currentDiskUsage
       - currentGpuUsage
       - currentMemoryUsage
+      - maxCpuPerGpuSandbox
       - maxCpuPerSandbox
+      - maxDiskPerGpuSandbox
       - maxDiskPerNonEphemeralSandbox
       - maxDiskPerSandbox
+      - maxMemoryPerGpuSandbox
       - maxMemoryPerSandbox
       - regionId
       - totalCpuQuota
@@ -9990,14 +10005,16 @@ components:
       type: object
     OrganizationUsageOverview:
       example:
-        totalSnapshotQuota: 1.2315135367772556
-        currentVolumeUsage: 6.84685269835264
-        totalVolumeQuota: 1.4894159098541704
-        currentSnapshotUsage: 1.0246457001441578
+        totalSnapshotQuota: 6.84685269835264
+        currentVolumeUsage: 4.965218492984954
+        totalVolumeQuota: 1.1730742509559433
+        currentSnapshotUsage: 7.457744773683766
         regionUsage:
         - totalCpuQuota: 0.8008281904610115
           currentGpuUsage: 9.301444243932576
+          maxDiskPerGpuSandbox: 1.4894159098541704
           totalGpuQuota: 7.061401241503109
+          maxCpuPerGpuSandbox: 1.2315135367772556
           maxCpuPerSandbox: 3.616076749251911
           maxDiskPerSandbox: 4.145608029883936
           maxDiskPerNonEphemeralSandbox: 7.386281948385884
@@ -10008,9 +10025,12 @@ components:
           maxMemoryPerSandbox: 2.027123023002322
           totalMemoryQuota: 1.4658129805029452
           totalDiskQuota: 5.637376656633329
+          maxMemoryPerGpuSandbox: 1.0246457001441578
         - totalCpuQuota: 0.8008281904610115
           currentGpuUsage: 9.301444243932576
+          maxDiskPerGpuSandbox: 1.4894159098541704
           totalGpuQuota: 7.061401241503109
+          maxCpuPerGpuSandbox: 1.2315135367772556
           maxCpuPerSandbox: 3.616076749251911
           maxDiskPerSandbox: 4.145608029883936
           maxDiskPerNonEphemeralSandbox: 7.386281948385884
@@ -10021,6 +10041,7 @@ components:
           maxMemoryPerSandbox: 2.027123023002322
           totalMemoryQuota: 1.4658129805029452
           totalDiskQuota: 5.637376656633329
+          maxMemoryPerGpuSandbox: 1.0246457001441578
       properties:
         regionUsage:
           items:
@@ -10118,10 +10139,13 @@ components:
         maxCpuPerSandbox: 5.637376656633329
         maxDiskPerSandbox: 7.061401241503109
         maxDiskPerNonEphemeralSandbox: 9.301444243932576
+        maxDiskPerGpuSandbox: 4.145608029883936
         maxMemoryPerSandbox: 2.3021358869347655
         totalGpuQuota: 5.962133916683182
         totalMemoryQuota: 6.027456183070403
         totalDiskQuota: 1.4658129805029452
+        maxCpuPerGpuSandbox: 3.616076749251911
+        maxMemoryPerGpuSandbox: 2.027123023002322
       properties:
         totalCpuQuota:
           nullable: true
@@ -10145,6 +10169,15 @@ components:
           nullable: true
           type: number
         maxDiskPerNonEphemeralSandbox:
+          nullable: true
+          type: number
+        maxCpuPerGpuSandbox:
+          nullable: true
+          type: number
+        maxMemoryPerGpuSandbox:
+          nullable: true
+          type: number
+        maxDiskPerGpuSandbox:
           nullable: true
           type: number
       required:
@@ -11500,16 +11533,19 @@ components:
       type: object
     RegionQuota:
       example:
-        organizationId: organizationId
         totalCpuQuota: 0.8008281904610115
+        maxDiskPerGpuSandbox: 4.145608029883936
+        totalGpuQuota: 5.962133916683182
+        maxCpuPerGpuSandbox: 3.616076749251911
+        organizationId: organizationId
         maxCpuPerSandbox: 5.637376656633329
         maxDiskPerSandbox: 7.061401241503109
         maxDiskPerNonEphemeralSandbox: 9.301444243932576
         regionId: regionId
         maxMemoryPerSandbox: 2.3021358869347655
-        totalGpuQuota: 5.962133916683182
         totalMemoryQuota: 6.027456183070403
         totalDiskQuota: 1.4658129805029452
+        maxMemoryPerGpuSandbox: 2.027123023002322
       properties:
         organizationId:
           type: string
@@ -11535,10 +11571,22 @@ components:
         maxDiskPerNonEphemeralSandbox:
           nullable: true
           type: number
+        maxCpuPerGpuSandbox:
+          nullable: true
+          type: number
+        maxMemoryPerGpuSandbox:
+          nullable: true
+          type: number
+        maxDiskPerGpuSandbox:
+          nullable: true
+          type: number
       required:
+      - maxCpuPerGpuSandbox
       - maxCpuPerSandbox
+      - maxDiskPerGpuSandbox
       - maxDiskPerNonEphemeralSandbox
       - maxDiskPerSandbox
+      - maxMemoryPerGpuSandbox
       - maxMemoryPerSandbox
       - organizationId
       - regionId

--- a/libs/api-client-go/model_region_quota.go
+++ b/libs/api-client-go/model_region_quota.go
@@ -26,6 +26,7 @@ type RegionQuota struct {
 	TotalCpuQuota float32 `json:"totalCpuQuota"`
 	TotalMemoryQuota float32 `json:"totalMemoryQuota"`
 	TotalDiskQuota float32 `json:"totalDiskQuota"`
+	TotalGpuQuota float32 `json:"totalGpuQuota"`
 	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
@@ -39,13 +40,14 @@ type _RegionQuota RegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionQuota {
+func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, totalGpuQuota float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionQuota {
 	this := RegionQuota{}
 	this.OrganizationId = organizationId
 	this.RegionId = regionId
 	this.TotalCpuQuota = totalCpuQuota
 	this.TotalMemoryQuota = totalMemoryQuota
 	this.TotalDiskQuota = totalDiskQuota
+	this.TotalGpuQuota = totalGpuQuota
 	this.MaxCpuPerSandbox = maxCpuPerSandbox
 	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
 	this.MaxDiskPerSandbox = maxDiskPerSandbox
@@ -181,6 +183,30 @@ func (o *RegionQuota) SetTotalDiskQuota(v float32) {
 	o.TotalDiskQuota = v
 }
 
+// GetTotalGpuQuota returns the TotalGpuQuota field value
+func (o *RegionQuota) GetTotalGpuQuota() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.TotalGpuQuota
+}
+
+// GetTotalGpuQuotaOk returns a tuple with the TotalGpuQuota field value
+// and a boolean to check if the value has been set.
+func (o *RegionQuota) GetTotalGpuQuotaOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.TotalGpuQuota, true
+}
+
+// SetTotalGpuQuota sets field value
+func (o *RegionQuota) SetTotalGpuQuota(v float32) {
+	o.TotalGpuQuota = v
+}
+
 // GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value
 // If the value is explicit nil, the zero value for float32 will be returned
 func (o *RegionQuota) GetMaxCpuPerSandbox() float32 {
@@ -300,6 +326,7 @@ func (o RegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["totalCpuQuota"] = o.TotalCpuQuota
 	toSerialize["totalMemoryQuota"] = o.TotalMemoryQuota
 	toSerialize["totalDiskQuota"] = o.TotalDiskQuota
+	toSerialize["totalGpuQuota"] = o.TotalGpuQuota
 	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
 	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
 	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
@@ -322,6 +349,7 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"totalCpuQuota",
 		"totalMemoryQuota",
 		"totalDiskQuota",
+		"totalGpuQuota",
 		"maxCpuPerSandbox",
 		"maxMemoryPerSandbox",
 		"maxDiskPerSandbox",
@@ -360,6 +388,7 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "totalCpuQuota")
 		delete(additionalProperties, "totalMemoryQuota")
 		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "totalGpuQuota")
 		delete(additionalProperties, "maxCpuPerSandbox")
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")

--- a/libs/api-client-go/model_region_quota.go
+++ b/libs/api-client-go/model_region_quota.go
@@ -31,6 +31,9 @@ type RegionQuota struct {
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
 	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox"`
+	MaxCpuPerGpuSandbox NullableFloat32 `json:"maxCpuPerGpuSandbox"`
+	MaxMemoryPerGpuSandbox NullableFloat32 `json:"maxMemoryPerGpuSandbox"`
+	MaxDiskPerGpuSandbox NullableFloat32 `json:"maxDiskPerGpuSandbox"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -40,7 +43,7 @@ type _RegionQuota RegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, totalGpuQuota float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionQuota {
+func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float32, totalMemoryQuota float32, totalDiskQuota float32, totalGpuQuota float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32, maxCpuPerGpuSandbox NullableFloat32, maxMemoryPerGpuSandbox NullableFloat32, maxDiskPerGpuSandbox NullableFloat32) *RegionQuota {
 	this := RegionQuota{}
 	this.OrganizationId = organizationId
 	this.RegionId = regionId
@@ -52,6 +55,9 @@ func NewRegionQuota(organizationId string, regionId string, totalCpuQuota float3
 	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
 	this.MaxDiskPerSandbox = maxDiskPerSandbox
 	this.MaxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
+	this.MaxCpuPerGpuSandbox = maxCpuPerGpuSandbox
+	this.MaxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox
+	this.MaxDiskPerGpuSandbox = maxDiskPerGpuSandbox
 	return &this
 }
 
@@ -311,6 +317,84 @@ func (o *RegionQuota) SetMaxDiskPerNonEphemeralSandbox(v float32) {
 	o.MaxDiskPerNonEphemeralSandbox.Set(&v)
 }
 
+// GetMaxCpuPerGpuSandbox returns the MaxCpuPerGpuSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionQuota) GetMaxCpuPerGpuSandbox() float32 {
+	if o == nil || o.MaxCpuPerGpuSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxCpuPerGpuSandbox.Get()
+}
+
+// GetMaxCpuPerGpuSandboxOk returns a tuple with the MaxCpuPerGpuSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionQuota) GetMaxCpuPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxCpuPerGpuSandbox.Get(), o.MaxCpuPerGpuSandbox.IsSet()
+}
+
+// SetMaxCpuPerGpuSandbox sets field value
+func (o *RegionQuota) SetMaxCpuPerGpuSandbox(v float32) {
+	o.MaxCpuPerGpuSandbox.Set(&v)
+}
+
+// GetMaxMemoryPerGpuSandbox returns the MaxMemoryPerGpuSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionQuota) GetMaxMemoryPerGpuSandbox() float32 {
+	if o == nil || o.MaxMemoryPerGpuSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxMemoryPerGpuSandbox.Get()
+}
+
+// GetMaxMemoryPerGpuSandboxOk returns a tuple with the MaxMemoryPerGpuSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionQuota) GetMaxMemoryPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxMemoryPerGpuSandbox.Get(), o.MaxMemoryPerGpuSandbox.IsSet()
+}
+
+// SetMaxMemoryPerGpuSandbox sets field value
+func (o *RegionQuota) SetMaxMemoryPerGpuSandbox(v float32) {
+	o.MaxMemoryPerGpuSandbox.Set(&v)
+}
+
+// GetMaxDiskPerGpuSandbox returns the MaxDiskPerGpuSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionQuota) GetMaxDiskPerGpuSandbox() float32 {
+	if o == nil || o.MaxDiskPerGpuSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerGpuSandbox.Get()
+}
+
+// GetMaxDiskPerGpuSandboxOk returns a tuple with the MaxDiskPerGpuSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionQuota) GetMaxDiskPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerGpuSandbox.Get(), o.MaxDiskPerGpuSandbox.IsSet()
+}
+
+// SetMaxDiskPerGpuSandbox sets field value
+func (o *RegionQuota) SetMaxDiskPerGpuSandbox(v float32) {
+	o.MaxDiskPerGpuSandbox.Set(&v)
+}
+
 func (o RegionQuota) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -331,6 +415,9 @@ func (o RegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
 	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
 	toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
+	toSerialize["maxCpuPerGpuSandbox"] = o.MaxCpuPerGpuSandbox.Get()
+	toSerialize["maxMemoryPerGpuSandbox"] = o.MaxMemoryPerGpuSandbox.Get()
+	toSerialize["maxDiskPerGpuSandbox"] = o.MaxDiskPerGpuSandbox.Get()
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -354,6 +441,9 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"maxMemoryPerSandbox",
 		"maxDiskPerSandbox",
 		"maxDiskPerNonEphemeralSandbox",
+		"maxCpuPerGpuSandbox",
+		"maxMemoryPerGpuSandbox",
+		"maxDiskPerGpuSandbox",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -393,6 +483,9 @@ func (o *RegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")
 		delete(additionalProperties, "maxDiskPerNonEphemeralSandbox")
+		delete(additionalProperties, "maxCpuPerGpuSandbox")
+		delete(additionalProperties, "maxMemoryPerGpuSandbox")
+		delete(additionalProperties, "maxDiskPerGpuSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-go/model_region_usage_overview.go
+++ b/libs/api-client-go/model_region_usage_overview.go
@@ -34,6 +34,9 @@ type RegionUsageOverview struct {
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
 	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox"`
+	MaxCpuPerGpuSandbox NullableFloat32 `json:"maxCpuPerGpuSandbox"`
+	MaxMemoryPerGpuSandbox NullableFloat32 `json:"maxMemoryPerGpuSandbox"`
+	MaxDiskPerGpuSandbox NullableFloat32 `json:"maxDiskPerGpuSandbox"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -43,7 +46,7 @@ type _RegionUsageOverview RegionUsageOverview
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUsage float32, totalMemoryQuota float32, currentMemoryUsage float32, totalDiskQuota float32, currentDiskUsage float32, totalGpuQuota float32, currentGpuUsage float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionUsageOverview {
+func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUsage float32, totalMemoryQuota float32, currentMemoryUsage float32, totalDiskQuota float32, currentDiskUsage float32, totalGpuQuota float32, currentGpuUsage float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32, maxCpuPerGpuSandbox NullableFloat32, maxMemoryPerGpuSandbox NullableFloat32, maxDiskPerGpuSandbox NullableFloat32) *RegionUsageOverview {
 	this := RegionUsageOverview{}
 	this.RegionId = regionId
 	this.TotalCpuQuota = totalCpuQuota
@@ -58,6 +61,9 @@ func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUs
 	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
 	this.MaxDiskPerSandbox = maxDiskPerSandbox
 	this.MaxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
+	this.MaxCpuPerGpuSandbox = maxCpuPerGpuSandbox
+	this.MaxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox
+	this.MaxDiskPerGpuSandbox = maxDiskPerGpuSandbox
 	return &this
 }
 
@@ -389,6 +395,84 @@ func (o *RegionUsageOverview) SetMaxDiskPerNonEphemeralSandbox(v float32) {
 	o.MaxDiskPerNonEphemeralSandbox.Set(&v)
 }
 
+// GetMaxCpuPerGpuSandbox returns the MaxCpuPerGpuSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionUsageOverview) GetMaxCpuPerGpuSandbox() float32 {
+	if o == nil || o.MaxCpuPerGpuSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxCpuPerGpuSandbox.Get()
+}
+
+// GetMaxCpuPerGpuSandboxOk returns a tuple with the MaxCpuPerGpuSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionUsageOverview) GetMaxCpuPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxCpuPerGpuSandbox.Get(), o.MaxCpuPerGpuSandbox.IsSet()
+}
+
+// SetMaxCpuPerGpuSandbox sets field value
+func (o *RegionUsageOverview) SetMaxCpuPerGpuSandbox(v float32) {
+	o.MaxCpuPerGpuSandbox.Set(&v)
+}
+
+// GetMaxMemoryPerGpuSandbox returns the MaxMemoryPerGpuSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionUsageOverview) GetMaxMemoryPerGpuSandbox() float32 {
+	if o == nil || o.MaxMemoryPerGpuSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxMemoryPerGpuSandbox.Get()
+}
+
+// GetMaxMemoryPerGpuSandboxOk returns a tuple with the MaxMemoryPerGpuSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionUsageOverview) GetMaxMemoryPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxMemoryPerGpuSandbox.Get(), o.MaxMemoryPerGpuSandbox.IsSet()
+}
+
+// SetMaxMemoryPerGpuSandbox sets field value
+func (o *RegionUsageOverview) SetMaxMemoryPerGpuSandbox(v float32) {
+	o.MaxMemoryPerGpuSandbox.Set(&v)
+}
+
+// GetMaxDiskPerGpuSandbox returns the MaxDiskPerGpuSandbox field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *RegionUsageOverview) GetMaxDiskPerGpuSandbox() float32 {
+	if o == nil || o.MaxDiskPerGpuSandbox.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.MaxDiskPerGpuSandbox.Get()
+}
+
+// GetMaxDiskPerGpuSandboxOk returns a tuple with the MaxDiskPerGpuSandbox field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *RegionUsageOverview) GetMaxDiskPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerGpuSandbox.Get(), o.MaxDiskPerGpuSandbox.IsSet()
+}
+
+// SetMaxDiskPerGpuSandbox sets field value
+func (o *RegionUsageOverview) SetMaxDiskPerGpuSandbox(v float32) {
+	o.MaxDiskPerGpuSandbox.Set(&v)
+}
+
 func (o RegionUsageOverview) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -412,6 +496,9 @@ func (o RegionUsageOverview) ToMap() (map[string]interface{}, error) {
 	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
 	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
 	toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
+	toSerialize["maxCpuPerGpuSandbox"] = o.MaxCpuPerGpuSandbox.Get()
+	toSerialize["maxMemoryPerGpuSandbox"] = o.MaxMemoryPerGpuSandbox.Get()
+	toSerialize["maxDiskPerGpuSandbox"] = o.MaxDiskPerGpuSandbox.Get()
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -438,6 +525,9 @@ func (o *RegionUsageOverview) UnmarshalJSON(data []byte) (err error) {
 		"maxMemoryPerSandbox",
 		"maxDiskPerSandbox",
 		"maxDiskPerNonEphemeralSandbox",
+		"maxCpuPerGpuSandbox",
+		"maxMemoryPerGpuSandbox",
+		"maxDiskPerGpuSandbox",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -480,6 +570,9 @@ func (o *RegionUsageOverview) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")
 		delete(additionalProperties, "maxDiskPerNonEphemeralSandbox")
+		delete(additionalProperties, "maxCpuPerGpuSandbox")
+		delete(additionalProperties, "maxMemoryPerGpuSandbox")
+		delete(additionalProperties, "maxDiskPerGpuSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-go/model_region_usage_overview.go
+++ b/libs/api-client-go/model_region_usage_overview.go
@@ -28,6 +28,8 @@ type RegionUsageOverview struct {
 	CurrentMemoryUsage float32 `json:"currentMemoryUsage"`
 	TotalDiskQuota float32 `json:"totalDiskQuota"`
 	CurrentDiskUsage float32 `json:"currentDiskUsage"`
+	TotalGpuQuota float32 `json:"totalGpuQuota"`
+	CurrentGpuUsage float32 `json:"currentGpuUsage"`
 	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox"`
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox"`
@@ -41,7 +43,7 @@ type _RegionUsageOverview RegionUsageOverview
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUsage float32, totalMemoryQuota float32, currentMemoryUsage float32, totalDiskQuota float32, currentDiskUsage float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionUsageOverview {
+func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUsage float32, totalMemoryQuota float32, currentMemoryUsage float32, totalDiskQuota float32, currentDiskUsage float32, totalGpuQuota float32, currentGpuUsage float32, maxCpuPerSandbox NullableFloat32, maxMemoryPerSandbox NullableFloat32, maxDiskPerSandbox NullableFloat32, maxDiskPerNonEphemeralSandbox NullableFloat32) *RegionUsageOverview {
 	this := RegionUsageOverview{}
 	this.RegionId = regionId
 	this.TotalCpuQuota = totalCpuQuota
@@ -50,6 +52,8 @@ func NewRegionUsageOverview(regionId string, totalCpuQuota float32, currentCpuUs
 	this.CurrentMemoryUsage = currentMemoryUsage
 	this.TotalDiskQuota = totalDiskQuota
 	this.CurrentDiskUsage = currentDiskUsage
+	this.TotalGpuQuota = totalGpuQuota
+	this.CurrentGpuUsage = currentGpuUsage
 	this.MaxCpuPerSandbox = maxCpuPerSandbox
 	this.MaxMemoryPerSandbox = maxMemoryPerSandbox
 	this.MaxDiskPerSandbox = maxDiskPerSandbox
@@ -233,6 +237,54 @@ func (o *RegionUsageOverview) SetCurrentDiskUsage(v float32) {
 	o.CurrentDiskUsage = v
 }
 
+// GetTotalGpuQuota returns the TotalGpuQuota field value
+func (o *RegionUsageOverview) GetTotalGpuQuota() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.TotalGpuQuota
+}
+
+// GetTotalGpuQuotaOk returns a tuple with the TotalGpuQuota field value
+// and a boolean to check if the value has been set.
+func (o *RegionUsageOverview) GetTotalGpuQuotaOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.TotalGpuQuota, true
+}
+
+// SetTotalGpuQuota sets field value
+func (o *RegionUsageOverview) SetTotalGpuQuota(v float32) {
+	o.TotalGpuQuota = v
+}
+
+// GetCurrentGpuUsage returns the CurrentGpuUsage field value
+func (o *RegionUsageOverview) GetCurrentGpuUsage() float32 {
+	if o == nil {
+		var ret float32
+		return ret
+	}
+
+	return o.CurrentGpuUsage
+}
+
+// GetCurrentGpuUsageOk returns a tuple with the CurrentGpuUsage field value
+// and a boolean to check if the value has been set.
+func (o *RegionUsageOverview) GetCurrentGpuUsageOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.CurrentGpuUsage, true
+}
+
+// SetCurrentGpuUsage sets field value
+func (o *RegionUsageOverview) SetCurrentGpuUsage(v float32) {
+	o.CurrentGpuUsage = v
+}
+
 // GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value
 // If the value is explicit nil, the zero value for float32 will be returned
 func (o *RegionUsageOverview) GetMaxCpuPerSandbox() float32 {
@@ -354,6 +406,8 @@ func (o RegionUsageOverview) ToMap() (map[string]interface{}, error) {
 	toSerialize["currentMemoryUsage"] = o.CurrentMemoryUsage
 	toSerialize["totalDiskQuota"] = o.TotalDiskQuota
 	toSerialize["currentDiskUsage"] = o.CurrentDiskUsage
+	toSerialize["totalGpuQuota"] = o.TotalGpuQuota
+	toSerialize["currentGpuUsage"] = o.CurrentGpuUsage
 	toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
 	toSerialize["maxMemoryPerSandbox"] = o.MaxMemoryPerSandbox.Get()
 	toSerialize["maxDiskPerSandbox"] = o.MaxDiskPerSandbox.Get()
@@ -378,6 +432,8 @@ func (o *RegionUsageOverview) UnmarshalJSON(data []byte) (err error) {
 		"currentMemoryUsage",
 		"totalDiskQuota",
 		"currentDiskUsage",
+		"totalGpuQuota",
+		"currentGpuUsage",
 		"maxCpuPerSandbox",
 		"maxMemoryPerSandbox",
 		"maxDiskPerSandbox",
@@ -418,6 +474,8 @@ func (o *RegionUsageOverview) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "currentMemoryUsage")
 		delete(additionalProperties, "totalDiskQuota")
 		delete(additionalProperties, "currentDiskUsage")
+		delete(additionalProperties, "totalGpuQuota")
+		delete(additionalProperties, "currentGpuUsage")
 		delete(additionalProperties, "maxCpuPerSandbox")
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")

--- a/libs/api-client-go/model_update_organization_region_quota.go
+++ b/libs/api-client-go/model_update_organization_region_quota.go
@@ -24,6 +24,7 @@ type UpdateOrganizationRegionQuota struct {
 	TotalCpuQuota NullableFloat32 `json:"totalCpuQuota"`
 	TotalMemoryQuota NullableFloat32 `json:"totalMemoryQuota"`
 	TotalDiskQuota NullableFloat32 `json:"totalDiskQuota"`
+	TotalGpuQuota NullableFloat32 `json:"totalGpuQuota"`
 	MaxCpuPerSandbox NullableFloat32 `json:"maxCpuPerSandbox,omitempty"`
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox,omitempty"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox,omitempty"`
@@ -37,11 +38,12 @@ type _UpdateOrganizationRegionQuota UpdateOrganizationRegionQuota
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32) *UpdateOrganizationRegionQuota {
+func NewUpdateOrganizationRegionQuota(totalCpuQuota NullableFloat32, totalMemoryQuota NullableFloat32, totalDiskQuota NullableFloat32, totalGpuQuota NullableFloat32) *UpdateOrganizationRegionQuota {
 	this := UpdateOrganizationRegionQuota{}
 	this.TotalCpuQuota = totalCpuQuota
 	this.TotalMemoryQuota = totalMemoryQuota
 	this.TotalDiskQuota = totalDiskQuota
+	this.TotalGpuQuota = totalGpuQuota
 	return &this
 }
 
@@ -129,6 +131,32 @@ func (o *UpdateOrganizationRegionQuota) GetTotalDiskQuotaOk() (*float32, bool) {
 // SetTotalDiskQuota sets field value
 func (o *UpdateOrganizationRegionQuota) SetTotalDiskQuota(v float32) {
 	o.TotalDiskQuota.Set(&v)
+}
+
+// GetTotalGpuQuota returns the TotalGpuQuota field value
+// If the value is explicit nil, the zero value for float32 will be returned
+func (o *UpdateOrganizationRegionQuota) GetTotalGpuQuota() float32 {
+	if o == nil || o.TotalGpuQuota.Get() == nil {
+		var ret float32
+		return ret
+	}
+
+	return *o.TotalGpuQuota.Get()
+}
+
+// GetTotalGpuQuotaOk returns a tuple with the TotalGpuQuota field value
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetTotalGpuQuotaOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.TotalGpuQuota.Get(), o.TotalGpuQuota.IsSet()
+}
+
+// SetTotalGpuQuota sets field value
+func (o *UpdateOrganizationRegionQuota) SetTotalGpuQuota(v float32) {
+	o.TotalGpuQuota.Set(&v)
 }
 
 // GetMaxCpuPerSandbox returns the MaxCpuPerSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -312,6 +340,7 @@ func (o UpdateOrganizationRegionQuota) ToMap() (map[string]interface{}, error) {
 	toSerialize["totalCpuQuota"] = o.TotalCpuQuota.Get()
 	toSerialize["totalMemoryQuota"] = o.TotalMemoryQuota.Get()
 	toSerialize["totalDiskQuota"] = o.TotalDiskQuota.Get()
+	toSerialize["totalGpuQuota"] = o.TotalGpuQuota.Get()
 	if o.MaxCpuPerSandbox.IsSet() {
 		toSerialize["maxCpuPerSandbox"] = o.MaxCpuPerSandbox.Get()
 	}
@@ -340,6 +369,7 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		"totalCpuQuota",
 		"totalMemoryQuota",
 		"totalDiskQuota",
+		"totalGpuQuota",
 	}
 
 	allProperties := make(map[string]interface{})
@@ -372,6 +402,7 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "totalCpuQuota")
 		delete(additionalProperties, "totalMemoryQuota")
 		delete(additionalProperties, "totalDiskQuota")
+		delete(additionalProperties, "totalGpuQuota")
 		delete(additionalProperties, "maxCpuPerSandbox")
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")

--- a/libs/api-client-go/model_update_organization_region_quota.go
+++ b/libs/api-client-go/model_update_organization_region_quota.go
@@ -29,6 +29,9 @@ type UpdateOrganizationRegionQuota struct {
 	MaxMemoryPerSandbox NullableFloat32 `json:"maxMemoryPerSandbox,omitempty"`
 	MaxDiskPerSandbox NullableFloat32 `json:"maxDiskPerSandbox,omitempty"`
 	MaxDiskPerNonEphemeralSandbox NullableFloat32 `json:"maxDiskPerNonEphemeralSandbox,omitempty"`
+	MaxCpuPerGpuSandbox NullableFloat32 `json:"maxCpuPerGpuSandbox,omitempty"`
+	MaxMemoryPerGpuSandbox NullableFloat32 `json:"maxMemoryPerGpuSandbox,omitempty"`
+	MaxDiskPerGpuSandbox NullableFloat32 `json:"maxDiskPerGpuSandbox,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -327,6 +330,132 @@ func (o *UpdateOrganizationRegionQuota) UnsetMaxDiskPerNonEphemeralSandbox() {
 	o.MaxDiskPerNonEphemeralSandbox.Unset()
 }
 
+// GetMaxCpuPerGpuSandbox returns the MaxCpuPerGpuSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateOrganizationRegionQuota) GetMaxCpuPerGpuSandbox() float32 {
+	if o == nil || IsNil(o.MaxCpuPerGpuSandbox.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.MaxCpuPerGpuSandbox.Get()
+}
+
+// GetMaxCpuPerGpuSandboxOk returns a tuple with the MaxCpuPerGpuSandbox field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxCpuPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxCpuPerGpuSandbox.Get(), o.MaxCpuPerGpuSandbox.IsSet()
+}
+
+// HasMaxCpuPerGpuSandbox returns a boolean if a field has been set.
+func (o *UpdateOrganizationRegionQuota) HasMaxCpuPerGpuSandbox() bool {
+	if o != nil && o.MaxCpuPerGpuSandbox.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxCpuPerGpuSandbox gets a reference to the given NullableFloat32 and assigns it to the MaxCpuPerGpuSandbox field.
+func (o *UpdateOrganizationRegionQuota) SetMaxCpuPerGpuSandbox(v float32) {
+	o.MaxCpuPerGpuSandbox.Set(&v)
+}
+// SetMaxCpuPerGpuSandboxNil sets the value for MaxCpuPerGpuSandbox to be an explicit nil
+func (o *UpdateOrganizationRegionQuota) SetMaxCpuPerGpuSandboxNil() {
+	o.MaxCpuPerGpuSandbox.Set(nil)
+}
+
+// UnsetMaxCpuPerGpuSandbox ensures that no value is present for MaxCpuPerGpuSandbox, not even an explicit nil
+func (o *UpdateOrganizationRegionQuota) UnsetMaxCpuPerGpuSandbox() {
+	o.MaxCpuPerGpuSandbox.Unset()
+}
+
+// GetMaxMemoryPerGpuSandbox returns the MaxMemoryPerGpuSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateOrganizationRegionQuota) GetMaxMemoryPerGpuSandbox() float32 {
+	if o == nil || IsNil(o.MaxMemoryPerGpuSandbox.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.MaxMemoryPerGpuSandbox.Get()
+}
+
+// GetMaxMemoryPerGpuSandboxOk returns a tuple with the MaxMemoryPerGpuSandbox field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxMemoryPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxMemoryPerGpuSandbox.Get(), o.MaxMemoryPerGpuSandbox.IsSet()
+}
+
+// HasMaxMemoryPerGpuSandbox returns a boolean if a field has been set.
+func (o *UpdateOrganizationRegionQuota) HasMaxMemoryPerGpuSandbox() bool {
+	if o != nil && o.MaxMemoryPerGpuSandbox.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxMemoryPerGpuSandbox gets a reference to the given NullableFloat32 and assigns it to the MaxMemoryPerGpuSandbox field.
+func (o *UpdateOrganizationRegionQuota) SetMaxMemoryPerGpuSandbox(v float32) {
+	o.MaxMemoryPerGpuSandbox.Set(&v)
+}
+// SetMaxMemoryPerGpuSandboxNil sets the value for MaxMemoryPerGpuSandbox to be an explicit nil
+func (o *UpdateOrganizationRegionQuota) SetMaxMemoryPerGpuSandboxNil() {
+	o.MaxMemoryPerGpuSandbox.Set(nil)
+}
+
+// UnsetMaxMemoryPerGpuSandbox ensures that no value is present for MaxMemoryPerGpuSandbox, not even an explicit nil
+func (o *UpdateOrganizationRegionQuota) UnsetMaxMemoryPerGpuSandbox() {
+	o.MaxMemoryPerGpuSandbox.Unset()
+}
+
+// GetMaxDiskPerGpuSandbox returns the MaxDiskPerGpuSandbox field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerGpuSandbox() float32 {
+	if o == nil || IsNil(o.MaxDiskPerGpuSandbox.Get()) {
+		var ret float32
+		return ret
+	}
+	return *o.MaxDiskPerGpuSandbox.Get()
+}
+
+// GetMaxDiskPerGpuSandboxOk returns a tuple with the MaxDiskPerGpuSandbox field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateOrganizationRegionQuota) GetMaxDiskPerGpuSandboxOk() (*float32, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.MaxDiskPerGpuSandbox.Get(), o.MaxDiskPerGpuSandbox.IsSet()
+}
+
+// HasMaxDiskPerGpuSandbox returns a boolean if a field has been set.
+func (o *UpdateOrganizationRegionQuota) HasMaxDiskPerGpuSandbox() bool {
+	if o != nil && o.MaxDiskPerGpuSandbox.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxDiskPerGpuSandbox gets a reference to the given NullableFloat32 and assigns it to the MaxDiskPerGpuSandbox field.
+func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerGpuSandbox(v float32) {
+	o.MaxDiskPerGpuSandbox.Set(&v)
+}
+// SetMaxDiskPerGpuSandboxNil sets the value for MaxDiskPerGpuSandbox to be an explicit nil
+func (o *UpdateOrganizationRegionQuota) SetMaxDiskPerGpuSandboxNil() {
+	o.MaxDiskPerGpuSandbox.Set(nil)
+}
+
+// UnsetMaxDiskPerGpuSandbox ensures that no value is present for MaxDiskPerGpuSandbox, not even an explicit nil
+func (o *UpdateOrganizationRegionQuota) UnsetMaxDiskPerGpuSandbox() {
+	o.MaxDiskPerGpuSandbox.Unset()
+}
+
 func (o UpdateOrganizationRegionQuota) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -352,6 +481,15 @@ func (o UpdateOrganizationRegionQuota) ToMap() (map[string]interface{}, error) {
 	}
 	if o.MaxDiskPerNonEphemeralSandbox.IsSet() {
 		toSerialize["maxDiskPerNonEphemeralSandbox"] = o.MaxDiskPerNonEphemeralSandbox.Get()
+	}
+	if o.MaxCpuPerGpuSandbox.IsSet() {
+		toSerialize["maxCpuPerGpuSandbox"] = o.MaxCpuPerGpuSandbox.Get()
+	}
+	if o.MaxMemoryPerGpuSandbox.IsSet() {
+		toSerialize["maxMemoryPerGpuSandbox"] = o.MaxMemoryPerGpuSandbox.Get()
+	}
+	if o.MaxDiskPerGpuSandbox.IsSet() {
+		toSerialize["maxDiskPerGpuSandbox"] = o.MaxDiskPerGpuSandbox.Get()
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -407,6 +545,9 @@ func (o *UpdateOrganizationRegionQuota) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "maxMemoryPerSandbox")
 		delete(additionalProperties, "maxDiskPerSandbox")
 		delete(additionalProperties, "maxDiskPerNonEphemeralSandbox")
+		delete(additionalProperties, "maxCpuPerGpuSandbox")
+		delete(additionalProperties, "maxMemoryPerGpuSandbox")
+		delete(additionalProperties, "maxDiskPerGpuSandbox")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
@@ -76,6 +76,11 @@ public class RegionQuota {
   @javax.annotation.Nonnull
   private BigDecimal totalDiskQuota;
 
+  public static final String SERIALIZED_NAME_TOTAL_GPU_QUOTA = "totalGpuQuota";
+  @SerializedName(SERIALIZED_NAME_TOTAL_GPU_QUOTA)
+  @javax.annotation.Nonnull
+  private BigDecimal totalGpuQuota;
+
   public static final String SERIALIZED_NAME_MAX_CPU_PER_SANDBOX = "maxCpuPerSandbox";
   @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_SANDBOX)
   @javax.annotation.Nullable
@@ -191,6 +196,25 @@ public class RegionQuota {
 
   public void setTotalDiskQuota(@javax.annotation.Nonnull BigDecimal totalDiskQuota) {
     this.totalDiskQuota = totalDiskQuota;
+  }
+
+
+  public RegionQuota totalGpuQuota(@javax.annotation.Nonnull BigDecimal totalGpuQuota) {
+    this.totalGpuQuota = totalGpuQuota;
+    return this;
+  }
+
+  /**
+   * Get totalGpuQuota
+   * @return totalGpuQuota
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getTotalGpuQuota() {
+    return totalGpuQuota;
+  }
+
+  public void setTotalGpuQuota(@javax.annotation.Nonnull BigDecimal totalGpuQuota) {
+    this.totalGpuQuota = totalGpuQuota;
   }
 
 
@@ -329,6 +353,7 @@ public class RegionQuota {
         Objects.equals(this.totalCpuQuota, regionQuota.totalCpuQuota) &&
         Objects.equals(this.totalMemoryQuota, regionQuota.totalMemoryQuota) &&
         Objects.equals(this.totalDiskQuota, regionQuota.totalDiskQuota) &&
+        Objects.equals(this.totalGpuQuota, regionQuota.totalGpuQuota) &&
         Objects.equals(this.maxCpuPerSandbox, regionQuota.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, regionQuota.maxMemoryPerSandbox) &&
         Objects.equals(this.maxDiskPerSandbox, regionQuota.maxDiskPerSandbox) &&
@@ -338,7 +363,7 @@ public class RegionQuota {
 
   @Override
   public int hashCode() {
-    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
+    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, totalGpuQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
   }
 
   @Override
@@ -350,6 +375,7 @@ public class RegionQuota {
     sb.append("    totalCpuQuota: ").append(toIndentedString(totalCpuQuota)).append("\n");
     sb.append("    totalMemoryQuota: ").append(toIndentedString(totalMemoryQuota)).append("\n");
     sb.append("    totalDiskQuota: ").append(toIndentedString(totalDiskQuota)).append("\n");
+    sb.append("    totalGpuQuota: ").append(toIndentedString(totalGpuQuota)).append("\n");
     sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
@@ -373,10 +399,10 @@ public class RegionQuota {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionQuota.java
@@ -101,6 +101,21 @@ public class RegionQuota {
   @javax.annotation.Nullable
   private BigDecimal maxDiskPerNonEphemeralSandbox;
 
+  public static final String SERIALIZED_NAME_MAX_CPU_PER_GPU_SANDBOX = "maxCpuPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxCpuPerGpuSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_MEMORY_PER_GPU_SANDBOX = "maxMemoryPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_MEMORY_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxMemoryPerGpuSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_GPU_SANDBOX = "maxDiskPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerGpuSandbox;
+
   public RegionQuota() {
   }
 
@@ -293,6 +308,63 @@ public class RegionQuota {
     this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
   }
 
+
+  public RegionQuota maxCpuPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerGpuSandbox) {
+    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxCpuPerGpuSandbox
+   * @return maxCpuPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxCpuPerGpuSandbox() {
+    return maxCpuPerGpuSandbox;
+  }
+
+  public void setMaxCpuPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerGpuSandbox) {
+    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox;
+  }
+
+
+  public RegionQuota maxMemoryPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerGpuSandbox) {
+    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxMemoryPerGpuSandbox
+   * @return maxMemoryPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxMemoryPerGpuSandbox() {
+    return maxMemoryPerGpuSandbox;
+  }
+
+  public void setMaxMemoryPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerGpuSandbox) {
+    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox;
+  }
+
+
+  public RegionQuota maxDiskPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerGpuSandbox) {
+    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerGpuSandbox
+   * @return maxDiskPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerGpuSandbox() {
+    return maxDiskPerGpuSandbox;
+  }
+
+  public void setMaxDiskPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerGpuSandbox) {
+    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -357,13 +429,16 @@ public class RegionQuota {
         Objects.equals(this.maxCpuPerSandbox, regionQuota.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, regionQuota.maxMemoryPerSandbox) &&
         Objects.equals(this.maxDiskPerSandbox, regionQuota.maxDiskPerSandbox) &&
-        Objects.equals(this.maxDiskPerNonEphemeralSandbox, regionQuota.maxDiskPerNonEphemeralSandbox)&&
+        Objects.equals(this.maxDiskPerNonEphemeralSandbox, regionQuota.maxDiskPerNonEphemeralSandbox) &&
+        Objects.equals(this.maxCpuPerGpuSandbox, regionQuota.maxCpuPerGpuSandbox) &&
+        Objects.equals(this.maxMemoryPerGpuSandbox, regionQuota.maxMemoryPerGpuSandbox) &&
+        Objects.equals(this.maxDiskPerGpuSandbox, regionQuota.maxDiskPerGpuSandbox)&&
         Objects.equals(this.additionalProperties, regionQuota.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, totalGpuQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
+    return Objects.hash(organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, totalGpuQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, maxCpuPerGpuSandbox, maxMemoryPerGpuSandbox, maxDiskPerGpuSandbox, additionalProperties);
   }
 
   @Override
@@ -380,6 +455,9 @@ public class RegionQuota {
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
     sb.append("    maxDiskPerNonEphemeralSandbox: ").append(toIndentedString(maxDiskPerNonEphemeralSandbox)).append("\n");
+    sb.append("    maxCpuPerGpuSandbox: ").append(toIndentedString(maxCpuPerGpuSandbox)).append("\n");
+    sb.append("    maxMemoryPerGpuSandbox: ").append(toIndentedString(maxMemoryPerGpuSandbox)).append("\n");
+    sb.append("    maxDiskPerGpuSandbox: ").append(toIndentedString(maxDiskPerGpuSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -399,10 +477,10 @@ public class RegionQuota {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"));
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionUsageOverview.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionUsageOverview.java
@@ -116,6 +116,21 @@ public class RegionUsageOverview {
   @javax.annotation.Nullable
   private BigDecimal maxDiskPerNonEphemeralSandbox;
 
+  public static final String SERIALIZED_NAME_MAX_CPU_PER_GPU_SANDBOX = "maxCpuPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxCpuPerGpuSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_MEMORY_PER_GPU_SANDBOX = "maxMemoryPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_MEMORY_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxMemoryPerGpuSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_GPU_SANDBOX = "maxDiskPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerGpuSandbox;
+
   public RegionUsageOverview() {
   }
 
@@ -365,6 +380,63 @@ public class RegionUsageOverview {
     this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
   }
 
+
+  public RegionUsageOverview maxCpuPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerGpuSandbox) {
+    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxCpuPerGpuSandbox
+   * @return maxCpuPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxCpuPerGpuSandbox() {
+    return maxCpuPerGpuSandbox;
+  }
+
+  public void setMaxCpuPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerGpuSandbox) {
+    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox;
+  }
+
+
+  public RegionUsageOverview maxMemoryPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerGpuSandbox) {
+    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxMemoryPerGpuSandbox
+   * @return maxMemoryPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxMemoryPerGpuSandbox() {
+    return maxMemoryPerGpuSandbox;
+  }
+
+  public void setMaxMemoryPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerGpuSandbox) {
+    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox;
+  }
+
+
+  public RegionUsageOverview maxDiskPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerGpuSandbox) {
+    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerGpuSandbox
+   * @return maxDiskPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerGpuSandbox() {
+    return maxDiskPerGpuSandbox;
+  }
+
+  public void setMaxDiskPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerGpuSandbox) {
+    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -432,13 +504,16 @@ public class RegionUsageOverview {
         Objects.equals(this.maxCpuPerSandbox, regionUsageOverview.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, regionUsageOverview.maxMemoryPerSandbox) &&
         Objects.equals(this.maxDiskPerSandbox, regionUsageOverview.maxDiskPerSandbox) &&
-        Objects.equals(this.maxDiskPerNonEphemeralSandbox, regionUsageOverview.maxDiskPerNonEphemeralSandbox)&&
+        Objects.equals(this.maxDiskPerNonEphemeralSandbox, regionUsageOverview.maxDiskPerNonEphemeralSandbox) &&
+        Objects.equals(this.maxCpuPerGpuSandbox, regionUsageOverview.maxCpuPerGpuSandbox) &&
+        Objects.equals(this.maxMemoryPerGpuSandbox, regionUsageOverview.maxMemoryPerGpuSandbox) &&
+        Objects.equals(this.maxDiskPerGpuSandbox, regionUsageOverview.maxDiskPerGpuSandbox)&&
         Objects.equals(this.additionalProperties, regionUsageOverview.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(regionId, totalCpuQuota, currentCpuUsage, totalMemoryQuota, currentMemoryUsage, totalDiskQuota, currentDiskUsage, totalGpuQuota, currentGpuUsage, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
+    return Objects.hash(regionId, totalCpuQuota, currentCpuUsage, totalMemoryQuota, currentMemoryUsage, totalDiskQuota, currentDiskUsage, totalGpuQuota, currentGpuUsage, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, maxCpuPerGpuSandbox, maxMemoryPerGpuSandbox, maxDiskPerGpuSandbox, additionalProperties);
   }
 
   @Override
@@ -458,6 +533,9 @@ public class RegionUsageOverview {
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
     sb.append("    maxDiskPerNonEphemeralSandbox: ").append(toIndentedString(maxDiskPerNonEphemeralSandbox)).append("\n");
+    sb.append("    maxCpuPerGpuSandbox: ").append(toIndentedString(maxCpuPerGpuSandbox)).append("\n");
+    sb.append("    maxMemoryPerGpuSandbox: ").append(toIndentedString(maxMemoryPerGpuSandbox)).append("\n");
+    sb.append("    maxDiskPerGpuSandbox: ").append(toIndentedString(maxDiskPerGpuSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -477,10 +555,10 @@ public class RegionUsageOverview {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"));
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionUsageOverview.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RegionUsageOverview.java
@@ -86,6 +86,16 @@ public class RegionUsageOverview {
   @javax.annotation.Nonnull
   private BigDecimal currentDiskUsage;
 
+  public static final String SERIALIZED_NAME_TOTAL_GPU_QUOTA = "totalGpuQuota";
+  @SerializedName(SERIALIZED_NAME_TOTAL_GPU_QUOTA)
+  @javax.annotation.Nonnull
+  private BigDecimal totalGpuQuota;
+
+  public static final String SERIALIZED_NAME_CURRENT_GPU_USAGE = "currentGpuUsage";
+  @SerializedName(SERIALIZED_NAME_CURRENT_GPU_USAGE)
+  @javax.annotation.Nonnull
+  private BigDecimal currentGpuUsage;
+
   public static final String SERIALIZED_NAME_MAX_CPU_PER_SANDBOX = "maxCpuPerSandbox";
   @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_SANDBOX)
   @javax.annotation.Nullable
@@ -242,6 +252,44 @@ public class RegionUsageOverview {
   }
 
 
+  public RegionUsageOverview totalGpuQuota(@javax.annotation.Nonnull BigDecimal totalGpuQuota) {
+    this.totalGpuQuota = totalGpuQuota;
+    return this;
+  }
+
+  /**
+   * Get totalGpuQuota
+   * @return totalGpuQuota
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getTotalGpuQuota() {
+    return totalGpuQuota;
+  }
+
+  public void setTotalGpuQuota(@javax.annotation.Nonnull BigDecimal totalGpuQuota) {
+    this.totalGpuQuota = totalGpuQuota;
+  }
+
+
+  public RegionUsageOverview currentGpuUsage(@javax.annotation.Nonnull BigDecimal currentGpuUsage) {
+    this.currentGpuUsage = currentGpuUsage;
+    return this;
+  }
+
+  /**
+   * Get currentGpuUsage
+   * @return currentGpuUsage
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getCurrentGpuUsage() {
+    return currentGpuUsage;
+  }
+
+  public void setCurrentGpuUsage(@javax.annotation.Nonnull BigDecimal currentGpuUsage) {
+    this.currentGpuUsage = currentGpuUsage;
+  }
+
+
   public RegionUsageOverview maxCpuPerSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerSandbox) {
     this.maxCpuPerSandbox = maxCpuPerSandbox;
     return this;
@@ -379,6 +427,8 @@ public class RegionUsageOverview {
         Objects.equals(this.currentMemoryUsage, regionUsageOverview.currentMemoryUsage) &&
         Objects.equals(this.totalDiskQuota, regionUsageOverview.totalDiskQuota) &&
         Objects.equals(this.currentDiskUsage, regionUsageOverview.currentDiskUsage) &&
+        Objects.equals(this.totalGpuQuota, regionUsageOverview.totalGpuQuota) &&
+        Objects.equals(this.currentGpuUsage, regionUsageOverview.currentGpuUsage) &&
         Objects.equals(this.maxCpuPerSandbox, regionUsageOverview.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, regionUsageOverview.maxMemoryPerSandbox) &&
         Objects.equals(this.maxDiskPerSandbox, regionUsageOverview.maxDiskPerSandbox) &&
@@ -388,7 +438,7 @@ public class RegionUsageOverview {
 
   @Override
   public int hashCode() {
-    return Objects.hash(regionId, totalCpuQuota, currentCpuUsage, totalMemoryQuota, currentMemoryUsage, totalDiskQuota, currentDiskUsage, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
+    return Objects.hash(regionId, totalCpuQuota, currentCpuUsage, totalMemoryQuota, currentMemoryUsage, totalDiskQuota, currentDiskUsage, totalGpuQuota, currentGpuUsage, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
   }
 
   @Override
@@ -402,6 +452,8 @@ public class RegionUsageOverview {
     sb.append("    currentMemoryUsage: ").append(toIndentedString(currentMemoryUsage)).append("\n");
     sb.append("    totalDiskQuota: ").append(toIndentedString(totalDiskQuota)).append("\n");
     sb.append("    currentDiskUsage: ").append(toIndentedString(currentDiskUsage)).append("\n");
+    sb.append("    totalGpuQuota: ").append(toIndentedString(totalGpuQuota)).append("\n");
+    sb.append("    currentGpuUsage: ").append(toIndentedString(currentGpuUsage)).append("\n");
     sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
@@ -425,10 +477,10 @@ public class RegionUsageOverview {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
   }
 
   /**

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
@@ -92,6 +92,21 @@ public class UpdateOrganizationRegionQuota {
   @javax.annotation.Nullable
   private BigDecimal maxDiskPerNonEphemeralSandbox;
 
+  public static final String SERIALIZED_NAME_MAX_CPU_PER_GPU_SANDBOX = "maxCpuPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxCpuPerGpuSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_MEMORY_PER_GPU_SANDBOX = "maxMemoryPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_MEMORY_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxMemoryPerGpuSandbox;
+
+  public static final String SERIALIZED_NAME_MAX_DISK_PER_GPU_SANDBOX = "maxDiskPerGpuSandbox";
+  @SerializedName(SERIALIZED_NAME_MAX_DISK_PER_GPU_SANDBOX)
+  @javax.annotation.Nullable
+  private BigDecimal maxDiskPerGpuSandbox;
+
   public UpdateOrganizationRegionQuota() {
   }
 
@@ -246,6 +261,63 @@ public class UpdateOrganizationRegionQuota {
     this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox;
   }
 
+
+  public UpdateOrganizationRegionQuota maxCpuPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerGpuSandbox) {
+    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxCpuPerGpuSandbox
+   * @return maxCpuPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxCpuPerGpuSandbox() {
+    return maxCpuPerGpuSandbox;
+  }
+
+  public void setMaxCpuPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxCpuPerGpuSandbox) {
+    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox;
+  }
+
+
+  public UpdateOrganizationRegionQuota maxMemoryPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerGpuSandbox) {
+    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxMemoryPerGpuSandbox
+   * @return maxMemoryPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxMemoryPerGpuSandbox() {
+    return maxMemoryPerGpuSandbox;
+  }
+
+  public void setMaxMemoryPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxMemoryPerGpuSandbox) {
+    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox;
+  }
+
+
+  public UpdateOrganizationRegionQuota maxDiskPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerGpuSandbox) {
+    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox;
+    return this;
+  }
+
+  /**
+   * Get maxDiskPerGpuSandbox
+   * @return maxDiskPerGpuSandbox
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getMaxDiskPerGpuSandbox() {
+    return maxDiskPerGpuSandbox;
+  }
+
+  public void setMaxDiskPerGpuSandbox(@javax.annotation.Nullable BigDecimal maxDiskPerGpuSandbox) {
+    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -308,7 +380,10 @@ public class UpdateOrganizationRegionQuota {
         Objects.equals(this.maxCpuPerSandbox, updateOrganizationRegionQuota.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, updateOrganizationRegionQuota.maxMemoryPerSandbox) &&
         Objects.equals(this.maxDiskPerSandbox, updateOrganizationRegionQuota.maxDiskPerSandbox) &&
-        Objects.equals(this.maxDiskPerNonEphemeralSandbox, updateOrganizationRegionQuota.maxDiskPerNonEphemeralSandbox)&&
+        Objects.equals(this.maxDiskPerNonEphemeralSandbox, updateOrganizationRegionQuota.maxDiskPerNonEphemeralSandbox) &&
+        Objects.equals(this.maxCpuPerGpuSandbox, updateOrganizationRegionQuota.maxCpuPerGpuSandbox) &&
+        Objects.equals(this.maxMemoryPerGpuSandbox, updateOrganizationRegionQuota.maxMemoryPerGpuSandbox) &&
+        Objects.equals(this.maxDiskPerGpuSandbox, updateOrganizationRegionQuota.maxDiskPerGpuSandbox)&&
         Objects.equals(this.additionalProperties, updateOrganizationRegionQuota.additionalProperties);
   }
 
@@ -318,7 +393,7 @@ public class UpdateOrganizationRegionQuota {
 
   @Override
   public int hashCode() {
-    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, totalGpuQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
+    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, totalGpuQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, maxCpuPerGpuSandbox, maxMemoryPerGpuSandbox, maxDiskPerGpuSandbox, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -340,6 +415,9 @@ public class UpdateOrganizationRegionQuota {
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
     sb.append("    maxDiskPerNonEphemeralSandbox: ").append(toIndentedString(maxDiskPerNonEphemeralSandbox)).append("\n");
+    sb.append("    maxCpuPerGpuSandbox: ").append(toIndentedString(maxCpuPerGpuSandbox)).append("\n");
+    sb.append("    maxMemoryPerGpuSandbox: ").append(toIndentedString(maxMemoryPerGpuSandbox)).append("\n");
+    sb.append("    maxDiskPerGpuSandbox: ").append(toIndentedString(maxDiskPerGpuSandbox)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -359,7 +437,7 @@ public class UpdateOrganizationRegionQuota {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiFields = new HashSet<String>(Arrays.asList("totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota"));

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/UpdateOrganizationRegionQuota.java
@@ -67,6 +67,11 @@ public class UpdateOrganizationRegionQuota {
   @javax.annotation.Nullable
   private BigDecimal totalDiskQuota;
 
+  public static final String SERIALIZED_NAME_TOTAL_GPU_QUOTA = "totalGpuQuota";
+  @SerializedName(SERIALIZED_NAME_TOTAL_GPU_QUOTA)
+  @javax.annotation.Nullable
+  private BigDecimal totalGpuQuota;
+
   public static final String SERIALIZED_NAME_MAX_CPU_PER_SANDBOX = "maxCpuPerSandbox";
   @SerializedName(SERIALIZED_NAME_MAX_CPU_PER_SANDBOX)
   @javax.annotation.Nullable
@@ -144,6 +149,25 @@ public class UpdateOrganizationRegionQuota {
 
   public void setTotalDiskQuota(@javax.annotation.Nullable BigDecimal totalDiskQuota) {
     this.totalDiskQuota = totalDiskQuota;
+  }
+
+
+  public UpdateOrganizationRegionQuota totalGpuQuota(@javax.annotation.Nullable BigDecimal totalGpuQuota) {
+    this.totalGpuQuota = totalGpuQuota;
+    return this;
+  }
+
+  /**
+   * Get totalGpuQuota
+   * @return totalGpuQuota
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getTotalGpuQuota() {
+    return totalGpuQuota;
+  }
+
+  public void setTotalGpuQuota(@javax.annotation.Nullable BigDecimal totalGpuQuota) {
+    this.totalGpuQuota = totalGpuQuota;
   }
 
 
@@ -280,6 +304,7 @@ public class UpdateOrganizationRegionQuota {
     return Objects.equals(this.totalCpuQuota, updateOrganizationRegionQuota.totalCpuQuota) &&
         Objects.equals(this.totalMemoryQuota, updateOrganizationRegionQuota.totalMemoryQuota) &&
         Objects.equals(this.totalDiskQuota, updateOrganizationRegionQuota.totalDiskQuota) &&
+        Objects.equals(this.totalGpuQuota, updateOrganizationRegionQuota.totalGpuQuota) &&
         Objects.equals(this.maxCpuPerSandbox, updateOrganizationRegionQuota.maxCpuPerSandbox) &&
         Objects.equals(this.maxMemoryPerSandbox, updateOrganizationRegionQuota.maxMemoryPerSandbox) &&
         Objects.equals(this.maxDiskPerSandbox, updateOrganizationRegionQuota.maxDiskPerSandbox) &&
@@ -293,7 +318,7 @@ public class UpdateOrganizationRegionQuota {
 
   @Override
   public int hashCode() {
-    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
+    return Objects.hash(totalCpuQuota, totalMemoryQuota, totalDiskQuota, totalGpuQuota, maxCpuPerSandbox, maxMemoryPerSandbox, maxDiskPerSandbox, maxDiskPerNonEphemeralSandbox, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -310,6 +335,7 @@ public class UpdateOrganizationRegionQuota {
     sb.append("    totalCpuQuota: ").append(toIndentedString(totalCpuQuota)).append("\n");
     sb.append("    totalMemoryQuota: ").append(toIndentedString(totalMemoryQuota)).append("\n");
     sb.append("    totalDiskQuota: ").append(toIndentedString(totalDiskQuota)).append("\n");
+    sb.append("    totalGpuQuota: ").append(toIndentedString(totalGpuQuota)).append("\n");
     sb.append("    maxCpuPerSandbox: ").append(toIndentedString(maxCpuPerSandbox)).append("\n");
     sb.append("    maxMemoryPerSandbox: ").append(toIndentedString(maxMemoryPerSandbox)).append("\n");
     sb.append("    maxDiskPerSandbox: ").append(toIndentedString(maxDiskPerSandbox)).append("\n");
@@ -333,10 +359,10 @@ public class UpdateOrganizationRegionQuota {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
+    openapiFields = new HashSet<String>(Arrays.asList("totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("totalCpuQuota", "totalMemoryQuota", "totalDiskQuota"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota"));
   }
 
   /**

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
@@ -79,6 +79,14 @@ public class RegionQuotaTest {
     }
 
     /**
+     * Test the property 'totalGpuQuota'
+     */
+    @Test
+    public void totalGpuQuotaTest() {
+        // TODO: test totalGpuQuota
+    }
+
+    /**
      * Test the property 'maxCpuPerSandbox'
      */
     @Test

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionQuotaTest.java
@@ -118,4 +118,28 @@ public class RegionQuotaTest {
         // TODO: test maxDiskPerNonEphemeralSandbox
     }
 
+    /**
+     * Test the property 'maxCpuPerGpuSandbox'
+     */
+    @Test
+    public void maxCpuPerGpuSandboxTest() {
+        // TODO: test maxCpuPerGpuSandbox
+    }
+
+    /**
+     * Test the property 'maxMemoryPerGpuSandbox'
+     */
+    @Test
+    public void maxMemoryPerGpuSandboxTest() {
+        // TODO: test maxMemoryPerGpuSandbox
+    }
+
+    /**
+     * Test the property 'maxDiskPerGpuSandbox'
+     */
+    @Test
+    public void maxDiskPerGpuSandboxTest() {
+        // TODO: test maxDiskPerGpuSandbox
+    }
+
 }

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionUsageOverviewTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionUsageOverviewTest.java
@@ -95,6 +95,22 @@ public class RegionUsageOverviewTest {
     }
 
     /**
+     * Test the property 'totalGpuQuota'
+     */
+    @Test
+    public void totalGpuQuotaTest() {
+        // TODO: test totalGpuQuota
+    }
+
+    /**
+     * Test the property 'currentGpuUsage'
+     */
+    @Test
+    public void currentGpuUsageTest() {
+        // TODO: test currentGpuUsage
+    }
+
+    /**
      * Test the property 'maxCpuPerSandbox'
      */
     @Test

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionUsageOverviewTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RegionUsageOverviewTest.java
@@ -142,4 +142,28 @@ public class RegionUsageOverviewTest {
         // TODO: test maxDiskPerNonEphemeralSandbox
     }
 
+    /**
+     * Test the property 'maxCpuPerGpuSandbox'
+     */
+    @Test
+    public void maxCpuPerGpuSandboxTest() {
+        // TODO: test maxCpuPerGpuSandbox
+    }
+
+    /**
+     * Test the property 'maxMemoryPerGpuSandbox'
+     */
+    @Test
+    public void maxMemoryPerGpuSandboxTest() {
+        // TODO: test maxMemoryPerGpuSandbox
+    }
+
+    /**
+     * Test the property 'maxDiskPerGpuSandbox'
+     */
+    @Test
+    public void maxDiskPerGpuSandboxTest() {
+        // TODO: test maxDiskPerGpuSandbox
+    }
+
 }

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
@@ -64,6 +64,14 @@ public class UpdateOrganizationRegionQuotaTest {
     }
 
     /**
+     * Test the property 'totalGpuQuota'
+     */
+    @Test
+    public void totalGpuQuotaTest() {
+        // TODO: test totalGpuQuota
+    }
+
+    /**
      * Test the property 'maxCpuPerSandbox'
      */
     @Test

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/UpdateOrganizationRegionQuotaTest.java
@@ -103,4 +103,28 @@ public class UpdateOrganizationRegionQuotaTest {
         // TODO: test maxDiskPerNonEphemeralSandbox
     }
 
+    /**
+     * Test the property 'maxCpuPerGpuSandbox'
+     */
+    @Test
+    public void maxCpuPerGpuSandboxTest() {
+        // TODO: test maxCpuPerGpuSandbox
+    }
+
+    /**
+     * Test the property 'maxMemoryPerGpuSandbox'
+     */
+    @Test
+    public void maxMemoryPerGpuSandboxTest() {
+        // TODO: test maxMemoryPerGpuSandbox
+    }
+
+    /**
+     * Test the property 'maxDiskPerGpuSandbox'
+     */
+    @Test
+    public void maxDiskPerGpuSandboxTest() {
+        // TODO: test maxDiskPerGpuSandbox
+    }
+
 }

--- a/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
@@ -35,12 +35,13 @@ class RegionQuota(BaseModel):
     total_cpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
+    total_gpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalGpuQuota")
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -124,6 +125,7 @@ class RegionQuota(BaseModel):
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
             "total_disk_quota": obj.get("totalDiskQuota"),
+            "total_gpu_quota": obj.get("totalGpuQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/region_quota.py
@@ -40,8 +40,11 @@ class RegionQuota(BaseModel):
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerGpuSandbox")
+    max_memory_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerGpuSandbox")
+    max_disk_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerGpuSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,6 +111,21 @@ class RegionQuota(BaseModel):
         if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
             _dict['maxDiskPerNonEphemeralSandbox'] = None
 
+        # set to None if max_cpu_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_gpu_sandbox is None and "max_cpu_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerGpuSandbox'] = None
+
+        # set to None if max_memory_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_gpu_sandbox is None and "max_memory_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerGpuSandbox'] = None
+
+        # set to None if max_disk_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_gpu_sandbox is None and "max_disk_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerGpuSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -129,7 +147,10 @@ class RegionQuota(BaseModel):
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
-            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox"),
+            "max_cpu_per_gpu_sandbox": obj.get("maxCpuPerGpuSandbox"),
+            "max_memory_per_gpu_sandbox": obj.get("maxMemoryPerGpuSandbox"),
+            "max_disk_per_gpu_sandbox": obj.get("maxDiskPerGpuSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/region_usage_overview.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/region_usage_overview.py
@@ -37,12 +37,14 @@ class RegionUsageOverview(BaseModel):
     current_memory_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentMemoryUsage")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
     current_disk_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentDiskUsage")
+    total_gpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalGpuQuota")
+    current_gpu_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentGpuUsage")
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -128,6 +130,8 @@ class RegionUsageOverview(BaseModel):
             "current_memory_usage": obj.get("currentMemoryUsage"),
             "total_disk_quota": obj.get("totalDiskQuota"),
             "current_disk_usage": obj.get("currentDiskUsage"),
+            "total_gpu_quota": obj.get("totalGpuQuota"),
+            "current_gpu_usage": obj.get("currentGpuUsage"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),

--- a/libs/api-client-python-async/daytona_api_client_async/models/region_usage_overview.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/region_usage_overview.py
@@ -43,8 +43,11 @@ class RegionUsageOverview(BaseModel):
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerGpuSandbox")
+    max_memory_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerGpuSandbox")
+    max_disk_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerGpuSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -111,6 +114,21 @@ class RegionUsageOverview(BaseModel):
         if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
             _dict['maxDiskPerNonEphemeralSandbox'] = None
 
+        # set to None if max_cpu_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_gpu_sandbox is None and "max_cpu_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerGpuSandbox'] = None
+
+        # set to None if max_memory_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_gpu_sandbox is None and "max_memory_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerGpuSandbox'] = None
+
+        # set to None if max_disk_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_gpu_sandbox is None and "max_disk_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerGpuSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -135,7 +153,10 @@ class RegionUsageOverview(BaseModel):
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
-            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox"),
+            "max_cpu_per_gpu_sandbox": obj.get("maxCpuPerGpuSandbox"),
+            "max_memory_per_gpu_sandbox": obj.get("maxMemoryPerGpuSandbox"),
+            "max_disk_per_gpu_sandbox": obj.get("maxDiskPerGpuSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
@@ -38,8 +38,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxCpuPerGpuSandbox")
+    max_memory_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerGpuSandbox")
+    max_disk_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerGpuSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -126,6 +129,21 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
             _dict['maxDiskPerNonEphemeralSandbox'] = None
 
+        # set to None if max_cpu_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_gpu_sandbox is None and "max_cpu_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerGpuSandbox'] = None
+
+        # set to None if max_memory_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_gpu_sandbox is None and "max_memory_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerGpuSandbox'] = None
+
+        # set to None if max_disk_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_gpu_sandbox is None and "max_disk_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerGpuSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -145,7 +163,10 @@ class UpdateOrganizationRegionQuota(BaseModel):
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
-            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox"),
+            "max_cpu_per_gpu_sandbox": obj.get("maxCpuPerGpuSandbox"),
+            "max_memory_per_gpu_sandbox": obj.get("maxMemoryPerGpuSandbox"),
+            "max_disk_per_gpu_sandbox": obj.get("maxDiskPerGpuSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/update_organization_region_quota.py
@@ -33,12 +33,13 @@ class UpdateOrganizationRegionQuota(BaseModel):
     total_cpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalDiskQuota")
+    total_gpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalGpuQuota")
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -100,6 +101,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.total_disk_quota is None and "total_disk_quota" in self.model_fields_set:
             _dict['totalDiskQuota'] = None
 
+        # set to None if total_gpu_quota (nullable) is None
+        # and model_fields_set contains the field
+        if self.total_gpu_quota is None and "total_gpu_quota" in self.model_fields_set:
+            _dict['totalGpuQuota'] = None
+
         # set to None if max_cpu_per_sandbox (nullable) is None
         # and model_fields_set contains the field
         if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
@@ -135,6 +141,7 @@ class UpdateOrganizationRegionQuota(BaseModel):
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
             "total_disk_quota": obj.get("totalDiskQuota"),
+            "total_gpu_quota": obj.get("totalGpuQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),

--- a/libs/api-client-python/daytona_api_client/models/region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/region_quota.py
@@ -35,12 +35,13 @@ class RegionQuota(BaseModel):
     total_cpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
+    total_gpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalGpuQuota")
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -124,6 +125,7 @@ class RegionQuota(BaseModel):
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
             "total_disk_quota": obj.get("totalDiskQuota"),
+            "total_gpu_quota": obj.get("totalGpuQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),

--- a/libs/api-client-python/daytona_api_client/models/region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/region_quota.py
@@ -40,8 +40,11 @@ class RegionQuota(BaseModel):
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerGpuSandbox")
+    max_memory_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerGpuSandbox")
+    max_disk_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerGpuSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["organizationId", "regionId", "totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,6 +111,21 @@ class RegionQuota(BaseModel):
         if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
             _dict['maxDiskPerNonEphemeralSandbox'] = None
 
+        # set to None if max_cpu_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_gpu_sandbox is None and "max_cpu_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerGpuSandbox'] = None
+
+        # set to None if max_memory_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_gpu_sandbox is None and "max_memory_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerGpuSandbox'] = None
+
+        # set to None if max_disk_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_gpu_sandbox is None and "max_disk_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerGpuSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -129,7 +147,10 @@ class RegionQuota(BaseModel):
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
-            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox"),
+            "max_cpu_per_gpu_sandbox": obj.get("maxCpuPerGpuSandbox"),
+            "max_memory_per_gpu_sandbox": obj.get("maxMemoryPerGpuSandbox"),
+            "max_disk_per_gpu_sandbox": obj.get("maxDiskPerGpuSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/region_usage_overview.py
+++ b/libs/api-client-python/daytona_api_client/models/region_usage_overview.py
@@ -37,12 +37,14 @@ class RegionUsageOverview(BaseModel):
     current_memory_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentMemoryUsage")
     total_disk_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalDiskQuota")
     current_disk_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentDiskUsage")
+    total_gpu_quota: Union[StrictFloat, StrictInt] = Field(serialization_alias="totalGpuQuota")
+    current_gpu_usage: Union[StrictFloat, StrictInt] = Field(serialization_alias="currentGpuUsage")
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -128,6 +130,8 @@ class RegionUsageOverview(BaseModel):
             "current_memory_usage": obj.get("currentMemoryUsage"),
             "total_disk_quota": obj.get("totalDiskQuota"),
             "current_disk_usage": obj.get("currentDiskUsage"),
+            "total_gpu_quota": obj.get("totalGpuQuota"),
+            "current_gpu_usage": obj.get("currentGpuUsage"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),

--- a/libs/api-client-python/daytona_api_client/models/region_usage_overview.py
+++ b/libs/api-client-python/daytona_api_client/models/region_usage_overview.py
@@ -43,8 +43,11 @@ class RegionUsageOverview(BaseModel):
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxCpuPerGpuSandbox")
+    max_memory_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxMemoryPerGpuSandbox")
+    max_disk_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="maxDiskPerGpuSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["regionId", "totalCpuQuota", "currentCpuUsage", "totalMemoryQuota", "currentMemoryUsage", "totalDiskQuota", "currentDiskUsage", "totalGpuQuota", "currentGpuUsage", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -111,6 +114,21 @@ class RegionUsageOverview(BaseModel):
         if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
             _dict['maxDiskPerNonEphemeralSandbox'] = None
 
+        # set to None if max_cpu_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_gpu_sandbox is None and "max_cpu_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerGpuSandbox'] = None
+
+        # set to None if max_memory_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_gpu_sandbox is None and "max_memory_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerGpuSandbox'] = None
+
+        # set to None if max_disk_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_gpu_sandbox is None and "max_disk_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerGpuSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -135,7 +153,10 @@ class RegionUsageOverview(BaseModel):
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
-            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox"),
+            "max_cpu_per_gpu_sandbox": obj.get("maxCpuPerGpuSandbox"),
+            "max_memory_per_gpu_sandbox": obj.get("maxMemoryPerGpuSandbox"),
+            "max_disk_per_gpu_sandbox": obj.get("maxDiskPerGpuSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
@@ -38,8 +38,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerNonEphemeralSandbox")
+    max_cpu_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxCpuPerGpuSandbox")
+    max_memory_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerGpuSandbox")
+    max_disk_per_gpu_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerGpuSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox", "maxCpuPerGpuSandbox", "maxMemoryPerGpuSandbox", "maxDiskPerGpuSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -126,6 +129,21 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.max_disk_per_non_ephemeral_sandbox is None and "max_disk_per_non_ephemeral_sandbox" in self.model_fields_set:
             _dict['maxDiskPerNonEphemeralSandbox'] = None
 
+        # set to None if max_cpu_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_cpu_per_gpu_sandbox is None and "max_cpu_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxCpuPerGpuSandbox'] = None
+
+        # set to None if max_memory_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_memory_per_gpu_sandbox is None and "max_memory_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxMemoryPerGpuSandbox'] = None
+
+        # set to None if max_disk_per_gpu_sandbox (nullable) is None
+        # and model_fields_set contains the field
+        if self.max_disk_per_gpu_sandbox is None and "max_disk_per_gpu_sandbox" in self.model_fields_set:
+            _dict['maxDiskPerGpuSandbox'] = None
+
         return _dict
 
     @classmethod
@@ -145,7 +163,10 @@ class UpdateOrganizationRegionQuota(BaseModel):
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),
-            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox")
+            "max_disk_per_non_ephemeral_sandbox": obj.get("maxDiskPerNonEphemeralSandbox"),
+            "max_cpu_per_gpu_sandbox": obj.get("maxCpuPerGpuSandbox"),
+            "max_memory_per_gpu_sandbox": obj.get("maxMemoryPerGpuSandbox"),
+            "max_disk_per_gpu_sandbox": obj.get("maxDiskPerGpuSandbox")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
+++ b/libs/api-client-python/daytona_api_client/models/update_organization_region_quota.py
@@ -33,12 +33,13 @@ class UpdateOrganizationRegionQuota(BaseModel):
     total_cpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalCpuQuota")
     total_memory_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalMemoryQuota")
     total_disk_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalDiskQuota")
+    total_gpu_quota: Optional[Union[StrictFloat, StrictInt]] = Field(serialization_alias="totalGpuQuota")
     max_cpu_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxCpuPerSandbox")
     max_memory_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxMemoryPerSandbox")
     max_disk_per_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerSandbox")
     max_disk_per_non_ephemeral_sandbox: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, serialization_alias="maxDiskPerNonEphemeralSandbox")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
+    __properties: ClassVar[List[str]] = ["totalCpuQuota", "totalMemoryQuota", "totalDiskQuota", "totalGpuQuota", "maxCpuPerSandbox", "maxMemoryPerSandbox", "maxDiskPerSandbox", "maxDiskPerNonEphemeralSandbox"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -100,6 +101,11 @@ class UpdateOrganizationRegionQuota(BaseModel):
         if self.total_disk_quota is None and "total_disk_quota" in self.model_fields_set:
             _dict['totalDiskQuota'] = None
 
+        # set to None if total_gpu_quota (nullable) is None
+        # and model_fields_set contains the field
+        if self.total_gpu_quota is None and "total_gpu_quota" in self.model_fields_set:
+            _dict['totalGpuQuota'] = None
+
         # set to None if max_cpu_per_sandbox (nullable) is None
         # and model_fields_set contains the field
         if self.max_cpu_per_sandbox is None and "max_cpu_per_sandbox" in self.model_fields_set:
@@ -135,6 +141,7 @@ class UpdateOrganizationRegionQuota(BaseModel):
             "total_cpu_quota": obj.get("totalCpuQuota"),
             "total_memory_quota": obj.get("totalMemoryQuota"),
             "total_disk_quota": obj.get("totalDiskQuota"),
+            "total_gpu_quota": obj.get("totalGpuQuota"),
             "max_cpu_per_sandbox": obj.get("maxCpuPerSandbox"),
             "max_memory_per_sandbox": obj.get("maxMemoryPerSandbox"),
             "max_disk_per_sandbox": obj.get("maxDiskPerSandbox"),

--- a/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
@@ -35,6 +35,12 @@ module DaytonaApiClient
 
     attr_accessor :max_disk_per_non_ephemeral_sandbox
 
+    attr_accessor :max_cpu_per_gpu_sandbox
+
+    attr_accessor :max_memory_per_gpu_sandbox
+
+    attr_accessor :max_disk_per_gpu_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -47,7 +53,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
         :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
-        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox'
+        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox',
+        :'max_cpu_per_gpu_sandbox' => :'maxCpuPerGpuSandbox',
+        :'max_memory_per_gpu_sandbox' => :'maxMemoryPerGpuSandbox',
+        :'max_disk_per_gpu_sandbox' => :'maxDiskPerGpuSandbox'
       }
     end
 
@@ -73,7 +82,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
         :'max_disk_per_sandbox' => :'Float',
-        :'max_disk_per_non_ephemeral_sandbox' => :'Float'
+        :'max_disk_per_non_ephemeral_sandbox' => :'Float',
+        :'max_cpu_per_gpu_sandbox' => :'Float',
+        :'max_memory_per_gpu_sandbox' => :'Float',
+        :'max_disk_per_gpu_sandbox' => :'Float'
       }
     end
 
@@ -83,7 +95,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox',
         :'max_memory_per_sandbox',
         :'max_disk_per_sandbox',
-        :'max_disk_per_non_ephemeral_sandbox'
+        :'max_disk_per_non_ephemeral_sandbox',
+        :'max_cpu_per_gpu_sandbox',
+        :'max_memory_per_gpu_sandbox',
+        :'max_disk_per_gpu_sandbox'
       ])
     end
 
@@ -161,6 +176,24 @@ module DaytonaApiClient
         self.max_disk_per_non_ephemeral_sandbox = attributes[:'max_disk_per_non_ephemeral_sandbox']
       else
         self.max_disk_per_non_ephemeral_sandbox = nil
+      end
+
+      if attributes.key?(:'max_cpu_per_gpu_sandbox')
+        self.max_cpu_per_gpu_sandbox = attributes[:'max_cpu_per_gpu_sandbox']
+      else
+        self.max_cpu_per_gpu_sandbox = nil
+      end
+
+      if attributes.key?(:'max_memory_per_gpu_sandbox')
+        self.max_memory_per_gpu_sandbox = attributes[:'max_memory_per_gpu_sandbox']
+      else
+        self.max_memory_per_gpu_sandbox = nil
+      end
+
+      if attributes.key?(:'max_disk_per_gpu_sandbox')
+        self.max_disk_per_gpu_sandbox = attributes[:'max_disk_per_gpu_sandbox']
+      else
+        self.max_disk_per_gpu_sandbox = nil
       end
     end
 
@@ -283,7 +316,10 @@ module DaytonaApiClient
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
           max_disk_per_sandbox == o.max_disk_per_sandbox &&
-          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox
+          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox &&
+          max_cpu_per_gpu_sandbox == o.max_cpu_per_gpu_sandbox &&
+          max_memory_per_gpu_sandbox == o.max_memory_per_gpu_sandbox &&
+          max_disk_per_gpu_sandbox == o.max_disk_per_gpu_sandbox
     end
 
     # @see the `==` method
@@ -295,7 +331,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota, total_gpu_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
+      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota, total_gpu_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox, max_cpu_per_gpu_sandbox, max_memory_per_gpu_sandbox, max_disk_per_gpu_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/region_quota.rb
@@ -25,6 +25,8 @@ module DaytonaApiClient
 
     attr_accessor :total_disk_quota
 
+    attr_accessor :total_gpu_quota
+
     attr_accessor :max_cpu_per_sandbox
 
     attr_accessor :max_memory_per_sandbox
@@ -41,6 +43,7 @@ module DaytonaApiClient
         :'total_cpu_quota' => :'totalCpuQuota',
         :'total_memory_quota' => :'totalMemoryQuota',
         :'total_disk_quota' => :'totalDiskQuota',
+        :'total_gpu_quota' => :'totalGpuQuota',
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
         :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
@@ -66,6 +69,7 @@ module DaytonaApiClient
         :'total_cpu_quota' => :'Float',
         :'total_memory_quota' => :'Float',
         :'total_disk_quota' => :'Float',
+        :'total_gpu_quota' => :'Float',
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
         :'max_disk_per_sandbox' => :'Float',
@@ -129,6 +133,12 @@ module DaytonaApiClient
         self.total_disk_quota = nil
       end
 
+      if attributes.key?(:'total_gpu_quota')
+        self.total_gpu_quota = attributes[:'total_gpu_quota']
+      else
+        self.total_gpu_quota = nil
+      end
+
       if attributes.key?(:'max_cpu_per_sandbox')
         self.max_cpu_per_sandbox = attributes[:'max_cpu_per_sandbox']
       else
@@ -179,6 +189,10 @@ module DaytonaApiClient
         invalid_properties.push('invalid value for "total_disk_quota", total_disk_quota cannot be nil.')
       end
 
+      if @total_gpu_quota.nil?
+        invalid_properties.push('invalid value for "total_gpu_quota", total_gpu_quota cannot be nil.')
+      end
+
       invalid_properties
     end
 
@@ -191,6 +205,7 @@ module DaytonaApiClient
       return false if @total_cpu_quota.nil?
       return false if @total_memory_quota.nil?
       return false if @total_disk_quota.nil?
+      return false if @total_gpu_quota.nil?
       true
     end
 
@@ -244,6 +259,16 @@ module DaytonaApiClient
       @total_disk_quota = total_disk_quota
     end
 
+    # Custom attribute writer method with validation
+    # @param [Object] total_gpu_quota Value to be assigned
+    def total_gpu_quota=(total_gpu_quota)
+      if total_gpu_quota.nil?
+        fail ArgumentError, 'total_gpu_quota cannot be nil'
+      end
+
+      @total_gpu_quota = total_gpu_quota
+    end
+
     # Checks equality by comparing each attribute.
     # @param [Object] Object to be compared
     def ==(o)
@@ -254,6 +279,7 @@ module DaytonaApiClient
           total_cpu_quota == o.total_cpu_quota &&
           total_memory_quota == o.total_memory_quota &&
           total_disk_quota == o.total_disk_quota &&
+          total_gpu_quota == o.total_gpu_quota &&
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
           max_disk_per_sandbox == o.max_disk_per_sandbox &&
@@ -269,7 +295,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
+      [organization_id, region_id, total_cpu_quota, total_memory_quota, total_disk_quota, total_gpu_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/region_usage_overview.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/region_usage_overview.rb
@@ -29,6 +29,10 @@ module DaytonaApiClient
 
     attr_accessor :current_disk_usage
 
+    attr_accessor :total_gpu_quota
+
+    attr_accessor :current_gpu_usage
+
     attr_accessor :max_cpu_per_sandbox
 
     attr_accessor :max_memory_per_sandbox
@@ -47,6 +51,8 @@ module DaytonaApiClient
         :'current_memory_usage' => :'currentMemoryUsage',
         :'total_disk_quota' => :'totalDiskQuota',
         :'current_disk_usage' => :'currentDiskUsage',
+        :'total_gpu_quota' => :'totalGpuQuota',
+        :'current_gpu_usage' => :'currentGpuUsage',
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
         :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
@@ -74,6 +80,8 @@ module DaytonaApiClient
         :'current_memory_usage' => :'Float',
         :'total_disk_quota' => :'Float',
         :'current_disk_usage' => :'Float',
+        :'total_gpu_quota' => :'Float',
+        :'current_gpu_usage' => :'Float',
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
         :'max_disk_per_sandbox' => :'Float',
@@ -149,6 +157,18 @@ module DaytonaApiClient
         self.current_disk_usage = nil
       end
 
+      if attributes.key?(:'total_gpu_quota')
+        self.total_gpu_quota = attributes[:'total_gpu_quota']
+      else
+        self.total_gpu_quota = nil
+      end
+
+      if attributes.key?(:'current_gpu_usage')
+        self.current_gpu_usage = attributes[:'current_gpu_usage']
+      else
+        self.current_gpu_usage = nil
+      end
+
       if attributes.key?(:'max_cpu_per_sandbox')
         self.max_cpu_per_sandbox = attributes[:'max_cpu_per_sandbox']
       else
@@ -207,6 +227,14 @@ module DaytonaApiClient
         invalid_properties.push('invalid value for "current_disk_usage", current_disk_usage cannot be nil.')
       end
 
+      if @total_gpu_quota.nil?
+        invalid_properties.push('invalid value for "total_gpu_quota", total_gpu_quota cannot be nil.')
+      end
+
+      if @current_gpu_usage.nil?
+        invalid_properties.push('invalid value for "current_gpu_usage", current_gpu_usage cannot be nil.')
+      end
+
       invalid_properties
     end
 
@@ -221,6 +249,8 @@ module DaytonaApiClient
       return false if @current_memory_usage.nil?
       return false if @total_disk_quota.nil?
       return false if @current_disk_usage.nil?
+      return false if @total_gpu_quota.nil?
+      return false if @current_gpu_usage.nil?
       true
     end
 
@@ -294,6 +324,26 @@ module DaytonaApiClient
       @current_disk_usage = current_disk_usage
     end
 
+    # Custom attribute writer method with validation
+    # @param [Object] total_gpu_quota Value to be assigned
+    def total_gpu_quota=(total_gpu_quota)
+      if total_gpu_quota.nil?
+        fail ArgumentError, 'total_gpu_quota cannot be nil'
+      end
+
+      @total_gpu_quota = total_gpu_quota
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] current_gpu_usage Value to be assigned
+    def current_gpu_usage=(current_gpu_usage)
+      if current_gpu_usage.nil?
+        fail ArgumentError, 'current_gpu_usage cannot be nil'
+      end
+
+      @current_gpu_usage = current_gpu_usage
+    end
+
     # Checks equality by comparing each attribute.
     # @param [Object] Object to be compared
     def ==(o)
@@ -306,6 +356,8 @@ module DaytonaApiClient
           current_memory_usage == o.current_memory_usage &&
           total_disk_quota == o.total_disk_quota &&
           current_disk_usage == o.current_disk_usage &&
+          total_gpu_quota == o.total_gpu_quota &&
+          current_gpu_usage == o.current_gpu_usage &&
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
           max_disk_per_sandbox == o.max_disk_per_sandbox &&
@@ -321,7 +373,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [region_id, total_cpu_quota, current_cpu_usage, total_memory_quota, current_memory_usage, total_disk_quota, current_disk_usage, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
+      [region_id, total_cpu_quota, current_cpu_usage, total_memory_quota, current_memory_usage, total_disk_quota, current_disk_usage, total_gpu_quota, current_gpu_usage, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/region_usage_overview.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/region_usage_overview.rb
@@ -41,6 +41,12 @@ module DaytonaApiClient
 
     attr_accessor :max_disk_per_non_ephemeral_sandbox
 
+    attr_accessor :max_cpu_per_gpu_sandbox
+
+    attr_accessor :max_memory_per_gpu_sandbox
+
+    attr_accessor :max_disk_per_gpu_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -56,7 +62,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
         :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
-        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox'
+        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox',
+        :'max_cpu_per_gpu_sandbox' => :'maxCpuPerGpuSandbox',
+        :'max_memory_per_gpu_sandbox' => :'maxMemoryPerGpuSandbox',
+        :'max_disk_per_gpu_sandbox' => :'maxDiskPerGpuSandbox'
       }
     end
 
@@ -85,7 +94,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
         :'max_disk_per_sandbox' => :'Float',
-        :'max_disk_per_non_ephemeral_sandbox' => :'Float'
+        :'max_disk_per_non_ephemeral_sandbox' => :'Float',
+        :'max_cpu_per_gpu_sandbox' => :'Float',
+        :'max_memory_per_gpu_sandbox' => :'Float',
+        :'max_disk_per_gpu_sandbox' => :'Float'
       }
     end
 
@@ -95,7 +107,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox',
         :'max_memory_per_sandbox',
         :'max_disk_per_sandbox',
-        :'max_disk_per_non_ephemeral_sandbox'
+        :'max_disk_per_non_ephemeral_sandbox',
+        :'max_cpu_per_gpu_sandbox',
+        :'max_memory_per_gpu_sandbox',
+        :'max_disk_per_gpu_sandbox'
       ])
     end
 
@@ -191,6 +206,24 @@ module DaytonaApiClient
         self.max_disk_per_non_ephemeral_sandbox = attributes[:'max_disk_per_non_ephemeral_sandbox']
       else
         self.max_disk_per_non_ephemeral_sandbox = nil
+      end
+
+      if attributes.key?(:'max_cpu_per_gpu_sandbox')
+        self.max_cpu_per_gpu_sandbox = attributes[:'max_cpu_per_gpu_sandbox']
+      else
+        self.max_cpu_per_gpu_sandbox = nil
+      end
+
+      if attributes.key?(:'max_memory_per_gpu_sandbox')
+        self.max_memory_per_gpu_sandbox = attributes[:'max_memory_per_gpu_sandbox']
+      else
+        self.max_memory_per_gpu_sandbox = nil
+      end
+
+      if attributes.key?(:'max_disk_per_gpu_sandbox')
+        self.max_disk_per_gpu_sandbox = attributes[:'max_disk_per_gpu_sandbox']
+      else
+        self.max_disk_per_gpu_sandbox = nil
       end
     end
 
@@ -361,7 +394,10 @@ module DaytonaApiClient
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
           max_disk_per_sandbox == o.max_disk_per_sandbox &&
-          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox
+          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox &&
+          max_cpu_per_gpu_sandbox == o.max_cpu_per_gpu_sandbox &&
+          max_memory_per_gpu_sandbox == o.max_memory_per_gpu_sandbox &&
+          max_disk_per_gpu_sandbox == o.max_disk_per_gpu_sandbox
     end
 
     # @see the `==` method
@@ -373,7 +409,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [region_id, total_cpu_quota, current_cpu_usage, total_memory_quota, current_memory_usage, total_disk_quota, current_disk_usage, total_gpu_quota, current_gpu_usage, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
+      [region_id, total_cpu_quota, current_cpu_usage, total_memory_quota, current_memory_usage, total_disk_quota, current_disk_usage, total_gpu_quota, current_gpu_usage, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox, max_cpu_per_gpu_sandbox, max_memory_per_gpu_sandbox, max_disk_per_gpu_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
@@ -31,6 +31,12 @@ module DaytonaApiClient
 
     attr_accessor :max_disk_per_non_ephemeral_sandbox
 
+    attr_accessor :max_cpu_per_gpu_sandbox
+
+    attr_accessor :max_memory_per_gpu_sandbox
+
+    attr_accessor :max_disk_per_gpu_sandbox
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -41,7 +47,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
         :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
-        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox'
+        :'max_disk_per_non_ephemeral_sandbox' => :'maxDiskPerNonEphemeralSandbox',
+        :'max_cpu_per_gpu_sandbox' => :'maxCpuPerGpuSandbox',
+        :'max_memory_per_gpu_sandbox' => :'maxMemoryPerGpuSandbox',
+        :'max_disk_per_gpu_sandbox' => :'maxDiskPerGpuSandbox'
       }
     end
 
@@ -65,7 +74,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
         :'max_disk_per_sandbox' => :'Float',
-        :'max_disk_per_non_ephemeral_sandbox' => :'Float'
+        :'max_disk_per_non_ephemeral_sandbox' => :'Float',
+        :'max_cpu_per_gpu_sandbox' => :'Float',
+        :'max_memory_per_gpu_sandbox' => :'Float',
+        :'max_disk_per_gpu_sandbox' => :'Float'
       }
     end
 
@@ -79,7 +91,10 @@ module DaytonaApiClient
         :'max_cpu_per_sandbox',
         :'max_memory_per_sandbox',
         :'max_disk_per_sandbox',
-        :'max_disk_per_non_ephemeral_sandbox'
+        :'max_disk_per_non_ephemeral_sandbox',
+        :'max_cpu_per_gpu_sandbox',
+        :'max_memory_per_gpu_sandbox',
+        :'max_disk_per_gpu_sandbox'
       ])
     end
 
@@ -138,6 +153,18 @@ module DaytonaApiClient
       if attributes.key?(:'max_disk_per_non_ephemeral_sandbox')
         self.max_disk_per_non_ephemeral_sandbox = attributes[:'max_disk_per_non_ephemeral_sandbox']
       end
+
+      if attributes.key?(:'max_cpu_per_gpu_sandbox')
+        self.max_cpu_per_gpu_sandbox = attributes[:'max_cpu_per_gpu_sandbox']
+      end
+
+      if attributes.key?(:'max_memory_per_gpu_sandbox')
+        self.max_memory_per_gpu_sandbox = attributes[:'max_memory_per_gpu_sandbox']
+      end
+
+      if attributes.key?(:'max_disk_per_gpu_sandbox')
+        self.max_disk_per_gpu_sandbox = attributes[:'max_disk_per_gpu_sandbox']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -167,7 +194,10 @@ module DaytonaApiClient
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
           max_disk_per_sandbox == o.max_disk_per_sandbox &&
-          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox
+          max_disk_per_non_ephemeral_sandbox == o.max_disk_per_non_ephemeral_sandbox &&
+          max_cpu_per_gpu_sandbox == o.max_cpu_per_gpu_sandbox &&
+          max_memory_per_gpu_sandbox == o.max_memory_per_gpu_sandbox &&
+          max_disk_per_gpu_sandbox == o.max_disk_per_gpu_sandbox
     end
 
     # @see the `==` method
@@ -179,7 +209,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [total_cpu_quota, total_memory_quota, total_disk_quota, total_gpu_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
+      [total_cpu_quota, total_memory_quota, total_disk_quota, total_gpu_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox, max_cpu_per_gpu_sandbox, max_memory_per_gpu_sandbox, max_disk_per_gpu_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/update_organization_region_quota.rb
@@ -21,6 +21,8 @@ module DaytonaApiClient
 
     attr_accessor :total_disk_quota
 
+    attr_accessor :total_gpu_quota
+
     attr_accessor :max_cpu_per_sandbox
 
     attr_accessor :max_memory_per_sandbox
@@ -35,6 +37,7 @@ module DaytonaApiClient
         :'total_cpu_quota' => :'totalCpuQuota',
         :'total_memory_quota' => :'totalMemoryQuota',
         :'total_disk_quota' => :'totalDiskQuota',
+        :'total_gpu_quota' => :'totalGpuQuota',
         :'max_cpu_per_sandbox' => :'maxCpuPerSandbox',
         :'max_memory_per_sandbox' => :'maxMemoryPerSandbox',
         :'max_disk_per_sandbox' => :'maxDiskPerSandbox',
@@ -58,6 +61,7 @@ module DaytonaApiClient
         :'total_cpu_quota' => :'Float',
         :'total_memory_quota' => :'Float',
         :'total_disk_quota' => :'Float',
+        :'total_gpu_quota' => :'Float',
         :'max_cpu_per_sandbox' => :'Float',
         :'max_memory_per_sandbox' => :'Float',
         :'max_disk_per_sandbox' => :'Float',
@@ -71,6 +75,7 @@ module DaytonaApiClient
         :'total_cpu_quota',
         :'total_memory_quota',
         :'total_disk_quota',
+        :'total_gpu_quota',
         :'max_cpu_per_sandbox',
         :'max_memory_per_sandbox',
         :'max_disk_per_sandbox',
@@ -110,6 +115,12 @@ module DaytonaApiClient
         self.total_disk_quota = attributes[:'total_disk_quota']
       else
         self.total_disk_quota = nil
+      end
+
+      if attributes.key?(:'total_gpu_quota')
+        self.total_gpu_quota = attributes[:'total_gpu_quota']
+      else
+        self.total_gpu_quota = nil
       end
 
       if attributes.key?(:'max_cpu_per_sandbox')
@@ -152,6 +163,7 @@ module DaytonaApiClient
           total_cpu_quota == o.total_cpu_quota &&
           total_memory_quota == o.total_memory_quota &&
           total_disk_quota == o.total_disk_quota &&
+          total_gpu_quota == o.total_gpu_quota &&
           max_cpu_per_sandbox == o.max_cpu_per_sandbox &&
           max_memory_per_sandbox == o.max_memory_per_sandbox &&
           max_disk_per_sandbox == o.max_disk_per_sandbox &&
@@ -167,7 +179,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [total_cpu_quota, total_memory_quota, total_disk_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
+      [total_cpu_quota, total_memory_quota, total_disk_quota, total_gpu_quota, max_cpu_per_sandbox, max_memory_per_sandbox, max_disk_per_sandbox, max_disk_per_non_ephemeral_sandbox].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/models/region-quota.ts
+++ b/libs/api-client/src/models/region-quota.ts
@@ -20,6 +20,7 @@ export interface RegionQuota {
     'totalCpuQuota': number;
     'totalMemoryQuota': number;
     'totalDiskQuota': number;
+    'totalGpuQuota': number;
     'maxCpuPerSandbox': number | null;
     'maxMemoryPerSandbox': number | null;
     'maxDiskPerSandbox': number | null;

--- a/libs/api-client/src/models/region-quota.ts
+++ b/libs/api-client/src/models/region-quota.ts
@@ -25,5 +25,8 @@ export interface RegionQuota {
     'maxMemoryPerSandbox': number | null;
     'maxDiskPerSandbox': number | null;
     'maxDiskPerNonEphemeralSandbox': number | null;
+    'maxCpuPerGpuSandbox': number | null;
+    'maxMemoryPerGpuSandbox': number | null;
+    'maxDiskPerGpuSandbox': number | null;
 }
 

--- a/libs/api-client/src/models/region-usage-overview.ts
+++ b/libs/api-client/src/models/region-usage-overview.ts
@@ -22,6 +22,8 @@ export interface RegionUsageOverview {
     'currentMemoryUsage': number;
     'totalDiskQuota': number;
     'currentDiskUsage': number;
+    'totalGpuQuota': number;
+    'currentGpuUsage': number;
     'maxCpuPerSandbox': number | null;
     'maxMemoryPerSandbox': number | null;
     'maxDiskPerSandbox': number | null;

--- a/libs/api-client/src/models/region-usage-overview.ts
+++ b/libs/api-client/src/models/region-usage-overview.ts
@@ -28,5 +28,8 @@ export interface RegionUsageOverview {
     'maxMemoryPerSandbox': number | null;
     'maxDiskPerSandbox': number | null;
     'maxDiskPerNonEphemeralSandbox': number | null;
+    'maxCpuPerGpuSandbox': number | null;
+    'maxMemoryPerGpuSandbox': number | null;
+    'maxDiskPerGpuSandbox': number | null;
 }
 

--- a/libs/api-client/src/models/update-organization-region-quota.ts
+++ b/libs/api-client/src/models/update-organization-region-quota.ts
@@ -18,6 +18,7 @@ export interface UpdateOrganizationRegionQuota {
     'totalCpuQuota': number | null;
     'totalMemoryQuota': number | null;
     'totalDiskQuota': number | null;
+    'totalGpuQuota': number | null;
     'maxCpuPerSandbox'?: number | null;
     'maxMemoryPerSandbox'?: number | null;
     'maxDiskPerSandbox'?: number | null;

--- a/libs/api-client/src/models/update-organization-region-quota.ts
+++ b/libs/api-client/src/models/update-organization-region-quota.ts
@@ -23,5 +23,8 @@ export interface UpdateOrganizationRegionQuota {
     'maxMemoryPerSandbox'?: number | null;
     'maxDiskPerSandbox'?: number | null;
     'maxDiskPerNonEphemeralSandbox'?: number | null;
+    'maxCpuPerGpuSandbox'?: number | null;
+    'maxMemoryPerGpuSandbox'?: number | null;
+    'maxDiskPerGpuSandbox'?: number | null;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add GPU region quotas and per‑GPU‑sandbox limits, enforce them across scheduling/validation/usage, and surface GPU usage in the dashboard and snapshots. Non‑GPU sandboxes can’t use GPU runners; GPU sandboxes are always ephemeral (now noted in the dashboard create/preview flows).

- **New Features**
  - Region GPU quota `totalGpuQuota` and per‑GPU‑sandbox overrides: `maxCpuPerGpuSandbox`, `maxMemoryPerGpuSandbox`, `maxDiskPerGpuSandbox`.
  - Validation: `gpu` allowed 0–1; other resources ≥ 0; GPU sandboxes forced ephemeral.
  - Usage accounting includes GPU for current and pending usage; create/start/resize/snapshot reserve/release/rollback paths updated (recover paths skip GPU as needed).
  - Runner selection: GPU‑enabled runners are used only by GPU sandboxes; `gpu` flag passed through build/migrate/snapshot/start flows.
  - Dashboard: Usage Overview shows GPU quota/usage; Limits shows GPU overrides; sandbox/snapshot lists and details display GPU; create forms (sandbox and snapshot) include a GPU option and show an “ephemeral” note when GPU is selected.
  - API schema updated (`RegionQuota`, `RegionUsageOverview`, `UpdateOrganizationRegionQuota`); `@daytona/api-client` and Go/Java/Python/Ruby clients regenerated.
  - Metrics: export total GPU capacity as `daytona.sandbox.total_gpu`.

- **Migration**
  - Run DB migration `1779840000000` to add `total_gpu_quota`, `max_cpu_per_gpu_sandbox`, `max_memory_per_gpu_sandbox`, `max_disk_per_gpu_sandbox` to `region_quota`.
  - After deploy, set per‑region `totalGpuQuota` and optional GPU per‑sandbox overrides; when GPU overrides are null, non‑GPU per‑sandbox limits are used.

<sup>Written for commit 6399668fa082b2690beea505a9e24e191bfdb9a7. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4772?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

