### PR TITLE
fix(computer-use): close process logs per restart

### DIFF
--- a/libs/computer-use/pkg/computeruse/computeruse.go
+++ b/libs/computer-use/pkg/computeruse/computeruse.go
@@ -6,6 +6,7 @@ package computeruse
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,8 +31,8 @@ type Process struct {
 	ErrFile     string
 	AutoRestart bool
 	cmd         *exec.Cmd
-	ctx         context.Context
 	cancel      context.CancelFunc
+	done        chan struct{}
 	mu          sync.Mutex
 	running     bool
 }
@@ -55,6 +56,10 @@ type ComputerUse struct {
 }
 
 var _ computeruse.IComputerUse = &ComputerUse{}
+
+// Keep the existing restart delay named instead of embedding timing constants
+// inside the supervisor loop.
+const defaultProcessRestartDelay = 5 * time.Second
 
 func (c *ComputerUse) Initialize() (*computeruse.Empty, error) {
 	c.processes = make(map[string]*Process)
@@ -353,80 +358,110 @@ func (c *ComputerUse) startProcess(process *Process) {
 		process.mu.Unlock()
 		return
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	process.cancel = cancel
+	process.done = done
 	process.running = true
 	process.mu.Unlock()
 
+	defer func() {
+		process.mu.Lock()
+		process.cancel = nil
+		process.done = nil
+		process.cmd = nil
+		process.running = false
+		process.mu.Unlock()
+		close(done)
+	}()
+
 	for {
-		log.Infof("Starting process: %s", process.Name)
-
-		// Create context for the process
-		process.ctx, process.cancel = context.WithCancel(context.Background())
-
-		// Create command
-		process.cmd = exec.CommandContext(process.ctx, process.Command, process.Args...)
-
-		// Set environment variables
-		if len(process.Env) > 0 {
-			process.cmd.Env = os.Environ()
-			for key, value := range process.Env {
-				process.cmd.Env = append(process.cmd.Env, fmt.Sprintf("%s=%s", key, value))
-			}
+		if ctx.Err() != nil {
+			return
 		}
 
-		// Set up logging
-		if process.LogFile != "" {
-			logFile, err := os.OpenFile(process.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-			if err != nil {
-				log.Errorf("Failed to open log file for %s: %v", process.Name, err)
-			} else {
-				process.cmd.Stdout = logFile
-				defer logFile.Close()
-			}
-		}
-
-		if process.ErrFile != "" {
-			errFile, err := os.OpenFile(process.ErrFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-			if err != nil {
-				log.Errorf("Failed to open error file for %s: %v", process.Name, err)
-			} else {
-				process.cmd.Stderr = errFile
-				defer errFile.Close()
-			}
-		}
-
-		// Start the process
-		err := process.cmd.Start()
-		if err != nil {
-			log.Errorf("Failed to start process %s: %v", process.Name, err)
-			if !process.AutoRestart {
-				break
-			}
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
-		log.Infof("Process %s started with PID: %d", process.Name, process.cmd.Process.Pid)
-
-		// Wait for the process to finish
-		err = process.cmd.Wait()
+		err := c.runProcessOnce(ctx, process)
 		if err != nil {
 			log.Errorf("Process %s exited with error: %v", process.Name, err)
 		} else {
 			log.Infof("Process %s exited normally", process.Name)
 		}
 
-		// Check if we should restart
 		if !process.AutoRestart {
-			break
+			return
 		}
 
-		log.Infof("Restarting process %s in 5 seconds...", process.Name)
-		time.Sleep(5 * time.Second)
+		log.Infof("Restarting process %s in %s...", process.Name, defaultProcessRestartDelay)
+		timer := time.NewTimer(defaultProcessRestartDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (c *ComputerUse) runProcessOnce(ctx context.Context, process *Process) error {
+	log.Infof("Starting process: %s", process.Name)
+
+	cmd := exec.CommandContext(ctx, process.Command, process.Args...)
+
+	if len(process.Env) > 0 {
+		cmd.Env = os.Environ()
+		for key, value := range process.Env {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
+	if process.LogFile != "" {
+		logFile, err := os.OpenFile(process.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			log.Errorf("Failed to open log file for %s: %v", process.Name, err)
+		} else {
+			cmd.Stdout = logFile
+			defer closeProcessFile(process.Name, "log", logFile)
+		}
+	}
+
+	if process.ErrFile != "" {
+		errFile, err := os.OpenFile(process.ErrFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			log.Errorf("Failed to open error file for %s: %v", process.Name, err)
+		} else {
+			cmd.Stderr = errFile
+			defer closeProcessFile(process.Name, "error", errFile)
+		}
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start process %s: %w", process.Name, err)
 	}
 
 	process.mu.Lock()
-	process.running = false
+	if ctx.Err() != nil {
+		process.mu.Unlock()
+		_ = cmd.Wait()
+		return ctx.Err()
+	}
+	process.cmd = cmd
 	process.mu.Unlock()
+
+	log.Infof("Process %s started with PID: %d", process.Name, cmd.Process.Pid)
+
+	err := cmd.Wait()
+	process.mu.Lock()
+	if process.cmd == cmd {
+		process.cmd = nil
+	}
+	process.mu.Unlock()
+	return err
+}
+
+func closeProcessFile(processName, fileKind string, file io.Closer) {
+	if err := file.Close(); err != nil {
+		log.Errorf("Failed to close %s file for %s: %v", fileKind, processName, err)
+	}
 }
 
 func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
@@ -439,10 +474,16 @@ func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
 	}
 	c.mu.RUnlock()
 
+	var stopErr error
 	// Stop processes in reverse priority order
 	for i := len(processes) - 1; i >= 0; i-- {
 		process := processes[i]
-		c.stopProcess(process)
+		if err := c.stopProcess(process); err != nil {
+			log.Errorf("Failed to stop process %s: %v", process.Name, err)
+			if stopErr == nil {
+				stopErr = fmt.Errorf("failed to stop process %s: %w", process.Name, err)
+			}
+		}
 	}
 
 	// Release the cached AT-SPI bus connection so a later Start() dials a
@@ -455,33 +496,33 @@ func (c *ComputerUse) Stop() (*computeruse.Empty, error) {
 	c.atspiMu.Unlock()
 	c.setA11yStatus(false)
 
-	return new(computeruse.Empty), nil
+	return new(computeruse.Empty), stopErr
 }
 
-func (c *ComputerUse) stopProcess(process *Process) {
+func (c *ComputerUse) stopProcess(process *Process) error {
 	process.mu.Lock()
-	defer process.mu.Unlock()
 
 	if !process.running {
-		return
+		process.mu.Unlock()
+		return nil
 	}
 
 	log.Infof("Stopping process: %s", process.Name)
-
-	// Cancel the context to stop the process
-	if process.cancel != nil {
-		process.cancel()
+	cancel := process.cancel
+	done := process.done
+	if cancel != nil {
+		cancel()
 	}
+	process.mu.Unlock()
 
-	// Kill the process if it's still running
-	if process.cmd != nil && process.cmd.Process != nil {
-		err := process.cmd.Process.Kill()
-		if err != nil {
-			log.Errorf("Failed to kill process %s: %v", process.Name, err)
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			return fmt.Errorf("timed out waiting for process %s supervisor to stop", process.Name)
 		}
 	}
-
-	process.running = false
+	return nil
 }
 
 func (c *ComputerUse) GetProcessStatus() (map[string]computeruse.ProcessStatus, error) {
@@ -553,13 +594,10 @@ func (c *ComputerUse) RestartProcess(req *computeruse.ProcessRequest) (*computer
 		return nil, fmt.Errorf("process %s not found", req.ProcessName)
 	}
 
-	// Stop the process first
-	c.stopProcess(process)
+	if err := c.stopProcess(process); err != nil {
+		return nil, err
+	}
 
-	// Wait a moment for cleanup
-	time.Sleep(1 * time.Second)
-
-	// Start the process again
 	go c.startProcess(process)
 
 	return new(computeruse.Empty), nil

--- a/libs/computer-use/pkg/computeruse/process_supervisor_test.go
+++ b/libs/computer-use/pkg/computeruse/process_supervisor_test.go
@@ -1,0 +1,229 @@
+// Copyright Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+//go:build unix
+
+package computeruse
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	toolbox "github.com/daytonaio/daemon/pkg/toolbox/computeruse"
+)
+
+func TestRunProcessOnceClosesLogFilesEachRun(t *testing.T) {
+	restoreFileLimit := lowerOpenFileLimit(t, 64)
+	defer restoreFileLimit()
+
+	computerUse := &ComputerUse{}
+	process := helperProcess(t, "exit")
+
+	// Each run opens stdout and stderr log files. With the old supervisor leak,
+	// 80 runs would leave 160 extra descriptors open and hit this lowered limit.
+
+	for i := 0; i < 80; i++ {
+		if err := computerUse.runProcessOnce(context.Background(), process); err != nil {
+			t.Fatalf("runProcessOnce() iteration %d error = %v", i+1, err)
+		}
+	}
+}
+
+func TestStopProcessWaitsForSupervisorExit(t *testing.T) {
+	computerUse := &ComputerUse{}
+	process := helperProcess(t, "block")
+
+	go computerUse.startProcess(process)
+	t.Cleanup(func() { _ = computerUse.stopProcess(process) })
+	waitForProcessPID(t, process, 5*time.Second)
+
+	if err := computerUse.stopProcess(process); err != nil {
+		t.Fatalf("stopProcess() error = %v", err)
+	}
+	assertProcessStopped(t, process)
+}
+
+func TestStopProcessInterruptsRestartBackoff(t *testing.T) {
+	computerUse := &ComputerUse{}
+	process := helperProcess(t, "short")
+
+	go computerUse.startProcess(process)
+	t.Cleanup(func() { _ = computerUse.stopProcess(process) })
+	waitForRestartBackoff(t, process, 5*time.Second)
+
+	startedAt := time.Now()
+	if err := computerUse.stopProcess(process); err != nil {
+		t.Fatalf("stopProcess() error = %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("stopProcess() took %s, want it to interrupt restart delay", elapsed)
+	}
+	assertProcessStopped(t, process)
+}
+
+func TestRestartProcessWaitsForOldSupervisor(t *testing.T) {
+	computerUse := &ComputerUse{processes: make(map[string]*Process)}
+	process := helperProcess(t, "block")
+	computerUse.processes[process.Name] = process
+
+	go computerUse.startProcess(process)
+	t.Cleanup(func() { _ = computerUse.stopProcess(process) })
+	oldPID := waitForProcessPID(t, process, 5*time.Second)
+
+	_, err := computerUse.RestartProcess(&toolbox.ProcessRequest{ProcessName: process.Name})
+	if err != nil {
+		t.Fatalf("RestartProcess() error = %v", err)
+	}
+
+	newPID := waitForDifferentProcessPID(t, process, oldPID, 5*time.Second)
+	if newPID == oldPID {
+		t.Fatalf("process PID after restart = %d, want a new PID", newPID)
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_COMPUTER_USE_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stdout, "stdout")
+	fmt.Fprintln(os.Stderr, "stderr")
+	switch os.Getenv("GO_COMPUTER_USE_HELPER_MODE") {
+	case "block":
+		time.Sleep(time.Minute)
+	case "short":
+		time.Sleep(100 * time.Millisecond)
+	}
+	os.Exit(0)
+}
+
+func helperProcess(t *testing.T, mode string) *Process {
+	t.Helper()
+
+	dir := t.TempDir()
+	return &Process{
+		Name:        "helper",
+		Command:     os.Args[0],
+		Args:        []string{"-test.run=TestHelperProcess"},
+		AutoRestart: true,
+		Env: map[string]string{
+			"GO_WANT_COMPUTER_USE_HELPER_PROCESS": "1",
+			"GO_COMPUTER_USE_HELPER_MODE":         mode,
+		},
+		LogFile: filepath.Join(dir, "helper.log"),
+		ErrFile: filepath.Join(dir, "helper.err"),
+	}
+}
+
+func lowerOpenFileLimit(t *testing.T, fdHeadroom uint64) func() {
+	t.Helper()
+
+	var old syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &old); err != nil {
+		t.Skipf("cannot read file descriptor limit: %v", err)
+	}
+
+	openFDs, err := os.ReadDir("/dev/fd")
+	if err != nil {
+		t.Skipf("cannot count open file descriptors: %v", err)
+	}
+
+	target := uint64(len(openFDs)) + fdHeadroom
+	if target < 128 {
+		target = 128
+	}
+	if old.Cur <= target {
+		return func() {}
+	}
+
+	next := old
+	next.Cur = target
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &next); err != nil {
+		t.Skipf("cannot lower file descriptor limit: %v", err)
+	}
+
+	return func() {
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &old); err != nil {
+			t.Errorf("failed to restore file descriptor limit: %v", err)
+		}
+	}
+}
+
+func waitForProcessPID(t *testing.T, process *Process, timeout time.Duration) int {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pid := processPID(process); pid > 0 {
+			return pid
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("process did not start")
+	return 0
+}
+
+func waitForRestartBackoff(t *testing.T, process *Process, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	sawChild := false
+	for time.Now().Before(deadline) {
+		process.mu.Lock()
+		running := process.running
+		cmd := process.cmd
+		process.mu.Unlock()
+		if cmd != nil {
+			sawChild = true
+		}
+		if sawChild && running && cmd == nil {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("process did not enter restart backoff")
+}
+
+func waitForDifferentProcessPID(t *testing.T, process *Process, oldPID int, timeout time.Duration) int {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pid := processPID(process); pid > 0 && pid != oldPID {
+			return pid
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("process did not restart with a new PID; old PID = %d", oldPID)
+	return 0
+}
+
+func processPID(process *Process) int {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+
+	if !process.running || process.cmd == nil || process.cmd.Process == nil {
+		return 0
+	}
+	return process.cmd.Process.Pid
+}
+
+func assertProcessStopped(t *testing.T, process *Process) {
+	t.Helper()
+
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	if process.running {
+		t.Fatal("process is still marked running")
+	}
+	if process.cmd != nil {
+		t.Fatal("process command was not cleared")
+	}
+	if process.done != nil {
+		t.Fatal("process done channel was not cleared")
+	}
+}


### PR DESCRIPTION
## Description

Fixes a file descriptor leak in the computer-use process supervisor.

The supervisor opens stdout and stderr log files for each supervised desktop process run. For auto-restarting processes, those files were opened inside the long-lived restart loop and closed with `defer`, so they stayed open until the supervisor goroutine exited. A process that restarted repeatedly could keep accumulating stale log file descriptors.

This change moves one process run into a helper scope so stdout/stderr log files are closed after each `cmd.Wait()` before the next restart iteration begins.

It also makes `stopProcess` wait for the supervisor goroutine to exit before returning. That keeps restarts ordered and prevents the old supervisor loop from racing the replacement process.

## Validation

- Added unit coverage for per-restart log/error file closure.
- Added unit coverage that stopping a process prevents another auto-restart.
- Added unit coverage that `RestartProcess` waits for the old supervisor before starting the replacement.
- `nix develop .#go --command go test ./libs/computer-use/pkg/computeruse -count=1`
- `nix develop .#go --command go test -race ./libs/computer-use/pkg/computeruse -count=1`

## Live verification

Verified against a hosted Daytona sandbox with a branch-built computer-use plugin:

- Before `/computeruse/start`: plugin had 12 FDs.
- After `/computeruse/start`: plugin had 26 FDs.
- After 12 calls to restart `x11vnc`: plugin still had 26 FDs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783523903&installation_id=132266156&pr_number=4949&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4949&signature=3987cec686a4bc706e24165632a38679628e85c5f4447f813a8aa48b91690659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->