### PR TITLE
chore(security): use constant-time compare for runner bearer token

### DIFF
--- a/apps/runner/pkg/api/middlewares/auth.go
+++ b/apps/runner/pkg/api/middlewares/auth.go
@@ -4,6 +4,7 @@
 package middlewares
 
 import (
+	"crypto/subtle"
 	"errors"
 	"strings"
 
@@ -38,7 +39,7 @@ func AuthMiddleware(apiToken string) gin.HandlerFunc {
 
 		token := parts[1]
 
-		if token != apiToken {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(apiToken)) != 1 {
 			ctx.Error(common_errors.NewUnauthorizedError(errors.New("invalid token")))
 			ctx.Abort()
 			return


### PR DESCRIPTION
Replace Go's non-constant-time `!=` comparison of the runner API bearer token in `apps/runner/pkg/api/middlewares/auth.go` with `subtle.ConstantTimeCompare`. Same semantics; removes the textbook timing-oracle surface flagged by SAST.

Constant-time guarantee covers token content. Token length is protocol-fixed (e.g., 32-char hex from `openssl rand -hex 16` in the OSS setup script) and not treated as a secret.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch runner bearer token validation to constant-time comparison to prevent timing side-channels. Replaces string inequality with `crypto/subtle` ConstantTimeCompare in apps/runner/pkg/api/middlewares/auth.go.

- **Bug Fixes**
  - Mitigates timing-oracle risk in token checks; behavior unchanged. Token length is fixed by protocol and not secret.

<sup>Written for commit b03758a35d7afd71cbecd821b46003b59d051c40. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4828?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

