### PR TITLE
fix(dashboard): allow selecting toast text

### DIFF
--- a/apps/dashboard/src/components/ui/sonner.tsx
+++ b/apps/dashboard/src/components/ui/sonner.tsx
@@ -36,12 +36,15 @@ const Toaster = ({ className, toastOptions, ...props }: ToasterProps) => {
                 toastOptions?.classNames?.toast,
               ),
               icon: cn('mt-0.5', toastOptions?.classNames?.icon),
-              content: cn('gap-1', toastOptions?.classNames?.content),
+              content: cn('gap-1 select-text cursor-text', toastOptions?.classNames?.content),
               title: cn(
-                'font-medium group-data-[type=error]:text-destructive group-data-[type=success]:text-success group-data-[type=warning]:text-warning group-data-[type=info]:text-foreground',
+                'select-text cursor-text font-medium group-data-[type=error]:text-destructive group-data-[type=success]:text-success group-data-[type=warning]:text-warning group-data-[type=info]:text-foreground',
                 toastOptions?.classNames?.title,
               ),
-              description: cn('whitespace-pre-line !text-muted-foreground', toastOptions?.classNames?.description),
+              description: cn(
+                'select-text cursor-text whitespace-pre-line !text-muted-foreground',
+                toastOptions?.classNames?.description,
+              ),
               actionButton: cn(
                 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
                 toastOptions?.classNames?.actionButton,


### PR DESCRIPTION
## Summary

Fixes #4906.

Allows dashboard toast text to be selected and copied by applying selectable text styling to the shared Sonner toast content, title, and description classes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783255155&installation_id=132266156&pr_number=4933&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4933&signature=bfd084fe2d08ffe7f7861056859314feb19af28768ea6aa205da4ce3a12b3f17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow selecting and copying text in dashboard toasts by making the toast content, title, and description selectable (adds select-text and cursor-text).

<sup>Written for commit 4208ae2d85e40cca10a0d8bafad74adb5383c85c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

