### PR TITLE
feat(api): api level recovery

### DIFF
--- a/apps/api/src/sandbox/constants/errors-for-recovery.ts
+++ b/apps/api/src/sandbox/constants/errors-for-recovery.ts
@@ -8,7 +8,12 @@ export const RECOVERY_ERROR_SUBSTRINGS: string[] = ['Can not connect to the Dock
 
 // Substrings that indicate the API should recover by archiving and restoring from backup
 // rather than delegating to the runner for an in-place fix.
-const API_RECOVERABLE_SUBSTRINGS: string[] = ['timeout', 'job timed out']
+const API_RECOVERABLE_SUBSTRINGS: string[] = [
+  'timeout while creating',
+  'timeout while starting',
+  'timeout while pulling',
+  'job timed out',
+]
 
 export function isApiRecoverableError(errorReason: string | null | undefined): boolean {
   if (!errorReason) {

--- a/apps/api/src/sandbox/constants/errors-for-recovery.ts
+++ b/apps/api/src/sandbox/constants/errors-for-recovery.ts
@@ -1,7 +1,19 @@
 /*
- * Copyright 2025 Daytona Platforms Inc.
+ * Copyright Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
 
 // Substrings in an error message that should trigger an automatic restore
 export const RECOVERY_ERROR_SUBSTRINGS: string[] = ['Can not connect to the Docker daemon']
+
+// Substrings that indicate the API should recover by archiving and restoring from backup
+// rather than delegating to the runner for an in-place fix.
+const API_RECOVERABLE_SUBSTRINGS: string[] = ['timeout', 'job timed out']
+
+export function isApiRecoverableError(errorReason: string | null | undefined): boolean {
+  if (!errorReason) {
+    return false
+  }
+  const lower = errorReason.toLowerCase()
+  return API_RECOVERABLE_SUBSTRINGS.some((s) => lower.includes(s))
+}

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -417,6 +417,10 @@ export class Sandbox {
       changes.backupState = BackupState.NONE
     }
 
+    if (this.state === SandboxState.ERROR && this.backupState === BackupState.COMPLETED && this.backupSnapshot) {
+      changes.recoverable = true
+    }
+
     return changes
   }
 }

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -24,6 +24,7 @@ import { SandboxVolume } from '../dto/sandbox.dto'
 import { BuildInfo } from './build-info.entity'
 import { nanoid } from 'nanoid'
 import { SandboxLastActivity } from './sandbox-last-activity.entity'
+import { isApiRecoverableError } from '../constants/errors-for-recovery'
 
 @Entity()
 @Unique(['organizationId', 'name'])
@@ -417,7 +418,12 @@ export class Sandbox {
       changes.backupState = BackupState.NONE
     }
 
-    if (this.state === SandboxState.ERROR && this.backupState === BackupState.COMPLETED && this.backupSnapshot) {
+    if (
+      this.state === SandboxState.ERROR &&
+      this.backupState === BackupState.COMPLETED &&
+      this.backupSnapshot &&
+      isApiRecoverableError(this.errorReason)
+    ) {
       changes.recoverable = true
     }
 

--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -422,6 +422,7 @@ export class Sandbox {
       this.state === SandboxState.ERROR &&
       this.backupState === BackupState.COMPLETED &&
       this.backupSnapshot &&
+      this.backupRegistryId &&
       isApiRecoverableError(this.errorReason)
     ) {
       changes.recoverable = true

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1987,13 +1987,9 @@ export class SandboxService {
       if (
         isApiRecoverableError(sandbox.errorReason) &&
         sandbox.backupState === BackupState.COMPLETED &&
-        sandbox.backupSnapshot
+        sandbox.backupSnapshot &&
+        sandbox.backupRegistryId
       ) {
-        const cooldownKey = `sandbox:recover-from-backup:${sandbox.id}`
-        const alreadyAttempted = await this.redis.set(cooldownKey, '1', 'EX', 3600, 'NX')
-        if (!alreadyAttempted) {
-          throw new ConflictException('Sandbox recovery has been attempted recently. Please try again later')
-        }
         return await this.recoverFromBackup(sandbox, organization, region)
       }
 
@@ -2005,6 +2001,12 @@ export class SandboxService {
   }
 
   private async recoverFromBackup(sandbox: Sandbox, organization: Organization, region: Region): Promise<Sandbox> {
+    const cooldownKey = `sandbox:recover-from-backup:${sandbox.id}`
+    const existing = await this.redis.get(cooldownKey)
+    if (existing) {
+      throw new ConflictException('Sandbox recovery has been attempted recently. Please try again later')
+    }
+
     // The sandbox will be fully recreated from backup on a new runner, so reserve all resources.
     const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
       await this.validateOrganizationQuotas(
@@ -2035,6 +2037,8 @@ export class SandboxService {
         updateData,
         whereCondition: { recoverable: true, pending: false, state: SandboxState.ERROR },
       })
+
+      await this.redis.set(cooldownKey, '1', 'EX', 3600)
 
       this.eventEmitter.emit(SandboxEvents.STARTED, new SandboxStartedEvent(updatedSandbox))
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -41,6 +41,7 @@ import { WarmPoolTopUpRequested } from '../events/warmpool-topup-requested.event
 import { Runner } from '../entities/runner.entity'
 import { Organization } from '../../organization/entities/organization.entity'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
+import { isApiRecoverableError } from '../constants/errors-for-recovery'
 import { SandboxStateUpdatedEvent } from '../events/sandbox-state-updated.event'
 import { BuildInfo } from '../entities/build-info.entity'
 import { generateBuildInfoHash as generateBuildSnapshotRef } from '../entities/build-info.entity'
@@ -1955,11 +1956,6 @@ export class SandboxService {
   }
 
   async recover(sandboxIdOrName: string, organization: Organization, skipStart = false): Promise<Sandbox> {
-    let pendingCpuIncrement: number | undefined
-    let pendingMemoryIncrement: number | undefined
-    let pendingDiskIncrement: number | undefined
-    let pendingGpuIncrement: number | undefined
-
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
     if (!sandbox.recoverable) {
@@ -1984,46 +1980,112 @@ export class SandboxService {
         throw new BadRequestError('Sandbox must be in error state to recover')
       }
 
-      if (!sandbox.runnerId) {
-        throw new NotFoundException(`Sandbox with ID ${sandbox.id} does not have a runner`)
-      }
-      const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
-      const willStartOnV2 = runner.apiVersion === '2' && !skipStart
+      this.organizationService.assertOrganizationIsNotSuspended(organization)
 
-      // The chained start on v2 is queued by the job-completion handler via SandboxStartedEvent
-      // and bypasses SandboxService.start(); replicate the suspended-org check here.
-      if (willStartOnV2) {
-        this.organizationService.assertOrganizationIsNotSuspended(organization)
-      }
-
-      // ERROR → STOPPED activates disk usage; v2 + !skipStart additionally activates cpu/mem/gpu
-      // because there is no trailing start() call to validate them.
-      const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
-        await this.validateOrganizationQuotas(
-          organization,
-          region,
-          willStartOnV2 ? sandbox.cpu : 0,
-          willStartOnV2 ? sandbox.mem : 0,
-          sandbox.disk,
-          willStartOnV2 ? sandbox.gpu : 0,
-          isEphemeral(sandbox),
-          sandbox.id,
-        )
-      if (pendingCpuIncremented) {
-        pendingCpuIncrement = sandbox.cpu
-      }
-      if (pendingMemoryIncremented) {
-        pendingMemoryIncrement = sandbox.mem
-      }
-      if (pendingDiskIncremented) {
-        pendingDiskIncrement = sandbox.disk
-      }
-      if (pendingGpuIncremented) {
-        pendingGpuIncrement = sandbox.gpu
+      // API-level recoverable errors (e.g. timeouts) bypass the runner and restore
+      // from backup on a new runner, provided a completed backup exists.
+      if (
+        isApiRecoverableError(sandbox.errorReason) &&
+        sandbox.backupState === BackupState.COMPLETED &&
+        sandbox.backupSnapshot
+      ) {
+        const cooldownKey = `sandbox:recover-from-backup:${sandbox.id}`
+        const alreadyAttempted = await this.redis.set(cooldownKey, '1', 'EX', 3600, 'NX')
+        if (!alreadyAttempted) {
+          throw new ConflictException('Sandbox recovery has been attempted recently. Please try again later')
+        }
+        return await this.recoverFromBackup(sandbox, organization, region)
       }
 
-      // Normalize desiredState upfront so the job handler can detect mid-job intent changes
-      // (e.g. /destroy). For v2 + !skipStart, also refresh authToken since we're bypassing start().
+      // Everything else goes to the runner for in-place recovery (e.g. disk expansion).
+      return await this.recoverInPlace(sandbox, organization, region, skipStart)
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
+  }
+
+  private async recoverFromBackup(sandbox: Sandbox, organization: Organization, region: Region): Promise<Sandbox> {
+    // The sandbox will be fully recreated from backup on a new runner, so reserve all resources.
+    const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
+      await this.validateOrganizationQuotas(
+        organization,
+        region,
+        sandbox.cpu,
+        sandbox.mem,
+        sandbox.disk,
+        sandbox.gpu,
+        isEphemeral(sandbox),
+        sandbox.id,
+      )
+
+    try {
+      // Transition the sandbox to ARCHIVED with desired state STARTED so the sync loop
+      // picks it up, assigns a new runner, and restores from the completed backup.
+      // enforceInvariants will set pending=true and runnerId=null for ARCHIVED state.
+      const updateData: Partial<Sandbox> = {
+        state: SandboxState.ARCHIVED,
+        desiredState: SandboxDesiredState.STARTED,
+        errorReason: null,
+        recoverable: false,
+        authToken: nanoid(32).toLocaleLowerCase(),
+        ...(sandbox.runnerId && { prevRunnerId: sandbox.runnerId }),
+      }
+
+      const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
+        updateData,
+        whereCondition: { recoverable: true, pending: false, state: SandboxState.ERROR },
+      })
+
+      this.eventEmitter.emit(SandboxEvents.STARTED, new SandboxStartedEvent(updatedSandbox))
+
+      return updatedSandbox
+    } catch (error) {
+      await this.rollbackPendingUsage(
+        organization.id,
+        sandbox.region,
+        pendingCpuIncremented ? sandbox.cpu : undefined,
+        pendingMemoryIncremented ? sandbox.mem : undefined,
+        pendingDiskIncremented ? sandbox.disk : undefined,
+        pendingGpuIncremented ? sandbox.gpu : undefined,
+      )
+      throw error
+    }
+  }
+
+  private async recoverInPlace(
+    sandbox: Sandbox,
+    organization: Organization,
+    region: Region,
+    skipStart: boolean,
+  ): Promise<Sandbox> {
+    if (!sandbox.runnerId) {
+      throw new NotFoundException(`Sandbox with ID ${sandbox.id} does not have a runner`)
+    }
+    const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
+    const willStartOnV2 = runner.apiVersion === '2' && !skipStart
+
+    // The chained start on v2 is queued by the job-completion handler via SandboxStartedEvent
+    // and bypasses SandboxService.start(); replicate the suspended-org check here.
+    if (willStartOnV2) {
+      this.organizationService.assertOrganizationIsNotSuspended(organization)
+    }
+
+    // ERROR → STOPPED activates disk usage; v2 + !skipStart additionally activates cpu/mem/gpu
+    // because there is no trailing start() call to validate them.
+    const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =
+      await this.validateOrganizationQuotas(
+        organization,
+        region,
+        willStartOnV2 ? sandbox.cpu : 0,
+        willStartOnV2 ? sandbox.mem : 0,
+        sandbox.disk,
+        willStartOnV2 ? sandbox.gpu : 0,
+        isEphemeral(sandbox),
+        sandbox.id,
+      )
+
+    try {
+      // Normalize desiredState upfront so the job handler can detect mid-job intent changes.
       if (runner.apiVersion === '2') {
         await this.sandboxRepository.updateWhere(sandbox.id, {
           updateData: {
@@ -2092,14 +2154,12 @@ export class SandboxService {
       await this.rollbackPendingUsage(
         organization.id,
         sandbox.region,
-        pendingCpuIncrement,
-        pendingMemoryIncrement,
-        pendingDiskIncrement,
-        pendingGpuIncrement,
+        pendingCpuIncremented ? sandbox.cpu : undefined,
+        pendingMemoryIncremented ? sandbox.mem : undefined,
+        pendingDiskIncremented ? sandbox.disk : undefined,
+        pendingGpuIncremented ? sandbox.gpu : undefined,
       )
       throw error
-    } finally {
-      await this.redisLockProvider.unlock(lockKey)
     }
   }
 

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -2068,12 +2068,6 @@ export class SandboxService {
     const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
     const willStartOnV2 = runner.apiVersion === '2' && !skipStart
 
-    // The chained start on v2 is queued by the job-completion handler via SandboxStartedEvent
-    // and bypasses SandboxService.start(); replicate the suspended-org check here.
-    if (willStartOnV2) {
-      this.organizationService.assertOrganizationIsNotSuspended(organization)
-    }
-
     // ERROR → STOPPED activates disk usage; v2 + !skipStart additionally activates cpu/mem/gpu
     // because there is no trailing start() call to validate them.
     const { pendingCpuIncremented, pendingMemoryIncremented, pendingDiskIncremented, pendingGpuIncremented } =


### PR DESCRIPTION
## Description

Lets the users autorecover some sandbox error states - sets the recoverable property to true based on a regex of the error message with redis-based call limiting

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds API-level recovery for timeout-related sandbox failures by restoring from backup on a new runner, with a 1-hour Redis cooldown. Other errors still recover in place via the runner.

- New Features
  - Detect API-recoverable errors via `isApiRecoverableError` (matches "timeout while creating/starting/pulling", "job timed out").
  - Auto-mark sandboxes as recoverable when in ERROR with a completed `backupSnapshot`, a `backupRegistryId`, and a matching error.
  - API recovery path: set ARCHIVED + desired STARTED, clear error, set `recoverable=false`, rotate auth token, keep `prevRunnerId`, emit start; requires `backupSnapshot` and `backupRegistryId`; validates quotas with rollback on failure.
  - 1-hour per-sandbox Redis cooldown for backup recovery (conflict if active); non-API errors recover in place with quotas and the v2 start flow.

<sup>Written for commit 2f2db037b391a58f652651f363f3b096147e9377. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4836?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

