### PR TITLE
Fix Go SDK ExecuteCommand timeout overridden by HTTP client's 60s limit (#4750)

### DIFF
--- a/libs/sdk-go/pkg/daytona/client.go
+++ b/libs/sdk-go/pkg/daytona/client.go
@@ -314,7 +314,13 @@ func (c *Client) createToolboxClient(proxyURL string, sandboxID string) (*toolbo
 	cfg := toolbox.NewConfiguration()
 	cfg.Host = common.ExtractHost(toolboxURL)
 	cfg.Scheme = common.ExtractScheme(toolboxURL)
-	cfg.HTTPClient = c.httpClient
+	// Use a dedicated client with no fixed timeout so that long-running
+	// ExecuteCommand calls are not killed by the default 60-second limit.
+	// Each call is responsible for providing an appropriate context deadline.
+	cfg.HTTPClient = &http.Client{
+		Timeout:   0,
+		Transport: c.httpClient.Transport,
+	}
 
 	// Set base path
 	basePath := common.ExtractPath(toolboxURL)

--- a/libs/sdk-go/pkg/daytona/process.go
+++ b/libs/sdk-go/pkg/daytona/process.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/common"
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
@@ -105,6 +106,12 @@ func (p *ProcessService) ExecuteCommand(ctx context.Context, command string, opt
 		}
 		if execOpts.Timeout != nil {
 			req.SetTimeout(int32(execOpts.Timeout.Seconds()))
+			// Set a context deadline slightly beyond the command timeout so the
+			// HTTP connection is cancelled if the server never responds after
+			// the command times out on its end.
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, *execOpts.Timeout+30*time.Second)
+			defer cancel()
 		}
 		if execOpts.Env != nil {
 			req.SetEnvs(execOpts.Env)


### PR DESCRIPTION
## Description

`options.WithExecuteTimeout()` correctly serialises the requested duration into the toolbox daemon's `timeout` request body field. The server respects that value. However, the toolbox `http.Client` was shared with the main Daytona API client, which has a hard 60-second `Timeout`. This client-side timer fires regardless of context and kills the TCP connection before the server can return the result of a long-running command, producing:

```
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Users see the call always fail at exactly 60 seconds no matter what value they pass to `WithExecuteTimeout`.

### Root cause

`createToolboxClient` (sdk-go/pkg/daytona/client.go):
```go
cfg.HTTPClient = c.httpClient  // inherits Timeout: 60s — wrong for toolbox
```

### Fix

**1.** `createToolboxClient` now creates a dedicated `http.Client` with `Timeout: 0` (no fixed limit), sharing only the `Transport` from the main client so connection pooling and OpenTelemetry instrumentation are preserved.

**2.** `ExecuteCommand` (sdk-go/pkg/daytona/process.go) attaches a context deadline of `commandTimeout + 30 s` when a timeout option is present. This prevents the call from hanging indefinitely if the daemon silently drops the connection after its own timeout fires.

```go
if execOpts.Timeout != nil {
    req.SetTimeout(int32(execOpts.Timeout.Seconds()))
    var cancel context.CancelFunc
    ctx, cancel = context.WithTimeout(ctx, *execOpts.Timeout+30*time.Second)
    defer cancel()
}
```

Files changed:
- `libs/sdk-go/pkg/daytona/client.go`
- `libs/sdk-go/pkg/daytona/process.go`

## Documentation

- [ ] This change requires a documentation update
- [x] No documentation change needed

## Related Issue(s)

This PR addresses issue #4750

## Notes

Both changed packages build cleanly. The 30-second buffer between the server-side timeout and the context deadline gives the daemon time to return a proper error response before the client-side context fires.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Go SDK `ExecuteCommand` timeout being cut off by the shared client's 60s limit. Long-running toolbox commands now honor `options.WithExecuteTimeout()` (addresses #4750).

- **Bug Fixes**
  - Toolbox client now uses a dedicated `http.Client` with `Timeout: 0`, reusing the main client's `Transport` for pooling and tracing.
  - `ExecuteCommand` adds a context deadline of `commandTimeout + 30s` when a timeout is set, so the call cancels cleanly if the daemon doesn't respond.

<sup>Written for commit 709448bf11409d7f1d9407f044c10b2b337e4f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

