### PR TITLE
fix(proxy): preserve upstream X-Forwarded-Host instead of appending

### DIFF
--- a/apps/proxy/pkg/proxy/extra_headers.go
+++ b/apps/proxy/pkg/proxy/extra_headers.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import "fmt"
+
+// BuildExtraHeaders constructs the extra header map for proxy target builders.
+// X-Forwarded-Host is only set when the incoming request does not already carry
+// one, preserving the upstream value per standard reverse-proxy convention.
+func BuildExtraHeaders(apiKey, incomingXForwardedHost, requestHost string) map[string]string {
+	extraHeaders := map[string]string{
+		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", apiKey),
+	}
+	if incomingXForwardedHost == "" {
+		extraHeaders["X-Forwarded-Host"] = requestHost
+	}
+	return extraHeaders
+}

--- a/apps/proxy/pkg/proxy/extra_headers_test.go
+++ b/apps/proxy/pkg/proxy/extra_headers_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package proxy
+
+import "testing"
+
+func TestBuildExtraHeaders(t *testing.T) {
+	cases := []struct {
+		name                   string
+		apiKey                 string
+		incomingXForwardedHost string
+		requestHost            string
+		wantXForwardedHost     string
+		wantXForwardedHostSet  bool
+	}{
+		{
+			name:                   "no incoming X-Forwarded-Host: set from request host",
+			apiKey:                 "tok-123",
+			incomingXForwardedHost: "",
+			requestHost:            "3000-sandbox.proxy.daytona.work",
+			wantXForwardedHost:     "3000-sandbox.proxy.daytona.work",
+			wantXForwardedHostSet:  true,
+		},
+		{
+			name:                   "existing X-Forwarded-Host: not overwritten (upstream preserved)",
+			apiKey:                 "tok-456",
+			incomingXForwardedHost: "customer.example.com",
+			requestHost:            "3000-sandbox.proxy.daytona.work",
+			wantXForwardedHostSet:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildExtraHeaders(tc.apiKey, tc.incomingXForwardedHost, tc.requestHost)
+
+			if got["X-Daytona-Authorization"] != "Bearer "+tc.apiKey {
+				t.Errorf("X-Daytona-Authorization = %q, want %q", got["X-Daytona-Authorization"], "Bearer "+tc.apiKey)
+			}
+
+			val, ok := got["X-Forwarded-Host"]
+			if tc.wantXForwardedHostSet {
+				if !ok || val != tc.wantXForwardedHost {
+					t.Errorf("X-Forwarded-Host = (%q, present=%v), want (%q, present=true)", val, ok, tc.wantXForwardedHost)
+				}
+			} else {
+				if ok {
+					t.Errorf("X-Forwarded-Host should not be set when upstream already carries one, got %q", val)
+				}
+			}
+		})
+	}
+}

--- a/apps/proxy/pkg/proxy/get_sandbox_build_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_build_target.go
@@ -56,10 +56,7 @@ func (p *Proxy) getSandboxBuildTarget(ctx *gin.Context) (*url.URL, map[string]st
 	}
 	target.RawQuery = queryParams.Encode()
 
-	return target, map[string]string{
-		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
-		"X-Forwarded-Host":        ctx.Request.Host,
-	}, nil
+	return target, BuildExtraHeaders(runnerInfo.ApiKey, ctx.Request.Header.Get("X-Forwarded-Host"), ctx.Request.Host), nil
 }
 
 func (p *Proxy) getSandbox(ctx *gin.Context, sandboxId string) (*apiclient.Sandbox, error) {

--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -115,10 +115,7 @@ func (p *Proxy) GetProxyTarget(ctx *gin.Context) (*url.URL, map[string]string, e
 		return nil, nil, fmt.Errorf("failed to parse target URL: %w", err)
 	}
 
-	return target, map[string]string{
-		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
-		"X-Forwarded-Host":        ctx.Request.Host,
-	}, nil
+	return target, BuildExtraHeaders(runnerInfo.ApiKey, ctx.Request.Header.Get("X-Forwarded-Host"), ctx.Request.Host), nil
 }
 
 func (p *Proxy) getSandboxRunnerInfo(ctx context.Context, sandboxId string) (*RunnerInfo, error) {

--- a/apps/proxy/pkg/proxy/get_snapshot_target.go
+++ b/apps/proxy/pkg/proxy/get_snapshot_target.go
@@ -65,10 +65,7 @@ func (p *Proxy) getSnapshotTarget(ctx *gin.Context) (*url.URL, map[string]string
 	}
 	target.RawQuery = queryParams.Encode()
 
-	return target, map[string]string{
-		"X-Daytona-Authorization": fmt.Sprintf("Bearer %s", runnerInfo.ApiKey),
-		"X-Forwarded-Host":        ctx.Request.Host,
-	}, nil
+	return target, BuildExtraHeaders(runnerInfo.ApiKey, ctx.Request.Header.Get("X-Forwarded-Host"), ctx.Request.Host), nil
 }
 
 func (p *Proxy) getSnapshot(ctx *gin.Context, snapshotId string) (*apiclient.SnapshotDto, error) {

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -61,7 +61,7 @@ func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.UR
 					req.URL.RawQuery = target.RawQuery + "&" + req.URL.RawQuery
 				}
 				for key, value := range extraHeaders {
-					req.Header.Add(key, value)
+					req.Header.Set(key, value)
 				}
 			},
 			Transport:      proxyTransport,

--- a/libs/common-go/pkg/proxy/proxy_test.go
+++ b/libs/common-go/pkg/proxy/proxy_test.go
@@ -168,3 +168,115 @@ func TestNewProxyRequestHandler_PreservesPathEncoding(t *testing.T) {
 		})
 	}
 }
