### PR TITLE
fix(runner): discover Docker data root for metrics

### DIFF
--- a/apps/docs/src/content/docs/en/runners.mdx
+++ b/apps/docs/src/content/docs/en/runners.mdx
@@ -886,6 +886,7 @@ Set these variables before running the install script to customize the runner co
 | **Variable name**           | **Description**              | **Default value / notes**                     |
 | --------------------------- | ---------------------------- | --------------------------------------------- |
 | **`CONTAINER_RUNTIME`**     | Container runtime to use     | `sysbox-runc`                                 |
+| **`DOCKER_DATA_ROOT`**      | Docker data root path for runner disk metrics | Auto-discovered from Docker; set when the reported path is not reachable from the runner |
 | **`API_TOKEN`**             | API token for runner         | Auto-generated or user-provided               |
 | **`TLS_CERT_FILE`**         | Path to TLS certificate file | `/etc/letsencrypt/live/$DOMAIN/fullchain.pem` |
 | **`TLS_KEY_FILE`**          | Path to TLS key file         | `/etc/letsencrypt/live/$DOMAIN/privkey.pem`   |

--- a/apps/runner/cmd/runner/config/config.go
+++ b/apps/runner/cmd/runner/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Environment                        string        `envconfig:"ENVIRONMENT"`
 	ContainerRuntime                   string        `envconfig:"CONTAINER_RUNTIME"`
 	ContainerNetwork                   string        `envconfig:"CONTAINER_NETWORK"`
+	DockerDataRoot                     string        `envconfig:"DOCKER_DATA_ROOT"`
 	InterSandboxNetworkEnabled         bool          `envconfig:"INTER_SANDBOX_NETWORK_ENABLED" default:"true"`
 	GpuEnabled                         bool          `envconfig:"GPU_ENABLED" default:"false"`
 	LogFilePath                        string        `envconfig:"LOG_FILE_PATH"`

--- a/apps/runner/cmd/runner/main.go
+++ b/apps/runner/cmd/runner/main.go
@@ -224,6 +224,7 @@ func run() int {
 		WindowSize:                         cfg.CollectorWindowSize,
 		CPUUsageSnapshotInterval:           cfg.CPUUsageSnapshotInterval,
 		AllocatedResourcesSnapshotInterval: cfg.AllocatedResourcesSnapshotInterval,
+		DockerDataRoot:                     cfg.DockerDataRoot,
 	})
 	metricsCollector.Start(ctx)
 

--- a/apps/runner/internal/metrics/collector.go
+++ b/apps/runner/internal/metrics/collector.go
@@ -17,11 +17,14 @@ import (
 	"github.com/daytonaio/runner/pkg/common"
 	"github.com/daytonaio/runner/pkg/docker"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/system"
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
 	"github.com/shirou/gopsutil/v4/load"
 	"github.com/shirou/gopsutil/v4/mem"
 )
+
+const defaultDockerDataRoot = "/var/lib/docker"
 
 // CollectorConfig holds configuration for the metrics collector
 type CollectorConfig struct {
@@ -30,6 +33,9 @@ type CollectorConfig struct {
 	WindowSize                         int
 	CPUUsageSnapshotInterval           time.Duration
 	AllocatedResourcesSnapshotInterval time.Duration
+	// Optional override for the path used to measure Docker-backed disk usage.
+	// Empty means use DockerRootDir reported by the daemon.
+	DockerDataRoot string
 }
 
 // Collector collects system metrics
@@ -50,6 +56,9 @@ type Collector struct {
 	// Intervals for snapshotting metrics in seconds
 	cpuUsageSnapshotInterval           time.Duration
 	allocatedResourcesSnapshotInterval time.Duration
+	dockerDataRoot                     string
+	dockerInfo                         func(context.Context) (system.Info, error)
+	dockerDataRootFallbackWarnOnce     sync.Once
 }
 
 // CPUSnapshot represents a point-in-time CPU measurement
@@ -82,6 +91,10 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		cpuRing:                            ring.New(cfg.WindowSize),
 		cpuUsageSnapshotInterval:           cfg.CPUUsageSnapshotInterval,
 		allocatedResourcesSnapshotInterval: cfg.AllocatedResourcesSnapshotInterval,
+		dockerDataRoot:                     cfg.DockerDataRoot,
+		dockerInfo: func(ctx context.Context) (system.Info, error) {
+			return cfg.Docker.ApiClient().Info(ctx)
+		},
 	}
 }
 
