### PR TITLE
fix(api): un-deprecate sandboxClass and set enumName

### DIFF
--- a/apps/api/src/sandbox/dto/sandbox-list-item.dto.ts
+++ b/apps/api/src/sandbox/dto/sandbox-list-item.dto.ts
@@ -78,9 +78,9 @@ export class SandboxListItemDto {
   @ApiPropertyOptional({
     description: 'The class of the sandbox',
     enum: SandboxClass,
+    enumName: 'SandboxClass',
     example: Object.values(SandboxClass)[0],
     required: false,
-    deprecated: true,
   })
   @IsEnum(SandboxClass)
   @IsOptional()

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -10804,20 +10804,10 @@ components:
           example: runner123
           type: string
         sandboxClass:
-          deprecated: true
+          allOf:
+          - $ref: "#/components/schemas/SandboxClass"
           description: The class of the sandbox
-          enum:
-          - linux-vm
-          - container
-          - android
-          - windows
           example: linux-vm
-          type: string
-          x-enum-varnames:
-          - LINUX_VM
-          - CONTAINER
-          - ANDROID
-          - WINDOWS
         state:
           allOf:
           - $ref: "#/components/schemas/SandboxState"

--- a/libs/api-client-go/model_sandbox_list_item.go
+++ b/libs/api-client-go/model_sandbox_list_item.go
@@ -32,8 +32,7 @@ type SandboxListItem struct {
 	// The runner ID of the sandbox
 	RunnerId *string `json:"runnerId,omitempty"`
 	// The class of the sandbox
-	// Deprecated
-	SandboxClass *string `json:"sandboxClass,omitempty"`
+	SandboxClass *SandboxClass `json:"sandboxClass,omitempty"`
 	// The state of the sandbox
 	State *SandboxState `json:"state,omitempty"`
 	// The desired state of the sandbox
@@ -241,10 +240,9 @@ func (o *SandboxListItem) SetRunnerId(v string) {
 }
 
 // GetSandboxClass returns the SandboxClass field value if set, zero value otherwise.
-// Deprecated
-func (o *SandboxListItem) GetSandboxClass() string {
+func (o *SandboxListItem) GetSandboxClass() SandboxClass {
 	if o == nil || IsNil(o.SandboxClass) {
-		var ret string
+		var ret SandboxClass
 		return ret
 	}
 	return *o.SandboxClass
@@ -252,8 +250,7 @@ func (o *SandboxListItem) GetSandboxClass() string {
 
 // GetSandboxClassOk returns a tuple with the SandboxClass field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-// Deprecated
-func (o *SandboxListItem) GetSandboxClassOk() (*string, bool) {
+func (o *SandboxListItem) GetSandboxClassOk() (*SandboxClass, bool) {
 	if o == nil || IsNil(o.SandboxClass) {
 		return nil, false
 	}
@@ -269,9 +266,8 @@ func (o *SandboxListItem) HasSandboxClass() bool {
 	return false
 }
 
-// SetSandboxClass gets a reference to the given string and assigns it to the SandboxClass field.
-// Deprecated
-func (o *SandboxListItem) SetSandboxClass(v string) {
+// SetSandboxClass gets a reference to the given SandboxClass and assigns it to the SandboxClass field.
+func (o *SandboxListItem) SetSandboxClass(v SandboxClass) {
 	o.SandboxClass = &v
 }
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxListItem.java
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import io.daytona.api.client.model.GpuType;
+import io.daytona.api.client.model.SandboxClass;
 import io.daytona.api.client.model.SandboxDesiredState;
 import io.daytona.api.client.model.SandboxState;
 import java.io.IOException;
@@ -81,69 +82,10 @@ public class SandboxListItem {
   @javax.annotation.Nullable
   private String runnerId;
 
-  /**
-   * The class of the sandbox
-   */
-  @JsonAdapter(SandboxClassEnum.Adapter.class)
-  public enum SandboxClassEnum {
-    LINUX_VM("linux-vm"),
-    
-    CONTAINER("container"),
-    
-    ANDROID("android"),
-    
-    WINDOWS("windows"),
-    
-    UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
-
-    private String value;
-
-    SandboxClassEnum(String value) {
-      this.value = value;
-    }
-
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    public static SandboxClassEnum fromValue(String value) {
-      for (SandboxClassEnum b : SandboxClassEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      return UNKNOWN_DEFAULT_OPEN_API;
-    }
-
-    public static class Adapter extends TypeAdapter<SandboxClassEnum> {
-      @Override
-      public void write(final JsonWriter jsonWriter, final SandboxClassEnum enumeration) throws IOException {
-        jsonWriter.value(enumeration.getValue());
-      }
-
-      @Override
-      public SandboxClassEnum read(final JsonReader jsonReader) throws IOException {
-        String value =  jsonReader.nextString();
-        return SandboxClassEnum.fromValue(value);
-      }
-    }
-
-    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
-      String value = jsonElement.getAsString();
-      SandboxClassEnum.fromValue(value);
-    }
-  }
-
   public static final String SERIALIZED_NAME_SANDBOX_CLASS = "sandboxClass";
-  @Deprecated
   @SerializedName(SERIALIZED_NAME_SANDBOX_CLASS)
   @javax.annotation.Nullable
-  private SandboxClassEnum sandboxClass;
+  private SandboxClass sandboxClass;
 
   public static final String SERIALIZED_NAME_STATE = "state";
   @SerializedName(SERIALIZED_NAME_STATE)
@@ -413,8 +355,7 @@ public class SandboxListItem {
   }
 
 
-  @Deprecated
-  public SandboxListItem sandboxClass(@javax.annotation.Nullable SandboxClassEnum sandboxClass) {
+  public SandboxListItem sandboxClass(@javax.annotation.Nullable SandboxClass sandboxClass) {
     this.sandboxClass = sandboxClass;
     return this;
   }
@@ -422,16 +363,13 @@ public class SandboxListItem {
   /**
    * The class of the sandbox
    * @return sandboxClass
-   * @deprecated
    */
-  @Deprecated
   @javax.annotation.Nullable
-  public SandboxClassEnum getSandboxClass() {
+  public SandboxClass getSandboxClass() {
     return sandboxClass;
   }
 
-  @Deprecated
-  public void setSandboxClass(@javax.annotation.Nullable SandboxClassEnum sandboxClass) {
+  public void setSandboxClass(@javax.annotation.Nullable SandboxClass sandboxClass) {
     this.sandboxClass = sandboxClass;
   }
 
@@ -1044,12 +982,9 @@ public class SandboxListItem {
       if ((jsonObj.get("runnerId") != null && !jsonObj.get("runnerId").isJsonNull()) && !jsonObj.get("runnerId").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `runnerId` to be a primitive type in the JSON string but got `%s`", jsonObj.get("runnerId").toString()));
       }
-      if ((jsonObj.get("sandboxClass") != null && !jsonObj.get("sandboxClass").isJsonNull()) && !jsonObj.get("sandboxClass").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format(java.util.Locale.ROOT, "Expected the field `sandboxClass` to be a primitive type in the JSON string but got `%s`", jsonObj.get("sandboxClass").toString()));
-      }
       // validate the optional field `sandboxClass`
       if (jsonObj.get("sandboxClass") != null && !jsonObj.get("sandboxClass").isJsonNull()) {
-        SandboxClassEnum.validateJsonElement(jsonObj.get("sandboxClass"));
+        SandboxClass.validateJsonElement(jsonObj.get("sandboxClass"));
       }
       // validate the optional field `state`
       if (jsonObj.get("state") != null && !jsonObj.get("state").isJsonNull()) {

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxListItemTest.java
@@ -19,6 +19,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import io.daytona.api.client.model.GpuType;
+import io.daytona.api.client.model.SandboxClass;
 import io.daytona.api.client.model.SandboxDesiredState;
 import io.daytona.api.client.model.SandboxState;
 import java.io.IOException;

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox_list_item.py
@@ -21,6 +21,7 @@ import json
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional, Union
 from daytona_api_client_async.models.gpu_type import GpuType
+from daytona_api_client_async.models.sandbox_class import SandboxClass
 from daytona_api_client_async.models.sandbox_desired_state import SandboxDesiredState
 from daytona_api_client_async.models.sandbox_state import SandboxState
 from pydantic import TypeAdapter
@@ -38,7 +39,7 @@ class SandboxListItem(BaseModel):
     name: StrictStr = Field(description="The name of the sandbox")
     target: StrictStr = Field(description="The target environment for the sandbox")
     runner_id: Optional[StrictStr] = Field(default=None, description="The runner ID of the sandbox", serialization_alias="runnerId")
-    sandbox_class: Optional[StrictStr] = Field(default=None, description="The class of the sandbox", serialization_alias="sandboxClass")
+    sandbox_class: Optional[SandboxClass] = Field(default=None, description="The class of the sandbox", serialization_alias="sandboxClass")
     state: Optional[SandboxState] = Field(default=None, description="The state of the sandbox")
     desired_state: Optional[SandboxDesiredState] = Field(default=None, description="The desired state of the sandbox", serialization_alias="desiredState")
     snapshot: Optional[StrictStr] = Field(default=None, description="The snapshot used for the sandbox")

--- a/libs/api-client-python/daytona_api_client/models/sandbox_list_item.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox_list_item.py
@@ -21,6 +21,7 @@ import json
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional, Union
 from daytona_api_client.models.gpu_type import GpuType
+from daytona_api_client.models.sandbox_class import SandboxClass
 from daytona_api_client.models.sandbox_desired_state import SandboxDesiredState
 from daytona_api_client.models.sandbox_state import SandboxState
 from pydantic import TypeAdapter
@@ -38,7 +39,7 @@ class SandboxListItem(BaseModel):
     name: StrictStr = Field(description="The name of the sandbox")
     target: StrictStr = Field(description="The target environment for the sandbox")
     runner_id: Optional[StrictStr] = Field(default=None, description="The runner ID of the sandbox", serialization_alias="runnerId")
-    sandbox_class: Optional[StrictStr] = Field(default=None, description="The class of the sandbox", serialization_alias="sandboxClass")
+    sandbox_class: Optional[SandboxClass] = Field(default=None, description="The class of the sandbox", serialization_alias="sandboxClass")
     state: Optional[SandboxState] = Field(default=None, description="The state of the sandbox")
     desired_state: Optional[SandboxDesiredState] = Field(default=None, description="The desired state of the sandbox", serialization_alias="desiredState")
     snapshot: Optional[StrictStr] = Field(default=None, description="The snapshot used for the sandbox")

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_list_item.rb
@@ -173,7 +173,7 @@ module DaytonaApiClient
         :'name' => :'String',
         :'target' => :'String',
         :'runner_id' => :'String',
-        :'sandbox_class' => :'String',
+        :'sandbox_class' => :'SandboxClass',
         :'state' => :'SandboxState',
         :'desired_state' => :'SandboxDesiredState',
         :'snapshot' => :'String',
@@ -424,8 +424,6 @@ module DaytonaApiClient
       return false if @organization_id.nil?
       return false if @name.nil?
       return false if @target.nil?
-      sandbox_class_validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
-      return false unless sandbox_class_validator.valid?(@sandbox_class)
       return false if @user.nil?
       return false if @public.nil?
       return false if @cpu.nil?
@@ -477,16 +475,6 @@ module DaytonaApiClient
       end
 
       @target = target
-    end
-
-    # Custom attribute writer method checking allowed values (enum).
-    # @param [Object] sandbox_class Object to be assigned
-    def sandbox_class=(sandbox_class)
-      validator = EnumAttributeValidator.new('String', ["linux-vm", "container", "android", "windows", "unknown_default_open_api"])
-      unless validator.valid?(sandbox_class)
-        fail ArgumentError, "invalid value for \"sandbox_class\", must be one of #{validator.allowable_values}."
-      end
-      @sandbox_class = sandbox_class
     end
 
     # Custom attribute writer method with validation

--- a/libs/api-client/src/models/sandbox-list-item.ts
+++ b/libs/api-client/src/models/sandbox-list-item.ts
@@ -18,6 +18,9 @@
 import type { GpuType } from './gpu-type';
 // May contain unused imports in some cases
 // @ts-ignore
+import type { SandboxClass } from './sandbox-class';
+// May contain unused imports in some cases
+// @ts-ignore
 import type { SandboxDesiredState } from './sandbox-desired-state';
 // May contain unused imports in some cases
 // @ts-ignore
@@ -46,9 +49,8 @@ export interface SandboxListItem {
     'runnerId'?: string;
     /**
      * The class of the sandbox
-     * @deprecated
      */
-    'sandboxClass'?: SandboxListItemSandboxClassEnum;
+    'sandboxClass'?: SandboxClass;
     /**
      * The state of the sandbox
      */
@@ -139,15 +141,6 @@ export interface SandboxListItem {
     'toolboxProxyUrl': string;
 }
 
-export const SandboxListItemSandboxClassEnum = {
-    LINUX_VM: 'linux-vm',
-    CONTAINER: 'container',
-    ANDROID: 'android',
-    WINDOWS: 'windows',
-    UNKNOWN_DEFAULT_OPEN_API: '11184809',
-} as const;
-
-export type SandboxListItemSandboxClassEnum = typeof SandboxListItemSandboxClassEnum[keyof typeof SandboxListItemSandboxClassEnum];
 export const SandboxListItemBackupStateEnum = {
     NONE: 'None',
     PENDING: 'Pending',


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783510057&installation_id=132266156&pr_number=4942&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4942&signature=a484dee3fc60882c00215895a2cb64ee7051e1044926159ac275de6dc86dd67a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Un-deprecates sandboxClass and makes it a proper enum across the API and all SDKs. Sets enumName to 'SandboxClass' for consistent OpenAPI generation and strongly-typed clients.

- **Bug Fixes**
  - API DTO: restore sandboxClass and set enumName: 'SandboxClass'.
  - OpenAPI: reference SandboxClass via allOf; remove inline enum and deprecated flag.
  - SDKs (Go, Java, Python, Ruby, TS): use SandboxClass type instead of string; remove local enums/validators.

- **Migration**
  - Update client code to use the SandboxClass type. In TS, import SandboxClass; in Ruby, stop validating against string enums.

<sup>Written for commit f9653a9c09eed779cb83cc50d15ba1347b8eb6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

