### PR TITLE
docs: document one-time Homebrew tap trust for the Daytona CLI

### DIFF
--- a/apps/docs/src/content/docs/en/getting-started.mdx
+++ b/apps/docs/src/content/docs/en/getting-started.mdx
@@ -27,6 +27,12 @@ Daytona provides command-line access to core features for interacting with Dayto
 brew install daytonaio/cli/daytona
 ```
 
+Trust the tap once so routine `brew upgrade` keeps the Daytona CLI up to date. Recent Homebrew versions require third-party taps to be explicitly trusted; without it, a bare `brew upgrade` skips the Daytona tap and the CLI goes stale:
+
+```bash
+brew trust daytonaio/cli
+```
+
 To upgrade the Daytona CLI to the latest version:
 
 ```bash

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -24,6 +24,12 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 brew install daytonaio/cli/daytona
 ```
 
+Trust the tap once so routine `brew upgrade` keeps the Daytona CLI up to date. Recent Homebrew versions require third-party taps to be explicitly trusted; without it, a bare `brew upgrade` skips the Daytona tap and the CLI goes stale:
+
+```bash
+brew trust daytonaio/cli
+```
+
 To upgrade the Daytona CLI to the latest version:
 
 ```bash

--- a/apps/docs/tools/update-cli-reference.js
+++ b/apps/docs/tools/update-cli-reference.js
@@ -37,6 +37,12 @@ Install the Daytona CLI to interact with Daytona sandboxes from the command line
 brew install daytonaio/cli/daytona
 \`\`\`
 
+Trust the tap once so routine \`brew upgrade\` keeps the Daytona CLI up to date. Recent Homebrew versions require third-party taps to be explicitly trusted; without it, a bare \`brew upgrade\` skips the Daytona tap and the CLI goes stale:
+
+\`\`\`bash
+brew trust daytonaio/cli
+\`\`\`
+
 To upgrade the Daytona CLI to the latest version:
 
 \`\`\`bash


### PR DESCRIPTION
## What

Documents the one-time `brew trust daytonaio/cli` step alongside the Homebrew install/upgrade commands for the Daytona CLI.

## Why

Recent Homebrew versions require third-party (non-official) taps to be explicitly trusted. Fully-qualified commands such as `brew install daytonaio/cli/daytona` still work, but a routine bare `brew upgrade` now silently skips the Daytona tap:

> Warning: Skipping daytonaio/cli because it is not trusted. Run 'brew trust daytonaio/cli' to trust it.

The installed CLI then goes stale without the user realizing why. Running `brew trust daytonaio/cli` once resolves this so routine `brew upgrade` keeps Daytona current.

## Changes

- `apps/docs/src/content/docs/en/getting-started.mdx` — add the trust step to the CLI (Mac) install block.
- `apps/docs/src/content/docs/en/tools/cli.mdx` — same step in the CLI reference (generated file).
- `apps/docs/tools/update-cli-reference.js` — same step in the generator's `prepend` template, so the generated page stays in sync.

Verified `node tools/update-cli-reference.js --local` reproduces `cli.mdx` with no diff beyond this change (the `pr_checks` sync gate passes).

## Notes (not in this PR)

- The `ja` locale and the bare `brew install` one-liners in guides (`en/mcp.mdx`, Claude/OpenClaw guides) still show install only; the `gt-translate` workflow should carry the `en` change into `ja`.
- Longer term, submitting the formula to homebrew-core would auto-trust it, but that requires building from source rather than the current prebuilt-binary download — left as a follow-up.
- A companion PR updates the tap README in `daytonaio/homebrew-cli`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783580009&installation_id=132266156&pr_number=4953&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4953&signature=9f0a7c836c68034ceae685d8c15447a4678034e69df804ea7ed9eeaf667a9d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-time Homebrew tap trust step to the Daytona CLI install docs so `brew upgrade` keeps the CLI current on newer Homebrew versions. Updated Getting Started, the CLI reference, and the generator template to keep them in sync.

- **Migration**
  - Run `brew trust daytonaio/cli` once so future `brew upgrade` updates the Daytona CLI.

<sup>Written for commit 5541767523f71c9144a422886744c29d09c292e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

