### PR TITLE
fix(guides): links update

### DIFF
--- a/apps/docs/src/content/docs/en/architecture.mdx
+++ b/apps/docs/src/content/docs/en/architecture.mdx
@@ -90,6 +90,6 @@ Container registries serve as the source for sandbox base images. When creating 
 
 - [Docker Hub](/docs/en/snapshots#docker-hub)
 - [Google Artifact Registry](/docs/en/snapshots#google-artifact-registry)
-- [GitHub Container Registry (GHCR)](/docs/en/snapshots#github-container-registry-ghcr)
+- [GitHub Container Registry (GHCR)](/docs/en/snapshots#github-container-registry)
 - [Private registries](/docs/en/snapshots#using-images-from-private-registries): any registry that implements the OCI distribution specification
 

--- a/apps/docs/src/content/docs/en/guides/claude/claude-agent-sdk-connect-service-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/guides/claude/claude-agent-sdk-connect-service-sandbox.mdx
@@ -15,7 +15,7 @@ A key advantage of this approach is its **extensibility**: you can easily replac
 
 When the main module is launched, a Daytona sandbox is created for the Developer Agent, and a Project Manager Agent is initialized locally. Interaction with the system occurs via a command line chat interface. The Project Manager Agent receives prompts, plans the workflow, and delegates coding tasks to the Developer Agent. The Developer Agent executes tasks in the sandbox and streams results back to the Project Manager, who reviews and coordinates further actions. All logs and outputs from both agents are streamed in real time to the terminal, providing full visibility into the process as it is managed by the Project Manager Agent.
 
-The Developer Agent can also host web apps and provide preview links using [Daytona Preview Links](https://www.daytona.io/docs/en/preview-and-authentication/). The Project Manager Agent will present these links and summarize the results for you.
+The Developer Agent can also host web apps and provide preview links using [Daytona Preview Links](https://www.daytona.io/docs/en/preview/). The Project Manager Agent will present these links and summarize the results for you.
 
 You can continue interacting with the system until you are finished. When you exit the program, the sandbox is deleted automatically.
 
@@ -164,11 +164,11 @@ This system is composed of two collaborating agents, each with a distinct role a
 1. **Provisioning:**
   - The Developer Agent is provisioned inside a Daytona sandbox and is responsible for executing coding tasks.
 2. **SDK Installation:**
-  - The system installs the Claude Agent SDK in the sandbox by running `pip install` (see [process execution](/docs/en/process-code-execution#process-execution)).
+  - The system installs the Claude Agent SDK in the sandbox by running `pip install` (see [process execution](/docs/en/process-code-execution#command-execution)).
 3. **Interpreter Context:**
-  - A new [code interpreter context](/docs/en/process-code-execution#stateful-code-interpreter) is created for isolated execution.
+  - A new [code interpreter context](/docs/en/process-code-execution#run-code-stateful) is created for isolated execution.
 4. **Script Upload:**
-  - The coding agent script is uploaded to the sandbox using [file uploading](/docs/file-system-operations#uploading-a-single-file).
+  - The coding agent script is uploaded to the sandbox using [file uploading](/docs/en/file-system-operations#upload-a-single-file).
 5. **SDK Initialization:**
   - The Claude Agent SDK is initialized in the interpreter context (e.g., `import coding_agent`).
 6. **Task Execution:**

--- a/apps/docs/src/content/docs/en/guides/claude/claude-agent-sdk-interactive-terminal-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/guides/claude/claude-agent-sdk-interactive-terminal-sandbox.mdx
@@ -69,7 +69,7 @@ Enjoy your adventure! 🗡️✨
 User:
 ```
 
-The agent can also host web apps and provide you with a preview link using the [Daytona Preview Links](https://www.daytona.io/docs/en/preview-and-authentication/) feature. When your task involves running or previewing a web application, the agent automatically reasons about this need, hosts the app, and generates a preview link for you to inspect the live result:
+The agent can also host web apps and provide you with a preview link using the [Daytona Preview Links](https://www.daytona.io/docs/en/preview/) feature. When your task involves running or previewing a web application, the agent automatically reasons about this need, hosts the app, and generates a preview link for you to inspect the live result:
 
 <Image
   src={claudeAgentSDKInteractiveTerminalSandboxResult}
@@ -226,9 +226,9 @@ This example consists of two main components:
 On initialization, the main program:
 
 1. Creates a new [Daytona sandbox](/docs/en/sandboxes) with your Anthropic API key included in the environment variables.
-2. Installs the Claude Agent SDK by running `pip install` in the sandbox with [process execution](/docs/en/process-code-execution#process-execution).
-3. Creates a new [code interpreter context](/docs/en/process-code-execution#stateful-code-interpreter).
-4. Uploads the coding agent script to the sandbox with [file uploading](/docs/file-system-operations#uploading-a-single-file).
+2. Installs the Claude Agent SDK by running `pip install` in the sandbox with [process execution](/docs/en/process-code-execution#command-execution).
+3. Creates a new [code interpreter context](/docs/en/process-code-execution#run-code-stateful).
+4. Uploads the coding agent script to the sandbox with [file uploading](/docs/en/file-system-operations#upload-a-single-file).
 5. Initializes the Claude Agent SDK by running `import coding_agent` in the code interpreter context.
 6. Waits for user input and sends prompts to the agent in the code interpreter context as shown below.
 
@@ -254,7 +254,7 @@ The `onStdout` and `onStderr` callbacks are used to pass the agent's output back
 #### Sandbox Agent Code
 
 The sandbox agent uses the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) to create a customized coding agent based on Claude Code.
-The agent is initialized with a system prompt that includes the workspace directory and an example of the [preview URL format](/docs/en/preview-and-authentication):
+The agent is initialized with a system prompt that includes the workspace directory and an example of the [preview URL format](/docs/en/preview):
 
 ```python
 system_prompt = """

--- a/apps/docs/src/content/docs/en/guides/codex/codex-sdk-interactive-terminal-sandbox.mdx
+++ b/apps/docs/src/content/docs/en/guides/codex/codex-sdk-interactive-terminal-sandbox.mdx
@@ -56,7 +56,7 @@ User:
 Cleaning up...
 ```
 
-The agent can also host web apps and provide you with a preview link using the [Daytona Preview Links](https://www.daytona.io/docs/en/preview-and-authentication/) feature. When your task involves running or previewing a web application, the agent automatically reasons about this need, hosts the app, and generates a preview link for you to inspect the live result:
+The agent can also host web apps and provide you with a preview link using the [Daytona Preview Links](https://www.daytona.io/docs/en/preview/) feature. When your task involves running or previewing a web application, the agent automatically reasons about this need, hosts the app, and generates a preview link for you to inspect the live result:
 
 <Image
   src={codexSdkLunarLanderResult}
@@ -128,7 +128,7 @@ This example consists of two main components:
 On initialization, the main program:
 1. Creates a new [Daytona sandbox](/docs/en/sandboxes) with your OpenAI API key included in the environment variables.
 2. Configures the Codex system prompt with Daytona-specific instructions and writes it to a `.codex/config.toml` file in the sandbox.
-3. Uploads the agent package to the sandbox with [file uploading](/docs/file-system-operations#uploading-a-single-file).
+3. Uploads the agent package to the sandbox with [file uploading](/docs/en/file-system-operations#upload-a-single-file).
 4. Installs the agent dependencies by running `npm install` in the uploaded agent directory.
 5. Waits for user input and runs the agent asynchronously for each prompt.
 

--- a/apps/docs/src/content/docs/en/guides/data-analysis-with-ai.mdx
+++ b/apps/docs/src/content/docs/en/guides/data-analysis-with-ai.mdx
@@ -70,7 +70,7 @@ Download the file and save it as `dataset.csv` in your project directory.
 
 #### 2.2 Initialize Sandbox
 
-Now create a [Daytona sandbox](/docs/en/sandboxes/#basic-sandbox-creation) and upload your dataset:
+Now create a [Daytona sandbox](/docs/en/sandboxes/#create-sandboxes) and upload your dataset:
 
 <Tabs syncKey="language">
   <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/guides/flue/flue-autonomous-bug-fix-agent.mdx
+++ b/apps/docs/src/content/docs/en/guides/flue/flue-autonomous-bug-fix-agent.mdx
@@ -266,7 +266,7 @@ return await session.skill('bug-fix', {
 
 A few details worth highlighting:
 
-- **Two agents, one sandbox.** The setup agent installs `gh`, configures auth, clones the repo, and installs dependencies. A second agent (given a different `id` and `cwd`) operates inside the cloned repo and discovers our `bug-fix` skill from `.agents/skills/bug-fix/SKILL.md`, which the orchestrator uploads into the cloned worktree just before init. Both agents share the same Daytona sandbox. The distinct `id` matters: a fresh `id` opens a fresh Flue session — see [What `<id>` actually means: sessions](#what-id-actually-means-sessions) for the full lifecycle.
+- **Two agents, one sandbox.** The setup agent installs `gh`, configures auth, clones the repo, and installs dependencies. A second agent (given a different `id` and `cwd`) operates inside the cloned repo and discovers our `bug-fix` skill from `.agents/skills/bug-fix/SKILL.md`, which the orchestrator uploads into the cloned worktree just before init. Both agents share the same Daytona sandbox. The distinct `id` matters: a fresh `id` opens a fresh Flue session — see [What `id` actually means: sessions](#what-id-actually-means-sessions) for the full lifecycle.
 - **No `AGENTS.md` upload.** Flue would happily read an `AGENTS.md` from the session cwd and prepend it to every system prompt, but that file lives at the cloned repo's root and uploading our own would overwrite the target's `AGENTS.md` if it has one. Every guardrail we'd put there (TDD discipline, minimal change, match host code style) is already covered by the `test-driven-developer` role and the `bug-fix` skill body, so the harness ships nothing at the worktree root.
 - **`.git/info/exclude` keeps the worktree clean.** After uploading `SKILL.md` to `.agents/skills/bug-fix/`, the orchestrator appends `.agents/` to the cloned repo's `.git/info/exclude` (git's local-only ignore — does NOT modify the target's `.gitignore`). The harness scaffolding stays invisible to `git status` and never accidentally lands in a commit.
 - **Two repos, one workflow.** `repo` is the user's fork (where branches and the PR land); `issueRepo` is where the issue lives (the upstream parent, auto-detected via `gh repo view --json parent` because GitHub disables issues on forks).
@@ -357,7 +357,7 @@ npm run run
 
 `flue run` builds, spawns the server, POSTs with `Accept: text/event-stream`, streams events to stderr, prints the final result to stdout, and shuts the server down. Perfect for CI.
 
-#### What `<id>` actually means: sessions
+#### What `id` actually means: sessions
 
 The `<id>` segment in `POST /agents/bug-fix/<id>` is not just a label. It identifies a Flue **session**: the persistent message history and conversation metadata that `agent.session()` opens inside your handler.
 

--- a/apps/docs/src/content/docs/en/guides/letta-code/letta-code-agent.mdx
+++ b/apps/docs/src/content/docs/en/guides/letta-code/letta-code-agent.mdx
@@ -49,7 +49,7 @@ https://8080-c157e5cb-5e11-4bb6-883d-c873169223b8.proxy.daytona.works
 📥 **Export** — Download as `.md` or standalone `.html`
 ```
 
-The agent can host web apps and provide you with a preview link using the [Daytona Preview Links](https://www.daytona.io/docs/en/preview-and-authentication/) feature. When your task involves running or previewing a web application, the agent automatically hosts the app and generates a link for you to inspect the live result:
+The agent can host web apps and provide you with a preview link using the [Daytona Preview Links](https://www.daytona.io/docs/en/preview/) feature. When your task involves running or previewing a web application, the agent automatically hosts the app and generates a link for you to inspect the live result:
 
 <Image
   src={lettaCodeAgentResult}
@@ -117,7 +117,7 @@ This example consists of two main TypeScript files:
 
 On initialization, the main program:
 1. Creates a new [Daytona sandbox](/docs/en/sandboxes) with your Letta API key included in the environment variables.
-2. Installs Letta Code globally inside the sandbox by running `npm install` with [process execution](/docs/en/process-code-execution#process-execution).
+2. Installs Letta Code globally inside the sandbox by running `npm install` with [process execution](/docs/en/process-code-execution#command-execution).
 3. Creates a [PTY (pseudoterminal)](/docs/en/pty/) session in the sandbox for bidirectional communication with Letta Code.
 4. Launches Letta Code in [bidirectional headless mode](https://docs.letta.com/letta-code/headless/) with stream-json format through the PTY.
 5. Waits for user input and sends prompts to the agent through the PTY session.

--- a/apps/docs/src/content/docs/en/guides/opencode/opencode-web-agent.mdx
+++ b/apps/docs/src/content/docs/en/guides/opencode/opencode-web-agent.mdx
@@ -35,7 +35,7 @@ Press Ctrl+C to stop.
   Web interface:      https://3000-1e0f775c-c01b-40e7-8c64-062fd3dadd75.proxy.daytona.works/
 ```
 
-The agent can host web apps and provide you with a preview link using the [Daytona Preview Links](/docs/en/preview-and-authentication/) feature. When your task involves running or previewing a web application, the agent automatically reasons about this need, hosts the app, and generates a preview link for you to inspect the live result:
+The agent can host web apps and provide you with a preview link using the [Daytona Preview Links](/docs/en/preview/) feature. When your task involves running or previewing a web application, the agent automatically reasons about this need, hosts the app, and generates a preview link for you to inspect the live result:
 
 <Image
   src={opencodeResult}
@@ -113,10 +113,10 @@ This example consists of a Node.js script that installs, configures and runs Ope
 
 On initialization, the main script:
 1. Creates a new [Daytona sandbox](/docs/en/sandboxes).
-2. Installs OpenCode globally inside the sandbox using npm with [process execution](/docs/en/process-code-execution#process-execution).
+2. Installs OpenCode globally inside the sandbox using npm with [process execution](/docs/en/process-code-execution#command-execution).
 3. Creates and uploads a [custom agent configuration](https://opencode.ai/docs/agents/) with Daytona-specific system prompt.
 4. Starts the OpenCode web server inside the sandbox on port 3000.
-5. Substitutes the URL in OpenCode's output with a [Daytona preview link](/docs/en/preview-and-authentication/) for the web interface.
+5. Substitutes the URL in OpenCode's output with a [Daytona preview link](/docs/en/preview/) for the web interface.
 
 #### Main Script Code
 
@@ -158,7 +158,7 @@ A custom system prompt is used to instruct the agent on how to use Daytona sandb
 }
 ```
 
-The `<PREVIEW_URL_PATTERN>` in the agent prompt is a template URL where `{PORT}` is a placeholder for the port to access on the Daytona sandbox. This template string is created by generating a [preview link](/docs/en/preview-and-authentication/) for a specific port number and then replacing the port number with `{PORT}`.
+The `<PREVIEW_URL_PATTERN>` in the agent prompt is a template URL where `{PORT}` is a placeholder for the port to access on the Daytona sandbox. This template string is created by generating a [preview link](/docs/en/preview/) for a specific port number and then replacing the port number with `{PORT}`.
 
 #### Clean up
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated docs links and anchors across guides to point to current routes and fix broken references. Improves navigation and keeps examples aligned with the latest docs structure.

- **Bug Fixes**
  - Replaced preview docs links from `/en/preview-and-authentication/` to `/en/preview/` in multiple guides.
  - Updated process execution and interpreter anchors: `#process-execution` → `#command-execution`, `#stateful-code-interpreter` → `#run-code-stateful`.
  - Corrected file upload and sandbox creation anchors: `/docs/file-system-operations#uploading-a-single-file` → `/docs/en/file-system-operations#upload-a-single-file`, `#basic-sandbox-creation` → `#create-sandboxes`.
  - Fixed GHCR snapshots anchor: `#github-container-registry-ghCR` → `#github-container-registry`.
  - Standardized Flue guide wording by removing angle brackets around `id` in headings and references.

<sup>Written for commit ea7bfd884de3ec013dced42e56556b72064cd0ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

