### PR TITLE
fix(sdk-typescript): route stream module through dynamicImport in ESM downloadFile path

### DIFF
--- a/libs/sdk-typescript/runtime-tests/nextjs-external/app/api/download/route.ts
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/app/api/download/route.ts
@@ -1,0 +1,35 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Daytona } from '@daytona/sdk'
+
+export const dynamic = 'force-dynamic'
+
+// Exercises the exact bug path from issue #4771:
+//   Next.js App Router (Node runtime) + serverExternalPackages → SDK loaded as
+//   ESM → sandbox.fs.downloadFile() → processDownloadFilesResponseWithBusboy →
+//   bare `require()` in compiled SDK. Before the fix this throws
+//   `ReferenceError: require is not defined`.
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const sandboxId = url.searchParams.get('sandboxId')
+  const expectedContent = url.searchParams.get('expected')
+  if (!sandboxId || !expectedContent) {
+    return Response.json({ error: 'sandboxId and expected params required' }, { status: 400 })
+  }
+
+  try {
+    const daytona = new Daytona()
+    const sandbox = await daytona.get(sandboxId)
+    const buf = await sandbox.fs.downloadFile('test.txt')
+    return Response.json({
+      downloadOk: buf.toString('utf-8') === expectedContent,
+    })
+  } catch (e: unknown) {
+    return Response.json({
+      downloadOk: false,
+      error: e instanceof Error ? e.message : String(e),
+      stack: e instanceof Error ? e.stack : undefined,
+    })
+  }
+}

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/app/api/sandboxes/route.ts
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/app/api/sandboxes/route.ts
@@ -1,0 +1,16 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Daytona, Image } from '@daytona/sdk'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const image = Image.base('alpine').env({ FOO: 'bar' })
+  const daytona = new Daytona()
+  const r = await daytona.snapshot.list()
+  return Response.json({
+    imageOk: image.dockerfile.includes('FROM alpine'),
+    listOk: Array.isArray(r.items),
+  })
+}

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/app/layout.tsx
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/app/layout.tsx
@@ -1,0 +1,10 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/app/page.tsx
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/app/page.tsx
@@ -1,0 +1,6 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export default function Page() {
+  return <main>ok</main>
+}

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/next-env.d.ts
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/next-env.d.ts
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/next-env.d.ts
@@ -1,3 +1,6 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/next.config.js
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/next.config.js
@@ -1,0 +1,9 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Externalize the SDK and its sibling client packages so Next.js does NOT
+// bundle them via webpack. Node loads them as ESM at runtime, which is the
+// failure mode reported in issue #4771.
+module.exports = {
+  serverExternalPackages: ['@daytona/sdk', '@daytona/api-client', '@daytona/toolbox-api-client'],
+}

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/package.json
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "runtime-test-nextjs-external",
+  "private": true,
+  "scripts": {
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/run.sh
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reproduces and regression-tests issue #4771: sandbox.fs.downloadFile() in
+# Next.js App Router when the SDK is externalized via `serverExternalPackages`.
+
+set -euo pipefail
+rm -rf node_modules package-lock.json .next
+
+npm install --silent
+npm install --silent "$API_CLIENT_TARBALL" "$TOOLBOX_API_CLIENT_TARBALL" "$SDK_TARBALL"
+
+# ---------------------------------------------------------------------------
+# Create a sandbox and upload a test file for the downloadFile assertion.
+# Uses the SDK from Node.js directly (CJS path — not the bug scenario).
+# ---------------------------------------------------------------------------
+FILE_CONTENT="hello from nextjs-external"
+FILE_PATH="test.txt"
+
+SANDBOX_ID=$(node --input-type=module -e "
+import { Daytona } from '@daytona/sdk';
+const d = new Daytona();
+const s = await d.create({ timeout: 120, labels: { purpose: 'runtime-test-nextjs-external' } });
+await s.fs.uploadFile(Buffer.from('${FILE_CONTENT}'), '${FILE_PATH}');
+process.stdout.write(s.id);
+")
+echo "Sandbox created: $SANDBOX_ID"
+
+cleanup() {
+  node --input-type=module -e "
+    import { Daytona } from '@daytona/sdk';
+    const d = new Daytona();
+    try { const s = await d.get('${SANDBOX_ID}'); await d.delete(s); } catch {}
+  " 2>/dev/null || true
+  kill -9 "${SERVER_PID:-}" 2>/dev/null || true
+  pkill -9 -f 'next start' 2>/dev/null || true
+}
+trap cleanup EXIT
+
+NODE_ENV=production npm run build >/dev/null
+
+PORT=${RUNTIME_TEST_PORT:-3804}
+NODE_ENV=production npx next start -p "$PORT" >/tmp/nextjs-external-runtime.log 2>&1 &
+SERVER_PID=$!
+
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:$PORT/api/sandboxes" >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+# --- Test 1: basic import (Image + list) ---
+RESPONSE=$(curl -sf -m 30 "http://localhost:$PORT/api/sandboxes")
+echo "Response: $RESPONSE"
+echo "$RESPONSE" | grep -q '"imageOk":true' || { echo "FAIL: imageOk false"; exit 1; }
+echo "$RESPONSE" | grep -q '"listOk":true' || { echo "FAIL: listOk false"; exit 1; }
+
+# --- Test 2: downloadFile (the bug path from #4771) ---
+# urlencode FILE_CONTENT via node to avoid a python3 dependency.
+ENCODED_CONTENT=$(node -e "process.stdout.write(encodeURIComponent('${FILE_CONTENT}'))")
+DL_RESPONSE=$(curl -sf -m 60 "http://localhost:$PORT/api/download?sandboxId=${SANDBOX_ID}&expected=${ENCODED_CONTENT}")
+echo "Download response: $DL_RESPONSE"
+echo "$DL_RESPONSE" | grep -q '"downloadOk":true' || { echo "FAIL: downloadOk false"; exit 1; }
+
+echo "PASS"

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/run.sh
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/run.sh
@@ -18,6 +18,24 @@ npm install --silent "$API_CLIENT_TARBALL" "$TOOLBOX_API_CLIENT_TARBALL" "$SDK_T
 FILE_CONTENT="hello from nextjs-external"
 FILE_PATH="test.txt"
 
+# Register cleanup BEFORE creating the sandbox so any failure during creation
+# (or between creation and the rest of the script) is still cleaned up.
+SANDBOX_ID=""
+SERVER_PID=""
+cleanup() {
+  if [ -n "$SANDBOX_ID" ]; then
+    node --input-type=module -e "
+      import { Daytona } from '@daytona/sdk';
+      const d = new Daytona();
+      try { const s = await d.get('${SANDBOX_ID}'); await d.delete(s); } catch {}
+    " 2>/dev/null || true
+  fi
+  if [ -n "$SERVER_PID" ]; then
+    kill -9 "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
 SANDBOX_ID=$(node --input-type=module -e "
 import { Daytona } from '@daytona/sdk';
 const d = new Daytona();
@@ -26,17 +44,6 @@ await s.fs.uploadFile(Buffer.from('${FILE_CONTENT}'), '${FILE_PATH}');
 process.stdout.write(s.id);
 ")
 echo "Sandbox created: $SANDBOX_ID"
-
-cleanup() {
-  node --input-type=module -e "
-    import { Daytona } from '@daytona/sdk';
-    const d = new Daytona();
-    try { const s = await d.get('${SANDBOX_ID}'); await d.delete(s); } catch {}
-  " 2>/dev/null || true
-  kill -9 "${SERVER_PID:-}" 2>/dev/null || true
-  pkill -9 -f 'next start' 2>/dev/null || true
-}
-trap cleanup EXIT
 
 NODE_ENV=production npm run build >/dev/null
 

--- a/libs/sdk-typescript/runtime-tests/nextjs-external/tsconfig.json
+++ b/libs/sdk-typescript/runtime-tests/nextjs-external/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -358,6 +358,11 @@ export class FileSystem {
     const metadataMap = new Map<string, DownloadMetadata>()
     metadataMap.set(remotePath, {})
 
+    // Pre-resolve `stream` so the synchronous `onFileStream` callback below
+    // never needs to call `require()` — bare `require()` is unavailable in
+    // ESM under Next.js `serverExternalPackages` (issue #4771).
+    const { Transform } = await dynamicImport('stream', 'downloadFileStream progress tracking is not supported: ')
+
     return new Promise<Readable>((resolve, reject) => {
       let resolvedStream: Readable | null = null
 
@@ -367,7 +372,6 @@ export class FileSystem {
         metadataMap,
         (_source, fileStream, totalBytes) => {
           if (options.onProgress) {
-            const { Transform } = require('stream') as typeof import('stream')
             let bytesReceived = 0
             const progress = new Transform({
               transform(chunk, _encoding, callback) {

--- a/libs/sdk-typescript/src/FileSystem.ts
+++ b/libs/sdk-typescript/src/FileSystem.ts
@@ -331,6 +331,9 @@ export class FileSystem {
       throw new DaytonaError('Download cancelled')
     }
 
+    // Pre-resolve `stream` so the sync `onFileStream` callback below is await-free.
+    const { Transform } = await dynamicImport('stream', 'downloadFileStream progress tracking is not supported: ')
+
     const toDownloadCancelledError = () => new DaytonaError('Download cancelled')
     const isCanceledError = (err: unknown) => {
       const error = err as { code?: string; name?: string }
@@ -357,11 +360,6 @@ export class FileSystem {
     const responseStream = normalizeResponseStream(response.data)
     const metadataMap = new Map<string, DownloadMetadata>()
     metadataMap.set(remotePath, {})
-
-    // Pre-resolve `stream` so the synchronous `onFileStream` callback below
-    // never needs to call `require()` — bare `require()` is unavailable in
-    // ESM under Next.js `serverExternalPackages` (issue #4771).
-    const { Transform } = await dynamicImport('stream', 'downloadFileStream progress tracking is not supported: ')
 
     return new Promise<Readable>((resolve, reject) => {
       let resolvedStream: Readable | null = null

--- a/libs/sdk-typescript/src/utils/FileTransfer.ts
+++ b/libs/sdk-typescript/src/utils/FileTransfer.ts
@@ -358,7 +358,7 @@ async function feedStreamToBusboy(stream: any, bb: any, observer: MultipartHeade
   // always emits DaytonaError, not a raw library error.
   if (typeof stream?.pipe === 'function') {
     if (observer) {
-      const { Transform } = require('stream') as typeof import('stream')
+      const { Transform } = await dynamicImport('stream', '"downloadFiles" is not supported: ')
       const tapStream = new Transform({
         transform(chunk: any, _encoding: BufferEncoding, callback: (err?: Error | null, data?: any) => void) {
           const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)


### PR DESCRIPTION
Fixes #4771 — `sandbox.fs.downloadFile()` throws `ReferenceError: require is not defined` when the SDK is externalized via Next.js `serverExternalPackages`.

### Cause

The `createRequire` shim that `scripts/post-build.js` prepends to the ESM build is only injected into `utils/Import.js`. Two production sites had **direct** `require('stream')` calls compiled into other ESM files where the shim is out of scope:

- `utils/FileTransfer.ts#feedStreamToBusboy` — hit by `downloadFile`/`downloadFiles`/`downloadFileStream`
- `FileSystem.ts#downloadFileStream` (with `onProgress`)

Webpack normally bundles these away, but `serverExternalPackages` skips webpack and lets Node load the SDK as ESM — bare `require` is undefined.

### Fix

Both sites now use `await dynamicImport('stream', ...)`. `dynamicImport` is ESM-native and doesn't depend on the shim. Audited the rest of the SDK — all other `dynamicRequire` calls live in genuinely sync paths (`Image` builders, OTel setup, `Buffer` fallback) and continue to work via `Import.ts`.

### Regression test

New `libs/sdk-typescript/runtime-tests/nextjs-external/` — Next 15 + React 19 App Router with `serverExternalPackages` set, two routes covering `Image`/`snapshot.list` and `downloadFile`. Verified against `https://app.daytona.io/api`:

```
Response: {"imageOk":true,"listOk":true}
Download response: {"downloadOk":true}
PASS
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sandbox.fs.downloadFile*` failing in Next.js ESM when `@daytona/sdk` is externalized by loading `stream` via `dynamicImport` and hoisting it before sync callbacks. Adds a Next 15 runtime test with `serverExternalPackages` and safer cleanup to prevent regressions.

- **Bug Fixes**
  - Replaced `require('stream')` with `await dynamicImport('stream', ...)` in `FileSystem.downloadFileStream` and `utils/FileTransfer.feedStreamToBusboy`.
  - Hoisted the `stream` import so the sync `onProgress` callback doesn’t call `require` or `await`, fixing ESM usage with Next.js `serverExternalPackages`.
  - Added `libs/sdk-typescript/runtime-tests/nextjs-external` (Next 15 App Router) and `run.sh` that verifies `Image`/`snapshot.list` and `downloadFile`, with improved trap-based sandbox/server cleanup.

<sup>Written for commit 35012c5236d7133f32b2de4e2d0306af4cd3665c. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4773?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

