### PR TITLE
refactor(dashboard): extract base page header for custom header actions

### DIFF
--- a/apps/dashboard/src/components/PageLayout.tsx
+++ b/apps/dashboard/src/components/PageLayout.tsx
@@ -46,7 +46,12 @@ function PageLayout({ className, contained = false, ...props }: ComponentProps<'
   )
 }
 
-function PageHeader({ className, children, ...props }: ComponentProps<'header'>) {
+function PageHeaderBase({
+  className,
+  children,
+  actions,
+  ...props
+}: ComponentProps<'header'> & { actions?: ReactNode }) {
   return (
     <header
       className={cn(
@@ -57,17 +62,28 @@ function PageHeader({ className, children, ...props }: ComponentProps<'header'>)
     >
       <SidebarTrigger className="shrink-0 [&_svg]:size-5 md:hidden" />
       <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-4">{children}</div>
-      <div className="flex shrink-0 items-center">
-        <PageHeaderExternalAction
-          label="Docs"
-          href={DAYTONA_DOCS_URL}
-          icon={<BookOpen className="size-4" />}
-          variant="link"
-        />
-        <PageHeaderSupportAction />
-        <PageHeaderProfileMenu />
-      </div>
+      {actions ? <div className="flex shrink-0 items-center">{actions}</div> : null}
     </header>
+  )
+}
+
+function PageHeader(props: ComponentProps<'header'>) {
+  return (
+    <PageHeaderBase
+      {...props}
+      actions={
+        <>
+          <PageHeaderExternalAction
+            label="Docs"
+            href={DAYTONA_DOCS_URL}
+            icon={<BookOpen className="size-4" />}
+            variant="link"
+          />
+          <PageHeaderSupportAction />
+          <PageHeaderProfileMenu />
+        </>
+      }
+    />
   )
 }
 
@@ -296,4 +312,4 @@ function PageFooter({ className, children, ...props }: ComponentProps<'footer'>)
   )
 }
 
-export { PageContent, PageFooter, PageFooterPortal, PageHeader, PageIntro, PageLayout, PageTitle }
+export { PageContent, PageFooter, PageFooterPortal, PageHeader, PageHeaderBase, PageIntro, PageLayout, PageTitle }


### PR DESCRIPTION
## Description

Splits PageHeader into a PageHeaderBase that accepts an optional actions slot, plus a PageHeader wrapper that supplies the default docs, support, profile actions. No visual or behavioral change to existing PageHeader usages  - this just exposes PageHeaderBase for pages that need a different action set (or none).

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable `PageHeaderBase` with an optional `actions` slot to enable custom header actions. `PageHeader` now wraps the base and keeps the default Docs, Support, and Profile actions, so existing pages are unchanged.

- **Refactors**
  - Added and exported `PageHeaderBase` with an `actions` prop.
  - Updated `PageHeader` to use the base and supply default actions.

<sup>Written for commit 2f3aba8239664f5699637f5493b8358fc9ffa9d2. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4814?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

