### PR TITLE
fix(sdk-typescript): isolate per-Sandbox Configuration; support process.env on serverless

### DIFF
--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -669,10 +669,6 @@ export class Daytona implements AsyncDisposable {
   public list(query?: ListSandboxesQuery): AsyncIterableIterator<Sandbox> {
     const { sandboxApi, clientConfig } = this
     const tracer = trace.getTracer('')
-    // Clone once per list() call — the config is read-only after construction
-    // and each Sandbox holds its own reference; cloning per page or per item
-    // would be wasteful.
-    const clonedConfig = structuredClone(clientConfig)
 
     async function* generator(): AsyncGenerator<Sandbox> {
       let cursor: string | undefined = undefined
@@ -741,7 +737,8 @@ export class Daytona implements AsyncDisposable {
         firstPage = false
 
         for (const sandbox of response.data.items) {
-          yield new Sandbox(sandbox, clonedConfig, Daytona.createAxiosInstance(), sandboxApi)
+          // Sandbox ctor mutates clientConfig.basePath — clone per item.
+          yield new Sandbox(sandbox, structuredClone(clientConfig), Daytona.createAxiosInstance(), sandboxApi)
         }
 
         cursor = response.data.nextCursor ?? undefined

--- a/libs/sdk-typescript/src/__tests__/Daytona.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Daytona.test.ts
@@ -98,7 +98,7 @@ jest.mock('../Volume', () => ({
 }))
 
 jest.mock('../Sandbox', () => ({
-  Sandbox: jest.fn().mockImplementation((dto: { id: string; state?: string }) => {
+  Sandbox: jest.fn().mockImplementation((dto: { id: string; state?: string }, ...rest: unknown[]) => {
     const sandbox = {
       ...dto,
       start: jest.fn(),
@@ -107,7 +107,7 @@ jest.mock('../Sandbox', () => ({
       waitUntilStarted: jest.fn(),
       _experimental_fork: jest.fn(),
     }
-    mockSandboxCtor(dto)
+    mockSandboxCtor(dto, ...rest)
     return sandbox
   }),
 }))
@@ -409,6 +409,30 @@ describe('Daytona', () => {
     await expect(instance.create({ language: 'python' }, { timeout: 7 })).rejects.toThrow(
       'Failed to create and start sandbox within 7 seconds. Operation timed out.',
     )
+  })
+
+  it('gives each listed sandbox its own Configuration instance', async () => {
+    const { Daytona } = await import('../Daytona')
+    const instance = new Daytona({ apiKey: 'k', apiUrl: 'http://api', target: 'us' })
+
+    mockSandboxApi.listSandboxes.mockResolvedValue(
+      createApiResponse({
+        items: [
+          { id: 'sb-1', labels: {} },
+          { id: 'sb-2', labels: {} },
+          { id: 'sb-3', labels: {} },
+        ],
+        nextCursor: null,
+      }),
+    )
+
+    for await (const _ of instance.list()) {
+      void _
+    }
+
+    expect(mockSandboxCtor).toHaveBeenCalledTimes(3)
+    const configs = mockSandboxCtor.mock.calls.map((call: unknown[]) => call[1])
+    expect(new Set(configs).size).toBe(3)
   })
 
   it('serializes label filters when listing sandboxes', async () => {

--- a/libs/sdk-typescript/src/utils/Runtime.ts
+++ b/libs/sdk-typescript/src/utils/Runtime.ts
@@ -53,7 +53,7 @@ export const RUNTIME =
             : Runtime.UNKNOWN
 
 export function getEnvVar(name: string): string | undefined {
-  if (RUNTIME === Runtime.NODE || RUNTIME === Runtime.BUN) {
+  if (typeof process !== 'undefined' && process.env) {
     return process.env[name]
   }
   if (RUNTIME === Runtime.DENO) {


### PR DESCRIPTION
## Summary

Two independent SDK-TypeScript bug fixes:

1. **Per-`Sandbox` `Configuration` isolation** in `Daytona.list()` — each yielded `Sandbox` now receives its own `Configuration` instance, fixing a P1 raised by `cubic-dev-ai` on #4606.
2. **`process.env` on serverless runtimes** — `getEnvVar()` no longer gates on `Runtime.NODE` / `Runtime.BUN`, so `DAYTONA_API_KEY` & friends are picked up on Cloudflare Workers (`nodejs_compat`), Vercel, Lambda, etc. Ports #4510 (closes #4484).

Either fix can stand alone — happy to split into two PRs if preferred.

## Fix 1: Per-`Sandbox` `Configuration` isolation

### Problem

In `Daytona.list()`, every `Sandbox` yielded by the generator received the **same** `Configuration` reference:

```ts
// Before
const clonedConfig = structuredClone(clientConfig)
// ...
for (const sandbox of response.data.items) {
  yield new Sandbox(sandbox, clonedConfig, Daytona.createAxiosInstance(), sandboxApi)
}
```

`Sandbox`'s constructor mutates that object — `Sandbox.ts:150` sets `this.clientConfig.basePath = this.axiosInstance.defaults.baseURL`. Because every sibling `Sandbox` aliased the same `Configuration`, the **last** Sandbox's `basePath` overwrote every earlier sibling's `basePath`.

Anything that reads `clientConfig.basePath` at request time was therefore corrupted for all but the last Sandbox in the list:

| File | Usage |
|---|---|
| `CodeInterpreter.ts:81` | WebSocket URL for `process/interpreter/execute` |
| `Process.ts:390 / 439 / 585` | WebSocket URLs for session-command logs, entrypoint logs, PTY connect |
| `FileSystem.ts:795` | `POST /files/bulk-upload` |

Trivial repro: `for await (const sb of daytona.list()) { sandboxes.push(sb) }`, then use any earlier `sb`'s websocket-backed feature — it talks to the last sandbox's toolbox proxy.

The original outer `structuredClone` was guarded by a comment claiming `Configuration` is read-only after construction — which is exactly the misconception that produced the bug.

### Fix

`libs/sdk-typescript/src/Daytona.ts`:

```ts
// After
for (const sandbox of response.data.items) {
  // Sandbox ctor mutates clientConfig.basePath — clone per item.
  yield new Sandbox(sandbox, structuredClone(clientConfig), Daytona.createAxiosInstance(), sandboxApi)
}
```

Net production-code change: **−3 LOC**. The outer single clone + its misleading comment are gone; each yielded `Sandbox` gets its own clone. Same total clone count as the bot's literal suggestion (`structuredClone(clonedConfig)` inside the loop) but without the redundant double-clone.

### Regression test

`libs/sdk-typescript/src/__tests__/Daytona.test.ts`:

```ts
it('gives each listed sandbox its own Configuration instance', async () => {
  // ... list 3 sandboxes ...
  const configs = mockSandboxCtor.mock.calls.map((call) => call[1])
  expect(new Set(configs).size).toBe(3)
})
```

Confirmed to catch the original bug — fails with `Received: 1, Expected: 3` against the pre-fix code.

The existing `Sandbox` jest mock was also widened to capture all constructor args (was only capturing the `dto`).

## Fix 2: Read `process.env` on serverless runtimes (ports #4510)

### Problem

`getEnvVar()` only read `process.env` when `RUNTIME` was `NODE` or `BUN`:

```ts
// Before
if (RUNTIME === Runtime.NODE || RUNTIME === Runtime.BUN) {
  return process.env[name]
}
```

On Cloudflare Workers with `nodejs_compat`, `Runtime` resolves to `SERVERLESS` (per `isServerlessRuntime()`), so `getEnvVar('DAYTONA_API_KEY')` returned `undefined` even though `process.env.DAYTONA_API_KEY` was set. `new Daytona()` then failed constructor-time auth with `DaytonaAuthenticationError: Organization ID is required when using JWT token`.

Same shape on Vercel, AWS Lambda, Netlify Functions, GCF — all detected as `SERVERLESS`, all support `process.env`, none could read Daytona env vars.

### Fix

`libs/sdk-typescript/src/utils/Runtime.ts`:

```ts
// After
if (typeof process !== 'undefined' && process.env) {
  return process.env[name]
}
```

This matches the final state of #4510 after maintainer review (`@MDzaja` requested simplification away from an explicit `Runtime.SERVERLESS` check, which `cubic-dev-ai` correctly flagged as crash-prone on Worker-like environments that lack `process` entirely). The capability check is strictly broader than the runtime check — every previous true case still returns `process.env[name]`; previous `undefined` cases on runtimes that *do* expose `process.env` are now served correctly.

### Credit

Original work by [@avasis-ai](https://github.com/avasis-ai) in #4510. Ported here so we don't block on the DCO sign-off discussion blocking that PR.

Closes #4484.

## Files changed

| File | Change | Δ |
|---|---|---|
| `libs/sdk-typescript/src/Daytona.ts` | Drop outer `clonedConfig` + stale comment; `structuredClone(clientConfig)` per yield | +2 / −5 |
| `libs/sdk-typescript/src/__tests__/Daytona.test.ts` | Widen `Sandbox` mock to capture all ctor args; add regression test for distinct configs | +26 / −2 |
| `libs/sdk-typescript/src/utils/Runtime.ts` | `getEnvVar` capability-checks `process.env` instead of gating on `RUNTIME` enum | +1 / −1 |

Net: **+29 / −8**.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two SDK-TypeScript bugs: each `Sandbox` from `Daytona.list()` now gets its own `Configuration`, and env vars are read from `process.env` on serverless runtimes. This prevents cross-sandbox URL mixups and enables `DAYTONA_API_KEY` on Cloudflare Workers, Vercel, Lambda, and similar.

- Bug Fixes
  - Per-Sandbox `Configuration`: clone `clientConfig` per item in `Daytona.list()` to avoid shared `basePath` mutations that broke WebSocket and file APIs across sandboxes.
  - Serverless env vars: `getEnvVar()` now uses `process.env` when available, so `DAYTONA_API_KEY` and related vars load correctly on serverless platforms that expose it.

<sup>Written for commit 34ece66e778295557c34f4a6c6c28801a143cf9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4858?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

