### PR TITLE
fix(api,dashboard): remove obsolete runner class property

### DIFF
--- a/apps/api/src/common/constants/feature-flags.ts
+++ b/apps/api/src/common/constants/feature-flags.ts
@@ -6,5 +6,4 @@
 export const FeatureFlags = {
   ORGANIZATION_INFRASTRUCTURE: 'organization_infrastructure',
   SANDBOX_RESIZE: 'sandbox_resize',
-  SANDBOX_LINUX_VM: 'sandbox_linux_vm',
 } as const

--- a/apps/api/src/common/providers/openfeature-posthog.provider.ts
+++ b/apps/api/src/common/providers/openfeature-posthog.provider.ts
@@ -43,7 +43,7 @@ export class OpenFeaturePostHogProvider implements Provider {
    * Returns true if the given flag key is listed in the
    * `OPENFEATURE_FORCE_ENABLED_FLAGS` env var (comma-separated). Used by the
    * E2E setup to force-enable feature-flag-gated endpoints (e.g.
-   * `sandbox_linux_vm`) when no real flag provider (PostHog) is configured.
+   * `sandbox_resize`) when no real flag provider (PostHog) is configured.
    *
    * Production deployments configure PostHog and never hit the unconfigured
    * code path that consults this list, so this is a no-op in production.

--- a/apps/api/src/migrations/post-deploy/1780918142801-migration.ts
+++ b/apps/api/src/migrations/post-deploy/1780918142801-migration.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1780918142801 implements MigrationInterface {
+  name = 'Migration1780918142801'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "runner" DROP COLUMN "runnerClass"`)
+    await queryRunner.query(`DROP TYPE "public"."runner_runnerclass_enum"`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TYPE "public"."runner_runnerclass_enum" AS ENUM('container', 'vm')`)
+    await queryRunner.query(
+      `ALTER TABLE "runner" ADD "runnerClass" "public"."runner_runnerclass_enum" NOT NULL DEFAULT 'container'`,
+    )
+  }
+}

