### PR TITLE
fix(ssh-gateway,runner): close upstream channel on client disconnect to stop stale keepalive

### DIFF
--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -136,14 +136,23 @@ func (s *Service) handleConnection(conn net.Conn, serverConfig *ssh.ServerConfig
 		}
 	}()
 
+	// connClosed signals per-channel watchers when the client connection dies.
+	// A single Wait() goroutine per connection lets every channel select on it
+	// instead of each blocking its own Wait() call.
+	connClosed := make(chan struct{})
+	go func() {
+		serverConn.Wait() // nolint:errcheck
+		close(connClosed)
+	}()
+
 	// Handle channels
 	for newChannel := range chans {
-		go s.handleChannel(newChannel, serverConn, sandboxId)
+		go s.handleChannel(newChannel, connClosed, sandboxId)
 	}
 }
 
 // handleChannel handles an individual SSH channel
-func (s *Service) handleChannel(newChannel ssh.NewChannel, clientConn *ssh.ServerConn, sandboxId string) {
+func (s *Service) handleChannel(newChannel ssh.NewChannel, connClosed <-chan struct{}, sandboxId string) {
 	s.log.Debug("New channel", "channelType", newChannel.ChannelType(), "sandboxID", sandboxId)
 
 	// Accept the channel from the client
@@ -230,10 +239,17 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, clientConn *ssh.Serve
 	// MSG_CHANNEL_EOF. Watch the client connection itself instead: when it dies,
 	// hard-close the sandbox channel — MSG_CHANNEL_CLOSE forces a reply, which unblocks
 	// io.Copy(clientChannel, sandboxChannel) below and lets the sandbox shell receive
-	// a hangup signal so orphaned processes exit cleanly.
+	// a hangup signal so orphaned processes exit cleanly. The watcher exits with the
+	// session (sessionDone) so goroutines don't accumulate on long-lived connections
+	// that open many channels.
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		clientConn.Wait()      // nolint:errcheck
-		sandboxChannel.Close() // nolint:errcheck
+		select {
+		case <-connClosed:
+			sandboxChannel.Close() // nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 
 	_, err = io.Copy(clientChannel, sandboxChannel)

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -138,12 +138,12 @@ func (s *Service) handleConnection(conn net.Conn, serverConfig *ssh.ServerConfig
 
 	// Handle channels
 	for newChannel := range chans {
-		go s.handleChannel(newChannel, sandboxId)
+		go s.handleChannel(newChannel, serverConn, sandboxId)
 	}
 }
 
 // handleChannel handles an individual SSH channel
-func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
+func (s *Service) handleChannel(newChannel ssh.NewChannel, clientConn *ssh.ServerConn, sandboxId string) {
 	s.log.Debug("New channel", "channelType", newChannel.ChannelType(), "sandboxID", sandboxId)
 
 	// Accept the channel from the client
@@ -212,21 +212,27 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 		}
 	}()
 
-	// Bidirectional data forwarding
+	// Bidirectional data forwarding.
+	// On client EOF, half-close the sandbox channel (MSG_CHANNEL_EOF via CloseWrite)
+	// so the command in the sandbox can keep writing output and deliver its
+	// exit-status (RFC 4254 half-close, e.g. `cat file | ssh host cmd`).
 	go func() {
 		_, err := io.Copy(sandboxChannel, clientChannel)
 		if err != nil {
 			s.log.Debug("Client to sandbox copy error", "error", err)
 		}
-		// Always send MSG_CHANNEL_CLOSE (not just MSG_CHANNEL_EOF via CloseWrite).
-		// The SSH library surfaces transport errors as io.EOF on channel reads, so
-		// io.Copy returns nil even after an abrupt SIGKILL/network-drop — meaning
-		// CloseWrite would be taken in all cases.  More importantly, MSG_CHANNEL_EOF
-		// is silently ignored by long-lived processes such as VS Code Remote Server
-		// and JetBrains Gateway, leaving io.Copy(clientChannel, sandboxChannel)
-		// blocked and orphaned sandbox processes alive indefinitely.
-		// MSG_CHANNEL_CLOSE forces a reply, which unblocks the read and lets the
-		// sandbox shell receive a hangup signal so it can exit cleanly.
+		sandboxChannel.CloseWrite() // nolint:errcheck
+	}()
+
+	// The SSH library surfaces client transport failures as io.EOF on channel reads,
+	// so the copy above cannot tell a clean stdin EOF from a SIGKILL/network drop, and
+	// long-lived processes (VS Code Remote Server, JetBrains Gateway) silently ignore
+	// MSG_CHANNEL_EOF. Watch the client connection itself instead: when it dies,
+	// hard-close the sandbox channel — MSG_CHANNEL_CLOSE forces a reply, which unblocks
+	// io.Copy(clientChannel, sandboxChannel) below and lets the sandbox shell receive
+	// a hangup signal so orphaned processes exit cleanly.
+	go func() {
+		clientConn.Wait()      // nolint:errcheck
 		sandboxChannel.Close() // nolint:errcheck
 	}()
 

--- a/apps/runner/pkg/sshgateway/service.go
+++ b/apps/runner/pkg/sshgateway/service.go
@@ -155,12 +155,13 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 	defer clientChannel.Close()
 
 	// Connect to the sandbox container via toolbox
-	sandboxChannel, sandboxRequests, err := s.connectToSandbox(sandboxId, newChannel.ChannelType(), newChannel.ExtraData())
+	sandboxChannel, sandboxRequests, sandboxClient, err := s.connectToSandbox(sandboxId, newChannel.ChannelType(), newChannel.ExtraData())
 	if err != nil {
 		s.log.Warn("Could not connect to sandbox", "sandboxID", sandboxId, "error", err)
 		clientChannel.Close()
 		return
 	}
+	defer sandboxClient.Close()
 	defer sandboxChannel.Close()
 
 	// Forward requests from client to sandbox
@@ -217,6 +218,16 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 		if err != nil {
 			s.log.Debug("Client to sandbox copy error", "error", err)
 		}
+		// Always send MSG_CHANNEL_CLOSE (not just MSG_CHANNEL_EOF via CloseWrite).
+		// The SSH library surfaces transport errors as io.EOF on channel reads, so
+		// io.Copy returns nil even after an abrupt SIGKILL/network-drop — meaning
+		// CloseWrite would be taken in all cases.  More importantly, MSG_CHANNEL_EOF
+		// is silently ignored by long-lived processes such as VS Code Remote Server
+		// and JetBrains Gateway, leaving io.Copy(clientChannel, sandboxChannel)
+		// blocked and orphaned sandbox processes alive indefinitely.
+		// MSG_CHANNEL_CLOSE forces a reply, which unblocks the read and lets the
+		// sandbox shell receive a hangup signal so it can exit cleanly.
+		sandboxChannel.Close() // nolint:errcheck
 	}()
 
 	_, err = io.Copy(clientChannel, sandboxChannel)
@@ -228,11 +239,11 @@ func (s *Service) handleChannel(newChannel ssh.NewChannel, sandboxId string) {
 }
 
 // connectToSandbox connects to the sandbox container via the toolbox
-func (s *Service) connectToSandbox(sandboxId, channelType string, extraData []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+func (s *Service) connectToSandbox(sandboxId, channelType string, extraData []byte) (ssh.Channel, <-chan *ssh.Request, *ssh.Client, error) {
 	// Get sandbox details via toolbox API
 	sandboxDetails, err := s.getSandboxDetails(sandboxId)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get sandbox details: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get sandbox details: %w", err)
 	}
 
 	// Create SSH client config to connect to the sandbox
@@ -246,18 +257,18 @@ func (s *Service) connectToSandbox(sandboxId, channelType string, extraData []by
 	// Connect to the sandbox container via toolbox
 	sandboxClient, err := ssh.Dial("tcp", fmt.Sprintf("%s:22220", sandboxDetails.Hostname), clientConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to connect to sandbox: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to connect to sandbox: %w", err)
 	}
 
 	// Open channel to the sandbox
 	sandboxChannel, sandboxRequests, err := sandboxClient.OpenChannel(channelType, extraData)
 	if err != nil {
 		sandboxClient.Close()
-		return nil, nil, fmt.Errorf("failed to open channel to sandbox: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to open channel to sandbox: %w", err)
 	}
 
-	// Return the real sandbox channel and requests
-	return sandboxChannel, sandboxRequests, nil
+	// Return the real sandbox channel, requests, and client (caller must close client)
+	return sandboxChannel, sandboxRequests, sandboxClient, nil
 }
 
 // getSandboxDetails gets sandbox information via docker client

--- a/apps/runner/pkg/sshgateway/service_test.go
+++ b/apps/runner/pkg/sshgateway/service_test.go
@@ -1,0 +1,253 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build linux
+
+package sshgateway
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// testSigner generates a throwaway RSA signer for in-memory SSH tests.
+func testSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("make signer: %v", err)
+	}
+	return signer
+}
+
+// channelPair holds both ends of an in-memory SSH channel.
+type channelPair struct {
+	// server is the channel as seen by the SSH server (Accept()-returned).
+	server ssh.Channel
+	// client is the channel as seen by the SSH client (OpenChannel()-returned).
+	client ssh.Channel
+	// closeConns tears down both sides of the underlying TCP connection.
+	closeConns func()
+	// closeClient closes only the client-side TCP connection, simulating an
+	// abrupt SSH client disconnect (SIGKILL / network drop). This causes any
+	// in-progress Read on server to return a non-nil error.
+	closeClient func()
+}
+
+// newChannelPair creates an SSH connection backed by a loopback TCP socket and
+// returns a connected channel pair. A loopback socket is used instead of
+// net.Pipe() because net.Pipe() is synchronous with no kernel buffer: when both
+// sides of an SSH handshake write their version string simultaneously, both block
+// indefinitely. TCP's OS send buffer absorbs the small version string so neither
+// side stalls.
+func newChannelPair(t *testing.T) *channelPair {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		ln.Close() //nolint:errcheck — only one connection needed
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	var srvConn net.Conn
+	select {
+	case srvConn = <-accepted:
+	case <-time.After(5 * time.Second):
+		cliConn.Close() //nolint:errcheck
+		t.Fatal("accept timeout")
+	}
+
+	serverCfg := &ssh.ServerConfig{NoClientAuth: true}
+	serverCfg.AddHostKey(testSigner(t))
+
+	serverChanCh := make(chan ssh.Channel, 1)
+	go func() {
+		_, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		newCh, ok := <-chans
+		if !ok {
+			return
+		}
+		ch, reqs, err := newCh.Accept()
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		serverChanCh <- ch
+		for range chans {
+		} // drain remaining channels
+	}()
+
+	clientCfg := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	cc, cliChans, cliReqs, err := ssh.NewClientConn(cliConn, "", clientCfg)
+	if err != nil {
+		t.Fatalf("ssh client connect: %v", err)
+	}
+	go ssh.DiscardRequests(cliReqs)
+	go func() {
+		for range cliChans {
+		}
+	}()
+
+	clientCh, chReqs, err := cc.OpenChannel("session", nil)
+	if err != nil {
+		t.Fatalf("open channel: %v", err)
+	}
+	go ssh.DiscardRequests(chReqs)
+
+	var serverCh ssh.Channel
+	select {
+	case serverCh = <-serverChanCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for server to accept channel")
+	}
+
+	return &channelPair{
+		server: serverCh,
+		client: clientCh,
+		closeConns: func() {
+			cliConn.Close() //nolint:errcheck
+			srvConn.Close() //nolint:errcheck
+		},
+		closeClient: func() {
+			cliConn.Close() //nolint:errcheck
+		},
+	}
+}
+
+// TestClientDisconnectClosesSandboxChannel is the regression test for the stale SSH
+// keepalive bug (https://github.com/daytonaio/daytona/issues/4805) at the runner layer.
+//
+// When the SSH gateway closes its channel to the runner (because the external client
+// disconnected), the runner must close the downstream sandbox channel. Without this,
+// the sandbox-to-client io.Copy blocks forever, the sandbox shell (and any VS Code /
+// JetBrains remote server processes) stays alive, and the gateway's keepalive ticker
+// keeps refreshing lastActivityAt every 45 s.
+//
+// The fix always calls sandboxChannel.Close() (MSG_CHANNEL_CLOSE), which forces the sandbox
+// to send its own MSG_CHANNEL_CLOSE in reply, unblocking the reverse io.Copy.
+func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
+	t.Parallel()
+
+	// clientPair simulates the runner receiving a channel from the gateway.
+	// clientPair.server == clientChannel in Service.handleChannel (runner's server-side view).
+	// clientPair.closeClient() simulates the gateway dropping (external client died):
+	// closes the TCP connection so io.Copy returns a non-nil error, triggering Close().
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	// sandboxPair simulates the runner opening a channel into the sandbox container.
+	// sandboxPair.client == sandboxChannel in Service.handleChannel.
+	// sandboxPair.server == the sandbox container's sshd end.
+	sandboxPair := newChannelPair(t)
+	defer sandboxPair.closeConns()
+
+	clientChannel := clientPair.server   // runner accepted this from the gateway
+	sandboxChannel := sandboxPair.client // runner opened this to the sandbox container
+
+	// done is closed when the main blocking io.Copy (sandbox→client) returns.
+	done := make(chan struct{})
+
+	// Mirror the goroutine from apps/runner/pkg/sshgateway/service.go rather than calling
+	// Service.handleChannel directly: handleChannel requires a running toolbox API and live
+	// SSH connections. The mechanism being tested (Close unblocks the reverse io.Copy) is
+	// fully captured here without those dependencies.
+	go func() {
+		_, _ = io.Copy(sandboxChannel, clientChannel)
+		sandboxChannel.Close() //nolint:errcheck
+	}()
+
+	// Main blocking copy: sandbox→client.
+	// This previously blocked forever when the gateway closed its channel.
+	go func() {
+		_, _ = io.Copy(clientChannel, sandboxChannel)
+		close(done)
+	}()
+
+	// Simulate gateway dropping (external SSH client disconnected).
+	clientPair.closeClient()
+
+	select {
+	case <-done:
+		// Both copies returned. The orphaned sandbox shell will receive HUP/EOF and exit.
+	case <-time.After(2 * time.Second):
+		t.Fatal("sandbox-side channel copy did not unblock after client disconnect; " +
+			"orphaned sandbox processes (bash, VS Code remote, JetBrains) would persist indefinitely")
+	}
+}
+
+// TestSandboxChannelReceivesCloseOnClientDisconnect verifies that the sandbox container's
+// channel receives a close signal after the external client disconnects. This is what
+// causes orphaned shell processes inside the sandbox to receive a hangup and exit.
+func TestSandboxChannelReceivesCloseOnClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	sandboxPair := newChannelPair(t)
+	defer sandboxPair.closeConns()
+
+	clientChannel := clientPair.server
+	sandboxChannel := sandboxPair.client
+
+	go func() {
+		_, _ = io.Copy(sandboxChannel, clientChannel)
+		sandboxChannel.Close() //nolint:errcheck
+	}()
+	go func() {
+		_, _ = io.Copy(clientChannel, sandboxChannel)
+	}()
+
+	// Simulate abrupt SSH client disconnect (SIGKILL / network drop).
+	clientPair.closeClient()
+
+	// The sandbox container's sshd side (sandboxPair.server) should receive EOF/close,
+	// which causes the sandbox shell process to receive a hangup and exit.
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := sandboxPair.server.Read(buf)
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("expected EOF/close on sandbox-side channel after client disconnect, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sandbox channel was not closed after client disconnect; " +
+			"orphaned shell processes would not receive hangup signal")
+	}
+}

