### PR TITLE
fix(api): handle invalid labels filter in deprecated sandbox list

### DIFF
--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -183,6 +183,15 @@ export class SandboxController {
       order: sortDirection,
     } = queryParams
 
+    let parsedLabels: { [key: string]: string } | undefined
+    if (labels) {
+      try {
+        parsedLabels = JSON.parse(labels)
+      } catch {
+        throw new BadRequestError('Invalid labels JSON format')
+      }
+    }
+
     const result = await this.sandboxService.findAllPaginatedDeprecated(
       authContext.organizationId,
       page,
@@ -190,7 +199,7 @@ export class SandboxController {
       {
         id,
         name,
-        labels: labels ? JSON.parse(labels) : undefined,
+        labels: parsedLabels,
         includeErroredDestroyed,
         states,
         snapshots,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Safely parse the labels query param in the deprecated sandbox list endpoint and return a 400 Bad Request when it’s invalid JSON. This prevents crashes from unhandled JSON parsing and gives clients a clear error.

<sup>Written for commit 54189f94c5b4d1b8a1ea0b1f2316a7c531f65922. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4822?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

