### PR TITLE
fix(daemon): format FileInfo.modTime as RFC 3339

### DIFF
--- a/apps/daemon/pkg/toolbox/fs/get_file_info.go
+++ b/apps/daemon/pkg/toolbox/fs/get_file_info.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -60,7 +61,7 @@ func getFileInfo(path string) (FileInfo, error) {
 		Name:        info.Name(),
 		Size:        info.Size(),
 		Mode:        info.Mode().String(),
-		ModTime:     info.ModTime().String(),
+		ModTime:     info.ModTime().Format(time.RFC3339Nano),
 		IsDir:       info.IsDir(),
 		Owner:       strconv.FormatUint(uint64(stat.Uid), 10),
 		Group:       strconv.FormatUint(uint64(stat.Gid), 10),


### PR DESCRIPTION
## What

`GET /files/info` and `GET /files` returned `modTime` in Go's default
`time.String()` layout (`"2025-05-29 14:30:45.123456789 +0000 UTC"`),
which propagated unchanged through every SDK. Reported by Sebastian.

## Fix

```diff
- ModTime: info.ModTime().String(),
+ ModTime: info.ModTime().Format(time.RFC3339Nano),
```

One line in `apps/daemon/pkg/toolbox/fs/get_file_info.go`. Fixes both
endpoints (they share the same helper) and every SDK at once.

Bonus: the Go SDK's existing `time.Parse(time.RFC3339, ...)` and the
dashboard's `new Date(modTime)` both silently failed on the old format —
they now work.

## Compatibility

Field stays `modTime: string`, only the content normalises to RFC 3339.
Sandboxes on older daemon images keep emitting the old format until
restart.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes file `modTime` to RFC 3339 (nanoseconds) in daemon responses to fix parsing in SDKs and the dashboard. Applies to GET /files and GET /files/info.

- **Bug Fixes**
  - Format `modTime` with `time.RFC3339Nano` in `apps/daemon/pkg/toolbox/fs/get_file_info.go`.
  - Go SDK `time.Parse(time.RFC3339, ...)` and dashboard `new Date(modTime)` now work; field stays `string`. Older daemons keep old format until restart.

<sup>Written for commit e825db2f42d6bd6cec07d8475fa59577c7f489a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4859?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

