### PR TITLE
chore(security): enforce TLS verification on daemon git clone

### DIFF
--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -19,15 +21,22 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
-func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.BasicAuth) error {
+func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.BasicAuth, insecureSkipTLS bool) error {
 	if isGitCLIModeEnabled() || os.Getenv(experimentalUseGitCloneCLIEnv) == "true" {
-		return s.CloneRepositoryCLI(repo, auth)
+		return s.CloneRepositoryCLI(repo, auth, insecureSkipTLS)
+	}
+
+	if insecureSkipTLS {
+		slog.Warn("git clone TLS verification disabled",
+			"url", sanitizeURLForLog(repo.Url),
+			"reason", "insecure_skip_tls=true")
 	}
 
 	cloneOptions := &git.CloneOptions{
-		URL:          repo.Url,
-		SingleBranch: true,
-		Auth:         auth,
+		URL:             repo.Url,
+		SingleBranch:    true,
+		InsecureSkipTLS: insecureSkipTLS,
+		Auth:            auth,
 	}
 
 	if s.LogWriter != nil {
@@ -84,8 +93,13 @@ esac
 
 // CloneRepositoryCLI clones via the `git` CLI. Bounded memory (mmap pack handling).
 // Creds flow through GIT_ASKPASS + env — never via URL or argv.
-func (s *Service) CloneRepositoryCLI(repo *gitprovider.GitRepository, auth *http.BasicAuth) error {
-	if err := s.gitCLIRun("git clone", buildCloneArgs(repo, s.WorkDir), auth, 64*1024); err != nil {
+func (s *Service) CloneRepositoryCLI(repo *gitprovider.GitRepository, auth *http.BasicAuth, insecureSkipTLS bool) error {
+	if insecureSkipTLS {
+		slog.Warn("git clone TLS verification disabled",
+			"url", sanitizeURLForLog(repo.Url),
+			"reason", "insecure_skip_tls=true")
+	}
+	if err := s.gitCLIRun("git clone", buildCloneArgs(repo, s.WorkDir, insecureSkipTLS), auth, 64*1024); err != nil {
 		return err
 	}
 
@@ -122,7 +136,11 @@ func (s *Service) attachCmdOutput(cmd *exec.Cmd, tailSize int) *tailBuffer {
 }
 
 // Credentials must NEVER be embedded in the URL — they flow via GIT_ASKPASS (see buildCloneEnv).
-func buildCloneArgs(repo *gitprovider.GitRepository, workDir string) []string {
+// When skipVerify is true, the caller has explicitly opted into insecure TLS via the
+// request's insecure_skip_tls flag; we forward that to git via -c http.sslVerify=false.
+// When skipVerify is false (default), we do NOT pin sslVerify=true so a sandbox-shell
+// user with their own ~/.gitconfig override is still honored on the CLI escape path.
+func buildCloneArgs(repo *gitprovider.GitRepository, workDir string, skipVerify bool) []string {
 	cloneURL := repo.Url
 	if !strings.Contains(cloneURL, "://") {
 		cloneURL = "https://" + cloneURL
@@ -131,15 +149,40 @@ func buildCloneArgs(repo *gitprovider.GitRepository, workDir string) []string {
 	args := []string{
 		"-c", "credential.helper=", // prevent any inherited helper from persisting the token
 		"-c", "core.hooksPath=/dev/null", // disable post-checkout (and any inherited core.hooksPath) — defense-in-depth so hooks can't read GIT_USERNAME / GIT_PASSWORD
+	}
+	if skipVerify {
+		args = append(args, "-c", "http.sslVerify=false")
+	}
+	args = append(args,
 		"clone",
 		"--single-branch",
 		"--progress",
-	}
+	)
 	if repo.Branch != "" {
 		args = append(args, "--branch", repo.Branch)
 	}
 	args = append(args, "--", cloneURL, workDir)
 	return args
+}
+
+// sanitizeURLForLog returns a string form of u with any embedded userinfo
+// removed. Prepends https:// when no scheme is present so net/url.Parse
+// treats the userinfo correctly (otherwise "user:pass@host/repo" parses as a
+// path, leaving creds in the result). Logs go to slog when the operator opts
+// into TLS bypass; this helper guarantees we don't echo creds back even
+// though TestBuildCloneArgs_NeverEmbedsCredsInURL already proves the daemon
+// refuses to embed them in clone args.
+func sanitizeURLForLog(u string) string {
+	parsed := u
+	if !strings.Contains(parsed, "://") {
+		parsed = "https://" + parsed
+	}
+	parsedURL, err := url.Parse(parsed)
+	if err != nil {
+		return "<unparseable url>"
+	}
+	parsedURL.User = nil
+	return parsedURL.String()
 }
 
 func buildCloneEnv(baseEnv []string, askPath string, auth *http.BasicAuth) []string {

--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -165,13 +165,14 @@ func buildCloneArgs(repo *gitprovider.GitRepository, workDir string, skipVerify 
 	return args
 }
 
-// sanitizeURLForLog returns a string form of u with any embedded userinfo
-// removed. Prepends https:// when no scheme is present so net/url.Parse
-// treats the userinfo correctly (otherwise "user:pass@host/repo" parses as a
-// path, leaving creds in the result). Logs go to slog when the operator opts
-// into TLS bypass; this helper guarantees we don't echo creds back even
-// though TestBuildCloneArgs_NeverEmbedsCredsInURL already proves the daemon
-// refuses to embed them in clone args.
+// sanitizeURLForLog returns a string form of u with any embedded userinfo,
+// query string, and fragment removed. Prepends https:// when no scheme is
+// present so net/url.Parse treats the userinfo correctly (otherwise
+// "user:pass@host/repo" parses as a path, leaving creds in the result).
+// Query and fragment are stripped as defense-in-depth: git URLs do not
+// normally carry credentials in those positions, but unusual proxy or
+// webhook-style URLs can (e.g. ?access_token=…), and the audit log line
+// should be safe to share regardless.
 func sanitizeURLForLog(u string) string {
 	parsed := u
 	if !strings.Contains(parsed, "://") {
@@ -182,6 +183,8 @@ func sanitizeURLForLog(u string) string {
 		return "<unparseable url>"
 	}
 	parsedURL.User = nil
+	parsedURL.RawQuery = ""
+	parsedURL.Fragment = ""
 	return parsedURL.String()
 }
 

--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -25,10 +25,9 @@ func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.Ba
 	}
 
 	cloneOptions := &git.CloneOptions{
-		URL:             repo.Url,
-		SingleBranch:    true,
-		InsecureSkipTLS: true,
-		Auth:            auth,
+		URL:          repo.Url,
+		SingleBranch: true,
+		Auth:         auth,
 	}
 
 	if s.LogWriter != nil {
@@ -131,7 +130,6 @@ func buildCloneArgs(repo *gitprovider.GitRepository, workDir string) []string {
 
 	args := []string{
 		"-c", "credential.helper=", // prevent any inherited helper from persisting the token
-		"-c", "http.sslVerify=false", // parity with go-git InsecureSkipTLS
 		"-c", "core.hooksPath=/dev/null", // disable post-checkout (and any inherited core.hooksPath) — defense-in-depth so hooks can't read GIT_USERNAME / GIT_PASSWORD
 		"clone",
 		"--single-branch",

--- a/apps/daemon/pkg/git/clone.go
+++ b/apps/daemon/pkg/git/clone.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log/slog"
-	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -24,12 +22,6 @@ import (
 func (s *Service) CloneRepository(repo *gitprovider.GitRepository, auth *http.BasicAuth, insecureSkipTLS bool) error {
 	if isGitCLIModeEnabled() || os.Getenv(experimentalUseGitCloneCLIEnv) == "true" {
 		return s.CloneRepositoryCLI(repo, auth, insecureSkipTLS)
-	}
-
-	if insecureSkipTLS {
-		slog.Warn("git clone TLS verification disabled",
-			"url", sanitizeURLForLog(repo.Url),
-			"reason", "insecure_skip_tls=true")
 	}
 
 	cloneOptions := &git.CloneOptions{
@@ -94,11 +86,6 @@ esac
 // CloneRepositoryCLI clones via the `git` CLI. Bounded memory (mmap pack handling).
 // Creds flow through GIT_ASKPASS + env — never via URL or argv.
 func (s *Service) CloneRepositoryCLI(repo *gitprovider.GitRepository, auth *http.BasicAuth, insecureSkipTLS bool) error {
-	if insecureSkipTLS {
-		slog.Warn("git clone TLS verification disabled",
-			"url", sanitizeURLForLog(repo.Url),
-			"reason", "insecure_skip_tls=true")
-	}
 	if err := s.gitCLIRun("git clone", buildCloneArgs(repo, s.WorkDir, insecureSkipTLS), auth, 64*1024); err != nil {
 		return err
 	}
@@ -163,29 +150,6 @@ func buildCloneArgs(repo *gitprovider.GitRepository, workDir string, skipVerify 
 	}
 	args = append(args, "--", cloneURL, workDir)
 	return args
-}
-
-// sanitizeURLForLog returns a string form of u with any embedded userinfo,
-// query string, and fragment removed. Prepends https:// when no scheme is
-// present so net/url.Parse treats the userinfo correctly (otherwise
-// "user:pass@host/repo" parses as a path, leaving creds in the result).
-// Query and fragment are stripped as defense-in-depth: git URLs do not
-// normally carry credentials in those positions, but unusual proxy or
-// webhook-style URLs can (e.g. ?access_token=…), and the audit log line
-// should be safe to share regardless.
-func sanitizeURLForLog(u string) string {
-	parsed := u
-	if !strings.Contains(parsed, "://") {
-		parsed = "https://" + parsed
-	}
-	parsedURL, err := url.Parse(parsed)
-	if err != nil {
-		return "<unparseable url>"
-	}
-	parsedURL.User = nil
-	parsedURL.RawQuery = ""
-	parsedURL.Fragment = ""
-	return parsedURL.String()
 }
 
 func buildCloneEnv(baseEnv []string, askPath string, auth *http.BasicAuth) []string {

--- a/apps/daemon/pkg/git/clone_internal_test.go
+++ b/apps/daemon/pkg/git/clone_internal_test.go
@@ -22,10 +22,11 @@ var testCreds = &http.BasicAuth{
 
 func TestBuildCloneArgs(t *testing.T) {
 	tests := []struct {
-		name     string
-		repo     *gitprovider.GitRepository
-		workDir  string
-		expected []string
+		name       string
+		repo       *gitprovider.GitRepository
+		workDir    string
+		skipVerify bool
+		expected   []string
 	}{
 		{
 			name: "https URL with branch",
@@ -85,16 +86,35 @@ func TestBuildCloneArgs(t *testing.T) {
 				"--", "https://github.com/daytonaio/daytona", "/work-dir",
 			},
 		},
+		{
+			name: "skipVerify=true adds http.sslVerify=false",
+			repo: &gitprovider.GitRepository{
+				Url:    "https://internal-git.example.com/org/repo",
+				Branch: "main",
+			},
+			workDir:    "/work-dir",
+			skipVerify: true,
+			expected: []string{
+				"-c", "credential.helper=",
+				"-c", "core.hooksPath=/dev/null",
+				"-c", "http.sslVerify=false",
+				"clone", "--single-branch", "--progress",
+				"--branch", "main",
+				"--", "https://internal-git.example.com/org/repo", "/work-dir",
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildCloneArgs(tc.repo, tc.workDir)
+			got := buildCloneArgs(tc.repo, tc.workDir, tc.skipVerify)
 			require.Equal(t, tc.expected, got)
 
-			for _, arg := range got {
-				require.NotEqual(t, "http.sslVerify=false", arg,
-					"regression: GHSA-375h-72g4-hc9c — daemon git clone must not disable TLS verification")
+			if !tc.skipVerify {
+				for _, arg := range got {
+					require.NotEqual(t, "http.sslVerify=false", arg,
+						"regression: GHSA-375h-72g4-hc9c — daemon git clone must not disable TLS verification by default")
+				}
 			}
 		})
 	}
@@ -108,7 +128,7 @@ func TestBuildCloneArgs_NeverEmbedsCredsInURL(t *testing.T) {
 		Url:    "https://github.com/daytonaio/daytona",
 		Branch: "main",
 	}
-	args := buildCloneArgs(repo, "/work-dir")
+	args := buildCloneArgs(repo, "/work-dir", false)
 
 	for _, arg := range args {
 		require.NotContains(t, arg, testCreds.Username, "username leaked into clone args: %q", arg)

--- a/apps/daemon/pkg/git/clone_internal_test.go
+++ b/apps/daemon/pkg/git/clone_internal_test.go
@@ -36,7 +36,6 @@ func TestBuildCloneArgs(t *testing.T) {
 			workDir: "/work-dir",
 			expected: []string{
 				"-c", "credential.helper=",
-				"-c", "http.sslVerify=false",
 				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--branch", "main",
@@ -52,7 +51,6 @@ func TestBuildCloneArgs(t *testing.T) {
 			workDir: "/work-dir",
 			expected: []string{
 				"-c", "credential.helper=",
-				"-c", "http.sslVerify=false",
 				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--branch", "main",
@@ -68,7 +66,6 @@ func TestBuildCloneArgs(t *testing.T) {
 			workDir: "/work-dir",
 			expected: []string{
 				"-c", "credential.helper=",
-				"-c", "http.sslVerify=false",
 				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--branch", "main",
@@ -83,7 +80,6 @@ func TestBuildCloneArgs(t *testing.T) {
 			workDir: "/work-dir",
 			expected: []string{
 				"-c", "credential.helper=",
-				"-c", "http.sslVerify=false",
 				"-c", "core.hooksPath=/dev/null",
 				"clone", "--single-branch", "--progress",
 				"--", "https://github.com/daytonaio/daytona", "/work-dir",
@@ -95,6 +91,11 @@ func TestBuildCloneArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := buildCloneArgs(tc.repo, tc.workDir)
 			require.Equal(t, tc.expected, got)
+
+			for _, arg := range got {
+				require.NotEqual(t, "http.sslVerify=false", arg,
+					"regression: GHSA-375h-72g4-hc9c — daemon git clone must not disable TLS verification")
+			}
 		})
 	}
 }

--- a/apps/daemon/pkg/git/clone_tls_regression_test.go
+++ b/apps/daemon/pkg/git/clone_tls_regression_test.go
@@ -1,0 +1,97 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package git
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+
+	"github.com/daytonaio/daemon/pkg/gitprovider"
+	"github.com/stretchr/testify/require"
+)
+
+// newChallengingTLSServer returns an httptest TLS server that always responds
+// with 401 + WWW-Authenticate: Basic. The challenge is required to provoke
+// native git (CLI path) into sending credentials via GIT_ASKPASS — without it,
+// native git never sends Authorization and a credential-leak regression would
+// silently pass. The go-git path sends BasicAuth preemptively on the first
+// request and is captured on the way in either way. The captured Authorization
+// header is exposed via the returned atomic value.
+func newChallengingTLSServer(t *testing.T) (*httptest.Server, *atomic.Value) {
+	t.Helper()
+	var receivedAuth atomic.Value
+	receivedAuth.Store("")
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h := r.Header.Get("Authorization"); h != "" {
+			receivedAuth.Store(h)
+		}
+		w.Header().Set("WWW-Authenticate", `Basic realm="git"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+	return server, &receivedAuth
+}
+
+// Regression for GHSA-375h-72g4-hc9c on the go-git clone path: a credentialed
+// clone against an HTTPS endpoint with an untrusted certificate must fail TLS
+// verification before any Authorization header reaches the server.
+func TestCloneRejectsUntrustedTLSBeforeSendingCredentials_GoGit(t *testing.T) {
+	t.Setenv(experimentalUseGitCLIEnv, "false")
+	t.Setenv(experimentalUseGitCloneCLIEnv, "false")
+
+	server, receivedAuth := newChallengingTLSServer(t)
+
+	svc := &Service{WorkDir: t.TempDir()}
+	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds)
+	require.Error(t, err, "expected clone to fail TLS verification")
+	require.Empty(t, receivedAuth.Load().(string),
+		"GHSA-375h-72g4-hc9c regression: credentials leaked to untrusted TLS endpoint")
+}
+
+// unsetEnvForTest fully removes an env var for the test's lifetime and
+// restores any prior value at cleanup. t.Setenv(key, "") sets the var to an
+// empty string but leaves it defined — and native git treats GIT_SSL_NO_VERIFY
+// as "skip verify" whenever it's defined at all (presence-based, not
+// value-based), so empty or "false" would silently disable TLS verification.
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+// Regression for GHSA-375h-72g4-hc9c on the native-git CLI clone path. Forces
+// the CLI mode AND isolates from any inherited native-git escape valves
+// (GIT_SSL_NO_VERIFY env, ~/.gitconfig / /etc/gitconfig http.sslVerify=false)
+// so the test exercises the safe-default code path regardless of the
+// developer/CI environment.
+func TestCloneRejectsUntrustedTLSBeforeSendingCredentials_CLI(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not found in PATH")
+	}
+
+	t.Setenv(experimentalUseGitCLIEnv, "true")
+	unsetEnvForTest(t, "GIT_SSL_NO_VERIFY")
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	t.Setenv("HOME", t.TempDir())
+
+	server, receivedAuth := newChallengingTLSServer(t)
+
+	svc := &Service{WorkDir: t.TempDir()}
+	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds)
+	require.Error(t, err, "expected clone to fail TLS verification")
+	require.Empty(t, receivedAuth.Load().(string),
+		"GHSA-375h-72g4-hc9c regression: credentials leaked to untrusted TLS endpoint")
+}

--- a/apps/daemon/pkg/git/clone_tls_regression_test.go
+++ b/apps/daemon/pkg/git/clone_tls_regression_test.go
@@ -47,7 +47,7 @@ func TestCloneRejectsUntrustedTLSBeforeSendingCredentials_GoGit(t *testing.T) {
 	server, receivedAuth := newChallengingTLSServer(t)
 
 	svc := &Service{WorkDir: t.TempDir()}
-	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds)
+	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds, false)
 	require.Error(t, err, "expected clone to fail TLS verification")
 	require.Empty(t, receivedAuth.Load().(string),
 		"GHSA-375h-72g4-hc9c regression: credentials leaked to untrusted TLS endpoint")
@@ -90,8 +90,52 @@ func TestCloneRejectsUntrustedTLSBeforeSendingCredentials_CLI(t *testing.T) {
 	server, receivedAuth := newChallengingTLSServer(t)
 
 	svc := &Service{WorkDir: t.TempDir()}
-	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds)
+	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds, false)
 	require.Error(t, err, "expected clone to fail TLS verification")
 	require.Empty(t, receivedAuth.Load().(string),
 		"GHSA-375h-72g4-hc9c regression: credentials leaked to untrusted TLS endpoint")
+}
+
+// Positive plumbing test for the insecure_skip_tls=true opt-in (go-git path):
+// when the caller explicitly opts into skipping TLS verification, the clone
+// completes the TLS handshake against the untrusted server, native git sends
+// credentials in response to the 401 challenge, and the server records the
+// Authorization header. This locks in that the flag actually wires through.
+func TestCloneSkipsTLSWhenInsecureSkipTLSTrue_GoGit(t *testing.T) {
+	t.Setenv(experimentalUseGitCLIEnv, "false")
+	t.Setenv(experimentalUseGitCloneCLIEnv, "false")
+
+	server, receivedAuth := newChallengingTLSServer(t)
+
+	svc := &Service{WorkDir: t.TempDir()}
+	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds, true)
+	// Clone still returns an error because the server replies 401 — but the
+	// TLS handshake completed and credentials were transmitted, which is the
+	// behavior we're locking in.
+	require.Error(t, err, "expected 401 from challenging server")
+	require.NotEmpty(t, receivedAuth.Load().(string),
+		"insecure_skip_tls=true must let the request complete TLS handshake and reach the server")
+}
+
+// Positive plumbing test for the insecure_skip_tls=true opt-in (CLI path).
+// Same contract as the go-git variant: with the flag on, the bypass kicks in
+// and credentials are transmitted to the fake server.
+func TestCloneSkipsTLSWhenInsecureSkipTLSTrue_CLI(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not found in PATH")
+	}
+
+	t.Setenv(experimentalUseGitCLIEnv, "true")
+	unsetEnvForTest(t, "GIT_SSL_NO_VERIFY")
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	t.Setenv("HOME", t.TempDir())
+
+	server, receivedAuth := newChallengingTLSServer(t)
+
+	svc := &Service{WorkDir: t.TempDir()}
+	err := svc.CloneRepository(&gitprovider.GitRepository{Url: server.URL}, testCreds, true)
+	require.Error(t, err, "expected 401 from challenging server")
+	require.NotEmpty(t, receivedAuth.Load().(string),
+		"insecure_skip_tls=true must let the request complete TLS handshake and reach the server")
 }

--- a/apps/daemon/pkg/git/pull.go
+++ b/apps/daemon/pkg/git/pull.go
@@ -37,11 +37,6 @@ func (s *Service) PullCLI(auth *http.BasicAuth) error {
 }
 
 func buildPullArgs(workDir string) []string {
-	// Note: no -c http.sslVerify=false here. go-git's default PullOptions
-	// does NOT skip TLS verification (unlike its CloneOptions, which we
-	// match with InsecureSkipTLS:true). Skipping verify on pull would be a
-	// behavior change and a MITM risk for the basic-auth token.
-	//
 	// --ff-only matches go-git's `w.Pull()` semantics, which fails with
 	// ErrNonFastForwardUpdate on divergent histories instead of producing
 	// a merge commit. Without --ff-only, plain `git pull` would honor the

--- a/apps/daemon/pkg/git/push.go
+++ b/apps/daemon/pkg/git/push.go
@@ -83,10 +83,6 @@ func resolveSymbolicHEAD(gitBin, workDir string) (string, error) {
 }
 
 func buildPushArgs(workDir, branchRef string) []string {
-	// Note: no -c http.sslVerify=false here. go-git's default PushOptions
-	// does NOT skip TLS verification (unlike CloneOptions, where we set
-	// InsecureSkipTLS:true). Skipping verify on push would be a behavior
-	// change and a MITM risk for the basic-auth token.
 	return []string{
 		"-C", workDir,
 		"-c", "credential.helper=",

--- a/apps/daemon/pkg/git/service.go
+++ b/apps/daemon/pkg/git/service.go
@@ -54,8 +54,8 @@ var MapStatus map[git.StatusCode]Status = map[git.StatusCode]Status{
 }
 
 type IGitService interface {
-	CloneRepository(repo *gitprovider.GitRepository, auth *http.BasicAuth) error
-	CloneRepositoryCLI(repo *gitprovider.GitRepository, auth *http.BasicAuth) error
+	CloneRepository(repo *gitprovider.GitRepository, auth *http.BasicAuth, insecureSkipTLS bool) error
+	CloneRepositoryCLI(repo *gitprovider.GitRepository, auth *http.BasicAuth, insecureSkipTLS bool) error
 	RepositoryExists() (bool, error)
 	SetGitConfig(userData *gitprovider.GitUser, providerConfig *gitprovider.GitProviderConfig) error
 	GetGitStatus() (*GitStatus, error)

--- a/apps/daemon/pkg/toolbox/docs/docs.go
+++ b/apps/daemon/pkg/toolbox/docs/docs.go
@@ -1170,7 +1170,6 @@ const docTemplate = `{
                     },
                     {
                         "type": "number",
-                        "format": "float64",
                         "description": "Scale factor (0.1-1.0)",
                         "name": "scale",
                         "in": "query"
@@ -1303,7 +1302,6 @@ const docTemplate = `{
                     },
                     {
                         "type": "number",
-                        "format": "float64",
                         "description": "Scale factor (0.1-1.0)",
                         "name": "scale",
                         "in": "query"
@@ -3482,8 +3480,7 @@ const docTemplate = `{
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number",
-                            "format": "float64"
+                            "type": "number"
                         }
                     }
                 },

--- a/apps/daemon/pkg/toolbox/docs/docs.go
+++ b/apps/daemon/pkg/toolbox/docs/docs.go
@@ -1170,6 +1170,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "number",
+                        "format": "float64",
                         "description": "Scale factor (0.1-1.0)",
                         "name": "scale",
                         "in": "query"
@@ -1302,6 +1303,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "number",
+                        "format": "float64",
                         "description": "Scale factor (0.1-1.0)",
                         "name": "scale",
                         "in": "query"
@@ -1968,7 +1970,7 @@ const docTemplate = `{
         },
         "/git/clone": {
             "post": {
-                "description": "Clone a Git repository to the specified path",
+                "description": "Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3480,7 +3482,8 @@ const docTemplate = `{
                     "items": {
                         "type": "array",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float64"
                         }
                     }
                 },
@@ -3942,6 +3945,10 @@ const docTemplate = `{
                 },
                 "commit_id": {
                     "type": "string"
+                },
+                "insecure_skip_tls": {
+                    "description": "Skip TLS certificate verification for this clone. Defaults to false (verify).\nSet to true ONLY for trusted internal Git servers with self-signed or\nprivate-CA certs; credentials, if supplied, will be transmitted over an\nunverified TLS connection and are exposed to any MITM on the route.",
+                    "type": "boolean"
                 },
                 "password": {
                     "type": "string"

--- a/apps/daemon/pkg/toolbox/docs/swagger.json
+++ b/apps/daemon/pkg/toolbox/docs/swagger.json
@@ -1026,7 +1026,6 @@
           },
           {
             "type": "number",
-            "format": "float64",
             "description": "Scale factor (0.1-1.0)",
             "name": "scale",
             "in": "query"
@@ -1151,7 +1150,6 @@
           },
           {
             "type": "number",
-            "format": "float64",
             "description": "Scale factor (0.1-1.0)",
             "name": "scale",
             "in": "query"
@@ -3038,8 +3036,7 @@
           "items": {
             "type": "array",
             "items": {
-              "type": "number",
-              "format": "float64"
+              "type": "number"
             }
           }
         },

--- a/apps/daemon/pkg/toolbox/docs/swagger.json
+++ b/apps/daemon/pkg/toolbox/docs/swagger.json
@@ -1026,6 +1026,7 @@
           },
           {
             "type": "number",
+            "format": "float64",
             "description": "Scale factor (0.1-1.0)",
             "name": "scale",
             "in": "query"
@@ -1150,6 +1151,7 @@
           },
           {
             "type": "number",
+            "format": "float64",
             "description": "Scale factor (0.1-1.0)",
             "name": "scale",
             "in": "query"
@@ -1726,7 +1728,7 @@
     },
     "/git/clone": {
       "post": {
-        "description": "Clone a Git repository to the specified path",
+        "description": "Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.",
         "consumes": ["application/json"],
         "produces": ["application/json"],
         "tags": ["git"],
@@ -3036,7 +3038,8 @@
           "items": {
             "type": "array",
             "items": {
-              "type": "number"
+              "type": "number",
+              "format": "float64"
             }
           }
         },
@@ -3451,6 +3454,10 @@
         },
         "commit_id": {
           "type": "string"
+        },
+        "insecure_skip_tls": {
+          "description": "Skip TLS certificate verification for this clone. Defaults to false (verify).\nSet to true ONLY for trusted internal Git servers with self-signed or\nprivate-CA certs; credentials, if supplied, will be transmitted over an\nunverified TLS connection and are exposed to any MITM on the route.",
+          "type": "boolean"
         },
         "password": {
           "type": "string"

--- a/apps/daemon/pkg/toolbox/docs/swagger.yaml
+++ b/apps/daemon/pkg/toolbox/docs/swagger.yaml
@@ -113,7 +113,6 @@ definitions:
       points:
         items:
           items:
-            format: float64
             type: number
           type: array
         type: array
@@ -1902,7 +1901,6 @@ paths:
           name: quality
           type: integer
         - description: Scale factor (0.1-1.0)
-          format: float64
           in: query
           name: scale
           type: number
@@ -1993,7 +1991,6 @@ paths:
           name: quality
           type: integer
         - description: Scale factor (0.1-1.0)
-          format: float64
           in: query
           name: scale
           type: number

--- a/apps/daemon/pkg/toolbox/docs/swagger.yaml
+++ b/apps/daemon/pkg/toolbox/docs/swagger.yaml
@@ -113,6 +113,7 @@ definitions:
       points:
         items:
           items:
+            format: float64
             type: number
           type: array
         type: array
@@ -419,6 +420,13 @@ definitions:
         type: string
       commit_id:
         type: string
+      insecure_skip_tls:
+        description: |-
+          Skip TLS certificate verification for this clone. Defaults to false (verify).
+          Set to true ONLY for trusted internal Git servers with self-signed or
+          private-CA certs; credentials, if supplied, will be transmitted over an
+          unverified TLS connection and are exposed to any MITM on the route.
+        type: boolean
       password:
         type: string
       path:
@@ -1894,6 +1902,7 @@ paths:
           name: quality
           type: integer
         - description: Scale factor (0.1-1.0)
+          format: float64
           in: query
           name: scale
           type: number
@@ -1984,6 +1993,7 @@ paths:
           name: quality
           type: integer
         - description: Scale factor (0.1-1.0)
+          format: float64
           in: query
           name: scale
           type: number
@@ -2436,7 +2446,9 @@ paths:
     post:
       consumes:
         - application/json
-      description: Clone a Git repository to the specified path
+      description: Clone a Git repository to the specified path. Defaults to strict
+        TLS verification; set insecure_skip_tls=true to skip verification for self-signed
+        or private-CA Git servers.
       operationId: CloneRepository
       parameters:
         - description: Clone repository request

--- a/apps/daemon/pkg/toolbox/git/clone_repository.go
+++ b/apps/daemon/pkg/toolbox/git/clone_repository.go
@@ -17,7 +17,7 @@ import (
 // CloneRepository godoc
 //
 //	@Summary		Clone a Git repository
-//	@Description	Clone a Git repository to the specified path
+//	@Description	Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 //	@Tags			git
 //	@Accept			json
 //	@Produce		json
@@ -62,7 +62,9 @@ func CloneRepository(c *gin.Context) {
 		}
 	}
 
-	err := gitService.CloneRepository(&repo, auth)
+	insecureSkipTLS := req.InsecureSkipTLS != nil && *req.InsecureSkipTLS
+
+	err := gitService.CloneRepository(&repo, auth, insecureSkipTLS)
 	if err != nil {
 		abortWithGitError(c, err)
 		return

--- a/apps/daemon/pkg/toolbox/git/types.go
+++ b/apps/daemon/pkg/toolbox/git/types.go
@@ -16,6 +16,11 @@ type GitCloneRequest struct {
 	Password *string `json:"password,omitempty" validate:"optional"`
 	Branch   *string `json:"branch,omitempty" validate:"optional"`
 	CommitID *string `json:"commit_id,omitempty" validate:"optional"`
+	// Skip TLS certificate verification for this clone. Defaults to false (verify).
+	// Set to true ONLY for trusted internal Git servers with self-signed or
+	// private-CA certs; credentials, if supplied, will be transmitted over an
+	// unverified TLS connection and are exposed to any MITM on the route.
+	InsecureSkipTLS *bool `json:"insecure_skip_tls,omitempty" validate:"optional"`
 } //	@name	GitCloneRequest
 
 type GitCommitRequest struct {

--- a/apps/docs/src/content/docs/en/git-operations.mdx
+++ b/apps/docs/src/content/docs/en/git-operations.mdx
@@ -17,6 +17,8 @@ Similar to [file system operations](/docs/en/file-system-operations), the starti
 
 Daytona provides methods to clone Git repositories into sandboxes. You can clone public or private repositories, specific branches, and authenticate using personal access tokens.
 
+Clones verify the remote's TLS certificate by default. For clones against internal Git servers that use self-signed or private-CA certificates, pass `insecure_skip_tls=true` (`insecureSkipTls: true` in TypeScript / Java). The bypass is per-request and disables TLS verification for that clone only; credentials, if supplied, are transmitted over an unverified TLS connection and are exposed to any MITM on the route. Prefer adding the server's CA to the sandbox base image's trust store when possible.
+
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
@@ -40,6 +42,13 @@ sandbox.git.clone(
     url="https://github.com/user/repo.git",
     path="workspace/repo",
     branch="develop"
+)
+
+# Clone from a self-signed internal Git server (insecure)
+sandbox.git.clone(
+    url="https://internal-git.example.com/org/repo.git",
+    path="workspace/repo",
+    insecure_skip_tls=True
 )
 ```
 
@@ -69,6 +78,17 @@ await sandbox.git.clone(
     "workspace/repo",
     "develop"
 );
+
+// Clone from a self-signed internal Git server (insecure)
+await sandbox.git.clone(
+    "https://internal-git.example.com/org/repo.git",
+    "workspace/repo",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    true
+);
 ```
 
 </TabItem>
@@ -95,6 +115,13 @@ sandbox.git.clone(
   path: 'workspace/repo',
   branch: 'develop'
 )
+
+# Clone from a self-signed internal Git server (insecure)
+sandbox.git.clone(
+  url: 'https://internal-git.example.com/org/repo.git',
+  path: 'workspace/repo',
+  insecure_skip_tls: true
+)
 ```
 
 </TabItem>
@@ -119,6 +146,14 @@ if err != nil {
 // Clone specific branch
 err = sandbox.Git.Clone(ctx, "https://github.com/user/repo.git", "workspace/repo",
 	options.WithBranch("develop"),
+)
+if err != nil {
+	log.Fatal(err)
+}
+
+// Clone from a self-signed internal Git server (insecure)
+err = sandbox.Git.Clone(ctx, "https://internal-git.example.com/org/repo.git", "workspace/repo",
+	options.WithInsecureSkipTLS(true),
 )
 if err != nil {
 	log.Fatal(err)
@@ -151,6 +186,17 @@ sandbox.git.clone(
     null,
     null
 );
+
+// Clone from a self-signed internal Git server (insecure)
+sandbox.git.clone(
+    "https://internal-git.example.com/org/repo.git",
+    "workspace/repo",
+    null,
+    null,
+    null,
+    null,
+    true
+);
 ```
 
 </TabItem>
@@ -163,6 +209,7 @@ curl 'https://proxy.app.daytona.io/toolbox/{sandboxId}/git/clone' \
   --data '{
   "branch": "",
   "commit_id": "",
+  "insecure_skip_tls": false,
   "password": "",
   "path": "",
   "url": "",

--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -654,7 +654,7 @@ for sandbox, err := range client.ListSeq(ctx, &ListSandboxesQuery{...}) {
 
 CodeInterpreterService provides Python code execution capabilities for a sandbox.
 
-CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through \[Sandbox.CodeInterpreter\].
+CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through [Sandbox.CodeInterpreter](<#Sandbox>).
 
 Example:
 
@@ -696,7 +696,7 @@ func NewCodeInterpreterService(toolboxClient *toolbox.APIClient, otel *otelState
 
 NewCodeInterpreterService creates a new CodeInterpreterService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through \[Sandbox.CodeInterpreter\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through [Sandbox.CodeInterpreter](<#Sandbox>) rather than creating it directly.
 
 <a name="CodeInterpreterService.CreateContext"></a>
 ### func \(\*CodeInterpreterService\) CreateContext
@@ -831,7 +831,7 @@ Returns [OutputChannels](<#OutputChannels>) for receiving streamed output, or an
 
 ComputerUseService provides desktop automation operations for a sandbox.
 
-ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through \[Sandbox.ComputerUse\].
+ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through [Sandbox.ComputerUse](<#Sandbox>).
 
 Example:
 
@@ -872,7 +872,7 @@ func NewComputerUseService(toolboxClient *toolbox.APIClient, otel *otelState) *C
 
 NewComputerUseService creates a new ComputerUseService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through \[Sandbox.ComputerUse\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through [Sandbox.ComputerUse](<#Sandbox>) rather than creating it directly.
 
 <a name="ComputerUseService.Accessibility"></a>
 ### func \(\*ComputerUseService\) Accessibility
@@ -1518,7 +1518,7 @@ WithDownloadProgress returns an option that enables progress tracking for stream
 
 FileSystemService provides file system operations for a sandbox.
 
-FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through \[Sandbox.FileSystem\].
+FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through [Sandbox.FileSystem](<#Sandbox>).
 
 Example:
 
@@ -1551,7 +1551,7 @@ func NewFileSystemService(toolboxClient *toolbox.APIClient, otel *otelState) *Fi
 
 NewFileSystemService creates a new FileSystemService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through \[Sandbox.FileSystem\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through [Sandbox.FileSystem](<#Sandbox>) rather than creating it directly.
 
 <a name="FileSystemService.CreateFolder"></a>
 ### func \(\*FileSystemService\) CreateFolder
@@ -1957,7 +1957,7 @@ err := sandbox.FileSystem.UploadFileStream(ctx, f, "/home/user/big.bin",
 
 GitService provides Git operations for a sandbox.
 
-GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the \[Sandbox.Git\] field.
+GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the [Sandbox.Git](<#Sandbox>) field.
 
 Example:
 
@@ -1991,7 +1991,7 @@ func NewGitService(toolboxClient *toolbox.APIClient, otel *otelState) *GitServic
 
 NewGitService creates a new GitService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through \[Sandbox.Git\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through [Sandbox.Git](<#Sandbox>) rather than creating it directly.
 
 <a name="GitService.Add"></a>
 ### func \(\*GitService\) Add
@@ -2856,7 +2856,7 @@ type OutputChannels struct {
 
 ProcessService provides process execution operations for a sandbox.
 
-ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through \[Sandbox.Process\].
+ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through [Sandbox.Process](<#Sandbox>).
 
 Example:
 
@@ -2891,7 +2891,7 @@ func NewProcessService(toolboxClient *toolbox.APIClient, otel *otelState, langua
 
 NewProcessService creates a new ProcessService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through \[Sandbox.Process\] rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through [Sandbox.Process](<#Sandbox>) rather than creating it directly.
 
 <a name="ProcessService.CodeRun"></a>
 ### func \(\*ProcessService\) CodeRun

--- a/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/daytona.mdx
@@ -654,7 +654,7 @@ for sandbox, err := range client.ListSeq(ctx, &ListSandboxesQuery{...}) {
 
 CodeInterpreterService provides Python code execution capabilities for a sandbox.
 
-CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through [Sandbox.CodeInterpreter](<#Sandbox>).
+CodeInterpreterService enables running Python code in isolated execution contexts with support for streaming output, persistent state, and environment variables. It uses WebSockets for real\-time output streaming. Access through \[Sandbox.CodeInterpreter\].
 
 Example:
 
@@ -696,7 +696,7 @@ func NewCodeInterpreterService(toolboxClient *toolbox.APIClient, otel *otelState
 
 NewCodeInterpreterService creates a new CodeInterpreterService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through [Sandbox.CodeInterpreter](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access CodeInterpreterService through \[Sandbox.CodeInterpreter\] rather than creating it directly.
 
 <a name="CodeInterpreterService.CreateContext"></a>
 ### func \(\*CodeInterpreterService\) CreateContext
@@ -831,7 +831,7 @@ Returns [OutputChannels](<#OutputChannels>) for receiving streamed output, or an
 
 ComputerUseService provides desktop automation operations for a sandbox.
 
-ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through [Sandbox.ComputerUse](<#Sandbox>).
+ComputerUseService enables GUI automation including mouse control, keyboard input, screenshots, display management, and screen recording. The desktop environment must be started before using these features. Access through \[Sandbox.ComputerUse\].
 
 Example:
 
@@ -872,7 +872,7 @@ func NewComputerUseService(toolboxClient *toolbox.APIClient, otel *otelState) *C
 
 NewComputerUseService creates a new ComputerUseService.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through [Sandbox.ComputerUse](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ComputerUseService through \[Sandbox.ComputerUse\] rather than creating it directly.
 
 <a name="ComputerUseService.Accessibility"></a>
 ### func \(\*ComputerUseService\) Accessibility
@@ -1518,7 +1518,7 @@ WithDownloadProgress returns an option that enables progress tracking for stream
 
 FileSystemService provides file system operations for a sandbox.
 
-FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through [Sandbox.FileSystem](<#Sandbox>).
+FileSystemService enables file and directory management including creating, reading, writing, moving, and deleting files. It also supports file searching and permission management. Access through \[Sandbox.FileSystem\].
 
 Example:
 
@@ -1551,7 +1551,7 @@ func NewFileSystemService(toolboxClient *toolbox.APIClient, otel *otelState) *Fi
 
 NewFileSystemService creates a new FileSystemService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through [Sandbox.FileSystem](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access FileSystemService through \[Sandbox.FileSystem\] rather than creating it directly.
 
 <a name="FileSystemService.CreateFolder"></a>
 ### func \(\*FileSystemService\) CreateFolder
@@ -1957,7 +1957,7 @@ err := sandbox.FileSystem.UploadFileStream(ctx, f, "/home/user/big.bin",
 
 GitService provides Git operations for a sandbox.
 
-GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the [Sandbox.Git](<#Sandbox>) field.
+GitService enables common Git workflows including cloning repositories, staging and committing changes, managing branches, and syncing with remote repositories. It is accessed through the \[Sandbox.Git\] field.
 
 Example:
 
@@ -1991,7 +1991,7 @@ func NewGitService(toolboxClient *toolbox.APIClient, otel *otelState) *GitServic
 
 NewGitService creates a new GitService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through [Sandbox.Git](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access GitService through \[Sandbox.Git\] rather than creating it directly.
 
 <a name="GitService.Add"></a>
 ### func \(\*GitService\) Add
@@ -2856,7 +2856,7 @@ type OutputChannels struct {
 
 ProcessService provides process execution operations for a sandbox.
 
-ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through [Sandbox.Process](<#Sandbox>).
+ProcessService enables command execution, session management, and PTY \(pseudo\-terminal\) operations. It supports both synchronous command execution and interactive terminal sessions. Access through \[Sandbox.Process\].
 
 Example:
 
@@ -2891,7 +2891,7 @@ func NewProcessService(toolboxClient *toolbox.APIClient, otel *otelState, langua
 
 NewProcessService creates a new ProcessService with the provided toolbox client.
 
-This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through [Sandbox.Process](<#Sandbox>) rather than creating it directly.
+This is typically called internally by the SDK when creating a [Sandbox](<#Sandbox>). Users should access ProcessService through \[Sandbox.Process\] rather than creating it directly.
 
 <a name="ProcessService.CodeRun"></a>
 ### func \(\*ProcessService\) CodeRun

--- a/apps/docs/src/content/docs/en/go-sdk/options.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/options.mdx
@@ -60,6 +60,7 @@ opts := options.Apply(
 - [func WithForce\(force bool\) func\(\*GitDeleteBranch\)](<#WithForce>)
 - [func WithGroup\(group string\) func\(\*SetFilePermissions\)](<#WithGroup>)
 - [func WithIndexURL\(url string\) func\(\*PipInstall\)](<#WithIndexURL>)
+- [func WithInsecureSkipTLS\(insecureSkipTLS bool\) func\(\*GitClone\)](<#WithInsecureSkipTLS>)
 - [func WithInterpreterTimeout\(timeout time.Duration\) func\(\*RunCode\)](<#WithInterpreterTimeout>)
 - [func WithLogChannel\(logChannel chan string\) func\(\*CreateSandbox\)](<#WithLogChannel>)
 - [func WithMode\(mode string\) func\(\*CreateFolder\)](<#WithMode>)
@@ -444,6 +445,23 @@ image := daytona.Base("python:3.11").PipInstall(
 )
 ```
 
+<a name="WithInsecureSkipTLS"></a>
+## func WithInsecureSkipTLS
+
+```go
+func WithInsecureSkipTLS(insecureSkipTLS bool) func(*GitClone)
+```
+
+WithInsecureSkipTLS opts into skipping TLS certificate verification for the clone. Use ONLY when cloning from a trusted internal Git server with a self\-signed or private\-CA certificate. Credentials, if supplied, will be transmitted over an unverified TLS connection and are exposed to any MITM on the route.
+
+Example:
+
+```
+err := sandbox.Git.Clone(ctx, url, path,
+    options.WithInsecureSkipTLS(true),
+)
+```
+
 <a name="WithInterpreterTimeout"></a>
 ## func WithInterpreterTimeout
 
@@ -819,10 +837,11 @@ Fields are pointers to distinguish between unset values and zero values. Use the
 
 ```go
 type GitClone struct {
-    Branch   *string // Branch to clone (defaults to repository's default branch)
-    CommitId *string // Specific commit SHA to checkout after cloning
-    Username *string // Username for HTTPS authentication
-    Password *string // Password or token for HTTPS authentication
+    Branch          *string // Branch to clone (defaults to repository's default branch)
+    CommitId        *string // Specific commit SHA to checkout after cloning
+    Username        *string // Username for HTTPS authentication
+    Password        *string // Password or token for HTTPS authentication
+    InsecureSkipTLS *bool   // Skip TLS certificate verification (insecure). Use only for trusted internal Git servers with self-signed or private-CA certs.
 }
 ```
 

--- a/apps/docs/src/content/docs/en/java-sdk/git.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/git.mdx
@@ -48,6 +48,27 @@ Clones a repository with optional branch, commit, and credentials.
 
 - `io.daytona.sdk.exception.DaytonaException` - if cloning fails
 
+#### clone()
+```java
+public void clone(String url, String path, String branch, String commitId, String username, String password, Boolean insecureSkipTls)
+```
+
+Clones a repository with optional branch, commit, credentials, and TLS verification override.
+
+**Parameters**:
+
+- `url` _String_ - repository URL
+- `path` _String_ - destination path in the Sandbox
+- `branch` _String_ - branch to clone; `null` uses default branch
+- `commitId` _String_ - commit SHA to checkout after clone; `null` skips detached checkout
+- `username` _String_ - username for authenticated remotes
+- `password` _String_ - password or token for authenticated remotes
+- `insecureSkipTls` _Boolean_ - when `true`, skip TLS certificate verification (insecure). Use only for trusted internal Git servers with self-signed or private-CA certs; credentials, if supplied, are transmitted over an unverified TLS connection. `null` or `false` keeps strict TLS verification.
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if cloning fails
+
 #### branches()
 ```java
 public Map<String, Object> branches(String path)

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-git.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-git.mdx
@@ -116,7 +116,8 @@ async def clone(url: str,
                 branch: str | None = None,
                 commit_id: str | None = None,
                 username: str | None = None,
-                password: str | None = None) -> None
+                password: str | None = None,
+                insecure_skip_tls: bool | None = None) -> None
 ```
 
 Clones a Git repository into the specified path. It supports
@@ -134,6 +135,9 @@ repository if credentials are provided.
   the repository will be left in a detached HEAD state at this commit.
 - `username` _str | None_ - Git username for authentication.
 - `password` _str | None_ - Git password or token for authentication.
+- `insecure_skip_tls` _bool | None_ - Skip TLS certificate verification (insecure).
+  Use only for trusted internal Git servers with self-signed or private-CA certs;
+  credentials, if supplied, are transmitted over an unverified TLS connection.
   
 
 **Example**:

--- a/apps/docs/src/content/docs/en/python-sdk/sync/git.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/git.mdx
@@ -116,7 +116,8 @@ def clone(url: str,
           branch: str | None = None,
           commit_id: str | None = None,
           username: str | None = None,
-          password: str | None = None) -> None
+          password: str | None = None,
+          insecure_skip_tls: bool | None = None) -> None
 ```
 
 Clones a Git repository into the specified path. It supports
@@ -134,6 +135,9 @@ repository if credentials are provided.
   the repository will be left in a detached HEAD state at this commit.
 - `username` _str | None_ - Git username for authentication.
 - `password` _str | None_ - Git password or token for authentication.
+- `insecure_skip_tls` _bool | None_ - Skip TLS certificate verification (insecure).
+  Use only for trusted internal Git servers with self-signed or private-CA certs;
+  credentials, if supplied, are transmitted over an unverified TLS connection.
   
 
 **Example**:

--- a/apps/docs/src/content/docs/en/ruby-sdk/git.mdx
+++ b/apps/docs/src/content/docs/en/ruby-sdk/git.mdx
@@ -124,7 +124,7 @@ puts "Branches: #{response.branches}"
 #### clone()
 
 ```ruby
-def clone(url:, path:, branch:, commit_id:, username:, password:)
+def clone(url:, path:, branch:, commit_id:, username:, password:, insecure_skip_tls:)
 
 ```
 
@@ -143,6 +143,9 @@ clones the default branch.
 the repository will be left in a detached HEAD state at this commit.
 - `username` _String, nil_ - Git username for authentication.
 - `password` _String, nil_ - Git password or token for authentication.
+- `insecure_skip_tls` _Boolean, nil_ - Skip TLS certificate verification (insecure).
+Use only for trusted internal Git servers with self-signed or private-CA certs;
+credentials, if supplied, are transmitted over an unverified TLS connection.
 
 **Returns**:
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/git.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/git.mdx
@@ -121,7 +121,8 @@ clone(
    branch?: string, 
    commitId?: string, 
    username?: string, 
-password?: string): Promise<void>
+   password?: string, 
+insecureSkipTls?: boolean): Promise<void>
 ```
 
 Clones a Git repository into the specified path. It supports
@@ -136,6 +137,7 @@ repository if credentials are provided.
 - `commitId?` _string_ - Specific commit to clone. If specified, the repository will be left in a detached HEAD state at this commit
 - `username?` _string_ - Git username for authentication
 - `password?` _string_ - Git password or token for authentication
+- `insecureSkipTls?` _boolean_ - Skip TLS certificate verification (insecure). Use only for trusted internal Git servers with self-signed or private-CA certs.
 
 
 **Returns**:

--- a/libs/sdk-go/pkg/daytona/git.go
+++ b/libs/sdk-go/pkg/daytona/git.go
@@ -95,6 +95,9 @@ func (g *GitService) Clone(ctx context.Context, url, path string, opts ...func(*
 		if cloneOpts.Password != nil {
 			req.SetPassword(*cloneOpts.Password)
 		}
+		if cloneOpts.InsecureSkipTLS != nil {
+			req.SetInsecureSkipTls(*cloneOpts.InsecureSkipTLS)
+		}
 
 		httpResp, err := g.toolboxClient.GitAPI.CloneRepository(ctx).Request(*req).Execute()
 		if err != nil {

--- a/libs/sdk-go/pkg/options/git.go
+++ b/libs/sdk-go/pkg/options/git.go
@@ -54,10 +54,11 @@ func Apply[T any](opts ...func(*T)) *T {
 // Fields are pointers to distinguish between unset values and zero values.
 // Use the corresponding With* functions to set these options.
 type GitClone struct {
-	Branch   *string // Branch to clone (defaults to repository's default branch)
-	CommitId *string // Specific commit SHA to checkout after cloning
-	Username *string // Username for HTTPS authentication
-	Password *string // Password or token for HTTPS authentication
+	Branch          *string // Branch to clone (defaults to repository's default branch)
+	CommitId        *string // Specific commit SHA to checkout after cloning
+	Username        *string // Username for HTTPS authentication
+	Password        *string // Password or token for HTTPS authentication
+	InsecureSkipTLS *bool   // Skip TLS certificate verification (insecure). Use only for trusted internal Git servers with self-signed or private-CA certs.
 }
 
 // WithBranch sets the branch to clone instead of the repository's default branch.
@@ -116,6 +117,23 @@ func WithUsername(username string) func(*GitClone) {
 func WithPassword(password string) func(*GitClone) {
 	return func(opts *GitClone) {
 		opts.Password = &password
+	}
+}
+
+// WithInsecureSkipTLS opts into skipping TLS certificate verification for the
+// clone. Use ONLY when cloning from a trusted internal Git server with a
+// self-signed or private-CA certificate. Credentials, if supplied, will be
+// transmitted over an unverified TLS connection and are exposed to any MITM
+// on the route.
+//
+// Example:
+//
+//	err := sandbox.Git.Clone(ctx, url, path,
+//	    options.WithInsecureSkipTLS(true),
+//	)
+func WithInsecureSkipTLS(insecureSkipTLS bool) func(*GitClone) {
+	return func(opts *GitClone) {
+		opts.InsecureSkipTLS = &insecureSkipTLS
 	}
 }
 

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/Git.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/Git.java
@@ -38,7 +38,7 @@ public class Git {
      * @throws io.daytona.sdk.exception.DaytonaException if cloning fails
      */
     public void clone(String url, String path) {
-        clone(url, path, null, null, null, null);
+        clone(url, path, null, null, null, null, null);
     }
 
     /**
@@ -53,11 +53,31 @@ public class Git {
      * @throws io.daytona.sdk.exception.DaytonaException if cloning fails
      */
     public void clone(String url, String path, String branch, String commitId, String username, String password) {
+        clone(url, path, branch, commitId, username, password, null);
+    }
+
+    /**
+     * Clones a repository with optional branch, commit, credentials, and TLS verification override.
+     *
+     * @param url repository URL
+     * @param path destination path in the Sandbox
+     * @param branch branch to clone; {@code null} uses default branch
+     * @param commitId commit SHA to checkout after clone; {@code null} skips detached checkout
+     * @param username username for authenticated remotes
+     * @param password password or token for authenticated remotes
+     * @param insecureSkipTls when {@code true}, skip TLS certificate verification (insecure).
+     *   Use only for trusted internal Git servers with self-signed or private-CA certs;
+     *   credentials, if supplied, are transmitted over an unverified TLS connection.
+     *   {@code null} or {@code false} keeps strict TLS verification.
+     * @throws io.daytona.sdk.exception.DaytonaException if cloning fails
+     */
+    public void clone(String url, String path, String branch, String commitId, String username, String password, Boolean insecureSkipTls) {
         GitCloneRequest request = new GitCloneRequest().url(url).path(path);
         if (branch != null) request.branch(branch);
         if (commitId != null) request.commitId(commitId);
         if (username != null) request.username(username);
         if (password != null) request.password(password);
+        if (insecureSkipTls != null) request.insecureSkipTls(insecureSkipTls);
         ExceptionMapper.runToolbox(() -> gitApi.cloneRepository(request));
     }
 

--- a/libs/sdk-python/src/daytona/_async/git.py
+++ b/libs/sdk-python/src/daytona/_async/git.py
@@ -118,6 +118,7 @@ class AsyncGit:
         commit_id: str | None = None,
         username: str | None = None,
         password: str | None = None,
+        insecure_skip_tls: bool | None = None,
     ) -> None:
         """Clones a Git repository into the specified path. It supports
         cloning specific branches or commits, and can authenticate with the remote
@@ -133,6 +134,9 @@ class AsyncGit:
                 the repository will be left in a detached HEAD state at this commit.
             username (str | None): Git username for authentication.
             password (str | None): Git password or token for authentication.
+            insecure_skip_tls (bool | None): Skip TLS certificate verification (insecure).
+                Use only for trusted internal Git servers with self-signed or private-CA certs;
+                credentials, if supplied, are transmitted over an unverified TLS connection.
 
         Example:
             ```python
@@ -167,6 +171,7 @@ class AsyncGit:
                 username=username,
                 password=password,
                 commit_id=commit_id,
+                insecure_skip_tls=insecure_skip_tls,
             ),
         )
 

--- a/libs/sdk-python/src/daytona/_sync/git.py
+++ b/libs/sdk-python/src/daytona/_sync/git.py
@@ -118,6 +118,7 @@ class Git:
         commit_id: str | None = None,
         username: str | None = None,
         password: str | None = None,
+        insecure_skip_tls: bool | None = None,
     ) -> None:
         """Clones a Git repository into the specified path. It supports
         cloning specific branches or commits, and can authenticate with the remote
@@ -133,6 +134,9 @@ class Git:
                 the repository will be left in a detached HEAD state at this commit.
             username (str | None): Git username for authentication.
             password (str | None): Git password or token for authentication.
+            insecure_skip_tls (bool | None): Skip TLS certificate verification (insecure).
+                Use only for trusted internal Git servers with self-signed or private-CA certs;
+                credentials, if supplied, are transmitted over an unverified TLS connection.
 
         Example:
             ```python
@@ -167,6 +171,7 @@ class Git:
                 username=username,
                 password=password,
                 commit_id=commit_id,
+                insecure_skip_tls=insecure_skip_tls,
             ),
         )
 

--- a/libs/sdk-ruby/lib/daytona/git.rb
+++ b/libs/sdk-ruby/lib/daytona/git.rb
@@ -82,6 +82,9 @@ module Daytona
     #   the repository will be left in a detached HEAD state at this commit.
     # @param username [String, nil] Git username for authentication.
     # @param password [String, nil] Git password or token for authentication.
+    # @param insecure_skip_tls [Boolean, nil] Skip TLS certificate verification (insecure).
+    #   Use only for trusted internal Git servers with self-signed or private-CA certs;
+    #   credentials, if supplied, are transmitted over an unverified TLS connection.
     # @return [void]
     # @raise [Daytona::Sdk::Error] if cloning repository fails
     #
@@ -107,7 +110,7 @@ module Daytona
     #     path: "workspace/repo-old",
     #     commit_id: "abc123"
     #   )
-    def clone(url:, path:, branch: nil, commit_id: nil, username: nil, password: nil) # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+    def clone(url:, path:, branch: nil, commit_id: nil, username: nil, password: nil, insecure_skip_tls: nil) # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
       toolbox_api.clone_repository(
         DaytonaToolboxApiClient::GitCloneRequest.new(
           url: url,
@@ -115,7 +118,8 @@ module Daytona
           path: path,
           username: username,
           password: password,
-          commit_id: commit_id
+          commit_id: commit_id,
+          insecure_skip_tls: insecure_skip_tls
         )
       )
     rescue DaytonaToolboxApiClient::ApiError => e

--- a/libs/sdk-typescript/src/Git.ts
+++ b/libs/sdk-typescript/src/Git.ts
@@ -133,6 +133,7 @@ export class Git {
    * @param {string} [commitId] - Specific commit to clone. If specified, the repository will be left in a detached HEAD state at this commit
    * @param {string} [username] - Git username for authentication
    * @param {string} [password] - Git password or token for authentication
+   * @param {boolean} [insecureSkipTls] - Skip TLS certificate verification (insecure). Use only for trusted internal Git servers with self-signed or private-CA certs.
    * @returns {Promise<void>}
    *
    * @example
@@ -168,6 +169,7 @@ export class Git {
     commitId?: string,
     username?: string,
     password?: string,
+    insecureSkipTls?: boolean,
   ): Promise<void> {
     await this.apiClient.cloneRepository({
       url: url,
@@ -176,6 +178,7 @@ export class Git {
       username,
       password,
       commit_id: commitId,
+      insecure_skip_tls: insecureSkipTls,
     })
   }
 

--- a/libs/toolbox-api-client-go/api/openapi.yaml
+++ b/libs/toolbox-api-client-go/api/openapi.yaml
@@ -844,7 +844,6 @@ paths:
         in: query
         name: scale
         schema:
-          format: float64
           type: number
       responses:
         "200":
@@ -948,7 +947,6 @@ paths:
         in: query
         name: scale
         schema:
-          format: float64
           type: number
       responses:
         "200":
@@ -1409,9 +1407,9 @@ paths:
       x-codegen-request-body-name: request
   /git/clone:
     post:
-      description: Clone a Git repository to the specified path. Defaults to strict
-        TLS verification; set insecure_skip_tls=true to skip verification for self-signed
-        or private-CA Git servers.
+      description: "Clone a Git repository to the specified path. Defaults to strict\
+        \ TLS verification; set insecure_skip_tls=true to skip verification for self-signed\
+        \ or private-CA Git servers."
       operationId: CloneRepository
       requestBody:
         content:
@@ -2612,7 +2610,6 @@ components:
         points:
           items:
             items:
-              format: float64
               type: number
             type: array
           type: array
@@ -3322,9 +3319,9 @@ components:
       example:
         path: path
         password: password
+        insecure_skip_tls: true
         branch: branch
         commit_id: commit_id
-        insecure_skip_tls: true
         url: url
         username: username
       properties:

--- a/libs/toolbox-api-client-go/api/openapi.yaml
+++ b/libs/toolbox-api-client-go/api/openapi.yaml
@@ -1407,9 +1407,9 @@ paths:
       x-codegen-request-body-name: request
   /git/clone:
     post:
-      description: "Clone a Git repository to the specified path. Defaults to strict\
-        \ TLS verification; set insecure_skip_tls=true to skip verification for self-signed\
-        \ or private-CA Git servers."
+      description: Clone a Git repository to the specified path. Defaults to strict
+        TLS verification; set insecure_skip_tls=true to skip verification for self-signed
+        or private-CA Git servers.
       operationId: CloneRepository
       requestBody:
         content:
@@ -3319,9 +3319,9 @@ components:
       example:
         path: path
         password: password
-        insecure_skip_tls: true
         branch: branch
         commit_id: commit_id
+        insecure_skip_tls: true
         url: url
         username: username
       properties:

--- a/libs/toolbox-api-client-go/api/openapi.yaml
+++ b/libs/toolbox-api-client-go/api/openapi.yaml
@@ -844,6 +844,7 @@ paths:
         in: query
         name: scale
         schema:
+          format: float64
           type: number
       responses:
         "200":
@@ -947,6 +948,7 @@ paths:
         in: query
         name: scale
         schema:
+          format: float64
           type: number
       responses:
         "200":
@@ -1407,7 +1409,9 @@ paths:
       x-codegen-request-body-name: request
   /git/clone:
     post:
-      description: Clone a Git repository to the specified path
+      description: Clone a Git repository to the specified path. Defaults to strict
+        TLS verification; set insecure_skip_tls=true to skip verification for self-signed
+        or private-CA Git servers.
       operationId: CloneRepository
       requestBody:
         content:
@@ -2608,6 +2612,7 @@ components:
         points:
           items:
             items:
+              format: float64
               type: number
             type: array
           type: array
@@ -3319,6 +3324,7 @@ components:
         password: password
         branch: branch
         commit_id: commit_id
+        insecure_skip_tls: true
         url: url
         username: username
       properties:
@@ -3326,6 +3332,13 @@ components:
           type: string
         commit_id:
           type: string
+        insecure_skip_tls:
+          description: |-
+            Skip TLS certificate verification for this clone. Defaults to false (verify).
+            Set to true ONLY for trusted internal Git servers with self-signed or
+            private-CA certs; credentials, if supplied, will be transmitted over an
+            unverified TLS connection and are exposed to any MITM on the route.
+          type: boolean
         password:
           type: string
         path:

--- a/libs/toolbox-api-client-go/api_git.go
+++ b/libs/toolbox-api-client-go/api_git.go
@@ -50,7 +50,7 @@ type GitAPI interface {
 	/*
 	CloneRepository Clone a Git repository
 
-	Clone a Git repository to the specified path
+	Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@return GitAPICloneRepositoryRequest
@@ -391,7 +391,7 @@ func (r GitAPICloneRepositoryRequest) Execute() (*http.Response, error) {
 /*
 CloneRepository Clone a Git repository
 
-Clone a Git repository to the specified path
+Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @return GitAPICloneRepositoryRequest

--- a/libs/toolbox-api-client-go/model_git_clone_request.go
+++ b/libs/toolbox-api-client-go/model_git_clone_request.go
@@ -23,6 +23,8 @@ var _ MappedNullable = &GitCloneRequest{}
 type GitCloneRequest struct {
 	Branch *string `json:"branch,omitempty"`
 	CommitId *string `json:"commit_id,omitempty"`
+	// Skip TLS certificate verification for this clone. Defaults to false (verify). Set to true ONLY for trusted internal Git servers with self-signed or private-CA certs; credentials, if supplied, will be transmitted over an unverified TLS connection and are exposed to any MITM on the route.
+	InsecureSkipTls *bool `json:"insecure_skip_tls,omitempty"`
 	Password *string `json:"password,omitempty"`
 	Path string `json:"path"`
 	Url string `json:"url"`
@@ -112,6 +114,38 @@ func (o *GitCloneRequest) HasCommitId() bool {
 // SetCommitId gets a reference to the given string and assigns it to the CommitId field.
 func (o *GitCloneRequest) SetCommitId(v string) {
 	o.CommitId = &v
+}
+
+// GetInsecureSkipTls returns the InsecureSkipTls field value if set, zero value otherwise.
+func (o *GitCloneRequest) GetInsecureSkipTls() bool {
+	if o == nil || IsNil(o.InsecureSkipTls) {
+		var ret bool
+		return ret
+	}
+	return *o.InsecureSkipTls
+}
+
+// GetInsecureSkipTlsOk returns a tuple with the InsecureSkipTls field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *GitCloneRequest) GetInsecureSkipTlsOk() (*bool, bool) {
+	if o == nil || IsNil(o.InsecureSkipTls) {
+		return nil, false
+	}
+	return o.InsecureSkipTls, true
+}
+
+// HasInsecureSkipTls returns a boolean if a field has been set.
+func (o *GitCloneRequest) HasInsecureSkipTls() bool {
+	if o != nil && !IsNil(o.InsecureSkipTls) {
+		return true
+	}
+
+	return false
+}
+
+// SetInsecureSkipTls gets a reference to the given bool and assigns it to the InsecureSkipTls field.
+func (o *GitCloneRequest) SetInsecureSkipTls(v bool) {
+	o.InsecureSkipTls = &v
 }
 
 // GetPassword returns the Password field value if set, zero value otherwise.
@@ -241,6 +275,9 @@ func (o GitCloneRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.CommitId) {
 		toSerialize["commit_id"] = o.CommitId
+	}
+	if !IsNil(o.InsecureSkipTls) {
+		toSerialize["insecure_skip_tls"] = o.InsecureSkipTls
 	}
 	if !IsNil(o.Password) {
 		toSerialize["password"] = o.Password

--- a/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/api/GitApi.java
+++ b/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/api/GitApi.java
@@ -396,7 +396,7 @@ public class GitApi {
 
     /**
      * Clone a Git repository
-     * Clone a Git repository to the specified path
+     * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls&#x3D;true to skip verification for self-signed or private-CA Git servers.
      * @param request Clone repository request (required)
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -412,7 +412,7 @@ public class GitApi {
 
     /**
      * Clone a Git repository
-     * Clone a Git repository to the specified path
+     * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls&#x3D;true to skip verification for self-signed or private-CA Git servers.
      * @param request Clone repository request (required)
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -430,7 +430,7 @@ public class GitApi {
 
     /**
      * Clone a Git repository (asynchronously)
-     * Clone a Git repository to the specified path
+     * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls&#x3D;true to skip verification for self-signed or private-CA Git servers.
      * @param request Clone repository request (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call

--- a/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/GitCloneRequest.java
+++ b/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/GitCloneRequest.java
@@ -60,6 +60,11 @@ public class GitCloneRequest {
   @javax.annotation.Nullable
   private String commitId;
 
+  public static final String SERIALIZED_NAME_INSECURE_SKIP_TLS = "insecure_skip_tls";
+  @SerializedName(SERIALIZED_NAME_INSECURE_SKIP_TLS)
+  @javax.annotation.Nullable
+  private Boolean insecureSkipTls;
+
   public static final String SERIALIZED_NAME_PASSWORD = "password";
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   @javax.annotation.Nullable
@@ -118,6 +123,25 @@ public class GitCloneRequest {
 
   public void setCommitId(@javax.annotation.Nullable String commitId) {
     this.commitId = commitId;
+  }
+
+
+  public GitCloneRequest insecureSkipTls(@javax.annotation.Nullable Boolean insecureSkipTls) {
+    this.insecureSkipTls = insecureSkipTls;
+    return this;
+  }
+
+  /**
+   * Skip TLS certificate verification for this clone. Defaults to false (verify). Set to true ONLY for trusted internal Git servers with self-signed or private-CA certs; credentials, if supplied, will be transmitted over an unverified TLS connection and are exposed to any MITM on the route.
+   * @return insecureSkipTls
+   */
+  @javax.annotation.Nullable
+  public Boolean getInsecureSkipTls() {
+    return insecureSkipTls;
+  }
+
+  public void setInsecureSkipTls(@javax.annotation.Nullable Boolean insecureSkipTls) {
+    this.insecureSkipTls = insecureSkipTls;
   }
 
 
@@ -253,6 +277,7 @@ public class GitCloneRequest {
     GitCloneRequest gitCloneRequest = (GitCloneRequest) o;
     return Objects.equals(this.branch, gitCloneRequest.branch) &&
         Objects.equals(this.commitId, gitCloneRequest.commitId) &&
+        Objects.equals(this.insecureSkipTls, gitCloneRequest.insecureSkipTls) &&
         Objects.equals(this.password, gitCloneRequest.password) &&
         Objects.equals(this.path, gitCloneRequest.path) &&
         Objects.equals(this.url, gitCloneRequest.url) &&
@@ -262,7 +287,7 @@ public class GitCloneRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(branch, commitId, password, path, url, username, additionalProperties);
+    return Objects.hash(branch, commitId, insecureSkipTls, password, path, url, username, additionalProperties);
   }
 
   @Override
@@ -271,6 +296,7 @@ public class GitCloneRequest {
     sb.append("class GitCloneRequest {\n");
     sb.append("    branch: ").append(toIndentedString(branch)).append("\n");
     sb.append("    commitId: ").append(toIndentedString(commitId)).append("\n");
+    sb.append("    insecureSkipTls: ").append(toIndentedString(insecureSkipTls)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    path: ").append(toIndentedString(path)).append("\n");
     sb.append("    url: ").append(toIndentedString(url)).append("\n");
@@ -294,7 +320,7 @@ public class GitCloneRequest {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("branch", "commit_id", "password", "path", "url", "username"));
+    openapiFields = new HashSet<String>(Arrays.asList("branch", "commit_id", "insecure_skip_tls", "password", "path", "url", "username"));
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>(Arrays.asList("path", "url"));

--- a/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/api/GitApiTest.java
+++ b/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/api/GitApiTest.java
@@ -72,7 +72,7 @@ public class GitApiTest {
     /**
      * Clone a Git repository
      *
-     * Clone a Git repository to the specified path
+     * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls&#x3D;true to skip verification for self-signed or private-CA Git servers.
      *
      * @throws ApiException if the Api call fails
      */

--- a/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/GitCloneRequestTest.java
+++ b/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/GitCloneRequestTest.java
@@ -54,6 +54,14 @@ public class GitCloneRequestTest {
     }
 
     /**
+     * Test the property 'insecureSkipTls'
+     */
+    @Test
+    public void insecureSkipTlsTest() {
+        // TODO: test insecureSkipTls
+    }
+
+    /**
      * Test the property 'password'
      */
     @Test

--- a/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/api/git_api.py
+++ b/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/api/git_api.py
@@ -599,7 +599,7 @@ class GitApi:
     ) -> None:
         """Clone a Git repository
 
-        Clone a Git repository to the specified path
+        Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
         :param request: Clone repository request (required)
         :type request: GitCloneRequest
@@ -666,7 +666,7 @@ class GitApi:
     ) -> ApiResponse[None]:
         """Clone a Git repository
 
-        Clone a Git repository to the specified path
+        Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
         :param request: Clone repository request (required)
         :type request: GitCloneRequest
@@ -733,7 +733,7 @@ class GitApi:
     ) -> RESTResponseType:
         """Clone a Git repository
 
-        Clone a Git repository to the specified path
+        Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
         :param request: Clone repository request (required)
         :type request: GitCloneRequest

--- a/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/git_clone_request.py
+++ b/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/git_clone_request.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
@@ -31,12 +31,13 @@ class GitCloneRequest(BaseModel):
     """ # noqa: E501
     branch: Optional[StrictStr] = None
     commit_id: Optional[StrictStr] = None
+    insecure_skip_tls: Optional[StrictBool] = Field(default=None, description="Skip TLS certificate verification for this clone. Defaults to false (verify). Set to true ONLY for trusted internal Git servers with self-signed or private-CA certs; credentials, if supplied, will be transmitted over an unverified TLS connection and are exposed to any MITM on the route.")
     password: Optional[StrictStr] = None
     path: StrictStr
     url: StrictStr
     username: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["branch", "commit_id", "password", "path", "url", "username"]
+    __properties: ClassVar[List[str]] = ["branch", "commit_id", "insecure_skip_tls", "password", "path", "url", "username"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,6 +98,7 @@ class GitCloneRequest(BaseModel):
         _obj = cls.model_validate({
             "branch": obj.get("branch"),
             "commit_id": obj.get("commit_id"),
+            "insecure_skip_tls": obj.get("insecure_skip_tls"),
             "password": obj.get("password"),
             "path": obj.get("path"),
             "url": obj.get("url"),

--- a/libs/toolbox-api-client-python/daytona_toolbox_api_client/api/git_api.py
+++ b/libs/toolbox-api-client-python/daytona_toolbox_api_client/api/git_api.py
@@ -599,7 +599,7 @@ class GitApi:
     ) -> None:
         """Clone a Git repository
 
-        Clone a Git repository to the specified path
+        Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
         :param request: Clone repository request (required)
         :type request: GitCloneRequest
@@ -666,7 +666,7 @@ class GitApi:
     ) -> ApiResponse[None]:
         """Clone a Git repository
 
-        Clone a Git repository to the specified path
+        Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
         :param request: Clone repository request (required)
         :type request: GitCloneRequest
@@ -733,7 +733,7 @@ class GitApi:
     ) -> RESTResponseType:
         """Clone a Git repository
 
-        Clone a Git repository to the specified path
+        Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
 
         :param request: Clone repository request (required)
         :type request: GitCloneRequest

--- a/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/git_clone_request.py
+++ b/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/git_clone_request.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import TypeAdapter
 from typing import Optional, Set
@@ -31,12 +31,13 @@ class GitCloneRequest(BaseModel):
     """ # noqa: E501
     branch: Optional[StrictStr] = None
     commit_id: Optional[StrictStr] = None
+    insecure_skip_tls: Optional[StrictBool] = Field(default=None, description="Skip TLS certificate verification for this clone. Defaults to false (verify). Set to true ONLY for trusted internal Git servers with self-signed or private-CA certs; credentials, if supplied, will be transmitted over an unverified TLS connection and are exposed to any MITM on the route.")
     password: Optional[StrictStr] = None
     path: StrictStr
     url: StrictStr
     username: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["branch", "commit_id", "password", "path", "url", "username"]
+    __properties: ClassVar[List[str]] = ["branch", "commit_id", "insecure_skip_tls", "password", "path", "url", "username"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,6 +98,7 @@ class GitCloneRequest(BaseModel):
         _obj = cls.model_validate({
             "branch": obj.get("branch"),
             "commit_id": obj.get("commit_id"),
+            "insecure_skip_tls": obj.get("insecure_skip_tls"),
             "password": obj.get("password"),
             "path": obj.get("path"),
             "url": obj.get("url"),

--- a/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/api/git_api.rb
+++ b/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/api/git_api.rb
@@ -152,7 +152,7 @@ module DaytonaToolboxApiClient
     end
 
     # Clone a Git repository
-    # Clone a Git repository to the specified path
+    # Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
     # @param request [GitCloneRequest] Clone repository request
     # @param [Hash] opts the optional parameters
     # @return [nil]
@@ -162,7 +162,7 @@ module DaytonaToolboxApiClient
     end
 
     # Clone a Git repository
-    # Clone a Git repository to the specified path
+    # Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls&#x3D;true to skip verification for self-signed or private-CA Git servers.
     # @param request [GitCloneRequest] Clone repository request
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers

--- a/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/git_clone_request.rb
+++ b/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/git_clone_request.rb
@@ -19,6 +19,9 @@ module DaytonaToolboxApiClient
 
     attr_accessor :commit_id
 
+    # Skip TLS certificate verification for this clone. Defaults to false (verify). Set to true ONLY for trusted internal Git servers with self-signed or private-CA certs; credentials, if supplied, will be transmitted over an unverified TLS connection and are exposed to any MITM on the route.
+    attr_accessor :insecure_skip_tls
+
     attr_accessor :password
 
     attr_accessor :path
@@ -32,6 +35,7 @@ module DaytonaToolboxApiClient
       {
         :'branch' => :'branch',
         :'commit_id' => :'commit_id',
+        :'insecure_skip_tls' => :'insecure_skip_tls',
         :'password' => :'password',
         :'path' => :'path',
         :'url' => :'url',
@@ -54,6 +58,7 @@ module DaytonaToolboxApiClient
       {
         :'branch' => :'String',
         :'commit_id' => :'String',
+        :'insecure_skip_tls' => :'Boolean',
         :'password' => :'String',
         :'path' => :'String',
         :'url' => :'String',
@@ -89,6 +94,10 @@ module DaytonaToolboxApiClient
 
       if attributes.key?(:'commit_id')
         self.commit_id = attributes[:'commit_id']
+      end
+
+      if attributes.key?(:'insecure_skip_tls')
+        self.insecure_skip_tls = attributes[:'insecure_skip_tls']
       end
 
       if attributes.key?(:'password')
@@ -164,6 +173,7 @@ module DaytonaToolboxApiClient
       self.class == o.class &&
           branch == o.branch &&
           commit_id == o.commit_id &&
+          insecure_skip_tls == o.insecure_skip_tls &&
           password == o.password &&
           path == o.path &&
           url == o.url &&
@@ -179,7 +189,7 @@ module DaytonaToolboxApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [branch, commit_id, password, path, url, username].hash
+      [branch, commit_id, insecure_skip_tls, password, path, url, username].hash
     end
 
     # Builds the object from hash

--- a/libs/toolbox-api-client/src/api/git-api.ts
+++ b/libs/toolbox-api-client/src/api/git-api.ts
@@ -117,7 +117,7 @@ export const GitApiAxiosParamCreator = function (configuration?: Configuration) 
             };
         },
         /**
-         * Clone a Git repository to the specified path
+         * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
          * @summary Clone a Git repository
          * @param {GitCloneRequest} request Clone repository request
          * @param {*} [options] Override http request option.
@@ -468,7 +468,7 @@ export const GitApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Clone a Git repository to the specified path
+         * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
          * @summary Clone a Git repository
          * @param {GitCloneRequest} request Clone repository request
          * @param {*} [options] Override http request option.
@@ -614,7 +614,7 @@ export const GitApiFactory = function (configuration?: Configuration, basePath?:
             return localVarFp.checkoutBranch(request, options).then((request) => request(axios, basePath));
         },
         /**
-         * Clone a Git repository to the specified path
+         * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
          * @summary Clone a Git repository
          * @param {GitCloneRequest} request Clone repository request
          * @param {*} [options] Override http request option.
@@ -733,7 +733,7 @@ export class GitApi extends BaseAPI {
     }
 
     /**
-     * Clone a Git repository to the specified path
+     * Clone a Git repository to the specified path. Defaults to strict TLS verification; set insecure_skip_tls=true to skip verification for self-signed or private-CA Git servers.
      * @summary Clone a Git repository
      * @param {GitCloneRequest} request Clone repository request
      * @param {*} [options] Override http request option.

--- a/libs/toolbox-api-client/src/models/git-clone-request.ts
+++ b/libs/toolbox-api-client/src/models/git-clone-request.ts
@@ -17,6 +17,10 @@
 export interface GitCloneRequest {
     'branch'?: string;
     'commit_id'?: string;
+    /**
+     * Skip TLS certificate verification for this clone. Defaults to false (verify). Set to true ONLY for trusted internal Git servers with self-signed or private-CA certs; credentials, if supplied, will be transmitted over an unverified TLS connection and are exposed to any MITM on the route.
+     */
+    'insecure_skip_tls'?: boolean;
     'password'?: string;
     'path': string;
     'url': string;


### PR DESCRIPTION
Daemon `git clone` verifies TLS certificates by default on both the go-git and CLI paths, matching the existing behavior of `pull` and `push`. Regression tests added to prevent the bypass being silently reintroduced.

Adds an opt-in `insecure_skip_tls` flag on the clone request for users hitting internal Git servers with self-signed or private-CA certificates. Strict TLS stays the default; setting `insecure_skip_tls=true` skips verification for that clone only. Plumbed through all five SDKs (Go / TypeScript / Python sync+async / Ruby / Java). OpenAPI spec and toolbox-api-client packages regenerated.

Operators with sandbox-shell access also retain a native escape valve: `GIT_SSL_NO_VERIFY=true git clone https://…` from inside the sandbox continues to work as before, untouched by this change.

## Test plan
- [ ] `go test ./apps/daemon/pkg/git/...` passes locally (covers strict-default regression + opt-in plumbing)
- [ ] `nx run docs:build` clean