### PR TITLE
fix(dashboard): conditionally render sandbox class indicators based o…

### DIFF
--- a/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTable.tsx
@@ -6,6 +6,7 @@
 import { DEFAULT_PAGE_SIZE } from '@/constants/Pagination'
 import { LocalStorageKey } from '@/enums/LocalStorageKey'
 import { RoutePath } from '@/enums/RoutePath'
+import { useAvailableSandboxClassesForOrganization } from '@/hooks/useAvailableSandboxClasses'
 import { useCommandPaletteAnalytics } from '@/hooks/useCommandPaletteAnalytics'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { getLocalStorageItem, setLocalStorageItem } from '@/lib/local-storage'
@@ -118,6 +119,14 @@ export function SandboxTable({
     setLocalStorageItem(LocalStorageKey.SandboxTableColumnVisibility, JSON.stringify(columnVisibility))
   }, [columnVisibility])
 
+  const availableSandboxClasses = useAvailableSandboxClassesForOrganization()
+  const visibleColumns = useMemo(() => {
+    if (availableSandboxClasses.length > 1) {
+      return columns
+    }
+    return columns.filter((column) => column.id !== 'sandboxClass')
+  }, [availableSandboxClasses])
+
   const tableSorting = useMemo(() => convertApiSortingToTableSorting(sorting), [sorting])
   const tableFilters = useMemo(() => convertApiFiltersToTableFilters(filters), [filters])
 
@@ -134,7 +143,7 @@ export function SandboxTable({
 
   const table = useReactTable({
     data,
-    columns,
+    columns: visibleColumns,
     manualFiltering: true,
     onColumnFiltersChange: (updater) => {
       const newTableFilters = typeof updater === 'function' ? updater(table.getState().columnFilters) : updater

--- a/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
+++ b/apps/dashboard/src/components/snapshots/CreateSnapshotSheet.tsx
@@ -273,34 +273,36 @@ export const CreateSnapshotSheet = ({
               )}
             </form.Field>
 
-            <form.Field name="sandboxClass">
-              {(field) => (
-                <Field>
-                  <FieldLabel htmlFor={field.name}>Sandbox Class</FieldLabel>
-                  <Select
-                    value={field.state.value ?? SandboxClass.CONTAINER}
-                    onValueChange={(value) => field.handleChange(value as SandboxClass)}
-                    disabled={!selectedRegionId}
-                  >
-                    <SelectTrigger className="h-8" id={field.name}>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {SANDBOX_CLASS_OPTIONS.filter((option) => availableSandboxClasses.includes(option.value)).map(
-                        (option) => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ),
-                      )}
-                    </SelectContent>
-                  </Select>
-                  <FieldDescription>
-                    The target platform sandboxes created from this snapshot will run on.
-                  </FieldDescription>
-                </Field>
-              )}
-            </form.Field>
+            {availableSandboxClasses.length > 1 && (
+              <form.Field name="sandboxClass">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={field.name}>Sandbox Class</FieldLabel>
+                    <Select
+                      value={field.state.value ?? SandboxClass.CONTAINER}
+                      onValueChange={(value) => field.handleChange(value as SandboxClass)}
+                      disabled={!selectedRegionId}
+                    >
+                      <SelectTrigger className="h-8" id={field.name}>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SANDBOX_CLASS_OPTIONS.filter((option) => availableSandboxClasses.includes(option.value)).map(
+                          (option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ),
+                        )}
+                      </SelectContent>
+                    </Select>
+                    <FieldDescription>
+                      The target platform sandboxes created from this snapshot will run on.
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
+            )}
 
             <div className="flex flex-col gap-2">
               <Label className="text-sm font-medium">Resources</Label>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide sandbox class UI when only one class is available. The snapshot sheet shows the selector only if multiple classes exist, and the sandbox table hides the sandboxClass column accordingly to reduce noise.

- **Bug Fixes**
  - SandboxTable: use `useAvailableSandboxClassesForOrganization` and hide the `sandboxClass` column when only one class is available.
  - CreateSnapshotSheet: render the sandbox class selector only when more than one class is available; otherwise use the default.

<sup>Written for commit 78aa2a1c2140de49a1a861de6182810c4ec7f991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

