### PR TITLE
fix(api): v2 backup hardening

### DIFF
--- a/apps/api/src/sandbox/entities/sandbox.entity.ts
+++ b/apps/api/src/sandbox/entities/sandbox.entity.ts
@@ -268,11 +268,16 @@ export class Sandbox {
       case BackupState.COMPLETED: {
         const now = new Date()
         update.lastBackupAt = now
-        if (sandbox.backupSnapshot) {
+        // The snapshot that just completed is normally the one already tracked on the sandbox.
+        // If it was cleared while the job ran, fall back to the recovered reference passed in so
+        // the backup is still recorded in history - restore scans existingBackupSnapshots, so a
+        // missing entry would strand the sandbox with no discoverable backup.
+        const completedSnapshot = sandbox.backupSnapshot ?? backupSnapshot
+        if (completedSnapshot) {
           update.existingBackupSnapshots = [
             ...sandbox.existingBackupSnapshots,
             {
-              snapshotName: sandbox.backupSnapshot,
+              snapshotName: completedSnapshot,
               createdAt: now,
             },
           ]

--- a/apps/api/src/sandbox/managers/backup.manager.ts
+++ b/apps/api/src/sandbox/managers/backup.manager.ts
@@ -5,7 +5,8 @@
 
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common'
 import { Cron, CronExpression } from '@nestjs/schedule'
-import { In, IsNull, LessThan, Not, Or } from 'typeorm'
+import { In, IsNull, LessThan, Not, Or, Repository } from 'typeorm'
+import { InjectRepository } from '@nestjs/typeorm'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxState } from '../enums/sandbox-state.enum'
 import { RunnerService } from '../services/runner.service'
@@ -36,6 +37,12 @@ import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { DockerRegistry } from '../../docker-registry/entities/docker-registry.entity'
 import { SandboxService } from '../services/sandbox.service'
 import { SandboxRepository } from '../repositories/sandbox.repository'
+import { Job } from '../entities/job.entity'
+import { JobStatus } from '../enums/job-status.enum'
+import { JobType } from '../enums/job-type.enum'
+import { ResourceType } from '../enums/resource-type.enum'
+import { JobStateHandlerService } from '../services/job-state-handler.service'
+import { SandboxConflictError } from '../errors/sandbox-conflict.error'
 
 @Injectable()
 export class BackupManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -52,6 +59,9 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     @InjectRedis() private readonly redis: Redis,
     private readonly redisLockProvider: RedisLockProvider,
     private readonly configService: TypedConfigService,
+    @InjectRepository(Job)
+    private readonly jobRepository: Repository<Job>,
+    private readonly jobStateHandlerService: JobStateHandlerService,
   ) {}
 
   //  on init
@@ -571,9 +581,51 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.PENDING, backupSnapshot, registry.id)
   }
 
+  /**
+   * Reconcile an in-progress backup on a v2 runner from its CREATE_BACKUP job.
+   *
+   * On v2 runners backup completion is driven by the job-state handler, which is invoked
+   * once (fire-and-forget) when the runner reports the job terminal. If that invocation is
+   * lost (e.g. a transient error, or it raced with the PENDING->IN_PROGRESS write), the
+   * sandbox is stranded in InProgress while its job is already Completed/Failed - the
+   * stale-job sweep ignores terminal jobs and the runner has nothing left to report.
+   *
+   * Re-running the authoritative completion handler here is idempotent and resolves the
+   * sandbox to Completed/Error. The v2 RunnerAdapter's `sandboxInfo` only echoes the DB
+   * backupState, so the runner-polling path below would otherwise be a no-op for v2.
+   */
+  private async reconcileV2BackupFromJob(sandbox: Sandbox): Promise<void> {
+    const job = await this.jobRepository.findOne({
+      where: {
+        resourceType: ResourceType.SANDBOX,
+        resourceId: sandbox.id,
+        type: JobType.CREATE_BACKUP,
+      },
+      order: { createdAt: 'DESC' },
+    })
+
+    if (!job) {
+      return
+    }
+
+    if (job.status === JobStatus.COMPLETED || job.status === JobStatus.FAILED) {
+      // handleJobCompletion -> handleCreateBackupJobCompletion swallows its own errors,
+      // so this won't throw and won't trip the caller's error-retry/ERROR path.
+      await this.jobStateHandlerService.handleJobCompletion(job)
+    }
+  }
+
   private async checkBackupProgress(sandbox: Sandbox): Promise<void> {
     try {
       const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
+
+      // v2+ runners don't expose live backup state via the runner API - completion is
+      // tracked through the CREATE_BACKUP job. Reconcile from the job instead of polling.
+      if (runner.apiVersion !== '0') {
+        await this.reconcileV2BackupFromJob(sandbox)
+        return
+      }
+
       const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
       // Get sandbox info from runner
@@ -670,6 +722,34 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
     }
   }
 
