### PR TITLE
fix(api): make entity constructor params optional per typeorm contract

### DIFF
--- a/apps/api/src/audit/entities/audit-log.entity.ts
+++ b/apps/api/src/audit/entities/audit-log.entity.ts
@@ -64,7 +64,7 @@ export class AuditLog {
   })
   createdAt: Date
 
-  constructor(params: {
+  constructor(params?: {
     id?: string
     actorId: string
     actorEmail: string
@@ -82,6 +82,7 @@ export class AuditLog {
     metadata?: AuditLogMetadata
     createdAt?: Date
   }) {
+    if (!params) return
     this.id = params.id || v4()
     this.actorId = params.actorId
     this.actorEmail = params.actorEmail

--- a/apps/api/src/organization/entities/region-quota.entity.ts
+++ b/apps/api/src/organization/entities/region-quota.entity.ts
@@ -124,33 +124,34 @@ export class RegionQuota {
   })
   updatedAt: Date
 
-  constructor(
-    organizationId: string,
-    regionId: string,
-    totalCpuQuota: number,
-    totalMemoryQuota: number,
-    totalDiskQuota: number,
-    totalGpuQuota = 0,
-    maxCpuPerSandbox: number | null = null,
-    maxMemoryPerSandbox: number | null = null,
-    maxDiskPerSandbox: number | null = null,
-    maxDiskPerNonEphemeralSandbox: number | null = null,
-    maxCpuPerGpuSandbox: number | null = null,
-    maxMemoryPerGpuSandbox: number | null = null,
-    maxDiskPerGpuSandbox: number | null = null,
-  ) {
-    this.organizationId = organizationId
-    this.regionId = regionId
-    this.totalCpuQuota = totalCpuQuota
-    this.totalMemoryQuota = totalMemoryQuota
-    this.totalDiskQuota = totalDiskQuota
-    this.totalGpuQuota = totalGpuQuota
-    this.maxCpuPerSandbox = maxCpuPerSandbox
-    this.maxMemoryPerSandbox = maxMemoryPerSandbox
-    this.maxDiskPerSandbox = maxDiskPerSandbox
-    this.maxDiskPerNonEphemeralSandbox = maxDiskPerNonEphemeralSandbox
-    this.maxCpuPerGpuSandbox = maxCpuPerGpuSandbox
-    this.maxMemoryPerGpuSandbox = maxMemoryPerGpuSandbox
-    this.maxDiskPerGpuSandbox = maxDiskPerGpuSandbox
+  constructor(params?: {
+    organizationId: string
+    regionId: string
+    totalCpuQuota: number
+    totalMemoryQuota: number
+    totalDiskQuota: number
+    totalGpuQuota?: number
+    maxCpuPerSandbox?: number | null
+    maxMemoryPerSandbox?: number | null
+    maxDiskPerSandbox?: number | null
+    maxDiskPerNonEphemeralSandbox?: number | null
+    maxCpuPerGpuSandbox?: number | null
+    maxMemoryPerGpuSandbox?: number | null
+    maxDiskPerGpuSandbox?: number | null
+  }) {
+    if (!params) return
+    this.organizationId = params.organizationId
+    this.regionId = params.regionId
+    this.totalCpuQuota = params.totalCpuQuota
+    this.totalMemoryQuota = params.totalMemoryQuota
+    this.totalDiskQuota = params.totalDiskQuota
+    this.totalGpuQuota = params.totalGpuQuota ?? 0
+    this.maxCpuPerSandbox = params.maxCpuPerSandbox ?? null
+    this.maxMemoryPerSandbox = params.maxMemoryPerSandbox ?? null
+    this.maxDiskPerSandbox = params.maxDiskPerSandbox ?? null
+    this.maxDiskPerNonEphemeralSandbox = params.maxDiskPerNonEphemeralSandbox ?? null
+    this.maxCpuPerGpuSandbox = params.maxCpuPerGpuSandbox ?? null
+    this.maxMemoryPerGpuSandbox = params.maxMemoryPerGpuSandbox ?? null
+    this.maxDiskPerGpuSandbox = params.maxDiskPerGpuSandbox ?? null
   }
 }

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -371,13 +371,13 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
     organization.defaultRegionId = defaultRegionId
 
     if (defaultRegion.enforceQuotas) {
-      const regionQuota = new RegionQuota(
-        organization.id,
-        defaultRegionId,
-        this.defaultOrganizationQuota.totalCpuQuota,
-        this.defaultOrganizationQuota.totalMemoryQuota,
-        this.defaultOrganizationQuota.totalDiskQuota,
-      )
+      const regionQuota = new RegionQuota({
+        organizationId: organization.id,
+        regionId: defaultRegionId,
+        totalCpuQuota: this.defaultOrganizationQuota.totalCpuQuota,
+        totalMemoryQuota: this.defaultOrganizationQuota.totalMemoryQuota,
+        totalDiskQuota: this.defaultOrganizationQuota.totalDiskQuota,
+      })
       if (organization.regionQuotas) {
         organization.regionQuotas = [...organization.regionQuotas, regionQuota]
       } else {
@@ -563,13 +563,13 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
       const defaultRegion = await this.validateOrganizationDefaultRegion(createOrganizationDto.defaultRegionId)
 
       if (defaultRegion.enforceQuotas) {
-        const regionQuota = new RegionQuota(
-          organization.id,
-          createOrganizationDto.defaultRegionId,
-          quota.totalCpuQuota,
-          quota.totalMemoryQuota,
-          quota.totalDiskQuota,
-        )
+        const regionQuota = new RegionQuota({
+          organizationId: organization.id,
+          regionId: createOrganizationDto.defaultRegionId,
+          totalCpuQuota: quota.totalCpuQuota,
+          totalMemoryQuota: quota.totalMemoryQuota,
+          totalDiskQuota: quota.totalDiskQuota,
+        })
         organization.regionQuotas = [regionQuota]
       }
     }

--- a/apps/api/src/region/entities/region.entity.ts
+++ b/apps/api/src/region/entities/region.entity.ts
@@ -92,7 +92,7 @@ export class Region {
   @Column({ nullable: true })
   snapshotManagerUrl: string | null
 
-  constructor(params: {
+  constructor(params?: {
     name: string
     enforceQuotas: boolean
     regionType: RegionType
@@ -105,6 +105,7 @@ export class Region {
     sshGatewayApiKeyHash?: string | null
     snapshotManagerUrl?: string | null
   }) {
+    if (!params) return
     this.name = params.name
     this.enforceQuotas = params.enforceQuotas
     this.regionType = params.regionType

--- a/apps/api/src/sandbox/entities/job.entity.ts
+++ b/apps/api/src/sandbox/entities/job.entity.ts
@@ -112,7 +112,7 @@ export class Job {
   })
   updatedAt: Date
 
-  constructor(params: {
+  constructor(params?: {
     id?: string
     type: JobType
     status?: JobStatus
@@ -125,6 +125,7 @@ export class Job {
     startedAt?: Date | null
     completedAt?: Date | null
   }) {
+    if (!params) return
     this.id = params.id || v4()
     this.version = 1
     this.type = params.type

--- a/apps/api/src/sandbox/entities/runner.entity.ts
+++ b/apps/api/src/sandbox/entities/runner.entity.ts
@@ -198,7 +198,7 @@ export class Runner {
   })
   updatedAt: Date
 
-  constructor(params: {
+  constructor(params?: {
     region: string
     name: string
     apiKey: string
@@ -212,6 +212,7 @@ export class Runner {
     appVersion?: string | null
     tags?: string[]
   }) {
+    if (!params) return
     this.region = params.region
     this.name = params.name
     this.apiKey = params.apiKey

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -224,7 +224,8 @@ export class Sandbox {
   @Column({ nullable: true })
   daemonVersion?: string
 
-  constructor(region: string, name?: string) {
+  constructor(region?: string, name?: string) {
+    if (!region) return
     this.id = uuidv4()
     // Set name - use provided name or fallback to ID
     this.name = name || this.id

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -224,12 +224,11 @@ export class Sandbox {
   @Column({ nullable: true })
   daemonVersion?: string
 
-  constructor(region?: string, name?: string) {
-    if (!region) return
+  constructor(params?: { region: string; name?: string }) {
+    if (!params) return
     this.id = uuidv4()
-    // Set name - use provided name or fallback to ID
-    this.name = name || this.id
-    this.region = region
+    this.name = params.name || this.id
+    this.region = params.region
   }
 
   /**

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -367,7 +367,7 @@ export class SandboxService {
   }
 
   async createForWarmPool(warmPoolItem: WarmPool): Promise<Sandbox> {
-    const sandbox = new Sandbox(warmPoolItem.target)
+    const sandbox = new Sandbox({ region: warmPoolItem.target })
 
     sandbox.organizationId = SANDBOX_WARM_POOL_UNASSIGNED_ORGANIZATION
 
@@ -555,7 +555,7 @@ export class SandboxService {
         gpu,
       })
 
-      const sandbox = new Sandbox(region.id, createSandboxDto.name)
+      const sandbox = new Sandbox({ region: region.id, name: createSandboxDto.name })
 
       sandbox.organizationId = organization.id
 
@@ -752,7 +752,7 @@ export class SandboxService {
         await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
       }
 
-      const sandbox = new Sandbox(region.id, createSandboxDto.name)
+      const sandbox = new Sandbox({ region: region.id, name: createSandboxDto.name })
 
       sandbox.organizationId = organization.id
 
@@ -937,7 +937,7 @@ export class SandboxService {
       }
 
       // Copy all properties from source sandbox to forked sandbox
-      const forkedSandbox = new Sandbox(sourceSandbox.region, dto.name)
+      const forkedSandbox = new Sandbox({ region: sourceSandbox.region, name: dto.name })
       forkedSandbox.organizationId = organization.id
       forkedSandbox.class = sourceSandbox.class
       forkedSandbox.snapshot = sourceSandbox.snapshot


### PR DESCRIPTION
## Description

TypeORM's docs say entity constructor arguments must be optional, since the ORM instantiates entities with no args when hydrating from the database and during repository.create(partial). This brings region, job, audit-log, sandbox, and region-quota in line with that contract so they don't break the next time something triggers a zero-arg construction (backoffice in our case).

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make entity constructors accept optional params to match the `typeorm` contract and prevent zero-arg construction errors during hydration and `repository.create`. Also switch `Sandbox` and `RegionQuota` to params-object constructors and update services; fixes backoffice crashes.

- **Bug Fixes**
  - Made constructors optional for `AuditLog`, `Region`, `Job`, `Runner`, `Sandbox`, and `RegionQuota` (early return when no params).
  - Switched `RegionQuota` to a params object with sane defaults and updated `OrganizationService`.
  - Switched `Sandbox` to a params object and updated `SandboxService` call sites.

- **Migration**
  - Instantiate `RegionQuota` with: new RegionQuota({ organizationId, regionId, totalCpuQuota, totalMemoryQuota, totalDiskQuota, ... }).
  - Instantiate `Sandbox` with: new Sandbox({ region, name }).

<sup>Written for commit f30bf0a4d2b2ed6910d52fb95bf8f68784639444. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4811?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

