### PR TITLE
fix(api): return correct gpu type in sandbox list item

### DIFF
--- a/apps/api/src/sandbox/adapters/sandbox-opensearch-search.adapter.ts
+++ b/apps/api/src/sandbox/adapters/sandbox-opensearch-search.adapter.ts
@@ -373,7 +373,7 @@ export class SandboxOpenSearchSearchAdapter implements SandboxSearchAdapter, OnM
       public: source.public,
       cpu: source.cpu,
       gpu: source.gpu,
-      gpuType: source.gpuType ?? undefined,
+      gpuType: source.gpu_type ?? undefined,
       memory: source.mem,
       disk: source.disk,
       labels,


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783090617&installation_id=132266156&pr_number=4924&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4924&signature=960bbba0dd4534c1c05470057970459cf24ec79a260ba05cc6da779f4d0ebd26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox list API to map OpenSearch `gpu_type` to the response `gpuType`. This returns the correct GPU type in list items instead of empty values.

<sup>Written for commit bb6a0dfd2b91755a0cb1aabe590982072e395902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

