### PR TITLE
fix(ssh-gateway,runner): close upstream channel on client disconnect to stop stale keepalive

### DIFF
--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -155,12 +155,13 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 	defer clientChannel.Close()
 
 	// Connect to the sandbox container via toolbox
-	sandboxChannel, sandboxRequests, err := s.connectToSandbox(sandboxId, newChannel.ChannelType(), newChannel.ExtraData())
+	sandboxChannel, sandboxRequests, sandboxClient, err := s.connectToSandbox(sandboxId, newChannel.ChannelType(), newChannel.ExtraData())
 	if err != nil {
 		s.log.Warn("Could not connect to sandbox", "sandboxID", sandboxId, "error", err)
 		clientChannel.Close()
 		return
 	}
+	defer sandboxClient.Close()
 	defer sandboxChannel.Close()
 
 	// Forward requests from client to sandbox
@@ -217,6 +218,8 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 		if err != nil {
 			s.log.Debug("Client to sandbox copy error", "error", err)
 		}
+		// Client disconnected — close sandbox channel so the reverse copy unblocks and the session is cleaned up.
+		sandboxChannel.Close() // nolint:errcheck
 	}()
 
 	_, err = io.Copy(clientChannel, sandboxChannel)
@@ -228,11 +231,11 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 }
 
 // connectToSandbox connects to the sandbox container via the toolbox
-func (s *Service) connectToSandbox(sandboxId, channelType string, extraData []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+func (s *Service) connectToSandbox(sandboxId, channelType string, extraData []byte) (ssh.Channel, <-chan *ssh.Request, *ssh.Client, error) {
 	// Get sandbox details via toolbox API
 	sandboxDetails, err := s.getSandboxDetails(sandboxId)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get sandbox details: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get sandbox details: %w", err)
 	}
 
 	// Create SSH client config to connect to the sandbox
@@ -246,18 +249,18 @@ func (s *Service) connectToSandbox(sandboxId, channelType string, extraData []by
 	// Connect to the sandbox container via toolbox
 	sandboxClient, err := ssh.Dial("tcp", fmt.Sprintf("%s:22220", sandboxDetails.Hostname), clientConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to connect to sandbox: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to connect to sandbox: %w", err)
 	}
 
 	// Open channel to the sandbox
 	sandboxChannel, sandboxRequests, err := sandboxClient.OpenChannel(channelType, extraData)
 	if err != nil {
 		sandboxClient.Close()
-		return nil, nil, fmt.Errorf("failed to open channel to sandbox: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to open channel to sandbox: %w", err)
 	}
 
-	// Return the real sandbox channel and requests
-	return sandboxChannel, sandboxRequests, nil
+	// Return the real sandbox channel, requests, and client (caller must close client)
+	return sandboxChannel, sandboxRequests, sandboxClient, nil
 }
 
 // getSandboxDetails gets sandbox information via docker client

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -218,7 +218,15 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 		if err != nil {
 			s.log.Debug("Client to sandbox copy error", "error", err)
 		}
-		// Client disconnected — close sandbox channel so the reverse copy unblocks and the session is cleaned up.
+		// Always send MSG_CHANNEL_CLOSE (not just MSG_CHANNEL_EOF via CloseWrite).
+		// The SSH library surfaces transport errors as io.EOF on channel reads, so
+		// io.Copy returns nil even after an abrupt SIGKILL/network-drop — meaning
+		// CloseWrite would be taken in all cases.  More importantly, MSG_CHANNEL_EOF
+		// is silently ignored by long-lived processes such as VS Code Remote Server
+		// and JetBrains Gateway, leaving io.Copy(clientChannel, sandboxChannel)
+		// blocked and orphaned sandbox processes alive indefinitely.
+		// MSG_CHANNEL_CLOSE forces a reply, which unblocks the read and lets the
+		// sandbox shell receive a hangup signal so it can exit cleanly.
 		sandboxChannel.Close() // nolint:errcheck
 	}()
 

