### PR TITLE
fix(dashboard): check payment methods instead of wallet

### DIFF
--- a/apps/dashboard/src/hooks/useSuspensionBanner.tsx
+++ b/apps/dashboard/src/hooks/useSuspensionBanner.tsx
@@ -5,6 +5,7 @@
 
 import { useBanner } from '@/components/Banner'
 import { RoutePath } from '@/enums/RoutePath'
+import { usePaymentMethodsQuery } from '@/hooks/queries/usePaymentMethodsQuery'
 import { Organization } from '@daytona/api-client'
 import { addHours, formatDistanceToNow } from 'date-fns'
 import { CreditCardIcon, MailIcon } from 'lucide-react'
@@ -28,7 +29,7 @@ function isCreditsDepletionSuspension(reason: string) {
 
 type Suspension = Pick<
   Organization,
-  'suspended' | 'suspensionReason' | 'suspendedAt' | 'suspensionCleanupGracePeriodHours'
+  'id' | 'suspended' | 'suspensionReason' | 'suspendedAt' | 'suspensionCleanupGracePeriodHours'
 >
 
 export function useSuspensionBanner(suspension?: Suspension | null) {
@@ -37,6 +38,11 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
   const location = useLocation()
   const path = location?.pathname
   const previousSuspendedRef = useRef<boolean | undefined>(undefined)
+  const paymentMethodsQuery = usePaymentMethodsQuery({
+    organizationId: suspension?.id ?? '',
+    enabled: suspension?.suspensionReason === PAYMENT_METHOD_REQUIRED_REASON,
+  })
+  const hasPaymentMethod = (paymentMethodsQuery.data?.length ?? 0) > 0
 
   useEffect(() => {
     const wasSuspended = previousSuspendedRef.current
@@ -58,6 +64,30 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
 
     if (isSetupRequiredSuspension(reason)) {
       if (reason === PAYMENT_METHOD_REQUIRED_REASON) {
+        if (paymentMethodsQuery.isLoading) {
+          removeBanner(SUSPENSION_BANNER_ID)
+          return
+        }
+
+        if (hasPaymentMethod) {
+          addBanner({
+            id: SUSPENSION_BANNER_ID,
+            variant: 'error',
+            title: 'No credits',
+            description: 'Top up your wallet to continue creating sandboxes.',
+            icon: <CreditCardIcon className="h-4 w-4 flex-shrink-0 text-current" />,
+            action:
+              path !== RoutePath.BILLING_WALLET
+                ? {
+                    label: 'Go to Billing',
+                    onClick: () => navigate(RoutePath.BILLING_WALLET),
+                  }
+                : undefined,
+            isDismissible: false,
+          })
+          return
+        }
+
         addBanner({
           id: SUSPENSION_BANNER_ID,
           variant: 'info',
@@ -136,5 +166,5 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
       description: reason ? `${reason}. ${cleanupText}` : cleanupText,
       isDismissible: false,
     })
-  }, [suspension, addBanner, removeBanner, navigate, path])
+  }, [suspension, addBanner, removeBanner, navigate, path, hasPaymentMethod, paymentMethodsQuery.isLoading])
 }

--- a/apps/dashboard/src/hooks/useSuspensionBanner.tsx
+++ b/apps/dashboard/src/hooks/useSuspensionBanner.tsx
@@ -43,7 +43,6 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
     enabled: suspension?.suspensionReason === PAYMENT_METHOD_REQUIRED_REASON,
   })
   const paymentMethods = paymentMethodsQuery.data
-  const paymentMethodsUnavailable = paymentMethodsQuery.isError && paymentMethods === undefined
   const hasPaymentMethod = (paymentMethods?.length ?? 0) > 0
 
   useEffect(() => {
@@ -66,7 +65,7 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
 
     if (isSetupRequiredSuspension(reason)) {
       if (reason === PAYMENT_METHOD_REQUIRED_REASON) {
-        if (paymentMethodsQuery.isLoading || paymentMethodsUnavailable) {
+        if (paymentMethodsQuery.isLoading) {
           removeBanner(SUSPENSION_BANNER_ID)
           return
         }
@@ -168,14 +167,5 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
       description: reason ? `${reason}. ${cleanupText}` : cleanupText,
       isDismissible: false,
     })
-  }, [
-    suspension,
-    addBanner,
-    removeBanner,
-    navigate,
-    path,
-    hasPaymentMethod,
-    paymentMethodsQuery.isLoading,
-    paymentMethodsUnavailable,
-  ])
+  }, [suspension, addBanner, removeBanner, navigate, path, hasPaymentMethod, paymentMethodsQuery.isLoading])
 }

--- a/apps/dashboard/src/hooks/useSuspensionBanner.tsx
+++ b/apps/dashboard/src/hooks/useSuspensionBanner.tsx
@@ -42,7 +42,9 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
     organizationId: suspension?.id ?? '',
     enabled: suspension?.suspensionReason === PAYMENT_METHOD_REQUIRED_REASON,
   })
