### PR TITLE
feat(api,runner): assign one physical GPU per sandbox on multi-GPU runner

### DIFF
--- a/apps/api/src/sandbox/dto/runner-health.dto.ts
+++ b/apps/api/src/sandbox/dto/runner-health.dto.ts
@@ -92,6 +92,22 @@ export class RunnerHealthMetricsDto {
   })
   @IsNumber()
   diskGiB: number
+
+  @ApiPropertyOptional({
+    description: 'Total number of GPUs on the runner',
+    example: 4,
+  })
+  @IsOptional()
+  @IsNumber()
+  gpu?: number
+
+  @ApiPropertyOptional({
+    description: 'GPU model name',
+    example: 'NVIDIA H100 80GB HBM3',
+  })
+  @IsOptional()
+  @IsString()
+  gpuType?: string
 }
 
 @ApiSchema({ name: 'RunnerServiceHealth' })

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -475,9 +475,18 @@ export class RunnerService {
 
       if (metrics.gpu !== undefined) {
         updateData.gpu = metrics.gpu
+      } else if (runner.apiVersion === '2') {
+        // v2 runners are the source of truth for their own GPU capacity;
+        // omitting `gpu` means "no GPUs visible to nvidia-smi right now", so
+        // clear any previously persisted value to keep the scheduler from
+        // sending GPU sandboxes to a runner that can no longer host them.
+        // v0 runners never report `gpu`, so leave operator-set values alone.
+        updateData.gpu = null
       }
       if (metrics.gpuType !== undefined) {
         updateData.gpuType = metrics.gpuType
+      } else if (runner.apiVersion === '2') {
+        updateData.gpuType = null
       }
 
       updateData.availabilityScore = this.calculateAvailabilityScore(runnerId, {

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -313,11 +313,11 @@ export class RunnerService {
 
     const excludedRunnerIds = new Set((params.excludedRunnerIds ?? []).filter((id): id is string => !!id))
 
-    // GPU sandboxes get exclusive ownership of a runner: skip any runner that
-    // already hosts an active sandbox, regardless of whether that sandbox uses GPU.
+    // A runner with runner.gpu = N can host up to N concurrent GPU sandboxes.
+    // Skip runners that have already reached their GPU sandbox capacity.
     if (params.gpu > 0) {
-      const occupiedRunnerIds = await this.getRunnersWithActiveGpuSandbox()
-      for (const id of occupiedRunnerIds) {
+      const fullRunnerIds = await this.getRunnersAtGpuCapacity()
+      for (const id of fullRunnerIds) {
         excludedRunnerIds.add(id)
       }
     }
@@ -406,6 +406,8 @@ export class RunnerService {
       cpu?: number
       memoryGiB?: number
       diskGiB?: number
+      gpu?: number
+      gpuType?: string
     },
     appVersion?: string,
   ): Promise<void> {
@@ -470,6 +472,13 @@ export class RunnerService {
       updateData.cpu = metrics.cpu
       updateData.memoryGiB = metrics.memoryGiB
       updateData.diskGiB = metrics.diskGiB
+
+      if (metrics.gpu !== undefined) {
+        updateData.gpu = metrics.gpu
+      }
+      if (metrics.gpuType !== undefined) {
+        updateData.gpuType = metrics.gpuType
+      }
 
       updateData.availabilityScore = this.calculateAvailabilityScore(runnerId, {
         cpuLoadAverage: updateData.currentCpuLoadAverage,
@@ -900,23 +909,28 @@ export class RunnerService {
   }
 
   /**
-   * Returns runner IDs that currently host at least one GPU sandbox in a
-   * non-terminal state. Used by the GPU scheduler to enforce
-   * one-gpu-sandbox-per-runner exclusivity.
+   * Returns runner IDs that have reached their GPU sandbox capacity. A runner
+   * with `runner.gpu = N` can host up to N concurrent GPU sandboxes; this
+   * method returns runners where the count of active GPU sandboxes is `>= N`.
    *
    * Includes the conditionally-consuming states (RESIZING, SNAPSHOTTING) because a
    * GPU sandbox in either of those states is still physically present on its runner,
-   * regardless of `desiredState`. The runner cannot host a second GPU sandbox.
+   * regardless of `desiredState`, and therefore still consumes a GPU slot.
    */
-  async getRunnersWithActiveGpuSandbox(): Promise<string[]> {
+  async getRunnersAtGpuCapacity(): Promise<string[]> {
     const rows = await this.sandboxRepository
       .createQueryBuilder('sandbox')
-      .select('DISTINCT sandbox.runnerId', 'runnerId')
+      .innerJoin(Runner, 'runner', 'runner.id = sandbox.runnerId')
+      .select('sandbox.runnerId', 'runnerId')
       .where('sandbox.runnerId IS NOT NULL')
       .andWhere('sandbox.gpu > 0')
+      .andWhere('runner.gpu IS NOT NULL AND runner.gpu > 0')
       .andWhere('sandbox.state IN (:...states)', {
         states: [...SANDBOX_STATES_CONSUMING_COMPUTE, ...SANDBOX_STATES_CONDITIONALLY_CONSUMING_COMPUTE],
       })
+      .groupBy('sandbox.runnerId')
+      .addGroupBy('runner.gpu')
+      .having('COUNT(*) >= runner.gpu')
       .getRawMany()
 
     return rows.map((r) => r.runnerId).filter((id): id is string => !!id)
@@ -1142,7 +1156,8 @@ export class GetRunnerParams {
   excludedRunnerIds?: string[]
   availabilityScoreThreshold?: number
   // When > 0, only consider runners that have at least this much GPU capacity
-  // and do not currently host any active sandbox (one-GPU-sandbox-per-runner rule).
+  // and have not yet reached their GPU sandbox capacity (a runner with
+  // runner.gpu = N can host up to N concurrent GPU sandboxes).
   gpu: number
 }
 

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -17,6 +17,9 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/shirou/gopsutil/v4/mem"
 )
 
 type DockerClientConfig struct {
@@ -117,12 +120,14 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 
 	gpuCount := 0
 	gpuType := ""
+	var hostCPUCores, hostMemoryGiB, hostDiskGiB int64
 	if config.GpuEnabled {
 		gpuCount, gpuType = detectGpus(ctx)
 		if gpuCount == 0 {
 			logger.Warn("GPU_ENABLED=true but nvidia-smi did not report any GPUs; runner will not host GPU sandboxes")
 		} else {
 			logger.Info("Detected GPUs", "count", gpuCount, "type", gpuType)
+			hostCPUCores, hostMemoryGiB, hostDiskGiB = detectHostCapacity(ctx, logger)
 		}
 	}
 
@@ -157,8 +162,40 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 		gpuCount:                     gpuCount,
 		gpuType:                      gpuType,
 		gpuAllocator:                 newGpuAllocator(gpuCount),
+		hostCPUCores:                 hostCPUCores,
+		hostMemoryGiB:                hostMemoryGiB,
+		hostDiskGiB:                  hostDiskGiB,
 		filesystem:                   filesystem,
 	}, nil
+}
+
+// detectHostCapacity reads the host's total CPU cores, RAM, and the size of
+// the filesystem backing /var/lib/docker. It is called once at startup, only
+// when GPU support is enabled, so it can be used to compute the per-GPU slice
+// for GPU sandboxes (host_total / gpu_count).
+func detectHostCapacity(ctx context.Context, logger *slog.Logger) (int64, int64, int64) {
+	var cores, memGiB, diskGiB int64
+
+	if n, err := cpu.CountsWithContext(ctx, true); err == nil {
+		cores = int64(n)
+	} else {
+		logger.Warn("Failed to detect host CPU count; GPU sandbox CPU slice unavailable", "error", err)
+	}
+
+	if m, err := mem.VirtualMemoryWithContext(ctx); err == nil {
+		memGiB = int64(m.Total / (1024 * 1024 * 1024))
+	} else {
+		logger.Warn("Failed to detect host memory; GPU sandbox memory slice unavailable", "error", err)
+	}
+
+	if d, err := disk.UsageWithContext(ctx, "/var/lib/docker"); err == nil {
+		diskGiB = int64(d.Total / (1024 * 1024 * 1024))
+	} else {
+		logger.Warn("Failed to detect host disk; GPU sandbox disk slice unavailable", "error", err)
+	}
+
+	logger.Info("Detected host capacity", "cpuCores", cores, "memoryGiB", memGiB, "diskGiB", diskGiB)
+	return cores, memGiB, diskGiB
 }
 
 // GpuCount returns the number of NVIDIA GPUs detected on the host at startup.
@@ -215,4 +252,7 @@ type DockerClient struct {
 	gpuCount                     int
 	gpuType                      string
 	gpuAllocator                 *gpuAllocator
+	hostCPUCores                 int64
+	hostMemoryGiB                int64
+	hostDiskGiB                  int64
 }

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -115,6 +115,17 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 		}
 	}
 
+	gpuCount := 0
+	gpuType := ""
+	if config.GpuEnabled {
+		gpuCount, gpuType = detectGpus(ctx)
+		if gpuCount == 0 {
+			logger.Warn("GPU_ENABLED=true but nvidia-smi did not report any GPUs; runner will not host GPU sandboxes")
+		} else {
+			logger.Info("Detected GPUs", "count", gpuCount, "type", gpuType)
+		}
+	}
+
 	return &DockerClient{
 		apiClient:                    config.ApiClient,
 		backupInfoCache:              config.BackupInfoCache,
@@ -143,8 +154,24 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 		initializeDaemonTelemetry:    config.InitializeDaemonTelemetry,
 		interSandboxNetworkEnabled:   config.InterSandboxNetworkEnabled,
 		gpuEnabled:                   config.GpuEnabled,
+		gpuCount:                     gpuCount,
+		gpuType:                      gpuType,
+		gpuAllocator:                 newGpuAllocator(gpuCount),
 		filesystem:                   filesystem,
 	}, nil
+}
+
+// GpuCount returns the number of NVIDIA GPUs detected on the host at startup.
+// Returns 0 when GPU support is disabled or no GPU is present.
+func (d *DockerClient) GpuCount() int {
+	return d.gpuCount
+}
+
+// GpuType returns the human-readable name of the first GPU detected on the
+// host at startup (e.g. "NVIDIA H100 80GB HBM3"). Returns "" when no GPU is
+// present.
+func (d *DockerClient) GpuType() string {
+	return d.gpuType
 }
 
 func (d *DockerClient) ApiClient() client.APIClient {
@@ -185,4 +212,7 @@ type DockerClient struct {
 	filesystem                   string
 	interSandboxNetworkEnabled   bool
 	gpuEnabled                   bool
+	gpuCount                     int
+	gpuType                      string
+	gpuAllocator                 *gpuAllocator
 }

--- a/apps/runner/pkg/docker/client.go
+++ b/apps/runner/pkg/docker/client.go
@@ -17,9 +17,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
-	"github.com/shirou/gopsutil/v4/cpu"
-	"github.com/shirou/gopsutil/v4/disk"
-	"github.com/shirou/gopsutil/v4/mem"
 )
 
 type DockerClientConfig struct {
@@ -120,14 +117,12 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 
 	gpuCount := 0
 	gpuType := ""
-	var hostCPUCores, hostMemoryGiB, hostDiskGiB int64
 	if config.GpuEnabled {
 		gpuCount, gpuType = detectGpus(ctx)
 		if gpuCount == 0 {
 			logger.Warn("GPU_ENABLED=true but nvidia-smi did not report any GPUs; runner will not host GPU sandboxes")
 		} else {
 			logger.Info("Detected GPUs", "count", gpuCount, "type", gpuType)
-			hostCPUCores, hostMemoryGiB, hostDiskGiB = detectHostCapacity(ctx, logger)
 		}
 	}
 
@@ -162,40 +157,8 @@ func NewDockerClient(ctx context.Context, config DockerClientConfig) (*DockerCli
 		gpuCount:                     gpuCount,
 		gpuType:                      gpuType,
 		gpuAllocator:                 newGpuAllocator(gpuCount),
-		hostCPUCores:                 hostCPUCores,
-		hostMemoryGiB:                hostMemoryGiB,
-		hostDiskGiB:                  hostDiskGiB,
 		filesystem:                   filesystem,
 	}, nil
-}
-
-// detectHostCapacity reads the host's total CPU cores, RAM, and the size of
-// the filesystem backing /var/lib/docker. It is called once at startup, only
-// when GPU support is enabled, so it can be used to compute the per-GPU slice
-// for GPU sandboxes (host_total / gpu_count).
-func detectHostCapacity(ctx context.Context, logger *slog.Logger) (int64, int64, int64) {
-	var cores, memGiB, diskGiB int64
-
-	if n, err := cpu.CountsWithContext(ctx, true); err == nil {
-		cores = int64(n)
-	} else {
-		logger.Warn("Failed to detect host CPU count; GPU sandbox CPU slice unavailable", "error", err)
-	}
-
-	if m, err := mem.VirtualMemoryWithContext(ctx); err == nil {
-		memGiB = int64(m.Total / (1024 * 1024 * 1024))
-	} else {
-		logger.Warn("Failed to detect host memory; GPU sandbox memory slice unavailable", "error", err)
-	}
-
-	if d, err := disk.UsageWithContext(ctx, "/var/lib/docker"); err == nil {
-		diskGiB = int64(d.Total / (1024 * 1024 * 1024))
-	} else {
-		logger.Warn("Failed to detect host disk; GPU sandbox disk slice unavailable", "error", err)
-	}
-
-	logger.Info("Detected host capacity", "cpuCores", cores, "memoryGiB", memGiB, "diskGiB", diskGiB)
-	return cores, memGiB, diskGiB
 }
 
 // GpuCount returns the number of NVIDIA GPUs detected on the host at startup.
@@ -252,7 +215,4 @@ type DockerClient struct {
 	gpuCount                     int
 	gpuType                      string
 	gpuAllocator                 *gpuAllocator
-	hostCPUCores                 int64
-	hostMemoryGiB                int64
-	hostDiskGiB                  int64
 }

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -55,13 +55,18 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 	}
 
 	// GPU sandboxes run non-privileged so CDI's per-device cgroup rules
-	// actually take effect; also pin the NVIDIA / CUDA env vars to the
-	// allocated index so userspace tools and libraries target only it.
+	// actually take effect. CDI already restricts the container to the one
+	// allocated physical GPU (see DeviceRequests below), and Linux/CUDA
+	// renumber the exposed devices starting at 0 - so from inside the
+	// container the GPU is always index 0 regardless of which host slot
+	// was allocated. Hard-code the env vars to "0" so CUDA/userspace tools
+	// don't try to address a host-side index that doesn't exist in the
+	// container's view (which would break e.g. cudaSetDevice while letting
+	// nvidia-smi work).
 	if gpuIndex != nil {
-		idx := strconv.Itoa(*gpuIndex)
 		envVars = append(envVars,
-			"NVIDIA_VISIBLE_DEVICES="+idx,
-			"CUDA_VISIBLE_DEVICES="+idx,
+			"NVIDIA_VISIBLE_DEVICES=0",
+			"CUDA_VISIBLE_DEVICES=0",
 		)
 	}
 

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -19,6 +19,15 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
+// Fixed sandbox slice applied to every GPU sandbox regardless of host size.
+// Keeping these constant across runners makes user-visible GPU sandbox
+// capacity uniform on heterogeneous GPU fleets.
+const (
+	gpuSandboxCPUCores  int64 = 16
+	gpuSandboxMemoryGiB int64 = 256
+	gpuSandboxDiskGiB   int64 = 512
+)
+
 func (d *DockerClient) getContainerConfigs(sandboxDto dto.CreateSandboxDTO, image *image.InspectResponse, volumeMountPathBinds []string, gpuIndex *int) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
 	containerConfig, err := d.getContainerCreateConfig(sandboxDto, image, gpuIndex)
 	if err != nil {
@@ -160,22 +169,17 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 		}
 	}
 
-	// GPU sandboxes ignore the API-requested resources and instead receive
-	// a fixed slice of the host equal to host_total / gpu_count, so every
-	// allocated GPU card gets a balanced share of CPU, memory and disk.
+	// GPU sandboxes ignore the API-requested resources and instead get a
+	// uniform slice that is identical on every GPU runner regardless of
+	// host size. This keeps user-visible sandbox capacity consistent
+	// across heterogeneous GPU fleets (e.g. H100 NVL vs H100 SXM5 hosts).
 	cpuQuota := sandboxDto.CpuQuota
 	memoryQuotaGiB := sandboxDto.MemoryQuota
 	storageQuotaGiB := sandboxDto.StorageQuota
-	if gpuIndex != nil && d.gpuCount > 0 {
-		if d.hostCPUCores > 0 {
-			cpuQuota = d.hostCPUCores / int64(d.gpuCount)
-		}
-		if d.hostMemoryGiB > 0 {
-			memoryQuotaGiB = d.hostMemoryGiB / int64(d.gpuCount)
-		}
-		if d.hostDiskGiB > 0 {
-			storageQuotaGiB = d.hostDiskGiB / int64(d.gpuCount)
-		}
+	if gpuIndex != nil {
+		cpuQuota = gpuSandboxCPUCores
+		memoryQuotaGiB = gpuSandboxMemoryGiB
+		storageQuotaGiB = gpuSandboxDiskGiB
 	}
 
 	if !d.resourceLimitsDisabled {

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -6,6 +6,7 @@ package docker
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/daytonaio/runner/cmd/runner/config"
@@ -18,13 +19,13 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
-func (d *DockerClient) getContainerConfigs(sandboxDto dto.CreateSandboxDTO, image *image.InspectResponse, volumeMountPathBinds []string) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
-	containerConfig, err := d.getContainerCreateConfig(sandboxDto, image)
+func (d *DockerClient) getContainerConfigs(sandboxDto dto.CreateSandboxDTO, image *image.InspectResponse, volumeMountPathBinds []string, gpuIndex *int) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
+	containerConfig, err := d.getContainerCreateConfig(sandboxDto, image, gpuIndex)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	hostConfig, err := d.getContainerHostConfig(sandboxDto, volumeMountPathBinds)
+	hostConfig, err := d.getContainerHostConfig(sandboxDto, volumeMountPathBinds, gpuIndex)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -33,7 +34,7 @@ func (d *DockerClient) getContainerConfigs(sandboxDto dto.CreateSandboxDTO, imag
 	return containerConfig, hostConfig, networkingConfig, nil
 }
 
-func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO, image *image.InspectResponse) (*container.Config, error) {
+func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO, image *image.InspectResponse, gpuIndex *int) (*container.Config, error) {
 	if image == nil {
 		return nil, fmt.Errorf("image not found for sandbox: %s", sandboxDto.Id)
 	}
@@ -42,6 +43,17 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 		"DAYTONA_SANDBOX_ID=" + sandboxDto.Id,
 		"DAYTONA_SANDBOX_SNAPSHOT=" + sandboxDto.Snapshot,
 		"DAYTONA_SANDBOX_USER=" + sandboxDto.OsUser,
+	}
+
+	// Privileged sandboxes still see every /dev/nvidia*, so the CDI device
+	// request alone cannot hide unassigned cards. Scope CUDA / NVML to the
+	// allocated index so cooperative workloads only target their own GPU.
+	if gpuIndex != nil {
+		idx := strconv.Itoa(*gpuIndex)
+		envVars = append(envVars,
+			"NVIDIA_VISIBLE_DEVICES="+idx,
+			"CUDA_VISIBLE_DEVICES="+idx,
+		)
 	}
 
 	for key, value := range sandboxDto.Env {
@@ -75,6 +87,9 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 		if orgName, ok := sandboxDto.Metadata["organizationName"]; ok && orgName != "" {
 			labels["daytona.organization_name"] = orgName
 		}
+	}
+	if gpuIndex != nil {
+		labels[GpuIndexLabel] = strconv.Itoa(*gpuIndex)
 	}
 
 	workingDir := ""
@@ -116,7 +131,7 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 	}, nil
 }
 
-func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, volumeMountPathBinds []string) (*container.HostConfig, error) {
+func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, volumeMountPathBinds []string, gpuIndex *int) (*container.HostConfig, error) {
 	var binds []string
 
 	binds = append(binds, fmt.Sprintf("%s:%s:ro", d.daemonPath, common.DAEMON_PATH))
@@ -161,21 +176,11 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 		}
 	}
 
