### PR TITLE
chore(security): add PR-time Docker build verification via nx affected

### DIFF
--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -35,6 +35,7 @@ jobs:
           install-java: 'false'
           install-poetry: 'false'
           install-swag: 'false'
+          run-poetry-install: 'false'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -37,6 +37,12 @@ jobs:
           install-swag: 'false'
           run-poetry-install: 'false'
 
+      - name: Ensure go.work.sum exists
+        # The composite runs `go work sync` but does not `touch go.work.sum`.
+        # When sync has nothing to write, the file is not created, and the Go
+        # Dockerfiles' `COPY go.work go.work.sum` fails. Matches release.yaml:270.
+        run: touch go.work.sum
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -45,6 +45,11 @@ jobs:
           go-version-file: go.work
           cache: false
 
+      - name: Install Go CGO deps for libs/computer-use
+        # runner:docker dependsOn computer-use:build-amd64, which native-compiles
+        # robotgo (X11 bindings). Same packages codeql.yml installs (line 62).
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libx11-dev libxtst-dev
+
       - name: Generate go.work.sum
         run: |
           GONOSUMDB=github.com/daytonaio/daytona go work sync

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -47,9 +47,13 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build all Docker targets
+        # sandbox and sandbox-slim excluded: their base mcr.microsoft.com/devcontainers/python
+        # is anonymous-pulled from GHA runners and flakes with 403 Forbidden. Sandbox image
+        # validation happens via default_image_publish.yaml on release dispatch.
         run: |
           yarn nx run-many \
             --target=docker \
             --configuration=pr-build \
+            --exclude=sandbox,sandbox-slim \
             --parallel=2 \
             --nxBail=true

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -1,0 +1,64 @@
+name: '[PR] Docker build'
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    name: Docker build (affected)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VERSION: v0.0.0-pr
+      NX_DAEMON: 'false'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0   # nx affected needs base-branch history
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Enable corepack
+        run: npm install -g corepack && corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.work
+          cache: false
+
+      - name: Generate go.work.sum
+        run: |
+          GONOSUMDB=github.com/daytonaio/daytona go work sync
+          touch go.work.sum
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build affected Docker targets
+        run: |
+          yarn nx affected \
+            --base=origin/${{ github.base_ref }} \
+            --head=HEAD \
+            --target=docker \
+            --configuration=pr-build \
+            --parallel=2 \
+            --nxBail=true

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -15,9 +15,9 @@ concurrency:
 
 jobs:
   docker-build:
-    name: Docker build (affected)
+    name: Docker build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       VERSION: v0.0.0-pr
       NX_DAEMON: 'false'
@@ -25,44 +25,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0   # nx affected needs base-branch history
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
         with:
-          node-version: 22
-
-      - name: Enable corepack
-        run: npm install -g corepack && corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.work
-          cache: false
-
-      - name: Install Go CGO deps for libs/computer-use
-        # runner:docker dependsOn computer-use:build-amd64, which native-compiles
-        # robotgo (X11 bindings). Same packages codeql.yml installs (line 62).
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc libx11-dev libxtst-dev
-
-      - name: Generate go.work.sum
-        run: |
-          GONOSUMDB=github.com/daytonaio/daytona go work sync
-          touch go.work.sum
+          install-python: 'false'
+          install-ruby: 'false'
+          install-java: 'false'
+          install-poetry: 'false'
+          install-swag: 'false'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Build affected Docker targets
+      - name: Build all Docker targets
         run: |
-          yarn nx affected \
-            --base=origin/${{ github.base_ref }} \
-            --head=HEAD \
+          yarn nx run-many \
             --target=docker \
             --configuration=pr-build \
             --parallel=2 \

--- a/images/sandbox-slim/project.json
+++ b/images/sandbox-slim/project.json
@@ -10,6 +10,11 @@
         "tags": ["daytonaio/sandbox:$VERSION-slim$ARCH"],
         "cache-from": ["type=registry,ref=daytonaio/sandbox:buildcache-slim$ARCH"],
         "cache-to": ["type=registry,ref=daytonaio/sandbox:buildcache-slim$ARCH,mode=max"]
+      },
+      "configurations": {
+        "pr-build": {
+          "tags": ["daytonaio/sandbox:$VERSION-slim"]
+        }
       }
     }
   }

--- a/images/sandbox-slim/project.json
+++ b/images/sandbox-slim/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "sandbox-slim",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "images/sandbox-slim",
+  "tags": [],
+  "targets": {
+    "docker": {
+      "options": {
+        "tags": ["daytonaio/sandbox:$VERSION-slim$ARCH"],
+        "cache-from": ["type=registry,ref=daytonaio/sandbox:buildcache-slim$ARCH"],
+        "cache-to": ["type=registry,ref=daytonaio/sandbox:buildcache-slim$ARCH,mode=max"]
+      }
+    }
+  }
+}

--- a/images/sandbox/project.json
+++ b/images/sandbox/project.json
@@ -10,6 +10,11 @@
         "tags": ["daytonaio/sandbox:$VERSION$ARCH"],
         "cache-from": ["type=registry,ref=daytonaio/sandbox:buildcache$ARCH"],
         "cache-to": ["type=registry,ref=daytonaio/sandbox:buildcache$ARCH,mode=max"]
