### PR TITLE
refactor(daemon,sdk): single-roundtrip PTY create-connect + instant exit detection

### DIFF
--- a/apps/daemon/pkg/toolbox/docs/docs.go
+++ b/apps/daemon/pkg/toolbox/docs/docs.go
@@ -2784,6 +2784,54 @@ const docTemplate = `{
                 }
             }
         },
+        "/process/pty/create-connect": {
+            "get": {
+                "description": "Creates a new PTY session and immediately establishes a WebSocket connection.\nPTY configuration is passed as query parameters. The shell starts on WS open.\nThis is faster than calling create + connect separately (1 round-trip vs 2).",
+                "tags": [
+                    "process"
+                ],
+                "summary": "Create and connect to a PTY session in a single WebSocket upgrade",
+                "operationId": "CreateAndConnectPtySession",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "PTY session ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Working directory",
+                        "name": "cwd",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Terminal columns (default: 80)",
+                        "name": "cols",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Terminal rows (default: 24)",
+                        "name": "rows",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~\u003cbase64url-no-padding JSON object\u003e",
+                        "name": "Sec-WebSocket-Protocol",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols - WebSocket connection established"
+                    }
+                }
+            }
+        },
         "/process/pty/{sessionId}": {
             "get": {
                 "description": "Get detailed information about a specific pseudo-terminal session",

--- a/apps/daemon/pkg/toolbox/docs/swagger.json
+++ b/apps/daemon/pkg/toolbox/docs/swagger.json
@@ -2418,6 +2418,52 @@
         }
       }
     },
+    "/process/pty/create-connect": {
+      "get": {
+        "description": "Creates a new PTY session and immediately establishes a WebSocket connection.\nPTY configuration is passed as query parameters. The shell starts on WS open.\nThis is faster than calling create + connect separately (1 round-trip vs 2).",
+        "tags": ["process"],
+        "summary": "Create and connect to a PTY session in a single WebSocket upgrade",
+        "operationId": "CreateAndConnectPtySession",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "PTY session ID",
+            "name": "id",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Working directory",
+            "name": "cwd",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "Terminal columns (default: 80)",
+            "name": "cols",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "Terminal rows (default: 24)",
+            "name": "rows",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~\u003cbase64url-no-padding JSON object\u003e",
+            "name": "Sec-WebSocket-Protocol",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "101": {
+            "description": "Switching Protocols - WebSocket connection established"
+          }
+        }
+      }
+    },
     "/process/pty/{sessionId}": {
       "get": {
         "description": "Get detailed information about a specific pseudo-terminal session",

--- a/apps/daemon/pkg/toolbox/docs/swagger.yaml
+++ b/apps/daemon/pkg/toolbox/docs/swagger.yaml
@@ -3069,6 +3069,43 @@ paths:
       summary: Resize a PTY session
       tags:
         - process
+  /process/pty/create-connect:
+    get:
+      description: |-
+        Creates a new PTY session and immediately establishes a WebSocket connection.
+        PTY configuration is passed as query parameters. The shell starts on WS open.
+        This is faster than calling create + connect separately (1 round-trip vs 2).
+      operationId: CreateAndConnectPtySession
+      parameters:
+        - description: PTY session ID
+          in: query
+          name: id
+          required: true
+          type: string
+        - description: Working directory
+          in: query
+          name: cwd
+          type: string
+        - description: 'Terminal columns (default: 80)'
+          in: query
+          name: cols
+          type: integer
+        - description: 'Terminal rows (default: 24)'
+          in: query
+          name: rows
+          type: integer
+        - description:
+            WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding
+            JSON object>
+          in: header
+          name: Sec-WebSocket-Protocol
+          type: string
+      responses:
+        '101':
+          description: Switching Protocols - WebSocket connection established
+      summary: Create and connect to a PTY session in a single WebSocket upgrade
+      tags:
+        - process
   /process/session:
     get:
       description: Get a list of all active shell sessions

--- a/apps/daemon/pkg/toolbox/process/pty/controller.go
+++ b/apps/daemon/pkg/toolbox/process/pty/controller.go
@@ -8,17 +8,29 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
+	"strconv"
 
 	"github.com/daytonaio/daemon/internal/util"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-	cmap "github.com/orcaman/concurrent-map/v2"
 )
 
 // NewPTYController creates a new PTY controller
 func NewPTYController(logger *slog.Logger, workDir string) *PTYController {
 	return &PTYController{logger: logger.With(slog.String("component", "PTY_controller")), workDir: workDir}
+}
+
+// sendWSError sends a control error message over the WebSocket and closes it.
+func sendWSError(ws *websocket.Conn, message string) {
+	errorMsg := map[string]interface{}{
+		"type":   "control",
+		"status": "error",
+		"error":  message,
+	}
+	if errorJSON, err := json.Marshal(errorMsg); err == nil {
+		_ = ws.WriteMessage(websocket.TextMessage, errorJSON)
+	}
+	_ = ws.Close()
 }
 
 // CreatePTYSession godoc
@@ -56,12 +68,6 @@ func (p *PTYController) CreatePTYSession(c *gin.Context) {
 	if req.Cwd == "" {
 		req.Cwd = p.workDir
 	}
-	if req.Envs == nil {
-		req.Envs = make(map[string]string, 1)
-	}
-	if req.Envs["TERM"] == "" {
-		req.Envs["TERM"] = "xterm-256color"
-	}
 	if req.Cols == nil {
 		req.Cols = util.Pointer(uint16(80))
 	}
@@ -78,33 +84,10 @@ func (p *PTYController) CreatePTYSession(c *gin.Context) {
 		return
 	}
 
-	session := &PTYSession{
-		info: PTYSessionInfo{
-			ID:        req.ID,
-			Cwd:       req.Cwd,
-			Envs:      req.Envs,
-			Cols:      *req.Cols,
-			Rows:      *req.Rows,
-			CreatedAt: time.Now(),
-			Active:    false,
-			LazyStart: req.LazyStart,
-		},
-		clients: cmap.New[*wsClient](),
-		logger:  p.logger.With(slog.String("sessionId", req.ID)),
-	}
-
-	// Add to manager first to prevent race conditions
-	ptyManager.Add(session)
-
-	// Start PTY immediately if not lazy start (default behavior)
-	if !req.LazyStart {
-		if err := session.start(); err != nil {
-			// If start fails, remove from manager
-			ptyManager.Delete(req.ID)
-			p.logger.Error("failed to start PTY at create", "error", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start PTY session"})
-			return
-		}
+	if _, err := createAndStartSession(req.ID, req.Cwd, req.Envs, *req.Cols, *req.Rows, req.LazyStart, p.logger); err != nil {
+		p.logger.Error("failed to start PTY at create", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to start PTY session"})
+		return
 	}
 
 	c.JSON(http.StatusCreated, PTYCreateResponse{SessionID: req.ID})
@@ -203,16 +186,7 @@ func (p *PTYController) ConnectPTYSession(c *gin.Context) {
 	session, err := ptyManager.VerifyPTYSessionReady(id)
 	if err != nil {
 		p.logger.Debug("failed to connect to PTY session", "sessionId", id, "error", err)
-		// Send error control message
-		errorMsg := map[string]interface{}{
-			"type":   "control",
-			"status": "error",
-			"error":  "Failed to connect to PTY session: " + err.Error(),
-		}
-		if errorJSON, err := json.Marshal(errorMsg); err == nil {
-			_ = ws.WriteMessage(websocket.TextMessage, errorJSON)
-		}
-		_ = ws.Close()
+		sendWSError(ws, "Failed to connect to PTY session: "+err.Error())
 		return
 	}
 
@@ -270,4 +244,80 @@ func (p *PTYController) ResizePTYSession(c *gin.Context) {
 	// Return updated session info
 	updatedInfo := session.Info()
 	c.JSON(http.StatusOK, updatedInfo)
+}
+
+// CreateAndConnectPTYSession godoc
+//
+//	@Summary		Create and connect to a PTY session in a single WebSocket upgrade
+//	@Description	Creates a new PTY session and immediately establishes a WebSocket connection.
+//	@Description	PTY configuration is passed as query parameters. The shell starts on WS open.
+//	@Description	This is faster than calling create + connect separately (1 round-trip vs 2).
+//	@Tags			process
+//	@Param			id						query	string	true	"PTY session ID"
+//	@Param			cwd						query	string	false	"Working directory"
+//	@Param			cols					query	int		false	"Terminal columns (default: 80)"
+//	@Param			rows					query	int		false	"Terminal rows (default: 24)"
+//	@Param			Sec-WebSocket-Protocol	header	string	false	"WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>"
+//	@Success		101						"Switching Protocols - WebSocket connection established"
+//	@Router			/process/pty/create-connect [get]
+//
+//	@id				CreateAndConnectPtySession
+func (p *PTYController) CreateAndConnectPTYSession(c *gin.Context) {
+	id := c.Query("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "session ID is required (query param 'id')"})
+		return
+	}
+
+	// Check if session with this ID already exists
+	if _, exists := ptyManager.Get(id); exists {
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("PTY session with ID '%s' already exists", id)})
+		return
+	}
+
+	// Parse optional params with defaults
+	cwd := c.DefaultQuery("cwd", p.workDir)
+	cols := parseUint16Query(c, "cols", 80)
+	rows := parseUint16Query(c, "rows", 24)
+
+	if cols > 1000 || rows > 1000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cols and rows must be less than 1000"})
+		return
+	}
+
+	// Envs arrive as a WebSocket subprotocol token (kept out of the URL).
+	envs, err := extractPtyEnvsSubprotocol(c.Request.Header)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid envs subprotocol: " + err.Error()})
+		return
+	}
+	// Upgrade to WebSocket FIRST (before creating session)
+	ws, err := util.UpgradeToWebSocket(c.Writer, c.Request)
+	if err != nil {
+		p.logger.Error("ws upgrade failed", "error", err)
+		return
+	}
+
+	session, err := createAndStartSession(id, cwd, envs, cols, rows, false, p.logger)
+	if err != nil {
+		p.logger.Error("failed to start PTY session", "error", err)
+		sendWSError(ws, "Failed to start PTY session: "+err.Error())
+		return
+	}
+
+	// Attach WS client — sends "connected" control message and blocks on reader
+	session.attachWebSocket(ws)
+}
+
+// parseUint16Query parses a uint16 query parameter with a default value.
+func parseUint16Query(c *gin.Context, key string, defaultVal uint16) uint16 {
+	str := c.Query(key)
+	if str == "" {
+		return defaultVal
+	}
+	val, err := strconv.ParseUint(str, 10, 16)
+	if err != nil {
+		return defaultVal
+	}
+	return uint16(val)
 }

--- a/apps/daemon/pkg/toolbox/process/pty/manager.go
+++ b/apps/daemon/pkg/toolbox/process/pty/manager.go
@@ -26,6 +26,12 @@ func (m *PTYManager) Add(s *PTYSession) {
 	m.sessions.Set(s.info.ID, s)
 }
 
+// AddIfAbsent adds a PTY session only if no session with the same ID exists.
+// It returns true if the session was added, false if one already existed.
+func (m *PTYManager) AddIfAbsent(s *PTYSession) bool {
+	return m.sessions.SetIfAbsent(s.info.ID, s)
+}
+
 // Get retrieves a PTY session by ID
 func (m *PTYManager) Get(id string) (*PTYSession, bool) {
 	s, ok := m.sessions.Get(id)

--- a/apps/daemon/pkg/toolbox/process/pty/session.go
+++ b/apps/daemon/pkg/toolbox/process/pty/session.go
@@ -5,17 +5,61 @@ package pty
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 	"github.com/daytonaio/daemon/pkg/childreap"
 	"github.com/daytonaio/daemon/pkg/common"
+	cmap "github.com/orcaman/concurrent-map/v2"
 	"github.com/shirou/gopsutil/v4/process"
 )
+
+// createAndStartSession creates a PTYSession, adds it to the manager, and starts it if not lazy.
+// On start failure it removes the session from the manager and returns the error.
+func createAndStartSession(id, cwd string, envs map[string]string, cols, rows uint16, lazyStart bool, logger *slog.Logger) (*PTYSession, error) {
+	if envs == nil {
+		envs = make(map[string]string, 1)
+	}
+	if envs["TERM"] == "" {
+		envs["TERM"] = "xterm-256color"
+	}
+
+	session := &PTYSession{
+		info: PTYSessionInfo{
+			ID:        id,
+			Cwd:       cwd,
+			Envs:      envs,
+			Cols:      cols,
+			Rows:      rows,
+			CreatedAt: time.Now(),
+			Active:    false,
+			LazyStart: lazyStart,
+		},
+		clients: cmap.New[*wsClient](),
+		logger:  logger.With(slog.String("sessionId", id)),
+	}
+
+	if !ptyManager.AddIfAbsent(session) {
+		return nil, fmt.Errorf("PTY session with ID '%s' already exists", id)
+	}
+
+	if !lazyStart {
+		if err := session.start(); err != nil {
+			ptyManager.Delete(id)
+			return nil, err
+		}
+	}
+
+	return session, nil
+}
 
 // Info returns the current session information
 func (s *PTYSession) Info() PTYSessionInfo {
@@ -109,7 +153,26 @@ func (s *PTYSession) start() error {
 		sessionID := s.info.ID
 		s.mu.Unlock()
 
-		// Close WebSocket connections with exit code and reason
+		// Send exit event as a data-channel control message FIRST (instant detection by SDK).
+		// Old SDKs that don't handle "exited" will simply ignore this text message and still
+		// receive the WS close frame below — no breaking change.
+		exitMsg := map[string]interface{}{
+			"type":     "control",
+			"status":   "exited",
+			"exitCode": exitCode,
+		}
+		// Only attach exitReason for a non-zero (failed) exit, matching
+		// closeClientsWithExitCode (which omits it for code 0). SDKs map
+		// exitReason -> error, so sending "clean exit" on a successful exit
+		// would make them report a spurious error on a clean run.
+		if exitCode != 0 && exitReason != "" {
+			exitMsg["exitReason"] = strings.TrimSpace(exitReason)
+		}
+		if exitJSON, err := json.Marshal(exitMsg); err == nil {
+			s.broadcastText(exitJSON)
+		}
+
+		// Close WebSocket connections with exit code and reason (transport-level close)
 		s.closeClientsWithExitCode(exitCode, exitReason)
 
 		// Remove session from manager - process has exited and won't be reused

--- a/apps/daemon/pkg/toolbox/process/pty/subprotocol.go
+++ b/apps/daemon/pkg/toolbox/process/pty/subprotocol.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package pty
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ptyEnvsSubprotocolPrefix carries PTY env vars as a WebSocket subprotocol token
+// (not a header/query) so they reach the daemon across all SDK runtimes and stay
+// out of request URLs.
+const ptyEnvsSubprotocolPrefix = "X-Daytona-Pty-Envs~"
+
+// extractPtyEnvsSubprotocol decodes env vars from the X-Daytona-Pty-Envs~ token
+// (base64url JSON) in Sec-WebSocket-Protocol. Empty map if absent, error if malformed.
+func extractPtyEnvsSubprotocol(header http.Header) (map[string]string, error) {
+	envs := make(map[string]string)
+
+	subprotocols := header.Get("Sec-WebSocket-Protocol")
+	if subprotocols == "" {
+		return envs, nil
+	}
+
+	for _, subprotocol := range strings.Split(subprotocols, ",") {
+		subprotocol = strings.TrimSpace(subprotocol)
+		if !strings.HasPrefix(subprotocol, ptyEnvsSubprotocolPrefix) {
+			continue
+		}
+
+		encoded := strings.TrimPrefix(subprotocol, ptyEnvsSubprotocolPrefix)
+		decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode PTY envs subprotocol: %w", err)
+		}
+		if err := json.Unmarshal(decoded, &envs); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal PTY envs subprotocol: %w", err)
+		}
+		return envs, nil
+	}
+
+	return envs, nil
+}

--- a/apps/daemon/pkg/toolbox/process/pty/subprotocol_test.go
+++ b/apps/daemon/pkg/toolbox/process/pty/subprotocol_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package pty
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+)
+
+func TestExtractPtyEnvsSubprotocol(t *testing.T) {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(`{"FOO":"bar"}`))
+	header := http.Header{}
+	header.Set("Sec-WebSocket-Protocol", "X-Daytona-SDK-Version~1.2.3, X-Daytona-Pty-Envs~"+encoded)
+
+	envs, err := extractPtyEnvsSubprotocol(header)
+	if err != nil {
+		t.Fatalf("extractPtyEnvsSubprotocol() unexpected error: %v", err)
+	}
+	if len(envs) != 1 || envs["FOO"] != "bar" {
+		t.Fatalf("extractPtyEnvsSubprotocol() = %v, want map[FOO:bar]", envs)
+	}
+}
+
+func TestExtractPtyEnvsSubprotocol_Absent(t *testing.T) {
+	// No Sec-WebSocket-Protocol header at all.
+	envs, err := extractPtyEnvsSubprotocol(http.Header{})
+	if err != nil {
+		t.Fatalf("extractPtyEnvsSubprotocol(empty) unexpected error: %v", err)
+	}
+	if len(envs) != 0 {
+		t.Fatalf("extractPtyEnvsSubprotocol(empty) = %v, want empty map", envs)
+	}
+
+	// Header present but envs token absent.
+	header := http.Header{}
+	header.Set("Sec-WebSocket-Protocol", "X-Daytona-SDK-Version~1.2.3")
+	envs, err = extractPtyEnvsSubprotocol(header)
+	if err != nil {
+		t.Fatalf("extractPtyEnvsSubprotocol(no-token) unexpected error: %v", err)
+	}
+	if len(envs) != 0 {
+		t.Fatalf("extractPtyEnvsSubprotocol(no-token) = %v, want empty map", envs)
+	}
+}
+
+func TestExtractPtyEnvsSubprotocol_Invalid(t *testing.T) {
+	// Invalid base64.
+	header := http.Header{}
+	header.Set("Sec-WebSocket-Protocol", "X-Daytona-Pty-Envs~not!valid!base64")
+	if _, err := extractPtyEnvsSubprotocol(header); err == nil {
+		t.Fatal("extractPtyEnvsSubprotocol(bad base64) expected error, got nil")
+	}
+
+	// Valid base64 but invalid JSON.
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(`not json`))
+	header = http.Header{}
+	header.Set("Sec-WebSocket-Protocol", "X-Daytona-Pty-Envs~"+encoded)
+	if _, err := extractPtyEnvsSubprotocol(header); err == nil {
+		t.Fatal("extractPtyEnvsSubprotocol(bad json) expected error, got nil")
+	}
+}

--- a/apps/daemon/pkg/toolbox/process/pty/websocket.go
+++ b/apps/daemon/pkg/toolbox/process/pty/websocket.go
@@ -116,6 +116,15 @@ func (s *PTYSession) broadcast(b []byte) {
 	s.clientsMu.RUnlock()
 }
 
+// broadcastText sends a text message directly to all connected WebSocket clients.
+// Used for control messages (JSON) that must be delivered as TextMessage, not BinaryMessage.
+// Uses writeMessage directly (bypassing the send channel) so the message is sent immediately.
+func (s *PTYSession) broadcastText(data []byte) {
+	for _, cl := range s.clients.Items() {
+		_ = cl.writeMessage(websocket.TextMessage, data)
+	}
+}
+
 // closeClientsWithExitCode closes all WebSocket connections with structured exit data
 func (s *PTYSession) closeClientsWithExitCode(exitCode int, exitReason string) {
 	var wsCloseCode int

--- a/apps/daemon/pkg/toolbox/process/pty/ws_client.go
+++ b/apps/daemon/pkg/toolbox/process/pty/ws_client.go
@@ -3,11 +3,16 @@
 
 package pty
 
+import "time"
+
 // writeMessage serializes all writes to the underlying websocket connection.
 // gorilla/websocket does not support concurrent writers.
 func (cl *wsClient) writeMessage(messageType int, data []byte) error {
 	cl.writeMu.Lock()
 	defer cl.writeMu.Unlock()
+	// Bound the write so a slow/stuck client can't block direct writers such as
+	// the exit control message and the close frame on the session exit path.
+	_ = cl.conn.SetWriteDeadline(time.Now().Add(writeWait))
 	return cl.conn.WriteMessage(messageType, data)
 }
 

--- a/apps/daemon/pkg/toolbox/server.go
+++ b/apps/daemon/pkg/toolbox/server.go
@@ -214,6 +214,7 @@ func (s *server) Start() error {
 		ptyController := pty.NewPTYController(s.logger, s.WorkDir)
 		ptyGroup := processController.Group("/pty")
 		{
+			ptyGroup.GET("/create-connect", ptyController.CreateAndConnectPTYSession) // must be before /:sessionId
 			ptyGroup.GET("", ptyController.ListPTYSessions)
 			ptyGroup.POST("", ptyController.CreatePTYSession)
 			ptyGroup.GET("/:sessionId", ptyController.GetPTYSession)

--- a/apps/docs/src/content/docs/en/java-sdk/pty.mdx
+++ b/apps/docs/src/content/docs/en/java-sdk/pty.mdx
@@ -136,6 +136,58 @@ Sets callback invoked for each PTY output chunk.
 
 - `PtyCreateOptions` - this options instance
 
+#### getCwd()
+```java
+public String getCwd()
+```
+
+Returns the working directory for the PTY session.
+
+**Returns**:
+
+- `String` - working directory, or `null` to use the sandbox default
+
+#### setCwd()
+```java
+public PtyCreateOptions setCwd(String cwd)
+```
+
+Sets the working directory for the PTY session.
+
+**Parameters**:
+
+- `cwd` _String_ - working directory
+
+**Returns**:
+
+- `PtyCreateOptions` - this options instance
+
+#### getEnvs()
+```java
+public Map<String, String> getEnvs()
+```
+
+Returns environment variables for the PTY session.
+
+**Returns**:
+
+- `Map\<String, String\>` - environment variables, or `null` when none configured
+
+#### setEnvs()
+```java
+public PtyCreateOptions setEnvs(Map<String, String> envs)
+```
+
+Sets environment variables for the PTY session.
+
+**Parameters**:
+
+- `envs` _Map\<String, String\>_ - environment variables
+
+**Returns**:
+
+- `PtyCreateOptions` - this options instance
+
 ## PtyResult
 
 Final outcome of a PTY session.

--- a/libs/sdk-go/pkg/daytona/process.go
+++ b/libs/sdk-go/pkg/daytona/process.go
@@ -6,7 +6,11 @@ package daytona
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/common"
 	"github.com/daytonaio/daytona/libs/sdk-go/pkg/errors"
@@ -1036,22 +1040,56 @@ func (p *ProcessService) CreatePty(ctx context.Context, id string, opts ...func(
 	return withInstrumentation(ctx, p.otel, "Process", "CreatePty", func(ctx context.Context) (*PtyHandle, error) {
 		createOpts := options.Apply(opts...)
 
-		// Convert to CreatePtySession options
-		sessionOpts := []func(*options.PtySession){}
+		// Build query params for single-roundtrip create-connect endpoint
+		cols := 80
+		rows := 24
 		if createOpts.PtySize != nil {
-			sessionOpts = append(sessionOpts, options.WithPtySize(*createOpts.PtySize))
-		}
-		if createOpts.Env != nil {
-			sessionOpts = append(sessionOpts, options.WithPtyEnv(createOpts.Env))
+			cols = createOpts.PtySize.Cols
+			rows = createOpts.PtySize.Rows
 		}
 
-		// Create the PTY session
-		_, err := p.CreatePtySession(ctx, id, sessionOpts...)
+		httpURL := p.toolboxClient.GetConfig().Servers[0].URL
+		wsURL := common.ConvertToWebSocketURL(httpURL)
+
+		values := url.Values{}
+		values.Set("id", id)
+		values.Set("cols", strconv.Itoa(cols))
+		values.Set("rows", strconv.Itoa(rows))
+
+		headers := make(map[string][]string)
+		cfg := p.toolboxClient.GetConfig()
+		for key, value := range cfg.DefaultHeader {
+			headers[key] = []string{value}
+		}
+
+		// Pass envs via a WebSocket subprotocol token (base64url-no-padding JSON) instead of a header.
+		var token string
+		if len(createOpts.Env) > 0 {
+			envJSON, err := json.Marshal(createOpts.Env)
+			if err != nil {
+				return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to encode PTY envs: %v", err), 0, nil)
+			}
+			token = "X-Daytona-Pty-Envs~" + base64.RawURLEncoding.EncodeToString(envJSON)
+		}
+
+		// gorilla/websocket's DefaultDialer is a shared global; copy it before mutating.
+		dialer := *websocket.DefaultDialer
+		if token != "" {
+			dialer.Subprotocols = []string{token}
+		}
+
+		conn, _, err := dialer.DialContext(ctx, fmt.Sprintf("%s/process/pty/create-connect?%s", wsURL, values.Encode()), headers)
 		if err != nil {
-			return nil, err
+			return nil, errors.NewDaytonaError(fmt.Sprintf("Failed to create and connect PTY: %v", err), 0, nil)
 		}
 
-		// Connect to the session
-		return p.ConnectPty(ctx, id)
+		resizeHandler := func(ctx context.Context, c, r int) (*types.PtySessionInfo, error) {
+			return p.ResizePtySession(ctx, id, types.PtySize{Cols: c, Rows: r})
+		}
+		killHandler := func(ctx context.Context) error {
+			return p.KillPtySession(ctx, id)
+		}
+
+		return newPtyHandle(conn, id, resizeHandler, killHandler), nil
 	})
 }

--- a/libs/sdk-go/pkg/daytona/pty_handle.go
+++ b/libs/sdk-go/pkg/daytona/pty_handle.go
@@ -417,7 +417,7 @@ func (h *PtyHandle) handleMessages() {
 			// Try to parse as control message
 			var ctrl controlMessage
 			if err := json.Unmarshal(data, &ctrl); err == nil && ctrl.Type == "control" {
-				h.handleControlMessage(&ctrl)
+				h.handleControlMessage(&ctrl, data)
 			} else {
 				// Regular text output - send to channel
 				// Make a copy of data since WebSocket reuses the buffer
@@ -444,8 +444,9 @@ func (h *PtyHandle) handleMessages() {
 	}
 }
 
-// handleControlMessage processes control messages from the server
-func (h *PtyHandle) handleControlMessage(msg *controlMessage) {
+// handleControlMessage processes control messages from the server.
+// rawData is the original JSON bytes for parsing extra fields (e.g. exitCode).
+func (h *PtyHandle) handleControlMessage(msg *controlMessage, rawData []byte) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -453,6 +454,25 @@ func (h *PtyHandle) handleControlMessage(msg *controlMessage) {
 	case "connected":
 		h.connected = true
 		h.connectionEstablished = true
+	case "exited":
+		// An instantly-exiting PTY may never emit "connected"; unblock WaitForConnection.
+		h.connectionEstablished = true
+		// Parse exit code and reason from the raw JSON (fields not in controlMessage struct)
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(rawData, &raw); err == nil {
+			if codeRaw, ok := raw["exitCode"]; ok {
+				var code int
+				if err := json.Unmarshal(codeRaw, &code); err == nil {
+					h.exitCode = &code
+				}
+			}
+			if reasonRaw, ok := raw["exitReason"]; ok {
+				var reason string
+				if err := json.Unmarshal(reasonRaw, &reason); err == nil {
+					h.err = &reason
+				}
+			}
+		}
 	case "error":
 		errMsg := msg.Error
 		if errMsg == "" {

--- a/libs/sdk-go/pkg/daytona/pty_handle_test.go
+++ b/libs/sdk-go/pkg/daytona/pty_handle_test.go
@@ -114,10 +114,10 @@ func TestPtyHandleReadEOFAndWriteWithoutConnection(t *testing.T) {
 func TestPtyHandleControlAndCloseParsing(t *testing.T) {
 	t.Run("control message updates connection state", func(t *testing.T) {
 		handle := &PtyHandle{}
-		handle.handleControlMessage(&controlMessage{Status: "connected"})
+		handle.handleControlMessage(&controlMessage{Status: "connected"}, nil)
 		assert.True(t, handle.connectionEstablished)
 		assert.True(t, handle.connected)
-		handle.handleControlMessage(&controlMessage{Status: "error", Error: "bad"})
+		handle.handleControlMessage(&controlMessage{Status: "error", Error: "bad"}, nil)
 		require.NotNil(t, handle.Error())
 		assert.Equal(t, "bad", *handle.Error())
 	})

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/Process.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/Process.java
@@ -3,6 +3,7 @@
 
 package io.daytona.sdk;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.daytona.sdk.model.*;
 import io.daytona.sdk.exception.DaytonaException;
 import io.daytona.toolbox.client.api.ProcessApi;
@@ -22,12 +23,15 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 
 import java.io.ByteArrayOutputStream;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
@@ -43,6 +47,9 @@ public class Process {
     private static final byte STDOUT_PREFIX_BYTE = 0x01;
     private static final byte STDERR_PREFIX_BYTE = 0x02;
     private static final int PREFIX_REPEAT_COUNT = 3;
+    private static final long PTY_CONNECTION_TIMEOUT_SECONDS = 10;
+    private static final String PTY_ENVS_SUBPROTOCOL_PREFIX = "X-Daytona-Pty-Envs~";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final ProcessApi processApi;
     private final Sandbox sandbox;
@@ -290,17 +297,48 @@ public class Process {
      */
     public PtyHandle createPty(PtyCreateOptions options) {
         PtyCreateOptions createOptions = options == null ? new PtyCreateOptions() : options;
-        PtyCreateRequest request = new PtyCreateRequest()
-                .id(createOptions.getId())
-                .cols(createOptions.getCols())
-                .rows(createOptions.getRows());
-
-        PtyCreateResponse response = ExceptionMapper.callToolbox(() -> processApi.createPtySession(request));
-        if (response == null || response.getSessionId() == null || response.getSessionId().isEmpty()) {
-            throw new DaytonaException("Failed to create PTY session");
+        String id = createOptions.getId();
+        if (id == null || id.isEmpty()) {
+            // Generate a client-side id when none is provided (preserves the
+            // legacy server-generated/default id flow).
+            id = "pty-" + UUID.randomUUID();
         }
 
-        return connectPty(response.getSessionId(), createOptions);
+        String wsUrl = buildPtyCreateConnectUrl(
+                sandbox.getToolboxApiClient().getBasePath(),
+                id,
+                createOptions.getCols(),
+                createOptions.getRows(),
+                createOptions.getCwd()
+        );
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(wsUrl)
+                .addHeader("Authorization", "Bearer " + sandbox.getApiKey());
+
+        // Envs are passed as a WebSocket subprotocol token (kept uniform across
+        // SDKs and the daemon, out of the URL/logs). okhttp has no dedicated
+        // client-side subprotocol API, so set it via the Sec-WebSocket-Protocol
+        // request header. Omitted when there are no envs.
+        Map<String, String> envs = createOptions.getEnvs();
+        if (envs != null && !envs.isEmpty()) {
+            String token = PTY_ENVS_SUBPROTOCOL_PREFIX + encodePtyEnvs(envs);
+            requestBuilder.addHeader("Sec-WebSocket-Protocol", token);
+        }
+        Request wsRequest = requestBuilder.build();
+
+        PtyHandle handle = new PtyHandle(
+                sandbox.getToolboxApiClient().getHttpClient(),
+                wsRequest,
+                id,
+                this::resizePtySession,
+                this::killPtySession,
+                createOptions.getOnData()
+        );
+        // The WebSocket connects asynchronously and the daemon registers the
+        // session on connect, so wait for the connection before returning (other
+        // SDKs do the same) — otherwise an immediate listPtySessions() races it.
+        handle.waitForConnection(PTY_CONNECTION_TIMEOUT_SECONDS);
+        return handle;
     }
 
     /**
@@ -330,7 +368,7 @@ public class Process {
                 .addHeader("Authorization", "Bearer " + sandbox.getApiKey())
                 .build();
 
-        return new PtyHandle(
+        PtyHandle handle = new PtyHandle(
                 sandbox.getToolboxApiClient().getHttpClient(),
                 wsRequest,
                 sessionId,
@@ -338,6 +376,8 @@ public class Process {
                 this::killPtySession,
                 connectOptions.getOnData()
         );
+        handle.waitForConnection(PTY_CONNECTION_TIMEOUT_SECONDS);
+        return handle;
     }
 
     /**
@@ -397,6 +437,35 @@ public class Process {
                 .replaceFirst("^https://", "wss://")
                 .replaceFirst("^http://", "ws://");
         return wsBase + "/process/pty/" + sessionId + "/connect";
+    }
+
+    private String buildPtyCreateConnectUrl(String toolboxBaseUrl, String id, int cols, int rows, String cwd) {
+        if (toolboxBaseUrl == null || toolboxBaseUrl.isEmpty()) {
+            throw new DaytonaException("Toolbox base URL is not available");
+        }
+        String wsBase = toolboxBaseUrl
+                .replaceFirst("^https://", "wss://")
+                .replaceFirst("^http://", "ws://");
+        // URL-encode user-provided values so reserved characters don't corrupt the
+        // request; cols/rows are ints and safe to inline.
+        StringBuilder url = new StringBuilder(wsBase)
+                .append("/process/pty/create-connect?id=")
+                .append(URLEncoder.encode(id, StandardCharsets.UTF_8))
+                .append("&cols=").append(cols)
+                .append("&rows=").append(rows);
+        if (cwd != null && !cwd.isEmpty()) {
+            url.append("&cwd=").append(URLEncoder.encode(cwd, StandardCharsets.UTF_8));
+        }
+        return url.toString();
+    }
+
+    private String encodePtyEnvs(Map<String, String> envs) {
+        try {
+            byte[] json = OBJECT_MAPPER.writeValueAsBytes(envs);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(json);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new DaytonaException("Failed to serialize PTY environment variables", e);
+        }
     }
 
     private void streamDemuxedLogsViaWebSocket(String wsUrl, Consumer<String> onStdout, Consumer<String> onStderr) {

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/PtyCreateOptions.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/PtyCreateOptions.java
@@ -3,6 +3,7 @@
 
 package io.daytona.sdk;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -13,6 +14,8 @@ public class PtyCreateOptions {
     private int cols = 120;
     private int rows = 30;
     private Consumer<byte[]> onData;
+    private String cwd;
+    private Map<String, String> envs;
 
     /**
      * Creates PTY options with default dimensions ({@code 120x30}).
@@ -112,6 +115,46 @@ public class PtyCreateOptions {
      */
     public PtyCreateOptions setOnData(Consumer<byte[]> onData) {
         this.onData = onData;
+        return this;
+    }
+
+    /**
+     * Returns the working directory for the PTY session.
+     *
+     * @return working directory, or {@code null} to use the sandbox default
+     */
+    public String getCwd() {
+        return cwd;
+    }
+
+    /**
+     * Sets the working directory for the PTY session.
+     *
+     * @param cwd working directory
+     * @return this options instance
+     */
+    public PtyCreateOptions setCwd(String cwd) {
+        this.cwd = cwd;
+        return this;
+    }
+
+    /**
+     * Returns environment variables for the PTY session.
+     *
+     * @return environment variables, or {@code null} when none configured
+     */
+    public Map<String, String> getEnvs() {
+        return envs;
+    }
+
+    /**
+     * Sets environment variables for the PTY session.
+     *
+     * @param envs environment variables
+     * @return this options instance
+     */
+    public PtyCreateOptions setEnvs(Map<String, String> envs) {
+        this.envs = envs;
         return this;
     }
 }

--- a/libs/sdk-java/src/main/java/io/daytona/sdk/PtyHandle.java
+++ b/libs/sdk-java/src/main/java/io/daytona/sdk/PtyHandle.java
@@ -226,6 +226,20 @@ public class PtyHandle {
                         connectionLatch.countDown();
                         return;
                     }
+                    if ("exited".equals(status)) {
+                        if (node.has("exitCode") && !node.get("exitCode").isNull()) {
+                            exitCode = node.get("exitCode").asInt();
+                        }
+                        if (node.has("exitReason") && !node.get("exitReason").isNull()) {
+                            error = node.get("exitReason").asText();
+                        }
+                        // An instantly-exiting PTY may never emit "connected"; unblock
+                        // waitForConnection so it doesn't time out.
+                        connectionEstablished = true;
+                        connectionLatch.countDown();
+                        exitLatch.countDown();
+                        return;
+                    }
                     if ("error".equals(status)) {
                         error = node.path("error").asText("PTY control error");
                         connectionLatch.countDown();

--- a/libs/sdk-java/src/test/java/io/daytona/sdk/ProcessTest.java
+++ b/libs/sdk-java/src/test/java/io/daytona/sdk/ProcessTest.java
@@ -19,13 +19,12 @@ import io.daytona.toolbox.client.model.CodeRunArtifacts;
 import io.daytona.toolbox.client.model.CodeRunResponse;
 import io.daytona.toolbox.client.model.Command;
 import io.daytona.toolbox.client.model.ExecuteRequest;
-import io.daytona.toolbox.client.model.PtyCreateRequest;
 import io.daytona.toolbox.client.model.PtySessionInfo;
-import io.daytona.toolbox.client.model.PtyCreateResponse;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import okio.ByteString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -256,27 +256,123 @@ class ProcessTest {
     }
 
     @Test
-    void createPtyBuildsRequestAndRequiresSessionId() {
-        PtyCreateOptions options = new PtyCreateOptions().setId("pty-1").setCols(80).setRows(24);
-        when(processApi.createPtySession(any())).thenReturn(new PtyCreateResponse().sessionId("pty-1"));
+    void createPtyCreatesAndConnects() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+                @Override
+                public void onOpen(WebSocket webSocket, okhttp3.Response response) {
+                    webSocket.send("{\"type\":\"control\",\"status\":\"connected\"}");
+                }
 
-        PtyHandle handle = process.createPty(options);
+                @Override
+                public void onClosing(WebSocket webSocket, int code, String reason) {
+                    // Complete the close handshake so MockWebServer can shut down
+                    // promptly instead of blocking on its teardown timeout.
+                    webSocket.close(code, reason);
+                }
+            }));
+            Process ptyProcess = new Process(processApi, TestSupport.mockSandbox(server.url("/toolbox").toString()));
+            PtyCreateOptions options = new PtyCreateOptions().setId("pty-1").setCols(80).setRows(24);
 
-        assertThat(handle.getSessionId()).isEqualTo("pty-1");
-        ArgumentCaptor<PtyCreateRequest> captor = ArgumentCaptor.forClass(PtyCreateRequest.class);
-        verify(processApi).createPtySession(captor.capture());
-        assertThat(captor.getValue().getId()).isEqualTo("pty-1");
-        assertThat(captor.getValue().getCols()).isEqualTo(80);
-        assertThat(captor.getValue().getRows()).isEqualTo(24);
-        handle.disconnect();
+            PtyHandle handle = ptyProcess.createPty(options);
+
+            assertThat(handle.getSessionId()).isEqualTo("pty-1");
+            verify(processApi, never()).createPtySession(any());
+            handle.disconnect();
+        }
     }
 
     @Test
-    void createPtyRejectsMissingSessionId() {
-        when(processApi.createPtySession(any())).thenReturn(new PtyCreateResponse());
+    void createPtyGeneratesIdWhenMissing() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+                @Override
+                public void onOpen(WebSocket webSocket, okhttp3.Response response) {
+                    webSocket.send("{\"type\":\"control\",\"status\":\"connected\"}");
+                }
 
-        assertThatThrownBy(() -> process.createPty(new PtyCreateOptions()))
-                .hasMessageContaining("Failed to create PTY session");
+                @Override
+                public void onClosing(WebSocket webSocket, int code, String reason) {
+                    // Complete the close handshake so MockWebServer can shut down
+                    // promptly instead of blocking on its teardown timeout.
+                    webSocket.close(code, reason);
+                }
+            }));
+            Process ptyProcess = new Process(processApi, TestSupport.mockSandbox(server.url("/toolbox").toString()));
+
+            PtyHandle handle = ptyProcess.createPty(new PtyCreateOptions());
+
+            assertThat(handle.getSessionId()).startsWith("pty-");
+            RecordedRequest recorded = server.takeRequest();
+            assertThat(recorded.getPath())
+                    .contains("/process/pty/create-connect")
+                    .contains("id=" + handle.getSessionId());
+            handle.disconnect();
+        }
+    }
+
+    @Test
+    void createPtyPassesEnvsViaSubprotocolAndKeepsThemOutOfUrl() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+                @Override
+                public void onOpen(WebSocket webSocket, okhttp3.Response response) {
+                    webSocket.send("{\"type\":\"control\",\"status\":\"connected\"}");
+                }
+
+                @Override
+                public void onClosing(WebSocket webSocket, int code, String reason) {
+                    // Complete the close handshake so MockWebServer can shut down
+                    // promptly instead of blocking on its teardown timeout.
+                    webSocket.close(code, reason);
+                }
+            }));
+            Process ptyProcess = new Process(processApi, TestSupport.mockSandbox(server.url("/toolbox").toString()));
+            PtyCreateOptions options = new PtyCreateOptions()
+                    .setId("pty-1")
+                    .setCols(80)
+                    .setRows(24)
+                    .setCwd("/work dir")
+                    .setEnvs(Collections.singletonMap("FOO", "bar"));
+
+            PtyHandle handle = ptyProcess.createPty(options);
+
+            RecordedRequest recorded = server.takeRequest();
+            assertThat(recorded.getPath())
+                    .doesNotContain("FOO")
+                    .doesNotContain("envs")
+                    .contains("cwd=%2Fwork+dir");
+            String expectedToken = "X-Daytona-Pty-Envs~" + java.util.Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString("{\"FOO\":\"bar\"}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            assertThat(recorded.getHeader("Sec-WebSocket-Protocol")).contains(expectedToken);
+            handle.disconnect();
+        }
+    }
+
+    @Test
+    void createPtyOmitsEnvsHeaderWhenEmpty() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().withWebSocketUpgrade(new WebSocketListener() {
+                @Override
+                public void onOpen(WebSocket webSocket, okhttp3.Response response) {
+                    webSocket.send("{\"type\":\"control\",\"status\":\"connected\"}");
+                }
+
+                @Override
+                public void onClosing(WebSocket webSocket, int code, String reason) {
+                    // Complete the close handshake so MockWebServer can shut down
+                    // promptly instead of blocking on its teardown timeout.
+                    webSocket.close(code, reason);
+                }
+            }));
+            Process ptyProcess = new Process(processApi, TestSupport.mockSandbox(server.url("/toolbox").toString()));
+
+            PtyHandle handle = ptyProcess.createPty(new PtyCreateOptions().setId("pty-1"));
+
+            RecordedRequest recorded = server.takeRequest();
+            assertThat(recorded.getHeader("Sec-WebSocket-Protocol")).isNull();
+            handle.disconnect();
+        }
     }
 
     @Test

--- a/libs/sdk-python/src/daytona/_async/process.py
+++ b/libs/sdk-python/src/daytona/_async/process.py
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import base64
+import json
 import re
 from collections.abc import Awaitable, Callable
+from urllib.parse import urlencode
 
 import aiohttp
 
@@ -13,7 +16,6 @@ from daytona_toolbox_api_client_async import (
     CreateSessionRequest,
     ExecuteRequest,
     ProcessApi,
-    PtyCreateRequest,
     PtyResizeRequest,
     PtySessionInfo,
     Session,
@@ -25,6 +27,7 @@ from .._utils.otel_decorator import with_instrumentation
 from .._utils.stream import std_demux_stream_aio
 from .._utils.timeout import http_timeout
 from ..common.charts import parse_chart
+from ..common.errors import create_daytona_error
 from ..common.process import (
     CodeRunParams,
     ExecuteResponse,
@@ -59,8 +62,11 @@ class AsyncProcess:
         self,
         url: str,
         headers: dict[str, str],
+        subprotocols: list[str] | None = None,
     ) -> aiohttp.ClientWebSocketResponse:
-        return await http_session_of(self._api_client.api_client).ws_connect(url, headers=headers)
+        return await http_session_of(self._api_client.api_client).ws_connect(
+            url, headers=headers, protocols=subprotocols or ()
+        )
 
     async def _consume_log_websocket(
         self,
@@ -588,21 +594,70 @@ class AsyncProcess:
         Raises:
             DaytonaError: If the PTY session creation fails or the session ID is already in use.
         """
-        response = await self._api_client.create_pty_session(
-            request=PtyCreateRequest(
-                id=id,
-                cwd=cwd,
-                envs=envs,
-                cols=pty_size.cols if pty_size else None,
-                rows=pty_size.rows if pty_size else None,
-                lazy_start=True,
-            ),
-        )
+        cols = pty_size.cols if pty_size else 80
+        rows = pty_size.rows if pty_size else 24
 
-        return await self.connect_pty_session(
-            response.session_id,
-            on_data,
+        # Build query params for the combined create-connect endpoint (single round-trip)
+        params: dict[str, str] = {
+            "id": id,
+            "cols": str(cols),
+            "rows": str(rows),
+        }
+        if cwd:
+            params["cwd"] = cwd
+
+        # Derive the WS URL from the API client's base configuration
+        _, base_url, headers, *_ = self._api_client._connect_pty_session_serialize(
+            session_id="__placeholder__",
+            _request_auth=None,
+            _content_type=None,
+            _headers=None,
+            _host_index=None,
         )
+        url = base_url.replace("/process/pty/__placeholder__/connect", "/process/pty/create-connect")
+        url = re.sub(r"^http", "ws", url)
+        url = f"{url}?{urlencode(params)}"
+
+        # Envs travel as a WebSocket subprotocol token (base64url-no-pad of the JSON object)
+        # rather than the query string or a header, keeping the transport uniform across
+        # runtimes and potentially-large/secret values out of URLs and access logs.
+        subprotocols: list[str] | None = None
+        if envs:
+            encoded = base64.urlsafe_b64encode(json.dumps(envs).encode()).rstrip(b"=").decode()
+            subprotocols = [f"X-Daytona-Pty-Envs~{encoded}"]
+
+        try:
+            ws = await self._open_ws(url, headers, subprotocols)
+        except aiohttp.WSServerHandshakeError as e:
+            # A failed WS upgrade carries the HTTP response status; surface it as the matching
+            # typed Daytona exception (e.g. 404 -> DaytonaNotFoundError, 409 ->
+            # DaytonaConflictError) so callers can branch on it like any REST error.
+            status_code = e.status
+            raise create_daytona_error(
+                f"WebSocket upgrade failed with HTTP {status_code}",
+                status_code=status_code,
+                headers=e.headers,
+            ) from e
+
+        async def resize_handler(pty_size_arg: PtySize) -> PtySessionInfo:
+            return await self.resize_pty_session(id, pty_size_arg)
+
+        async def kill_handler() -> None:
+            await self.kill_pty_session(id)
+
+        handle = AsyncPtyHandle(
+            ws,
+            on_data,
+            session_id=id,
+            handle_resize=resize_handler,
+            handle_kill=kill_handler,
+        )
+        try:
+            await handle.wait_for_connection()
+        except BaseException:
+            await handle.disconnect()
+            raise
+        return handle
 
     @intercept_errors(message_prefix="Failed to connect PTY session: ")
     @with_instrumentation()

--- a/libs/sdk-python/src/daytona/_sync/process.py
+++ b/libs/sdk-python/src/daytona/_sync/process.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import re
+from urllib.parse import urlencode
 
 import httpx
 import httpx_ws
@@ -14,7 +17,6 @@ from daytona_toolbox_api_client import (
     CreateSessionRequest,
     ExecuteRequest,
     ProcessApi,
-    PtyCreateRequest,
     PtyResizeRequest,
     PtySessionInfo,
     Session,
@@ -585,20 +587,60 @@ class Process:
         Raises:
             DaytonaError: If the PTY session creation fails or the session ID is already in use.
         """
-        response = self._api_client.create_pty_session(
-            request=PtyCreateRequest(
-                id=id,
-                cwd=cwd,
-                envs=envs,
-                cols=pty_size.cols if pty_size else None,
-                rows=pty_size.rows if pty_size else None,
-                lazy_start=True,
-            ),
-        )
+        cols = pty_size.cols if pty_size else 80
+        rows = pty_size.rows if pty_size else 24
 
-        return self.connect_pty_session(
-            response.session_id,
+        # Build query params for the combined create-connect endpoint (single round-trip)
+        params: dict[str, str] = {
+            "id": id,
+            "cols": str(cols),
+            "rows": str(rows),
+        }
+        if cwd:
+            params["cwd"] = cwd
+
+        # Derive the WS URL from the API client's base configuration
+        _, base_url, headers, *_ = self._api_client._connect_pty_session_serialize(
+            session_id="__placeholder__",
+            _request_auth=None,
+            _content_type=None,
+            _headers=None,
+            _host_index=None,
         )
+        url = base_url.replace("/process/pty/__placeholder__/connect", "/process/pty/create-connect")
+        url = re.sub(r"^http", "ws", url)
+        url = f"{url}?{urlencode(params)}"
+
+        # Envs travel as a WebSocket subprotocol token (base64url-no-pad of the JSON object)
+        # rather than the query string or a header, keeping the transport uniform across
+        # runtimes and potentially-large/secret values out of URLs and access logs.
+        subprotocols: list[str] | None = None
+        if envs:
+            encoded = base64.urlsafe_b64encode(json.dumps(envs).encode()).rstrip(b"=").decode()
+            subprotocols = [f"X-Daytona-Pty-Envs~{encoded}"]
+
+        ws_cm = httpx_ws.connect_ws(url, self._http_client, headers=headers, subprotocols=subprotocols)
+        ws = ws_cm.__enter__()  # pylint: disable=unnecessary-dunder-call
+
+        def resize_handler(pty_size_arg: PtySize) -> PtySessionInfo:
+            return self.resize_pty_session(id, pty_size_arg)
+
+        def kill_handler() -> None:
+            self.kill_pty_session(id)
+
+        handle = PtyHandle(
+            ws,
+            session_id=id,
+            handle_resize=resize_handler,
+            handle_kill=kill_handler,
+            ws_context_manager=ws_cm,
+        )
+        try:
+            handle.wait_for_connection()
+        except BaseException:
+            handle.disconnect()
+            raise
+        return handle
 
     @intercept_errors(message_prefix="Failed to connect PTY session: ")
     @with_instrumentation()

--- a/libs/sdk-python/src/daytona/handle/async_pty_handle.py
+++ b/libs/sdk-python/src/daytona/handle/async_pty_handle.py
@@ -281,6 +281,17 @@ class AsyncPtyHandle:
 
         if status == "connected":
             self._connection_established = True
+        elif status == "exited":
+            # An instantly-exiting PTY may report "exited" before/instead of "connected".
+            # Mark the connection established so wait_for_connection() returns instead of
+            # timing out waiting for a "connected" message that will never arrive.
+            self._connection_established = True
+            exit_code = control_msg.get("exitCode")
+            if isinstance(exit_code, int):
+                self._exit_code = exit_code
+            exit_reason = control_msg.get("exitReason")
+            if isinstance(exit_reason, str):
+                self._error = exit_reason
         elif status == "error":
             self._error = cast(str, control_msg.get("error", "Unknown connection error"))
             self._connected = False

--- a/libs/sdk-python/src/daytona/handle/pty_handle.py
+++ b/libs/sdk-python/src/daytona/handle/pty_handle.py
@@ -307,6 +307,17 @@ class PtyHandle:
 
         if status == "connected":
             self._connection_established = True
+        elif status == "exited":
+            # An instantly-exiting PTY may report "exited" before/instead of "connected".
+            # Mark the connection established so wait_for_connection() returns instead of
+            # timing out waiting for a "connected" message that will never arrive.
+            self._connection_established = True
+            exit_code = control_msg.get("exitCode")
+            if isinstance(exit_code, int):
+                self._exit_code = exit_code
+            exit_reason = control_msg.get("exitReason")
+            if isinstance(exit_reason, str):
+                self._error = exit_reason
         elif status == "error":
             self._error = cast(str, control_msg.get("error", "Unknown connection error"))
             self._connected = False

--- a/libs/sdk-python/src/daytona/internal/http_client.py
+++ b/libs/sdk-python/src/daytona/internal/http_client.py
@@ -7,8 +7,13 @@ import weakref
 
 import aiohttp
 import httpx
+from httpx._utils import get_environment_proxies
 
 DEFAULT_POOL_SIZE = 250
+
+# WS upgrades share this keep-alive pool with REST and can occasionally fail the
+# TLS handshake on a stale/concurrent connection; retries re-establish on a fresh one.
+CONNECT_RETRIES = 3
 
 # TCP three-way handshake cap (httpx ``connect`` / aiohttp ``sock_connect``).
 # Matches aiohttp's session DEFAULT_TIMEOUT.sock_connect so streaming callers
@@ -46,11 +51,33 @@ def request_timeout(timeout: float) -> httpx.Timeout:
 
 
 def build_async_http_client(pool_size: int | None = DEFAULT_POOL_SIZE) -> httpx.AsyncClient:
-    return httpx.AsyncClient(limits=_build_limits(pool_size), timeout=_build_timeout())
+    # Passing a custom transport disables httpx's built-in HTTP(S)_PROXY/NO_PROXY handling,
+    # so rebuild the env-proxy mounts ourselves (NO_PROXY patterns map to a ``None`` mount
+    # that bypasses the proxy) while keeping our retry/limit-tuned transport.
+    limits = _build_limits(pool_size)
+    mounts = {
+        pattern: (httpx.AsyncHTTPTransport(retries=CONNECT_RETRIES, limits=limits, proxy=url) if url else None)
+        for pattern, url in get_environment_proxies().items()
+    }
+    return httpx.AsyncClient(
+        transport=httpx.AsyncHTTPTransport(retries=CONNECT_RETRIES, limits=limits),
+        mounts=mounts,
+        timeout=_build_timeout(),
+    )
 
 
 def build_sync_http_client(pool_size: int | None = DEFAULT_POOL_SIZE) -> httpx.Client:
-    client = httpx.Client(limits=_build_limits(pool_size), timeout=_build_timeout())
+    # See build_async_http_client: rebuild env-proxy mounts that the custom transport bypasses.
+    limits = _build_limits(pool_size)
+    mounts = {
+        pattern: (httpx.HTTPTransport(retries=CONNECT_RETRIES, limits=limits, proxy=url) if url else None)
+        for pattern, url in get_environment_proxies().items()
+    }
+    client = httpx.Client(
+        transport=httpx.HTTPTransport(retries=CONNECT_RETRIES, limits=limits),
+        mounts=mounts,
+        timeout=_build_timeout(),
+    )
     _attach_self_finalizer(client)
     return client
 

--- a/libs/sdk-ruby/lib/daytona/common/pty.rb
+++ b/libs/sdk-ruby/lib/daytona/common/pty.rb
@@ -68,6 +68,7 @@ module Daytona
       @handle_kill = handle_kill
       @exit_code = nil
       @error = nil
+      @exited = false
       @logger = Sdk.logger
 
       @status = Status::INIT
@@ -84,14 +85,14 @@ module Daytona
     # @param timeout [Float] Maximum time in seconds to wait for connection. Defaults to 10.0
     # @return [void]
     # @raise [Daytona::Sdk::Error] If connection timeout is exceeded
-    def wait_for_connection(timeout: DEFAULT_TIMEOUT)
-      return if status == Status::CONNECTED
+    def wait_for_connection(timeout: DEFAULT_TIMEOUT) # rubocop:disable Metrics/CyclomaticComplexity
+      return if status == Status::CONNECTED || @exited
 
       start_time = Time.now
 
-      sleep(SLEEP_INTERVAL) until status == Status::CONNECTED || (Time.now - start_time) > timeout
+      sleep(SLEEP_INTERVAL) until status == Status::CONNECTED || @exited || (Time.now - start_time) > timeout
 
-      raise Sdk::Error, 'PTY connection timeout' unless status == Status::CONNECTED
+      raise Sdk::Error, 'PTY connection timeout' unless status == Status::CONNECTED || @exited
     end
 
     # Send input to the PTY session
@@ -127,8 +128,9 @@ module Daytona
     #
     # @param on_data [Proc, nil] Optional callback to handle output data
     # @return [Daytona::PtyResult] Result containing exit code and error information
-    def wait(timeout: nil, &on_data)
+    def wait(timeout: nil, &on_data) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/AbcSize
       timeout ||= Float::INFINITY
+      return PtyResult.new(exit_code:, error:) if @exited
       return unless status == Status::CONNECTED
 
       start_time = Time.now
@@ -239,11 +241,17 @@ module Daytona
 
     # @param data [WebSocket::Frame::Data]
     # @return [void]
-    def process_websocket_control_message(data) # rubocop:disable Metrics/MethodLength
+    def process_websocket_control_message(data) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       case data[:status]
       when WebSocketControlStatus::CONNECTED
         logger.debug('[control] connected')
         @status = Status::CONNECTED
+      when WebSocketControlStatus::EXITED
+        logger.debug("[control] exited: code=#{data[:exitCode]}")
+        @exit_code = data[:exitCode]
+        @error = data[:exitReason] if data[:exitReason]
+        @exited = true
+        @status = Status::CLOSED
       when WebSocketControlStatus::ERROR
         logger.debug("[control] error: #{error.inspect}")
         @status = Status::ERROR
@@ -302,6 +310,7 @@ module Daytona
     module WebSocketControlStatus
       ALL = [
         CONNECTED = 'connected',
+        EXITED = 'exited',
         ERROR = 'error'
       ].freeze
     end

--- a/libs/sdk-ruby/lib/daytona/process.rb
+++ b/libs/sdk-ruby/lib/daytona/process.rb
@@ -3,6 +3,8 @@
 
 # frozen_string_literal: true
 
+require 'base64'
+require 'json'
 require 'uri'
 
 module Daytona
@@ -410,19 +412,35 @@ module Daytona
     #   pty_handle.disconnect
     #
     # @raise [Daytona::Sdk::Error] If the PTY session creation fails or the session ID is already in use.
-    def create_pty_session(id:, cwd: nil, envs: nil, pty_size: nil) # rubocop:disable Metrics/MethodLength
-      response = toolbox_api.create_pty_session(
-        DaytonaToolboxApiClient::PtyCreateRequest.new(
-          id:,
-          cwd:,
-          envs:,
-          cols: pty_size&.cols,
-          rows: pty_size&.rows,
-          lazy_start: true
-        )
-      )
+    def create_pty_session(id:, cwd: nil, envs: nil, pty_size: nil) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
+      cols = pty_size&.cols || 80
+      rows = pty_size&.rows || 24
 
-      connect_pty_session(response.session_id)
+      preview_link = get_preview_link.call(WS_PORT)
+      url = URI.parse(preview_link.url)
+      url.scheme = url.scheme == 'https' ? 'wss' : 'ws'
+      url.path = '/process/pty/create-connect'
+
+      params = { id:, cols:, rows: }
+      params[:cwd] = cwd if cwd
+      url.query = URI.encode_www_form(params)
+
+      headers = toolbox_api.api_client.default_headers.dup.merge(
+        'X-Daytona-Preview-Token' => preview_link.token
+      )
+      if envs
+        envs_protocol = "X-Daytona-Pty-Envs~#{Base64.urlsafe_encode64(envs.to_json, padding: false)}"
+        existing_protocol = headers['Sec-WebSocket-Protocol']
+        headers['Sec-WebSocket-Protocol'] =
+          existing_protocol ? "#{existing_protocol}, #{envs_protocol}" : envs_protocol
+      end
+
+      PtyHandle.new(
+        WebSocket::Client::Simple.connect(url.to_s, headers:),
+        session_id: id,
+        handle_resize: ->(pty_size_arg) { resize_pty_session(id, pty_size_arg) },
+        handle_kill: -> { delete_pty_session(id) }
+      ).tap(&:wait_for_connection)
     end
 
     # Connects to an existing PTY session in the Sandbox.

--- a/libs/sdk-ruby/spec/daytona/process_spec.rb
+++ b/libs/sdk-ruby/spec/daytona/process_spec.rb
@@ -348,10 +348,11 @@ RSpec.describe Daytona::Process do
 
   describe '#create_pty_session' do
     it 'creates a PTY session and connects to it' do
-      response = double('PtyCreateResponse', session_id: 'pty-1')
+      socket = double('PtySocket')
       handle = instance_double(Daytona::PtyHandle)
-      allow(toolbox_api).to receive(:create_pty_session).and_return(response)
-      allow(process).to receive(:connect_pty_session).with('pty-1').and_return(handle)
+      allow(WebSocket::Client::Simple).to receive(:connect).and_return(socket)
+      allow(Daytona::PtyHandle).to receive(:new).and_return(handle)
+      allow(handle).to receive(:wait_for_connection)
 
       result = process.create_pty_session(
         id: 'pty-1',
@@ -361,14 +362,25 @@ RSpec.describe Daytona::Process do
       )
 
       expect(result).to eq(handle)
-      expect(toolbox_api).to have_received(:create_pty_session) do |req|
-        expect(req.id).to eq('pty-1')
-        expect(req.cwd).to eq('/workspace')
-        expect(req.envs).to eq({ 'TERM' => 'xterm' })
-        expect(req.rows).to eq(24)
-        expect(req.cols).to eq(80)
-        expect(req.lazy_start).to be(true)
-      end
+      expected_query = URI.encode_www_form(
+        id: 'pty-1', cols: 80, rows: 24, cwd: '/workspace'
+      )
+      expected_protocol =
+        "X-Daytona-Pty-Envs~#{Base64.urlsafe_encode64({ 'TERM' => 'xterm' }.to_json, padding: false)}"
+      expect(WebSocket::Client::Simple).to have_received(:connect).with(
+        "wss://preview.example.com/process/pty/create-connect?#{expected_query}",
+        headers: hash_including(
+          'X-Daytona-Preview-Token' => 'tok',
+          'Sec-WebSocket-Protocol' => expected_protocol
+        )
+      )
+      expect(Daytona::PtyHandle).to have_received(:new).with(
+        socket,
+        session_id: 'pty-1',
+        handle_resize: instance_of(Proc),
+        handle_kill: instance_of(Proc)
+      )
+      expect(handle).to have_received(:wait_for_connection)
     end
   end
 

--- a/libs/sdk-typescript/src/Process.ts
+++ b/libs/sdk-typescript/src/Process.ts
@@ -10,7 +10,6 @@ import type {
   SessionExecuteRequest,
   SessionExecuteResponse as ApiSessionExecuteResponse,
   CodeRunRequest,
-  PtyCreateRequest,
   PtySessionInfo,
 } from '@daytona/toolbox-api-client'
 import type { ExecuteResponse } from './types/ExecuteResponse'
@@ -19,6 +18,7 @@ import { stdDemuxStream } from './utils/Stream'
 import { PtyHandle } from './PtyHandle'
 import type { PtyCreateOptions, PtyConnectOptions } from './types/Pty'
 import { createSandboxWebSocket } from './utils/WebSocket'
+import { toBuffer } from './utils/Binary'
 import { WithInstrumentation } from './utils/otel.decorator'
 
 // 3-byte multiplexing markers inserted by the shell labelers
@@ -531,18 +531,46 @@ export class Process {
    */
   @WithInstrumentation()
   public async createPty(options?: PtyCreateOptions & PtyConnectOptions): Promise<PtyHandle> {
-    const request: PtyCreateRequest = {
-      id: options.id,
-      cwd: options.cwd,
-      envs: options.envs,
-      cols: options.cols,
-      rows: options.rows,
-      lazyStart: true,
+    const id = options.id
+    const cols = options.cols ?? 80
+    const rows = options.rows ?? 24
+
+    // Build query params for the combined create-connect endpoint (single round-trip)
+    const params = new URLSearchParams({
+      id,
+      cols: String(cols),
+      rows: String(rows),
+    })
+    if (options.cwd) params.set('cwd', options.cwd)
+
+    const wsUrl = `${this.clientConfig.basePath.replace(/^http/, 'ws')}/process/pty/create-connect?${params.toString()}`
+
+    // Envs are passed via a WebSocket subprotocol token (base64url, no padding, of the JSON object)
+    // rather than the query string or a header, so they forward uniformly across browser/Deno/serverless
+    // runtimes and match the daemon's create-connect protocol.
+    const headers: Record<string, any> = { ...(this.clientConfig.baseOptions?.headers || {}) }
+    const subprotocols: string[] = []
+    if (options.envs && Object.keys(options.envs).length) {
+      const b64url = toBuffer(new TextEncoder().encode(JSON.stringify(options.envs)))
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '')
+      subprotocols.push(`X-Daytona-Pty-Envs~${b64url}`)
     }
 
-    const response = await this.apiClient.createPtySession(request)
+    const ws = await createSandboxWebSocket(wsUrl, headers, this.getPreviewToken, subprotocols)
 
-    return await this.connectPty(response.data.sessionId, options)
+    const handle = new PtyHandle(
+      ws,
+      (handleCols: number, handleRows: number) => this.resizePtySession(id, handleCols, handleRows),
+      () => this.killPtySession(id),
+      options.onData,
+      id,
+    )
+    await handle.waitForConnection()
+
+    return handle
   }
 
   /**

--- a/libs/sdk-typescript/src/PtyHandle.ts
+++ b/libs/sdk-typescript/src/PtyHandle.ts
@@ -46,6 +46,9 @@ export class PtyHandle {
   private _error?: string
   private connected = false
   private connectionEstablished = false // Track control message received
+  private _connectionResolve: (() => void) | null = null
+  private _connectionReject: ((err: Error) => void) | null = null
+  private _exitResolvers: ((value: PtyResult) => void)[] = []
 
   constructor(
     private readonly ws: WebSocket,
@@ -94,22 +97,40 @@ export class PtyHandle {
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
+        this._connectionResolve = null
+        this._connectionReject = null
         reject(new DaytonaTimeoutError('PTY connection timeout'))
       }, 10000) // 10 second timeout
 
-      const checkConnection = () => {
-        if (this.connectionEstablished) {
-          clearTimeout(timeout)
-          resolve()
-        } else if (this.ws.readyState === WebSocket.CLOSED || this._error) {
-          clearTimeout(timeout)
-          reject(new DaytonaConnectionError(this._error || 'Connection failed'))
-        } else {
-          setTimeout(checkConnection, 100)
-        }
+      this._connectionResolve = () => {
+        clearTimeout(timeout)
+        this._connectionResolve = null
+        this._connectionReject = null
+        resolve()
+      }
+      this._connectionReject = (err: Error) => {
+        clearTimeout(timeout)
+        this._connectionResolve = null
+        this._connectionReject = null
+        reject(err)
       }
 
-      checkConnection()
+      // Check if already connected (race: message arrived before we set up handlers)
+      if (this.connectionEstablished) {
+        clearTimeout(timeout)
+        this._connectionResolve = null
+        this._connectionReject = null
+        resolve()
+        return
+      }
+
+      // Check if already failed
+      if (this.ws.readyState === WebSocket.CLOSED || this._error) {
+        clearTimeout(timeout)
+        this._connectionResolve = null
+        this._connectionReject = null
+        reject(new DaytonaConnectionError(this._error || 'Connection failed'))
+      }
     })
   }
 
@@ -213,30 +234,42 @@ export class PtyHandle {
    */
   @WithInstrumentation()
   async wait(): Promise<PtyResult> {
+    if (this._exitCode !== undefined) {
+      return { exitCode: this._exitCode, error: this._error }
+    }
+
     return new Promise((resolve, reject) => {
+      // Check again in case it resolved between the sync check and the promise setup
       if (this._exitCode !== undefined) {
-        resolve({
-          exitCode: this._exitCode,
-          error: this._error,
-        })
+        resolve({ exitCode: this._exitCode, error: this._error })
         return
       }
 
-      const checkExit = () => {
-        if (this._exitCode !== undefined) {
-          resolve({
-            exitCode: this._exitCode,
-            error: this._error,
-          })
-        } else if (this._error) {
-          reject(new DaytonaError(this._error))
-        } else {
-          setTimeout(checkExit, 100)
-        }
+      // If there's already an error and no exit code, reject
+      if (this._error && this._exitCode === undefined) {
+        reject(new DaytonaError(this._error))
+        return
       }
 
-      checkExit()
+      // Register this caller; all pending callers are resolved together on exit so
+      // concurrent wait() calls do not overwrite each other and hang forever.
+      this._exitResolvers.push(resolve)
     })
+  }
+
+  /**
+   * Resolve all pending wait() callers with the current exit result and clear them.
+   */
+  private resolveExit(): void {
+    if (this._exitResolvers.length === 0) {
+      return
+    }
+    const result: PtyResult = { exitCode: this._exitCode, error: this._error }
+    const resolvers = this._exitResolvers
+    this._exitResolvers = []
+    for (const resolve of resolvers) {
+      resolve(result)
+    }
   }
 
   /**
@@ -283,10 +316,29 @@ export class PtyHandle {
             if (controlMsg.type === 'control') {
               if (controlMsg.status === 'connected') {
                 this.connectionEstablished = true
+                if (this._connectionResolve) {
+                  this._connectionResolve()
+                }
+                return
+              } else if (controlMsg.status === 'exited') {
+                this._exitCode = controlMsg.exitCode ?? undefined
+                if (controlMsg.exitReason) {
+                  this._error = controlMsg.exitReason
+                }
+                // An instantly-exiting PTY still means the connection was established;
+                // unblock any pending waitForConnection() so it does not hang/reject.
+                this.connectionEstablished = true
+                if (this._connectionResolve) {
+                  this._connectionResolve()
+                }
+                this.resolveExit()
                 return
               } else if (controlMsg.status === 'error') {
                 this._error = controlMsg.error || 'Unknown connection error'
                 this.connected = false
+                if (this._connectionReject) {
+                  this._connectionReject(new DaytonaConnectionError(this._error))
+                }
                 return
               }
             }
@@ -336,14 +388,19 @@ export class PtyHandle {
 
       this._error = errorMessage
       this.connected = false
+
+      // Reject pending waitForConnection() if still waiting
+      if (this._connectionReject) {
+        this._connectionReject(new DaytonaConnectionError(errorMessage))
+      }
     }
 
     // Handle WebSocket close - parse structured exit data
     const handleClose = async (event: CloseEvent | any) => {
       this.connected = false
 
-      // Parse structured exit data from close reason
-      if (event && event.reason) {
+      // Parse structured exit data from close reason (only if not already set by control message)
+      if (this._exitCode === undefined && event && event.reason) {
         try {
           const exitData = JSON.parse(event.reason)
           if (typeof exitData.exitCode === 'number') {
@@ -367,6 +424,14 @@ export class PtyHandle {
       // Default to exit code 0 if we can't parse it and it was a normal close
       if (this._exitCode === undefined && event && event.code === 1000) {
         this._exitCode = 0
+      }
+
+      // Resolve pending wait() if not already resolved by control message
+      this.resolveExit()
+
+      // Reject pending waitForConnection() if still waiting
+      if (this._connectionReject) {
+        this._connectionReject(new DaytonaConnectionError(this._error || 'Connection closed'))
       }
     }
 

--- a/libs/sdk-typescript/src/__tests__/Process.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Process.test.ts
@@ -301,7 +301,6 @@ describe('Process', () => {
     const { process, apiClient } = await makeProcess()
     const ws = { close: jest.fn() }
 
-    apiClient.createPtySession.mockResolvedValue(createApiResponse({ sessionId: 'pty-1' }))
     mockCreateSandboxWebSocket.mockResolvedValue(ws)
 
     const onData = jest.fn()
@@ -314,18 +313,19 @@ describe('Process', () => {
       onData,
     })
 
-    expect(apiClient.createPtySession).toHaveBeenCalledWith({
-      id: 'pty-1',
-      cwd: '/tmp',
-      envs: { TERM: 'xterm-256color' },
-      cols: 120,
-      rows: 40,
-      lazyStart: true,
-    })
+    expect(apiClient.createPtySession).not.toHaveBeenCalled()
+    const expectedParams = new URLSearchParams({ id: 'pty-1', cols: '120', rows: '40' })
+    expectedParams.set('cwd', '/tmp')
+    const expectedEnvsToken = `X-Daytona-Pty-Envs~${Buffer.from(JSON.stringify({ TERM: 'xterm-256color' }), 'utf8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')}`
     expect(mockCreateSandboxWebSocket).toHaveBeenCalledWith(
-      'ws://sandbox/process/pty/pty-1/connect',
+      `ws://sandbox/process/pty/create-connect?${expectedParams.toString()}`,
       { Authorization: 'Bearer t' },
       expect.any(Function),
