### PR TITLE
fix(api): scope organization role lookups to caller's organization

### DIFF
--- a/apps/api/src/organization/controllers/organization-role.controller.ts
+++ b/apps/api/src/organization/controllers/organization-role.controller.ts
@@ -123,7 +123,7 @@ export class OrganizationRoleController {
     @Param('roleId') roleId: string,
     @Body() updateOrganizationRoleDto: UpdateOrganizationRoleDto,
   ): Promise<OrganizationRoleDto> {
-    const updatedRole = await this.organizationRoleService.update(roleId, updateOrganizationRoleDto)
+    const updatedRole = await this.organizationRoleService.update(organizationId, roleId, updateOrganizationRoleDto)
     return OrganizationRoleDto.fromOrganizationRole(updatedRole)
   }
 
@@ -153,6 +153,6 @@ export class OrganizationRoleController {
     targetIdFromRequest: (req) => req.params.roleId,
   })
   async delete(@Param('organizationId') organizationId: string, @Param('roleId') roleId: string): Promise<void> {
-    return this.organizationRoleService.delete(roleId)
+    return this.organizationRoleService.delete(organizationId, roleId)
   }
 }

--- a/apps/api/src/organization/services/organization-invitation.service.ts
+++ b/apps/api/src/organization/services/organization-invitation.service.ts
@@ -84,7 +84,10 @@ export class OrganizationInvitationService {
     invitation.role = createOrganizationInvitationDto.role
     invitation.invitedBy = invitedBy
 
-    const assignedRoles = await this.organizationRoleService.findByIds(createOrganizationInvitationDto.assignedRoleIds)
+    const assignedRoles = await this.organizationRoleService.findByIds(
+      organizationId,
+      createOrganizationInvitationDto.assignedRoleIds,
+    )
     if (assignedRoles.length !== createOrganizationInvitationDto.assignedRoleIds.length) {
       throw new BadRequestException('One or more role IDs are invalid')
     }
@@ -136,7 +139,10 @@ export class OrganizationInvitationService {
     }
     invitation.role = updateOrganizationInvitationDto.role
 
-    const assignedRoles = await this.organizationRoleService.findByIds(updateOrganizationInvitationDto.assignedRoleIds)
+    const assignedRoles = await this.organizationRoleService.findByIds(
+      organizationId,
+      updateOrganizationInvitationDto.assignedRoleIds,
+    )
     if (assignedRoles.length !== updateOrganizationInvitationDto.assignedRoleIds.length) {
       throw new BadRequestException('One or more role IDs are invalid')
     }

--- a/apps/api/src/organization/services/organization-role.service.ts
+++ b/apps/api/src/organization/services/organization-role.service.ts
@@ -38,21 +38,26 @@ export class OrganizationRoleService {
     })
   }
 
-  async findByIds(roleIds: string[]): Promise<OrganizationRole[]> {
+  async findByIds(organizationId: string, roleIds: string[]): Promise<OrganizationRole[]> {
     if (roleIds.length === 0) {
       return []
     }
 
     return this.organizationRoleRepository.find({
-      where: {
-        id: In(roleIds),
-      },
+      where: [
+        { id: In(roleIds), organizationId },
+        { id: In(roleIds), isGlobal: true },
+      ],
     })
   }
 
-  async update(roleId: string, updateOrganizationRoleDto: UpdateOrganizationRoleDto): Promise<OrganizationRole> {
+  async update(
+    organizationId: string,
+    roleId: string,
+    updateOrganizationRoleDto: UpdateOrganizationRoleDto,
+  ): Promise<OrganizationRole> {
     const role = await this.organizationRoleRepository.findOne({
-      where: { id: roleId },
+      where: { id: roleId, organizationId },
     })
 
     if (!role) {
@@ -70,9 +75,9 @@ export class OrganizationRoleService {
     return this.organizationRoleRepository.save(role)
   }
 
-  async delete(roleId: string): Promise<void> {
+  async delete(organizationId: string, roleId: string): Promise<void> {
     const role = await this.organizationRoleRepository.findOne({
-      where: { id: roleId },
+      where: { id: roleId, organizationId },
     })
 
     if (!role) {

--- a/apps/api/src/organization/services/organization-user.service.ts
+++ b/apps/api/src/organization/services/organization-user.service.ts
@@ -103,7 +103,7 @@ export class OrganizationUserService {
     }
 
     // validate assignments
-    const assignedRoles = await this.organizationRoleService.findByIds(assignedRoleIds)
+    const assignedRoles = await this.organizationRoleService.findByIds(organizationId, assignedRoleIds)
     if (assignedRoles.length !== assignedRoleIds.length) {
       throw new BadRequestException('One or more role IDs are invalid')
     }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783522992&installation_id=132266156&pr_number=4948&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4948&signature=8079d082eab2f6c7c80a4148eb4cea38d6ee9aec7cf6b8883ccca3057d6e96df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped all organization role queries and mutations to the request’s `organizationId` to prevent cross-organization access. Tightened role validation in invitations and user assignments; `findByIds` now resolves org roles and `isGlobal` roles only.

- **Bug Fixes**
  - `update`/`delete` now query roles by `{ id, organizationId }`.
  - `findByIds(organizationId, roleIds)` filters by org and includes `isGlobal` roles.
  - Controller passes `organizationId` to role update/delete calls.
  - Invitation and user services validate `assignedRoleIds` with org-scoped lookups.

<sup>Written for commit 812ae6eb1a8ad6e983884dc2cd38e3e8490971c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

