### PR TITLE
feat(runner): request GPUs through Docker CDI

### DIFF
--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -117,6 +117,13 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 }
 
 func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, volumeMountPathBinds []string) (*container.HostConfig, error) {
+	if d.gpuEnabled && sandboxDto.GpuQuota <= 0 {
+		return nil, fmt.Errorf("cpu-only sandbox cannot run on GPU-enabled runner")
+	}
+	if !d.gpuEnabled && sandboxDto.GpuQuota > 0 {
+		return nil, fmt.Errorf("GPU sandbox cannot run on non-GPU runner")
+	}
+
 	var binds []string
 
 	binds = append(binds, fmt.Sprintf("%s:%s:ro", d.daemonPath, common.DAEMON_PATH))
@@ -161,21 +168,11 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 		}
 	}
 
-	if d.gpuEnabled {
-		nvidiaDevices := []string{
-			"/dev/nvidia0",
-			"/dev/nvidiactl",
-			"/dev/nvidia-uvm",
-			"/dev/nvidia-uvm-tools",
-			"/dev/nvidia-modeset",
-		}
-		for _, dev := range nvidiaDevices {
-			hostConfig.Devices = append(hostConfig.Devices, container.DeviceMapping{
-				PathOnHost:        dev,
-				PathInContainer:   dev,
-				CgroupPermissions: "rwm",
-			})
-		}
+	if d.gpuEnabled && sandboxDto.GpuQuota > 0 {
+		hostConfig.DeviceRequests = append(hostConfig.DeviceRequests, container.DeviceRequest{
+			Driver:    "cdi",
+			DeviceIDs: []string{"nvidia.com/gpu=all"},
+		})
 	}
 
 	return hostConfig, nil

--- a/apps/runner/pkg/docker/container_configs_test.go
+++ b/apps/runner/pkg/docker/container_configs_test.go
@@ -1,0 +1,117 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package docker
+
+import (
+	"os"
+	"testing"
+
+	"github.com/daytonaio/runner/cmd/runner/config"
+	"github.com/daytonaio/runner/pkg/api/dto"
+)
+
+func TestGetContainerHostConfigAddsCDIForGpuSandbox(t *testing.T) {
+	ensureRunnerConfig(t)
+
+	d := &DockerClient{
+		daemonPath: "/opt/daytona-runner/daytona-daemon",
+		gpuEnabled: true,
+	}
+
+	hostConfig, err := d.getContainerHostConfig(dto.CreateSandboxDTO{GpuQuota: 1}, nil)
+	if err != nil {
+		t.Fatalf("getContainerHostConfig returned error: %v", err)
+	}
+
+	if len(hostConfig.Devices) != 0 {
+		t.Fatalf("expected no explicit device mappings, got %d", len(hostConfig.Devices))
+	}
+
+	if len(hostConfig.DeviceRequests) != 1 {
+		t.Fatalf("expected one CDI device request, got %d", len(hostConfig.DeviceRequests))
+	}
+
+	request := hostConfig.DeviceRequests[0]
+	if request.Driver != "cdi" {
+		t.Fatalf("expected CDI driver, got %q", request.Driver)
+	}
+	if len(request.DeviceIDs) != 1 || request.DeviceIDs[0] != "nvidia.com/gpu=all" {
+		t.Fatalf("expected nvidia.com/gpu=all device ID, got %#v", request.DeviceIDs)
+	}
+}
+
+func TestGetContainerHostConfigRejectsCpuSandboxOnGpuRunner(t *testing.T) {
+	ensureRunnerConfig(t)
+
+	d := &DockerClient{
+		daemonPath: "/opt/daytona-runner/daytona-daemon",
+		gpuEnabled: true,
+	}
+
+	hostConfig, err := d.getContainerHostConfig(dto.CreateSandboxDTO{GpuQuota: 0}, nil)
+	if err == nil {
+		t.Fatalf("expected getContainerHostConfig to reject CPU-only sandbox on GPU runner")
+	}
+
+	if hostConfig != nil {
+		t.Fatalf("expected no host config for rejected CPU-only sandbox, got %#v", hostConfig)
+	}
+}
+
+func TestGetContainerHostConfigAllowsCpuSandboxOnNonGpuRunner(t *testing.T) {
+	ensureRunnerConfig(t)
+
+	d := &DockerClient{
+		daemonPath: "/opt/daytona-runner/daytona-daemon",
+		gpuEnabled: false,
+	}
+
+	hostConfig, err := d.getContainerHostConfig(dto.CreateSandboxDTO{GpuQuota: 0}, nil)
+	if err != nil {
+		t.Fatalf("getContainerHostConfig returned error: %v", err)
+	}
+
+	if len(hostConfig.DeviceRequests) != 0 {
+		t.Fatalf("expected no CDI device requests, got %d", len(hostConfig.DeviceRequests))
+	}
+	if len(hostConfig.Devices) != 0 {
+		t.Fatalf("expected no explicit device mappings, got %d", len(hostConfig.Devices))
+	}
+}
+
+func TestGetContainerHostConfigRejectsGpuSandboxOnNonGpuRunner(t *testing.T) {
+	ensureRunnerConfig(t)
+
+	d := &DockerClient{
+		daemonPath: "/opt/daytona-runner/daytona-daemon",
+		gpuEnabled: false,
+	}
+
+	hostConfig, err := d.getContainerHostConfig(dto.CreateSandboxDTO{GpuQuota: 1}, nil)
+	if err == nil {
+		t.Fatalf("expected getContainerHostConfig to reject GPU sandbox on non-GPU runner")
+	}
+
+	if hostConfig != nil {
+		t.Fatalf("expected no host config for rejected GPU sandbox, got %#v", hostConfig)
+	}
+}
+
+func ensureRunnerConfig(t *testing.T) {
+	t.Helper()
+
+	setEnvIfUnset("SERVER_URL", "https://daytona.example.test")
+	setEnvIfUnset("API_TOKEN", "test-token")
+	setEnvIfUnset("RUNNER_DOMAIN", "127.0.0.1")
+
+	if _, err := config.GetConfig(); err != nil {
+		t.Fatalf("failed to initialize runner config: %v", err)
+	}
+}
+
+func setEnvIfUnset(key, value string) {
+	if _, ok := os.LookupEnv(key); !ok {
+		_ = os.Setenv(key, value)
+	}
+}


### PR DESCRIPTION
## Summary

Switches GPU sandbox creation in the runner from explicit NVIDIA device-node bind mappings to Docker CDI.

This PR:

- requests `nvidia.com/gpu=all` through Docker's CDI device request path for GPU sandboxes on GPU-enabled runners
- removes hard-coded `/dev/nvidia*` device mappings from the runner Docker host config
- rejects CPU-only sandboxes on GPU-enabled runners
- rejects GPU sandboxes on non-GPU runners
- adds runner Docker host-config tests for GPU and CPU sandbox placement combinations

## Why

The companion infra PR provisions NVIDIA CDI on GPU runner hosts. Once that is available, the runner should ask Docker for the CDI device instead of manually binding a fixed set of `/dev/nvidia*` nodes.

CDI lets the host-side provisioning own the NVIDIA device, library, binary, and runtime details. That is especially important for Sysbox sandboxes, where the infra PR generates a Sysbox-compatible NVIDIA CDI spec.

The runner now also fails closed if sandbox GPU requirements do not match the runner's GPU mode. Daytona's scheduler already treats GPU runners as reserved for GPU sandboxes, and GPU sandboxes get exclusive runner ownership. This guard prevents a misrouted CPU-only sandbox from starting on a GPU host where `Privileged: true` can otherwise expose `/dev/nvidia*` device nodes.

## Validation

Local runner package test:

```text
GOCACHE=/tmp/daytona-go-build-cache go test ./apps/runner/pkg/docker
```

End-to-end validation was run on a fresh Latitude H100 host with the companion infra PR applied. A temporary runner built from this branch successfully created GPU sandboxes via the runner API, and GPU access was verified with PyTorch, generic NVIDIA library loading, and the official `vllm/vllm-openai:latest` image. The detailed host/CDI validation lives in the companion infra PR.

## Rollout Notes

- Depends on the companion infra PR that installs the NVIDIA driver/tooling and generates the Sysbox-compatible CDI spec on GPU hosts.
- GPU runner hosts must have a valid CDI spec containing `nvidia.com/gpu=all` before this runner change is deployed there.
- This preserves the current GPU scheduling model: `GpuQuota` remains a placement signal and GPU sandboxes get exclusive runner ownership.
