### PR TITLE
fix(runner): service health reporting

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -489,6 +489,8 @@ export class RunnerService {
         runnerDiskGiB: updateData.diskGiB || runner.diskGiB,
         startedSandboxes: updateData.currentStartedSandboxes || 0,
       })
+    } else {
+      this.logger.warn(`Runner ${runnerId} reported null metrics`)
     }
 
     await this.updateRunner(runnerId, updateData)

--- a/apps/runner/pkg/api/controllers/info.go
+++ b/apps/runner/pkg/api/controllers/info.go
@@ -29,17 +29,24 @@ func RunnerInfo(ctx *gin.Context) {
 		return
 	}
 
-	metrics, err := runnerInstance.MetricsCollector.Collect(ctx.Request.Context())
-	if err != nil {
-		ctx.Error(err)
-		return
-	}
-
+	// Inspect services first so that failures in dependent subsystems
+	// (e.g. metrics collection, which talks to Docker) do not prevent us
+	// from reporting unhealthy services back to the API.
 	servicesInfo := runnerInstance.InspectRunnerServices(ctx.Request.Context())
 
 	response := dto.RunnerInfoResponseDTO{
 		ServiceHealth: mapRunnerServiceInfoToDTO(servicesInfo),
-		Metrics: &dto.RunnerMetrics{
+		AppVersion:    internal.Version,
+	}
+
+	metrics, err := runnerInstance.MetricsCollector.Collect(ctx.Request.Context())
+	if err != nil {
+		// Metric collection depends on Docker; if Docker is down we still
+		// want to surface the serviceHealth payload above. Log and continue
+		// with a metrics-less response rather than failing the whole call.
+		runnerInstance.Logger.WarnContext(ctx.Request.Context(), "Failed to collect runner metrics; returning info without metrics", "error", err)
+	} else {
+		response.Metrics = &dto.RunnerMetrics{
 			CurrentCpuLoadAverage:        float64(metrics.CPULoadAverage),
 			CurrentCpuUsagePercentage:    float64(metrics.CPUUsagePercentage),
 			CurrentMemoryUsagePercentage: float64(metrics.MemoryUsagePercentage),
@@ -49,8 +56,7 @@ func RunnerInfo(ctx *gin.Context) {
 			CurrentAllocatedDiskGiB:      float64(metrics.AllocatedDiskGiB),
 			CurrentSnapshotCount:         int(metrics.SnapshotCount),
 			CurrentStartedSandboxes:      int64(metrics.StartedSandboxCount),
-		},
-		AppVersion: internal.Version,
+		}
 	}
 
 	ctx.JSON(http.StatusOK, response)


### PR DESCRIPTION
## Description

Fix for proper Docker health reporting from the runner, instead of the service health being null

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the runner always reports service health by inspecting services before metrics. The info API now returns `serviceHealth` and `appVersion` even when metrics collection fails (e.g., `Docker` down), and logs warnings when metrics are missing.

- **Bug Fixes**
  - Inspect services before collecting metrics to decouple health reporting from failures.
  - Log warnings on metrics errors or null metrics and omit `metrics` instead of failing, preventing `serviceHealth: null`.

<sup>Written for commit fc009456ef2b8b397ada2bf0f7e6a7701266178b. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4837?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

