### PR TITLE
fix(api): scope object-storage push-access ListBucket to caller org prefix

### DIFF
--- a/apps/api/src/docker-registry/controllers/docker-registry.controller.auth.spec.ts
+++ b/apps/api/src/docker-registry/controllers/docker-registry.controller.auth.spec.ts
@@ -57,7 +57,9 @@ describe('[AUTH] DockerRegistryController', () => {
     ])
     expectArrayMatch(getAuthContextGuards(DockerRegistryController, methodName), [OrganizationAuthContextGuard])
     expect(getRequiredOrganizationMemberRole(DockerRegistryController, methodName)).toBeUndefined()
-    expect(getRequiredOrganizationResourcePermissions(DockerRegistryController, methodName)).toBeUndefined()
+    expectArrayMatch(getRequiredOrganizationResourcePermissions(DockerRegistryController, methodName), [
+      OrganizationResourcePermission.WRITE_SNAPSHOTS,
+    ])
   })
 
   it('findOne', () => {

--- a/apps/api/src/docker-registry/controllers/docker-registry.controller.ts
+++ b/apps/api/src/docker-registry/controllers/docker-registry.controller.ts
@@ -107,6 +107,7 @@ export class DockerRegistryController {
 
   @Get('registry-push-access')
   @HttpCode(200)
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_SNAPSHOTS])
   @ApiOperation({
     summary: 'Get temporary registry access for pushing snapshots',
     operationId: 'getTransientPushAccess',

--- a/apps/api/src/object-storage/controllers/object-storage.controller.auth.spec.ts
+++ b/apps/api/src/object-storage/controllers/object-storage.controller.auth.spec.ts
@@ -6,9 +6,11 @@
 import { ObjectStorageController } from './object-storage.controller'
 import { OrganizationAuthContextGuard } from '../../organization/guards/organization-auth-context.guard'
 import { AuthStrategyType } from '../../auth/enums/auth-strategy-type.enum'
+import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
 import {
   getAuthContextGuards,
   getAllowedAuthStrategies,
+  getRequiredOrganizationResourcePermissions,
   expectArrayMatch,
   createCoverageTracker,
   isPublicEndpoint,
@@ -25,5 +27,8 @@ describe('[AUTH] ObjectStorageController', () => {
       AuthStrategyType.JWT,
     ])
     expectArrayMatch(getAuthContextGuards(ObjectStorageController, methodName), [OrganizationAuthContextGuard])
+    expectArrayMatch(getRequiredOrganizationResourcePermissions(ObjectStorageController, methodName), [
+      OrganizationResourcePermission.WRITE_SNAPSHOTS,
+    ])
   })
 })

--- a/apps/api/src/object-storage/controllers/object-storage.controller.ts
+++ b/apps/api/src/object-storage/controllers/object-storage.controller.ts
@@ -14,6 +14,8 @@ import { IsOrganizationAuthContext } from '../../common/decorators/auth-context.
 import { AuthenticatedRateLimitGuard } from '../../common/guards/authenticated-rate-limit.guard'
 import { AuthStrategy } from '../../auth/decorators/auth-strategy.decorator'
 import { AuthStrategyType } from '../../auth/enums/auth-strategy-type.enum'
+import { RequiredOrganizationResourcePermissions } from '../../organization/decorators/required-organization-resource-permissions.decorator'
+import { OrganizationResourcePermission } from '../../organization/enums/organization-resource-permission.enum'
 
 @Controller('object-storage')
 @ApiTags('object-storage')
@@ -28,6 +30,7 @@ export class ObjectStorageController {
 
   @Get('push-access')
   @HttpCode(200)
+  @RequiredOrganizationResourcePermissions([OrganizationResourcePermission.WRITE_SNAPSHOTS])
   @ApiOperation({
     summary: 'Get temporary storage access for pushing objects',
     operationId: 'getPushAccess',

--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -55,11 +55,19 @@ export class ObjectStorageService {
               Action: ['s3:PutObject', 's3:GetObject'],
               Resource: [`arn:aws:s3:::${bucket}/${organizationId}/*`],
             },
-            // ListBucket only shows object keys and some metadata, not the actual objects
+            // ListBucket only shows object keys and some metadata, not the actual objects.
+            // Scope it to the organization's own prefix so a caller cannot enumerate object
+            // keys across other tenants. The CLI lists with prefix=<organizationId> (no trailing
+            // slash), so both the bare org id and the nested prefix must be permitted.
             {
               Effect: 'Allow',
               Action: ['s3:ListBucket'],
               Resource: [`arn:aws:s3:::${bucket}`],
+              Condition: {
+                StringLike: {
+                  's3:prefix': [`${organizationId}`, `${organizationId}/*`],
+                },
+              },
             },
           ],
         },


### PR DESCRIPTION
## What

Scope the `s3:ListBucket` grant in the temporary credentials minted by `GET /object-storage/push-access` to the caller's own organization prefix, rather than the whole bucket.

## Notes

- The CLI lists with `prefix=<organizationId>` (no trailing slash), so the `s3:prefix` condition permits both the bare org id and the nested prefix — existing builds are unaffected.
- The minted session policy intersects with the assuming role's identity policy, so this only narrows access.
