### PR TITLE
fix(api): enforce GPU filter in snapshot propagation

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -7,7 +7,7 @@ import { Injectable, Logger, NotFoundException, OnApplicationShutdown } from '@n
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
-import { In, IsNull, LessThan, Not, Repository } from 'typeorm'
+import { Equal, In, IsNull, LessThan, MoreThanOrEqual, Not, Or, Repository } from 'typeorm'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { Snapshot } from '../entities/snapshot.entity'
 import { SnapshotState } from '../enums/snapshot-state.enum'
@@ -342,6 +342,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
           state: RunnerState.READY,
           unschedulable: Not(true),
           region: In([...sharedRegionIds, ...organizationRegionIds]),
+          gpu: snapshot.gpu > 0 ? MoreThanOrEqual(snapshot.gpu) : Or(IsNull(), Equal(0)),
         },
       })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces GPU requirements during snapshot propagation so snapshots only schedule to runners with enough GPU capacity. If a snapshot needs GPUs (>0), we select runners with gpu >= required; otherwise, we allow runners with gpu null or 0.

<sup>Written for commit 4170492c9d305ea74663b559fe04741c32bc1315. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4816?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

