### PR TITLE
feat(api): auto-assign OTEL endpoint from env var to new orgs

### DIFF
--- a/apps/api/src/config/configuration.ts
+++ b/apps/api/src/config/configuration.ts
@@ -297,6 +297,7 @@ const configuration = {
     snapshotQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_SNAPSHOT_QUOTA || '30', 10),
     maxSnapshotSize: parseInt(process.env.DEFAULT_ORG_QUOTA_MAX_SNAPSHOT_SIZE || '20', 10),
     volumeQuota: parseInt(process.env.DEFAULT_ORG_QUOTA_VOLUME_QUOTA || '100', 10),
+    otelEndpoint: process.env.DEFAULT_ORG_QUOTA_OTEL_ENDPOINT,
   },
   defaultRegion: {
     id: process.env.DEFAULT_REGION_ID || 'us',

--- a/apps/api/src/organization/dto/create-organization-quota.dto.ts
+++ b/apps/api/src/organization/dto/create-organization-quota.dto.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
-import { IsNumber, IsOptional } from 'class-validator'
+import { IsNumber, IsOptional, IsString } from 'class-validator'
 
 @ApiSchema({ name: 'CreateOrganizationQuota' })
 export class CreateOrganizationQuotaDto {
@@ -52,4 +52,9 @@ export class CreateOrganizationQuotaDto {
   @IsNumber()
   @IsOptional()
   volumeQuota?: number
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  otelEndpoint?: string
 }

--- a/apps/api/src/organization/services/organization.service.ts
+++ b/apps/api/src/organization/services/organization.service.ts
@@ -642,6 +642,10 @@ export class OrganizationService implements OnModuleInit, TrackableJobExecutions
 
     organization.sandboxLimitedNetworkEgress = sandboxLimitedNetworkEgress
 
+    if (this.defaultOrganizationQuota.otelEndpoint) {
+      organization.otelConfig = { endpoint: this.defaultOrganizationQuota.otelEndpoint, headers: {} }
+    }
+
     const owner = new OrganizationUser()
     owner.userId = createdBy
     owner.role = OrganizationMemberRole.OWNER


### PR DESCRIPTION
When DEFAULT_ORG_QUOTA_OTEL_ENDPOINT is set, every newly created organization (personal or collaborative) automatically gets its otelConfig populated with that endpoint. This removes the need for per-org manual OTEL configuration via dashboard or API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically assigns an OTEL endpoint to every new organization when `DEFAULT_ORG_QUOTA_OTEL_ENDPOINT` is set, removing per-org manual setup. Adds an optional `otelEndpoint` field to the organization quota DTO.

- **Migration**
  - Set `DEFAULT_ORG_QUOTA_OTEL_ENDPOINT` to your collector URL to enable this for new orgs; existing orgs are unaffected.

<sup>Written for commit 0b5353ba2970e1e40a0eedff966c981228801b11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

