### PR TITLE
feat(docs): sandboxes lifecycle ttl

### DIFF
--- a/apps/docs/src/content/docs/en/sandboxes.mdx
+++ b/apps/docs/src/content/docs/en/sandboxes.mdx
@@ -1713,7 +1713,7 @@ If omitted, the Daytona SDK will default to `python`. To override this, explicit
 
 ## Automated lifecycle management
 
-Daytona sandboxes can be automatically stopped, archived, and deleted based on user-defined intervals. You can also refresh the last activity timestamp to explicitly signal activity when lifecycle behavior depends on inactivity windows.
+Sandboxes can be automatically stopped, archived, and deleted based on user-defined intervals. The intervals act as a TTL (time-to-live) mechanism for the sandbox. You can also refresh the last activity timestamp to explicitly signal activity when lifecycle behavior depends on inactivity intervals.
 
 ### Update sandbox last activity
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated sandboxes lifecycle docs to state that stop/archive/delete intervals act as a sandbox TTL, and revised wording to “inactivity intervals.” Also clarified you can refresh the last-activity timestamp to signal activity when lifecycle behavior depends on inactivity.

<sup>Written for commit c1c827733bc02df78322fecf39f644e95353bb12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

