### PR TITLE
feat(api): sandbox creation timeout to 30

### DIFF
--- a/apps/api/src/sandbox/services/job.service.ts
+++ b/apps/api/src/sandbox/services/job.service.ts
@@ -31,6 +31,7 @@ const JOB_STALE_TIMEOUT_MINUTES: Partial<Record<JobType, number>> = {
   [JobType.CREATE_BACKUP]: 120,
   [JobType.PULL_SNAPSHOT]: 120,
   [JobType.SNAPSHOT_SANDBOX]: 120,
+  [JobType.CREATE_SANDBOX]: 30,
 }
 
 @Injectable()


### PR DESCRIPTION
## Description

Bumps v2 runner sandbox creation timeout to 30 to handle the restore job temporarily until a proper refactor

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase sandbox creation job timeout to 30 minutes so restore jobs don’t get cut off on the v2 runner. Temporary mitigation until we refactor the restore flow.

<sup>Written for commit 792db359f916ecf2d371b005286d15bfff07bbbe. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4810?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

