### PR TITLE
feat(dashboard): members page show cta on personal

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -21,6 +21,7 @@ import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { BannerProvider } from './components/Banner'
 import { CommandPaletteProvider } from './components/CommandPalette'
 import LoadingFallback from './components/LoadingFallback'
+import { SandboxDetails } from './components/sandboxes'
 import { Button } from './components/ui/button'
 import {
   Dialog,
@@ -54,7 +55,6 @@ import Volumes from './pages/Volumes'
 import Wallet from './pages/Wallet'
 import WebhookEndpointDetails from './pages/WebhookEndpointDetails'
 import Webhooks from './pages/Webhooks'
-import { SandboxDetails } from './components/sandboxes'
 import { ApiProvider } from './providers/ApiProvider'
 import { RegionsProvider } from './providers/RegionsProvider'
 import { SvixProvider } from './providers/SvixProvider'
@@ -203,14 +203,7 @@ function App() {
             <Route path={getRouteSubPath(RoutePath.EMAIL_VERIFY)} element={<EmailVerify />} />
           </>
         )}
-        <Route
-          path={getRouteSubPath(RoutePath.MEMBERS)}
-          element={
-            <NonPersonalOrganizationPageWrapper>
-              <OrganizationMembers />
-            </NonPersonalOrganizationPageWrapper>
-          }
-        />
+        <Route path={getRouteSubPath(RoutePath.MEMBERS)} element={<OrganizationMembers />} />
         {
           // TODO: uncomment when we allow creating custom roles
           /* <Route

--- a/apps/dashboard/src/components/Organizations/CreateOrganizationSheet.tsx
+++ b/apps/dashboard/src/components/Organizations/CreateOrganizationSheet.tsx
@@ -14,15 +14,16 @@ import { Spinner } from '@/components/ui/spinner'
 import { Organization, Region } from '@daytona/api-client'
 import { useForm } from '@tanstack/react-form'
 import { TriangleAlertIcon } from 'lucide-react'
-import { useCallback, useEffect, useRef } from 'react'
+import { Ref, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { z } from 'zod'
 
 interface CreateOrganizationSheetProps {
-  open: boolean
+  open?: boolean
   regions: Region[]
   loadingRegions: boolean
-  onOpenChange: (open: boolean) => void
+  onOpenChange?: (open: boolean) => void
   onCreateOrganization: (name: string, defaultRegionId: string) => Promise<Organization | null>
+  ref?: Ref<{ open: () => void }>
 }
 
 const formSchema = z.object({
@@ -43,9 +44,23 @@ export const CreateOrganizationSheet: React.FC<CreateOrganizationSheetProps> = (
   loadingRegions,
   onOpenChange,
   onCreateOrganization,
+  ref,
 }) => {
+  const [internalOpen, setInternalOpen] = useState(false)
   const formRef = useRef<HTMLFormElement>(null)
   const defaultRegionIdRef = useRef<string>(regions[0]?.id ?? '')
+  const isControlled = open !== undefined
+  const isOpen = open ?? internalOpen
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isControlled) {
+        setInternalOpen(isOpen)
+      }
+      onOpenChange?.(isOpen)
+    },
+    [isControlled, onOpenChange],
+  )
 
   const form = useForm({
     defaultValues,
@@ -62,24 +77,13 @@ export const CreateOrganizationSheet: React.FC<CreateOrganizationSheetProps> = (
       }
     },
     onSubmit: async ({ value }) => {
-      await onCreateOrganization(value.name.trim(), value.defaultRegionId)
+      const organization = await onCreateOrganization(value.name.trim(), value.defaultRegionId)
+      if (organization) {
+        handleOpenChange(false)
+      }
     },
   })
   const { reset: resetForm } = form
-
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    if (!form.getFieldValue('defaultRegionId') && regions[0]?.id) {
-      form.setFieldValue('defaultRegionId', regions[0].id)
-    }
-  }, [form, open, regions])
-
-  useEffect(() => {
-    defaultRegionIdRef.current = regions[0]?.id ?? ''
-  }, [regions])
 
   const resetState = useCallback(() => {
     resetForm({
@@ -88,22 +92,32 @@ export const CreateOrganizationSheet: React.FC<CreateOrganizationSheetProps> = (
     })
   }, [resetForm])
 
+  useImperativeHandle(ref, () => ({
+    open: () => handleOpenChange(true),
+  }))
+
   useEffect(() => {
-    if (open) {
+    if (!isOpen) {
+      return
+    }
+
+    if (!form.getFieldValue('defaultRegionId') && regions[0]?.id) {
+      form.setFieldValue('defaultRegionId', regions[0].id)
+    }
+  }, [form, isOpen, regions])
+
+  useEffect(() => {
+    defaultRegionIdRef.current = regions[0]?.id ?? ''
+  }, [regions])
+
+  useEffect(() => {
+    if (isOpen) {
       resetState()
     }
-  }, [open, resetState])
+  }, [isOpen, resetState])
 
   return (
-    <Sheet
-      open={open}
-      onOpenChange={(isOpen) => {
-        onOpenChange(isOpen)
-        if (!isOpen) {
-          resetState()
-        }
-      }}
-    >
+    <Sheet open={isOpen} onOpenChange={handleOpenChange}>
       <SheetContent className="w-dvw sm:w-[560px] p-0 flex flex-col gap-0">
         <SheetHeader className="border-b border-border p-4 px-5 items-center flex text-left flex-row">
           <SheetTitle>Create Organization</SheetTitle>
@@ -195,7 +209,7 @@ export const CreateOrganizationSheet: React.FC<CreateOrganizationSheetProps> = (
         </ScrollArea>
 
         <SheetFooter className="border-t border-border p-4 px-5">
-          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+          <Button type="button" variant="secondary" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
           <form.Subscribe

--- a/apps/dashboard/src/components/Organizations/OrganizationPicker.tsx
+++ b/apps/dashboard/src/components/Organizations/OrganizationPicker.tsx
@@ -19,7 +19,7 @@ import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import { Organization } from '@daytona/api-client'
 import { Building2, ChevronsUpDown, Copy, PlusCircle, SquareUserRound } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { CommandHighlight, useRegisterCommands, type CommandConfig } from '../CommandPalette'
 import { CreateOrganizationSheet } from './CreateOrganizationSheet'
@@ -75,6 +75,7 @@ export const OrganizationPicker: React.FC = () => {
 
   const [optimisticSelectedOrganization, setOptimisticSelectedOrganization] = useState(selectedOrganization)
   const [loadingSelectOrganization, setLoadingSelectOrganization] = useState(false)
+  const createOrganizationSheetRef = useRef<{ open: () => void }>(null)
 
   useOrganizationCommands()
 
@@ -96,8 +97,6 @@ export const OrganizationPicker: React.FC = () => {
     }
     setLoadingSelectOrganization(false)
   }
-
-  const [showCreateOrganizationSheet, setShowCreateOrganizationSheet] = useState(false)
 
   const handleCreateOrganization = async (name: string, defaultRegionId: string) => {
     try {
@@ -174,7 +173,7 @@ export const OrganizationPicker: React.FC = () => {
           <div>
             <DropdownMenuItem
               className="cursor-pointer text-primary flex items-center gap-2"
-              onClick={() => setShowCreateOrganizationSheet(true)}
+              onClick={() => createOrganizationSheetRef.current?.open()}
             >
               <PlusCircle className="w-4 h-4 flex-shrink-0" />
               <span>Create Organization</span>
@@ -184,8 +183,7 @@ export const OrganizationPicker: React.FC = () => {
       </DropdownMenu>
 
       <CreateOrganizationSheet
-        open={showCreateOrganizationSheet}
-        onOpenChange={setShowCreateOrganizationSheet}
+        ref={createOrganizationSheetRef}
         regions={regions}
         loadingRegions={loadingRegions}
         onCreateOrganization={handleCreateOrganization}

--- a/apps/dashboard/src/components/Sidebar.tsx
+++ b/apps/dashboard/src/components/Sidebar.tsx
@@ -92,8 +92,7 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
   const { pathname, search } = useLocation()
   const sidebar = useSidebar()
   const { isMobile, setOpenMobile } = sidebar
-  const { selectedOrganization, authenticatedUserOrganizationMember, authenticatedUserHasPermission } =
-    useSelectedOrganization()
+  const { authenticatedUserOrganizationMember, authenticatedUserHasPermission } = useSelectedOrganization()
   const orgInfraEnabled = useFeatureFlagEnabled(FeatureFlags.ORGANIZATION_INFRASTRUCTURE)
 
   const sidebarItems = useMemo(() => {
@@ -152,17 +151,15 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
       })
     }
 
-    if (!selectedOrganization?.personal) {
-      arr.push({
-        icon: <Users size={16} strokeWidth={1.5} />,
-        label: 'Members',
-        path: RoutePath.MEMBERS,
-      })
-      // TODO: uncomment when we allow creating custom roles
-      // if (authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER) {
-      //   arr.push({ icon: <UserCog className="w-5 h-5" />, label: 'Roles', path: RoutePath.ROLES })
-      // }
-    }
+    arr.push({
+      icon: <Users size={16} strokeWidth={1.5} />,
+      label: 'Members',
+      path: RoutePath.MEMBERS,
+    })
+    // TODO: uncomment when we allow creating custom roles
+    // if (authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER) {
+    //   arr.push({ icon: <UserCog className="w-5 h-5" />, label: 'Roles', path: RoutePath.ROLES })
+    // }
 
     arr.push({
       icon: <Settings size={16} strokeWidth={1.5} />,
@@ -171,7 +168,7 @@ export function Sidebar({ isBannerVisible, billingEnabled, version }: SidebarPro
     })
 
     return arr
-  }, [authenticatedUserOrganizationMember?.role, selectedOrganization?.personal])
+  }, [authenticatedUserOrganizationMember?.role])
 
   const billingItems = useMemo(() => {
     if (!billingEnabled || authenticatedUserOrganizationMember?.role !== OrganizationUserRoleEnum.OWNER) {

--- a/apps/dashboard/src/hooks/queries/useOrganizationInvitationsQuery.ts
+++ b/apps/dashboard/src/hooks/queries/useOrganizationInvitationsQuery.ts
@@ -9,7 +9,7 @@ import { useApi } from '../useApi'
 import { useSelectedOrganization } from '../useSelectedOrganization'
 import { queryKeys } from './queryKeys'
 
-export function useOrganizationInvitationsQuery() {
+export function useOrganizationInvitationsQuery({ enabled = true }: { enabled?: boolean } = {}) {
   const { organizationsApi } = useApi()
   const { selectedOrganization } = useSelectedOrganization()
 
@@ -23,6 +23,6 @@ export function useOrganizationInvitationsQuery() {
       const response = await organizationsApi.listOrganizationInvitations(selectedOrganization.id)
       return response.data
     },
-    enabled: !!selectedOrganization,
+    enabled: enabled && !!selectedOrganization,
   })
 }

--- a/apps/dashboard/src/pages/OrganizationMembers.tsx
+++ b/apps/dashboard/src/pages/OrganizationMembers.tsx
@@ -7,6 +7,7 @@ import { type CommandConfig, useRegisterCommands } from '@/components/CommandPal
 import { OrganizationInvitationTable } from '@/components/OrganizationMembers/OrganizationInvitationTable'
 import { OrganizationMemberTable } from '@/components/OrganizationMembers/OrganizationMemberTable'
 import { UpsertOrganizationAccessSheet } from '@/components/OrganizationMembers/UpsertOrganizationAccessSheet'
+import { CreateOrganizationSheet } from '@/components/Organizations/CreateOrganizationSheet'
 import { PageContent, PageHeader, PageIntro, PageLayout } from '@/components/PageLayout'
 import { Button } from '@/components/ui/button'
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
@@ -18,16 +19,19 @@ import { useUpdateOrganizationInvitationMutation } from '@/hooks/mutations/useUp
 import { useUpdateOrganizationMemberAccessMutation } from '@/hooks/mutations/useUpdateOrganizationMemberAccessMutation'
 import { useOrganizationInvitationsQuery } from '@/hooks/queries/useOrganizationInvitationsQuery'
 import { useOrganizationMembersQuery } from '@/hooks/queries/useOrganizationMembersQuery'
+import { useApi } from '@/hooks/useApi'
 import { useOrganizations } from '@/hooks/useOrganizations'
 import { usePendingMutationKeys } from '@/hooks/usePendingMutationKeys'
+import { useRegions } from '@/hooks/useRegions'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { handleApiError } from '@/lib/error-handling'
 import {
   CreateOrganizationInvitationRoleEnum,
+  type Organization,
   OrganizationUserRoleEnum,
   UpdateOrganizationInvitationRoleEnum,
 } from '@daytona/api-client'
-import { AlertCircle, PlusIcon, RefreshCw } from 'lucide-react'
+import { AlertCircle, Building2, PlusIcon, RefreshCw } from 'lucide-react'
 import React, { useMemo, useRef } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { toast } from 'sonner'
@@ -53,10 +57,13 @@ function usePendingInvitationIds() {
 const OrganizationMembers: React.FC = () => {
   const { user } = useAuth()
 
+  const { organizationsApi } = useApi()
   const { refreshOrganizations } = useOrganizations()
+  const { sharedRegions: regions, loadingSharedRegions: loadingRegions } = useRegions()
   const { selectedOrganization, authenticatedUserOrganizationMember } = useSelectedOrganization()
+  const isPersonalOrganization = !!selectedOrganization?.personal
   const { data: organizationMembers = [], isLoading: loadingMembers } = useOrganizationMembersQuery(
-    selectedOrganization?.id,
+    isPersonalOrganization ? null : selectedOrganization?.id,
   )
 
   const {
@@ -64,13 +71,14 @@ const OrganizationMembers: React.FC = () => {
     isLoading: loadingInvitations,
     isError: invitationsError,
     refetch: refetchInvitations,
-  } = useOrganizationInvitationsQuery()
+  } = useOrganizationInvitationsQuery({ enabled: !isPersonalOrganization })
   const updateMemberAccessMutation = useUpdateOrganizationMemberAccessMutation()
   const removeMemberMutation = useDeleteOrganizationMemberMutation()
   const createInvitationMutation = useCreateOrganizationInvitationMutation()
   const updateInvitationMutation = useUpdateOrganizationInvitationMutation()
   const cancelInvitationMutation = useCancelOrganizationInvitationMutation()
   const createInvitationSheetRef = useRef<{ open: () => void }>(null)
+  const createOrganizationSheetRef = useRef<{ open: () => void }>(null)
 
   const pendingMemberIds = usePendingMemberIds()
   const pendingInvitationIds = usePendingInvitationIds()
@@ -178,9 +186,10 @@ const OrganizationMembers: React.FC = () => {
   }
 
   const authenticatedUserIsOwner = authenticatedUserOrganizationMember?.role === OrganizationUserRoleEnum.OWNER
+  const canInviteMembers = authenticatedUserIsOwner && !isPersonalOrganization
 
   const rootCommands: CommandConfig[] = useMemo(() => {
-    if (!authenticatedUserIsOwner) {
+    if (!canInviteMembers) {
       return []
     }
 
@@ -192,9 +201,26 @@ const OrganizationMembers: React.FC = () => {
         onSelect: () => createInvitationSheetRef.current?.open(),
       },
     ]
-  }, [authenticatedUserIsOwner])
+  }, [canInviteMembers])
 
   useRegisterCommands(rootCommands, { groupId: 'member-actions', groupLabel: 'Member actions', groupOrder: 0 })
+
+  const handleCreateOrganization = async (name: string, defaultRegionId: string): Promise<Organization | null> => {
+    try {
+      const organization = (
+        await organizationsApi.createOrganization({
+          name: name.trim(),
+          defaultRegionId,
+        })
+      ).data
+      toast.success('Organization created successfully')
+      await refreshOrganizations(organization.id)
+      return organization
+    } catch (error) {
+      handleApiError(error, 'Failed to create organization')
+      return null
+    }
+  }
 
   return (
     <PageLayout>
@@ -204,7 +230,7 @@ const OrganizationMembers: React.FC = () => {
         <PageIntro
           title="Members"
           actions={
-            authenticatedUserIsOwner ? (
+            canInviteMembers ? (
               <UpsertOrganizationAccessSheet
                 mode="create"
                 onSubmit={({ email, role, assignedRoleIds }) => handleCreateInvitation(email, role, assignedRoleIds)}
@@ -213,51 +239,79 @@ const OrganizationMembers: React.FC = () => {
             ) : undefined
           }
         />
-        <div className="flex flex-col gap-14">
-          <OrganizationMemberTable
-            data={organizationMembers}
-            loadingData={loadingMembers}
-            onUpdateMemberAccess={handleUpdateMemberAccess}
-            onRemoveMember={handleRemoveMember}
-            pendingMemberIds={pendingMemberIds}
-            ownerMode={authenticatedUserIsOwner}
-            currentUserId={user?.profile.sub}
-          />
+        {isPersonalOrganization ? (
+          <>
+            <Empty className="flex-none py-12 rounded-md border">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Building2 />
+                </EmptyMedia>
+                <EmptyTitle>Organizations support member invitations</EmptyTitle>
+                <EmptyDescription>
+                  Personal accounts cannot invite members. Create an organization to collaborate with other users.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button variant="secondary" size="sm" onClick={() => createOrganizationSheetRef.current?.open()}>
+                  <PlusIcon />
+                  Create Organization
+                </Button>
+              </EmptyContent>
+            </Empty>
+            <CreateOrganizationSheet
+              ref={createOrganizationSheetRef}
+              regions={regions}
+              loadingRegions={loadingRegions}
+              onCreateOrganization={handleCreateOrganization}
+            />
+          </>
+        ) : (
+          <div className="flex flex-col gap-14">
+            <OrganizationMemberTable
+              data={organizationMembers}
+              loadingData={loadingMembers}
+              onUpdateMemberAccess={handleUpdateMemberAccess}
+              onRemoveMember={handleRemoveMember}
+              pendingMemberIds={pendingMemberIds}
+              ownerMode={authenticatedUserIsOwner}
+              currentUserId={user?.profile.sub}
+            />
 
-          {authenticatedUserIsOwner && (
-            <div>
-              <h1 className="text-2xl font-medium mb-3">Invitations</h1>
+            {authenticatedUserIsOwner && (
+              <div>
+                <h1 className="text-2xl font-medium mb-3">Invitations</h1>
 
-              {invitationsError ? (
-                <Empty className="py-12 rounded-md border">
-                  <EmptyHeader>
-                    <EmptyMedia variant="icon" className="bg-destructive-background text-destructive">
-                      <AlertCircle />
-                    </EmptyMedia>
-                    <EmptyTitle className="text-destructive">Failed to load invitations</EmptyTitle>
-                    <EmptyDescription>
-                      Something went wrong while fetching organization invitations. Please try again.
-                    </EmptyDescription>
-                  </EmptyHeader>
-                  <EmptyContent>
-                    <Button variant="secondary" size="sm" onClick={() => refetchInvitations()}>
-                      <RefreshCw />
-                      Retry
-                    </Button>
-                  </EmptyContent>
-                </Empty>
-              ) : (
-                <OrganizationInvitationTable
-                  data={invitations}
-                  loadingData={loadingInvitations}
-                  onCancelInvitation={handleCancelInvitation}
-                  onUpdateInvitation={handleUpdateInvitation}
-                  pendingInvitationIds={pendingInvitationIds}
-                />
-              )}
-            </div>
-          )}
-        </div>
+                {invitationsError ? (
+                  <Empty className="py-12 rounded-md border">
+                    <EmptyHeader>
+                      <EmptyMedia variant="icon" className="bg-destructive-background text-destructive">
+                        <AlertCircle />
+                      </EmptyMedia>
+                      <EmptyTitle className="text-destructive">Failed to load invitations</EmptyTitle>
+                      <EmptyDescription>
+                        Something went wrong while fetching organization invitations. Please try again.
+                      </EmptyDescription>
+                    </EmptyHeader>
+                    <EmptyContent>
+                      <Button variant="secondary" size="sm" onClick={() => refetchInvitations()}>
+                        <RefreshCw />
+                        Retry
+                      </Button>
+                    </EmptyContent>
+                  </Empty>
+                ) : (
+                  <OrganizationInvitationTable
+                    data={invitations}
+                    loadingData={loadingInvitations}
+                    onCancelInvitation={handleCancelInvitation}
+                    onUpdateInvitation={handleUpdateInvitation}
+                    pendingInvitationIds={pendingInvitationIds}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </PageContent>
     </PageLayout>
   )


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a create-organization CTA on the Members page for personal accounts, and let users create an organization directly from there. Members is now always visible in the sidebar, with queries and routing adjusted to work for personal accounts.

- New Features
  - Personal accounts: Members page shows an empty state with a “Create Organization” CTA.
  - Create flow opens `CreateOrganizationSheet` and refreshes orgs on success.
  - Members nav item is always visible; invite actions are disabled for personal accounts.

- Refactors
  - `CreateOrganizationSheet` supports uncontrolled usage with `ref.open()` and closes on success.
  - `OrganizationPicker` now opens the sheet via ref (no local open state).
  - `useOrganizationInvitationsQuery` accepts `enabled` and is disabled for personal accounts.
  - Members page skips member/invitation queries for personal accounts and handles create-org inline.
  - Members route no longer wrapped by `NonPersonalOrganizationPageWrapper`.

<sup>Written for commit 8be804a9769d007551057a14659bc6dcd1c2b4c5. Summary will update on new commits. <a href="https://cubic.dev/pr/daytonaio/daytona/pull/4841?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