--- a/apps/runner/pkg/sshgateway/service_test.go
+++ b/apps/runner/pkg/sshgateway/service_test.go
@@ -91,17 +91,18 @@ func newChannelPair(t *testing.T) *channelPair {
 			return
 		}
 		go ssh.DiscardRequests(reqs)
-		for newCh := range chans {
-			ch, reqs, err := newCh.Accept()
-			if err != nil {
-				return
-			}
-			go ssh.DiscardRequests(reqs)
-			serverChanCh <- ch
-			for range chans {
-			} // drain remaining channels
+		newCh, ok := <-chans
+		if !ok {
 			return
 		}
+		ch, reqs, err := newCh.Accept()
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		serverChanCh <- ch
+		for range chans {
+		} // drain remaining channels
 	}()
 
 	clientCfg := &ssh.ClientConfig{

--- a/apps/runner/pkg/sshgateway/service_test.go
+++ b/apps/runner/pkg/sshgateway/service_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build linux
+
+package sshgateway
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// testSigner generates a throwaway RSA signer for in-memory SSH tests.
+func testSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("make signer: %v", err)
+	}
+	return signer
+}
+
+// channelPair holds both ends of an in-memory SSH channel.
+type channelPair struct {
+	// server is the channel as seen by the SSH server (Accept()-returned).
+	server ssh.Channel
+	// client is the channel as seen by the SSH client (OpenChannel()-returned).
+	client ssh.Channel
+	// closeConns tears down the underlying net.Pipe connections.
+	closeConns func()
+}
+
+// newChannelPair creates an SSH connection backed by a loopback TCP socket and
+// returns a connected channel pair. A loopback socket is used instead of
+// net.Pipe() because net.Pipe() is synchronous with no kernel buffer: when both
+// sides of an SSH handshake write their version string simultaneously, both block
+// indefinitely. TCP's OS send buffer absorbs the small version string so neither
+// side stalls.
+func newChannelPair(t *testing.T) *channelPair {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		ln.Close() //nolint:errcheck — only one connection needed
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	var srvConn net.Conn
+	select {
+	case srvConn = <-accepted:
+	case <-time.After(5 * time.Second):
+		cliConn.Close() //nolint:errcheck
+		t.Fatal("accept timeout")
+	}
+
+	serverCfg := &ssh.ServerConfig{NoClientAuth: true}
+	serverCfg.AddHostKey(testSigner(t))
+
+	serverChanCh := make(chan ssh.Channel, 1)
+	go func() {
+		_, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		for newCh := range chans {
+			ch, reqs, err := newCh.Accept()
+			if err != nil {
+				return
+			}
+			go ssh.DiscardRequests(reqs)
+			serverChanCh <- ch
+			for range chans {
+			} // drain remaining channels
+			return
+		}
+	}()
+
+	clientCfg := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	cc, cliChans, cliReqs, err := ssh.NewClientConn(cliConn, "", clientCfg)
+	if err != nil {
+		t.Fatalf("ssh client connect: %v", err)
+	}
+	go ssh.DiscardRequests(cliReqs)
+	go func() {
+		for range cliChans {
+		}
+	}()
+
+	clientCh, chReqs, err := cc.OpenChannel("session", nil)
+	if err != nil {
+		t.Fatalf("open channel: %v", err)
+	}
+	go ssh.DiscardRequests(chReqs)
+
+	var serverCh ssh.Channel
+	select {
+	case serverCh = <-serverChanCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for server to accept channel")
+	}
+
+	return &channelPair{
+		server: serverCh,
+		client: clientCh,
+		closeConns: func() {
+			cliConn.Close() //nolint:errcheck
+			srvConn.Close() //nolint:errcheck
+		},
+	}
+}
+
+// TestClientDisconnectClosesSandboxChannel is the regression test for the stale SSH
+// keepalive bug (https://github.com/daytonaio/daytona/issues/4805) at the runner layer.
+//
+// When the SSH gateway closes its channel to the runner (because the external client
+// disconnected), the runner must close the downstream sandbox channel. Without this,
+// the sandbox-to-client io.Copy blocks forever, the sandbox shell (and any VS Code /
+// JetBrains remote server processes) stays alive, and the gateway's keepalive ticker
+// keeps refreshing lastActivityAt every 45 s.
+//
+// The fix adds sandboxChannel.Close() at the end of the client→sandbox goroutine.
+func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
+	t.Parallel()
+
+	// clientPair simulates the runner receiving a channel from the gateway.
+	// clientPair.server == clientChannel in Service.handleChannel (runner's server-side view).
+	// clientPair.client == the gateway's end; closing it simulates the external client dying.
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	// sandboxPair simulates the runner opening a channel into the sandbox container.
+	// sandboxPair.client == sandboxChannel in Service.handleChannel.
+	// sandboxPair.server == the sandbox container's sshd end.
+	sandboxPair := newChannelPair(t)
+	defer sandboxPair.closeConns()
+
+	clientChannel := clientPair.server   // runner accepted this from the gateway
+	sandboxChannel := sandboxPair.client // runner opened this to the sandbox container
+
+	// done is closed when the main blocking io.Copy (sandbox→client) returns.
+	done := make(chan struct{})
+
+	// Fixed goroutine: client→sandbox copy, then close sandbox on disconnect.
+	// This is the goroutine that was modified in apps/runner/pkg/sshgateway/service.go.
+	go func() {
+		_, _ = io.Copy(sandboxChannel, clientChannel)
+		sandboxChannel.Close() //nolint:errcheck — the fix
+	}()
+
+	// Main blocking copy: sandbox→client.
+	// This previously blocked forever when the gateway closed its channel.
+	go func() {
+		_, _ = io.Copy(clientChannel, sandboxChannel)
+		close(done)
+	}()
+
+	// Allow goroutines to reach their blocking io.Copy calls.
+	time.Sleep(10 * time.Millisecond)
+
+	// Simulate gateway closing its channel (because the external SSH client disconnected).
+	clientPair.client.Close() //nolint:errcheck
+
+	select {
+	case <-done:
+		// Both copies returned. The orphaned sandbox shell will receive HUP/EOF and exit.
+	case <-time.After(2 * time.Second):
+		t.Fatal("sandbox-side channel copy did not unblock after client disconnect; " +
+			"orphaned sandbox processes (bash, VS Code remote, JetBrains) would persist indefinitely")
+	}
+}
+
+// TestSandboxChannelReceivesCloseOnClientDisconnect verifies that the sandbox container's
+// channel receives a close signal after the external client disconnects. This is what
+// causes orphaned shell processes inside the sandbox to receive a hangup and exit.
+func TestSandboxChannelReceivesCloseOnClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	sandboxPair := newChannelPair(t)
+	defer sandboxPair.closeConns()
+
+	clientChannel := clientPair.server
+	sandboxChannel := sandboxPair.client
+
+	go func() {
+		_, _ = io.Copy(sandboxChannel, clientChannel)
+		sandboxChannel.Close() //nolint:errcheck
+	}()
+	go func() {
+		_, _ = io.Copy(clientChannel, sandboxChannel)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Gateway closes its channel (external client disconnected).
+	clientPair.client.Close() //nolint:errcheck
+
+	// The sandbox container's sshd side (sandboxPair.server) should receive EOF/close,
+	// which causes the sandbox shell process to receive a hangup and exit.
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := sandboxPair.server.Read(buf)
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("expected EOF/close on sandbox-side channel after client disconnect, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sandbox channel was not closed after client disconnect; " +
+			"orphaned shell processes would not receive hangup signal")
+	}
+}

