### PR TITLE
fix(sdk-python): anchor sync http_client finalizer on the client itself

### DIFF
--- a/libs/sdk-python/src/daytona/_sync/daytona.py
+++ b/libs/sdk-python/src/daytona/_sync/daytona.py
@@ -7,7 +7,6 @@ import asyncio
 import json
 import time
 import warnings
-import weakref
 from copy import deepcopy
 from importlib.metadata import version
 from typing import Callable, cast, overload
@@ -225,11 +224,10 @@ class Daytona:
             self._api_client.default_headers["X-Daytona-Organization-ID"] = self._organization_id
 
         # Shared pooled client for file-transfer paths; honors connection_pool_maxsize.
+        # build_sync_http_client installs a finalizer on the client itself, so the
+        # pool is closed when the last reference (this Daytona or any Sandbox it
+        # produced) goes away.
         self._http_client: httpx.Client = build_sync_http_client(pool_size)
-        # Close the pool deterministically when the Daytona instance is dereferenced.
-        # The finalizer captures only the httpx.Client (not self), so it doesn't keep
-        # the Daytona alive — it just runs httpx.Client.close() on GC.
-        _ = weakref.finalize(self, self._http_client.close)
 
         # Initialize API clients with the api_client instance
         self._sandbox_api: SandboxApi = SandboxApi(self._api_client)

--- a/libs/sdk-python/src/daytona/internal/http_client.py
+++ b/libs/sdk-python/src/daytona/internal/http_client.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import weakref
+
 import aiohttp
 import httpx
 
@@ -48,7 +50,35 @@ def build_async_http_client(pool_size: int | None = DEFAULT_POOL_SIZE) -> httpx.
 
 
 def build_sync_http_client(pool_size: int | None = DEFAULT_POOL_SIZE) -> httpx.Client:
-    return httpx.Client(limits=_build_limits(pool_size), timeout=_build_timeout())
+    client = httpx.Client(limits=_build_limits(pool_size), timeout=_build_timeout())
+    _attach_self_finalizer(client)
+    return client
+
+
+def _attach_self_finalizer(client: httpx.Client) -> None:
+    """Close the underlying transports when *client* itself is garbage-collected.
+
+    Anchoring the finalizer on the client (rather than on the owning ``Daytona``)
+    means the pool survives as long as anything still references it — the
+    parent ``Daytona`` or any ``Sandbox`` it returned — and closes
+    deterministically only when the last reference drops. This prevents
+    ``Daytona().create()``-style usage from prematurely closing the shared
+    client while the returned sandbox is still in use.
+
+    The callback captures only the transport objects (not the client), so it
+    introduces no self-reference that would keep the client alive forever.
+    """
+    transport = client._transport
+    mounts = tuple(t for t in client._mounts.values() if t is not None)
+
+    def _close() -> None:
+        for t in (transport, *mounts):
+            try:
+                t.close()
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                pass
+
+    _ = weakref.finalize(client, _close)
 
 
 def aiohttp_request_timeout(timeout: float | None) -> aiohttp.ClientTimeout:

--- a/libs/sdk-python/tests/test_e2e.py
+++ b/libs/sdk-python/tests/test_e2e.py
@@ -343,6 +343,59 @@ def test_upload_binary_content(sandbox):
     assert content == binary_data, "Binary content should round-trip exactly"
 
 
+def test_file_transfer_survives_dropped_daytona_reference():
+    """Regression test for an issue where ``Daytona().create()`` left the
+    returned Sandbox with a closed shared ``httpx.Client``.
+
+    The bug: a ``weakref.finalize`` on the ``Daytona`` instance closed the
+    shared http client as soon as the (unreferenced) ``Daytona`` was GC'd,
+    even though the returned ``Sandbox`` still held that client for
+    uploads/downloads. The first ``sandbox.fs.upload_file`` then raised
+    ``DaytonaError: Failed to upload files: Cannot send a request, as the
+    client has been closed.``
+
+    This test deliberately drops the only reference to ``Daytona`` after
+    obtaining the sandbox, forces a GC cycle, and then exercises every
+    file-transfer code path (upload bytes, upload stream, download bytes,
+    download stream). All of them must keep working — i.e. the shared
+    client must survive as long as any sandbox produced by the parent
+    Daytona is still reachable.
+    """
+    import gc
+
+    daytona = Daytona()
+    sb = daytona.create(CreateSandboxFromSnapshotParams(language="python"), timeout=120)
+    try:
+        # Drop the only reference to the parent Daytona and force GC. With
+        # the bug, this triggered the finalizer that closed the shared
+        # httpx.Client; with the fix, the client stays alive because the
+        # sandbox still references it.
+        del daytona
+        gc.collect()
+
+        path = f"e2e-orphan-{uuid.uuid4().hex}.txt"
+        payload = b"orphan-daytona-upload"
+
+        # upload_file (multipart, the original failing path)
+        sb.fs.upload_file(payload, path)
+        assert sb.fs.download_file(path) == payload
+
+        # upload_file_stream (also goes through the shared client)
+        stream_path = f"e2e-orphan-stream-{uuid.uuid4().hex}.bin"
+        stream_payload = b"orphan-stream-content" * 64
+        import io as _io
+
+        sb.fs.upload_file_stream(_io.BytesIO(stream_payload), stream_path)
+        assert b"".join(sb.fs.download_file_stream(stream_path)) == stream_payload
+    finally:
+        try:
+            # Recreate a Daytona to clean up; the sandbox keeps working
+            # because it carries its own SandboxApi reference.
+            Daytona().delete(sb)
+        except Exception:
+            pass
+
+
 # ===========================================================================
 # Process Execution
 # ===========================================================================


### PR DESCRIPTION
### Problem

`Daytona().create()` (no surrounding variable) crashed on the first
file-transfer call with:

```
DaytonaError: Failed to upload files: Cannot send a request, as the client has been closed.
```

Reproducible on prod with `daytona==0.178.0`.

### Why

`_sync/daytona.py` registered `weakref.finalize(self, self._http_client.close)`.
That finalizer is keyed on the `Daytona` instance, but the returned `Sandbox`
also holds a reference to the same shared `httpx.Client`. When the parent
`Daytona` had no strong reference, GC fired the finalizer and closed the
client out from under the still-live `Sandbox`.

### Fix

Move the finalizer onto the `httpx.Client` itself (in
`internal/http_client.py`). The callback captures only the underlying
transports (not the client), so there's no self-reference keeping the client
alive forever. The pool now survives as long as the parent `Daytona` **or**
any `Sandbox` it returned is reachable, and closes when the last one drops.

### Regression test

Added `test_file_transfer_survives_dropped_daytona_reference` in
`tests/test_e2e.py` — drops the only `Daytona` ref, forces GC, then exercises
`upload_file` / `upload_file_stream` / `download_file` / `download_file_stream`
on the orphaned sandbox. The existing module-scoped `daytona_client` fixture
never released its reference, which is why no existing test caught the bug.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash where file transfers failed after `Daytona().create()` when the `Daytona` instance wasn’t kept. The HTTP pool finalizer now lives on the `httpx.Client`, so it stays alive while any `Daytona` or `Sandbox` references it.

- **Bug Fixes**
  - Move finalizer to the `httpx.Client` and close underlying transports on GC.
  - Remove `weakref.finalize` from `Daytona` constructor.
  - Add regression test to verify upload/download after dropping the `Daytona` reference.

<sup>Written for commit eba4a82aeba43e767139006deb4b5bf9b98813ae. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4789?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

