### PR TITLE
fix(computer-use): reject unsupported screenshot formats

### DIFF
--- a/apps/docs/src/content/docs/en/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/computer-use.mdx
@@ -1235,7 +1235,7 @@ from daytona import ScreenshotRegion, ScreenshotOptions
 region = ScreenshotRegion(x=0, y=0, width=800, height=600)
 screenshot = sandbox.computer_use.screenshot.take_compressed_region(
     region,
-    ScreenshotOptions(format="webp", quality=80, show_cursor=True)
+    ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
 )
 print(f"Compressed size: {screenshot.size_bytes} bytes")
 ```
@@ -1246,7 +1246,7 @@ print(f"Compressed size: {screenshot.size_bytes} bytes")
 ```typescript
 const region = { x: 0, y: 0, width: 800, height: 600 };
 const screenshot = await sandbox.computerUse.screenshot.takeCompressedRegion(region, {
-  format: 'webp',
+  format: 'jpeg',
   quality: 80,
   showCursor: true
 });
@@ -1260,7 +1260,7 @@ console.log(`Compressed size: ${screenshot.size_bytes} bytes`);
 region = Daytona::ComputerUse::ScreenshotRegion.new(x: 0, y: 0, width: 800, height: 600)
 screenshot = sandbox.computer_use.screenshot.take_compressed_region(
   region: region,
-  options: Daytona::ComputerUse::ScreenshotOptions.new(format: "webp", quality: 80, show_cursor: true)
+  options: Daytona::ComputerUse::ScreenshotOptions.new(format: "jpeg", quality: 80, show_cursor: true)
 )
 puts "Compressed size: #{screenshot.size_bytes} bytes"
 ```

--- a/apps/docs/src/content/docs/en/go-sdk/types.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/types.mdx
@@ -456,8 +456,8 @@ type SandboxBaseParams struct {
 ```go
 type ScreenshotOptions struct {
     ShowCursor *bool    // nil = default, true = show, false = hide
-    Format     *string  // nil = default format (PNG), or "jpeg", "webp", etc.
-    Quality    *int     // nil = default quality, 0-100 for JPEG/WebP
+    Format     *string  // nil = default format (PNG), or "jpeg"
+    Quality    *int     // nil = default quality, 0-100 for JPEG
     Scale      *float64 // nil = 1.0, scaling factor for the screenshot
 }
 ```
@@ -573,4 +573,3 @@ type VolumeMount struct {
     Subpath   *string // Optional subpath within the volume; nil = mount entire volume
 }
 ```
-

--- a/apps/docs/src/content/docs/en/java-sdk/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/computer-use.mdx
@@ -198,7 +198,7 @@ Captures a compressed full-screen screenshot.
 
 **Parameters**:
 
-- `format` _String_ - output image format (for example: `png`, `jpeg`, `webp`)
+- `format` _String_ - output image format (for example: `png`, `jpeg`)
 - `quality` _int_ - compression quality (typically 1-100, format dependent)
 - `scale` _double_ - screenshot scale factor (for example: `0.5` for 50%)
 

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-computer-use.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-computer-use.mdx
@@ -603,12 +603,12 @@ screenshot = await sandbox.computer_use.screenshot.take_compressed()
 
 # High quality JPEG
 jpeg = await sandbox.computer_use.screenshot.take_compressed(
-    ScreenshotOptions(format="jpeg", quality=95, show_cursor=True)
+    ScreenshotOptions(fmt="jpeg", quality=95, show_cursor=True)
 )
 
 # Scaled down PNG
 scaled = await sandbox.computer_use.screenshot.take_compressed(
-    ScreenshotOptions(format="png", scale=0.5)
+    ScreenshotOptions(fmt="png", scale=0.5)
 )
 ```
 
@@ -642,7 +642,7 @@ Takes a compressed screenshot of a specific region.
 region = ScreenshotRegion(x=0, y=0, width=800, height=600)
 screenshot = await sandbox.computer_use.screenshot.take_compressed_region(
     region,
-    ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
+    ScreenshotOptions(fmt="jpeg", quality=80, show_cursor=True)
 )
 print(f"Compressed size: {screenshot.size_bytes} bytes")
 ```

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-computer-use.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-computer-use.mdx
@@ -642,7 +642,7 @@ Takes a compressed screenshot of a specific region.
 region = ScreenshotRegion(x=0, y=0, width=800, height=600)
 screenshot = await sandbox.computer_use.screenshot.take_compressed_region(
     region,
-    ScreenshotOptions(format="webp", quality=80, show_cursor=True)
+    ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
 )
 print(f"Compressed size: {screenshot.size_bytes} bytes")
 ```
@@ -1062,7 +1062,6 @@ Options for screenshot compression and display.
 **Attributes**:
 
 - `show_cursor` _bool | None_ - Whether to show the cursor in the screenshot.
-- `fmt` _str | None_ - Image format (e.g., 'png', 'jpeg', 'webp').
+- `fmt` _str | None_ - Image format (e.g., 'png', 'jpeg').
 - `quality` _int | None_ - Compression quality (0-100).
 - `scale` _float | None_ - Scale factor for the screenshot.
-

--- a/apps/docs/src/content/docs/en/python-sdk/sync/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/computer-use.mdx
@@ -642,7 +642,7 @@ Takes a compressed screenshot of a specific region.
 region = ScreenshotRegion(x=0, y=0, width=800, height=600)
 screenshot = sandbox.computer_use.screenshot.take_compressed_region(
     region,
-    ScreenshotOptions(format="webp", quality=80, show_cursor=True)
+    ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
 )
 print(f"Compressed size: {screenshot.size_bytes} bytes")
 ```