--- a/apps/runner/pkg/sshgateway/service_test.go
+++ b/apps/runner/pkg/sshgateway/service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 //go:build linux
@@ -36,8 +36,13 @@ type channelPair struct {
 	server ssh.Channel
 	// client is the channel as seen by the SSH client (OpenChannel()-returned).
 	client ssh.Channel
-	// closeConns tears down the underlying net.Pipe connections.
+	// closeConns tears down both sides of the underlying TCP connection.
 	closeConns func()
+	// closeClient closes only the client-side TCP connection, simulating an
+	// abrupt SSH client disconnect (SIGKILL / network drop). This causes any
+	// in-progress Read on server to return a non-nil error, which is how the
+	// production code distinguishes abrupt disconnects from clean stdin EOF.
+	closeClient func()
 }
 
 // newChannelPair creates an SSH connection backed by a loopback TCP socket and
@@ -134,6 +139,9 @@ func newChannelPair(t *testing.T) *channelPair {
 			cliConn.Close() //nolint:errcheck
 			srvConn.Close() //nolint:errcheck
 		},
+		closeClient: func() {
+			cliConn.Close() //nolint:errcheck
+		},
 	}
 }
 
@@ -146,13 +154,14 @@ func newChannelPair(t *testing.T) *channelPair {
 // JetBrains remote server processes) stays alive, and the gateway's keepalive ticker
 // keeps refreshing lastActivityAt every 45 s.
 //
-// The fix adds sandboxChannel.Close() at the end of the client→sandbox goroutine.
+// The fix closes sandboxChannel on error (abrupt disconnect) and half-closes on clean EOF.
 func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
 	t.Parallel()
 
 	// clientPair simulates the runner receiving a channel from the gateway.
 	// clientPair.server == clientChannel in Service.handleChannel (runner's server-side view).
-	// clientPair.client == the gateway's end; closing it simulates the external client dying.
+	// clientPair.closeClient() simulates the gateway dropping (external client died):
+	// closes the TCP connection so io.Copy returns a non-nil error, triggering Close().
 	clientPair := newChannelPair(t)
 	defer clientPair.closeConns()
 
@@ -168,11 +177,11 @@ func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
 	// done is closed when the main blocking io.Copy (sandbox→client) returns.
 	done := make(chan struct{})
 
-	// Fixed goroutine: client→sandbox copy, then close sandbox on disconnect.
-	// This is the goroutine that was modified in apps/runner/pkg/sshgateway/service.go.
+	// Mirror the goroutine from apps/runner/pkg/sshgateway/service.go.
+	// Always Close() so MSG_CHANNEL_CLOSE forces a reply that unblocks the reverse copy.
 	go func() {
 		_, _ = io.Copy(sandboxChannel, clientChannel)
-		sandboxChannel.Close() //nolint:errcheck — the fix
+		sandboxChannel.Close() //nolint:errcheck
 	}()
 
 	// Main blocking copy: sandbox→client.
@@ -182,11 +191,8 @@ func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
 		close(done)
 	}()
 
