### PR TITLE
fix(runner): non force removal of snapshots on runner

### DIFF
--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	InitializeDaemonTelemetry          bool          `envconfig:"INITIALIZE_DAEMON_TELEMETRY" default:"true"`
 	SnapshotErrorCacheRetention        time.Duration `envconfig:"SNAPSHOT_ERROR_CACHE_RETENTION" default:"10m" validate:"min=5m"`
 	BuildEngine                        string        `envconfig:"BUILD_ENGINE" default:"buildkit" validate:"oneof=buildkit legacy"`
+	ForceSnapshotRemoval               bool          `envconfig:"FORCE_SNAPSHOT_REMOVAL" default:"true"`
 }
 
 var DEFAULT_API_PORT int = 8080
@@ -154,6 +155,10 @@ func GetEnvironment() string {
 
 func GetBuildEngine() string {
 	return config.BuildEngine
+}
+
+func GetForceSnapshotRemoval() bool {
+	return config.ForceSnapshotRemoval
 }
 
 func GetBuildLogFilePath(snapshotRef string) (string, error) {

--- a/apps/runner/pkg/api/controllers/snapshot.go
+++ b/apps/runner/pkg/api/controllers/snapshot.go
@@ -270,7 +270,7 @@ func RemoveSnapshot(logger *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
-		err = runner.Docker.RemoveImage(ctx.Request.Context(), snapshot, false)
+		err = runner.Docker.RemoveImage(ctx.Request.Context(), snapshot, config.GetForceSnapshotRemoval())
 		if err != nil {
 			ctx.Error(err)
 			return

--- a/apps/runner/pkg/api/controllers/snapshot.go
+++ b/apps/runner/pkg/api/controllers/snapshot.go
@@ -270,7 +270,7 @@ func RemoveSnapshot(logger *slog.Logger) gin.HandlerFunc {
 			return
 		}
 
-		err = runner.Docker.RemoveImage(ctx.Request.Context(), snapshot, true)
+		err = runner.Docker.RemoveImage(ctx.Request.Context(), snapshot, false)
 		if err != nil {
 			ctx.Error(err)
 			return

--- a/apps/runner/pkg/docker/image_remove.go
+++ b/apps/runner/pkg/docker/image_remove.go
@@ -20,6 +20,11 @@ func (d *DockerClient) RemoveImage(ctx context.Context, imageName string, force 
 			d.logger.InfoContext(ctx, "Image already removed and not found", "imageName", imageName)
 			return nil
 		}
+		if !force && errdefs.IsConflict(err) {
+			// Image still in use by a container — expected, not an error.
+			d.logger.InfoContext(ctx, "Image still in use by a container, skipping non-force removal", "imageName", imageName)
+			return nil
+		}
 		return err
 	}
 

--- a/apps/runner/pkg/runner/v2/executor/snapshot.go
+++ b/apps/runner/pkg/runner/v2/executor/snapshot.go
@@ -69,7 +69,7 @@ func (e *Executor) pullSnapshot(ctx context.Context, job *apiclient.Job) (any, e
 }
 
 func (e *Executor) removeSnapshot(ctx context.Context, job *apiclient.Job) (any, error) {
-	return nil, e.docker.RemoveImage(ctx, job.ResourceId, true)
+	return nil, e.docker.RemoveImage(ctx, job.ResourceId, false)
 }
 
 func (e *Executor) inspectSnapshotInRegistry(ctx context.Context, job *apiclient.Job) (any, error) {

--- a/apps/runner/pkg/runner/v2/executor/snapshot.go
+++ b/apps/runner/pkg/runner/v2/executor/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/daytonaio/runner/cmd/runner/config"
 	"github.com/daytonaio/runner/pkg/api/dto"
 )
 
@@ -69,7 +70,7 @@ func (e *Executor) pullSnapshot(ctx context.Context, job *apiclient.Job) (any, e
 }
 
 func (e *Executor) removeSnapshot(ctx context.Context, job *apiclient.Job) (any, error) {
-	return nil, e.docker.RemoveImage(ctx, job.ResourceId, false)
+	return nil, e.docker.RemoveImage(ctx, job.ResourceId, config.GetForceSnapshotRemoval())
 }
 
 func (e *Executor) inspectSnapshotInRegistry(ctx context.Context, job *apiclient.Job) (any, error) {


### PR DESCRIPTION
## Description

Snapshot image cleanup on runners used a force remove, which untagged images even while a sandbox container still used them. That freed no disk anyway (the container pins the layers) but left the image unusable, so a later resize or recover couldn't recreate the container from it. This switches snapshot removal to non-force, leaving images that still back a live sandbox intact. When Docker refuses removal because the image is in use, that's now treated as the expected outcome, not an error.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation