### PR TITLE
Fix resource validation incorrectly blocking non-snapshot sandboxes in MCP (#4660)

### DIFF
--- a/apps/cli/mcp/tools/create_sandbox.go
+++ b/apps/cli/mcp/tools/create_sandbox.go
@@ -129,7 +129,7 @@ func createSandboxRequest(args CreateSandboxArgs) (*apiclient.CreateSandbox, err
 		if args.Snapshot != nil && *args.Snapshot != "" {
 			return nil, fmt.Errorf("cannot specify a snapshot when using a build info entry")
 		}
-	} else {
+	} else if args.Snapshot != nil && *args.Snapshot != "" {
 		if args.Cpu != nil || args.Gpu != nil || args.Memory != nil || args.Disk != nil {
 			return nil, fmt.Errorf("cannot specify sandbox resources when using a snapshot")
 		}


### PR DESCRIPTION
## Description

The `createSandboxRequest` function in `apps/cli/mcp/tools/create_sandbox.go` contained a logic error in its validation block. The `else` branch ran whenever `BuildInfo` was `nil`, even when no `Snapshot` was provided either. This caused any MCP `create_sandbox` call that specified `cpu`, `gpu`, `memory`, or `disk` resources **without** a snapshot to fail with a misleading error:

```
cannot specify sandbox resources when using a snapshot
```

The fix changes the `else` to `else if args.Snapshot != nil && *args.Snapshot != ""`, so the resource restriction only applies when a snapshot is explicitly provided — matching the documented constraint.

**Before:**
```go
} else {
    if args.Cpu != nil || args.Gpu != nil || args.Memory != nil || args.Disk != nil {
        return nil, fmt.Errorf("cannot specify sandbox resources when using a snapshot")
    }
}
```

**After:**
```go
} else if args.Snapshot != nil && *args.Snapshot != "" {
    if args.Cpu != nil || args.Gpu != nil || args.Memory != nil || args.Disk != nil {
        return nil, fmt.Errorf("cannot specify sandbox resources when using a snapshot")
    }
}
```

## Documentation

- [ ] This change requires a documentation update
- [x] No documentation change needed (bug fix for validation logic)

## Related Issue(s)

This PR addresses issue #4660

## Notes

The fix is a single-character change (`else` → `else if args.Snapshot != nil && *args.Snapshot != ""`). No new dependencies, no API changes. Verified the package builds cleanly after the change.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resource validation in MCP `create_sandbox` so non-snapshot sandboxes can set `cpu`, `gpu`, `memory`, and `disk` without error; the restriction now applies only when a `snapshot` is provided. Fixes #4660.

<sup>Written for commit b1ec380ae4ca2e5e84eab51d48f0d26fcb24dd37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

