### PR TITLE
fix(api): exclude hidden general snapshots from user-facing lookups

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -460,13 +460,13 @@ export class SandboxService {
 
       const snapshotFilter: FindOptionsWhere<Snapshot>[] = [
         { organizationId: organization.id, name: snapshotIdOrName },
-        { general: true, name: snapshotIdOrName },
+        { general: true, hideFromUsers: false, name: snapshotIdOrName },
       ]
 
       if (isValidUuid(snapshotIdOrName)) {
         snapshotFilter.push(
           { organizationId: organization.id, id: snapshotIdOrName },
-          { general: true, id: snapshotIdOrName },
+          { general: true, hideFromUsers: false, id: snapshotIdOrName },
         )
       }
 

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -455,7 +455,7 @@ export class SnapshotService {
   async getSnapshotWithRegions(snapshotIdOrName: string, organizationId: string): Promise<Snapshot> {
     const where: FindOptionsWhere<Snapshot>[] = [
       { name: snapshotIdOrName, organizationId },
-      { name: snapshotIdOrName, general: true },
+      { name: snapshotIdOrName, general: true, hideFromUsers: false },
     ]
     if (isUUID(snapshotIdOrName)) {
       where.push({ id: snapshotIdOrName })
@@ -488,7 +488,7 @@ export class SnapshotService {
     if (!snapshot) {
       //  check if the snapshot is general
       const generalSnapshot = await this.snapshotRepository.findOne({
-        where: { name: snapshotName, general: true },
+        where: { name: snapshotName, general: true, hideFromUsers: false },
       })
       if (generalSnapshot) {
         return generalSnapshot


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide hidden general snapshots from user-facing lookups to prevent exposure of internal snapshots. Queries now only return general snapshots where hideFromUsers is false.

- **Bug Fixes**
  - Added hideFromUsers: false to general snapshot filters in `SandboxService` (name and UUID lookups).
  - Applied the same filter in `SnapshotService.getSnapshotWithRegions` and its general snapshot fallback.

<sup>Written for commit 78bca544a979fd907dbbd83374e1d99823169d3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4852?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

