### PR TITLE
fix(api): volumeid path traversal bug fix

### DIFF
--- a/apps/api/src/sandbox/dto/create-sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/create-sandbox.dto.ts
@@ -14,8 +14,9 @@ import {
   IsArray,
   Max,
   Min,
+  ValidateNested,
 } from 'class-validator'
-import { Transform } from 'class-transformer'
+import { Transform, Type } from 'class-transformer'
 import { ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { SandboxVolume } from './sandbox.dto'
 import { CreateBuildInfoDto } from './create-build-info.dto'
@@ -200,6 +201,8 @@ export class CreateSandboxDto {
   })
   @IsOptional()
   @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SandboxVolume)
   volumes?: SandboxVolume[]
 
   @ApiPropertyOptional({

--- a/apps/api/src/sandbox/dto/sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/sandbox.dto.ts
@@ -17,7 +17,8 @@ import { GpuType } from '../enums/gpu-type.enum'
 export class SandboxVolume {
   @ApiProperty({
     description: 'The ID of the volume',
-    example: 'volume123',
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    format: 'uuid',
   })
   // Must be the volume UUID, never a name. This value is forwarded to the runner
   // and used to build the host bind-mount source (/mnt/daytona-volume-<volumeId>);

--- a/apps/api/src/sandbox/dto/sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/sandbox.dto.ts
@@ -5,7 +5,7 @@
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { SandboxState } from '../enums/sandbox-state.enum'
-import { IsEnum, IsOptional } from 'class-validator'
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator'
 import { BackupState } from '../enums/backup-state.enum'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
@@ -19,12 +19,17 @@ export class SandboxVolume {
     description: 'The ID of the volume',
     example: 'volume123',
   })
+  // Must be the volume UUID, never a name. This value is forwarded to the runner
+  // and used to build the host bind-mount source (/mnt/daytona-volume-<volumeId>);
+  // a non-UUID (e.g. a name containing "../") would escape that base path.
+  @IsUUID()
   volumeId: string
 
   @ApiProperty({
     description: 'The mount path for the volume',
     example: '/data',
   })
+  @IsString()
   mountPath: string
 
   @ApiPropertyOptional({
@@ -32,6 +37,8 @@ export class SandboxVolume {
       'Optional subpath within the volume to mount. When specified, only this S3 prefix will be accessible. When omitted, the entire volume is mounted.',
     example: 'users/alice',
   })
+  @IsOptional()
+  @IsString()
   subpath?: string
 }
 

--- a/apps/api/src/sandbox/dto/sandbox.dto.ts
+++ b/apps/api/src/sandbox/dto/sandbox.dto.ts
@@ -5,7 +5,7 @@
 
 import { ApiProperty, ApiPropertyOptional, ApiSchema } from '@nestjs/swagger'
 import { SandboxState } from '../enums/sandbox-state.enum'
-import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator'
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 import { BackupState } from '../enums/backup-state.enum'
 import { Sandbox } from '../entities/sandbox.entity'
 import { SandboxDesiredState } from '../enums/sandbox-desired-state.enum'
@@ -16,14 +16,14 @@ import { GpuType } from '../enums/gpu-type.enum'
 @ApiSchema({ name: 'SandboxVolume' })
 export class SandboxVolume {
   @ApiProperty({
-    description: 'The ID of the volume',
+    description: 'The ID or name of the volume. Resolved to the volume ID on sandbox create.',
     example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-    format: 'uuid',
   })
-  // Must be the volume UUID, never a name. This value is forwarded to the runner
-  // and used to build the host bind-mount source (/mnt/daytona-volume-<volumeId>);
-  // a non-UUID (e.g. a name containing "../") would escape that base path.
-  @IsUUID()
+  // Kept as volumeId (not volumeIdOrName): the schema is shared with responses/storage
+  // where it is always the UUID. SandboxService.resolveVolumes swaps names for UUIDs
+  // before storage/forwarding; the runner rejects non-UUIDs.
+  @IsString()
+  @IsNotEmpty()
   volumeId: string
 
   @ApiProperty({

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -63,7 +63,6 @@ import { OrganizationUsageService } from '../../organization/services/organizati
 import { SshAccess } from '../entities/ssh-access.entity'
 import { SshAccessDto, SshAccessValidationDto } from '../dto/ssh-access.dto'
 import { VolumeService } from './volume.service'
-import { Volume } from '../entities/volume.entity'
 import { PaginatedList } from '../../common/interfaces/paginated-list.interface'
 import {
   SandboxSortFieldDeprecated,
@@ -3214,22 +3213,10 @@ export class SandboxService {
     }
 
     const volumeIdOrNames = volumes.map((volume) => volume.volumeId)
-    const foundVolumes = await this.volumeService.validateVolumes(organizationId, volumeIdOrNames)
-
-    // The batch query result carries no link back to the input entries — index it
-    // so each entry can pick up the ID of the volume it referenced.
-    const volumesById = new Map<string, Volume>()
-    const volumesByName = new Map<string, Volume>()
-    for (const foundVolume of foundVolumes) {
-      volumesById.set(foundVolume.id, foundVolume)
-      volumesByName.set(foundVolume.name, foundVolume)
-    }
+    const foundVolumes = await this.volumeService.getVolumesByIdOrName(organizationId, volumeIdOrNames)
 
     const resolved = volumes.map((volume) => {
-      // UUID-shaped references are IDs, anything else is a name (same rule as snapshots)
-      const matchedVolume = isValidUuid(volume.volumeId)
-        ? volumesById.get(volume.volumeId)
-        : volumesByName.get(volume.volumeId)
+      const matchedVolume = foundVolumes.get(volume.volumeId)
       if (matchedVolume === undefined || !isValidUuid(matchedVolume.id)) {
         throw new BadRequestError(`Volume '${volume.volumeId}' could not be resolved to a valid volume ID`)
       }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -63,6 +63,7 @@ import { OrganizationUsageService } from '../../organization/services/organizati
 import { SshAccess } from '../entities/ssh-access.entity'
 import { SshAccessDto, SshAccessValidationDto } from '../dto/ssh-access.dto'
 import { VolumeService } from './volume.service'
+import { Volume } from '../entities/volume.entity'
 import { PaginatedList } from '../../common/interfaces/paginated-list.interface'
 import {
   SandboxSortFieldDeprecated,
@@ -563,16 +564,14 @@ export class SandboxService {
         pendingGpuIncrement = gpu
       }
 
+      // Resolve volume names to UUIDs before runner assignment, so invalid references fail fast
+      const resolvedVolumes = await this.resolveVolumes(organization.id, createSandboxDto.volumes)
+
       // GPU sandboxes are always ephemeral: they get exclusive ownership of a
       // runner for their lifetime and are auto-deleted on first stop. Skip the
       // warm-pool path entirely so we always provision a fresh container on a
       // currently-unoccupied GPU runner.
-      if (gpu > 0) {
-        const volumeIdOrNames = (createSandboxDto.volumes ?? []).map((v) => v.volumeId)
-        if (volumeIdOrNames.length > 0) {
-          await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
-        }
-      } else if (!linkedSandbox && (!createSandboxDto.volumes || createSandboxDto.volumes.length === 0)) {
+      if (gpu <= 0 && !linkedSandbox && (!createSandboxDto.volumes || createSandboxDto.volumes.length === 0)) {
         const skipWarmPool = (await this.redis.exists(`warm-pool:skip:${snapshot.id}`)) === 1
 
         if (!skipWarmPool) {
@@ -593,9 +592,6 @@ export class SandboxService {
             return await this.assignWarmPoolSandbox(warmPoolSandbox, createSandboxDto, organization)
           }
         }
-      } else if (createSandboxDto.volumes && createSandboxDto.volumes.length > 0) {
-        const volumeIdOrNames = createSandboxDto.volumes.map((v) => v.volumeId)
-        await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
       }
 
       // Serialize GPU runner assignment per region: getRunnersAtGpuCapacity reads
@@ -670,8 +666,8 @@ export class SandboxService {
         sandbox.autoDeleteInterval = createSandboxDto.autoDeleteInterval
       }
 
-      if (createSandboxDto.volumes !== undefined) {
-        sandbox.volumes = this.resolveVolumes(createSandboxDto.volumes)
+      if (resolvedVolumes !== undefined) {
+        sandbox.volumes = resolvedVolumes
       }
 
       sandbox.runnerId = runner.id
@@ -893,10 +889,8 @@ export class SandboxService {
         pendingGpuIncrement = gpu
       }
 
-      if (createSandboxDto.volumes && createSandboxDto.volumes.length > 0) {
-        const volumeIdOrNames = createSandboxDto.volumes.map((v) => v.volumeId)
-        await this.volumeService.validateVolumes(organization.id, volumeIdOrNames)
-      }
+      // Resolve volume names to UUIDs, failing fast on invalid references
+      const resolvedVolumes = await this.resolveVolumes(organization.id, createSandboxDto.volumes)
 
       const sandbox = new Sandbox({ region: region.id, name: createSandboxDto.name })
 
@@ -933,8 +927,8 @@ export class SandboxService {
         sandbox.autoDeleteInterval = createSandboxDto.autoDeleteInterval
       }
 
-      if (createSandboxDto.volumes !== undefined) {
-        sandbox.volumes = this.resolveVolumes(createSandboxDto.volumes)
+      if (resolvedVolumes !== undefined) {
+        sandbox.volumes = resolvedVolumes
       }
 
       if (sandbox.sandboxClass !== SandboxClass.CONTAINER) {
@@ -3209,20 +3203,52 @@ export class SandboxService {
     return networkAllowList
   }
 
-  private resolveVolumes(volumes: SandboxVolume[]): SandboxVolume[] {
+  // Resolves each volumeId (which may be a volume name) to the volume's UUID — the
+  // runner builds a host mount path from this value, so only UUIDs may be stored.
+  private async resolveVolumes(
+    organizationId: string,
+    volumes?: SandboxVolume[],
+  ): Promise<SandboxVolume[] | undefined> {
+    if (volumes === undefined || volumes.length === 0) {
+      return volumes
+    }
+
+    const volumeIdOrNames = volumes.map((volume) => volume.volumeId)
+    const foundVolumes = await this.volumeService.validateVolumes(organizationId, volumeIdOrNames)
+
+    // The batch query result carries no link back to the input entries — index it
+    // so each entry can pick up the ID of the volume it referenced.
+    const volumesById = new Map<string, Volume>()
+    const volumesByName = new Map<string, Volume>()
+    for (const foundVolume of foundVolumes) {
+      volumesById.set(foundVolume.id, foundVolume)
+      volumesByName.set(foundVolume.name, foundVolume)
+    }
+
+    const resolved = volumes.map((volume) => {
+      // UUID-shaped references are IDs, anything else is a name (same rule as snapshots)
+      const matchedVolume = isValidUuid(volume.volumeId)
+        ? volumesById.get(volume.volumeId)
+        : volumesByName.get(volume.volumeId)
+      if (matchedVolume === undefined || !isValidUuid(matchedVolume.id)) {
+        throw new BadRequestError(`Volume '${volume.volumeId}' could not be resolved to a valid volume ID`)
+      }
+      return { ...volume, volumeId: matchedVolume.id }
+    })
+
     try {
-      validateMountPaths(volumes)
+      validateMountPaths(resolved)
     } catch (error) {
       throw new BadRequestError(error instanceof Error ? error.message : 'Invalid volume mount configuration')
     }
 
     try {
-      validateSubpaths(volumes)
+      validateSubpaths(resolved)
     } catch (error) {
       throw new BadRequestError(error instanceof Error ? error.message : 'Invalid volume subpath configuration')
     }
 
-    return volumes
+    return resolved
   }
 
   async createSshAccess(

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -224,7 +224,11 @@ export class VolumeService {
     // The id column is a Postgres uuid — filtering it by a non-UUID string makes the
     // query itself throw, so only UUID-shaped references go into the id filter. Names
     // may also be UUID-shaped, so every reference goes into the name filter.
-    const uuidRefs = volumeIdOrNames.filter((idOrName) => isValidUuid(idOrName))
+    // Postgres compares uuids case-insensitively but the in-memory maps below cannot,
+    // so UUID-shaped references are canonicalized to lowercase here and when matching.
+    const uuidRefs = volumeIdOrNames
+      .filter((idOrName) => isValidUuid(idOrName))
+      .map((idOrName) => idOrName.toLowerCase())
     const where: FindOptionsWhere<Volume>[] = [
       { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
     ]
@@ -243,7 +247,10 @@ export class VolumeService {
 
     const volumes = new Map<string, Volume>()
     for (const idOrName of volumeIdOrNames) {
-      const matchedById = volumesById.get(idOrName)
+      let matchedById: Volume | undefined
+      if (isValidUuid(idOrName)) {
+        matchedById = volumesById.get(idOrName.toLowerCase())
+      }
       const matchedByName = volumesByName.get(idOrName)
       if (matchedById !== undefined && matchedByName !== undefined && matchedById.id !== matchedByName.id) {
         throw new BadRequestError(

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -212,9 +212,9 @@ export class VolumeService {
     return volume
   }
 
-  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<void> {
+  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<Volume[]> {
     if (!volumeIdOrNames.length) {
-      return
+      return []
     }
 
     const volumes = await this.volumeRepository.find({
@@ -239,6 +239,8 @@ export class VolumeService {
         throw new BadRequestError(`Volume '${volume.name}' is not in a ready state. Current state: ${volume.state}`)
       }
     }
+
+    return volumes
   }
 
   async getOrganizationId(params: { id: string } | { name: string; organizationId: string }): Promise<string> {

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -5,12 +5,13 @@
 
 import { ConflictException, Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository, Not, In } from 'typeorm'
+import { Repository, Not, In, FindOptionsWhere } from 'typeorm'
 import { Volume } from '../entities/volume.entity'
 import { VolumeState } from '../enums/volume-state.enum'
 import { CreateVolumeDto } from '../dto/create-volume.dto'
 import { v4 as uuidv4 } from 'uuid'
 import { BadRequestError } from '../../exceptions/bad-request.exception'
+import { isValidUuid } from '../../common/utils/uuid'
 import { Organization } from '../../organization/entities/organization.entity'
 import { OnEvent } from '@nestjs/event-emitter'
 import { SandboxEvents } from '../constants/sandbox-events.constants'
@@ -212,32 +213,61 @@ export class VolumeService {
     return volume
   }
 
-  async validateVolumes(organizationId: string, volumeIdOrNames: string[]): Promise<Volume[]> {
+  // Looks up volumes where each reference may be a volume ID or a volume name, and
+  // returns them keyed by the requested reference. Throws when a reference is unknown,
+  // ambiguous, or points at a volume that is not ready.
+  async getVolumesByIdOrName(organizationId: string, volumeIdOrNames: string[]): Promise<Map<string, Volume>> {
     if (!volumeIdOrNames.length) {
-      return []
+      return new Map()
     }
 
-    const volumes = await this.volumeRepository.find({
-      where: [
-        { id: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
-        { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
-      ],
-    })
+    // The id column is a Postgres uuid — filtering it by a non-UUID string makes the
+    // query itself throw, so only UUID-shaped references go into the id filter. Names
+    // may also be UUID-shaped, so every reference goes into the name filter.
+    const uuidRefs = volumeIdOrNames.filter((idOrName) => isValidUuid(idOrName))
+    const where: FindOptionsWhere<Volume>[] = [
+      { name: In(volumeIdOrNames), organizationId, state: Not(VolumeState.DELETED) },
+    ]
+    if (uuidRefs.length > 0) {
+      where.push({ id: In(uuidRefs), organizationId, state: Not(VolumeState.DELETED) })
+    }
 
-    // Check if all requested volumes were found and are in a READY state
-    const foundIds = new Set(volumes.map((v) => v.id))
-    const foundNames = new Set(volumes.map((v) => v.name))
+    const foundVolumes = await this.volumeRepository.find({ where })
 
+    const volumesById = new Map<string, Volume>()
+    const volumesByName = new Map<string, Volume>()
+    for (const foundVolume of foundVolumes) {
+      volumesById.set(foundVolume.id, foundVolume)
+      volumesByName.set(foundVolume.name, foundVolume)
+    }
+
+    const volumes = new Map<string, Volume>()
     for (const idOrName of volumeIdOrNames) {
-      if (!foundIds.has(idOrName) && !foundNames.has(idOrName)) {
+      const matchedById = volumesById.get(idOrName)
+      const matchedByName = volumesByName.get(idOrName)
+      if (matchedById !== undefined && matchedByName !== undefined && matchedById.id !== matchedByName.id) {
+        throw new BadRequestError(
+          `Volume reference '${idOrName}' matches one volume's ID and another volume's name; rename the volume to remove the ambiguity`,
+        )
+      }
+
+      let matchedVolume: Volume | undefined
+      if (matchedById !== undefined) {
+        matchedVolume = matchedById
+      } else {
+        matchedVolume = matchedByName
+      }
+
+      if (matchedVolume === undefined) {
         throw new NotFoundException(`Volume '${idOrName}' not found`)
       }
-    }
-
-    for (const volume of volumes) {
-      if (volume.state !== VolumeState.READY) {
-        throw new BadRequestError(`Volume '${volume.name}' is not in a ready state. Current state: ${volume.state}`)
+      if (matchedVolume.state !== VolumeState.READY) {
+        throw new BadRequestError(
+          `Volume '${matchedVolume.name}' is not in a ready state. Current state: ${matchedVolume.state}`,
+        )
       }
+
+      volumes.set(idOrName, matchedVolume)
     }
 
     return volumes

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -226,7 +226,7 @@ func init() {
 	CreateCmd.Flags().Int32Var(&autoStopFlag, "auto-stop", 15, "Auto-stop interval in minutes (0 means disabled)")
 	CreateCmd.Flags().Int32Var(&autoArchiveFlag, "auto-archive", 10080, "Auto-archive interval in minutes (0 means the maximum interval will be used)")
 	CreateCmd.Flags().Int32Var(&autoDeleteFlag, "auto-delete", -1, "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)")
-	CreateCmd.Flags().StringArrayVarP(&volumesFlag, "volume", "v", []string{}, "Volumes to mount (format: VOLUME_ID:MOUNT_PATH)")
+	CreateCmd.Flags().StringArrayVarP(&volumesFlag, "volume", "v", []string{}, "Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)")
 	CreateCmd.Flags().StringVarP(&dockerfileFlag, "dockerfile", "f", "", "Path to Dockerfile for Sandbox snapshot")
 	CreateCmd.Flags().StringArrayVarP(&contextFlag, "context", "c", []string{}, "Files or directories to include in the build context (can be specified multiple times)")
 	CreateCmd.Flags().BoolVar(&networkBlockAllFlag, "network-block-all", false, "Whether to block all network access for the sandbox")

--- a/apps/cli/cmd/sandbox/create.go
+++ b/apps/cli/cmd/sandbox/create.go
@@ -226,7 +226,7 @@ func init() {
 	CreateCmd.Flags().Int32Var(&autoStopFlag, "auto-stop", 15, "Auto-stop interval in minutes (0 means disabled)")
 	CreateCmd.Flags().Int32Var(&autoArchiveFlag, "auto-archive", 10080, "Auto-archive interval in minutes (0 means the maximum interval will be used)")
 	CreateCmd.Flags().Int32Var(&autoDeleteFlag, "auto-delete", -1, "Auto-delete interval in minutes (negative value means disabled, 0 means delete immediately upon stopping)")
-	CreateCmd.Flags().StringArrayVarP(&volumesFlag, "volume", "v", []string{}, "Volumes to mount (format: VOLUME_NAME:MOUNT_PATH)")
+	CreateCmd.Flags().StringArrayVarP(&volumesFlag, "volume", "v", []string{}, "Volumes to mount (format: VOLUME_ID:MOUNT_PATH)")
 	CreateCmd.Flags().StringVarP(&dockerfileFlag, "dockerfile", "f", "", "Path to Dockerfile for Sandbox snapshot")
 	CreateCmd.Flags().StringArrayVarP(&contextFlag, "context", "c", []string{}, "Files or directories to include in the build context (can be specified multiple times)")
 	CreateCmd.Flags().BoolVar(&networkBlockAllFlag, "network-block-all", false, "Whether to block all network access for the sandbox")

--- a/apps/cli/cmd/volume/delete.go
+++ b/apps/cli/cmd/volume/delete.go
@@ -6,6 +6,7 @@ package volume
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
@@ -14,7 +15,7 @@ import (
 )
 
 var DeleteCmd = &cobra.Command{
-	Use:     "delete [VOLUME_ID]",
+	Use:     "delete [VOLUME_ID_OR_NAME]",
 	Short:   "Delete a volume",
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("delete"),
@@ -26,7 +27,27 @@ var DeleteCmd = &cobra.Command{
 			return err
 		}
 
-		res, err := apiClient.VolumesAPI.DeleteVolume(ctx, args[0]).Execute()
+		// UUID-shaped arguments are treated as volume IDs first, but volume names
+		// may also be UUID-shaped, so resolve by name when no ID matches. The
+		// fallback only runs when the ID lookup found nothing, so it can never
+		// delete a different volume than the one referenced.
+		if isVolumeId(args[0]) {
+			res, err := apiClient.VolumesAPI.DeleteVolume(ctx, args[0]).Execute()
+			if err == nil {
+				view_common.RenderInfoMessageBold(fmt.Sprintf("Volume %s deleted", args[0]))
+				return nil
+			}
+			if res == nil || res.StatusCode != http.StatusNotFound {
+				return apiclient.HandleErrorResponse(res, err)
+			}
+		}
+
+		vol, res, err := apiClient.VolumesAPI.GetVolumeByName(ctx, args[0]).Execute()
+		if err != nil {
+			return apiclient.HandleErrorResponse(res, err)
+		}
+
+		res, err = apiClient.VolumesAPI.DeleteVolume(ctx, vol.Id).Execute()
 		if err != nil {
 			return apiclient.HandleErrorResponse(res, err)
 		}

--- a/apps/cli/cmd/volume/delete.go
+++ b/apps/cli/cmd/volume/delete.go
@@ -6,7 +6,6 @@ package volume
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
@@ -27,27 +26,12 @@ var DeleteCmd = &cobra.Command{
 			return err
 		}
 
-		// UUID-shaped arguments are treated as volume IDs first, but volume names
-		// may also be UUID-shaped, so resolve by name when no ID matches. The
-		// fallback only runs when the ID lookup found nothing, so it can never
-		// delete a different volume than the one referenced.
-		if isVolumeId(args[0]) {
-			res, err := apiClient.VolumesAPI.DeleteVolume(ctx, args[0]).Execute()
-			if err == nil {
-				view_common.RenderInfoMessageBold(fmt.Sprintf("Volume %s deleted", args[0]))
-				return nil
-			}
-			if res == nil || res.StatusCode != http.StatusNotFound {
-				return apiclient.HandleErrorResponse(res, err)
-			}
-		}
-
-		vol, res, err := apiClient.VolumesAPI.GetVolumeByName(ctx, args[0]).Execute()
+		vol, err := resolveVolume(ctx, apiClient, args[0])
 		if err != nil {
-			return apiclient.HandleErrorResponse(res, err)
+			return err
 		}
 
-		res, err = apiClient.VolumesAPI.DeleteVolume(ctx, vol.Id).Execute()
+		res, err := apiClient.VolumesAPI.DeleteVolume(ctx, vol.Id).Execute()
 		if err != nil {
 			return apiclient.HandleErrorResponse(res, err)
 		}

--- a/apps/cli/cmd/volume/get.go
+++ b/apps/cli/cmd/volume/get.go
@@ -5,29 +5,45 @@ package volume
 
 import (
 	"context"
+	"net/http"
 
-	"github.com/daytonaio/daytona/cli/apiclient"
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/views/volume"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
+// isVolumeId reports whether the argument is a canonical UUID (the length check
+// excludes braced/URN/dashless variants).
+func isVolumeId(arg string) bool {
+	return len(arg) == 36 && uuid.Validate(arg) == nil
+}
+
 var GetCmd = &cobra.Command{
-	Use:     "get [VOLUME_ID]",
+	Use:     "get [VOLUME_ID_OR_NAME]",
 	Short:   "Get volume details",
 	Args:    cobra.ExactArgs(1),
 	Aliases: common.GetAliases("get"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
-		apiClient, err := apiclient.GetApiClient(nil, nil)
+		apiClient, err := apiclient_cli.GetApiClient(nil, nil)
 		if err != nil {
 			return err
 		}
 
-		vol, res, err := apiClient.VolumesAPI.GetVolume(ctx, args[0]).Execute()
+		// UUID-shaped arguments are volume IDs, anything else is a name
+		var vol *apiclient.VolumeDto
+		var res *http.Response
+		if isVolumeId(args[0]) {
+			vol, res, err = apiClient.VolumesAPI.GetVolume(ctx, args[0]).Execute()
+		} else {
+			vol, res, err = apiClient.VolumesAPI.GetVolumeByName(ctx, args[0]).Execute()
+		}
 		if err != nil {
-			return apiclient.HandleErrorResponse(res, err)
+			return apiclient_cli.HandleErrorResponse(res, err)
 		}
 
 		if common.FormatFlag != "" {

--- a/apps/cli/cmd/volume/get.go
+++ b/apps/cli/cmd/volume/get.go
@@ -34,11 +34,15 @@ var GetCmd = &cobra.Command{
 			return err
 		}
 
-		// UUID-shaped arguments are volume IDs, anything else is a name
+		// UUID-shaped arguments are looked up as volume IDs first, but volume names
+		// may also be UUID-shaped, so fall back to a name lookup when no ID matches
 		var vol *apiclient.VolumeDto
 		var res *http.Response
 		if isVolumeId(args[0]) {
 			vol, res, err = apiClient.VolumesAPI.GetVolume(ctx, args[0]).Execute()
+			if err != nil && res != nil && res.StatusCode == http.StatusNotFound {
+				vol, res, err = apiClient.VolumesAPI.GetVolumeByName(ctx, args[0]).Execute()
+			}
 		} else {
 			vol, res, err = apiClient.VolumesAPI.GetVolumeByName(ctx, args[0]).Execute()
 		}

--- a/apps/cli/cmd/volume/get.go
+++ b/apps/cli/cmd/volume/get.go
@@ -5,21 +5,12 @@ package volume
 
 import (
 	"context"
-	"net/http"
 
 	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
 	"github.com/daytonaio/daytona/cli/cmd/common"
 	"github.com/daytonaio/daytona/cli/views/volume"
-	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
-
-// isVolumeId reports whether the argument is a canonical UUID (the length check
-// excludes braced/URN/dashless variants).
-func isVolumeId(arg string) bool {
-	return len(arg) == 36 && uuid.Validate(arg) == nil
-}
 
 var GetCmd = &cobra.Command{
 	Use:     "get [VOLUME_ID_OR_NAME]",
@@ -34,20 +25,9 @@ var GetCmd = &cobra.Command{
 			return err
 		}
 
-		// UUID-shaped arguments are looked up as volume IDs first, but volume names
-		// may also be UUID-shaped, so fall back to a name lookup when no ID matches
-		var vol *apiclient.VolumeDto
-		var res *http.Response
-		if isVolumeId(args[0]) {
-			vol, res, err = apiClient.VolumesAPI.GetVolume(ctx, args[0]).Execute()
-			if err != nil && res != nil && res.StatusCode == http.StatusNotFound {
-				vol, res, err = apiClient.VolumesAPI.GetVolumeByName(ctx, args[0]).Execute()
-			}
-		} else {
-			vol, res, err = apiClient.VolumesAPI.GetVolumeByName(ctx, args[0]).Execute()
-		}
+		vol, err := resolveVolume(ctx, apiClient, args[0])
 		if err != nil {
-			return apiclient_cli.HandleErrorResponse(res, err)
+			return err
 		}
 
 		if common.FormatFlag != "" {

--- a/apps/cli/cmd/volume/resolve.go
+++ b/apps/cli/cmd/volume/resolve.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Daytona Platforms Inc.
+// SPDX-License-Identifier: AGPL-3.0
+
+package volume
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	apiclient_cli "github.com/daytonaio/daytona/cli/apiclient"
+	apiclient "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/google/uuid"
+)
+
+// isVolumeId reports whether the argument is a canonical UUID (the length check
+// excludes braced/URN/dashless variants).
+func isVolumeId(arg string) bool {
+	return len(arg) == 36 && uuid.Validate(arg) == nil
+}
+
+// resolveVolume resolves a VOLUME_ID_OR_NAME argument to a volume. A UUID-shaped
+// argument may be a volume ID or another volume's name, so it is looked up both
+// ways; when the lookups find two different volumes the reference is ambiguous
+// and resolution fails rather than guessing — the same rule the API applies when
+// resolving volume mounts on sandbox create.
+func resolveVolume(ctx context.Context, apiClient *apiclient.APIClient, ref string) (*apiclient.VolumeDto, error) {
+	var idVolume *apiclient.VolumeDto
+	if isVolumeId(ref) {
+		volume, res, err := apiClient.VolumesAPI.GetVolume(ctx, ref).Execute()
+		if err == nil {
+			// Deleted volumes keep their row and stay fetchable by ID; treat them
+			// as not found, the same way the by-name lookup does.
+			if volume.State != apiclient.VOLUMESTATE_DELETED {
+				idVolume = volume
+			}
+		} else if res == nil || res.StatusCode != http.StatusNotFound {
+			return nil, apiclient_cli.HandleErrorResponse(res, err)
+		}
+	}
+
+	nameVolume, nameRes, nameErr := apiClient.VolumesAPI.GetVolumeByName(ctx, ref).Execute()
+	if nameErr != nil && (nameRes == nil || nameRes.StatusCode != http.StatusNotFound) {
+		return nil, apiclient_cli.HandleErrorResponse(nameRes, nameErr)
+	}
+
+	if idVolume != nil && nameErr == nil && idVolume.Id != nameVolume.Id {
+		return nil, fmt.Errorf("volume reference %q matches one volume's ID and another volume's name; rename the volume to remove the ambiguity", ref)
+	}
+	if idVolume != nil {
+		return idVolume, nil
+	}
+	if nameErr == nil {
+		return nameVolume, nil
+	}
+	return nil, apiclient_cli.HandleErrorResponse(nameRes, nameErr)
+}

--- a/apps/cli/docs/daytona_create.md
+++ b/apps/cli/docs/daytona_create.md
@@ -27,7 +27,7 @@ daytona create [flags]
       --snapshot string             Snapshot to use for the sandbox
       --target string               Target region (eu, us)
       --user string                 User associated with the sandbox
-  -v, --volume stringArray          Volumes to mount (format: VOLUME_NAME:MOUNT_PATH)
+  -v, --volume stringArray          Volumes to mount (format: VOLUME_ID:MOUNT_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/apps/cli/docs/daytona_create.md
+++ b/apps/cli/docs/daytona_create.md
@@ -27,7 +27,7 @@ daytona create [flags]
       --snapshot string             Snapshot to use for the sandbox
       --target string               Target region (eu, us)
       --user string                 User associated with the sandbox
-  -v, --volume stringArray          Volumes to mount (format: VOLUME_ID:MOUNT_PATH)
+  -v, --volume stringArray          Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)
 ```
 
 ### Options inherited from parent commands

--- a/apps/cli/docs/daytona_volume_delete.md
+++ b/apps/cli/docs/daytona_volume_delete.md
@@ -3,7 +3,7 @@
 Delete a volume
 
 ```
-daytona volume delete [VOLUME_ID] [flags]
+daytona volume delete [VOLUME_ID_OR_NAME] [flags]
 ```
 
 ### Options inherited from parent commands

--- a/apps/cli/docs/daytona_volume_get.md
+++ b/apps/cli/docs/daytona_volume_get.md
@@ -3,7 +3,7 @@
 Get volume details
 
 ```
-daytona volume get [VOLUME_ID] [flags]
+daytona volume get [VOLUME_ID_OR_NAME] [flags]
 ```
 
 ### Options

--- a/apps/cli/go.mod
+++ b/apps/cli/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.1.0
 	github.com/daytonaio/daytona/libs/api-client-go v0.185.0
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.32.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sirupsen/logrus v1.9.4
@@ -40,7 +41,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/apps/cli/hack/docs/daytona_create.yaml
+++ b/apps/cli/hack/docs/daytona_create.yaml
@@ -61,7 +61,7 @@ options:
   - name: volume
     shorthand: v
     default_value: '[]'
-    usage: 'Volumes to mount (format: VOLUME_ID:MOUNT_PATH)'
+    usage: 'Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH)'
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/daytona_create.yaml
+++ b/apps/cli/hack/docs/daytona_create.yaml
@@ -61,7 +61,7 @@ options:
   - name: volume
     shorthand: v
     default_value: '[]'
-    usage: 'Volumes to mount (format: VOLUME_NAME:MOUNT_PATH)'
+    usage: 'Volumes to mount (format: VOLUME_ID:MOUNT_PATH)'
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/daytona_volume_delete.yaml
+++ b/apps/cli/hack/docs/daytona_volume_delete.yaml
@@ -1,6 +1,6 @@
 name: daytona volume delete
 synopsis: Delete a volume
-usage: daytona volume delete [VOLUME_ID] [flags]
+usage: daytona volume delete [VOLUME_ID_OR_NAME] [flags]
 inherited_options:
   - name: help
     default_value: 'false'

--- a/apps/cli/hack/docs/daytona_volume_get.yaml
+++ b/apps/cli/hack/docs/daytona_volume_get.yaml
@@ -1,6 +1,6 @@
 name: daytona volume get
 synopsis: Get volume details
-usage: daytona volume get [VOLUME_ID] [flags]
+usage: daytona volume get [VOLUME_ID_OR_NAME] [flags]
 options:
   - name: format
     shorthand: f

--- a/apps/docs/src/content/docs/en/go-sdk/types.mdx
+++ b/apps/docs/src/content/docs/en/go-sdk/types.mdx
@@ -615,7 +615,7 @@ VolumeMount represents a volume mount configuration
 
 ```go
 type VolumeMount struct {
-    VolumeID  string
+    VolumeID  string // ID or name of the volume to mount
     MountPath string
     Subpath   *string // Optional subpath within the volume; nil = mount entire volume
 }

--- a/apps/docs/src/content/docs/en/python-sdk/async/async-volume.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/async/async-volume.mdx
@@ -140,7 +140,7 @@ Represents a Volume mount configuration for a Sandbox.
 
 **Attributes**:
 
-- `volume_id` _str_ - ID of the volume to mount.
+- `volume_id` _str_ - ID or name of the volume to mount.
 - `mount_path` _str_ - Path where the volume will be mounted in the sandbox.
 - `subpath` _str | None_ - Optional S3 subpath/prefix within the volume to mount.
   When specified, only this prefix will be accessible. When omitted,

--- a/apps/docs/src/content/docs/en/python-sdk/sync/volume.mdx
+++ b/apps/docs/src/content/docs/en/python-sdk/sync/volume.mdx
@@ -140,7 +140,7 @@ Represents a Volume mount configuration for a Sandbox.
 
 **Attributes**:
 
-- `volume_id` _str_ - ID of the volume to mount.
+- `volume_id` _str_ - ID or name of the volume to mount.
 - `mount_path` _str_ - Path where the volume will be mounted in the sandbox.
 - `subpath` _str | None_ - Optional S3 subpath/prefix within the volume to mount.
   When specified, only this prefix will be accessible. When omitted,

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -132,7 +132,7 @@ __Flags__
 | `--snapshot` |  | Snapshot to use for the sandbox |
 | `--target` |  | Target region (eu, us) |
 | `--user` |  | User associated with the sandbox |
-| `--volume` | `-v` | Volumes to mount (format: VOLUME_NAME:MOUNT_PATH) |
+| `--volume` | `-v` | Volumes to mount (format: VOLUME_ID:MOUNT_PATH) |
 | `--help` |  | help for daytona |
 
 

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -132,7 +132,7 @@ __Flags__
 | `--snapshot` |  | Snapshot to use for the sandbox |
 | `--target` |  | Target region (eu, us) |
 | `--user` |  | User associated with the sandbox |
-| `--volume` | `-v` | Volumes to mount (format: VOLUME_ID:MOUNT_PATH) |
+| `--volume` | `-v` | Volumes to mount (format: VOLUME_ID_OR_NAME:MOUNT_PATH) |
 | `--help` |  | help for daytona |
 
 
@@ -550,7 +550,7 @@ __Flags__
 Get volume details
 
 ```shell
-daytona volume get [VOLUME_ID] [flags]
+daytona volume get [VOLUME_ID_OR_NAME] [flags]
 ```
 
 __Flags__

--- a/apps/docs/src/content/docs/en/tools/cli.mdx
+++ b/apps/docs/src/content/docs/en/tools/cli.mdx
@@ -537,7 +537,7 @@ __Flags__
 Delete a volume
 
 ```shell
-daytona volume delete [VOLUME_ID] [flags]
+daytona volume delete [VOLUME_ID_OR_NAME] [flags]
 ```
 
 __Flags__

--- a/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
+++ b/apps/docs/src/content/docs/en/typescript-sdk/daytona.mdx
@@ -504,7 +504,7 @@ Represents a volume mount for a Sandbox.
     
 - `subpath?` _string_ - Optional subpath within the volume to mount. When specified, only this S3 prefix will be accessible. When omitted, the entire volume is mounted.
     - _Inherited from_: `SandboxVolume.subpath`
-- `volumeId` _string_ - ID of the Volume to mount
+- `volumeId` _string_ - ID or name of the Volume to mount
     
 
 

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -326,7 +326,7 @@ daytona volume create my-awesome-volume
 daytona create --volume my-awesome-volume:/home/daytona/volume
 ```
 
-The `--volume` flag accepts `VOLUME_ID:MOUNT_PATH` only. For a **subpath** mount, use a [SDK](#mount-volumes) or the [API](#mount-volumes) and set `subpath` on the volume entry.
+The `--volume` flag accepts `VOLUME_ID_OR_NAME:MOUNT_PATH` only. For a **subpath** mount, use a [SDK](#mount-volumes) or the [API](#mount-volumes) and set `subpath` on the volume entry.
 
 </TabItem>
 <TabItem label="API" icon="seti:json">

--- a/apps/docs/src/content/docs/en/volumes.mdx
+++ b/apps/docs/src/content/docs/en/volumes.mdx
@@ -326,7 +326,7 @@ daytona volume create my-awesome-volume
 daytona create --volume my-awesome-volume:/home/daytona/volume
 ```
 
-The `--volume` flag accepts `VOLUME_NAME:MOUNT_PATH` only. For a **subpath** mount, use a [SDK](#mount-volumes) or the [API](#mount-volumes) and set `subpath` on the volume entry.
+The `--volume` flag accepts `VOLUME_ID:MOUNT_PATH` only. For a **subpath** mount, use a [SDK](#mount-volumes) or the [API](#mount-volumes) and set `subpath` on the volume entry.
 
 </TabItem>
 <TabItem label="API" icon="seti:json">

--- a/apps/runner/go.mod
+++ b/apps/runner/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/google/go-containerregistry v0.20.7
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lmittmann/tint v1.1.2
@@ -90,7 +91,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect

--- a/apps/runner/pkg/docker/volumes_mountpaths.go
+++ b/apps/runner/pkg/docker/volumes_mountpaths.go
@@ -17,9 +17,16 @@ import (
 	"github.com/daytonaio/common-go/pkg/log"
 	"github.com/daytonaio/runner/cmd/runner/config"
 	"github.com/daytonaio/runner/pkg/api/dto"
+	"github.com/google/uuid"
 )
 
 const volumeMountPrefix = "daytona-volume-"
+
+// volumeId becomes part of the host mount path and the S3 bucket name, so require
+// the canonical UUID form (the length check excludes braced/URN/dashless variants).
+func isValidVolumeId(volumeId string) bool {
+	return len(volumeId) == 36 && uuid.Validate(volumeId) == nil
+}
 
 func getVolumeMountBasePath() string {
 	if config.GetEnvironment() == "development" {
@@ -36,15 +43,14 @@ func (d *DockerClient) getVolumesMountPathBinds(ctx context.Context, volumes []d
 	uniqueMounts := make(map[string]string, len(volumes)) // volumeIdPrefixed -> baseMountPath
 	mountBase := filepath.Clean(getVolumeMountBasePath())
 	for _, vol := range volumes {
+		if !isValidVolumeId(vol.VolumeId) {
+			return nil, fmt.Errorf("invalid volumeId %q: must be a volume UUID", vol.VolumeId)
+		}
 		volumeIdPrefixed := fmt.Sprintf("%s%s", volumeMountPrefix, vol.VolumeId)
 		if _, ok := uniqueMounts[volumeIdPrefixed]; !ok {
 			baseMountPath := filepath.Join(getVolumeMountBasePath(), volumeIdPrefixed)
-			// Defense in depth: the volumeId is server-controlled (a UUID), but if a
-			// traversal string or separator ever reached here it could escape the
-			// mount base (e.g. "/.." -> "/mnt", "../../.." -> "/") or collide with
-			// another volume's path (e.g. "/../daytona-volume-other"). Require the
-			// resolved path to be a direct child of mountBase whose final segment is
-			// exactly the prefixed volumeId.
+			// Defense in depth: the path must stay a direct child of mountBase so a
+			// traversal string can never escape it or collide with another volume.
 			if filepath.Dir(baseMountPath) != mountBase || filepath.Base(baseMountPath) != volumeIdPrefixed {
 				return nil, fmt.Errorf("invalid volumeId %q: resolves outside volume mount base", vol.VolumeId)
 			}

--- a/apps/runner/pkg/docker/volumes_mountpaths.go
+++ b/apps/runner/pkg/docker/volumes_mountpaths.go
@@ -34,10 +34,19 @@ func (d *DockerClient) getVolumesMountPathBinds(ctx context.Context, volumes []d
 	// mount to become ready; doing them sequentially made create-time scale
 	// linearly with the number of mounted volumes.
 	uniqueMounts := make(map[string]string, len(volumes)) // volumeIdPrefixed -> baseMountPath
+	mountBase := filepath.Clean(getVolumeMountBasePath())
 	for _, vol := range volumes {
 		volumeIdPrefixed := fmt.Sprintf("%s%s", volumeMountPrefix, vol.VolumeId)
 		if _, ok := uniqueMounts[volumeIdPrefixed]; !ok {
-			uniqueMounts[volumeIdPrefixed] = filepath.Join(getVolumeMountBasePath(), volumeIdPrefixed)
+			baseMountPath := filepath.Join(getVolumeMountBasePath(), volumeIdPrefixed)
+			// Defense in depth: the volumeId is server-controlled (a UUID), but if a
+			// traversal string ever reached here it would escape the mount base
+			// (e.g. "../../.." -> "/"). Confine baseMountPath to mountBase, same as
+			// the subpath check below.
+			if baseMountPath != mountBase && !strings.HasPrefix(baseMountPath, mountBase+string(os.PathSeparator)) {
+				return nil, fmt.Errorf("invalid volumeId %q: resolves outside volume mount base", vol.VolumeId)
+			}
+			uniqueMounts[volumeIdPrefixed] = baseMountPath
 		}
 	}
 

--- a/apps/runner/pkg/docker/volumes_mountpaths.go
+++ b/apps/runner/pkg/docker/volumes_mountpaths.go
@@ -23,9 +23,14 @@ import (
 const volumeMountPrefix = "daytona-volume-"
 
 // volumeId becomes part of the host mount path and the S3 bucket name, so require
-// the canonical UUID form (the length check excludes braced/URN/dashless variants).
+// the canonical lowercase UUID form (rejects braced/URN/dashless/uppercase variants,
+// which uuid.Parse would otherwise accept).
 func isValidVolumeId(volumeId string) bool {
-	return len(volumeId) == 36 && uuid.Validate(volumeId) == nil
+	parsed, err := uuid.Parse(volumeId)
+	if err != nil {
+		return false
+	}
+	return parsed.String() == volumeId
 }
 
 func getVolumeMountBasePath() string {

--- a/apps/runner/pkg/docker/volumes_mountpaths.go
+++ b/apps/runner/pkg/docker/volumes_mountpaths.go
@@ -40,10 +40,12 @@ func (d *DockerClient) getVolumesMountPathBinds(ctx context.Context, volumes []d
 		if _, ok := uniqueMounts[volumeIdPrefixed]; !ok {
 			baseMountPath := filepath.Join(getVolumeMountBasePath(), volumeIdPrefixed)
 			// Defense in depth: the volumeId is server-controlled (a UUID), but if a
-			// traversal string ever reached here it would escape the mount base
-			// (e.g. "../../.." -> "/"). Confine baseMountPath to mountBase, same as
-			// the subpath check below.
-			if baseMountPath != mountBase && !strings.HasPrefix(baseMountPath, mountBase+string(os.PathSeparator)) {
+			// traversal string or separator ever reached here it could escape the
+			// mount base (e.g. "/.." -> "/mnt", "../../.." -> "/") or collide with
+			// another volume's path (e.g. "/../daytona-volume-other"). Require the
+			// resolved path to be a direct child of mountBase whose final segment is
+			// exactly the prefixed volumeId.
+			if filepath.Dir(baseMountPath) != mountBase || filepath.Base(baseMountPath) != volumeIdPrefixed {
 				return nil, fmt.Errorf("invalid volumeId %q: resolves outside volume mount base", vol.VolumeId)
 			}
 			uniqueMounts[volumeIdPrefixed] = baseMountPath

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -11002,12 +11002,13 @@ components:
     SandboxVolume:
       example:
         mountPath: /data
-        volumeId: volume123
+        volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
         subpath: users/alice
       properties:
         volumeId:
           description: The ID of the volume
-          example: volume123
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+          format: uuid
           type: string
         mountPath:
           description: The mount path for the volume
@@ -11083,10 +11084,10 @@ components:
         networkAllowList: "192.168.1.0/16,10.0.0.0/24"
         volumes:
         - mountPath: /data
-          volumeId: volume123
+          volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
           subpath: users/alice
         - mountPath: /data
-          volumeId: volume123
+          volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
           subpath: users/alice
         cpu: 2
         recoverable: true
@@ -11318,10 +11319,10 @@ components:
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
           volumes:
           - mountPath: /data
-            volumeId: volume123
+            volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
             subpath: users/alice
           - mountPath: /data
-            volumeId: volume123
+            volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
             subpath: users/alice
           cpu: 2
           recoverable: true
@@ -11361,10 +11362,10 @@ components:
           networkAllowList: "192.168.1.0/16,10.0.0.0/24"
           volumes:
           - mountPath: /data
-            volumeId: volume123
+            volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
             subpath: users/alice
           - mountPath: /data
-            volumeId: volume123
+            volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
             subpath: users/alice
           cpu: 2
           recoverable: true
@@ -11428,10 +11429,10 @@ components:
         networkAllowList: "192.168.1.0/16,10.0.0.0/24"
         volumes:
         - mountPath: /data
-          volumeId: volume123
+          volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
           subpath: users/alice
         - mountPath: /data
-          volumeId: volume123
+          volumeId: 3fa85f64-5717-4562-b3fc-2c963f66afa6
           subpath: users/alice
         cpu: 2
         env:

--- a/libs/api-client-go/api/openapi.yaml
+++ b/libs/api-client-go/api/openapi.yaml
@@ -11006,9 +11006,9 @@ components:
         subpath: users/alice
       properties:
         volumeId:
-          description: The ID of the volume
+          description: The ID or name of the volume. Resolved to the volume ID on
+            sandbox create.
           example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
-          format: uuid
           type: string
         mountPath:
           description: The mount path for the volume

--- a/libs/api-client-go/model_sandbox_volume.go
+++ b/libs/api-client-go/model_sandbox_volume.go
@@ -21,7 +21,7 @@ var _ MappedNullable = &SandboxVolume{}
 
 // SandboxVolume struct for SandboxVolume
 type SandboxVolume struct {
-	// The ID of the volume
+	// The ID or name of the volume. Resolved to the volume ID on sandbox create.
 	VolumeId string `json:"volumeId"`
 	// The mount path for the volume
 	MountPath string `json:"mountPath"`

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxVolume.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxVolume.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.UUID;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,7 +54,7 @@ public class SandboxVolume {
   public static final String SERIALIZED_NAME_VOLUME_ID = "volumeId";
   @SerializedName(SERIALIZED_NAME_VOLUME_ID)
   @javax.annotation.Nonnull
-  private String volumeId;
+  private UUID volumeId;
 
   public static final String SERIALIZED_NAME_MOUNT_PATH = "mountPath";
   @SerializedName(SERIALIZED_NAME_MOUNT_PATH)
@@ -68,7 +69,7 @@ public class SandboxVolume {
   public SandboxVolume() {
   }
 
-  public SandboxVolume volumeId(@javax.annotation.Nonnull String volumeId) {
+  public SandboxVolume volumeId(@javax.annotation.Nonnull UUID volumeId) {
     this.volumeId = volumeId;
     return this;
   }
@@ -78,11 +79,11 @@ public class SandboxVolume {
    * @return volumeId
    */
   @javax.annotation.Nonnull
-  public String getVolumeId() {
+  public UUID getVolumeId() {
     return volumeId;
   }
 
-  public void setVolumeId(@javax.annotation.Nonnull String volumeId) {
+  public void setVolumeId(@javax.annotation.Nonnull UUID volumeId) {
     this.volumeId = volumeId;
   }
 

--- a/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxVolume.java
+++ b/libs/api-client-java/src/main/java/io/daytona/api/client/model/SandboxVolume.java
@@ -21,7 +21,6 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.UUID;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -54,7 +53,7 @@ public class SandboxVolume {
   public static final String SERIALIZED_NAME_VOLUME_ID = "volumeId";
   @SerializedName(SERIALIZED_NAME_VOLUME_ID)
   @javax.annotation.Nonnull
-  private UUID volumeId;
+  private String volumeId;
 
   public static final String SERIALIZED_NAME_MOUNT_PATH = "mountPath";
   @SerializedName(SERIALIZED_NAME_MOUNT_PATH)
@@ -69,21 +68,21 @@ public class SandboxVolume {
   public SandboxVolume() {
   }
 
-  public SandboxVolume volumeId(@javax.annotation.Nonnull UUID volumeId) {
+  public SandboxVolume volumeId(@javax.annotation.Nonnull String volumeId) {
     this.volumeId = volumeId;
     return this;
   }
 
   /**
-   * The ID of the volume
+   * The ID or name of the volume. Resolved to the volume ID on sandbox create.
    * @return volumeId
    */
   @javax.annotation.Nonnull
-  public UUID getVolumeId() {
+  public String getVolumeId() {
     return volumeId;
   }
 
-  public void setVolumeId(@javax.annotation.Nonnull UUID volumeId) {
+  public void setVolumeId(@javax.annotation.Nonnull String volumeId) {
     this.volumeId = volumeId;
   }
 

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxVolumeTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxVolumeTest.java
@@ -20,6 +20,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.UUID;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxVolumeTest.java
+++ b/libs/api-client-java/src/test/java/io/daytona/api/client/model/SandboxVolumeTest.java
@@ -20,7 +20,6 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.UUID;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox_volume.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox_volume.py
@@ -20,6 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
+from uuid import UUID
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -30,7 +31,7 @@ class SandboxVolume(BaseModel):
     """
     SandboxVolume
     """ # noqa: E501
-    volume_id: StrictStr = Field(description="The ID of the volume", serialization_alias="volumeId")
+    volume_id: UUID = Field(description="The ID of the volume", serialization_alias="volumeId")
     mount_path: StrictStr = Field(description="The mount path for the volume", serialization_alias="mountPath")
     subpath: Optional[StrictStr] = Field(default=None, description="Optional subpath within the volume to mount. When specified, only this S3 prefix will be accessible. When omitted, the entire volume is mounted.")
     additional_properties: Dict[str, Any] = {}

--- a/libs/api-client-python-async/daytona_api_client_async/models/sandbox_volume.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/sandbox_volume.py
@@ -20,7 +20,6 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
-from uuid import UUID
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -31,7 +30,7 @@ class SandboxVolume(BaseModel):
     """
     SandboxVolume
     """ # noqa: E501
-    volume_id: UUID = Field(description="The ID of the volume", serialization_alias="volumeId")
+    volume_id: StrictStr = Field(description="The ID or name of the volume. Resolved to the volume ID on sandbox create.", serialization_alias="volumeId")
     mount_path: StrictStr = Field(description="The mount path for the volume", serialization_alias="mountPath")
     subpath: Optional[StrictStr] = Field(default=None, description="Optional subpath within the volume to mount. When specified, only this S3 prefix will be accessible. When omitted, the entire volume is mounted.")
     additional_properties: Dict[str, Any] = {}

--- a/libs/api-client-python/daytona_api_client/models/sandbox_volume.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox_volume.py
@@ -20,6 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
+from uuid import UUID
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -30,7 +31,7 @@ class SandboxVolume(BaseModel):
     """
     SandboxVolume
     """ # noqa: E501
-    volume_id: StrictStr = Field(description="The ID of the volume", serialization_alias="volumeId")
+    volume_id: UUID = Field(description="The ID of the volume", serialization_alias="volumeId")
     mount_path: StrictStr = Field(description="The mount path for the volume", serialization_alias="mountPath")
     subpath: Optional[StrictStr] = Field(default=None, description="Optional subpath within the volume to mount. When specified, only this S3 prefix will be accessible. When omitted, the entire volume is mounted.")
     additional_properties: Dict[str, Any] = {}

--- a/libs/api-client-python/daytona_api_client/models/sandbox_volume.py
+++ b/libs/api-client-python/daytona_api_client/models/sandbox_volume.py
@@ -20,7 +20,6 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
-from uuid import UUID
 from pydantic import TypeAdapter
 from typing import Optional, Set
 from typing_extensions import Self
@@ -31,7 +30,7 @@ class SandboxVolume(BaseModel):
     """
     SandboxVolume
     """ # noqa: E501
-    volume_id: UUID = Field(description="The ID of the volume", serialization_alias="volumeId")
+    volume_id: StrictStr = Field(description="The ID or name of the volume. Resolved to the volume ID on sandbox create.", serialization_alias="volumeId")
     mount_path: StrictStr = Field(description="The mount path for the volume", serialization_alias="mountPath")
     subpath: Optional[StrictStr] = Field(default=None, description="Optional subpath within the volume to mount. When specified, only this S3 prefix will be accessible. When omitted, the entire volume is mounted.")
     additional_properties: Dict[str, Any] = {}

--- a/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_volume.rb
+++ b/libs/api-client-ruby/lib/daytona_api_client/models/sandbox_volume.rb
@@ -15,7 +15,7 @@ require 'time'
 
 module DaytonaApiClient
   class SandboxVolume < ApiModelBase
-    # The ID of the volume
+    # The ID or name of the volume. Resolved to the volume ID on sandbox create.
     attr_accessor :volume_id
 
     # The mount path for the volume

--- a/libs/api-client/src/models/sandbox-volume.ts
+++ b/libs/api-client/src/models/sandbox-volume.ts
@@ -16,7 +16,7 @@
 
 export interface SandboxVolume {
     /**
-     * The ID of the volume
+     * The ID or name of the volume. Resolved to the volume ID on sandbox create.
      */
     'volumeId': string;
     /**

--- a/libs/sdk-go/pkg/types/types.go
+++ b/libs/sdk-go/pkg/types/types.go
@@ -71,7 +71,7 @@ type Resources struct {
 
 // VolumeMount represents a volume mount configuration
 type VolumeMount struct {
-	VolumeID  string
+	VolumeID  string // ID or name of the volume to mount
 	MountPath string
 	Subpath   *string // Optional subpath within the volume; nil = mount entire volume
 }

--- a/libs/sdk-python/src/daytona/common/volume.py
+++ b/libs/sdk-python/src/daytona/common/volume.py
@@ -13,7 +13,7 @@ class VolumeMount(ApiVolumeMount, AsyncApiVolumeMount):
     """Represents a Volume mount configuration for a Sandbox.
 
     Attributes:
-        volume_id (str): ID of the volume to mount.
+        volume_id (str): ID or name of the volume to mount.
         mount_path (str): Path where the volume will be mounted in the sandbox.
         subpath (str | None): Optional S3 subpath/prefix within the volume to mount.
             When specified, only this prefix will be accessible. When omitted,

--- a/libs/sdk-typescript/src/Daytona.ts
+++ b/libs/sdk-typescript/src/Daytona.ts
@@ -42,7 +42,7 @@ export const CODE_TOOLBOX_LANGUAGE_LABEL = 'code-toolbox-language'
  * Represents a volume mount for a Sandbox.
  *
  * @interface
- * @property {string} volumeId - ID of the Volume to mount
+ * @property {string} volumeId - ID or name of the Volume to mount
  * @property {string} mountPath - Path on the Sandbox to mount the Volume
  */
 


### PR DESCRIPTION
## Description

Forwarding a raw volumeId to the runner let a volume named ../../.. escape the host mount base. volumeId (an ID or name) is now resolved to the volume UUID in the API before storage/forwarding (with nested DTO validation so the field validators actually run), the runner enforces a UUID and path-confinement backstop, and the CLI/docs now say VOLUME_ID_OR_NAME. No client breaks; malformed input now returns 400 and unknown volumes 404 instead of reaching the runner.

## Documentation

- [x] This change requires a documentation update
- [x] I have made corresponding changes to the documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a path traversal bug by resolving volume references to UUIDs in the API and enforcing UUID-only, confined mounts in the runner. CLI and SDKs now accept a volume ID or name (including UUID-like names) with early validation and clear errors.

- **Bug Fixes**
  - API/Schema: `SandboxVolume.volumeId` accepts ID or name; added `@ValidateNested`/`@Type` and string/non-empty checks for `volumeId`/`mountPath`/`subpath`. OpenAPI and SDK docs updated with ID-or-name wording and UUID examples.
  - API: New `getVolumesByIdOrName(orgId, refs)` maps refs to volumes; unknown refs 404, not-ready 400, ambiguous ID-vs-name 400. `resolveVolumes(orgId, volumes)` swaps names for UUIDs and validates mounts/subpaths; used on all create paths before runner assignment.
  - Runner: Requires canonical lowercase UUIDs for `volumeId` and confines host bind paths to the mount base; rejects non-UUIDs/variants and any path that escapes the base.
  - CLI: `daytona create --volume` uses `VOLUME_ID_OR_NAME:MOUNT_PATH`. `daytona volume get|delete` accept ID or name, resolve UUID-shaped names by checking ID and name, detect ambiguity, and treat deleted-by-ID as not found.

- **Migration**
  - Use ID or name with `-v/--volume` and in SDKs (example: `VOLUME_ID_OR_NAME:/path`).
  - Invalid input returns 400; unknown volumes 404; ambiguous UUID-shaped names 400.

<sup>Written for commit 581deb12da4a4d6024013d60cca39b42817f10bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

