### PR TITLE
fix(docker): make api migration jobs work as non-root without network

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -45,7 +45,16 @@ ENV CI=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
-RUN npm install -g corepack && corepack enable
+# Pin corepack's home to a shared, world-readable path and pre-fetch the pinned
+# yarn release at build time. Without this, a pod running as a non-root user
+# (e.g. a hardened k8s securityContext) gets a different $HOME, misses the
+# root-owned corepack cache, and corepack tries to download yarn from
+# repo.yarnpkg.com at startup — which fails on air-gapped/egress-restricted
+# clusters running the migration jobs.
+ENV COREPACK_HOME=/opt/corepack
+RUN npm install -g corepack && corepack enable && \
+    corepack prepare yarn@4.13.0 --activate && \
+    chmod -R a+rX /opt/corepack
 
 WORKDIR /daytona
 
@@ -68,10 +77,12 @@ COPY --from=builder /daytona/dist ./dist
 # The migration:run:* scripts execute the typeorm CLI through ts-node against
 # the TypeScript data-sources (apps/api/src/migrations/**), which load entities
 # via a `*.entity.ts` glob. Ship that source + the tsconfigs they extend so the
-# deploy migration jobs resolve identically to a full checkout.
-COPY --from=builder /daytona/apps/api/src ./apps/api/src
-COPY --from=builder /daytona/apps/api/tsconfig.json /daytona/apps/api/tsconfig.app.json /daytona/apps/api/tsconfig.spec.json ./apps/api/
-COPY --from=builder /daytona/tsconfig.base.json ./
+# deploy migration jobs resolve identically to a full checkout. --chmod makes
+# them world-readable: the sources carry restrictive repo perms that would
+# otherwise be unreadable to a non-root migration pod.
+COPY --from=builder --chmod=0755 /daytona/apps/api/src ./apps/api/src
+COPY --from=builder --chmod=0644 /daytona/apps/api/tsconfig.json /daytona/apps/api/tsconfig.app.json /daytona/apps/api/tsconfig.spec.json ./apps/api/
+COPY --from=builder --chmod=0644 /daytona/tsconfig.base.json ./
 
 ARG VERSION=0.0.1
 ENV VERSION=${VERSION}


### PR DESCRIPTION
## What

Makes the api image's typeorm migration jobs (`migration:run:init` / `:pre-deploy` / `:post-deploy`) work when the pod runs as a **non-root user** with **no outbound network** — the configuration self-hosted customers use on hardened k8s clusters.

## Why it broke

Two non-root failures in the current image:

1. **corepack downloads yarn at startup.** corepack's package cache is `$HOME`-relative. The image bakes yarn into root's home, but a pod with a non-root `securityContext` gets a different `$HOME`, misses that cache, and corepack falls back to fetching `yarn@4.13.0` from `repo.yarnpkg.com` — which fails on egress-restricted clusters:
   ```
   ! Corepack is about to download https://repo.yarnpkg.com/4.13.0/packages/yarnpkg-cli/bin/yarn.js
   Error: ... read ECONNRESET
   ```
2. **Source/tsconfigs are unreadable to non-root.** The COPY'd `apps/api/src` and tsconfigs inherit restrictive repo perms (mode 600), so a non-root migration pod can't read them and ts-node fails with `Cannot read file '.../tsconfig.json'`.

## Fix

- Pin `COREPACK_HOME=/opt/corepack` (shared, world-readable) and pre-fetch the pinned yarn at build time, so no download is attempted at runtime for any UID.
- `COPY --chmod` the migration source + tsconfigs so they're world-readable.

## Verification (local, from the slim image)

- `yarn --version` resolves offline (`--network none`) as non-root uid 1000 and as an arbitrary high UID — zero corepack fetch attempts.
- `migration:run:init` runs all migrations against Postgres as non-root with corepack offline — exit 0, all migrations recorded, zero read/permission errors.
- App boot path and module resolution unaffected; heavy devDependencies (`vite`, `vitest`, `storybook`, `jsdom`, `esbuild`, `@nx/*`) remain absent from the runtime image.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make API TypeORM migration jobs (`migration:run:init`, `:pre-deploy`, `:post-deploy`) work when the pod runs as non-root without outbound network. Ensures `yarn` resolves offline and sources are readable under hardened k8s settings.

- **Bug Fixes**
  - Pin `COREPACK_HOME=/opt/corepack` and prefetch `yarn@4.13.0` at build time to prevent `corepack` runtime downloads for any UID.
  - Copy `apps/api/src` and related tsconfigs with permissive modes (`--chmod`) so `ts-node`/`typeorm` can read them as non-root.

<sup>Written for commit 5bf07b64715a1e0ad0a1e59cbd43a830f003c187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

