### PR TITLE
fix(daemon): add modifiedAt (ISO 8601) to FileInfo and deprecate modTime

### DIFF
--- a/apps/daemon/pkg/toolbox/docs/docs.go
+++ b/apps/daemon/pkg/toolbox/docs/docs.go
@@ -3782,6 +3782,7 @@ const docTemplate = `{
                 "isDir",
                 "modTime",
                 "mode",
+                "modifiedAt",
                 "name",
                 "owner",
                 "permissions",
@@ -3795,9 +3796,13 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "modTime": {
+                    "description": "Deprecated: ModTime uses Go's time.String() layout which is not a standard format.\nUse ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.",
                     "type": "string"
                 },
                 "mode": {
+                    "type": "string"
+                },
+                "modifiedAt": {
                     "type": "string"
                 },
                 "name": {

--- a/apps/daemon/pkg/toolbox/docs/swagger.json
+++ b/apps/daemon/pkg/toolbox/docs/swagger.json
@@ -3314,7 +3314,7 @@
     },
     "FileInfo": {
       "type": "object",
-      "required": ["group", "isDir", "modTime", "mode", "name", "owner", "permissions", "size"],
+      "required": ["group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"],
       "properties": {
         "group": {
           "type": "string"
@@ -3323,9 +3323,13 @@
           "type": "boolean"
         },
         "modTime": {
+          "description": "Deprecated: ModTime uses Go's time.String() layout which is not a standard format.\nUse ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.",
           "type": "string"
         },
         "mode": {
+          "type": "string"
+        },
+        "modifiedAt": {
           "type": "string"
         },
         "name": {

--- a/apps/daemon/pkg/toolbox/docs/swagger.yaml
+++ b/apps/daemon/pkg/toolbox/docs/swagger.yaml
@@ -314,8 +314,13 @@ definitions:
       isDir:
         type: boolean
       modTime:
+        description: |-
+          Deprecated: ModTime uses Go's time.String() layout which is not a standard format.
+          Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.
         type: string
       mode:
+        type: string
+      modifiedAt:
         type: string
       name:
         type: string
@@ -330,6 +335,7 @@ definitions:
       - isDir
       - modTime
       - mode
+      - modifiedAt
       - name
       - owner
       - permissions

--- a/apps/daemon/pkg/toolbox/fs/get_file_info.go
+++ b/apps/daemon/pkg/toolbox/fs/get_file_info.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strconv"
 	"syscall"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -61,7 +60,8 @@ func getFileInfo(path string) (FileInfo, error) {
 		Name:        info.Name(),
 		Size:        info.Size(),
 		Mode:        info.Mode().String(),
-		ModTime:     info.ModTime().Format(time.RFC3339Nano),
+		ModTime:     info.ModTime().String(),
+		ModifiedAt:  info.ModTime(),
 		IsDir:       info.IsDir(),
 		Owner:       strconv.FormatUint(uint64(stat.Uid), 10),
 		Group:       strconv.FormatUint(uint64(stat.Gid), 10),

--- a/apps/daemon/pkg/toolbox/fs/types.go
+++ b/apps/daemon/pkg/toolbox/fs/types.go
@@ -3,15 +3,20 @@
 
 package fs
 
+import "time"
+
 type FileInfo struct {
-	Name        string `json:"name" validate:"required"`
-	Size        int64  `json:"size" validate:"required"`
-	Mode        string `json:"mode" validate:"required"`
-	ModTime     string `json:"modTime" validate:"required"`
-	IsDir       bool   `json:"isDir" validate:"required"`
-	Owner       string `json:"owner" validate:"required"`
-	Group       string `json:"group" validate:"required"`
-	Permissions string `json:"permissions" validate:"required"`
+	Name string `json:"name" validate:"required"`
+	Size int64  `json:"size" validate:"required"`
+	Mode string `json:"mode" validate:"required"`
+	// Deprecated: ModTime uses Go's time.String() layout which is not a standard format.
+	// Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.
+	ModTime     string    `json:"modTime" validate:"required"`
+	ModifiedAt  time.Time `json:"modifiedAt" validate:"required"`
+	IsDir       bool      `json:"isDir" validate:"required"`
+	Owner       string    `json:"owner" validate:"required"`
+	Group       string    `json:"group" validate:"required"`
+	Permissions string    `json:"permissions" validate:"required"`
 } //	@name	FileInfo
 
 type ReplaceRequest struct {

--- a/libs/toolbox-api-client-go/api/openapi.yaml
+++ b/libs/toolbox-api-client-go/api/openapi.yaml
@@ -3174,6 +3174,7 @@ components:
         owner: owner
         size: 0
         modTime: modTime
+        modifiedAt: modifiedAt
         permissions: permissions
         name: name
         group: group
@@ -3184,8 +3185,13 @@ components:
         isDir:
           type: boolean
         modTime:
+          description: |-
+            Deprecated: ModTime uses Go's time.String() layout which is not a standard format.
+            Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.
           type: string
         mode:
+          type: string
+        modifiedAt:
           type: string
         name:
           type: string
@@ -3200,6 +3206,7 @@ components:
       - isDir
       - modTime
       - mode
+      - modifiedAt
       - name
       - owner
       - permissions

--- a/libs/toolbox-api-client-go/model_file_info.go
+++ b/libs/toolbox-api-client-go/model_file_info.go
@@ -23,8 +23,10 @@ var _ MappedNullable = &FileInfo{}
 type FileInfo struct {
 	Group string `json:"group"`
 	IsDir bool `json:"isDir"`
+	// Deprecated: ModTime uses Go's time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.
 	ModTime string `json:"modTime"`
 	Mode string `json:"mode"`
+	ModifiedAt string `json:"modifiedAt"`
 	Name string `json:"name"`
 	Owner string `json:"owner"`
 	Permissions string `json:"permissions"`
@@ -37,12 +39,13 @@ type _FileInfo FileInfo
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewFileInfo(group string, isDir bool, modTime string, mode string, name string, owner string, permissions string, size int32) *FileInfo {
+func NewFileInfo(group string, isDir bool, modTime string, mode string, modifiedAt string, name string, owner string, permissions string, size int32) *FileInfo {
 	this := FileInfo{}
 	this.Group = group
 	this.IsDir = isDir
 	this.ModTime = modTime
 	this.Mode = mode
+	this.ModifiedAt = modifiedAt
 	this.Name = name
 	this.Owner = owner
 	this.Permissions = permissions
@@ -152,6 +155,30 @@ func (o *FileInfo) GetModeOk() (*string, bool) {
 // SetMode sets field value
 func (o *FileInfo) SetMode(v string) {
 	o.Mode = v
+}
+
+// GetModifiedAt returns the ModifiedAt field value
+func (o *FileInfo) GetModifiedAt() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.ModifiedAt
+}
+
+// GetModifiedAtOk returns a tuple with the ModifiedAt field value
+// and a boolean to check if the value has been set.
+func (o *FileInfo) GetModifiedAtOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.ModifiedAt, true
+}
+
+// SetModifiedAt sets field value
+func (o *FileInfo) SetModifiedAt(v string) {
+	o.ModifiedAt = v
 }
 
 // GetName returns the Name field value
@@ -264,6 +291,7 @@ func (o FileInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize["isDir"] = o.IsDir
 	toSerialize["modTime"] = o.ModTime
 	toSerialize["mode"] = o.Mode
+	toSerialize["modifiedAt"] = o.ModifiedAt
 	toSerialize["name"] = o.Name
 	toSerialize["owner"] = o.Owner
 	toSerialize["permissions"] = o.Permissions
@@ -280,6 +308,7 @@ func (o *FileInfo) UnmarshalJSON(data []byte) (err error) {
 		"isDir",
 		"modTime",
 		"mode",
+		"modifiedAt",
 		"name",
 		"owner",
 		"permissions",

--- a/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/FileInfo.java
+++ b/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/model/FileInfo.java
@@ -70,6 +70,11 @@ public class FileInfo {
   @javax.annotation.Nonnull
   private String mode;
 
+  public static final String SERIALIZED_NAME_MODIFIED_AT = "modifiedAt";
+  @SerializedName(SERIALIZED_NAME_MODIFIED_AT)
+  @javax.annotation.Nonnull
+  private String modifiedAt;
+
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
   @javax.annotation.Nonnull
@@ -137,7 +142,7 @@ public class FileInfo {
   }
 
   /**
-   * Get modTime
+   * Deprecated: ModTime uses Go&#39;s time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.
    * @return modTime
    */
   @javax.annotation.Nonnull
@@ -166,6 +171,25 @@ public class FileInfo {
 
   public void setMode(@javax.annotation.Nonnull String mode) {
     this.mode = mode;
+  }
+
+
+  public FileInfo modifiedAt(@javax.annotation.Nonnull String modifiedAt) {
+    this.modifiedAt = modifiedAt;
+    return this;
+  }
+
+  /**
+   * Get modifiedAt
+   * @return modifiedAt
+   */
+  @javax.annotation.Nonnull
+  public String getModifiedAt() {
+    return modifiedAt;
+  }
+
+  public void setModifiedAt(@javax.annotation.Nonnull String modifiedAt) {
+    this.modifiedAt = modifiedAt;
   }
 
 
@@ -303,6 +327,7 @@ public class FileInfo {
         Objects.equals(this.isDir, fileInfo.isDir) &&
         Objects.equals(this.modTime, fileInfo.modTime) &&
         Objects.equals(this.mode, fileInfo.mode) &&
+        Objects.equals(this.modifiedAt, fileInfo.modifiedAt) &&
         Objects.equals(this.name, fileInfo.name) &&
         Objects.equals(this.owner, fileInfo.owner) &&
         Objects.equals(this.permissions, fileInfo.permissions) &&
@@ -312,7 +337,7 @@ public class FileInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(group, isDir, modTime, mode, name, owner, permissions, size, additionalProperties);
+    return Objects.hash(group, isDir, modTime, mode, modifiedAt, name, owner, permissions, size, additionalProperties);
   }
 
   @Override
@@ -323,6 +348,7 @@ public class FileInfo {
     sb.append("    isDir: ").append(toIndentedString(isDir)).append("\n");
     sb.append("    modTime: ").append(toIndentedString(modTime)).append("\n");
     sb.append("    mode: ").append(toIndentedString(mode)).append("\n");
+    sb.append("    modifiedAt: ").append(toIndentedString(modifiedAt)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
     sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
@@ -346,10 +372,10 @@ public class FileInfo {
 
   static {
     // a set of all properties/fields (JSON key names)
-    openapiFields = new HashSet<String>(Arrays.asList("group", "isDir", "modTime", "mode", "name", "owner", "permissions", "size"));
+    openapiFields = new HashSet<String>(Arrays.asList("group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"));
 
     // a set of required properties/fields (JSON key names)
-    openapiRequiredFields = new HashSet<String>(Arrays.asList("group", "isDir", "modTime", "mode", "name", "owner", "permissions", "size"));
+    openapiRequiredFields = new HashSet<String>(Arrays.asList("group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"));
   }
 
   /**
@@ -380,6 +406,9 @@ public class FileInfo {
       }
       if (!jsonObj.get("mode").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `mode` to be a primitive type in the JSON string but got `%s`", jsonObj.get("mode").toString()));
+      }
+      if (!jsonObj.get("modifiedAt").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `modifiedAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("modifiedAt").toString()));
       }
       if (!jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));

