### PR TITLE
chore(security): ignore Docker base-image major bumps for node and python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,7 +50,16 @@ updates:
         patterns:
           - "docker"
     ignore:
+      # docker: dind major bumps need Sysbox compatibility review first
       - dependency-name: "docker"
+        update-types:
+          - "version-update:semver-major"
+      # node: pin to LTS lines; majors land manually after they reach Active LTS
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
+      # python: sandbox-slim runs user code; minor jumps need lifecycle validation
+      - dependency-name: "python"
         update-types:
           - "version-update:semver-major"
     commit-message:


### PR DESCRIPTION
## Description

Ignores `version-update:semver-major` for `node` and `python` in the Docker ecosystem, matching the existing rule for `docker`.

## Why

The first weekly run after #4752 opened #4797 proposing node 22/24 → 26 across 8 Dockerfiles and python 3.11 → 3.14 on sandbox-slim. Node 26 isn't Active LTS until 2026-10-28 (node 24 is the current LTS); python 3.11 → 3.14 spans three minors on the image end users run code in. Patch and minor bumps still flow weekly; majors land via manual, tested PRs.

## Test plan

- [x] YAML parses
- [ ] Next Monday run does not propose node 22/24 → 26 or python 3.11 → 3.14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Dependabot to ignore semver-major bumps for Docker `node` and `python` base images, matching the existing rule for `docker`. This avoids auto-upgrading to non‑LTS Node and big Python jumps; major upgrades will be done manually after validation.

- **Dependencies**
  - Added `version-update:semver-major` ignore rules for `node` and `python` in `.github/dependabot.yml`.
  - Patch and minor updates continue weekly.

<sup>Written for commit 256df9f7f502e0eaf67fa7523e06999cd75d86e4. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4804?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

