### PR TITLE
fix(api): notification module socket init

### DIFF
--- a/apps/api/src/notification/gateways/notification.gateway.ts
+++ b/apps/api/src/notification/gateways/notification.gateway.ts
@@ -26,6 +26,7 @@ import { RunnerDto } from '../../sandbox/dto/runner.dto'
 import { RunnerState } from '../../sandbox/enums/runner-state.enum'
 import { RunnerEvents } from '../../sandbox/constants/runner-events'
 import { NotificationEmitter } from './notification-emitter.abstract'
+import { OrganizationUserService } from '../../organization/services/organization-user.service'
 
 @WebSocketGateway({
   path: '/api/socket.io/',
@@ -40,6 +41,7 @@ export class NotificationGateway extends NotificationEmitter implements OnGatewa
   constructor(
     private readonly jwtStrategy: JwtStrategy,
     private readonly apiKeyStrategy: ApiKeyStrategy,
+    private readonly organizationUserService: OrganizationUserService,
     @InjectRedis() private readonly redis: Redis,
   ) {
     super()
@@ -71,6 +73,9 @@ export class NotificationGateway extends NotificationEmitter implements OnGatewa
         // Join the organization room for organization scoped notifications
         const organizationId = socket.handshake.query.organizationId as string | undefined
         if (organizationId) {
+          if (!(await this.organizationUserService.exists(organizationId, payload.sub))) {
+            return next(new UnauthorizedException())
+          }
           await socket.join(organizationId)
         }
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783517953&installation_id=132266156&pr_number=4946&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4946&signature=1b1e8f9457496a52325f050c04cf4a5f1190c0fea3042a8b14057d4ea5bf6c5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix WebSocket initialization in the notification gateway by validating organization membership before joining org rooms, preventing unauthorized access.

- **Bug Fixes**
  - Injected `OrganizationUserService` into the gateway.
  - Validate user membership with `organizationUserService.exists(organizationId, payload.sub)` before `socket.join`.
  - Reject non-members with `UnauthorizedException`.

<sup>Written for commit 0c222ac95c0429c47f1bde85f4f4719ee3b574b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