--- a/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/FileInfoTest.java
+++ b/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/model/FileInfoTest.java
@@ -70,6 +70,14 @@ public class FileInfoTest {
     }
 
     /**
+     * Test the property 'modifiedAt'
+     */
+    @Test
+    public void modifiedAtTest() {
+        // TODO: test modifiedAt
+    }
+
+    /**
      * Test the property 'name'
      */
     @Test

--- a/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/file_info.py
+++ b/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/models/file_info.py
@@ -31,14 +31,15 @@ class FileInfo(BaseModel):
     """ # noqa: E501
     group: StrictStr
     is_dir: StrictBool = Field(serialization_alias="isDir")
-    mod_time: StrictStr = Field(serialization_alias="modTime")
+    mod_time: StrictStr = Field(description="Deprecated: ModTime uses Go's time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.", serialization_alias="modTime")
     mode: StrictStr
+    modified_at: StrictStr = Field(serialization_alias="modifiedAt")
     name: StrictStr
     owner: StrictStr
     permissions: StrictStr
     size: StrictInt
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "name", "owner", "permissions", "size"]
+    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,6 +102,7 @@ class FileInfo(BaseModel):
             "is_dir": obj.get("isDir"),
             "mod_time": obj.get("modTime"),
             "mode": obj.get("mode"),
+            "modified_at": obj.get("modifiedAt"),
             "name": obj.get("name"),
             "owner": obj.get("owner"),
             "permissions": obj.get("permissions"),

--- a/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/file_info.py
+++ b/libs/toolbox-api-client-python/daytona_toolbox_api_client/models/file_info.py
@@ -31,14 +31,15 @@ class FileInfo(BaseModel):
     """ # noqa: E501
     group: StrictStr
     is_dir: StrictBool = Field(serialization_alias="isDir")
