### PR TITLE
feat(docs): update gpu sandboxes and snapshots

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -6,7 +6,7 @@ description: Isolated runtime environments you can manage programmatically to ru
 import { TabItem, Tabs } from '@astrojs/starlight/components'
 import SandboxDiagram from '@components/SandboxDiagram.astro'
 
-Daytona provides **full composable computers** &mdash; **sandboxes** &mdash; for AI agents. Sandboxes are isolated runtime environments you can manage programmatically to run code. Each sandbox runs in isolation, giving it a dedicated kernel, filesystem, network stack, and allocated vCPU, RAM, and disk. Agents get access to a full composable computer environment where they can install packages, run servers, compile code, and manage processes.
+Daytona provides **full composable computers** &mdash; **sandboxes** &mdash; for AI agents. Sandboxes are isolated runtime environments you can manage programmatically to run code. Each sandbox runs in isolation, giving it a dedicated kernel, filesystem, network stack, and allocated vCPU, RAM, and disk. Agents get access to a full composable computer where they can install packages, run servers, compile code, and manage processes.
 
 Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. Organizations get a maximum sandbox resource limit of **4 vCPUs**, **8GB RAM**, and **10GB disk**.
 
@@ -117,14 +117,16 @@ Daytona provides methods to create GPU sandboxes.
 
 Daytona supports NVIDIA GPU devices for creating GPU sandboxes. Use GPU sandboxes for workloads such as model inference, fine-tuning, and CUDA-accelerated compute.
 
-Daytona provides a pre-built `daytona-gpu` snapshot for creating GPU sandboxes. Each GPU sandbox is ephemeral and supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
+- **NVIDIA H100**
+- **NVIDIA RTX Pro 6000**
 
