### PR TITLE
fix(api): validate region access before per-sandbox limits

### DIFF
--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -187,8 +187,22 @@ export class SandboxService {
     pendingDiskIncremented: boolean
     pendingGpuIncremented: boolean
   }> {
-    if (!regionQuota && region.enforceQuotas) {
-      regionQuota = await this.organizationService.getRegionQuota(organization.id, region.id, sandboxClass)
+    if (region.enforceQuotas) {
+      if (!regionQuota) {
+        regionQuota = await this.organizationService.getRegionQuota(organization.id, region.id, sandboxClass)
+      }
+
+      if (!regionQuota) {
+        if (region.regionType === RegionType.SHARED) {
+          // region is public, but the organization does not have a quota for it
+          throw new ForbiddenException(
+            `Region ${region.id} is not available to the organization for class ${sandboxClass}`,
+          )
+        } else {
+          // region is not public, respond as if the region was not found
+          throw new NotFoundException('Region not found')
+        }
+      }
     }
 
     // validate per-sandbox quotas
@@ -229,18 +243,6 @@ export class SandboxService {
         pendingMemoryIncremented: false,
         pendingDiskIncremented: false,
         pendingGpuIncremented: false,
-      }
-    }
-
-    if (!regionQuota) {
-      if (region.regionType === RegionType.SHARED) {
-        // region is public, but the organization does not have a quota for it
-        throw new ForbiddenException(
-          `Region ${region.id} is not available to the organization for class ${sandboxClass}`,
-        )
-      } else {
-        // region is not public, respond as if the region was not found
-        throw new NotFoundException('Region not found')
       }
     }
 


### PR DESCRIPTION
## Description

Creating a sandbox in a region where the organization has no quota with resource requests larger than the organization default values returns a misleading per-sandbox limit error instead of a region-access error.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783514868&installation_id=132266156&pr_number=4944&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4944&signature=5c64b46518257233e87ba2d0c632acfbaff110a166fa8856cdb2d2867aa2e91c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates region access before per-sandbox limit checks so users get the correct error when the organization has no quota in a region. Returns 403 for shared regions without quota and 404 for private regions, instead of misleading per-sandbox limit errors.

- **Bug Fixes**
  - Validate access when `region.enforceQuotas` is true; fetch missing quota via `getRegionQuota`.
  - If no quota: throw Forbidden for `SHARED` regions, NotFound for non-public regions.
  - Run per-sandbox quota checks only after region access is confirmed.

<sup>Written for commit fc7a6355c7d622d023ef803f082003441785aee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