-    mod_time: StrictStr = Field(serialization_alias="modTime")
+    mod_time: StrictStr = Field(description="Deprecated: ModTime uses Go's time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.", serialization_alias="modTime")
     mode: StrictStr
+    modified_at: StrictStr = Field(serialization_alias="modifiedAt")
     name: StrictStr
     owner: StrictStr
     permissions: StrictStr
     size: StrictInt
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "name", "owner", "permissions", "size"]
+    __properties: ClassVar[List[str]] = ["group", "isDir", "modTime", "mode", "modifiedAt", "name", "owner", "permissions", "size"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,6 +102,7 @@ class FileInfo(BaseModel):
             "is_dir": obj.get("isDir"),
             "mod_time": obj.get("modTime"),
             "mode": obj.get("mode"),
+            "modified_at": obj.get("modifiedAt"),
             "name": obj.get("name"),
             "owner": obj.get("owner"),
             "permissions": obj.get("permissions"),

--- a/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/file_info.rb
+++ b/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/models/file_info.rb
@@ -19,9 +19,12 @@ module DaytonaToolboxApiClient
 
     attr_accessor :is_dir
 
+    # Deprecated: ModTime uses Go's time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.
     attr_accessor :mod_time
 
     attr_accessor :mode
+
+    attr_accessor :modified_at
 
     attr_accessor :name
 
@@ -38,6 +41,7 @@ module DaytonaToolboxApiClient
         :'is_dir' => :'isDir',
         :'mod_time' => :'modTime',
         :'mode' => :'mode',
+        :'modified_at' => :'modifiedAt',
         :'name' => :'name',
         :'owner' => :'owner',
         :'permissions' => :'permissions',
@@ -62,6 +66,7 @@ module DaytonaToolboxApiClient
         :'is_dir' => :'Boolean',
         :'mod_time' => :'String',
         :'mode' => :'String',
+        :'modified_at' => :'String',
         :'name' => :'String',
         :'owner' => :'String',
         :'permissions' => :'String',
@@ -115,6 +120,12 @@ module DaytonaToolboxApiClient
         self.mode = nil
       end
 
+      if attributes.key?(:'modified_at')
+        self.modified_at = attributes[:'modified_at']
+      else
+        self.modified_at = nil
+      end
+
       if attributes.key?(:'name')
         self.name = attributes[:'name']
       else
@@ -161,6 +172,10 @@ module DaytonaToolboxApiClient
         invalid_properties.push('invalid value for "mode", mode cannot be nil.')
       end
 
+      if @modified_at.nil?
+        invalid_properties.push('invalid value for "modified_at", modified_at cannot be nil.')
+      end
+
       if @name.nil?
         invalid_properties.push('invalid value for "name", name cannot be nil.')
       end
@@ -188,6 +203,7 @@ module DaytonaToolboxApiClient
       return false if @is_dir.nil?
       return false if @mod_time.nil?
       return false if @mode.nil?
+      return false if @modified_at.nil?
       return false if @name.nil?
       return false if @owner.nil?
       return false if @permissions.nil?
@@ -233,6 +249,16 @@ module DaytonaToolboxApiClient
       end
 
       @mode = mode
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] modified_at Value to be assigned
+    def modified_at=(modified_at)
+      if modified_at.nil?
+        fail ArgumentError, 'modified_at cannot be nil'
+      end
+
+      @modified_at = modified_at
     end
 
     # Custom attribute writer method with validation