+
+// TestNewProxyRequestHandler_ExtraHeadersUseSetSemantics verifies that
+// extra headers passed via getProxyTarget replace (not append to) any
+// same-named header already present on the incoming request.
+//
+// Regression for: https://github.com/daytonaio/daytona/issues/4846
+// Before fix: req.Header.Add caused "upstream-value, proxy-value" on the wire.
+// After fix:  req.Header.Set causes only "proxy-value" to reach the backend.
+//
+// Note: this test validates Option A (Add→Set semantics in the shared proxy
+// helper). Option B (conditional X-Forwarded-Host injection in the target
+// builders) is validated by inspection — those callers omit the header from
+// extraHeaders when the incoming request already carries one, so the upstream
+// value passes through to the backend without any modification.
+func TestNewProxyRequestHandler_ExtraHeadersUseSetSemantics(t *testing.T) {
+	cases := []struct {
+		name            string
+		incomingHeaders map[string]string // headers on the incoming request
+		extraHeaders    map[string]string // headers returned by getProxyTarget
+		wantHeaders     map[string]string // exact single value expected at backend
+	}{
+		{
+			name: "upstream X-Forwarded-Host is replaced by proxy value",
+			incomingHeaders: map[string]string{
+				"X-Forwarded-Host": "customer-host.example.com",
+			},
+			extraHeaders: map[string]string{
+				"X-Forwarded-Host": "3000-sandboxid.proxy.daytona.work",
+			},
+			wantHeaders: map[string]string{
+				"X-Forwarded-Host": "3000-sandboxid.proxy.daytona.work",
+			},
+		},
+		{
+			name:            "no upstream X-Forwarded-Host: proxy value forwarded",
+			incomingHeaders: map[string]string{},
+			extraHeaders: map[string]string{
+				"X-Forwarded-Host": "3000-sandboxid.proxy.daytona.work",
+			},
+			wantHeaders: map[string]string{
+				"X-Forwarded-Host": "3000-sandboxid.proxy.daytona.work",
+			},
+		},
+		{
+			name: "X-Daytona-Authorization always set by proxy regardless of incoming",
+			incomingHeaders: map[string]string{
+				"X-Daytona-Authorization": "Bearer old-token",
+			},
+			extraHeaders: map[string]string{
+				"X-Daytona-Authorization": "Bearer new-token",
+			},
+			wantHeaders: map[string]string{
+				"X-Daytona-Authorization": "Bearer new-token",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Backend records the headers it receives.
+			backendHeaders := make(http.Header)
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for k := range tc.wantHeaders {
+					backendHeaders[k] = r.Header[http.CanonicalHeaderKey(k)]
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			backendURL, _ := url.Parse(backend.URL)
+
+			capturedExtra := tc.extraHeaders
+			getTarget := func(ctx *gin.Context) (*url.URL, map[string]string, error) {
+				target := &url.URL{
+					Scheme: backendURL.Scheme,
+					Host:   backendURL.Host,
+					Path:   "/",
+				}
+				return target, capturedExtra, nil
+			}
+
+			router := gin.New()
+			router.GET("/*path", proxy.NewProxyRequestHandler(getTarget, nil))
+
+			proxyServer := httptest.NewServer(router)
+			defer proxyServer.Close()
+
+			req, _ := http.NewRequest(http.MethodGet, proxyServer.URL+"/", nil)
+			for k, v := range tc.incomingHeaders {
+				req.Header.Set(k, v)
+			}
+
+			client := &http.Client{}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("proxy request failed: %v", err)
+			}
+			resp.Body.Close()
+
+			for header, wantValue := range tc.wantHeaders {
+				got := backendHeaders[http.CanonicalHeaderKey(header)]
+				if len(got) != 1 {
+					t.Errorf("header %q: got %d values %v, want exactly 1", header, len(got), got)
+					continue
+				}
+				if got[0] != wantValue {
+					t.Errorf("header %q: got %q, want %q", header, got[0], wantValue)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Switch `Header.Add` → `Header.Set` in the shared `NewProxyRequestHandler` so extra headers always replace rather than append to same-named headers already on the request (defense-in-depth for `X-Daytona-Authorization` and any future headers).
- In the three preview target builders (`get_sandbox_target`, `get_snapshot_target`, `get_sandbox_build_target`) only inject `X-Forwarded-Host` when the incoming request does not already carry one — preserving the upstream value per standard reverse-proxy convention.
- Adds a regression test with three table cases: replacement of an upstream `X-Forwarded-Host`, fresh injection when absent, and replacement of `X-Daytona-Authorization`.

Closes #4846

## Root cause

`NewProxyRequestHandler` was calling `req.Header.Add(key, value)` for every entry in `extraHeaders`. Go's `Add` appends to the existing slice; when serialised to the wire multiple values become a comma-joined list. A request from a Custom Preview Proxy Cloudflare Worker carrying `X-Forwarded-Host: customer-host.example.com` would arrive at the container as:

```
X-Forwarded-Host: customer-host.example.com, 3000-<sandboxId>.proxy.daytona.work
```

Frameworks that read the last hop (Symfony, some PHP routers, `next.config.js` `trustHostHeader`, etc.) then see the internal hostname, causing infinite redirect loops and broken absolute URLs.

## Test plan

- [x] `go test ./libs/common-go/pkg/proxy/... -run TestNewProxyRequestHandler` — all cases pass including the new `ExtraHeadersUseSetSemantics` test
- [x] Existing `TestNewProxyRequestHandler_PreservesPathEncoding` still passes (no regression)
- [x] Manual reproduction: `curl -H "X-Forwarded-Host: my-public-host.example.com" https://3000-<sandboxId>.proxy.daytona.work/` — container now receives only `my-public-host.example.com`