### PR TITLE
fix(api): exclude build failed from gpu allocation count

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -939,9 +939,9 @@ export class RunnerService {
    * with `runner.gpu = N` can host up to N concurrent GPU sandboxes; this
    * method returns runners where the count of GPU sandboxes is `>= N`.
    *
-   * Every GPU sandbox in any state other than DESTROYED / ARCHIVED counts
-   * toward capacity - including STOPPED, ERROR, RESIZING, SNAPSHOTTING, etc. -
-   * because the GPU index is pinned into the container's
+   * Every GPU sandbox in any state other than DESTROYED / ARCHIVED /
+   * BUILD_FAILED counts toward capacity - including STOPPED, ERROR, RESIZING,
+   * SNAPSHOTTING, etc. - because the GPU index is pinned into the container's
    * HostConfig.DeviceRequests at create time and survives any subsequent
    * restart, so the physical card stays reserved for that sandbox until it
    * is fully destroyed.
@@ -950,6 +950,9 @@ export class RunnerService {
    * ephemeral (see SandboxService) so they cannot legitimately reach the
    * archived state, but if one ever does (legacy data, manual bypass) the
    * container is no longer on the runner and the card is effectively free.
+   *
+   * BUILD_FAILED is excluded because the build failed before a GPU container
+   * was created on the runner, so no physical card is reserved.
    */
   async getRunnersAtGpuCapacity(): Promise<string[]> {
     const rows = await this.sandboxRepository
@@ -960,7 +963,7 @@ export class RunnerService {
       .andWhere('sandbox.gpu > 0')
       .andWhere('runner.gpu IS NOT NULL AND runner.gpu > 0')
       .andWhere('sandbox.state NOT IN (:...freeStates)', {
-        freeStates: [SandboxState.DESTROYED, SandboxState.ARCHIVED],
+        freeStates: [SandboxState.DESTROYED, SandboxState.ARCHIVED, SandboxState.BUILD_FAILED],
       })
       .groupBy('sandbox.runnerId')
       .addGroupBy('runner.gpu')


### PR DESCRIPTION
## Description

Don't consider the `build_failed` state when counting GPU sandboxes on runners - the sandbox doesn't really exist

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `BUILD_FAILED` sandboxes from GPU allocation counts so runners aren’t incorrectly marked at capacity. This prevents build failures from blocking available GPUs.

- **Bug Fixes**
  - In `getRunnersAtGpuCapacity`, added `BUILD_FAILED` to free states (with DESTROYED/ARCHIVED) and updated comments to reflect that no GPU is reserved when builds fail.

<sup>Written for commit 347f18db1f549bce4b34781fc92cec507f0edcd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

