### PR TITLE
update(default-image): update openclaw version in default image

### DIFF
--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -1323,7 +1323,7 @@ All default snapshots are based on the `daytonaio/sandbox:<version>` image. For 
 - `@anthropic-ai/claude-code` (v2.1.19)
 - `@openai/codex` (0.128.0)
 - `bun` (v1.3.6)
-- `openclaw` (v2026.2.1)
+- `openclaw` (v2026.5.22)
 - `opencode-ai` (v1.1.35)
 - `ts-node` (v10.9.2)
 - `typescript` (v5.9.3)

--- a/images/sandbox/Dockerfile
+++ b/images/sandbox/Dockerfile
@@ -81,7 +81,7 @@ RUN useradd -m daytona && echo "daytona ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d
 RUN bash -c "source /usr/local/share/nvm/nvm.sh && nvm install 25 && nvm use 25 && nvm alias default 25" \
   && chown -R daytona:daytona /usr/local/share/nvm
 
-RUN npm install -g ts-node@10.9.2 typescript@5.9.3 typescript-language-server@5.1.3 bun@1.3.6 @anthropic-ai/claude-code@2.1.19 @openai/codex@0.128.0 openclaw@2026.2.1 opencode-ai@1.1.35
+RUN npm install -g ts-node@10.9.2 typescript@5.9.3 typescript-language-server@5.1.3 bun@1.3.6 @anthropic-ai/claude-code@2.1.19 @openai/codex@0.128.0 openclaw@2026.5.22 opencode-ai@1.1.35
 
 # Create directory for computer use plugin
 RUN mkdir -p /usr/local/lib && chown daytona:daytona /usr/local/lib


### PR DESCRIPTION
Bumped the openclaw version in the default image to 2026.5.22. Tested and seems to work in the local repro. Updated the documentation as well that references the versioning

## Description

OpenClaw version was from February, updated the version to May 22nd release (2026.5.22). Updated the documentation that references the OpenClaw version in Snapshots `Node.js packages (npm)`. Tested with a simple local repro.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation


## Notes

No other dependencies had to be updated
