### PR TITLE
feat(docs): add windows and update gpu sandboxes

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -122,7 +122,8 @@ Daytona provides a pre-built `daytona-gpu` snapshot for GPU sandboxes. Each GPU 
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
-3. Select a **GPU snapshot**
+3. Select a **GPU snapshot** (`daytona-gpu`)
+4. Select **`us-east-1`** region
 4. Click **Create** to create a GPU sandbox
 
 To create a GPU sandbox programmatically, use the pre-built `daytona-gpu` snapshot, target `us-east-1` region, and set `auto_delete_interval` to `0` (ephemeral).
@@ -263,7 +264,7 @@ Daytona provides a pre-built `windows-server-2025` snapshot for Windows sandboxe
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
-3. Select a Windows snapshot
+3. Select a Windows snapshot (`windows-server-2025`)
 4. Select **`us`** region
 5. Click **Create** to create a Windows sandbox
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -275,7 +275,7 @@ from daytona import Daytona, DaytonaConfig, CreateSandboxFromSnapshotParams
 daytona = Daytona(DaytonaConfig(target="us"))
 sandbox = daytona.create(
     CreateSandboxFromSnapshotParams(
-        snapshot="windows-server-2025",
+        snapshot="windows",
     )
 )
 ```
@@ -290,7 +290,7 @@ const daytona = new Daytona({
   target: "us",
 });
 const sandbox = await daytona.create({
-  snapshot: "windows-server-2025",
+  snapshot: "windows",
 });
 ```
 
