### PR TITLE
fix(api): lock runners gpu capacity query

### DIFF
--- a/apps/api/src/sandbox/common/redis-lock.provider.ts
+++ b/apps/api/src/sandbox/common/redis-lock.provider.ts
@@ -44,11 +44,11 @@ export class RedisLockProvider {
   async waitForLock(key: string, ttl: number, timeoutMs?: number): Promise<void> {
     const deadline = timeoutMs !== undefined ? Date.now() + timeoutMs : null
     while (true) {
-      const acquired = await this.lock(key, ttl)
-      if (acquired) break
       if (deadline !== null && Date.now() >= deadline) {
         throw new Error(`Timed out after ${timeoutMs}ms waiting for lock '${key}'`)
       }
+      const acquired = await this.lock(key, ttl)
+      if (acquired) break
       await new Promise((resolve) => setTimeout(resolve, 50))
     }
   }

--- a/apps/api/src/sandbox/common/redis-lock.provider.ts
+++ b/apps/api/src/sandbox/common/redis-lock.provider.ts
@@ -41,10 +41,14 @@ export class RedisLockProvider {
     return exists === 1
   }
 
-  async waitForLock(key: string, ttl: number): Promise<void> {
+  async waitForLock(key: string, ttl: number, timeoutMs?: number): Promise<void> {
+    const deadline = timeoutMs !== undefined ? Date.now() + timeoutMs : null
     while (true) {
       const acquired = await this.lock(key, ttl)
       if (acquired) break
+      if (deadline !== null && Date.now() >= deadline) {
+        throw new Error(`Timed out after ${timeoutMs}ms waiting for lock '${key}'`)
+      }
       await new Promise((resolve) => setTimeout(resolve, 50))
     }
   }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -399,18 +399,44 @@ export class SandboxService {
       throw new BadRequestError(`Snapshot ${sandbox.snapshot} not found while creating warm pool sandbox`)
     }
 
-    const runner = await this.runnerService.getRandomAvailableRunner({
-      regions: [sandbox.region],
-      sandboxClass: sandbox.class,
-      snapshotRef: snapshot.ref,
-      gpu: sandbox.gpu,
-    })
+    let gpuRunnerAssignmentLockKey: string | undefined
 
-    sandbox.runnerId = runner.id
-    sandbox.pending = true
+    try {
+      // Same per-region GPU runner assignment serialization as createFromSnapshot.
+      if (sandbox.gpu > 0) {
+        const key = `gpu-runner-assignment:${sandbox.region}`
+        await this.redisLockProvider.waitForLock(key, 60, 30000)
+        gpuRunnerAssignmentLockKey = key
+      }
 
-    await this.sandboxRepository.insert(sandbox)
-    return sandbox
+      const runner = await this.runnerService.getRandomAvailableRunner({
+        regions: [sandbox.region],
+        sandboxClass: sandbox.class,
+        snapshotRef: snapshot.ref,
+        gpu: sandbox.gpu,
+      })
+
+      sandbox.runnerId = runner.id
+      sandbox.pending = true
+
+      await this.sandboxRepository.insert(sandbox)
+
+      if (gpuRunnerAssignmentLockKey) {
+        const key = gpuRunnerAssignmentLockKey
+        gpuRunnerAssignmentLockKey = undefined
+        await this.redisLockProvider
+          .unlock(key)
+          .catch((err) => this.logger.error('Failed to release GPU runner assignment lock', err))
+      }
+
+      return sandbox
+    } finally {
+      if (gpuRunnerAssignmentLockKey) {
+        await this.redisLockProvider
+          .unlock(gpuRunnerAssignmentLockKey)
+          .catch((err) => this.logger.error('Failed to release GPU runner assignment lock', err))
+      }
+    }
   }
 
   async createFromSnapshot(createSandboxDto: CreateSandboxDto, organization: Organization): Promise<SandboxDto> {
@@ -539,10 +565,12 @@ export class SandboxService {
       // the DB to find runners at capacity, but the just-assigned runnerId on a
       // concurrent request is not yet persisted, so two concurrent creates can
       // pick the same already-full runner. Hold the lock until the runnerId is
-      // written to the DB.
+      // written to the DB. Only mark the key as held after acquisition succeeds —
+      // otherwise a timed-out waiter would unlock the actual holder in finally.
       if (gpu > 0) {
-        gpuRunnerAssignmentLockKey = `gpu-runner-assignment:${region.id}`
-        await this.redisLockProvider.waitForLock(gpuRunnerAssignmentLockKey, 60, 30000)
+        const key = `gpu-runner-assignment:${region.id}`
+        await this.redisLockProvider.waitForLock(key, 60, 30000)
+        gpuRunnerAssignmentLockKey = key
       }
 
       const runner = await this.runnerService.getRandomAvailableRunner({
@@ -601,8 +629,11 @@ export class SandboxService {
       const insertedSandbox = await this.sandboxRepository.insert(sandbox)
 
       if (gpuRunnerAssignmentLockKey) {
-        await this.redisLockProvider.unlock(gpuRunnerAssignmentLockKey)
+        const key = gpuRunnerAssignmentLockKey
         gpuRunnerAssignmentLockKey = undefined
+        await this.redisLockProvider
+          .unlock(key)
+          .catch((err) => this.logger.error('Failed to release GPU runner assignment lock', err))
       }
 
       this.eventEmitter
@@ -811,10 +842,12 @@ export class SandboxService {
       // the DB to find runners at capacity, but the just-assigned runnerId on a
       // concurrent request is not yet persisted, so two concurrent creates can
       // pick the same already-full runner. Hold the lock until the runnerId is
-      // written to the DB.
+      // written to the DB. Only mark the key as held after acquisition succeeds —
+      // otherwise a timed-out waiter would unlock the actual holder in finally.
       if (sandbox.gpu > 0) {
-        gpuRunnerAssignmentLockKey = `gpu-runner-assignment:${region.id}`
-        await this.redisLockProvider.waitForLock(gpuRunnerAssignmentLockKey, 60, 30000)
+        const key = `gpu-runner-assignment:${region.id}`
+        await this.redisLockProvider.waitForLock(key, 60, 30000)
+        gpuRunnerAssignmentLockKey = key
       }
 
       try {
@@ -881,8 +914,11 @@ export class SandboxService {
       const insertedSandbox = await this.sandboxRepository.insert(sandbox)
 
       if (gpuRunnerAssignmentLockKey) {
-        await this.redisLockProvider.unlock(gpuRunnerAssignmentLockKey)
+        const key = gpuRunnerAssignmentLockKey
         gpuRunnerAssignmentLockKey = undefined
+        await this.redisLockProvider
+          .unlock(key)
+          .catch((err) => this.logger.error('Failed to release GPU runner assignment lock', err))
       }
 
       this.eventEmitter

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -418,6 +418,7 @@ export class SandboxService {
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
     let pendingGpuIncrement: number | undefined
+    let gpuRunnerAssignmentLockKey: string | undefined
 
     const region = await this.getValidatedOrDefaultRegion(organization, createSandboxDto.target)
 
@@ -534,6 +535,16 @@ export class SandboxService {
         await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
       }
 
+      // Serialize GPU runner assignment per region: getRunnersAtGpuCapacity reads
+      // the DB to find runners at capacity, but the just-assigned runnerId on a
+      // concurrent request is not yet persisted, so two concurrent creates can
+      // pick the same already-full runner. Hold the lock until the runnerId is
+      // written to the DB.
+      if (gpu > 0) {
+        gpuRunnerAssignmentLockKey = `gpu-runner-assignment:${region.id}`
+        await this.redisLockProvider.waitForLock(gpuRunnerAssignmentLockKey, 60, 30000)
+      }
+
       const runner = await this.runnerService.getRandomAvailableRunner({
         regions: [region.id],
         sandboxClass,
@@ -589,6 +600,11 @@ export class SandboxService {
 
       const insertedSandbox = await this.sandboxRepository.insert(sandbox)
 
+      if (gpuRunnerAssignmentLockKey) {
+        await this.redisLockProvider.unlock(gpuRunnerAssignmentLockKey)
+        gpuRunnerAssignmentLockKey = undefined
+      }
+
       this.eventEmitter
         .emitAsync(SandboxEvents.CREATED, new SandboxCreatedEvent(insertedSandbox))
         .catch((err) => this.logger.error('Failed to emit SandboxCreatedEvent', err))
@@ -609,6 +625,12 @@ export class SandboxService {
       }
 
       throw error
+    } finally {
+      if (gpuRunnerAssignmentLockKey) {
+        await this.redisLockProvider
+          .unlock(gpuRunnerAssignmentLockKey)
+          .catch((err) => this.logger.error('Failed to release GPU runner assignment lock', err))
+      }
     }
   }
 
@@ -699,6 +721,7 @@ export class SandboxService {
     let pendingMemoryIncrement: number | undefined
     let pendingDiskIncrement: number | undefined
     let pendingGpuIncrement: number | undefined
+    let gpuRunnerAssignmentLockKey: string | undefined
 
     const region = await this.getValidatedOrDefaultRegion(organization, createSandboxDto.target)
 
@@ -784,6 +807,16 @@ export class SandboxService {
 
       let runner: Runner
 
+      // Serialize GPU runner assignment per region: getRunnersAtGpuCapacity reads
+      // the DB to find runners at capacity, but the just-assigned runnerId on a
+      // concurrent request is not yet persisted, so two concurrent creates can
+      // pick the same already-full runner. Hold the lock until the runnerId is
+      // written to the DB.
+      if (sandbox.gpu > 0) {
+        gpuRunnerAssignmentLockKey = `gpu-runner-assignment:${region.id}`
+        await this.redisLockProvider.waitForLock(gpuRunnerAssignmentLockKey, 60, 30000)
+      }
+
       try {
         const declarativeBuildScoreThreshold = this.configService.get('runnerScore.thresholds.declarativeBuild')
         const maxCpuPerRunner = this.configService.getOrThrow('buildInfo.maxCpuPerRunner')
@@ -847,6 +880,11 @@ export class SandboxService {
 
       const insertedSandbox = await this.sandboxRepository.insert(sandbox)
 
+      if (gpuRunnerAssignmentLockKey) {
+        await this.redisLockProvider.unlock(gpuRunnerAssignmentLockKey)
+        gpuRunnerAssignmentLockKey = undefined
+      }
+
       this.eventEmitter
         .emitAsync(SandboxEvents.CREATED, new SandboxCreatedEvent(insertedSandbox))
         .catch((err) => this.logger.error('Failed to emit SandboxCreatedEvent', err))
@@ -867,6 +905,12 @@ export class SandboxService {
       }
 
       throw error
+    } finally {
+      if (gpuRunnerAssignmentLockKey) {
+        await this.redisLockProvider
+          .unlock(gpuRunnerAssignmentLockKey)
+          .catch((err) => this.logger.error('Failed to release GPU runner assignment lock', err))
+      }
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents GPU runner over-allocation under concurrency by serializing per-region GPU runner selection with a Redis lock across all sandbox creation paths. Adds a timeout and safer unlock behavior to remove race conditions and deadlocks under load.

- **Bug Fixes**
  - Serialize per-region GPU runner assignment with `gpu-runner-assignment:${region.id}` in create, createFromSnapshot, and warm pool flows; hold the lock until `runnerId` is persisted.
  - Extend `RedisLockProvider.waitForLock(key, ttl, timeoutMs)` and throw on timeout (TTL 60s, timeout 30s).
  - Set the held-lock flag only after acquisition; always release on success or error and log unlock failures, avoiding accidental unlocks by timed-out waiters.

<sup>Written for commit f67ecb9fd9044bd82f40821789a154ae9ce069bf. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4823?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

