### PR TITLE
fix(docs): update preview port range and auth details

### DIFF
--- a/apps/docs/src/content/docs/en/preview.mdx
+++ b/apps/docs/src/content/docs/en/preview.mdx
@@ -5,11 +5,11 @@ description: Access services running in your sandboxes through preview URLs.
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 
-Daytona provides preview URLs for accessing services running in your sandboxes. Any process listening for HTTP traffic on ports `3000` - `9999` can be previewed through a generated URL.
+Daytona provides preview URLs for accessing services running in your sandboxes. Any process listening for HTTP traffic on ports `1` - `65535` can be previewed through a generated URL.
 
 Daytona supports two types of preview URLs, each with a different authentication mechanism:
 
-- [Standard preview URL](#standard-preview-url) uses the sandbox ID in the URL and requires a token sent via header
+- [Standard preview URL](#standard-preview-url) uses the sandbox ID in the URL and requires a separate token for authentication
 - [Signed preview URL](#signed-preview-url) embeds the authentication token directly in the URL, requiring no headers
 
 ## Authentication
@@ -17,12 +17,12 @@ Daytona supports two types of preview URLs, each with a different authentication
 If a sandbox has its `public` property set to `true`, preview links are publicly accessible without authentication. Otherwise, authentication is required. The authentication mechanism depends on the preview URL type.
 
 :::note
-Standard and signed preview tokens are not interchangeable. The token from `get_preview_link()` must be sent via the `x-daytona-preview-token` header. The token from `create_signed_preview_url()` is embedded in the URL itself: it cannot be used as a header value, and vice versa.
+Standard and signed preview tokens are not interchangeable. The token from `get_preview_link()` is used as a preview access token (sent via the `x-daytona-preview-token` header). The token from `create_signed_preview_url()` is embedded in the URL itself: it cannot be used as a standard preview token, and vice versa.
 :::
 
 ## Standard preview URL
 
-The standard preview URL includes your sandbox ID in the URL and provides a separate token for authentication via the `x-daytona-preview-token` request header.
+The standard preview URL includes your sandbox ID in the URL and provides a separate token for authentication.
 
 URL structure: `https://{port}-{sandboxId}.{daytonaProxyDomain}`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update preview URL docs to reflect the full port range (1–65535) and clarify authentication behavior. Standard preview uses a separate access token (sent via the x-daytona-preview-token header), while signed preview embeds the token; tokens are not interchangeable.

<sup>Written for commit f17c3a05d8685a9d893cfeded422657d4786b3c5. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4831?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