-	if d.gpuEnabled {
-		nvidiaDevices := []string{
-			"/dev/nvidia0",
-			"/dev/nvidiactl",
-			"/dev/nvidia-uvm",
-			"/dev/nvidia-uvm-tools",
-			"/dev/nvidia-modeset",
-		}
-		for _, dev := range nvidiaDevices {
-			hostConfig.Devices = append(hostConfig.Devices, container.DeviceMapping{
-				PathOnHost:        dev,
-				PathInContainer:   dev,
-				CgroupPermissions: "rwm",
-			})
-		}
+	if d.gpuEnabled && gpuIndex != nil {
+		hostConfig.DeviceRequests = []container.DeviceRequest{{
+			Driver:    "cdi",
+			DeviceIDs: []string{fmt.Sprintf("nvidia.com/gpu=%d", *gpuIndex)},
+		}}
 	}
 
 	return hostConfig, nil

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -45,9 +45,9 @@ func (d *DockerClient) getContainerCreateConfig(sandboxDto dto.CreateSandboxDTO,
 		"DAYTONA_SANDBOX_USER=" + sandboxDto.OsUser,
 	}
 
-	// Privileged sandboxes still see every /dev/nvidia*, so the CDI device
-	// request alone cannot hide unassigned cards. Scope CUDA / NVML to the
-	// allocated index so cooperative workloads only target their own GPU.
+	// GPU sandboxes run non-privileged so CDI's per-device cgroup rules
+	// actually take effect; also pin the NVIDIA / CUDA env vars to the
+	// allocated index so userspace tools and libraries target only it.
 	if gpuIndex != nil {
 		idx := strconv.Itoa(*gpuIndex)
 		envVars = append(envVars,
@@ -146,7 +146,11 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 	}
 
 	hostConfig := &container.HostConfig{
-		Privileged: true,
+		// Privileged mode exposes every /dev/nvidia* node and bypasses the
+		// CDI cgroup rules, so GPU sandboxes have to opt out to keep their
+		// allocated card isolated. Non-GPU sandboxes still need privileged
+		// for their current workloads.
+		Privileged: gpuIndex == nil,
 		Binds:      binds,
 	}
 

--- a/apps/runner/pkg/docker/container_configs.go
+++ b/apps/runner/pkg/docker/container_configs.go
@@ -160,12 +160,30 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 		}
 	}
 
