### PR TITLE
Stop keepalive goroutine when SSH client disconnects abruptly (#4805)

### DIFF
--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -331,6 +331,10 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, runnerID string, r
 		if err != nil {
 			log.Printf("Client to runner copy error: %v", err)
 		}
+		// Client disconnected (clean or abrupt). Close the runner channel so
+		// the main goroutine's io.Copy(clientChannel, runnerChannel) unblocks,
+		// which lets defer cancel() fire and stop the keepalive goroutine.
+		runnerChannel.Close()
 	}()
 
 	keepAliveContext, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Description

When an SSH client disconnected **abruptly** (VS Code Remote-SSH tab closed, terminal `SIGKILL`ed, network drop), the sandbox could remain indefinitely blocked from auto-stopping because `lastActivityAt` continued refreshing every 45 seconds.

### Root cause

`handleChannel` in `apps/ssh-gateway/main.go` runs two concurrent `io.Copy` calls:

```
goroutine:   io.Copy(runnerChannel, clientChannel)   // client → runner
main:        io.Copy(clientChannel, runnerChannel)   // runner → client  ← blocks here
```

On a clean SSH disconnect, the SSH channel close message causes both copies to return. On an **abrupt** disconnect (TCP RST / SIGKILL), only the `clientChannel` is seen as closed:

1. The goroutine's `io.Copy(runnerChannel, clientChannel)` returns immediately.
2. The runner-side channel **stays open** (idle shell still running).
3. `io.Copy(clientChannel, runnerChannel)` blocks waiting for data from the runner.
4. `defer cancel()` never fires → the keepalive goroutine keeps calling `UpdateLastActivity` every 45 s.

### Fix

After the client→runner copy finishes, **close the runner channel**. This sends `SSH_MSG_CHANNEL_CLOSE` to the runner, which causes `io.Copy(clientChannel, runnerChannel)` in the main goroutine to return, triggering `defer cancel()` and stopping the keepalive goroutine cleanly.

```go
go func() {
    _, err := io.Copy(runnerChannel, clientChannel)
    if err != nil {
        log.Printf("Client to runner copy error: %v", err)
    }
    // Client disconnected. Close runner channel so the main goroutine unblocks.
    runnerChannel.Close()
}()
```

`ssh.Channel.Close()` is safe to call when the channel is already being closed by the deferred `defer runnerChannel.Close()` — the SSH library's implementation is idempotent.

## Documentation

- [ ] This change requires a documentation update
- [x] No documentation change needed

## Related Issue(s)

This PR addresses issue #4805

## Notes

`apps/ssh-gateway` builds cleanly after the change. The fix is a 4-line addition; no interface or API changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop stale keepalive updates after abrupt SSH client disconnects so sandboxes can auto-stop again. Fixes #4805.

- **Bug Fixes**
  - In `apps/ssh-gateway/main.go`, after `io.Copy(runnerChannel, clientChannel)` returns, call `runnerChannel.Close()` to propagate channel close, unblock `io.Copy(clientChannel, runnerChannel)`, and trigger `defer cancel()`.

<sup>Written for commit ce26fd704f07daca5e139cdfd3c5d28a5d04f558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