-  const hasPaymentMethod = (paymentMethodsQuery.data?.length ?? 0) > 0
+  const paymentMethods = paymentMethodsQuery.data
+  const paymentMethodsUnavailable = paymentMethodsQuery.isError && paymentMethods === undefined
+  const hasPaymentMethod = (paymentMethods?.length ?? 0) > 0
 
   useEffect(() => {
     const wasSuspended = previousSuspendedRef.current
@@ -64,7 +66,7 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
 
     if (isSetupRequiredSuspension(reason)) {
       if (reason === PAYMENT_METHOD_REQUIRED_REASON) {
-        if (paymentMethodsQuery.isLoading) {
+        if (paymentMethodsQuery.isLoading || paymentMethodsUnavailable) {
           removeBanner(SUSPENSION_BANNER_ID)
           return
         }
@@ -166,5 +168,14 @@ export function useSuspensionBanner(suspension?: Suspension | null) {
       description: reason ? `${reason}. ${cleanupText}` : cleanupText,
       isDismissible: false,
     })
-  }, [suspension, addBanner, removeBanner, navigate, path, hasPaymentMethod, paymentMethodsQuery.isLoading])
+  }, [
+    suspension,
+    addBanner,
+    removeBanner,
+    navigate,
+    path,
+    hasPaymentMethod,
+    paymentMethodsQuery.isLoading,
+    paymentMethodsUnavailable,
+  ])
 }

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -10,11 +10,13 @@ import { TierUpgradeCard } from '@/components/TierUpgradeCard'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { UsageOverview, UsageOverviewSkeleton } from '@/components/UsageOverview'
 import { RoutePath } from '@/enums/RoutePath'