+Daytona provides a pre-built `daytona-gpu` snapshot for creating GPU sandboxes. Each GPU sandbox is ephemeral and supports up to **16 vCPUs**, **192GB RAM**, and **512GB disk**.
 
 1. Navigate to [Daytona Sandboxes ↗](https://app.daytona.io/dashboard/sandboxes)
 2. Click **Create Sandbox**
 3. Select a GPU snapshot (**`daytona-gpu`**)
 4. Select **`us-east-1`** region
-4. Click **Create** to create a GPU sandbox
+5. Click **Create** to create a GPU sandbox
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -137,7 +139,7 @@ sandbox = daytona.create(
         CreateSandboxFromSnapshotParams(
             snapshot="daytona-gpu",
             auto_delete_interval=0
-            ),
+        ),
 )
 ```
 
@@ -246,6 +248,160 @@ curl 'https://app.daytona.io/api/sandbox' \
   "target": "us-east-1",
   "snapshot": "daytona-gpu",
   "autoDeleteInterval": 0
+}'
+```
+
+</TabItem>
+</Tabs>
+
+To create a GPU sandbox with custom GPU count and types:
+
+1. Create a sandbox from an **`image`**
+2. Set the **`auto-delete interval`** to **`0`** (ephemeral)
+3. Set the **`GPU`** count to the number of GPUs you want
+4. Specify the **`GPU type`**(s): **`H100`** **`RTX-PRO-6000`**
+
+    The GPU type field accepts a single value or an ordered list of preferred types.
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import Daytona, CreateSandboxFromImageParams, Image, Resources, GpuType, DaytonaConfig
+
+daytona = Daytona(DaytonaConfig(target="us-east-1"))
+sandbox = daytona.create(
+    CreateSandboxFromImageParams(
+        image=Image.debian_slim("3.12"),
+        auto_delete_interval=0,
+        resources=Resources(
+            gpu=1,
+            gpu_type=[GpuType.H100, GpuType.RTX_PRO_6000],
+        ),
+    )
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona, GpuType, Image } from "@daytona/sdk";
+
+const daytona = new Daytona({
+  target: "us-east-1",
+});
+const sandbox = await daytona.create({
+  image: Image.debianSlim("3.12"),
+  autoDeleteInterval: 0,
+  resources: {
+    gpu: 1,
+    gpuType: [GpuType.H100, GpuType.RTX_PRO_6000],
+  },
+});
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+require 'daytona'
+
+daytona = Daytona::Daytona.new(
+  Daytona::Config.new(
+    target: "us-east-1"
+  )
+)
+sandbox = daytona.create(
+  Daytona::CreateSandboxFromImageParams.new(
+    image: Daytona::Image.debian_slim('3.12'),
+    auto_delete_interval: 0,
+    resources: Daytona::Resources.new(
+      gpu: 1,
+      gpu_type: [Daytona::GpuType::H100, Daytona::GpuType::RTX_PRO_6000]
+    )
+  )
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+package main
+
+import (
+	"context"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+	client, _ := daytona.NewClientWithConfig(&types.DaytonaConfig{
+		Target: "us-east-1",
+	})
+	ctx := context.Background()
+	autoDelete := 0
+	_, _ = client.Create(ctx, types.ImageParams{
+		Image: "python:3.12",
+		SandboxBaseParams: types.SandboxBaseParams{
+			AutoDeleteInterval: &autoDelete,
+		},
+		Resources: &types.Resources{
+			GPU:     1,
+			GpuType: []types.GpuType{types.GpuTypeH100, types.GpuTypeRtxPro6000},
+		},
+	})
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+import io.daytona.sdk.Daytona;
+import io.daytona.sdk.DaytonaConfig;
+import io.daytona.sdk.Sandbox;
+import io.daytona.sdk.model.CreateSandboxFromImageParams;
+import io.daytona.sdk.model.Resources;
+import io.daytona.api.client.model.GpuType;
+import java.util.List;
+
+final class CreateGpuSandbox {
+    public static void main(String[] args) {
+        DaytonaConfig config = new DaytonaConfig.Builder()
+                .apiKey(System.getenv("DAYTONA_API_KEY"))
+                .target("us-east-1")
+                .build();
+
+        try (Daytona daytona = new Daytona(config)) {
+            CreateSandboxFromImageParams params = new CreateSandboxFromImageParams();
+            params.setImage("python:3.12");
+            params.setAutoDeleteInterval(0);
+            Resources resources = new Resources();
+            resources.setGpu(1);
+            resources.setGpuType(List.of(GpuType.H100, GpuType.RTX_PRO_6000));
+            params.setResources(resources);
+            Sandbox sandbox = daytona.create(params);
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --data '{
+  "target": "us-east-1",
+  "image": "python:3.12",
+  "autoDeleteInterval": 0,
+  "gpu": 1,
+  "gpuType": ["H100", "RTX-PRO-6000"]
 }'
 ```
 
@@ -494,7 +650,125 @@ Sandboxes have **1 vCPU**, **1GB RAM**, and **3GiB disk** by default. Organizati
 | Memory       | GiB      | **`1`**     | **`1`**     | **`8`**     |
 | Disk         | GiB      | **`3`**     | **`1`**     | **`10`**    |
 
-To set custom sandbox resources, use the `Resources` class. All resource parameters are optional and must be integers. If not specified, Daytona will use the default values. Maximum values are per-sandbox limits set at the organization level.
+##### Pre-built snapshots
+
+Daytona provides pre-built [default snapshots](/docs/en/snapshots#default-snapshots) with fixed resource sizes for creating sandboxes.
+
+| **Snapshot**         | **vCPU** | **Memory** | **Storage** |
+| -------------------- | -------- | ---------- | ----------- |
+| **`daytona-small`**  | 1        | 1GiB       | 3GiB        |
+| **`daytona-medium`** | 2        | 4GiB       | 8GiB        |
+| **`daytona-large`**  | 4        | 8GiB       | 10GiB       |
+
+<Tabs syncKey="language">
+<TabItem label="Python" icon="seti:python">
+
+```python
+from daytona import Daytona, CreateSandboxFromSnapshotParams
+
+daytona = Daytona()
+sandbox = daytona.create(
+    CreateSandboxFromSnapshotParams(
+        snapshot="daytona-medium",
+    )
+)
+```
+
+</TabItem>
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```typescript
+import { Daytona } from "@daytona/sdk";
+
+const daytona = new Daytona();
+const sandbox = await daytona.create({
+  snapshot: "daytona-medium",
+});
+```
+
+</TabItem>
+<TabItem label="Ruby" icon="seti:ruby">
+
+```ruby
+require 'daytona'
+
+daytona = Daytona::Daytona.new
+sandbox = daytona.create(
+  Daytona::CreateSandboxFromSnapshotParams.new(
+    snapshot: 'daytona-medium'
+  )
+)
+```
+
+</TabItem>
+<TabItem label="Go" icon="seti:go">
+
+```go
+package main
+
+import (
+	"context"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	"github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+)
+
+func main() {
+	client, _ := daytona.NewClient()
+	ctx := context.Background()
+	params := types.SnapshotParams{
+		Snapshot: "daytona-medium",
+	}
+	_, _ = client.Create(ctx, params)
+}
+```
+
+</TabItem>
+<TabItem label="Java" icon="seti:java">
+
+```java
+import io.daytona.sdk.Daytona;
+import io.daytona.sdk.Sandbox;
+import io.daytona.sdk.model.CreateSandboxFromSnapshotParams;
+
+public class App {
+    public static void main(String[] args) {
+        try (Daytona daytona = new Daytona()) {
+            CreateSandboxFromSnapshotParams params = new CreateSandboxFromSnapshotParams();
+            params.setSnapshot("daytona-medium");
+            Sandbox sandbox = daytona.create(params);
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem label="CLI" icon="seti:shell">
+
+```bash
+daytona create --snapshot daytona-medium
+```
+
+</TabItem>
+<TabItem label="API" icon="seti:json">
+
+```bash
+curl 'https://app.daytona.io/api/sandbox' \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --data '{
+  "snapshot": "daytona-medium"
+}'
+```
+
+</TabItem>
+</Tabs>
+
+##### Custom resources
+
+Daytona provides methods to create sandboxes with custom resources.
+
+Use the `Resources` class to set custom sandbox resources. All resource parameters are optional and must be integers. If not specified, Daytona will use the default values. Maximum values are per-sandbox limits set at the organization level.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">

--- a/apps/docs/src/content/docs/en/snapshots.mdx
+++ b/apps/docs/src/content/docs/en/snapshots.mdx
@@ -28,7 +28,7 @@ Daytona provides methods to create snapshots. You can create a snapshot from:
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click **Create Snapshot**
-3. Enter the snapshot **name** and **image**
+3. Enter the snapshot **`name`** and **`image`**
 
 - **Snapshot name**: identifier used to reference the snapshot
 - **Snapshot image**: base image for the snapshot, must include either a tag or a digest (e.g., **`ubuntu:22.04`**); the `latest`/`lts`/`stable` tags are not supported
@@ -148,9 +148,9 @@ GPU snapshots are used to create [GPU sandboxes](/docs/en/sandboxes#gpu-sandboxe
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click **Create Snapshot**
-3. Enter the snapshot **name** and **image**
+3. Enter the snapshot **`name`** and **`image`**
 4. Select **`us-east-1`** region
-5. Select the **Allocate GPU** checkbox
+5. Select the **`Allocate GPU`** checkbox
 6. Click **Create** to create a GPU snapshot
 
 <Tabs syncKey="language">
@@ -298,9 +298,7 @@ Daytona supports creating snapshots from any publicly accessible image or contai
 
 1. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 2. Click the **Create Snapshot** button
-3. Enter the **snapshot name** and **image** (tag or digest) of any publicly accessible image or container registry
-
-Once the snapshot is pulled, validated, and has an `Active` state, it is ready to be used.
+3. Enter the snapshot **`name`** and **`image`** of any publicly accessible image or container registry
 
 <Tabs>
 <TabItem label="Python" icon="seti:python">
@@ -412,7 +410,9 @@ curl https://app.daytona.io/api/snapshots \
 <a id="using-local-images"></a>
 ### Local images
 
-Daytona supports creating snapshots from local images or from local Dockerfiles. To create a snapshot from a local image or from a local Dockerfile, use the [Daytona CLI](/docs/en/tools/cli#daytona-snapshot).
+Daytona supports creating snapshots from local images or from local Dockerfiles. 
+
+To create a snapshot from a local image or from a local Dockerfile, use the [Daytona CLI](/docs/en/tools/cli#daytona-snapshot).
 
 Daytona expects the local image to be built for AMD64 architecture. Therefore, the `--platform=linux/amd64` flag is required when building the Docker image if your machine is running on a different architecture.
 
@@ -428,29 +428,10 @@ docker images
 daytona snapshot push custom-alpine:3.21 --name alpine-minimal
 ```
 
-:::tip
-Use the flags `--cpu`, `--memory` and `--disk` to specify the [resources](/docs/en/sandboxes#resources) you want the underlying sandboxes to have. Example:
-<br />
-```bash
-daytona snapshot push custom-alpine:3.21 --name alpine-minimal --cpu 2 --memory 4 --disk 8
-```
-:::
-
 Alternatively, use the `--dockerfile` flag under `create` to pass the path to the Dockerfile you want to use and Daytona will build the snapshot for you. The `COPY`/`ADD` commands will be automatically parsed and added to the context. To manually add files to the context, use the `--context` flag.
 
 ```bash
 daytona snapshot create my-awesome-snapshot --dockerfile ./Dockerfile
-```
-
-```text
-Building image from /Users/user/docs/Dockerfile
-Step 1/5 : FROM alpine:latest
-
-...
- ⡿  Waiting for the Snapshot to be validated ...
-...
-
- ✓  Use 'harbor-transient.internal.daytona.app/daytona/trying-daytona:0.0.1' to create a new sandbox using this Snapshot
 ```
 
 <a id="using-images-from-private-registries"></a>
@@ -458,55 +439,54 @@ Step 1/5 : FROM alpine:latest
 
 Daytona supports creating snapshots from images from [Docker Hub](#docker-hub), [Google Artifact Registry](#google-artifact-registry), [GitHub Container Registry](#github-container-registry-ghcr), [Amazon ECR](#amazon-elastic-container-registry-ecr) or other private container registries.
 
-The **Add Registry** form has a tab per provider — Docker Hub, Google, GitHub, Amazon ECR, and Generic. Select the tab that matches your registry; the form will pre-fill or hide fields whose value is fixed for that provider (so you only fill in what's actually account-specific). The provider-specific sections below list exactly what to enter, and what gets auto-filled behind the scenes.
-
 1. Navigate to [Daytona Registries ↗](https://app.daytona.io/dashboard/registries)
-2. Click **Add Registry** and pick the tab for your provider
-3. Fill in the visible fields (see the section for your provider below)
-4. After the registry is created, navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
+2. Click **Add Registry** and select your provider
+3. Fill in the visible fields
+4. Navigate to [Daytona Snapshots ↗](https://app.daytona.io/dashboard/snapshots)
 5. Click **Create Snapshot**
-6. Enter the **snapshot name** and the full **image** reference, including the registry host and repository (e.g. `my-registry.com/<repo>/custom-alpine:3.21`)
-
-Optionally, set the **`CreateSandboxFromSnapshotParams`** field to use the custom snapshot.
+6. Enter the snapshot **`name`** and the full **`image`** reference, including the registry host and repository (e.g. **`my-registry.com/<repo>/custom-alpine:3.21`**)
 
 #### Docker Hub
 
 Daytona supports creating snapshots from Docker Hub images.
 
-1. On [Daytona Registries ↗](https://app.daytona.io/dashboard/registries), click **Add Registry** and select the **Docker Hub** tab.
-2. Fill in:
+1. Navigate to [Daytona Registries ↗](https://app.daytona.io/dashboard/registries), 
+2. Click **Add Registry** and select the **Docker Hub** tab
+3. Input the following fields:
    - **Username**: your Docker Hub username (the account with access to the image)
    - **Personal Access Token**: a [Docker Hub PAT](https://docs.docker.com/security/access-tokens/) — not your account password
-
-   Registry URL is auto-filled with `docker.io` and not shown in the form.
-3. Create the snapshot using the full image reference, e.g. `docker.io/<username>/<image>:<tag>`.
+   - **Registry URL**: auto-filled with **`docker.io`** and not shown in the form
+4. Create the snapshot using the full image reference, e.g. **`docker.io/<username>/<image>:<tag>`**
 
 #### Google Artifact Registry
 
 Daytona supports creating snapshots from images from Google Artifact Registry, authenticated with a [service account key](https://cloud.google.com/iam/docs/keys-create-delete) in JSON format.
 
-1. On [Daytona Registries ↗](https://app.daytona.io/dashboard/registries), click **Add Registry** and select the **Google** tab.
-2. Fill in:
-   - **Registry URL**: the base URL for your region (e.g. `https://us-central1-docker.pkg.dev`)
-   - **Service Account JSON Key**: paste the full contents of your service account key JSON file
+1. Navigate to [Daytona Registries ↗](https://app.daytona.io/dashboard/registries), 
+2. Click **Add Registry** and select the **Google** tab
+2. Input the following fields:
+   - **Registry URL**: the base URL for your region (e.g. **`https://us-central1-docker.pkg.dev`**)
+   - **Service Account JSON Key**: the contents of your service account key JSON file
    - **Google Cloud Project ID**: your GCP project ID
+   - **Username**: auto-filled with **`_json_key`** (required by Google for service-account auth)
+3. Create the snapshot using the full image reference, e.g.
 
-   Username is auto-filled with `_json_key` (required by Google for service-account auth) and not shown in the form.
-3. Create the snapshot using the full image reference, e.g. `us-central1-docker.pkg.dev/<project>/<repo>/<image>:<tag>`.
+    **`us-central1-docker.pkg.dev/<project>/<repo>/<image>:<tag>`**
 
 <a id="github-container-registry-ghcr"></a>
 #### GitHub Container Registry
 
 Daytona supports creating snapshots from images from GitHub Container Registry.
 
-1. On [Daytona Registries ↗](https://app.daytona.io/dashboard/registries), click **Add Registry** and select the **GitHub** tab.
-2. Fill in:
+1. Navigate to [Daytona Registries ↗](https://app.daytona.io/dashboard/registries), 
+2. Click **Add Registry** and select the **GitHub** tab
+2. Input the following fields:
    - **GitHub Username**: the account with access to the image
-   - **Personal Access Token**: a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with `read:packages` scope (and `write:packages` / `delete:packages` if you'll push or delete)
+   - **Personal Access Token**: a [GitHub PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with **`read:packages`** scope (and **`write:packages`** / **`delete:packages`** if you'll push or delete)
+   - **Registry URL**: auto-filled with **`ghcr.io`** and not shown in the form
+3. Create the snapshot using the full image reference, e.g. 
 
-   Registry URL is auto-filled with `ghcr.io` and not shown in the form.
-3. Create the snapshot using the full image reference, e.g. `ghcr.io/<owner>/<image>:<tag>`.
-
+    **`ghcr.io/<owner>/<image>:<tag>`**
 
 <a id="amazon-elastic-container-registry-ecr"></a>
 #### Amazon Elastic Container Registry
@@ -594,7 +574,7 @@ Daytona sends a `daytona-<orgId>-pull` session name on every AssumeRole call. Yo
 
 Snapshots can be customized with specific [sandbox resources](/docs/en/sandboxes#resources). By default, Daytona sandboxes use **1 vCPU**, **1GB RAM**, and **3GiB disk**. To view your available resources and limits, see [limits](/docs/en/limits) or navigate to [Daytona Limits ↗](https://app.daytona.io/dashboard/limits).
 
-To set custom sandbox resources, use the `Resources` class.
+To set custom snapshot resources, use the `Resources` class.
 
 <Tabs syncKey="language">
 <TabItem label="Python" icon="seti:python">
@@ -1312,7 +1292,9 @@ All default snapshots are based on the `daytonaio/sandbox:<version>` image. For 
 - `opencv-python` (v4.13.0.90)
 - `pandas` (v2.3.3)
 - `pillow` (v12.1.0)
+- `pipx` (v1.8.0)
 - `pydantic-ai` (v1.47.0)
+- `python-lsp-server` (v1.14.0)
 - `requests` (v2.32.5)
 - `scikit-learn` (v1.8.0)
 - `scipy` (v1.17.0)
@@ -1320,6 +1302,7 @@ All default snapshots are based on the `daytonaio/sandbox:<version>` image. For 
 - `sqlalchemy` (v2.0.46)
 - `torch` (v2.10.0)
 - `transformers` (v4.57.6)
+- `uv` (v0.9.26)
 
 ### Node.js packages (npm)
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783202107&installation_id=132266156&pr_number=4930&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4930&signature=c5f69279d109dd85eb933749843456442eab334a594edb4e5be7740cf880724f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Sandboxes and Snapshots docs to add clear GPU sandbox guidance (H100/RTX Pro 6000, custom GPU count/types) and simplify snapshot/registry workflows. Also listed pre-built snapshot sizes and updated default snapshot packages.

- **Refactors**
  - GPU sandboxes: documented supported GPUs (H100, RTX Pro 6000) and added examples to set `gpu` and `gpuType` across SDKs (`@daytona/sdk`, Python, Ruby, Go, Java) and API.
  - Added pre-built snapshot sizes and examples for `daytona-small`, `daytona-medium`, `daytona-large`.
  - Split resources docs into “Pre-built snapshots” and “Custom resources”; clarified limits and defaults.
  - Snapshots: clearer field formatting, streamlined private registry steps (Docker Hub, Google, GHCR), improved local image/`Dockerfile` guidance; corrected wording to “custom snapshot resources.”
  - Default snapshot packages: added `pipx`, `python-lsp-server`, and `uv`.

<sup>Written for commit 3bc873f630e9dce43c5472a2d0658e3de03b65e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

