### PR TITLE
chore(sdk-typescript): improve build target inputs

### DIFF
--- a/libs/sdk-typescript/project.json
+++ b/libs/sdk-typescript/project.json
@@ -52,7 +52,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "inputs": ["default", "{projectRoot}/package.json"],
+      "inputs": ["default", "{projectRoot}/package.json", { "dependentTasksOutputFiles": "**/*", "transitive": true }],
       "outputs": ["{workspaceRoot}/dist/libs/sdk-typescript"],
       "options": {
         "cwd": "{projectRoot}",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `nx` build inputs for the TypeScript SDK to account for transitive outputs of dependent tasks. This ensures correct cache invalidation and affected runs when upstream libraries change.

<sup>Written for commit 6d47a6df308b5a6ea63ec82c830cd959434efc6a. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4819?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

