### PR TITLE
fix(dashboard): preserve hidden provider defaults on registry tab switch

### DIFF
--- a/apps/dashboard/src/components/UpsertRegistrySheet.tsx
+++ b/apps/dashboard/src/components/UpsertRegistrySheet.tsx
@@ -243,13 +243,16 @@ export const UpsertRegistrySheet = ({
     }
   }, [isOpen, resetState])
 
-  // Tab switch wipes per-tab fields so prior provider values can't leak into
-  // the next provider's submission. Name is preserved as a quality-of-life win.
   const handleProviderChange = useCallback(
     (next: RegistryProvider) => {
       setProvider(next)
       const currentName = form.getFieldValue('name')
-      form.reset({ ...createDefaultsFor(REGISTRY_PROVIDER_SPECS[next]), name: currentName })
+      // keepDefaultValues so the next render's useForm sync doesn't wipe
+      // hidden defaults (e.g. GCP's username '_json_key').
+      form.reset(
+        { ...createDefaultsFor(REGISTRY_PROVIDER_SPECS[next]), name: currentName },
+        { keepDefaultValues: true },
+      )
       setPasswordVisible(false)
     },
     [form],


### PR DESCRIPTION
## Description

Adding a GCP registry silently disabled the Add button. On tab switch, form.reset wrote hidden defaults like username='_json_key', but the next useForm render diffed defaultValues and wiped them back to ''. Zod then failed on the hidden field with no visible error. Pass keepDefaultValues: true.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the registry form: switching provider tabs now preserves hidden default values (e.g., GCP username '_json_key'), preventing a disabled Add button and hidden-field validation errors. Done by passing keepDefaultValues: true to form.reset so the next render doesn’t wipe those defaults.

<sup>Written for commit 1f84933f311ac738df8eb90d4f65e7e3cbc43d20. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4818?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