--- a/apps/api/src/sandbox/controllers/sandbox.controller.ts
+++ b/apps/api/src/sandbox/controllers/sandbox.controller.ts
@@ -710,7 +710,6 @@ export class SandboxController {
 
   @Post(':sandboxIdOrName/snapshot')
   @HttpCode(200)
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.SANDBOX_LINUX_VM, defaultValue: false }] })
   @ApiOperation({
     summary: 'Create a snapshot from a sandbox',
     operationId: 'createSandboxSnapshot',
@@ -746,7 +745,6 @@ export class SandboxController {
   @HttpCode(200)
   @SkipThrottle({ authenticated: true })
   @ThrottlerScope('sandbox-create')
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.SANDBOX_LINUX_VM, defaultValue: false }] })
   @ApiOperation({
     summary: 'Fork a sandbox',
     operationId: 'forkSandbox',
@@ -779,7 +777,6 @@ export class SandboxController {
   }
 
   @Get(':sandboxIdOrName/forks')
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.SANDBOX_LINUX_VM, defaultValue: false }] })
   @ApiOperation({
     summary: 'Get sandbox fork children',
     operationId: 'getSandboxForks',
@@ -802,7 +799,6 @@ export class SandboxController {
   }
 
   @Get(':sandboxIdOrName/parent')
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.SANDBOX_LINUX_VM, defaultValue: false }] })
   @ApiOperation({
     summary: 'Get sandbox fork parent',
     operationId: 'getSandboxParent',
@@ -822,7 +818,6 @@ export class SandboxController {
   }
 
   @Get(':sandboxIdOrName/ancestors')
-  @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.SANDBOX_LINUX_VM, defaultValue: false }] })
   @ApiOperation({
     summary: 'Get sandbox fork ancestor chain',
     operationId: 'getSandboxAncestors',

--- a/apps/api/src/sandbox/dto/runner.dto.ts
+++ b/apps/api/src/sandbox/dto/runner.dto.ts
@@ -8,7 +8,7 @@ import { IsEnum, IsOptional } from 'class-validator'
 import { Runner } from '../entities/runner.entity'
 import { SandboxClass } from '../enums/sandbox-class.enum'
 import { RunnerState } from '../enums/runner-state.enum'
-import { RunnerClass } from '../enums/runner-class.enum'
+import { RunnerClass } from '../enums/runner-class.deprecated.enum'
 
 @ApiSchema({ name: 'Runner' })
 export class RunnerDto {
@@ -207,10 +207,12 @@ export class RunnerDto {
   apiVersion: string
 
   @ApiProperty({
-    description: 'The class of the runner',
+    description:
+      'The class of the runner. Deprecated and always returns "container" for backward compatibility - use sandboxClass instead.',
     enum: RunnerClass,
     enumName: 'RunnerClass',
     example: RunnerClass.CONTAINER,
+    deprecated: true,
   })
   @IsEnum(RunnerClass)
   runnerClass: RunnerClass
@@ -235,7 +237,7 @@ export class RunnerDto {
       gpu: runner.gpu,
       gpuType: runner.gpuType,
       sandboxClass: runner.sandboxClass,
-      runnerClass: runner.runnerClass,
+      runnerClass: RunnerClass.CONTAINER,
       currentCpuUsagePercentage: runner.currentCpuUsagePercentage,
       currentMemoryUsagePercentage: runner.currentMemoryUsagePercentage,
       currentDiskUsagePercentage: runner.currentDiskUsagePercentage,

--- a/apps/api/src/sandbox/entities/runner.entity.ts
+++ b/apps/api/src/sandbox/entities/runner.entity.ts
@@ -5,7 +5,6 @@
 
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, Unique, UpdateDateColumn } from 'typeorm'
 import { SandboxClass } from '../enums/sandbox-class.enum'
-import { RunnerClass } from '../enums/runner-class.enum'
 import { GpuType } from '../enums/gpu-type.enum'
 import { RunnerState } from '../enums/runner-state.enum'
 import { RunnerServiceInfo } from '../common/runner-service-info'
@@ -71,13 +70,6 @@ export class Runner {
     default: SandboxClass.CONTAINER,
   })
   sandboxClass: SandboxClass = SandboxClass.CONTAINER
-
-  @Column({
-    type: 'enum',
-    enum: RunnerClass,
-    default: RunnerClass.CONTAINER,
-  })
-  runnerClass = RunnerClass.CONTAINER
 
   @Column({
     type: 'float',

--- a/apps/api/src/sandbox/enums/runner-class.deprecated.enum.ts
+++ b/apps/api/src/sandbox/enums/runner-class.deprecated.enum.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+/**
+ * @deprecated The `runnerClass` concept has been superseded by `SandboxClass`.
+ *
+ * This enum is retained ONLY to preserve the `runnerClass` field on the
+ * public `RunnerDto` for backward compatibility with existing API consumers
+ * (proxies, older SDK versions). The DTO hardcodes `RunnerClass.CONTAINER`
+ * regardless of the actual runner's workload class.
+ *
+ * DO NOT import this enum anywhere outside of `runner.dto.ts`. Use
+ * `SandboxClass` from `sandbox-class.enum.ts` for any new runner /
+ * sandbox class routing, gating, or scheduling decisions.
+ */
+export enum RunnerClass {
+  CONTAINER = 'container',
+}

--- a/apps/api/src/sandbox/enums/runner-class.enum.ts
+++ b/apps/api/src/sandbox/enums/runner-class.enum.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright Daytona Platforms Inc.
- * SPDX-License-Identifier: AGPL-3.0
- */
-
-export enum RunnerClass {
-  CONTAINER = 'container',
-  VM = 'vm',
-}

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -25,7 +25,6 @@ import { SandboxState } from '../enums/sandbox-state.enum'
 import { SandboxClass } from '../enums/sandbox-class.enum'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
 import { resolveGpuTypePreferences } from '../utils/gpu-type-preferences.util'
-import { RunnerClass } from '../enums/runner-class.enum'
 import { RunnerService } from './runner.service'
 import { SandboxError } from '../../exceptions/sandbox-error.exception'
 import { StateChangeInProgressError } from '../../exceptions/state-change-in-progress.exception'
@@ -984,13 +983,6 @@ export class SandboxService {
           }),
         })
 
-        if (runner.runnerClass !== RunnerClass.CONTAINER) {
-          throw new HttpException(
-            'Declarative build is not supported for the selected runner class',
-            HttpStatus.UNPROCESSABLE_ENTITY,
-          )
-        }
-
         sandbox.runnerId = runner.id
         sandbox.gpuType = sandbox.gpu > 0 ? runner.gpuType : null
       } catch (error) {
@@ -1088,6 +1080,10 @@ export class SandboxService {
 
     const sourceSandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
+    if (![SandboxClass.LINUX_VM, SandboxClass.WINDOWS].includes(sourceSandbox.sandboxClass)) {
+      throw new HttpException('Forking is not supported for this sandbox', HttpStatus.UNPROCESSABLE_ENTITY)
+    }
+
     const region = await this.regionService.findOne(sourceSandbox.region)
     if (!region) {
       throw new NotFoundException(`Region with ID ${sourceSandbox.region} not found`)
@@ -1106,15 +1102,11 @@ export class SandboxService {
         throw new NotFoundException(`Sandbox with ID ${sourceSandbox.id} does not have a runner`)
       }
 
-      const runner = await this.runnerService.findOneOrFail(sourceSandbox.runnerId)
-
-      if (runner.runnerClass !== RunnerClass.VM) {
-        throw new HttpException('Forking is not supported for this sandbox', HttpStatus.UNPROCESSABLE_ENTITY)
-      }
-
       if (sourceSandbox.gpu > 0) {
         throw new HttpException('Forking is not supported for GPU sandboxes', HttpStatus.UNPROCESSABLE_ENTITY)
       }
+
+      const runner = await this.runnerService.findOneOrFail(sourceSandbox.runnerId)
 
       // Copy all properties from source sandbox to forked sandbox
       const forkedSandbox = new Sandbox({ region: sourceSandbox.region, name: dto.name })
@@ -1301,6 +1293,10 @@ export class SandboxService {
 
     const sandbox = await this.findOneByIdOrName(sandboxIdOrName, organization.id)
 
+    if (![SandboxClass.LINUX_VM, SandboxClass.WINDOWS].includes(sandbox.sandboxClass)) {
+      throw new HttpException('Snapshotting is not supported for this sandbox', HttpStatus.UNPROCESSABLE_ENTITY)
+    }
+
     try {
       if (![SandboxState.STARTED, SandboxState.STOPPED].includes(sandbox.state)) {
         throw new BadRequestError('Sandbox must be in started or stopped state to create a snapshot')
@@ -1316,10 +1312,6 @@ export class SandboxService {
 
       const runner = await this.runnerService.findOneOrFail(sandbox.runnerId)
 
-      if (![RunnerClass.VM, RunnerClass.CONTAINER].includes(runner.runnerClass)) {
-        throw new HttpException('Snapshotting is not supported for this sandbox', HttpStatus.UNPROCESSABLE_ENTITY)
-      }
-
       this.organizationService.assertOrganizationIsNotSuspended(organization)
 
       const region = await this.regionService.findOne(sandbox.region)
@@ -1328,12 +1320,6 @@ export class SandboxService {
       }
 
       const registry = (await this.dockerRegistryService.getAvailableInternalRegistry(sandbox.region)) ?? undefined
-
-      if (runner.runnerClass === RunnerClass.CONTAINER && !registry) {
-        throw new BadRequestError(
-          'No internal registry is available for this sandbox region; cannot snapshot a Docker sandbox',
-        )
-      }
 
       const { pendingSnapshotCountIncremented } = await this.snapshotService.validateOrganizationQuotas(
         organization,

--- a/apps/dashboard/src/components/SandboxTable/SandboxTableActions.tsx
+++ b/apps/dashboard/src/components/SandboxTable/SandboxTableActions.tsx
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { FeatureFlags } from '@/enums/FeatureFlags'
-import { useRegions } from '@/hooks/useRegions'
-import { SandboxState } from '@daytona/api-client'
+import { SandboxClass, SandboxState } from '@daytona/api-client'
 import { Loader2, MoreHorizontal, Play, Square, Terminal, Wrench } from 'lucide-react'
-import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useMemo } from 'react'
 import TooltipButton from '../TooltipButton'
 import { Button } from '../ui/button'
@@ -25,7 +22,6 @@ export function SandboxTableActions({
   writePermitted,
   deletePermitted,
   isLoading,
-  runnerClass,
   onStart,
   onStop,
   onDelete,
@@ -40,9 +36,7 @@ export function SandboxTableActions({
   onViewForks,
   onOpenTerminal,
 }: SandboxTableActionsProps) {
-  const linuxVmEnabled = useFeatureFlagEnabled(FeatureFlags.SANDBOX_LINUX_VM)
-  const { getRegionName } = useRegions()
-  const isExperimentalRegion = (getRegionName(sandbox.target) ?? '').toLowerCase() === 'experimental'
+  const isVmSandbox = sandbox.sandboxClass === SandboxClass.LINUX_VM || sandbox.sandboxClass === SandboxClass.WINDOWS
   const primaryActionTooltip =
     sandbox.state === SandboxState.STARTING
       ? 'Starting sandbox'
@@ -109,11 +103,7 @@ export function SandboxTableActions({
         })
       }
 
-      if (
-        linuxVmEnabled &&
-        isExperimentalRegion &&
-        (sandbox.state === SandboxState.STARTED || sandbox.state === SandboxState.STOPPED)
-      ) {
+      if (isVmSandbox && (sandbox.state === SandboxState.STARTED || sandbox.state === SandboxState.STOPPED)) {
         items.push({
           key: 'create-snapshot',
           label: 'Create Snapshot',
@@ -129,7 +119,7 @@ export function SandboxTableActions({
         })
       }
 
-      if (linuxVmEnabled && isExperimentalRegion) {
+      if (isVmSandbox) {
         items.push({
           key: 'view-forks',
           label: 'View Fork Tree',
@@ -174,7 +164,6 @@ export function SandboxTableActions({
     sandbox.state,
     sandbox.id,
     isLoading,
-    runnerClass,
     sandbox.recoverable,
     onStart,
     onStop,
@@ -188,9 +177,7 @@ export function SandboxTableActions({
     onScreenRecordings,
     onFork,
     onViewForks,
-    linuxVmEnabled,
-    isExperimentalRegion,
-    sandbox.target,
+    isVmSandbox,
   ])
 
   if (!writePermitted && !deletePermitted) {

--- a/apps/dashboard/src/components/SandboxTable/types.ts
+++ b/apps/dashboard/src/components/SandboxTable/types.ts
@@ -66,7 +66,6 @@ export interface SandboxTableActionsProps {
   writePermitted: boolean
   deletePermitted: boolean
   isLoading: boolean
-  runnerClass?: string
   onStart: (id: string) => void
   onStop: (id: string) => void
   onDelete: (id: string) => void

--- a/apps/dashboard/src/enums/FeatureFlags.ts
+++ b/apps/dashboard/src/enums/FeatureFlags.ts
@@ -6,5 +6,4 @@
 export enum FeatureFlags {
   ORGANIZATION_INFRASTRUCTURE = 'organization_infrastructure',
   ORGANIZATION_EXPERIMENTS = 'organization_experiments',
-  SANDBOX_LINUX_VM = 'sandbox_linux_vm',
 }

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -11937,10 +11937,10 @@ components:
       - unresponsive
       type: string
     RunnerClass:
-      description: The class of the runner
+      description: The class of the runner. Deprecated and always returns "container"
+        for backward compatibility - use sandboxClass instead.
       enum:
       - container
-      - vm
       type: string
     RunnerFull:
       example:
@@ -12106,7 +12106,9 @@ components:
         runnerClass:
           allOf:
           - $ref: "#/components/schemas/RunnerClass"
-          description: The class of the runner
+          deprecated: true
+          description: The class of the runner. Deprecated and always returns "container"
+            for backward compatibility - use sandboxClass instead.
           example: container
         appVersion:
           deprecated: true
@@ -12323,7 +12325,9 @@ components:
         runnerClass:
           allOf:
           - $ref: "#/components/schemas/RunnerClass"
-          description: The class of the runner
+          deprecated: true
+          description: The class of the runner. Deprecated and always returns "container"
+            for backward compatibility - use sandboxClass instead.
           example: container
         appVersion:
           deprecated: true

--- a/libs/api-client-go/model_runner.go
+++ b/libs/api-client-go/model_runner.go
@@ -81,7 +81,8 @@ type Runner struct {
 	// The api version of the runner
 	// Deprecated
 	ApiVersion string `json:"apiVersion"`
-	// The class of the runner
+	// The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
+	// Deprecated
 	RunnerClass RunnerClass `json:"runnerClass"`
 	// The app version of the runner
 	// Deprecated
@@ -953,6 +954,7 @@ func (o *Runner) SetApiVersion(v string) {
 }
 
 // GetRunnerClass returns the RunnerClass field value
+// Deprecated
 func (o *Runner) GetRunnerClass() RunnerClass {
 	if o == nil {
 		var ret RunnerClass
@@ -964,6 +966,7 @@ func (o *Runner) GetRunnerClass() RunnerClass {
 
 // GetRunnerClassOk returns a tuple with the RunnerClass field value
 // and a boolean to check if the value has been set.
+// Deprecated
 func (o *Runner) GetRunnerClassOk() (*RunnerClass, bool) {
 	if o == nil {
 		return nil, false
@@ -972,6 +975,7 @@ func (o *Runner) GetRunnerClassOk() (*RunnerClass, bool) {
 }
 
 // SetRunnerClass sets field value
+// Deprecated
 func (o *Runner) SetRunnerClass(v RunnerClass) {
 	o.RunnerClass = v
 }

--- a/libs/api-client-go/model_runner_class.go
+++ b/libs/api-client-go/model_runner_class.go
@@ -15,20 +15,18 @@ import (
 	"encoding/json"
 )
 
-// RunnerClass The class of the runner
+// RunnerClass The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
 type RunnerClass string
 
 // List of RunnerClass
 const (
 	RUNNERCLASS_CONTAINER RunnerClass = "container"
-	RUNNERCLASS_VM RunnerClass = "vm"
 	RUNNERCLASS_UNKNOWN_DEFAULT_OPEN_API RunnerClass = "11184809"
 )
 
 // All allowed values of RunnerClass enum
 var AllowedRunnerClassEnumValues = []RunnerClass{
 	"container",
-	"vm",
 	"11184809",
 }
 

--- a/libs/api-client-go/model_runner_full.go
+++ b/libs/api-client-go/model_runner_full.go
@@ -81,7 +81,8 @@ type RunnerFull struct {
 	// The api version of the runner
 	// Deprecated
 	ApiVersion string `json:"apiVersion"`
-	// The class of the runner
+	// The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
+	// Deprecated
 	RunnerClass RunnerClass `json:"runnerClass"`
 	// The app version of the runner
 	// Deprecated
@@ -958,6 +959,7 @@ func (o *RunnerFull) SetApiVersion(v string) {
 }
 
 // GetRunnerClass returns the RunnerClass field value
+// Deprecated
 func (o *RunnerFull) GetRunnerClass() RunnerClass {
 	if o == nil {
 		var ret RunnerClass
@@ -969,6 +971,7 @@ func (o *RunnerFull) GetRunnerClass() RunnerClass {
 
 // GetRunnerClassOk returns a tuple with the RunnerClass field value
 // and a boolean to check if the value has been set.
+// Deprecated
 func (o *RunnerFull) GetRunnerClassOk() (*RunnerClass, bool) {
 	if o == nil {
 		return nil, false
@@ -977,6 +980,7 @@ func (o *RunnerFull) GetRunnerClassOk() (*RunnerClass, bool) {
 }
 
 // SetRunnerClass sets field value
+// Deprecated
 func (o *RunnerFull) SetRunnerClass(v RunnerClass) {
 	o.RunnerClass = v
 }

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/Runner.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/Runner.java
@@ -204,6 +204,7 @@ public class Runner {
   private String apiVersion;
 
   public static final String SERIALIZED_NAME_RUNNER_CLASS = "runnerClass";
+  @Deprecated
   @SerializedName(SERIALIZED_NAME_RUNNER_CLASS)
   @javax.annotation.Nonnull
   private RunnerClass runnerClass;
@@ -784,20 +785,24 @@ public class Runner {
   }
 
 
+  @Deprecated
   public Runner runnerClass(@javax.annotation.Nonnull RunnerClass runnerClass) {
     this.runnerClass = runnerClass;
     return this;
   }
 
   /**
-   * The class of the runner
+   * The class of the runner. Deprecated and always returns \&quot;container\&quot; for backward compatibility - use sandboxClass instead.
    * @return runnerClass
+   * @deprecated
    */
+  @Deprecated
   @javax.annotation.Nonnull
   public RunnerClass getRunnerClass() {
     return runnerClass;
   }
 
+  @Deprecated
   public void setRunnerClass(@javax.annotation.Nonnull RunnerClass runnerClass) {
     this.runnerClass = runnerClass;
   }

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerClass.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerClass.java
@@ -24,14 +24,12 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 /**
- * The class of the runner
+ * The class of the runner. Deprecated and always returns \&quot;container\&quot; for backward compatibility - use sandboxClass instead.
  */
 @JsonAdapter(RunnerClass.Adapter.class)
 public enum RunnerClass {
   
   CONTAINER("container"),
-  
-  VM("vm"),
   
   UNKNOWN_DEFAULT_OPEN_API("unknown_default_open_api");
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerFull.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/RunnerFull.java
@@ -205,6 +205,7 @@ public class RunnerFull {
   private String apiVersion;
 
   public static final String SERIALIZED_NAME_RUNNER_CLASS = "runnerClass";
+  @Deprecated
   @SerializedName(SERIALIZED_NAME_RUNNER_CLASS)
   @javax.annotation.Nonnull
   private RunnerClass runnerClass;
@@ -795,20 +796,24 @@ public class RunnerFull {
   }
 
 
+  @Deprecated
   public RunnerFull runnerClass(@javax.annotation.Nonnull RunnerClass runnerClass) {
     this.runnerClass = runnerClass;
     return this;
   }
 
   /**
-   * The class of the runner
+   * The class of the runner. Deprecated and always returns \&quot;container\&quot; for backward compatibility - use sandboxClass instead.
    * @return runnerClass
+   * @deprecated
    */
+  @Deprecated
   @javax.annotation.Nonnull
   public RunnerClass getRunnerClass() {
     return runnerClass;
   }
 
+  @Deprecated
   public void setRunnerClass(@javax.annotation.Nonnull RunnerClass runnerClass) {
     this.runnerClass = runnerClass;
   }

--- a/libs/api-client-python-async/daytona_api_client_async/models/runner.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/runner.py
@@ -62,7 +62,7 @@ class Runner(BaseModel):
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
     api_version: StrictStr = Field(description="The api version of the runner", serialization_alias="apiVersion")
-    runner_class: RunnerClass = Field(description="The class of the runner", serialization_alias="runnerClass")
+    runner_class: RunnerClass = Field(description="The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.", serialization_alias="runnerClass")
     app_version: Optional[StrictStr] = Field(default=None, description="The app version of the runner", serialization_alias="appVersion")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "sandboxClass", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"]

--- a/libs/api-client-python-async/daytona_api_client_async/models/runner_class.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/runner_class.py
@@ -21,14 +21,13 @@ from typing_extensions import Self
 
 class RunnerClass(str, Enum):
     """
-    The class of the runner
+    The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
     """
 
     """
     allowed enum values
     """
     CONTAINER = 'container'
-    VM = 'vm'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/libs/api-client-python-async/daytona_api_client_async/models/runner_full.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/runner_full.py
@@ -63,7 +63,7 @@ class RunnerFull(BaseModel):
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
     api_version: StrictStr = Field(description="The api version of the runner", serialization_alias="apiVersion")
-    runner_class: RunnerClass = Field(description="The class of the runner", serialization_alias="runnerClass")
+    runner_class: RunnerClass = Field(description="The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.", serialization_alias="runnerClass")
     app_version: Optional[StrictStr] = Field(default=None, description="The app version of the runner", serialization_alias="appVersion")
     api_key: StrictStr = Field(description="The API key for the runner", serialization_alias="apiKey")
     region_type: Optional[RegionType] = Field(default=None, description="The region type of the runner", serialization_alias="regionType")

--- a/libs/api-client-python/daytona_api_client/models/runner.py
+++ b/libs/api-client-python/daytona_api_client/models/runner.py
@@ -62,7 +62,7 @@ class Runner(BaseModel):
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
     api_version: StrictStr = Field(description="The api version of the runner", serialization_alias="apiVersion")
-    runner_class: RunnerClass = Field(description="The class of the runner", serialization_alias="runnerClass")
+    runner_class: RunnerClass = Field(description="The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.", serialization_alias="runnerClass")
     app_version: Optional[StrictStr] = Field(default=None, description="The app version of the runner", serialization_alias="appVersion")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id", "domain", "apiUrl", "proxyUrl", "cpu", "memory", "disk", "gpu", "gpuType", "sandboxClass", "currentCpuUsagePercentage", "currentMemoryUsagePercentage", "currentDiskUsagePercentage", "currentAllocatedCpu", "currentAllocatedMemoryGiB", "currentAllocatedDiskGiB", "currentSnapshotCount", "currentStartedSandboxes", "availabilityScore", "region", "name", "state", "lastChecked", "unschedulable", "tags", "createdAt", "updatedAt", "version", "apiVersion", "runnerClass", "appVersion"]

--- a/libs/api-client-python/daytona_api_client/models/runner_class.py
+++ b/libs/api-client-python/daytona_api_client/models/runner_class.py
@@ -21,14 +21,13 @@ from typing_extensions import Self
 
 class RunnerClass(str, Enum):
     """
-    The class of the runner
+    The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
     """
 
     """
     allowed enum values
     """
     CONTAINER = 'container'
-    VM = 'vm'
     UNKNOWN_DEFAULT_OPEN_API = 'unknown_default_open_api'
 
     @classmethod

--- a/libs/api-client-python/daytona_api_client/models/runner_full.py
+++ b/libs/api-client-python/daytona_api_client/models/runner_full.py
@@ -63,7 +63,7 @@ class RunnerFull(BaseModel):
     updated_at: StrictStr = Field(description="The last update timestamp of the runner", serialization_alias="updatedAt")
     version: StrictStr = Field(description="The version of the runner (deprecated in favor of apiVersion)")
     api_version: StrictStr = Field(description="The api version of the runner", serialization_alias="apiVersion")
-    runner_class: RunnerClass = Field(description="The class of the runner", serialization_alias="runnerClass")
+    runner_class: RunnerClass = Field(description="The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.", serialization_alias="runnerClass")
     app_version: Optional[StrictStr] = Field(default=None, description="The app version of the runner", serialization_alias="appVersion")
     api_key: StrictStr = Field(description="The API key for the runner", serialization_alias="apiKey")
     region_type: Optional[RegionType] = Field(default=None, description="The region type of the runner", serialization_alias="regionType")

--- a/libs/api-client-ruby/lib/daytona_api_client/models/runner.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/runner.rb
@@ -102,7 +102,7 @@ module DaytonaApiClient
     # The api version of the runner
     attr_accessor :api_version
 
-    # The class of the runner
+    # The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
     attr_accessor :runner_class
 
     # The app version of the runner

--- a/libs/api-client-ruby/lib/daytona_api_client/models/runner_class.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/runner_class.rb
@@ -16,11 +16,10 @@ require 'time'
 module DaytonaApiClient
   class RunnerClass
     CONTAINER = "container".freeze
-    VM = "vm".freeze
     UNKNOWN_DEFAULT_OPEN_API = "unknown_default_open_api".freeze
 
     def self.all_vars
-      @all_vars ||= [CONTAINER, VM, UNKNOWN_DEFAULT_OPEN_API].freeze
+      @all_vars ||= [CONTAINER, UNKNOWN_DEFAULT_OPEN_API].freeze
     end
 
     # Builds the enum from string

--- a/libs/api-client-ruby/lib/daytona_api_client/models/runner_full.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/runner_full.rb
@@ -102,7 +102,7 @@ module DaytonaApiClient
     # The api version of the runner
     attr_accessor :api_version
 
-    # The class of the runner
+    # The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
     attr_accessor :runner_class
 
     # The app version of the runner

--- a/libs/api-client/src/models/runner-class.ts
+++ b/libs/api-client/src/models/runner-class.ts
@@ -15,12 +15,11 @@
 
 
 /**
- * The class of the runner
+ * The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
  */
 
 export const RunnerClass = {
     CONTAINER: 'container',
-    VM: 'vm',
     UNKNOWN_DEFAULT_OPEN_API: '11184809',
 } as const;
 

--- a/libs/api-client/src/models/runner-full.ts
+++ b/libs/api-client/src/models/runner-full.ts
@@ -146,7 +146,8 @@ export interface RunnerFull {
      */
     'apiVersion': string;
     /**
-     * The class of the runner
+     * The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
+     * @deprecated
      */
     'runnerClass': RunnerClass;
     /**

--- a/libs/api-client/src/models/runner.ts
+++ b/libs/api-client/src/models/runner.ts
@@ -143,7 +143,8 @@ export interface Runner {
      */
     'apiVersion': string;
     /**
-     * The class of the runner
+     * The class of the runner. Deprecated and always returns \"container\" for backward compatibility - use sandboxClass instead.
+     * @deprecated
      */
     'runnerClass': RunnerClass;
     /**


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783510526&installation_id=132266156&pr_number=4943&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4943&signature=c39b48bb10ae2f6e0297b0e2d56f5a89922ba5199ba9154cbc07c5345703557f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the obsolete `runnerClass` across API, DB, SDKs, and dashboard, standardizing on `sandboxClass`. Forking and snapshots are now allowed only for VM sandboxes (Linux/Windows) and are no longer behind a feature flag.

- **Refactors**
  - Dropped `runner.runnerClass` column and enum via a post-deploy migration; kept a minimal deprecated `RunnerClass` in `RunnerDto` that always returns "container". OpenAPI marks it deprecated; Go/Java/Python/TypeScript/Ruby SDKs updated and removed the `vm` value.
  - Removed `SANDBOX_LINUX_VM` flag and all region gating from snapshot/fork endpoints and dashboard; actions and validation now use `sandboxClass` only.
  - Updated `SandboxService` to enforce fork/snapshot only for `LINUX_VM` and `WINDOWS`; removed container registry checks and all `runnerClass` references.

- **Migration**
  - Run the post-deploy DB migration to drop `runner.runnerClass` and its enum type.
  - Update to the latest SDKs (e.g., `@daytona/api-client`) and replace any `runnerClass` usage with `sandboxClass` (note: `RunnerClass` is deprecated and fixed to "container").

<sup>Written for commit 91aba1f38c84450f39c86b351d04f9886f7c343f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