+	// GPU sandboxes ignore the API-requested resources and instead receive
+	// a fixed slice of the host equal to host_total / gpu_count, so every
+	// allocated GPU card gets a balanced share of CPU, memory and disk.
+	cpuQuota := sandboxDto.CpuQuota
+	memoryQuotaGiB := sandboxDto.MemoryQuota
+	storageQuotaGiB := sandboxDto.StorageQuota
+	if gpuIndex != nil && d.gpuCount > 0 {
+		if d.hostCPUCores > 0 {
+			cpuQuota = d.hostCPUCores / int64(d.gpuCount)
+		}
+		if d.hostMemoryGiB > 0 {
+			memoryQuotaGiB = d.hostMemoryGiB / int64(d.gpuCount)
+		}
+		if d.hostDiskGiB > 0 {
+			storageQuotaGiB = d.hostDiskGiB / int64(d.gpuCount)
+		}
+	}
+
 	if !d.resourceLimitsDisabled {
 		hostConfig.Resources = container.Resources{
 			CPUPeriod:  100000,
-			CPUQuota:   sandboxDto.CpuQuota * 100000,
-			Memory:     common.GBToBytes(float64(sandboxDto.MemoryQuota)),
-			MemorySwap: common.GBToBytes(float64(sandboxDto.MemoryQuota)),
+			CPUQuota:   cpuQuota * 100000,
+			Memory:     common.GBToBytes(float64(memoryQuotaGiB)),
+			MemorySwap: common.GBToBytes(float64(memoryQuotaGiB)),
 		}
 	}
 