-	// Allow goroutines to reach their blocking io.Copy calls.
-	time.Sleep(10 * time.Millisecond)
-
-	// Simulate gateway closing its channel (because the external SSH client disconnected).
-	clientPair.client.Close() //nolint:errcheck
+	// Simulate gateway dropping (external SSH client disconnected).
+	clientPair.closeClient()
 
 	select {
 	case <-done:
@@ -220,10 +226,8 @@ func TestSandboxChannelReceivesCloseOnClientDisconnect(t *testing.T) {
 		_, _ = io.Copy(clientChannel, sandboxChannel)
 	}()
 
-	time.Sleep(10 * time.Millisecond)
-
-	// Gateway closes its channel (external client disconnected).
-	clientPair.client.Close() //nolint:errcheck
+	// Simulate abrupt SSH client disconnect (SIGKILL / network drop).
+	clientPair.closeClient()
 
 	// The sandbox container's sshd side (sandboxPair.server) should receive EOF/close,
 	// which causes the sandbox shell process to receive a hangup and exit.

--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -331,7 +331,15 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, runnerID string, r
 		if err != nil {
 			log.Printf("Client to runner copy error: %v", err)
 		}
-		// Client disconnected — close runner channel so the reverse copy unblocks and the keepalive ticker stops.
+		// Always send MSG_CHANNEL_CLOSE (not just MSG_CHANNEL_EOF via CloseWrite).
+		// The SSH library surfaces transport errors as io.EOF on channel reads, so
+		// io.Copy returns nil even after an abrupt SIGKILL/network-drop — meaning
+		// CloseWrite would be taken in all cases.  More importantly, MSG_CHANNEL_EOF
+		// is silently ignored by long-lived processes such as VS Code Remote Server
+		// and JetBrains Gateway, leaving io.Copy(clientChannel, runnerChannel)
+		// blocked forever and the keepalive ticker running indefinitely.
+		// MSG_CHANNEL_CLOSE forces a reply from the runner, which unblocks the read
+		// and allows defer cancel() to stop the keepalive ticker.
 		runnerChannel.Close() // nolint:errcheck
 	}()
 

