### PR TITLE
fix(sdk): use modifiedAt in Go SDK and add API client inputs to all SDK test caches

### DIFF
--- a/libs/sdk-go/pkg/daytona/filesystem.go
+++ b/libs/sdk-go/pkg/daytona/filesystem.go
@@ -123,7 +123,7 @@ func (f *FileSystemService) ListFiles(ctx context.Context, path string) ([]*type
 		// Convert toolbox.FileInfo to types.FileInfo
 		result := make([]*types.FileInfo, len(files))
 		for i, file := range files {
-			modTime, _ := time.Parse(time.RFC3339, file.GetModTime())
+			modTime, _ := time.Parse(time.RFC3339, file.GetModifiedAt())
 			result[i] = &types.FileInfo{
 				Name:         file.GetName(),
 				Size:         int64(file.GetSize()),
@@ -160,7 +160,7 @@ func (f *FileSystemService) GetFileInfo(ctx context.Context, path string) (*type
 			return nil, errors.ConvertToolboxError(err, httpResp)
 		}
 
-		modTime, _ := time.Parse(time.RFC3339, fileInfo.GetModTime())
+		modTime, _ := time.Parse(time.RFC3339, fileInfo.GetModifiedAt())
 		return &types.FileInfo{
 			Name:         fileInfo.GetName(),
 			Size:         int64(fileInfo.GetSize()),

--- a/libs/sdk-go/pkg/daytona/filesystem_test.go
+++ b/libs/sdk-go/pkg/daytona/filesystem_test.go
@@ -471,6 +471,7 @@ func TestFileSystemListAndInfoConversions(t *testing.T) {
 				"size":        12,
 				"mode":        "0644",
 				"modTime":     time.Now().UTC().Format(time.RFC3339),
+				"modifiedAt":  time.Now().UTC().Format(time.RFC3339),
 				"isDir":       false,
 			}, {
 				"group":       "staff",
@@ -480,6 +481,7 @@ func TestFileSystemListAndInfoConversions(t *testing.T) {
 				"size":        0,
 				"mode":        "0755",
 				"modTime":     "not-a-timestamp",
+				"modifiedAt":  "not-a-timestamp",
 				"isDir":       true,
 			}})
 		}))
@@ -504,6 +506,7 @@ func TestFileSystemListAndInfoConversions(t *testing.T) {
 				"size":        44,
 				"mode":        "0644",
 				"modTime":     time.Now().UTC().Format(time.RFC3339),
+				"modifiedAt":  time.Now().UTC().Format(time.RFC3339),
 				"isDir":       false,
 			})
 		}))

--- a/libs/sdk-go/project.json
+++ b/libs/sdk-go/project.json
@@ -17,7 +17,11 @@
     "test": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["default", { "env": "DAYTONA_API_KEY" }, { "env": "DAYTONA_API_URL" }, { "env": "DAYTONA_JWT_TOKEN" }, { "env": "DAYTONA_ORGANIZATION_ID" }, { "env": "DAYTONA_TARGET" }],
+      "inputs": [
+        "default",
+        "{workspaceRoot}/libs/api-client-go/**/*",
+        "{workspaceRoot}/libs/toolbox-api-client-go/**/*"
+      ],
       "outputs": [],
       "options": {
         "cwd": "{projectRoot}",

--- a/libs/sdk-java/project.json
+++ b/libs/sdk-java/project.json
@@ -69,7 +69,11 @@
     "test": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["default", { "env": "DAYTONA_API_KEY" }, { "env": "DAYTONA_API_URL" }, { "env": "DAYTONA_JWT_TOKEN" }, { "env": "DAYTONA_ORGANIZATION_ID" }, { "env": "DAYTONA_TARGET" }],
+      "inputs": [
+        "default",
+        "{workspaceRoot}/libs/api-client-java/**/*",
+        "{workspaceRoot}/libs/toolbox-api-client-java/**/*"
+      ],
       "outputs": [],
       "options": {
         "cwd": "{projectRoot}",
@@ -83,5 +87,5 @@
         "command": "./gradlew testE2E --info"
       }
     }
-  }
+}
 }

--- a/libs/sdk-python/project.json
+++ b/libs/sdk-python/project.json
@@ -15,7 +15,13 @@
     "test": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["default", { "env": "DAYTONA_API_KEY" }, { "env": "DAYTONA_API_URL" }, { "env": "DAYTONA_JWT_TOKEN" }, { "env": "DAYTONA_ORGANIZATION_ID" }, { "env": "DAYTONA_TARGET" }],
