### PR TITLE
Feat/sandbox win

### DIFF
--- a/apps/api/src/sandbox/controllers/snapshot.controller.ts
+++ b/apps/api/src/sandbox/controllers/snapshot.controller.ts
@@ -54,6 +54,7 @@ import { AuditAction } from '../../audit/enums/audit-action.enum'
 import { AuditTarget } from '../../audit/enums/audit-target.enum'
 import { ListSnapshotsQueryDto } from '../dto/list-snapshots-query.dto'
 import { SnapshotState } from '../enums/snapshot-state.enum'
+import { SandboxClass } from '../enums/sandbox-class.enum'
 import { AuthenticatedRateLimitGuard } from '../../common/guards/authenticated-rate-limit.guard'
 import { UrlDto } from '../../common/dto/url.dto'
 import { AuthStrategy } from '../../auth/decorators/auth-strategy.decorator'
@@ -113,6 +114,12 @@ export class SnapshotController {
     @IsOrganizationAuthContext() authContext: OrganizationAuthContext,
     @Body() createSnapshotDto: CreateSnapshotDto,
   ): Promise<SnapshotDto> {
+    if (createSnapshotDto.sandboxClass === SandboxClass.WINDOWS) {
+      throw new BadRequestError(
+        'Windows snapshots cannot be created via this endpoint; they are produced by snapshot-from-sandbox flows.',
+      )
+    }
+
     if (createSnapshotDto.buildInfo) {
       if (createSnapshotDto.imageName) {
         throw new BadRequestError('Cannot specify an image name when using a build info entry')

--- a/apps/api/src/sandbox/controllers/snapshot.controller.ts
+++ b/apps/api/src/sandbox/controllers/snapshot.controller.ts
@@ -54,7 +54,6 @@ import { AuditAction } from '../../audit/enums/audit-action.enum'
 import { AuditTarget } from '../../audit/enums/audit-target.enum'
 import { ListSnapshotsQueryDto } from '../dto/list-snapshots-query.dto'
 import { SnapshotState } from '../enums/snapshot-state.enum'
-import { SandboxClass } from '../enums/sandbox-class.enum'
 import { AuthenticatedRateLimitGuard } from '../../common/guards/authenticated-rate-limit.guard'
 import { UrlDto } from '../../common/dto/url.dto'
 import { AuthStrategy } from '../../auth/decorators/auth-strategy.decorator'
@@ -114,12 +113,6 @@ export class SnapshotController {
     @IsOrganizationAuthContext() authContext: OrganizationAuthContext,
     @Body() createSnapshotDto: CreateSnapshotDto,
   ): Promise<SnapshotDto> {
-    if (createSnapshotDto.sandboxClass === SandboxClass.WINDOWS) {
-      throw new BadRequestError(
-        'Windows snapshots cannot be created via this endpoint; they are produced by snapshot-from-sandbox flows.',
-      )
-    }
-
     if (createSnapshotDto.buildInfo) {
       if (createSnapshotDto.imageName) {
         throw new BadRequestError('Cannot specify an image name when using a build info entry')

--- a/apps/api/src/sandbox/enums/sandbox-class.enum.ts
+++ b/apps/api/src/sandbox/enums/sandbox-class.enum.ts
@@ -7,4 +7,5 @@ export enum SandboxClass {
   LINUX_VM = 'linux-vm',
   CONTAINER = 'container',
   ANDROID = 'android',
+  WINDOWS = 'windows',
 }

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -30,7 +30,7 @@ import { InjectRedis } from '@nestjs-modules/ioredis'
 import Redis from 'ioredis'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
 import { SandboxActivityService } from '../../services/sandbox-activity.service'
-import { getRunnerSandboxClass } from '../../utils/sandbox-class.util'
+import { getRunnerSandboxClass, isRegistryBasedSandboxClass } from '../../utils/sandbox-class.util'
 
 @Injectable()
 export class SandboxStartAction extends SandboxAction {
@@ -319,18 +319,26 @@ export class SandboxStartAction extends SandboxAction {
   }
 
   async pullSnapshotToRunner(snapshot: Snapshot, runner: Runner) {
-    const internalRegistry = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(
-      snapshot.ref,
-      runner.region,
-    )
-    if (!internalRegistry) {
-      throw new Error('No internal registry found for sandbox snapshot')
+    let internalRegistry: DockerRegistry | undefined
+    if (isRegistryBasedSandboxClass(snapshot.sandboxClass)) {
+      const found = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(snapshot.ref, runner.region)
+      if (!found) {
+        throw new Error('No internal registry found for sandbox snapshot')
+      }
+      internalRegistry = found
     }
 
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
     // Fire the pull request (runner returns 202 immediately)
-    await runnerAdapter.pullSnapshot(snapshot.ref, internalRegistry)
+    await runnerAdapter.pullSnapshot(
+      snapshot.ref,
+      internalRegistry,
+      undefined,
+      undefined,
+      undefined,
+      snapshot.sandboxClass,
+    )
 
     const pollTimeoutMs = 60 * 60 * 1_000 // 1 hour
     const pollIntervalMs = 5 * 1_000 // 5 seconds
@@ -407,7 +415,7 @@ export class SandboxStartAction extends SandboxAction {
 
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
-    let internalRegistry: DockerRegistry
+    let internalRegistry: DockerRegistry | undefined
     let entrypoint: string[]
     let snapshotRef: string
     if (!sandbox.buildInfo) {
@@ -415,9 +423,12 @@ export class SandboxStartAction extends SandboxAction {
       const snapshot = await this.snapshotService.getSnapshotByName(sandbox.snapshot, sandbox.organizationId)
       snapshotRef = snapshot.ref
 
-      internalRegistry = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(snapshotRef, runner.region)
-      if (!internalRegistry) {
-        throw new Error('No registry found for snapshot')
+      if (isRegistryBasedSandboxClass(snapshot.sandboxClass)) {
+        const found = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(snapshotRef, runner.region)
+        if (!found) {
+          throw new Error('No registry found for snapshot')
+        }
+        internalRegistry = found
       }
 
       entrypoint = snapshot.entrypoint

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -584,7 +584,14 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     const retryTimeoutMs = retryTimeoutMinutes * 60 * 1000
     if (Date.now() - snapshotRunner.createdAt.getTime() > retryTimeoutMs) {
       const snapshot = await this.snapshotRepository.findOne({ where: { ref: snapshotRunner.snapshotRef } })
-      const sandboxClass = snapshot?.sandboxClass
+      let sandboxClass = snapshot?.sandboxClass
+      if (!sandboxClass) {
+        // Backup-snapshot refs do not have a Snapshot row; fall back to the owning sandbox's class.
+        const sandbox = await this.sandboxRepository.findOne({
+          where: { backupSnapshot: snapshotRunner.snapshotRef },
+        })
+        sandboxClass = sandbox?.sandboxClass
+      }
       let internalRegistry: DockerRegistry | undefined
       if (!sandboxClass || isRegistryBasedSandboxClass(sandboxClass)) {
         const found = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -37,6 +37,8 @@ import { SnapshotCreatedEvent } from '../events/snapshot-created.event'
 import { SnapshotService } from '../services/snapshot.service'
 import { OnAsyncEvent } from '../../common/decorators/on-async-event.decorator'
 import { parseDockerImage } from '../../common/utils/docker-image.util'
+import { getRunnerSandboxClass, isRegistryBasedSandboxClass } from '../utils/sandbox-class.util'
+import { SandboxClass } from '../enums/sandbox-class.enum'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { BackupState } from '../enums/backup-state.enum'
@@ -46,8 +48,6 @@ import { SnapshotInfoResponse } from '@daytona/runner-api-client'
 import { SnapshotActivatedEvent } from '../events/snapshot-activated.event'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { RegionType } from '../../region/enums/region-type.enum'
-import { SandboxClass } from '../enums/sandbox-class.enum'
-import { getRunnerSandboxClass } from '../utils/sandbox-class.util'
 
 /** Fisher-Yates shuffle — uniform random permutation in O(n). */
 function shuffleArray<T>(array: T[]): T[] {
@@ -404,18 +404,21 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
 
       // regionId -> registry
       const internalRegistriesMap = new Map<string, DockerRegistry>()
+      const registryBased = isRegistryBasedSandboxClass(snapshot.sandboxClass)
 
-      for (const regionId of [...sharedRegionIds, ...organizationRegionIds]) {
-        const registry = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(snapshot.ref, regionId)
-        if (registry) {
-          internalRegistriesMap.set(regionId, registry)
+      if (registryBased) {
+        for (const regionId of [...sharedRegionIds, ...organizationRegionIds]) {
+          const registry = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(snapshot.ref, regionId)
+          if (registry) {
+            internalRegistriesMap.set(regionId, registry)
+          }
         }
       }
 
       const results = await Promise.allSettled(
         runnersToPropagateTo.map(async (runner) => {
           const internalRegistry = internalRegistriesMap.get(runner.region)
-          if (!internalRegistry) {
+          if (registryBased && !internalRegistry) {
             throw new Error(`No internal registry found for snapshot ${snapshot.ref} in region ${runner.region}`)
           }
 
@@ -428,7 +431,14 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
                 snapshot.ref,
                 SnapshotRunnerState.PULLING_SNAPSHOT,
               )
-              await this.pullSnapshotRunner(runner, snapshot.ref, internalRegistry)
+              await this.pullSnapshotRunner(
+                runner,
+                snapshot.ref,
+                internalRegistry,
+                undefined,
+                undefined,
+                snapshot.sandboxClass,
+              )
             } else if (snapshotRunner.state === SnapshotRunnerState.PULLING_SNAPSHOT) {
               await this.handleSnapshotRunnerStatePullingSnapshot(snapshotRunner, runner)
             }
@@ -531,10 +541,18 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     registry?: DockerRegistry,
     destinationRegistry?: DockerRegistry,
     destinationRef?: string,
+    sandboxClass?: SandboxClass,
   ) {
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
     // Runner returns immediately; polling for completion is handled by syncRunnerSnapshotStates cron
-    await runnerAdapter.pullSnapshot(snapshotRef, registry, destinationRegistry, destinationRef)
+    await runnerAdapter.pullSnapshot(
+      snapshotRef,
+      registry,
+      destinationRegistry,
+      destinationRef,
+      undefined,
+      sandboxClass,
+    )
   }
 
   async handleSnapshotRunnerStatePullingSnapshot(snapshotRunner: SnapshotRunner, runner: Runner) {
@@ -565,16 +583,29 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     const retryTimeoutMinutes = 10
     const retryTimeoutMs = retryTimeoutMinutes * 60 * 1000
     if (Date.now() - snapshotRunner.createdAt.getTime() > retryTimeoutMs) {
-      const internalRegistry = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(
-        snapshotRunner.snapshotRef,
-        runner.region,
-      )
-      if (!internalRegistry) {
-        throw new Error(
-          `No internal registry found for snapshot ${snapshotRunner.snapshotRef} in region ${runner.region}`,
+      const snapshot = await this.snapshotRepository.findOne({ where: { ref: snapshotRunner.snapshotRef } })
+      const sandboxClass = snapshot?.sandboxClass
+      let internalRegistry: DockerRegistry | undefined
+      if (!sandboxClass || isRegistryBasedSandboxClass(sandboxClass)) {
+        const found = await this.dockerRegistryService.findInternalRegistryBySnapshotRef(
+          snapshotRunner.snapshotRef,
+          runner.region,
         )
+        if (!found) {
+          throw new Error(
+            `No internal registry found for snapshot ${snapshotRunner.snapshotRef} in region ${runner.region}`,
+          )
+        }
+        internalRegistry = found
       }
-      await this.pullSnapshotRunner(runner, snapshotRunner.snapshotRef, internalRegistry)
+      await this.pullSnapshotRunner(
+        runner,
+        snapshotRunner.snapshotRef,
+        internalRegistry,
+        undefined,
+        undefined,
+        sandboxClass,
+      )
       return
     }
   }
@@ -709,7 +740,14 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
                     sandbox.backupSnapshot,
                     SnapshotRunnerState.PULLING_SNAPSHOT,
                   )
-                  await this.pullSnapshotRunner(targetRunner, sandbox.backupSnapshot, registry)
+                  await this.pullSnapshotRunner(
+                    targetRunner,
+                    sandbox.backupSnapshot,
+                    registry,
+                    undefined,
+                    undefined,
+                    sandbox.sandboxClass,
+                  )
 
                   this.logger.log(
                     `Created snapshot runner entry for sandbox ${sandbox.id} backup ${sandbox.backupSnapshot} on runner ${targetRunner.id} (migrating from draining runner ${runner.id})`,
@@ -927,12 +965,17 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     })
 
     if (snapshot.ref && snapshotRunner) {
-      if (snapshotRunner.state === SnapshotRunnerState.READY && snapshot.size != null) {
+      const readyForActive = isRegistryBasedSandboxClass(snapshot.sandboxClass) ? snapshot.size != null : true
+      if (snapshotRunner.state === SnapshotRunnerState.READY && readyForActive) {
         await this.updateSnapshotState(snapshot, SnapshotState.ACTIVE)
         return DONT_SYNC_AGAIN
       } else if (snapshotRunner.state === SnapshotRunnerState.ERROR) {
         await this.snapshotRunnerRepository.delete(snapshotRunner.id)
       }
+    }
+
+    if (!isRegistryBasedSandboxClass(snapshot.sandboxClass)) {
+      return DONT_SYNC_AGAIN
     }
 
     const runner = await this.runnerService.findOneOrFail(snapshot.initialRunnerId)
@@ -1058,26 +1101,31 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       return DONT_SYNC_AGAIN
     }
 
-    let sourceRegistry = await this.dockerRegistryService.findSourceRegistryBySnapshotImageName(
-      snapshot.imageName,
-      runner.region,
-      snapshot.organizationId,
-    )
-    if (!sourceRegistry) {
-      sourceRegistry = await this.dockerRegistryService.getDefaultDockerHubRegistry()
-    }
-    const destinationRegistry = await this.dockerRegistryService.getAvailableInternalRegistry(runner.region)
-
-    // Fire pull request (runner returns 202 immediately)
-    // Post-processing (digest, cleanup) is handled by handleCheckInitialRunnerSnapshot on the next poll cycle
     try {
-      await this.pullSnapshotRunner(
-        runner,
-        snapshot.imageName,
-        sourceRegistry,
-        destinationRegistry ?? undefined,
-        snapshot.ref ? snapshot.ref : undefined,
-      )
+      if (isRegistryBasedSandboxClass(snapshot.sandboxClass)) {
+        let sourceRegistry =
+          (await this.dockerRegistryService.findSourceRegistryBySnapshotImageName(
+            snapshot.imageName,
+            runner.region,
+            snapshot.organizationId,
+          )) ?? undefined
+        if (!sourceRegistry) {
+          sourceRegistry = (await this.dockerRegistryService.getDefaultDockerHubRegistry()) ?? undefined
+        }
+        const destinationRegistry =
+          (await this.dockerRegistryService.getAvailableInternalRegistry(runner.region)) ?? undefined
+
+        await this.pullSnapshotRunner(
+          runner,
+          snapshot.imageName,
+          sourceRegistry,
+          destinationRegistry,
+          snapshot.ref ? snapshot.ref : undefined,
+          snapshot.sandboxClass,
+        )
+      } else {
+        await this.pullSnapshotRunner(runner, snapshot.ref, undefined, undefined, undefined, snapshot.sandboxClass)
+      }
     } catch (err) {
       // Validation errors are still returned synchronously
       await this.updateSnapshotState(snapshot, SnapshotState.ERROR, err.message)

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -725,15 +725,19 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
                     }
                   }
 
-                  // Find the backup registry to use as source for the pull
+                  // Find the backup registry to use as source for the pull.
+                  // Non-registry-based classes (e.g. Windows) reference an S3 key rather than a
+                  // Docker registry, so skip the registry lookup for them.
                   const registry = sandbox.backupRegistryId
                     ? await this.dockerRegistryService.findOne(sandbox.backupRegistryId)
-                    : await this.dockerRegistryService.findInternalRegistryBySnapshotRef(
-                        sandbox.backupSnapshot,
-                        targetRunner.region,
-                      )
+                    : isRegistryBasedSandboxClass(sandbox.sandboxClass)
+                      ? await this.dockerRegistryService.findInternalRegistryBySnapshotRef(
+                          sandbox.backupSnapshot,
+                          targetRunner.region,
+                        )
+                      : undefined
 
-                  if (!registry) {
+                  if (isRegistryBasedSandboxClass(sandbox.sandboxClass) && !registry) {
                     this.logger.warn(
                       `No registry found for backup snapshot ${sandbox.backupSnapshot} of sandbox ${sandbox.id}`,
                     )

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.ts
@@ -12,6 +12,7 @@ import { BuildInfo } from '../entities/build-info.entity'
 import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxState } from '../enums/sandbox-state.enum'
+import { SandboxClass } from '../enums/sandbox-class.enum'
 import { BackupState } from '../enums/backup-state.enum'
 import { RunnerServiceInfo } from '../common/runner-service-info'
 
@@ -110,6 +111,7 @@ export interface RunnerAdapter {
     destinationRegistry?: DockerRegistry,
     destinationRef?: string,
     newTag?: string,
+    sandboxClass?: SandboxClass,
   ): Promise<void>
   snapshotExists(snapshotRef: string): Promise<boolean>
   getSnapshotInfo(snapshotName: string): Promise<RunnerSnapshotInfo>

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -23,7 +23,6 @@ import { BuildInfo } from '../entities/build-info.entity'
 import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { SandboxClass } from '../enums/sandbox-class.enum'
-import { getRunnerPullClass } from '../utils/sandbox-class.util'
 import { JobType } from '../enums/job-type.enum'
 import { JobStatus } from '../enums/job-status.enum'
 import { ResourceType } from '../enums/resource-type.enum'
@@ -355,13 +354,7 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     const payload: PullSnapshotRequestDTO = {
       snapshot: snapshotName,
       newTag,
-    }
-
-    if (sandboxClass) {
-      const pullClass = getRunnerPullClass(sandboxClass)
-      if (pullClass) {
-        payload.class = pullClass
-      }
+      sandboxClass,
     }
 
     if (registry) {

--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v2.ts
@@ -22,6 +22,8 @@ import { Job } from '../entities/job.entity'
 import { BuildInfo } from '../entities/build-info.entity'
 import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
 import { SandboxState } from '../enums/sandbox-state.enum'
+import { SandboxClass } from '../enums/sandbox-class.enum'
+import { getRunnerPullClass } from '../utils/sandbox-class.util'
 import { JobType } from '../enums/job-type.enum'
 import { JobStatus } from '../enums/job-status.enum'
 import { ResourceType } from '../enums/resource-type.enum'
@@ -348,10 +350,18 @@ export class RunnerAdapterV2 implements RunnerAdapter {
     destinationRegistry?: DockerRegistry,
     destinationRef?: string,
     newTag?: string,
+    sandboxClass?: SandboxClass,
   ): Promise<void> {
     const payload: PullSnapshotRequestDTO = {
       snapshot: snapshotName,
       newTag,
+    }
+
+    if (sandboxClass) {
+      const pullClass = getRunnerPullClass(sandboxClass)
+      if (pullClass) {
+        payload.class = pullClass
+      }
     }
 
     if (registry) {

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -176,6 +176,12 @@ export class SnapshotService {
 
       const sandboxClass = createSnapshotDto.sandboxClass ?? this.configService.getOrThrow('defaultSandboxClass')
 
+      if (sandboxClass === SandboxClass.WINDOWS) {
+        throw new BadRequestException(
+          'Windows snapshots cannot be created via this endpoint; they are produced by snapshot-from-sandbox flows.',
+        )
+      }
+
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
       const newSnapshotCount = 1
@@ -248,6 +254,12 @@ export class SnapshotService {
       }
 
       const sandboxClass = createSnapshotDto.sandboxClass ?? this.configService.getOrThrow('defaultSandboxClass')
+
+      if (sandboxClass === SandboxClass.WINDOWS) {
+        throw new BadRequestException(
+          'Windows snapshots cannot be created via this endpoint; they are produced by snapshot-from-sandbox flows.',
+        )
+      }
 
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 

--- a/apps/api/src/sandbox/utils/sandbox-class.util.ts
+++ b/apps/api/src/sandbox/utils/sandbox-class.util.ts
@@ -27,15 +27,3 @@ export function getRunnerSandboxClass(sandboxClass: SandboxClass): SandboxClass 
 export function isRegistryBasedSandboxClass(sandboxClass: SandboxClass): boolean {
   return sandboxClass !== SandboxClass.WINDOWS
 }
-
-/**
- * Returns the runner-pull dispatch hint to embed in `PullSnapshotRequestDTO.class`.
- *
- * The runner pulls a snapshot by either the Docker registry path (default; field omitted)
- * or the VM/object-storage path (`'vm'`). This intentionally collapses every non-registry
- * SandboxClass — Windows today, future macOS / Linux VHDs / etc. — onto a single dispatch
- * value so the runner only needs to discriminate "registry vs object-storage", not per-OS.
- */
-export function getRunnerPullClass(sandboxClass: SandboxClass): string | undefined {
-  return isRegistryBasedSandboxClass(sandboxClass) ? undefined : 'vm'
-}

--- a/apps/api/src/sandbox/utils/sandbox-class.util.ts
+++ b/apps/api/src/sandbox/utils/sandbox-class.util.ts
@@ -14,3 +14,28 @@ export function getRunnerSandboxClass(sandboxClass: SandboxClass): SandboxClass 
 
   return SandboxClass.CONTAINER
 }
+
+/**
+ * Returns true when snapshots of this class are stored as Docker/OCI references in a registry
+ * (and therefore go through `parseDockerImage` / `findInternalRegistryBySnapshotRef` / runner Docker pulls).
+ *
+ * Returns false for classes whose `snapshot.ref` is NOT a registry reference — currently only
+ * `WINDOWS`, where `snapshot.ref` is an S3 object key pointing at a VHD blob. Callers that
+ * extract a registry from `snapshot.ref`, propagate via Docker pull, or otherwise treat the
+ * ref as an OCI name MUST short-circuit for non-registry-based classes.
+ */
+export function isRegistryBasedSandboxClass(sandboxClass: SandboxClass): boolean {
+  return sandboxClass !== SandboxClass.WINDOWS
+}
+
+/**
+ * Returns the runner-pull dispatch hint to embed in `PullSnapshotRequestDTO.class`.
+ *
+ * The runner pulls a snapshot by either the Docker registry path (default; field omitted)
+ * or the VM/object-storage path (`'vm'`). This intentionally collapses every non-registry
+ * SandboxClass — Windows today, future macOS / Linux VHDs / etc. — onto a single dispatch
+ * value so the runner only needs to discriminate "registry vs object-storage", not per-OS.
+ */
+export function getRunnerPullClass(sandboxClass: SandboxClass): string | undefined {
+  return isRegistryBasedSandboxClass(sandboxClass) ? undefined : 'vm'
+}

--- a/apps/dashboard/src/components/SandboxTable/constants.ts
+++ b/apps/dashboard/src/components/SandboxTable/constants.ts
@@ -13,6 +13,7 @@ import {
   Container,
   Server,
   Smartphone,
+  Monitor,
   LucideIcon,
 } from 'lucide-react'
 import { FacetedFilterOption } from './types'
@@ -115,6 +116,7 @@ const SANDBOX_CLASS_LABEL_MAPPING: Record<SandboxClass, string> = {
   [SandboxClass.CONTAINER]: 'Container',
   [SandboxClass.LINUX_VM]: 'Linux VM',
   [SandboxClass.ANDROID]: 'Android',
+  [SandboxClass.WINDOWS]: 'Windows',
   [SandboxClass.UNKNOWN_DEFAULT_OPEN_API]: 'Unknown',
 }
 
@@ -122,6 +124,7 @@ const SANDBOX_CLASS_ICON_MAPPING: Record<SandboxClass, LucideIcon> = {
   [SandboxClass.CONTAINER]: Container,
   [SandboxClass.LINUX_VM]: Server,
   [SandboxClass.ANDROID]: Smartphone,
+  [SandboxClass.WINDOWS]: Monitor,
   [SandboxClass.UNKNOWN_DEFAULT_OPEN_API]: Container,
 }
 
@@ -140,6 +143,11 @@ export const SANDBOX_CLASS_OPTIONS: FacetedFilterOption[] = [
     label: SANDBOX_CLASS_LABEL_MAPPING[SandboxClass.ANDROID],
     value: SandboxClass.ANDROID,
     icon: SANDBOX_CLASS_ICON_MAPPING[SandboxClass.ANDROID],
+  },
+  {
+    label: SANDBOX_CLASS_LABEL_MAPPING[SandboxClass.WINDOWS],
+    value: SandboxClass.WINDOWS,
+    icon: SANDBOX_CLASS_ICON_MAPPING[SandboxClass.WINDOWS],
   },
 ]
 

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1738,9 +1738,6 @@ const docTemplate = `{
                 "snapshot"
             ],
             "properties": {
-                "class": {
-                    "type": "string"
-                },
                 "destinationRef": {
                     "type": "string"
                 },
@@ -1752,6 +1749,9 @@ const docTemplate = `{
                 },
                 "registry": {
                     "$ref": "#/definitions/RegistryDTO"
+                },
+                "sandboxClass": {
+                    "type": "string"
                 },
                 "snapshot": {
                     "type": "string"

--- a/apps/runner/pkg/api/docs/docs.go
+++ b/apps/runner/pkg/api/docs/docs.go
@@ -1738,6 +1738,9 @@ const docTemplate = `{
                 "snapshot"
             ],
             "properties": {
+                "class": {
+                    "type": "string"
+                },
                 "destinationRef": {
                     "type": "string"
                 },

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1619,9 +1619,6 @@
       "type": "object",
       "required": ["snapshot"],
       "properties": {
-        "class": {
-          "type": "string"
-        },
         "destinationRef": {
           "type": "string"
         },
@@ -1633,6 +1630,9 @@
         },
         "registry": {
           "$ref": "#/definitions/RegistryDTO"
+        },
+        "sandboxClass": {
+          "type": "string"
         },
         "snapshot": {
           "type": "string"

--- a/apps/runner/pkg/api/docs/swagger.json
+++ b/apps/runner/pkg/api/docs/swagger.json
@@ -1619,6 +1619,9 @@
       "type": "object",
       "required": ["snapshot"],
       "properties": {
+        "class": {
+          "type": "string"
+        },
         "destinationRef": {
           "type": "string"
         },

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -176,6 +176,8 @@ definitions:
     type: object
   PullSnapshotRequestDTO:
     properties:
+      class:
+        type: string
       destinationRef:
         type: string
       destinationRegistry:

--- a/apps/runner/pkg/api/docs/swagger.yaml
+++ b/apps/runner/pkg/api/docs/swagger.yaml
@@ -176,8 +176,6 @@ definitions:
     type: object
   PullSnapshotRequestDTO:
     properties:
-      class:
-        type: string
       destinationRef:
         type: string
       destinationRegistry:
@@ -186,6 +184,8 @@ definitions:
         type: string
       registry:
         $ref: '#/definitions/RegistryDTO'
+      sandboxClass:
+        type: string
       snapshot:
         type: string
     required:

--- a/apps/runner/pkg/api/dto/image.go
+++ b/apps/runner/pkg/api/dto/image.go
@@ -5,6 +5,7 @@ package dto
 
 type PullSnapshotRequestDTO struct {
 	Snapshot            string       `json:"snapshot" validate:"required"`
+	Class               *string      `json:"class,omitempty"`
 	Registry            *RegistryDTO `json:"registry,omitempty"`
 	DestinationRegistry *RegistryDTO `json:"destinationRegistry,omitempty"`
 	DestinationRef      *string      `json:"destinationRef,omitempty"`

--- a/apps/runner/pkg/api/dto/image.go
+++ b/apps/runner/pkg/api/dto/image.go
@@ -5,7 +5,7 @@ package dto
 
 type PullSnapshotRequestDTO struct {
 	Snapshot            string       `json:"snapshot" validate:"required"`
-	Class               *string      `json:"class,omitempty"`
+	SandboxClass        *string      `json:"sandboxClass,omitempty"`
 	Registry            *RegistryDTO `json:"registry,omitempty"`
 	DestinationRegistry *RegistryDTO `json:"destinationRegistry,omitempty"`
 	DestinationRef      *string      `json:"destinationRef,omitempty"`

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9770,6 +9770,7 @@ components:
       - linux-vm
       - container
       - android
+      - windows
       type: string
     RegionUsageOverview:
       example:
@@ -10678,6 +10679,7 @@ components:
           - linux-vm
           - container
           - android
+          - windows
           example: linux-vm
           type: string
         state:
@@ -11108,6 +11110,7 @@ components:
           - linux-vm
           - container
           - android
+          - windows
           example: linux-vm
           type: string
         daemonVersion:
@@ -13914,6 +13917,7 @@ components:
           - linux-vm
           - container
           - android
+          - windows
           example: linux-vm
           type: string
       required:

--- a/libs/api-client-go/model_sandbox_class.go
+++ b/libs/api-client-go/model_sandbox_class.go
@@ -23,6 +23,7 @@ const (
 	SANDBOXCLASS_LINUX_VM SandboxClass = "linux-vm"
 	SANDBOXCLASS_CONTAINER SandboxClass = "container"
 	SANDBOXCLASS_ANDROID SandboxClass = "android"
+	SANDBOXCLASS_WINDOWS SandboxClass = "windows"
 	SANDBOXCLASS_UNKNOWN_DEFAULT_OPEN_API SandboxClass = "11184809"
 )
 
@@ -31,6 +32,7 @@ var AllowedSandboxClassEnumValues = []SandboxClass{
 	"linux-vm",
 	"container",
 	"android",
+	"windows",
 	"11184809",
 }
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Sandbox.java
@@ -275,6 +275,8 @@ public class Sandbox {
     
     ANDROID("android"),
     
+    WINDOWS("windows"),
+    
     UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
     private String value;

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxClass.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxClass.java
@@ -35,6 +35,8 @@ public enum SandboxClass {
   
   ANDROID("android"),
   
+  WINDOWS("windows"),
+  
   UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
   private String value;

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
@@ -91,6 +91,8 @@ public class SandboxListItem {
     
     ANDROID("android"),
     
+    WINDOWS("windows"),
+    
     UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
     private String value;

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SnapshotDto.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SnapshotDto.java
@@ -167,6 +167,8 @@ public class SnapshotDto {
     
     ANDROID("android"),
     
+    WINDOWS("windows"),
+    
     UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 
     private String value;

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox_class.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox_class.py
@@ -30,6 +30,7 @@ class SandboxClass(str, Enum):
     LINUX_MINUS_VM = 'linux-vm'
     CONTAINER = 'container'
     ANDROID = 'android'
+    WINDOWS = 'windows'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/libs/api-client-python/daytona_api_client/models/sandbox_class.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox_class.py
@@ -30,6 +30,7 @@ class SandboxClass(str, Enum):
     LINUX_MINUS_VM = 'linux-vm'
     CONTAINER = 'container'
     ANDROID = 'android'
+    WINDOWS = 'windows'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox.rb
@@ -505,7 +505,7 @@ module DaytonaApiClient
       return false if @disk.nil?
       backup_state_validator = EnumAttributeValidator.new('String', ["None", "Pending", "InProgress", "Completed", "Error", "unknown_default_open_api"])
       return false unless backup_state_validator.valid?(@backup_state)
-      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
+      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
       return false unless sandbox_class_validator.valid?(@sandbox_class)
       return false if @toolbox_proxy_url.nil?
       true
@@ -654,7 +654,7 @@ module DaytonaApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] sandbox_class Object to be assigned
     def sandbox_class=(sandbox_class)
-      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
+      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
       unless validator.valid?(sandbox_class)
         fail ArgumentError, "invalid value for \"sandbox_class\", must be one of #{validator.allowable_values}."
       end

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_class.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_class.rb
@@ -18,10 +18,11 @@ module DaytonaApiClient
     LINUX_VM = "linux-vm".freeze
     CONTAINER = "container".freeze
     ANDROID = "android".freeze
+    WINDOWS = "windows".freeze
     UNKNOWN_DEFAULT_OPEN_API = "unknown_default_open_api".freeze
 
     def self.all_vars
-      @all_vars ||= [LINUX_VM, CONTAINER, ANDROID, UNKNOWN_DEFAULT_OPEN_API].freeze
+      @all_vars ||= [LINUX_VM, CONTAINER, ANDROID, WINDOWS, UNKNOWN_DEFAULT_OPEN_API].freeze
     end
 
     # Builds the enum from string

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
@@ -415,7 +415,7 @@ module DaytonaApiClient
       return false if @organization_id.nil?
       return false if @name.nil?
       return false if @target.nil?
-      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
+      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
       return false unless sandbox_class_validator.valid?(@sandbox_class)
       return false if @user.nil?
       return false if @public.nil?
@@ -473,7 +473,7 @@ module DaytonaApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] sandbox_class Object to be assigned
     def sandbox_class=(sandbox_class)
-      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
+      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
       unless validator.valid?(sandbox_class)
         fail ArgumentError, "invalid value for \"sandbox_class\", must be one of #{validator.allowable_values}."
       end

--- a/libs/api-client-ruby/lib/daytona_api_client/models/snapshot_dto.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/snapshot_dto.rb
@@ -353,7 +353,7 @@ module DaytonaApiClient
       return false if @disk.nil?
       return false if @created_at.nil?
       return false if @updated_at.nil?
-      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
+      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
       return false unless sandbox_class_validator.valid?(@sandbox_class)
       true
     end
@@ -461,7 +461,7 @@ module DaytonaApiClient
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] sandbox_class Object to be assigned
     def sandbox_class=(sandbox_class)
-      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "unknown_default_open_api"])
+      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
       unless validator.valid?(sandbox_class)
         fail ArgumentError, "invalid value for \"sandbox_class\", must be one of #{validator.allowable_values}."
       end

--- a/libs/api-client/src/models/sandbox-class.ts
+++ b/libs/api-client/src/models/sandbox-class.ts
@@ -19,6 +19,7 @@ export const SandboxClass = {
     LINUX_VM: 'linux-vm',
     CONTAINER: 'container',
     ANDROID: 'android',
+    WINDOWS: 'windows',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/api-client/src/models/sandbox-list-item.ts
+++ b/libs/api-client/src/models/sandbox-list-item.ts
@@ -136,6 +136,7 @@ export const SandboxListItemSandboxClassEnum = {
     LINUX_VM: 'linux-vm',
     CONTAINER: 'container',
     ANDROID: 'android',
+    WINDOWS: 'windows',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/api-client/src/models/sandbox.ts
+++ b/libs/api-client/src/models/sandbox.ts
@@ -179,6 +179,7 @@ export const SandboxSandboxClassEnum = {
     LINUX_VM: 'linux-vm',
     CONTAINER: 'container',
     ANDROID: 'android',
+    WINDOWS: 'windows',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/api-client/src/models/snapshot-dto.ts
+++ b/libs/api-client/src/models/snapshot-dto.ts
@@ -63,6 +63,7 @@ export const SnapshotDtoSandboxClassEnum = {
     LINUX_VM: 'linux-vm',
     CONTAINER: 'container',
     ANDROID: 'android',
+    WINDOWS: 'windows',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/runner-api-client/src/models/pull-snapshot-request-dto.ts
+++ b/libs/runner-api-client/src/models/pull-snapshot-request-dto.ts
@@ -18,11 +18,11 @@
 import type { RegistryDTO } from './registry-dto';
 
 export interface PullSnapshotRequestDTO {
-    'class'?: string;
     'destinationRef'?: string;
     'destinationRegistry'?: RegistryDTO;
     'newTag'?: string;
     'registry'?: RegistryDTO;
+    'sandboxClass'?: string;
     'snapshot': string;
 }
 

--- a/libs/runner-api-client/src/models/pull-snapshot-request-dto.ts
+++ b/libs/runner-api-client/src/models/pull-snapshot-request-dto.ts
@@ -18,6 +18,7 @@
 import type { RegistryDTO } from './registry-dto';
 
 export interface PullSnapshotRequestDTO {
+    'class'?: string;
     'destinationRef'?: string;
     'destinationRegistry'?: RegistryDTO;
     'newTag'?: string;


### PR DESCRIPTION
## Description

Please include a summary of the change or the feature being introduced. Include relevant motivation and context. List any dependencies that are required for this change.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

If relevant, please add screenshots.

## Notes

Please add any relevant notes if necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows sandbox support end-to-end with S3-backed VHD snapshots and updates APIs, runner, and dashboard. Snapshot flows now branch on registry-based vs VM storage; VM snapshots support `includeMemory`.

- **New Features**
  - Added `SandboxClass.WINDOWS`; `snapshot.ref` is an S3 key. Registry lookups and Docker pulls are gated by `isRegistryBasedSandboxClass`; non-registry snapshots activate without image-size wait. Runner pull accepts optional `sandboxClass`; runner Swagger and `@daytona/runner-api-client` updated. Dashboard adds Windows label/icon/filter. SDKs regenerated across TS, Go, Java, Python, and Ruby.
  - Snapshot-from-sandbox supports `includeMemory` for VM sandboxes: STARTED when true, STOPPED when false; containers reject the flag. Plumbed to runner v2 via `SnapshotSandboxPayload.include_memory` (v0 ignores).

- **Bug Fixes**
  - Backup-snapshot retry falls back to the owning sandbox’s class when no `Snapshot` row exists.
  - POST `/snapshots` rejects Windows after resolving the default class to prevent config bypass.
  - Draining: migrating snapshot pulls off draining runners now handles non-registry snapshots (e.g., Windows) without registry lookups.
  - Renamed pull-snapshot request field from `class` to `sandboxClass` across runner DTOs, Swagger, and clients.

<sup>Written for commit 7596a967667fddde89943edb22e15fba5a01b6ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