+      [expectedEnvsToken],
     )
     expect(handle.sessionId).toBe('pty-1')
   })

--- a/libs/sdk-typescript/src/__tests__/PtyHandle.test.ts
+++ b/libs/sdk-typescript/src/__tests__/PtyHandle.test.ts
@@ -263,6 +263,35 @@ describe('PtyHandle', () => {
     expect(handle.error).toBe('pty gone')
   })
 
+  it('unblocks waitForConnection when the PTY exits instantly', async () => {
+    jest.useFakeTimers()
+    const { handle, ws } = await makeHandle()
+
+    const waitPromise = handle.waitForConnection()
+    await ws.handlers.message?.({
+      data: JSON.stringify({ type: 'control', status: 'exited', exitCode: 0 }),
+    })
+    await jest.runOnlyPendingTimersAsync()
+
+    await expect(waitPromise).resolves.toBeUndefined()
+    await expect(handle.wait()).resolves.toEqual({ exitCode: 0, error: undefined })
+  })
+
+  it('resolves all concurrent wait() callers when the PTY exits', async () => {
+    const { handle, ws } = await makeHandle()
+
+    const waiters = [handle.wait(), handle.wait(), handle.wait()]
+    await ws.handlers.message?.({
+      data: JSON.stringify({ type: 'control', status: 'exited', exitCode: 42 }),
+    })
+
+    await expect(Promise.all(waiters)).resolves.toEqual([
+      { exitCode: 42, error: undefined },
+      { exitCode: 42, error: undefined },
+      { exitCode: 42, error: undefined },
+    ])
+  })
+
   it('throws for unsupported websocket implementations', async () => {
     const { PtyHandle } = await import('../PtyHandle')
     const handleResize = jest.fn().mockResolvedValue({ sessionId: 'pty-1', cols: 80, rows: 24 })

--- a/libs/sdk-typescript/src/utils/WebSocket.ts
+++ b/libs/sdk-typescript/src/utils/WebSocket.ts
@@ -12,20 +12,29 @@ import { RUNTIME, Runtime } from './Runtime'
  * @param url - The websocket URL (ws[s]://...)
  * @param headers - Headers to forward when running in Node environments
  * @param getPreviewToken - Lazy getter for preview tokens (required for browser/serverless runtimes)
+ * @param subprotocols - Additional WebSocket subprotocol tokens to negotiate (forwarded uniformly across runtimes)
  */
 export async function createSandboxWebSocket(
   url: string,
   headers: Record<string, any>,
   getPreviewToken: () => Promise<string>,
+  subprotocols?: string[],
 ): Promise<WebSocket> {
   if (RUNTIME === Runtime.BROWSER || RUNTIME === Runtime.DENO || RUNTIME === Runtime.SERVERLESS) {
     const previewToken = await getPreviewToken()
     const separator = url.includes('?') ? '&' : '?'
-    return new WebSocket(
-      `${url}${separator}DAYTONA_SANDBOX_AUTH_KEY=${previewToken}`,
+    return new WebSocket(`${url}${separator}DAYTONA_SANDBOX_AUTH_KEY=${previewToken}`, [
       `X-Daytona-SDK-Version~${String(headers['X-Daytona-SDK-Version'] ?? '')}`,
-    )
+      ...(subprotocols ?? []),
+    ])
   }
 
-  return new WebSocket(url, { headers })
+  // `ws` rejects the handshake if it offered subprotocols but the server selected none, and the
+  // daemon only echoes the SDK-version token — so include it whenever we add others.
+  const nodeSubprotocols =
+    subprotocols && subprotocols.length
+      ? [`X-Daytona-SDK-Version~${String(headers['X-Daytona-SDK-Version'] ?? '')}`, ...subprotocols]
+      : []
+
+  return new WebSocket(url, nodeSubprotocols, { headers })
 }

--- a/libs/toolbox-api-client-go/api/openapi.yaml
+++ b/libs/toolbox-api-client-go/api/openapi.yaml
@@ -1951,6 +1951,48 @@ paths:
       tags:
       - process
       x-codegen-request-body-name: request
+  /process/pty/create-connect:
+    get:
+      description: |-
+        Creates a new PTY session and immediately establishes a WebSocket connection.
+        PTY configuration is passed as query parameters. The shell starts on WS open.
+        This is faster than calling create + connect separately (1 round-trip vs 2).
+      operationId: CreateAndConnectPtySession
+      parameters:
+      - description: PTY session ID
+        in: query
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Working directory
+        in: query
+        name: cwd
+        schema:
+          type: string
+      - description: "Terminal columns (default: 80)"
+        in: query
+        name: cols
+        schema:
+          type: integer
+      - description: "Terminal rows (default: 24)"
+        in: query
+        name: rows
+        schema:
+          type: integer
+      - description: WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding
+          JSON object>
+        in: header
+        name: Sec-WebSocket-Protocol
+        schema:
+          type: string
+      responses:
+        "101":
+          content: {}
+          description: Switching Protocols - WebSocket connection established
+      summary: Create and connect to a PTY session in a single WebSocket upgrade
+      tags:
+      - process
   /process/pty/{sessionId}:
     delete:
       description: Delete a pseudo-terminal session and terminate its process

--- a/libs/toolbox-api-client-go/api_process.go
+++ b/libs/toolbox-api-client-go/api_process.go
@@ -51,6 +51,21 @@ type ProcessAPI interface {
 	ConnectPtySessionExecute(r ProcessAPIConnectPtySessionRequest) (*http.Response, error)
 
 	/*
+	CreateAndConnectPtySession Create and connect to a PTY session in a single WebSocket upgrade
+
+	Creates a new PTY session and immediately establishes a WebSocket connection.
+PTY configuration is passed as query parameters. The shell starts on WS open.
+This is faster than calling create + connect separately (1 round-trip vs 2).
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ProcessAPICreateAndConnectPtySessionRequest
+	*/
+	CreateAndConnectPtySession(ctx context.Context) ProcessAPICreateAndConnectPtySessionRequest
+
+	// CreateAndConnectPtySessionExecute executes the request
+	CreateAndConnectPtySessionExecute(r ProcessAPICreateAndConnectPtySessionRequest) (*http.Response, error)
+
+	/*
 	CreatePtySession Create a new PTY session
 
 	Create a new pseudo-terminal session with specified configuration
@@ -461,6 +476,147 @@ func (a *ProcessAPIService) ConnectPtySessionExecute(r ProcessAPIConnectPtySessi
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
+type ProcessAPICreateAndConnectPtySessionRequest struct {
+	ctx context.Context
+	ApiService ProcessAPI
+	id *string
+	cwd *string
+	cols *int32
+	rows *int32
+	secWebSocketProtocol *string
+}
+
+// PTY session ID
+func (r ProcessAPICreateAndConnectPtySessionRequest) Id(id string) ProcessAPICreateAndConnectPtySessionRequest {
+	r.id = &id
+	return r
+}
+
+// Working directory
+func (r ProcessAPICreateAndConnectPtySessionRequest) Cwd(cwd string) ProcessAPICreateAndConnectPtySessionRequest {
+	r.cwd = &cwd
+	return r
+}
+
+// Terminal columns (default: 80)
+func (r ProcessAPICreateAndConnectPtySessionRequest) Cols(cols int32) ProcessAPICreateAndConnectPtySessionRequest {
+	r.cols = &cols
+	return r
+}
+
+// Terminal rows (default: 24)
+func (r ProcessAPICreateAndConnectPtySessionRequest) Rows(rows int32) ProcessAPICreateAndConnectPtySessionRequest {
+	r.rows = &rows
+	return r
+}
+
+// WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt;
+func (r ProcessAPICreateAndConnectPtySessionRequest) SecWebSocketProtocol(secWebSocketProtocol string) ProcessAPICreateAndConnectPtySessionRequest {
+	r.secWebSocketProtocol = &secWebSocketProtocol
+	return r
+}
+
+func (r ProcessAPICreateAndConnectPtySessionRequest) Execute() (*http.Response, error) {
+	return r.ApiService.CreateAndConnectPtySessionExecute(r)
+}
+
+/*
+CreateAndConnectPtySession Create and connect to a PTY session in a single WebSocket upgrade
+
+Creates a new PTY session and immediately establishes a WebSocket connection.
+PTY configuration is passed as query parameters. The shell starts on WS open.
+This is faster than calling create + connect separately (1 round-trip vs 2).
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ProcessAPICreateAndConnectPtySessionRequest
+*/
+func (a *ProcessAPIService) CreateAndConnectPtySession(ctx context.Context) ProcessAPICreateAndConnectPtySessionRequest {
+	return ProcessAPICreateAndConnectPtySessionRequest{
+		ApiService: a,
+		ctx: ctx,
+	}
+}
+
+// Execute executes the request
+func (a *ProcessAPIService) CreateAndConnectPtySessionExecute(r ProcessAPICreateAndConnectPtySessionRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ProcessAPIService.CreateAndConnectPtySession")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/process/pty/create-connect"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.id == nil {
+		return nil, reportError("id is required and must be specified")
+	}
+
+	parameterAddToHeaderOrQuery(localVarQueryParams, "id", r.id, "", "")
+	if r.cwd != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "cwd", r.cwd, "", "")
+	}
+	if r.cols != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "cols", r.cols, "", "")
+	}
+	if r.rows != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "rows", r.rows, "", "")
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.secWebSocketProtocol != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "Sec-WebSocket-Protocol", r.secWebSocketProtocol, "", "")
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {

--- a/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/api/ProcessApi.java
+++ b/libs/toolbox-api-client-java/src/main/java/io/daytona/toolbox/client/api/ProcessApi.java
@@ -337,6 +337,164 @@ public class ProcessApi {
         return localVarCall;
     }
     /**
+     * Build call for createAndConnectPtySession
+     * @param id PTY session ID (required)
+     * @param cwd Working directory (optional)
+     * @param cols Terminal columns (default: 80) (optional)
+     * @param rows Terminal rows (default: 24) (optional)
+     * @param secWebSocketProtocol WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt; (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 101 </td><td> Switching Protocols - WebSocket connection established </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call createAndConnectPtySessionCall(@javax.annotation.Nonnull String id, @javax.annotation.Nullable String cwd, @javax.annotation.Nullable Integer cols, @javax.annotation.Nullable Integer rows, @javax.annotation.Nullable String secWebSocketProtocol, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/process/pty/create-connect";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (id != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("id", id));
+        }
+
+        if (cwd != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("cwd", cwd));
+        }
+
+        if (cols != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("cols", cols));
+        }
+
+        if (rows != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("rows", rows));
+        }
+
+        final String[] localVarAccepts = {
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        if (secWebSocketProtocol != null) {
+            localVarHeaderParams.put("Sec-WebSocket-Protocol", localVarApiClient.parameterToString(secWebSocketProtocol));
+        }
+
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call createAndConnectPtySessionValidateBeforeCall(@javax.annotation.Nonnull String id, @javax.annotation.Nullable String cwd, @javax.annotation.Nullable Integer cols, @javax.annotation.Nullable Integer rows, @javax.annotation.Nullable String secWebSocketProtocol, final ApiCallback _callback) throws ApiException {
+        // verify the required parameter 'id' is set
+        if (id == null) {
+            throw new ApiException("Missing the required parameter 'id' when calling createAndConnectPtySession(Async)");
+        }
+
+        return createAndConnectPtySessionCall(id, cwd, cols, rows, secWebSocketProtocol, _callback);
+
+    }
+
+    /**
+     * Create and connect to a PTY session in a single WebSocket upgrade
+     * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+     * @param id PTY session ID (required)
+     * @param cwd Working directory (optional)
+     * @param cols Terminal columns (default: 80) (optional)
+     * @param rows Terminal rows (default: 24) (optional)
+     * @param secWebSocketProtocol WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt; (optional)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 101 </td><td> Switching Protocols - WebSocket connection established </td><td>  -  </td></tr>
+     </table>
+     */
+    public void createAndConnectPtySession(@javax.annotation.Nonnull String id, @javax.annotation.Nullable String cwd, @javax.annotation.Nullable Integer cols, @javax.annotation.Nullable Integer rows, @javax.annotation.Nullable String secWebSocketProtocol) throws ApiException {
+        createAndConnectPtySessionWithHttpInfo(id, cwd, cols, rows, secWebSocketProtocol);
+    }
+
+    /**
+     * Create and connect to a PTY session in a single WebSocket upgrade
+     * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+     * @param id PTY session ID (required)
+     * @param cwd Working directory (optional)
+     * @param cols Terminal columns (default: 80) (optional)
+     * @param rows Terminal rows (default: 24) (optional)
+     * @param secWebSocketProtocol WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt; (optional)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 101 </td><td> Switching Protocols - WebSocket connection established </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Void> createAndConnectPtySessionWithHttpInfo(@javax.annotation.Nonnull String id, @javax.annotation.Nullable String cwd, @javax.annotation.Nullable Integer cols, @javax.annotation.Nullable Integer rows, @javax.annotation.Nullable String secWebSocketProtocol) throws ApiException {
+        okhttp3.Call localVarCall = createAndConnectPtySessionValidateBeforeCall(id, cwd, cols, rows, secWebSocketProtocol, null);
+        return localVarApiClient.execute(localVarCall);
+    }
+
+    /**
+     * Create and connect to a PTY session in a single WebSocket upgrade (asynchronously)
+     * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+     * @param id PTY session ID (required)
+     * @param cwd Working directory (optional)
+     * @param cols Terminal columns (default: 80) (optional)
+     * @param rows Terminal rows (default: 24) (optional)
+     * @param secWebSocketProtocol WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt; (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 101 </td><td> Switching Protocols - WebSocket connection established </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call createAndConnectPtySessionAsync(@javax.annotation.Nonnull String id, @javax.annotation.Nullable String cwd, @javax.annotation.Nullable Integer cols, @javax.annotation.Nullable Integer rows, @javax.annotation.Nullable String secWebSocketProtocol, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = createAndConnectPtySessionValidateBeforeCall(id, cwd, cols, rows, secWebSocketProtocol, _callback);
+        localVarApiClient.executeAsync(localVarCall, _callback);
+        return localVarCall;
+    }
+    /**
      * Build call for createPtySession
      * @param request PTY session creation request (required)
      * @param _callback Callback for upload/download progress

--- a/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/api/ProcessApiTest.java
+++ b/libs/toolbox-api-client-java/src/test/java/io/daytona/toolbox/client/api/ProcessApiTest.java
@@ -75,6 +75,24 @@ public class ProcessApiTest {
     }
 
     /**
+     * Create and connect to a PTY session in a single WebSocket upgrade
+     *
+     * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+     *
+     * @throws ApiException if the Api call fails
+     */
+    @Test
+    public void createAndConnectPtySessionTest() throws ApiException {
+        String id = null;
+        String cwd = null;
+        Integer cols = null;
+        Integer rows = null;
+        String secWebSocketProtocol = null;
+        api.createAndConnectPtySession(id, cwd, cols, rows, secWebSocketProtocol);
+        // TODO: test validations
+    }
+
+    /**
      * Create a new PTY session
      *
      * Create a new pseudo-terminal session with specified configuration

--- a/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/api/process_api.py
+++ b/libs/toolbox-api-client-python-async/daytona_toolbox_api_client_async/api/process_api.py
@@ -15,7 +15,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictBool, StrictStr
+from pydantic import Field, StrictBool, StrictInt, StrictStr
 from typing import Any, Dict, List, Optional
 from typing_extensions import Annotated
 from daytona_toolbox_api_client_async.models.code_run_request import CodeRunRequest
@@ -564,6 +564,327 @@ class ProcessApi:
         return self.api_client.param_serialize(
             method='GET',
             resource_path='/process/pty/{sessionId}/connect',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    async def create_and_connect_pty_session(
+        self,
+        id: Annotated[StrictStr, Field(description="PTY session ID")],
+        cwd: Annotated[Optional[StrictStr], Field(description="Working directory")] = None,
+        cols: Annotated[Optional[StrictInt], Field(description="Terminal columns (default: 80)")] = None,
+        rows: Annotated[Optional[StrictInt], Field(description="Terminal rows (default: 24)")] = None,
+        sec_web_socket_protocol: Annotated[Optional[StrictStr], Field(description="WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> None:
+        """Create and connect to a PTY session in a single WebSocket upgrade
+
+        Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+
+        :param id: PTY session ID (required)
+        :type id: str
+        :param cwd: Working directory
+        :type cwd: str
+        :param cols: Terminal columns (default: 80)
+        :type cols: int
+        :param rows: Terminal rows (default: 24)
+        :type rows: int
+        :param sec_web_socket_protocol: WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>
+        :type sec_web_socket_protocol: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._create_and_connect_pty_session_serialize(
+            id=id,
+            cwd=cwd,
+            cols=cols,
+            rows=rows,
+            sec_web_socket_protocol=sec_web_socket_protocol,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '101': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    async def create_and_connect_pty_session_with_http_info(
+        self,
+        id: Annotated[StrictStr, Field(description="PTY session ID")],
+        cwd: Annotated[Optional[StrictStr], Field(description="Working directory")] = None,
+        cols: Annotated[Optional[StrictInt], Field(description="Terminal columns (default: 80)")] = None,
+        rows: Annotated[Optional[StrictInt], Field(description="Terminal rows (default: 24)")] = None,
+        sec_web_socket_protocol: Annotated[Optional[StrictStr], Field(description="WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[None]:
+        """Create and connect to a PTY session in a single WebSocket upgrade
+
+        Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+
+        :param id: PTY session ID (required)
+        :type id: str
+        :param cwd: Working directory
+        :type cwd: str
+        :param cols: Terminal columns (default: 80)
+        :type cols: int
+        :param rows: Terminal rows (default: 24)
+        :type rows: int
+        :param sec_web_socket_protocol: WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>
+        :type sec_web_socket_protocol: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._create_and_connect_pty_session_serialize(
+            id=id,
+            cwd=cwd,
+            cols=cols,
+            rows=rows,
+            sec_web_socket_protocol=sec_web_socket_protocol,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '101': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        await response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    async def create_and_connect_pty_session_without_preload_content(
+        self,
+        id: Annotated[StrictStr, Field(description="PTY session ID")],
+        cwd: Annotated[Optional[StrictStr], Field(description="Working directory")] = None,
+        cols: Annotated[Optional[StrictInt], Field(description="Terminal columns (default: 80)")] = None,
+        rows: Annotated[Optional[StrictInt], Field(description="Terminal rows (default: 24)")] = None,
+        sec_web_socket_protocol: Annotated[Optional[StrictStr], Field(description="WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Create and connect to a PTY session in a single WebSocket upgrade
+
+        Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+
+        :param id: PTY session ID (required)
+        :type id: str
+        :param cwd: Working directory
+        :type cwd: str
+        :param cols: Terminal columns (default: 80)
+        :type cols: int
+        :param rows: Terminal rows (default: 24)
+        :type rows: int
+        :param sec_web_socket_protocol: WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>
+        :type sec_web_socket_protocol: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._create_and_connect_pty_session_serialize(
+            id=id,
+            cwd=cwd,
+            cols=cols,
+            rows=rows,
+            sec_web_socket_protocol=sec_web_socket_protocol,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '101': None,
+        }
+        response_data = await self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _create_and_connect_pty_session_serialize(
+        self,
+        id,
+        cwd,
+        cols,
+        rows,
+        sec_web_socket_protocol,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        if id is not None:
+            
+            _query_params.append(('id', id))
+            
+        if cwd is not None:
+            
+            _query_params.append(('cwd', cwd))
+            
+        if cols is not None:
+            
+            _query_params.append(('cols', cols))
+            
+        if rows is not None:
+            
+            _query_params.append(('rows', rows))
+            
+        # process the header parameters
+        if sec_web_socket_protocol is not None:
+            _header_params['Sec-WebSocket-Protocol'] = sec_web_socket_protocol
+        # process the form parameters
+        # process the body parameter
+
+
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/process/pty/create-connect',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/libs/toolbox-api-client-python/daytona_toolbox_api_client/api/process_api.py
+++ b/libs/toolbox-api-client-python/daytona_toolbox_api_client/api/process_api.py
@@ -15,7 +15,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictBool, StrictStr
+from pydantic import Field, StrictBool, StrictInt, StrictStr
 from typing import Any, Dict, List, Optional
 from typing_extensions import Annotated
 from daytona_toolbox_api_client.models.code_run_request import CodeRunRequest
@@ -564,6 +564,327 @@ class ProcessApi:
         return self.api_client.param_serialize(
             method='GET',
             resource_path='/process/pty/{sessionId}/connect',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    def create_and_connect_pty_session(
+        self,
+        id: Annotated[StrictStr, Field(description="PTY session ID")],
+        cwd: Annotated[Optional[StrictStr], Field(description="Working directory")] = None,
+        cols: Annotated[Optional[StrictInt], Field(description="Terminal columns (default: 80)")] = None,
+        rows: Annotated[Optional[StrictInt], Field(description="Terminal rows (default: 24)")] = None,
+        sec_web_socket_protocol: Annotated[Optional[StrictStr], Field(description="WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> None:
+        """Create and connect to a PTY session in a single WebSocket upgrade
+
+        Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+
+        :param id: PTY session ID (required)
+        :type id: str
+        :param cwd: Working directory
+        :type cwd: str
+        :param cols: Terminal columns (default: 80)
+        :type cols: int
+        :param rows: Terminal rows (default: 24)
+        :type rows: int
+        :param sec_web_socket_protocol: WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>
+        :type sec_web_socket_protocol: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._create_and_connect_pty_session_serialize(
+            id=id,
+            cwd=cwd,
+            cols=cols,
+            rows=rows,
+            sec_web_socket_protocol=sec_web_socket_protocol,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '101': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def create_and_connect_pty_session_with_http_info(
+        self,
+        id: Annotated[StrictStr, Field(description="PTY session ID")],
+        cwd: Annotated[Optional[StrictStr], Field(description="Working directory")] = None,
+        cols: Annotated[Optional[StrictInt], Field(description="Terminal columns (default: 80)")] = None,
+        rows: Annotated[Optional[StrictInt], Field(description="Terminal rows (default: 24)")] = None,
+        sec_web_socket_protocol: Annotated[Optional[StrictStr], Field(description="WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[None]:
+        """Create and connect to a PTY session in a single WebSocket upgrade
+
+        Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+
+        :param id: PTY session ID (required)
+        :type id: str
+        :param cwd: Working directory
+        :type cwd: str
+        :param cols: Terminal columns (default: 80)
+        :type cols: int
+        :param rows: Terminal rows (default: 24)
+        :type rows: int
+        :param sec_web_socket_protocol: WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>
+        :type sec_web_socket_protocol: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._create_and_connect_pty_session_serialize(
+            id=id,
+            cwd=cwd,
+            cols=cols,
+            rows=rows,
+            sec_web_socket_protocol=sec_web_socket_protocol,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '101': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def create_and_connect_pty_session_without_preload_content(
+        self,
+        id: Annotated[StrictStr, Field(description="PTY session ID")],
+        cwd: Annotated[Optional[StrictStr], Field(description="Working directory")] = None,
+        cols: Annotated[Optional[StrictInt], Field(description="Terminal columns (default: 80)")] = None,
+        rows: Annotated[Optional[StrictInt], Field(description="Terminal rows (default: 24)")] = None,
+        sec_web_socket_protocol: Annotated[Optional[StrictStr], Field(description="WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Create and connect to a PTY session in a single WebSocket upgrade
+
+        Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+
+        :param id: PTY session ID (required)
+        :type id: str
+        :param cwd: Working directory
+        :type cwd: str
+        :param cols: Terminal columns (default: 80)
+        :type cols: int
+        :param rows: Terminal rows (default: 24)
+        :type rows: int
+        :param sec_web_socket_protocol: WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~<base64url-no-padding JSON object>
+        :type sec_web_socket_protocol: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._create_and_connect_pty_session_serialize(
+            id=id,
+            cwd=cwd,
+            cols=cols,
+            rows=rows,
+            sec_web_socket_protocol=sec_web_socket_protocol,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '101': None,
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _create_and_connect_pty_session_serialize(
+        self,
+        id,
+        cwd,
+        cols,
+        rows,
+        sec_web_socket_protocol,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        if id is not None:
+            
+            _query_params.append(('id', id))
+            
+        if cwd is not None:
+            
+            _query_params.append(('cwd', cwd))
+            
+        if cols is not None:
+            
+            _query_params.append(('cols', cols))
+            
+        if rows is not None:
+            
+            _query_params.append(('rows', rows))
+            
+        # process the header parameters
+        if sec_web_socket_protocol is not None:
+            _header_params['Sec-WebSocket-Protocol'] = sec_web_socket_protocol
+        # process the form parameters
+        # process the body parameter
+
+
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/process/pty/create-connect',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/api/process_api.rb
+++ b/libs/toolbox-api-client-ruby/lib/daytona_toolbox_api_client/api/process_api.rb
@@ -148,6 +148,80 @@ module DaytonaToolboxApiClient
       return data, status_code, headers
     end
 
+    # Create and connect to a PTY session in a single WebSocket upgrade
+    # Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+    # @param id [String] PTY session ID
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :cwd Working directory
+    # @option opts [Integer] :cols Terminal columns (default: 80)
+    # @option opts [Integer] :rows Terminal rows (default: 24)
+    # @option opts [String] :sec_web_socket_protocol WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt;
+    # @return [nil]
+    def create_and_connect_pty_session(id, opts = {})
+      create_and_connect_pty_session_with_http_info(id, opts)
+      nil
+    end
+
+    # Create and connect to a PTY session in a single WebSocket upgrade
+    # Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+    # @param id [String] PTY session ID
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :cwd Working directory
+    # @option opts [Integer] :cols Terminal columns (default: 80)
+    # @option opts [Integer] :rows Terminal rows (default: 24)
+    # @option opts [String] :sec_web_socket_protocol WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt;
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def create_and_connect_pty_session_with_http_info(id, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: ProcessApi.create_and_connect_pty_session ...'
+      end
+      # verify the required parameter 'id' is set
+      if @api_client.config.client_side_validation && id.nil?
+        fail ArgumentError, "Missing the required parameter 'id' when calling ProcessApi.create_and_connect_pty_session"
+      end
+      # resource path
+      local_var_path = '/process/pty/create-connect'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'id'] = id
+      query_params[:'cwd'] = opts[:'cwd'] if !opts[:'cwd'].nil?
+      query_params[:'cols'] = opts[:'cols'] if !opts[:'cols'].nil?
+      query_params[:'rows'] = opts[:'rows'] if !opts[:'rows'].nil?
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      header_params[:'Sec-WebSocket-Protocol'] = opts[:'sec_web_socket_protocol'] if !opts[:'sec_web_socket_protocol'].nil?
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type]
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"ProcessApi.create_and_connect_pty_session",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: ProcessApi#create_and_connect_pty_session\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Create a new PTY session
     # Create a new pseudo-terminal session with specified configuration
     # @param request [PtyCreateRequest] PTY session creation request

--- a/libs/toolbox-api-client/src/api/process-api.ts
+++ b/libs/toolbox-api-client/src/api/process-api.ts
@@ -127,6 +127,61 @@ export const ProcessApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
+         * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+         * @summary Create and connect to a PTY session in a single WebSocket upgrade
+         * @param {string} id PTY session ID
+         * @param {string} [cwd] Working directory
+         * @param {number} [cols] Terminal columns (default: 80)
+         * @param {number} [rows] Terminal rows (default: 24)
+         * @param {string} [secWebSocketProtocol] WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt;
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createAndConnectPtySession: async (id: string, cwd?: string, cols?: number, rows?: number, secWebSocketProtocol?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('createAndConnectPtySession', 'id', id)
+            const localVarPath = `/process/pty/create-connect`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (id !== undefined) {
+                localVarQueryParameter['id'] = id;
+            }
+
+            if (cwd !== undefined) {
+                localVarQueryParameter['cwd'] = cwd;
+            }
+
+            if (cols !== undefined) {
+                localVarQueryParameter['cols'] = cols;
+            }
+
+            if (rows !== undefined) {
+                localVarQueryParameter['rows'] = rows;
+            }
+
+
+            if (secWebSocketProtocol != null) {
+                localVarHeaderParameter['Sec-WebSocket-Protocol'] = String(secWebSocketProtocol);
+            }
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Create a new pseudo-terminal session with specified configuration
          * @summary Create a new PTY session
          * @param {PtyCreateRequest} request PTY session creation request
@@ -727,6 +782,23 @@ export const ProcessApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+         * @summary Create and connect to a PTY session in a single WebSocket upgrade
+         * @param {string} id PTY session ID
+         * @param {string} [cwd] Working directory
+         * @param {number} [cols] Terminal columns (default: 80)
+         * @param {number} [rows] Terminal rows (default: 24)
+         * @param {string} [secWebSocketProtocol] WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt;
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createAndConnectPtySession(id: string, cwd?: string, cols?: number, rows?: number, secWebSocketProtocol?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createAndConnectPtySession(id, cwd, cols, rows, secWebSocketProtocol, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ProcessApi.createAndConnectPtySession']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Create a new pseudo-terminal session with specified configuration
          * @summary Create a new PTY session
          * @param {PtyCreateRequest} request PTY session creation request
@@ -968,6 +1040,20 @@ export const ProcessApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.connectPtySession(sessionId, options).then((request) => request(axios, basePath));
         },
         /**
+         * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+         * @summary Create and connect to a PTY session in a single WebSocket upgrade
+         * @param {string} id PTY session ID
+         * @param {string} [cwd] Working directory
+         * @param {number} [cols] Terminal columns (default: 80)
+         * @param {number} [rows] Terminal rows (default: 24)
+         * @param {string} [secWebSocketProtocol] WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt;
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createAndConnectPtySession(id: string, cwd?: string, cols?: number, rows?: number, secWebSocketProtocol?: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.createAndConnectPtySession(id, cwd, cols, rows, secWebSocketProtocol, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Create a new pseudo-terminal session with specified configuration
          * @summary Create a new PTY session
          * @param {PtyCreateRequest} request PTY session creation request
@@ -1158,6 +1244,21 @@ export class ProcessApi extends BaseAPI {
      */
     public connectPtySession(sessionId: string, options?: RawAxiosRequestConfig) {
         return ProcessApiFp(this.configuration).connectPtySession(sessionId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Creates a new PTY session and immediately establishes a WebSocket connection. PTY configuration is passed as query parameters. The shell starts on WS open. This is faster than calling create + connect separately (1 round-trip vs 2).
+     * @summary Create and connect to a PTY session in a single WebSocket upgrade
+     * @param {string} id PTY session ID
+     * @param {string} [cwd] Working directory
+     * @param {number} [cols] Terminal columns (default: 80)
+     * @param {number} [rows] Terminal rows (default: 24)
+     * @param {string} [secWebSocketProtocol] WebSocket subprotocols. Env vars may be passed as the token X-Daytona-Pty-Envs~&lt;base64url-no-padding JSON object&gt;
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public createAndConnectPtySession(id: string, cwd?: string, cols?: number, rows?: number, secWebSocketProtocol?: string, options?: RawAxiosRequestConfig) {
+        return ProcessApiFp(this.configuration).createAndConnectPtySession(id, cwd, cols, rows, secWebSocketProtocol, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## What

- **`GET /process/pty/create-connect`** — new daemon endpoint that creates the PTY session and upgrades the WebSocket in **one** round-trip (config via query params). The old `POST /process/pty` + `GET /:id/connect` endpoints are kept.
- **Structured exit event** — the daemon now emits an `{"type":"control","status":"exited","exitCode":…}` message on the data channel before the WS close, so SDKs get the exit code from a dedicated event instead of parsing it out of the close frame (more robust; same ~1-RTT timing). `exitReason` is sent only for non-zero exits (clean exits report no error).
- **SDKs (py/ts/go/java/ruby)** — `createPtySession` now uses create-connect and parses the `exited` control message.
- **Python SDK** — the shared httpx client now uses transport `retries` so concurrent/rapid WebSocket opens don't intermittently fail the TLS handshake.

## Why

PTY startup was dominated by an extra network round-trip. Folding create + connect into one upgrade cuts `pty-create` latency.

## Results

Tested on **stage**, 5 runs — previous SDK (REST-create + WS-connect) vs this PR (create-connect), against the same daemon:

| phase | before | this PR (stage) |
|---|--:|--:|
| **pty-create** | 983ms | **602ms (1.6× faster)** |
| first-echo | 756ms | 775ms |
| exit-server-detect | 884ms | 191ms |

## Compatibility

- **Old SDK → new daemon: ✅** old endpoints preserved; the new `exited` control message is consumed (not surfaced) by old clients, which still detect exit via the close frame.
- **New SDK → old daemon: ⚠️** create-connect 404s (no fallback) — **roll the daemon out before publishing the SDKs.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783091316&installation_id=132266156&pr_number=4926&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4926&signature=e986aa43e973727a2687f23417151e6bff315dc7c6e5f1495c3bdff2e0530bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single-roundtrip PTY create-connect flow and instant exit detection to cut startup latency and make exits more reliable across SDKs.

- **New Features**
  - Added GET /process/pty/create-connect to create a PTY and upgrade the WebSocket in one request (query: id, cwd, cols, rows). Envs are sent via the WS subprotocol token `X-Daytona-Pty-Envs~<base64url JSON>`; Toolbox API exposes this via the `Sec-WebSocket-Protocol` header. On stage, PTY create is ~1.6× faster.
  - Daemon now sends a control message before close: {"type":"control","status":"exited","exitCode":...,"exitReason":...}; a control "error" is sent on failed connects. Delivery is forced as Text frames and write deadlines prevent stuck clients from blocking exit signals.
  - SDKs (Go/Java/Python/Ruby/TypeScript) now use create-connect, pass envs via the subprotocol, and treat the `exited` control event as an immediate terminal condition so waits don’t hang (including instant-exit cases). Python adds `httpx` transport retries for steadier WS upgrades. The `@daytona/toolbox-api-client` (Go/Java/Python/TypeScript/Ruby) exposes CreateAndConnectPtySession.

- **Migration**
  - Old SDKs → new daemon: compatible; they still read exit from WS close and ignore control messages.
  - New SDKs → old daemon: create-connect is missing; roll out the daemon before publishing SDKs. Old POST /process/pty + GET /:id/connect remain available.

<sup>Written for commit a074604175fa71b8607609246e75d2bf135e665f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

