### PR TITLE
feat(api,dashboard,runner): android sandbox class

### DIFF
--- a/apps/api/src/sandbox/enums/sandbox-class.enum.ts
+++ b/apps/api/src/sandbox/enums/sandbox-class.enum.ts
@@ -6,4 +6,5 @@
 export enum SandboxClass {
   LINUX_VM = 'linux-vm',
   CONTAINER = 'container',
+  ANDROID = 'android',
 }

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -46,6 +46,7 @@ import { SnapshotInfoResponse } from '@daytona/runner-api-client'
 import { SnapshotActivatedEvent } from '../events/snapshot-activated.event'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { RegionType } from '../../region/enums/region-type.enum'
+import { SandboxClass } from '../enums/sandbox-class.enum'
 
 /** Fisher-Yates shuffle — uniform random permutation in O(n). */
 function shuffleArray<T>(array: T[]): T[] {
@@ -341,7 +342,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
           state: RunnerState.READY,
           unschedulable: Not(true),
           region: In([...sharedRegionIds, ...organizationRegionIds]),
-          sandboxClass: snapshot.sandboxClass,
+          // Temporary: Android snapshots can go to container runners
+          sandboxClass:
+            snapshot.sandboxClass === SandboxClass.ANDROID
+              ? In([SandboxClass.CONTAINER, SandboxClass.ANDROID])
+              : snapshot.sandboxClass,
         },
       })
 

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -1133,7 +1133,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
 
         initialRunner = await this.runnerService.getRandomAvailableRunner({
           regions: regions.map((region) => region.id),
-          sandboxClass: snapshot.sandboxClass,
+          // Temporary: Android snapshots can go to container runners
+          sandboxClass: snapshot.sandboxClass === SandboxClass.ANDROID ? SandboxClass.CONTAINER : snapshot.sandboxClass,
           excludedRunnerIds: excludedRunnerIds,
           availabilityScoreThreshold: availabilityThreshold,
           gpu: snapshot.gpu,

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -230,6 +230,7 @@ export class RunnerAdapterV0 implements RunnerAdapter {
       organizationId: sandbox.organizationId,
       regionId: sandbox.region,
       linkedSandboxId: sandbox.linkedSandboxId ?? undefined,
+      sandboxClass: sandbox.sandboxClass,
     }
 
     const response = await this.sandboxApiClient.create(createSandboxDto)

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -179,6 +179,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
       organizationId: sandbox.organizationId,
       regionId: sandbox.region,
       linkedSandboxId: sandbox.linkedSandboxId ?? undefined,
+      sandboxClass: sandbox.sandboxClass,
     }
 
     await this.jobService.createJob(

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -502,6 +502,10 @@ export class SandboxService {
         throw new BadRequestError('GPU sandboxes must be ephemeral - set autoDeleteInterval to 0')
       }
 
+      if (snapshot.sandboxClass === SandboxClass.ANDROID && !createSandboxDto.linkedSandbox) {
+        throw new BadRequestError('Android sandboxes must be linked to another sandbox')
+      }
+
       // Resolve and validate an optional linked sandbox. When set, the new sandbox is pinned
       // to the same runner as the linked sandbox so a local network can be established.
       // Constraints:

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
@@ -67,6 +67,7 @@ export function SandboxTableHeader({
   snapshots,
   loadingSnapshots,
 }: SandboxTableHeaderProps) {
+  const classColumnAvailable = Boolean(table.getColumn('class'))
   const hasStateFilter = ((table.getColumn('state')?.getFilterValue() as string[]) || []).length > 0
   const hasClassFilter = ((table.getColumn('class')?.getFilterValue() as string[]) || []).length > 0
   const hasSnapshotFilter = ((table.getColumn('snapshot')?.getFilterValue() as string[]) || []).length > 0
@@ -125,20 +126,22 @@ export function SandboxTableHeader({
                   </DropdownMenuSubContent>
                 </DropdownMenuPortal>
               </DropdownMenuSub>
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <Boxes className="w-4 h-4" />
-                  Class
-                </DropdownMenuSubTrigger>
-                <DropdownMenuPortal>
-                  <DropdownMenuSubContent className="p-0 w-64">
-                    <SandboxClassFilter
-                      value={(table.getColumn('class')?.getFilterValue() as string[]) || []}
-                      onFilterChange={(value) => table.getColumn('class')?.setFilterValue(value)}
-                    />
-                  </DropdownMenuSubContent>
-                </DropdownMenuPortal>
-              </DropdownMenuSub>
+              {classColumnAvailable && (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <Boxes className="w-4 h-4" />
+                    Class
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuPortal>
+                    <DropdownMenuSubContent className="p-0 w-64">
+                      <SandboxClassFilter
+                        value={(table.getColumn('class')?.getFilterValue() as string[]) || []}
+                        onFilterChange={(value) => table.getColumn('class')?.setFilterValue(value)}
+                      />
+                    </DropdownMenuSubContent>
+                  </DropdownMenuPortal>
+                </DropdownMenuSub>
+              )}
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>
                   <Camera className="w-4 h-4" />

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableHeader.tsx
@@ -3,7 +3,19 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Calendar, Camera, Columns, Cpu, Globe, HardDrive, ListFilter, MemoryStick, Square, Tag } from 'lucide-react'
+import {
+  Boxes,
+  Calendar,
+  Camera,
+  Columns,
+  Cpu,
+  Globe,
+  HardDrive,
+  ListFilter,
+  MemoryStick,
+  Square,
+  Tag,
+} from 'lucide-react'
 import { SearchInput } from '../SearchInput'
 import { Button } from '../ui/button'
 import {
@@ -23,6 +35,7 @@ import { LabelFilter, LabelFilterIndicator } from './filters/LabelFilter'
 import { LastEventFilter, LastEventFilterIndicator } from './filters/LastEventFilter'
 import { RegionFilter, RegionFilterIndicator } from './filters/RegionFilter'
 import { ResourceFilter, ResourceFilterIndicator, ResourceFilterValue } from './filters/ResourceFilter'
+import { SandboxClassFilter, SandboxClassFilterIndicator } from './filters/SandboxClassFilter'
 import { SnapshotFilter, SnapshotFilterIndicator } from './filters/SnapshotFilter'
 import { StateFilter, StateFilterIndicator } from './filters/StateFilter'
 import { SandboxTableHeaderProps } from './types'
@@ -37,6 +50,7 @@ const SANDBOX_TABLE_COLUMN_LABELS: Record<string, string> = {
   name: 'Name',
   id: 'UUID',
   state: 'State',
+  class: 'Class',
   snapshot: 'Snapshot',
   region: 'Region',
   resources: 'Resources',
@@ -54,6 +68,7 @@ export function SandboxTableHeader({
   loadingSnapshots,
 }: SandboxTableHeaderProps) {
   const hasStateFilter = ((table.getColumn('state')?.getFilterValue() as string[]) || []).length > 0
+  const hasClassFilter = ((table.getColumn('class')?.getFilterValue() as string[]) || []).length > 0
   const hasSnapshotFilter = ((table.getColumn('snapshot')?.getFilterValue() as string[]) || []).length > 0
   const hasRegionFilter = ((table.getColumn('region')?.getFilterValue() as string[]) || []).length > 0
   const hasLabelsFilter = ((table.getColumn('labels')?.getFilterValue() as string[]) || []).length > 0
@@ -63,7 +78,13 @@ export function SandboxTableHeader({
   })
 
   const hasActiveFilters =
-    hasStateFilter || hasSnapshotFilter || hasRegionFilter || hasLabelsFilter || hasLastEventFilter || hasResourceFilter
+    hasStateFilter ||
+    hasClassFilter ||
+    hasSnapshotFilter ||
+    hasRegionFilter ||
+    hasLabelsFilter ||
+    hasLastEventFilter ||
+    hasResourceFilter
 
   const handleChangeFilter = (value: string) => {
     table.setGlobalFilter(value)
@@ -100,6 +121,20 @@ export function SandboxTableHeader({
                     <StateFilter
                       value={(table.getColumn('state')?.getFilterValue() as string[]) || []}
                       onFilterChange={(value) => table.getColumn('state')?.setFilterValue(value)}
+                    />
+                  </DropdownMenuSubContent>
+                </DropdownMenuPortal>
+              </DropdownMenuSub>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <Boxes className="w-4 h-4" />
+                  Class
+                </DropdownMenuSubTrigger>
+                <DropdownMenuPortal>
+                  <DropdownMenuSubContent className="p-0 w-64">
+                    <SandboxClassFilter
+                      value={(table.getColumn('class')?.getFilterValue() as string[]) || []}
+                      onFilterChange={(value) => table.getColumn('class')?.setFilterValue(value)}
                     />
                   </DropdownMenuSubContent>
                 </DropdownMenuPortal>
@@ -199,6 +234,13 @@ export function SandboxTableHeader({
             <StateFilterIndicator
               value={(table.getColumn('state')?.getFilterValue() as string[]) || []}
               onFilterChange={(value) => table.getColumn('state')?.setFilterValue(value)}
+            />
+          )}
+
+          {hasClassFilter && (
+            <SandboxClassFilterIndicator
+              value={(table.getColumn('class')?.getFilterValue() as string[]) || []}
+              onFilterChange={(value) => table.getColumn('class')?.setFilterValue(value)}
             />
           )}
 

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -4,7 +4,7 @@
  */
 
 import { getRelativeTimeString } from '@/lib/utils'
-import { Sandbox, SandboxDesiredState, SandboxState } from '@daytona/api-client'
+import { Sandbox, SandboxClass, SandboxDesiredState, SandboxState } from '@daytona/api-client'
 import { ColumnDef } from '@tanstack/react-table'
 import React from 'react'
 import { CopyButton } from '../CopyButton'
@@ -17,7 +17,7 @@ import { Badge } from '../ui/badge'
 import { Checkbox } from '../ui/checkbox'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { SandboxTableActions } from './SandboxTableActions'
-import { STATE_PRIORITY_ORDER } from './constants'
+import { STATE_PRIORITY_ORDER, getSandboxClassIcon, getSandboxClassLabel } from './constants'
 import { ResourceFilterValue } from './filters/ResourceFilter'
 import { arrayIncludesFilter, arrayIntersectionFilter, dateRangeFilter, resourceRangeFilter } from './filters/utils'
 
@@ -200,6 +200,29 @@ export function getColumns({
         }
 
         return STATE_PRIORITY_ORDER[stateA] - STATE_PRIORITY_ORDER[stateB]
+      },
+      filterFn: (row, id, value) => arrayIncludesFilter(row, id, value),
+    },
+    {
+      id: 'class',
+      size: 130,
+      maxSize: 130,
+      enableSorting: true,
+      enableHiding: true,
+      header: ({ column }) => {
+        return <SortableHeader column={column} label="Class" />
+      },
+      accessorFn: (row) => row.sandboxClass ?? SandboxClass.CONTAINER,
+      cell: ({ row }) => {
+        const sandboxClass = row.original.sandboxClass
+        const Icon = getSandboxClassIcon(sandboxClass)
+        const label = getSandboxClassLabel(sandboxClass)
+        return (
+          <div className="w-full truncate flex items-center gap-2">
+            <Icon className="size-4 text-muted-foreground shrink-0" />
+            <span className="truncate block">{label}</span>
+          </div>
+        )
       },
       filterFn: (row, id, value) => arrayIncludesFilter(row, id, value),
     },

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -73,6 +73,7 @@ interface GetColumnsProps {
   handleFork: (id: string) => void
   handleViewForks: (id: string) => void
   handleOpenTerminal: (sandbox: Sandbox) => void
+  includeClassColumn: boolean
 }
 
 export function getColumns({
@@ -93,6 +94,7 @@ export function getColumns({
   handleFork,
   handleViewForks,
   handleOpenTerminal,
+  includeClassColumn,
 }: GetColumnsProps): ColumnDef<Sandbox>[] {
   const columns: ColumnDef<Sandbox>[] = [
     {
@@ -415,7 +417,7 @@ export function getColumns({
     },
   ]
 
-  return columns
+  return includeClassColumn ? columns : columns.filter((column) => column.id !== 'class')
 }
 
 function getDisplayName(sandbox: Sandbox): string {

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -205,8 +205,8 @@ export function getColumns({
     },
     {
       id: 'class',
-      size: 130,
-      maxSize: 130,
+      size: 64,
+      maxSize: 64,
       enableSorting: true,
       enableHiding: true,
       header: ({ column }) => {
@@ -218,10 +218,14 @@ export function getColumns({
         const Icon = getSandboxClassIcon(sandboxClass)
         const label = getSandboxClassLabel(sandboxClass)
         return (
-          <div className="w-full truncate flex items-center gap-2">
-            <Icon className="size-4 text-muted-foreground shrink-0" />
-            <span className="truncate block">{label}</span>
-          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex items-center" aria-label={label}>
+                <Icon className="size-4 text-muted-foreground shrink-0" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
         )
       },
       filterFn: (row, id, value) => arrayIncludesFilter(row, id, value),

--- a/apps/dashboard/src/components/SandboxTable/constants.ts
+++ b/apps/dashboard/src/components/SandboxTable/constants.ts
@@ -3,8 +3,18 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { SandboxState } from '@daytona/api-client'
-import { CheckCircle, Circle, AlertTriangle, Timer, Archive } from 'lucide-react'
+import { SandboxClass, SandboxState } from '@daytona/api-client'
+import {
+  CheckCircle,
+  Circle,
+  AlertTriangle,
+  Timer,
+  Archive,
+  Container,
+  Server,
+  Smartphone,
+  LucideIcon,
+} from 'lucide-react'
 import { FacetedFilterOption } from './types'
 
 const STATE_PRIORITY_ORDER_ARRAY = [
@@ -99,4 +109,50 @@ export function getStateLabel(state?: SandboxState): string {
     return 'Unknown'
   }
   return STATE_LABEL_MAPPING[state]
+}
+
+const SANDBOX_CLASS_LABEL_MAPPING: Record<SandboxClass, string> = {
+  [SandboxClass.CONTAINER]: 'Container',
+  [SandboxClass.LINUX_VM]: 'Linux VM',
+  [SandboxClass.ANDROID]: 'Android',
+  [SandboxClass.UNKNOWN_DEFAULT_OPEN_API]: 'Unknown',
+}
+
+const SANDBOX_CLASS_ICON_MAPPING: Record<SandboxClass, LucideIcon> = {
+  [SandboxClass.CONTAINER]: Container,
+  [SandboxClass.LINUX_VM]: Server,
+  [SandboxClass.ANDROID]: Smartphone,
+  [SandboxClass.UNKNOWN_DEFAULT_OPEN_API]: Container,
+}
+
+export const SANDBOX_CLASS_OPTIONS: FacetedFilterOption[] = [
+  {
+    label: SANDBOX_CLASS_LABEL_MAPPING[SandboxClass.CONTAINER],
+    value: SandboxClass.CONTAINER,
+    icon: SANDBOX_CLASS_ICON_MAPPING[SandboxClass.CONTAINER],
+  },
+  {
+    label: SANDBOX_CLASS_LABEL_MAPPING[SandboxClass.LINUX_VM],
+    value: SandboxClass.LINUX_VM,
+    icon: SANDBOX_CLASS_ICON_MAPPING[SandboxClass.LINUX_VM],
+  },
+  {
+    label: SANDBOX_CLASS_LABEL_MAPPING[SandboxClass.ANDROID],
+    value: SandboxClass.ANDROID,
+    icon: SANDBOX_CLASS_ICON_MAPPING[SandboxClass.ANDROID],
+  },
+]
+
+export function getSandboxClassLabel(sandboxClass?: SandboxClass): string {
+  if (!sandboxClass) {
+    return SANDBOX_CLASS_LABEL_MAPPING[SandboxClass.CONTAINER]
+  }
+  return SANDBOX_CLASS_LABEL_MAPPING[sandboxClass]
+}
+
+export function getSandboxClassIcon(sandboxClass?: SandboxClass): LucideIcon {
+  if (!sandboxClass) {
+    return SANDBOX_CLASS_ICON_MAPPING[SandboxClass.CONTAINER]
+  }
+  return SANDBOX_CLASS_ICON_MAPPING[sandboxClass]
 }

--- a/apps/dashboard/src/components/SandboxTable/filters/SandboxClassFilter.tsx
+++ b/apps/dashboard/src/components/SandboxTable/filters/SandboxClassFilter.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import {
+  Command,
+  CommandCheckboxItem,
+  CommandGroup,
+  CommandInput,
+  CommandInputButton,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { SandboxClass } from '@daytona/api-client'
+import { X } from 'lucide-react'
+import { SANDBOX_CLASS_OPTIONS, getSandboxClassLabel } from '../constants'
+
+interface SandboxClassFilterProps {
+  value: string[]
+  onFilterChange: (value: string[] | undefined) => void
+}
+
+export function SandboxClassFilterIndicator({ value, onFilterChange }: SandboxClassFilterProps) {
+  const selectedLabels = value.map((v) => getSandboxClassLabel(v as SandboxClass))
+  return (
+    <div className="flex items-center h-6 gap-0.5 rounded-sm border border-border bg-muted/80 hover:bg-muted/50 text-sm">
+      <Popover>
+        <PopoverTrigger className="max-w-[240px] overflow-hidden text-ellipsis whitespace-nowrap text-muted-foreground px-2">
+          Class:{' '}
+          <span className="text-primary font-medium">
+            {selectedLabels.length > 0
+              ? selectedLabels.length > 2
+                ? `${selectedLabels[0]}, ${selectedLabels[1]}, +${selectedLabels.length - 2}`
+                : `${selectedLabels.join(', ')}`
+              : ''}
+          </span>
+        </PopoverTrigger>
+
+        <PopoverContent className="p-0 w-64" align="start">
+          <SandboxClassFilter value={value} onFilterChange={onFilterChange} />
+        </PopoverContent>
+      </Popover>
+
+      <button className="h-6 w-5 p-0 border-0 hover:text-muted-foreground" onClick={() => onFilterChange(undefined)}>
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  )
+}
+
+export function SandboxClassFilter({ value, onFilterChange }: SandboxClassFilterProps) {
+  return (
+    <Command>
+      <CommandInput placeholder="Search...">
+        <CommandInputButton
+          className="text-sm text-muted-foreground hover:text-primary px-2"
+          onClick={() => onFilterChange(undefined)}
+        >
+          Clear
+        </CommandInputButton>
+      </CommandInput>
+
+      <CommandList>
+        <CommandGroup>
+          {SANDBOX_CLASS_OPTIONS.map((option) => {
+            const Icon = option.icon
+            return (
+              <CommandCheckboxItem
+                key={option.value}
+                checked={value.includes(option.value)}
+                onSelect={() => {
+                  const newValue = value.includes(option.value)
+                    ? value.filter((v) => v !== option.value)
+                    : [...value, option.value]
+                  onFilterChange(newValue.length > 0 ? newValue : undefined)
+                }}
+              >
+                <span className="flex items-center gap-2">
+                  {Icon ? <Icon className="size-4 text-muted-foreground" /> : null}
+                  {option.label}
+                </span>
+              </CommandCheckboxItem>
+            )
+          })}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}

--- a/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
+++ b/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
@@ -6,8 +6,9 @@
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
+import { useAvailableSandboxClassesForOrganization } from '@/hooks/useAvailableSandboxClasses'
 import { getRegionFullDisplayName } from '@/lib/utils'
-import { Region, Sandbox } from '@daytona/api-client'
+import { Region, Sandbox, SandboxClass } from '@daytona/api-client'
 import { getSandboxClassLabel } from './constants'
 import {
   ColumnFiltersState,
@@ -145,6 +146,12 @@ export function useSandboxTable({
     }))
   }, [regionsData])
 
+  const availableSandboxClasses = useAvailableSandboxClassesForOrganization()
+  const includeClassColumn = useMemo(
+    () => availableSandboxClasses.some((c) => c !== SandboxClass.CONTAINER),
+    [availableSandboxClasses],
+  )
+
   const columns = useMemo(
     () =>
       getColumns({
@@ -165,6 +172,7 @@ export function useSandboxTable({
         handleFork,
         handleViewForks,
         handleOpenTerminal,
+        includeClassColumn,
       }),
     [
       handleStart,
@@ -184,6 +192,7 @@ export function useSandboxTable({
       handleFork,
       handleViewForks,
       handleOpenTerminal,
+      includeClassColumn,
     ],
   )
 

--- a/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
+++ b/apps/dashboard/src/components/SandboxTable/useSandboxTable.ts
@@ -8,6 +8,7 @@ import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
 import { getRegionFullDisplayName } from '@/lib/utils'
 import { Region, Sandbox } from '@daytona/api-client'
+import { getSandboxClassLabel } from './constants'
 import {
   ColumnFiltersState,
   getCoreRowModel,
@@ -211,10 +212,17 @@ export function useSandboxTable({
       const labels = Object.entries(sandbox.labels ?? {})
         .map(([key, value]) => `${key}: ${value}`)
         .join(' ')
+      const sandboxClassLabel = getSandboxClassLabel(sandbox.sandboxClass)
 
-      return [sandbox.name, sandbox.id, sandbox.state, sandbox.snapshot ?? '', regionName, labels].some((value) =>
-        String(value).toLowerCase().includes(searchValue),
-      )
+      return [
+        sandbox.name,
+        sandbox.id,
+        sandbox.state,
+        sandbox.snapshot ?? '',
+        regionName,
+        labels,
+        sandboxClassLabel,
+      ].some((value) => String(value).toLowerCase().includes(searchValue))
     },
     state: {
       globalFilter,

--- a/apps/dashboard/src/components/sandboxes/SandboxInfoPanel.tsx
+++ b/apps/dashboard/src/components/sandboxes/SandboxInfoPanel.tsx
@@ -6,6 +6,7 @@
 import { CopyButton } from '@/components/CopyButton'
 import { ResourceChip } from '@/components/ResourceChip'
 import { SandboxLabel } from '@/components/SandboxLabel'
+import { getSandboxClassIcon, getSandboxClassLabel } from '@/components/SandboxTable/constants'
 import { TimestampTooltip } from '@/components/TimestampTooltip'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -93,6 +94,17 @@ export function SandboxInfoPanel({
             <span className="truncate">{getRegionName(sandbox.target) ?? sandbox.target}</span>
             <CopyButton value={sandbox.target} tooltipText="Copy" size="icon-xs" />
           </div>
+        </InfoRow>
+        <InfoRow label="Class">
+          {(() => {
+            const ClassIcon = getSandboxClassIcon(sandbox.sandboxClass)
+            return (
+              <div className="flex items-center gap-1.5 justify-end">
+                <ClassIcon className="size-4 text-muted-foreground shrink-0" />
+                <span className="truncate">{getSandboxClassLabel(sandbox.sandboxClass)}</span>
+              </div>
+            )
+          })()}
         </InfoRow>
         <InfoRow label="Snapshot" className="-mr-2">
           {sandbox.snapshot ? (

--- a/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
@@ -46,6 +46,7 @@ const snapshotNameSchema = z
 const SANDBOX_CLASS_OPTIONS: { value: SandboxClass; label: string }[] = [
   { value: SandboxClass.CONTAINER, label: 'Container' },
   { value: SandboxClass.LINUX_VM, label: 'Linux VM' },
+  { value: SandboxClass.ANDROID, label: 'Android' },
 ]
 
 const formSchema = z.object({

--- a/apps/dashboard/src/hooks/useAvailableSandboxClasses.ts
+++ b/apps/dashboard/src/hooks/useAvailableSandboxClasses.ts
@@ -23,3 +23,16 @@ export function useAvailableSandboxClasses(regionId: string | undefined): Sandbo
     return Object.values(SandboxClass)
   }, [usageOverview?.regionUsage, regionId])
 }
+
+export function useAvailableSandboxClassesForOrganization(): SandboxClass[] {
+  const { selectedOrganization } = useSelectedOrganization()
+  const { data: usageOverview } = useOrganizationUsageOverviewQuery({
+    organizationId: selectedOrganization?.id ?? '',
+  })
+
+  return useMemo<SandboxClass[]>(() => {
+    const regionUsage = usageOverview?.regionUsage ?? []
+    if (regionUsage.length === 0) return Object.values(SandboxClass)
+    return [...new Set(regionUsage.map((q) => q.sandboxClass))]
+  }, [usageOverview?.regionUsage])
+}

--- a/apps/docs/src/content/docs/en/oss-deployment.mdx
+++ b/apps/docs/src/content/docs/en/oss-deployment.mdx
@@ -487,6 +487,7 @@ Below is a full list of environment variables with their default values:
 | `AWS_DEFAULT_BUCKET`                    | string  | `daytona`                         | AWS default bucket name                               |
 | `DAEMON_START_TIMEOUT_SEC`              | number  | `60`                              | Daemon start timeout in seconds                       |
 | `SANDBOX_START_TIMEOUT_SEC`             | number  | `30`                              | Sandbox start timeout in seconds                      |
+| `ANDROID_BOOT_TIMEOUT_SEC`              | number  | `300`                             | Android emulator boot timeout in seconds              |
 | `USE_SNAPSHOT_ENTRYPOINT`               | boolean | `false`                           | Use snapshot entrypoint for sandbox                   |
 | `RUNNER_DOMAIN`                         | string  | (none)                            | Runner domain name (hostname for runner URLs)         |
 | `VOLUME_CLEANUP_INTERVAL`               | number  | `30s`                             | Volume cleanup interval in seconds (minimum: 10s)     |
@@ -502,6 +503,7 @@ Below is a full list of environment variables with their default values:
 | `CONTAINER_NETWORK`                     | string  | (none)                            | Custom docker network for sandboxes                   |
 | `INTER_SANDBOX_NETWORK_ENABLED`         | boolean | `false`                           | Enable or disable inter-sandbox network connectivity  |
 | `BUILD_ENGINE`                          | string  | `buildkit`                        | Docker image build engine (`buildkit` or `legacy`)    |
+| `MOUNT_KVM_TO_ANDROID_SANDBOX`          | boolean | `false`                           | Mount KVM device to Android sandbox                   |
 
 ### SSH Gateway
 

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	ResourceLimitsDisabled             bool          `envconfig:"RESOURCE_LIMITS_DISABLED"`
 	DaemonStartTimeoutSec              int           `envconfig:"DAEMON_START_TIMEOUT_SEC"`
 	SandboxStartTimeoutSec             int           `envconfig:"SANDBOX_START_TIMEOUT_SEC"`
+	AndroidBootTimeoutSec              int           `envconfig:"ANDROID_BOOT_TIMEOUT_SEC"`
 	UseSnapshotEntrypoint              bool          `envconfig:"USE_SNAPSHOT_ENTRYPOINT"`
 	Domain                             string        `envconfig:"RUNNER_DOMAIN" validate:"omitempty,hostname|ip"`
 	VolumeCleanupInterval              time.Duration `envconfig:"VOLUME_CLEANUP_INTERVAL" default:"30s" validate:"min=10s"`
@@ -64,6 +65,7 @@ type Config struct {
 	InitializeDaemonTelemetry          bool          `envconfig:"INITIALIZE_DAEMON_TELEMETRY" default:"true"`
 	SnapshotErrorCacheRetention        time.Duration `envconfig:"SNAPSHOT_ERROR_CACHE_RETENTION" default:"10m" validate:"min=5m"`
 	BuildEngine                        string        `envconfig:"BUILD_ENGINE" default:"buildkit" validate:"oneof=buildkit legacy"`
+	MountKvmToAndroidSandbox           bool          `envconfig:"MOUNT_KVM_TO_ANDROID_SANDBOX" default:"false"`
 }
 
 var DEFAULT_API_PORT int = 8080

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -155,6 +155,7 @@ func run() int {
 		ResourceLimitsDisabled:       cfg.ResourceLimitsDisabled,
 		DaemonStartTimeoutSec:        cfg.DaemonStartTimeoutSec,
 		SandboxStartTimeoutSec:       cfg.SandboxStartTimeoutSec,
+		AndroidBootTimeoutSec:        cfg.AndroidBootTimeoutSec,
 		UseSnapshotEntrypoint:        cfg.UseSnapshotEntrypoint,
 		VolumeCleanupInterval:        cfg.VolumeCleanupInterval,
 		VolumeCleanupDryRun:          cfg.VolumeCleanupDryRun,
@@ -167,6 +168,7 @@ func run() int {
 		InitializeDaemonTelemetry:    cfg.InitializeDaemonTelemetry,
 		InterSandboxNetworkEnabled:   cfg.InterSandboxNetworkEnabled,
 		GpuEnabled:                   cfg.GpuEnabled,
+		MountKvmToAndroidSandbox:     cfg.MountKvmToAndroidSandbox,
 	})
 	if err != nil {
 		logger.Error("Error creating Docker client wrapper", "error", err)

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1618,6 +1618,10 @@ const docTemplate = `{
                 "registry": {
                     "$ref": "#/definitions/RegistryDTO"
                 },
+                "sandboxClass": {
+                    "description": "Optional for backward compatibility, but when provided, indicates the class of sandbox to create.",
+                    "type": "string"
+                },
                 "skipStart": {
                     "type": "boolean"
                 },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1513,6 +1513,10 @@
         "registry": {
           "$ref": "#/definitions/RegistryDTO"
         },
+        "sandboxClass": {
+          "description": "Optional for backward compatibility, but when provided, indicates the class of sandbox to create.",
+          "type": "string"
+        },
         "skipStart": {
           "type": "boolean"
         },

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -89,6 +89,10 @@ definitions:
         type: string
       registry:
         $ref: '#/definitions/RegistryDTO'
+      sandboxClass:
+        description: Optional for backward compatibility, but when provided, indicates
+          the class of sandbox to create.
+        type: string
       skipStart:
         type: boolean
       snapshot:

--- a/apps/runner/pkg/api/dto/sandbox.go
+++ b/apps/runner/pkg/api/dto/sandbox.go
@@ -28,6 +28,9 @@ type CreateSandboxDTO struct {
 	OtelEndpoint     *string           `json:"otelEndpoint,omitempty"`
 	SkipStart        *bool             `json:"skipStart,omitempty"`
 
+	// Optional for backward compatibility, but when provided, indicates the class of sandbox to create.
+	SandboxClass *string `json:"sandboxClass,omitempty"`
+
 	// Nullable for backward compatibility
 	OrganizationId *string `json:"organizationId,omitempty"`
 	RegionId       *string `json:"regionId,omitempty"`
@@ -36,6 +39,13 @@ type CreateSandboxDTO struct {
 	// When set, the runner should attach both sandboxes to a shared local network so they can communicate.
 	LinkedSandboxId *string `json:"linkedSandboxId,omitempty"`
 } //	@name	CreateSandboxDTO
+
+func (c *CreateSandboxDTO) IsAndroidSandbox() bool {
+	if c.SandboxClass != nil && *c.SandboxClass == "android" {
+		return true
+	}
+	return false
+}
 
 type ResizeSandboxDTO struct {
 	Cpu      int64        `json:"cpu,omitempty" validate:"omitempty,min=1"`

--- a/apps/runner/pkg/docker/adb.go
+++ b/apps/runner/pkg/docker/adb.go
@@ -1,0 +1,72 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/daytonaio/common-go/pkg/timer"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// androidAdbPort is the standard ADB port exposed inside android-device containers.
+// We treat a successful TCP dial to it as "the emulator is ready to accept connections".
+const androidAdbPort = 5555
+
+// waitForAdbRunning polls the ADB port inside an android-device container until it accepts
+// TCP connections or the androidBootTimeoutSec is exceeded. It does not speak the ADB
+// protocol — a successful TCP handshake is enough to know the emulator has booted far
+// enough to be reachable over the runner's container network. The Android emulator's
+// cold boot regularly takes two or more minutes, so this probe uses a dedicated longer
+// timeout instead of the generic sandbox start timeout.
+func (d *DockerClient) waitForAdbRunning(ctx context.Context, containerIP string) error {
+	defer timer.Timer()()
+
+	tracer := otel.Tracer("runner")
+	ctx, span := tracer.Start(ctx, "wait_for_adb_running",
+		trace.WithAttributes(attribute.String("container.ip", containerIP)),
+	)
+	defer span.End()
+
+	addr := net.JoinHostPort(containerIP, strconv.Itoa(androidAdbPort))
+
+	timeout := time.Duration(d.androidBootTimeoutSec) * time.Second
+	span.SetAttributes(attribute.Int64("timeout_sec", int64(d.androidBootTimeoutSec)))
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	dialer := &net.Dialer{Timeout: 500 * time.Millisecond}
+
+	retries := 0
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			span.SetAttributes(attribute.Int("retries", retries))
+			err := fmt.Errorf("timeout waiting for ADB port on %s", addr)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "timeout waiting for adb")
+			return err
+		case <-ticker.C:
+			conn, err := dialer.DialContext(timeoutCtx, "tcp", addr)
+			if err != nil {
+				retries++
+				continue
+			}
+			_ = conn.Close()
+			span.SetAttributes(attribute.Int("retries", retries))
+			span.SetStatus(codes.Ok, "adb ready")
+			return nil
+		}
+	}
+}

--- a/apps/runner/pkg/docker/adb.go
+++ b/apps/runner/pkg/docker/adb.go
@@ -53,9 +53,16 @@ func (d *DockerClient) waitForAdbRunning(ctx context.Context, containerIP string
 		select {
 		case <-timeoutCtx.Done():
 			span.SetAttributes(attribute.Int("retries", retries))
-			err := fmt.Errorf("timeout waiting for ADB port on %s", addr)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "timeout waiting for adb")
+			var err error
+			if ctx.Err() != nil {
+				err = fmt.Errorf("waiting for ADB port on %s cancelled: %w", addr, ctx.Err())
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "wait for adb cancelled")
+			} else {
+				err = fmt.Errorf("timeout waiting for ADB port on %s", addr)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "timeout waiting for adb")
+			}
 			return err
 		case <-ticker.C:
 			conn, err := dialer.DialContext(timeoutCtx, "tcp", addr)

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -33,6 +33,7 @@ type DockerClientConfig struct {
 	ResourceLimitsDisabled       bool
 	DaemonStartTimeoutSec        int
 	SandboxStartTimeoutSec       int
+	AndroidBootTimeoutSec        int
 	UseSnapshotEntrypoint        bool
 	VolumeCleanupInterval        time.Duration
 	VolumeCleanupDryRun          bool
@@ -45,6 +46,7 @@ type DockerClientConfig struct {
 	InitializeDaemonTelemetry    bool
 	InterSandboxNetworkEnabled   bool
 	GpuEnabled                   bool
+	MountKvmToAndroidSandbox     bool
 }
 
 func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerClient, error) {
@@ -61,6 +63,13 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 	if config.SandboxStartTimeoutSec <= 0 {
 		logger.Warn("Invalid sandbox start timeout value. Using default value of 30 seconds")
 		config.SandboxStartTimeoutSec = 30
+	}
+
+	// Android emulator cold boot can take well over a minute even on capable hosts,
+	// so we allow a dedicated longer timeout for the ADB readiness probe.
+	if config.AndroidBootTimeoutSec <= 0 {
+		logger.Warn("Invalid android boot timeout value. Using default value of 300 seconds")
+		config.AndroidBootTimeoutSec = 300
 	}
 
 	if config.BackupTimeoutMin <= 0 {
@@ -131,6 +140,7 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 		resourceLimitsDisabled:       config.ResourceLimitsDisabled,
 		daemonStartTimeoutSec:        config.DaemonStartTimeoutSec,
 		sandboxStartTimeoutSec:       config.SandboxStartTimeoutSec,
+		androidBootTimeoutSec:        config.AndroidBootTimeoutSec,
 		useSnapshotEntrypoint:        config.UseSnapshotEntrypoint,
 		volumeCleanupInterval:        config.VolumeCleanupInterval,
 		volumeCleanupDryRun:          config.VolumeCleanupDryRun,
@@ -144,6 +154,7 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 		interSandboxNetworkEnabled:   config.InterSandboxNetworkEnabled,
 		gpuEnabled:                   config.GpuEnabled,
 		filesystem:                   filesystem,
+		mountKvmToAndroidSandbox:     config.MountKvmToAndroidSandbox,
 	}, nil
 }
 
@@ -170,6 +181,7 @@ type DockerClient struct {
 	resourceLimitsDisabled       bool
 	daemonStartTimeoutSec        int
 	sandboxStartTimeoutSec       int
+	androidBootTimeoutSec        int
 	useSnapshotEntrypoint        bool
 	volumeCleanupInterval        time.Duration
 	volumeCleanupDryRun          bool
@@ -185,4 +197,5 @@ type DockerClient struct {
 	filesystem                   string
 	interSandboxNetworkEnabled   bool
 	gpuEnabled                   bool
+	mountKvmToAndroidSandbox     bool
 }

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -18,6 +18,19 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
+// androidDeviceLabel is set on containers created for sandboxes tagged as "android-device".
+// The Start path reads it to skip the daytona daemon exec/wait that regular sandboxes need.
+const androidDeviceLabel = "daytona.android_device"
+
+// isAndroidDeviceContainer reports whether an already-created container was provisioned for
+// an android-device sandbox, based on the label written at create time.
+func isAndroidDeviceContainer(c *container.InspectResponse) bool {
+	if c == nil || c.Config == nil {
+		return false
+	}
+	return c.Config.Labels[androidDeviceLabel] == "true"
+}
+
 func (d *DockerClient) getContainerConfigs(sandboxDto dto.CreateSandboxDTO, image *image.InspectResponse, volumeMountPathBinds []string) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
 	containerConfig, err := d.getContainerCreateConfig(sandboxDto, image)
 	if err != nil {
@@ -29,7 +42,7 @@ func (d *DockerClient) getContainerConfigs(sandboxDto dto.CreateSandboxDTO, imag
 		return nil, nil, nil, err
 	}
 
-	networkingConfig := d.getContainerNetworkingConfig()
+	networkingConfig := d.getContainerNetworkingConfig(sandboxDto)
 
 	return containerConfig, hostConfig, networkingConfig, nil
 }
@@ -81,6 +94,21 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 		}
 	}
 
+	// Android-device sandboxes run the image's native entrypoint (e.g. the docker-android
+	// emulator bootstrap) and never host the daytona daemon. We mark the container with a
+	// label so the Start path can detect this later without needing the original DTO.
+	if sandboxDto.IsAndroidSandbox() {
+		labels[androidDeviceLabel] = "true"
+		return &container.Config{
+			Hostname:     sandboxDto.Id,
+			Image:        sandboxDto.Snapshot,
+			Env:          envVars,
+			Labels:       labels,
+			AttachStdout: true,
+			AttachStderr: true,
+		}, nil
+	}
+
 	workingDir := ""
 	cmd := []string{}
 	entrypoint := sandboxDto.Entrypoint
@@ -121,6 +149,12 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 }
 
 func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, volumeMountPathBinds []string) (*container.HostConfig, error) {
+	// Android-device sandboxes run on plain docker runtime, without the bundled
+	// daytona daemon, and require /dev/kvm to be mounted for emulator acceleration.
+	if sandboxDto.IsAndroidSandbox() {
+		return d.getAndroidDeviceHostConfig(sandboxDto, volumeMountPathBinds), nil
+	}
+
 	var binds []string
 
 	binds = append(binds, fmt.Sprintf("%s:%s:ro", d.daemonPath, common.DAEMON_PATH))
@@ -185,7 +219,23 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 	return hostConfig, nil
 }
 
-func (d *DockerClient) getContainerNetworkingConfig() *network.NetworkingConfig {
+func (d *DockerClient) getContainerNetworkingConfig(sandboxDto dto.CreateSandboxDTO) *network.NetworkingConfig {
+	// Android-device followers attach directly to the owner's link network at create
+	// time (skipping the default bridge / runner-bridge) so the link network becomes
+	// eth0 inside the container. This is required for the docker-android entrypoint,
+	// which binds its ADB/emulator forwarders to eth0's IP only.
+	if sandboxDto.IsAndroidSandbox() && sandboxDto.LinkedSandboxId != nil && *sandboxDto.LinkedSandboxId != "" {
+		aliases := []string{}
+		if sandboxDto.Name != "" && sandboxDto.Name != sandboxDto.Id {
+			aliases = append(aliases, sandboxDto.Name)
+		}
+		return &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				linkNetworkName(*sandboxDto.LinkedSandboxId): {Aliases: aliases},
+			},
+		}
+	}
+
 	containerNetwork := config.GetContainerNetwork()
 	var networkingConfig *network.NetworkingConfig
 	if containerNetwork != "" {
@@ -206,4 +256,55 @@ func (d *DockerClient) getContainerNetworkingConfig() *network.NetworkingConfig 
 	}
 
 	return networkingConfig
+}
+
+func (d *DockerClient) getAndroidDeviceHostConfig(sandboxDto dto.CreateSandboxDTO, volumeMountPathBinds []string) *container.HostConfig {
+	hostConfig := &container.HostConfig{
+		Privileged: false,
+		Binds:      append([]string{}, volumeMountPathBinds...),
+	}
+
+	if d.mountKvmToAndroidSandbox {
+		hostConfig.Resources = container.Resources{
+			Devices: []container.DeviceMapping{{
+				PathOnHost:        "/dev/kvm",
+				PathInContainer:   "/dev/kvm",
+				CgroupPermissions: "rwm",
+			}},
+		}
+	}
+
+	if sandboxDto.OtelEndpoint != nil && strings.Contains(*sandboxDto.OtelEndpoint, "host.docker.internal") {
+		hostConfig.ExtraHosts = []string{
+			"host.docker.internal:host-gateway",
+		}
+	}
+
+	if !d.resourceLimitsDisabled {
+		hostConfig.Resources = container.Resources{
+			CPUPeriod:  100000,
+			CPUQuota:   sandboxDto.CpuQuota * 100000,
+			Memory:     common.GBToBytes(float64(sandboxDto.MemoryQuota)),
+			MemorySwap: common.GBToBytes(float64(sandboxDto.MemoryQuota)),
+		}
+	}
+
+	if !d.resourceLimitsDisabled && d.filesystem == "xfs" {
+		hostConfig.StorageOpt = map[string]string{
+			"size": fmt.Sprintf("%dG", sandboxDto.StorageQuota),
+		}
+	}
+
+	// Android-device follower containers pin the link network as their only (and
+	// therefore primary / eth0) network. The docker-android entrypoint binds its
+	// ADB and emulator-console socat forwarders to eth0's IP; anchoring eth0 to
+	// the link network is what makes owner→follower connections work.
+	if sandboxDto.LinkedSandboxId != nil && *sandboxDto.LinkedSandboxId != "" {
+		hostConfig.NetworkMode = container.NetworkMode(linkNetworkName(*sandboxDto.LinkedSandboxId))
+	}
+
+	// Android-device sandboxes always use the stock docker runtime which is able to access /dev/kvm
+	hostConfig.Runtime = ""
+
+	return hostConfig
 }

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -264,16 +264,6 @@ func (d *DockerClient) getAndroidDeviceHostConfig(sandboxDto dto.CreateSandboxDT
 		Binds:      append([]string{}, volumeMountPathBinds...),
 	}
 
-	if d.mountKvmToAndroidSandbox {
-		hostConfig.Resources = container.Resources{
-			Devices: []container.DeviceMapping{{
-				PathOnHost:        "/dev/kvm",
-				PathInContainer:   "/dev/kvm",
-				CgroupPermissions: "rwm",
-			}},
-		}
-	}
-
 	if sandboxDto.OtelEndpoint != nil && strings.Contains(*sandboxDto.OtelEndpoint, "host.docker.internal") {
 		hostConfig.ExtraHosts = []string{
 			"host.docker.internal:host-gateway",
@@ -287,6 +277,14 @@ func (d *DockerClient) getAndroidDeviceHostConfig(sandboxDto dto.CreateSandboxDT
 			Memory:     common.GBToBytes(float64(sandboxDto.MemoryQuota)),
 			MemorySwap: common.GBToBytes(float64(sandboxDto.MemoryQuota)),
 		}
+	}
+
+	if d.mountKvmToAndroidSandbox {
+		hostConfig.Devices = append(hostConfig.Devices, container.DeviceMapping{
+			PathOnHost:        "/dev/kvm",
+			PathInContainer:   "/dev/kvm",
+			CgroupPermissions: "rwm",
+		})
 	}
 
 	if !d.resourceLimitsDisabled && d.filesystem == "xfs" {

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -85,6 +85,15 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 			return "", "", errors.New("sandbox IP not found? Is the sandbox started?")
 		}
 
+		// Android-device sandboxes do not run the daytona daemon; their readiness is
+		// signaled by the ADB port accepting TCP connections.
+		if sandboxDto.IsAndroidSandbox() {
+			if err := d.waitForAdbRunning(ctx, containerIP); err != nil {
+				return "", "", err
+			}
+			return sandboxDto.Id, "", nil
+		}
+
 		daemonVersion, err := d.waitForDaemonRunning(ctx, containerIP, sandboxDto.AuthToken)
 		if err != nil {
 			return "", "", err
@@ -166,9 +175,19 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 
 	// Attach the follower to the owner's link network before it starts so DNS
 	// resolution between the two sandboxes works from the very first boot.
+	// Android-device followers are already created directly on the link network
+	// (see getContainerNetworkingConfig) so that the link network becomes eth0
+	// and docker-android's eth0-bound socat forwarders reach their ADB port; for
+	// those we skip the post-create connect — but we still need to clear the
+	// bridge port isolation Docker stamps on the freshly-created veth, since
+	// connectFollowerToLinkNetwork is what does that for non-android followers.
 	if linkedOwnerId != "" {
-		if err := d.connectFollowerToLinkNetwork(ctx, linkedOwnerId, sandboxDto.Id, sandboxDto.Name); err != nil {
-			return "", "", err
+		if !sandboxDto.IsAndroidSandbox() {
+			if err := d.connectFollowerToLinkNetwork(ctx, linkedOwnerId, sandboxDto.Id, sandboxDto.Name); err != nil {
+				return "", "", err
+			}
+		} else {
+			d.clearLinkNetworkIsolation(ctx, linkedOwnerId)
 		}
 	}
 

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -86,8 +86,9 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		}
 
 		// Android-device sandboxes do not run the daytona daemon; their readiness is
-		// signaled by the ADB port accepting TCP connections.
-		if sandboxDto.IsAndroidSandbox() {
+		// signaled by the ADB port accepting TCP connections. Match Start's behavior
+		// by branching on the inspected container label rather than the DTO.
+		if isAndroidDeviceContainer(c) {
 			if err := d.waitForAdbRunning(ctx, containerIP); err != nil {
 				return "", "", err
 			}

--- a/apps/runner/pkg/docker/ip.go
+++ b/apps/runner/pkg/docker/ip.go
@@ -5,22 +5,30 @@ package docker
 
 import (
 	"context"
+	"strings"
 
 	"github.com/docker/docker/api/types/container"
 )
 
 // GetContainerIpAddress returns the IP address of the container on its primary
-// reachable network — the runner bridge network, falling back to the default
-// Docker bridge. Secondary attachments such as per-owner link networks are
-// deliberately ignored: callers use the returned IP as the iptables source
-// address for per-sandbox network rules (block / allow / egress limiter), and
-// the sandbox's outbound traffic always egresses via its default-route
-// interface, which is the runner bridge.
+// reachable network.
+//
+// Resolution order:
+//  1. Android-device containers prefer their link network IP. Their ADB/emulator
+//     socat forwarders bind to eth0, which for followers is the link network.
+//  2. The runner bridge network (daytona-internal inter-sandbox network).
+//  3. The default Docker bridge.
 //
 // Returns an empty string when no known network is attached.
 func GetContainerIpAddress(ctx context.Context, container *container.InspectResponse) string {
 	if container == nil || container.NetworkSettings == nil || container.NetworkSettings.Networks == nil {
 		return ""
+	}
+
+	if isAndroidDeviceContainer(container) {
+		if ip := linkNetworkIP(container); ip != "" {
+			return ip
+		}
 	}
 
 	if networkSettings, ok := container.NetworkSettings.Networks[RUNNER_BRIDGE_NETWORK_NAME]; ok && networkSettings != nil && networkSettings.IPAddress != "" {
@@ -31,5 +39,19 @@ func GetContainerIpAddress(ctx context.Context, container *container.InspectResp
 		return networkSettings.IPAddress
 	}
 
+	return ""
+}
+
+// linkNetworkIP returns the IP address of the first attached network whose name
+// starts with linkNetworkPrefix, or an empty string when none is attached.
+func linkNetworkIP(container *container.InspectResponse) string {
+	for name, settings := range container.NetworkSettings.Networks {
+		if settings == nil || settings.IPAddress == "" {
+			continue
+		}
+		if strings.HasPrefix(name, linkNetworkPrefix) {
+			return settings.IPAddress
+		}
+	}
 	return ""
 }

--- a/apps/runner/pkg/docker/ip.go
+++ b/apps/runner/pkg/docker/ip.go
@@ -25,7 +25,12 @@ func GetContainerIpAddress(ctx context.Context, container *container.InspectResp
 		return ""
 	}
 
-	if isAndroidDeviceContainer(container) {
+	// Only Android followers (primary NetworkMode set to the link network) need
+	// the link IP — that's where their eth0-bound ADB/emulator forwarders listen.
+	// Android containers attached to a link network as a secondary network must
+	// still report their primary bridge IP.
+	if isAndroidDeviceContainer(container) && container.HostConfig != nil &&
+		strings.HasPrefix(string(container.HostConfig.NetworkMode), linkNetworkPrefix) {
 		if ip := linkNetworkIP(container); ip != "" {
 			return ip
 		}

--- a/apps/runner/pkg/docker/link_network.go
+++ b/apps/runner/pkg/docker/link_network.go
@@ -380,6 +380,17 @@ func (d *DockerClient) reconcileFollowerLinkNetwork(ctx context.Context, sandbox
 	}
 
 	if err := d.connectFollowerToLinkNetwork(ctx, ownerId, sandboxDto.Id, sandboxDto.Name); err != nil {
+		// Android-device followers pin the link network via HostConfig.NetworkMode at
+		// container create time, so an explicit connect here races with docker's own
+		// attachment and can surface "container not found" if the container hasn't
+		// been created yet, or succeed as a no-op once it has. Non-android followers
+		// always need the explicit connect. Swallow not-found for android-device so
+		// reconcile is safe to call pre-ContainerCreate; any real failure still bubbles
+		// up from the post-create reconcile in the main Create flow.
+		if sandboxDto.IsAndroidSandbox() && (errdefs.IsNotFound(err) || common_errors.IsNotFoundError(err)) {
+			return ownerId, nil
+		}
+
 		return "", err
 	}
 	return ownerId, nil

--- a/apps/runner/pkg/docker/start.go
+++ b/apps/runner/pkg/docker/start.go
@@ -37,6 +37,13 @@ func (d *DockerClient) Start(ctx context.Context, containerId string, authToken 
 			return nil, "", errors.New("sandbox IP not found? Is the sandbox started?")
 		}
 
+		if isAndroidDeviceContainer(c) {
+			if err := d.waitForAdbRunning(ctx, containerIP); err != nil {
+				return nil, "", err
+			}
+			return c, "", nil
+		}
+
 		daemonVersion, err := d.waitForDaemonRunning(ctx, containerIP, authToken)
 		if err != nil {
 			return nil, "", err
@@ -70,6 +77,25 @@ func (d *DockerClient) Start(ctx context.Context, containerId string, authToken 
 	containerIP := GetContainerIpAddress(ctx, runningContainer)
 	if containerIP == "" {
 		return nil, "", errors.New("sandbox IP not found? Is the sandbox started?")
+	}
+
+	// Android-device sandboxes do not run the daytona daemon. Readiness is signaled by
+	// the ADB port accepting TCP connections inside the container.
+	if isAndroidDeviceContainer(runningContainer) {
+		if err := d.waitForAdbRunning(ctx, containerIP); err != nil {
+			return nil, "", err
+		}
+
+		if metadata["limitNetworkEgress"] == "true" {
+			go func() {
+				containerShortId := c.ID[:12]
+				if err := d.netRulesManager.SetNetworkLimiter(containerShortId, containerIP); err != nil {
+					d.logger.ErrorContext(ctx, "Failed to set network limiter", "error", err)
+				}
+			}()
+		}
+
+		return runningContainer, "", nil
 	}
 
 	if !slices.Equal(c.Config.Entrypoint, strslice.StrSlice{common.DAEMON_PATH}) {

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -10129,6 +10129,7 @@ components:
       enum:
       - linux-vm
       - container
+      - android
       type: string
     RegionUsageOverview:
       example:
@@ -11209,6 +11210,7 @@ components:
           enum:
           - linux-vm
           - container
+          - android
           example: linux-vm
           type: string
         daemonVersion:
@@ -14294,6 +14296,7 @@ components:
           enum:
           - linux-vm
           - container
+          - android
           example: linux-vm
           type: string
         daemonVersion:

--- a/libs/api-client-go/model_sandbox_class.go
+++ b/libs/api-client-go/model_sandbox_class.go
@@ -22,6 +22,7 @@ type SandboxClass string
 const (
 	SANDBOXCLASS_LINUX_VM SandboxClass = "linux-vm"
 	SANDBOXCLASS_CONTAINER SandboxClass = "container"
+	SANDBOXCLASS_ANDROID SandboxClass = "android"
 	SANDBOXCLASS_UNKNOWN_DEFAULT_OPEN_API SandboxClass = "11184809"
 )
 
@@ -29,6 +30,7 @@ const (
 var AllowedSandboxClassEnumValues = []SandboxClass{
 	"linux-vm",
 	"container",
+	"android",
 	"11184809",
 }
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -273,6 +273,8 @@ public class Sandbox {
     
     CONTAINER("container"),
     
+    ANDROID("android"),
+    
     UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
     private String value;

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxClass.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxClass.java
@@ -33,6 +33,8 @@ public enum SandboxClass {
   
   CONTAINER("container"),
   
+  ANDROID("android"),
+  
   UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
   private String value;

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Workspace.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Workspace.java
@@ -274,6 +274,8 @@ public class Workspace {
     
     CONTAINER("container"),
     
+    ANDROID("android"),
+    
     UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
     private String value;

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox_class.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox_class.py
@@ -29,6 +29,7 @@ class SandboxClass(str, Enum):
     """
     LINUX_MINUS_VM = 'linux-vm'
     CONTAINER = 'container'
+    ANDROID = 'android'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/libs/api-client-python/daytona_api_client/models/sandbox_class.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox_class.py
@@ -29,6 +29,7 @@ class SandboxClass(str, Enum):
     """
     LINUX_MINUS_VM = 'linux-vm'
     CONTAINER = 'container'
+    ANDROID = 'android'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -505,7 +505,7 @@ module DaytonaApiClient
       return false if @disk.nil?
       backup_state_validator = EnumAttributeValidator.new('String', ["None", "Pending", "InProgress", "Completed", "Error", "unknown_default_open_api"])
       return false unless backup_state_validator.valid?(@backup_state)
-      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "unknown_default_open_api"])
+      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
       return false unless sandbox_class_validator.valid?(@sandbox_class)
       return false if @toolbox_proxy_url.nil?
       true
@@ -654,7 +654,7 @@ module DaytonaApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] sandbox_class Object to be assigned
     def sandbox_class=(sandbox_class)
-      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "unknown_default_open_api"])
+      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
       unless validator.valid?(sandbox_class)
         fail ArgumentError, "invalid value for \"sandbox_class\", must be one of #{validator.allowable_values}."
       end

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_class.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_class.rb
@@ -17,10 +17,11 @@ module DaytonaApiClient
   class SandboxClass
     LINUX_VM = "linux-vm".freeze
     CONTAINER = "container".freeze
+    ANDROID = "android".freeze
     UNKNOWN_DEFAULT_OPEN_API = "unknown_default_open_api".freeze
 
     def self.all_vars
-      @all_vars ||= [LINUX_VM, CONTAINER, UNKNOWN_DEFAULT_OPEN_API].freeze
+      @all_vars ||= [LINUX_VM, CONTAINER, ANDROID, UNKNOWN_DEFAULT_OPEN_API].freeze
     end
 
     # Builds the enum from string

--- a/libs/api-client-ruby/lib/daytona_api_client/models/workspace.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/workspace.rb
@@ -541,7 +541,7 @@ module DaytonaApiClient
       return false if @disk.nil?
       backup_state_validator = EnumAttributeValidator.new('String', ["None", "Pending", "InProgress", "Completed", "Error", "unknown_default_open_api"])
       return false unless backup_state_validator.valid?(@backup_state)
-      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "unknown_default_open_api"])
+      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
       return false unless sandbox_class_validator.valid?(@sandbox_class)
       return false if @toolbox_proxy_url.nil?
       snapshot_state_validator = EnumAttributeValidator.new('String', ["None", "Pending", "InProgress", "Completed", "Error", "unknown_default_open_api"])
@@ -692,7 +692,7 @@ module DaytonaApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] sandbox_class Object to be assigned
     def sandbox_class=(sandbox_class)
-      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "unknown_default_open_api"])
+      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
       unless validator.valid?(sandbox_class)
         fail ArgumentError, "invalid value for \"sandbox_class\", must be one of #{validator.allowable_values}."
       end

--- a/libs/api-client/src/models/sandbox-class.ts
+++ b/libs/api-client/src/models/sandbox-class.ts
@@ -18,6 +18,7 @@
 export const SandboxClass = {
     LINUX_VM: 'linux-vm',
     CONTAINER: 'container',
+    ANDROID: 'android',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/api-client/src/models/sandbox.ts
+++ b/libs/api-client/src/models/sandbox.ts
@@ -178,6 +178,7 @@ export type SandboxBackupStateEnum = typeof SandboxBackupStateEnum[keyof typeof 
 export const SandboxSandboxClassEnum = {
     LINUX_VM: 'linux-vm',
     CONTAINER: 'container',
+    ANDROID: 'android',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/api-client/src/models/workspace.ts
+++ b/libs/api-client/src/models/workspace.ts
@@ -197,6 +197,7 @@ export type WorkspaceBackupStateEnum = typeof WorkspaceBackupStateEnum[keyof typ
 export const WorkspaceSandboxClassEnum = {
     LINUX_VM: 'linux-vm',
     CONTAINER: 'container',
+    ANDROID: 'android',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/runner-api-client/src/models/create-sandbox-dto.ts
+++ b/libs/runner-api-client/src/models/create-sandbox-dto.ts
@@ -48,6 +48,10 @@ export interface CreateSandboxDTO {
     'otelEndpoint'?: string;
     'regionId'?: string;
     'registry'?: RegistryDTO;
+    /**
+     * Optional for backward compatibility, but when provided, indicates the class of sandbox to create.
+     */
+    'sandboxClass'?: string;
     'skipStart'?: boolean;
     'snapshot': string;
     'storageQuota'?: number;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an Android sandbox class across API, dashboard, and runner with ADB-based readiness and a class-aware UI. Android sandboxes must be linked; scheduling temporarily prefers container runners, including initial runner selection.

- **New Features**
  - API
    - Added `SandboxClass.ANDROID`; forward `sandboxClass` to runner.
    - Enforce linked owner for Android; temporarily route Android snapshots to container runners (including initial runner).
  - Dashboard
    - New “Class” column with icon + tooltip; only shown when the org has more than one class.
    - Class filter and indicator; global search includes class; Info panel shows class with icon.
    - Create Snapshot sheet includes the Android class option.
  - Runner
    - `CreateSandboxDTO` accepts optional `sandboxClass`; OpenAPI and all client SDKs updated.
    - Android containers:
      - Skip daemon; wait for ADB on port 5555 to mark ready.
      - Attach to owner link network as primary (eth0); auto-clear isolation.
      - Optional `/dev/kvm` via `MOUNT_KVM_TO_ANDROID_SANDBOX`.
      - `ANDROID_BOOT_TIMEOUT_SEC` for emulator boot (default 300s).
    - Docs list the new env vars.

- **Migration**
  - For Android sandboxes, set `sandboxClass: 'android'` and provide `linkedSandboxId`; the API rejects unlinked requests.
  - Runner config:
    - `ANDROID_BOOT_TIMEOUT_SEC` (default 300).
    - `MOUNT_KVM_TO_ANDROID_SANDBOX` (default false) if hardware acceleration is desired.
  - Update to the latest `@daytona/api-client`, `libs/api-client-go`, `libs/api-client-java`, `libs/api-client-python`, `libs/api-client-ruby`, and `libs/runner-api-client` to use the new enum and `sandboxClass` field.

<sup>Written for commit 87425c882b9e8998da2a713d7ef63e04056f1928. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4790?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

