### PR TITLE
fix(dashboard): allow write-only users to perform bulk sandbox actions

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
@@ -162,7 +162,9 @@ export function SandboxTable({
       minSize: 0,
     },
     enableRowSelection: (row) =>
-      deletePermitted && !sandboxIsLoading[row.original.id] && row.original.state !== SandboxState.DESTROYED,
+      (writePermitted || deletePermitted) &&
+      !sandboxIsLoading[row.original.id] &&
+      row.original.state !== SandboxState.DESTROYED,
     meta: {
       sandbox: {
         sandboxIsLoading,

--- a/apps/dashboard/src/components/SandboxTable/columns.tsx
+++ b/apps/dashboard/src/components/SandboxTable/columns.tsx
@@ -91,13 +91,13 @@ const columns: ColumnDef<SandboxListItem>[] = [
     minSize: 44,
     maxSize: 44,
     header: ({ table }) => {
-      const { deletePermitted, selectableCount } = getMeta(table)
+      const { writePermitted, deletePermitted, selectableCount } = getMeta(table)
       const selectedCount = table.getSelectedRowModel().rows.length
       const anySelectable = selectableCount > 0
       const allSelected = selectedCount > 0 && selectedCount === selectableCount
       const partiallySelected = selectedCount > 0 && selectedCount < selectableCount
 
-      if (!deletePermitted || !anySelectable) {
+      if ((!writePermitted && !deletePermitted) || !anySelectable) {
         return null
       }
 
@@ -121,10 +121,10 @@ const columns: ColumnDef<SandboxListItem>[] = [
       )
     },
     cell: ({ row, table }) => {
-      const { deletePermitted, sandboxIsLoading } = getMeta(table)
+      const { writePermitted, deletePermitted, sandboxIsLoading } = getMeta(table)
       const isLoading = Boolean(sandboxIsLoading[row.original.id])
 
-      if (!deletePermitted || !row.getCanSelect()) {
+      if ((!writePermitted && !deletePermitted) || !row.getCanSelect()) {
         return null
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow write-only users to select sandboxes and run bulk actions in the dashboard by respecting write permission for selection and checkboxes.

- **Bug Fixes**
  - Allow row selection when write or delete is permitted, excluding loading and destroyed rows.
  - Render header and row checkboxes when at least one permission is present; hide if none or no selectable rows.

<sup>Written for commit 258a5b6ac27b88e51af60660114ea3fdde6935ae. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4826?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