@@ -1062,7 +1062,6 @@ Options for screenshot compression and display.
 **Attributes**:
 
 - `show_cursor` _bool | None_ - Whether to show the cursor in the screenshot.
-- `fmt` _str | None_ - Image format (e.g., 'png', 'jpeg', 'webp').
+- `fmt` _str | None_ - Image format (e.g., 'png', 'jpeg').
 - `quality` _int | None_ - Compression quality (0-100).
 - `scale` _float | None_ - Scale factor for the screenshot.
-

--- a/apps/docs/src/content/docs/en/python-sdk/sync/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/computer-use.mdx
@@ -603,12 +603,12 @@ screenshot = sandbox.computer_use.screenshot.take_compressed()
 
 # High quality JPEG
 jpeg = sandbox.computer_use.screenshot.take_compressed(
-    ScreenshotOptions(format="jpeg", quality=95, show_cursor=True)
+    ScreenshotOptions(fmt="jpeg", quality=95, show_cursor=True)
 )
 
 # Scaled down PNG
 scaled = sandbox.computer_use.screenshot.take_compressed(
-    ScreenshotOptions(format="png", scale=0.5)
+    ScreenshotOptions(fmt="png", scale=0.5)
 )
 ```
 
@@ -642,7 +642,7 @@ Takes a compressed screenshot of a specific region.
 region = ScreenshotRegion(x=0, y=0, width=800, height=600)
 screenshot = sandbox.computer_use.screenshot.take_compressed_region(
     region,
-    ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
+    ScreenshotOptions(fmt="jpeg", quality=80, show_cursor=True)
 )
 print(f"Compressed size: {screenshot.size_bytes} bytes")
 ```

