### PR TITLE
feat(images): add an image for GPU workloads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,7 @@ updates:
       - "/apps/docs"
       - "/images/sandbox"
       - "/images/sandbox-slim"
+      - "/images/sandbox-gpu"
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -18,6 +18,7 @@ env:
   VERSION: ${{ inputs.version }}
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
   REGISTRY_IMAGE: daytonaio/sandbox
+  GPU_REGISTRY_IMAGE: daytonaio/sandbox-gpu
 
 jobs:
   docker_build:
@@ -121,8 +122,70 @@ jobs:
           docker logout docker.io 2>/dev/null || true
           docker logout ghcr.io 2>/dev/null || true
 
+  docker_gpu_build:
+    # sandbox-gpu is amd64-only: its vllm/vllm-openai base targets x86 GPU hosts
+    # and parts of the GPU stack (e.g. bitsandbytes) lack arm64 wheels.
+    runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Validate version format
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.Z-suffix)"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: docker.io
+          username: daytonaio
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push sandbox-gpu by digest
+        id: build-sandbox-gpu
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./images/sandbox-gpu
+          file: ./images/sandbox-gpu/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ env.GPU_REGISTRY_IMAGE }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64
+          cache-to: type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64,mode=max
+
+      - name: Export sandbox-gpu digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/sandbox-gpu
+          digest="${{ steps.build-sandbox-gpu.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/sandbox-gpu/${digest#sha256:}"
+
+      - name: Upload sandbox-gpu digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-gpu-linux-amd64
+          path: ${{ runner.temp }}/digests/sandbox-gpu/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          docker logout docker.io 2>/dev/null || true
+          docker logout ghcr.io 2>/dev/null || true
+
   docker_manifest:
-    needs: docker_build
+    needs: [docker_build, docker_gpu_build]
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
     permissions: {}
 
@@ -139,6 +202,13 @@ jobs:
         with:
           path: ${{ runner.temp }}/digests/sandbox-slim
           pattern: digests-slim-*
+          merge-multiple: true
+
+      - name: Download sandbox-gpu digest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests/sandbox-gpu
+          pattern: digests-gpu-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -175,10 +245,23 @@ jobs:
           docker buildx imagetools create $TAGS \
             $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
 
+      - name: Create and push sandbox-gpu manifest
+        working-directory: ${{ runner.temp }}/digests/sandbox-gpu
+        env:
+          PUSH_LATEST: ${{ inputs.push_latest }}
+        run: |
+          TAGS="-t ${GPU_REGISTRY_IMAGE}:${VERSION}"
+          if [ "$PUSH_LATEST" = "true" ]; then
+            TAGS="$TAGS -t ${GPU_REGISTRY_IMAGE}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf "${GPU_REGISTRY_IMAGE}@sha256:%s " *)
+
       - name: Inspect images
         run: |
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}"
           docker buildx imagetools inspect "${REGISTRY_IMAGE}:${VERSION}-slim"
