### PR TITLE
chore(security): skip workflows on forks

### DIFF
--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   build:
+    if: github.repository == 'daytonaio/daytona'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/default_image_publish.yaml
+++ b/.github/workflows/default_image_publish.yaml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   docker_build:
+    if: github.repository == 'daytonaio/daytona'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e_pr_tests.yaml
+++ b/.github/workflows/e2e_pr_tests.yaml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   e2e-pr-tests:
+    if: github.repository == 'daytonaio/daytona'
     name: E2E sandbox lifecycle (from source)
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   go-work:
+    if: github.repository == 'daytonaio/daytona'
     name: Go work
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +38,7 @@ jobs:
           git diff --exit-code -- 'go.work*' '*/go.mod' '*/go.sum' || (echo "Go workspace files are not up to date! Please run 'go work sync' and commit the changes." && exit 1)
 
   cli-docs:
+    if: github.repository == 'daytonaio/daytona'
     name: CLI docs
     runs-on: ubuntu-latest
     steps:
@@ -63,6 +65,7 @@ jobs:
           git diff --exit-code -- src/content/docs/en/tools/cli.mdx || (echo "CLI reference docs on the docs site are out of sync! Please run 'cd apps/docs && node tools/update-cli-reference.js --local' and commit the changes." && exit 1)
 
   golangci:
+    if: github.repository == 'daytonaio/daytona'
     name: Go lint
     runs-on: ubuntu-latest
     strategy:
@@ -90,6 +93,7 @@ jobs:
           git diff --exit-code '**/*.go' || (echo "Code is not formatted! Please run 'go fmt ./...' and commit" && exit 1)
 
   lint-computer-use:
+    if: github.repository == 'daytonaio/daytona'
     name: Go lint (Computer Use)
     runs-on: ubuntu-latest
     steps:
@@ -115,6 +119,7 @@ jobs:
           args: --timeout=5m ./...
 
   lint-python:
+    if: github.repository == 'daytonaio/daytona'
     name: Python lint
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +150,7 @@ jobs:
           yarn lint:py
 
   format-lint-api-clients:
+    if: github.repository == 'daytonaio/daytona'
     name: Format, lint and generate API clients
     runs-on: ubuntu-latest
     steps:
@@ -171,6 +177,7 @@ jobs:
           git diff --exit-code || (echo "Code not formatted or linting errors! Hint: 'yarn generate:api-client', 'yarn lint:fix', 'yarn docs' and commit" && exit 1)
 
   typecheck-sdk-typescript:
+    if: github.repository == 'daytonaio/daytona'
     name: TypeScript SDK type check
     runs-on: ubuntu-latest
     steps:
@@ -197,6 +204,7 @@ jobs:
             --module preserve --moduleResolution bundler
 
   test:
+    if: github.repository == 'daytonaio/daytona'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -215,6 +223,7 @@ jobs:
         run: yarn test
 
   build:
+    if: github.repository == 'daytonaio/daytona'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -227,6 +236,7 @@ jobs:
           VERSION=v0.0.0-dev yarn build --nxBail=true
 
   license-check:
+    if: github.repository == 'daytonaio/daytona'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -248,6 +258,7 @@ jobs:
           mode: 'check'
 
   yarnrc-lint:
+    if: github.repository == 'daytonaio/daytona'
     name: Yarnrc integrity check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   docker-build:
+    if: github.repository == 'daytonaio/daytona'
     name: Docker build
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   prepare:
+    if: github.repository == 'daytonaio/daytona'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   publish:
+    if: github.repository == 'daytonaio/daytona'
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
     permissions:
       contents: write

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -37,6 +37,7 @@ permissions: {}
 
 jobs:
   publish:
+    if: github.repository == 'daytonaio/daytona'
     runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
     permissions:
       contents: read

--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   translate:
     runs-on: ubuntu-latest
-    if: ${{ github.event.head_commit.author.name != 'github-actions[bot]' && !contains(github.event.head_commit.message, 'gt-translate/') }}
+    if: ${{ github.repository == 'daytonaio/daytona' && github.event.head_commit.author.name != 'github-actions[bot]' && !contains(github.event.head_commit.message, 'gt-translate/') }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Adds job-level guards so workflows skip when running outside `daytonaio/daytona`. Eliminates fork-execution noise that users hit after syncing main on their fork (push-on-main jobs trying to push to `ghcr.io/daytonaio` or call upstream secrets).

**Guard pattern**
```
if: github.repository == 'daytonaio/daytona'
```

**Coverage**
- push: `build_devcontainer`, `translate`
- pull_request: `pr_checks` (all 11 jobs), `pr_docker_build`, `e2e_pr_tests`
- workflow_dispatch: `release`, `prepare-release`, `sdk_publish`, `default_image_publish`

`needs:` chains carry the skip to dependent jobs; only the entry job in each chain gets the explicit guard.

**Upstream fork PRs unaffected** — GHA evaluates the condition against the base repo context, so PRs from community forks to `daytonaio/daytona` continue to run.

**Validation**
- `actionlint` clean (excl. pre-existing shellcheck noise)
- `zizmor` baseline preserved (no new findings)
- YAML parse OK on all 9 files