+  /**
+   * Transition a backup from PENDING to IN_PROGRESS without clobbering a terminal state
+   * that a concurrent completion may have already written.
+   *
+   * On v2 runners a CREATE_BACKUP job can be claimed and completed (or fail fast, e.g.
+   * "No such container") within milliseconds of being created. The fire-and-forget job
+   * completion handler then writes Completed/Error. An unconditional write here would
+   * overwrite that terminal state back to InProgress and strand the sandbox forever
+   * (the job is already terminal, so neither the stale-job sweep nor the in-progress
+   * poller would ever resolve it). The guarded update is a no-op once the sandbox has
+   * left PENDING.
+   */
+  private async markBackupInProgressIfPending(sandboxId: string): Promise<void> {
+    try {
+      await this.sandboxRepository.updateWhere(sandboxId, {
+        updateData: { backupState: BackupState.IN_PROGRESS },
+        whereCondition: { backupState: BackupState.PENDING },
+      })
+    } catch (error) {
+      if (error instanceof SandboxConflictError) {
+        // Backup already left PENDING (e.g. completion handler set Completed/Error). Don't clobber it.
+        this.logger.debug(`Skipping InProgress transition for sandbox ${sandboxId}: backup no longer PENDING`)
+        return
+      }
+      throw error
+    }
+  }
+
   private async handlePendingBackup(sandbox: Sandbox): Promise<void> {
     const lockKey = `runner-${sandbox.runnerId}-backup-lock`
     try {
@@ -696,17 +776,17 @@ export class BackupManager implements TrackableJobExecutions, OnApplicationShutd
       //  check if backup is already in progress on the runner
       const runnerSandbox = await runnerAdapter.sandboxInfo(sandbox.id)
       if (runnerSandbox.backupState === BackupState.IN_PROGRESS) {
-        await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.IN_PROGRESS)
+        await this.markBackupInProgressIfPending(sandbox.id)
         return
       }
 
       // Initiate backup on runner
       await runnerAdapter.createBackup(sandbox, sandbox.backupSnapshot, registry)
 
-      await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.IN_PROGRESS)
+      await this.markBackupInProgressIfPending(sandbox.id)
     } catch (error) {
       if (error.response?.status === 400 && error.response?.data?.message.includes('A backup is already in progress')) {
-        await this.sandboxService.updateSandboxBackupState(sandbox.id, BackupState.IN_PROGRESS)
+        await this.markBackupInProgressIfPending(sandbox.id)
         return
       }
       const { recoverable, errorReason } = sanitizeSandboxError(error)

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -487,6 +487,12 @@ export class JobStateHandlerService {
       const updateData: Partial<Sandbox> = {}
 
       if (job.status === JobStatus.COMPLETED) {
+        if (sandbox.backupState === BackupState.COMPLETED) {
+          this.logger.debug(
+            `CREATE_BACKUP job ${job.id} already applied for sandbox ${sandboxId}; skipping duplicate completion`,
+          )
+          return
+        }
         this.logger.debug(
           `CREATE_BACKUP job ${job.id} completed successfully, marking sandbox ${sandboxId} as BACKUP_COMPLETED`,
         )

--- a/apps/api/src/sandbox/services/job-state-handler.service.ts
+++ b/apps/api/src/sandbox/services/job-state-handler.service.ts
@@ -473,9 +473,11 @@ export class JobStateHandlerService {
       // perform stale-snapshot checks when the field is present.
       const jobSnapshot = job.getPayload<{ snapshot?: string }>()?.snapshot
 
-      // Ignore stale backup results if the job's snapshot doesn't match the current DB snapshot.
-      // Old v2 runners may not include snapshot in the payload — skip this check for them.
-      if (jobSnapshot && jobSnapshot !== sandbox.backupSnapshot) {
+      // Ignore stale backup results if the sandbox is tracking a *different* snapshot
+      // (i.e. a newer backup superseded this one). A null/empty DB snapshot means there's
+      // no newer backup to protect, so we must NOT drop the result - doing so would strand
+      // the sandbox in InProgress. Old v2 runners that omit the snapshot also skip this check.
+      if (jobSnapshot && sandbox.backupSnapshot && jobSnapshot !== sandbox.backupSnapshot) {
         this.logger.warn(
           `Ignoring stale backup ${job.status} for sandbox ${sandboxId}: job snapshot ${jobSnapshot} does not match DB snapshot ${sandbox.backupSnapshot}`,
         )
@@ -488,7 +490,10 @@ export class JobStateHandlerService {
         this.logger.debug(
           `CREATE_BACKUP job ${job.id} completed successfully, marking sandbox ${sandboxId} as BACKUP_COMPLETED`,
         )
-        Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.COMPLETED))
+        // If the DB snapshot was cleared while the job ran, recover the reference from the job
+        // so the completed backup remains usable for restore.
+        const completionSnapshot = sandbox.backupSnapshot ? undefined : (jobSnapshot ?? undefined)
+        Object.assign(updateData, Sandbox.getBackupStateUpdate(sandbox, BackupState.COMPLETED, completionSnapshot))
       } else if (job.status === JobStatus.FAILED) {
         this.logger.error(`CREATE_BACKUP job ${job.id} failed for sandbox ${sandboxId}: ${job.errorMessage}`)
         const { recoverable, errorReason } = sanitizeSandboxError(job.errorMessage)


### PR DESCRIPTION
## Description

Adds handlers for cases where v2 runners had their backups stuck in incorrect states due to the same backup jobs triggering twice and affecting the sandbox state

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783507973&installation_id=132266156&pr_number=4941&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4941&signature=55d9a90640b528f1cb6ab254e56c4c785bb100f8bfef70cd49507d798340093d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the v2 backup flow to prevent sandboxes getting stuck and to reconcile backup state from job results. Makes state transitions idempotent and ensures completed snapshots are recorded even if the DB snapshot was cleared.

- **Bug Fixes**
  - Reconcile v2 backups from the latest `CREATE_BACKUP` job; if the job is terminal, invoke the completion handler and skip runner polling for v2.
  - Guard PENDING→IN_PROGRESS by updating only when still PENDING; ignore `SandboxConflictError` and use this path for all start/in-progress cases.
  - Treat results as stale only when both job and DB snapshots exist and differ; on success, recover the snapshot from the job if the DB value was cleared so history is preserved.
  - Skip duplicate completion if the sandbox is already marked COMPLETED to avoid reapplying job results.

<sup>Written for commit ce865cae0f9ee5a48cbee8509b1b220362ffb39e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