+          docker buildx imagetools inspect "${GPU_REGISTRY_IMAGE}:${VERSION}"
 
       - name: Cleanup credentials
         if: always()

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -116,62 +116,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - name: Cleanup credentials
-        if: always()
-        run: |
-          docker logout docker.io 2>/dev/null || true
-          docker logout ghcr.io 2>/dev/null || true
-
-  docker_gpu_build:
-    needs: docker_build
-    # sandbox-gpu is amd64-only: the GPU stack (CUDA toolkit, torch cu130, bitsandbytes)
-    # targets x86 GPU hosts and parts lack arm64 wheels.
-    runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
-    permissions:
-      contents: read
-
-    steps:
-      - name: Validate version format
-        run: |
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.Z-suffix)"
-            exit 1
-          fi
-
-      - name: Download sandbox amd64 digest
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: digests-default-linux-amd64
-          path: ${{ runner.temp }}/digests/sandbox-base
-
-      - name: Resolve sandbox base image
-        id: sandbox-base
-        run: |
-          shopt -s nullglob
-          digest_files=("${{ runner.temp }}/digests/sandbox-base"/*)
-          if [ "${#digest_files[@]}" -ne 1 ]; then
-            echo "::error::Expected exactly one sandbox amd64 digest, found ${#digest_files[@]}"
-            exit 1
-          fi
-          digest="$(basename "${digest_files[0]}")"
-          echo "image=${REGISTRY_IMAGE}@sha256:${digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: docker.io
-          username: daytonaio
-          password: ${{ secrets.DOCKER_TOKEN }}
-
       - name: Build and push sandbox-gpu by digest
+        if: matrix.platform == 'linux/amd64'
         id: build-sandbox-gpu
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -180,18 +126,20 @@ jobs:
           platforms: linux/amd64
           tags: ${{ env.GPU_REGISTRY_IMAGE }}
           build-args: |
-            SANDBOX_IMAGE=${{ steps.sandbox-base.outputs.image }}
+            SANDBOX_IMAGE=${{ env.REGISTRY_IMAGE }}@${{ steps.build-sandbox.outputs.digest }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64
           cache-to: type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64,mode=max
 
       - name: Export sandbox-gpu digest
+        if: matrix.platform == 'linux/amd64'
         run: |
           mkdir -p ${{ runner.temp }}/digests/sandbox-gpu
           digest="${{ steps.build-sandbox-gpu.outputs.digest }}"
           touch "${{ runner.temp }}/digests/sandbox-gpu/${digest#sha256:}"
 
       - name: Upload sandbox-gpu digest
+        if: matrix.platform == 'linux/amd64'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-gpu-linux-amd64
@@ -206,7 +154,7 @@ jobs:
           docker logout ghcr.io 2>/dev/null || true
 
   docker_manifest:
-    needs: [docker_build, docker_gpu_build]
+    needs: docker_build
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
     permissions: {}
 

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -123,8 +123,9 @@ jobs:
           docker logout ghcr.io 2>/dev/null || true
 
   docker_gpu_build:
-    # sandbox-gpu is amd64-only: its vllm/vllm-openai base targets x86 GPU hosts
-    # and parts of the GPU stack (e.g. bitsandbytes) lack arm64 wheels.
+    needs: docker_build
+    # sandbox-gpu is amd64-only: the GPU stack (CUDA toolkit, torch cu130, bitsandbytes)
+    # targets x86 GPU hosts and parts lack arm64 wheels.
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
     permissions:
       contents: read
@@ -136,6 +137,24 @@ jobs:
             echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.Z-suffix)"
             exit 1
           fi
+
+      - name: Download sandbox amd64 digest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: digests-default-linux-amd64
+          path: ${{ runner.temp }}/digests/sandbox-base
+
+      - name: Resolve sandbox base image
+        id: sandbox-base
+        run: |
+          shopt -s nullglob
+          digest_files=("${{ runner.temp }}/digests/sandbox-base"/*)
+          if [ "${#digest_files[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one sandbox amd64 digest, found ${#digest_files[@]}"
+            exit 1
+          fi
+          digest="$(basename "${digest_files[0]}")"
+          echo "image=${REGISTRY_IMAGE}@sha256:${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -160,6 +179,8 @@ jobs:
           file: ./images/sandbox-gpu/Dockerfile
           platforms: linux/amd64
           tags: ${{ env.GPU_REGISTRY_IMAGE }}
+          build-args: |
+            SANDBOX_IMAGE=${{ steps.sandbox-base.outputs.image }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64
           cache-to: type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64,mode=max

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -49,9 +49,9 @@ jobs:
       - name: Build all Docker targets
         # sandbox, sandbox-slim and sandbox-gpu excluded: sandbox/sandbox-slim's base
         # mcr.microsoft.com/devcontainers/python is anonymous-pulled from GHA runners and
-        # flakes with 403 Forbidden; sandbox-gpu's vllm/vllm-openai base is large and GPU
-        # oriented. Sandbox image validation happens in the default image publish workflow
-        # on release dispatch.
+        # flakes with 403 Forbidden; sandbox-gpu builds FROM the sandbox image (large, GPU
+        # oriented, amd64-only). Sandbox image validation happens in the default image
+        # publish workflow on release dispatch.
         run: |
           yarn nx run-many \
             --target=docker \

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -47,13 +47,15 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build all Docker targets
-        # sandbox and sandbox-slim excluded: their base mcr.microsoft.com/devcontainers/python
-        # is anonymous-pulled from GHA runners and flakes with 403 Forbidden. Sandbox image
-        # validation happens via default_image_publish.yaml on release dispatch.
+        # sandbox, sandbox-slim and sandbox-gpu excluded: sandbox/sandbox-slim's base
+        # mcr.microsoft.com/devcontainers/python is anonymous-pulled from GHA runners and
+        # flakes with 403 Forbidden; sandbox-gpu's vllm/vllm-openai base is large and GPU
+        # oriented. Sandbox image validation happens in the default image publish workflow
+        # on release dispatch.
         run: |
           yarn nx run-many \
             --target=docker \
             --configuration=pr-build \
-            --exclude=sandbox,sandbox-slim \
+            --exclude=sandbox,sandbox-slim,sandbox-gpu \
             --parallel=2 \
             --nxBail=true

--- a/images/sandbox-gpu/Dockerfile
+++ b/images/sandbox-gpu/Dockerfile
@@ -42,7 +42,8 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages \
       tensorboard==2.20.0 \
       jupyterlab==4.5.7 \
       ipykernel==7.2.0 \
-      ipywidgets==8.1.8
+      ipywidgets==8.1.8 \
+      transformers==5.9.0
 
 USER daytona
 # Cache FlashInfer cubins as daytona so they land in a runtime-readable home.

--- a/images/sandbox-gpu/Dockerfile
+++ b/images/sandbox-gpu/Dockerfile
@@ -46,5 +46,5 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages \
 
 USER daytona
 # Cache FlashInfer cubins as daytona so they land in a runtime-readable home.
-RUN flashinfer download-cubin || true
+RUN flashinfer download-cubin
 ENTRYPOINT ["sleep", "infinity"]

--- a/images/sandbox-gpu/Dockerfile
+++ b/images/sandbox-gpu/Dockerfile
@@ -3,8 +3,10 @@ FROM ${SANDBOX_IMAGE}
 USER root
 
 # CUDA 13 toolkit (nvcc) via runfile -- NVIDIA's apt repo is unusable on Debian trixie.
-# --toolkit only; the host provides the driver.
+# --toolkit only; the host provides the driver. SHA-256 verified before executing as root.
+ARG CUDA_RUN_SHA256=81a5d0d0870ba2022efb0a531dcc60adbdc2bbff7b3ef19d6fd6d8105406c775
 RUN curl -fsSL -o /tmp/cuda.run https://developer.download.nvidia.com/compute/cuda/13.0.2/local_installers/cuda_13.0.2_580.95.05_linux.run \
+    && echo "${CUDA_RUN_SHA256}  /tmp/cuda.run" | sha256sum -c - \
     && sh /tmp/cuda.run --silent --toolkit --override \
     && rm -f /tmp/cuda.run
 ENV CUDA_HOME=/usr/local/cuda

--- a/images/sandbox-gpu/Dockerfile
+++ b/images/sandbox-gpu/Dockerfile
@@ -26,12 +26,22 @@ RUN FIV=$(python3 -c "import flashinfer; print(flashinfer.__version__)") \
 
 # GPU/ML packages the base image lacks
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
-      accelerate datasets safetensors peft trl einops sentencepiece sentence-transformers \
-      huggingface_hub[hf_xet] nvitop wandb tensorboard jupyterlab ipykernel ipywidgets
+      accelerate==1.13.0 \
+      datasets==4.8.5 \
+      safetensors==0.7.0 \
+      peft==0.19.1 \
+      bitsandbytes==0.49.2 \
+      trl==1.5.0 \
+      einops==0.8.2 \
+      sentencepiece==0.2.1 \
+      sentence-transformers==5.5.1 \
+      nvitop==1.7.0 \
+      wandb==0.27.0 \
+      tensorboard==2.20.0 \
+      jupyterlab==4.5.7 \
+      ipykernel==7.2.0 \
+      ipywidgets==8.1.8
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages bitsandbytes
-
-ENV HF_XET_HIGH_PERFORMANCE=1
 USER daytona
 # Cache FlashInfer cubins as daytona so they land in a runtime-readable home.
 RUN flashinfer download-cubin || true

--- a/images/sandbox-gpu/Dockerfile
+++ b/images/sandbox-gpu/Dockerfile
@@ -1,68 +1,38 @@
-FROM vllm/vllm-openai:v0.21.0@sha256:a230095847e93bd4df9888b33dab956fa9504537b828a23657d2b26fed57b5c9
+ARG SANDBOX_IMAGE=daytonaio/sandbox:latest
+FROM ${SANDBOX_IMAGE}
+USER root
 
-ENV CUDA_HOME=/usr/local/cuda \
-    HF_HOME=/home/daytona/.cache/huggingface \
-    HF_XET_HIGH_PERFORMANCE=1 \
-    DEBIAN_FRONTEND=noninteractive
+# CUDA 13 toolkit (nvcc) via runfile -- NVIDIA's apt repo is unusable on Debian trixie.
+# --toolkit only; the host provides the driver.
+RUN curl -fsSL -o /tmp/cuda.run https://developer.download.nvidia.com/compute/cuda/13.0.2/local_installers/cuda_13.0.2_580.95.05_linux.run \
+    && sh /tmp/cuda.run --silent --toolkit --override \
+    && rm -f /tmp/cuda.run
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:${PATH}
+# Put CUDA libs (libnvrtc.so.13) on the loader path, else vLLM's DeepGEMM warmup crashes.
+RUN printf '/usr/local/cuda/lib64\n/usr/local/cuda/targets/x86_64-linux/lib\n' > /etc/ld.so.conf.d/cuda.conf \
+    && ldconfig
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      sudo \
-      build-essential cmake ninja-build pkg-config \
-      git git-lfs curl wget aria2 rsync ca-certificates openssh-client \
-      nvtop htop tmux vim less jq unzip zip \
-    && git lfs install --system \
-    && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --no-cache-dir --break-system-packages \
+      torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 \
+      --index-url https://download.pytorch.org/whl/cu130
 
-RUN python3 -m pip install --no-cache-dir uv==0.11.16
+RUN python3 -m pip install --no-cache-dir --break-system-packages vllm==0.21.0
 
-RUN uv pip install --system --no-cache \
-      transformers==5.8.1 \
-      accelerate==1.13.0 \
-      datasets==4.8.5 \
-      safetensors==0.7.0 \
-      peft==0.19.1 \
-      bitsandbytes==0.49.2 \
-      trl==1.5.0 \
-      einops==0.8.2 \
-      sentencepiece==0.2.1 \
-      sentence-transformers==5.5.1 \
-      huggingface_hub[hf_xet]==1.14.0 \
-      nvitop==1.7.0 \
-      wandb==0.27.0 \
-      tensorboard==2.20.0 \
-      jupyterlab==4.5.7 \
-      ipython==9.13.0 \
-      ipykernel==7.2.0 \
-      ipywidgets==8.1.8 \
-      numpy==2.2.6 \
-      pandas==3.0.3 \
-      scipy==1.17.1 \
-      scikit-learn==1.8.0 \
-      matplotlib==3.10.9 \
-      seaborn==0.13.2 \
-      pillow==12.2.0 \
-      openai==2.36.0 \
-      anthropic==0.102.0 \
-      ollama==0.6.2 \
-      langchain==1.3.1 \
-      llama-index==0.14.22 \
-      instructor==1.15.1 \
-      mistralai==1.12.4 \
-      pydantic-ai==1.94.0 \
-      openai-agents==0.17.4 \
-      claude-agent-sdk==0.2.87 \
-      django==6.0.5 \
-      flask==3.1.3 \
-      sqlalchemy==2.0.50 \
-      requests==2.34.2 \
-      beautifulsoup4==4.14.3 \
-      daytona==0.181.0
+# Pre-stage FlashInfer kernels, else vLLM JIT-compiles them on first serve (~60s cold start).
+RUN FIV=$(python3 -c "import flashinfer; print(flashinfer.__version__)") \
+    && python3 -m pip install --no-cache-dir --break-system-packages "flashinfer-jit-cache==${FIV}" \
+       --extra-index-url https://flashinfer.ai/whl/cu130
 
-RUN useradd -m -s /bin/bash daytona \
-    && echo "daytona ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/91-daytona \
-    && chmod 0440 /etc/sudoers.d/91-daytona
+# GPU/ML packages the base image lacks
+RUN python3 -m pip install --no-cache-dir --break-system-packages \
+      accelerate datasets safetensors peft trl einops sentencepiece sentence-transformers \
+      huggingface_hub[hf_xet] nvitop wandb tensorboard jupyterlab ipykernel ipywidgets
 
-ENV HOME=/home/daytona
-WORKDIR /home/daytona
+RUN python3 -m pip install --no-cache-dir --break-system-packages bitsandbytes
+
+ENV HF_XET_HIGH_PERFORMANCE=1
 USER daytona
+# Cache FlashInfer cubins as daytona so they land in a runtime-readable home.
+RUN flashinfer download-cubin || true
 ENTRYPOINT ["sleep", "infinity"]

--- a/images/sandbox-gpu/Dockerfile
+++ b/images/sandbox-gpu/Dockerfile
@@ -1,0 +1,68 @@
+FROM vllm/vllm-openai:v0.21.0@sha256:a230095847e93bd4df9888b33dab956fa9504537b828a23657d2b26fed57b5c9
+
+ENV CUDA_HOME=/usr/local/cuda \
+    HF_HOME=/home/daytona/.cache/huggingface \
+    HF_XET_HIGH_PERFORMANCE=1 \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      sudo \
+      build-essential cmake ninja-build pkg-config \
+      git git-lfs curl wget aria2 rsync ca-certificates openssh-client \
+      nvtop htop tmux vim less jq unzip zip \
+    && git lfs install --system \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --no-cache-dir uv==0.11.16
+
+RUN uv pip install --system --no-cache \
+      transformers==5.8.1 \
+      accelerate==1.13.0 \
+      datasets==4.8.5 \
+      safetensors==0.7.0 \
+      peft==0.19.1 \
+      bitsandbytes==0.49.2 \
+      trl==1.5.0 \
+      einops==0.8.2 \
+      sentencepiece==0.2.1 \
+      sentence-transformers==5.5.1 \
+      huggingface_hub[hf_xet]==1.14.0 \
+      nvitop==1.7.0 \
+      wandb==0.27.0 \
+      tensorboard==2.20.0 \
+      jupyterlab==4.5.7 \
+      ipython==9.13.0 \
+      ipykernel==7.2.0 \
+      ipywidgets==8.1.8 \
+      numpy==2.2.6 \
+      pandas==3.0.3 \
+      scipy==1.17.1 \
+      scikit-learn==1.8.0 \
+      matplotlib==3.10.9 \
+      seaborn==0.13.2 \
+      pillow==12.2.0 \
+      openai==2.36.0 \
+      anthropic==0.102.0 \
+      ollama==0.6.2 \
+      langchain==1.3.1 \
+      llama-index==0.14.22 \
+      instructor==1.15.1 \
+      mistralai==1.12.4 \
+      pydantic-ai==1.94.0 \
+      openai-agents==0.17.4 \
+      claude-agent-sdk==0.2.87 \
+      django==6.0.5 \
+      flask==3.1.3 \
+      sqlalchemy==2.0.50 \
+      requests==2.34.2 \
+      beautifulsoup4==4.14.3 \
+      daytona==0.181.0
+
+RUN useradd -m -s /bin/bash daytona \
+    && echo "daytona ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/91-daytona \
+    && chmod 0440 /etc/sudoers.d/91-daytona
+
+ENV HOME=/home/daytona
+WORKDIR /home/daytona
+USER daytona
+ENTRYPOINT ["sleep", "infinity"]

--- a/images/sandbox-gpu/Dockerfile
+++ b/images/sandbox-gpu/Dockerfile
@@ -47,4 +47,5 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages \
 USER daytona
 # Cache FlashInfer cubins as daytona so they land in a runtime-readable home.
 RUN flashinfer download-cubin
+RUN python3 -c "import torch, vllm, flashinfer"
 ENTRYPOINT ["sleep", "infinity"]

--- a/images/sandbox-gpu/README.md
+++ b/images/sandbox-gpu/README.md
@@ -1,0 +1,91 @@
+# Daytona Sandbox GPU Image
+
+[Dockerfile](./Dockerfile) contains the definition for [daytonaio/sandbox-gpu](https://hub.docker.com/r/daytonaio/sandbox-gpu) images (`:$VERSION`), intended for GPU-enabled sandboxes.
+
+It is built on the official [`vllm/vllm-openai`](https://hub.docker.com/r/vllm/vllm-openai) image, which already ships a working CUDA toolchain and inference stack:
+
+- CUDA 13.0 toolkit (`nvcc`)
+- PyTorch (CUDA build)
+- vLLM
+- FlashAttention, FlashInfer, cuDNN
+
+On top of that base it adds general GPU/ML development tooling.
+
+## NOTE
+
+This image is **amd64-only** — it targets x86 GPU hosts (e.g. H100). There is no arm64 variant.
+
+## System tooling
+
+- build-essential, cmake, ninja-build, pkg-config (for compiling CUDA extensions)
+- git, git-lfs (model/dataset repos)
+- curl, wget, aria2, rsync
+- nvtop, htop (GPU/system monitoring)
+- tmux, vim, less, jq, unzip, zip
+- uv (Python package/environment manager)
+
+## Python packages
+
+GPU / ML / fine-tuning:
+
+- transformers
+- accelerate
+- datasets
+- safetensors
+- peft
+- bitsandbytes
+- trl
+- einops
+- sentencepiece
+- sentence-transformers
+- huggingface-hub (with hf_xet)
+- nvitop
+
+Experiment tracking:
+
+- wandb
+- tensorboard
+
+Interactive:
+
+- jupyterlab
+- ipython
+- ipykernel
+- ipywidgets
+
+Data science / viz:
+
+- numpy
+- pandas
+- scipy
+- scikit-learn
+- matplotlib
+- seaborn
+- pillow
+
+LLM clients:
+
+- openai
+- anthropic
+- ollama
+
+Agent / app frameworks:
+
+- langchain
+- llama-index
+- instructor
+- pydantic-ai
+- openai-agents
+- claude-agent-sdk
+
+Web / DB / misc:
+
+- django
+- flask
+- sqlalchemy
+- requests
+- beautifulsoup4
+
+Daytona:
+
+- daytona

--- a/images/sandbox-gpu/README.md
+++ b/images/sandbox-gpu/README.md
@@ -1,34 +1,24 @@
 # Daytona Sandbox GPU Image
 
-[Dockerfile](./Dockerfile) contains the definition for [daytonaio/sandbox-gpu](https://hub.docker.com/r/daytonaio/sandbox-gpu) images (`:$VERSION`), intended for GPU-enabled sandboxes.
+[Dockerfile](./Dockerfile) defines [daytonaio/sandbox-gpu](https://hub.docker.com/r/daytonaio/sandbox-gpu), a GPU-enabled sandbox image for x86 GPU hosts (e.g. H100).
 
-It is built on the official [`vllm/vllm-openai`](https://hub.docker.com/r/vllm/vllm-openai) image, which already ships a working CUDA toolchain and inference stack:
-
-- CUDA 13.0 toolkit (`nvcc`)
-- PyTorch (CUDA build)
-- vLLM
-- FlashAttention, FlashInfer, cuDNN
-
-On top of that base it adds general GPU/ML development tooling.
+It is a **superset of the default [`daytonaio/sandbox`](../sandbox) image** — it builds `FROM daytonaio/sandbox` and layers the GPU stack on top, so everything in the standard sandbox (Python, Node, language servers, the computer-use/VNC tooling, the default Python/agent packages, the `daytona` user) is present, plus GPU support.
 
 ## NOTE
 
-This image is **amd64-only** — it targets x86 GPU hosts (e.g. H100). There is no arm64 variant.
+This image is **amd64-only** — there is no arm64 variant.
 
-## System tooling
+## Added on top of the base image
 
-- build-essential, cmake, ninja-build, pkg-config (for compiling CUDA extensions)
-- git, git-lfs (model/dataset repos)
-- curl, wget, aria2, rsync
-- nvtop, htop (GPU/system monitoring)
-- tmux, vim, less, jq, unzip, zip
-- uv (Python package/environment manager)
+CUDA / GPU runtime:
 
-## Python packages
+- CUDA 13 toolkit (`nvcc`), installed via the NVIDIA runfile
+- PyTorch (CUDA 13 build) — `torch`, `torchvision`, `torchaudio`
+- vLLM, with FlashInfer kernels pre-staged so first-serve cold-start stays fast
+- FlashAttention (bundled with vLLM), cuDNN
 
 GPU / ML / fine-tuning:
 
-- transformers
 - accelerate
 - datasets
 - safetensors
@@ -49,43 +39,5 @@ Experiment tracking:
 Interactive:
 
 - jupyterlab
-- ipython
 - ipykernel
 - ipywidgets
-
-Data science / viz:
-
-- numpy
-- pandas
-- scipy
-- scikit-learn
-- matplotlib
-- seaborn
-- pillow
-
-LLM clients:
-
-- openai
-- anthropic
-- ollama
-
-Agent / app frameworks:
-
-- langchain
-- llama-index
-- instructor
-- pydantic-ai
-- openai-agents
-- claude-agent-sdk
-
-Web / DB / misc:
-
-- django
-- flask
-- sqlalchemy
-- requests
-- beautifulsoup4
-
-Daytona:
-
-- daytona

--- a/images/sandbox-gpu/README.md
+++ b/images/sandbox-gpu/README.md
@@ -28,7 +28,6 @@ GPU / ML / fine-tuning:
 - einops
 - sentencepiece
 - sentence-transformers
-- huggingface-hub (with hf_xet)
 - nvitop
 
 Experiment tracking:

--- a/images/sandbox-gpu/project.json
+++ b/images/sandbox-gpu/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "sandbox-gpu",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "images/sandbox-gpu",
+  "tags": [],
+  "targets": {
+    "docker": {
+      "options": {
+        "platforms": ["linux/amd64"],
+        "tags": ["daytonaio/sandbox-gpu:$VERSION"],
+        "cache-from": ["type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64"],
+        "cache-to": ["type=registry,ref=daytonaio/sandbox-gpu:buildcache-linux-amd64,mode=max"]
+      },
+      "configurations": {
+        "pr-build": {
+          "tags": ["daytonaio/sandbox-gpu:$VERSION"]
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "nx run-many --target=test:e2e --all --nxBail=true",
     "build": "nx run-many --target=build --all --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",
     "build:production": "nx run-many --target=build --all --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=production --nxBail=true",
-    "docker:production": "SKIP_COMPUTER_USE_BUILD=true nx run-many --target=docker --all --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=production --output-style=stream",
+    "docker:production": "SKIP_COMPUTER_USE_BUILD=true nx run-many --target=docker --all --exclude=sandbox-gpu --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=production --output-style=stream",
     "serve": "nx run-many --target=serve --all --exclude=daemon --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",
     "serve-slim": "nx run-many --target=serve --projects=api,runner,proxy,dashboard --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",
     "serve:skip-runner": "nx run-many --target=serve --all --exclude=runner,daemon --parallel=$(getconf _NPROCESSORS_ONLN) --configuration=development",


### PR DESCRIPTION
## Summary

Adds a new amd64-only GPU sandbox image, published as `daytonaio/sandbox-gpu:<version>` (and `:latest`).

`images/sandbox-gpu` is built as a **superset of the default `daytonaio/sandbox` image**: it builds `FROM daytonaio/sandbox` and layers the GPU stack on top, so everything in the standard sandbox (Python, Node, language servers, computer-use tooling, the default Python/agent packages, the `daytona` user) is present, plus particular libraries for GPU workloads. It targets x86 GPU hosts and intentionally has no arm64 variant.

The GPU layer adds:

- CUDA 13 toolkit (`nvcc`), installed via the NVIDIA runfile (the apt repo is unusable on the base's Debian trixie)
- PyTorch (CUDA 13 build), vLLM with FlashInfer kernels pre-staged so first-serve cold start stays fast
- GPU/ML/fine-tuning packages the base lacks (accelerate, datasets, safetensors, peft, bitsandbytes, trl, sentence-transformers, …), experiment tracking (wandb, tensorboard), and JupyterLab

## Changes

- Adds the `sandbox-gpu` image (`Dockerfile`, `README.md`, `project.json`).
- Wires the GPU image into `default_image_publish.yaml`: it builds **after** the sandbox image and is pinned to that exact build **by digest** (passed via the `SANDBOX_IMAGE` build-arg), then tagged `:<version>`/`:latest` in the manifest step.
- Excludes `sandbox-gpu` from the PR and production multi-arch Docker fan-out (it's amd64-only and GPU-oriented).
- Adds `images/sandbox-gpu` to Dependabot Docker base-image tracking.

## Validation

Built and exercised on amd64 H100 hardware: runs as non-root `daytona`, `nvcc` compiles and runs a CUDA kernel, real GPU workloads succeed (PyTorch training, QLoRA fine-tuning, 4-bit inference, embeddings), and vLLM serves a model cleanly out of the box.
