### PR TITLE
fix(api): snapshot scaling eligible runners

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -7,7 +7,7 @@ import { Injectable, Logger, NotFoundException, OnApplicationShutdown } from '@n
 import { InjectRepository } from '@nestjs/typeorm'
 import { Cron, CronExpression } from '@nestjs/schedule'
 import { SnapshotRepository } from '../repositories/snapshot.repository'
-import { Equal, In, IsNull, LessThan, MoreThanOrEqual, Not, Or, Repository } from 'typeorm'
+import { Equal, FindOptionsWhere, In, IsNull, LessThan, MoreThanOrEqual, Not, Or, Repository } from 'typeorm'
 import { DockerRegistryService } from '../../docker-registry/services/docker-registry.service'
 import { Snapshot } from '../entities/snapshot.entity'
 import { SnapshotState } from '../enums/snapshot-state.enum'
@@ -334,20 +334,28 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
     }
   }
 
+  // Shared by propagateSnapshotToRunners and scaleDownSnapshotFromRunners so both operate on the same data
+  private eligibleRunnerWhere(snapshot: Snapshot, regionIds: string[]): FindOptionsWhere<Runner> {
+    return {
+      state: RunnerState.READY,
+      unschedulable: Not(true),
+      region: In(regionIds),
+      gpu: snapshot.gpu > 0 ? MoreThanOrEqual(snapshot.gpu) : Or(IsNull(), Equal(0)),
+      gpuType: snapshot.gpuType ? snapshot.gpuType : IsNull(),
+      sandboxClass: getRunnerSandboxClass(snapshot.sandboxClass),
+    }
+  }
+
+  private getTargetSharedRunnerCount(eligibleSharedRunnerCount: number, propagationFactor: number): number {
+    return Math.ceil(propagationFactor * eligibleSharedRunnerCount)
+  }
+
   async propagateSnapshotToRunners(snapshot: Snapshot, sharedRegionIds: string[], organizationRegionIds: string[]) {
     //  todo: remove try catch block and implement error handling
     try {
       //  get all runners in the regions to propagate to
       const runners = await this.runnerRepository.find({
-        where: {
-          state: RunnerState.READY,
-          unschedulable: Not(true),
-          region: In([...sharedRegionIds, ...organizationRegionIds]),
-          gpu: snapshot.gpu > 0 ? MoreThanOrEqual(snapshot.gpu) : Or(IsNull(), Equal(0)),
-          gpuType: snapshot.gpuType ? snapshot.gpuType : IsNull(),
-          // Temporary: Android snapshots can go to container runners
-          sandboxClass: getRunnerSandboxClass(snapshot.sandboxClass),
-        },
+        where: this.eligibleRunnerWhere(snapshot, [...sharedRegionIds, ...organizationRegionIds]),
       })
 
       const sharedRunners = runners.filter((runner) => sharedRegionIds.includes(runner.region))
@@ -393,9 +401,10 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       runnersToPropagateTo.push(...unallocatedOrganizationRunners)
 
       // respect the propagation limit for shared runners
+      const targetSharedRunnerCount = this.getTargetSharedRunnerCount(sharedRunners.length, BASE_PROPAGATION_FACTOR)
       const sharedRunnersPropagateLimit = Math.max(
         0,
-        Math.ceil(sharedRunners.length * BASE_PROPAGATION_FACTOR) - sharedSnapshotRunnersDistinctRunnersIds.size,
+        targetSharedRunnerCount - sharedSnapshotRunnersDistinctRunnersIds.size,
       )
       runnersToPropagateTo.push(...shuffleArray(unallocatedSharedRunners).slice(0, sharedRunnersPropagateLimit))
 
@@ -423,7 +432,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
             throw new Error(`No internal registry found for snapshot ${snapshot.ref} in region ${runner.region}`)
           }
 
-          const snapshotRunner = await this.runnerService.getSnapshotRunner(runner.id, snapshot.ref)
+          let snapshotRunner = await this.runnerService.getSnapshotRunner(runner.id, snapshot.ref)
 
           try {
             if (!snapshotRunner) {
@@ -445,9 +454,15 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
             }
           } catch (err) {
             this.logger.error(`Error propagating snapshot to runner ${runner.id}: ${fromAxiosError(err)}`)
-            snapshotRunner.state = SnapshotRunnerState.ERROR
-            snapshotRunner.errorReason = err.message
-            await this.snapshotRunnerRepository.update(snapshotRunner.id, snapshotRunner)
+            // The entry may have just been created above (snapshotRunner was null), so re-fetch it to update.
+            if (!snapshotRunner) {
+              snapshotRunner = await this.runnerService.getSnapshotRunner(runner.id, snapshot.ref)
+            }
+            if (snapshotRunner) {
+              snapshotRunner.state = SnapshotRunnerState.ERROR
+              snapshotRunner.errorReason = err.message
+              await this.snapshotRunnerRepository.update(snapshotRunner.id, snapshotRunner)
+            }
           }
         }),
       )
@@ -472,16 +487,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         return 0
       }
 
-      // Get all shared runners in the regions
       const sharedRunners = await this.runnerRepository.find({
-        where: {
-          state: RunnerState.READY,
-          unschedulable: Not(true),
-          region: In(sharedRegionIds),
-          gpu: snapshot.gpu > 0 ? MoreThanOrEqual(snapshot.gpu) : Or(IsNull(), Equal(0)),
-          gpuType: snapshot.gpuType ? snapshot.gpuType : IsNull(),
-          sandboxClass: getRunnerSandboxClass(snapshot.sandboxClass),
-        },
+        where: this.eligibleRunnerWhere(snapshot, sharedRegionIds),
       })
 
       const sharedRunnerIds = sharedRunners.map((runner) => runner.id)
@@ -501,8 +508,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         },
       })
 
-      // Calculate the maximum allowed number of snapshot runners (same formula as propagation)
-      const maxSharedSnapshotRunners = Math.ceil(propagationFactor * sharedRunners.length)
+      // Must match propagateSnapshotToRunners: use the same target formula
+      const maxSharedSnapshotRunners = this.getTargetSharedRunnerCount(sharedRunners.length, propagationFactor)
 
       // Only scale down if the propagated amount exceeds the limit by more than 15%
       const scaleDownThreshold = Math.ceil(maxSharedSnapshotRunners * 1.15)


### PR DESCRIPTION
## Description

Fixes snapshot scaling to use the same set of eligible runners on distribution. Also fixes "Cannot set properties of null (setting 'state')"" 

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns snapshot propagation and scale-down to use the same eligible runners and target counts, preventing mismatched scaling on shared runners. Also fixes a crash when an error occurs during propagation and the `snapshotRunner` record is not yet created.

- **Bug Fixes**
  - Use the same eligibility filter and target-count formula for both propagation and scale-down (READY, schedulable, region match, GPU count/type, sandbox class).
  - Prevent "Cannot set properties of null (setting 'state')" by re-fetching the `snapshotRunner` before updating on error.

- **Refactors**
  - Extracted shared helpers for runner eligibility and target count to keep logic in sync.
  - Reduced duplicated query logic by reusing the eligibility filter.

<sup>Written for commit 3859484bf7ad4e2151dd096e3bcb8b2633f09ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

