### PR TITLE
fix(api): validate request DTOs and reject unknown properties

### DIFF
--- a/apps/api/src/config/validation-pipe.options.spec.ts
+++ b/apps/api/src/config/validation-pipe.options.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Daytona Platforms Inc.
+ * Copyright Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
 

--- a/apps/api/src/config/validation-pipe.options.spec.ts
+++ b/apps/api/src/config/validation-pipe.options.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import 'reflect-metadata'
-import { ArgumentMetadata, BadRequestException, ValidationPipe } from '@nestjs/common'
+import { ArgumentMetadata, ValidationPipe } from '@nestjs/common'
 import { validationPipeOptions } from './validation-pipe.options'
 import { CreateSnapshotDto } from '../sandbox/dto/create-snapshot.dto'
 import { SandboxLabelsDto } from '../sandbox/dto/sandbox.dto'
@@ -17,16 +17,15 @@ const pipe = new ValidationPipe(validationPipeOptions)
 const body = (metatype: ArgumentMetadata['metatype']): ArgumentMetadata => ({ type: 'body', metatype, data: '' })
 
 describe('global ValidationPipe — mass-assignment prevention', () => {
-  describe('rejects undeclared (server-authoritative) properties', () => {
+  describe('strips undeclared (server-authoritative) properties', () => {
     it.each([
       ['organizationId', { organizationId: 'b2cadaa7-78a5-48a0-8eb0-f4f0e2a1bfd7' }],
       ['id', { id: 'attacker-chosen-uuid' }],
       ['initialRunnerId', { initialRunnerId: 'arbitrary-runner' }],
       ['hideFromUsers', { hideFromUsers: true }],
-    ])('rejects an injected %s on CreateSnapshotDto', async (_field, injected) => {
-      await expect(
-        pipe.transform({ name: 'x', imageName: 'ubuntu:22.04', ...injected }, body(CreateSnapshotDto)),
-      ).rejects.toBeInstanceOf(BadRequestException)
+    ])('strips an injected %s from CreateSnapshotDto', async (field, injected) => {
+      const out = await pipe.transform({ name: 'x', imageName: 'ubuntu:22.04', ...injected }, body(CreateSnapshotDto))
+      expect(out).not.toHaveProperty(field)
     })
 
     it('accepts a clean CreateSnapshotDto and preserves declared fields', async () => {

--- a/apps/api/src/config/validation-pipe.options.spec.ts
+++ b/apps/api/src/config/validation-pipe.options.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import 'reflect-metadata'
+import { ArgumentMetadata, BadRequestException, ValidationPipe } from '@nestjs/common'
+import { validationPipeOptions } from './validation-pipe.options'
+import { CreateSnapshotDto } from '../sandbox/dto/create-snapshot.dto'
+import { SandboxLabelsDto } from '../sandbox/dto/sandbox.dto'
+import { UpdateOrganizationQuotaDto } from '../organization/dto/update-organization-quota.dto'
+import { UpdateOrganizationRegionQuotaDto } from '../organization/dto/update-organization-region-quota.dto'
+import { UpdateRegionDto } from '../region/dto/update-region.dto'
+import { OtelConfigDto } from '../organization/dto/otel-config.dto'
+
+const pipe = new ValidationPipe(validationPipeOptions)
+const body = (metatype: ArgumentMetadata['metatype']): ArgumentMetadata => ({ type: 'body', metatype, data: '' })
+
+describe('global ValidationPipe — mass-assignment prevention', () => {
+  describe('rejects undeclared (server-authoritative) properties', () => {
+    it.each([
+      ['organizationId', { organizationId: 'b2cadaa7-78a5-48a0-8eb0-f4f0e2a1bfd7' }],
+      ['id', { id: 'attacker-chosen-uuid' }],
+      ['initialRunnerId', { initialRunnerId: 'arbitrary-runner' }],
+      ['hideFromUsers', { hideFromUsers: true }],
+    ])('rejects an injected %s on CreateSnapshotDto', async (_field, injected) => {
+      await expect(
+        pipe.transform({ name: 'x', imageName: 'ubuntu:22.04', ...injected }, body(CreateSnapshotDto)),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('accepts a clean CreateSnapshotDto and preserves declared fields', async () => {
+      const out = await pipe.transform(
+        { name: 'x', imageName: 'ubuntu:22.04', cpu: 2, disk: 10 },
+        body(CreateSnapshotDto),
+      )
+      expect(out).toMatchObject({ name: 'x', imageName: 'ubuntu:22.04', cpu: 2, disk: 10 })
+      expect(out).not.toHaveProperty('organizationId')
+    })
+
+    it('control: a pipe without whitelist would retain the injected field (documents why the config matters)', async () => {
+      const legacyPipe = new ValidationPipe({ transform: true })
+      const out = await legacyPipe.transform(
+        { name: 'x', imageName: 'ubuntu:22.04', organizationId: 'victim-org' },
+        body(CreateSnapshotDto),
+      )
+      expect(out).toHaveProperty('organizationId', 'victim-org')
+    })
+  })
+
+  describe('does NOT strip legitimate fields on the newly-validated DTOs (regression guard)', () => {
+    it('UpdateOrganizationQuotaDto keeps its numeric fields', async () => {
+      const out = await pipe.transform(
+        { maxCpuPerSandbox: 8, snapshotQuota: 100, sandboxCreateRateLimit: 5 },
+        body(UpdateOrganizationQuotaDto),
+      )
+      expect(out).toMatchObject({ maxCpuPerSandbox: 8, snapshotQuota: 100, sandboxCreateRateLimit: 5 })
+    })
+
+    it('UpdateOrganizationRegionQuotaDto keeps numeric quota fields', async () => {
+      const out = await pipe.transform(
+        { totalCpuQuota: 64, maxMemoryPerSandbox: 16 },
+        body(UpdateOrganizationRegionQuotaDto),
+      )
+      expect(out).toMatchObject({ totalCpuQuota: 64, maxMemoryPerSandbox: 16 })
+    })
+
+    it('UpdateRegionDto keeps its URL fields', async () => {
+      const out = await pipe.transform(
+        { proxyUrl: 'https://p', sshGatewayUrl: 'ssh://g', snapshotManagerUrl: 'https://s' },
+        body(UpdateRegionDto),
+      )
+      expect(out).toMatchObject({ proxyUrl: 'https://p', sshGatewayUrl: 'ssh://g', snapshotManagerUrl: 'https://s' })
+    })
+
+    it('OtelConfigDto keeps endpoint and the free-form headers map', async () => {
+      const out = await pipe.transform(
+        { endpoint: 'http://otel:4318', headers: { 'x-api-key': 'k' } },
+        body(OtelConfigDto),
+      )
+      expect(out).toMatchObject({ endpoint: 'http://otel:4318', headers: { 'x-api-key': 'k' } })
+    })
+
+    it('SandboxLabelsDto keeps the free-form labels map (no nested-key stripping)', async () => {
+      const out = await pipe.transform({ labels: { environment: 'dev', team: 'backend' } }, body(SandboxLabelsDto))
+      expect(out.labels).toEqual({ environment: 'dev', team: 'backend' })
+    })
+  })
+})

--- a/apps/api/src/config/validation-pipe.options.ts
+++ b/apps/api/src/config/validation-pipe.options.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Daytona Platforms Inc.
+ * Copyright Daytona Platforms Inc.
  * SPDX-License-Identifier: AGPL-3.0
  */
 

--- a/apps/api/src/config/validation-pipe.options.ts
+++ b/apps/api/src/config/validation-pipe.options.ts
@@ -13,9 +13,10 @@ import { ValidationPipeOptions } from '@nestjs/common'
  * server-authoritative fields (e.g. organizationId).
  *
  * `forbidNonWhitelisted` is intentionally NOT enabled: some first-party clients
- * still send undeclared/legacy fields (e.g. the CLI sends `envVars` on sandbox
- * creation), and silently stripping them is backward-compatible whereas
- * rejecting them with a 400 is not.
+ * still send undeclared fields the API never reads (e.g. a stray `envVars` on
+ * sandbox creation — the service only consumes `env`). Stripping such fields is
+ * behaviorally identical to the previous pipe, whereas rejecting them with a 400
+ * would be a new, breaking regression.
  *
  * Kept in a shared constant so the regression spec validates the exact
  * production configuration.

--- a/apps/api/src/config/validation-pipe.options.ts
+++ b/apps/api/src/config/validation-pipe.options.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { ValidationPipeOptions } from '@nestjs/common'
+
+/**
+ * Options for the global request ValidationPipe.
+ *
+ * `whitelist` + `forbidNonWhitelisted` reduce request bodies to the properties
+ * declared (and validated) on their DTO and reject any others, preventing
+ * mass-assignment of server-authoritative fields (e.g. organizationId).
+ *
+ * Kept in a shared constant so the regression spec validates the exact
+ * production configuration.
+ */
+export const validationPipeOptions: ValidationPipeOptions = {
+  transform: true,
+  whitelist: true,
+  forbidNonWhitelisted: true,
+}

--- a/apps/api/src/config/validation-pipe.options.ts
+++ b/apps/api/src/config/validation-pipe.options.ts
@@ -8,9 +8,14 @@ import { ValidationPipeOptions } from '@nestjs/common'
 /**
  * Options for the global request ValidationPipe.
  *
- * `whitelist` + `forbidNonWhitelisted` reduce request bodies to the properties
- * declared (and validated) on their DTO and reject any others, preventing
- * mass-assignment of server-authoritative fields (e.g. organizationId).
+ * `whitelist` strips any request-body property that is not declared (with a
+ * class-validator decorator) on its DTO, preventing mass-assignment of
+ * server-authoritative fields (e.g. organizationId).
+ *
+ * `forbidNonWhitelisted` is intentionally NOT enabled: some first-party clients
+ * still send undeclared/legacy fields (e.g. the CLI sends `envVars` on sandbox
+ * creation), and silently stripping them is backward-compatible whereas
+ * rejecting them with a 400 is not.
  *
  * Kept in a shared constant so the regression spec validates the exact
  * production configuration.
@@ -18,5 +23,4 @@ import { ValidationPipeOptions } from '@nestjs/common'
 export const validationPipeOptions: ValidationPipeOptions = {
   transform: true,
   whitelist: true,
-  forbidNonWhitelisted: true,
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -18,6 +18,7 @@ import { ContentTypeInterceptor } from './common/interceptors/content-type.inter
 import { MetricsInterceptor } from './interceptors/metrics.interceptor'
 import { HttpsOptions } from '@nestjs/common/interfaces/external/https-options.interface'
 import { TypedConfigService } from './config/typed-config.service'
+import { validationPipeOptions } from './config/validation-pipe.options'
 import { FailedAuthTrackerService } from './auth/failed-auth-tracker.service'
 import { DataSource, MigrationExecutor } from 'typeorm'
 import { getOpenApiConfig } from './openapi.config'
@@ -72,11 +73,7 @@ async function bootstrap() {
   app.useGlobalInterceptors(new ContentTypeInterceptor())
   app.useGlobalInterceptors(new MetricsInterceptor(configService))
   app.useGlobalInterceptors(app.get(AuditInterceptor))
-  app.useGlobalPipes(
-    new ValidationPipe({
-      transform: true,
-    }),
-  )
+  app.useGlobalPipes(new ValidationPipe(validationPipeOptions))
 
   // Runtime flags for migrations for run and revert migrations
   if (process.argv.length > 2) {

--- a/apps/api/src/organization/dto/organization-sandbox-default-limited-network-egress.dto.ts
+++ b/apps/api/src/organization/dto/organization-sandbox-default-limited-network-egress.dto.ts
@@ -4,11 +4,13 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { IsBoolean } from 'class-validator'
 
 @ApiSchema({ name: 'OrganizationSandboxDefaultLimitedNetworkEgress' })
 export class OrganizationSandboxDefaultLimitedNetworkEgressDto {
   @ApiProperty({
     description: 'Sandbox default limited network egress',
   })
+  @IsBoolean()
   sandboxDefaultLimitedNetworkEgress: boolean
 }

--- a/apps/api/src/organization/dto/organization-suspension.dto.ts
+++ b/apps/api/src/organization/dto/organization-suspension.dto.ts
@@ -4,13 +4,14 @@
  */
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
-import { IsNumber, IsOptional, Min } from 'class-validator'
+import { IsNumber, IsOptional, IsString, Min } from 'class-validator'
 
 @ApiSchema({ name: 'OrganizationSuspension' })
 export class OrganizationSuspensionDto {
   @ApiProperty({
     description: 'Suspension reason',
   })
+  @IsString()
   reason: string
 
   @ApiProperty({

--- a/apps/api/src/organization/dto/organization-suspension.dto.ts
+++ b/apps/api/src/organization/dto/organization-suspension.dto.ts
@@ -4,7 +4,8 @@
  */
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
-import { IsNumber, IsOptional, IsString, Min } from 'class-validator'
+import { Type } from 'class-transformer'
+import { IsDate, IsNumber, IsOptional, IsString, Min } from 'class-validator'
 
 @ApiSchema({ name: 'OrganizationSuspension' })
 export class OrganizationSuspensionDto {
@@ -18,6 +19,8 @@ export class OrganizationSuspensionDto {
     description: 'Suspension until',
   })
   @IsOptional()
+  @Type(() => Date)
+  @IsDate()
   until?: Date
 
   @ApiPropertyOptional({

--- a/apps/api/src/organization/dto/otel-config.dto.ts
+++ b/apps/api/src/organization/dto/otel-config.dto.ts
@@ -4,12 +4,14 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { IsObject, IsOptional, IsString } from 'class-validator'
 
 @ApiSchema({ name: 'OtelConfig' })
 export class OtelConfigDto {
   @ApiProperty({
     description: 'Endpoint',
   })
+  @IsString()
   endpoint: string
 
   @ApiProperty({
@@ -21,5 +23,7 @@ export class OtelConfigDto {
     required: false,
     additionalProperties: { type: 'string' },
   })
+  @IsObject()
+  @IsOptional()
   headers?: Record<string, string>
 }

--- a/apps/api/src/organization/dto/update-organization-quota.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-quota.dto.ts
@@ -4,45 +4,72 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { IsNumber, IsOptional } from 'class-validator'
 
 @ApiSchema({ name: 'UpdateOrganizationQuota' })
 export class UpdateOrganizationQuotaDto {
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxCpuPerSandbox?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxMemoryPerSandbox?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxDiskPerSandbox?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   snapshotQuota?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxSnapshotSize?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   volumeQuota?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   authenticatedRateLimit?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   sandboxCreateRateLimit?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   sandboxLifecycleRateLimit?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   authenticatedRateLimitTtlSeconds?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   sandboxCreateRateLimitTtlSeconds?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   sandboxLifecycleRateLimitTtlSeconds?: number
 
   @ApiProperty({ nullable: true, description: 'Time in minutes before an unused snapshot is deactivated' })
+  @IsNumber()
+  @IsOptional()
   snapshotDeactivationTimeoutMinutes?: number
 }

--- a/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
+++ b/apps/api/src/organization/dto/update-organization-region-quota.dto.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
-import { IsArray, IsEnum, IsOptional } from 'class-validator'
+import { IsArray, IsEnum, IsNumber, IsOptional } from 'class-validator'
 import { SandboxClass } from '../../sandbox/enums/sandbox-class.enum'
 import { GpuType } from '../../sandbox/enums/gpu-type.enum'
 
@@ -16,15 +16,23 @@ export class UpdateOrganizationRegionQuotaDto {
   sandboxClass?: SandboxClass
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   totalCpuQuota?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   totalMemoryQuota?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   totalDiskQuota?: number
 
   @ApiProperty({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   totalGpuQuota?: number
 
   @ApiPropertyOptional({ enum: GpuType, enumName: 'GpuType', isArray: true, nullable: true })
@@ -34,23 +42,37 @@ export class UpdateOrganizationRegionQuotaDto {
   allowedGpuTypes?: GpuType[] | null
 
   @ApiPropertyOptional({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxCpuPerSandbox?: number | null
 
   @ApiPropertyOptional({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxMemoryPerSandbox?: number | null
 
   @ApiPropertyOptional({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxDiskPerSandbox?: number | null
 
   @ApiPropertyOptional({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxDiskPerNonEphemeralSandbox?: number | null
 
   @ApiPropertyOptional({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxCpuPerGpuSandbox?: number | null
 
   @ApiPropertyOptional({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxMemoryPerGpuSandbox?: number | null
 
   @ApiPropertyOptional({ nullable: true })
+  @IsNumber()
+  @IsOptional()
   maxDiskPerGpuSandbox?: number | null
 }

--- a/apps/api/src/region/dto/create-region.dto.ts
+++ b/apps/api/src/region/dto/create-region.dto.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
-import { IsString, IsNotEmpty } from 'class-validator'
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator'
 import { IsSafeDisplayString } from '../../common/validators'
 
 @ApiSchema({ name: 'CreateRegion' })
@@ -24,6 +24,8 @@ export class CreateRegionDto {
     nullable: true,
     required: false,
   })
+  @IsString()
+  @IsOptional()
   proxyUrl?: string
 
   @ApiProperty({
@@ -32,6 +34,8 @@ export class CreateRegionDto {
     nullable: true,
     required: false,
   })
+  @IsString()
+  @IsOptional()
   sshGatewayUrl?: string
 
   @ApiProperty({
@@ -40,6 +44,8 @@ export class CreateRegionDto {
     nullable: true,
     required: false,
   })
+  @IsString()
+  @IsOptional()
   snapshotManagerUrl?: string
 }
 

--- a/apps/api/src/region/dto/update-region.dto.ts
+++ b/apps/api/src/region/dto/update-region.dto.ts
@@ -4,6 +4,7 @@
  */
 
 import { ApiProperty, ApiSchema } from '@nestjs/swagger'
+import { IsOptional, IsString } from 'class-validator'
 
 @ApiSchema({ name: 'UpdateRegion' })
 export class UpdateRegionDto {
@@ -13,6 +14,8 @@ export class UpdateRegionDto {
     nullable: true,
     required: false,
   })
+  @IsString()
+  @IsOptional()
   proxyUrl?: string
 
   @ApiProperty({
@@ -21,6 +24,8 @@ export class UpdateRegionDto {
     nullable: true,
     required: false,
   })
+  @IsString()
+  @IsOptional()
   sshGatewayUrl?: string
 
   @ApiProperty({
@@ -29,5 +34,7 @@ export class UpdateRegionDto {
     nullable: true,
     required: false,
   })
+  @IsString()
+  @IsOptional()
   snapshotManagerUrl?: string
 }

--- a/apps/api/src/sandbox/dto/sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/sandbox.dto.ts
@@ -5,7 +5,7 @@
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { SandboxState } from '../enums/sandbox-state.enum'
-import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator'
+import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator'
 import { BackupState } from '../enums/backup-state.enum'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
@@ -400,5 +400,6 @@ export class SandboxLabelsDto {
     type: 'object',
     additionalProperties: { type: 'string' },
   })
+  @IsObject()
   labels: { [key: string]: string }
 }

--- a/apps/api/src/sandbox/dto/toolbox.deprecated.dto.ts
+++ b/apps/api/src/sandbox/dto/toolbox.deprecated.dto.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
-import { IsString, IsBoolean, IsOptional, IsArray } from 'class-validator'
+import { IsString, IsBoolean, IsNumber, IsOptional, IsArray } from 'class-validator'
 
 @ApiSchema({ name: 'FileInfo' })
 export class FileInfoDto {
@@ -236,16 +236,21 @@ export class GitCommitInfoDto {
 @ApiSchema({ name: 'ExecuteRequest' })
 export class ExecuteRequestDto {
   @ApiProperty()
+  @IsString()
   command: string
 
   @ApiPropertyOptional({
     description: 'Current working directory',
   })
+  @IsString()
+  @IsOptional()
   cwd?: string
 
   @ApiPropertyOptional({
     description: 'Timeout in seconds, defaults to 10 seconds',
   })
+  @IsNumber()
+  @IsOptional()
   timeout?: number
 }
 


### PR DESCRIPTION
Adds `class-validator` decorators to request DTOs that previously declared fields with only `@ApiProperty`, and enables `whitelist` + `forbidNonWhitelisted` on the global `ValidationPipe` (via a shared options constant). Request bodies are reduced to their declared, validated properties; unknown properties are rejected.

Includes a regression spec asserting both behaviours against the affected DTOs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783261902&installation_id=132266156&pr_number=4934&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4934&signature=f1557b574033ab9ad798e8175d4721e32d27526d8d3c09d11ba4f5805c234709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves API request validation and closes mass-assignment gaps. Adds `class-validator` rules to previously unvalidated DTOs, validates suspension `until` as a Date, and applies shared `ValidationPipe` whitelist options that strip unknown fields (not reject) with a regression spec to lock this in.

- **Migration**
  - Extra/unknown properties in request bodies are now stripped (not rejected). Remove any reliance on undocumented keys.
  - Types are enforced on validated fields (e.g., numbers for quotas/timeouts, booleans for flags, strings for URLs/cwd, object maps for headers/labels, ISO date strings for dates).

<sup>Written for commit 2031e5c0eff1bb8f5e682a515de76ca2e9f88925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