@@ -176,7 +194,7 @@ func (d *DockerClient) getContainerHostConfig(sandboxDto dto.CreateSandboxDTO, v
 
 	if !d.resourceLimitsDisabled && d.filesystem == "xfs" {
 		hostConfig.StorageOpt = map[string]string{
-			"size": fmt.Sprintf("%dG", sandboxDto.StorageQuota),
+			"size": fmt.Sprintf("%dG", storageQuotaGiB),
 		}
 	}
 

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -125,16 +125,29 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		}
 	}
 
-	// Pin GPU sandboxes to a single physical card. The mutex is held until
-	// ContainerCreate finishes (via the deferred release) so concurrent
-	// creators read the new daytona.gpu_index label and skip this index.
-	var gpuIndex *int
+	// Pin GPU sandboxes to a single physical card. The allocator mutex must
+	// be held across ContainerCreate so concurrent creators see the new
+	// daytona.gpu_index label on their next scan and skip this index, but it
+	// must NOT be held across the subsequent Start() / network setup which
+	// can take seconds and would otherwise serialize every GPU sandbox
+	// creation on the runner.
+	var (
+		gpuIndex   *int
+		releaseGpu func()
+	)
 	if d.gpuEnabled && sandboxDto.GpuQuota > 0 {
 		idx, release, err := d.gpuAllocator.Acquire(ctx, d)
 		if err != nil {
 			return "", "", err
 		}
-		defer release()
+		releaseGpu = release
+		// Safety net: if anything between here and the explicit release
+		// below returns / panics, the mutex still gets released.
+		defer func() {
+			if releaseGpu != nil {
+				releaseGpu()
+			}
+		}()
 		gpuIndex = &idx
 	}
 
