### PR TITLE
chore(e2e): print runner row from db on propagation failure

### DIFF
--- a/.github/workflows/e2e_pr_tests.yaml
+++ b/.github/workflows/e2e_pr_tests.yaml
@@ -173,6 +173,12 @@ jobs:
           echo "Last snapshot response:"
           echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
           echo ""
+          echo "=== Runner DB entry (state inspection) ==="
+          docker compose -f apps/daytona-e2e/docker-compose.e2e.yaml exec -T db \
+            psql -U user -d application_ctx -x -c \
+            'SELECT id, domain, "apiUrl", "proxyUrl", region, name, state, "appVersion", "apiVersion", "lastChecked", unschedulable, draining, "availabilityScore", "currentSnapshotCount", "serviceHealth", "createdAt", "updatedAt" FROM runner;' \
+            2>/dev/null || echo "Failed to query runner table"
+          echo ""
           echo "=== Runner logs (full) ==="
           cat /tmp/runner.log 2>/dev/null || echo "No runner logs found"
           echo ""

--- a/.github/workflows/e2e_pr_tests.yaml
+++ b/.github/workflows/e2e_pr_tests.yaml
@@ -177,7 +177,7 @@ jobs:
           docker compose -f apps/daytona-e2e/docker-compose.e2e.yaml exec -T db \
             psql -U user -d application_ctx -x -c \
             'SELECT id, domain, "apiUrl", "proxyUrl", region, name, state, "appVersion", "apiVersion", "lastChecked", unschedulable, draining, "availabilityScore", "currentSnapshotCount", "serviceHealth", "createdAt", "updatedAt" FROM runner;' \
-            2>/dev/null || echo "Failed to query runner table"
+            || echo "Failed to query runner table"
           echo ""
           echo "=== Runner logs (full) ==="
           cat /tmp/runner.log 2>/dev/null || echo "No runner logs found"


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/daytonaio/codesmith/daytona/pr/4954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584774&installation_id=132266156&pr_number=4954&repository=daytonaio%2Fdaytona&return_to=https%3A%2F%2Fgithub.com%2Fdaytonaio%2Fdaytona%2Fpull%2F4954&signature=0be1b854d2c15660710bc9ea47656d83610a097cad6804d609b06521160dbfba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add DB state inspection to the E2E PR workflow to print the current `runner` row when snapshot propagation fails. This improves failure diagnosis by showing the runner’s state alongside logs.

- **New Features**
  - Prints the `runner` row from `application_ctx` via `psql -x` in the e2e DB container.
  - On query error, logs "Failed to query runner table" and still prints runner logs.

<sup>Written for commit a90b5f121319ff577d6fe085334c05045162feef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