--- a/apps/docs/src/content/docs/en/typescript-sdk/computer-use.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/computer-use.mdx
@@ -1073,7 +1073,7 @@ Takes a compressed screenshot of a specific region
 ```typescript
 const region = { x: 0, y: 0, width: 800, height: 600 };
 const screenshot = await sandbox.computerUse.screenshot.takeCompressedRegion(region, {
-  format: 'webp',
+  format: 'jpeg',
   quality: 80,
   showCursor: true
 });

--- a/libs/computer-use/pkg/computeruse/display.go
+++ b/libs/computer-use/pkg/computeruse/display.go
@@ -29,6 +29,16 @@ func encodeImageWithCompression(img *image.RGBA, params ImageCompressionParams) 
 	var buf bytes.Buffer
 
 	switch params.Format {
+	case "", "png":
+		// Scale the image if needed
+		var scaledImg image.Image = img
+		if params.Scale != 1.0 {
+			scaledImg = scaleImage(img, params.Scale)
+		}
+		err := png.Encode(&buf, scaledImg)
+		if err != nil {
+			return nil, err
+		}
 	case "jpeg":
 		// Scale the image if needed
 		var scaledImg image.Image = img
@@ -39,22 +49,8 @@ func encodeImageWithCompression(img *image.RGBA, params ImageCompressionParams) 
 		if err != nil {
 			return nil, err
 		}
-	case "png":
-		// Scale the image if needed
-		var scaledImg image.Image = img
-		if params.Scale != 1.0 {
-			scaledImg = scaleImage(img, params.Scale)
-		}
-		err := png.Encode(&buf, scaledImg)
-		if err != nil {
-			return nil, err
-		}
 	default:
-		// Default to PNG
-		err := png.Encode(&buf, img)
-		if err != nil {
-			return nil, err
-		}
+		return nil, fmt.Errorf("unsupported image format %q: supported formats are png and jpeg", params.Format)
 	}
 
 	return buf.Bytes(), nil

--- a/libs/computer-use/pkg/computeruse/display_test.go
+++ b/libs/computer-use/pkg/computeruse/display_test.go
@@ -4,6 +4,7 @@
 package computeruse
 
 import (
+	"bytes"
 	"image"
 	"testing"
 
@@ -17,4 +18,31 @@ func TestScaleImageKeepsTinyPositiveImagesNonZero(t *testing.T) {
 
 	assert.Equal(t, 1, scaled.Bounds().Dx())
 	assert.Equal(t, 1, scaled.Bounds().Dy())
+}
+
+func TestEncodeImageWithCompressionSupportsPngAndJpeg(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+
+	defaultData, err := encodeImageWithCompression(img, ImageCompressionParams{})
+	assert.NoError(t, err)
+	assert.True(t, bytes.HasPrefix(defaultData, []byte{0x89, 'P', 'N', 'G'}))
+
+	pngData, err := encodeImageWithCompression(img, ImageCompressionParams{Format: "png"})
+	assert.NoError(t, err)
+	assert.True(t, bytes.HasPrefix(pngData, []byte{0x89, 'P', 'N', 'G'}))
+
+	jpegData, err := encodeImageWithCompression(img, ImageCompressionParams{Format: "jpeg", Quality: 90})
+	assert.NoError(t, err)
+	assert.True(t, bytes.HasPrefix(jpegData, []byte{0xff, 0xd8}))
+}
+
+func TestEncodeImageWithCompressionRejectsUnsupportedFormat(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+
+	unsupportedFormats := []string{"webp", "gif"}
+	for _, format := range unsupportedFormats {
+		_, err := encodeImageWithCompression(img, ImageCompressionParams{Format: format})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "unsupported image format")
+	}
 }

--- a/libs/sdk-go/pkg/types/types.go
+++ b/libs/sdk-go/pkg/types/types.go
@@ -257,8 +257,8 @@ type ScreenshotRegion struct {
 
 type ScreenshotOptions struct {
 	ShowCursor *bool    // nil = default, true = show, false = hide
-	Format     *string  // nil = default format (PNG), or "jpeg", "webp", etc.
-	Quality    *int     // nil = default quality, 0-100 for JPEG/WebP
+	Format     *string  // nil = default format (PNG), or "jpeg"
+	Quality    *int     // nil = default quality, 0-100 for JPEG
 	Scale      *float64 // nil = 1.0, scaling factor for the screenshot
 }
 

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/ComputerUse.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/ComputerUse.java
@@ -225,7 +225,7 @@ public class ComputerUse {
     /**
      * Captures a compressed full-screen screenshot.
      *
-     * @param format output image format (for example: {@code png}, {@code jpeg}, {@code webp})
+     * @param format output image format (for example: {@code png}, {@code jpeg})
      * @param quality compression quality (typically 1-100, format dependent)
      * @param scale screenshot scale factor (for example: {@code 0.5} for 50%)
      * @return compressed screenshot payload

--- a/libs/sdk-python/src/daytona/_async/computer_use.py
+++ b/libs/sdk-python/src/daytona/_async/computer_use.py
@@ -368,12 +368,12 @@ class AsyncScreenshot:
 
             # High quality JPEG
             jpeg = await sandbox.computer_use.screenshot.take_compressed(
-                ScreenshotOptions(format="jpeg", quality=95, show_cursor=True)
+                ScreenshotOptions(fmt="jpeg", quality=95, show_cursor=True)
             )
 
             # Scaled down PNG
             scaled = await sandbox.computer_use.screenshot.take_compressed(
-                ScreenshotOptions(format="png", scale=0.5)
+                ScreenshotOptions(fmt="png", scale=0.5)
             )
             ```
         """
@@ -407,7 +407,7 @@ class AsyncScreenshot:
             region = ScreenshotRegion(x=0, y=0, width=800, height=600)
             screenshot = await sandbox.computer_use.screenshot.take_compressed_region(
                 region,
-                ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
+                ScreenshotOptions(fmt="jpeg", quality=80, show_cursor=True)
             )
             print(f"Compressed size: {screenshot.size_bytes} bytes")
             ```

--- a/libs/sdk-python/src/daytona/_async/computer_use.py
+++ b/libs/sdk-python/src/daytona/_async/computer_use.py
@@ -407,7 +407,7 @@ class AsyncScreenshot:
             region = ScreenshotRegion(x=0, y=0, width=800, height=600)
             screenshot = await sandbox.computer_use.screenshot.take_compressed_region(
                 region,
-                ScreenshotOptions(format="webp", quality=80, show_cursor=True)
+                ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
             )
             print(f"Compressed size: {screenshot.size_bytes} bytes")
             ```

--- a/libs/sdk-python/src/daytona/_sync/computer_use.py
+++ b/libs/sdk-python/src/daytona/_sync/computer_use.py
@@ -367,12 +367,12 @@ class Screenshot:
 
             # High quality JPEG
             jpeg = sandbox.computer_use.screenshot.take_compressed(
-                ScreenshotOptions(format="jpeg", quality=95, show_cursor=True)
+                ScreenshotOptions(fmt="jpeg", quality=95, show_cursor=True)
             )
 
             # Scaled down PNG
             scaled = sandbox.computer_use.screenshot.take_compressed(
-                ScreenshotOptions(format="png", scale=0.5)
+                ScreenshotOptions(fmt="png", scale=0.5)
             )
             ```
         """
