### PR TITLE
Refresh container security dependencies

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-slim AS daytona
+FROM node:24-trixie-slim AS daytona
 
 ENV CI=true
 

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.10-alpine3.22 /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -41,9 +41,9 @@ RUN mkdir -p dist/apps/otel-collector
 
 RUN yarn nx build otel-collector --configuration=production --nxBail=true
 
-FROM alpine:3.22 AS otel-collector
+FROM alpine:3.22.4 AS otel-collector
 
-RUN apk add --no-cache curl
+RUN apk upgrade --no-cache && apk add --no-cache curl
 
 WORKDIR /usr/local/bin
 

--- a/apps/proxy/Dockerfile
+++ b/apps/proxy/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.10-alpine3.22 /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -40,9 +40,9 @@ ARG VERSION=0.0.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
   VERSION=$VERSION yarn nx build proxy --configuration=production --nxBail=true
 
-FROM alpine:3.22 AS proxy
+FROM alpine:3.22.4 AS proxy
 
-RUN apk add --no-cache curl
+RUN apk upgrade --no-cache && apk add --no-cache curl
 
 WORKDIR /usr/local/bin
 

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.10-alpine3.22 /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -55,9 +55,9 @@ ARG VERSION=0.0.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
   SKIP_COMPUTER_USE_BUILD=true VERSION=$VERSION yarn nx build runner --configuration=production --nxBail=true
 
-FROM docker:28.2.2-dind-alpine3.22 AS runner
+FROM docker:28.5.2-dind-alpine3.22 AS runner
 
-RUN apk add --no-cache curl rsync
+RUN apk upgrade --no-cache && apk add --no-cache curl rsync
 
 WORKDIR /usr/local/bin
 

--- a/apps/snapshot-manager/Dockerfile
+++ b/apps/snapshot-manager/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.10-alpine3.22 /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -36,9 +36,9 @@ ARG VERSION=0.0.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
   VERSION=$VERSION yarn nx build snapshot-manager --configuration=production --nxBail=true
 
-FROM alpine:3.22 AS snapshot-manager
+FROM alpine:3.22.4 AS snapshot-manager
 
-RUN apk add --no-cache curl
+RUN apk upgrade --no-cache && apk add --no-cache curl
 
 WORKDIR /usr/local/bin
 

--- a/apps/ssh-gateway/Dockerfile
+++ b/apps/ssh-gateway/Dockerfile
@@ -4,7 +4,7 @@ ENV CI=true
 
 RUN npm install -g corepack && corepack enable
 
-COPY --from=golang:1.25.4-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.25.10-alpine3.22 /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -36,7 +36,9 @@ COPY libs/api-client-go/ libs/api-client-go/
 
 RUN yarn nx build ssh-gateway --configuration=production --nxBail=true
 
-FROM alpine:3.22 AS ssh-gateway
+FROM alpine:3.22.4 AS ssh-gateway
+
+RUN apk upgrade --no-cache
 
 WORKDIR /usr/local/bin
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10314,6 +10314,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/codegen@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10c0/1b8a2ae56ee60a56e9d205cd4b6072a1503c5069b8ebb905710f974ff0098a0d0700641c137e0a8d98dedf14423156a106a9433695cbf52574810f55000fdcab
+  languageName: node
+  linkType: hard
+
 "@protobufjs/eventemitter@npm:^1.1.0":
   version: 1.1.0
   resolution: "@protobufjs/eventemitter@npm:1.1.0"
@@ -10345,6 +10352,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/inquire@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/inquire@npm:1.1.1"
+  checksum: 10c0/a638d981adabdbdd61fba04e5045e0d2f98fa557eb0e705482a6dc25e84318bc736b0cd4aaee5d6b9941f121b488ece872c203af2a665b6dfefa95c903bb0cc8
+  languageName: node
+  linkType: hard
+
 "@protobufjs/path@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/path@npm:1.1.2"
@@ -10363,6 +10377,13 @@ __metadata:
   version: 1.1.0
   resolution: "@protobufjs/utf8@npm:1.1.0"
   checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/utf8@npm:1.1.1"
+  checksum: 10c0/641fc145f00626405e8984b6e90b9edcbcc072ffc82d0647ca3176e09c730b2d022f988e65f011a7a17e2e4d77cde7733643aa10d8ac2bfa30f134dbcad553fd
   languageName: node
   linkType: hard
 
