### PR TITLE
feat(docs): verify cpu and memory limits after resize

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1040,6 +1040,14 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/resize' \
 </TabItem>
 </Tabs>
 
+To verify CPU and memory limits inside the sandbox after resizing, read `cgroup` values directly. Tools such as `nproc`, `free`, `top`, `htop`, `/proc/cpuinfo`, and `/proc/meminfo` read host-level values and do not reflect sandbox resource limits.
+
+```bash
+cat /sys/fs/cgroup/cpu.max      # "<quota> <period>" (cores = quota / period)
+cat /sys/fs/cgroup/memory.max   # bytes
+df -h /                         # disk
+```
+
 ## Fork Sandboxes
 
 :::caution[Experimental]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Document how to verify CPU, memory, and disk limits after a sandbox resize by reading cgroup values instead of host-level tools. Adds examples using /sys/fs/cgroup/cpu.max, /sys/fs/cgroup/memory.max, and df -h /.

<sup>Written for commit 9a957b2f6273d3ae2421c4cf5779a8e73cd9b7c7. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4825?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

