### PR TITLE
fix(api): assign server-owned fields after request input when creating snapshots and regions

### DIFF
--- a/apps/api/src/organization/controllers/organization-region.controller.ts
+++ b/apps/api/src/organization/controllers/organization-region.controller.ts
@@ -101,7 +101,11 @@ export class OrganizationRegionController {
   ): Promise<CreateRegionResponseDto> {
     return await this.regionService.create(
       {
-        ...createRegionDto,
+        // Map only client-supplied fields; never propagate the internal-only `id`.
+        name: createRegionDto.name,
+        proxyUrl: createRegionDto.proxyUrl,
+        sshGatewayUrl: createRegionDto.sshGatewayUrl,
+        snapshotManagerUrl: createRegionDto.snapshotManagerUrl,
         enforceQuotas: false,
         regionType: RegionType.CUSTOM,
       },

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -224,9 +224,10 @@ export class SnapshotService {
         const snapshotId = uuidv4()
 
         const snapshot = this.snapshotRepository.create({
+          // Request input first; server-authoritative fields below cannot be overridden by it.
+          ...createSnapshotDto,
           id: snapshotId,
           organizationId: organization.id,
-          ...createSnapshotDto,
           gpuType: resolvedGpuType,
           entrypoint: this.processEntrypoint(entrypoint),
           mem: createSnapshotDto.memory, // Map memory to mem
@@ -234,6 +235,8 @@ export class SnapshotService {
           state,
           ref,
           general,
+          hideFromUsers: false,
+          initialRunnerId: undefined,
           snapshotRegions: [{ snapshotId, regionId: region.id }],
         })
 
@@ -321,15 +324,18 @@ export class SnapshotService {
       const snapshotId = uuidv4()
 
       const snapshot = this.snapshotRepository.create({
+        // Request input first; server-authoritative fields below cannot be overridden by it.
+        ...createSnapshotDto,
         id: snapshotId,
         organizationId: organization.id,
-        ...createSnapshotDto,
         gpuType: resolvedGpuType,
         entrypoint: this.processEntrypoint(entrypoint),
         mem: createSnapshotDto.memory, // Map memory to mem
         sandboxClass,
         state: SnapshotState.PENDING,
         general,
+        hideFromUsers: false,
+        initialRunnerId: undefined,
         snapshotRegions: [{ snapshotId, regionId: region.id }],
       })
 

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -224,10 +224,15 @@ export class SnapshotService {
         const snapshotId = uuidv4()
 
         const snapshot = this.snapshotRepository.create({
-          // Request input first; server-authoritative fields below cannot be overridden by it.
-          ...createSnapshotDto,
           id: snapshotId,
           organizationId: organization.id,
+          // Map only client-settable fields explicitly; the raw DTO is never spread, so
+          // request input cannot assign server-owned columns (e.g. organizationId, initialRunnerId).
+          name: createSnapshotDto.name,
+          imageName: createSnapshotDto.imageName,
+          cpu: createSnapshotDto.cpu,
+          gpu: createSnapshotDto.gpu,
+          disk: createSnapshotDto.disk,
           gpuType: resolvedGpuType,
           entrypoint: this.processEntrypoint(entrypoint),
           mem: createSnapshotDto.memory, // Map memory to mem
@@ -235,8 +240,6 @@ export class SnapshotService {
           state,
           ref,
           general,
-          hideFromUsers: false,
-          initialRunnerId: undefined,
           snapshotRegions: [{ snapshotId, regionId: region.id }],
         })
 
@@ -324,18 +327,21 @@ export class SnapshotService {
       const snapshotId = uuidv4()
 
       const snapshot = this.snapshotRepository.create({
-        // Request input first; server-authoritative fields below cannot be overridden by it.
-        ...createSnapshotDto,
         id: snapshotId,
         organizationId: organization.id,
+        // Map only client-settable fields explicitly; the raw DTO is never spread, so
+        // request input cannot assign server-owned columns (e.g. organizationId, initialRunnerId).
+        // imageName is intentionally omitted: it is rejected for the build-info path.
+        name: createSnapshotDto.name,
+        cpu: createSnapshotDto.cpu,
+        gpu: createSnapshotDto.gpu,
+        disk: createSnapshotDto.disk,
         gpuType: resolvedGpuType,
         entrypoint: this.processEntrypoint(entrypoint),
         mem: createSnapshotDto.memory, // Map memory to mem
         sandboxClass,
         state: SnapshotState.PENDING,
         general,
-        hideFromUsers: false,
-        initialRunnerId: undefined,
         snapshotRegions: [{ snapshotId, regionId: region.id }],
       })
 


### PR DESCRIPTION
Builds the `Snapshot` entity by spreading the request DTO before the server-derived fields, and maps region-create input explicitly, so request input cannot override server-owned columns (organization, id, runner assignment).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783261904&installation_id=132266156&pr_number=4935&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4935&signature=17b87e0b2d406e54fd65a5d1f4a412383abe86f7d918c940addb0c932a8b9984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents clients from setting server-owned fields when creating snapshots and regions. Snapshot creation now uses explicit field mapping (no DTO spread), and region creation whitelists allowed props.

- **Bug Fixes**
  - Regions: Map only `name`, `proxyUrl`, `sshGatewayUrl`, `snapshotManagerUrl`; ignore client `id`; force `enforceQuotas: false` and `regionType: CUSTOM`.
  - Snapshots: Stop spreading the request DTO; map only allowed fields (`name`, `imageName` when allowed, `cpu`, `gpu`, `disk`). Enforce server fields (`id`, `organizationId`, `gpuType`, processed `entrypoint`, `mem` from `memory`), default `hideFromUsers: false`, and `initialRunnerId: undefined`. Omit `imageName` on the build-info path.

<sup>Written for commit 79ed1010b128eda0067e76d3561a345a623b5ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