+      },
+      "configurations": {
+        "pr-build": {
+          "tags": ["daytonaio/sandbox:$VERSION"]
+        }
       }
     }
   }

--- a/images/sandbox/project.json
+++ b/images/sandbox/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "sandbox",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "images/sandbox",
+  "tags": [],
+  "targets": {
+    "docker": {
+      "options": {
+        "tags": ["daytonaio/sandbox:$VERSION$ARCH"],
+        "cache-from": ["type=registry,ref=daytonaio/sandbox:buildcache$ARCH"],
+        "cache-to": ["type=registry,ref=daytonaio/sandbox:buildcache$ARCH,mode=max"]
+      }
+    }
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -186,6 +186,13 @@
           ],
           "cache-from": ["type=registry,ref=registry:5000/daytonaio/test-daytona-{projectName}:buildcache"],
           "cache-to": ["type=registry,ref=registry:5000/daytonaio/test-daytona-{projectName}:buildcache,mode=max"]
+        },
+        "pr-build": {
+          "push": false,
+          "load": false,
+          "platforms": ["linux/amd64"],
+          "cache-from": ["type=gha,scope=docker-{projectName}"],
+          "cache-to": ["type=gha,scope=docker-{projectName},mode=max"]
         }
       },
       "dependsOn": ["check-version-env"]

--- a/nx.json
+++ b/nx.json
@@ -191,6 +191,7 @@
           "push": false,
           "load": false,
           "platforms": ["linux/amd64"],
+          "tags": ["daytonaio/daytona-{projectName}:$VERSION"],
           "cache-from": ["type=gha,scope=docker-{projectName}"],
           "cache-to": ["type=gha,scope=docker-{projectName},mode=max"]
         }


### PR DESCRIPTION
## What

Adds a PR-time Docker build check that runs `yarn nx run-many --target=docker --configuration=pr-build` on every PR. Catches broken Dependabot base-image bumps (from #4752) before merge.

## Why

Follow-up to #4752 (Dependabot for Docker base images). Without a PR-time build check, weekly Dependabot bump PRs get green CI signals that never actually exercise the Docker build — broken bumps surface only at release time.

Replaces a closed earlier attempt (#4800) that reimplemented change detection and dependency ordering externally via dorny/paths-filter + matrix + stubs. nx already handles all of that, so this version uses it.

## Three changes

**1. `nx.json` — new `pr-build` configuration on the `docker` targetDefault**

```json
"pr-build": {
  "push": false,
  "load": false,
  "platforms": ["linux/amd64"],
  "tags": ["daytonaio/daytona-{projectName}:$VERSION"],
  "cache-from": ["type=gha,scope=docker-{projectName}"],
  "cache-to": ["type=gha,scope=docker-{projectName},mode=max"]
}
```

Reuses everything from the existing target — context, file path, build-args, `dependsOn` graph. Overrides `tags` to drop the `$ARCH` suffix (single-platform builds don't set ARCH) and switches cache from registry to GHA.

**2. `images/sandbox/project.json` + `images/sandbox-slim/project.json`**

Minimal nx project definitions so the sandbox Dockerfiles are addressable by `yarn nx`. Override `tags` and `cache-from/to` to use the `daytonaio/sandbox` naming scheme (the targetDefault uses `daytonaio/daytona-{projectName}` which does not fit sandbox). Sandbox release flows still go through `default_image_publish.yaml` unchanged.

**3. `.github/workflows/pr_docker_build.yaml`**

~45 lines. Single job: checkout, `./.github/actions/setup-toolchain` (composite handles Go, Node, yarn install, X11 deps, `go work sync` — disables Python/Ruby/Java/Poetry/swag since docker builds don't need them), `touch go.work.sum` (the composite runs `go work sync` but does not touch the file when sync has nothing to write), set up Buildx, then:

```bash
yarn nx run-many \
  --target=docker \
  --configuration=pr-build \
  --exclude=sandbox,sandbox-slim \
  --parallel=2 \
  --nxBail=true
```

`run-many` (rather than `nx affected`) — predictable cost regardless of which files the PR touches, BuildKit GHA cache handles speed for unchanged layers.

## Scope

| Built on every PR | Excluded |
|---|---|
| api, dashboard, proxy, runner, snapshot-manager, ssh-gateway, otel-collector, docs (8 targets) | sandbox, sandbox-slim (MCR pull flakes from GHA runners with 403; validated via default_image_publish.yaml on release dispatch) |

## Test plan

- [x] YAML + actionlint pass
- [ ] PR self-validates: touching `nx.json` and adding two `project.json` files causes `nx run-many` to build the 8 in-scope targets and report green
- [ ] After merge: admin configures the `Docker build` status check as required on `main`

## Follow-on (NOT optional)

A repo admin must add `Docker build` (job name from this workflow) as a required status check on `main` after this PR has run at least once. Without it, the workflow is decoration rather than a guard rail.