### PR TITLE
fix(api): scope object-storage push-access ListBucket to caller org prefix

### DIFF
--- a/apps/api/src/object-storage/services/object-storage.service.ts
+++ b/apps/api/src/object-storage/services/object-storage.service.ts
@@ -55,11 +55,19 @@ export class ObjectStorageService {
               Action: ['s3:PutObject', 's3:GetObject'],
               Resource: [`arn:aws:s3:::${bucket}/${organizationId}/*`],
             },
-            // ListBucket only shows object keys and some metadata, not the actual objects
+            // ListBucket only shows object keys and some metadata, not the actual objects.
+            // Scope it to the organization's own prefix so a caller cannot enumerate object
+            // keys across other tenants. The CLI lists with prefix=<organizationId> (no trailing
+            // slash), so both the bare org id and the nested prefix must be permitted.
             {
               Effect: 'Allow',
               Action: ['s3:ListBucket'],
               Resource: [`arn:aws:s3:::${bucket}`],
+              Condition: {
+                StringLike: {
+                  's3:prefix': [`${organizationId}`, `${organizationId}/*`],
+                },
+              },
             },
           ],
         },


### PR DESCRIPTION
## What

Scope the `s3:ListBucket` grant in the temporary credentials minted by `GET /object-storage/push-access` to the caller's own organization prefix, rather than the whole bucket.

## Notes

- The CLI lists with `prefix=<organizationId>` (no trailing slash), so the `s3:prefix` condition permits both the bare org id and the nested prefix — existing builds are unaffected.
- The minted session policy intersects with the assuming role's identity policy, so this only narrows access.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the `s3:ListBucket` permission in temporary creds from `GET /object-storage/push-access` to the caller’s organization prefix to prevent cross-tenant key enumeration. Supports both `prefix=<organizationId>` and `${organizationId}/*`, so existing CLI behavior is unaffected.

<sup>Written for commit 87193bbcf0d03d0dc5d48a0d79ff93e29136b753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

