### PR TITLE
chore(api): add x-enum-varnames to prevent mangled enum names in generated python API clients

### DIFF
--- a/apps/api/src/generate-openapi.ts
+++ b/apps/api/src/generate-openapi.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
 import { SwaggerModule } from '@nestjs/swagger'
+import type { OpenAPIObject } from '@nestjs/swagger'
 import { getOpenApiConfig } from './openapi.config'
 import { addWebhookDocumentation } from './openapi-webhooks'
 import {
@@ -27,6 +28,7 @@ async function generateOpenAPI() {
     const document = {
       ...SwaggerModule.createDocument(app, config),
     }
+    addEnumVarnames(document)
     const openapiPath = './dist/apps/api/openapi.json'
     fs.mkdirSync(path.dirname(openapiPath), { recursive: true })
     fs.writeFileSync(openapiPath, JSON.stringify(document, null, 2))
@@ -47,6 +49,7 @@ async function generateOpenAPI() {
       }),
       openapi: '3.1.0',
     }
+    addEnumVarnames(document_3_1_0)
     const documentWithWebhooks = addWebhookDocumentation(document_3_1_0)
     const openapi310Path = './dist/apps/api/openapi.3.1.0.json'
     fs.mkdirSync(path.dirname(openapi310Path), { recursive: true })