-import { useOwnerTierQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
+import { useOwnerTierQuery } from '@/hooks/queries/billingQueries'
 import { useOrganizationUsageOverviewQuery } from '@/hooks/queries/useOrganizationUsageOverviewQuery'
+import { usePaymentMethodsQuery } from '@/hooks/queries/usePaymentMethodsQuery'
 import { useTiersQuery } from '@/hooks/queries/useTiersQuery'
 import { useConfig } from '@/hooks/useConfig'
 import { useRegions } from '@/hooks/useRegions'
@@ -23,7 +25,7 @@ import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
 import type { Organization, RegionUsageOverview, SandboxClass } from '@daytona/api-client'
 import { keepPreviousData } from '@tanstack/react-query'
-import { RefreshCcw } from 'lucide-react'
+import { AlertCircle, RefreshCcw } from 'lucide-react'
 import { ReactNode, useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { useNavigate } from 'react-router-dom'
@@ -32,16 +34,19 @@ export default function Limits() {
   const { user } = useAuth()
   const { selectedOrganization } = useSelectedOrganization()
   const organizationTierQuery = useOwnerTierQuery()
-  const walletQuery = useOwnerWalletQuery()
   const tiersQuery = useTiersQuery()
 
   const organizationTier = organizationTierQuery.data
   const tiers = tiersQuery.data?.slice().sort((a, b) => (a.tier ?? 0) - (b.tier ?? 0))
-  const wallet = walletQuery.data
 
   const { getRegionName } = useRegions()
   const config = useConfig()
   const navigate = useNavigate()
+  const paymentMethodsQuery = usePaymentMethodsQuery({
+    organizationId: selectedOrganization?.id ?? '',
+    enabled: Boolean(config.billingApiUrl && selectedOrganization),
+  })
+  const hasPaymentMethod = (paymentMethodsQuery.data?.length ?? 0) > 0
 
   useEffect(() => {
     if (selectedOrganization && !selectedOrganization.defaultRegionId) {
@@ -72,15 +77,15 @@ export default function Limits() {
     currentEntry: currentRegionUsageOverview,
   } = useRegionClassSelection(usageOverview?.regionUsage, selectedOrganization?.defaultRegionId)
 
-  const isLoading = organizationTierQuery.isLoading || tiersQuery.isLoading || walletQuery.isLoading
+  const isLoading = organizationTierQuery.isLoading || tiersQuery.isLoading || paymentMethodsQuery.isLoading
   const isError =
-    organizationTierQuery.isError || tiersQuery.isError || usageOverviewQuery.isError || walletQuery.isError
+    organizationTierQuery.isError || tiersQuery.isError || usageOverviewQuery.isError || paymentMethodsQuery.isError
 
   const handleRetry = () => {
     organizationTierQuery.refetch()
     tiersQuery.refetch()
     usageOverviewQuery.refetch()
-    walletQuery.refetch()
+    paymentMethodsQuery.refetch()
   }
 
   return (
@@ -90,18 +95,21 @@ export default function Limits() {
       <PageContent>
         <PageIntro title="Limits" />
         {isError ? (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-center">Oops, something went wrong</CardTitle>
-            </CardHeader>
-            <CardContent className="flex justify-between items-center flex-col gap-3">
-              <div>There was an error loading your limits.</div>
-              <Button variant="outline" onClick={handleRetry}>
-                <RefreshCcw className="mr-2 h-4 w-4" />
+          <Empty className="py-12 max-h-64 border" variant="destructive">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <AlertCircle />
+              </EmptyMedia>
+              <EmptyTitle>Failed to load limits</EmptyTitle>
+              <EmptyDescription>Something went wrong while fetching your limits. Please try again.</EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button variant="secondary" size="sm" onClick={handleRetry}>
+                <RefreshCcw />
                 Retry
               </Button>
-            </CardContent>
-          </Card>
+            </EmptyContent>
+          </Empty>
         ) : (
           <>
             <Card>
@@ -222,15 +230,17 @@ export default function Limits() {
 
             {config.billingApiUrl && selectedOrganization && (
               <>
-                <TierUpgradeCard
-                  organizationTier={organizationTier}
-                  tiers={tiers || []}
-                  organization={selectedOrganization}
-                  requirementsState={{
-                    emailVerified: !!user?.profile?.email_verified,
-                    creditCardLinked: !!wallet?.creditCardConnected,
-                  }}
-                />
+                {!isLoading && (
+                  <TierUpgradeCard
+                    organizationTier={organizationTier}
+                    tiers={tiers || []}
+                    organization={selectedOrganization}
+                    requirementsState={{
+                      emailVerified: !!user?.profile?.email_verified,
+                      creditCardLinked: hasPaymentMethod,
+                    }}
+                  />
+                )}
 
                 <Card className="mb-10">
                   <CardHeader>

--- a/apps/dashboard/src/pages/Limits.tsx
+++ b/apps/dashboard/src/pages/Limits.tsx
@@ -10,7 +10,7 @@ import { TierUpgradeCard } from '@/components/TierUpgradeCard'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty'
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { UsageOverview, UsageOverviewSkeleton } from '@/components/UsageOverview'
 import { RoutePath } from '@/enums/RoutePath'
@@ -25,7 +25,7 @@ import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { cn } from '@/lib/utils'
 import type { Organization, RegionUsageOverview, SandboxClass } from '@daytona/api-client'
 import { keepPreviousData } from '@tanstack/react-query'
-import { AlertCircle, RefreshCcw } from 'lucide-react'
+import { RefreshCcw } from 'lucide-react'
 import { ReactNode, useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
 import { useNavigate } from 'react-router-dom'
@@ -46,7 +46,9 @@ export default function Limits() {
     organizationId: selectedOrganization?.id ?? '',
     enabled: Boolean(config.billingApiUrl && selectedOrganization),
   })
-  const hasPaymentMethod = (paymentMethodsQuery.data?.length ?? 0) > 0
+  const paymentMethods = paymentMethodsQuery.data
+  const paymentMethodsUnavailable = paymentMethodsQuery.isError && paymentMethods === undefined
+  const hasPaymentMethod = (paymentMethods?.length ?? 0) > 0
 
   useEffect(() => {
     if (selectedOrganization && !selectedOrganization.defaultRegionId) {
@@ -77,14 +79,21 @@ export default function Limits() {
     currentEntry: currentRegionUsageOverview,
   } = useRegionClassSelection(usageOverview?.regionUsage, selectedOrganization?.defaultRegionId)
 
-  const isLoading = organizationTierQuery.isLoading || tiersQuery.isLoading || paymentMethodsQuery.isLoading
-  const isError =
-    organizationTierQuery.isError || tiersQuery.isError || usageOverviewQuery.isError || paymentMethodsQuery.isError
+  const tierDataLoading = organizationTierQuery.isLoading || tiersQuery.isLoading
+  const tierDataError = organizationTierQuery.isError || tiersQuery.isError
+  const upgradeRequirementsLoading = tierDataLoading || paymentMethodsQuery.isLoading
+  const upgradeRequirementsError = paymentMethodsUnavailable && !tierDataError
 
-  const handleRetry = () => {
+  const handleRetryUsage = () => {
+    usageOverviewQuery.refetch()
+  }
+
+  const handleRetryTierData = () => {
     organizationTierQuery.refetch()
     tiersQuery.refetch()
-    usageOverviewQuery.refetch()
+  }
+
+  const handleRetryPaymentMethods = () => {
     paymentMethodsQuery.refetch()
   }
 
@@ -94,172 +103,180 @@ export default function Limits() {
 
       <PageContent>
         <PageIntro title="Limits" />
-        {isError ? (
-          <Empty className="py-12 max-h-64 border" variant="destructive">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <AlertCircle />
-              </EmptyMedia>
-              <EmptyTitle>Failed to load limits</EmptyTitle>
-              <EmptyDescription>Something went wrong while fetching your limits. Please try again.</EmptyDescription>
-            </EmptyHeader>
-            <EmptyContent>
-              <Button variant="secondary" size="sm" onClick={handleRetry}>
-                <RefreshCcw />
-                Retry
-              </Button>
-            </EmptyContent>
-          </Empty>
-        ) : (
-          <>
-            <Card>
-              <CardHeader className="p-4">
-                <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
-                  <CardTitle className="flex justify-between gap-x-4 gap-y-2 flex-row flex-wrap items-center">
-                    <div className="flex items-center gap-2">
-                      Current Usage{' '}
-                      {organizationTier && (
-                        <Badge variant="outline" className="font-mono uppercase">
-                          Tier {organizationTier.tier}
-                        </Badge>
-                      )}
-                    </div>
-                  </CardTitle>
-                  {regionIds.length > 0 && (
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm text-muted-foreground">Region:</span>
-                      <Select value={selectedRegionId} onValueChange={setSelectedRegionId}>
-                        <SelectTrigger
-                          size="xs"
-                          disabled={regionIds.length === 1}
-                          className={`uppercase w-auto min-w-12 max-w-48 gap-x-2 ${regionIds.length === 1 ? 'pointer-events-none select-none [&>svg]:hidden min-w-10 disabled:opacity-100' : ''}`}
-                        >
-                          <SelectValue placeholder="Select region" />
+        <Card>
+          <CardHeader className="p-4">
+            <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+              <CardTitle className="flex justify-between gap-x-4 gap-y-2 flex-row flex-wrap items-center">
+                <div className="flex items-center gap-2">
+                  Current Usage{' '}
+                  {organizationTier && (
+                    <Badge variant="outline" className="font-mono uppercase">
+                      Tier {organizationTier.tier}
+                    </Badge>
+                  )}
+                </div>
+              </CardTitle>
+              {regionIds.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">Region:</span>
+                  <Select value={selectedRegionId} onValueChange={setSelectedRegionId}>
+                    <SelectTrigger
+                      size="xs"
+                      disabled={regionIds.length === 1}
+                      className={`uppercase w-auto min-w-12 max-w-48 gap-x-2 ${regionIds.length === 1 ? 'pointer-events-none select-none [&>svg]:hidden min-w-10 disabled:opacity-100' : ''}`}
+                    >
+                      <SelectValue placeholder="Select region" />
+                    </SelectTrigger>
+                    <SelectContent className="min-w-24 max-w-48" align="end">
+                      {regionIds.map((regionId) => (
+                        <SelectItem key={regionId} value={regionId} className="uppercase">
+                          {getRegionName(regionId) ?? regionId}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {showClassSelector && (
+                    <>
+                      <span className="text-sm text-muted-foreground">Class:</span>
+                      <Select
+                        value={selectedSandboxClass}
+                        onValueChange={(value) => setSelectedSandboxClass(value as SandboxClass)}
+                      >
+                        <SelectTrigger size="xs" className="uppercase w-auto min-w-12 max-w-48 gap-x-2">
+                          <SelectValue placeholder="Select class" />
                         </SelectTrigger>
                         <SelectContent className="min-w-24 max-w-48" align="end">
-                          {regionIds.map((regionId) => (
-                            <SelectItem key={regionId} value={regionId} className="uppercase">
-                              {getRegionName(regionId) ?? regionId}
+                          {classesForSelectedRegion.map((usage) => (
+                            <SelectItem key={usage.sandboxClass} value={usage.sandboxClass} className="uppercase">
+                              {usage.sandboxClass}
                             </SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
-                      {showClassSelector && (
-                        <>
-                          <span className="text-sm text-muted-foreground">Class:</span>
-                          <Select
-                            value={selectedSandboxClass}
-                            onValueChange={(value) => setSelectedSandboxClass(value as SandboxClass)}
-                          >
-                            <SelectTrigger size="xs" className="uppercase w-auto min-w-12 max-w-48 gap-x-2">
-                              <SelectValue placeholder="Select class" />
-                            </SelectTrigger>
-                            <SelectContent className="min-w-24 max-w-48" align="end">
-                              {classesForSelectedRegion.map((usage) => (
-                                <SelectItem key={usage.sandboxClass} value={usage.sandboxClass} className="uppercase">
-                                  {usage.sandboxClass}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </>
-                      )}
-                    </div>
+                    </>
                   )}
                 </div>
-                <CardDescription>
-                  Limits help us mitigate misuse and manage infrastructure resources. <br /> Ensuring fair and stable
-                  access to sandboxes and compute capacity across all users.
-                </CardDescription>
+              )}
+            </div>
+            <CardDescription>
+              Limits help us mitigate misuse and manage infrastructure resources. <br /> Ensuring fair and stable access
+              to sandboxes and compute capacity across all users.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-0 flex flex-col">
+            {usageOverviewQuery.isLoading ? (
+              <UsageOverviewSkeleton />
+            ) : usageOverviewQuery.isError ? (
+              <div className="border-t border-border flex">
+                <LimitsSectionErrorState
+                  title="Failed to load resource usage"
+                  description="Something went wrong while fetching your current resource usage."
+                  onRetry={handleRetryUsage}
+                />
+              </div>
+            ) : (
+              usageOverview &&
+              currentRegionUsageOverview && (
+                <div className="p-4 border-t border-border flex flex-col gap-2">
+                  <div className="flex items-center gap-4">
+                    <div className="text-sm font-medium">Resources</div>
+                    <LiveIndicator
+                      isUpdating={usageOverviewQuery.isFetching}
+                      intervalMs={10_000}
+                      lastUpdatedAt={usageOverviewQuery.dataUpdatedAt || 0}
+                    />
+                  </div>
+                  <UsageOverview usageOverview={currentRegionUsageOverview} />
+                </div>
+              )
+            )}
+            <RateLimits
+              title="Sandbox Limits"
+              description="Resources limit per sandbox."
+              className="border-t border-border"
+              rateLimits={buildSandboxLimitItems(currentRegionUsageOverview, selectedOrganization)}
+            />
+
+            <RateLimits
+              title="Rate Limits"
+              description="How many requests you can make."
+              className="border-t border-border"
+              rateLimits={[
+                {
+                  value: selectedOrganization?.authenticatedRateLimit || config?.rateLimit?.authenticated?.limit,
+                  label: 'General Requests',
+                  ttlSeconds:
+                    selectedOrganization?.authenticatedRateLimitTtlSeconds ?? config?.rateLimit?.authenticated?.ttl,
+                },
+                {
+                  value: selectedOrganization?.sandboxCreateRateLimit || config?.rateLimit?.sandboxCreate?.limit,
+                  label: 'Sandbox Creation',
+                  ttlSeconds:
+                    selectedOrganization?.sandboxCreateRateLimitTtlSeconds ?? config?.rateLimit?.sandboxCreate?.ttl,
+                },
+                {
+                  value: selectedOrganization?.sandboxLifecycleRateLimit || config?.rateLimit?.sandboxLifecycle?.limit,
+                  label: 'Sandbox Lifecycle',
+                  ttlSeconds:
+                    selectedOrganization?.sandboxLifecycleRateLimitTtlSeconds ??
+                    config?.rateLimit?.sandboxLifecycle?.ttl,
+                },
+              ]}
+            />
+          </CardContent>
+        </Card>
+
+        {config.billingApiUrl && selectedOrganization && (
+          <>
+            {upgradeRequirementsError ? (
+              <Card>
+                <CardContent className="flex p-0">
+                  <LimitsSectionErrorState
+                    title="Failed to load upgrade requirements"
+                    description="Something went wrong while fetching your billing requirements."
+                    onRetry={handleRetryPaymentMethods}
+                  />
+                </CardContent>
+              </Card>
+            ) : (
+              !upgradeRequirementsLoading &&
+              !tierDataError && (
+                <TierUpgradeCard
+                  organizationTier={organizationTier}
+                  tiers={tiers || []}
+                  organization={selectedOrganization}
+                  requirementsState={{
+                    emailVerified: !!user?.profile?.email_verified,
+                    creditCardLinked: hasPaymentMethod,
+                  }}
+                />
+              )
+            )}
+
+            <Card className="mb-10">
+              <CardHeader>
+                <CardTitle className="flex items-center mb-2">Limits</CardTitle>
               </CardHeader>
-              <CardContent className="p-0 flex flex-col">
-                {usageOverviewQuery.isLoading ? (
-                  <UsageOverviewSkeleton />
+              <CardContent className="p-0">
+                {tierDataLoading ? (
+                  <TierComparisonTableSkeleton />
+                ) : tierDataError ? (
+                  <div className="flex">
+                    <LimitsSectionErrorState
+                      title="Failed to load tier limits"
+                      description="Something went wrong while fetching billing tiers."
+                      onRetry={handleRetryTierData}
+                    />
+                  </div>
                 ) : (
-                  usageOverview &&
-                  currentRegionUsageOverview && (
-                    <div className="p-4 border-t border-border flex flex-col gap-2">
-                      <div className="flex items-center gap-4">
-                        <div className="text-sm font-medium">Resources</div>
-                        <LiveIndicator
-                          isUpdating={usageOverviewQuery.isFetching}
-                          intervalMs={10_000}
-                          lastUpdatedAt={usageOverviewQuery.dataUpdatedAt || 0}
-                        />
-                      </div>
-                      <UsageOverview usageOverview={currentRegionUsageOverview} />
-                    </div>
-                  )
-                )}
-                <RateLimits
-                  title="Sandbox Limits"
-                  description="Resources limit per sandbox."
-                  className="border-t border-border"
-                  rateLimits={buildSandboxLimitItems(currentRegionUsageOverview, selectedOrganization)}
-                />
-
-                <RateLimits
-                  title="Rate Limits"
-                  description="How many requests you can make."
-                  className="border-t border-border"
-                  rateLimits={[
-                    {
-                      value: selectedOrganization?.authenticatedRateLimit || config?.rateLimit?.authenticated?.limit,
-                      label: 'General Requests',
-                      ttlSeconds:
-                        selectedOrganization?.authenticatedRateLimitTtlSeconds ?? config?.rateLimit?.authenticated?.ttl,
-                    },
-                    {
-                      value: selectedOrganization?.sandboxCreateRateLimit || config?.rateLimit?.sandboxCreate?.limit,
-                      label: 'Sandbox Creation',
-                      ttlSeconds:
-                        selectedOrganization?.sandboxCreateRateLimitTtlSeconds ?? config?.rateLimit?.sandboxCreate?.ttl,
-                    },
-                    {
-                      value:
-                        selectedOrganization?.sandboxLifecycleRateLimit || config?.rateLimit?.sandboxLifecycle?.limit,
-                      label: 'Sandbox Lifecycle',
-                      ttlSeconds:
-                        selectedOrganization?.sandboxLifecycleRateLimitTtlSeconds ??
-                        config?.rateLimit?.sandboxLifecycle?.ttl,
-                    },
-                  ]}
-                />
-              </CardContent>
-            </Card>
-
-            {config.billingApiUrl && selectedOrganization && (
-              <>
-                {!isLoading && (
-                  <TierUpgradeCard
-                    organizationTier={organizationTier}
+                  <TierComparisonTable
+                    className="only:mb-4 border-l-0 border-r-0"
                     tiers={tiers || []}
-                    organization={selectedOrganization}
-                    requirementsState={{
-                      emailVerified: !!user?.profile?.email_verified,
-                      creditCardLinked: hasPaymentMethod,
-                    }}
+                    currentTier={organizationTier}
                   />
                 )}
-
-                <Card className="mb-10">
-                  <CardHeader>
-                    <CardTitle className="flex items-center mb-2">Limits</CardTitle>
-                  </CardHeader>
-                  <CardContent className="p-0">
-                    {isLoading ? (
-                      <TierComparisonTableSkeleton />
-                    ) : (
-                      <TierComparisonTable
-                        className="only:mb-4 border-l-0 border-r-0"
-                        tiers={tiers || []}
-                        currentTier={organizationTier}
-                      />
-                    )}
-                  </CardContent>
-                </Card>
-              </>
-            )}
+              </CardContent>
+            </Card>
           </>
         )}
       </PageContent>
@@ -275,6 +292,29 @@ interface LimitItem {
   label: string
   ttlSeconds?: number | null
   resourceType?: ResourceType
+}
+
+function LimitsSectionErrorState({
+  title,
+  description,
+  onRetry,
+}: {
+  title: string
+  description: string
+  onRetry: () => void
+}) {
+  return (
+    <Empty className="flex-1 border-0 py-8">
+      <EmptyHeader>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        <RefreshCcw className="size-4" />
+        Retry
+      </Button>
+    </Empty>
+  )
 }
 
 function buildSandboxLimitItems(region: RegionUsageOverview | null, org: Organization | null | undefined): LimitItem[] {

--- a/apps/dashboard/src/pages/Wallet.tsx
+++ b/apps/dashboard/src/pages/Wallet.tsx
@@ -61,8 +61,8 @@ const Wallet = () => {
 
   const wallet = walletQuery.data
   const paymentMethods = paymentMethodsQuery.data
-  const hasNoPaymentMethod = paymentMethods?.length === 0
   const paymentMethodsLoading = paymentMethodsQuery.isLoading
+  const hasNoPaymentMethod = (paymentMethods?.length ?? 0) === 0
   const setAutomaticTopUpMutation = useSetAutomaticTopUpMutation()
   const redeemCouponMutation = useRedeemCouponMutation()
   const topUpWalletMutation = useTopUpWalletMutation()

--- a/apps/dashboard/src/pages/Wallet.tsx
+++ b/apps/dashboard/src/pages/Wallet.tsx
@@ -24,9 +24,10 @@ import { useSetAutomaticTopUpMutation } from '@/hooks/mutations/useSetAutomaticT
 import { useTopUpWalletMutation } from '@/hooks/mutations/useTopUpWalletMutation'
 import { useOwnerInvoicesQuery, useOwnerWalletQuery } from '@/hooks/queries/billingQueries'
 import { useChargesQuery } from '@/hooks/queries/useChargesQuery'
+import { usePaymentMethodsQuery } from '@/hooks/queries/usePaymentMethodsQuery'
 import { useSelectedOrganization } from '@/hooks/useSelectedOrganization'
 import { formatAmount } from '@/lib/utils'
-import { InfoIcon, SparklesIcon, TriangleAlertIcon } from 'lucide-react'
+import { CreditCardIcon, InfoIcon, SparklesIcon, TriangleAlertIcon } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { NumericFormat } from 'react-number-format'
 import { useAuth } from 'react-oidc-context'
@@ -53,8 +54,14 @@ const Wallet = () => {
     organizationId: selectedOrganization?.id ?? '',
     enabled: Boolean(selectedOrganization),
   })
+  const paymentMethodsQuery = usePaymentMethodsQuery({
+    organizationId: selectedOrganization?.id ?? '',
+    enabled: Boolean(selectedOrganization),
+  })
 
   const wallet = walletQuery.data
+  const hasPaymentMethod = (paymentMethodsQuery.data?.length ?? 0) > 0
+  const paymentMethodsLoading = paymentMethodsQuery.isLoading
   const setAutomaticTopUpMutation = useSetAutomaticTopUpMutation()
   const redeemCouponMutation = useRedeemCouponMutation()
   const topUpWalletMutation = useTopUpWalletMutation()
@@ -204,8 +211,10 @@ const Wallet = () => {
 
   const isBillingLoading = walletQuery.isLoading
   const isPostPaid = wallet?.billingType === BillingType.BillingTypePostPaid
-  const topUpEnabled =
-    wallet?.creditCardConnected && !topUpWalletMutation.isPending && (selectedPreset || oneTimeTopUpAmount)
+  const topUpDisabledBecauseMissingPaymentMethod = Boolean(wallet && !paymentMethodsLoading && !hasPaymentMethod)
+  const topUpEnabled = Boolean(
+    hasPaymentMethod && !topUpWalletMutation.isPending && (selectedPreset || oneTimeTopUpAmount),
+  )
 
   return (
     <PageLayout>
@@ -261,12 +270,17 @@ const Wallet = () => {
                     </AlertDescription>
                   </Alert>
                 )}
-                {!wallet.creditCardConnected && user.profile.email_verified && selectedOrganization?.personal && (
-                  <Alert variant="neutral">
-                    <SparklesIcon />
-                    <AlertDescription>Connect a credit card to receive an additional $100 of credits.</AlertDescription>
-                  </Alert>
-                )}
+                {!paymentMethodsLoading &&
+                  !hasPaymentMethod &&
+                  user.profile.email_verified &&
+                  selectedOrganization?.personal && (
+                    <Alert variant="neutral">
+                      <SparklesIcon />
+                      <AlertDescription>
+                        Connect a credit card to receive an additional $100 of credits.
+                      </AlertDescription>
+                    </Alert>
+                  )}
               </>
             )}
             {wallet.hasFailedOrPendingInvoice && (
@@ -356,7 +370,7 @@ const Wallet = () => {
               </>
             )}
 
-            {wallet.creditCardConnected && !isPostPaid && (
+            {hasPaymentMethod && !isPostPaid && (
               <Card className="w-full">
                 <CardHeader>
                   <CardTitle>Automatic top-up</CardTitle>
@@ -470,16 +484,16 @@ const Wallet = () => {
                 <div className="grid grid-cols-1 gap-10 items-center lg:grid-cols-2">
                   <div className="flex flex-col gap-2">
                     <Label className="text-sm font-medium">Select amount</Label>
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                    <div className="grid grid-cols-1 xxs:grid-cols-4 overflow-hidden rounded-md border border-input">
                       {[25, 500, 1000, 2000].map((amount) => (
                         <Button
                           key={amount}
                           type="button"
-                          variant={selectedPreset === amount ? 'default' : 'outline'}
+                          variant={selectedPreset === amount ? 'default' : 'ghost'}
                           size="default"
-                          className="flex h-9"
+                          className="flex h-9 min-w-0 rounded-none border-t border-border px-2 text-[13px] first:border-t-0 xxs:border-l xxs:border-t-0 xxs:first:border-l-0"
                           onClick={() => {
-                            setSelectedPreset(amount)
+                            setSelectedPreset((currentPreset) => (currentPreset === amount ? null : amount))
                             setOneTimeTopUpAmount(undefined)
                           }}
                         >
@@ -526,9 +540,18 @@ const Wallet = () => {
                 </div>
               </CardContent>
               <CardFooter className="flex justify-between gap-2">
-                <div className="text-sm text-muted-foreground">
-                  You will be redirected to Stripe to complete the payment.
-                </div>
+                {paymentMethodsLoading ? (
+                  <Skeleton className="h-4 w-64 max-w-full" />
+                ) : topUpDisabledBecauseMissingPaymentMethod ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <CreditCardIcon className="w-4 h-4 shrink-0" />
+                    <span>Add a payment method to top up.</span>
+                  </div>
+                ) : (
+                  <div className="text-sm text-muted-foreground">
+                    You will be redirected to Stripe to complete the payment.
+                  </div>
+                )}
                 <Button onClick={handleTopUpWallet} disabled={!topUpEnabled} size="sm">
                   {topUpWalletMutation.isPending && <Spinner />}
                   Top up

--- a/apps/dashboard/src/pages/Wallet.tsx
+++ b/apps/dashboard/src/pages/Wallet.tsx
@@ -60,7 +60,8 @@ const Wallet = () => {
   })
 
   const wallet = walletQuery.data
-  const hasPaymentMethod = (paymentMethodsQuery.data?.length ?? 0) > 0
+  const paymentMethods = paymentMethodsQuery.data
+  const hasNoPaymentMethod = paymentMethods?.length === 0
   const paymentMethodsLoading = paymentMethodsQuery.isLoading
   const setAutomaticTopUpMutation = useSetAutomaticTopUpMutation()
   const redeemCouponMutation = useRedeemCouponMutation()
@@ -115,37 +116,33 @@ const Wallet = () => {
     }
   }, [selectedOrganization, couponCode, redeemCouponMutation])
 
-  const saveAutomaticTopUpDisabled = useMemo(() => {
-    if (setAutomaticTopUpMutation.isPending) {
-      return true
-    }
-
+  const automaticTopUpHasChanges = useMemo(() => {
     if (wallet?.automaticTopUp?.disabled && (automaticTopUp?.thresholdAmount || 0) > 0) {
-      return false
+      return true
     }
 
     if (automaticTopUp?.thresholdAmount !== wallet?.automaticTopUp?.thresholdAmount) {
       if (!wallet?.automaticTopUp) {
         if ((automaticTopUp?.thresholdAmount || 0) !== 0) {
-          return false
+          return true
         }
       } else {
-        return false
+        return true
       }
     }
 
     if (automaticTopUp?.targetAmount !== wallet?.automaticTopUp?.targetAmount) {
       if (!wallet?.automaticTopUp) {
         if ((automaticTopUp?.targetAmount || 0) !== 0) {
-          return false
+          return true
         }
       } else {
-        return false
+        return true
       }
     }
 
-    return true
-  }, [setAutomaticTopUpMutation.isPending, wallet, automaticTopUp])
+    return false
+  }, [wallet, automaticTopUp])
 
   const handleTopUpWallet = useCallback(async () => {
     if (!selectedOrganization) {
@@ -211,9 +208,22 @@ const Wallet = () => {
 
   const isBillingLoading = walletQuery.isLoading
   const isPostPaid = wallet?.billingType === BillingType.BillingTypePostPaid
-  const topUpDisabledBecauseMissingPaymentMethod = Boolean(wallet && !paymentMethodsLoading && !hasPaymentMethod)
+  const showCreditCardBonusPrompt = Boolean(
+    hasNoPaymentMethod && user?.profile.email_verified && selectedOrganization?.personal,
+  )
+  const showMissingPaymentMethodTopUpMessage = Boolean(wallet && hasNoPaymentMethod)
+  const automaticTopUpSaveDisabled =
+    !automaticTopUpHasChanges ||
+    setAutomaticTopUpMutation.isPending ||
+    walletQuery.isLoading ||
+    !wallet ||
+    paymentMethodsLoading ||
+    hasNoPaymentMethod
   const topUpEnabled = Boolean(
-    hasPaymentMethod && !topUpWalletMutation.isPending && (selectedPreset || oneTimeTopUpAmount),
+    !paymentMethodsLoading &&
+      !hasNoPaymentMethod &&
+      !topUpWalletMutation.isPending &&
+      (selectedPreset || oneTimeTopUpAmount),
   )
 
   return (
@@ -270,17 +280,12 @@ const Wallet = () => {
                     </AlertDescription>
                   </Alert>
                 )}
-                {!paymentMethodsLoading &&
-                  !hasPaymentMethod &&
-                  user.profile.email_verified &&
-                  selectedOrganization?.personal && (
-                    <Alert variant="neutral">
-                      <SparklesIcon />
-                      <AlertDescription>
-                        Connect a credit card to receive an additional $100 of credits.
-                      </AlertDescription>
-                    </Alert>
-                  )}
+                {showCreditCardBonusPrompt && (
+                  <Alert variant="neutral">
+                    <SparklesIcon />
+                    <AlertDescription>Connect a credit card to receive an additional $100 of credits.</AlertDescription>
+                  </Alert>
+                )}
               </>
             )}
             {wallet.hasFailedOrPendingInvoice && (
@@ -370,7 +375,7 @@ const Wallet = () => {
               </>
             )}
 
-            {hasPaymentMethod && !isPostPaid && (
+            {!isPostPaid && (
               <Card className="w-full">
                 <CardHeader>
                   <CardTitle>Automatic top-up</CardTitle>
@@ -462,10 +467,7 @@ const Wallet = () => {
                     <span className="text-sm ">Setting both values to 0 will disable automatic top-ups.</span>
                   </div>
                   <div className="flex gap-2 items-center ml-auto">
-                    <Button
-                      onClick={handleSetAutomaticTopUp}
-                      disabled={saveAutomaticTopUpDisabled || walletQuery.isLoading || !wallet}
-                    >
+                    <Button onClick={handleSetAutomaticTopUp} disabled={automaticTopUpSaveDisabled}>
                       {setAutomaticTopUpMutation.isPending && <Spinner />} Save
                     </Button>
                   </div>
@@ -542,7 +544,7 @@ const Wallet = () => {
               <CardFooter className="flex justify-between gap-2">
                 {paymentMethodsLoading ? (
                   <Skeleton className="h-4 w-64 max-w-full" />
-                ) : topUpDisabledBecauseMissingPaymentMethod ? (
+                ) : showMissingPaymentMethodTopUpMessage ? (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <CreditCardIcon className="w-4 h-4 shrink-0" />
                     <span>Add a payment method to top up.</span>

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -17,6 +17,7 @@ module.exports = {
   theme: {
     extend: {
       screens: {
+        xxs: '360px',
         xs: '480px',
       },
       fontSize: {


### PR DESCRIPTION

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783518344&installation_id=132266156&pr_number=4947&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4947&signature=63fabc131945bc020e2dc229e77190c472869416404d713935ffffa7d17e1ba0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches billing checks to use actual payment methods instead of the wallet flag. Adds granular, per-section error handling so users see accurate states and targeted retries.

- **Bug Fixes**
  - Suspension banner: when suspension is “payment method required,” use `usePaymentMethodsQuery`; if a method exists, show a “No credits” banner with a Billing link; hide the “add payment method” banner; wait for loading.
  - Limits: replace wallet checks with payment methods; pass `creditCardLinked` from payment methods; gate `TierUpgradeCard` until requirements load; show a dedicated error when requirements fail.
  - Wallet: require a payment method for one-time and automatic top-ups; show a clear “add a payment method” prompt when missing; no longer use `wallet.creditCardConnected`.

- **UI Improvements**
  - Limits: granular error states for usage, tier limits, and upgrade requirements using `Empty` with a retry action.
  - Wallet: toggleable amount presets with better small-screen layout; footer shows a Stripe redirect note or an “add a payment method” hint; skeleton while payment methods load.
  - Wallet: Save for automatic top-up only enables when values change and a payment method exists; clearer disabled states.
  - Tailwind: added `xxs` (360px) breakpoint.

<sup>Written for commit 3406fc9e4bd435f6840fd357f72f2fb288f59476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