@@ -284,6 +310,7 @@ module DaytonaToolboxApiClient
           is_dir == o.is_dir &&
           mod_time == o.mod_time &&
           mode == o.mode &&
+          modified_at == o.modified_at &&
           name == o.name &&
           owner == o.owner &&
           permissions == o.permissions &&
@@ -299,7 +326,7 @@ module DaytonaToolboxApiClient
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [group, is_dir, mod_time, mode, name, owner, permissions, size].hash
+      [group, is_dir, mod_time, mode, modified_at, name, owner, permissions, size].hash
     end
 
     # Builds the object from hash

--- a/libs/toolbox-api-client/src/models/file-info.ts
+++ b/libs/toolbox-api-client/src/models/file-info.ts
@@ -17,8 +17,12 @@
 export interface FileInfo {
     'group': string;
     'isDir': boolean;
+    /**
+     * Deprecated: ModTime uses Go\'s time.String() layout which is not a standard format. Use ModifiedAt instead, which is serialized as ISO 8601 / RFC 3339.
+     */
     'modTime': string;
     'mode': string;
+    'modifiedAt': string;
     'name': string;
     'owner': string;
     'permissions': string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `modifiedAt` (ISO 8601/RFC 3339, required) to daemon `FileInfo` and deprecated `modTime`, which now uses Go’s default time.Time.String(). Updated OpenAPI schemas and regenerated clients (Go, Java, Python, Ruby, TypeScript).

<sup>Written for commit 6a2e69bf9dae0610bf89768012b2b3ec4f857f25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