@@ -406,7 +406,7 @@ class Screenshot:
             region = ScreenshotRegion(x=0, y=0, width=800, height=600)
             screenshot = sandbox.computer_use.screenshot.take_compressed_region(
                 region,
-                ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
+                ScreenshotOptions(fmt="jpeg", quality=80, show_cursor=True)
             )
             print(f"Compressed size: {screenshot.size_bytes} bytes")
             ```

--- a/libs/sdk-python/src/daytona/_sync/computer_use.py
+++ b/libs/sdk-python/src/daytona/_sync/computer_use.py
@@ -406,7 +406,7 @@ class Screenshot:
             region = ScreenshotRegion(x=0, y=0, width=800, height=600)
             screenshot = sandbox.computer_use.screenshot.take_compressed_region(
                 region,
-                ScreenshotOptions(format="webp", quality=80, show_cursor=True)
+                ScreenshotOptions(format="jpeg", quality=80, show_cursor=True)
             )
             print(f"Compressed size: {screenshot.size_bytes} bytes")
             ```

--- a/libs/sdk-python/src/daytona/common/computer_use.py
+++ b/libs/sdk-python/src/daytona/common/computer_use.py
@@ -31,7 +31,7 @@ class ScreenshotOptions(BaseModel):
 
     Attributes:
         show_cursor (bool | None): Whether to show the cursor in the screenshot.
