### PR TITLE
Respect Go SDK execute timeout for long commands

### DIFF
--- a/libs/sdk-go/pkg/daytona/process.go
+++ b/libs/sdk-go/pkg/daytona/process.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/common"
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
@@ -110,7 +112,12 @@ func (p *ProcessService) ExecuteCommand(ctx context.Context, command string, opt
 			req.SetEnvs(execOpts.Env)
 		}
 
-		resp, httpResp, err := p.toolboxClient.ProcessAPI.ExecuteCommand(ctx).Request(*req).Execute()
+		toolboxClient := p.toolboxClient
+		if execOpts.Timeout != nil {
+			toolboxClient = toolboxClientWithTimeout(p.toolboxClient, *execOpts.Timeout)
+		}
+
+		resp, httpResp, err := toolboxClient.ProcessAPI.ExecuteCommand(ctx).Request(*req).Execute()
 		if err != nil {
 			return nil, errors.ConvertToolboxError(err, httpResp)
 		}
@@ -128,6 +135,26 @@ func (p *ProcessService) ExecuteCommand(ctx context.Context, command string, opt
 			},
 		}, nil
 	})
+}
+
+func toolboxClientWithTimeout(client *toolbox.APIClient, timeout time.Duration) *toolbox.APIClient {
+	if client == nil || timeout <= 0 {
+		return client
+	}
+
+	cfg := *client.GetConfig()
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: timeout}
+		return toolbox.NewAPIClient(&cfg)
+	}
+
+	httpClient := *cfg.HTTPClient
+	if httpClient.Timeout > 0 && httpClient.Timeout < timeout {
+		httpClient.Timeout = timeout
+	}
+	cfg.HTTPClient = &httpClient
+
+	return toolbox.NewAPIClient(&cfg)
 }
 
 // CodeRun executes code in a language-specific runtime and returns the result.

--- a/libs/sdk-go/pkg/daytona/process_test.go
+++ b/libs/sdk-go/pkg/daytona/process_test.go
@@ -366,6 +366,27 @@ func TestProcessExecuteCommandRequestMapping(t *testing.T) {
 	assert.Equal(t, "hello", result.Artifacts.Stdout)
 }
 
+func TestProcessExecuteCommandExtendsHTTPTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(30 * time.Millisecond)
+		writeJSONResponse(t, w, http.StatusOK, map[string]any{"result": "done", "exitCode": 0})
+	}))
+	defer server.Close()
+
+	client := createTestToolboxClient(server)
+	client.GetConfig().HTTPClient = &http.Client{Timeout: 10 * time.Millisecond}
+
+	service := NewProcessService(client, nil, types.CodeLanguagePython)
+	result, err := service.ExecuteCommand(
+		context.Background(),
+		"sleep 0.03",
+		options.WithExecuteTimeout(100*time.Millisecond),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "done", result.Result)
+	assert.Equal(t, 10*time.Millisecond, client.GetConfig().HTTPClient.Timeout)
+}
+
 func TestProcessCodeRunAndSessionOperations(t *testing.T) {
 	t.Run("code run maps charts and explicit language", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Create a per-call toolbox client when ExecuteCommand receives a timeout longer than the configured HTTP client timeout.
- Preserve the caller's shared HTTP client configuration instead of mutating it.
- Add a regression test for a short HTTP client timeout with a longer execute timeout.

## Why
Fixes #4750. The SDK currently sends the command timeout in the request body, but the generated toolbox HTTP client can still time out first, so long-running commands fail around the default 60s client deadline.

## Testing
- Not run locally: go is not installed in this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the Go SDK respects per-call execute timeouts by creating a temporary `toolbox.APIClient` with an extended HTTP timeout when `ExecuteCommand` specifies a longer timeout. Prevents early HTTP client deadlines on long-running commands without mutating the shared client.

- **Bug Fixes**
  - Extend per-call HTTP timeout only when the execute timeout exceeds the client’s; keep longer or unlimited timeouts unchanged.
  - Preserve the caller’s shared HTTP client config by cloning the API client.
  - Add a regression test to verify longer execute timeouts work and the original client timeout remains unchanged.

<sup>Written for commit 971e762d9ad0c8ff785b2e60cff98a39b3114c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

