### PR TITLE
feat(api): unlink runner on destroyed

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -1995,6 +1995,17 @@ export class SandboxService {
 
     const updateData = Sandbox.getSoftDeleteUpdate(sandbox)
 
+    // When destroying a sandbox that is in error state, its instance may no longer exist on the
+    // runner. If the runner reports the sandbox as gone, detach it from the runner so the destroy
+    // doesn't get stuck waiting for a non-existent instance to be cleaned up.
+    if (sandbox.state === SandboxState.ERROR && sandbox.runnerId) {
+      const existsOnRunner = await this.sandboxExistsOnRunner(sandbox)
+      if (!existsOnRunner) {
+        updateData.prevRunnerId = sandbox.runnerId
+        updateData.runnerId = null
+      }
+    }
+
     const updatedSandbox = await this.sandboxRepository.updateWhere(sandbox.id, {
       updateData,
       whereCondition: { pending: sandbox.pending, state: sandbox.state },
@@ -2002,6 +2013,29 @@ export class SandboxService {
 
     this.eventEmitter.emit(SandboxEvents.DESTROYED, new SandboxDestroyedEvent(updatedSandbox))
     return updatedSandbox
+  }
+
+  // Checks whether the sandbox instance still exists on its assigned runner.
+  // The runner reports a missing instance as a DESTROYED state (HTTP 200), not a 404.
+  private async sandboxExistsOnRunner(sandbox: Sandbox): Promise<boolean> {
+    if (!sandbox.runnerId) {
+      return false
+    }
+
+    const runner = await this.runnerService.findOne(sandbox.runnerId)
+    if (!runner) {
+      return false
+    }
+
+    try {
+      const runnerAdapter = await this.runnerAdapterFactory.create(runner)
+      const info = await runnerAdapter.sandboxInfo(sandbox.id)
+      return info.state !== SandboxState.DESTROYED
+    } catch (error) {
+      this.logger.error(`Failed to check if sandbox ${sandbox.id} exists on runner ${sandbox.runnerId}:`, error)
+      // If we can't determine existence, assume it still exists to avoid detaching prematurely.
+      return true
+    }
   }
 
   async start(sandboxIdOrName: string, organization: Organization): Promise<Sandbox> {


### PR DESCRIPTION
## Description

Deleting sandboxes which don't exist on runners now unlinks the "runnerId" - this helps with sandbox distribution logic in other parts of the system

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detaches a sandbox from its runner during destroy when the instance is already gone on the runner. This prevents hanging destroys and keeps runner distribution accurate.

- **Bug Fixes**
  - Check runner via `sandboxInfo`; if it returns DESTROYED, set `prevRunnerId` and clear `runnerId`.
  - On check failure, assume the instance still exists to avoid premature detach.

<sup>Written for commit ccca9af7749425d78b9efe1f3baee24aa7cd3f48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