--- a/apps/runner/pkg/sshgateway/service_test.go
+++ b/apps/runner/pkg/sshgateway/service_test.go
@@ -36,11 +36,15 @@ type channelPair struct {
 	server ssh.Channel
 	// client is the channel as seen by the SSH client (OpenChannel()-returned).
 	client ssh.Channel
+	// serverConn is the server's view of the SSH connection. Its Wait() returns
+	// when the client connection dies — the signal the production watcher
+	// goroutine uses to hard-close the upstream channel.
+	serverConn *ssh.ServerConn
 	// closeConns tears down both sides of the underlying TCP connection.
 	closeConns func()
 	// closeClient closes only the client-side TCP connection, simulating an
-	// abrupt SSH client disconnect (SIGKILL / network drop). This causes any
-	// in-progress Read on server to return a non-nil error.
+	// abrupt SSH client disconnect (SIGKILL / network drop). This makes
+	// serverConn.Wait() return.
 	closeClient func()
 }
 
@@ -84,11 +88,13 @@ func newChannelPair(t *testing.T) *channelPair {
 	serverCfg.AddHostKey(testSigner(t))
 
 	serverChanCh := make(chan ssh.Channel, 1)
+	serverConnCh := make(chan *ssh.ServerConn, 1)
 	go func() {
-		_, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
+		sconn, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
 		if err != nil {
 			return
 		}
+		serverConnCh <- sconn
 		go ssh.DiscardRequests(reqs)
 		newCh, ok := <-chans
 		if !ok {
@@ -133,8 +139,9 @@ func newChannelPair(t *testing.T) *channelPair {
 	}
 
 	return &channelPair{
-		server: serverCh,
-		client: clientCh,
+		server:     serverCh,
+		client:     clientCh,
+		serverConn: <-serverConnCh,
 		closeConns: func() {
 			cliConn.Close() //nolint:errcheck
 			srvConn.Close() //nolint:errcheck
@@ -154,15 +161,18 @@ func newChannelPair(t *testing.T) *channelPair {
 // JetBrains remote server processes) stays alive, and the gateway's keepalive ticker
 // keeps refreshing lastActivityAt every 45 s.
 //
-// The fix always calls sandboxChannel.Close() (MSG_CHANNEL_CLOSE), which forces the sandbox
-// to send its own MSG_CHANNEL_CLOSE in reply, unblocking the reverse io.Copy.
+// The fix watches the client connection itself: when it dies, sandboxChannel.Close()
+// (MSG_CHANNEL_CLOSE) forces the sandbox to send its own MSG_CHANNEL_CLOSE in reply,
+// unblocking the reverse io.Copy. A clean stdin EOF only half-closes (CloseWrite),
+// preserving remaining output and exit-status.
 func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
 	t.Parallel()
 
 	// clientPair simulates the runner receiving a channel from the gateway.
 	// clientPair.server == clientChannel in Service.handleChannel (runner's server-side view).
 	// clientPair.closeClient() simulates the gateway dropping (external client died):
-	// closes the TCP connection so io.Copy returns a non-nil error, triggering Close().
+	// closes the TCP connection so clientPair.serverConn.Wait() returns, after which
+	// sandboxChannel.Close() is called in the production code.
 	clientPair := newChannelPair(t)
 	defer clientPair.closeConns()
 
@@ -178,12 +188,17 @@ func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
 	// done is closed when the main blocking io.Copy (sandbox→client) returns.
 	done := make(chan struct{})
 
-	// Mirror the goroutine from apps/runner/pkg/sshgateway/service.go rather than calling
+	// Mirror the goroutines from apps/runner/pkg/sshgateway/service.go rather than calling
 	// Service.handleChannel directly: handleChannel requires a running toolbox API and live
-	// SSH connections. The mechanism being tested (Close unblocks the reverse io.Copy) is
-	// fully captured here without those dependencies.
+	// SSH connections. The mechanism being tested (a dead client connection hard-closes the
+	// sandbox channel, unblocking the reverse io.Copy) is fully captured here without those
+	// dependencies.
 	go func() {
 		_, _ = io.Copy(sandboxChannel, clientChannel)
+		sandboxChannel.CloseWrite() //nolint:errcheck
+	}()
+	go func() {
+		_ = clientPair.serverConn.Wait()
 		sandboxChannel.Close() //nolint:errcheck
 	}()
 
@@ -223,6 +238,10 @@ func TestSandboxChannelReceivesCloseOnClientDisconnect(t *testing.T) {
 
 	go func() {
 		_, _ = io.Copy(sandboxChannel, clientChannel)
+		sandboxChannel.CloseWrite() //nolint:errcheck
+	}()
+	go func() {
+		_ = clientPair.serverConn.Wait()
 		sandboxChannel.Close() //nolint:errcheck
 	}()
 	go func() {
@@ -249,5 +268,81 @@ func TestSandboxChannelReceivesCloseOnClientDisconnect(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("sandbox channel was not closed after client disconnect; " +
 			"orphaned shell processes would not receive hangup signal")
+	}
+}
+
+// TestStdinEOFPreservesHalfClose verifies that a clean stdin EOF from the client
+// (e.g. `cat file | ssh host cmd`) only half-closes the sandbox channel: the command
+// in the sandbox can still send output and exit-status afterwards. A hard Close() here
+// would truncate them — the regression flagged in the PR review of the keepalive fix.
+func TestStdinEOFPreservesHalfClose(t *testing.T) {
+	t.Parallel()
+
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	sandboxPair := newChannelPair(t)
+	defer sandboxPair.closeConns()
+
+	clientChannel := clientPair.server
+	sandboxChannel := sandboxPair.client
+
+	// Mirror the production goroutines from Service.handleChannel.
+	go func() {
+		_, _ = io.Copy(sandboxChannel, clientChannel)
+		sandboxChannel.CloseWrite() //nolint:errcheck
+	}()
+	go func() {
+		_ = clientPair.serverConn.Wait()
+		sandboxChannel.Close() //nolint:errcheck
+	}()
+	go func() {
+		_, _ = io.Copy(clientChannel, sandboxChannel)
+	}()
+
+	// Clean stdin EOF: the client half-closes its channel while the SSH
+	// connection stays alive.
+	if err := clientPair.client.CloseWrite(); err != nil {
+		t.Fatalf("client CloseWrite: %v", err)
+	}
+
+	// The sandbox side must observe EOF on its read...
+	eofErr := make(chan error, 1)
+	go func() {
+		_, err := sandboxPair.server.Read(make([]byte, 1))
+		eofErr <- err
+	}()
+	select {
+	case err := <-eofErr:
+		if err != io.EOF {
+			t.Fatalf("expected io.EOF on sandbox side after stdin EOF, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sandbox side did not observe stdin EOF")
+	}
+
+	// ...and must still be able to send output, which the client receives.
+	// With a hard Close() this write fails because the channel is torn down.
+	want := "late output"
+	if _, err := sandboxPair.server.Write([]byte(want)); err != nil {
+		t.Fatalf("sandbox write after stdin EOF failed (half-close broken): %v", err)
+	}
+
+	got := make([]byte, len(want))
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(clientPair.client, got)
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("client read after stdin EOF failed: %v", err)
+		}
+		if string(got) != want {
+			t.Fatalf("client got %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not receive output sent after stdin EOF; half-close broken")
 	}
 }

--- a/apps/runner/pkg/sshgateway/service_test.go
+++ b/apps/runner/pkg/sshgateway/service_test.go
@@ -36,15 +36,14 @@ type channelPair struct {
 	server ssh.Channel
 	// client is the channel as seen by the SSH client (OpenChannel()-returned).
 	client ssh.Channel
-	// serverConn is the server's view of the SSH connection. Its Wait() returns
-	// when the client connection dies — the signal the production watcher
-	// goroutine uses to hard-close the upstream channel.
-	serverConn *ssh.ServerConn
+	// connClosed is closed when the client connection dies — the signal the
+	// production watcher goroutine selects on to hard-close the upstream channel.
+	connClosed chan struct{}
 	// closeConns tears down both sides of the underlying TCP connection.
 	closeConns func()
 	// closeClient closes only the client-side TCP connection, simulating an
-	// abrupt SSH client disconnect (SIGKILL / network drop). This makes
-	// serverConn.Wait() return.
+	// abrupt SSH client disconnect (SIGKILL / network drop). This closes
+	// connClosed.
 	closeClient func()
 }
 
@@ -138,10 +137,19 @@ func newChannelPair(t *testing.T) *channelPair {
 		t.Fatal("timeout waiting for server to accept channel")
 	}
 
+	// Mirror handleConnection: one Wait() goroutine per connection closes
+	// connClosed for all per-channel watchers.
+	connClosed := make(chan struct{})
+	go func() {
+		serverConn := <-serverConnCh
+		_ = serverConn.Wait()
+		close(connClosed)
+	}()
+
 	return &channelPair{
 		server:     serverCh,
 		client:     clientCh,
-		serverConn: <-serverConnCh,
+		connClosed: connClosed,
 		closeConns: func() {
 			cliConn.Close() //nolint:errcheck
 			srvConn.Close() //nolint:errcheck
@@ -171,7 +179,7 @@ func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
 	// clientPair simulates the runner receiving a channel from the gateway.
 	// clientPair.server == clientChannel in Service.handleChannel (runner's server-side view).
 	// clientPair.closeClient() simulates the gateway dropping (external client died):
-	// closes the TCP connection so clientPair.serverConn.Wait() returns, after which
+	// closes the TCP connection so clientPair.connClosed fires, after which
 	// sandboxChannel.Close() is called in the production code.
 	clientPair := newChannelPair(t)
 	defer clientPair.closeConns()
@@ -197,9 +205,14 @@ func TestClientDisconnectClosesSandboxChannel(t *testing.T) {
 		_, _ = io.Copy(sandboxChannel, clientChannel)
 		sandboxChannel.CloseWrite() //nolint:errcheck
 	}()
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		_ = clientPair.serverConn.Wait()
-		sandboxChannel.Close() //nolint:errcheck
+		select {
+		case <-clientPair.connClosed:
+			sandboxChannel.Close() //nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 
 	// Main blocking copy: sandbox→client.
@@ -240,9 +253,14 @@ func TestSandboxChannelReceivesCloseOnClientDisconnect(t *testing.T) {
 		_, _ = io.Copy(sandboxChannel, clientChannel)
 		sandboxChannel.CloseWrite() //nolint:errcheck
 	}()
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		_ = clientPair.serverConn.Wait()
-		sandboxChannel.Close() //nolint:errcheck
+		select {
+		case <-clientPair.connClosed:
+			sandboxChannel.Close() //nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 	go func() {
 		_, _ = io.Copy(clientChannel, sandboxChannel)
@@ -292,9 +310,14 @@ func TestStdinEOFPreservesHalfClose(t *testing.T) {
 		_, _ = io.Copy(sandboxChannel, clientChannel)
 		sandboxChannel.CloseWrite() //nolint:errcheck
 	}()
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		_ = clientPair.serverConn.Wait()
-		sandboxChannel.Close() //nolint:errcheck
+		select {
+		case <-clientPair.connClosed:
+			sandboxChannel.Close() //nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 	go func() {
 		_, _ = io.Copy(clientChannel, sandboxChannel)

--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -331,6 +331,16 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, runnerID string, r
 		if err != nil {
 			log.Printf("Client to runner copy error: %v", err)
 		}
+		// Always send MSG_CHANNEL_CLOSE (not just MSG_CHANNEL_EOF via CloseWrite).
+		// The SSH library surfaces transport errors as io.EOF on channel reads, so
+		// io.Copy returns nil even after an abrupt SIGKILL/network-drop — meaning
+		// CloseWrite would be taken in all cases.  More importantly, MSG_CHANNEL_EOF
+		// is silently ignored by long-lived processes such as VS Code Remote Server
+		// and JetBrains Gateway, leaving io.Copy(clientChannel, runnerChannel)
+		// blocked forever and the keepalive ticker running indefinitely.
+		// MSG_CHANNEL_CLOSE forces a reply from the runner, which unblocks the read
+		// and allows defer cancel() to stop the keepalive ticker.
+		runnerChannel.Close() // nolint:errcheck
 	}()
 
 	keepAliveContext, cancel := context.WithCancel(context.Background())

--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -250,11 +250,11 @@ func (g *SSHGateway) handleConnection(conn net.Conn, serverConfig *ssh.ServerCon
 
 	// Handle channels
 	for newChannel := range chans {
-		go g.handleChannel(newChannel, runnerID, runnerDomain, token, sandboxId)
+		go g.handleChannel(newChannel, serverConn, runnerID, runnerDomain, token, sandboxId)
 	}
 }
 
-func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, runnerID string, runnerDomain string, token string, sandboxId string) {
+func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, clientConn *ssh.ServerConn, runnerID string, runnerDomain string, token string, sandboxId string) {
 	log.Printf("New channel: %s for runner: %s", newChannel.ChannelType(), runnerID)
 
 	// Accept the channel from the client
@@ -325,21 +325,27 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, runnerID string, r
 		}
 	}()
 
-	// Bidirectional data forwarding
+	// Bidirectional data forwarding.
+	// On client EOF, half-close the runner channel (MSG_CHANNEL_EOF via CloseWrite)
+	// so the remote command can keep writing output and deliver its exit-status
+	// (RFC 4254 half-close, e.g. `cat file | ssh host cmd`).
 	go func() {
 		_, err := io.Copy(runnerChannel, clientChannel)
 		if err != nil {
 			log.Printf("Client to runner copy error: %v", err)
 		}
-		// Always send MSG_CHANNEL_CLOSE (not just MSG_CHANNEL_EOF via CloseWrite).
-		// The SSH library surfaces transport errors as io.EOF on channel reads, so
-		// io.Copy returns nil even after an abrupt SIGKILL/network-drop — meaning
-		// CloseWrite would be taken in all cases.  More importantly, MSG_CHANNEL_EOF
-		// is silently ignored by long-lived processes such as VS Code Remote Server
-		// and JetBrains Gateway, leaving io.Copy(clientChannel, runnerChannel)
-		// blocked forever and the keepalive ticker running indefinitely.
-		// MSG_CHANNEL_CLOSE forces a reply from the runner, which unblocks the read
-		// and allows defer cancel() to stop the keepalive ticker.
+		runnerChannel.CloseWrite() // nolint:errcheck
+	}()
+
+	// The SSH library surfaces client transport failures as io.EOF on channel reads,
+	// so the copy above cannot tell a clean stdin EOF from a SIGKILL/network drop, and
+	// long-lived remote processes (VS Code Remote Server, JetBrains Gateway) silently
+	// ignore MSG_CHANNEL_EOF. Watch the client connection itself instead: when it dies,
+	// hard-close the runner channel — MSG_CHANNEL_CLOSE forces a reply from the runner,
+	// which unblocks io.Copy(clientChannel, runnerChannel) below and lets defer cancel()
+	// stop the keepalive ticker.
+	go func() {
+		clientConn.Wait()     // nolint:errcheck
 		runnerChannel.Close() // nolint:errcheck
 	}()
 

--- a/apps/ssh-gateway/main.go
+++ b/apps/ssh-gateway/main.go
@@ -248,13 +248,22 @@ func (g *SSHGateway) handleConnection(conn net.Conn, serverConfig *ssh.ServerCon
 		}
 	}()
 
+	// connClosed signals per-channel watchers when the client connection dies.
+	// A single Wait() goroutine per connection lets every channel select on it
+	// instead of each blocking its own Wait() call.
+	connClosed := make(chan struct{})
+	go func() {
+		serverConn.Wait() // nolint:errcheck
+		close(connClosed)
+	}()
+
 	// Handle channels
 	for newChannel := range chans {
-		go g.handleChannel(newChannel, serverConn, runnerID, runnerDomain, token, sandboxId)
+		go g.handleChannel(newChannel, connClosed, runnerID, runnerDomain, token, sandboxId)
 	}
 }
 
-func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, clientConn *ssh.ServerConn, runnerID string, runnerDomain string, token string, sandboxId string) {
+func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, connClosed <-chan struct{}, runnerID string, runnerDomain string, token string, sandboxId string) {
 	log.Printf("New channel: %s for runner: %s", newChannel.ChannelType(), runnerID)
 
 	// Accept the channel from the client
@@ -343,10 +352,16 @@ func (g *SSHGateway) handleChannel(newChannel ssh.NewChannel, clientConn *ssh.Se
 	// ignore MSG_CHANNEL_EOF. Watch the client connection itself instead: when it dies,
 	// hard-close the runner channel — MSG_CHANNEL_CLOSE forces a reply from the runner,
 	// which unblocks io.Copy(clientChannel, runnerChannel) below and lets defer cancel()
-	// stop the keepalive ticker.
+	// stop the keepalive ticker. The watcher exits with the session (sessionDone) so
+	// goroutines don't accumulate on long-lived connections that open many channels.
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		clientConn.Wait()     // nolint:errcheck
-		runnerChannel.Close() // nolint:errcheck
+		select {
+		case <-connClosed:
+			runnerChannel.Close() // nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 
 	keepAliveContext, cancel := context.WithCancel(context.Background())

--- a/apps/ssh-gateway/teardown_test.go
+++ b/apps/ssh-gateway/teardown_test.go
@@ -34,11 +34,15 @@ type channelPair struct {
 	server ssh.Channel
 	// client is the channel as seen by the SSH client (OpenChannel()-returned).
 	client ssh.Channel
+	// serverConn is the server's view of the SSH connection. Its Wait() returns
+	// when the client connection dies — the signal the production watcher
+	// goroutine uses to hard-close the upstream channel.
+	serverConn *ssh.ServerConn
 	// closeConns tears down both sides of the underlying TCP connection.
 	closeConns func()
 	// closeClient closes only the client-side TCP connection, simulating an
-	// abrupt SSH client disconnect (SIGKILL / network drop). This causes any
-	// in-progress Read on server to return a non-nil error.
+	// abrupt SSH client disconnect (SIGKILL / network drop). This makes
+	// serverConn.Wait() return.
 	closeClient func()
 }
 
@@ -82,11 +86,13 @@ func newChannelPair(t *testing.T) *channelPair {
 	serverCfg.AddHostKey(testSigner(t))
 
 	serverChanCh := make(chan ssh.Channel, 1)
+	serverConnCh := make(chan *ssh.ServerConn, 1)
 	go func() {
-		_, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
+		sconn, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
 		if err != nil {
 			return
 		}
+		serverConnCh <- sconn
 		go ssh.DiscardRequests(reqs)
 		newCh, ok := <-chans
 		if !ok {
@@ -131,8 +137,9 @@ func newChannelPair(t *testing.T) *channelPair {
 	}
 
 	return &channelPair{
-		server: serverCh,
-		client: clientCh,
+		server:     serverCh,
+		client:     clientCh,
+		serverConn: <-serverConnCh,
 		closeConns: func() {
 			cliConn.Close() //nolint:errcheck
 			srvConn.Close() //nolint:errcheck
@@ -151,15 +158,18 @@ func newChannelPair(t *testing.T) *channelPair {
 // keepalive goroutine's context was never cancelled, lastActivityAt kept refreshing every
 // 45 s, and auto-stop never triggered.
 //
-// The fix always calls runnerChannel.Close() (MSG_CHANNEL_CLOSE), which forces the runner
-// to send its own MSG_CHANNEL_CLOSE in reply, unblocking the reverse io.Copy.
+// The fix watches the client connection itself: when it dies, runnerChannel.Close()
+// (MSG_CHANNEL_CLOSE) forces the runner to send its own MSG_CHANNEL_CLOSE in reply,
+// unblocking the reverse io.Copy. A clean stdin EOF only half-closes (CloseWrite),
+// preserving remaining output and exit-status.
 func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 	t.Parallel()
 
 	// clientPair simulates the gateway receiving a channel from the external SSH client.
 	// clientPair.server == clientChannel in handleChannel (gateway's server-side view).
-	// clientPair.closeClient() simulates SIGKILL: drops the TCP connection so io.Copy
-	// returns, after which runnerChannel.Close() is called in the production code.
+	// clientPair.closeClient() simulates SIGKILL: drops the TCP connection so
+	// clientPair.serverConn.Wait() returns, after which runnerChannel.Close() is called
+	// in the production code.
 	clientPair := newChannelPair(t)
 	defer clientPair.closeConns()
 
@@ -175,12 +185,17 @@ func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 	// proving that the keepalive context would be cancelled via defer cancel().
 	done := make(chan struct{})
 
-	// Mirror the goroutine from apps/ssh-gateway/main.go rather than calling handleChannel
+	// Mirror the goroutines from apps/ssh-gateway/main.go rather than calling handleChannel
 	// directly: handleChannel requires a live SSH server listener and API client, making it
-	// unsuitable for a unit test. The mechanism being tested (Close unblocks the reverse
-	// io.Copy) is fully captured here without those dependencies.
+	// unsuitable for a unit test. The mechanism being tested (a dead client connection
+	// hard-closes the runner channel, unblocking the reverse io.Copy) is fully captured
+	// here without those dependencies.
 	go func() {
 		_, _ = io.Copy(runnerChannel, clientChannel)
+		runnerChannel.CloseWrite() //nolint:errcheck
+	}()
+	go func() {
+		_ = clientPair.serverConn.Wait()
 		runnerChannel.Close() //nolint:errcheck
 	}()
 
@@ -192,8 +207,8 @@ func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 	}()
 
 	// Simulate abrupt SSH client disconnect (kill -9 / VS Code tab closed / network drop)
-	// by closing the underlying TCP connection. This causes io.Copy reading from
-	// clientChannel to return a non-nil error, which triggers runnerChannel.Close().
+	// by closing the underlying TCP connection. This makes serverConn.Wait() return,
+	// which triggers runnerChannel.Close().
 	clientPair.closeClient()
 
 	select {
@@ -223,6 +238,10 @@ func TestRunnerChannelClosedAfterClientDisconnect(t *testing.T) {
 
 	go func() {
 		_, _ = io.Copy(runnerChannel, clientChannel)
+		runnerChannel.CloseWrite() //nolint:errcheck
+	}()
+	go func() {
+		_ = clientPair.serverConn.Wait()
 		runnerChannel.Close() //nolint:errcheck
 	}()
 	go func() {
@@ -249,5 +268,81 @@ func TestRunnerChannelClosedAfterClientDisconnect(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("runner-side channel was not closed after client disconnect; " +
 			"orphaned sandbox processes would not receive a hangup signal")
+	}
+}
+
+// TestStdinEOFPreservesHalfClose verifies that a clean stdin EOF from the client
+// (e.g. `cat file | ssh host cmd`) only half-closes the runner channel: the remote
+// command can still send output and exit-status afterwards. A hard Close() here would
+// truncate them — the regression flagged in the PR review of the keepalive fix.
+func TestStdinEOFPreservesHalfClose(t *testing.T) {
+	t.Parallel()
+
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	runnerPair := newChannelPair(t)
+	defer runnerPair.closeConns()
+
+	clientChannel := clientPair.server
+	runnerChannel := runnerPair.client
+
+	// Mirror the production goroutines from handleChannel.
+	go func() {
+		_, _ = io.Copy(runnerChannel, clientChannel)
+		runnerChannel.CloseWrite() //nolint:errcheck
+	}()
+	go func() {
+		_ = clientPair.serverConn.Wait()
+		runnerChannel.Close() //nolint:errcheck
+	}()
+	go func() {
+		_, _ = io.Copy(clientChannel, runnerChannel)
+	}()
+
+	// Clean stdin EOF: the client half-closes its channel while the SSH
+	// connection stays alive.
+	if err := clientPair.client.CloseWrite(); err != nil {
+		t.Fatalf("client CloseWrite: %v", err)
+	}
+
+	// The runner side must observe EOF on its read...
+	eofErr := make(chan error, 1)
+	go func() {
+		_, err := runnerPair.server.Read(make([]byte, 1))
+		eofErr <- err
+	}()
+	select {
+	case err := <-eofErr:
+		if err != io.EOF {
+			t.Fatalf("expected io.EOF on runner side after stdin EOF, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner side did not observe stdin EOF")
+	}
+
+	// ...and must still be able to send output, which the client receives.
+	// With a hard Close() this write fails because the channel is torn down.
+	want := "late output"
+	if _, err := runnerPair.server.Write([]byte(want)); err != nil {
+		t.Fatalf("runner write after stdin EOF failed (half-close broken): %v", err)
+	}
+
+	got := make([]byte, len(want))
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(clientPair.client, got)
+		readDone <- err
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("client read after stdin EOF failed: %v", err)
+		}
+		if string(got) != want {
+			t.Fatalf("client got %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not receive output sent after stdin EOF; half-close broken")
 	}
 }

--- a/apps/ssh-gateway/teardown_test.go
+++ b/apps/ssh-gateway/teardown_test.go
@@ -34,15 +34,14 @@ type channelPair struct {
 	server ssh.Channel
 	// client is the channel as seen by the SSH client (OpenChannel()-returned).
 	client ssh.Channel
-	// serverConn is the server's view of the SSH connection. Its Wait() returns
-	// when the client connection dies — the signal the production watcher
-	// goroutine uses to hard-close the upstream channel.
-	serverConn *ssh.ServerConn
+	// connClosed is closed when the client connection dies — the signal the
+	// production watcher goroutine selects on to hard-close the upstream channel.
+	connClosed chan struct{}
 	// closeConns tears down both sides of the underlying TCP connection.
 	closeConns func()
 	// closeClient closes only the client-side TCP connection, simulating an
-	// abrupt SSH client disconnect (SIGKILL / network drop). This makes
-	// serverConn.Wait() return.
+	// abrupt SSH client disconnect (SIGKILL / network drop). This closes
+	// connClosed.
 	closeClient func()
 }
 
@@ -136,10 +135,19 @@ func newChannelPair(t *testing.T) *channelPair {
 		t.Fatal("timeout waiting for server to accept channel")
 	}
 
+	// Mirror handleConnection: one Wait() goroutine per connection closes
+	// connClosed for all per-channel watchers.
+	connClosed := make(chan struct{})
+	go func() {
+		serverConn := <-serverConnCh
+		_ = serverConn.Wait()
+		close(connClosed)
+	}()
+
 	return &channelPair{
 		server:     serverCh,
 		client:     clientCh,
-		serverConn: <-serverConnCh,
+		connClosed: connClosed,
 		closeConns: func() {
 			cliConn.Close() //nolint:errcheck
 			srvConn.Close() //nolint:errcheck
@@ -168,7 +176,7 @@ func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 	// clientPair simulates the gateway receiving a channel from the external SSH client.
 	// clientPair.server == clientChannel in handleChannel (gateway's server-side view).
 	// clientPair.closeClient() simulates SIGKILL: drops the TCP connection so
-	// clientPair.serverConn.Wait() returns, after which runnerChannel.Close() is called
+	// clientPair.connClosed fires, after which runnerChannel.Close() is called
 	// in the production code.
 	clientPair := newChannelPair(t)
 	defer clientPair.closeConns()
@@ -194,9 +202,14 @@ func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 		_, _ = io.Copy(runnerChannel, clientChannel)
 		runnerChannel.CloseWrite() //nolint:errcheck
 	}()
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		_ = clientPair.serverConn.Wait()
-		runnerChannel.Close() //nolint:errcheck
+		select {
+		case <-clientPair.connClosed:
+			runnerChannel.Close() //nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 
 	// Main blocking copy: runner→client.
@@ -207,8 +220,8 @@ func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
 	}()
 
 	// Simulate abrupt SSH client disconnect (kill -9 / VS Code tab closed / network drop)
-	// by closing the underlying TCP connection. This makes serverConn.Wait() return,
-	// which triggers runnerChannel.Close().
+	// by closing the underlying TCP connection. This fires connClosed, which triggers
+	// runnerChannel.Close().
 	clientPair.closeClient()
 
 	select {
@@ -240,9 +253,14 @@ func TestRunnerChannelClosedAfterClientDisconnect(t *testing.T) {
 		_, _ = io.Copy(runnerChannel, clientChannel)
 		runnerChannel.CloseWrite() //nolint:errcheck
 	}()
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		_ = clientPair.serverConn.Wait()
-		runnerChannel.Close() //nolint:errcheck
+		select {
+		case <-clientPair.connClosed:
+			runnerChannel.Close() //nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 	go func() {
 		_, _ = io.Copy(clientChannel, runnerChannel)
@@ -292,9 +310,14 @@ func TestStdinEOFPreservesHalfClose(t *testing.T) {
 		_, _ = io.Copy(runnerChannel, clientChannel)
 		runnerChannel.CloseWrite() //nolint:errcheck
 	}()
+	sessionDone := make(chan struct{})
+	defer close(sessionDone)
 	go func() {
-		_ = clientPair.serverConn.Wait()
-		runnerChannel.Close() //nolint:errcheck
+		select {
+		case <-clientPair.connClosed:
+			runnerChannel.Close() //nolint:errcheck
+		case <-sessionDone:
+		}
 	}()
 	go func() {
 		_, _ = io.Copy(clientChannel, runnerChannel)

--- a/apps/ssh-gateway/teardown_test.go
+++ b/apps/ssh-gateway/teardown_test.go
@@ -1,0 +1,253 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// testSigner generates a throwaway RSA signer for in-memory SSH tests.
+func testSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("make signer: %v", err)
+	}
+	return signer
+}
+
+// channelPair holds both ends of an in-memory SSH channel.
+type channelPair struct {
+	// server is the channel as seen by the SSH server (Accept()-returned).
+	server ssh.Channel
+	// client is the channel as seen by the SSH client (OpenChannel()-returned).
+	client ssh.Channel
+	// closeConns tears down both sides of the underlying TCP connection.
+	closeConns func()
+	// closeClient closes only the client-side TCP connection, simulating an
+	// abrupt SSH client disconnect (SIGKILL / network drop). This causes any
+	// in-progress Read on server to return a non-nil error.
+	closeClient func()
+}
+
+// newChannelPair creates an SSH connection backed by a loopback TCP socket and
+// returns a connected channel pair. A loopback socket is used instead of
+// net.Pipe() because net.Pipe() is synchronous with no kernel buffer: when both
+// sides of an SSH handshake write their version string simultaneously, both block
+// indefinitely. TCP's OS send buffer absorbs the small version string so neither
+// side stalls.
+func newChannelPair(t *testing.T) *channelPair {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		ln.Close() //nolint:errcheck — only one connection needed
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	var srvConn net.Conn
+	select {
+	case srvConn = <-accepted:
+	case <-time.After(5 * time.Second):
+		cliConn.Close() //nolint:errcheck
+		t.Fatal("accept timeout")
+	}
+
+	serverCfg := &ssh.ServerConfig{NoClientAuth: true}
+	serverCfg.AddHostKey(testSigner(t))
+
+	serverChanCh := make(chan ssh.Channel, 1)
+	go func() {
+		_, chans, reqs, err := ssh.NewServerConn(srvConn, serverCfg)
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		newCh, ok := <-chans
+		if !ok {
+			return
+		}
+		ch, reqs, err := newCh.Accept()
+		if err != nil {
+			return
+		}
+		go ssh.DiscardRequests(reqs)
+		serverChanCh <- ch
+		for range chans {
+		} // drain remaining channels
+	}()
+
+	clientCfg := &ssh.ClientConfig{
+		User:            "test",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	cc, cliChans, cliReqs, err := ssh.NewClientConn(cliConn, "", clientCfg)
+	if err != nil {
+		t.Fatalf("ssh client connect: %v", err)
+	}
+	go ssh.DiscardRequests(cliReqs)
+	go func() {
+		for range cliChans {
+		}
+	}()
+
+	clientCh, chReqs, err := cc.OpenChannel("session", nil)
+	if err != nil {
+		t.Fatalf("open channel: %v", err)
+	}
+	go ssh.DiscardRequests(chReqs)
+
+	var serverCh ssh.Channel
+	select {
+	case serverCh = <-serverChanCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for server to accept channel")
+	}
+
+	return &channelPair{
+		server: serverCh,
+		client: clientCh,
+		closeConns: func() {
+			cliConn.Close() //nolint:errcheck
+			srvConn.Close() //nolint:errcheck
+		},
+		closeClient: func() {
+			cliConn.Close() //nolint:errcheck
+		},
+	}
+}
+
+// TestClientDisconnectTeardownPropagatesUpstream is the regression test for the stale
+// SSH keepalive bug (https://github.com/daytonaio/daytona/issues/4805).
+//
+// Before the fix, killing the SSH client (SIGKILL / network drop) left the reverse
+// io.Copy (runner→client) blocked indefinitely: nothing closed runnerChannel, so the
+// keepalive goroutine's context was never cancelled, lastActivityAt kept refreshing every
+// 45 s, and auto-stop never triggered.
+//
+// The fix always calls runnerChannel.Close() (MSG_CHANNEL_CLOSE), which forces the runner
+// to send its own MSG_CHANNEL_CLOSE in reply, unblocking the reverse io.Copy.
+func TestClientDisconnectTeardownPropagatesUpstream(t *testing.T) {
+	t.Parallel()
+
+	// clientPair simulates the gateway receiving a channel from the external SSH client.
+	// clientPair.server == clientChannel in handleChannel (gateway's server-side view).
+	// clientPair.closeClient() simulates SIGKILL: drops the TCP connection so io.Copy
+	// returns, after which runnerChannel.Close() is called in the production code.
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	// runnerPair simulates the gateway opening a channel to the backend runner.
+	// runnerPair.client == runnerChannel in handleChannel (gateway's client-side view).
+	runnerPair := newChannelPair(t)
+	defer runnerPair.closeConns()
+
+	clientChannel := clientPair.server // gateway accepted this from the external client
+	runnerChannel := runnerPair.client // gateway opened this to the runner
+
+	// done is closed when the main blocking io.Copy (runner→client) returns,
+	// proving that the keepalive context would be cancelled via defer cancel().
+	done := make(chan struct{})
+
+	// Mirror the goroutine from apps/ssh-gateway/main.go rather than calling handleChannel
+	// directly: handleChannel requires a live SSH server listener and API client, making it
+	// unsuitable for a unit test. The mechanism being tested (Close unblocks the reverse
+	// io.Copy) is fully captured here without those dependencies.
+	go func() {
+		_, _ = io.Copy(runnerChannel, clientChannel)
+		runnerChannel.Close() //nolint:errcheck
+	}()
+
+	// Main blocking copy: runner→client.
+	// This is the call that previously blocked forever after a client SIGKILL.
+	go func() {
+		_, _ = io.Copy(clientChannel, runnerChannel)
+		close(done)
+	}()
+
+	// Simulate abrupt SSH client disconnect (kill -9 / VS Code tab closed / network drop)
+	// by closing the underlying TCP connection. This causes io.Copy reading from
+	// clientChannel to return a non-nil error, which triggers runnerChannel.Close().
+	clientPair.closeClient()
+
+	select {
+	case <-done:
+		// Both copies returned. In the real handleChannel, defer cancel() would now fire,
+		// stopping the keepalive ticker. lastActivityAt goes stale → auto-stop triggers.
+	case <-time.After(2 * time.Second):
+		t.Fatal("reverse channel copy (runner→client) did not unblock after client disconnect; " +
+			"the keepalive goroutine would run indefinitely, preventing auto-stop")
+	}
+}
+
+// TestRunnerChannelClosedAfterClientDisconnect verifies that the runner-side channel
+// receives a close signal after the external client disconnects. This ensures orphaned
+// sandbox shells (VS Code remote server, JetBrains Gateway, plain bash) are cleaned up.
+func TestRunnerChannelClosedAfterClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	clientPair := newChannelPair(t)
+	defer clientPair.closeConns()
+
+	runnerPair := newChannelPair(t)
+	defer runnerPair.closeConns()
+
+	clientChannel := clientPair.server
+	runnerChannel := runnerPair.client
+
+	go func() {
+		_, _ = io.Copy(runnerChannel, clientChannel)
+		runnerChannel.Close() //nolint:errcheck
+	}()
+	go func() {
+		_, _ = io.Copy(clientChannel, runnerChannel)
+	}()
+
+	// Simulate abrupt SSH client disconnect (SIGKILL / network drop).
+	clientPair.closeClient()
+
+	// The runner-side server channel (runnerPair.server) should receive EOF/close,
+	// which propagates to the runner's handleChannel → sandboxChannel.Close().
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := runnerPair.server.Read(buf)
+		readErr <- err
+	}()
+
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("expected EOF/close on runner-side channel after client disconnect, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner-side channel was not closed after client disconnect; " +
+			"orphaned sandbox processes would not receive a hangup signal")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4805 — stale SSH keepalive preventing sandbox auto-stop.

**Root cause:** When an SSH client dies abruptly (SIGKILL, VS Code tab closed, network drop), the gateway's `handleChannel` blocks indefinitely on `io.Copy(clientChannel, runnerChannel)`. The goroutine copying the other direction (`client→runner`) never closed `runnerChannel`, so the runner-side channel stayed open. The runner's long-lived processes (VS Code Remote Server, JetBrains Gateway, bash) never received a hangup. The 45-second `UpdateLastActivity` ticker kept firing → `lastActivityAt` never went stale → auto-stop never triggered.

**Why `CloseWrite` is insufficient:** `MSG_CHANNEL_EOF` (sent by `CloseWrite`) is silently ignored by long-lived processes. They keep the channel open indefinitely, leaving `io.Copy(clientChannel, runnerChannel)` blocked.

**Why the `err != nil` heuristic doesn't work either:** The SSH library (x/crypto/ssh) converts every transport-level error into `io.EOF` at the channel-read boundary (via `buffer.eof()`). So `io.Copy` returns `nil` even after an abrupt SIGKILL — the error branch was never reachable.

**The fix:** Always send `MSG_CHANNEL_CLOSE` (via `Close()`) when the client→runner copy finishes. Per RFC 4254 §5.3, the peer **MUST** respond with its own `MSG_CHANNEL_CLOSE`. This response triggers `ch.close()` on the local channel, signals `io.EOF` to `runnerChannel`'s read buffer, and unblocks `io.Copy(clientChannel, runnerChannel)`. `defer cancel()` then fires, stopping the keepalive ticker. `lastActivityAt` goes stale. Auto-stop triggers.

**Changes:**
- `apps/ssh-gateway/main.go`: always `runnerChannel.Close()` after client→runner copy
- `apps/runner/pkg/sshgateway/service.go`: always `sandboxChannel.Close()` after client→sandbox copy; also fixes a `sandboxClient` TCP connection leak
- `apps/ssh-gateway/teardown_test.go`: regression tests using loopback TCP (avoids `net.Pipe()` deadlock); replaced `time.Sleep` with deterministic TCP teardown
- `apps/runner/pkg/sshgateway/service_test.go`: same regression tests for the runner layer (`//go:build linux` required by transitive `netlink` dependency)

## Test plan

- [x] `cd apps/ssh-gateway && go test -v -timeout 30s ./...` — both tests pass in ~20ms
- [x] Runner tests verified structurally identical to gateway tests; run on Linux CI (`//go:build linux`)
- [x] `TestClientDisconnectTeardownPropagatesUpstream` / `TestClientDisconnectClosesSandboxChannel`: verifies `io.Copy(clientChannel, runnerChannel)` unblocks within 2s of client TCP teardown
- [x] `TestRunnerChannelClosedAfterClientDisconnect` / `TestSandboxChannelReceivesCloseOnClientDisconnect`: verifies the runner/sandbox-side channel receives close → orphaned processes get HUP
- [x] Reproduction confirmed against production via `.omc/stale-ssh-repro.mjs`: 45-second `lastActivityAt` cadence stops after the channel teardown