### PR TITLE
fix(api): invalidate proxy public-status cache on visibility change

### DIFF
--- a/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
+++ b/apps/api/src/sandbox/services/proxy-cache-invalidation.service.ts
@@ -10,11 +10,13 @@ import Redis from 'ioredis'
 
 import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxArchivedEvent } from '../events/sandbox-archived.event'
+import { SandboxPublicStatusUpdatedEvent } from '../events/sandbox-public-status-updated.event'
 
 @Injectable()
 export class ProxyCacheInvalidationService {
   private readonly logger = new Logger(ProxyCacheInvalidationService.name)
   private static readonly RUNNER_INFO_CACHE_PREFIX = 'proxy:sandbox-runner-info:'
+  private static readonly PUBLIC_CACHE_PREFIX = 'proxy:sandbox-public:'
 
   constructor(@InjectRedis() private readonly redis: Redis) {}
 
@@ -23,12 +25,26 @@ export class ProxyCacheInvalidationService {
     await this.invalidateRunnerCache(event.sandbox.id)
   }
 
+  @OnEvent(SandboxEvents.PUBLIC_STATUS_UPDATED)
+  async handleSandboxPublicStatusUpdated(event: SandboxPublicStatusUpdatedEvent): Promise<void> {
+    await this.invalidatePublicCache(event.sandbox.id)
+  }
+
   private async invalidateRunnerCache(sandboxId: string): Promise<void> {
     try {
       await this.redis.del(`${ProxyCacheInvalidationService.RUNNER_INFO_CACHE_PREFIX}${sandboxId}`)
       this.logger.debug(`Invalidated sandbox runner cache for ${sandboxId}`)
     } catch (error) {
       this.logger.warn(`Failed to invalidate runner cache for sandbox ${sandboxId}: ${error.message}`)
+    }
+  }
+
+  private async invalidatePublicCache(sandboxId: string): Promise<void> {
+    try {
+      await this.redis.del(`${ProxyCacheInvalidationService.PUBLIC_CACHE_PREFIX}${sandboxId}`)
+      this.logger.debug(`Invalidated sandbox public cache for ${sandboxId}`)
+    } catch (error) {
+      this.logger.warn(`Failed to invalidate public cache for sandbox ${sandboxId}: ${error.message}`)
     }
   }
 }


### PR DESCRIPTION
### What

`ProxyCacheInvalidationService` only invalidated the runner-info cache on sandbox archive. The proxy also caches sandbox public-status under `proxy:sandbox-public:<id>` with a 1h TTL, and nothing invalidated it when a sandbox's public status changed, so the proxy could keep serving the previous value until the cache entry expired.

### Change

Adds an `@OnEvent(SandboxEvents.PUBLIC_STATUS_UPDATED)` handler that deletes the proxy public-status cache key. The event is already emitted on every public-status transition (`sandbox.repository.ts`), so this only wires a handler to the existing event.

Invalidation is unconditional, so both public to private and private to public transitions clear the cache (the latter also avoids a stale `false` blocking a freshly published preview).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate the proxy’s sandbox public-status cache on visibility changes so the proxy doesn’t serve stale values. Wires an `@OnEvent(SandboxEvents.PUBLIC_STATUS_UPDATED)` handler to delete `proxy:sandbox-public:<id>`, covering both public→private and private→public transitions.

<sup>Written for commit bd3be16b48b83772b4cc91689615e292e018bff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

