### PR TITLE
feat(cli): auto-emit TSV when stdout is piped

### DIFF
--- a/apps/cli/cmd/common/format.go
+++ b/apps/cli/cmd/common/format.go
@@ -22,10 +22,7 @@ const (
 	formatFlagShortHand   = "f"
 )
 
-var (
-	FormatFlag  string
-	standardOut *os.File
-)
+var standardOut *os.File
 
 func init() {
 	cobra.OnInitialize(resolveOutputMode)
@@ -45,21 +42,12 @@ func resolveOutputMode() {
 // applyDefaults is the pure-function core of resolveOutputMode; isolated so
 // tests can exercise the precedence rules without touching real fds or env.
 func applyDefaults(isStdoutTTY bool, noColor string) {
-	if FormatFlag == "" && !isStdoutTTY {
-		FormatFlag = "tsv"
+	if internal.FormatFlag == "" && !isStdoutTTY {
+		internal.FormatFlag = "tsv"
 	}
 	if !isStdoutTTY || noColor != "" {
 		lipgloss.SetColorProfile(termenv.Ascii)
 	}
-}
-
-// IsStructuredOutput reports whether the user (or auto-detection) selected a
-// fully-serialized format (json/yaml). The list/info commands use this to
-// decide between calling NewFormatter and falling through to the view layer.
-// Note that "tsv" is *not* structured here: tsv output is generated inside
-// the view layer (where curated column data lives), not via NewFormatter.
-func IsStructuredOutput() bool {
-	return FormatFlag == "json" || FormatFlag == "yaml"
 }
 
 type outputFormatter struct {
@@ -69,7 +57,7 @@ type outputFormatter struct {
 
 func NewFormatter(data interface{}) *outputFormatter {
 	var formatter Formatter
-	switch FormatFlag {
+	switch internal.FormatFlag {
 	case "json":
 		formatter = JSONFormatter{}
 	case "yaml":
@@ -139,9 +127,9 @@ func UnblockStdOut() {
 }
 
 func RegisterFormatFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&FormatFlag, formatFlagName, formatFlagShortHand, FormatFlag, formatFlagDescription)
+	cmd.Flags().StringVarP(&internal.FormatFlag, formatFlagName, formatFlagShortHand, internal.FormatFlag, formatFlagDescription)
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		if IsStructuredOutput() {
+		if internal.IsStructuredOutput() {
 			BlockStdOut()
 			// When a structured output format is requested, suppress
 			// noisy warnings such as version mismatch so scripts

--- a/apps/cli/cmd/common/format.go
+++ b/apps/cli/cmd/common/format.go
@@ -8,13 +8,16 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/daytonaio/daytona/cli/internal"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v2"
 )
 
 const (
-	formatFlagDescription = `Output format. Must be one of (yaml, json)`
+	formatFlagDescription = `Output format. Must be one of (tsv, yaml, json). Defaults to tsv when stdout is piped.`
 	formatFlagName        = "format"
 	formatFlagShortHand   = "f"
 )
@@ -23,6 +26,41 @@ var (
 	FormatFlag  string
 	standardOut *os.File
 )
+
+func init() {
+	cobra.OnInitialize(resolveOutputMode)
+}
+
+// resolveOutputMode adapts CLI output to the terminal context. When stdout is
+// not a TTY, FormatFlag defaults to "tsv" so piped consumers (grep, awk, ...)
+// get machine-friendly rows. NO_COLOR and non-TTY stdout both strip ANSI from
+// styled output.
+func resolveOutputMode() {
+	applyDefaults(
+		term.IsTerminal(int(os.Stdout.Fd())),
+		os.Getenv("NO_COLOR"),
+	)
+}
+
+// applyDefaults is the pure-function core of resolveOutputMode; isolated so
+// tests can exercise the precedence rules without touching real fds or env.
+func applyDefaults(isStdoutTTY bool, noColor string) {
+	if FormatFlag == "" && !isStdoutTTY {
+		FormatFlag = "tsv"
+	}
+	if !isStdoutTTY || noColor != "" {
+		lipgloss.SetColorProfile(termenv.Ascii)
+	}
+}
+
+// IsStructuredOutput reports whether the user (or auto-detection) selected a
+// fully-serialized format (json/yaml). The list/info commands use this to
+// decide between calling NewFormatter and falling through to the view layer.
+// Note that "tsv" is *not* structured here: tsv output is generated inside
+// the view layer (where curated column data lives), not via NewFormatter.
+func IsStructuredOutput() bool {
+	return FormatFlag == "json" || FormatFlag == "yaml"
+}
 
 type outputFormatter struct {
 	data      interface{}
@@ -103,7 +141,7 @@ func UnblockStdOut() {
 func RegisterFormatFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&FormatFlag, formatFlagName, formatFlagShortHand, FormatFlag, formatFlagDescription)
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		if FormatFlag != "" {
+		if IsStructuredOutput() {
 			BlockStdOut()
 			// When a structured output format is requested, suppress
 			// noisy warnings such as version mismatch so scripts

--- a/apps/cli/cmd/common/format_test.go
+++ b/apps/cli/cmd/common/format_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 )
@@ -33,10 +34,10 @@ func TestIsStructuredOutput(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.format, func(t *testing.T) {
-			FormatFlag = tt.format
-			defer func() { FormatFlag = "" }()
-			if got := IsStructuredOutput(); got != tt.want {
-				t.Errorf("IsStructuredOutput() = %v, want %v", got, tt.want)
+			internal.FormatFlag = tt.format
+			defer func() { internal.FormatFlag = "" }()
+			if got := internal.IsStructuredOutput(); got != tt.want {
+				t.Errorf("internal.IsStructuredOutput() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -45,42 +46,42 @@ func TestIsStructuredOutput(t *testing.T) {
 func TestResolveOutputModePicksTSVWhenNotTTY(t *testing.T) {
 	// Going through resolveOutputMode would hit the real os.Stdout; instead we
 	// exercise the same logic with the predicate exposed for testing.
-	FormatFlag = ""
-	defer func() { FormatFlag = "" }()
+	internal.FormatFlag = ""
+	defer func() { internal.FormatFlag = "" }()
 
 	applyDefaults(false /* isStdoutTTY */, "" /* NO_COLOR */)
-	if FormatFlag != "tsv" {
-		t.Errorf("FormatFlag = %q, want %q", FormatFlag, "tsv")
+	if internal.FormatFlag != "tsv" {
+		t.Errorf("internal.FormatFlag = %q, want %q", internal.FormatFlag, "tsv")
 	}
 }
 
 func TestResolveOutputModeKeepsExplicitFormat(t *testing.T) {
-	FormatFlag = "json"
-	defer func() { FormatFlag = "" }()
+	internal.FormatFlag = "json"
+	defer func() { internal.FormatFlag = "" }()
 
 	applyDefaults(false, "")
-	if FormatFlag != "json" {
-		t.Errorf("explicit FormatFlag should win: got %q, want %q", FormatFlag, "json")
+	if internal.FormatFlag != "json" {
+		t.Errorf("explicit internal.FormatFlag should win: got %q, want %q", internal.FormatFlag, "json")
 	}
 }
 
 func TestResolveOutputModeKeepsFormatWhenTTY(t *testing.T) {
-	FormatFlag = ""
-	defer func() { FormatFlag = "" }()
+	internal.FormatFlag = ""
+	defer func() { internal.FormatFlag = "" }()
 
 	applyDefaults(true, "")
-	if FormatFlag != "" {
-		t.Errorf("interactive TTY should not auto-set format: got %q", FormatFlag)
+	if internal.FormatFlag != "" {
+		t.Errorf("interactive TTY should not auto-set format: got %q", internal.FormatFlag)
 	}
 }
 
 // TestApplyDefaultsNoColorStripsInTTY pins the headline acceptance criterion:
 // NO_COLOR=1 must strip ANSI even when stdout is an interactive terminal.
-// We assert the lipgloss color profile directly (not just FormatFlag).
+// We assert the lipgloss color profile directly (not just internal.FormatFlag).
 func TestApplyDefaultsNoColorStripsInTTY(t *testing.T) {
 	withColorProfile(t)
-	FormatFlag = ""
-	defer func() { FormatFlag = "" }()
+	internal.FormatFlag = ""
+	defer func() { internal.FormatFlag = "" }()
 
 	// Seed a non-Ascii profile so we can verify the call actually changes it.
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -90,8 +91,8 @@ func TestApplyDefaultsNoColorStripsInTTY(t *testing.T) {
 	if got := lipgloss.DefaultRenderer().ColorProfile(); got != termenv.Ascii {
 		t.Errorf("NO_COLOR in TTY should set profile to Ascii, got %v", got)
 	}
-	if FormatFlag != "" {
-		t.Errorf("NO_COLOR alone should not auto-set format: got %q", FormatFlag)
+	if internal.FormatFlag != "" {
+		t.Errorf("NO_COLOR alone should not auto-set format: got %q", internal.FormatFlag)
 	}
 }
 
@@ -99,8 +100,8 @@ func TestApplyDefaultsNoColorStripsInTTY(t *testing.T) {
 // colors (not just sets tsv). Same headline guarantee, different path.
 func TestApplyDefaultsPipedSetsAsciiProfile(t *testing.T) {
 	withColorProfile(t)
-	FormatFlag = ""
-	defer func() { FormatFlag = "" }()
+	internal.FormatFlag = ""
+	defer func() { internal.FormatFlag = "" }()
 
 	lipgloss.SetColorProfile(termenv.TrueColor)
 
@@ -121,13 +122,13 @@ func TestRegisterFormatFlagPreRunDoesNotBlockStdoutForTSV(t *testing.T) {
 	t.Cleanup(func() {
 		os.Stdout = origStdout
 		standardOut = nil
-		FormatFlag = ""
+		internal.FormatFlag = ""
 	})
 
 	cmd := &cobra.Command{Use: "fake"}
 	RegisterFormatFlag(cmd)
 
-	FormatFlag = "tsv"
+	internal.FormatFlag = "tsv"
 	cmd.PreRun(cmd, nil)
 
 	if os.Stdout == nil {
@@ -143,13 +144,13 @@ func TestRegisterFormatFlagPreRunBlocksStdoutForJSON(t *testing.T) {
 	t.Cleanup(func() {
 		os.Stdout = origStdout
 		standardOut = nil
-		FormatFlag = ""
+		internal.FormatFlag = ""
 	})
 
 	cmd := &cobra.Command{Use: "fake"}
 	RegisterFormatFlag(cmd)
 
-	FormatFlag = "json"
+	internal.FormatFlag = "json"
 	cmd.PreRun(cmd, nil)
 
 	if os.Stdout != nil {

--- a/apps/cli/cmd/common/format_test.go
+++ b/apps/cli/cmd/common/format_test.go
@@ -4,8 +4,21 @@
 package common
 
 import (
+	"os"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
 )
+
+// withColorProfile saves the current default lipgloss color profile and
+// restores it after the test, so applyDefaults doesn't leak global state.
+func withColorProfile(t *testing.T) {
+	t.Helper()
+	prev := lipgloss.DefaultRenderer().ColorProfile()
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
 
 func TestIsStructuredOutput(t *testing.T) {
 	tests := []struct {
@@ -58,5 +71,88 @@ func TestResolveOutputModeKeepsFormatWhenTTY(t *testing.T) {
 	applyDefaults(true, "")
 	if FormatFlag != "" {
 		t.Errorf("interactive TTY should not auto-set format: got %q", FormatFlag)
+	}
+}
+
+// TestApplyDefaultsNoColorStripsInTTY pins the headline acceptance criterion:
+// NO_COLOR=1 must strip ANSI even when stdout is an interactive terminal.
+// We assert the lipgloss color profile directly (not just FormatFlag).
+func TestApplyDefaultsNoColorStripsInTTY(t *testing.T) {
+	withColorProfile(t)
+	FormatFlag = ""
+	defer func() { FormatFlag = "" }()
+
+	// Seed a non-Ascii profile so we can verify the call actually changes it.
+	lipgloss.SetColorProfile(termenv.TrueColor)
+
+	applyDefaults(true /* isStdoutTTY */, "1" /* NO_COLOR */)
+
+	if got := lipgloss.DefaultRenderer().ColorProfile(); got != termenv.Ascii {
+		t.Errorf("NO_COLOR in TTY should set profile to Ascii, got %v", got)
+	}
+	if FormatFlag != "" {
+		t.Errorf("NO_COLOR alone should not auto-set format: got %q", FormatFlag)
+	}
+}
+
+// TestApplyDefaultsPipedSetsAsciiProfile pins that piped stdout also strips
+// colors (not just sets tsv). Same headline guarantee, different path.
+func TestApplyDefaultsPipedSetsAsciiProfile(t *testing.T) {
+	withColorProfile(t)
+	FormatFlag = ""
+	defer func() { FormatFlag = "" }()
+
+	lipgloss.SetColorProfile(termenv.TrueColor)
+
+	applyDefaults(false, "")
+
+	if got := lipgloss.DefaultRenderer().ColorProfile(); got != termenv.Ascii {
+		t.Errorf("piped stdout should set profile to Ascii, got %v", got)
+	}
+}
+
+// TestRegisterFormatFlagPreRunDoesNotBlockStdoutForTSV pins a regression-class
+// concern: BlockStdOut() sets os.Stdout = nil, which silently discards all
+// writes. Before this change, any non-empty FormatFlag triggered it, which
+// would have swallowed our new TSV output. The gate is now IsStructuredOutput()
+// so tsv falls through with stdout intact.
+func TestRegisterFormatFlagPreRunDoesNotBlockStdoutForTSV(t *testing.T) {
+	origStdout := os.Stdout
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		standardOut = nil
+		FormatFlag = ""
+	})
+
+	cmd := &cobra.Command{Use: "fake"}
+	RegisterFormatFlag(cmd)
+
+	FormatFlag = "tsv"
+	cmd.PreRun(cmd, nil)
+
+	if os.Stdout == nil {
+		t.Fatal("PreRun should not BlockStdOut for tsv; got nil os.Stdout")
+	}
+}
+
+// TestRegisterFormatFlagPreRunBlocksStdoutForJSON pins the *other* side of
+// the gating: json/yaml must still trigger BlockStdOut so version-mismatch
+// warnings (and other stray writes) don't contaminate structured output.
+func TestRegisterFormatFlagPreRunBlocksStdoutForJSON(t *testing.T) {
+	origStdout := os.Stdout
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		standardOut = nil
+		FormatFlag = ""
+	})
+
+	cmd := &cobra.Command{Use: "fake"}
+	RegisterFormatFlag(cmd)
+
+	FormatFlag = "json"
+	cmd.PreRun(cmd, nil)
+
+	if os.Stdout != nil {
+		t.Fatal("PreRun should BlockStdOut for json; os.Stdout was not nilled")
 	}
 }

--- a/apps/cli/cmd/common/format_test.go
+++ b/apps/cli/cmd/common/format_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package common
+
+import (
+	"testing"
+)
+
+func TestIsStructuredOutput(t *testing.T) {
+	tests := []struct {
+		format string
+		want   bool
+	}{
+		{"", false},
+		{"tsv", false},
+		{"json", true},
+		{"yaml", true},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			FormatFlag = tt.format
+			defer func() { FormatFlag = "" }()
+			if got := IsStructuredOutput(); got != tt.want {
+				t.Errorf("IsStructuredOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveOutputModePicksTSVWhenNotTTY(t *testing.T) {
+	// Going through resolveOutputMode would hit the real os.Stdout; instead we
+	// exercise the same logic with the predicate exposed for testing.
+	FormatFlag = ""
+	defer func() { FormatFlag = "" }()
+
+	applyDefaults(false /* isStdoutTTY */, "" /* NO_COLOR */)
+	if FormatFlag != "tsv" {
+		t.Errorf("FormatFlag = %q, want %q", FormatFlag, "tsv")
+	}
+}
+
+func TestResolveOutputModeKeepsExplicitFormat(t *testing.T) {
+	FormatFlag = "json"
+	defer func() { FormatFlag = "" }()
+
+	applyDefaults(false, "")
+	if FormatFlag != "json" {
+		t.Errorf("explicit FormatFlag should win: got %q, want %q", FormatFlag, "json")
+	}
+}
+
+func TestResolveOutputModeKeepsFormatWhenTTY(t *testing.T) {
+	FormatFlag = ""
+	defer func() { FormatFlag = "" }()
+
+	applyDefaults(true, "")
+	if FormatFlag != "" {
+		t.Errorf("interactive TTY should not auto-set format: got %q", FormatFlag)
+	}
+}

--- a/apps/cli/cmd/organization/list.go
+++ b/apps/cli/cmd/organization/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/organization"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +32,7 @@ var ListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.IsStructuredOutput() {
+		if internal.IsStructuredOutput() {
 			formattedData := common.NewFormatter(organizationList)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/organization/list.go
+++ b/apps/cli/cmd/organization/list.go
@@ -31,7 +31,7 @@ var ListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.FormatFlag != "" {
+		if common.IsStructuredOutput() {
 			formattedData := common.NewFormatter(organizationList)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/sandbox/info.go
+++ b/apps/cli/cmd/sandbox/info.go
@@ -32,7 +32,7 @@ var InfoCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.FormatFlag != "" {
+		if common.IsStructuredOutput() {
 			formattedData := common.NewFormatter(sb)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/sandbox/info.go
+++ b/apps/cli/cmd/sandbox/info.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/sandbox"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +33,7 @@ var InfoCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.IsStructuredOutput() {
+		if internal.IsStructuredOutput() {
 			formattedData := common.NewFormatter(sb)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/sandbox/list.go
+++ b/apps/cli/cmd/sandbox/list.go
@@ -49,7 +49,7 @@ var ListCmd = &cobra.Command{
 
 		sandbox.SortSandboxes(&sandboxList.Items)
 
-		if common.FormatFlag != "" {
+		if common.IsStructuredOutput() {
 			formattedData := common.NewFormatter(sandboxList)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/sandbox/list.go
+++ b/apps/cli/cmd/sandbox/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/sandbox"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +50,7 @@ var ListCmd = &cobra.Command{
 
 		sandbox.SortSandboxes(&sandboxList.Items)
 
-		if common.IsStructuredOutput() {
+		if internal.IsStructuredOutput() {
 			formattedData := common.NewFormatter(sandboxList)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/snapshot/list.go
+++ b/apps/cli/cmd/snapshot/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/snapshot"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +50,7 @@ var ListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.IsStructuredOutput() {
+		if internal.IsStructuredOutput() {
 			formattedData := common.NewFormatter(snapshots.Items)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/snapshot/list.go
+++ b/apps/cli/cmd/snapshot/list.go
@@ -49,7 +49,7 @@ var ListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.FormatFlag != "" {
+		if common.IsStructuredOutput() {
 			formattedData := common.NewFormatter(snapshots.Items)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/volume/get.go
+++ b/apps/cli/cmd/volume/get.go
@@ -30,7 +30,7 @@ var GetCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.FormatFlag != "" {
+		if common.IsStructuredOutput() {
 			formattedData := common.NewFormatter(vol)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/volume/get.go
+++ b/apps/cli/cmd/volume/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/volume"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,7 @@ var GetCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.IsStructuredOutput() {
+		if internal.IsStructuredOutput() {
 			formattedData := common.NewFormatter(vol)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/volume/list.go
+++ b/apps/cli/cmd/volume/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/config"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/volume"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +32,7 @@ var ListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.IsStructuredOutput() {
+		if internal.IsStructuredOutput() {
 			formattedData := common.NewFormatter(volumes)
 			formattedData.Print()
 			return nil

--- a/apps/cli/cmd/volume/list.go
+++ b/apps/cli/cmd/volume/list.go
@@ -31,7 +31,7 @@ var ListCmd = &cobra.Command{
 			return apiclient.HandleErrorResponse(res, err)
 		}
 
-		if common.FormatFlag != "" {
+		if common.IsStructuredOutput() {
 			formattedData := common.NewFormatter(volumes)
 			formattedData.Print()
 			return nil

--- a/apps/cli/internal/format.go
+++ b/apps/cli/internal/format.go
@@ -1,0 +1,20 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package internal
+
+// FormatFlag is the resolved output format for the current invocation,
+// one of: "" (default/styled), "tsv", "json", "yaml".
+//
+// Storage lives in this leaf package so both cmd/* (which sets it via
+// cobra) and views/* (which branches on it during rendering) can read
+// it without creating an import cycle.
+var FormatFlag string
+
+// IsStructuredOutput reports whether FormatFlag selects a fully-serialized
+// format (json/yaml) handled by cmd/common.NewFormatter. TSV is *not*
+// structured here: TSV rendering lives in the view layer where curated
+// column data is available.
+func IsStructuredOutput() bool {
+	return FormatFlag == "json" || FormatFlag == "yaml"
+}

--- a/apps/cli/views/organization/info.go
+++ b/apps/cli/views/organization/info.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
+	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -15,6 +16,11 @@ import (
 )
 
 func RenderInfo(organization *apiclient.Organization, forceUnstyled bool) {
+	if commoncmd.FormatFlag == "tsv" {
+		renderTSVInfo(organization)
+		return
+	}
+
 	var output string
 	nameLabel := "Organization"
 
@@ -41,6 +47,12 @@ func RenderInfo(organization *apiclient.Organization, forceUnstyled bool) {
 
 func renderUnstyledInfo(output string) {
 	fmt.Println(output)
+}
+
+func renderTSVInfo(o *apiclient.Organization) {
+	fmt.Printf("organization\t%s\n", o.Name)
+	fmt.Printf("created\t%s\n", o.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	fmt.Printf("id\t%s\n", o.Id)
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/organization/info.go
+++ b/apps/cli/views/organization/info.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -17,7 +18,7 @@ import (
 )
 
 func RenderInfo(organization *apiclient.Organization, forceUnstyled bool) {
-	if commoncmd.FormatFlag == "tsv" {
+	if internal.FormatFlag == "tsv" {
 		renderTSVInfo(os.Stdout, organization)
 		return
 	}
@@ -51,9 +52,9 @@ func renderUnstyledInfo(output string) {
 }
 
 func renderTSVInfo(w io.Writer, o *apiclient.Organization) {
-	fmt.Fprintf(w, "organization\t%s\n", o.Name)
-	fmt.Fprintf(w, "created\t%s\n", o.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	fmt.Fprintf(w, "id\t%s\n", o.Id)
+	fmt.Fprintf(w, "organization\t%s\n", util.SanitizeTSV(o.Name))
+	fmt.Fprintf(w, "created\t%s\n", o.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(w, "id\t%s\n", util.SanitizeTSV(o.Id))
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/organization/info.go
+++ b/apps/cli/views/organization/info.go
@@ -5,6 +5,7 @@ package organization
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
@@ -17,7 +18,7 @@ import (
 
 func RenderInfo(organization *apiclient.Organization, forceUnstyled bool) {
 	if commoncmd.FormatFlag == "tsv" {
-		renderTSVInfo(organization)
+		renderTSVInfo(os.Stdout, organization)
 		return
 	}
 
@@ -49,10 +50,10 @@ func renderUnstyledInfo(output string) {
 	fmt.Println(output)
 }
 
-func renderTSVInfo(o *apiclient.Organization) {
-	fmt.Printf("organization\t%s\n", o.Name)
-	fmt.Printf("created\t%s\n", o.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	fmt.Printf("id\t%s\n", o.Id)
+func renderTSVInfo(w io.Writer, o *apiclient.Organization) {
+	fmt.Fprintf(w, "organization\t%s\n", o.Name)
+	fmt.Fprintf(w, "created\t%s\n", o.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	fmt.Fprintf(w, "id\t%s\n", o.Id)
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/organization/info_test.go
+++ b/apps/cli/views/organization/info_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package organization
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestRenderTSVInfoEmitsCuratedKeys(t *testing.T) {
+	o := &apiclient.Organization{
+		Id:        "org-abc",
+		Name:      "acme",
+		CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, o)
+	out := buf.String()
+
+	pairs := map[string]string{}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		k, v, _ := strings.Cut(line, "\t")
+		pairs[k] = v
+	}
+
+	want := map[string]string{
+		"organization": "acme",
+		"created":      "2026-05-01T10:00:00Z",
+		"id":           "org-abc",
+	}
+	for k, v := range want {
+		if pairs[k] != v {
+			t.Errorf("key %q = %q, want %q (full output:\n%s)", k, pairs[k], v, out)
+		}
+	}
+}

--- a/apps/cli/views/sandbox/info.go
+++ b/apps/cli/views/sandbox/info.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -16,6 +17,11 @@ import (
 )
 
 func RenderInfo(sandbox *apiclient.Sandbox, forceUnstyled bool) {
+	if commoncmd.FormatFlag == "tsv" {
+		renderTSVInfo(sandbox)
+		return
+	}
+
 	var output string
 
 	output += "\n"
@@ -79,6 +85,31 @@ func RenderInfo(sandbox *apiclient.Sandbox, forceUnstyled bool) {
 
 func renderUnstyledInfo(output string) {
 	fmt.Println(output)
+}
+
+func renderTSVInfo(s *apiclient.Sandbox) {
+	fmt.Printf("id\t%s\n", s.Id)
+	if s.State != nil {
+		fmt.Printf("state\t%s\n", string(*s.State))
+	}
+	if s.Snapshot != nil {
+		fmt.Printf("snapshot\t%s\n", *s.Snapshot)
+	}
+	fmt.Printf("region\t%s\n", s.Target)
+	if s.Class != nil {
+		fmt.Printf("class\t%s\n", *s.Class)
+	}
+	if s.CreatedAt != nil {
+		fmt.Printf("created\t%s\n", *s.CreatedAt)
+	}
+	if s.LastActivityAt != nil {
+		fmt.Printf("last_event\t%s\n", *s.LastActivityAt)
+	} else if s.UpdatedAt != nil {
+		fmt.Printf("last_event\t%s\n", *s.UpdatedAt)
+	}
+	for k, v := range s.Labels {
+		fmt.Printf("label.%s\t%s\n", k, v)
+	}
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/sandbox/info.go
+++ b/apps/cli/views/sandbox/info.go
@@ -5,6 +5,7 @@ package sandbox
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -18,7 +19,7 @@ import (
 
 func RenderInfo(sandbox *apiclient.Sandbox, forceUnstyled bool) {
 	if commoncmd.FormatFlag == "tsv" {
-		renderTSVInfo(sandbox)
+		renderTSVInfo(os.Stdout, sandbox)
 		return
 	}
 
@@ -87,28 +88,28 @@ func renderUnstyledInfo(output string) {
 	fmt.Println(output)
 }
 
-func renderTSVInfo(s *apiclient.Sandbox) {
-	fmt.Printf("id\t%s\n", s.Id)
+func renderTSVInfo(w io.Writer, s *apiclient.Sandbox) {
+	fmt.Fprintf(w, "id\t%s\n", s.Id)
 	if s.State != nil {
-		fmt.Printf("state\t%s\n", string(*s.State))
+		fmt.Fprintf(w, "state\t%s\n", string(*s.State))
 	}
 	if s.Snapshot != nil {
-		fmt.Printf("snapshot\t%s\n", *s.Snapshot)
+		fmt.Fprintf(w, "snapshot\t%s\n", *s.Snapshot)
 	}
-	fmt.Printf("region\t%s\n", s.Target)
+	fmt.Fprintf(w, "region\t%s\n", s.Target)
 	if s.Class != nil {
-		fmt.Printf("class\t%s\n", *s.Class)
+		fmt.Fprintf(w, "class\t%s\n", *s.Class)
 	}
 	if s.CreatedAt != nil {
-		fmt.Printf("created\t%s\n", *s.CreatedAt)
+		fmt.Fprintf(w, "created\t%s\n", *s.CreatedAt)
 	}
 	if s.LastActivityAt != nil {
-		fmt.Printf("last_event\t%s\n", *s.LastActivityAt)
+		fmt.Fprintf(w, "last_event\t%s\n", *s.LastActivityAt)
 	} else if s.UpdatedAt != nil {
-		fmt.Printf("last_event\t%s\n", *s.UpdatedAt)
+		fmt.Fprintf(w, "last_event\t%s\n", *s.UpdatedAt)
 	}
 	for k, v := range s.Labels {
-		fmt.Printf("label.%s\t%s\n", k, v)
+		fmt.Fprintf(w, "label.%s\t%s\n", k, v)
 	}
 }
 

--- a/apps/cli/views/sandbox/info.go
+++ b/apps/cli/views/sandbox/info.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -18,7 +18,7 @@ import (
 )
 
 func RenderInfo(sandbox *apiclient.Sandbox, forceUnstyled bool) {
-	if commoncmd.FormatFlag == "tsv" {
+	if internal.FormatFlag == "tsv" {
 		renderTSVInfo(os.Stdout, sandbox)
 		return
 	}
@@ -89,27 +89,27 @@ func renderUnstyledInfo(output string) {
 }
 
 func renderTSVInfo(w io.Writer, s *apiclient.Sandbox) {
-	fmt.Fprintf(w, "id\t%s\n", s.Id)
+	fmt.Fprintf(w, "id\t%s\n", util.SanitizeTSV(s.Id))
 	if s.State != nil {
-		fmt.Fprintf(w, "state\t%s\n", string(*s.State))
+		fmt.Fprintf(w, "state\t%s\n", util.SanitizeTSV(string(*s.State)))
 	}
 	if s.Snapshot != nil {
-		fmt.Fprintf(w, "snapshot\t%s\n", *s.Snapshot)
+		fmt.Fprintf(w, "snapshot\t%s\n", util.SanitizeTSV(*s.Snapshot))
 	}
-	fmt.Fprintf(w, "region\t%s\n", s.Target)
+	fmt.Fprintf(w, "region\t%s\n", util.SanitizeTSV(s.Target))
 	if s.Class != nil {
-		fmt.Fprintf(w, "class\t%s\n", *s.Class)
+		fmt.Fprintf(w, "class\t%s\n", util.SanitizeTSV(*s.Class))
 	}
 	if s.CreatedAt != nil {
-		fmt.Fprintf(w, "created\t%s\n", *s.CreatedAt)
+		fmt.Fprintf(w, "created\t%s\n", util.SanitizeTSV(*s.CreatedAt))
 	}
 	if s.LastActivityAt != nil {
-		fmt.Fprintf(w, "last_event\t%s\n", *s.LastActivityAt)
+		fmt.Fprintf(w, "last_event\t%s\n", util.SanitizeTSV(*s.LastActivityAt))
 	} else if s.UpdatedAt != nil {
-		fmt.Fprintf(w, "last_event\t%s\n", *s.UpdatedAt)
+		fmt.Fprintf(w, "last_event\t%s\n", util.SanitizeTSV(*s.UpdatedAt))
 	}
 	for k, v := range s.Labels {
-		fmt.Fprintf(w, "label.%s\t%s\n", k, v)
+		fmt.Fprintf(w, "label.%s\t%s\n", util.SanitizeTSV(k), util.SanitizeTSV(v))
 	}
 }
 

--- a/apps/cli/views/sandbox/info_test.go
+++ b/apps/cli/views/sandbox/info_test.go
@@ -73,6 +73,46 @@ func TestRenderTSVInfoOmitsNilFields(t *testing.T) {
 	}
 }
 
+// TestRenderTSVInfoSanitizesAdversarialFields pins that user-controlled
+// fields containing tab/newline/ANSI bytes cannot inject extra rows or
+// terminal-injection sequences into the TSV output. Sandbox names and
+// labels are the most likely attacker-controlled inputs in practice.
+func TestRenderTSVInfoSanitizesAdversarialFields(t *testing.T) {
+	sb := &apiclient.Sandbox{
+		Id:     "sb\tinject\nfake",
+		Target: "us\x1b]8;;https://evil/\x07click\x1b]8;;\x07",
+		Labels: map[string]string{
+			"key\twith\ttab": "val\nwith\nnewline",
+			"normal":         "ok",
+		},
+	}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, sb)
+	out := buf.String()
+
+	if strings.ContainsRune(out, '\x1b') {
+		t.Errorf("output contains stray ESC byte after sanitization: %q", out)
+	}
+
+	// The structural invariant we care about: every emitted line is exactly
+	// one `key<TAB>value` pair. If sanitization had failed, the malicious id
+	// or label value would have introduced extra newlines and extra tabs,
+	// producing rows with !=1 tab.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	for i, line := range lines {
+		if got := strings.Count(line, "\t"); got != 1 {
+			t.Errorf("line %d should have exactly 1 tab (key<TAB>value); got %d in %q", i, got, line)
+		}
+	}
+
+	// Sandbox has 1 id + 1 region + 2 labels = 4 lines (no state/snapshot/etc set).
+	// Without sanitization, the adversarial id+labels would expand to ~10+ rows.
+	if len(lines) != 4 {
+		t.Errorf("expected exactly 4 lines (id, region, 2 labels); got %d:\n%s", len(lines), out)
+	}
+}
+
 // TestRenderTSVInfoLastEventFallback exercises the LastActivityAt/UpdatedAt
 // fallback branch (LastActivityAt nil → use UpdatedAt).
 func TestRenderTSVInfoLastEventFallback(t *testing.T) {

--- a/apps/cli/views/sandbox/info_test.go
+++ b/apps/cli/views/sandbox/info_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package sandbox
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestRenderTSVInfoEmitsCuratedKeys(t *testing.T) {
+	state := apiclient.SANDBOXSTATE_STARTED
+	snapshot := "node:20"
+	createdAt := "2026-05-01T10:00:00Z"
+	lastActivity := "2026-05-23T15:30:00Z"
+	class := "small"
+
+	sb := &apiclient.Sandbox{
+		Id:             "sb-abc",
+		State:          &state,
+		Snapshot:       &snapshot,
+		Target:         "us",
+		Class:          &class,
+		CreatedAt:      &createdAt,
+		LastActivityAt: &lastActivity,
+		Labels:         map[string]string{"env": "prod"},
+	}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, sb)
+	out := buf.String()
+
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if !strings.Contains(line, "\t") {
+			t.Errorf("every line should contain a tab; got %q", line)
+		}
+	}
+
+	wantPairs := map[string]string{
+		"id":         "sb-abc",
+		"state":      "started",
+		"snapshot":   "node:20",
+		"region":     "us",
+		"class":      "small",
+		"created":    "2026-05-01T10:00:00Z",
+		"last_event": "2026-05-23T15:30:00Z",
+		"label.env":  "prod",
+	}
+	got := parseTSVPairs(out)
+	for k, want := range wantPairs {
+		if got[k] != want {
+			t.Errorf("key %q = %q, want %q (full output:\n%s)", k, got[k], want, out)
+		}
+	}
+}
+
+// TestRenderTSVInfoOmitsNilFields verifies optional fields drop out of the
+// output entirely when nil (no stray "snapshot\t" line, etc.).
+func TestRenderTSVInfoOmitsNilFields(t *testing.T) {
+	sb := &apiclient.Sandbox{Id: "sb-min", Target: "eu"}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, sb)
+	out := buf.String()
+
+	for _, banned := range []string{"state\t", "snapshot\t", "class\t", "created\t", "last_event\t", "label."} {
+		if strings.Contains(out, banned) {
+			t.Errorf("output should not contain %q for a minimal sandbox; got:\n%s", banned, out)
+		}
+	}
+}
+
+// TestRenderTSVInfoLastEventFallback exercises the LastActivityAt/UpdatedAt
+// fallback branch (LastActivityAt nil → use UpdatedAt).
+func TestRenderTSVInfoLastEventFallback(t *testing.T) {
+	updated := "2026-05-23T15:30:00Z"
+	sb := &apiclient.Sandbox{Id: "sb-fb", Target: "us", UpdatedAt: &updated}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, sb)
+
+	pairs := parseTSVPairs(buf.String())
+	if pairs["last_event"] != updated {
+		t.Errorf("last_event = %q, want %q", pairs["last_event"], updated)
+	}
+}
+
+// parseTSVPairs splits TSV output into a key→value map for assertion ergonomics.
+// Behavior on duplicate keys (e.g. multiple labels): last write wins. Tests
+// that need to assert on multiple labels should walk the output directly.
+func parseTSVPairs(out string) map[string]string {
+	pairs := map[string]string{}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		k, v, _ := strings.Cut(line, "\t")
+		pairs[k] = v
+	}
+	return pairs
+}

--- a/apps/cli/views/snapshot/info.go
+++ b/apps/cli/views/snapshot/info.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
+	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -15,6 +16,11 @@ import (
 )
 
 func RenderInfo(snapshot *apiclient.SnapshotDto, forceUnstyled bool) {
+	if commoncmd.FormatFlag == "tsv" {
+		renderTSVInfo(snapshot)
+		return
+	}
+
 	var output string
 	nameLabel := "Snapshot"
 
@@ -48,6 +54,16 @@ func RenderInfo(snapshot *apiclient.SnapshotDto, forceUnstyled bool) {
 
 func renderUnstyledInfo(output string) {
 	fmt.Println(output)
+}
+
+func renderTSVInfo(s *apiclient.SnapshotDto) {
+	fmt.Printf("snapshot\t%s\n", s.Name)
+	fmt.Printf("state\t%s\n", string(s.State))
+	if size := s.Size.Get(); size != nil {
+		fmt.Printf("size_gb\t%.2f\n", *size)
+	}
+	fmt.Printf("created\t%s\n", s.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	fmt.Printf("id\t%s\n", s.Id)
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/snapshot/info.go
+++ b/apps/cli/views/snapshot/info.go
@@ -5,6 +5,7 @@ package snapshot
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
@@ -17,7 +18,7 @@ import (
 
 func RenderInfo(snapshot *apiclient.SnapshotDto, forceUnstyled bool) {
 	if commoncmd.FormatFlag == "tsv" {
-		renderTSVInfo(snapshot)
+		renderTSVInfo(os.Stdout, snapshot)
 		return
 	}
 
@@ -56,14 +57,14 @@ func renderUnstyledInfo(output string) {
 	fmt.Println(output)
 }
 
-func renderTSVInfo(s *apiclient.SnapshotDto) {
-	fmt.Printf("snapshot\t%s\n", s.Name)
-	fmt.Printf("state\t%s\n", string(s.State))
+func renderTSVInfo(w io.Writer, s *apiclient.SnapshotDto) {
+	fmt.Fprintf(w, "snapshot\t%s\n", s.Name)
+	fmt.Fprintf(w, "state\t%s\n", string(s.State))
 	if size := s.Size.Get(); size != nil {
-		fmt.Printf("size_gb\t%.2f\n", *size)
+		fmt.Fprintf(w, "size_gb\t%.2f\n", *size)
 	}
-	fmt.Printf("created\t%s\n", s.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	fmt.Printf("id\t%s\n", s.Id)
+	fmt.Fprintf(w, "created\t%s\n", s.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	fmt.Fprintf(w, "id\t%s\n", s.Id)
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/snapshot/info.go
+++ b/apps/cli/views/snapshot/info.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -17,7 +18,7 @@ import (
 )
 
 func RenderInfo(snapshot *apiclient.SnapshotDto, forceUnstyled bool) {
-	if commoncmd.FormatFlag == "tsv" {
+	if internal.FormatFlag == "tsv" {
 		renderTSVInfo(os.Stdout, snapshot)
 		return
 	}
@@ -58,13 +59,13 @@ func renderUnstyledInfo(output string) {
 }
 
 func renderTSVInfo(w io.Writer, s *apiclient.SnapshotDto) {
-	fmt.Fprintf(w, "snapshot\t%s\n", s.Name)
-	fmt.Fprintf(w, "state\t%s\n", string(s.State))
+	fmt.Fprintf(w, "snapshot\t%s\n", util.SanitizeTSV(s.Name))
+	fmt.Fprintf(w, "state\t%s\n", util.SanitizeTSV(string(s.State)))
 	if size := s.Size.Get(); size != nil {
 		fmt.Fprintf(w, "size_gb\t%.2f\n", *size)
 	}
-	fmt.Fprintf(w, "created\t%s\n", s.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
-	fmt.Fprintf(w, "id\t%s\n", s.Id)
+	fmt.Fprintf(w, "created\t%s\n", s.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(w, "id\t%s\n", util.SanitizeTSV(s.Id))
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/snapshot/info_test.go
+++ b/apps/cli/views/snapshot/info_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package snapshot
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestRenderTSVInfoEmitsCuratedKeys(t *testing.T) {
+	size := float32(12.5)
+	sn := &apiclient.SnapshotDto{
+		Id:        "snap-abc",
+		Name:      "node-20",
+		State:     apiclient.SNAPSHOTSTATE_ACTIVE,
+		Size:      *apiclient.NewNullableFloat32(&size),
+		CreatedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, sn)
+	out := buf.String()
+
+	pairs := map[string]string{}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		k, v, _ := strings.Cut(line, "\t")
+		pairs[k] = v
+	}
+
+	want := map[string]string{
+		"snapshot": "node-20",
+		"state":    "active",
+		"size_gb":  "12.50",
+		"created":  "2026-05-01T10:00:00Z",
+		"id":       "snap-abc",
+	}
+	for k, v := range want {
+		if pairs[k] != v {
+			t.Errorf("key %q = %q, want %q (full output:\n%s)", k, pairs[k], v, out)
+		}
+	}
+}
+
+func TestRenderTSVInfoOmitsNilSize(t *testing.T) {
+	sn := &apiclient.SnapshotDto{
+		Id:        "snap-min",
+		Name:      "minimal",
+		State:     apiclient.SNAPSHOTSTATE_PENDING,
+		CreatedAt: time.Now(),
+	}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, sn)
+	if strings.Contains(buf.String(), "size_gb\t") {
+		t.Errorf("nil size should be omitted; got:\n%s", buf.String())
+	}
+}

--- a/apps/cli/views/util/table.go
+++ b/apps/cli/views/util/table.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"golang.org/x/term"
 )
@@ -21,8 +22,19 @@ var AdditionalPropertyPadding = "  "
 var RowWhiteSpace = 1 + 4 + len(AdditionalPropertyPadding)*2 + 4 + 4 + 1
 var ArbitrarySpace = 10
 
+var ansiRegex = regexp.MustCompile("\x1b\\[[0-9;]*[a-zA-Z]")
+
+// StripANSI removes ANSI escape sequences from s.
+func StripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
 // Gets the table view string or falls back to an unstyled view for lower terminal widths
 func GetTableView(data [][]string, headers []string, activeOrganizationName *string, fallbackRender func()) string {
+	if commoncmd.FormatFlag == "tsv" {
+		return renderTSV(data)
+	}
+
 	re := lipgloss.NewRenderer(os.Stdout)
 
 	terminalWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
@@ -65,10 +77,7 @@ func getMinimumWidth(data [][]string) int {
 	widestRow := 0
 	for _, row := range data {
 		for _, cell := range row {
-			// Remove ANSI escape codes
-			regex := regexp.MustCompile("\x1b\\[[0-9;]*[a-zA-Z]")
-			strippedCell := regex.ReplaceAllString(cell, "")
-			width += longestLineLength(strippedCell)
+			width += longestLineLength(StripANSI(cell))
 			if width > widestRow {
 				widestRow = width
 			}
@@ -76,6 +85,23 @@ func getMinimumWidth(data [][]string) int {
 		width = 0
 	}
 	return widestRow
+}
+
+// renderTSV emits the rows as literal tab-separated values, stripping any
+// ANSI bytes the upstream styling layer may have applied. Headers are
+// intentionally omitted (kubectl-style) so scripts like
+// `daytona sandbox list | awk '{print $1}'` work without skipping a leading row.
+func renderTSV(data [][]string) string {
+	var b strings.Builder
+	for _, row := range data {
+		cells := make([]string, len(row))
+		for i, cell := range row {
+			cells[i] = strings.TrimSpace(StripANSI(cell))
+		}
+		b.WriteString(strings.Join(cells, "\t"))
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // Returns the length of the longest line in a string

--- a/apps/cli/views/util/table.go
+++ b/apps/cli/views/util/table.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
-	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"golang.org/x/term"
 )
@@ -22,16 +22,57 @@ var AdditionalPropertyPadding = "  "
 var RowWhiteSpace = 1 + 4 + len(AdditionalPropertyPadding)*2 + 4 + 4 + 1
 var ArbitrarySpace = 10
 
-var ansiRegex = regexp.MustCompile("\x1b\\[[0-9;]*[a-zA-Z]")
+// ansiRegex matches the full ANSI escape family, not just CSI color codes:
+//   - OSC (Operating System Command) — terminal title, OSC-52 clipboard, OSC-8 hyperlinks
+//   - DCS (Device Control String)
+//   - CSI (Control Sequence Introducer) — colors, cursor movement, etc.
+//   - Charset-designation escapes (ESC ( F, ESC ) F, etc.)
+//   - Plain 2-byte ESC sequences (excluding [, ], P which introduce CSI/OSC/DCS)
+//   - Stray bare ESC bytes as a last-resort fallback
+//   - C0 control bytes and DEL (except \t \n \r — handled by tsvUnsafe below)
+//
+// A narrow CSI-only strip is unsafe here because user-controlled strings
+// (sandbox names, label values) flow into output that may later be rendered
+// in a real terminal. OSC-8 hyperlinks enable phishing; OSC-52 enables
+// clipboard hijack; DCS can elicit terminal responses that the shell reads
+// back as input. Order matters: Go's regexp picks leftmost-first among
+// alternatives, so longer/more-specific patterns come first.
+var ansiRegex = regexp.MustCompile(
+	`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)` + // OSC, terminated by BEL or ST
+		`|\x1bP[^\x1b]*\x1b\\` + // DCS, ST-terminated (before 2-byte ESC so \x1bP matches DCS)
+		`|\x1b\[[0-?]*[ -/]*[@-~]` + // CSI: intro + params + intermediates + final
+		`|\x1b[()*+\-./][@-~]` + // Charset designation: ESC <intermediate> <final>
+		`|\x1b[@A-OQ-Z\\^_]` + // Plain 2-byte ESC (excludes [, ], P)
+		`|\x1b` + // Stray bare ESC — drop alone
+		`|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]`, // C0 / DEL (keeps \t \n \r — handled by tsvUnsafe)
+)
 
-// StripANSI removes ANSI escape sequences from s.
+// tsvUnsafe replaces row-/field-delimiter characters that would corrupt the
+// TSV stream. The replacement choices match kubectl's convention (drop, don't
+// quote) so downstream `awk -F'\t'` and `cut -f` parsers see a stable row
+// count regardless of upstream field contents.
+var tsvUnsafe = strings.NewReplacer("\t", " ", "\n", " ", "\r", " ")
+
+// StripANSI removes ANSI escape sequences from s. See ansiRegex doc for the
+// covered families.
 func StripANSI(s string) string {
 	return ansiRegex.ReplaceAllString(s, "")
 }
 
+// SanitizeTSV prepares a string for emission as a TSV cell value. It strips
+// ANSI escapes (preventing terminal injection when the output is later
+// rendered) and replaces row/field delimiters (preventing row injection).
+// Use this at every TSV emission site that handles user-controlled data.
+func SanitizeTSV(s string) string {
+	return tsvUnsafe.Replace(StripANSI(s))
+}
+
 // Gets the table view string or falls back to an unstyled view for lower terminal widths
 func GetTableView(data [][]string, headers []string, activeOrganizationName *string, fallbackRender func()) string {
-	if commoncmd.FormatFlag == "tsv" {
+	if internal.FormatFlag == "tsv" {
+		// Headers and the active-org banner are intentionally dropped in TSV
+		// mode (kubectl-style): scripts grep/awk on data rows; a header row
+		// would force them to `tail -n +2`.
 		return renderTSV(data)
 	}
 
@@ -96,7 +137,7 @@ func renderTSV(data [][]string) string {
 	for _, row := range data {
 		cells := make([]string, len(row))
 		for i, cell := range row {
-			cells[i] = strings.TrimSpace(StripANSI(cell))
+			cells[i] = strings.TrimSpace(SanitizeTSV(cell))
 		}
 		b.WriteString(strings.Join(cells, "\t"))
 		b.WriteByte('\n')

--- a/apps/cli/views/util/table_test.go
+++ b/apps/cli/views/util/table_test.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 )
 
 func TestGetTableViewTSVStripsANSIAndUsesTabs(t *testing.T) {
-	commoncmd.FormatFlag = "tsv"
-	defer func() { commoncmd.FormatFlag = "" }()
+	internal.FormatFlag = "tsv"
+	defer func() { internal.FormatFlag = "" }()
 
 	rows := [][]string{
 		{"\x1b[1;32msb-abc\x1b[0m", "STARTED", "us"},
@@ -49,8 +49,8 @@ func TestStripANSI(t *testing.T) {
 // TestGetTableViewTSVEmptyData pins the acceptance criterion:
 // "Empty list in piped mode: zero bytes on stdout, exit code 0."
 func TestGetTableViewTSVEmptyData(t *testing.T) {
-	commoncmd.FormatFlag = "tsv"
-	defer func() { commoncmd.FormatFlag = "" }()
+	internal.FormatFlag = "tsv"
+	defer func() { internal.FormatFlag = "" }()
 
 	out := GetTableView(nil, []string{"Sandbox"}, nil, func() {})
 	if out != "" {
@@ -60,5 +60,77 @@ func TestGetTableViewTSVEmptyData(t *testing.T) {
 	out = GetTableView([][]string{}, []string{"Sandbox"}, nil, func() {})
 	if out != "" {
 		t.Errorf("zero-length data should yield empty string, got %q", out)
+	}
+}
+
+// TestGetTableViewTSVResistsRowInjection pins that a single input row
+// containing literal tab/newline/CR characters in any cell still yields
+// exactly one output line. Without sanitization an attacker who controls
+// a sandbox name field could inject fake rows that downstream `awk` /
+// `xargs` pipelines would act on.
+func TestGetTableViewTSVResistsRowInjection(t *testing.T) {
+	internal.FormatFlag = "tsv"
+	defer func() { internal.FormatFlag = "" }()
+
+	rows := [][]string{
+		{"sb-victim\tSTARTED\tus\tlarge\tINJECTED\nsb-attacker", "real-state", "eu"},
+		{"normal\rrow", "ok", "us"},
+	}
+	out := GetTableView(rows, []string{"a", "b", "c"}, nil, func() {})
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d output lines, want 2 (one per input row); output=%q", len(lines), out)
+	}
+	for i, line := range lines {
+		if strings.ContainsAny(line, "\n\r") {
+			t.Errorf("line %d contains stray CR/LF after sanitization: %q", i, line)
+		}
+		if got := strings.Count(line, "\t"); got != 2 {
+			t.Errorf("line %d has %d tabs, want 2 (3 columns): %q", i, got, line)
+		}
+	}
+}
+
+// TestStripANSICoversOSCAndDCS pins that StripANSI catches the full ANSI
+// family — not just CSI color codes. OSC-8 hyperlinks in user-controlled
+// strings are a phishing vector if they survive the strip.
+func TestStripANSICoversOSCAndDCS(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"OSC-8 hyperlink", "\x1b]8;;https://evil.example/\x07click\x1b]8;;\x07", "click"},
+		{"OSC-0 title set", "\x1b]0;malicious-title\x07after", "after"},
+		{"OSC-52 clipboard (ST-terminated)", "\x1b]52;c;abc\x1b\\after", "after"},
+		{"DCS sequence", "\x1bP1;2$rresponse\x1b\\after", "after"},
+		{"2-byte ESC (charset designation)", "\x1b(Bnormal", "normal"},
+		{"CSI cursor (legacy regression)", "\x1b[2K\x1b[Hcleared", "cleared"},
+		{"stray bare ESC", "before\x1bafter", "beforeafter"},
+		{"plain text unchanged", "hello world", "hello world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripANSI(tt.in); got != tt.want {
+				t.Errorf("StripANSI(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeTSVStripsControlChars verifies the row-/field-injection
+// defense composed on top of StripANSI.
+func TestSanitizeTSVStripsControlChars(t *testing.T) {
+	in := "a\tb\nc\rd\x1b[31me\x1b[0m\x1b]8;;u\x07f\x1b]8;;\x07"
+	got := SanitizeTSV(in)
+
+	if strings.ContainsAny(got, "\t\n\r\x1b") {
+		t.Errorf("SanitizeTSV result contains delimiter or escape bytes: %q", got)
+	}
+	for _, want := range []string{"a", "b", "c", "d", "e", "f"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("SanitizeTSV dropped legitimate content %q from %q (got %q)", want, in, got)
+		}
 	}
 }

--- a/apps/cli/views/util/table_test.go
+++ b/apps/cli/views/util/table_test.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package util
+
+import (
+	"strings"
+	"testing"
+
+	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
+)
+
+func TestGetTableViewTSVStripsANSIAndUsesTabs(t *testing.T) {
+	commoncmd.FormatFlag = "tsv"
+	defer func() { commoncmd.FormatFlag = "" }()
+
+	rows := [][]string{
+		{"\x1b[1;32msb-abc\x1b[0m", "STARTED", "us"},
+		{"sb-def", "STOPPED", "eu"},
+	}
+
+	out := GetTableView(rows, []string{"Sandbox", "State", "Region"}, nil, func() {})
+
+	if strings.ContainsRune(out, '\x1b') {
+		t.Errorf("TSV output contains ANSI escape bytes: %q", out)
+	}
+	if !strings.Contains(out, "sb-abc") {
+		t.Errorf("TSV output missing first row id: %q", out)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d rows, want 2; output=%q", len(lines), out)
+	}
+	for i, line := range lines {
+		if got := strings.Count(line, "\t"); got != 2 {
+			t.Errorf("row %d has %d tabs, want 2 (3 columns): %q", i, got, line)
+		}
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	in := "\x1b[1;32mhello\x1b[0m world"
+	want := "hello world"
+	if got := StripANSI(in); got != want {
+		t.Errorf("StripANSI(%q) = %q, want %q", in, got, want)
+	}
+}

--- a/apps/cli/views/util/table_test.go
+++ b/apps/cli/views/util/table_test.go
@@ -45,3 +45,20 @@ func TestStripANSI(t *testing.T) {
 		t.Errorf("StripANSI(%q) = %q, want %q", in, got, want)
 	}
 }
+
+// TestGetTableViewTSVEmptyData pins the acceptance criterion:
+// "Empty list in piped mode: zero bytes on stdout, exit code 0."
+func TestGetTableViewTSVEmptyData(t *testing.T) {
+	commoncmd.FormatFlag = "tsv"
+	defer func() { commoncmd.FormatFlag = "" }()
+
+	out := GetTableView(nil, []string{"Sandbox"}, nil, func() {})
+	if out != "" {
+		t.Errorf("empty data should yield empty string, got %q", out)
+	}
+
+	out = GetTableView([][]string{}, []string{"Sandbox"}, nil, func() {})
+	if out != "" {
+		t.Errorf("zero-length data should yield empty string, got %q", out)
+	}
+}

--- a/apps/cli/views/volume/info.go
+++ b/apps/cli/views/volume/info.go
@@ -5,6 +5,7 @@ package volume
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
@@ -17,7 +18,7 @@ import (
 
 func RenderInfo(volume *apiclient.VolumeDto, forceUnstyled bool) {
 	if commoncmd.FormatFlag == "tsv" {
-		renderTSVInfo(volume)
+		renderTSVInfo(os.Stdout, volume)
 		return
 	}
 
@@ -50,11 +51,11 @@ func renderUnstyledInfo(output string) {
 	fmt.Println(output)
 }
 
-func renderTSVInfo(v *apiclient.VolumeDto) {
-	fmt.Printf("volume\t%s\n", v.Name)
-	fmt.Printf("id\t%s\n", v.Id)
-	fmt.Printf("state\t%s\n", string(v.State))
-	fmt.Printf("created\t%s\n", v.CreatedAt)
+func renderTSVInfo(w io.Writer, v *apiclient.VolumeDto) {
+	fmt.Fprintf(w, "volume\t%s\n", v.Name)
+	fmt.Fprintf(w, "id\t%s\n", v.Id)
+	fmt.Fprintf(w, "state\t%s\n", string(v.State))
+	fmt.Fprintf(w, "created\t%s\n", v.CreatedAt)
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/volume/info.go
+++ b/apps/cli/views/volume/info.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
+	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -15,6 +16,11 @@ import (
 )
 
 func RenderInfo(volume *apiclient.VolumeDto, forceUnstyled bool) {
+	if commoncmd.FormatFlag == "tsv" {
+		renderTSVInfo(volume)
+		return
+	}
+
 	var output string
 	nameLabel := "Volume"
 
@@ -42,6 +48,13 @@ func RenderInfo(volume *apiclient.VolumeDto, forceUnstyled bool) {
 
 func renderUnstyledInfo(output string) {
 	fmt.Println(output)
+}
+
+func renderTSVInfo(v *apiclient.VolumeDto) {
+	fmt.Printf("volume\t%s\n", v.Name)
+	fmt.Printf("id\t%s\n", v.Id)
+	fmt.Printf("state\t%s\n", string(v.State))
+	fmt.Printf("created\t%s\n", v.CreatedAt)
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/volume/info.go
+++ b/apps/cli/views/volume/info.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
-	commoncmd "github.com/daytonaio/daytona/cli/cmd/common"
+	"github.com/daytonaio/daytona/cli/internal"
 	"github.com/daytonaio/daytona/cli/views/common"
 	"github.com/daytonaio/daytona/cli/views/util"
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
@@ -17,7 +17,7 @@ import (
 )
 
 func RenderInfo(volume *apiclient.VolumeDto, forceUnstyled bool) {
-	if commoncmd.FormatFlag == "tsv" {
+	if internal.FormatFlag == "tsv" {
 		renderTSVInfo(os.Stdout, volume)
 		return
 	}
@@ -52,10 +52,10 @@ func renderUnstyledInfo(output string) {
 }
 
 func renderTSVInfo(w io.Writer, v *apiclient.VolumeDto) {
-	fmt.Fprintf(w, "volume\t%s\n", v.Name)
-	fmt.Fprintf(w, "id\t%s\n", v.Id)
-	fmt.Fprintf(w, "state\t%s\n", string(v.State))
-	fmt.Fprintf(w, "created\t%s\n", v.CreatedAt)
+	fmt.Fprintf(w, "volume\t%s\n", util.SanitizeTSV(v.Name))
+	fmt.Fprintf(w, "id\t%s\n", util.SanitizeTSV(v.Id))
+	fmt.Fprintf(w, "state\t%s\n", util.SanitizeTSV(string(v.State)))
+	fmt.Fprintf(w, "created\t%s\n", util.SanitizeTSV(v.CreatedAt))
 }
 
 func renderTUIView(output string, width int) {

--- a/apps/cli/views/volume/info_test.go
+++ b/apps/cli/views/volume/info_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package volume
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestRenderTSVInfoEmitsCuratedKeys(t *testing.T) {
+	v := &apiclient.VolumeDto{
+		Id:        "vol-abc",
+		Name:      "shared-cache",
+		State:     apiclient.VOLUMESTATE_READY,
+		CreatedAt: "2026-05-01T10:00:00Z",
+	}
+
+	var buf bytes.Buffer
+	renderTSVInfo(&buf, v)
+	out := buf.String()
+
+	pairs := map[string]string{}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		k, val, _ := strings.Cut(line, "\t")
+		pairs[k] = val
+	}
+
+	want := map[string]string{
+		"volume":  "shared-cache",
+		"id":      "vol-abc",
+		"state":   "ready",
+		"created": "2026-05-01T10:00:00Z",
+	}
+	for k, v := range want {
+		if pairs[k] != v {
+			t.Errorf("key %q = %q, want %q (full output:\n%s)", k, pairs[k], v, out)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3494.

## Summary

Auto-detects when `stdout` is not a terminal and switches to machine-friendly TSV output instead of styled tables and spinners. Mirrors the Unix convention used by `gh`, `docker`, and `kubectl` (and the TypeScript reference [prisma/prisma-next#240](https://github.com/prisma/prisma-next/pull/240) cited in the issue).

```bash
# TTY: unchanged
$ daytona sandbox list
┌──────────────┬─────────┬────────┐ ...

# Piped: auto TSV, no ANSI, no borders
$ daytona sandbox list | grep us
sb-abc<TAB>STARTED<TAB>us<TAB>small<TAB>2m ago

# Explicit format still works
$ daytona sandbox list --format tsv
$ daytona sandbox list --format json | jq '.items[].id'

# NO_COLOR honored
$ NO_COLOR=1 daytona sandbox list   # styled table, no colors
```

## Mechanism

One `cobra.OnInitialize` callback in `apps/cli/cmd/common/format.go`:

```go
func applyDefaults(isStdoutTTY bool, noColor string) {
    if internal.FormatFlag == "" && !isStdoutTTY {
        internal.FormatFlag = "tsv"
    }
    if !isStdoutTTY || noColor != "" {
        lipgloss.SetColorProfile(termenv.Ascii)
    }
}
```

Plus a TSV branch in `views/util/table.go`'s `GetTableView`, and a `renderTSVInfo` function per resource (sandbox, snapshot, volume, organization) for the `info` / `get` paths. The 6 list/info commands tighten their early-return check from `FormatFlag != \"\"` to `internal.IsStructuredOutput()` so `tsv` falls through to the view layer (where curated column data lives) instead of the JSON/YAML formatter.

`OnInitialize` is used rather than `PersistentPreRunE` so detection runs for every subcommand, including those (like `organization`) that define their own `PersistentPreRunE` — Cobra does not chain those automatically.

## Security hardening

User-controlled fields (sandbox names, label keys/values, snapshot/volume/organization names) are sanitized at every TSV emission site to prevent two real attack classes:

- **Row injection** via embedded \`\\t\` / \`\\n\` / \`\\r\`. Without sanitization a single input row with a malicious label value would expand into multiple output rows, letting an attacker who controls a label trick downstream pipelines (e.g. \`daytona sandbox list | awk '{print \$1}' | xargs daytona sandbox delete\`) into acting on a fabricated row. Confirmed exploitable in a local PoC during review.
- **Terminal injection** via OSC-8 hyperlinks, OSC-52 clipboard sequences, DCS, charset designations, etc. A narrow CSI-only ANSI strip leaves these intact; a crafted sandbox name with an OSC-8 hyperlink would render as a clickable phishing link when the TSV output is later \`cat\`ed to a real terminal.

`SanitizeTSV()` (in \`views/util/table.go\`) composes a broadened \`StripANSI()\` covering OSC / DCS / CSI / charset / 2-byte ESC / bare ESC with a tab/newline/CR replacer. Applied at every \`fmt.Fprintf\` field in the four \`renderTSVInfo\` paths and per-cell in \`renderTSV\`.

## Layering

\`FormatFlag\` and \`IsStructuredOutput\` live in the existing leaf package \`apps/cli/internal\` so both \`cmd/*\` (which sets it via Cobra) and \`views/*\` (which branches on it during rendering) can read it without inverting the conventional \`cmd → views\` import direction.

## Testing

47 tests passing across 26 packages; \`go test -race ./...\` clean; \`go vet\` clean.

- TTY auto-detection precedence (4 tests)
- NO_COLOR honored in TTY (2 tests)
- \`RegisterFormatFlag\`'s PreRun gating (json/yaml block stdout; tsv does not — otherwise the new TSV output would be silently discarded)
- TSV happy path, empty data, and row-injection resistance
- Per-resource \`renderTSVInfo\` curated field emission (sandbox, snapshot, volume, organization)
- Adversarial inputs: control chars, OSC-8 hyperlinks, DCS sequences

## Commits

1. \`feat(cli): auto-emit TSV when stdout is piped\` — core feature.
2. \`test(cli): close coverage gaps in TSV output\` — gap-fill after self-review (NO_COLOR in TTY, per-resource info tests, empty data, BlockStdOut gating). Includes the \`io.Writer\` refactor of \`renderTSVInfo\` for testability.
3. \`fix(cli): harden TSV output and break view→cmd layering inversion\` — security hardening (control-char + broad ANSI sanitization) and the layering fix described above.

## Out of scope

- Pre-existing pattern: view layer uses \`fmt.Println\` to \`os.Stdout\` directly. Going forward this should be replaced with \`cmd.OutOrStdout()\` to make end-to-end command tests cleaner, but that touches the entire view layer and is independent of this feature. Happy to file a follow-up issue.
- The \`BlockStdOut\` / \`UnblockStdOut\` mechanism in \`cmd/common/format.go\` is also pre-existing; this PR tightens the gating (json/yaml only) but leaves the design intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default to TSV when stdout is piped so CLI output is easy to script, and strip ANSI in non-TTY or when `NO_COLOR` is set. Interactive TTY output is unchanged; explicit `--format json|yaml|tsv` still works.

- New Features
  - Auto `--format tsv` when stdout is not a TTY; no ANSI, borders, or header row.
  - Honor `NO_COLOR` in TTY by disabling colors.
  - `--format json|yaml` take precedence and remain byte-identical; TSV is rendered in views using curated columns.
  - Gating uses `internal.IsStructuredOutput()` so TSV does not block stdout; `FormatFlag` moved to `apps/cli/internal`.
  - Applied globally via `cobra.OnInitialize` so all subcommands inherit detection.

- Security
  - Sanitize all TSV fields with `SanitizeTSV()` to prevent row injection and terminal escape injection.
  - Broad `StripANSI()` removes OSC/DCS/CSI, bare ESC, and control bytes; tabs/newlines/CR are replaced with spaces.
  - Applied in `renderTSV` and per-resource `renderTSVInfo` for sandbox, snapshot, volume, and organization.

<sup>Written for commit cdb5e570e0960ffcc48d4c6930f5154a3159c650. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4834?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

