### PR TITLE
fix(api): close usage period on desired state destroyed

### DIFF
--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -21,6 +21,8 @@ import { setTimeout as sleep } from 'timers/promises'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
 import { WithInstrumentation } from '../../common/decorators/otel.decorator'
 import { SandboxRepository } from '../../sandbox/repositories/sandbox.repository'
+import { SandboxDesiredStateUpdatedEvent } from '../../sandbox/events/sandbox-desired-state-updated.event'
+import { SandboxDesiredState } from '../../sandbox/enums/sandbox-desired-state.enum'
 
 @Injectable()
 export class UsageService implements TrackableJobExecutions, OnApplicationShutdown {
@@ -39,6 +41,25 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
     while (this.activeJobs.size > 0) {
       this.logger.log(`Waiting for ${this.activeJobs.size} active jobs to finish`)
       await sleep(1000)
+    }
+  }
+
+  @OnEvent(SandboxEvents.DESIRED_STATE_UPDATED)
+  @TrackJobExecution()
+  async handleSandboxDesiredStateUpdate(event: SandboxDesiredStateUpdatedEvent) {
+    await this.waitForLock(event.sandbox.id)
+
+    try {
+      switch (event.newDesiredState) {
+        case SandboxDesiredState.DESTROYED: {
+          await this.closeUsagePeriod(event.sandbox.id)
+          break
+        }
+      }
+    } finally {
+      this.releaseLock(event.sandbox.id).catch((error) => {
+        this.logger.error(`Error releasing lock for sandbox ${event.sandbox.id}`, error)
+      })
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Close sandbox usage periods as soon as their desired state becomes `DESTROYED`, preventing lingering usage after delete.

- **Bug Fixes**
  - Listen to `SandboxEvents.DESIRED_STATE_UPDATED` and call `closeUsagePeriod` when the new desired state is `DESTROYED`.
  - Guard with the existing per-sandbox lock and ensure lock release in `finally` to avoid races.

<sup>Written for commit 65b29f52e9595f8d91492012f9a3e5d8ad2799af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

