### PR TITLE
chore(security): bump runner docker dind base from 28.2.2 to 28.5.2

### DIFF
--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -55,7 +55,7 @@ ARG VERSION=0.0.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
   SKIP_COMPUTER_USE_BUILD=true VERSION=$VERSION yarn nx build runner --configuration=production --nxBail=true
 
-FROM docker:28.2.2-dind-alpine3.22 AS runner
+FROM docker:28.5.2-dind-alpine3.22 AS runner
 
 RUN apk add --no-cache curl rsync
 


### PR DESCRIPTION
## Description

Bumps the runner's dind base image from `docker:28.2.2-dind-alpine3.22` to `docker:28.5.2-dind-alpine3.22`.

| | |
|---|---|
| Previous pin | `28.2.2-dind-alpine3.22` (released 2025-06) |
| New pin | `28.5.2-dind-alpine3.22` (released 2025-11-05) |
| Alpine base | unchanged (3.22) |
| Docker line | unchanged (28.x) |

Picks up the 28.3.x → 28.4.x → 28.5.x patch releases on top of the upstream Alpine 3.22 package set as of 2025-11. No application logic or entrypoint changes.

### Why not Docker 29.x

29.x ships with Alpine 3.23 and is a major-version bump for dockerd. That belongs in a separate, tested change — this PR keeps the runtime base inside the line the rest of the codebase already targets.

### Conflict note

PR #4770 (from a fork) also touches this file. If it merges first, this PR will conflict on line 58 only — a one-line rebase. If this merges first, #4770 will rebase cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update runner base image to `docker:28.5.2-dind-alpine3.22` (from `docker:28.2.2-dind-alpine3.22`) to pick up the latest 28.x patches and security fixes. Alpine stays at 3.22; not moving to Docker 29.x.

<sup>Written for commit e9a0eabb758191957ec3a54c5c1d253441fa4f33. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4787?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

