### PR TITLE
chore(ci): read prod buildcache as additional source for PR docker build

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -192,7 +192,10 @@
           "load": false,
           "platforms": ["linux/amd64"],
           "tags": ["daytonaio/daytona-{projectName}:$VERSION"],
-          "cache-from": ["type=gha,scope=docker-{projectName}"],
+          "cache-from": [
+            "type=registry,ref=daytonaio/daytona-{projectName}:buildcache-amd64",
+            "type=gha,scope=docker-{projectName}"
+          ],
           "cache-to": ["type=gha,scope=docker-{projectName},mode=max"]
         }
       },


### PR DESCRIPTION
## Why

The `Docker build` PR check rebuilds every image from scratch (~18 min on each PR). The `pr-build` configuration declares a `type=gha` cache, but those entries get LRU-evicted from GitHub's 10 GB per-repo cache quota — the quota is dominated by `setup-go` entries (~650 MB each, scoped per PR ref) and buildkit blobs don't survive long enough to be reused.

Verified state at time of writing:

| Cache pool | Size |
|---|---|
| Total active | 9.28 GB / 10 GB |
| setup-go-* | 8.32 GB (9 entries) |
| buildkit docker-* | 0 GB |

Two consecutive runs on the same branch (only 2 TS files changed between commits) took 19 min and 17.5 min — cache that worked should bring the second run down to 2–5 min.

## What

Add the existing `daytonaio/daytona-{projectName}:buildcache-amd64` registry image (written by `release.yaml` on every dispatch — `tag_last_pushed: 2026-05-26T10:30`) as an additional `cache-from` source. Buildkit pulls layers anonymously from public Docker Hub, hits cache on base images, package installs, and `go mod download`, then falls back to the GHA scope for any layers the registry doesn't cover.

```diff
 \"pr-build\": {
   \"push\": false,
   \"load\": false,
   \"platforms\": [\"linux/amd64\"],
   \"tags\": [\"daytonaio/daytona-{projectName}:\$VERSION\"],
-  \"cache-from\": [\"type=gha,scope=docker-{projectName}\"],
+  \"cache-from\": [
+    \"type=registry,ref=daytonaio/daytona-{projectName}:buildcache-amd64\",
+    \"type=gha,scope=docker-{projectName}\"
+  ],
   \"cache-to\": [\"type=gha,scope=docker-{projectName},mode=max\"]
 }
```

Expected runtime: ~18 min → ~5–8 min for PRs whose lockfiles match the latest release.

## What this does not change

- No new workflow, no new auth, no new tag.
- `production` configuration in `nx.json` is untouched.
- `Docker build` job name unchanged — required-check enforcement in `Security baseline` ruleset unaffected.

## Risk

Worst case: registry pull fails or layer hashes don't match → buildkit falls through to the existing GHA cache (status quo) → PR builds run cold. Same as today.

Caveat to watch: anonymous Docker Hub pulls from GHA runners share egress IPs (200 / 6 h / IP). If we see 429s during the first week, a one-line follow-up adds a conditional `docker/login-action` on non-fork PRs using existing `DOCKER_TOKEN`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up PR Docker builds by adding the production build cache as an extra cache source. Typical PR runs drop from ~18 min to ~5–8 min when lockfiles match the latest release.

- **Performance**
  - Read `daytonaio/daytona-{projectName}:buildcache-amd64` via `cache-from` in `pr-build` (`nx.json`).
  - Keep existing `type=gha,scope=docker-{projectName}` as fallback; if the registry misses, builds run as today.
  - No workflow, auth, or tag changes; required checks remain the same.

<sup>Written for commit 78013465b7b41aec2d77eed321850947093f464a. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4829?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

