### PR TITLE
fix(sdk-typescript): deserialize snapshot date fields

### DIFF
--- a/libs/sdk-typescript/src/Snapshot.ts
+++ b/libs/sdk-typescript/src/Snapshot.ts
@@ -46,6 +46,31 @@ export interface PaginatedSnapshots extends Omit<PaginatedSnapshotsDto, 'items'>
   items: Snapshot[]
 }
 
+type SnapshotWithWireDates = Omit<SnapshotDto, 'createdAt' | 'updatedAt' | 'lastUsedAt'> & {
+  createdAt?: Date | string
+  updatedAt?: Date | string
+  lastUsedAt?: Date | string | null
+}
+
+const deserializeSnapshotDate = (value: Date | string): Date => (value instanceof Date ? value : new Date(value))
+
+const deserializeSnapshot = (snapshot: SnapshotDto): Snapshot => {
+  const wireSnapshot = snapshot as SnapshotWithWireDates
+  const deserialized = { ...wireSnapshot }
+
+  if (wireSnapshot.createdAt !== undefined) {
+    deserialized.createdAt = deserializeSnapshotDate(wireSnapshot.createdAt)
+  }
+  if (wireSnapshot.updatedAt !== undefined) {
+    deserialized.updatedAt = deserializeSnapshotDate(wireSnapshot.updatedAt)
+  }
+  if (wireSnapshot.lastUsedAt !== undefined) {
+    deserialized.lastUsedAt = wireSnapshot.lastUsedAt === null ? null : deserializeSnapshotDate(wireSnapshot.lastUsedAt)
+  }
+
+  return deserialized as Snapshot
+}
+
 /**
  * Parameters for creating a new snapshot.
  *
@@ -94,7 +119,7 @@ export class SnapshotService {
   async list(page?: number, limit?: number): Promise<PaginatedSnapshots> {
     const response = await this.snapshotsApi.getAllSnapshots(undefined, page, limit)
     return {
-      items: response.data.items.map((snapshot) => snapshot as Snapshot),
+      items: response.data.items.map(deserializeSnapshot),
       total: response.data.total,
       page: response.data.page,
       totalPages: response.data.totalPages,
@@ -116,7 +141,7 @@ export class SnapshotService {
   @WithInstrumentation()
   async get(name: string): Promise<Snapshot> {
     const response = await this.snapshotsApi.getSnapshot(name)
-    return response.data as Snapshot
+    return deserializeSnapshot(response.data)
   }
 
   /**
@@ -254,7 +279,7 @@ export class SnapshotService {
       throw new DaytonaError(errMsg)
     }
 
-    return createdSnapshot as Snapshot
+    return deserializeSnapshot(createdSnapshot)
   }
 
   /**
@@ -265,7 +290,7 @@ export class SnapshotService {
    */
   @WithInstrumentation()
   async activate(snapshot: Snapshot): Promise<Snapshot> {
-    return (await this.snapshotsApi.activateSnapshot(snapshot.id)).data as Snapshot
+    return deserializeSnapshot((await this.snapshotsApi.activateSnapshot(snapshot.id)).data)
   }
 
   /**

--- a/libs/sdk-typescript/src/__tests__/Snapshot.test.ts
+++ b/libs/sdk-typescript/src/__tests__/Snapshot.test.ts
@@ -73,6 +73,36 @@ describe('SnapshotService', () => {
     await service.delete({ id: 's1' } as never)
   })
 
+  it('deserializes snapshot date fields returned by the API', async () => {
+    const snapshot = {
+      id: 's1',
+      name: 'snap1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      lastUsedAt: null,
+    }
+
+    snapshotsApi.getAllSnapshots.mockResolvedValue(
+      createApiResponse({ items: [snapshot], total: 1, page: 1, totalPages: 1 }),
+    )
+    snapshotsApi.getSnapshot.mockResolvedValue(createApiResponse(snapshot))
+    snapshotsApi.createSnapshot.mockResolvedValue(createApiResponse({ ...snapshot, state: 'active' }))
+    snapshotsApi.activateSnapshot.mockResolvedValue(createApiResponse(snapshot))
+
+    const listResult = await service.list()
+    const getResult = await service.get('snap1')
+    const createResult = await service.create({ name: 'snap1', image: 'python:3.12' })
+    const activateResult = await service.activate({ id: 's1' } as never)
+
+    for (const result of [listResult.items[0], getResult, createResult, activateResult]) {
+      expect(result.createdAt).toBeInstanceOf(Date)
+      expect(result.updatedAt).toBeInstanceOf(Date)
+      expect(result.createdAt.toISOString()).toBe(snapshot.createdAt)
+      expect(result.updatedAt.toISOString()).toBe(snapshot.updatedAt)
+      expect(result.lastUsedAt).toBeNull()
+    }
+  })
+
   it('creates snapshot from image name with resources and region', async () => {
     snapshotsApi.createSnapshot.mockResolvedValue(createApiResponse({ id: 's2', name: 'snap2', state: 'active' }))
 


### PR DESCRIPTION
## Description

Fixes #2421.

The TypeScript SDK's generated `SnapshotDto` type declares snapshot timestamp fields as `Date`, but JSON responses arrive as strings. `SnapshotService` previously returned those raw wire values from `list`, `get`, `create`, and `activate`, so callers saw `typeof snapshot.createdAt === "string"` at runtime.

This adds SDK-layer snapshot deserialization for `createdAt`, `updatedAt`, and `lastUsedAt`, preserving `null` for `lastUsedAt` and leaving already-deserialized `Date` values unchanged.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

No documentation update is needed; this aligns runtime SDK values with the existing public TypeScript type.

## Related Issue(s)

This PR addresses issue #2421.

## Screenshots

Not applicable.

## Notes

Validation:
- Red before fix: `yarn jest --config libs/sdk-typescript/jest.config.js --runInBand libs/sdk-typescript/src/__tests__/Snapshot.test.ts` failed on `createdAt` being a string.
- `yarn jest --config libs/sdk-typescript/jest.config.js --runInBand libs/sdk-typescript/src/__tests__/Snapshot.test.ts`
- `yarn tsc -p libs/sdk-typescript/tsconfig.spec.json --noEmit`
- `yarn nx build api-client`
- `yarn nx build toolbox-api-client`
- `yarn tsc -p libs/sdk-typescript/tsconfig.cjs.json --noEmit`
- `yarn nx build sdk-typescript`
- `yarn nx test sdk-typescript`
- `yarn eslint libs/sdk-typescript/src/Snapshot.ts libs/sdk-typescript/src/__tests__/Snapshot.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783141779&installation_id=132266156&pr_number=4928&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4928&signature=68954545ecf67fcc487e0d87da1d776cb59022802bbbee938b8dc948021dc7f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deserializes snapshot timestamp fields so the SDK returns Date objects instead of strings. Applies to list, get, create, and activate.

- **Bug Fixes**
  - Convert createdAt, updatedAt, and lastUsedAt; preserve null for lastUsedAt.
  - Leave already-parsed Date values unchanged.
  - Add unit tests to verify conversion.

<sup>Written for commit e668712b92510ef769aabc2c14ce62b3796ca527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

