### PR TITLE
fix(dashboard): use sessionStorage for OIDC token storage

### DIFF
--- a/apps/dashboard/src/providers/ConfigProvider.tsx
+++ b/apps/dashboard/src/providers/ConfigProvider.tsx
@@ -7,7 +7,7 @@ import { RoutePath } from '@/enums/RoutePath'
 import { queryKeys } from '@/hooks/queries/queryKeys'
 import { DaytonaConfiguration } from '@daytona/api-client'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { InMemoryWebStorage, WebStorageStateStore } from 'oidc-client-ts'
+import { WebStorageStateStore } from 'oidc-client-ts'
 import { ReactNode, useMemo } from 'react'
 import { AuthProvider, AuthProviderProps } from 'react-oidc-context'
 import { ConfigContext } from '../contexts/ConfigContext'
@@ -31,9 +31,6 @@ export function ConfigProvider(props: Props) {
   })
 
   const oidcConfig: AuthProviderProps = useMemo(() => {
-    const isLocalhost = window.location.hostname === 'localhost'
-    const stateStore = isLocalhost ? window.sessionStorage : new InMemoryWebStorage()
-
     return {
       authority: config.oidc.issuer,
       client_id: config.oidc.clientId,
@@ -44,7 +41,7 @@ export function ConfigProvider(props: Props) {
       redirect_uri: window.location.origin,
       staleStateAgeInSeconds: 60,
       accessTokenExpiringNotificationTimeInSeconds: 290,
-      userStore: new WebStorageStateStore({ store: stateStore }),
+      userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       onSigninCallback: (user) => {
         const state = user?.state as { returnTo?: string } | undefined
         const targetUrl = state?.returnTo || RoutePath.DASHBOARD


### PR DESCRIPTION
Replace InMemoryWebStorage with window.sessionStorage for OIDC token persistence. The previous code used InMemoryWebStorage (a plain JS Map) in all non-localhost environments, which is destroyed on every page reload, forcing users to re-authenticate via DEX.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `window.sessionStorage` for OIDC token storage in the dashboard so sessions persist across page reloads in all environments. Remove the `InMemoryWebStorage` fallback and localhost check to prevent forced re-authentication via DEX.

<sup>Written for commit 0b94c7dca36da34792a5f24bc7cbba93e163d494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

