### PR TITLE
fix(api): infer restoring case on create sandbox v2

### DIFF
--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -123,7 +123,13 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     // Map job types to transitional states
     switch (job.type) {
       case JobType.CREATE_SANDBOX:
-        return job.status === JobStatus.COMPLETED ? SandboxState.STARTED : SandboxState.CREATING
+        if (job.status === JobStatus.COMPLETED) {
+          return SandboxState.STARTED
+        }
+        if (sandbox.state === SandboxState.RESTORING) {
+          return SandboxState.RESTORING
+        }
+        return SandboxState.CREATING
       case JobType.START_SANDBOX:
         return job.status === JobStatus.COMPLETED ? SandboxState.STARTED : SandboxState.STARTING
       case JobType.STOP_SANDBOX:


### PR DESCRIPTION
## Description

Fix that makes the v2 state inferring correctly map to "restoring" instead of "creating" which would shorten the error-out interval

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix v2 sandbox state inference so a restoring sandbox is reported as `RESTORING` instead of `CREATING`. This shortens error-out intervals and shows the correct status.

- **Bug Fixes**
  - Update `RunnerAdapterV2`: for `CREATE_SANDBOX`, return `SandboxState.STARTED` if the job is completed; otherwise return `SandboxState.RESTORING` when the sandbox is restoring, else `SandboxState.CREATING`.

<sup>Written for commit 333f89e1b8ec14f0929be2639e3f51f610d2c263. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4812?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

