### PR TITLE
fix(dashboard): banner padding fix

### DIFF
--- a/apps/dashboard/src/components/LoadingFallback.tsx
+++ b/apps/dashboard/src/components/LoadingFallback.tsx
@@ -6,7 +6,6 @@
 import {
   Sidebar as SidebarComponent,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarHeader,
   SidebarInset,
@@ -92,10 +91,6 @@ const LoadingFallback = () => {
             </div>
           ))}
         </SidebarContent>
-
-        <SidebarFooter className="pb-4">
-          <Skeleton className="mx-2 h-3 w-20 group-data-[collapsible=icon]:hidden" />
-        </SidebarFooter>
       </SidebarComponent>
       <SidebarInset className="overflow-hidden">
         <div className="absolute inset-0 p-6 bg-background z-[3]">

--- a/apps/dashboard/src/components/Webhooks/WebhooksPageSkeleton.tsx
+++ b/apps/dashboard/src/components/Webhooks/WebhooksPageSkeleton.tsx
@@ -13,28 +13,30 @@ export function WebhooksPageSkeleton() {
     <PageLayout contained>
       <PageHeader />
 
-      <PageContent size="full" className="!p-0 overflow-hidden">
-        <PageIntro title="Webhooks" className="mb-8 px-4 pt-4" actions={<Skeleton className="h-9 w-36" />} />
-        <Tabs value="endpoints" className="flex min-h-0 flex-1 flex-col gap-0">
-          <div className="flex items-center justify-between shadow-[inset_0_-1px] shadow-border">
-            <TabsList variant="underline">
-              <TabsTrigger value="endpoints">Endpoints</TabsTrigger>
-              <TabsTrigger value="messages">Messages</TabsTrigger>
-            </TabsList>
-          </div>
-          <TabsContent
-            value="endpoints"
-            className="min-h-0 p-4 data-[state=active]:flex data-[state=active]:flex-1 flex-col"
-          >
-            <WebhooksEndpointTable
-              data={[]}
-              loading={true}
-              isLoadingEndpoint={() => false}
-              onDisable={() => undefined}
-              onDelete={() => undefined}
-            />
-          </TabsContent>
-        </Tabs>
+      <PageContent size="full" className="overflow-hidden">
+        <PageIntro title="Webhooks" className="mb-8" actions={<Skeleton className="h-9 w-36" />} />
+        <div className="min-h-0 flex-1 -mx-4 flex-col flex">
+          <Tabs value="endpoints" className="flex min-h-0 flex-1 flex-col gap-0">
+            <div className="flex items-center justify-between shadow-[inset_0_-1px] shadow-border">
+              <TabsList variant="underline">
+                <TabsTrigger value="endpoints">Endpoints</TabsTrigger>
+                <TabsTrigger value="messages">Messages</TabsTrigger>
+              </TabsList>
+            </div>
+            <TabsContent
+              value="endpoints"
+              className="min-h-0 p-4 data-[state=active]:flex data-[state=active]:flex-1 flex-col"
+            >
+              <WebhooksEndpointTable
+                data={[]}
+                loading={true}
+                isLoadingEndpoint={() => false}
+                onDisable={() => undefined}
+                onDelete={() => undefined}
+              />
+            </TabsContent>
+          </Tabs>
+        </div>
       </PageContent>
       <PageFooter />
     </PageLayout>

--- a/apps/dashboard/src/pages/Playground.tsx
+++ b/apps/dashboard/src/pages/Playground.tsx
@@ -91,9 +91,9 @@ const Playground: React.FC = () => {
     <PageLayout className="max-h-[100vh] overflow-auto">
       <PageHeader />
 
-      <PageContent size="full" className="!p-0 h-full flex flex-col flex-1 overflow-auto" ref={pageContentRef}>
-        <PageIntro title="Playground" className="mb-8 px-4 pt-4" />
-        <div className="min-h-0 flex-1">
+      <PageContent size="full" className="h-full flex flex-col flex-1 overflow-auto" ref={pageContentRef}>
+        <PageIntro title="Playground" className="mb-8" />
+        <div className="min-h-0 flex-1 -mx-4 flex flex-col">
           <PlaygroundProvider>
             <PlaygroundSandboxProvider activeTab={playgroundCategory}>
               <Tabs

--- a/apps/dashboard/src/pages/Webhooks.tsx
+++ b/apps/dashboard/src/pages/Webhooks.tsx
@@ -125,10 +125,10 @@ const Webhooks: React.FC = () => {
     <PageLayout contained>
       <PageHeader />
 
-      <PageContent size="full" className="!p-0 overflow-hidden">
+      <PageContent size="full" className="overflow-hidden">
         <PageIntro
           title="Webhooks"
-          className="mb-8 px-4 pt-4"
+          className="mb-8"
           actions={
             <UpsertEndpointSheet
               onSuccess={handleSuccess}
@@ -137,32 +137,34 @@ const Webhooks: React.FC = () => {
             />
           }
         />
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="flex min-h-0 flex-1 flex-col gap-0">
-          <div className="flex items-center justify-between shadow-[inset_0_-1px] shadow-border">
-            <TabsList variant="underline">
-              <TabsTrigger value="endpoints">Endpoints</TabsTrigger>
-              <TabsTrigger value="messages">Messages</TabsTrigger>
-            </TabsList>
-          </div>
-          <TabsContent
-            value="endpoints"
-            className="min-h-0 p-4 data-[state=active]:flex data-[state=active]:flex-1 flex-col"
-          >
-            <WebhooksEndpointTable
-              data={endpoints.data || []}
-              loading={endpoints.loading}
-              isLoadingEndpoint={isLoadingEndpoint}
-              onDisable={handleDisable}
-              onDelete={handleDelete}
-            />
-          </TabsContent>
-          <TabsContent
-            value="messages"
-            className="min-h-0 p-4 data-[state=active]:flex data-[state=active]:flex-1 flex-col"
-          >
-            <WebhooksMessagesTable />
-          </TabsContent>
-        </Tabs>
+        <div className="min-h-0 flex-1 -mx-4 flex flex-col">
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="flex min-h-0 flex-1 flex-col gap-0">
+            <div className="flex items-center justify-between shadow-[inset_0_-1px] shadow-border">
+              <TabsList variant="underline">
+                <TabsTrigger value="endpoints">Endpoints</TabsTrigger>
+                <TabsTrigger value="messages">Messages</TabsTrigger>
+              </TabsList>
+            </div>
+            <TabsContent
+              value="endpoints"
+              className="min-h-0 p-4 data-[state=active]:flex data-[state=active]:flex-1 flex-col"
+            >
+              <WebhooksEndpointTable
+                data={endpoints.data || []}
+                loading={endpoints.loading}
+                isLoadingEndpoint={isLoadingEndpoint}
+                onDisable={handleDisable}
+                onDelete={handleDelete}
+              />
+            </TabsContent>
+            <TabsContent
+              value="messages"
+              className="min-h-0 p-4 data-[state=active]:flex data-[state=active]:flex-1 flex-col"
+            >
+              <WebhooksMessagesTable />
+            </TabsContent>
+          </Tabs>
+        </div>
       </PageContent>
       <PageFooter />
     </PageLayout>

--- a/apps/dashboard/src/providers/SvixProvider.tsx
+++ b/apps/dashboard/src/providers/SvixProvider.tsx
@@ -66,9 +66,9 @@ export function SvixProvider({ children }: SvixProviderProps) {
         <PageHeader />
         <PageContent
           size={isWebhooksListPage ? 'full' : 'default'}
-          className={cn({ '!p-0 overflow-hidden': isWebhooksListPage })}
+          className={cn({ 'overflow-hidden': isWebhooksListPage })}
         >
-          <PageIntro title="Webhooks" className={cn({ 'mb-8 px-4 pt-4': isWebhooksListPage })} />
+          <PageIntro title="Webhooks" className={cn({ 'mb-8': isWebhooksListPage })} />
           <Card className={cn({ 'mx-4': isWebhooksListPage })}>
             <CardHeader>
               <CardTitle className="text-center">Oops, something went wrong</CardTitle>


### PR DESCRIPTION
## Description

Fixes banner missing gap.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing gap below the top banner and standardizes page spacing so content no longer overlaps or clips. Aligns `PageIntro` and tabs layout for consistent, full-width tables without breaking banner spacing.

- Bug Fixes
  - Webhooks (page and skeleton): removed `!p-0` and extra `px-4 pt-4`; added wrapper with `-mx-4`; kept `PageIntro` as `mb-8`; set `overflow-hidden` on `PageContent`.
  - Playground: same spacing fix with `-mx-4` wrapper and `mb-8` intro.
  - `SvixProvider`: aligned error layout spacing by dropping `!p-0` and `px-4 pt-4`; kept `mb-8` intro.
  - Loading fallback: removed `SidebarFooter` skeleton to avoid extra bottom padding.

<sup>Written for commit 0dda0aa6b243638970827bbdb5623917ca627f67. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4835?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

