### PR TITLE
chore(docs): add native dep dependencies to dockerfile

### DIFF
--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -2,6 +2,11 @@ FROM node:22-alpine AS build
 
 ENV CI=true
 
+# Build toolchain (python3/make/g++) is needed when a native module's prebuilt
+# binary download fails and node-gyp falls back to compiling from source —
+# it stays out of the runtime image.
+RUN apk add --no-cache python3 make g++
+
 RUN npm install -g corepack && corepack enable
 
 WORKDIR /daytona


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `python3`, `make`, and `g++` to the docs Dockerfile build stage to allow compiling native modules when prebuilt binaries are missing. Prevents `node-gyp` build failures and keeps the runtime image unchanged.

<sup>Written for commit 57a51df9f640a73cc59aee94a0fb5c37d55bd2a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/daytonaio/daytona/pull/4970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

