### PR TITLE
chore: run PR docker build on self-hosted runners

### DIFF
--- a/.github/workflows/pr_docker_build.yaml
+++ b/.github/workflows/pr_docker_build.yaml
@@ -17,7 +17,7 @@ jobs:
   docker-build:
     if: github.repository == 'daytonaio/daytona'
     name: Docker build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, github-actions-runner-amd64]
     timeout-minutes: 40
     env:
       VERSION: v0.0.0-pr


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run PR Docker builds on self-hosted Linux x64 runners. This reduces queue time and ensures a consistent build environment using labels `self-hosted`, `Linux`, `X64`, `github-actions-runner-amd64`.

<sup>Written for commit 993f95e4d7bb5ca2c1b6d70bb5d25db41c16c3f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