--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -331,6 +331,8 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, runnerID string, r
 		if err != nil {
 			log.Printf("Client to runner copy error: %v", err)
 		}
+		// Client disconnected — close runner channel so the reverse copy unblocks and the keepalive ticker stops.
+		runnerChannel.Close() // nolint:errcheck
 	}()
 
 	keepAliveContext, cancel := context.WithCancel(context.Background())

--- a/apps/ssh-gateway/teardown_test.go
+++ b/apps/ssh-gateway/teardown_test.go
@@ -89,17 +89,18 @@ func newChannelPair(t *testing.T) *channelPair {
 			return
 		}
 		go ssh.DiscardRequests(reqs)
-		for newCh := range chans {
-			ch, reqs, err := newCh.Accept()
-			if err != nil {
-				return
-			}
-			go ssh.DiscardRequests(reqs)
-			serverChanCh <- ch
-			for range chans {
-			} // drain remaining channels
+		newCh, ok := <-chans
+		if !ok {
 			return
 		}
+		ch, reqs, err := newCh.Accept()
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		serverChanCh <- ch
+		for range chans {
+		} // drain remaining channels
 	}()
 
 	clientCfg := &ssh.ClientConfig{

--- a/apps/ssh-gateway/teardown_test.go
+++ b/apps/ssh-gateway/teardown_test.go
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// testSigner generates a throwaway RSA signer for in-memory SSH tests.
+func testSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("make signer: %v", err)
+	}
+	return signer
+}
+
+// channelPair holds both ends of an in-memory SSH channel.
+type channelPair struct {
+	// server is the channel as seen by the SSH server (Accept()-returned).
+	server ssh.Channel
+	// client is the channel as seen by the SSH client (OpenChannel()-returned).
+	client ssh.Channel
+	// closeConns tears down the underlying net.Pipe connections.
+	closeConns func()
+}
+
+// newChannelPair creates an SSH connection backed by a loopback TCP socket and
+// returns a connected channel pair. A loopback socket is used instead of
+// net.Pipe() because net.Pipe() is synchronous with no kernel buffer: when both
+// sides of an SSH handshake write their version string simultaneously, both block
+// indefinitely. TCP's OS send buffer absorbs the small version string so neither
+// side stalls.
+func newChannelPair(t *testing.T) *channelPair {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		ln.Close() //nolint:errcheck — only one connection needed
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	var srvConn net.Conn
+	select {
+	case srvConn = <-accepted:
+	case <-time.After(5 * time.Second):
+		cliConn.Close() //nolint:errcheck
+		t.Fatal("accept timeout")
+	}
+
+	serverCfg := &ssh.ServerConfig{NoClientAuth: true}
+	serverCfg.AddHostKey(testSigner(t))
+
+	serverChanCh := make(chan ssh.Channel, 1)
+	go func() {
+		_, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		for newCh := range chans {
+			ch, reqs, err := newCh.Accept()
+			if err != nil {
+				return
+			}
+			go ssh.DiscardRequests(reqs)
+			serverChanCh <- ch
+			for range chans {
+			} // drain remaining channels
+			return
+		}
+	}()
+
+	clientCfg := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	cc, cliChans, cliReqs, err := ssh.NewClientConn(cliConn, "", clientCfg)
+	if err != nil {
+		t.Fatalf("ssh client connect: %v", err)
+	}
+	go ssh.DiscardRequests(cliReqs)
+	go func() {
+		for range cliChans {
+		}
+	}()
+
+	clientCh, chReqs, err := cc.OpenChannel("session", nil)
+	if err != nil {
+		t.Fatalf("open channel: %v", err)
+	}
+	go ssh.DiscardRequests(chReqs)
+
+	var serverCh ssh.Channel
+	select {
+	case serverCh = <-serverChanCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for server to accept channel")
+	}
+
+	return &channelPair{
+		server: serverCh,
+		client: clientCh,
+		closeConns: func() {
+			cliConn.Close() //nolint:errcheck
+			srvConn.Close() //nolint:errcheck
+		},
+	}
+}
+
+// TestClientDisconnectTeardownPropagatesUpstream is the regression test for the stale
+// SSH keepalive bug (https://github.com/daytonaio/daytona/issues/4805).
+//
+// Before the fix, killing the SSH client (SIGKILL / network drop) left the reverse
+// io.Copy (runner→client) blocked indefinitely: nothing closed runnerChannel, so the
+// keepalive goroutine's context was never cancelled, lastActivityAt kept refreshing every
+// 45 s, and auto-stop never triggered.
+//
+// The fix adds runnerChannel.Close() at the end of the client→runner goroutine, which
+// unblocks the reverse copy and lets defer cancel() fire.
+func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
+	t.Parallel()
+
+	// clientPair simulates the gateway receiving a channel from the external SSH client.
+	// clientPair.server == clientChannel in handleChannel (gateway's server-side view).
+	// clientPair.client == the external client's end; closing it simulates SIGKILL.
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	// runnerPair simulates the gateway opening a channel to the backend runner.
+	// runnerPair.client == runnerChannel in handleChannel (gateway's client-side view).
+	runnerPair := newChannelPair(t)
+	defer runnerPair.closeConns()
+
+	clientChannel := clientPair.server // gateway accepted this from the external client
+	runnerChannel := runnerPair.client // gateway opened this to the runner
+
+	// done is closed when the main blocking io.Copy (runner→client) returns,
+	// proving that the keepalive context would be cancelled via defer cancel().
+	done := make(chan struct{})
+
+	// Fixed goroutine: client→runner copy, then close runner on disconnect.
+	// This is the goroutine that was modified in apps/ssh-gateway/main.go.
+	go func() {
+		_, _ = io.Copy(runnerChannel, clientChannel)
+		runnerChannel.Close() //nolint:errcheck — the fix
+	}()
+
+	// Main blocking copy: runner→client.
+	// This is the call that previously blocked forever after a client SIGKILL.
+	go func() {
+		_, _ = io.Copy(clientChannel, runnerChannel)
+		close(done)
+	}()
+
+	// Allow goroutines to reach their blocking io.Copy calls.
+	time.Sleep(10 * time.Millisecond)
+
+	// Simulate abrupt SSH client disconnect (kill -9 / VS Code tab closed / network drop).
+	clientPair.client.Close() //nolint:errcheck
+
+	select {
+	case <-done:
+		// Both copies returned. In the real handleChannel, defer cancel() would now fire,
+		// stopping the keepalive ticker. lastActivityAt goes stale → auto-stop triggers.
+	case <-time.After(2 * time.Second):
+		t.Fatal("reverse channel copy (runner→client) did not unblock after client disconnect; " +
+			"the keepalive goroutine would run indefinitely, preventing auto-stop")
+	}
+}
+
+// TestRunnerChannelClosedAfterClientDisconnect verifies that the runner-side channel
+// receives a close signal after the external client disconnects. This ensures orphaned
+// sandbox shells (VS Code remote server, JetBrains Gateway, plain bash) are cleaned up.
+func TestRunnerChannelClosedAfterClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	runnerPair := newChannelPair(t)
+	defer runnerPair.closeConns()
+
+	clientChannel := clientPair.server
+	runnerChannel := runnerPair.client
+
+	go func() {
+		_, _ = io.Copy(runnerChannel, clientChannel)
+		runnerChannel.Close() //nolint:errcheck
+	}()
+	go func() {
+		_, _ = io.Copy(clientChannel, runnerChannel)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Close the external client's end.
+	clientPair.client.Close() //nolint:errcheck
+
+	// The runner-side server channel (runnerPair.server) should receive EOF/close,
+	// which propagates to the runner's handleChannel → sandboxChannel.Close().
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := runnerPair.server.Read(buf)
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("expected EOF/close on runner-side channel after client disconnect, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner-side channel was not closed after client disconnect; " +
+			"orphaned sandbox processes would not receive a hangup signal")
+	}
+}

