### PR TITLE
fix(cli): organization create failing due to regionId issue

### DIFF
--- a/apps/cli/cmd/organization/create.go
+++ b/apps/cli/cmd/organization/create.go
@@ -5,7 +5,9 @@ package organization
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/charmbracelet/huh"
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/config"
 	"github.com/daytonaio/daytona/cli/views/common"
@@ -13,6 +15,8 @@ import (
 	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
 	"github.com/spf13/cobra"
 )
+
+var regionFlag string
 
 var CreateCmd = &cobra.Command{
 	Use:   "create [ORGANIZATION_NAME]",
@@ -26,8 +30,54 @@ var CreateCmd = &cobra.Command{
 			return err
 		}
 
+		regions, res, err := apiClient.RegionsAPI.ListSharedRegions(ctx).Execute()
+		if err != nil {
+			return apiclient_cli.HandleErrorResponse(res, err)
+		}
+
+		var chosenRegion *apiclient.Region
+		switch {
+		case regionFlag != "":
+			chosenRegion, err = resolveRegion(regions, regionFlag)
+			if err != nil {
+				return err
+			}
+		case len(regions) == 0:
+			return fmt.Errorf("no shared regions available; contact your administrator")
+		case len(regions) == 1:
+			chosenRegion = &regions[0]
+		default:
+			var chosenRegionId string
+			var regionOptions []huh.Option[string]
+
+			for _, region := range regions {
+				regionOptions = append(regionOptions, huh.NewOption(region.Name, region.Id))
+			}
+
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewSelect[string]().
+						Title("Choose a Region").
+						Options(
+							regionOptions...,
+						).
+						Value(&chosenRegionId),
+				).WithTheme(common.GetCustomTheme()),
+			)
+
+			if err := form.Run(); err != nil {
+				return err
+			}
+
+			chosenRegion, err = resolveRegion(regions, chosenRegionId)
+			if err != nil {
+				return err
+			}
+		}
+
 		createOrganizationDto := apiclient.CreateOrganization{
-			Name: args[0],
+			Name:            args[0],
+			DefaultRegionId: chosenRegion.Id,
 		}
 
 		org, res, err := apiClient.OrganizationsAPI.CreateOrganization(ctx).CreateOrganization(createOrganizationDto).Execute()
@@ -56,4 +106,19 @@ var CreateCmd = &cobra.Command{
 		common.RenderInfoMessageBold("Your organization has been created and its approval is pending\nOur team has been notified and will set up your resource quotas shortly")
 		return nil
 	},
+}
+
+// resolveRegion picks a region from the list whose Id or Name matches identifier.
+// Pure function  no I/O.
+func resolveRegion(regions []apiclient.Region, identifier string) (*apiclient.Region, error) {
+	for _, region := range regions {
+		if region.Id == identifier || region.Name == identifier {
+			return &region, nil
+		}
+	}
+	return nil, fmt.Errorf("region %q not found", identifier)
+}
+
+func init() {
+	CreateCmd.Flags().StringVarP(&regionFlag, "region", "r", "", "Default region (id or name) for the organization")
 }

--- a/apps/cli/cmd/organization/create_test.go
+++ b/apps/cli/cmd/organization/create_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package organization
+
+import (
+	"testing"
+
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+)
+
+func TestResolveRegion(t *testing.T) {
+	regions := []apiclient.Region{
+		{Id: "abc-123", Name: "us"},
+		{Id: "def-456", Name: "eu"},
+	}
+
+	tests := []struct {
+		name       string
+		identifier string
+		wantId     string
+		wantErr    bool
+	}{
+		{name: "match by id", identifier: "abc-123", wantId: "abc-123"},
+		{name: "match by name", identifier: "eu", wantId: "def-456"},
+		{name: "no match returns error", identifier: "nonexistent", wantErr: true},
+		{name: "empty identifier returns error", identifier: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRegion(regions, tt.identifier)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveRegion(%q) expected error, got nil", tt.identifier)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveRegion(%q) unexpected error: %v", tt.identifier, err)
+			}
+			if got == nil {
+				t.Fatalf("resolveRegion(%q) returned nil region", tt.identifier)
+			}
+			if got.Id != tt.wantId {
+				t.Errorf("resolveRegion(%q) returned id %q, want %q", tt.identifier, got.Id, tt.wantId)
+			}
+		})
+	}
+}

--- a/apps/cli/cmd/organization/create_test.go
+++ b/apps/cli/cmd/organization/create_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Daytona Platforms Inc.
+// Copyright Daytona Platforms Inc.
 // SPDX-License-Identifier: AGPL-3.0
 
 package organization


### PR DESCRIPTION
## Description

The  `daytona organization create $ORG_NAME` command was failing with a fatal error for having no defaultRegionId set. PR #2984 and PR #3112 modified how the behavior of create organization functions and it seems like the CLI was never updated to reflect these changes.

This fix is isolated to a single file and shares compatability with the rest of the repo and some of the other commands in the CLI. A single-region deployments (the most common case, including app.daytona.io for most accounts) work unchanged with the bare daytona organization create <name>, no flag required. The new optional -r flag follows the same package-var-plus-init() registration pattern as volume create's --size/-s flag; the pure resolveRegion helper has a 4-case table-driven unit test matching the existing apiclient/error_handler_test.go pure helpers get a test convention.

## Documentation

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issues caused by #2984 and #3112 

## Screenshots

<img width="1001" height="716" alt="cli-pr-fix" src="https://github.com/user-attachments/assets/7cc1c9e0-d028-4663-a1e3-104ebad97203" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783547548&installation_id=132266156&pr_number=4951&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4951&signature=becfbd9fc2e952933b1d4199e2a33817e43350ed8f26d392f7f16decf2ac4e5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->