@@ -97,14 +110,23 @@ func (c *Collector) Collect(ctx context.Context) (*Metrics, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	var lastErr error
+	attempt := 0
 	for {
 		select {
 		case <-timeoutCtx.Done():
+			if lastErr != nil {
+				return nil, fmt.Errorf("timeout collecting metrics: %w", lastErr)
+			}
 			return nil, errors.New("timeout collecting metrics")
 		default:
 			metrics, err := c.collect(timeoutCtx)
 			if err != nil {
-				c.log.DebugContext(ctx, "Failed to collect metrics", "error", err)
+				lastErr = err
+				attempt++
+				if attempt == 1 || attempt%5 == 0 {
+					c.log.WarnContext(ctx, "Failed to collect metrics", "attempt", attempt, "error", err)
+				}
 				time.Sleep(1 * time.Second)
 				continue
 			}
@@ -151,8 +173,10 @@ func (c *Collector) collect(ctx context.Context) (*Metrics, error) {
 	// Convert bytes to GiB (1 GiB = 1024^3 bytes)
 	metrics.TotalRAMGiB = float32(memStats.Total) / (1024 * 1024 * 1024)
 
+	info, dockerDataRoot, infoErr := c.dockerInfoAndDataRoot(ctx)
+
 	// Collect disk usage and total
-	diskStats, err := disk.UsageWithContext(ctx, "/var/lib/docker")
+	diskStats, err := disk.UsageWithContext(ctx, dockerDataRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect disk usage: %v", err)
 	}
@@ -161,9 +185,8 @@ func (c *Collector) collect(ctx context.Context) (*Metrics, error) {
 	metrics.TotalDiskGiB = float32(diskStats.Total) / (1024 * 1024 * 1024)
 
 	// Get snapshot count
-	info, err := c.docker.ApiClient().Info(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get snapshot count: %v", err)
+	if infoErr != nil {
+		return nil, fmt.Errorf("failed to get Docker info: %w", infoErr)
 	}
 	metrics.SnapshotCount = float32(info.Images)
 
@@ -175,6 +198,28 @@ func (c *Collector) collect(ctx context.Context) (*Metrics, error) {
 	c.resourcesMutex.RUnlock()
 
 	return metrics, nil
+}
+
+func (c *Collector) dockerInfoAndDataRoot(ctx context.Context) (system.Info, string, error) {
+	info, err := c.dockerInfo(ctx)
+	if c.dockerDataRoot != "" {
+		return info, c.dockerDataRoot, err
+	}
+	if err != nil {
+		c.warnDockerDataRootFallback(ctx, err)
+		return info, defaultDockerDataRoot, err
+	}
+	if info.DockerRootDir == "" {
+		c.warnDockerDataRootFallback(ctx, errors.New("Docker info did not include DockerRootDir"))
+		return info, defaultDockerDataRoot, nil
+	}
+	return info, info.DockerRootDir, nil
+}
+
+func (c *Collector) warnDockerDataRootFallback(ctx context.Context, err error) {
+	c.dockerDataRootFallbackWarnOnce.Do(func() {
+		c.log.WarnContext(ctx, "Falling back to default Docker data root", "path", defaultDockerDataRoot, "error", err)
+	})
 }
 
 // snapshotCPUUsage runs in a background goroutine, continuously monitoring CPU usage

--- a/apps/runner/internal/metrics/collector_test.go
+++ b/apps/runner/internal/metrics/collector_test.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+package metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/docker/docker/api/types/system"
+)
+
+func TestDockerInfoAndDataRootUsesConfiguredOverride(t *testing.T) {
+	ctx := context.Background()
+	infoCalls := 0
+	collector := newTestCollector(func(context.Context) (system.Info, error) {
+		infoCalls++
+		return system.Info{
+			DockerRootDir: "/data/docker",
+			Images:        17,
+		}, nil
+	})
+	collector.dockerDataRoot = "/mnt/runner/docker"
+
+	info, dataRoot, err := collector.dockerInfoAndDataRoot(ctx)
+	if err != nil {
+		t.Fatalf("dockerInfoAndDataRoot returned error: %v", err)
+	}
+	if infoCalls != 1 {
+		t.Fatalf("expected one Docker info call for snapshot count, got %d", infoCalls)
+	}
+	if dataRoot != "/mnt/runner/docker" {
+		t.Fatalf("expected configured data root, got %q", dataRoot)
+	}
+	if info.Images != 17 {
+		t.Fatalf("expected Docker info to be returned, got Images=%d", info.Images)
+	}
+}
+
+func TestDockerInfoAndDataRootUsesDockerReportedRoot(t *testing.T) {
+	ctx := context.Background()
+	infoCalls := 0
+	collector := newTestCollector(func(context.Context) (system.Info, error) {
+		infoCalls++
+		return system.Info{
+			DockerRootDir: "/data/docker",
+			Images:        3,
+		}, nil
+	})
+
+	info, dataRoot, err := collector.dockerInfoAndDataRoot(ctx)
+	if err != nil {
+		t.Fatalf("dockerInfoAndDataRoot returned error: %v", err)
+	}
+	if infoCalls != 1 {
+		t.Fatalf("expected one Docker info call, got %d", infoCalls)
+	}
+	if dataRoot != "/data/docker" {
+		t.Fatalf("expected Docker-reported data root, got %q", dataRoot)
+	}
+	if info.Images != 3 {
+		t.Fatalf("expected Docker info to be returned, got Images=%d", info.Images)
+	}
+}
+
+func TestDockerInfoAndDataRootFallsBackWhenInfoFails(t *testing.T) {
+	ctx := context.Background()
+	infoErr := errors.New("docker unavailable")
+	collector := newTestCollector(func(context.Context) (system.Info, error) {
+		return system.Info{}, infoErr
+	})
+
+	_, dataRoot, err := collector.dockerInfoAndDataRoot(ctx)
+	if !errors.Is(err, infoErr) {
+		t.Fatalf("expected Docker info error to be returned, got %v", err)
+	}
+	if dataRoot != defaultDockerDataRoot {
+		t.Fatalf("expected fallback data root %q, got %q", defaultDockerDataRoot, dataRoot)
+	}
+}
+
+func newTestCollector(dockerInfo func(context.Context) (system.Info, error)) *Collector {
+	return &Collector{
+		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dockerInfo: dockerInfo,
+	}
+}


### PR DESCRIPTION
## What changed

- Use Docker's reported `DockerRootDir` for runner disk metrics instead of always measuring `/var/lib/docker`.
- Add an optional `DOCKER_DATA_ROOT` runner override for deployments where the reported path is not visible from the runner process.
- Preserve `/var/lib/docker` as the fallback path when Docker info cannot be read, and include the last collection error in metrics timeout failures.
- Document the new runner environment variable and add focused tests for override, discovered, and fallback paths.

Refs #4683

## Verification

- `GOOS=linux go test ./... -count=1 -exec /usr/bin/true` from `apps/runner`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discovers the Docker data root for runner disk metrics using the daemon’s reported path and adds an optional `DOCKER_DATA_ROOT` override. Fixes incorrect disk usage on hosts with non-default data roots and improves error reporting. Addresses #4683.

- **Bug Fixes**
  - Use Docker `DockerRootDir` instead of hardcoded `/var/lib/docker`.
  - Warn once and fall back to `/var/lib/docker` if Docker info is unavailable or missing.
  - Include the last collection error in metrics timeout errors and throttle retry logs.

- **New Features**
  - Add `DOCKER_DATA_ROOT` env to override the path when the daemon’s path isn’t reachable from the runner.
  - Update runner docs and add tests for override, discovered, and fallback paths.

<sup>Written for commit 4baa5f525e6d2af5fce6068c8d5dba124b644fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