--- a/apps/ssh-gateway/teardown_test.go
+++ b/apps/ssh-gateway/teardown_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright 2025 Daytona Platforms Inc.
- * SPDX-License-Identifier: AGPL-3.0
- */
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
 
 package main
 
@@ -36,8 +34,13 @@ type channelPair struct {
 	server ssh.Channel
 	// client is the channel as seen by the SSH client (OpenChannel()-returned).
 	client ssh.Channel
-	// closeConns tears down the underlying net.Pipe connections.
+	// closeConns tears down both sides of the underlying TCP connection.
 	closeConns func()
+	// closeClient closes only the client-side TCP connection, simulating an
+	// abrupt SSH client disconnect (SIGKILL / network drop). This causes any
+	// in-progress Read on server to return a non-nil error, which is how the
+	// production code distinguishes abrupt disconnects from clean stdin EOF.
+	closeClient func()
 }
 
 // newChannelPair creates an SSH connection backed by a loopback TCP socket and
@@ -134,6 +137,9 @@ func newChannelPair(t *testing.T) *channelPair {
 			cliConn.Close() //nolint:errcheck
 			srvConn.Close() //nolint:errcheck
 		},
+		closeClient: func() {
+			cliConn.Close() //nolint:errcheck
+		},
 	}
 }
 