+      "inputs": [
+        "default",
+        "{workspaceRoot}/libs/api-client-python/**/*",
+        "{workspaceRoot}/libs/api-client-python-async/**/*",
+        "{workspaceRoot}/libs/toolbox-api-client-python/**/*",
+        "{workspaceRoot}/libs/toolbox-api-client-python-async/**/*"
+      ],
       "outputs": [],
       "options": {
         "cwd": "{workspaceRoot}",

--- a/libs/sdk-ruby/project.json
+++ b/libs/sdk-ruby/project.json
@@ -44,7 +44,11 @@
     "test": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["default", { "env": "DAYTONA_API_KEY" }, { "env": "DAYTONA_API_URL" }, { "env": "DAYTONA_JWT_TOKEN" }, { "env": "DAYTONA_ORGANIZATION_ID" }, { "env": "DAYTONA_TARGET" }],
+      "inputs": [
+        "default",
+        "{workspaceRoot}/libs/api-client-ruby/**/*",
+        "{workspaceRoot}/libs/toolbox-api-client-ruby/**/*"
+      ],
       "outputs": [],
       "options": {
         "cwd": "{projectRoot}",

--- a/libs/sdk-typescript/project.json
+++ b/libs/sdk-typescript/project.json
@@ -15,7 +15,10 @@
     "test": {
       "executor": "nx:run-commands",
       "cache": true,
-      "inputs": ["default", { "env": "DAYTONA_API_KEY" }, { "env": "DAYTONA_API_URL" }, { "env": "DAYTONA_JWT_TOKEN" }, { "env": "DAYTONA_ORGANIZATION_ID" }, { "env": "DAYTONA_TARGET" }],
+      "inputs": [
+        "default",
+        { "dependentTasksOutputFiles": "**/*", "transitive": true }
+      ],
       "outputs": [],
       "options": {
         "cwd": "{projectRoot}",
@@ -43,7 +46,6 @@
     },
     "test:runtime": {
       "executor": "nx:run-commands",
-      "inputs": ["{projectRoot}/runtime-tests/**/*", { "env": "DAYTONA_API_KEY" }, { "env": "DAYTONA_API_URL" }],
       "options": {
         "cwd": "{projectRoot}/runtime-tests",
         "command": "bash run-all.sh"


### PR DESCRIPTION
### Problem

PR #4890 added a required `modifiedAt` field to the `FileInfo` model in the toolbox API client and deprecated `modTime`. This broke the Go SDK's `TestFileSystemListAndInfoConversions` test in CI because:

1. The test mock servers didn't include the new required `modifiedAt` field, causing `UnmarshalJSON` to fail with `"no value given for required property modifiedAt"`
2. The Go SDK's `ListFiles` and `GetFileInfo` still used the deprecated `GetModTime()` instead of `GetModifiedAt()`

The test passed in PR #4890's CI because Nx served a **stale cache hit** for `sdk-go:test` — the cache didn't know it needed invalidation when `toolbox-api-client-go` changed.

### Root Cause

None of the SDK `project.json` files tracked their API client dependencies as test cache inputs. When API clients were regenerated (e.g., adding `modifiedAt` to `FileInfo`), Nx would serve cached test results from before the change, masking test failures until a cache miss occurred.

### Changes

**Go SDK code fix:**
- `filesystem.go`: Use `file.GetModifiedAt()` instead of deprecated `file.GetModTime()` in `ListFiles` and `GetFileInfo`
- `filesystem_test.go`: Add `modifiedAt` field to all `FileInfo` mock payloads

**Nx cache invalidation fix (all 5 SDKs):**

Added explicit API client directory paths as test cache inputs so any change to an API client invalidates the corresponding SDK's test cache:

| SDK | API client inputs added |
|---|---|
| `sdk-go` | `libs/api-client-go/**/*`, `libs/toolbox-api-client-go/**/*` |
| `sdk-typescript` | `"dependentTasksOutputFiles": "**/*", "transitive": true` |
| `sdk-python` | `libs/api-client-python/**/*`, `libs/api-client-python-async/**/*`, `libs/toolbox-api-client-python/**/*`, `libs/toolbox-api-client-python-async/**/*` |
| `sdk-ruby` | `libs/api-client-ruby/**/*`, `libs/toolbox-api-client-ruby/**/*` |
| `sdk-java` | `libs/api-client-java/**/*`, `libs/toolbox-api-client-java/**/*` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Go SDK filesystem conversions to use the new `modifiedAt` field and updates SDK test cache inputs so API client changes invalidate unit test caches, preventing stale results and JSON errors.

- **Bug Fixes**
  - Go SDK: `ListFiles` and `GetFileInfo` now parse `GetModifiedAt()` instead of deprecated `GetModTime()`.
  - Tests: Added `modifiedAt` to all `FileInfo` mock payloads to match the API schema.

- **Dependencies**
  - Nx: Added API client paths as test cache inputs so unit tests are re-run when clients change:
    - `sdk-go`: `libs/api-client-go/**/*`, `libs/toolbox-api-client-go/**/*`
    - `sdk-typescript`: `{ dependentTasksOutputFiles: "**/*", transitive: true }`
    - `sdk-python`: `libs/api-client-python/**/*`, `libs/api-client-python-async/**/*`, `libs/toolbox-api-client-python/**/*`, `libs/toolbox-api-client-python-async/**/*`
    - `sdk-ruby`: `libs/api-client-ruby/**/*`, `libs/toolbox-api-client-ruby/**/*`
    - `sdk-java`: `libs/api-client-java/**/*`, `libs/toolbox-api-client-java/**/*`

<sup>Written for commit 531055de327341ae908b7eb74677751192419cb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

