### PR TITLE
feat(docs): content negotiation

### DIFF
--- a/apps/docs/server/index.mjs
+++ b/apps/docs/server/index.mjs
@@ -34,7 +34,9 @@ app.use((req, res, next) => {
 app.use('/docs', express.static('client/'))
 app.use(ssrHandler)
 app.use((req, res) => {
-  res.sendFile('404.html', { root: 'client/' })
+  const accept = (req.headers.accept ?? '').toLowerCase()
+  const wantsMarkdown = accept.includes('text/markdown')
+  res.status(wantsMarkdown ? 200 : 404).sendFile('404.html', { root: 'client/' })
 })
 
 app.listen(env.FUNCTIONS_PORT, () => {

--- a/apps/docs/server/util/redirects.mjs
+++ b/apps/docs/server/util/redirects.mjs
@@ -1,8 +1,6 @@
 /**
- * Redirect map for pages that changed URLs during the content architecture refactor.
+ * Redirect map for documentation pages.
  *
- * The single source of truth used by the Express production server (server/index.mjs)
- * and the Astro middleware (src/middleware.ts).
  */
 export const redirects = {
   'inngest-agentkit-coding-agent': 'guides/agentkit/inngest-agentkit-coding-agent',
@@ -26,4 +24,28 @@ export const redirects = {
   'computer-use-macos': 'computer-use',
   'computer-use-windows': 'computer-use',
   'computer-use-linux': 'computer-use',
+  'api': 'tools/api#daytona',
+  'api-reference': 'tools/api#daytona',
+  'rest-api': 'tools/api#daytona',
+  'reference/api': 'tools/api#daytona',
+  'tools/api/daytona': 'tools/api#daytona',
+  'tools/api/sandbox-api': 'tools/api#daytona',
+  'sdk': 'getting-started',
+  'sdk/node': 'typescript-sdk',
+  'sdk/typescript': 'typescript-sdk',
+  'sdk/typescript-sdk': 'typescript-sdk',
+  'sdk/python': 'python-sdk',
+  'sdk/python-sdk': 'python-sdk',
+  'sdk-reference/typescript-sdk-reference': 'typescript-sdk',
+  'tools/typescript-sdk': 'typescript-sdk',
+  'tools/python-sdk': 'python-sdk',
+  'tools/python-sdk/overview': 'python-sdk',
+  'typescript-sdk/sandbox-process': 'typescript-sdk/process',
+  'tools/process-code-execution': 'process-code-execution',
+  'quick-start': 'getting-started',
+  'getting-started/quick-start': 'getting-started',
+  'getting-started/quickstart-python': 'python-sdk',
+  'miscellaneous/create-api-key': 'api-keys',
+  'guides/claude/coding-agent': 'guides/claude',
+  'agent-tools/log-streaming': 'log-streaming',
 }

--- a/apps/docs/src/i18n/routing.ts
+++ b/apps/docs/src/i18n/routing.ts
@@ -14,7 +14,7 @@
  * This approach preserves static generation benefits while enabling dynamic language routing.
  */
 import config from '../../gt.config.json'
-import { acceptsMarkdown } from '../utils/content-negotiation'
+import { rewrite404ForMarkdownAccept } from '../utils/content-negotiation'
 
 const defaultLocale = config.defaultLocale
 const allLocales = [defaultLocale, ...config.locales]
@@ -164,12 +164,12 @@ export async function handleLanguageRouting(
 
   const serveCustom404 = async (): Promise<Response> => {
     const response = await proxyLocalizedContent('/docs/404', request)
-    const wantsMarkdown = acceptsMarkdown(request.headers.get('accept') ?? '')
-    return new Response(response.body, {
-      status: wantsMarkdown ? 200 : 404,
-      statusText: wantsMarkdown ? 'OK' : 'Not Found',
+    const notFound = new Response(response.body, {
+      status: 404,
+      statusText: 'Not Found',
       headers: response.headers,
     })
+    return rewrite404ForMarkdownAccept(notFound, request)
   }
 
   if (isLocalizedPath(normalizedSlug)) return await serveCustom404()
@@ -177,8 +177,6 @@ export async function handleLanguageRouting(
   const preferredLanguage = getPreferredLanguage(request)
 
   if (normalizedSlug) {
-    // For unprefixed docs paths, use the default locale canonical URL.
-    // This avoids SSR self-fetch loops that can incorrectly produce 404.
     return redirectFn(`/docs/${defaultLocale}/${normalizedSlug}`)
   }
 

--- a/apps/docs/src/i18n/routing.ts
+++ b/apps/docs/src/i18n/routing.ts
@@ -14,6 +14,7 @@
  * This approach preserves static generation benefits while enabling dynamic language routing.
  */
 import config from '../../gt.config.json'
+import { acceptsMarkdown } from '../utils/content-negotiation'
 
 const defaultLocale = config.defaultLocale
 const allLocales = [defaultLocale, ...config.locales]
@@ -163,9 +164,10 @@ export async function handleLanguageRouting(
 
   const serveCustom404 = async (): Promise<Response> => {
     const response = await proxyLocalizedContent('/docs/404', request)
+    const wantsMarkdown = acceptsMarkdown(request.headers.get('accept') ?? '')
     return new Response(response.body, {
-      status: 404,
-      statusText: 'Not Found',
+      status: wantsMarkdown ? 200 : 404,
+      statusText: wantsMarkdown ? 'OK' : 'Not Found',
       headers: response.headers,
     })
   }

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -1,5 +1,6 @@
 import { defineMiddleware } from 'astro:middleware'
 
+import { rewrite404ForMarkdownAccept } from './utils/content-negotiation'
 import { redirects } from './utils/redirects'
 
 function filterProxyHeaders(headers: Headers): Headers {
@@ -31,11 +32,14 @@ export const onRequest = defineMiddleware(
               : request.body,
         })
 
-        return new Response(response.body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: filterProxyHeaders(response.headers),
-        })
+        return rewrite404ForMarkdownAccept(
+          new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: filterProxyHeaders(response.headers),
+          }),
+          request
+        )
       } catch {
         // During prerender the target server doesn't exist yet; fall through
         return next()
@@ -81,6 +85,7 @@ export const onRequest = defineMiddleware(
       }
     }
 
-    return next()
+    const response = await next()
+    return rewrite404ForMarkdownAccept(response, request)
   }
 )

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -42,7 +42,7 @@ export const onRequest = defineMiddleware(
         )
       } catch {
         // During prerender the target server doesn't exist yet; fall through
-        return next()
+        return rewrite404ForMarkdownAccept(await next(), request)
       }
     }
 

--- a/apps/docs/src/utils/content-negotiation.ts
+++ b/apps/docs/src/utils/content-negotiation.ts
@@ -1,5 +1,32 @@
 export function acceptsMarkdown(acceptHeader: string): boolean {
-  return acceptHeader.toLowerCase().includes('text/markdown')
+  for (const entry of acceptHeader.split(',')) {
+    const [mediaType, ...params] = entry.split(';')
+    if (mediaType.trim().toLowerCase() !== 'text/markdown') continue
+
+    const qParam = params
+      .map(p => p.trim().toLowerCase())
+      .find(p => p.startsWith('q='))
+    if (!qParam) return true
+
+    const q = Number.parseFloat(qParam.slice(2))
+    return Number.isNaN(q) || q > 0
+  }
+  return false
+}
+
+function withVaryAccept(headers: Headers): Headers {
+  const result = new Headers(headers)
+  const vary = result.get('vary')
+  if (!vary) {
+    result.set('vary', 'Accept')
+    return result
+  }
+
+  const fields = vary.split(',').map(f => f.trim().toLowerCase())
+  if (!fields.includes('*') && !fields.includes('accept')) {
+    result.set('vary', `${vary}, Accept`)
+  }
+  return result
 }
 
 export function rewrite404ForMarkdownAccept(
@@ -7,11 +34,11 @@ export function rewrite404ForMarkdownAccept(
   request: Request
 ): Response {
   if (response.status !== 404) return response
-  if (!acceptsMarkdown(request.headers.get('accept') ?? '')) return response
 
+  const wantsMarkdown = acceptsMarkdown(request.headers.get('accept') ?? '')
   return new Response(response.body, {
-    status: 200,
-    statusText: 'OK',
-    headers: response.headers,
+    status: wantsMarkdown ? 200 : 404,
+    statusText: wantsMarkdown ? 'OK' : response.statusText,
+    headers: withVaryAccept(response.headers),
   })
 }

--- a/apps/docs/src/utils/content-negotiation.ts
+++ b/apps/docs/src/utils/content-negotiation.ts
@@ -1,0 +1,17 @@
+export function acceptsMarkdown(acceptHeader: string): boolean {
+  return acceptHeader.toLowerCase().includes('text/markdown')
+}
+
+export function rewrite404ForMarkdownAccept(
+  response: Response,
+  request: Request
+): Response {
+  if (response.status !== 404) return response
+  if (!acceptsMarkdown(request.headers.get('accept') ?? '')) return response
+
+  return new Response(response.body, {
+    status: 200,
+    statusText: 'OK',
+    headers: response.headers,
+  })
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add content negotiation to the docs app so requests that accept Markdown get 200 OK instead of 404 for the 404 page. Also expands redirects for legacy docs paths to current URLs.

- **New Features**
  - Added `acceptsMarkdown` and `rewrite404ForMarkdownAccept`; integrated into Astro middleware, i18n routing, and the Express 404 handler to rewrite 404s to 200 when `Accept` includes `text/markdown`.
  - Expanded redirect map for common legacy paths (API and SDK routes) to current pages like `tools/api#daytona`, `typescript-sdk`, and `python-sdk`.

<sup>Written for commit a9d08851e2edc24147c59da53312ffc4240f5d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