@@ -153,6 +166,14 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 			return sandboxDto.Id, "", nil
 		}
 		return "", "", err
+	}
+
+	// Container with the daytona.gpu_index label now exists; concurrent
+	// allocator scans will see it, so the mutex can be released even though
+	// Start() has not run yet.
+	if releaseGpu != nil {
+		releaseGpu()
+		releaseGpu = nil
 	}
 
 	// Skip starting the container if explicitly requested

--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -125,7 +125,20 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 		}
 	}
 
-	containerConfig, hostConfig, networkingConfig, err := d.getContainerConfigs(sandboxDto, image, volumeMountPathBinds)
+	// Pin GPU sandboxes to a single physical card. The mutex is held until
+	// ContainerCreate finishes (via the deferred release) so concurrent
+	// creators read the new daytona.gpu_index label and skip this index.
+	var gpuIndex *int
+	if d.gpuEnabled && sandboxDto.GpuQuota > 0 {
+		idx, release, err := d.gpuAllocator.Acquire(ctx, d)
+		if err != nil {
+			return "", "", err
+		}
+		defer release()
+		gpuIndex = &idx
+	}
+
+	containerConfig, hostConfig, networkingConfig, err := d.getContainerConfigs(sandboxDto, image, volumeMountPathBinds, gpuIndex)
 	if err != nil {
 		return "", "", err
 	}

--- a/apps/runner/pkg/docker/gpu_allocator.go
+++ b/apps/runner/pkg/docker/gpu_allocator.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+// GpuIndexLabel is set on every GPU sandbox container with the index of the
+// physical GPU the container has been pinned to. The allocator scans this
+// label on existing containers to determine which indices are still free.
+const GpuIndexLabel = "daytona.gpu_index"
+
+// gpuAllocator hands out GPU device indices to GPU sandboxes on a runner.
+// Allocation is serialized by a mutex so concurrent sandbox creations cannot
+// pick the same physical card.
+type gpuAllocator struct {
+	mu    sync.Mutex
+	total int
+}
+
+func newGpuAllocator(total int) *gpuAllocator {
+	return &gpuAllocator{total: total}
+}
+
+// Acquire locks the allocator, scans all containers on the runner for the
+// daytona.gpu_index label, and returns the lowest free GPU index in
+// [0, total). The caller MUST defer the returned release() and MUST call
+// ContainerCreate (which sets the label on the new container) BEFORE
+// release() runs so concurrent allocators see the new label on their next
+// scan.
+func (a *gpuAllocator) Acquire(ctx context.Context, d *DockerClient) (int, func(), error) {
+	a.mu.Lock()
+	release := func() { a.mu.Unlock() }
+
+	if a.total <= 0 {
+		release()
+		return 0, nil, fmt.Errorf("runner has no GPUs to assign")
+	}
+
+	containers, err := d.apiClient.ContainerList(ctx, container.ListOptions{All: true})
+	if err != nil {
+		release()
+		return 0, nil, fmt.Errorf("list containers for GPU allocation: %w", err)
+	}
+
+	used := make(map[int]struct{}, len(containers))
+	for _, c := range containers {
+		if v, ok := c.Labels[GpuIndexLabel]; ok {
+			if n, err := strconv.Atoi(v); err == nil {
+				used[n] = struct{}{}
+			}
+		}
+	}
+
+	for i := 0; i < a.total; i++ {
+		if _, taken := used[i]; !taken {
+			return i, release, nil
+		}
+	}
+
+	release()
+	return 0, nil, fmt.Errorf("no free GPU on runner (capacity %d)", a.total)
+}