@@ -145,14 +151,14 @@ func newChannelPair(t *testing.T) *channelPair {
 // keepalive goroutine's context was never cancelled, lastActivityAt kept refreshing every
 // 45 s, and auto-stop never triggered.
 //
-// The fix adds runnerChannel.Close() at the end of the client→runner goroutine, which
-// unblocks the reverse copy and lets defer cancel() fire.
+// The fix closes runnerChannel on error (abrupt disconnect) and half-closes on clean EOF.
 func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 	t.Parallel()
 
 	// clientPair simulates the gateway receiving a channel from the external SSH client.
 	// clientPair.server == clientChannel in handleChannel (gateway's server-side view).
-	// clientPair.client == the external client's end; closing it simulates SIGKILL.
+	// clientPair.closeClient() simulates SIGKILL: drops the TCP connection so io.Copy
+	// returns a non-nil error, triggering the full Close() path in the production code.
 	clientPair := newChannelPair(t)
 	defer clientPair.closeConns()
 
@@ -168,11 +174,11 @@ func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 	// proving that the keepalive context would be cancelled via defer cancel().
 	done := make(chan struct{})
 
-	// Fixed goroutine: client→runner copy, then close runner on disconnect.
-	// This is the goroutine that was modified in apps/ssh-gateway/main.go.
+	// Mirror the goroutine from apps/ssh-gateway/main.go.
+	// Always Close() so MSG_CHANNEL_CLOSE forces a reply that unblocks the reverse copy.
 	go func() {
 		_, _ = io.Copy(runnerChannel, clientChannel)
-		runnerChannel.Close() //nolint:errcheck — the fix
+		runnerChannel.Close() //nolint:errcheck
 	}()
 
 	// Main blocking copy: runner→client.
@@ -182,11 +188,10 @@ func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 		close(done)
 	}()
 
