### PR TITLE
feat(sdk): expose sandboxClass param in snapshot creation across all SDKs

### DIFF
--- a/apps/docs/src/content/docs/en/go-sdk/types.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/types.mdx
@@ -42,6 +42,7 @@ import "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
 - [type PtySize](<#PtySize>)
 - [type Resources](<#Resources>)
 - [type SandboxBaseParams](<#SandboxBaseParams>)
+- [type SandboxClass](<#SandboxClass>)
 - [type ScreenshotOptions](<#ScreenshotOptions>)
 - [type ScreenshotRegion](<#ScreenshotRegion>)
 - [type ScreenshotResponse](<#ScreenshotResponse>)
@@ -112,6 +113,7 @@ type CreateSnapshotParams struct {
     Resources      *Resources
     Entrypoint     []string
     SkipValidation *bool
+    SandboxClass   *SandboxClass
 }
 ```
 
@@ -472,6 +474,25 @@ type SandboxBaseParams struct {
     // linked to another sandbox.
     LinkedSandbox string
 }
+```
+
+<a name="SandboxClass"></a>
+## type SandboxClass
+
+SandboxClass determines which runners can host sandboxes created from a snapshot. It is an alias for the API client's SandboxClass type.
+
+```go
+type SandboxClass = apiclient.SandboxClass
+```
+
+<a name="SandboxClassLinuxVM"></a>
+
+```go
+const (
+    SandboxClassLinuxVM   SandboxClass = apiclient.SANDBOXCLASS_LINUX_VM
+    SandboxClassContainer SandboxClass = apiclient.SANDBOXCLASS_CONTAINER
+    SandboxClassAndroid   SandboxClass = apiclient.SANDBOXCLASS_ANDROID
+)
 ```
 
 <a name="ScreenshotOptions"></a>

--- a/apps/docs/src/content/docs/en/java-sdk/snapshot.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/snapshot.mdx
@@ -33,6 +33,27 @@ Creates a snapshot from an existing image reference.
 
 #### create()
 ```java
+public Snapshot create(String name, String imageName, SandboxClass sandboxClass)
+```
+
+Creates a snapshot from an existing image reference with a target sandbox class.
+
+**Parameters**:
+
+- `name` _String_ - snapshot name
+- `imageName` _String_ - source image name or tag
+- `sandboxClass` _SandboxClass_ - target sandbox class; `null` for default
+
+**Returns**:
+
+- `Snapshot` - created `Snapshot`
+
+**Throws**:
+
+- `io.daytona.sdk.exception.DaytonaException` - if the API request fails
+
+#### create()
+```java
 public Snapshot create(String name, Image image, Consumer<String> onLogs)
 ```
 
@@ -64,6 +85,29 @@ Creates a snapshot from a declarative `Image` with resources and optional build 
 - `name` _String_ - snapshot name
 - `image` _Image_ - declarative image definition
 - `resources` _io.daytona.sdk.model.Resources_ - CPU/GPU/memory/disk resources; `null` for defaults
+- `onLogs` _Consumer\<String\>_ - callback for build log lines; `null` to skip streaming
+
+**Returns**:
+
+- `Snapshot` - created `Snapshot` in active or error state
+
+**Throws**:
+
+- `DaytonaException` - if the API request fails or the build fails
+
+#### create()
+```java
+public Snapshot create(String name, Image image, io.daytona.sdk.model.Resources resources, SandboxClass sandboxClass, Consumer<String> onLogs)
+```
+
+Creates a snapshot from a declarative `Image` with resources, sandbox class, and optional build log streaming.
+
+**Parameters**:
+
+- `name` _String_ - snapshot name
+- `image` _Image_ - declarative image definition
+- `resources` _io.daytona.sdk.model.Resources_ - CPU/GPU/memory/disk resources; `null` for defaults
+- `sandboxClass` _SandboxClass_ - target sandbox class; `null` for default
 - `onLogs` _Consumer\<String\>_ - callback for build log lines; `null` to skip streaming
 
 **Returns**:

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-snapshot.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-snapshot.mdx
@@ -221,4 +221,6 @@ Parameters for creating a new snapshot.
 - `entrypoint` _list[str] | None_ - Entrypoint of the snapshot.
 - `region_id` _str | None_ - ID of the region where the snapshot will be available.
   Defaults to organization default region if not specified.
+- `sandbox_class` _SandboxClass | None_ - Target sandbox class. Determines which runners
+  can host sandboxes created from this snapshot.
 

--- a/apps/docs/src/content/docs/en/python-sdk/sync/snapshot.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/snapshot.mdx
@@ -221,4 +221,6 @@ Parameters for creating a new snapshot.
 - `entrypoint` _list[str] | None_ - Entrypoint of the snapshot.
 - `region_id` _str | None_ - ID of the region where the snapshot will be available.
   Defaults to organization default region if not specified.
+- `sandbox_class` _SandboxClass | None_ - Target sandbox class. Determines which runners
+  can host sandboxes created from this snapshot.
 

--- a/apps/docs/src/content/docs/en/typescript-sdk/snapshot.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/snapshot.mdx
@@ -208,6 +208,7 @@ type CreateSnapshotParams = {
   name: string;
   regionId: string;
   resources: Resources;
+  sandboxClass: SandboxClass;
 };
 ```
 
@@ -220,6 +221,7 @@ Parameters for creating a new snapshot.
 - `name` _string_
 - `regionId?` _string_
 - `resources?` _Resources_
+- `sandboxClass?` _SandboxClass_
 
 
 ## Snapshot

--- a/libs/sdk-go/pkg/daytona/snapshot.go
+++ b/libs/sdk-go/pkg/daytona/snapshot.go
@@ -268,6 +268,10 @@ func (s *SnapshotService) doCreate(ctx context.Context, params *types.CreateSnap
 		createReq.Entrypoint = params.Entrypoint
 	}
 
+	if params.SandboxClass != nil {
+		createReq.SandboxClass = params.SandboxClass
+	}
+
 	result, httpResp, err := req.CreateSnapshot(createReq).Execute()
 	if err != nil {
 		return nil, nil, s.client.handleAPIError(err, httpResp)

--- a/libs/sdk-go/pkg/types/types.go
+++ b/libs/sdk-go/pkg/types/types.go
@@ -32,6 +32,16 @@ const (
 	GpuTypeRtxPro6000 GpuType = apiclient.GPUTYPE_RTX_PRO_6000
 )
 
+// SandboxClass determines which runners can host sandboxes created from a snapshot.
+// It is an alias for the API client's SandboxClass type.
+type SandboxClass = apiclient.SandboxClass
+
+const (
+	SandboxClassLinuxVM   SandboxClass = apiclient.SANDBOXCLASS_LINUX_VM
+	SandboxClassContainer SandboxClass = apiclient.SANDBOXCLASS_CONTAINER
+	SandboxClassAndroid   SandboxClass = apiclient.SANDBOXCLASS_ANDROID
+)
+
 // ExperimentalConfig holds experimental feature flags for the Daytona client.
 type ExperimentalConfig struct {
 	// Deprecated: use DaytonaConfig.OtelEnabled. Kept for backwards compatibility.
@@ -109,6 +119,7 @@ type CreateSnapshotParams struct {
 	Resources      *Resources
 	Entrypoint     []string
 	SkipValidation *bool
+	SandboxClass   *SandboxClass
 }
 
 // PaginatedSnapshots represents a paginated list of snapshots

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/SnapshotService.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/SnapshotService.java
@@ -6,6 +6,7 @@ package io.daytona.sdk;
 import io.daytona.api.client.api.SnapshotsApi;
 import io.daytona.api.client.model.CreateBuildInfo;
 import io.daytona.api.client.model.CreateSnapshot;
+import io.daytona.api.client.model.SandboxClass;
 import io.daytona.sdk.exception.DaytonaException;
 import io.daytona.sdk.model.PaginatedSnapshots;
 import io.daytona.sdk.model.Snapshot;
@@ -42,8 +43,25 @@ public class SnapshotService {
      * @throws io.daytona.sdk.exception.DaytonaException if the API request fails
      */
     public Snapshot create(String name, String imageName) {
+        return create(name, imageName, null);
+    }
+
+    /**
+     * Creates a snapshot from an existing image reference with a target sandbox class.
+     *
+     * @param name snapshot name
+     * @param imageName source image name or tag
+     * @param sandboxClass target sandbox class; {@code null} for default
+     * @return created {@link Snapshot}
+     * @throws io.daytona.sdk.exception.DaytonaException if the API request fails
+     */
+    public Snapshot create(String name, String imageName, SandboxClass sandboxClass) {
+        CreateSnapshot req = new CreateSnapshot().name(name).imageName(imageName);
+        if (sandboxClass != null) {
+            req.setSandboxClass(sandboxClass);
+        }
         io.daytona.api.client.model.SnapshotDto snapshotDto = ExceptionMapper.callMain(
-                () -> snapshotsApi.createSnapshot(new CreateSnapshot().name(name).imageName(imageName), null)
+                () -> snapshotsApi.createSnapshot(req, null)
         );
         return toSnapshot(snapshotDto);
     }
@@ -58,7 +76,7 @@ public class SnapshotService {
      * @throws DaytonaException if the API request fails or the build fails
      */
     public Snapshot create(String name, Image image, Consumer<String> onLogs) {
-        return create(name, image, null, onLogs);
+        return create(name, image, null, null, onLogs);
     }
 
     /**
@@ -72,6 +90,21 @@ public class SnapshotService {
      * @throws DaytonaException if the API request fails or the build fails
      */
     public Snapshot create(String name, Image image, io.daytona.sdk.model.Resources resources, Consumer<String> onLogs) {
+        return create(name, image, resources, null, onLogs);
+    }
+
+    /**
+     * Creates a snapshot from a declarative {@link Image} with resources, sandbox class, and optional build log streaming.
+     *
+     * @param name snapshot name
+     * @param image declarative image definition
+     * @param resources CPU/GPU/memory/disk resources; {@code null} for defaults
+     * @param sandboxClass target sandbox class; {@code null} for default
+     * @param onLogs callback for build log lines; {@code null} to skip streaming
+     * @return created {@link Snapshot} in active or error state
+     * @throws DaytonaException if the API request fails or the build fails
+     */
+    public Snapshot create(String name, Image image, io.daytona.sdk.model.Resources resources, SandboxClass sandboxClass, Consumer<String> onLogs) {
         CreateSnapshot req = new CreateSnapshot().name(name)
                 .buildInfo(new CreateBuildInfo().dockerfileContent(image.getDockerfile()))
                 .entrypoint(null);
@@ -82,6 +115,10 @@ public class SnapshotService {
             if (resources.getGpuType() != null) req.setGpuType(resources.getGpuType());
             if (resources.getMemory() != null) req.setMemory(resources.getMemory());
             if (resources.getDisk() != null) req.setDisk(resources.getDisk());
+        }
+
+        if (sandboxClass != null) {
+            req.setSandboxClass(sandboxClass);
         }
 
         final io.daytona.api.client.model.SnapshotDto[] ref = { ExceptionMapper.callMain(

--- a/libs/sdk-python/src/daytona/__init__.py
+++ b/libs/sdk-python/src/daytona/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from daytona_api_client import SandboxListSortDirection, SandboxListSortField, SandboxState
-    from daytona_api_client_async import GpuType
+    from daytona_api_client_async import GpuType, SandboxClass
     from daytona_toolbox_api_client import SessionExecuteResponse
 
     from ._async.computer_use import AsyncComputerUse, AsyncDisplay, AsyncKeyboard, AsyncMouse, AsyncScreenshot
@@ -77,6 +77,7 @@ __all__ = [
     "Sandbox",
     "Resources",
     "GpuType",
+    "SandboxClass",
     "SandboxState",
     "SandboxListSortField",
     "SandboxListSortDirection",
@@ -130,6 +131,7 @@ __all__ = [
 # Mapping of symbol name -> (absolute module path, attribute name) for external packages
 _EXTERNAL_IMPORTS: dict[str, tuple[str, str]] = {
     "GpuType": ("daytona_api_client_async.models.gpu_type", "GpuType"),
+    "SandboxClass": ("daytona_api_client_async.models.sandbox_class", "SandboxClass"),
     "SandboxState": ("daytona_api_client.models.sandbox_state", "SandboxState"),
     "SandboxListSortField": ("daytona_api_client.models.sandbox_list_sort_field", "SandboxListSortField"),
     "SandboxListSortDirection": (

--- a/libs/sdk-python/src/daytona/_async/snapshot.py
+++ b/libs/sdk-python/src/daytona/_async/snapshot.py
@@ -167,6 +167,7 @@ class AsyncSnapshotService:
             create_snapshot_req.disk = params.resources.disk
 
         create_snapshot_req.region_id = params.region_id or self.__default_region_id
+        create_snapshot_req.sandbox_class = params.sandbox_class
 
         created_snapshot: SnapshotDto = await self.__snapshots_api.create_snapshot(create_snapshot_req)
 

--- a/libs/sdk-python/src/daytona/_sync/snapshot.py
+++ b/libs/sdk-python/src/daytona/_sync/snapshot.py
@@ -10,7 +10,9 @@ from typing import Callable, cast
 
 from daytona_api_client import CreateBuildInfo, CreateSnapshot
 from daytona_api_client import GpuType as SyncGpuType
-from daytona_api_client import ObjectStorageApi, SnapshotDto, SnapshotsApi, SnapshotState
+from daytona_api_client import ObjectStorageApi
+from daytona_api_client import SandboxClass as SyncSandboxClass
+from daytona_api_client import SnapshotDto, SnapshotsApi, SnapshotState
 
 from .._utils.errors import intercept_errors
 from .._utils.otel_decorator import with_instrumentation
@@ -160,6 +162,9 @@ class SnapshotService:
             create_snapshot_req.disk = params.resources.disk
 
         create_snapshot_req.region_id = params.region_id or self.__default_region_id
+        create_snapshot_req.sandbox_class = (
+            SyncSandboxClass(params.sandbox_class.value) if params.sandbox_class is not None else None
+        )
 
         created_snapshot: SnapshotDto = self.__snapshots_api.create_snapshot(create_snapshot_req)
 

--- a/libs/sdk-python/src/daytona/common/snapshot.py
+++ b/libs/sdk-python/src/daytona/common/snapshot.py
@@ -9,6 +9,7 @@ from daytona_api_client import BuildInfo
 from daytona_api_client import PaginatedSnapshots as PaginatedSnapshotsDto
 from daytona_api_client import SnapshotDto as SyncSnapshotDto
 from daytona_api_client_async import BuildInfo as AsyncBuildInfo
+from daytona_api_client_async import SandboxClass
 from daytona_api_client_async import SnapshotDto as AsyncSnapshotDto
 
 from .image import Image
@@ -71,6 +72,8 @@ class CreateSnapshotParams(BaseModel):
         entrypoint (list[str] | None): Entrypoint of the snapshot.
         region_id (str | None): ID of the region where the snapshot will be available.
             Defaults to organization default region if not specified.
+        sandbox_class (SandboxClass | None): Target sandbox class. Determines which runners
+            can host sandboxes created from this snapshot.
     """
 
     name: str
@@ -78,3 +81,4 @@ class CreateSnapshotParams(BaseModel):
     resources: Resources | None = None
     entrypoint: list[str] | None = None
     region_id: str | None = None
+    sandbox_class: SandboxClass | None = None

--- a/libs/sdk-ruby/lib/daytona/common/response.rb
+++ b/libs/sdk-ruby/lib/daytona/common/response.rb
@@ -6,6 +6,7 @@
 module Daytona
   # Re-export of api-client enum constants under the Daytona namespace so
   # SDK consumers never need to import from DaytonaApiClient directly.
+  SandboxClass = DaytonaApiClient::SandboxClass
   SandboxState = DaytonaApiClient::SandboxState
   SandboxListSortField = DaytonaApiClient::SandboxListSortField
   SandboxListSortDirection = DaytonaApiClient::SandboxListSortDirection

--- a/libs/sdk-ruby/lib/daytona/common/snapshot.rb
+++ b/libs/sdk-ruby/lib/daytona/common/snapshot.rb
@@ -23,17 +23,22 @@ module Daytona
     #   Defaults to organization default region if not specified.
     attr_reader :region_id
 
+    # @return [DaytonaApiClient::SandboxClass, nil] Target sandbox class.
+    attr_reader :sandbox_class
+
     # @param name [String] Name of the snapshot
     # @param image [String, Daytona::Image] Image of the snapshot
     # @param resources [Daytona::Resources, nil] Resources of the snapshot
     # @param entrypoint [Array<String>, nil] Entrypoint of the snapshot
     # @param region_id [String, nil] ID of the region where the snapshot will be available
-    def initialize(name:, image:, resources: nil, entrypoint: nil, region_id: nil)
+    # @param sandbox_class [DaytonaApiClient::SandboxClass, nil] Target sandbox class
+    def initialize(name:, image:, resources: nil, entrypoint: nil, region_id: nil, sandbox_class: nil)
       @name = name
       @image = image
       @resources = resources
       @entrypoint = entrypoint
       @region_id = region_id
+      @sandbox_class = sandbox_class
     end
   end
 

--- a/libs/sdk-ruby/lib/daytona/snapshot_service.rb
+++ b/libs/sdk-ruby/lib/daytona/snapshot_service.rb
@@ -111,6 +111,7 @@ module Daytona
       end
 
       create_snapshot_req.region_id = params.region_id || @default_region_id
+      create_snapshot_req.sandbox_class = params.sandbox_class
 
       snapshot = snapshots_api.create_snapshot(create_snapshot_req)
 

--- a/libs/sdk-typescript/src/Snapshot.ts
+++ b/libs/sdk-typescript/src/Snapshot.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ObjectStorageApi, SnapshotsApi, SnapshotState, Configuration } from '@daytona/api-client'
+import { ObjectStorageApi, SnapshotsApi, SnapshotState, SandboxClass, Configuration } from '@daytona/api-client'
 import type { SnapshotDto, CreateSnapshot, PaginatedSnapshots as PaginatedSnapshotsDto } from '@daytona/api-client'
 import { DaytonaError } from './errors/DaytonaError'
 import { Image } from './Image'
@@ -55,6 +55,7 @@ export interface PaginatedSnapshots extends Omit<PaginatedSnapshotsDto, 'items'>
  * @property {Resources} resources - Resources of the snapshot.
  * @property {string[]} entrypoint - Entrypoint of the snapshot.
  * @property {string} regionId - ID of the region where the snapshot will be available. Defaults to organization default region if not specified.
+ * @property {SandboxClass} sandboxClass - Target sandbox class. Determines which runners can host sandboxes created from this snapshot.
  */
 export type CreateSnapshotParams = {
   name: string
@@ -62,6 +63,7 @@ export type CreateSnapshotParams = {
   resources?: Resources
   entrypoint?: string[]
   regionId?: string
+  sandboxClass?: SandboxClass
 }
 
 /**
@@ -185,6 +187,7 @@ export class SnapshotService {
     }
 
     createSnapshotReq.regionId = params.regionId || this.defaultRegionId
+    createSnapshotReq.sandboxClass = params.sandboxClass
 
     let createdSnapshot = (
       await this.snapshotsApi.createSnapshot(createSnapshotReq, undefined, {

--- a/libs/sdk-typescript/src/index.ts
+++ b/libs/sdk-typescript/src/index.ts
@@ -66,7 +66,13 @@ export type {
 export { ChartType } from './types/Charts'
 export type { ExecutionError, ExecutionResult, OutputMessage, RunCodeOptions } from './types/CodeInterpreter'
 
-export { GpuType, SandboxState, SandboxListSortField, SandboxListSortDirection } from '@daytona/api-client'
+export {
+  GpuType,
+  SandboxState,
+  SandboxListSortField,
+  SandboxListSortDirection,
+  SandboxClass,
+} from '@daytona/api-client'
 export type {
   FileInfo,
   GitStatus,


### PR DESCRIPTION
### Summary
- Expose the existing `sandboxClass` field from the API layer through the SDK-level snapshot creation params in all five SDKs (TypeScript, Go, Python, Ruby, Java)
- Allows users to specify which runner class (`linux-vm`, `container`, `android`) should host sandboxes created from a snapshot

### Changes
| SDK | Files |
|-----|-------|
| TypeScript | `Snapshot.ts` — added to `CreateSnapshotParams` type + `create()`, re-exported `SandboxClass` from `index.ts` |
| Go | `types.go` — new `SandboxClass` type with constants, added field to `CreateSnapshotParams`; `snapshot.go` — pass-through in `doCreate()` |
| Python | `common/snapshot.py` — new field on `CreateSnapshotParams`; `_sync/snapshot.py` + `_async/snapshot.py` — pass-through in `create()` |
| Ruby | `common/snapshot.rb` — new `attr_reader` + kwarg; `snapshot_service.rb` — pass-through in `create()` |
| Java | `SnapshotService.java` — new overloads: `create(name, imageName, sandboxClass)` and `create(name, image, resources, sandboxClass, onLogs)`; existing methods delegate with `null` |

All changes are backward-compatible — `sandboxClass` is optional/nullable everywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose an optional `sandboxClass` in snapshot creation across all SDKs to choose the runner class (`linux-vm`, `container`, `android`). Backward compatible; defaults unchanged.

- **New Features**
  - TypeScript: added `sandboxClass` to `CreateSnapshotParams`; pass-through in request; re-exported `SandboxClass` from `@daytona/api-client`; docs updated.
  - Go: `SandboxClass` alias + constants; added to `types.CreateSnapshotParams`; pass-through in `SnapshotService.doCreate`; docs updated.
  - Python: added `sandbox_class` to `CreateSnapshotParams`; async pass-through; sync maps to sync client enum; re-exported `SandboxClass` from `daytona`; docs updated.
  - Ruby: added `sandbox_class` to `CreateSnapshotParams`; pass-through in `SnapshotService#create`; re-exported `SandboxClass` under `Daytona`.
  - Java: new overloads `create(name, imageName, SandboxClass)` and `create(name, Image, Resources, SandboxClass, onLogs)`; existing methods delegate; docs updated.

<sup>Written for commit ae25c96f9143370995ded7cffc0f625ad453ed0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