@@ -18368,25 +18389,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.11.0, axios@npm:^1.13.5, axios@npm:^1.8.2, axios@npm:^1.8.3":
-  version: 1.14.0
-  resolution: "axios@npm:1.14.0"
+"axios@npm:^1.11.0, axios@npm:^1.13.5, axios@npm:^1.14.0, axios@npm:^1.8.2, axios@npm:^1.8.3":
+  version: 1.16.1
+  resolution: "axios@npm:1.16.1"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/2541f4aa215a7d1842429dad006fc682d82bc0e74bd14500823f7d8cce3bbae0e0a8c328c8538946718f366ab8ce5a4c12e9ad40e5a0f3482ff8bff0cd115d45
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.14.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
+  checksum: 10c0/2f77e37e6552bbff8a772d058fb09500198e9188c6b20dc799d82dbe12a8cb506f6eed4e4e62a9ba612a35cbab496faa26d68f9bff14a53af6d15c3e136391a7
   languageName: node
   linkType: hard
 
@@ -24478,13 +24489,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11":
+"follow-redirects@npm:^1.0.0":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
     debug:
       optional: true
   checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -25436,8 +25457,8 @@ __metadata:
   linkType: hard
 
 "handlebars@npm:4.7.8, handlebars@npm:^4.7.8":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -25449,7 +25470,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -34452,22 +34473,22 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
+  version: 7.5.8
+  resolution: "protobufjs@npm:7.5.8"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/codegen": "npm:^2.0.5"
     "@protobufjs/eventemitter": "npm:^1.1.0"
     "@protobufjs/fetch": "npm:^1.1.0"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/inquire": "npm:^1.1.1"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  checksum: 10c0/25968259084a634e035f865febd5a31f75bdaee4fda6fba4e14c57019024e7cada859b470eb69350f430fbd0d509c805249b9fe8a6c44a57a0b484a1ef685751
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR refreshes the container build/runtime security baseline for the Daytona API and the Go-based service images used by self-hosted/Kubernetes deployments.

It is motivated by a Mend/WhiteSource compliance scan we ran against the `v0.168.1-k8s.0-amd64` image set that Daytona provided to Athena for a KPMG review. The patched images improved the previous scan, but the current K8s image set still reports material reachable Critical/High findings, especially in:

- Go stdlib versions embedded in service binaries
- Alpine/OpenSSL runtime packages
- Docker-in-Docker runner base packages
- Node transitive packages such as `protobufjs`, `handlebars`, and `axios`

## Changes

- Bump Go builder image from `golang:1.25.4-alpine` to `golang:1.25.10-alpine3.22` for:
  - `proxy`
  - `runner`
  - `snapshot-manager`
  - `ssh-gateway`
  - `otel-collector`
- Pin final Alpine stages to `alpine:3.22.4` and run `apk upgrade --no-cache` before installing runtime packages.
- Bump the runner Docker-in-Docker base from `docker:28.2.2-dind-alpine3.22` to `docker:28.5.2-dind-alpine3.22`.
- Move the API image base from `node:24-slim` to `node:24-trixie-slim` for a fresher Debian base.
- Refresh Yarn lock entries for vulnerable transitive packages:
  - `axios` -> `1.16.1`
  - `protobufjs` -> `7.5.8` for the 7.x dependency line
  - `handlebars` -> `4.7.9`, including the exact `4.7.8` selector pulled by `verdaccio`

## Validation

- `yarn install --immutable` passes with existing peer dependency warnings.
- `docker build --check` passes for all touched Dockerfiles:
  - `apps/api/Dockerfile`
  - `apps/otel-collector/Dockerfile`
  - `apps/proxy/Dockerfile`
  - `apps/runner/Dockerfile`
  - `apps/snapshot-manager/Dockerfile`
  - `apps/ssh-gateway/Dockerfile`
- Verified dependency resolution with:
  - `yarn why axios`
  - `yarn why protobufjs`
  - `yarn why handlebars`

## Notes

This PR does not itself publish the special `*-k8s.0-amd64` images. Our ask is that Daytona cut a fresh self-hosted/K8s image set from this or equivalent changes so downstream users can validate the patched official images in Mend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes container build and runtime bases to cut Critical/High CVEs across the API and Go service images. Pins Alpine and updates Go, Node, and DinD bases; also refreshes vulnerable Node transitive deps.

- **Dependencies**
  - Go builder base: `golang:1.25.4-alpine` → `golang:1.25.10-alpine3.22` for proxy, runner, snapshot-manager, ssh-gateway, otel-collector
  - Final images: pin `alpine:3.22.4` and run `apk upgrade --no-cache` before package installs
  - Runner base: `docker:28.2.2-dind-alpine3.22` → `docker:28.5.2-dind-alpine3.22`
  - API base: `node:24-slim` → `node:24-trixie-slim`
  - Yarn lock: `axios@1.16.1`, `protobufjs@7.5.8`, `handlebars@4.7.9`

- **Migration**
  - Rebuild and publish the self-hosted/Kubernetes image set so downstream users can consume the patched images.

<sup>Written for commit ed624dee3b9ede17b0169fa773a684999eeef4fe. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4779?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