@@ -73,5 +76,45 @@ const timeout = setTimeout(() => {
 process.on('exit', () => {
   clearTimeout(timeout)
 })
+
+// https://openapi-generator.tech/docs/templating/#enum
+// Adds x-enum-varnames to string enums whose values contain characters that
+// OpenAPI Generator would otherwise mangle (e.g. "linux-vm" -> LINUX_MINUS_VM in Python).
+function addEnumVarnames(document: OpenAPIObject): void {
+  const visited = new WeakSet<object>()
+
+  const toVarname = (value: string, index: number): string => {
+    const cleaned = value
+      .replace(/[^A-Za-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .toUpperCase()
+    if (!cleaned) return `VALUE_${index}`
+    return /^\d/.test(cleaned) ? `_${cleaned}` : cleaned
+  }
+
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== 'object' || visited.has(node)) return
+    visited.add(node)
+
+    const schema = node as Record<string, unknown>
+    const values = schema.enum
+    if (
+      schema.type === 'string' &&
+      Array.isArray(values) &&
+      !schema['x-enum-varnames'] &&
+      values.every((v): v is string => typeof v === 'string') &&
+      values.some((v) => /[^A-Za-z0-9_]/.test(v))
+    ) {
+      const varnames = values.map(toVarname)
+      if (new Set(varnames).size === varnames.length) {
+        schema['x-enum-varnames'] = varnames
+      }
+    }
+
+    for (const value of Object.values(schema)) visit(value)
+  }
+
+  visit(document)
+}
 
 generateOpenAPI()

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -9281,6 +9281,22 @@ components:
             - delete:runners
             - read:audit_logs
             type: string
+            x-enum-varnames:
+            - WRITE_REGISTRIES
+            - DELETE_REGISTRIES
+            - WRITE_SNAPSHOTS
+            - DELETE_SNAPSHOTS
+            - WRITE_SANDBOXES
+            - DELETE_SANDBOXES
+            - READ_VOLUMES
+            - WRITE_VOLUMES
+            - DELETE_VOLUMES
+            - WRITE_REGIONS
+            - DELETE_REGIONS
+            - READ_RUNNERS
+            - WRITE_RUNNERS
+            - DELETE_RUNNERS
+            - READ_AUDIT_LOGS
           type: array
         expiresAt:
           description: When the API key expires
@@ -9336,6 +9352,22 @@ components:
             - delete:runners
             - read:audit_logs
             type: string
+            x-enum-varnames:
+            - WRITE_REGISTRIES
+            - DELETE_REGISTRIES
+            - WRITE_SNAPSHOTS
+            - DELETE_SNAPSHOTS
+            - WRITE_SANDBOXES
+            - DELETE_SANDBOXES
+            - READ_VOLUMES
+            - WRITE_VOLUMES
+            - DELETE_VOLUMES
+            - WRITE_REGIONS
+            - DELETE_REGIONS
+            - READ_RUNNERS
+            - WRITE_RUNNERS
+            - DELETE_RUNNERS
+            - READ_AUDIT_LOGS
           type: array
         expiresAt:
           description: When the API key expires
@@ -9396,6 +9428,22 @@ components:
             - delete:runners
             - read:audit_logs
             type: string
+            x-enum-varnames:
+            - WRITE_REGISTRIES
+            - DELETE_REGISTRIES
+            - WRITE_SNAPSHOTS
+            - DELETE_SNAPSHOTS
+            - WRITE_SANDBOXES
+            - DELETE_SANDBOXES
+            - READ_VOLUMES
+            - WRITE_VOLUMES
+            - DELETE_VOLUMES
+            - WRITE_REGIONS
+            - DELETE_REGIONS
+            - READ_RUNNERS
+            - WRITE_RUNNERS
+            - DELETE_RUNNERS
+            - READ_AUDIT_LOGS
           type: array
         lastUsedAt:
           description: When the API key was last used
@@ -9463,6 +9511,22 @@ components:
             - delete:runners
             - read:audit_logs
             type: string
+            x-enum-varnames:
+            - WRITE_REGISTRIES
+            - DELETE_REGISTRIES
+            - WRITE_SNAPSHOTS
+            - DELETE_SNAPSHOTS
+            - WRITE_SANDBOXES
+            - DELETE_SANDBOXES
+            - READ_VOLUMES
+            - WRITE_VOLUMES
+            - DELETE_VOLUMES
+            - WRITE_REGIONS
+            - DELETE_REGIONS
+            - READ_RUNNERS
+            - WRITE_RUNNERS
+            - DELETE_RUNNERS
+            - READ_AUDIT_LOGS
           type: array
         isGlobal:
           description: Global role flag
@@ -9772,6 +9836,11 @@ components:
       - android
       - windows
       type: string
+      x-enum-varnames:
+      - LINUX_VM
+      - CONTAINER
+      - ANDROID
+      - WINDOWS
     RegionUsageOverview:
       example:
         totalCpuQuota: 0.8008281904610115
@@ -10109,6 +10178,22 @@ components:
             - delete:runners
             - read:audit_logs
             type: string
+            x-enum-varnames:
+            - WRITE_REGISTRIES
+            - DELETE_REGISTRIES
+            - WRITE_SNAPSHOTS
+            - DELETE_SNAPSHOTS
+            - WRITE_SANDBOXES
+            - DELETE_SANDBOXES
+            - READ_VOLUMES
+            - WRITE_VOLUMES
+            - DELETE_VOLUMES
+            - WRITE_REGIONS
+            - DELETE_REGIONS
+            - READ_RUNNERS
+            - WRITE_RUNNERS
+            - DELETE_RUNNERS
+            - READ_AUDIT_LOGS
           type: array
       required:
       - description
@@ -10151,6 +10236,22 @@ components:
             - delete:runners
             - read:audit_logs
             type: string
+            x-enum-varnames:
+            - WRITE_REGISTRIES
+            - DELETE_REGISTRIES
+            - WRITE_SNAPSHOTS
+            - DELETE_SNAPSHOTS
+            - WRITE_SANDBOXES
+            - DELETE_SANDBOXES
+            - READ_VOLUMES
+            - WRITE_VOLUMES
+            - DELETE_VOLUMES
+            - WRITE_REGIONS
+            - DELETE_REGIONS
+            - READ_RUNNERS
+            - WRITE_RUNNERS
+            - DELETE_RUNNERS
+            - READ_AUDIT_LOGS
           type: array
       required:
       - description
@@ -10682,6 +10783,11 @@ components:
           - windows
           example: linux-vm
           type: string
+          x-enum-varnames:
+          - LINUX_VM
+          - CONTAINER
+          - ANDROID
+          - WINDOWS
         state:
           allOf:
           - $ref: "#/components/schemas/SandboxState"
@@ -11113,6 +11219,11 @@ components:
           - windows
           example: linux-vm
           type: string
+          x-enum-varnames:
+          - LINUX_VM
+          - CONTAINER
+          - ANDROID
+          - WINDOWS
         daemonVersion:
           description: The version of the daemon running in the sandbox
           example: 1.0.0
@@ -13920,6 +14031,11 @@ components:
           - windows
           example: linux-vm
           type: string
+          x-enum-varnames:
+          - LINUX_VM
+          - CONTAINER
+          - ANDROID
+          - WINDOWS
       required:
       - cpu
       - createdAt
@@ -14585,6 +14701,14 @@ components:
       - volume.created
       - volume.state.updated
       type: string
+      x-enum-varnames:
+      - SANDBOX_CREATED
+      - SANDBOX_STATE_UPDATED
+      - SNAPSHOT_CREATED
+      - SNAPSHOT_STATE_UPDATED
+      - SNAPSHOT_REMOVED
+      - VOLUME_CREATED
+      - VOLUME_STATE_UPDATED
     SendWebhookDto:
       example:
         eventId: evt_1234567890abcdef

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox_class.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox_class.py
@@ -27,7 +27,7 @@ class SandboxClass(str, Enum):
     """
     allowed enum values
     """
-    LINUX_MINUS_VM = 'linux-vm'
+    LINUX_VM = 'linux-vm'
     CONTAINER = 'container'
     ANDROID = 'android'
     WINDOWS = 'windows'

--- a/libs/api-client-python-async/daytona_api_client_async/models/webhook_event.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/webhook_event.py
@@ -27,13 +27,13 @@ class WebhookEvent(str, Enum):
     """
     allowed enum values
     """
-    SANDBOX_DOT_CREATED = 'sandbox.created'
-    SANDBOX_DOT_STATE_DOT_UPDATED = 'sandbox.state.updated'
-    SNAPSHOT_DOT_CREATED = 'snapshot.created'
-    SNAPSHOT_DOT_STATE_DOT_UPDATED = 'snapshot.state.updated'
-    SNAPSHOT_DOT_REMOVED = 'snapshot.removed'
-    VOLUME_DOT_CREATED = 'volume.created'
-    VOLUME_DOT_STATE_DOT_UPDATED = 'volume.state.updated'
+    SANDBOX_CREATED = 'sandbox.created'
+    SANDBOX_STATE_UPDATED = 'sandbox.state.updated'
+    SNAPSHOT_CREATED = 'snapshot.created'
+    SNAPSHOT_STATE_UPDATED = 'snapshot.state.updated'
+    SNAPSHOT_REMOVED = 'snapshot.removed'
+    VOLUME_CREATED = 'volume.created'
+    VOLUME_STATE_UPDATED = 'volume.state.updated'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/libs/api-client-python/daytona_api_client/models/sandbox_class.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox_class.py
@@ -27,7 +27,7 @@ class SandboxClass(str, Enum):
     """
     allowed enum values
     """
-    LINUX_MINUS_VM = 'linux-vm'
+    LINUX_VM = 'linux-vm'
     CONTAINER = 'container'
     ANDROID = 'android'
     WINDOWS = 'windows'

--- a/libs/api-client-python/daytona_api_client/models/webhook_event.py
+++ b/libs/api-client-python/daytona_api_client/models/webhook_event.py
@@ -27,13 +27,13 @@ class WebhookEvent(str, Enum):
     """
     allowed enum values
     """
-    SANDBOX_DOT_CREATED = 'sandbox.created'
-    SANDBOX_DOT_STATE_DOT_UPDATED = 'sandbox.state.updated'
-    SNAPSHOT_DOT_CREATED = 'snapshot.created'
-    SNAPSHOT_DOT_STATE_DOT_UPDATED = 'snapshot.state.updated'
-    SNAPSHOT_DOT_REMOVED = 'snapshot.removed'
-    VOLUME_DOT_CREATED = 'volume.created'
-    VOLUME_DOT_STATE_DOT_UPDATED = 'volume.state.updated'
+    SANDBOX_CREATED = 'sandbox.created'
+    SANDBOX_STATE_UPDATED = 'sandbox.state.updated'
+    SNAPSHOT_CREATED = 'snapshot.created'
+    SNAPSHOT_STATE_UPDATED = 'snapshot.state.updated'
+    SNAPSHOT_REMOVED = 'snapshot.removed'
+    VOLUME_CREATED = 'volume.created'
+    VOLUME_STATE_UPDATED = 'volume.state.updated'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod


### PR DESCRIPTION
### Problem

OpenAPI Generator's Python codegen mangles enum constant names when values contain hyphens or dots:

- `linux-vm` → `LINUX_MINUS_VM`
- `sandbox.created` → `SANDBOX_DOT_CREATED`
- `sandbox.state.updated` → `SANDBOX_DOT_STATE_DOT_UPDATED`

### Solution

Add `x-enum-varnames` — the [standard OpenAPI Generator extension](https://openapi-generator.tech/docs/templating/#enum) — to the generated OpenAPI spec during `generate-openapi.ts`. This tells all generators exactly what constant names to use.

The post-processor recursively walks the entire OpenAPI document (including inline enums in properties, array items, oneOf/anyOf/allOf) and adds `x-enum-varnames` only to string enums that contain non-alphanumeric characters.

### Before / After (Python)

```python
# Before
LINUX_MINUS_VM = 'linux-vm'
SANDBOX_DOT_CREATED = 'sandbox.created'
SANDBOX_DOT_STATE_DOT_UPDATED = 'sandbox.state.updated'

# After
LINUX_VM = 'linux-vm'
SANDBOX_CREATED = 'sandbox.created'
SANDBOX_STATE_UPDATED = 'sandbox.state.updated'
```

### Affected enums

| Enum | Values fixed |
|---|---|
| `SandboxClass` | `linux-vm` |
| `WebhookEvent` | `sandbox.created`, `sandbox.state.updated`, `snapshot.created`, `snapshot.state.updated`, `snapshot.removed`, `volume.created`, `volume.state.updated` |
| `OrganizationResourcePermission` (inline) | `write:registries`, `delete:registries`, `write:snapshots`, etc. |

### Changed files

- `apps/api/src/generate-openapi.ts` — added `addEnumVarnames()` post-processor
- `libs/api-client-go/api/openapi.yaml` — regenerated (now includes `x-enum-varnames`)
- `libs/api-client-python{,-async}/**/sandbox_class.py` — `LINUX_MINUS_VM` → `LINUX_VM`
- `libs/api-client-python{,-async}/**/webhook_event.py` — `*_DOT_*` → clean names

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `x-enum-varnames` during OpenAPI generation to stop mangled enum names in generated Python clients and standardize enum names across SDKs. Enums like `linux-vm` now produce `LINUX_VM` instead of `LINUX_MINUS_VM`.

- **Bug Fixes**
  - Added an `addEnumVarnames()` post-processor in `generate-openapi.ts` to inject `x-enum-varnames` for string enums with non‑alphanumeric values (walks the entire document, including inline schemas).
  - Regenerated `openapi.yaml` and Python clients so enums use clean names (e.g., `LINUX_VM`, `SANDBOX_CREATED`).
  - Affects `SandboxClass`, `WebhookEvent`, and inline organization permission scopes.

- **Migration**
  - Update Python code to new constants. Examples: `LINUX_MINUS_VM` -> `LINUX_VM`, `SANDBOX_DOT_STATE_DOT_UPDATED` -> `SANDBOX_STATE_UPDATED`.

<sup>Written for commit 61fc44c43d83e1c0ac12d2640641c8b1e7ed70be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

