### PR TITLE
docs: clarify limitations of object storage mounts

### DIFF
--- a/apps/docs/src/content/docs/en/mount-external-storage.mdx
+++ b/apps/docs/src/content/docs/en/mount-external-storage.mdx
@@ -4616,3 +4616,27 @@ sudo mount --move <your-mount-path> /tmp/.fuse-defunct-$$
 After this, your original mount path is free for remounting. The FUSE daemon stays alive serving the mount at the new path; both the relocated mount and the daemon are cleaned up automatically when the sandbox is deleted.
 
 This works for any FUSE-based mount — verified against `mount-s3`, `gcsfuse`, and `blobfuse2`.
+
+## Filesystem semantics and limitations
+
+Mounted object storage providers such as Amazon S3, Cloudflare R2, and Tigris appear as regular directories inside the sandbox. However, object storage does not provide full POSIX filesystem semantics.
+
+Avoid using mounted object storage for:
+
+- SQLite databases
+- Git repositories and worktrees
+- Append-heavy log files
+- Package manager caches
+- File locking workloads
+- Concurrent modification of the same file
+- Applications that require random writes or in-place file updates
+
+Recommended use cases include:
+
+- Datasets
+- Static assets
+- Model weights
+- Shared read-mostly content
+- Generated artifacts and output files
+
+For workloads requiring append operations, databases, file locking, or other mutable filesystem behavior, use the local sandbox filesystem instead.


### PR DESCRIPTION
## Summary

Adds documentation clarifying that object-storage-backed mounts (Amazon S3, Cloudflare R2, Tigris, etc.) do not provide full POSIX filesystem semantics.

## Changes

- Added filesystem semantics and limitations section
- Documented workloads that should avoid mounted object storage:
  - SQLite databases
  - Git repositories and worktrees
  - Append-heavy logs
  - Package manager caches
  - File locking workloads
  - Random-write and in-place update workloads

- Added recommended use cases:
  - Datasets
  - Static assets
  - Model weights
  - Shared read-mostly content
  - Generated artifacts and output files

## Motivation

Mounted object storage can appear as a normal filesystem inside sandboxes, which may lead users and AI agents to assume POSIX semantics that are not guaranteed by object storage backends.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783195246&installation_id=132266156&pr_number=4929&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4929&signature=40b471c154d1e665a66a9676608283840b01ef04134af2bf4356f6b41f0838e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that object‑storage mounts (S3, R2, Tigris) don’t provide full POSIX semantics and adds a “Filesystem semantics and limitations” section. Adds do/don’t guidance with examples (SQLite, Git repos, package caches, append‑heavy logs, file locking, concurrent writes, random/in‑place updates) and directs those workloads to the local sandbox filesystem; read‑mostly data like datasets, static assets, model weights, and generated artifacts are OK.

<sup>Written for commit a3ff3c663738a31e546f755e3b8433ed62cc2a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

