### PR TITLE
Preserve upstream X-Forwarded-Host in preview proxy instead of appending (#4846)

### DIFF
--- a/apps/proxy/pkg/proxy/get_sandbox_build_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_build_target.go
@@ -56,9 +56,14 @@ func (p *Proxy) getSandboxBuildTarget(ctx *gin.Context) (*url.URL, map[string]st
 	}
 	target.RawQuery = queryParams.Encode()
 
+	xForwardedHost := ctx.Request.Header.Get("X-Forwarded-Host")
+	if xForwardedHost == "" {
+		xForwardedHost = ctx.Request.Host
+	}
+
 	return target, map[string]string{
 		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
-		"X-Forwarded-Host":        ctx.Request.Host,
+		"X-Forwarded-Host":        xForwardedHost,
 	}, nil
 }
 

--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -115,9 +115,14 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 		return nil, nil, fmt.Errorf("failed to parse target URL: %w", err)
 	}
 
+	xForwardedHost := ctx.Request.Header.Get("X-Forwarded-Host")
+	if xForwardedHost == "" {
+		xForwardedHost = ctx.Request.Host
+	}
+
 	return target, map[string]string{
 		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
-		"X-Forwarded-Host":        ctx.Request.Host,
+		"X-Forwarded-Host":        xForwardedHost,
 	}, nil
 }
 

--- a/apps/proxy/pkg/proxy/get_snapshot_target.go
+++ b/apps/proxy/pkg/proxy/get_snapshot_target.go
@@ -65,9 +65,14 @@ func (p *Proxy) getSnapshotTarget(ctx *gin.Context) (*url.URL, map[string]string
 	}
 	target.RawQuery = queryParams.Encode()
 
+	xForwardedHost := ctx.Request.Header.Get("X-Forwarded-Host")
+	if xForwardedHost == "" {
+		xForwardedHost = ctx.Request.Host
+	}
+
 	return target, map[string]string{
 		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
-		"X-Forwarded-Host":        ctx.Request.Host,
+		"X-Forwarded-Host":        xForwardedHost,
 	}, nil
 }
 

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -61,7 +61,7 @@ func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.UR
 					req.URL.RawQuery = target.RawQuery + "&" + req.URL.RawQuery
 				}
 				for key, value := range extraHeaders {
-					req.Header.Add(key, value)
+					req.Header.Set(key, value)
 				}
 			},
 			Transport:      proxyTransport,


### PR DESCRIPTION
## Description

The preview proxy's reverse-proxy Director called `req.Header.Add()` for every extra header it injected. `Add` appends to existing header values, so when an upstream CDN or Custom Preview Proxy (e.g. a Cloudflare Worker fronting `*.proxy.daytona.work`) had already set `X-Forwarded-Host`, the request arriving inside the sandbox container contained a comma-joined pair:

```
X-Forwarded-Host: customer-host.example.com, 1234-<sandboxId>.proxy.daytona.work
```

Frameworks that read the **last** hop of `X-Forwarded-Host` to determine the canonical request host (Symfony trusted-proxies, some `next.config.js` setups, PHP frameworks in strict mode) then see the Daytona proxy hostname instead of the real customer domain, breaking URL generation, CSRF checks, and routing.

### Root cause

`libs/common-go/pkg/proxy/proxy.go` — Director loop:
```go
// Before
for key, value := range extraHeaders {
    req.Header.Add(key, value)   // appends — wrong
}
```

`apps/proxy/pkg/proxy/get_sandbox_target.go` (and the two sibling files) — always overwrote with Daytona's own host:
```go
"X-Forwarded-Host": ctx.Request.Host,
```

### Fix

**1.** Switch `Add` → `Set` in the common proxy Director so injected headers always replace rather than accumulate.

**2.** In all three `GetProxyTarget` implementations, read the incoming `X-Forwarded-Host` and pass it through unchanged; fall back to `ctx.Request.Host` only when no upstream value is present:

```go
xForwardedHost := ctx.Request.Header.Get("X-Forwarded-Host")
if xForwardedHost == "" {
    xForwardedHost = ctx.Request.Host
}
```

Files changed:
- `libs/common-go/pkg/proxy/proxy.go`
- `apps/proxy/pkg/proxy/get_sandbox_target.go`
- `apps/proxy/pkg/proxy/get_snapshot_target.go`
- `apps/proxy/pkg/proxy/get_sandbox_build_target.go`

## Documentation

- [ ] This change requires a documentation update
- [x] No documentation change needed (bug fix, behavior now matches the Custom Preview Proxy docs)

## Related Issue(s)

This PR addresses issue #4846

## Notes

All four changed packages build cleanly. No API or interface changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the upstream `X-Forwarded-Host` in the preview proxy and stops appending duplicate values, so apps see the real customer host. Fixes routing/CSRF issues behind CDNs or custom proxies (fixes #4846).

- **Bug Fixes**
  - Switched `req.Header.Add` → `req.Header.Set` in `libs/common-go/pkg/proxy/proxy.go` to avoid header accumulation.
  - In `apps/proxy/pkg/proxy/get_sandbox_target.go`, `get_snapshot_target.go`, and `get_sandbox_build_target.go`, forward the incoming `X-Forwarded-Host` and only fall back to `ctx.Request.Host` when missing.

<sup>Written for commit 7fac935baa8544c08e6a0f5e5b01b011e5b050b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

