### PR TITLE
fix: serveWarningPage https value

### DIFF
--- a/apps/proxy/pkg/proxy/warning_page.go
+++ b/apps/proxy/pkg/proxy/warning_page.go
@@ -98,7 +98,7 @@ func (p *Proxy) browserWarningMiddleware() gin.HandlerFunc {
 		}
 
 		// Serve the warning page
-		serveWarningPage(ctx, p.config.EnableTLS)
+		serveWarningPage(ctx, p.config.ProxyProtocol == "https")
 		ctx.Abort() // Stop further processing
 	}
 }


### PR DESCRIPTION
## Summary

On Tier 1 accounts, the Playground VNC tab embeds a preview URL in an iframe. When the preview warning page is shown, clicking "I Understand, Continue" has no effect — the warning stays, making the VNC tab unusable.

https://github.com/user-attachments/assets/3338e080-54d1-4ec8-898b-10b81dbf1ef7

## Root Cause

PR #2373 fixed the cookie to use `SameSite=None; Secure=true` (required for cross-origin iframe usage) by checking `ProxyProtocol == "https"`. However, the redirect URL in the warning page HTML was left using `EnableTLS` to determine the protocol:

```go
// Cookie handler (correct) — uses ProxyProtocol
handleAcceptProxyWarning(ctx, config.ProxyProtocol == "https")

// Warning page redirect URL (broken) — uses EnableTLS  
serveWarningPage(ctx, p.config.EnableTLS)
```

In production,`EnableTLS=false` while `ProxyProtocol=https`. This creates a contradiction:

1. Cookie is set with `Secure=true` (from `ProxyProtocol=https`) — correct
2. Redirect goes to `http://...` (from `EnableTLS=false`) — wrong
3. Browser won't send a `Secure` cookie over `http://`
4. Proxy middleware doesn't see the cookie → shows warning again → infinite loop

Chrome also blocks this as mixed content: `Mixed Content: The page at 'https://app.daytona.io/dashboard/playground' was loaded over HTTPS, but requested an insecure form action 'http://...'`

## Fix

One-line change — use `ProxyProtocol` instead of `EnableTLS` for the redirect URL, matching what the cookie handler already uses:

```go
-serveWarningPage(ctx, p.config.EnableTLS)
+serveWarningPage(ctx, p.config.ProxyProtocol == "https")
```

## Local Testing

Testing this locally requires actual HTTPS since `SameSite=None` requires `Secure=true` which requires HTTPS — there's no way to bypass this browser constraint over plain HTTP.

**Setup that reproduces and verifies the fix:**

1. Generate local TLS certs and place them in the repo root:
   ```bash
   brew install mkcert
   mkcert -install
   mkcert "*.proxy.localhost" proxy.localhost
   ```

2. Set env vars in `apps/proxy/.env`:
   ```
   PROXY_PROTOCOL=https
   PREVIEW_WARNING_ENABLED=true
   ENABLE_TLS=true
   TLS_CERT_FILE=_wildcard.proxy.localhost+1.pem
   TLS_KEY_FILE=_wildcard.proxy.localhost+1-key.pem
   ```

3. Set `PROXY_PROTOCOL=https` in `apps/api/.env`

**Other approaches tried that don't work locally:**
- `PROXY_PROTOCOL=http` — cookie gets `SameSite=Lax` which isn't sent in cross-origin iframes
- `PROXY_PROTOCOL=https` without `ENABLE_TLS=true` — the API generates `https://` iframe URLs but the proxy only speaks HTTP on port 4000, so the browser's TLS handshake fails ("sent an invalid response")
- Reverse proxy (Caddy) in front of the proxy — iframe URLs have port 4000 baked in, would need dashboard changes to route through the reverse proxy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the preview warning redirect to use `ProxyProtocol` (https) in `serveWarningPage`, resolving the Secure-cookie mismatch and stopping the infinite warning loop in the Playground VNC iframe. This restores the VNC tab functionality.

<sup>Written for commit 1fa580432a8108c1375eb01fb2b1b19ae9b1c613. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4817?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

