### PR TITLE
fix(api): require verified email to accept or decline organization invitations

### DIFF
--- a/apps/api/src/organization/controllers/organization.controller.ts
+++ b/apps/api/src/organization/controllers/organization.controller.ts
@@ -125,6 +125,11 @@ export class OrganizationController {
     @IsUserAuthContext() authContext: UserAuthContext,
     @Param('invitationId') invitationId: string,
   ): Promise<OrganizationInvitationDto> {
+    const user = await this.userService.findOne(authContext.userId)
+    if (!user.emailVerified && !this.configService.get('skipUserEmailVerification')) {
+      throw new ForbiddenException('Please verify your email address')
+    }
+
     try {
       const invitation = await this.organizationInvitationService.findOneOrFail(invitationId)
       if (!EmailUtils.areEqual(invitation.email, authContext.email)) {
@@ -162,6 +167,11 @@ export class OrganizationController {
     @IsUserAuthContext() authContext: UserAuthContext,
     @Param('invitationId') invitationId: string,
   ): Promise<void> {
+    const user = await this.userService.findOne(authContext.userId)
+    if (!user.emailVerified && !this.configService.get('skipUserEmailVerification')) {
+      throw new ForbiddenException('Please verify your email address')
+    }
+
     try {
       const invitation = await this.organizationInvitationService.findOneOrFail(invitationId)
       if (!EmailUtils.areEqual(invitation.email, authContext.email)) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require a verified email to accept or decline organization invitations. Enforce the check in the API and allow bypass via `skipUserEmailVerification`.

- **Bug Fixes**
  - Block invitation accept/decline when `emailVerified` is false; return 403 with "Please verify your email address".
  - Apply the check in both accept and decline endpoints; respect `skipUserEmailVerification`.

<sup>Written for commit b0ef21e33775b6872d44f4faa1b41e28701d31f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