-        fmt (str | None): Image format (e.g., 'png', 'jpeg', 'webp').
+        fmt (str | None): Image format (e.g., 'png', 'jpeg').
         quality (int | None): Compression quality (0-100).
         scale (float | None): Scale factor for the screenshot.
     """
@@ -39,6 +39,6 @@ class ScreenshotOptions(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     show_cursor: bool | None = Field(default=None, description="Whether to show the cursor in the screenshot.")
-    fmt: str | None = Field(default=None, description="Image format (png, jpeg, webp).")
+    fmt: str | None = Field(default=None, description="Image format (png, jpeg).")
     quality: int | None = Field(default=None, ge=0, le=100, description="Compression quality.")
     scale: float | None = Field(default=None, gt=0, description="Scale factor for the screenshot.")

--- a/libs/sdk-ruby/lib/daytona/computer_use.rb
+++ b/libs/sdk-ruby/lib/daytona/computer_use.rb
@@ -318,7 +318,7 @@ module Daytona
       #   region = ScreenshotRegion.new(x: 0, y: 0, width: 800, height: 600)
       #   screenshot = sandbox.computer_use.screenshot.take_compressed_region(
       #     region,
-      #     options: ScreenshotOptions.new(format: "webp", quality: 80, show_cursor: true)
+      #     options: ScreenshotOptions.new(format: "jpeg", quality: 80, show_cursor: true)
       #   )
       #   puts "Compressed size: #{screenshot.size_bytes} bytes"
       def take_compressed_region(region:, options: nil)
@@ -573,7 +573,7 @@ module Daytona
       # @return [Boolean, nil] Whether to show the cursor in the screenshot
       attr_accessor :show_cursor
 
-      # @return [String, nil] Image format (e.g., 'png', 'jpeg', 'webp')
+      # @return [String, nil] Image format (e.g., 'png', 'jpeg')
       attr_accessor :fmt
 
       # @return [Integer, nil] Compression quality (0-100)
@@ -583,7 +583,7 @@ module Daytona
       attr_accessor :scale
 
       # @param show_cursor [Boolean, nil] Whether to show the cursor in the screenshot
-      # @param format [String, nil] Image format (e.g., 'png', 'jpeg', 'webp')
+      # @param format [String, nil] Image format (e.g., 'png', 'jpeg')
       # @param quality [Integer, nil] Compression quality (0-100)
       # @param scale [Float, nil] Scale factor for the screenshot
       def initialize(show_cursor: nil, format: nil, quality: nil, scale: nil)

--- a/libs/sdk-typescript/src/ComputerUse.ts
+++ b/libs/sdk-typescript/src/ComputerUse.ts
@@ -418,7 +418,7 @@ export class Screenshot {
    * ```typescript
    * const region = { x: 0, y: 0, width: 800, height: 600 };
    * const screenshot = await sandbox.computerUse.screenshot.takeCompressedRegion(region, {
-   *   format: 'webp',
+   *   format: 'jpeg',
    *   quality: 80,
    *   showCursor: true
    * });

--- a/libs/sdk-typescript/src/__tests__/ComputerUse.test.ts
+++ b/libs/sdk-typescript/src/__tests__/ComputerUse.test.ts
@@ -120,11 +120,11 @@ describe('ComputerUse', () => {
     await computerUse.screenshot.takeCompressed({ showCursor: true, format: 'jpeg', quality: 90, scale: 0.5 })
     await computerUse.screenshot.takeCompressedRegion(
       { x: 10, y: 20, width: 30, height: 40 },
-      { showCursor: true, format: 'webp', quality: 80, scale: 2 },
+      { showCursor: true, format: 'jpeg', quality: 80, scale: 2 },
     )
 
     expect(apiClient.takeCompressedScreenshot).toHaveBeenCalledWith(true, 'jpeg', 90, 0.5)
-    expect(apiClient.takeCompressedRegionScreenshot).toHaveBeenCalledWith(10, 20, 30, 40, true, 'webp', 80, 2)
+    expect(apiClient.takeCompressedRegionScreenshot).toHaveBeenCalledWith(10, 20, 30, 40, true, 'jpeg', 80, 2)
   })
 
   it('delegates recording operations including download stream', async () => {


### PR DESCRIPTION
Fixes #4568.

Compressed screenshot requests accepted arbitrary `format` values. When callers requested `webp`, the encoder silently fell back to PNG, while SDK comments and docs advertised WebP as supported.

This change makes the runtime contract explicit:

- accept PNG by default and `format=png`
- accept `format=jpeg`
- reject unsupported formats such as `webp` instead of returning PNG bytes
- update SDK comments/examples and docs so they only advertise the currently supported formats

Validation:

- `go test ./libs/computer-use/...`
- `yarn nx test sdk-typescript --runInBand --testPathPatterns=ComputerUse.test.ts --skip-nx-cache`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unsupported screenshot formats in computer-use: only `png` (default) and `jpeg` are allowed; others now error instead of silently falling back to PNG. Fixes #4568.

- **Bug Fixes**
  - Runtime: `""`/`png` encode as PNG; `jpeg` encodes with quality; others error with a message listing supported formats.
  - Tests: cover PNG default/explicit, JPEG magic bytes, and rejection of `webp`/`gif`.
  - Docs/SDKs: replace `webp` with `jpeg`; Python examples and docstrings use `fmt` in `ScreenshotOptions`; comments list only `png`/`jpeg` and note JPEG-only quality.

- **Migration**
  - If you pass any format other than `png` or `jpeg`, switch to `png` or `jpeg`.
  - No API shape changes; only stricter validation.

<sup>Written for commit 5806c5eac467c4984a66e73f89d165f398b803c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