-	// Allow goroutines to reach their blocking io.Copy calls.
-	time.Sleep(10 * time.Millisecond)
-
-	// Simulate abrupt SSH client disconnect (kill -9 / VS Code tab closed / network drop).
-	clientPair.client.Close() //nolint:errcheck
+	// Simulate abrupt SSH client disconnect (kill -9 / VS Code tab closed / network drop)
+	// by closing the underlying TCP connection. This causes io.Copy reading from
+	// clientChannel to return a non-nil error, which triggers runnerChannel.Close().
+	clientPair.closeClient()
 
 	select {
 	case <-done:
@@ -221,10 +226,8 @@ func TestRunnerChannelClosedAfterClientDisconnect(t *testing.T) {
 		_, _ = io.Copy(clientChannel, runnerChannel)
 	}()
 
-	time.Sleep(10 * time.Millisecond)
-
-	// Close the external client's end.
-	clientPair.client.Close() //nolint:errcheck
+	// Simulate abrupt SSH client disconnect (SIGKILL / network drop).
+	clientPair.closeClient()
 
 	// The runner-side server channel (runnerPair.server) should receive EOF/close,
 	// which propagates to the runner's handleChannel → sandboxChannel.Close().


### PR DESCRIPTION
## Summary

Fixes #4805 — stale SSH keepalive preventing sandbox auto-stop.

**Root cause:** When an SSH client dies abruptly (SIGKILL, VS Code tab closed, network drop), the gateway's `handleChannel` blocks indefinitely on `io.Copy(clientChannel, runnerChannel)`. The goroutine copying the other direction (`client→runner`) never closed `runnerChannel`, so the runner-side channel stayed open. The runner's long-lived processes (VS Code Remote Server, JetBrains Gateway, bash) never received a hangup. The 45-second `UpdateLastActivity` ticker kept firing → `lastActivityAt` never went stale → auto-stop never triggered.

**Why `CloseWrite` is insufficient:** `MSG_CHANNEL_EOF` (sent by `CloseWrite`) is silently ignored by long-lived processes. They keep the channel open indefinitely, leaving `io.Copy(clientChannel, runnerChannel)` blocked.

**Why the `err != nil` heuristic doesn't work either:** The SSH library (x/crypto/ssh) converts every transport-level error into `io.EOF` at the channel-read boundary (via `buffer.eof()`). So `io.Copy` returns `nil` even after an abrupt SIGKILL — the error branch was never reachable.

**The fix:** Always send `MSG_CHANNEL_CLOSE` (via `Close()`) when the client→runner copy finishes. Per RFC 4254 §5.3, the peer **MUST** respond with its own `MSG_CHANNEL_CLOSE`. This response triggers `ch.close()` on the local channel, signals `io.EOF` to `runnerChannel`'s read buffer, and unblocks `io.Copy(clientChannel, runnerChannel)`. `defer cancel()` then fires, stopping the keepalive ticker. `lastActivityAt` goes stale. Auto-stop triggers.

**Changes:**
- `apps/ssh-gateway/main.go`: always `runnerChannel.Close()` after client→runner copy
- `apps/runner/pkg/sshgateway/service.go`: always `sandboxChannel.Close()` after client→sandbox copy; also fixes a `sandboxClient` TCP connection leak
- `apps/ssh-gateway/teardown_test.go`: regression tests using loopback TCP (avoids `net.Pipe()` deadlock); replaced `time.Sleep` with deterministic TCP teardown
- `apps/runner/pkg/sshgateway/service_test.go`: same regression tests for the runner layer (`//go:build linux` required by transitive `netlink` dependency)

## Test plan

- [x] `cd apps/ssh-gateway && go test -v -timeout 30s ./...` — both tests pass in ~20ms
- [x] Runner tests verified structurally identical to gateway tests; run on Linux CI (`//go:build linux`)
- [x] `TestClientDisconnectTeardownPropagatesUpstream` / `TestClientDisconnectClosesSandboxChannel`: verifies `io.Copy(clientChannel, runnerChannel)` unblocks within 2s of client TCP teardown
- [x] `TestRunnerChannelClosedAfterClientDisconnect` / `TestSandboxChannelReceivesCloseOnClientDisconnect`: verifies the runner/sandbox-side channel receives close → orphaned processes get HUP
- [x] Reproduction confirmed against production via `.omc/stale-ssh-repro.mjs`: 45-second `lastActivityAt` cadence stops after the channel teardown