### PR TITLE
feat(dashboard): show warning for missing permissions instead of redi…

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -188,7 +188,7 @@ function AccessRequiredPage({ pageTitle, requiredAccess }: { pageTitle: ReactNod
               <ShieldAlert />
             </EmptyMedia>
             <EmptyTitle>You don&apos;t have access to this page</EmptyTitle>
-            <EmptyDescription>Ask your organization administrator to grant you the required access.</EmptyDescription>
+            <EmptyDescription>Ask your organization owner to grant you the required access.</EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
             <div className="text-xs font-medium text-muted-foreground">Required access</div>

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import { SelectedOrganizationProvider } from '@/providers/SelectedOrganizationPr
 import { UserOrganizationInvitationsProvider } from '@/providers/UserOrganizationInvitationsProvider'
 import { initPylon } from '@/vendor/pylon'
 import { OrganizationRolePermissionsEnum, OrganizationUserRoleEnum } from '@daytona/api-client'
+import { ShieldAlert } from 'lucide-react'
 import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react'
 import { Suspense, useEffect, type ReactNode } from 'react'
 import { useAuth } from 'react-oidc-context'
@@ -28,6 +29,8 @@ import { CommandPaletteProvider } from './components/CommandPalette'
 import { ErrorBoundaryFallback } from './components/ErrorBoundaryFallback'
 import LoadingFallback from './components/LoadingFallback'
 import { LoadingFallbackContent } from './components/LoadingFallbackContent'
+import { PageContent, PageHeader, PageIntro, PageLayout } from './components/PageLayout'
+import { Badge } from './components/ui/badge'
 import { Button } from './components/ui/button'
 import {
   Dialog,
@@ -37,6 +40,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from './components/ui/dialog'
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './components/ui/empty'
 import { DAYTONA_DOCS_URL, DAYTONA_SLACK_URL } from './constants/ExternalLinks'
 import { FeatureFlags } from './enums/FeatureFlags'
 import { getRouteSubPath, RoutePath, trimLeadingSlash } from './enums/RoutePath'
@@ -168,11 +172,45 @@ function DashboardIndexRedirect() {
   return <Navigate to={`${getRouteSubPath(RoutePath.SANDBOXES)}${location.search}`} replace />
 }
 
-function OwnerAccessOrganizationPageWrapper({ children }: { children: ReactNode }) {
+function getAccessLabel(access: string) {
+  return access.replace(/[:_-]+/g, ' ').toLowerCase()
+}
+
+function AccessRequiredPage({ pageTitle, requiredAccess }: { pageTitle: ReactNode; requiredAccess: string[] }) {
+  return (
+    <PageLayout>
+      <PageHeader />
+      <PageContent>
+        <PageIntro title={pageTitle} />
+        <Empty className="flex-none rounded-md border py-12" variant="warning">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <ShieldAlert />
+            </EmptyMedia>
+            <EmptyTitle>You don&apos;t have access to this page</EmptyTitle>
+            <EmptyDescription>Ask your organization administrator to grant you the required access.</EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <div className="text-xs font-medium text-muted-foreground">Required access</div>
+            <div className="flex flex-wrap justify-center gap-2">
+              {requiredAccess.map((access) => (
+                <Badge key={access} className="capitalize" title={access}>
+                  {getAccessLabel(access)}
+                </Badge>
+              ))}
+            </div>
+          </EmptyContent>
+        </Empty>
+      </PageContent>
+    </PageLayout>
+  )
+}
+
+function OwnerAccessOrganizationPageWrapper({ children, pageTitle }: { children: ReactNode; pageTitle: ReactNode }) {
   const { authenticatedUserOrganizationMember } = useSelectedOrganization()
 
   if (authenticatedUserOrganizationMember?.role !== OrganizationUserRoleEnum.OWNER) {
-    return <Navigate to={RoutePath.DASHBOARD} replace />
+    return <AccessRequiredPage pageTitle={pageTitle} requiredAccess={['owner role']} />
   }
 
   return children
@@ -180,15 +218,20 @@ function OwnerAccessOrganizationPageWrapper({ children }: { children: ReactNode 
 
 function RequiredPermissionsOrganizationPageWrapper({
   children,
+  pageTitle,
   requiredPermissions,
 }: {
   children: ReactNode
+  pageTitle: ReactNode
   requiredPermissions: OrganizationRolePermissionsEnum[]
 }) {
   const { authenticatedUserHasPermission } = useSelectedOrganization()
+  const missingPermissions = requiredPermissions.filter((permission) => {
+    return !authenticatedUserHasPermission(permission)
+  })
 
-  if (!requiredPermissions.every((permission) => authenticatedUserHasPermission(permission))) {
-    return <Navigate to={RoutePath.DASHBOARD} replace />
+  if (missingPermissions.length > 0) {
+    return <AccessRequiredPage pageTitle={pageTitle} requiredAccess={missingPermissions} />
   }
 
   return children
@@ -204,21 +247,23 @@ function RequiredFeatureFlagWrapper({ children, flagKey }: { children: ReactNode
   return children
 }
 
-function OwnerAccessOrganizationOutlet() {
+function OwnerAccessOrganizationOutlet({ pageTitle }: { pageTitle: ReactNode }) {
   return (
-    <OwnerAccessOrganizationPageWrapper>
+    <OwnerAccessOrganizationPageWrapper pageTitle={pageTitle}>
       <Outlet />
     </OwnerAccessOrganizationPageWrapper>
   )
 }
 
 function RequiredPermissionsOrganizationOutlet({
+  pageTitle,
   requiredPermissions,
 }: {
+  pageTitle: ReactNode
   requiredPermissions: OrganizationRolePermissionsEnum[]
 }) {
   return (
-    <RequiredPermissionsOrganizationPageWrapper requiredPermissions={requiredPermissions}>
+    <RequiredPermissionsOrganizationPageWrapper pageTitle={pageTitle} requiredPermissions={requiredPermissions}>
       <Outlet />
     </RequiredPermissionsOrganizationPageWrapper>
   )
@@ -242,7 +287,7 @@ function BillingEnabledOutlet() {
   return <Outlet />
 }
 
-function BillingOwnerAccessOutlet() {
+function BillingOwnerAccessOutlet({ pageTitle }: { pageTitle: ReactNode }) {
   const config = useConfig()
 
   if (!config.billingApiUrl) {
@@ -250,7 +295,7 @@ function BillingOwnerAccessOutlet() {
   }
 
   return (
-    <OwnerAccessOrganizationPageWrapper>
+    <OwnerAccessOrganizationPageWrapper pageTitle={pageTitle}>
       <Outlet />
     </OwnerAccessOrganizationPageWrapper>
   )
@@ -259,7 +304,10 @@ function BillingOwnerAccessOutlet() {
 function RunnersAccessOutlet() {
   return (
     <RequiredFeatureFlagWrapper flagKey={FeatureFlags.ORGANIZATION_INFRASTRUCTURE}>
-      <RequiredPermissionsOrganizationPageWrapper requiredPermissions={[OrganizationRolePermissionsEnum.READ_RUNNERS]}>
+      <RequiredPermissionsOrganizationPageWrapper
+        pageTitle="Runners"
+        requiredPermissions={[OrganizationRolePermissionsEnum.READ_RUNNERS]}
+      >
         <Outlet />
       </RequiredPermissionsOrganizationPageWrapper>
     </RequiredFeatureFlagWrapper>
@@ -298,6 +346,7 @@ const router = createBrowserRouter([
             path: getRouteSubPath(RoutePath.VOLUMES),
             element: (
               <RequiredPermissionsOrganizationOutlet
+                pageTitle="Volumes"
                 requiredPermissions={[OrganizationRolePermissionsEnum.READ_VOLUMES]}
               />
             ),
@@ -305,17 +354,17 @@ const router = createBrowserRouter([
           },
           {
             path: getRouteSubPath(RoutePath.LIMITS),
-            element: <OwnerAccessOrganizationOutlet />,
+            element: <OwnerAccessOrganizationOutlet pageTitle="Limits" />,
             children: [{ index: true, lazy: lazyRoutes.Limits }],
           },
           {
             path: getRouteSubPath(RoutePath.BILLING_SPENDING),
-            element: <BillingOwnerAccessOutlet />,
+            element: <BillingOwnerAccessOutlet pageTitle="Spending" />,
             children: [{ index: true, lazy: lazyRoutes.Spending }],
           },
           {
             path: getRouteSubPath(RoutePath.BILLING_WALLET),
-            element: <BillingOwnerAccessOutlet />,
+            element: <BillingOwnerAccessOutlet pageTitle="Wallet" />,
             children: [{ index: true, lazy: lazyRoutes.Wallet }],
           },
           {
@@ -328,6 +377,7 @@ const router = createBrowserRouter([
             path: getRouteSubPath(RoutePath.AUDIT_LOGS),
             element: (
               <RequiredPermissionsOrganizationOutlet
+                pageTitle="Audit Logs"
                 requiredPermissions={[OrganizationRolePermissionsEnum.READ_AUDIT_LOGS]}
               />
             ),

--- a/apps/dashboard/src/components/ui/empty.tsx
+++ b/apps/dashboard/src/components/ui/empty.tsx
@@ -43,7 +43,7 @@ const emptyMediaVariants = cva(
     variants: {
       variant: {
         default: 'bg-transparent',
-        icon: "bg-muted text-foreground flex size-8 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-4",
+        icon: "text-current flex size-8 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-4 [background:color-mix(in_srgb,currentColor,transparent_90%)]",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
…rect

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783530743&installation_id=132266156&pr_number=4950&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4950&signature=7c163eaf2ec71adb8f54fb7aa2d12bef8ec5253b6863287a8f3a0549e1bc6a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an “Access required” page instead of redirecting when users lack permissions or the owner role. This keeps users on the requested page and clearly lists what access is missing.

- **New Features**
  - Added `AccessRequiredPage` using `PageLayout` and `Empty` (warning) with a `ShieldAlert` icon, clear copy, and readable badges for missing access.
  - Updated organization wrappers to show the warning for missing owner role or permissions; billing pages still redirect if billing is disabled.
  - Passed `pageTitle` through outlets for Volumes, Limits, Billing (Spending/Wallet), Audit Logs, and Runners.

- **Refactors**
  - Tweaked `Empty` icon variant styling to use a currentColor-tinted background for better contrast.

<sup>Written for commit b3cb13b99dd3d55b80ba5c97ee261993734acbfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



