### PR TITLE
fix(opencode): make git sync work on slim sandboxes

### DIFF
--- a/images/sandbox-slim/Dockerfile
+++ b/images/sandbox-slim/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     sudo \
     bash \
+    git \
     python3-pip \
     python3-venv \
     ripgrep \

--- a/libs/opencode-plugin/.opencode/plugin/daytona/git/sandbox-git-manager.ts
+++ b/libs/opencode-plugin/.opencode/plugin/daytona/git/sandbox-git-manager.ts
@@ -16,50 +16,57 @@ export class DaytonaSandboxGitManager {
     await this.sandbox.fs.createFolder(this.repoPath, '755')
   }
 
+  private async runGitCommand(command: string): Promise<string> {
+    const result = await this.sandbox.process.executeCommand(command, this.repoPath)
+    const output = result.result.trim()
+
+    if (result.exitCode !== undefined && result.exitCode !== 0) {
+      const installHint = output.includes('git: command not found')
+        ? '\nHint: git is not installed in this sandbox. Rebuild the sandbox image with git installed.'
+        : ''
+      throw new Error(`Git command failed: ${command}\nOutput: ${output || '(no output)'}${installHint}`)
+    }
+
+    return result.result
+  }
+
   async ensureRepo(): Promise<void> {
     await this.ensureDirectory()
-    const isGit = await this.sandbox.process.executeCommand('git rev-parse --is-inside-work-tree', this.repoPath)
-    if (!isGit || isGit.result.trim() !== 'true') {
-      await this.sandbox.process.executeCommand('git init', this.repoPath)
-      await this.sandbox.process.executeCommand('git config user.email "sandbox@example.com"', this.repoPath)
-      await this.sandbox.process.executeCommand('git config user.name "Daytona Sandbox"', this.repoPath)
+    const isGit = await this.runGitCommand(
+      'if [ -e .git ]; then git rev-parse --is-inside-work-tree; else echo false; fi',
+    )
+    if (isGit.trim() !== 'true') {
+      await this.runGitCommand('git init')
+      await this.runGitCommand('git config user.email "sandbox@example.com"')
+      await this.runGitCommand('git config user.name "Daytona Sandbox"')
       logger.info(`Initialized git repo in sandbox at ${this.repoPath}`)
     }
   }
 
   async autoCommit(): Promise<boolean> {
-    try {
-      // Check if there are any changes to commit
-      const statusResult = await this.sandbox.process.executeCommand('git status --porcelain', this.repoPath)
-      if (!statusResult.result.trim()) {
-        logger.info(`No changes to commit in sandbox at ${this.repoPath}`)
-        return false
-      }
-      await this.sandbox.process.executeCommand('git add .', this.repoPath)
-      await this.sandbox.process.executeCommand('git commit -am "Auto-commit from Daytona plugin"', this.repoPath)
-      logger.info(`Auto-committed changes in sandbox at ${this.repoPath}`)
-      return true
-    } catch (err) {
-      logger.error(`Failed to auto-commit in sandbox at ${this.repoPath}: ${err}`)
+    // Check if there are any changes to commit
+    const status = await this.runGitCommand('git status --porcelain')
+    if (!status.trim()) {
+      logger.info(`No changes to commit in sandbox at ${this.repoPath}`)
       return false
     }
+    await this.runGitCommand('git add .')
+    await this.runGitCommand('git commit -am "Auto-commit from Daytona plugin"')
+    logger.info(`Auto-committed changes in sandbox at ${this.repoPath}`)
+    return true
   }
 
   async resetToRemote(branch: string): Promise<void> {
-    try {
-      const result = await this.sandbox.process.executeCommand(`git checkout -B ${branch}`, this.repoPath)
-      logger.info(`Checked out branch '${branch}': ${result.result}`)
-      await this.sandbox.process.executeCommand('git reset --hard', this.repoPath)
-      await this.sandbox.process.executeCommand('git clean -fd', this.repoPath)
-      logger.info('Reset sandbox worktree to pushed state.')
-      const statusResult = await this.sandbox.process.executeCommand('git status --porcelain', this.repoPath)
-      if (statusResult.result.trim()) {
-        logger.warn(`Sandbox has uncommitted changes after reset:\n${statusResult.result}`)
-      } else {
-        logger.info('No uncommitted changes in sandbox after reset.')
-      }
-    } catch (err) {
-      logger.error(`Failed to reset sandbox worktree: ${err}`)
+    const checkout = await this.runGitCommand(`git checkout -B ${branch}`)
+    logger.info(`Checked out branch '${branch}': ${checkout}`)
+    await this.runGitCommand('git reset --hard')
+    await this.runGitCommand('git clean -fd')
+    logger.info('Reset sandbox worktree to pushed state.')
+    const status = await this.runGitCommand('git status --porcelain')
+    if (status.trim()) {
+      logger.warn(`Sandbox has uncommitted changes after reset:\n${status}`)
+    } else {
+      logger.info('No uncommitted changes in sandbox after reset.')
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `git` to the slim sandbox image so OpenCode git sync works with the default slim sandbox.
- Make sandbox git commands fail loudly on non-zero exit codes instead of logging command output as successful progress.
- Include an actionable hint when git is missing from a sandbox.

Fixes #4437

## Test plan
- `git diff --check`
- IDE lints on edited files: no errors
- Not run: `npx nx run opencode-plugin:type-check` and `npx nx run opencode-plugin:build` because npm cache writes are blocked in this environment
- Not run: sandbox-slim Docker build because Docker is not installed in this environment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783568900&installation_id=132266156&pr_number=4952&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4952&signature=9affc0eb8622167af98cbc09c0120ef961efb40db4bb658efeb71dd63acdd204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OpenCode git sync work on slim sandboxes by installing `git` and enforcing strict error handling for sandbox git commands. This prevents silent failures and makes sync reliable.

- **Bug Fixes**
  - Add `git` to the `sandbox-slim` Docker image.
  - Use a `runGitCommand` helper to check exit codes and surface errors instead of logging false progress.
  - Show a clear hint when `git` is missing in a sandbox.

<sup>Written for commit a779e57f142e69ef2cd9a9fe067119f3f44be5b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

