### PR TITLE
refactor(api): normalize runner-reported GPU type into canonical value

### DIFF
--- a/apps/api/src/sandbox/enums/gpu-type.enum.ts
+++ b/apps/api/src/sandbox/enums/gpu-type.enum.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export enum GpuType {
+  H100 = 'H100',
+  RTX_PRO_6000 = 'RTX-PRO-6000',
+}

--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -46,6 +46,7 @@ import { InjectRedis } from '@nestjs-modules/ioredis'
 import Redis from 'ioredis'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { runnerLookupCacheKeyById, RUNNER_LOOKUP_CACHE_TTL_MS } from '../utils/runner-lookup-cache.util'
+import { normalizeGpuType } from '../utils/gpu-type-normalizer.util'
 import { SandboxRepository } from '../repositories/sandbox.repository'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
 import { RunnerServiceInfo } from '../common/runner-service-info'
@@ -475,7 +476,11 @@ export class RunnerService {
         updateData.gpu = metrics.gpu
       }
       if (metrics.gpuType !== undefined) {
-        updateData.gpuType = metrics.gpuType
+        const normalized = normalizeGpuType(metrics.gpuType)
+        if (metrics.gpuType && !normalized) {
+          this.logger.warn(`Runner ${runnerId} reported unrecognized GPU type: "${metrics.gpuType}"`)
+        }
+        updateData.gpuType = normalized
       }
 
       updateData.availabilityScore = this.calculateAvailabilityScore(runnerId, {

--- a/apps/api/src/sandbox/utils/gpu-type-normalizer.util.spec.ts
+++ b/apps/api/src/sandbox/utils/gpu-type-normalizer.util.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { GpuType } from '../enums/gpu-type.enum'
+import { normalizeGpuType } from './gpu-type-normalizer.util'
+
+describe('normalizeGpuType', () => {
+  describe('H100 variants', () => {
+    it.each([
+      ['NVIDIA H100 80GB HBM3'],
+      ['NVIDIA H100 PCIe'],
+      ['NVIDIA H100'],
+      ['H100'],
+      ['nvidia h100 nvl'],
+      ['Tesla H100-SXM5-80GB'],
+    ])('canonicalizes %p to GpuType.H100', (raw) => {
+      expect(normalizeGpuType(raw)).toBe(GpuType.H100)
+    })
+  })
+
+  describe('RTX PRO 6000 variants', () => {
+    it.each([
+      ['NVIDIA RTX PRO 6000 Blackwell Workstation Edition'],
+      ['NVIDIA RTX PRO 6000'],
+      ['RTX PRO 6000'],
+      ['rtx pro 6000'],
+      ['RTX  PRO  6000'],
+      ['RTXPRO6000'],
+    ])('canonicalizes %p to GpuType.RTX_PRO_6000', (raw) => {
+      expect(normalizeGpuType(raw)).toBe(GpuType.RTX_PRO_6000)
+    })
+  })
+
+  describe('unsupported GPU strings', () => {
+    it.each([
+      ['NVIDIA L4'],
+      ['NVIDIA A100'],
+      ['NVIDIA GeForce RTX 4090'],
+      ['Tesla T4'],
+      ['some random string'],
+      ['RTX 6000'],
+      ['RTX PRO 5000'],
+    ])('returns null for unsupported GPU %p', (raw) => {
+      expect(normalizeGpuType(raw)).toBeNull()
+    })
+  })
+
+  describe('empty/nullish inputs', () => {
+    it('returns null for null', () => {
+      expect(normalizeGpuType(null)).toBeNull()
+    })
+
+    it('returns null for undefined', () => {
+      expect(normalizeGpuType(undefined)).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+      expect(normalizeGpuType('')).toBeNull()
+    })
+  })
+
+  describe('first-match precedence (H100 declared before RTX_PRO_6000)', () => {
+    it('returns H100 when both markers are present', () => {
+      expect(normalizeGpuType('H100 RTX PRO 6000')).toBe(GpuType.H100)
+    })
+  })
+})

--- a/apps/api/src/sandbox/utils/gpu-type-normalizer.util.ts
+++ b/apps/api/src/sandbox/utils/gpu-type-normalizer.util.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { GpuType } from '../enums/gpu-type.enum'
+
+const GPU_TYPE_PATTERNS: ReadonlyArray<readonly [RegExp, GpuType]> = [
+  [/h100/i, GpuType.H100],
+  [/rtx\s*pro\s*6000/i, GpuType.RTX_PRO_6000],
+]
+
+export function normalizeGpuType(raw: string | null | undefined): GpuType | null {
+  if (!raw) return null
+  for (const [pattern, type] of GPU_TYPE_PATTERNS) {
+    if (pattern.test(raw)) return type
+  }
+  return null
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize runner-reported GPU type strings into canonical enum values to keep metrics consistent. Currently supports H100 and RTX PRO 6000; unknown values are logged and stored as null.

- **Refactors**
  - Add `GpuType` enum and `normalizeGpuType` utility with regex matching.
  - Use normalization in `RunnerService`; warn on unrecognized types.
  - Add unit tests for variants, unsupported inputs, and precedence.

<sup>Written for commit 89c170c7cf413ffda5f9ead8b72daac64c3c8640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

