### PR TITLE
fix(api): enforce GPU filter in snapshot-runner fallback assignment

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -213,6 +213,16 @@ export class SandboxStartAction extends SandboxAction {
       // Consider removing the runner usage rate check or improving it
       const runner = await this.runnerService.findOneOrFail(snapshotRunner.runnerId)
 
+      // Mirror the GPU class filter in findAvailableRunners - getSnapshotRunners
+      // can return GPU/non-GPU mismatched runners via stale snapshot_runner rows.
+      if (sandbox.gpu > 0) {
+        if (runner.gpu === null || runner.gpu < sandbox.gpu) {
+          continue
+        }
+      } else if (runner.gpu !== null && runner.gpu > 0) {
+        continue
+      }
+
       if (snapshotRunner.state === SnapshotRunnerState.ERROR) {
         await this.updateSandboxState(sandbox, errorSandboxState, lockCode, runner.id, snapshotRunner.errorReason)
         return DONT_SYNC_AGAIN

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -471,18 +471,9 @@ export class RunnerService {
 
       if (metrics.gpu !== undefined) {
         updateData.gpu = metrics.gpu
-      } else if (runner.apiVersion === '2') {
-        // v2 runners are the source of truth for their own GPU capacity;
-        // omitting `gpu` means "no GPUs visible to nvidia-smi right now", so
-        // clear any previously persisted value to keep the scheduler from
-        // sending GPU sandboxes to a runner that can no longer host them.
-        // v0 runners never report `gpu`, so leave operator-set values alone.
-        updateData.gpu = null
       }
       if (metrics.gpuType !== undefined) {
         updateData.gpuType = metrics.gpuType
-      } else if (runner.apiVersion === '2') {
-        updateData.gpuType = null
       }
 
       updateData.availabilityScore = this.calculateAvailabilityScore(runnerId, {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces GPU filtering in fallback snapshot-runner assignment to match available-runner logic and avoid GPU/CPU mismatches from stale `snapshot_runner` rows. Updates v2 runner GPU health to only write `gpu`/`gpuType` when metrics exist (no nulling on missing fields).

<sup>Written for commit cd03a5fb27b2270db3143a35300da2bffbd5f57f. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4815?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

