### PR TITLE
fix(dashboard): invite members cta copy tweak

### DIFF
--- a/apps/dashboard/src/components/CreateResourceButton.tsx
+++ b/apps/dashboard/src/components/CreateResourceButton.tsx
@@ -10,9 +10,16 @@ import type { ComponentProps, ReactNode } from 'react'
 
 type CreateResourceButtonProps = Omit<ComponentProps<typeof Button>, 'asChild'> & {
   resource: ReactNode
+  label?: ReactNode
 }
 
-export function CreateResourceButton({ resource, children, className, ...props }: CreateResourceButtonProps) {
+export function CreateResourceButton({
+  resource,
+  children,
+  className,
+  label = 'Create',
+  ...props
+}: CreateResourceButtonProps) {
   return (
     <Button
       variant="default"
@@ -21,7 +28,7 @@ export function CreateResourceButton({ resource, children, className, ...props }
       {...props}
     >
       <Plus className="size-4" />
-      <span className="sr-only xs:not-sr-only">Create</span>
+      <span className="sr-only xs:not-sr-only">{label}</span>
       <span className="hidden sm:inline">{children ?? resource}</span>
     </Button>
   )

--- a/apps/dashboard/src/components/OrganizationMembers/UpsertOrganizationAccessSheet.tsx
+++ b/apps/dashboard/src/components/OrganizationMembers/UpsertOrganizationAccessSheet.tsx
@@ -18,8 +18,8 @@ import {
   SheetDescription,
   SheetFooter,
   SheetHeader,
-  SheetTrigger,
   SheetTitle,
+  SheetTrigger,
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { useOrganizationRolesQuery } from '@/hooks/queries/useOrganizationRolesQuery'
@@ -28,13 +28,13 @@ import { useForm } from '@tanstack/react-form'
 import { AlertTriangle } from 'lucide-react'
 import React, {
   Ref,
-  type ReactNode,
   useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from 'react'
 import { z } from 'zod'
 
@@ -236,7 +236,7 @@ export const UpsertOrganizationAccessSheet: React.FC<UpsertOrganizationAccessShe
       {trigger === undefined ? (
         <SheetTrigger asChild>
           {isCreateMode ? (
-            <CreateResourceButton resource="Member" className={className} disabled={disabled}>
+            <CreateResourceButton resource="Member" className={className} disabled={disabled} label="Invite">
               Member
             </CreateResourceButton>
           ) : (


### PR DESCRIPTION

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783091137&installation_id=132266156&pr_number=4925&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4925&signature=5a1bc03cfab876c88a5a15676d58a95b636c977c18426193a33d654dcc6efc53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the members CTA in the dashboard to say "Invite" instead of "Create" when adding organization members for clearer wording.
Added an optional `label` prop to `CreateResourceButton` (defaults to "Create") and used it in `UpsertOrganizationAccessSheet` to display "Invite".

<sup>Written for commit d0fbdb2be4f4c052d8bd41b2755c7dc907cd23e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

