### PR TITLE
fix(proxy): validate preview-warning accept redirect target

### DIFF
--- a/apps/proxy/pkg/proxy/warning_page.go
+++ b/apps/proxy/pkg/proxy/warning_page.go
@@ -22,6 +22,27 @@ const (
 	ACCEPT_PREVIEW_PAGE_WARNING_PATH = "/accept-daytona-preview-warning"
 )
 
+// isSafeRedirect permits only same-host absolute URLs (http/https) and
+// single-leading-slash relative paths, so the accept handler cannot be turned
+// into an open redirect. Validation runs on a backslash-normalized copy because
+// browsers fold "\" to "/" in the authority; the redirect still issues the
+// original value (any value that passes is an absolute same-host URL or a safe
+// relative path, and url.Parse fails closed on control characters).
+func isSafeRedirect(redirectURL, requestHost string) bool {
+	normalized := strings.ReplaceAll(redirectURL, "\\", "/")
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return false
+	}
+	if u.Host != "" {
+		if u.Scheme != "" && u.Scheme != "http" && u.Scheme != "https" {
+			return false
+		}
+		return strings.EqualFold(u.Host, requestHost)
+	}
+	return strings.HasPrefix(normalized, "/") && !strings.HasPrefix(normalized, "//")
+}
+
 func handleAcceptProxyWarning(ctx *gin.Context, secure bool) {
 	// Set SameSite attribute based on security context
 	if secure {
@@ -43,9 +64,10 @@ func handleAcceptProxyWarning(ctx *gin.Context, secure bool) {
 		true,
 	)
 
-	// Redirect to the original URL or root
+	// Redirect to the original URL or root. Reject any target that is not
+	// same-host (or a safe relative path) to prevent an open redirect.
 	redirectURL := ctx.Query("redirect")
-	if redirectURL == "" {
+	if redirectURL == "" || !isSafeRedirect(redirectURL, ctx.Request.Host) {
 		redirectURL = "/"
 	}
 

--- a/apps/proxy/pkg/proxy/warning_page_test.go
+++ b/apps/proxy/pkg/proxy/warning_page_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -93,5 +94,134 @@ func TestServeWarningPage_FormActionUrlEncodesPayload(t *testing.T) {
 	body := w.Body.String()
 	if strings.Contains(body, `action="`) && strings.Contains(body, `"><script>`) {
 		t.Fatalf("form action attribute appears to allow attribute breakout:\n%s", body)
+	}
+}
+
+func TestHandleAcceptProxyWarning_AllowsSameHostAbsoluteRedirect(t *testing.T) {
+	// This is exactly what serveWarningPage produces: an absolute URL on the
+	// same host the request arrived on. It must be honored, not downgraded.
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(
+		"POST",
+		ACCEPT_PREVIEW_PAGE_WARNING_PATH+"?redirect=https%3A%2F%2F3000-abc.daytonaproxy01.net%2Fdashboard%2Findex.html",
+		nil,
+	)
+	c.Request.Host = "3000-abc.daytonaproxy01.net"
+
+	handleAcceptProxyWarning(c, true)
+
+	// gin's ResponseWriter buffers the status; http.Redirect writes no body for
+	// POST, so assert the buffered status rather than the recorder's Code.
+	if c.Writer.Status() != http.StatusFound {
+		t.Fatalf("expected 302 Found; got %d", c.Writer.Status())
+	}
+	if loc := w.Header().Get("Location"); loc != "https://3000-abc.daytonaproxy01.net/dashboard/index.html" {
+		t.Fatalf("expected same-host redirect to be honored; got Location %q", loc)
+	}
+}
+
+func TestHandleAcceptProxyWarning_AllowsSameHostWithPortAndQuery(t *testing.T) {
+	// Dev http://localhost:port and host:port must pass: serveWarningPage and the
+	// validator both read the full raw Request.Host (incl. port).
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(
+		"POST",
+		ACCEPT_PREVIEW_PAGE_WARNING_PATH+"?redirect=http%3A%2F%2Flocalhost%3A8080%2Fdashboard%3Ftab%3Dlogs",
+		nil,
+	)
+	c.Request.Host = "localhost:8080"
+
+	handleAcceptProxyWarning(c, false)
+
+	// gin's ResponseWriter buffers the status; http.Redirect writes no body for
+	// POST, so assert the buffered status rather than the recorder's Code.
+	if c.Writer.Status() != http.StatusFound {
+		t.Fatalf("expected 302 Found; got %d", c.Writer.Status())
+	}
+	if loc := w.Header().Get("Location"); loc != "http://localhost:8080/dashboard?tab=logs" {
+		t.Fatalf("expected same-host:port redirect to be honored; got Location %q", loc)
+	}
+}
+
+func TestHandleAcceptProxyWarning_AllowsSameHostWithForwardedHostHeader(t *testing.T) {
+	// Custom Preview Proxy: the consent POST reaches Daytona on a daytona proxy
+	// host; X-Forwarded-Host is never read for host resolution, so the same-host
+	// redirect must still be honored.
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(
+		"POST",
+		ACCEPT_PREVIEW_PAGE_WARNING_PATH+"?redirect=https%3A%2F%2F3000-abc.daytonaproxy01.net%2Fapp",
+		nil,
+	)
+	c.Request.Host = "3000-abc.daytonaproxy01.net"
+	c.Request.Header.Set("X-Forwarded-Host", "preview.yourcompany.com")
+
+	handleAcceptProxyWarning(c, true)
+
+	if loc := w.Header().Get("Location"); loc != "https://3000-abc.daytonaproxy01.net/app" {
+		t.Fatalf("expected redirect to be unaffected by X-Forwarded-Host; got Location %q", loc)
+	}
+}
+
+func TestHandleAcceptProxyWarning_AllowsSafeRelativePath(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", ACCEPT_PREVIEW_PAGE_WARNING_PATH+"?redirect=%2Fdashboard", nil)
+	c.Request.Host = "3000-abc.daytonaproxy01.net"
+
+	handleAcceptProxyWarning(c, true)
+
+	if loc := w.Header().Get("Location"); loc != "/dashboard" {
+		t.Fatalf("expected safe relative path to be honored; got Location %q", loc)
+	}
+}
+
+func TestHandleAcceptProxyWarning_RejectsOpenRedirectTargets(t *testing.T) {
+	cases := []struct {
+		name     string
+		redirect string
+	}{
+		{"absolute-cross-host", "https://evil.com/phish"},
+		{"protocol-relative", "//evil.com/x"},
+		{"backslash-slash", "/\\evil.com"},
+		{"double-backslash", "\\\\evil.com"},
+		{"userinfo-confusion", "https://3000-abc.daytonaproxy01.net@evil.com"},
+		{"subdomain-lookalike", "https://host.evil.com"},
+		{"javascript-scheme", "javascript:alert(1)"},
+		{"data-scheme", "data:text/html,<script>alert(1)</script>"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest("POST", ACCEPT_PREVIEW_PAGE_WARNING_PATH, nil)
+			q := c.Request.URL.Query()
+			q.Set("redirect", tc.redirect)
+			c.Request.URL.RawQuery = q.Encode()
+			c.Request.Host = "3000-abc.daytonaproxy01.net"
+
+			handleAcceptProxyWarning(c, true)
+
+			if loc := w.Header().Get("Location"); loc != "/" {
+				t.Fatalf("expected unsafe redirect %q to fall back to \"/\"; got Location %q", tc.redirect, loc)
+			}
+		})
+	}
+}
+
+func TestHandleAcceptProxyWarning_EmptyRedirectFallsBackToRoot(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", ACCEPT_PREVIEW_PAGE_WARNING_PATH, nil)
+	c.Request.Host = "3000-abc.daytonaproxy01.net"
+
+	handleAcceptProxyWarning(c, true)
+
+	if loc := w.Header().Get("Location"); loc != "/" {
+		t.Fatalf("expected empty redirect to fall back to \"/\"; got Location %q", loc)
 	}
 }


### PR DESCRIPTION
The preview-warning accept handler (`POST /accept-daytona-preview-warning`) redirected to a client-supplied `redirect` query parameter without validation.

This restricts the redirect target to same-host absolute URLs (http/https) and safe single-leading-slash relative paths, falling back to `/` for anything else. The warning page only ever generates a same-host absolute URL, so legitimate preview flows are unaffected, including custom preview proxy deployments, dev http, and host:port.

Adds unit tests covering same-host (incl. port, query, and `X-Forwarded-Host` present), safe relative paths, empty redirect, and rejected cross-host/scheme targets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783502180&installation_id=132266156&pr_number=4940&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4940&signature=0f5495d8985bab1b1568b1035af354cf1d93c0146c93dbe92f145a289d749135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures the preview warning accept flow by validating the `redirect` query to prevent open redirects. Only same-host absolute http/https URLs or single-slash relative paths are allowed; everything else falls back to `/`.

- **Bug Fixes**
  - Hardened `POST /accept-daytona-preview-warning`: normalize and verify targets; reject cross-host, `//` protocol-relative, and non-http/https schemes.
  - Preserves existing preview flows, including custom proxy domains and `localhost:port`.
  - Added tests for same-host (with port/query), safe relative paths, empty redirect, and rejected cases; ignores `X-Forwarded-Host`.

<sup>Written for commit f9d599573de5db7480b3db36f61032a7523a415a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

