### PR TITLE
fix(sdk-typescript): make ESM require shim survive esbuild→CJS rebundle

### DIFF
--- a/libs/sdk-typescript/runtime-tests/README.md
+++ b/libs/sdk-typescript/runtime-tests/README.md
@@ -42,6 +42,7 @@ The orchestrator iterates every subdirectory that contains a `run.sh`, packs the
 | `remix` | `remix vite:build` + `remix-serve` + `curl` | Production Remix server |
 | `cloudflare-workers` | `wrangler dev --local` + `curl` | Real `workerd` (Cloudflare's actual Workers runtime) |
 | `aws-lambda` | `esbuild` bundle + [`lambda-local`](https://github.com/ashiina/lambda-local) (real Lambda event/context shapes, env vars, timeout) | Lambda emulator |
+| `esbuild-cjs` | `esbuild` bundle (`--platform=node --format=cjs`) + `node` runs the bundle and exercises `dynamicRequire` | Node.js |
 | `azure-functions` | `func start` (Azure Functions Core Tools host) + `curl` | Real Functions host |
 
 ## Required external tools

--- a/libs/sdk-typescript/runtime-tests/esbuild-cjs/package.json
+++ b/libs/sdk-typescript/runtime-tests/esbuild-cjs/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "runtime-test-esbuild-cjs",
+  "private": true,
+  "scripts": {
+    "build": "esbuild test.ts --bundle --outfile=dist/test.js --platform=node --target=node20 --format=cjs --log-level=error"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/libs/sdk-typescript/runtime-tests/esbuild-cjs/run.sh
+++ b/libs/sdk-typescript/runtime-tests/esbuild-cjs/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright Daytona Platforms Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+rm -rf node_modules package-lock.json dist
+npm install --silent
+npm install --silent "$API_CLIENT_TARBALL" "$TOOLBOX_API_CLIENT_TARBALL" "$SDK_TARBALL"
+# esbuild eagerly resolves require('expand-tilde') at bundle time
+npm install --silent expand-tilde
+npm run build >/dev/null
+node dist/test.js

--- a/libs/sdk-typescript/runtime-tests/esbuild-cjs/test.ts
+++ b/libs/sdk-typescript/runtime-tests/esbuild-cjs/test.ts
@@ -1,0 +1,41 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies dynamicRequire still works after esbuild re-bundles the ESM build
+// to CJS. pipInstallFromRequirements is a synchronous, no-network path that
+// exercises dynamicRequire('fs').
+
+import { Daytona, Image } from '@daytona/sdk'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+async function main() {
+  const image = Image.base('alpine').env({ FOO: 'bar' })
+  if (!image.dockerfile.includes('FROM alpine')) throw new Error('Image.base failed')
+  if (!image.dockerfile.includes('ENV FOO')) throw new Error('Image.env failed')
+
+  const daytona = new Daytona()
+  const iter = daytona.list()
+  if (typeof iter[Symbol.asyncIterator] !== 'function') {
+    throw new Error('list() did not return an async iterator')
+  }
+  const first = await iter.next()
+  if (typeof first !== 'object' || !('done' in first)) {
+    throw new Error('list() iterator did not yield a valid result')
+  }
+
+  const reqPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'daytona-esbuild-cjs-')), 'requirements.txt')
+  fs.writeFileSync(reqPath, 'requests==2.31.0\n')
+  const built = Image.debianSlim('3.12').pipInstallFromRequirements(reqPath)
+  if (!built.dockerfile.includes('pip install -r /.requirements.txt')) {
+    throw new Error('pipInstallFromRequirements did not produce the expected dockerfile')
+  }
+
+  console.log('PASS')
+}
+
+main().catch((e) => {
+  console.error('FAIL:', e && e.message ? e.message : e)
+  process.exit(1)
+})

