### PR TITLE
chore(deps): scope dependabot npm/pip ecosystem to production manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,7 @@ updates:
 
   - package-ecosystem: pip
     directories:
+      - "/libs/sdk-python"
       - "/libs/api-client-python"
       - "/libs/api-client-python-async"
       - "/libs/toolbox-api-client-python"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,3 +64,38 @@ updates:
           - "version-update:semver-major"
     commit-message:
       prefix: "chore(deps)"
+
+  # npm: scope to production manifests only.
+  # NOTE: This config controls Dependabot PR creation, NOT GitHub Advisory
+  # Database alert recurrence. Alerts in guides/ and runtime-tests/ paths
+  # are dismissed in GitHub directly (see scripts/dependabot-dismiss.sh
+  # for the auditable dismissal manifest and rationale).
+  - package-ecosystem: npm
+    directories:
+      - "/"
+      - "/libs/sdk-typescript"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      npm-prod:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: pip
+    directories:
+      - "/libs/api-client-python"
+      - "/libs/api-client-python-async"
+      - "/libs/toolbox-api-client-python"
+      - "/libs/toolbox-api-client-python-async"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      pip-prod:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Adds explicit `npm` and `pip` ecosystem blocks to Dependabot config, scoping PR creation to production manifests only.

**This change controls Dependabot PR creation only; it does NOT prevent the GitHub Advisory Database from raising new alerts.** Alerts in `guides/` and `runtime-tests/` paths are dismissed in GitHub directly with `state=dismissed`, `dismissed_reason=not_used` (guides) / `tolerable_risk` (runtime-tests).

## What changed

- Added `npm` ecosystem block scoped to `/` and `/libs/sdk-typescript` (production manifests)
- Added `pip` ecosystem block scoped to the main Python SDK (`/libs/sdk-python`) plus the 4 generated api-client/toolbox manifests (5 directories)
- `guides/typescript/mastra/coding-agent/openai/` excluded — orphaned doc template, alerts dismissed separately
- `libs/sdk-typescript/runtime-tests/` excluded — CI smoke tests excluded from Nx build per `.nxignore`, alerts dismissed separately

## What did NOT change

- `github-actions` ecosystem blocks: untouched
- `docker` ecosystem block: untouched
- All existing `ignore` rules: untouched

## Reviewers

Per CODEOWNERS, `.github/dependabot.yml` requires review from `@daytonaio/security` and `@Tpuljak`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Dependabot PRs to production manifests for `npm` and `pip`, with weekly Monday runs and grouped updates, to reduce noise and keep focus on prod code. This does not change security alerts; alerts in guides and runtime-tests are handled via GitHub dismissals.

- **Dependencies**
  - `npm`: only `/` and `/libs/sdk-typescript`; grouped as `npm-prod`
  - `pip`: only `/libs/sdk-python`, `/libs/api-client-python`, `/libs/api-client-python-async`, `/libs/toolbox-api-client-python`, `/libs/toolbox-api-client-python-async`; grouped as `pip-prod`
  - Unchanged: `github-actions`, `docker`, and all existing `ignore` rules
  - Note: Affects Dependabot PR creation only; alerts in `guides/` and `libs/sdk-typescript/runtime-tests/` are dismissed in GitHub

<sup>Written for commit 84177b9acaf69e204ac1d290de4f8cd3e0a9ff8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4827?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->


