### PR TITLE
feat(docs): gpu updates

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -305,26 +305,25 @@ Daytona provides methods to create GPU sandboxes using the [Daytona Dashboard �
 
 Daytona supports NVIDIA GPU devices for snapshot-based sandbox creation. This allows you to run GPU workloads such as model inference, fine-tuning, and CUDA-accelerated compute inside a sandbox created from a [GPU snapshot](/docs/en/snapshots#gpu-snapshots). GPU sandboxes must be ephemeral.
 
-Each GPU sandbox supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
+Use the pre-built `daytona-gpu` system snapshot to create a ready-to-use GPU environment. Create a custom GPU snapshot only when you need different packages, tooling, or configuration. Each GPU sandbox supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
 
-1. Create a [GPU Snapshot](/docs/en/snapshots#gpu-snapshots)
-2. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
-3. Click **Create Sandbox**
-4. Select your GPU snapshot
-5. Click **Create** to create a GPU sandbox
+1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
+2. Click **Create Sandbox**
+3. Select a GPU snapshot
+4. Click **Create** to create a GPU sandbox
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
 ```python
-from daytona import Daytona, CreateSandboxFromSnapshotParams
+from daytona import Daytona, DaytonaConfig, CreateSandboxFromSnapshotParams
 
-daytona = Daytona()
+daytona = Daytona(DaytonaConfig(target="us-east-1"))
 sandbox = daytona.create(
-    CreateSandboxFromSnapshotParams(
-        snapshot="my-gpu-snapshot",
-        ephemeral=True,
-    )
+        CreateSandboxFromSnapshotParams(
+            snapshot="daytona-gpu",
+            auto_delete_interval=0
+            ),
 )
 ```
 
@@ -334,9 +333,11 @@ sandbox = daytona.create(
 ```typescript
 import { Daytona } from "@daytona/sdk";
 
-const daytona = new Daytona();
+const daytona = new Daytona({
+  target: "us-east-1",
+});
 const sandbox = await daytona.create({
-  snapshot: "my-gpu-snapshot",
+  snapshot: "daytona-gpu",
   ephemeral: true,
 });
 ```
@@ -347,10 +348,13 @@ const sandbox = await daytona.create({
 ```ruby
 require 'daytona'
 
-daytona = Daytona::Daytona.new
+config = Daytona::Config.new(
+  target: "us-east-1"
+)
+daytona = Daytona::Daytona.new(config)
 sandbox = daytona.create(
   Daytona::CreateSandboxFromSnapshotParams.new(
-    snapshot: 'my-gpu-snapshot',
+    snapshot: 'daytona-gpu',
     ephemeral: true
   )
 )
@@ -369,10 +373,12 @@ import (
 )
 
 func main() {
-	client, _ := daytona.NewClient()
+	client, _ := daytona.NewClientWithConfig(&types.DaytonaConfig{
+		Target: "us-east-1",
+	})
 	ctx := context.Background()
 	params := types.SnapshotParams{
-		Snapshot: "my-gpu-snapshot",
+		Snapshot: "daytona-gpu",
 		SandboxBaseParams: types.SandboxBaseParams{
 			Ephemeral: true,
 		},
@@ -386,14 +392,20 @@ func main() {
 
 ```java
 import io.daytona.sdk.Daytona;
+import io.daytona.sdk.DaytonaConfig;
 import io.daytona.sdk.Sandbox;
 import io.daytona.sdk.model.CreateSandboxFromSnapshotParams;
 
 public class App {
     public static void main(String[] args) {
-        try (Daytona daytona = new Daytona()) {
+        DaytonaConfig config = new DaytonaConfig.Builder()
+                .apiKey(System.getenv("DAYTONA_API_KEY"))
+                .target("us-east-1")
+                .build();
+
+        try (Daytona daytona = new Daytona(config)) {
             CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
-            params.setSnapshot("my-gpu-snapshot");
+            params.setSnapshot("daytona-gpu");
             params.setAutoDeleteInterval(0);
             Sandbox sandbox = daytona.create(params);
         }
@@ -405,7 +417,7 @@ public class App {
 <TabItem label="CLI" icon="seti:shell">
 
 ```bash
-daytona create --snapshot my-gpu-snapshot --auto-delete 0
+daytona create --snapshot daytona-gpu --target us-east-1 --auto-delete 0
 ```
 
 </TabItem>
@@ -417,7 +429,8 @@ curl 'https://app.daytona.io/api/sandbox' \
   --header 'Content-Type: application/json' \
   --header 'Authorization: Bearer YOUR_API_KEY' \
   --data '{
-  "snapshot": "my-gpu-snapshot",
+  "target": "us-east-1",
+  "snapshot": "daytona-gpu",
   "autoDeleteInterval": 0
 }'
 ```

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -305,6 +305,8 @@ Daytona provides methods to create GPU sandboxes using the [Daytona Dashboard â†
 
 Daytona supports NVIDIA GPU devices for snapshot-based sandbox creation. This allows you to run GPU workloads such as model inference, fine-tuning, and CUDA-accelerated compute inside a sandbox created from a [GPU snapshot](/docs/en/snapshots#gpu-snapshots). GPU sandboxes must be ephemeral.
 
+Each GPU sandbox supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
+
 1. Create a [GPU Snapshot](/docs/en/snapshots#gpu-snapshots)
 2. Navigate to [Daytona Sandboxes â†—](https://app.daytona.io/dashboard/sandboxes)
 3. Click **Create Sandbox**

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -12,67 +12,19 @@ Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. [Organizat
 
 Sandboxes use [snapshots](/docs/en/snapshots) to capture a fully configured environment (base OS, installed packages, dependencies, and configuration) to create new sandboxes.
 
-Each sandbox has its own network stack with per-sandbox firewall rules. By default, sandboxes follow standard network policies, but you can restrict egress to a specific set of allowed destinations or block all outbound traffic entirely. For details on configuring network access, see [network limits](/docs/en/network-limits).
+Each sandbox has its own network stack with per-sandbox firewall rules. By default, sandboxes follow standard network policies, but you can restrict egress to a specific set of allowed destinations or block all outbound traffic entirely. For more details, see [network limits](/docs/en/network-limits).
 
-A detailed overview of the Daytona platform is available in the [architecture](/docs/en/architecture) section.
-
-## Sandbox lifecycle
-
-A sandbox can have several different states. Each state reflects the current status of your sandbox.
-
-- [**Creating**](#create-sandboxes): the sandbox is provisioning and will be ready to use
-- [**Starting**](#start-sandboxes): the sandbox is starting and will be ready to use
-- [**Started**](#start-sandboxes): the sandbox has started and is ready to use
-- [**Stopping**](#stop-sandboxes): the sandbox is stopping and will no longer accept requests
-- [**Stopped**](#stop-sandboxes): the sandbox has stopped and is no longer running
-- [**Deleting**](#delete-sandboxes): the sandbox is deleting and will be removed
-- [**Deleted**](#delete-sandboxes): the sandbox has been deleted and no longer exists
-- [**Archiving**](#archive-sandboxes): the sandbox is archiving and its state will be preserved
-- [**Archived**](#archive-sandboxes): the sandbox has been archived and its state is preserved
-- [**Resizing**](#resize-sandboxes): the sandbox is being resized to a new set of resources
-- [**Error**](#recover-sandboxes): the sandbox is in an error state and needs to be recovered
-- **Restoring**: the sandbox is being restored from archive and will be ready to use shortly
-- **Unknown**: the default sandbox state before it is created
-- **Pulling Snapshot**: the sandbox is pulling a [snapshot](/docs/en/snapshots) to provide a base environment
-- **Building Snapshot**: the sandbox is building a [snapshot](/docs/en/snapshots) to provide a base environment
-- **Build Pending**: the sandbox build is pending and will start shortly
-- **Build Failed**: the sandbox build failed and needs to be retried
-
-To view or update the current state of a sandbox, navigate to the [sandbox details page](#sandbox-details-page) or access the sandbox `state` attribute using the [SDKs](/docs/en/getting-started/#sdks), [API](/docs/en/tools/api/#daytona/tag/sandbox/GET/sandbox/{sandboxIdOrName}), or [CLI](/docs/en/tools/cli/#daytona-info).
-
-The diagram below demonstrates the states and possible transitions between them.
-
-<SandboxDiagram />
-
-## Multiple runtime support
-
-Daytona sandboxes support Python, TypeScript, and JavaScript programming language runtimes for direct code execution inside the sandbox. The `language` parameter controls which programming language runtime is used for the sandbox:
-
-- **`python`**
-- **`typescript`**
-- **`javascript`**
-
-If omitted, the Daytona SDK will default to `python`. To override this, explicitly set the `language` value when creating the sandbox.
+- **Sandbox SDKs**: [TypeScript](/docs/en/typescript-sdk/sandbox), [Python](/docs/en/python-sdk/sync/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox), [Java](/docs/en/java-sdk/sandbox)
+- **Sandbox API**: [RESTful API](/docs/en/tools/api/#daytona/tag/sandbox) ([OpenAPI spec](/docs/openapi.json)), [Toolbox API](/docs/en/tools/api#daytona-toolbox) ([OpenAPI spec](/docs/toolbox-openapi.json))
+- **Sandbox CLI**: [Mac/Linux/Windows](/docs/en/tools/cli)
 
 ## Create Sandboxes
 
-Daytona provides methods to create sandboxes using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/sandbox), [TypeScript](/docs/en/typescript-sdk/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox), [Java](/docs/en/java-sdk/sandbox) **SDKs**, [CLI](/docs/en/tools/cli#daytona-create), or [API](/docs/en/tools/api#daytona/tag/sandbox).
-
-You can specify [programming language runtime](/docs/en/sandboxes#multiple-runtime-support), [snapshots](/docs/en/snapshots), [resources](/docs/en/sandboxes#resources), [regions](/docs/en/regions), [environment variables](/docs/en/configuration), and [volumes](/docs/en/volumes) for each sandbox.
+Daytona provides methods to create sandboxes.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
 3. Click **Create** to create a sandbox
-
-Optionally, specify more parameters when creating a sandbox:
-
-- **Name**: enter the name of the sandbox
-- **Source**: select the source of the sandbox; [snapshot](/docs/en/snapshots) (a pre-configured sandbox template) or image (an OCI-compliant container image: [public](/docs/en/snapshots#using-public-images), [local](/docs/en/snapshots#using-local-images), [private registries](/docs/en/snapshots#using-images-from-private-registries)).
-- **Region**: select the region for the sandbox
-- **Lifecycle**: define [sandbox lifecycle management](#automated-lifecycle-management) or set as an [ephemeral sandbox](#ephemeral-sandboxes)
-- **Environment variables**: set in key-value pairs or import them from a **`.env`** file
-- **Labels**: set in key-value pairs to categorize and organize sandboxes
-- **Network settings**: [public HTTP preview](/docs/en/preview) or [block all network access](/docs/en/network-limits)
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -159,158 +111,24 @@ curl 'https://app.daytona.io/api/sandbox' \
 </TabItem>
 </Tabs>
 
-### Resources
-
-Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. Organizations get a maximum sandbox resource limit of **4 vCPUs**, **8GB RAM**, and **10GB disk**.
-
-| **Resource** | **Unit** | **Default** | **Minimum** | **Maximum** |
-| ------------ | -------- | ----------- | ----------- | ----------- |
-| CPU          | vCPU     | **`1`**     | **`1`**     | **`4`**     |
-| Memory       | GiB      | **`1`**     | **`1`**     | **`8`**     |
-| Disk         | GiB      | **`3`**     | **`1`**     | **`10`**    |
-
-To set custom sandbox resources, use the `Resources` class. All resource parameters are optional and must be integers. If not specified, Daytona will use the default values. Maximum values are per-sandbox limits set at the organization level. Contact [support@daytona.io](mailto:support@daytona.io) to increase limits.
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-
-```python
-from daytona import Daytona, CreateSandboxFromImageParams, Image, Resources
-
-daytona = Daytona()
-sandbox = daytona.create(
-    CreateSandboxFromImageParams(
-        image=Image.debian_slim("3.12"),
-        resources=Resources(cpu=2, memory=4, disk=8),
-    )
-)
-```
-
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-
-```typescript
-import { Daytona, Image } from "@daytona/sdk";
-
-const daytona = new Daytona();
-const sandbox = await daytona.create({
-  image: Image.debianSlim("3.12"),
-  resources: { cpu: 2, memory: 4, disk: 8 },
-});
-```
-
-</TabItem>
-<TabItem label="Ruby" icon="seti:ruby">
-
-```ruby
-require 'daytona'
-
-daytona = Daytona::Daytona.new
-sandbox = daytona.create(
-  Daytona::CreateSandboxFromImageParams.new(
-    image: Daytona::Image.debian_slim('3.12'),
-    resources: Daytona::Resources.new(
-      cpu: 2,
-      memory: 4,
-      disk: 8
-    )
-  )
-)
-```
-
-</TabItem>
-<TabItem label="Go" icon="seti:go">
-
-```go
-package main
-
-import (
-	"context"
-	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
-	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
-)
-
-func main() {
-	client, _ := daytona.NewClient()
-	ctx := context.Background()
-	_, _ = client.Create(ctx, types.ImageParams{
-		Image: "python:3.12",
-		Resources: &types.Resources{
-			CPU:    2,
-			Memory: 4,
-			Disk:   8,
-		},
-	})
-}
-```
-
-</TabItem>
-<TabItem label="Java" icon="seti:java">
-
-```java
-import io.daytona.sdk.Daytona;
-import io.daytona.sdk.Sandbox;
-import io.daytona.sdk.model.CreateSandboxFromImageParams;
-import io.daytona.sdk.model.Resources;
-
-final class CreateSandboxResources {
-    public static void main(String[] args) {
-        try (Daytona daytona = new Daytona()) {
-            CreateSandboxFromImageParams params = new CreateSandboxFromImageParams();
-            params.setImage("python:3.12");
-            Resources resources = new Resources();
-            resources.setCpu(2);
-            resources.setMemory(4);
-            resources.setDisk(8);
-            params.setResources(resources);
-            Sandbox sandbox = daytona.create(params);
-        }
-    }
-}
-```
-
-</TabItem>
-<TabItem label="CLI" icon="seti:shell">
-
-```bash
-# --memory is in MB; --disk is in GB
-daytona create --cpu 2 --memory 4096 --disk 8
-```
-
-</TabItem>
-<TabItem label="API" icon="seti:json">
-
-```bash
-curl 'https://app.daytona.io/api/sandbox' \
-  --request POST \
-  --header 'Content-Type: application/json' \
-  --header 'Authorization: Bearer YOUR_API_KEY' \
-  --data '{
-  "cpu": 2,
-  "memory": 4,
-  "disk": 8
-}'
-```
-
-</TabItem>
-</Tabs>
-
 ### GPU Sandboxes
 
 :::caution[Experimental]
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to create GPU sandboxes using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/sandboxes) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/sandbox), [TypeScript](/docs/en/typescript-sdk/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox), [Java](/docs/en/java-sdk/sandbox) **SDKs**, [CLI](/docs/en/tools/cli#daytona-create), or [API](/docs/en/tools/api#daytona/tag/sandbox).
+Daytona provides methods to create GPU sandboxes.
 
-Daytona supports NVIDIA GPU devices for snapshot-based sandbox creation. This allows you to run GPU workloads such as model inference, fine-tuning, and CUDA-accelerated compute inside a sandbox created from a [GPU snapshot](/docs/en/snapshots#gpu-snapshots). GPU sandboxes must be ephemeral.
+Daytona supports NVIDIA GPU devices for sandbox creation. This allows you to run GPU workloads such as model inference, fine-tuning, and CUDA-accelerated compute inside a sandbox. 
 
-Use the pre-built `daytona-gpu` system snapshot to create a ready-to-use GPU environment. Create a custom GPU snapshot only when you need different packages, tooling, or configuration. Each GPU sandbox supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
+Each GPU sandbox is ephemeral and supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
 3. Select a GPU snapshot
 4. Click **Create** to create a GPU sandbox
+
+To create a GPU sandbox programmatically, use the pre-built `daytona-gpu` snapshot, target `us-east-1` region, and set `auto_delete_interval` to `0` (ephemeral).
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -440,9 +258,11 @@ curl 'https://app.daytona.io/api/sandbox' \
 
 ### Ephemeral Sandboxes
 
+Daytona provides methods to create ephemeral sandboxes. 
+
 Ephemeral sandboxes are automatically deleted once they are stopped. They are useful for short-lived tasks or testing purposes.
 
-To create an ephemeral sandbox, set the `ephemeral` parameter to `True` when creating a sandbox. Setting [**`autoDeleteInterval: 0`**](#auto-delete-interval) has the same effect as setting `ephemeral` to `True`.
+To create an ephemeral sandbox, set the `ephemeral` parameter to `True` when creating a sandbox. Setting [**`autoDeleteInterval: 0`**](#auto-delete-interval) (ephemeral) has the same effect.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -536,16 +356,148 @@ public class App {
 </TabItem>
 </Tabs>
 
+### Resources
+
+Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. Organizations get a maximum sandbox resource limit of **4 vCPUs**, **8GB RAM**, and **10GB disk**.
+
+| **Resource** | **Unit** | **Default** | **Minimum** | **Maximum** |
+| ------------ | -------- | ----------- | ----------- | ----------- |
+| CPU          | vCPU     | **`1`**     | **`1`**     | **`4`**     |
+| Memory       | GiB      | **`1`**     | **`1`**     | **`8`**     |
+| Disk         | GiB      | **`3`**     | **`1`**     | **`10`**    |
+
+To set custom sandbox resources, use the `Resources` class. All resource parameters are optional and must be integers. If not specified, Daytona will use the default values. Maximum values are per-sandbox limits set at the organization level.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import Daytona, CreateSandboxFromImageParams, Image, Resources
+
+daytona = Daytona()
+sandbox = daytona.create(
+    CreateSandboxFromImageParams(
+        image=Image.debian_slim("3.12"),
+        resources=Resources(cpu=2, memory=4, disk=8),
+    )
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona, Image } from "@daytona/sdk";
+
+const daytona = new Daytona();
+const sandbox = await daytona.create({
+  image: Image.debianSlim("3.12"),
+  resources: { cpu: 2, memory: 4, disk: 8 },
+});
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+require 'daytona'
+
+daytona = Daytona::Daytona.new
+sandbox = daytona.create(
+  Daytona::CreateSandboxFromImageParams.new(
+    image: Daytona::Image.debian_slim('3.12'),
+    resources: Daytona::Resources.new(
+      cpu: 2,
+      memory: 4,
+      disk: 8
+    )
+  )
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+package main
+
+import (
+	"context"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+	client, _ := daytona.NewClient()
+	ctx := context.Background()
+	_, _ = client.Create(ctx, types.ImageParams{
+		Image: "python:3.12",
+		Resources: &types.Resources{
+			CPU:    2,
+			Memory: 4,
+			Disk:   8,
+		},
+	})
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+import io.daytona.sdk.Daytona;
+import io.daytona.sdk.Sandbox;
+import io.daytona.sdk.model.CreateSandboxFromImageParams;
+import io.daytona.sdk.model.Resources;
+
+final class CreateSandboxResources {
+    public static void main(String[] args) {
+        try (Daytona daytona = new Daytona()) {
+            CreateSandboxFromImageParams params = new CreateSandboxFromImageParams();
+            params.setImage("python:3.12");
+            Resources resources = new Resources();
+            resources.setCpu(2);
+            resources.setMemory(4);
+            resources.setDisk(8);
+            params.setResources(resources);
+            Sandbox sandbox = daytona.create(params);
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem label="CLI" icon="seti:shell">
+
+```bash
+# --memory is in MB; --disk is in GB
+daytona create --cpu 2 --memory 4096 --disk 8
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --data '{
+  "cpu": 2,
+  "memory": 4,
+  "disk": 8
+}'
+```
+
+</TabItem>
+</Tabs>
+
 ## Start Sandboxes
 
-Daytona provides methods to start sandboxes in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona#type-sandbox), [Java](/docs/en/java-sdk/sandbox) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona/).
+Daytona provides methods to start sandboxes.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click the start icon (**▶**) next to the sandbox you want to start
-
-```text
-Starting sandbox with ID: <sandbox-id>
-```
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -603,7 +555,7 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/start' \
 
 ## Get Sandbox
 
-Daytona provides methods to get a sandbox by ID or name using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), [Java](/docs/en/java-sdk/daytona) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona).
+Daytona provides methods to get a sandbox by ID or name.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -660,7 +612,7 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}' \
 
 ## List Sandboxes
 
-Daytona provides methods to list sandboxes and view their details in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) via the [sandbox details page](#sandbox-details-page) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), [Java](/docs/en/java-sdk/daytona) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona).
+Daytona provides methods to list sandboxes.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -760,16 +712,14 @@ The sandbox details page provides a summary of the sandbox information and actio
 
 ## Stop Sandboxes
 
-Daytona provides methods to stop sandboxes in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), [Java](/docs/en/java-sdk/daytona) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona).
+Daytona provides methods to stop sandboxes.
 
-Stopped sandboxes maintain filesystem persistence while their memory state is cleared. They incur only disk usage costs and can be started again when needed. The stopped state should be used when a sandbox is expected to be started again. Otherwise, it is recommended to stop and then archive the sandbox to eliminate disk usage costs.
+Stopped sandboxes maintain filesystem persistence while their memory state is cleared. They incur only disk usage costs and can be started again when needed. 
+
+The stopped state should be used when a sandbox is expected to be started again. Otherwise, it is recommended to stop and then archive the sandbox to eliminate disk usage costs.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click the stop icon (**⏹**) next to the sandbox you want to stop
-
-```text
-Stopping sandbox with ID: <sandbox-id>
-```
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -838,15 +788,19 @@ Common use cases for force stop include:
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to pause sandboxes. Pausing a sandbox keeps both filesystem state and memory persistence, so sandboxes can resume from in-memory runtime state. Compared to regular stop behavior, pause is useful for workloads with active in-memory context and state continuity.
+Daytona provides methods to pause sandboxes. 
+
+Pausing a sandbox keeps both filesystem state and memory persistence, so sandboxes can resume from in-memory runtime state. Compared to regular stop behavior, pause is useful for workloads with active in-memory context and state continuity.
 
 Daytona supports pause functionality through VM-based runners. Pause is handled through the existing stop action. This means stop behaves as pause and preserves memory state, while force stop performs a full shutdown without preserving memory state.
 
 ## Archive Sandboxes
 
-Daytona provides methods to archive sandboxes in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona).
+Daytona provides methods to archive sandboxes.
 
-A sandbox must be stopped before it can be archived. When a sandbox is archived, the entire filesystem state is moved to a cost-effective object storage, making it available for an extended period. Starting an archived sandbox takes more time than starting a stopped sandbox, depending on its size. It can be started again in the same way as a stopped sandbox.
+A sandbox must be stopped before it can be archived. When a sandbox is archived, the entire filesystem state is moved to a cost-effective object storage, making it available for an extended period. 
+
+Starting an archived sandbox takes more time than starting a stopped sandbox, depending on its size. It can be started again in the same way as a stopped sandbox.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -897,7 +851,7 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/archive' \
 
 ## Recover Sandboxes
 
-Daytona provides methods to recover sandboxes in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/) **SDKs**, and [API](/docs/en/tools/api/#daytona).
+Daytona provides methods to recover sandboxes.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -981,7 +935,9 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/recover' \
 
 ## Resize Sandboxes
 
-Daytona provides methods to resize [sandbox resources](#resources) after creation using [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/) **SDKs**, and [API](/docs/en/tools/api/#daytona). On a running sandbox, you can increase CPU and memory without interruption. To decrease CPU or memory, or to increase disk capacity, stop the sandbox first. Disk size can only be increased and cannot be decreased.
+Daytona provides methods to resize [sandbox resources](#resources) after creation.
+
+On a running sandbox, you can increase CPU and memory without interruption. To decrease CPU or memory, or to increase disk capacity, stop the sandbox first. Disk size can only be increased and cannot be decreased.
 
 Resizing updates the sandbox resource allocation (`cpu`, `memory`, and `disk`) for that sandbox only. CPU and memory control compute capacity for running workloads, while disk controls persistent filesystem capacity. Values must be integers and stay within your organization's per-sandbox resource limits.
 
@@ -1069,7 +1025,9 @@ df -h /                         # disk
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to fork sandboxes. Forking creates a duplicate of your sandbox's filesystem and memory, and copies it into a new sandbox. The new sandbox is fully independent: it can be started, stopped, and deleted without affecting the original. The sandbox must be in started state before forking.
+Daytona provides methods to fork sandboxes. 
+
+Forking creates a duplicate of your sandbox's filesystem and memory, and copies it into a new sandbox. The new sandbox is fully independent: it can be started, stopped, and deleted without affecting the original. The sandbox must be in started state before forking.
 
 Daytona tracks the parent-child relationship in a fork tree, so you can always trace a fork's lineage back to the sandbox it was created from. You can fork a fork, building out branches as needed. The parent sandbox cannot be deleted while it has active fork children.
 
@@ -1141,9 +1099,7 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/fork' \
 </TabItem>
 </Tabs>
 
-##### View Forks
-
-Daytona provides methods to view forks. You can view the fork tree for a sandbox and all its related sandboxes.
+To view the fork tree for a sandbox and all its related sandboxes:
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click the three-dot menu (**⋮**) next to a forked sandbox
@@ -1153,7 +1109,7 @@ The fork tree displays each sandbox in the hierarchy along with its current stat
 
 ## Label Sandboxes
 
-Daytona provides methods to set sandbox labels using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), and [Java](/docs/en/java-sdk/sandbox) **SDKs** and [API](/docs/en/tools/api/#daytona). Labels are key-value metadata associated with a sandbox that you can use for grouping, filtering, ownership, environment tagging, and automation.
+Daytona provides methods to set sandbox labels. 
 
 Setting labels replaces the full label set for the sandbox. Include all labels you want to keep in the request. If you omit an existing label, it will be removed.
 
@@ -1232,7 +1188,9 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/labels' \
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to create [snapshots](/docs/en/snapshots) from sandboxes. A snapshot captures an immutable, point-in-time copy of a sandbox's filesystem and memory that you can use as a base to create new sandboxes, effectively templating a known-good environment for reuse. You can think of it as a checkpoint you can restore from whenever you need a clean, identical starting point.
+Daytona provides methods to create [snapshots](/docs/en/snapshots) from sandboxes. 
+
+A snapshot captures an immutable, point-in-time copy of a sandbox's filesystem and memory that you can use as a base to create new sandboxes, effectively templating a known-good environment for reuse. You can think of it as a checkpoint you can restore from whenever you need a clean, identical starting point.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -1296,14 +1254,10 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/snapshot' \
 
 ## Delete Sandboxes
 
-Daytona provides methods to delete sandboxes in [Daytona Dashboard ↗](https://app.daytona.io/dashboard/) or programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), [Java](/docs/en/java-sdk/daytona) **SDKs**, [CLI](/docs/en/tools/cli/), and [API](/docs/en/tools/api/#daytona).
+Daytona provides methods to delete sandboxes.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click the **Delete** button next to the sandbox you want to delete.
-
-```text
-Deleting sandbox with ID: <sandbox-id>
-```
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -1359,15 +1313,53 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}' \
 </TabItem>
 </Tabs>
 
+## Sandbox lifecycle
+
+A sandbox can have several different states. Each state reflects the status of your sandbox.
+
+- [**Creating**](#create-sandboxes): the sandbox is provisioning and will be ready to use
+- [**Starting**](#start-sandboxes): the sandbox is starting and will be ready to use
+- [**Started**](#start-sandboxes): the sandbox has started and is ready to use
+- [**Stopping**](#stop-sandboxes): the sandbox is stopping and will no longer accept requests
+- [**Stopped**](#stop-sandboxes): the sandbox has stopped and is no longer running
+- [**Deleting**](#delete-sandboxes): the sandbox is deleting and will be removed
+- [**Deleted**](#delete-sandboxes): the sandbox has been deleted and no longer exists
+- [**Archiving**](#archive-sandboxes): the sandbox is archiving and its state will be preserved
+- [**Archived**](#archive-sandboxes): the sandbox has been archived and its state is preserved
+- [**Resizing**](#resize-sandboxes): the sandbox is being resized to a new set of resources
+- [**Error**](#recover-sandboxes): the sandbox is in an error state and needs to be recovered
+- **Restoring**: the sandbox is being restored from archive and will be ready to use shortly
+- **Unknown**: the default sandbox state before it is created
+- **Pulling Snapshot**: the sandbox is pulling a [snapshot](/docs/en/snapshots) to provide a base environment
+- **Building Snapshot**: the sandbox is building a [snapshot](/docs/en/snapshots) to provide a base environment
+- **Build Pending**: the sandbox build is pending and will start shortly
+- **Build Failed**: the sandbox build failed and needs to be retried
+
+The diagram demonstrates the states and possible transitions between them.
+
+<SandboxDiagram />
+
+## Multiple runtime support
+
+Daytona sandboxes support Python, TypeScript, and JavaScript programming language runtimes for direct code execution inside the sandbox. The `language` parameter controls which programming language runtime is used for the sandbox:
+
+- **`python`**
+- **`typescript`**
+- **`javascript`**
+
+If omitted, the Daytona SDK will default to `python`. To override this, explicitly set the `language` value when creating the sandbox.
+
 ## Automated lifecycle management
 
 Daytona sandboxes can be automatically stopped, archived, and deleted based on user-defined intervals. You can also refresh the last activity timestamp to explicitly signal activity when lifecycle behavior depends on inactivity windows.
 
 ### Update sandbox last activity
 
-Daytona provides methods to update a sandbox's last activity timestamp programmatically using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), and [Ruby](/docs/en/ruby-sdk/) **SDKs** and [API](/docs/en/tools/api/#daytona). Use this operation to explicitly signal activity when lifecycle behavior depends on inactivity windows.
+Daytona provides methods to update a sandbox's last activity timestamp.
 
-This updates the sandbox's recorded activity time without changing its runtime state. It is useful when your workflow is driven by external systems or background orchestration that may not reset inactivity tracking. For example, if you run long-lived automation around a sandbox and want to avoid unintended auto-stop behavior, call this operation periodically to indicate that the sandbox is still actively used.
+This updates the sandbox's recorded activity time without changing its runtime state. It is useful when your workflow is driven by external systems or background orchestration that may not reset inactivity tracking. 
+
+For example, if you run long-lived automation around a sandbox and want to avoid unintended auto-stop behavior, call this operation periodically to indicate that the sandbox is still actively used.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -1404,9 +1396,11 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxId}/last-activity' \
 
 ### Auto-stop interval
 
-The auto-stop interval parameter sets the amount of time after which a running sandbox will be automatically stopped.
+Daytona provides methods to set the auto-stop interval. 
 
-The auto-stop interval triggers even if there are internal processes running in the sandbox. The system differentiates between "internal processes" and "active user interaction". Merely having a script or background task running is not sufficient to keep the sandbox alive.
+The auto-stop interval sets the amount of time after which a running sandbox will be automatically stopped. The auto-stop triggers even if there are internal processes running in the sandbox. 
+
+The system differentiates between "internal processes" and "active user interaction". Merely having a script or background task running is not sufficient to keep the sandbox alive.
 
 - [What resets the timer](#what-resets-the-timer)
 - [What does not reset the timer](#what-does-not-reset-the-timer)
@@ -1523,9 +1517,9 @@ If you run a long-running task like LLM inference that takes more than 15 minute
 
 ### Auto-archive interval
 
-Daytona provides methods to set the auto-archive interval using the [Python SDK](/docs/en/python-sdk/), [TypeScript SDK](/docs/en/typescript-sdk/), [Ruby SDK](/docs/en/ruby-sdk/), and [Java SDK](/docs/en/java-sdk/sandbox).
+Daytona provides methods to set the auto-archive interval.
 
-The auto-archive interval parameter sets the amount of time after which a continuously stopped sandbox will be automatically archived. The parameter can either be set to:
+The auto-archive interval sets the amount of time after which a continuously stopped sandbox will be automatically archived. The parameter can either be set to:
 
 - a time interval in minutes
 - `0`: the maximum interval of `30 days` will be used
@@ -1617,9 +1611,9 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/autoarchive/{interval
 
 ### Auto-delete interval
 
-Daytona provides methods to set the auto-delete interval using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), [Java](/docs/en/java-sdk/daytona) **SDKs**, and [API](/docs/en/tools/api/#daytona).
+Daytona provides methods to set the auto-delete interval.
 
-The auto-delete interval parameter sets the amount of time after which a continuously stopped sandbox will be automatically deleted. By default, sandboxes will never be automatically deleted. The parameter can either be set to:
+The auto-delete interval sets the amount of time after which a continuously stopped sandbox will be automatically deleted. By default, sandboxes will never be automatically deleted. The parameter can either be set to:
 
 - a time interval in minutes
 - `-1`: disables the auto-delete functionality
@@ -1744,9 +1738,9 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/autodelete/{interval}
 
 ### Running indefinitely
 
-Daytona provides methods to run sandboxes indefinitely using the [Python](/docs/en/python-sdk/), [TypeScript](/docs/en/typescript-sdk/), [Ruby](/docs/en/ruby-sdk/), [Go](/docs/en/go-sdk/daytona/), and [Java](/docs/en/java-sdk/daytona) **SDKs**.
+Daytona provides methods to run sandboxes indefinitely.
 
-By default, Daytona Sandboxes auto-stop after 15 minutes of inactivity. To keep a sandbox running without interruption, set the auto-stop interval to `0` when creating a new sandbox:
+By default, Daytona sandboxes auto-stop after 15 minutes of inactivity. To keep a sandbox running without interruption, set the auto-stop interval to `0` when creating a new sandbox:
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -8,14 +8,18 @@ import Label from '@components/Label.astro'
 
 Snapshots are sandbox templates created from [Docker](https://www.docker.com/) or [OCI](https://opencontainers.org/) compatible images. Sandboxes can use a [default snapshot](#default-snapshots) or custom snapshots to provide a consistent and reproducible sandbox environments for your dependencies, settings, and resources.
 
+- **Snapshot SDKs**: [TypeScript](/docs/en/typescript-sdk/snapshot), [Python](/docs/en/python-sdk/sync/snapshot), [Ruby](/docs/en/ruby-sdk/snapshot), [Go](/docs/en/go-sdk/daytona#type-snapshotservice), [Java](/docs/en/java-sdk/snapshot)
+- **Snapshot API**: [RESTful API](/docs/en/tools/api/#daytona/tag/snapshots) ([OpenAPI spec](/docs/openapi.json)), [Toolbox API](/docs/en/tools/api#daytona-toolbox) ([OpenAPI spec](/docs/toolbox-openapi.json))
+- **Snapshot CLI**: [Mac/Linux/Windows](/docs/en/tools/cli)
+
 ## Create Snapshots
 
 Daytona provides methods to create snapshots. You can create a snapshot from:
 
-- [public images](#using-public-images)
-- [local images](#using-local-images)
-- [images from private registries](#using-images-from-private-registries)
-- [the declarative builder](#using-the-declarative-builder)
+- [public images](#public-images)
+- [local images](#local-images)
+- [images from private registries](#images-from-private-registries)
+- [the declarative builder](#declarative-builder)
 - [GPU snapshots](#gpu-snapshots) (for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes))
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -454,7 +454,9 @@ This feature is experimental. To request access, contact [support@daytona.io](ma
 
 Daytona provides methods to create GPU snapshots using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/snapshots) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/snapshot), [TypeScript](/docs/en/typescript-sdk/snapshot), [Ruby](/docs/en/ruby-sdk/snapshot), [Go](/docs/en/go-sdk/daytona/#type-snapshotservice), [Java](/docs/en/java-sdk/snapshot) **SDKs**, or [API](/docs/en/tools/api#daytona/tag/snapshots).
 
-GPU snapshots fit into the same snapshot creation flow as other snapshots, but with the additional option to enable the GPU. Create a GPU snapshot first, then use it as the source when creating a [GPU sandbox](/docs/en/sandboxes#gpu-sandboxes).
+GPU snapshots fit into the same snapshot creation flow as other snapshots, but with the additional option to enable the GPU.
+
+Use the pre-built `daytona-gpu` system snapshot directly when creating a [GPU sandbox](/docs/en/sandboxes#gpu-sandboxes). Create a custom GPU snapshot only when you need to customize the image or dependencies.
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click the **Create Snapshot** button
@@ -1262,6 +1264,8 @@ When a sandbox is created with no snapshot specified, Daytona uses a default sna
 | **`daytona-large`**  | 4        | 8GiB       | 10GiB       |
 
 All default snapshots are based on the `daytonaio/sandbox:<version>` image. For more information, see the [Dockerfile](https://github.com/daytonaio/daytona/blob/main/images/sandbox/Dockerfile).
+
+For GPU workloads, Daytona also provides a pre-built `daytona-gpu` system snapshot. Use it directly for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes), or create a custom GPU snapshot when you need custom dependencies.
 
 ### Python packages (pip)
 

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -579,31 +579,6 @@ curl https://app.daytona.io/api/snapshots \
 </TabItem>
 </Tabs>
 
-##### GPU Snapshot requirements
-
-Building a custom image for a GPU snapshot requires Ubuntu 24.04 and compatible NVIDIA userspace packages. Include the following in your snapshot Dockerfile:
-
-```dockerfile
-ARG NVIDIA_DRIVER_VERSION=580.126.20
-ARG UBUNTU_PKG_SUFFIX=0ubuntu0.24.04.2
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -qq \
- && apt-get install -y -qq --no-install-recommends \
-      nvidia-utils-580-server=${NVIDIA_DRIVER_VERSION}-${UBUNTU_PKG_SUFFIX} \
-      libnvidia-compute-580-server=${NVIDIA_DRIVER_VERSION}-${UBUNTU_PKG_SUFFIX} \
-      python3 \
-      ca-certificates \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-COPY verify-cuda.sh /verify-cuda.sh
-RUN chmod +x /verify-cuda.sh
-
-LABEL nvidia.driver.version="${NVIDIA_DRIVER_VERSION}"
-```
-
 ### Resources
 
 Snapshots can be customized with specific [sandbox resources](/docs/en/sandboxes#resources). By default, Daytona sandboxes use **1 vCPU**, **1GB RAM**, and **3GiB disk**. To view your available resources and limits, see [limits](/docs/en/limits) or navigate to [Daytona Limits ↗](https://app.daytona.io/dashboard/limits).

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -29,8 +29,7 @@ Daytona provides methods to create snapshots. You can create a snapshot from:
 - **Snapshot name**: identifier used to reference the snapshot
 - **Image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags are not supported
 - **Entrypoint** (optional): entrypoint command for the snapshot; ensure that the entrypoint is a long-running command; if not provided, or if the snapshot does not have an entrypoint, `sleep infinity` will be used as the default
-- [**Resources**](/docs/en/sandboxes#resources) (optional): resources you want the underlying sandboxes to have; by default, Daytona sandboxes use **1 vCPU**, **1GiB memory**, and **3GiB storage**
-- [**GPU**](#gpu-snapshots) (optional): GPU resources for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes)
+- [**Resources**](/docs/en/sandboxes#resources) (optional): resources underlying sandboxes have; by default, sandboxes use **1 vCPU**, **1GiB memory**, and **3GiB storage**; use [GPU snapshots](#gpu-snapshots) for GPU sandboxes
 
 <Tabs>
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -29,9 +29,7 @@ Inactive snapshots cannot be used to create sandboxes. They must be explicitly [
 
 ## Create Snapshots
 
-Daytona provides methods to create snapshots using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/snapshots) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/snapshot), [TypeScript](/docs/en/typescript-sdk/snapshot), [Ruby](/docs/en/ruby-sdk/snapshot), [Go](/docs/en/go-sdk/daytona#SnapshotService), [Java](/docs/en/java-sdk/snapshot) **SDKs**, [CLI](/docs/en/tools/cli#daytona-snapshot), or [API](/docs/en/tools/api#daytona/tag/snapshots).
-
-Snapshots can be created using:
+Daytona provides methods to create snapshots. You can create a snapshot from:
 
 - [public images](#using-public-images)
 - [local images](#using-local-images)
@@ -47,7 +45,7 @@ Snapshots can be created using:
 - **Image**: Base image for the snapshot. Must include either a tag or a digest (e.g., **`ubuntu:22.04`**). The **`latest`** tag is not allowed. Since images tagged `latest` get frequent updates, only specific tags are supported. Same applies to tags such as `lts` or `stable`, and we recommend avoiding those when defining an image to prevent unexpected behavior.
 - **Entrypoint** (optional): The entrypoint command for the snapshot. Ensure that the entrypoint is a long-running command. If not provided, or if the snapshot does not have an entrypoint, `sleep infinity` will be used as the default.
 - [**Resources**](/docs/en/sandboxes#resources) (optional): The resources you want the underlying Sandboxes to have. By default, Daytona Sandboxes use **1 vCPU**, **1GiB memory**, and **3GiB storage**.
-- **GPU** (optional): Enable the **GPU** option to create a GPU snapshot for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes).
+- **GPU** (optional): create a GPU snapshot for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes).
 
 <Tabs>
 <TabItem label="Python" icon="seti:python">
@@ -452,30 +450,30 @@ Daytona sends a `daytona-<orgId>-pull` session name on every AssumeRole call. Yo
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to create GPU snapshots using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/snapshots) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/snapshot), [TypeScript](/docs/en/typescript-sdk/snapshot), [Ruby](/docs/en/ruby-sdk/snapshot), [Go](/docs/en/go-sdk/daytona/#type-snapshotservice), [Java](/docs/en/java-sdk/snapshot) **SDKs**, or [API](/docs/en/tools/api#daytona/tag/snapshots).
+Daytona provides methods to create GPU snapshots.
 
-GPU snapshots fit into the same snapshot creation flow as other snapshots, but with the additional option to enable the GPU.
+Daytona provides a pre-built `daytona-gpu` system snapshot for GPU sandboxes. You can use this snapshot to create GPU sandboxes or create a custom GPU snapshot. GPU snapshots fit into the same snapshot creation flow, but with the additional option to enable and provide GPU resources.
 
 Use the pre-built `daytona-gpu` system snapshot directly when creating a [GPU sandbox](/docs/en/sandboxes#gpu-sandboxes). Create a custom GPU snapshot only when you need to customize the image or dependencies.
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click the **Create Snapshot** button
-3. Configure snapshot details and enable the GPU option
+3. Configure GPU snapshot
 
-To create a GPU-enabled snapshot programmatically, set GPU resources for the snapshot. The `gpu` value defines how many GPU units each sandbox created from this snapshot will request. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
+To create a GPU snapshot programmatically, set the `gpu` value to the number of GPU units you want to allocate and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
 ```python
-from daytona import Daytona, CreateSnapshotParams, Resources
+from daytona import CreateSnapshotParams, Daytona, DaytonaConfig, Image, Resources
 
-daytona = Daytona()
+daytona = Daytona(DaytonaConfig(target="us-east-1"))
 snapshot = daytona.snapshot.create(
     CreateSnapshotParams(
         name="my-gpu-snapshot",
-        image="python:3.12",
-        resources=Resources(gpu=1),
+        image=Image.base("python:3.12"),
+        resources=Resources(cpu=1, memory=1, disk=1, gpu=1),
     ),
 )
 ```
@@ -486,11 +484,11 @@ snapshot = daytona.snapshot.create(
 ```typescript
 import { Daytona } from "@daytona/sdk";
 
-const daytona = new Daytona();
+const daytona = new Daytona({ target: "us-east-1" });
 const snapshot = await daytona.snapshot.create({
   name: "my-gpu-snapshot",
   image: "python:3.12",
-  resources: { gpu: 1 },
+  resources: { cpu: 1, memory: 1, disk: 1, gpu: 1 },
 });
 ```
 
@@ -500,12 +498,15 @@ const snapshot = await daytona.snapshot.create({
 ```ruby
 require 'daytona'
 
-daytona = Daytona::Daytona.new
+config = Daytona::Config.new(
+  target: "us-east-1"
+)
+daytona = Daytona::Daytona.new(config)
 snapshot = daytona.snapshot.create(
   Daytona::CreateSnapshotParams.new(
     name: 'my-gpu-snapshot',
     image: 'python:3.12',
-    resources: Daytona::Resources.new(gpu: 1)
+    resources: Daytona::Resources.new(cpu: 1, memory: 1, disk: 1, gpu: 1)
   )
 )
 ```
@@ -523,12 +524,17 @@ import (
 )
 
 func main() {
-	client, _ := daytona.NewClient()
+	client, _ := daytona.NewClientWithConfig(&types.DaytonaConfig{
+		Target: "us-east-1",
+	})
 	ctx := context.Background()
 	snapshot, logCh, _ := client.Snapshot.Create(ctx, &types.CreateSnapshotParams{
 		Name:  "my-gpu-snapshot",
 		Image: "python:3.12",
 		Resources: &types.Resources{
+			CPU: 1,
+			Memory: 1,
+			Disk: 1,
 			GPU: 1,
 		},
 	})
@@ -543,14 +549,23 @@ func main() {
 
 ```java
 import io.daytona.sdk.Daytona;
+import io.daytona.sdk.DaytonaConfig;
 import io.daytona.sdk.Image;
 import io.daytona.sdk.model.Resources;
 import io.daytona.sdk.model.Snapshot;
 
 final class CreateGpuSnapshot {
     public static void main(String[] args) {
-        try (Daytona daytona = new Daytona()) {
+        DaytonaConfig config = new DaytonaConfig.Builder()
+                .apiKey(System.getenv("DAYTONA_API_KEY"))
+                .target("us-east-1")
+                .build();
+
+        try (Daytona daytona = new Daytona(config)) {
             Resources resources = new Resources();
+            resources.setCpu(1);
+            resources.setMemory(1);
+            resources.setDisk(1);
             resources.setGpu(1);
             Snapshot snapshot = daytona.snapshot().create(
                 "my-gpu-snapshot",
@@ -574,6 +589,10 @@ curl https://app.daytona.io/api/snapshots \
   --data '{
     "name": "my-gpu-snapshot",
     "imageName": "python:3.12",
+    "regionId": "us-east-1",
+    "cpu": 1,
+    "memory": 1,
+    "disk": 1,
     "gpu": 1
   }'
 ```

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -20,13 +20,13 @@ Daytona provides methods to create snapshots. You can create a snapshot from:
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click the **Create Snapshot** button
-3. Enter the **snapshot name**, **image** (tag or digest), **entrypoint**, and **resources**
+3. Enter the snapshot name and image (tag or digest)
 
-- **Snapshot name**: Identifier used to reference the snapshot in the SDK or CLI.
-- **Image**: Base image for the snapshot. Must include either a tag or a digest (e.g., **`ubuntu:22.04`**). The **`latest`** tag is not allowed. Since images tagged `latest` get frequent updates, only specific tags are supported. Same applies to tags such as `lts` or `stable`, and we recommend avoiding those when defining an image to prevent unexpected behavior.
-- **Entrypoint** (optional): The entrypoint command for the snapshot. Ensure that the entrypoint is a long-running command. If not provided, or if the snapshot does not have an entrypoint, `sleep infinity` will be used as the default.
-- [**Resources**](/docs/en/sandboxes#resources) (optional): The resources you want the underlying Sandboxes to have. By default, Daytona Sandboxes use **1 vCPU**, **1GiB memory**, and **3GiB storage**.
-- **GPU** (optional): create a GPU snapshot for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes).
+- **Snapshot name**: identifier used to reference the snapshot
+- **Image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags are not supported
+- **Entrypoint** (optional): entrypoint command for the snapshot; ensure that the entrypoint is a long-running command; if not provided, or if the snapshot does not have an entrypoint, `sleep infinity` will be used as the default
+- [**Resources**](/docs/en/sandboxes#resources) (optional): resources you want the underlying sandboxes to have; by default, Daytona sandboxes use **1 vCPU**, **1GiB memory**, and **3GiB storage**
+- [**GPU**](#gpu-snapshots) (optional): GPU resources for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes)
 
 <Tabs>
 <TabItem label="Python" icon="seti:python">
@@ -141,13 +141,13 @@ This feature is experimental. To request access, contact [support@daytona.io](ma
 
 Daytona provides methods to create GPU snapshots.
 
-Daytona provides a pre-built `daytona-gpu` system snapshot for GPU sandboxes. You can use this snapshot to create GPU sandboxes or create a custom GPU snapshot. GPU snapshots fit into the same snapshot creation flow, but with the additional option to enable and provide GPU resources.
+GPU snapshots are used to create [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes). Daytona provides a pre-built `daytona-gpu` system snapshot for creating GPU sandboxes. You can also create a custom GPU snapshot to customize the image or dependencies.
 
-Use the pre-built `daytona-gpu` system snapshot directly when creating a [GPU sandbox](/docs/en/sandboxes#gpu-sandboxes). Create a custom GPU snapshot only when you need to customize the image or dependencies.
+GPU snapshots follow the same snapshot creation flow, but with the additional option to enable and provide GPU resources.
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click the **Create Snapshot** button
-3. Configure GPU snapshot
+3. Configure GPU snapshot details and enable the GPU option
 
 To create a GPU snapshot programmatically, set the `gpu` value to the number of GPU units you want to allocate and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
 

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -133,6 +133,162 @@ curl https://app.daytona.io/api/snapshots \
 </TabItem>
 </Tabs>
 
+### GPU Snapshots
+
+:::caution[Experimental]
+This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
+:::
+
+Daytona provides methods to create GPU snapshots.
+
+Daytona provides a pre-built `daytona-gpu` system snapshot for GPU sandboxes. You can use this snapshot to create GPU sandboxes or create a custom GPU snapshot. GPU snapshots fit into the same snapshot creation flow, but with the additional option to enable and provide GPU resources.
+
+Use the pre-built `daytona-gpu` system snapshot directly when creating a [GPU sandbox](/docs/en/sandboxes#gpu-sandboxes). Create a custom GPU snapshot only when you need to customize the image or dependencies.
+
+1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
+2. Click the **Create Snapshot** button
+3. Configure GPU snapshot
+
+To create a GPU snapshot programmatically, set the `gpu` value to the number of GPU units you want to allocate and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import CreateSnapshotParams, Daytona, DaytonaConfig, Image, Resources
+
+daytona = Daytona(DaytonaConfig(target="us-east-1"))
+snapshot = daytona.snapshot.create(
+    CreateSnapshotParams(
+        name="my-gpu-snapshot",
+        image=Image.base("python:3.12"),
+        resources=Resources(cpu=1, memory=1, disk=1, gpu=1),
+    ),
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona } from "@daytona/sdk";
+
+const daytona = new Daytona({ target: "us-east-1" });
+const snapshot = await daytona.snapshot.create({
+  name: "my-gpu-snapshot",
+  image: "python:3.12",
+  resources: { cpu: 1, memory: 1, disk: 1, gpu: 1 },
+});
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+require 'daytona'
+
+config = Daytona::Config.new(
+  target: "us-east-1"
+)
+daytona = Daytona::Daytona.new(config)
+snapshot = daytona.snapshot.create(
+  Daytona::CreateSnapshotParams.new(
+    name: 'my-gpu-snapshot',
+    image: 'python:3.12',
+    resources: Daytona::Resources.new(cpu: 1, memory: 1, disk: 1, gpu: 1)
+  )
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+package main
+
+import (
+	"context"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+	client, _ := daytona.NewClientWithConfig(&types.DaytonaConfig{
+		Target: "us-east-1",
+	})
+	ctx := context.Background()
+	snapshot, logCh, _ := client.Snapshot.Create(ctx, &types.CreateSnapshotParams{
+		Name:  "my-gpu-snapshot",
+		Image: "python:3.12",
+		Resources: &types.Resources{
+			CPU: 1,
+			Memory: 1,
+			Disk: 1,
+			GPU: 1,
+		},
+	})
+	for range logCh {
+	}
+	_ = snapshot
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+import io.daytona.sdk.Daytona;
+import io.daytona.sdk.DaytonaConfig;
+import io.daytona.sdk.Image;
+import io.daytona.sdk.model.Resources;
+import io.daytona.sdk.model.Snapshot;
+
+final class CreateGpuSnapshot {
+    public static void main(String[] args) {
+        DaytonaConfig config = new DaytonaConfig.Builder()
+                .apiKey(System.getenv("DAYTONA_API_KEY"))
+                .target("us-east-1")
+                .build();
+
+        try (Daytona daytona = new Daytona(config)) {
+            Resources resources = new Resources();
+            resources.setCpu(1);
+            resources.setMemory(1);
+            resources.setDisk(1);
+            resources.setGpu(1);
+            Snapshot snapshot = daytona.snapshot().create(
+                "my-gpu-snapshot",
+                Image.base("python:3.12"),
+                resources,
+                null
+            );
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl https://app.daytona.io/api/snapshots \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer YOUR_SECRET_TOKEN' \
+  --data '{
+    "name": "my-gpu-snapshot",
+    "imageName": "python:3.12",
+    "regionId": "us-east-1",
+    "cpu": 1,
+    "memory": 1,
+    "disk": 1,
+    "gpu": 1
+  }'
+```
+
+</TabItem>
+</Tabs>
+
 <a id="using-public-images"></a>
 ### Public images
 
@@ -426,162 +582,6 @@ Daytona sends a `daytona-<orgId>-pull` session name on every AssumeRole call. Yo
   "sts:RoleSessionName": "daytona-<YOUR_EXTERNAL_ID>-*"
 }
 ```
-
-### GPU Snapshots
-
-:::caution[Experimental]
-This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
-:::
-
-Daytona provides methods to create GPU snapshots.
-
-Daytona provides a pre-built `daytona-gpu` system snapshot for GPU sandboxes. You can use this snapshot to create GPU sandboxes or create a custom GPU snapshot. GPU snapshots fit into the same snapshot creation flow, but with the additional option to enable and provide GPU resources.
-
-Use the pre-built `daytona-gpu` system snapshot directly when creating a [GPU sandbox](/docs/en/sandboxes#gpu-sandboxes). Create a custom GPU snapshot only when you need to customize the image or dependencies.
-
-1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
-2. Click the **Create Snapshot** button
-3. Configure GPU snapshot
-
-To create a GPU snapshot programmatically, set the `gpu` value to the number of GPU units you want to allocate and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
-
-<Tabs syncKey="language">
-<TabItem label="Python" icon="seti:python">
-
-```python
-from daytona import CreateSnapshotParams, Daytona, DaytonaConfig, Image, Resources
-
-daytona = Daytona(DaytonaConfig(target="us-east-1"))
-snapshot = daytona.snapshot.create(
-    CreateSnapshotParams(
-        name="my-gpu-snapshot",
-        image=Image.base("python:3.12"),
-        resources=Resources(cpu=1, memory=1, disk=1, gpu=1),
-    ),
-)
-```
-
-</TabItem>
-<TabItem label="TypeScript" icon="seti:typescript">
-
-```typescript
-import { Daytona } from "@daytona/sdk";
-
-const daytona = new Daytona({ target: "us-east-1" });
-const snapshot = await daytona.snapshot.create({
-  name: "my-gpu-snapshot",
-  image: "python:3.12",
-  resources: { cpu: 1, memory: 1, disk: 1, gpu: 1 },
-});
-```
-
-</TabItem>
-<TabItem label="Ruby" icon="seti:ruby">
-
-```ruby
-require 'daytona'
-
-config = Daytona::Config.new(
-  target: "us-east-1"
-)
-daytona = Daytona::Daytona.new(config)
-snapshot = daytona.snapshot.create(
-  Daytona::CreateSnapshotParams.new(
-    name: 'my-gpu-snapshot',
-    image: 'python:3.12',
-    resources: Daytona::Resources.new(cpu: 1, memory: 1, disk: 1, gpu: 1)
-  )
-)
-```
-
-</TabItem>
-<TabItem label="Go" icon="seti:go">
-
-```go
-package main
-
-import (
-	"context"
-	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
-	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
-)
-
-func main() {
-	client, _ := daytona.NewClientWithConfig(&types.DaytonaConfig{
-		Target: "us-east-1",
-	})
-	ctx := context.Background()
-	snapshot, logCh, _ := client.Snapshot.Create(ctx, &types.CreateSnapshotParams{
-		Name:  "my-gpu-snapshot",
-		Image: "python:3.12",
-		Resources: &types.Resources{
-			CPU: 1,
-			Memory: 1,
-			Disk: 1,
-			GPU: 1,
-		},
-	})
-	for range logCh {
-	}
-	_ = snapshot
-}
-```
-
-</TabItem>
-<TabItem label="Java" icon="seti:java">
-
-```java
-import io.daytona.sdk.Daytona;
-import io.daytona.sdk.DaytonaConfig;
-import io.daytona.sdk.Image;
-import io.daytona.sdk.model.Resources;
-import io.daytona.sdk.model.Snapshot;
-
-final class CreateGpuSnapshot {
-    public static void main(String[] args) {
-        DaytonaConfig config = new DaytonaConfig.Builder()
-                .apiKey(System.getenv("DAYTONA_API_KEY"))
-                .target("us-east-1")
-                .build();
-
-        try (Daytona daytona = new Daytona(config)) {
-            Resources resources = new Resources();
-            resources.setCpu(1);
-            resources.setMemory(1);
-            resources.setDisk(1);
-            resources.setGpu(1);
-            Snapshot snapshot = daytona.snapshot().create(
-                "my-gpu-snapshot",
-                Image.base("python:3.12"),
-                resources,
-                null
-            );
-        }
-    }
-}
-```
-
-</TabItem>
-<TabItem label="API" icon="seti:json">
-
-```bash
-curl https://app.daytona.io/api/snapshots \
-  --request POST \
-  --header 'Content-Type: application/json' \
-  --header 'Authorization: Bearer YOUR_SECRET_TOKEN' \
-  --data '{
-    "name": "my-gpu-snapshot",
-    "imageName": "python:3.12",
-    "regionId": "us-east-1",
-    "cpu": 1,
-    "memory": 1,
-    "disk": 1,
-    "gpu": 1
-  }'
-```
-
-</TabItem>
-</Tabs>
 
 <a id="using-the-declarative-builder"></a>
 ### Declarative builder

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -452,7 +452,7 @@ Daytona sends a `daytona-<orgId>-pull` session name on every AssumeRole call. Yo
 This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
 :::
 
-Daytona provides methods to create GPU snapshots using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/snapshots) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/snapshot), [TypeScript](/docs/en/typescript-sdk/snapshot), [Ruby](/docs/en/ruby-sdk/snapshot), [Go](/docs/en/go-sdk/daytona#SnapshotService), [Java](/docs/en/java-sdk/snapshot) **SDKs**, or [API](/docs/en/tools/api#daytona/tag/snapshots).
+Daytona provides methods to create GPU snapshots using the [Daytona Dashboard ↗](https://app.daytona.io/dashboard/snapshots) or programmatically using the Daytona [Python](/docs/en/python-sdk/sync/snapshot), [TypeScript](/docs/en/typescript-sdk/snapshot), [Ruby](/docs/en/ruby-sdk/snapshot), [Go](/docs/en/go-sdk/daytona/#type-snapshotservice), [Java](/docs/en/java-sdk/snapshot) **SDKs**, or [API](/docs/en/tools/api#daytona/tag/snapshots).
 
 GPU snapshots fit into the same snapshot creation flow as other snapshots, but with the additional option to enable the GPU. Create a GPU snapshot first, then use it as the source when creating a [GPU sandbox](/docs/en/sandboxes#gpu-sandboxes).
 

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -8,25 +8,6 @@ import Label from '@components/Label.astro'
 
 Snapshots are sandbox templates created from [Docker](https://www.docker.com/) or [OCI](https://opencontainers.org/) compatible images. Sandboxes can use a [default snapshot](#default-snapshots) or custom snapshots to provide a consistent and reproducible sandbox environments for your dependencies, settings, and resources.
 
-Daytona supports running [Docker](#run-docker-in-a-sandbox) and [Kubernetes](#run-kubernetes-in-a-sandbox) workloads inside sandboxes using snapshots.
-
-## Snapshot lifecycle
-
-A snapshot can have several different states. Each state reflects the current status of your snapshot.
-
-- **Pending**: the snapshot creation has been requested
-- **Building**: the snapshot is being built
-- **Pulling**: the snapshot image is being pulled from a registry
-- **Active**: the snapshot is ready to use for creating sandboxes
-- **Inactive**: the snapshot is deactivated
-- **Error**: the snapshot creation failed
-- **Build Failed**: the snapshot build process failed
-- **Removing**: the snapshot is being deleted
-
-:::note
-Inactive snapshots cannot be used to create sandboxes. They must be explicitly [re-activated](#activate-snapshots) before use. When activated, the snapshot returns to `pending` state and is re-processed before becoming `active` again.
-:::
-
 ## Create Snapshots
 
 Daytona provides methods to create snapshots. You can create a snapshot from:
@@ -152,7 +133,8 @@ curl https://app.daytona.io/api/snapshots \
 </TabItem>
 </Tabs>
 
-### Using public images
+<a id="using-public-images"></a>
+### Public images
 
 Daytona supports creating snapshots from any publicly accessible image or container registry.
 
@@ -269,7 +251,8 @@ curl https://app.daytona.io/api/snapshots \
 </TabItem>
 </Tabs>
 
-### Using local images
+<a id="using-local-images"></a>
+### Local images
 
 Daytona supports creating snapshots from local images or from local Dockerfiles. To create a snapshot from a local image or from a local Dockerfile, use the [Daytona CLI](/docs/en/tools/cli#daytona-snapshot).
 
@@ -312,7 +295,8 @@ Step 1/5 : FROM alpine:latest
  ✓  Use 'harbor-transient.internal.daytona.app/daytona/trying-daytona:0.0.1' to create a new sandbox using this Snapshot
 ```
 
-### Using images from private registries
+<a id="using-images-from-private-registries"></a>
+### Images from private registries
 
 Daytona supports creating snapshots from images from [Docker Hub](#docker-hub), [Google Artifact Registry](#google-artifact-registry), [GitHub Container Registry](#github-container-registry-ghcr), [Amazon ECR](#amazon-elastic-container-registry-ecr) or other private container registries.
 
@@ -352,7 +336,8 @@ Daytona supports creating snapshots from images from Google Artifact Registry, a
    Username is auto-filled with `_json_key` (required by Google for service-account auth) and not shown in the form.
 3. Create the snapshot using the full image reference, e.g. `us-central1-docker.pkg.dev/<project>/<repo>/<image>:<tag>`.
 
-#### GitHub Container Registry (GHCR)
+<a id="github-container-registry-ghcr"></a>
+#### GitHub Container Registry
 
 Daytona supports creating snapshots from images from GitHub Container Registry.
 
@@ -364,7 +349,9 @@ Daytona supports creating snapshots from images from GitHub Container Registry.
    Registry URL is auto-filled with `ghcr.io` and not shown in the form.
 3. Create the snapshot using the full image reference, e.g. `ghcr.io/<owner>/<image>:<tag>`.
 
-#### Amazon Elastic Container Registry (ECR)
+
+<a id="amazon-elastic-container-registry-ecr"></a>
+#### Amazon Elastic Container Registry
 
 Daytona pulls private ECR images via cross-account IAM role assumption — you create a role in your AWS account that trusts Daytona's broker principal, and Daytona assumes it on every pull to fetch a short-lived ECR token. No long-lived AWS credentials are shared, and no manual token rotation is needed.
 
@@ -439,10 +426,6 @@ Daytona sends a `daytona-<orgId>-pull` session name on every AssumeRole call. Yo
   "sts:RoleSessionName": "daytona-<YOUR_EXTERNAL_ID>-*"
 }
 ```
-
-### Using the declarative builder
-
-[Declarative Builder](/docs/en/declarative-builder) provides a powerful, code-first approach to defining dependencies for Daytona Sandboxes. Instead of importing images from a container registry, you can programmatically define them using the Daytona [SDKs](/docs/en/getting-started#sdks).
 
 ### GPU Snapshots
 
@@ -599,6 +582,11 @@ curl https://app.daytona.io/api/snapshots \
 
 </TabItem>
 </Tabs>
+
+<a id="using-the-declarative-builder"></a>
+### Declarative builder
+
+[Declarative Builder](/docs/en/declarative-builder) provides a powerful, code-first approach to defining dependencies for Daytona Sandboxes. Instead of importing images from a container registry, you can programmatically define them using the Daytona [SDKs](/docs/en/getting-started#sdks).
 
 ### Resources
 
@@ -1035,6 +1023,23 @@ curl https://app.daytona.io/api/snapshots/my-awesome-snapshot \
 </TabItem>
 </Tabs>
 
+## Snapshot lifecycle
+
+A snapshot can have several different states. Each state reflects the snapshot's current status.
+
+- **Pending**: the snapshot creation has been requested
+- **Building**: the snapshot is being built
+- **Pulling**: the snapshot image is being pulled from a registry
+- **Active**: the snapshot is ready to use for creating sandboxes
+- **Inactive**: the snapshot is deactivated
+- **Error**: the snapshot creation failed
+- **Build Failed**: the snapshot build process failed
+- **Removing**: the snapshot is being deleted
+
+:::note
+Inactive snapshots cannot be used to create sandboxes. They must be explicitly [re-activated](#activate-snapshots) before use. When activated, the snapshot returns to `pending` state and is re-processed before becoming `active` again.
+:::
+
 ## Run Docker in a Sandbox
 
 Daytona Sandboxes can run Docker containers inside them (**Docker-in-Docker**), enabling you to build, test, and deploy containerized applications. This is particularly useful when your projects have dependencies on external services like databases, message queues, or other microservices.
@@ -1283,8 +1288,6 @@ When a sandbox is created with no snapshot specified, Daytona uses a default sna
 | **`daytona-large`**  | 4        | 8GiB       | 10GiB       |
 
 All default snapshots are based on the `daytonaio/sandbox:<version>` image. For more information, see the [Dockerfile](https://github.com/daytonaio/daytona/blob/main/images/sandbox/Dockerfile).
-
-For GPU workloads, Daytona also provides a pre-built `daytona-gpu` system snapshot. Use it directly for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes), or create a custom GPU snapshot when you need custom dependencies.
 
 ### Python packages (pip)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined GPU docs: recommend the pre-built `daytona-gpu` snapshot for sandboxes, clarified GPU sandbox limits (up to 16 vCPUs, 192GB RAM, 512GB disk), and documented that GPU sandboxes are ephemeral with examples using `ephemeral: true` or `auto_delete_interval: 0`. Added quick SDK/API/CLI references to the top of Sandboxes and Snapshots; updated examples to target a region (e.g., `us-east-1`) and default to `daytona-gpu`.

- **Refactors**
  - Recommend the `daytona-gpu` system snapshot; create custom GPU snapshots only when needed.
  - Added a dedicated GPU Snapshots section; examples set `gpu` resources and `target`/`regionId`, and use `daytona-gpu` for GPU sandboxes.
  - Updated examples across Python, TypeScript (`@daytona/sdk`), Ruby, Go, Java, CLI, and API to include region targeting and show ephemeral settings; simplified prose; moved lifecycle sections to the end; added SDK/API/CLI and Toolbox API quick links.

- **Bug Fixes**
  - Removed the outdated “GPU Snapshot requirements” section and Dockerfile example.
  - Fixed anchors and hyperlinks for image/registry sections (public/local images, GHCR, ECR) and minor cross-links.

<sup>Written for commit fceec7684c328975c44cc211954b69f6a60c0cb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