--- a/libs/sdk-typescript/scripts/post-build.js
+++ b/libs/sdk-typescript/scripts/post-build.js
@@ -49,7 +49,9 @@ if (fs.existsSync(esmImportJs)) {
     `  ); };\n` +
     `})();\n`
   const original = fs.readFileSync(esmImportJs, 'utf8')
-  const rewritten = original.replace(/\brequire\s*\(/g, '__esmRequire(')
+  const rewritten = original
+    .replace(/require\s*\(\s*['"]\.\.\/\.\.\/package\.json['"]\s*\)/g, JSON.stringify({ name: pkg.name, version: pkg.version }))
+    .replace(/\brequire\s*\(/g, '__esmRequire(')
   fs.writeFileSync(esmImportJs, shim + rewritten)
 }
 

--- a/libs/sdk-typescript/scripts/post-build.js
+++ b/libs/sdk-typescript/scripts/post-build.js
@@ -36,8 +36,21 @@ writeJson(path.join(cjsDir, 'package.json'), { type: 'commonjs' })
 
 const esmImportJs = path.join(esmDir, 'utils', 'Import.js')
 if (fs.existsSync(esmImportJs)) {
-  const shim = `import * as _m from 'module';\nconst require = (() => { try { return _m.createRequire(import.meta.url); } catch { return (id) => { throw new Error('require("' + id + '") unavailable'); }; } })();\n`
-  fs.writeFileSync(esmImportJs, shim + fs.readFileSync(esmImportJs, 'utf8'))
+  // Named `__esmRequire` (not `require`) to avoid shadowing the host CJS
+  // `require` when a bundler re-compiles this ESM output to CommonJS.
+  const shim =
+    `import * as _m from 'module';\n` +
+    `const __esmRequire = (() => {\n` +
+    `  try { return _m.createRequire(import.meta.url); } catch {}\n` +
+    `  try { if (typeof require !== 'undefined') return require; } catch {}\n` +
+    `  return (id) => { throw new Error(\n` +
+    `    'cannot require("' + id + '"): no CommonJS require available. ' +\n` +
+    `    'If re-bundling @daytona/sdk to CJS, ensure createRequire or the host require is accessible.'\n` +
+    `  ); };\n` +
+    `})();\n`
+  const original = fs.readFileSync(esmImportJs, 'utf8')
+  const rewritten = original.replace(/\brequire\s*\(/g, '__esmRequire(')
+  fs.writeFileSync(esmImportJs, shim + rewritten)
 }
 
 writeJson(path.join(distDir, 'package.json'), pkg)

--- a/libs/sdk-typescript/src/utils/Import.ts
+++ b/libs/sdk-typescript/src/utils/Import.ts
@@ -2,10 +2,8 @@
  * Copyright 2025 Daytona Platforms Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Note: the ESM build of this file is prepended with a `createRequire` shim by
- * `scripts/post-build.js` so that synchronous `require()` works in ESM Node.js
- * (and any runtime that supports `createRequire(import.meta.url)`). The CJS
- * build uses the native `require`. See that script for the exact shim source.
+ * post-build.js rewrites every `require(` in the ESM output of this file to
+ * `__esmRequire(` — avoid that literal token in string literals here.
  */
 
 import { DaytonaError } from '../errors/DaytonaError'


### PR DESCRIPTION
## Summary

Fixes #4861 — SDK breaks at runtime when the ESM build is re-bundled to CJS (e.g. `esbuild --platform=node --format=cjs`).

The post-build shim declared `const require = createRequire(import.meta.url)`, which shadows the host CJS `require` when a bundler flattens ESM→CJS. Since `import.meta.url` is empty in CJS output, `createRequire` fails and installs a stub that throws for every `require()` call.

## Fix

- Rename the shim to `__esmRequire` so it never shadows the host `require`
- Rewrite all `require(` calls in the ESM output to `__esmRequire(` via post-build regex
- Add a fallback chain: `createRequire(import.meta.url)` → host `require` → throw with guidance

## Test

New `esbuild-cjs` runtime test: bundles the SDK with `esbuild --platform=node --format=cjs --bundle` and exercises `dynamicRequire` through `pipInstallFromRequirements`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4861 by making the `@daytona/sdk` ESM build safe to re-bundle to CJS (e.g. `esbuild --platform=node --format=cjs`) without breaking `require()` at runtime.

- **Bug Fixes**
  - Rename the ESM shim to `__esmRequire`, rewrite all ESM `require(` calls to use it, and inline package metadata to remove `require('../../package.json')`.
  - Add a fallback chain: `createRequire(import.meta.url)` → host `require` → throw with guidance.
  - Add a runtime test that bundles with `esbuild` to CJS and exercises `dynamicRequire` via `pipInstallFromRequirements`.

<sup>Written for commit 70556c6e92aab47bcd3a4b870fcae4ee1c3f175e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