@@ -306,7 +306,7 @@ config = Daytona::Config.new(
 daytona = Daytona::Daytona.new(config)
 sandbox = daytona.create(
   Daytona::CreateSandboxFromSnapshotParams.new(
-    snapshot: 'windows-server-2025'
+    snapshot: 'windows'
   )
 )
 ```
@@ -329,7 +329,7 @@ func main() {
 	})
 	ctx := context.Background()
 	params := types.SnapshotParams{
-		Snapshot: "windows-server-2025",
+		Snapshot: "windows",
 	}
 	_, _ = client.Create(ctx, params)
 }
@@ -353,7 +353,7 @@ public class App {
 
         try (Daytona daytona = new Daytona(config)) {
             CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
-            params.setSnapshot("windows-server-2025");
+            params.setSnapshot("windows");
             Sandbox sandbox = daytona.create(params);
         }
     }
@@ -364,7 +364,7 @@ public class App {
 <TabItem label="CLI" icon="seti:shell">
 
 ```bash
-daytona create --snapshot windows-server-2025 --target us
+daytona create --snapshot windows --target us
 ```
 
 </TabItem>
@@ -377,7 +377,7 @@ curl 'https://app.daytona.io/api/sandbox' \
   --header 'Authorization: Bearer YOUR_API_KEY' \
   --data '{
   "target": "us",
-  "snapshot": "windows-server-2025"
+  "snapshot": "windows"
 }'
 ```
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -126,8 +126,6 @@ Daytona provides a pre-built `daytona-gpu` snapshot for creating GPU sandboxes. 
 4. Select **`us-east-1`** region
 4. Click **Create** to create a GPU sandbox
 
-To create a GPU sandbox programmatically, use the pre-built `daytona-gpu` snapshot, target `us-east-1` region, and set `auto_delete_interval` to `0` (ephemeral).
-
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 
@@ -260,15 +258,13 @@ Daytona provides methods to create Windows sandboxes.
 
 Windows sandboxes are Windows OS runtime environments used to run Windows applications. They provide a consistent Windows baseline, so you can run Windows-specific tools and workflows in an isolated sandbox.
 
-Daytona provides a pre-built `windows-server-2025` snapshot for creating Windows sandboxes. The snapshot uses **2 vCPU**, **8GiB** memory, and **30GiB** disk.
+Daytona provides a pre-built `windows` snapshot for creating Windows sandboxes. The snapshot uses **2 vCPU**, **8GiB** memory, and **30GiB** disk.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
-3. Select a Windows snapshot (**`windows-server-2025`**)
+3. Select a Windows snapshot (**`windows`**)
 4. Select **`us`** region
 5. Click **Create** to create a Windows sandbox
-
-To create a Windows sandbox programmatically, use the pre-built `windows-server-2025` snapshot and target `us` region.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -256,6 +256,138 @@ curl 'https://app.daytona.io/api/sandbox' \
 </TabItem>
 </Tabs>
 
+### Windows Sandboxes
+
+Daytona provides methods to create Windows sandboxes. 
+
+Windows sandboxes are Windows OS runtime environments that can be used to run Windows applications. They provide a consistent Windows baseline, so you can run Windows-specific tools and workflows in an isolated sandbox.
+
+1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
+2. Click **Create Sandbox**
+3. Select a Windows snapshot
+4. Select **`us`** region
+5. Click **Create** to create a Windows sandbox
+
+To create a Windows sandbox programmatically, use the pre-built `windows-server-2025` snapshot and target `us` region.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import Daytona, DaytonaConfig, CreateSandboxFromSnapshotParams
+
+daytona = Daytona(DaytonaConfig(target="us"))
+sandbox = daytona.create(
+    CreateSandboxFromSnapshotParams(
+        snapshot="windows-server-2025",
+    )
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona } from "@daytona/sdk";
+
+const daytona = new Daytona({
+  target: "us",
+});
+const sandbox = await daytona.create({
+  snapshot: "windows-server-2025",
+});
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+require 'daytona'
+
+config = Daytona::Config.new(
+  target: "us"
+)
+daytona = Daytona::Daytona.new(config)
+sandbox = daytona.create(
+  Daytona::CreateSandboxFromSnapshotParams.new(
+    snapshot: 'windows-server-2025'
+  )
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+package main
+
+import (
+	"context"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+	client, _ := daytona.NewClientWithConfig(&types.DaytonaConfig{
+		Target: "us",
+	})
+	ctx := context.Background()
+	params := types.SnapshotParams{
+		Snapshot: "windows-server-2025",
+	}
+	_, _ = client.Create(ctx, params)
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+import io.daytona.sdk.Daytona;
+import io.daytona.sdk.DaytonaConfig;
+import io.daytona.sdk.Sandbox;
+import io.daytona.sdk.model.CreateSandboxFromSnapshotParams;
+
+public class App {
+    public static void main(String[] args) {
+        DaytonaConfig config = new DaytonaConfig.Builder()
+                .apiKey(System.getenv("DAYTONA_API_KEY"))
+                .target("us")
+                .build();
+
+        try (Daytona daytona = new Daytona(config)) {
+            CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
+            params.setSnapshot("windows-server-2025");
+            Sandbox sandbox = daytona.create(params);
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem label="CLI" icon="seti:shell">
+
+```bash
+daytona create --snapshot windows-server-2025 --target us
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --data '{
+  "target": "us",
+  "snapshot": "windows-server-2025"
+}'
+```
+
+</TabItem>
+</Tabs>
+
 ### Ephemeral Sandboxes
 
 Daytona provides methods to create ephemeral sandboxes. 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -122,7 +122,7 @@ Daytona provides a pre-built `daytona-gpu` snapshot for GPU sandboxes. Each GPU 
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
-3. Select a **GPU snapshot** (`daytona-gpu`)
+3. Select a GPU snapshot (**`daytona-gpu`**)
 4. Select **`us-east-1`** region
 4. Click **Create** to create a GPU sandbox
 
@@ -264,7 +264,7 @@ Daytona provides a pre-built `windows-server-2025` snapshot for Windows sandboxe
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
-3. Select a Windows snapshot (`windows-server-2025`)
+3. Select a Windows snapshot (**`windows-server-2025`**)
 4. Select **`us`** region
 5. Click **Create** to create a Windows sandbox
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -113,19 +113,16 @@ curl 'https://app.daytona.io/api/sandbox' \
 
 ### GPU Sandboxes
 
-:::caution[Experimental]
-This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
-:::
-
 Daytona provides methods to create GPU sandboxes.
 
-Daytona supports NVIDIA GPU devices for sandbox creation. This allows you to run GPU workloads such as model inference, fine-tuning, and CUDA-accelerated compute inside a sandbox. 
+Daytona supports NVIDIA GPU devices for sandbox creation. You can use GPU sandboxes for workloads such as model inference, fine-tuning, and CUDA-accelerated compute.
 
-Each GPU sandbox is ephemeral and supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
+Daytona provides a pre-built `daytona-gpu` snapshot for GPU sandboxes. Each GPU sandbox is ephemeral and supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
+
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
-3. Select a GPU snapshot
+3. Select a **GPU snapshot**
 4. Click **Create** to create a GPU sandbox
 
 To create a GPU sandbox programmatically, use the pre-built `daytona-gpu` snapshot, target `us-east-1` region, and set `auto_delete_interval` to `0` (ephemeral).
@@ -261,6 +258,8 @@ curl 'https://app.daytona.io/api/sandbox' \
 Daytona provides methods to create Windows sandboxes. 
 
 Windows sandboxes are Windows OS runtime environments that can be used to run Windows applications. They provide a consistent Windows baseline, so you can run Windows-specific tools and workflows in an isolated sandbox.
+
+Daytona provides a pre-built `windows-server-2025` snapshot for Windows sandboxes. The snapshot uses `2 vCPU`, `8GiB` memory, and `30GiB` disk.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
@@ -814,34 +813,6 @@ curl 'https://app.daytona.io/api/sandbox' \
 </TabItem>
 </Tabs>
 
-##### Sandbox details page
-
-[Daytona Dashboard ↗](https://app.daytona.io/dashboard/) provides a sandbox details page to view detailed information about a sandbox and interact with it directly.
-
-1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
-2. Click on a sandbox you want to view the details of
-3. Click **View** to open the sandbox details page
-
-The sandbox details page provides a summary of the sandbox information and actions to perform on the sandbox:
-
-- **Name**: the name of the sandbox
-- **UUID**: the unique identifier of the sandbox
-- **State**: the sandbox state with a visual indicator
-- **Actions**: [start](#start-sandboxes), [stop](#stop-sandboxes), [recover](#recover-sandboxes), [archive](#archive-sandboxes), [delete](#delete-sandboxes), refresh, [SSH access](/docs/en/ssh-access), [screen recordings](/docs/en/computer-use#screen-recording)
-- [**Region**](/docs/en/regions): the target region where the sandbox is running
-- [**Snapshot**](/docs/en/snapshots): the snapshot used to create the sandbox
-- [**Resources**](#resources): allocated sandbox CPU, memory, and disk
-- [**Lifecycle**](#sandbox-lifecycle): [auto-stop](#auto-stop-interval), [auto-archive](#auto-archive-interval), and [auto-delete](#auto-delete-interval) intervals
-- **Labels**: key-value pairs assigned to the sandbox
-- **Timestamps**: when the sandbox was created and when the last event occurred
-- [**Web terminal**](/docs/en/web-terminal): an embedded web terminal session directly in the browser
-- **Filesystem**: sandbox filesystem tree for viewing and managing files and directories: create, upload, download, copy, refresh, collapse, search, and delete capabilities
-- [**VNC**](/docs/en/vnc-access): a graphical desktop session for sandboxes that have a desktop environment
-- [**Logs**](/docs/en/observability/otel-collection): a detailed record of user and system activity for the sandbox
-- **Metrics**: sandbox metrics data displayed as charts
-- **Traces**: distributed traces and spans collected from the sandbox
-- **Spending**: usage and cost over time
-
 ## Stop Sandboxes
 
 Daytona provides methods to stop sandboxes.
@@ -915,10 +886,6 @@ Common use cases for force stop include:
 - the entrypoint ignores termination signals or hangs during shutdown
 
 ## Pause Sandboxes
-
-:::caution[Experimental]
-This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
-:::
 
 Daytona provides methods to pause sandboxes. 
 
@@ -1017,8 +984,6 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/recover' \
 
 </TabItem>
 </Tabs>
-
-##### Recover from error state
 
 When a sandbox enters an error state, it can sometimes be recovered using the `recover` method, depending on the underlying error reason. The `recoverable` flag indicates whether the error state can be resolved through an automated recovery procedure.
 
@@ -1152,10 +1117,6 @@ df -h /                         # disk
 ```
 
 ## Fork Sandboxes
-
-:::caution[Experimental]
-This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
-:::
 
 Daytona provides methods to fork sandboxes. 
 
@@ -1315,10 +1276,6 @@ curl 'https://app.daytona.io/api/sandbox/{sandboxIdOrName}/labels' \
 </Tabs>
 
 ## Create Snapshot from Sandbox
-
-:::caution[Experimental]
-This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
-:::
 
 Daytona provides methods to create [snapshots](/docs/en/snapshots) from sandboxes. 
 

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -8,11 +8,11 @@ import SandboxDiagram from '@components/SandboxDiagram.astro'
 
 Daytona provides **full composable computers** &mdash; **sandboxes** &mdash; for AI agents. Sandboxes are isolated runtime environments you can manage programmatically to run code. Each sandbox runs in isolation, giving it a dedicated kernel, filesystem, network stack, and allocated vCPU, RAM, and disk. Agents get access to a full composable computer environment where they can install packages, run servers, compile code, and manage processes.
 
-Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. [Organizations](/docs/en/organizations) get a maximum sandbox resource limit of **4 vCPUs**, **8GB RAM**, and **10GB disk**. For more power, see [resources](#resources) or contact [support@daytona.io](mailto:support@daytona.io).
+Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. Organizations get a maximum sandbox resource limit of **4 vCPUs**, **8GB RAM**, and **10GB disk**.
 
 Sandboxes use [snapshots](/docs/en/snapshots) to capture a fully configured environment (base OS, installed packages, dependencies, and configuration) to create new sandboxes.
 
-Each sandbox has its own network stack with per-sandbox firewall rules. By default, sandboxes follow standard network policies, but you can restrict egress to a specific set of allowed destinations or block all outbound traffic entirely. For more details, see [network limits](/docs/en/network-limits).
+Each sandbox has its own network stack with per-sandbox firewall rules. By default, sandboxes follow standard network policies, but you can restrict egress to a specific set of allowed destinations or block all outbound traffic entirely.
 
 - **Sandbox SDKs**: [TypeScript](/docs/en/typescript-sdk/sandbox), [Python](/docs/en/python-sdk/sync/sandbox), [Ruby](/docs/en/ruby-sdk/sandbox), [Go](/docs/en/go-sdk/daytona#type-sandbox), [Java](/docs/en/java-sdk/sandbox)
 - **Sandbox API**: [RESTful API](/docs/en/tools/api/#daytona/tag/sandbox) ([OpenAPI spec](/docs/openapi.json)), [Toolbox API](/docs/en/tools/api#daytona-toolbox) ([OpenAPI spec](/docs/toolbox-openapi.json))
@@ -259,7 +259,7 @@ Daytona provides methods to create Windows sandboxes.
 
 Windows sandboxes are Windows OS runtime environments that can be used to run Windows applications. They provide a consistent Windows baseline, so you can run Windows-specific tools and workflows in an isolated sandbox.
 
-Daytona provides a pre-built `windows-server-2025` snapshot for Windows sandboxes. The snapshot uses `2 vCPU`, `8GiB` memory, and `30GiB` disk.
+Daytona provides a pre-built `windows-server-2025` snapshot for Windows sandboxes. The snapshot uses **2 vCPU**, **8GiB** memory, and **30GiB** disk.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**

--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -10,7 +10,7 @@ Daytona provides **full composable computers** &mdash; **sandboxes** &mdash; for
 
 Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. Organizations get a maximum sandbox resource limit of **4 vCPUs**, **8GB RAM**, and **10GB disk**.
 
-Sandboxes use [snapshots](/docs/en/snapshots) to capture a fully configured environment (base OS, installed packages, dependencies, and configuration) to create new sandboxes.
+Sandboxes can use [snapshots](/docs/en/snapshots) to capture a fully configured environment (base operating system, installed packages, dependencies and configuration) to create new sandboxes.
 
 Each sandbox has its own network stack with per-sandbox firewall rules. By default, sandboxes follow standard network policies, but you can restrict egress to a specific set of allowed destinations or block all outbound traffic entirely.
 
@@ -115,9 +115,9 @@ curl 'https://app.daytona.io/api/sandbox' \
 
 Daytona provides methods to create GPU sandboxes.
 
-Daytona supports NVIDIA GPU devices for sandbox creation. You can use GPU sandboxes for workloads such as model inference, fine-tuning, and CUDA-accelerated compute.
+Daytona supports NVIDIA GPU devices for creating GPU sandboxes. Use GPU sandboxes for workloads such as model inference, fine-tuning, and CUDA-accelerated compute.
 
-Daytona provides a pre-built `daytona-gpu` snapshot for GPU sandboxes. Each GPU sandbox is ephemeral and supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
+Daytona provides a pre-built `daytona-gpu` snapshot for creating GPU sandboxes. Each GPU sandbox is ephemeral and supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
 
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
@@ -258,9 +258,9 @@ curl 'https://app.daytona.io/api/sandbox' \
 
 Daytona provides methods to create Windows sandboxes. 
 
-Windows sandboxes are Windows OS runtime environments that can be used to run Windows applications. They provide a consistent Windows baseline, so you can run Windows-specific tools and workflows in an isolated sandbox.
+Windows sandboxes are Windows OS runtime environments used to run Windows applications. They provide a consistent Windows baseline, so you can run Windows-specific tools and workflows in an isolated sandbox.
 
-Daytona provides a pre-built `windows-server-2025` snapshot for Windows sandboxes. The snapshot uses **2 vCPU**, **8GiB** memory, and **30GiB** disk.
+Daytona provides a pre-built `windows-server-2025` snapshot for creating Windows sandboxes. The snapshot uses **2 vCPU**, **8GiB** memory, and **30GiB** disk.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -153,8 +153,6 @@ GPU snapshots are used to create [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxe
 5. Select the **Allocate GPU** checkbox
 6. Click **Create** to create a GPU snapshot
 
-To create a GPU snapshot programmatically, set the `gpu` value to `1` and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
-
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
 

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -23,13 +23,11 @@ Daytona provides methods to create snapshots. You can create a snapshot from:
 - [GPU snapshots](#gpu-snapshots) (for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes))
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
-2. Click the **Create Snapshot** button
-3. Enter the snapshot name and image (tag or digest)
+2. Click **Create Snapshot**
+3. Enter the snapshot **name** and **image**
 
 - **Snapshot name**: identifier used to reference the snapshot
 - **Image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags are not supported
-- **Entrypoint** (optional): entrypoint command for the snapshot; ensure that the entrypoint is a long-running command; if not provided, or if the snapshot does not have an entrypoint, `sleep infinity` will be used as the default
-- [**Resources**](/docs/en/sandboxes#resources) (optional): resources underlying sandboxes have; by default, sandboxes use **1 vCPU**, **1GiB memory**, and **3GiB storage**; use [GPU snapshots](#gpu-snapshots) for GPU sandboxes
 
 <Tabs>
 <TabItem label="Python" icon="seti:python">
@@ -138,19 +136,16 @@ curl https://app.daytona.io/api/snapshots \
 
 ### GPU Snapshots
 
-:::caution[Experimental]
-This feature is experimental. To request access, contact [support@daytona.io](mailto:support@daytona.io).
-:::
-
 Daytona provides methods to create GPU snapshots.
 
-GPU snapshots are used to create [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes). Daytona provides a pre-built `daytona-gpu` system snapshot for creating GPU sandboxes. You can also create a custom GPU snapshot to customize the image or dependencies.
-
-GPU snapshots follow the same snapshot creation flow, but with the additional option to enable and provide GPU resources.
+GPU snapshots are used to create [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes). Daytona provides a pre-built `daytona-gpu` system snapshot for creating GPU sandboxes.
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
-2. Click the **Create Snapshot** button
-3. Configure GPU snapshot details and enable the GPU option
+2. Click **Create Snapshot**
+3. Enter the snapshot **name** and **image**
+4. Select **`us-east-1`** region
+5. Check the **Allocate GPU** option
+6. Click **Create** to create a GPU snapshot
 
 To create a GPU snapshot programmatically, set the `gpu` value to the number of GPU units you want to allocate and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
 

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -6,7 +6,11 @@ description: Pre-configured sandbox templates you can use to create sandboxes.
 import { TabItem, Tabs } from '@astrojs/starlight/components'
 import Label from '@components/Label.astro'
 
-Snapshots are sandbox templates created from [Docker](https://www.docker.com/) or [OCI](https://opencontainers.org/) compatible images. Sandboxes can use a [default snapshot](#default-snapshots) or custom snapshots to provide a consistent and reproducible sandbox environments for your dependencies, settings, and resources.
+Snapshots are reusable sandbox templates built from [Docker](https://www.docker.com/) or [OCI](https://opencontainers.org/) compatible images. Sandboxes can use snapshots to provide a consistent and reproducible environment for your dependencies, settings, and resources.
+
+A snapshot defines the base operating system, language runtimes, system packages, and project-level setup that should exist when a sandbox starts. Instead of repeating bootstrap steps on every sandbox creation, you capture that setup once as a snapshot and reuse it.
+
+You start with default snapshots for common stacks, or create custom snapshots for your own toolchain and constraints. Custom snapshots are useful when your workflow depends on specific package versions, private dependencies, startup scripts, or filesystem layout.
 
 - **Snapshot SDKs**: [TypeScript](/docs/en/typescript-sdk/snapshot), [Python](/docs/en/python-sdk/sync/snapshot), [Ruby](/docs/en/ruby-sdk/snapshot), [Go](/docs/en/go-sdk/daytona#type-snapshotservice), [Java](/docs/en/java-sdk/snapshot)
 - **Snapshot API**: [RESTful API](/docs/en/tools/api/#daytona/tag/snapshots) ([OpenAPI spec](/docs/openapi.json)), [Toolbox API](/docs/en/tools/api#daytona-toolbox) ([OpenAPI spec](/docs/toolbox-openapi.json))
@@ -16,18 +20,20 @@ Snapshots are sandbox templates created from [Docker](https://www.docker.com/) o
 
 Daytona provides methods to create snapshots. You can create a snapshot from:
 
+- [GPU snapshots](#gpu-snapshots) (for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes))
 - [public images](#public-images)
 - [local images](#local-images)
 - [images from private registries](#images-from-private-registries)
-- [the declarative builder](#declarative-builder)
-- [GPU snapshots](#gpu-snapshots) (for [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes))
+- [declarative builder](#declarative-builder)
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click **Create Snapshot**
 3. Enter the snapshot **name** and **image**
 
 - **Snapshot name**: identifier used to reference the snapshot
-- **Image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags are not supported
+- **Snapshot image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags not supported due to frequent changes
+
+4. Click **Create** to create a snapshot
 
 <Tabs>
 <TabItem label="Python" icon="seti:python">
@@ -138,16 +144,16 @@ curl https://app.daytona.io/api/snapshots \
 
 Daytona provides methods to create GPU snapshots.
 
-GPU snapshots are used to create [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes). Daytona provides a pre-built `daytona-gpu` system snapshot for creating GPU sandboxes.
+GPU snapshots are used to create [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxes). Daytona provides a pre-built `daytona-gpu` snapshot for creating GPU sandboxes.
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click **Create Snapshot**
 3. Enter the snapshot **name** and **image**
 4. Select **`us-east-1`** region
-5. Check the **Allocate GPU** option
+5. Select the **Allocate GPU** checkbox
 6. Click **Create** to create a GPU snapshot
 
-To create a GPU snapshot programmatically, set the `gpu` value to the number of GPU units you want to allocate and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
+To create a GPU snapshot programmatically, set the `gpu` value to `1` and target `us-east-1` region. If `gpu` is not set, it defaults to `0`, which creates a non-GPU snapshot.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -31,7 +31,7 @@ Daytona provides methods to create snapshots. You can create a snapshot from:
 3. Enter the snapshot **name** and **image**
 
 - **Snapshot name**: identifier used to reference the snapshot
-- **Snapshot image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags not supported due to frequent changes
+- **Snapshot image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags are not supported
 
 4. Click **Create** to create a snapshot
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Windows sandbox docs and update GPU sandbox/snapshot setup with clear region selection and steps. Tighten language, simplify snapshot intro, and remove experimental labels.

- **New Features**
  - Windows sandboxes: docs and examples for `windows` (2 vCPU/8GiB/30GiB), target `us` (SDKs, CLI, API).
  - GPU sandboxes: standardize on `daytona-gpu` and `us-east-1`; note sandboxes are ephemeral; add dashboard steps.
  - GPU snapshots: flow updated to select `us-east-1` and enable Allocate GPU; programmatic `gpu: 1`.
  - Cleanup: removed experimental banners (pause/fork/snapshot), removed sandbox details page, simplified snapshot creation steps and network notes, and clarified snapshot overview with practical guidance.

<sup>Written for commit 7fd7f8f14e6251ee37a94bb25cfaae59540d1672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