--- a/apps/runner/pkg/docker/gpu_allocator.go
+++ b/apps/runner/pkg/docker/gpu_allocator.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package docker
@@ -50,8 +50,18 @@ func (a *gpuAllocator) Acquire(ctx context.Context, d *DockerClient) (int, func(
 		return 0, nil, fmt.Errorf("list containers for GPU allocation: %w", err)
 	}
 
+	// Only containers whose process is alive can actually hold a GPU - Docker
+	// detaches the CDI device cgroup on exit, so an exited / dead / removing
+	// sandbox no longer occupies its physical card and its index must be
+	// reusable by the next allocation. (A subsequent restart of a stopped GPU
+	// sandbox is handled at start time by the per-card collision check rather
+	// than by keeping the slot reserved here.)
 	used := make(map[int]struct{}, len(containers))
 	for _, c := range containers {
+		switch c.State {
+		case "exited", "dead", "removing":
+			continue
+		}
 		if v, ok := c.Labels[GpuIndexLabel]; ok {
 			if n, err := strconv.Atoi(v); err == nil {
 				used[n] = struct{}{}

--- a/apps/runner/pkg/docker/gpu_info.go
+++ b/apps/runner/pkg/docker/gpu_info.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package docker

--- a/apps/runner/pkg/docker/gpu_info.go
+++ b/apps/runner/pkg/docker/gpu_info.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package docker
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// detectGpus probes the host for NVIDIA GPUs by invoking
+// `nvidia-smi --query-gpu=name --format=csv,noheader` and returns the number
+// of GPUs found together with the name of the first one. When nvidia-smi is
+// not installed or returns an error (which is the case on CPU-only hosts),
+// (0, "") is returned without surfacing the error - the runner simply has no
+// GPUs to schedule.
+func detectGpus(ctx context.Context) (int, string) {
+	cmd := exec.CommandContext(ctx, "nvidia-smi", "--query-gpu=name", "--format=csv,noheader")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, ""
+	}
+
+	var lines []string
+	for _, l := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if l = strings.TrimSpace(l); l != "" {
+			lines = append(lines, l)
+		}
+	}
+	if len(lines) == 0 {
+		return 0, ""
+	}
+	return len(lines), lines[0]
+}

--- a/apps/runner/pkg/runner/v2/healthcheck/healthcheck.go
+++ b/apps/runner/pkg/runner/v2/healthcheck/healthcheck.go
@@ -140,7 +140,7 @@ func (s *Service) sendHealthcheck(ctx context.Context) error {
 	if err != nil {
 		s.log.WarnContext(reqCtx, "Failed to collect metrics for healthcheck", "error", err)
 	} else {
-		healthcheck.SetMetrics(apiclient.RunnerHealthMetrics{
+		metrics := apiclient.RunnerHealthMetrics{
 			CurrentCpuLoadAverage:        m.CPULoadAverage,
 			CurrentCpuUsagePercentage:    m.CPUUsagePercentage,
 			CurrentMemoryUsagePercentage: m.MemoryUsagePercentage,
@@ -153,7 +153,12 @@ func (s *Service) sendHealthcheck(ctx context.Context) error {
 			Cpu:                          m.TotalCPU,
 			MemoryGiB:                    m.TotalRAMGiB,
 			DiskGiB:                      m.TotalDiskGiB,
-		})
+		}
+		if c := s.docker.GpuCount(); c > 0 {
+			metrics.SetGpu(float32(c))
+			metrics.SetGpuType(s.docker.GpuType())
+		}
+		healthcheck.SetMetrics(metrics)
 	}
 
 	req := s.client.RunnersAPI.RunnerHealthcheck(reqCtx).RunnerHealthcheck(*healthcheck)

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -12150,6 +12150,14 @@ components:
           description: Total disk space in GiB on the runner
           example: 100
           type: number
+        gpu:
+          description: Total number of GPUs on the runner
+          example: 4
+          type: number
+        gpuType:
+          description: GPU model name
+          example: NVIDIA H100 80GB HBM3
+          type: string
       required:
       - cpu
       - currentAllocatedCpu

--- a/libs/api-client-go/model_runner_health_metrics.go
+++ b/libs/api-client-go/model_runner_health_metrics.go
@@ -45,6 +45,10 @@ type RunnerHealthMetrics struct {
 	MemoryGiB float32 `json:"memoryGiB"`
 	// Total disk space in GiB on the runner
 	DiskGiB float32 `json:"diskGiB"`
+	// Total number of GPUs on the runner
+	Gpu *float32 `json:"gpu,omitempty"`
+	// GPU model name
+	GpuType *string `json:"gpuType,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -367,6 +371,70 @@ func (o *RunnerHealthMetrics) SetDiskGiB(v float32) {
 	o.DiskGiB = v
 }
 
+// GetGpu returns the Gpu field value if set, zero value otherwise.
+func (o *RunnerHealthMetrics) GetGpu() float32 {
+	if o == nil || IsNil(o.Gpu) {
+		var ret float32
+		return ret
+	}
+	return *o.Gpu
+}
+
+// GetGpuOk returns a tuple with the Gpu field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RunnerHealthMetrics) GetGpuOk() (*float32, bool) {
+	if o == nil || IsNil(o.Gpu) {
+		return nil, false
+	}
+	return o.Gpu, true
+}
+
+// HasGpu returns a boolean if a field has been set.
+func (o *RunnerHealthMetrics) HasGpu() bool {
+	if o != nil && !IsNil(o.Gpu) {
+		return true
+	}
+
+	return false
+}
+
+// SetGpu gets a reference to the given float32 and assigns it to the Gpu field.
+func (o *RunnerHealthMetrics) SetGpu(v float32) {
+	o.Gpu = &v
+}
+
+// GetGpuType returns the GpuType field value if set, zero value otherwise.
+func (o *RunnerHealthMetrics) GetGpuType() string {
+	if o == nil || IsNil(o.GpuType) {
+		var ret string
+		return ret
+	}
+	return *o.GpuType
+}
+
+// GetGpuTypeOk returns a tuple with the GpuType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RunnerHealthMetrics) GetGpuTypeOk() (*string, bool) {
+	if o == nil || IsNil(o.GpuType) {
+		return nil, false
+	}
+	return o.GpuType, true
+}
+
+// HasGpuType returns a boolean if a field has been set.
+func (o *RunnerHealthMetrics) HasGpuType() bool {
+	if o != nil && !IsNil(o.GpuType) {
+		return true
+	}
+
+	return false
+}
+
+// SetGpuType gets a reference to the given string and assigns it to the GpuType field.
+func (o *RunnerHealthMetrics) SetGpuType(v string) {
+	o.GpuType = &v
+}
+
 func (o RunnerHealthMetrics) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -389,6 +457,12 @@ func (o RunnerHealthMetrics) ToMap() (map[string]interface{}, error) {
 	toSerialize["cpu"] = o.Cpu
 	toSerialize["memoryGiB"] = o.MemoryGiB
 	toSerialize["diskGiB"] = o.DiskGiB
+	if !IsNil(o.Gpu) {
+		toSerialize["gpu"] = o.Gpu
+	}
+	if !IsNil(o.GpuType) {
+		toSerialize["gpuType"] = o.GpuType
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -455,6 +529,8 @@ func (o *RunnerHealthMetrics) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "cpu")
 		delete(additionalProperties, "memoryGiB")
 		delete(additionalProperties, "diskGiB")
+		delete(additionalProperties, "gpu")
+		delete(additionalProperties, "gpuType")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerHealthMetrics.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerHealthMetrics.java
@@ -111,6 +111,16 @@ public class RunnerHealthMetrics {
   @javax.annotation.Nonnull
   private BigDecimal diskGiB;
 
+  public static final String SERIALIZED_NAME_GPU = "gpu";
+  @SerializedName(SERIALIZED_NAME_GPU)
+  @javax.annotation.Nullable
+  private BigDecimal gpu;
+
+  public static final String SERIALIZED_NAME_GPU_TYPE = "gpuType";
+  @SerializedName(SERIALIZED_NAME_GPU_TYPE)
+  @javax.annotation.Nullable
+  private String gpuType;
+
   public RunnerHealthMetrics() {
   }
 
@@ -341,6 +351,44 @@ public class RunnerHealthMetrics {
     this.diskGiB = diskGiB;
   }
 
+
+  public RunnerHealthMetrics gpu(@javax.annotation.Nullable BigDecimal gpu) {
+    this.gpu = gpu;
+    return this;
+  }
+
+  /**
+   * Total number of GPUs on the runner
+   * @return gpu
+   */
+  @javax.annotation.Nullable
+  public BigDecimal getGpu() {
+    return gpu;
+  }
+
+  public void setGpu(@javax.annotation.Nullable BigDecimal gpu) {
+    this.gpu = gpu;
+  }
+
+
+  public RunnerHealthMetrics gpuType(@javax.annotation.Nullable String gpuType) {
+    this.gpuType = gpuType;
+    return this;
+  }
+
+  /**
+   * GPU model name
+   * @return gpuType
+   */
+  @javax.annotation.Nullable
+  public String getGpuType() {
+    return gpuType;
+  }
+
+  public void setGpuType(@javax.annotation.Nullable String gpuType) {
+    this.gpuType = gpuType;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -407,13 +455,15 @@ public class RunnerHealthMetrics {
         Objects.equals(this.currentStartedSandboxes, runnerHealthMetrics.currentStartedSandboxes) &&
         Objects.equals(this.cpu, runnerHealthMetrics.cpu) &&
         Objects.equals(this.memoryGiB, runnerHealthMetrics.memoryGiB) &&
-        Objects.equals(this.diskGiB, runnerHealthMetrics.diskGiB)&&
+        Objects.equals(this.diskGiB, runnerHealthMetrics.diskGiB) &&
+        Objects.equals(this.gpu, runnerHealthMetrics.gpu) &&
+        Objects.equals(this.gpuType, runnerHealthMetrics.gpuType)&&
         Objects.equals(this.additionalProperties, runnerHealthMetrics.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(currentCpuLoadAverage, currentCpuUsagePercentage, currentMemoryUsagePercentage, currentDiskUsagePercentage, currentAllocatedCpu, currentAllocatedMemoryGiB, currentAllocatedDiskGiB, currentSnapshotCount, currentStartedSandboxes, cpu, memoryGiB, diskGiB, additionalProperties);
+    return Objects.hash(currentCpuLoadAverage, currentCpuUsagePercentage, currentMemoryUsagePercentage, currentDiskUsagePercentage, currentAllocatedCpu, currentAllocatedMemoryGiB, currentAllocatedDiskGiB, currentSnapshotCount, currentStartedSandboxes, cpu, memoryGiB, diskGiB, gpu, gpuType, additionalProperties);
   }
 
   @Override
@@ -432,6 +482,8 @@ public class RunnerHealthMetrics {
     sb.append("    cpu: ").append(toIndentedString(cpu)).append("\n");
     sb.append("    memoryGiB: ").append(toIndentedString(memoryGiB)).append("\n");
     sb.append("    diskGiB: ").append(toIndentedString(diskGiB)).append("\n");
+    sb.append("    gpu: ").append(toIndentedString(gpu)).append("\n");
+    sb.append("    gpuType: ").append(toIndentedString(gpuType)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -451,7 +503,7 @@ public class RunnerHealthMetrics {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("currentCpuLoadAverage", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "cpu", "memoryGiB", "diskGiB"));
+    openapiFields = new HashSet<String>(Arrays.asList("currentCpuLoadAverage", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "cpu", "memoryGiB", "diskGiB", "gpu", "gpuType"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("currentCpuLoadAverage", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "cpu", "memoryGiB", "diskGiB"));
@@ -477,6 +529,9 @@ public class RunnerHealthMetrics {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
+      if ((jsonObj.get("gpuType") != null && !jsonObj.get("gpuType").isJsonNull()) && !jsonObj.get("gpuType").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `gpuType` to be a primitive type in the JSON string but got `%s`", jsonObj.get("gpuType").toString()));
+      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/RunnerHealthMetricsTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/RunnerHealthMetricsTest.java
@@ -134,4 +134,20 @@ public class RunnerHealthMetricsTest {
         // TODO: test diskGiB
     }
 
+    /**
+     * Test the property 'gpu'
+     */
+    @Test
+    public void gpuTest() {
+        // TODO: test gpu
+    }
+
+    /**
+     * Test the property 'gpuType'
+     */
+    @Test
+    public void gpuTypeTest() {
+        // TODO: test gpuType
+    }
+
 }

--- a/libs/api-client-python-async/daytona_api_client_async/models/runner_health_metrics.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/runner_health_metrics.py
@@ -18,8 +18,8 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt
-from typing import Any, ClassVar, Dict, List, Union
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -42,8 +42,10 @@ class RunnerHealthMetrics(BaseModel):
     cpu: Union[StrictFloat, StrictInt] = Field(description="Total CPU cores on the runner")
     memory_gi_b: Union[StrictFloat, StrictInt] = Field(description="Total RAM in GiB on the runner", serialization_alias="memoryGiB")
     disk_gi_b: Union[StrictFloat, StrictInt] = Field(description="Total disk space in GiB on the runner", serialization_alias="diskGiB")
+    gpu: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Total number of GPUs on the runner")
+    gpu_type: Optional[StrictStr] = Field(default=None, description="GPU model name", serialization_alias="gpuType")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["currentCpuLoadAverage", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "cpu", "memoryGiB", "diskGiB"]
+    __properties: ClassVar[List[str]] = ["currentCpuLoadAverage", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "cpu", "memoryGiB", "diskGiB", "gpu", "gpuType"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -113,7 +115,9 @@ class RunnerHealthMetrics(BaseModel):
             "current_started_sandboxes": obj.get("currentStartedSandboxes"),
             "cpu": obj.get("cpu"),
             "memory_gi_b": obj.get("memoryGiB"),
-            "disk_gi_b": obj.get("diskGiB")
+            "disk_gi_b": obj.get("diskGiB"),
+            "gpu": obj.get("gpu"),
+            "gpu_type": obj.get("gpuType")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-python/daytona_api_client/models/runner_health_metrics.py
+++ b/libs/api-client-python/daytona_api_client/models/runner_health_metrics.py
@@ -18,8 +18,8 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt
-from typing import Any, ClassVar, Dict, List, Union
+from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -42,8 +42,10 @@ class RunnerHealthMetrics(BaseModel):
     cpu: Union[StrictFloat, StrictInt] = Field(description="Total CPU cores on the runner")
     memory_gi_b: Union[StrictFloat, StrictInt] = Field(description="Total RAM in GiB on the runner", serialization_alias="memoryGiB")
     disk_gi_b: Union[StrictFloat, StrictInt] = Field(description="Total disk space in GiB on the runner", serialization_alias="diskGiB")
+    gpu: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Total number of GPUs on the runner")
+    gpu_type: Optional[StrictStr] = Field(default=None, description="GPU model name", serialization_alias="gpuType")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["currentCpuLoadAverage", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "cpu", "memoryGiB", "diskGiB"]
+    __properties: ClassVar[List[str]] = ["currentCpuLoadAverage", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "cpu", "memoryGiB", "diskGiB", "gpu", "gpuType"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -113,7 +115,9 @@ class RunnerHealthMetrics(BaseModel):
             "current_started_sandboxes": obj.get("currentStartedSandboxes"),
             "cpu": obj.get("cpu"),
             "memory_gi_b": obj.get("memoryGiB"),
-            "disk_gi_b": obj.get("diskGiB")
+            "disk_gi_b": obj.get("diskGiB"),
+            "gpu": obj.get("gpu"),
+            "gpu_type": obj.get("gpuType")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/libs/api-client-ruby/lib/daytona_api_client/models/runner_health_metrics.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/runner_health_metrics.rb
@@ -51,6 +51,12 @@ module DaytonaApiClient
     # Total disk space in GiB on the runner
     attr_accessor :disk_gi_b
 
+    # Total number of GPUs on the runner
+    attr_accessor :gpu
+
+    # GPU model name
+    attr_accessor :gpu_type
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -65,7 +71,9 @@ module DaytonaApiClient
         :'current_started_sandboxes' => :'currentStartedSandboxes',
         :'cpu' => :'cpu',
         :'memory_gi_b' => :'memoryGiB',
-        :'disk_gi_b' => :'diskGiB'
+        :'disk_gi_b' => :'diskGiB',
+        :'gpu' => :'gpu',
+        :'gpu_type' => :'gpuType'
       }
     end
 
@@ -93,7 +101,9 @@ module DaytonaApiClient
         :'current_started_sandboxes' => :'Float',
         :'cpu' => :'Float',
         :'memory_gi_b' => :'Float',
-        :'disk_gi_b' => :'Float'
+        :'disk_gi_b' => :'Float',
+        :'gpu' => :'Float',
+        :'gpu_type' => :'String'
       }
     end
 
@@ -189,6 +199,14 @@ module DaytonaApiClient
         self.disk_gi_b = attributes[:'disk_gi_b']
       else
         self.disk_gi_b = nil
+      end
+
+      if attributes.key?(:'gpu')
+        self.gpu = attributes[:'gpu']
+      end
+
+      if attributes.key?(:'gpu_type')
+        self.gpu_type = attributes[:'gpu_type']
       end
     end
 
@@ -403,7 +421,9 @@ module DaytonaApiClient
           current_started_sandboxes == o.current_started_sandboxes &&
           cpu == o.cpu &&
           memory_gi_b == o.memory_gi_b &&
-          disk_gi_b == o.disk_gi_b
+          disk_gi_b == o.disk_gi_b &&
+          gpu == o.gpu &&
+          gpu_type == o.gpu_type
     end
 
     # @see the `==` method
@@ -415,7 +435,7 @@ module DaytonaApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [current_cpu_load_average, current_cpu_usage_percentage, current_memory_usage_percentage, current_disk_usage_percentage, current_allocated_cpu, current_allocated_memory_gi_b, current_allocated_disk_gi_b, current_snapshot_count, current_started_sandboxes, cpu, memory_gi_b, disk_gi_b].hash
+      [current_cpu_load_average, current_cpu_usage_percentage, current_memory_usage_percentage, current_disk_usage_percentage, current_allocated_cpu, current_allocated_memory_gi_b, current_allocated_disk_gi_b, current_snapshot_count, current_started_sandboxes, cpu, memory_gi_b, disk_gi_b, gpu, gpu_type].hash
     end
 
     # Builds the object from hash

--- a/libs/api-client/src/models/runner-health-metrics.ts
+++ b/libs/api-client/src/models/runner-health-metrics.ts
@@ -63,5 +63,13 @@ export interface RunnerHealthMetrics {
      * Total disk space in GiB on the runner
      */
     'diskGiB': number;
+    /**
+     * Total number of GPUs on the runner
+     */
+    'gpu'?: number;
+    /**
+     * GPU model name
+     */
+    'gpuType'?: string;
 }
 


### PR DESCRIPTION
## Description

Replace the global "one GPU sandbox per runner" exclusivity with per-card scheduling so a multi-GPU runner (e.g. 4xH100) can host one GPU sandbox per physical card.

**API side**:

- Extends `RunnerHealthMetricsDto` with optional `gpu` (count) and `gpuType` (model name) fields.
- `RunnerService.updateRunnerHealth` now persists those values into the already-existing `runner.gpu` / `runner.gpuType` columns when present — no migration needed.
- Regenerated the Go, TypeScript, Python (sync + async), Ruby, and Java clients for the new optional fields.

**Runner side**:

- New `apps/runner/pkg/docker/gpu_info.go`: probes `nvidia-smi --query-gpu=name --format=csv,noheader` once at startup and caches `(count, firstName)`. Hosts without NVIDIA tooling silently return `(0, "")` and stay CPU-only.
- New `apps/runner/pkg/docker/gpu_allocator.go`: mutex-protected `Acquire` that lists containers, reads the `daytona.gpu_index` label on each, and returns the lowest free index in `[0, count)`. No explicit release on destroy — the label dies with the container.
- `DockerClient` now exposes `GpuCount()` / `GpuType()`; the v2 healthcheck loop populates `gpu`/`gpuType` on the outgoing metrics when GPUs are present.
- `getContainerConfigs`/`getContainerHostConfig`/`getContainerCreateConfig` now accept a `gpuIndex *int`. The hard-coded `/dev/nvidia0`, `/dev/nvidiactl`, `/dev/nvidia-uvm[-tools]`, `/dev/nvidia-modeset` bind-mounts (which forced every sandbox onto card 0) are replaced with a single `HostConfig.DeviceRequests{Driver:"nvidia", DeviceIDs:["<idx>"], Capabilities:[["gpu","compute","utility"]]}`. The chosen index is also written as the `daytona.gpu_index` container label.
- `Create` acquires a GPU before building the container configs and holds the allocator mutex through `ContainerCreate` via `defer release()`, so concurrent creators see the label on their next scan and skip that card.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

N/A — backend/runner change with no UI surface.

## Notes

- Requires the NVIDIA Container Toolkit to be present inside the runner image's DinD layer so `DeviceRequests{Driver:"nvidia"}` resolves; this is already bundled.
- Operators no longer have to manually set `runner.gpu` / `runner.gpuType` via the API — the v2 healthcheck populates them automatically once the runner restarts on a GPU host with `GPU_ENABLED=true`.

### Test plan

- [ ] Non-GPU host: runner starts, healthcheck omits `gpu`, API does not pick it for GPU sandboxes (`runner.gpu IS NOT NULL AND runner.gpu > 0` filter).
- [ ] 4xH100 host with `GPU_ENABLED=true`: healthcheck reports `gpu=4`, `gpuType="NVIDIA H100 ..."`; start 4 GPU sandboxes and confirm `nvidia-smi -L` inside each shows a different physical card; 5th request is rejected with "no available runner".
- [ ] Stop one GPU sandbox on the H100 host, start a new one, confirm it reuses the freed index.