### PR TITLE
fix(docker): multi-stage build for daytona-api to drop devDependencies and build toolchain from runtime

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,10 +1,13 @@
-FROM node:24-slim AS daytona
+# ── builder ──────────────────────────────────────────────────────────────
+FROM node:24-slim AS builder
 
 ENV CI=true
 
-# Install dependencies (apt instead of apk)
-RUN apt-get update && apt-get install -y --no-install-recommends bash curl python3 make g++ && \
-  rm -rf /var/lib/apt/lists/*
+# Build toolchain (python3/make/g++) is only needed to compile the bundle and
+# any native devDependencies — it stays out of the runtime image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
 RUN npm install -g corepack && corepack enable
 
 WORKDIR /daytona
@@ -34,6 +37,30 @@ ENV NX_DAEMON=false
 RUN yarn nx build api --configuration=production --nxBail=true
 
 RUN VITE_API_URL=%DAYTONA_BASE_API_URL%/api yarn nx build dashboard --configuration=production --nxBail=true --output-style=stream
+
+# ── runtime ──────────────────────────────────────────────────────────────
+FROM node:24-slim AS daytona
+
+ENV CI=true
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+RUN npm install -g corepack && corepack enable
+
+WORKDIR /daytona
+
+# Nx (generatePackageJson) emits a pruned manifest + pruned lockfile carrying
+# only the api bundle's runtime closure. apps/api/package.json augments it with
+# runtime deps Nx's static scan misses: @openfeature/core (a non-optional peer
+# of @openfeature/server-sdk) and pg (typeorm's Postgres driver, loaded via a
+# dynamic require). corepack hydrates yarn from the manifest's packageManager
+# field; .yarnrc.yml carries the supply-chain age gate into this install.
+COPY --from=builder /daytona/dist/apps/api/package.json /daytona/dist/apps/api/yarn.lock ./
+COPY --from=builder /daytona/.yarnrc.yml ./
+
+RUN yarn install --immutable
+
+COPY --from=builder /daytona/dist ./dist
 
 ARG VERSION=0.0.1
 ENV VERSION=${VERSION}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -53,14 +53,25 @@ WORKDIR /daytona
 # only the api bundle's runtime closure. apps/api/package.json augments it with
 # runtime deps Nx's static scan misses: @openfeature/core (a non-optional peer
 # of @openfeature/server-sdk) and pg (typeorm's Postgres driver, loaded via a
-# dynamic require). corepack hydrates yarn from the manifest's packageManager
-# field; .yarnrc.yml carries the supply-chain age gate into this install.
+# dynamic require). It also adds the typeorm-migration toolchain (ts-node,
+# tsconfig-paths, typescript, reflect-metadata, dotenv) plus the migration:run:*
+# scripts, so the deploy migration init/pre/post-deploy jobs run from this image.
+# corepack hydrates yarn from the manifest's packageManager field; .yarnrc.yml
+# carries the supply-chain age gate into this install.
 COPY --from=builder /daytona/dist/apps/api/package.json /daytona/dist/apps/api/yarn.lock ./
 COPY --from=builder /daytona/.yarnrc.yml ./
 
 RUN yarn install --immutable
 
 COPY --from=builder /daytona/dist ./dist
+
+# The migration:run:* scripts execute the typeorm CLI through ts-node against
+# the TypeScript data-sources (apps/api/src/migrations/**), which load entities
+# via a `*.entity.ts` glob. Ship that source + the tsconfigs they extend so the
+# deploy migration jobs resolve identically to a full checkout.
+COPY --from=builder /daytona/apps/api/src ./apps/api/src
+COPY --from=builder /daytona/apps/api/tsconfig.json /daytona/apps/api/tsconfig.app.json /daytona/apps/api/tsconfig.spec.json ./apps/api/
+COPY --from=builder /daytona/tsconfig.base.json ./
 
 ARG VERSION=0.0.1
 ENV VERSION=${VERSION}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "api",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "@openfeature/core": "^1.9.0",
+    "pg": "^8.13.3"
+  }
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,6 +4,17 @@
   "private": true,
   "dependencies": {
     "@openfeature/core": "^1.9.0",
-    "pg": "^8.13.3"
+    "pg": "^8.13.3",
+    "dotenv": "17.2.2",
+    "reflect-metadata": "0.1.14",
+    "ts-node": "10.9.1",
+    "tsconfig-paths": "4.2.0",
+    "typescript": "5.8.3",
+    "@types/node": "^22.13.4"
+  },
+  "scripts": {
+    "migration:run:init": "cd apps/api && npx ts-node -P ./tsconfig.json -r tsconfig-paths/register ../../node_modules/typeorm/cli.js migration:run -d ./src/migrations/data-source.ts",
+    "migration:run:pre-deploy": "cd apps/api && npx ts-node -P ./tsconfig.json -r tsconfig-paths/register ../../node_modules/typeorm/cli.js migration:run -d ./src/migrations/pre-deploy/data-source.ts",
+    "migration:run:post-deploy": "cd apps/api && npx ts-node -P ./tsconfig.json -r tsconfig-paths/register ../../node_modules/typeorm/cli.js migration:run -d ./src/migrations/post-deploy/data-source.ts"
   }
 }


### PR DESCRIPTION
## What

Split `apps/api/Dockerfile` into a `builder` stage and a slim runtime stage. devDependencies (`vite`, `vitest`, `storybook`, `tsx`, `jsdom`, `esbuild`, `@nx/*`, `ts-jest`, `typescript`) and the build toolchain (`python3`, `make`, `g++`) no longer ship in the runtime image. The runtime stage installs only the pruned dependency closure Nx emits via `generatePackageJson` (manifest + pruned lockfile).

## Why the naive prune breaks at runtime

Nx's bundle scan misses two runtime deps the prior single-stage image carried implicitly through the full workspace install:

- **`@openfeature/core`** — a non-optional peer of `@openfeature/server-sdk`, which declares no direct dependency on it. Without it the container boots and immediately dies with `Cannot find module '@openfeature/core'`.
- **`pg`** — typeorm's Postgres driver, loaded through a dynamic `require` and therefore invisible to the static scan. Absent, the API crashes on first DB access.

A project-level `apps/api/package.json` declares both, so Nx merges them into the generated manifest and pruned lockfile. The runtime install reuses `.yarnrc.yml` to honour the supply-chain age gate.

## Verification (local)

- Image builds clean.
- `@openfeature/core`, `pg`, and the nestjs/typeorm runtime closure all `require.resolve` in the runtime image.
- Dev/build packages confirmed absent from the runtime image.
- Container boots against Postgres via `docker-compose`, runs migrations, maps all routes, and serves `/api/config` with HTTP 200 (`Nest application successfully started`).
- Full boot log scan: zero `MODULE_NOT_FOUND` / `DriverPackageNotInstalledError`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `apps/api` to a multi-stage Docker build with a slim runtime, and add the TypeORM migration toolchain so deploy jobs can run migrations from the image. Also declare missing runtime deps so the API boots cleanly.

- **Refactors**
  - Split Dockerfile into `builder` and slim runtime; drop build toolchain and devDependencies from runtime.
  - Runtime installs Nx `generatePackageJson` output with `.yarnrc.yml` and ships only the pruned closure.

- **Bug Fixes**
  - Added `@openfeature/core` and `pg` to `apps/api/package.json` to satisfy runtime requires.
  - Restored migrations: added `migration:run:*` scripts and toolchain (`ts-node`, `tsconfig-paths`, `typescript`, `reflect-metadata`, `dotenv`, `@types/node`) and copied `apps/api/src` + tsconfigs so the TypeORM CLI resolves and runs.

<sup>Written for commit a21cc8797c2262b68e896feeffd11c721b2cefd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4854?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

